### PR TITLE
Story #23: Implement WAL replay logic

### DIFF
--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -13,12 +13,13 @@
 
 // Module declarations
 pub mod encoding; // Story #18: Entry encoding/decoding with CRC
+pub mod recovery; // Story #23: WAL replay logic
 pub mod wal; // Story #17-20: WALEntry types, File operations, Durability modes
 
 // Stubs for future stories
 // pub mod snapshot;   // M4
-// pub mod recovery;   // Story #23-25
 
 // Re-export commonly used types
 pub use encoding::{decode_entry, encode_entry};
+pub use recovery::{replay_wal, ReplayStats};
 pub use wal::{DurabilityMode, WALEntry, WAL};

--- a/crates/durability/src/recovery.rs
+++ b/crates/durability/src/recovery.rs
@@ -1,0 +1,666 @@
+//! WAL Replay Logic for Recovery
+//!
+//! This module implements WAL replay to restore storage state from the write-ahead log.
+//! It scans WAL entries, groups them by transaction ID, and applies only committed
+//! transactions to storage.
+//!
+//! ## Replay Process
+//!
+//! 1. Scan WAL entries from the beginning
+//! 2. Group entries by txn_id into Transaction structs
+//! 3. Identify committed transactions (those with CommitTxn entry)
+//! 4. Discard incomplete transactions (BeginTxn without CommitTxn - crashed mid-transaction)
+//! 5. Apply committed transactions in order to storage
+//! 6. Preserve version numbers from WAL (don't allocate new versions)
+//!
+//! ## Version Preservation
+//!
+//! CRITICAL: Replay must preserve the exact version numbers from WAL entries.
+//! This ensures that after replay, the database state is identical to what it was
+//! before the crash. We use `put_with_version()` and `delete_with_version()` to
+//! bypass normal version allocation.
+
+use crate::wal::{WALEntry, WAL};
+use in_mem_core::error::Result;
+use in_mem_core::types::RunId;
+use in_mem_storage::UnifiedStore;
+use std::collections::HashMap;
+
+/// Statistics from WAL replay
+///
+/// Tracks how many transactions and operations were applied during replay,
+/// useful for debugging and monitoring recovery performance.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ReplayStats {
+    /// Number of committed transactions that were applied
+    pub txns_applied: usize,
+    /// Number of Write operations applied
+    pub writes_applied: usize,
+    /// Number of Delete operations applied
+    pub deletes_applied: usize,
+    /// Final version after replay (highest version seen in WAL)
+    pub final_version: u64,
+    /// Number of incomplete transactions discarded (no CommitTxn)
+    pub incomplete_txns: usize,
+    /// Number of aborted transactions discarded
+    pub aborted_txns: usize,
+}
+
+/// Transaction state during replay
+///
+/// Groups WAL entries belonging to a single transaction.
+/// A transaction is committed only if it has a CommitTxn entry.
+#[derive(Debug)]
+struct Transaction {
+    /// Transaction identifier (stored for debugging via Debug trait)
+    #[allow(dead_code)]
+    txn_id: u64,
+    /// Run this transaction belongs to (stored for debugging via Debug trait)
+    #[allow(dead_code)]
+    run_id: RunId,
+    /// Entries in this transaction (in order)
+    entries: Vec<WALEntry>,
+    /// Whether this transaction was committed
+    committed: bool,
+    /// Whether this transaction was aborted
+    aborted: bool,
+}
+
+impl Transaction {
+    /// Create a new transaction from a BeginTxn entry
+    fn new(txn_id: u64, run_id: RunId) -> Self {
+        Self {
+            txn_id,
+            run_id,
+            entries: Vec::new(),
+            committed: false,
+            aborted: false,
+        }
+    }
+}
+
+/// Replay WAL entries to restore storage state
+///
+/// This is the main recovery function. It scans all WAL entries, groups them
+/// by transaction, and applies only committed transactions to storage.
+///
+/// # Arguments
+///
+/// * `wal` - The WAL to replay from
+/// * `storage` - The storage to apply transactions to (must be empty or at checkpoint)
+///
+/// # Returns
+///
+/// * `Ok(ReplayStats)` - Statistics about the replay
+/// * `Err` - If reading WAL or applying transactions fails
+///
+/// # Example
+///
+/// ```ignore
+/// use in_mem_durability::recovery::replay_wal;
+/// use in_mem_durability::wal::{WAL, DurabilityMode};
+/// use in_mem_storage::UnifiedStore;
+///
+/// let wal = WAL::open("data/wal/segment.wal", DurabilityMode::default())?;
+/// let storage = UnifiedStore::new();
+/// let stats = replay_wal(&wal, &storage)?;
+/// println!("Applied {} transactions, {} writes", stats.txns_applied, stats.writes_applied);
+/// ```
+pub fn replay_wal(wal: &WAL, storage: &UnifiedStore) -> Result<ReplayStats> {
+    // Read all entries from WAL
+    let entries = wal.read_all()?;
+
+    // Group entries by transaction
+    let mut transactions: HashMap<u64, Transaction> = HashMap::new();
+    // Track the currently active transaction for each run_id
+    // When a BeginTxn comes in, it becomes the active transaction for that run_id
+    let mut active_txn_per_run: HashMap<RunId, u64> = HashMap::new();
+    let mut max_version: u64 = 0;
+
+    for entry in entries {
+        // Track max version for final_version stat
+        if let Some(version) = entry.version() {
+            max_version = max_version.max(version);
+        }
+
+        match &entry {
+            WALEntry::BeginTxn { txn_id, run_id, .. } => {
+                // Start a new transaction and make it the active one for this run_id
+                transactions.insert(*txn_id, Transaction::new(*txn_id, *run_id));
+                active_txn_per_run.insert(*run_id, *txn_id);
+            }
+            WALEntry::Write { run_id, .. } | WALEntry::Delete { run_id, .. } => {
+                // Add to the currently active transaction for this run_id
+                if let Some(&active_txn_id) = active_txn_per_run.get(run_id) {
+                    if let Some(txn) = transactions.get_mut(&active_txn_id) {
+                        txn.entries.push(entry.clone());
+                    }
+                }
+                // If no active transaction for this run_id, skip the entry (orphaned)
+            }
+            WALEntry::CommitTxn { txn_id, run_id } => {
+                // Mark transaction as committed and clear active status
+                if let Some(txn) = transactions.get_mut(txn_id) {
+                    txn.committed = true;
+                }
+                // Clear active transaction for this run_id
+                if active_txn_per_run.get(run_id) == Some(txn_id) {
+                    active_txn_per_run.remove(run_id);
+                }
+            }
+            WALEntry::AbortTxn { txn_id, run_id } => {
+                // Mark transaction as aborted and clear active status
+                if let Some(txn) = transactions.get_mut(txn_id) {
+                    txn.aborted = true;
+                }
+                // Clear active transaction for this run_id
+                if active_txn_per_run.get(run_id) == Some(txn_id) {
+                    active_txn_per_run.remove(run_id);
+                }
+            }
+            WALEntry::Checkpoint { version, .. } => {
+                // Track checkpoint version
+                max_version = max_version.max(*version);
+            }
+        }
+    }
+
+    // Apply committed transactions and collect stats
+    let mut stats = ReplayStats {
+        final_version: max_version,
+        ..Default::default()
+    };
+
+    // Sort transactions by txn_id to ensure deterministic replay order
+    let mut txn_ids: Vec<u64> = transactions.keys().copied().collect();
+    txn_ids.sort();
+
+    for txn_id in txn_ids {
+        let txn = transactions.get(&txn_id).unwrap();
+
+        if txn.committed {
+            apply_transaction(storage, txn, &mut stats)?;
+        } else if txn.aborted {
+            stats.aborted_txns += 1;
+        } else {
+            // Incomplete transaction (no CommitTxn or AbortTxn)
+            stats.incomplete_txns += 1;
+        }
+    }
+
+    Ok(stats)
+}
+
+/// Apply a committed transaction to storage
+///
+/// Applies all Write and Delete operations from a transaction to storage,
+/// preserving the version numbers from the WAL entries.
+///
+/// # Arguments
+///
+/// * `storage` - The storage to apply to
+/// * `txn` - The committed transaction to apply
+/// * `stats` - Statistics to update
+///
+/// # Returns
+///
+/// * `Ok(())` - If all operations succeeded
+/// * `Err` - If any operation fails
+fn apply_transaction(
+    storage: &UnifiedStore,
+    txn: &Transaction,
+    stats: &mut ReplayStats,
+) -> Result<()> {
+    for entry in &txn.entries {
+        match entry {
+            WALEntry::Write {
+                key,
+                value,
+                version,
+                ..
+            } => {
+                // Apply write, preserving version from WAL
+                storage.put_with_version(key.clone(), value.clone(), *version)?;
+                stats.writes_applied += 1;
+                stats.final_version = stats.final_version.max(*version);
+            }
+            WALEntry::Delete { key, version, .. } => {
+                // Apply delete, preserving version from WAL
+                storage.delete_with_version(key, *version)?;
+                stats.deletes_applied += 1;
+                stats.final_version = stats.final_version.max(*version);
+            }
+            _ => {
+                // BeginTxn, CommitTxn, etc. are not applied to storage
+            }
+        }
+    }
+
+    stats.txns_applied += 1;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wal::DurabilityMode;
+    use chrono::Utc;
+    use in_mem_core::types::{Key, Namespace};
+    use in_mem_core::value::Value;
+    use in_mem_core::Storage; // Need trait in scope for .get() and .current_version()
+    use tempfile::TempDir;
+
+    /// Helper to get current timestamp
+    fn now() -> i64 {
+        Utc::now().timestamp()
+    }
+
+    #[test]
+    fn test_replay_empty_wal() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("empty.wal");
+
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        assert_eq!(stats.txns_applied, 0);
+        assert_eq!(stats.writes_applied, 0);
+        assert_eq!(stats.deletes_applied, 0);
+        assert_eq!(stats.incomplete_txns, 0);
+        assert_eq!(stats.aborted_txns, 0);
+    }
+
+    #[test]
+    fn test_replay_committed_transaction() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("committed.wal");
+
+        let run_id = RunId::new();
+        let ns = Namespace::new(
+            "tenant".to_string(),
+            "app".to_string(),
+            "agent".to_string(),
+            run_id,
+        );
+
+        // Write committed transaction to WAL
+        {
+            let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "key1"),
+                value: Value::Bytes(b"value1".to_vec()),
+                version: 1,
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "key2"),
+                value: Value::String("value2".to_string()),
+                version: 2,
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+                .unwrap();
+        }
+
+        // Replay to storage
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        assert_eq!(stats.txns_applied, 1);
+        assert_eq!(stats.writes_applied, 2);
+        assert_eq!(stats.deletes_applied, 0);
+        assert_eq!(stats.incomplete_txns, 0);
+        assert_eq!(stats.final_version, 2);
+
+        // Verify storage has data with correct versions
+        let key1 = Key::new_kv(ns.clone(), "key1");
+        let val1 = store.get(&key1).unwrap().unwrap();
+        assert_eq!(val1.value, Value::Bytes(b"value1".to_vec()));
+        assert_eq!(val1.version, 1);
+
+        let key2 = Key::new_kv(ns.clone(), "key2");
+        let val2 = store.get(&key2).unwrap().unwrap();
+        assert_eq!(val2.value, Value::String("value2".to_string()));
+        assert_eq!(val2.version, 2);
+    }
+
+    #[test]
+    fn test_replay_discards_incomplete_transaction() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("incomplete.wal");
+
+        let run_id = RunId::new();
+        let ns = Namespace::new(
+            "tenant".to_string(),
+            "app".to_string(),
+            "agent".to_string(),
+            run_id,
+        );
+
+        // Write incomplete transaction (no CommitTxn - simulates crash)
+        {
+            let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "key1"),
+                value: Value::Bytes(b"value1".to_vec()),
+                version: 1,
+            })
+            .unwrap();
+
+            // NO CommitTxn - simulates crash
+        }
+
+        // Replay to storage
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        assert_eq!(stats.txns_applied, 0);
+        assert_eq!(stats.writes_applied, 0);
+        assert_eq!(stats.incomplete_txns, 1);
+
+        // Storage should be empty
+        let key1 = Key::new_kv(ns, "key1");
+        assert!(store.get(&key1).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_replay_discards_aborted_transaction() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("aborted.wal");
+
+        let run_id = RunId::new();
+        let ns = Namespace::new(
+            "tenant".to_string(),
+            "app".to_string(),
+            "agent".to_string(),
+            run_id,
+        );
+
+        // Write aborted transaction
+        {
+            let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "key1"),
+                value: Value::Bytes(b"value1".to_vec()),
+                version: 1,
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::AbortTxn { txn_id: 1, run_id })
+                .unwrap();
+        }
+
+        // Replay to storage
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        assert_eq!(stats.txns_applied, 0);
+        assert_eq!(stats.writes_applied, 0);
+        assert_eq!(stats.aborted_txns, 1);
+        assert_eq!(stats.incomplete_txns, 0);
+
+        // Storage should be empty
+        let key1 = Key::new_kv(ns, "key1");
+        assert!(store.get(&key1).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_replay_multiple_transactions() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("multi.wal");
+
+        let run_id = RunId::new();
+        let ns = Namespace::new(
+            "tenant".to_string(),
+            "app".to_string(),
+            "agent".to_string(),
+            run_id,
+        );
+
+        // Write 3 transactions: 2 committed, 1 incomplete
+        {
+            let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+            // Txn 1 - committed
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "key1"),
+                value: Value::Bytes(b"v1".to_vec()),
+                version: 1,
+            })
+            .unwrap();
+            wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+                .unwrap();
+
+            // Txn 2 - incomplete (no commit)
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 2,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "key2"),
+                value: Value::Bytes(b"v2".to_vec()),
+                version: 2,
+            })
+            .unwrap();
+            // NO CommitTxn
+
+            // Txn 3 - committed
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 3,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "key3"),
+                value: Value::Bytes(b"v3".to_vec()),
+                version: 3,
+            })
+            .unwrap();
+            wal.append(&WALEntry::CommitTxn { txn_id: 3, run_id })
+                .unwrap();
+        }
+
+        // Replay
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        assert_eq!(stats.txns_applied, 2); // Txn 1 and 3
+        assert_eq!(stats.writes_applied, 2);
+        assert_eq!(stats.incomplete_txns, 1); // Txn 2
+
+        // Verify key1 and key3 exist, key2 doesn't
+        assert!(store
+            .get(&Key::new_kv(ns.clone(), "key1"))
+            .unwrap()
+            .is_some());
+        assert!(store
+            .get(&Key::new_kv(ns.clone(), "key2"))
+            .unwrap()
+            .is_none());
+        assert!(store
+            .get(&Key::new_kv(ns.clone(), "key3"))
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn test_replay_with_deletes() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("deletes.wal");
+
+        let run_id = RunId::new();
+        let ns = Namespace::new(
+            "tenant".to_string(),
+            "app".to_string(),
+            "agent".to_string(),
+            run_id,
+        );
+
+        // Write transaction with write then delete
+        {
+            let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            // Write then delete same key
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "key1"),
+                value: Value::Bytes(b"v1".to_vec()),
+                version: 1,
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::Delete {
+                run_id,
+                key: Key::new_kv(ns.clone(), "key1"),
+                version: 2,
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+                .unwrap();
+        }
+
+        // Replay
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        assert_eq!(stats.txns_applied, 1);
+        assert_eq!(stats.writes_applied, 1);
+        assert_eq!(stats.deletes_applied, 1);
+
+        // Key should be deleted (final state)
+        assert!(store.get(&Key::new_kv(ns, "key1")).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_replay_preserves_versions() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("versions.wal");
+
+        let run_id = RunId::new();
+        let ns = Namespace::new(
+            "tenant".to_string(),
+            "app".to_string(),
+            "agent".to_string(),
+            run_id,
+        );
+
+        // Write with specific versions (not 1, 2, 3 but 100, 200, 300)
+        {
+            let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "key1"),
+                value: Value::I64(100),
+                version: 100, // Non-sequential version
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "key2"),
+                value: Value::I64(200),
+                version: 200,
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "key3"),
+                value: Value::I64(300),
+                version: 300,
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+                .unwrap();
+        }
+
+        // Replay
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        assert_eq!(stats.final_version, 300);
+
+        // Verify versions are preserved exactly
+        let key1 = Key::new_kv(ns.clone(), "key1");
+        let val1 = store.get(&key1).unwrap().unwrap();
+        assert_eq!(val1.version, 100); // Version preserved, not re-allocated
+
+        let key2 = Key::new_kv(ns.clone(), "key2");
+        let val2 = store.get(&key2).unwrap().unwrap();
+        assert_eq!(val2.version, 200);
+
+        let key3 = Key::new_kv(ns.clone(), "key3");
+        let val3 = store.get(&key3).unwrap().unwrap();
+        assert_eq!(val3.version, 300);
+
+        // Global version should reflect max version from WAL
+        assert_eq!(store.current_version(), 300);
+    }
+}

