### PR TITLE
Story #8: Define Key and TypeTag enums

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod traits; // Story #11
 
 // Re-export commonly used types and traits
 pub use traits::{SnapshotView, Storage};
-pub use types::{Namespace, RunId};
+pub use types::{Key, Namespace, RunId, TypeTag};
 
 /// Placeholder for core functionality
 /// This will be populated by stories #7-11


### PR DESCRIPTION
## Summary
Implements Story #8 to define Key and TypeTag enums for unified storage.

### TypeTag enum
- 6 variants: KV, Event, StateMachine, Trace, RunMetadata, Vector
- Ordered for BTreeMap efficiency: KV < Event < StateMachine < Trace < RunMetadata < Vector
- All required derives: Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord
- Complete documentation

### Key struct
- Composite key: namespace + type_tag + user_key
- Critical ordering: namespace → type_tag → user_key (enables efficient prefix scans)
- Helper constructors for all primitive types
- `starts_with()` method for prefix matching
- All required derives

## Test Coverage
- **TypeTag tests (6)**: variants, ordering, serialization, equality, clone/copy, hash
- **Key tests (13)**: construction, helpers, BTreeMap ordering, prefix matching, serialization, equality, clone, hash, binary keys

**Total: 19 new tests** - all passing ✅

## TDD Methodology
Followed strict TDD:
1. ✅ Wrote all tests first
2. ✅ Implemented TypeTag to pass tests
3. ✅ Wrote Key tests
4. ✅ Implemented Key to pass tests

## Verification
```bash
cargo test -p in-mem-core --quiet
# running 39 tests - all passed!
```

## Resolves
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)