### PR TITLE
Story #14: Add TTL index and cleanup subsystem

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 in-mem-core = { path = "../core" }
+chrono = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/storage/src/cleaner.rs
+++ b/crates/storage/src/cleaner.rs
@@ -1,0 +1,232 @@
+//! TTL cleanup background task
+//!
+//! This module provides TTLCleaner that runs in a background thread
+//! and periodically cleans up expired keys using the normal delete() path.
+//!
+//! # Design Notes
+//!
+//! - Uses transactions (delete()) not direct mutation for proper coordination
+//! - Runs in background thread, doesn't block writes
+//! - Graceful shutdown via atomic flag
+//! - Configurable check interval
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use in_mem_core::Storage;
+
+use crate::UnifiedStore;
+
+/// Background TTL cleanup task
+///
+/// Periodically scans for expired keys and deletes them via
+/// normal transactional path (respects locks, WAL, etc.)
+///
+/// # Example
+///
+/// ```ignore
+/// use std::sync::Arc;
+/// use std::time::Duration;
+/// use in_mem_storage::{UnifiedStore, TTLCleaner};
+///
+/// let store = Arc::new(UnifiedStore::new());
+/// let cleaner = TTLCleaner::new(Arc::clone(&store), Duration::from_secs(60));
+/// let handle = cleaner.start();
+///
+/// // ... use the store ...
+///
+/// // Shutdown gracefully
+/// cleaner.shutdown();
+/// handle.join().unwrap();
+/// ```
+pub struct TTLCleaner {
+    /// Reference to the store to clean
+    store: Arc<UnifiedStore>,
+    /// How often to check for expired keys
+    check_interval: Duration,
+    /// Shutdown signal
+    shutdown: Arc<AtomicBool>,
+}
+
+impl TTLCleaner {
+    /// Create a new TTL cleaner
+    ///
+    /// # Arguments
+    ///
+    /// * `store` - The UnifiedStore to clean
+    /// * `check_interval` - How often to check for expired keys
+    pub fn new(store: Arc<UnifiedStore>, check_interval: Duration) -> Self {
+        Self {
+            store,
+            check_interval,
+            shutdown: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Start the background cleanup task
+    ///
+    /// Returns a JoinHandle that can be used to wait for the thread to complete.
+    /// The thread will run until `shutdown()` is called.
+    pub fn start(&self) -> JoinHandle<()> {
+        let store = Arc::clone(&self.store);
+        let shutdown = Arc::clone(&self.shutdown);
+        let check_interval = self.check_interval;
+
+        thread::spawn(move || {
+            while !shutdown.load(Ordering::Relaxed) {
+                // Sleep first (don't cleanup immediately on start)
+                // Use smaller sleep intervals to check shutdown more frequently
+                let sleep_interval = Duration::from_millis(100).min(check_interval);
+                let mut elapsed = Duration::ZERO;
+
+                while elapsed < check_interval {
+                    if shutdown.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    thread::sleep(sleep_interval);
+                    elapsed += sleep_interval;
+                }
+
+                // Find expired keys
+                if let Ok(expired) = store.find_expired_keys() {
+                    // Delete each via normal path (transactional)
+                    for key in expired {
+                        // Ignore errors (key might have been deleted by user)
+                        let _ = store.delete(&key);
+                    }
+                }
+            }
+        })
+    }
+
+    /// Signal shutdown (for graceful termination)
+    ///
+    /// After calling this, the background thread will exit on its next iteration.
+    pub fn shutdown(&self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+    }
+
+    /// Check if shutdown has been signaled
+    pub fn is_shutdown(&self) -> bool {
+        self.shutdown.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use in_mem_core::{Key, Namespace, RunId, Value};
+
+    #[test]
+    fn test_ttl_cleaner_creation() {
+        let store = Arc::new(UnifiedStore::new());
+        let cleaner = TTLCleaner::new(Arc::clone(&store), Duration::from_secs(60));
+
+        assert!(!cleaner.is_shutdown());
+    }
+
+    #[test]
+    fn test_ttl_cleaner_shutdown() {
+        let store = Arc::new(UnifiedStore::new());
+        let cleaner = TTLCleaner::new(Arc::clone(&store), Duration::from_secs(60));
+
+        cleaner.shutdown();
+        assert!(cleaner.is_shutdown());
+    }
+
+    #[test]
+    fn test_ttl_cleaner_deletes_expired() {
+        let store = Arc::new(UnifiedStore::new());
+        let run_id = RunId::new();
+        let ns = Namespace::new(
+            "tenant".to_string(),
+            "app".to_string(),
+            "agent".to_string(),
+            run_id,
+        );
+
+        // Put key with very short TTL (1 second)
+        let key = Key::new_kv(ns.clone(), "temp");
+        store
+            .put(
+                key.clone(),
+                Value::Bytes(b"data".to_vec()),
+                Some(Duration::from_secs(1)),
+            )
+            .unwrap();
+
+        // Key should exist initially
+        assert!(store.get(&key).unwrap().is_some());
+
+        // Start cleaner with fast interval
+        let cleaner = TTLCleaner::new(Arc::clone(&store), Duration::from_millis(100));
+        let handle = cleaner.start();
+
+        // Wait for TTL to expire and cleaner to run
+        thread::sleep(Duration::from_millis(1500));
+
+        // Key should be deleted
+        let result = store.get(&key).unwrap();
+        assert!(result.is_none());
+
+        // Shutdown cleaner
+        cleaner.shutdown();
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn test_ttl_cleaner_does_not_delete_non_expired() {
+        let store = Arc::new(UnifiedStore::new());
+        let run_id = RunId::new();
+        let ns = Namespace::new(
+            "tenant".to_string(),
+            "app".to_string(),
+            "agent".to_string(),
+            run_id,
+        );
+
+        // Put key with long TTL (60 seconds)
+        let key = Key::new_kv(ns.clone(), "persistent");
+        store
+            .put(
+                key.clone(),
+                Value::Bytes(b"data".to_vec()),
+                Some(Duration::from_secs(60)),
+            )
+            .unwrap();
+
+        // Start cleaner with fast interval
+        let cleaner = TTLCleaner::new(Arc::clone(&store), Duration::from_millis(100));
+        let handle = cleaner.start();
+
+        // Let cleaner run a few cycles
+        thread::sleep(Duration::from_millis(500));
+
+        // Key should still exist (not expired yet)
+        let result = store.get(&key).unwrap();
+        assert!(result.is_some());
+
+        // Shutdown cleaner
+        cleaner.shutdown();
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn test_ttl_cleaner_graceful_shutdown() {
+        let store = Arc::new(UnifiedStore::new());
+        let cleaner = TTLCleaner::new(Arc::clone(&store), Duration::from_secs(10));
+        let handle = cleaner.start();
+
+        // Immediately shutdown
+        cleaner.shutdown();
+
+        // Should complete quickly (not wait 10 seconds)
+        let start = std::time::Instant::now();
+        handle.join().unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(elapsed < Duration::from_secs(1), "Should shutdown quickly");
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -4,16 +4,20 @@
 //! - UnifiedStore: BTreeMap-based storage with RwLock
 //! - Secondary indices (run_index, type_index)
 //! - TTL index for expiration
+//! - TTL cleaner background task
 //! - Version management with AtomicU64
 //! - ClonedSnapshotView implementation
 
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 
+pub mod cleaner;
 pub mod index;
+pub mod ttl;
 pub mod unified;
-// pub mod ttl;        // Story #14
 // pub mod snapshot;   // Story #15
 
+pub use cleaner::TTLCleaner;
 pub use index::{RunIndex, TypeIndex};
+pub use ttl::TTLIndex;
 pub use unified::UnifiedStore;

--- a/crates/storage/src/ttl.rs
+++ b/crates/storage/src/ttl.rs
@@ -1,0 +1,233 @@
+//! TTL (Time-To-Live) index for efficient expiration cleanup
+//!
+//! This module provides TTLIndex that enables efficient queries for expired keys
+//! without scanning the entire data store:
+//! - Maps expiry_timestamp → Set<Key> using BTreeMap for sorted order
+//! - find_expired() returns all keys expired before a given timestamp
+//! - O(expired count) instead of O(total data)
+
+use in_mem_core::{Key, Timestamp};
+use std::collections::{BTreeMap, HashSet};
+
+/// TTL index: expiry_timestamp → Keys
+///
+/// Enables efficient cleanup of expired keys by maintaining a mapping from
+/// expiry timestamps to sets of keys that expire at that time.
+///
+/// Uses BTreeMap for sorted ordering, allowing efficient range queries
+/// for all keys expired before a given timestamp.
+#[derive(Debug, Default)]
+pub struct TTLIndex {
+    /// Index mapping expiry timestamp to keys expiring at that time
+    index: BTreeMap<Timestamp, HashSet<Key>>,
+}
+
+impl TTLIndex {
+    /// Create a new empty TTLIndex
+    pub fn new() -> Self {
+        Self {
+            index: BTreeMap::new(),
+        }
+    }
+
+    /// Add key to TTL index with given expiry timestamp
+    ///
+    /// The key will be included in `find_expired()` results when
+    /// the current time exceeds `expiry_timestamp`.
+    pub fn insert(&mut self, expiry_timestamp: Timestamp, key: Key) {
+        self.index.entry(expiry_timestamp).or_default().insert(key);
+    }
+
+    /// Remove key from TTL index at given expiry timestamp
+    ///
+    /// Used when a key is deleted or overwritten.
+    /// If the set becomes empty, removes the timestamp entry entirely.
+    pub fn remove(&mut self, expiry_timestamp: Timestamp, key: &Key) {
+        if let Some(keys) = self.index.get_mut(&expiry_timestamp) {
+            keys.remove(key);
+            if keys.is_empty() {
+                self.index.remove(&expiry_timestamp);
+            }
+        }
+    }
+
+    /// Find all keys that have expired before the given timestamp
+    ///
+    /// Returns a Vec of all keys where expiry_timestamp < now.
+    /// This is O(expired count) not O(total data) because we use
+    /// BTreeMap range query to only scan expired entries.
+    pub fn find_expired(&self, now: Timestamp) -> Vec<Key> {
+        self.index
+            .range(..=now)
+            .flat_map(|(_, keys)| keys.iter().cloned())
+            .collect()
+    }
+
+    /// Remove all entries for keys that have expired before the given timestamp
+    ///
+    /// This is used after cleanup to remove stale index entries.
+    /// Returns the number of entries removed.
+    pub fn remove_expired(&mut self, now: Timestamp) -> usize {
+        let expired_timestamps: Vec<Timestamp> =
+            self.index.range(..=now).map(|(ts, _)| *ts).collect();
+
+        let mut count = 0;
+        for ts in expired_timestamps {
+            if let Some(keys) = self.index.remove(&ts) {
+                count += keys.len();
+            }
+        }
+        count
+    }
+
+    /// Check if the index is empty
+    pub fn is_empty(&self) -> bool {
+        self.index.is_empty()
+    }
+
+    /// Get the total number of keys in the index
+    pub fn len(&self) -> usize {
+        self.index.values().map(|keys| keys.len()).sum()
+    }
+
+    /// Get the number of unique expiry timestamps
+    pub fn timestamp_count(&self) -> usize {
+        self.index.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use in_mem_core::{Namespace, RunId};
+
+    /// Helper to create a test key
+    fn test_key(suffix: &str) -> Key {
+        let run_id = RunId::new();
+        let ns = Namespace::new(
+            "tenant".to_string(),
+            "app".to_string(),
+            "agent".to_string(),
+            run_id,
+        );
+        Key::new_kv(ns, suffix)
+    }
+
+    #[test]
+    fn test_ttl_index_insert_and_find_expired() {
+        let mut index = TTLIndex::new();
+        let now = 1000i64; // Use a fixed timestamp for testing
+
+        // Insert keys with different expiry times
+        let key1 = test_key("expires_at_500");
+        let key2 = test_key("expires_at_800");
+        let key3 = test_key("expires_at_1200");
+        let key4 = test_key("expires_at_500_also");
+
+        index.insert(500, key1.clone());
+        index.insert(800, key2.clone());
+        index.insert(1200, key3.clone());
+        index.insert(500, key4.clone()); // Same expiry as key1
+
+        // Find expired at time 1000 - should include key1, key2, key4
+        let expired = index.find_expired(now);
+        assert_eq!(expired.len(), 3);
+        assert!(expired.contains(&key1));
+        assert!(expired.contains(&key2));
+        assert!(expired.contains(&key4));
+        assert!(!expired.contains(&key3)); // Not expired yet
+    }
+
+    #[test]
+    fn test_ttl_index_remove() {
+        let mut index = TTLIndex::new();
+
+        let key1 = test_key("key1");
+        let key2 = test_key("key2");
+
+        index.insert(500, key1.clone());
+        index.insert(500, key2.clone());
+
+        assert_eq!(index.len(), 2);
+
+        // Remove one key
+        index.remove(500, &key1);
+        assert_eq!(index.len(), 1);
+
+        // Verify only key2 remains
+        let expired = index.find_expired(600);
+        assert_eq!(expired.len(), 1);
+        assert!(expired.contains(&key2));
+
+        // Remove the last key - timestamp entry should be cleaned up
+        index.remove(500, &key2);
+        assert!(index.is_empty());
+        assert_eq!(index.timestamp_count(), 0);
+    }
+
+    #[test]
+    fn test_ttl_index_remove_expired() {
+        let mut index = TTLIndex::new();
+
+        let key1 = test_key("key1");
+        let key2 = test_key("key2");
+        let key3 = test_key("key3");
+
+        index.insert(500, key1);
+        index.insert(800, key2);
+        index.insert(1200, key3);
+
+        // Remove expired before 1000
+        let removed = index.remove_expired(1000);
+        assert_eq!(removed, 2); // key1 and key2
+
+        // Only key3 should remain
+        assert_eq!(index.len(), 1);
+        assert_eq!(index.timestamp_count(), 1);
+    }
+
+    #[test]
+    fn test_ttl_index_find_expired_empty() {
+        let index = TTLIndex::new();
+        let expired = index.find_expired(1000);
+        assert!(expired.is_empty());
+    }
+
+    #[test]
+    fn test_ttl_index_find_expired_none_expired() {
+        let mut index = TTLIndex::new();
+
+        let key = test_key("future_key");
+        index.insert(2000, key);
+
+        // At time 1000, nothing is expired
+        let expired = index.find_expired(1000);
+        assert!(expired.is_empty());
+    }
+
+    #[test]
+    fn test_ttl_index_default() {
+        let index = TTLIndex::default();
+        assert!(index.is_empty());
+        assert_eq!(index.len(), 0);
+        assert_eq!(index.timestamp_count(), 0);
+    }
+
+    #[test]
+    fn test_ttl_index_multiple_timestamps() {
+        let mut index = TTLIndex::new();
+
+        // Insert keys at 5 different timestamps
+        for i in 0..5 {
+            let key = test_key(&format!("key_{}", i));
+            index.insert((i + 1) * 100, key);
+        }
+
+        assert_eq!(index.len(), 5);
+        assert_eq!(index.timestamp_count(), 5);
+
+        // Find expired at 350 - should get keys at 100, 200, 300
+        let expired = index.find_expired(350);
+        assert_eq!(expired.len(), 3);
+    }
+}


### PR DESCRIPTION
## Summary

Implements TTL index for efficient expiration cleanup in UnifiedStore:

- **TTLIndex**: `BTreeMap<Timestamp, HashSet<Key>>` for sorted expiry times
  - O(expired count) queries via BTreeMap range operations
  - Enables efficient `find_expired_keys()` without full scan

- **TTLCleaner**: Background thread for periodic cleanup
  - Uses `delete()` for transactional cleanup (respects locks)
  - Configurable check interval
  - Graceful shutdown via atomic flag

### Changes

| File | Change |
|------|--------|
| `crates/storage/src/ttl.rs` | New - TTLIndex implementation |
| `crates/storage/src/cleaner.rs` | New - TTLCleaner background task |
| `crates/storage/src/unified.rs` | Added ttl_index, updated put/delete |
| `crates/storage/src/lib.rs` | Export new modules |
| `crates/storage/Cargo.toml` | Add chrono dependency |

### Key Implementation Details

1. **TTLIndex** (`ttl.rs`)
   - `insert(expiry_timestamp, key)` - Add key with expiry
   - `remove(expiry_timestamp, key)` - Remove key
   - `find_expired(now)` - Get all expired keys (O(expired))
   - `remove_expired(now)` - Bulk cleanup

2. **TTLCleaner** (`cleaner.rs`)
   - Background thread with configurable interval
   - Uses `delete()` path for proper coordination
   - Graceful shutdown via atomic flag

3. **UnifiedStore Updates** (`unified.rs`)
   - `put()` updates TTL index when TTL set, removes old entry on overwrite
   - `delete()` removes from TTL index
   - `find_expired_keys()` uses TTL index for O(expired) lookup

### Tests Added (18 new tests)

**ttl.rs (7 tests):**
- `test_ttl_index_insert_and_find_expired`
- `test_ttl_index_remove`
- `test_ttl_index_remove_expired`
- `test_ttl_index_find_expired_empty`
- `test_ttl_index_find_expired_none_expired`
- `test_ttl_index_default`
- `test_ttl_index_multiple_timestamps`

**cleaner.rs (4 tests):**
- `test_ttl_cleaner_creation`
- `test_ttl_cleaner_shutdown`
- `test_ttl_cleaner_deletes_expired`
- `test_ttl_cleaner_does_not_delete_non_expired`
- `test_ttl_cleaner_graceful_shutdown`

**unified.rs (7 tests):**
- `test_ttl_index_insert_and_find_expired`
- `test_ttl_index_removed_on_delete`
- `test_ttl_index_updated_on_overwrite`
- `test_ttl_index_not_updated_for_non_ttl_keys`
- `test_ttl_overwrite_from_ttl_to_no_ttl`
- `test_find_expired_keys_uses_index`

## Test Plan

- [x] All 47 storage tests pass
- [x] All 125 workspace tests pass
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` passes

## Acceptance Criteria

- [x] TTLIndex using BTreeMap<Timestamp, HashSet<Key>>
- [x] put() with TTL updates ttl_index
- [x] delete() removes key from ttl_index
- [x] find_expired_keys() uses index (O(expired) not O(total))
- [x] TTLCleaner background task works
- [x] Cleanup uses transactions (delete(), not direct mutation)
- [x] All tests pass

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)