### PR TITLE
Implement Database::open() integration (Story #25)

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -20,3 +20,4 @@ tracing = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 proptest = { workspace = true }
+chrono = { workspace = true }

--- a/crates/engine/src/database.rs
+++ b/crates/engine/src/database.rs
@@ -1,0 +1,417 @@
+//! Database struct and open/close logic
+//!
+//! This module provides the main Database struct that orchestrates:
+//! - Storage initialization
+//! - WAL opening
+//! - Automatic recovery on startup
+
+use in_mem_core::error::{Error, Result};
+use in_mem_durability::replay_wal;
+use in_mem_durability::wal::{DurabilityMode, WAL};
+use in_mem_storage::UnifiedStore;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use tracing::info;
+
+/// Main database struct
+///
+/// Orchestrates storage, WAL, and recovery.
+/// Create a database by calling `Database::open()`.
+pub struct Database {
+    /// Data directory path
+    data_dir: PathBuf,
+
+    /// Unified storage (thread-safe)
+    storage: Arc<UnifiedStore>,
+
+    /// Write-ahead log (protected by mutex for exclusive access)
+    wal: Arc<Mutex<WAL>>,
+}
+
+impl Database {
+    /// Open database at given path with automatic recovery
+    ///
+    /// This is the main entry point for database initialization.
+    /// Uses the default durability mode (Batched).
+    ///
+    /// # Flow
+    ///
+    /// 1. Create/open data directory
+    /// 2. Open WAL file at `<path>/wal/current.wal`
+    /// 3. Create empty storage
+    /// 4. Replay WAL to restore state
+    /// 5. Return ready database
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Directory path for the database
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Database)` - Ready-to-use database instance
+    /// * `Err` - If directory creation, WAL opening, or recovery fails
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use in_mem_engine::Database;
+    ///
+    /// let db = Database::open("/path/to/data")?;
+    /// let storage = db.storage();
+    /// ```
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+        Self::open_with_mode(path, DurabilityMode::default())
+    }
+
+    /// Open database with specific durability mode
+    ///
+    /// Allows selecting between Strict, Batched, or Async durability modes.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Directory path for the database
+    /// * `durability_mode` - Durability mode for WAL operations
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Database)` - Ready-to-use database instance
+    /// * `Err` - If directory creation, WAL opening, or recovery fails
+    pub fn open_with_mode<P: AsRef<Path>>(
+        path: P,
+        durability_mode: DurabilityMode,
+    ) -> Result<Self> {
+        let data_dir = path.as_ref().to_path_buf();
+
+        // Create data directory
+        std::fs::create_dir_all(&data_dir).map_err(Error::IoError)?;
+
+        // Create WAL directory and open WAL
+        let wal_dir = data_dir.join("wal");
+        std::fs::create_dir_all(&wal_dir).map_err(Error::IoError)?;
+
+        let wal_path = wal_dir.join("current.wal");
+        let wal = WAL::open(&wal_path, durability_mode)?;
+
+        // Create empty storage
+        let storage = Arc::new(UnifiedStore::new());
+
+        // Replay WAL to restore state
+        let stats = replay_wal(&wal, storage.as_ref())?;
+
+        info!(
+            txns_applied = stats.txns_applied,
+            writes_applied = stats.writes_applied,
+            deletes_applied = stats.deletes_applied,
+            incomplete_txns = stats.incomplete_txns,
+            orphaned_entries = stats.orphaned_entries,
+            final_version = stats.final_version,
+            "Recovery complete"
+        );
+
+        Ok(Self {
+            data_dir,
+            storage,
+            wal: Arc::new(Mutex::new(wal)),
+        })
+    }
+
+    /// Get reference to the storage layer
+    ///
+    /// Use this to perform read/write operations on the database.
+    pub fn storage(&self) -> &UnifiedStore {
+        &self.storage
+    }
+
+    /// Get the data directory path
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+
+    /// Get access to the WAL for appending entries
+    ///
+    /// Returns an Arc to the Mutex-protected WAL.
+    /// Lock the mutex to append entries.
+    pub fn wal(&self) -> Arc<Mutex<WAL>> {
+        Arc::clone(&self.wal)
+    }
+
+    /// Flush WAL to disk
+    ///
+    /// Forces all buffered WAL entries to be written to disk.
+    /// This is automatically done based on durability mode, but can
+    /// be called manually to ensure durability at a specific point.
+    pub fn flush(&self) -> Result<()> {
+        let wal = self.wal.lock().unwrap();
+        wal.fsync()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use in_mem_core::types::{Key, Namespace, RunId};
+    use in_mem_core::value::Value;
+    use in_mem_core::Storage;
+    use in_mem_durability::wal::WALEntry;
+    use tempfile::TempDir;
+
+    fn now() -> i64 {
+        Utc::now().timestamp()
+    }
+
+    #[test]
+    fn test_open_empty_database() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("db");
+
+        let db = Database::open(&db_path).unwrap();
+
+        // Should have empty storage
+        assert_eq!(db.storage().current_version(), 0);
+
+        // Data directory should exist
+        assert!(db_path.exists());
+        assert!(db_path.join("wal").exists());
+        assert!(db_path.join("wal/current.wal").exists());
+    }
+
+    #[test]
+    fn test_open_with_existing_wal() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("db");
+
+        let run_id = RunId::new();
+        let ns = Namespace::new(
+            "tenant".to_string(),
+            "app".to_string(),
+            "agent".to_string(),
+            run_id,
+        );
+
+        // Write data to WAL manually before opening database
+        {
+            std::fs::create_dir_all(db_path.join("wal")).unwrap();
+            let mut wal =
+                WAL::open(db_path.join("wal/current.wal"), DurabilityMode::Strict).unwrap();
+
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "key1"),
+                value: Value::Bytes(b"value1".to_vec()),
+                version: 1,
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+                .unwrap();
+        }
+
+        // Open database (should replay WAL)
+        let db = Database::open(&db_path).unwrap();
+
+        // Storage should have data from WAL
+        let key1 = Key::new_kv(ns, "key1");
+        let val = db.storage().get(&key1).unwrap().unwrap();
+
+        if let Value::Bytes(bytes) = val.value {
+            assert_eq!(bytes, b"value1");
+        } else {
+            panic!("Wrong value type");
+        }
+    }
+
+    #[test]
+    fn test_open_close_reopen() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("db");
+
+        let run_id = RunId::new();
+        let ns = Namespace::new(
+            "tenant".to_string(),
+            "app".to_string(),
+            "agent".to_string(),
+            run_id,
+        );
+
+        // Open database, write via WAL, close
+        {
+            let db = Database::open(&db_path).unwrap();
+
+            // Write to WAL
+            let wal = db.wal();
+            let mut wal_guard = wal.lock().unwrap();
+
+            wal_guard
+                .append(&WALEntry::BeginTxn {
+                    txn_id: 1,
+                    run_id,
+                    timestamp: now(),
+                })
+                .unwrap();
+
+            wal_guard
+                .append(&WALEntry::Write {
+                    run_id,
+                    key: Key::new_kv(ns.clone(), "persistent"),
+                    value: Value::Bytes(b"data".to_vec()),
+                    version: 1,
+                })
+                .unwrap();
+
+            wal_guard
+                .append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+                .unwrap();
+
+            drop(wal_guard); // Release lock
+            db.flush().unwrap(); // Ensure written to disk
+        }
+
+        // Reopen database
+        {
+            let db = Database::open(&db_path).unwrap();
+
+            // Data should be restored from WAL
+            let key = Key::new_kv(ns, "persistent");
+            let val = db.storage().get(&key).unwrap().unwrap();
+
+            if let Value::Bytes(bytes) = val.value {
+                assert_eq!(bytes, b"data");
+            } else {
+                panic!("Wrong value type");
+            }
+        }
+    }
+
+    #[test]
+    fn test_recovery_discards_incomplete() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("db");
+
+        let run_id = RunId::new();
+        let ns = Namespace::new(
+            "tenant".to_string(),
+            "app".to_string(),
+            "agent".to_string(),
+            run_id,
+        );
+
+        // Write incomplete transaction to WAL (simulates crash)
+        {
+            std::fs::create_dir_all(db_path.join("wal")).unwrap();
+            let mut wal =
+                WAL::open(db_path.join("wal/current.wal"), DurabilityMode::Strict).unwrap();
+
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "incomplete"),
+                value: Value::Bytes(b"never_committed".to_vec()),
+                version: 1,
+            })
+            .unwrap();
+
+            // NO CommitTxn - simulates crash
+        }
+
+        // Open database (recovery should discard incomplete transaction)
+        let db = Database::open(&db_path).unwrap();
+
+        // Incomplete transaction should NOT be in storage
+        let key = Key::new_kv(ns, "incomplete");
+        assert!(db.storage().get(&key).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_corrupted_wal_handled_gracefully() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("db");
+
+        // Create corrupted WAL
+        {
+            std::fs::create_dir_all(db_path.join("wal")).unwrap();
+            let wal_path = db_path.join("wal/current.wal");
+
+            // Write garbage data - WAL decoder will stop at first invalid entry
+            std::fs::write(&wal_path, b"CORRUPTED_DATA_NOT_VALID_WAL").unwrap();
+        }
+
+        // Open should succeed with empty storage (corrupted entries are skipped)
+        let result = Database::open(&db_path);
+        assert!(result.is_ok());
+
+        let db = result.unwrap();
+        // Storage should be empty since no valid entries could be decoded
+        assert_eq!(db.storage().current_version(), 0);
+    }
+
+    #[test]
+    fn test_open_with_different_durability_modes() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Strict mode
+        {
+            let db =
+                Database::open_with_mode(temp_dir.path().join("strict"), DurabilityMode::Strict)
+                    .unwrap();
+            assert!(db.data_dir().exists());
+        }
+
+        // Batched mode
+        {
+            let db = Database::open_with_mode(
+                temp_dir.path().join("batched"),
+                DurabilityMode::Batched {
+                    interval_ms: 100,
+                    batch_size: 1000,
+                },
+            )
+            .unwrap();
+            assert!(db.data_dir().exists());
+        }
+
+        // Async mode
+        {
+            let db = Database::open_with_mode(
+                temp_dir.path().join("async"),
+                DurabilityMode::Async { interval_ms: 50 },
+            )
+            .unwrap();
+            assert!(db.data_dir().exists());
+        }
+    }
+
+    #[test]
+    fn test_data_dir_accessor() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("db");
+
+        let db = Database::open(&db_path).unwrap();
+
+        assert_eq!(db.data_dir(), db_path);
+    }
+
+    #[test]
+    fn test_flush() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("db");
+
+        let db = Database::open(&db_path).unwrap();
+
+        // Flush should succeed
+        assert!(db.flush().is_ok());
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate orchestrates all lower layers:
 //! - Database: Main database struct with open/close
-//! - Run lifecycle: begin_run, end_run, fork_run
+//! - Run lifecycle: begin_run, end_run, fork_run (Epic 5)
 //! - Transaction coordination (M2)
 //! - Recovery integration
 //! - Background tasks (snapshots, TTL cleanup)
@@ -12,25 +12,11 @@
 //! - Cross-layer coordination (storage + WAL + recovery)
 //! - Replay logic
 
-// Module declarations (will be implemented in Epic 5)
-// pub mod database;     // Story #28, #25
-// pub mod run;          // Story #29
-// pub mod coordinator;  // M4
-
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 
-/// Placeholder for engine functionality
-pub fn placeholder() {
-    // This crate will contain the main Database struct and orchestration
-}
+pub mod database;
+// pub mod run;          // Story #29
+// pub mod coordinator;  // M4
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_placeholder() {
-        placeholder();
-    }
-}
+pub use database::Database;

--- a/crates/engine/tests/database_open_test.rs
+++ b/crates/engine/tests/database_open_test.rs
@@ -1,0 +1,697 @@
+//! Integration tests for Database::open() and recovery
+//!
+//! These tests verify the complete database open flow including:
+//! - Creating new databases
+//! - Reopening existing databases
+//! - Automatic WAL recovery
+//! - Multiple write/close/reopen cycles
+
+use chrono::Utc;
+use in_mem_core::types::{Key, Namespace, RunId};
+use in_mem_core::value::Value;
+use in_mem_core::Storage;
+use in_mem_durability::wal::{DurabilityMode, WALEntry};
+use in_mem_engine::Database;
+use tempfile::TempDir;
+
+fn now() -> i64 {
+    Utc::now().timestamp()
+}
+
+#[test]
+fn test_database_lifecycle() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("lifecycle_test");
+
+    let run_id = RunId::new();
+    let ns = Namespace::new(
+        "tenant".to_string(),
+        "app".to_string(),
+        "agent".to_string(),
+        run_id,
+    );
+
+    // Phase 1: Create database and write data
+    {
+        let db = Database::open(&db_path).expect("Failed to open database");
+
+        let wal = db.wal();
+        let mut wal_guard = wal.lock().unwrap();
+
+        // Write transaction 1
+        wal_guard
+            .append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "user:1"),
+                value: Value::String("Alice".to_string()),
+                version: 1,
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "user:2"),
+                value: Value::String("Bob".to_string()),
+                version: 2,
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+
+        drop(wal_guard);
+        db.flush().unwrap();
+    }
+
+    // Phase 2: Reopen and verify data
+    {
+        let db = Database::open(&db_path).expect("Failed to reopen database");
+
+        // Both users should be restored
+        let user1 = db
+            .storage()
+            .get(&Key::new_kv(ns.clone(), "user:1"))
+            .unwrap()
+            .expect("user:1 should exist");
+        assert_eq!(user1.value, Value::String("Alice".to_string()));
+        assert_eq!(user1.version, 1);
+
+        let user2 = db
+            .storage()
+            .get(&Key::new_kv(ns.clone(), "user:2"))
+            .unwrap()
+            .expect("user:2 should exist");
+        assert_eq!(user2.value, Value::String("Bob".to_string()));
+        assert_eq!(user2.version, 2);
+
+        // Add more data
+        let wal = db.wal();
+        let mut wal_guard = wal.lock().unwrap();
+
+        wal_guard
+            .append(&WALEntry::BeginTxn {
+                txn_id: 2,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "user:3"),
+                value: Value::String("Charlie".to_string()),
+                version: 3,
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::CommitTxn { txn_id: 2, run_id })
+            .unwrap();
+
+        drop(wal_guard);
+        db.flush().unwrap();
+    }
+
+    // Phase 3: Reopen again and verify all data persisted
+    {
+        let db = Database::open(&db_path).expect("Failed to reopen database again");
+
+        // All three users should exist
+        assert!(db
+            .storage()
+            .get(&Key::new_kv(ns.clone(), "user:1"))
+            .unwrap()
+            .is_some());
+        assert!(db
+            .storage()
+            .get(&Key::new_kv(ns.clone(), "user:2"))
+            .unwrap()
+            .is_some());
+        assert!(db
+            .storage()
+            .get(&Key::new_kv(ns.clone(), "user:3"))
+            .unwrap()
+            .is_some());
+
+        // Version should be at least 3
+        assert!(db.storage().current_version() >= 3);
+    }
+}
+
+#[test]
+fn test_crash_recovery() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("crash_test");
+
+    let run_id = RunId::new();
+    let ns = Namespace::new(
+        "tenant".to_string(),
+        "app".to_string(),
+        "agent".to_string(),
+        run_id,
+    );
+
+    // Write some committed and some uncommitted transactions
+    {
+        let db = Database::open(&db_path).expect("Failed to open database");
+
+        let wal = db.wal();
+        let mut wal_guard = wal.lock().unwrap();
+
+        // Committed transaction
+        wal_guard
+            .append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "committed_key"),
+                value: Value::I64(42),
+                version: 1,
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+
+        // Uncommitted transaction (simulates crash mid-transaction)
+        wal_guard
+            .append(&WALEntry::BeginTxn {
+                txn_id: 2,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "uncommitted_key"),
+                value: Value::I64(999),
+                version: 2,
+            })
+            .unwrap();
+
+        // NO CommitTxn - simulates crash
+
+        drop(wal_guard);
+        db.flush().unwrap();
+    }
+
+    // Reopen - uncommitted should be discarded
+    {
+        let db = Database::open(&db_path).expect("Failed to reopen after crash");
+
+        // Committed data should be there
+        let committed = db
+            .storage()
+            .get(&Key::new_kv(ns.clone(), "committed_key"))
+            .unwrap();
+        assert!(committed.is_some());
+        assert_eq!(committed.unwrap().value, Value::I64(42));
+
+        // Uncommitted data should NOT be there
+        let uncommitted = db
+            .storage()
+            .get(&Key::new_kv(ns.clone(), "uncommitted_key"))
+            .unwrap();
+        assert!(uncommitted.is_none());
+    }
+}
+
+#[test]
+fn test_multiple_run_ids() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("multi_run_test");
+
+    let run_id1 = RunId::new();
+    let run_id2 = RunId::new();
+
+    let ns1 = Namespace::new(
+        "tenant".to_string(),
+        "app".to_string(),
+        "agent".to_string(),
+        run_id1,
+    );
+    let ns2 = Namespace::new(
+        "tenant".to_string(),
+        "app".to_string(),
+        "agent".to_string(),
+        run_id2,
+    );
+
+    // Write data from two different runs
+    {
+        let db = Database::open(&db_path).expect("Failed to open database");
+
+        let wal = db.wal();
+        let mut wal_guard = wal.lock().unwrap();
+
+        // Transaction from run 1
+        wal_guard
+            .append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id: run_id1,
+                timestamp: now(),
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::Write {
+                run_id: run_id1,
+                key: Key::new_kv(ns1.clone(), "run1_key"),
+                value: Value::String("run1_value".to_string()),
+                version: 1,
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::CommitTxn {
+                txn_id: 1,
+                run_id: run_id1,
+            })
+            .unwrap();
+
+        // Transaction from run 2
+        wal_guard
+            .append(&WALEntry::BeginTxn {
+                txn_id: 2,
+                run_id: run_id2,
+                timestamp: now(),
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::Write {
+                run_id: run_id2,
+                key: Key::new_kv(ns2.clone(), "run2_key"),
+                value: Value::String("run2_value".to_string()),
+                version: 2,
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::CommitTxn {
+                txn_id: 2,
+                run_id: run_id2,
+            })
+            .unwrap();
+
+        drop(wal_guard);
+        db.flush().unwrap();
+    }
+
+    // Reopen and verify both runs' data is preserved
+    {
+        let db = Database::open(&db_path).expect("Failed to reopen database");
+
+        // Run 1 data
+        let run1_val = db
+            .storage()
+            .get(&Key::new_kv(ns1, "run1_key"))
+            .unwrap()
+            .expect("run1_key should exist");
+        assert_eq!(run1_val.value, Value::String("run1_value".to_string()));
+
+        // Run 2 data
+        let run2_val = db
+            .storage()
+            .get(&Key::new_kv(ns2, "run2_key"))
+            .unwrap()
+            .expect("run2_key should exist");
+        assert_eq!(run2_val.value, Value::String("run2_value".to_string()));
+    }
+}
+
+#[test]
+fn test_delete_operations() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("delete_test");
+
+    let run_id = RunId::new();
+    let ns = Namespace::new(
+        "tenant".to_string(),
+        "app".to_string(),
+        "agent".to_string(),
+        run_id,
+    );
+
+    // Write then delete
+    {
+        let db = Database::open(&db_path).expect("Failed to open database");
+
+        let wal = db.wal();
+        let mut wal_guard = wal.lock().unwrap();
+
+        // Create key
+        wal_guard
+            .append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "to_delete"),
+                value: Value::String("temp_value".to_string()),
+                version: 1,
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+
+        // Delete key
+        wal_guard
+            .append(&WALEntry::BeginTxn {
+                txn_id: 2,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::Delete {
+                run_id,
+                key: Key::new_kv(ns.clone(), "to_delete"),
+                version: 2,
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::CommitTxn { txn_id: 2, run_id })
+            .unwrap();
+
+        drop(wal_guard);
+        db.flush().unwrap();
+    }
+
+    // Reopen - key should still be deleted
+    {
+        let db = Database::open(&db_path).expect("Failed to reopen database");
+
+        let val = db.storage().get(&Key::new_kv(ns, "to_delete")).unwrap();
+        assert!(
+            val.is_none(),
+            "Deleted key should remain deleted after recovery"
+        );
+    }
+}
+
+#[test]
+fn test_durability_modes() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let run_id = RunId::new();
+    let ns = Namespace::new(
+        "tenant".to_string(),
+        "app".to_string(),
+        "agent".to_string(),
+        run_id,
+    );
+
+    // Test with Strict mode
+    {
+        let db_path = temp_dir.path().join("strict_db");
+        let db = Database::open_with_mode(&db_path, DurabilityMode::Strict)
+            .expect("Failed to open with Strict mode");
+
+        let wal = db.wal();
+        let mut wal_guard = wal.lock().unwrap();
+
+        wal_guard
+            .append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "strict_key"),
+                value: Value::I64(1),
+                version: 1,
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+
+        drop(wal_guard);
+
+        // Reopen and verify
+        drop(db);
+        let db2 = Database::open(&db_path).expect("Failed to reopen strict db");
+        assert!(db2
+            .storage()
+            .get(&Key::new_kv(ns.clone(), "strict_key"))
+            .unwrap()
+            .is_some());
+    }
+
+    // Test with Batched mode
+    {
+        let db_path = temp_dir.path().join("batched_db");
+        let db = Database::open_with_mode(
+            &db_path,
+            DurabilityMode::Batched {
+                interval_ms: 100,
+                batch_size: 10,
+            },
+        )
+        .expect("Failed to open with Batched mode");
+
+        let wal = db.wal();
+        let mut wal_guard = wal.lock().unwrap();
+
+        wal_guard
+            .append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "batched_key"),
+                value: Value::I64(2),
+                version: 1,
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+
+        drop(wal_guard);
+        db.flush().unwrap(); // Ensure flushed
+
+        // Reopen and verify
+        drop(db);
+        let db2 = Database::open(&db_path).expect("Failed to reopen batched db");
+        assert!(db2
+            .storage()
+            .get(&Key::new_kv(ns.clone(), "batched_key"))
+            .unwrap()
+            .is_some());
+    }
+}
+
+#[test]
+fn test_large_transaction() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("large_txn_test");
+
+    let run_id = RunId::new();
+    let ns = Namespace::new(
+        "tenant".to_string(),
+        "app".to_string(),
+        "agent".to_string(),
+        run_id,
+    );
+
+    const NUM_ENTRIES: usize = 100;
+
+    // Write large transaction
+    {
+        let db = Database::open(&db_path).expect("Failed to open database");
+
+        let wal = db.wal();
+        let mut wal_guard = wal.lock().unwrap();
+
+        wal_guard
+            .append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+        for i in 0..NUM_ENTRIES {
+            wal_guard
+                .append(&WALEntry::Write {
+                    run_id,
+                    key: Key::new_kv(ns.clone(), format!("key_{}", i)),
+                    value: Value::I64(i as i64),
+                    version: (i + 1) as u64,
+                })
+                .unwrap();
+        }
+
+        wal_guard
+            .append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+
+        drop(wal_guard);
+        db.flush().unwrap();
+    }
+
+    // Reopen and verify all entries
+    {
+        let db = Database::open(&db_path).expect("Failed to reopen database");
+
+        for i in 0..NUM_ENTRIES {
+            let val = db
+                .storage()
+                .get(&Key::new_kv(ns.clone(), format!("key_{}", i)))
+                .unwrap()
+                .expect(&format!("key_{} should exist", i));
+            assert_eq!(val.value, Value::I64(i as i64));
+            assert_eq!(val.version, (i + 1) as u64);
+        }
+
+        assert_eq!(db.storage().current_version(), NUM_ENTRIES as u64);
+    }
+}
+
+#[test]
+fn test_aborted_transaction_discarded() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("aborted_test");
+
+    let run_id = RunId::new();
+    let ns = Namespace::new(
+        "tenant".to_string(),
+        "app".to_string(),
+        "agent".to_string(),
+        run_id,
+    );
+
+    // Write committed and aborted transactions
+    {
+        let db = Database::open(&db_path).expect("Failed to open database");
+
+        let wal = db.wal();
+        let mut wal_guard = wal.lock().unwrap();
+
+        // Committed transaction
+        wal_guard
+            .append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "committed"),
+                value: Value::Bool(true),
+                version: 1,
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+            .unwrap();
+
+        // Aborted transaction
+        wal_guard
+            .append(&WALEntry::BeginTxn {
+                txn_id: 2,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "aborted"),
+                value: Value::Bool(false),
+                version: 2,
+            })
+            .unwrap();
+
+        wal_guard
+            .append(&WALEntry::AbortTxn { txn_id: 2, run_id })
+            .unwrap();
+
+        drop(wal_guard);
+        db.flush().unwrap();
+    }
+
+    // Reopen - aborted should not appear
+    {
+        let db = Database::open(&db_path).expect("Failed to reopen database");
+
+        // Committed data should be there
+        assert!(db
+            .storage()
+            .get(&Key::new_kv(ns.clone(), "committed"))
+            .unwrap()
+            .is_some());
+
+        // Aborted data should NOT be there
+        assert!(db
+            .storage()
+            .get(&Key::new_kv(ns.clone(), "aborted"))
+            .unwrap()
+            .is_none());
+    }
+}
+
+#[test]
+fn test_empty_database_reopen() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("empty_test");
+
+    // Create empty database
+    {
+        let _db = Database::open(&db_path).expect("Failed to open database");
+        // Don't write anything
+    }
+
+    // Reopen empty database
+    {
+        let db = Database::open(&db_path).expect("Failed to reopen empty database");
+        assert_eq!(db.storage().current_version(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

- Implement `Database::open()` that triggers automatic recovery
- Create data directory structure with `<path>/wal/current.wal`
- Replay WAL entries to restore storage state on startup
- Support all durability modes: Strict, Batched, Async

## Changes

- **crates/engine/src/database.rs**: New Database struct with:
  - `open(path)` - Opens database with default Batched durability mode
  - `open_with_mode(path, mode)` - Opens with specific durability mode
  - `storage()` - Get reference to UnifiedStore
  - `wal()` - Get Arc to Mutex-protected WAL for appending entries
  - `flush()` - Force WAL to disk

- **crates/engine/src/lib.rs**: Export database module and Database struct

- **crates/engine/Cargo.toml**: Add chrono to dev-dependencies for tests

## Testing

16 tests total:

**Unit tests (8):**
- Empty database open
- Open with existing WAL
- Open/close/reopen cycle
- Incomplete transaction discarded
- Corrupted WAL handled gracefully
- Different durability modes
- Data directory accessor
- Flush operation

**Integration tests (8):**
- Full database lifecycle (create, write, close, reopen, verify)
- Crash recovery (uncommitted transactions discarded)
- Multiple run IDs preserved
- Delete operations persist
- Durability modes work correctly
- Large transactions
- Aborted transactions discarded
- Empty database reopen

## Test plan

- [x] `cargo test -p in-mem-engine` passes (16 tests)
- [x] `cargo test --workspace` passes (268 tests)
- [x] `cargo clippy -p in-mem-engine` passes
- [x] `cargo fmt -- --check` passes

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)