### PR TITLE
Story #20: Add configurable durability modes with fsync

### DIFF
--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -13,7 +13,7 @@
 
 // Module declarations
 pub mod encoding; // Story #18: Entry encoding/decoding with CRC
-pub mod wal; // Story #17: WALEntry types, Story #19: File operations
+pub mod wal; // Story #17-20: WALEntry types, File operations, Durability modes
 
 // Stubs for future stories
 // pub mod snapshot;   // M4
@@ -21,4 +21,4 @@ pub mod wal; // Story #17: WALEntry types, Story #19: File operations
 
 // Re-export commonly used types
 pub use encoding::{decode_entry, encode_entry};
-pub use wal::{WALEntry, WAL};
+pub use wal::{DurabilityMode, WALEntry, WAL};


### PR DESCRIPTION
Implements #20

## Changes
- 5fa5ad5 Add configurable durability modes with fsync

## Testing
- [x] Tests pass: `cargo test --all`
- [x] Formatting: `cargo fmt --all -- --check`
- [x] Linting: `cargo clippy --all -- -D warnings`

## Checklist
- [x] Code written
- [x] Tests added
- [x] Documentation updated
- [x] CI ready to pass