--- a/crates/durability/tests/replay_test.rs
+++ b/crates/durability/tests/replay_test.rs
@@ -1,0 +1,833 @@
+//! Integration tests for WAL replay logic
+//!
+//! These tests verify that the WAL replay mechanism correctly:
+//! 1. Applies committed transactions
+//! 2. Discards incomplete/aborted transactions
+//! 3. Preserves version numbers from WAL entries
+//! 4. Handles multiple transactions correctly
+
+use chrono::Utc;
+use in_mem_core::types::{Key, Namespace, RunId};
+use in_mem_core::value::Value;
+use in_mem_core::Storage; // Need trait in scope for .get() and .current_version()
+use in_mem_durability::recovery::replay_wal;
+use in_mem_durability::wal::{DurabilityMode, WALEntry, WAL};
+use in_mem_storage::UnifiedStore;
+use tempfile::TempDir;
+
+/// Helper to get current timestamp
+fn now() -> i64 {
+    Utc::now().timestamp()
+}
+
+/// Helper to create a test namespace with a specific run_id
+fn test_namespace(run_id: RunId) -> Namespace {
+    Namespace::new(
+        "tenant".to_string(),
+        "app".to_string(),
+        "agent".to_string(),
+        run_id,
+    )
+}
+
+// ============================================================================
+// Single Transaction Tests
+// ============================================================================
+
+#[test]
+fn test_replay_single_committed_transaction() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_path = temp_dir.path().join("single.wal");
+
+    let run_id = RunId::new();
+    let ns = test_namespace(run_id);
+
+    // Write a simple committed transaction
+    {
+        let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 1,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "hello"),
+            value: Value::String("world".to_string()),
+            version: 1,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+    }
+
+    // Replay to empty storage
+    let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+    let store = UnifiedStore::new();
+    let stats = replay_wal(&wal, &store).unwrap();
+
+    // Verify stats
+    assert_eq!(stats.txns_applied, 1);
+    assert_eq!(stats.writes_applied, 1);
+    assert_eq!(stats.deletes_applied, 0);
+    assert_eq!(stats.incomplete_txns, 0);
+    assert_eq!(stats.aborted_txns, 0);
+
+    // Verify storage has the correct data
+    let key = Key::new_kv(ns, "hello");
+    let result = store.get(&key).unwrap();
+    assert!(result.is_some());
+    let vv = result.unwrap();
+    assert_eq!(vv.value, Value::String("world".to_string()));
+    assert_eq!(vv.version, 1);
+}
+
+#[test]
+fn test_replay_single_incomplete_transaction() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_path = temp_dir.path().join("incomplete.wal");
+
+    let run_id = RunId::new();
+    let ns = test_namespace(run_id);
+
+    // Write an incomplete transaction (simulates crash before commit)
+    {
+        let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 1,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "crash_data"),
+            value: Value::Bytes(b"should_not_persist".to_vec()),
+            version: 1,
+        })
+        .unwrap();
+
+        // NO CommitTxn - simulates crash
+    }
+
+    // Replay to empty storage
+    let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+    let store = UnifiedStore::new();
+    let stats = replay_wal(&wal, &store).unwrap();
+
+    // Verify stats - transaction should be discarded
+    assert_eq!(stats.txns_applied, 0);
+    assert_eq!(stats.writes_applied, 0);
+    assert_eq!(stats.incomplete_txns, 1);
+
+    // Verify storage is empty
+    let key = Key::new_kv(ns, "crash_data");
+    assert!(store.get(&key).unwrap().is_none());
+}
+
+// ============================================================================
+// Multiple Transaction Tests
+// ============================================================================
+
+#[test]
+fn test_replay_multiple_committed_transactions() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_path = temp_dir.path().join("multi_commit.wal");
+
+    let run_id = RunId::new();
+    let ns = test_namespace(run_id);
+
+    // Write 3 committed transactions
+    {
+        let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+        for i in 1..=3u64 {
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: i,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), format!("key{}", i)),
+                value: Value::I64(i as i64 * 100),
+                version: i,
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::CommitTxn { txn_id: i, run_id })
+                .unwrap();
+        }
+    }
+
+    // Replay
+    let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+    let store = UnifiedStore::new();
+    let stats = replay_wal(&wal, &store).unwrap();
+
+    // Verify stats
+    assert_eq!(stats.txns_applied, 3);
+    assert_eq!(stats.writes_applied, 3);
+    assert_eq!(stats.final_version, 3);
+
+    // Verify all keys exist with correct values
+    for i in 1..=3u64 {
+        let key = Key::new_kv(ns.clone(), format!("key{}", i));
+        let result = store.get(&key).unwrap().unwrap();
+        assert_eq!(result.value, Value::I64(i as i64 * 100));
+        assert_eq!(result.version, i);
+    }
+}
+
+#[test]
+fn test_replay_mixed_committed_and_incomplete() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_path = temp_dir.path().join("mixed.wal");
+
+    let run_id = RunId::new();
+    let ns = test_namespace(run_id);
+
+    // Write: committed, incomplete, committed, aborted, incomplete
+    {
+        let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+        // Txn 1 - committed
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 1,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "key1"),
+            value: Value::String("v1".to_string()),
+            version: 1,
+        })
+        .unwrap();
+        wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+
+        // Txn 2 - incomplete (crash simulation)
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 2,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "key2"),
+            value: Value::String("v2".to_string()),
+            version: 2,
+        })
+        .unwrap();
+        // NO commit
+
+        // Txn 3 - committed
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 3,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "key3"),
+            value: Value::String("v3".to_string()),
+            version: 3,
+        })
+        .unwrap();
+        wal.append(&WALEntry::CommitTxn { txn_id: 3, run_id })
+            .unwrap();
+
+        // Txn 4 - aborted
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 4,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "key4"),
+            value: Value::String("v4".to_string()),
+            version: 4,
+        })
+        .unwrap();
+        wal.append(&WALEntry::AbortTxn { txn_id: 4, run_id })
+            .unwrap();
+
+        // Txn 5 - incomplete
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 5,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "key5"),
+            value: Value::String("v5".to_string()),
+            version: 5,
+        })
+        .unwrap();
+        // NO commit
+    }
+
+    // Replay
+    let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+    let store = UnifiedStore::new();
+    let stats = replay_wal(&wal, &store).unwrap();
+
+    // Verify stats
+    assert_eq!(stats.txns_applied, 2); // Txn 1 and 3
+    assert_eq!(stats.writes_applied, 2);
+    assert_eq!(stats.incomplete_txns, 2); // Txn 2 and 5
+    assert_eq!(stats.aborted_txns, 1); // Txn 4
+
+    // Verify only committed data exists
+    assert!(store
+        .get(&Key::new_kv(ns.clone(), "key1"))
+        .unwrap()
+        .is_some());
+    assert!(store
+        .get(&Key::new_kv(ns.clone(), "key2"))
+        .unwrap()
+        .is_none()); // Incomplete
+    assert!(store
+        .get(&Key::new_kv(ns.clone(), "key3"))
+        .unwrap()
+        .is_some());
+    assert!(store
+        .get(&Key::new_kv(ns.clone(), "key4"))
+        .unwrap()
+        .is_none()); // Aborted
+    assert!(store
+        .get(&Key::new_kv(ns.clone(), "key5"))
+        .unwrap()
+        .is_none()); // Incomplete
+}
+
+// ============================================================================
+// Version Preservation Tests
+// ============================================================================
+
+#[test]
+fn test_replay_preserves_exact_versions() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_path = temp_dir.path().join("versions.wal");
+
+    let run_id = RunId::new();
+    let ns = test_namespace(run_id);
+
+    // Write with non-sequential versions (like after checkpoint)
+    {
+        let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 1,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+
+        // Use specific versions that are not sequential
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "alpha"),
+            value: Value::I64(111),
+            version: 1000, // High version number
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "beta"),
+            value: Value::I64(222),
+            version: 2000,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "gamma"),
+            value: Value::I64(333),
+            version: 3000,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+    }
+
+    // Replay
+    let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+    let store = UnifiedStore::new();
+    let stats = replay_wal(&wal, &store).unwrap();
+
+    // Verify final version reflects max from WAL
+    assert_eq!(stats.final_version, 3000);
+    assert_eq!(store.current_version(), 3000);
+
+    // Verify each key has its exact version preserved
+    let alpha = store
+        .get(&Key::new_kv(ns.clone(), "alpha"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(alpha.version, 1000); // Not 1, but 1000!
+    assert_eq!(alpha.value, Value::I64(111));
+
+    let beta = store
+        .get(&Key::new_kv(ns.clone(), "beta"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(beta.version, 2000); // Not 2, but 2000!
+    assert_eq!(beta.value, Value::I64(222));
+
+    let gamma = store
+        .get(&Key::new_kv(ns.clone(), "gamma"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(gamma.version, 3000); // Not 3, but 3000!
+    assert_eq!(gamma.value, Value::I64(333));
+}
+
+#[test]
+fn test_replay_version_ordering_preserved() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_path = temp_dir.path().join("order.wal");
+
+    let run_id = RunId::new();
+    let ns = test_namespace(run_id);
+
+    // Write with out-of-order versions in WAL
+    {
+        let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 1,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+
+        // Versions are not in increasing order in WAL
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "key_z"),
+            value: Value::Bool(true),
+            version: 50,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "key_a"),
+            value: Value::Bool(false),
+            version: 10,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "key_m"),
+            value: Value::Bool(true),
+            version: 30,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+    }
+
+    // Replay
+    let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+    let store = UnifiedStore::new();
+    let stats = replay_wal(&wal, &store).unwrap();
+
+    // Global version should be the max
+    assert_eq!(stats.final_version, 50);
+    assert_eq!(store.current_version(), 50);
+
+    // Each key should have its original version
+    assert_eq!(
+        store
+            .get(&Key::new_kv(ns.clone(), "key_z"))
+            .unwrap()
+            .unwrap()
+            .version,
+        50
+    );
+    assert_eq!(
+        store
+            .get(&Key::new_kv(ns.clone(), "key_a"))
+            .unwrap()
+            .unwrap()
+            .version,
+        10
+    );
+    assert_eq!(
+        store
+            .get(&Key::new_kv(ns.clone(), "key_m"))
+            .unwrap()
+            .unwrap()
+            .version,
+        30
+    );
+}
+
+// ============================================================================
+// Write and Delete Tests
+// ============================================================================
+
+#[test]
+fn test_replay_write_then_delete_same_key() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_path = temp_dir.path().join("write_delete.wal");
+
+    let run_id = RunId::new();
+    let ns = test_namespace(run_id);
+
+    // Write then delete same key in one transaction
+    {
+        let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 1,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "temp"),
+            value: Value::Bytes(b"created".to_vec()),
+            version: 1,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Delete {
+            run_id,
+            key: Key::new_kv(ns.clone(), "temp"),
+            version: 2,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+    }
+
+    // Replay
+    let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+    let store = UnifiedStore::new();
+    let stats = replay_wal(&wal, &store).unwrap();
+
+    // Verify stats
+    assert_eq!(stats.txns_applied, 1);
+    assert_eq!(stats.writes_applied, 1);
+    assert_eq!(stats.deletes_applied, 1);
+
+    // Key should NOT exist after replay (deleted)
+    assert!(store.get(&Key::new_kv(ns, "temp")).unwrap().is_none());
+}
+
+#[test]
+fn test_replay_delete_nonexistent_key() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_path = temp_dir.path().join("delete_none.wal");
+
+    let run_id = RunId::new();
+    let ns = test_namespace(run_id);
+
+    // Delete a key that was never created
+    {
+        let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 1,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Delete {
+            run_id,
+            key: Key::new_kv(ns.clone(), "never_existed"),
+            version: 1,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+    }
+
+    // Replay should succeed (deleting non-existent key is fine)
+    let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+    let store = UnifiedStore::new();
+    let stats = replay_wal(&wal, &store).unwrap();
+
+    // Delete was applied
+    assert_eq!(stats.txns_applied, 1);
+    assert_eq!(stats.deletes_applied, 1);
+
+    // Key still doesn't exist
+    assert!(store
+        .get(&Key::new_kv(ns, "never_existed"))
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn test_replay_multiple_writes_same_key() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_path = temp_dir.path().join("multi_write.wal");
+
+    let run_id = RunId::new();
+    let ns = test_namespace(run_id);
+
+    // Multiple writes to same key should result in last value
+    {
+        let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 1,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "counter"),
+            value: Value::I64(1),
+            version: 1,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "counter"),
+            value: Value::I64(2),
+            version: 2,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "counter"),
+            value: Value::I64(3),
+            version: 3,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+    }
+
+    // Replay
+    let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+    let store = UnifiedStore::new();
+    let stats = replay_wal(&wal, &store).unwrap();
+
+    // All 3 writes were applied
+    assert_eq!(stats.writes_applied, 3);
+
+    // Final value is the last one
+    let result = store.get(&Key::new_kv(ns, "counter")).unwrap().unwrap();
+    assert_eq!(result.value, Value::I64(3));
+    assert_eq!(result.version, 3);
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+#[test]
+fn test_replay_empty_transaction() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_path = temp_dir.path().join("empty_txn.wal");
+
+    let run_id = RunId::new();
+
+    // Transaction with no operations
+    {
+        let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 1,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+        // No writes or deletes
+        wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+    }
+
+    // Replay
+    let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+    let store = UnifiedStore::new();
+    let stats = replay_wal(&wal, &store).unwrap();
+
+    // Empty transaction still counts as applied
+    assert_eq!(stats.txns_applied, 1);
+    assert_eq!(stats.writes_applied, 0);
+    assert_eq!(stats.deletes_applied, 0);
+}
+
+#[test]
+fn test_replay_different_value_types() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_path = temp_dir.path().join("types.wal");
+
+    let run_id = RunId::new();
+    let ns = test_namespace(run_id);
+
+    // Write different value types
+    {
+        let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+        wal.append(&WALEntry::BeginTxn {
+            txn_id: 1,
+            run_id,
+            timestamp: now(),
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "string"),
+            value: Value::String("hello".to_string()),
+            version: 1,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "i64"),
+            value: Value::I64(-42),
+            version: 2,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "bool"),
+            value: Value::Bool(true),
+            version: 3,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::Write {
+            run_id,
+            key: Key::new_kv(ns.clone(), "bytes"),
+            value: Value::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF]),
+            version: 4,
+        })
+        .unwrap();
+
+        wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+    }
+
+    // Replay
+    let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+    let store = UnifiedStore::new();
+    let stats = replay_wal(&wal, &store).unwrap();
+
+    assert_eq!(stats.writes_applied, 4);
+
+    // Verify all types preserved correctly
+    assert_eq!(
+        store
+            .get(&Key::new_kv(ns.clone(), "string"))
+            .unwrap()
+            .unwrap()
+            .value,
+        Value::String("hello".to_string())
+    );
+    assert_eq!(
+        store
+            .get(&Key::new_kv(ns.clone(), "i64"))
+            .unwrap()
+            .unwrap()
+            .value,
+        Value::I64(-42)
+    );
+    assert_eq!(
+        store
+            .get(&Key::new_kv(ns.clone(), "bool"))
+            .unwrap()
+            .unwrap()
+            .value,
+        Value::Bool(true)
+    );
+    assert_eq!(
+        store
+            .get(&Key::new_kv(ns.clone(), "bytes"))
+            .unwrap()
+            .unwrap()
+            .value,
+        Value::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF])
+    );
+}
+
+#[test]
+fn test_replay_deterministic_order() {
+    // Replay should be deterministic - same WAL always produces same result
+    let temp_dir = TempDir::new().unwrap();
+    let wal_path = temp_dir.path().join("deterministic.wal");
+
+    let run_id = RunId::new();
+    let ns = test_namespace(run_id);
+
+    // Write transactions in specific order
+    {
+        let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+        for i in 1..=5u64 {
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: i,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), format!("k{}", i)),
+                value: Value::I64(i as i64),
+                version: i,
+            })
+            .unwrap();
+            wal.append(&WALEntry::CommitTxn { txn_id: i, run_id })
+                .unwrap();
+        }
+    }
+
+    // Replay multiple times - should always get same result
+    for _ in 0..3 {
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        assert_eq!(stats.txns_applied, 5);
+        assert_eq!(store.current_version(), 5);
+
+        for i in 1..=5u64 {
+            let key = Key::new_kv(ns.clone(), format!("k{}", i));
+            let vv = store.get(&key).unwrap().unwrap();
+            assert_eq!(vv.value, Value::I64(i as i64));
+            assert_eq!(vv.version, i);
+        }
+    }
+}

--- a/crates/storage/src/unified.rs
+++ b/crates/storage/src/unified.rs
@@ -161,6 +161,112 @@ impl UnifiedStore {
         let data = self.data.read();
         ClonedSnapshotView::new(version, data.clone())
     }
+
+    // ========================================
+    // Version-preserving methods (for replay)
+    // ========================================
+
+    /// Put with a specific version (for WAL replay only)
+    ///
+    /// Unlike `put()`, this method does NOT allocate a new version.
+    /// Instead, it uses the version from the WAL entry to ensure
+    /// the database state after replay is identical to before crash.
+    ///
+    /// # IMPORTANT
+    ///
+    /// This method should ONLY be used during WAL replay.
+    /// Normal operations should use `put()` which allocates versions.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to write
+    /// * `value` - The value to write
+    /// * `version` - The exact version from the WAL entry
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - Write succeeded
+    pub fn put_with_version(&self, key: Key, value: Value, version: u64) -> Result<()> {
+        let versioned_value = VersionedValue::new(value, version, None);
+        let new_expiry = Self::expiry_timestamp(&versioned_value);
+
+        // Acquire ALL locks (data + indices) for atomic update
+        let mut data = self.data.write();
+        let mut run_idx = self.run_index.write();
+        let mut type_idx = self.type_index.write();
+        let mut ttl_idx = self.ttl_index.write();
+
+        // Check if key already exists with TTL (need to remove old TTL entry)
+        if let Some(old_value) = data.get(&key) {
+            if let Some(old_expiry) = Self::expiry_timestamp(old_value) {
+                ttl_idx.remove(old_expiry, &key);
+            }
+        }
+
+        // Insert into main storage
+        data.insert(key.clone(), versioned_value);
+
+        // Update secondary indices
+        run_idx.insert(key.namespace.run_id, key.clone());
+        type_idx.insert(key.type_tag, key.clone());
+
+        // Update TTL index if TTL is set
+        if let Some(expiry) = new_expiry {
+            ttl_idx.insert(expiry, key);
+        }
+
+        // Update global version to be at least this version
+        // This ensures current_version() reflects the max version in the store
+        self.version
+            .fetch_max(version, std::sync::atomic::Ordering::SeqCst);
+
+        Ok(())
+    }
+
+    /// Delete with a specific version (for WAL replay only)
+    ///
+    /// Unlike `delete()`, this method updates the global version counter
+    /// to ensure it reflects the maximum version seen during replay.
+    ///
+    /// # IMPORTANT
+    ///
+    /// This method should ONLY be used during WAL replay.
+    /// Normal operations should use `delete()`.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to delete
+    /// * `version` - The version from the WAL entry
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Option<VersionedValue>)` - The deleted value, if it existed
+    pub fn delete_with_version(&self, key: &Key, version: u64) -> Result<Option<VersionedValue>> {
+        // Acquire ALL locks for atomic update
+        let mut data = self.data.write();
+        let mut run_idx = self.run_index.write();
+        let mut type_idx = self.type_index.write();
+        let mut ttl_idx = self.ttl_index.write();
+
+        let removed = data.remove(key);
+
+        if let Some(ref value) = removed {
+            // Update secondary indices
+            run_idx.remove(key.namespace.run_id, key);
+            type_idx.remove(key.type_tag, key);
+
+            // Remove from TTL index if it had TTL
+            if let Some(expiry) = Self::expiry_timestamp(value) {
+                ttl_idx.remove(expiry, key);
+            }
+        }
+
+        // Update global version to be at least this version
+        self.version
+            .fetch_max(version, std::sync::atomic::Ordering::SeqCst);
+
+        Ok(removed)
+    }
 }
 
 impl Default for UnifiedStore {


### PR DESCRIPTION
## Summary
- Add `recovery.rs` module with `replay_wal()` function
- Implement transaction grouping by tracking active transactions per run_id
- Apply only committed transactions, discard incomplete/aborted
- Preserve version numbers from WAL entries during replay
- Add `put_with_version()` and `delete_with_version()` to UnifiedStore
- Return `ReplayStats` with metrics (txns_applied, writes_applied, deletes_applied, final_version)

## Test plan
- [x] Unit tests in `recovery.rs` (6 tests)
- [x] Integration tests in `tests/replay_test.rs` (12 tests)
- [x] Version preservation verified
- [x] Run `cargo test -p in-mem-durability`
- [x] Run `cargo clippy -p in-mem-durability -- -D warnings`
- [x] Run `cargo fmt --check`

Implements #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)