### PR TITLE
Add M1 MVP integration tests and fix transaction ID collision - Story #32

### DIFF
--- a/crates/durability/src/encoding.rs
+++ b/crates/durability/src/encoding.rs
@@ -279,6 +279,8 @@ mod tests {
                 key: Key::new_kv(ns.clone(), "key"),
                 value: Value::Bytes(b"value".to_vec()),
                 version: 10,
+                timestamp: 0,
+                ttl: None,
             },
             WALEntry::Delete {
                 run_id,

--- a/crates/durability/tests/corruption_test.rs
+++ b/crates/durability/tests/corruption_test.rs
@@ -153,6 +153,8 @@ fn test_incomplete_transaction_detection() {
             key: Key::new_kv(ns.clone(), "key1"),
             value: Value::Bytes(b"value1".to_vec()),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -161,6 +163,8 @@ fn test_incomplete_transaction_detection() {
             key: Key::new_kv(ns.clone(), "key2"),
             value: Value::Bytes(b"value2".to_vec()),
             version: 2,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -291,6 +295,8 @@ fn test_valid_wal_after_drop_fsync() {
             key: Key::new_kv(ns.clone(), "key"),
             value: Value::Bytes(b"value".to_vec()),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -347,6 +353,8 @@ fn test_crc_on_all_entry_types() {
             key: Key::new_kv(ns.clone(), "key"),
             value: Value::Bytes(b"value".to_vec()),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 

--- a/crates/durability/tests/incomplete_txn_test.rs
+++ b/crates/durability/tests/incomplete_txn_test.rs
@@ -59,6 +59,8 @@ fn test_discard_incomplete_transaction() {
             key: Key::new_kv(ns.clone(), "incomplete_key"),
             value: Value::String("should_not_persist".to_string()),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -98,6 +100,8 @@ fn test_discard_orphaned_entries() {
             key: Key::new_kv(ns.clone(), "orphan_key"),
             value: Value::Bytes(b"orphaned_value".to_vec()),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -153,6 +157,8 @@ fn test_mixed_committed_and_incomplete() {
             key: Key::new_kv(ns.clone(), "committed_key"),
             value: Value::I64(100),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
@@ -170,6 +176,8 @@ fn test_mixed_committed_and_incomplete() {
             key: Key::new_kv(ns.clone(), "incomplete_key"),
             value: Value::I64(200),
             version: 2,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         // NO CommitTxn for txn 2
@@ -221,6 +229,8 @@ fn test_aborted_transactions_discarded() {
             key: Key::new_kv(ns.clone(), "aborted_key"),
             value: Value::String("should_not_persist".to_string()),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -274,6 +284,8 @@ fn test_multiple_incomplete_transactions() {
             key: Key::new_kv(ns.clone(), "k1"),
             value: Value::I64(1),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -289,6 +301,8 @@ fn test_multiple_incomplete_transactions() {
             key: Key::new_kv(ns.clone(), "k2"),
             value: Value::I64(2),
             version: 2,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         wal.append(&WALEntry::CommitTxn { txn_id: 2, run_id })
@@ -314,6 +328,8 @@ fn test_multiple_incomplete_transactions() {
             key: Key::new_kv(ns.clone(), "k4"),
             value: Value::I64(4),
             version: 4,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         wal.append(&WALEntry::AbortTxn { txn_id: 4, run_id })
@@ -331,6 +347,8 @@ fn test_multiple_incomplete_transactions() {
             key: Key::new_kv(ns.clone(), "k5"),
             value: Value::I64(5),
             version: 5,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         wal.append(&WALEntry::CommitTxn { txn_id: 5, run_id })
@@ -348,6 +366,8 @@ fn test_multiple_incomplete_transactions() {
             key: Key::new_kv(ns.clone(), "k6"),
             value: Value::I64(6),
             version: 6,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
     }
@@ -389,6 +409,8 @@ fn test_orphaned_entries_with_valid_transactions() {
             key: Key::new_kv(ns.clone(), "orphan1"),
             value: Value::I64(1),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         wal.append(&WALEntry::Delete {
@@ -410,6 +432,8 @@ fn test_orphaned_entries_with_valid_transactions() {
             key: Key::new_kv(ns.clone(), "valid"),
             value: Value::I64(100),
             version: 3,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
@@ -471,6 +495,8 @@ fn test_interleaved_transactions_different_run_ids() {
             key: Key::new_kv(ns2.clone(), "run2_key"),
             value: Value::I64(2),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         wal.append(&WALEntry::CommitTxn {
@@ -485,6 +511,8 @@ fn test_interleaved_transactions_different_run_ids() {
             key: Key::new_kv(ns1.clone(), "run1_key"),
             value: Value::I64(1),
             version: 2,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         // NO CommitTxn for run 1
@@ -560,6 +588,8 @@ fn test_crash_during_large_transaction() {
                 key: Key::new_kv(ns.clone(), format!("key_{}", i)),
                 value: Value::I64(i as i64),
                 version: i as u64 + 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
         }

--- a/crates/durability/tests/replay_test.rs
+++ b/crates/durability/tests/replay_test.rs
@@ -58,6 +58,8 @@ fn test_replay_single_committed_transaction() {
             key: Key::new_kv(ns.clone(), "hello"),
             value: Value::String("world".to_string()),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -110,6 +112,8 @@ fn test_replay_single_incomplete_transaction() {
             key: Key::new_kv(ns.clone(), "crash_data"),
             value: Value::Bytes(b"should_not_persist".to_vec()),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -160,6 +164,8 @@ fn test_replay_multiple_committed_transactions() {
                 key: Key::new_kv(ns.clone(), format!("key{}", i)),
                 value: Value::I64(i as i64 * 100),
                 version: i,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -211,6 +217,8 @@ fn test_replay_mixed_committed_and_incomplete() {
             key: Key::new_kv(ns.clone(), "key1"),
             value: Value::String("v1".to_string()),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
@@ -228,6 +236,8 @@ fn test_replay_mixed_committed_and_incomplete() {
             key: Key::new_kv(ns.clone(), "key2"),
             value: Value::String("v2".to_string()),
             version: 2,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         // NO commit
@@ -244,6 +254,8 @@ fn test_replay_mixed_committed_and_incomplete() {
             key: Key::new_kv(ns.clone(), "key3"),
             value: Value::String("v3".to_string()),
             version: 3,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         wal.append(&WALEntry::CommitTxn { txn_id: 3, run_id })
@@ -261,6 +273,8 @@ fn test_replay_mixed_committed_and_incomplete() {
             key: Key::new_kv(ns.clone(), "key4"),
             value: Value::String("v4".to_string()),
             version: 4,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         wal.append(&WALEntry::AbortTxn { txn_id: 4, run_id })
@@ -278,6 +292,8 @@ fn test_replay_mixed_committed_and_incomplete() {
             key: Key::new_kv(ns.clone(), "key5"),
             value: Value::String("v5".to_string()),
             version: 5,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
         // NO commit
@@ -346,6 +362,8 @@ fn test_replay_preserves_exact_versions() {
             key: Key::new_kv(ns.clone(), "alpha"),
             value: Value::I64(111),
             version: 1000, // High version number
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -354,6 +372,8 @@ fn test_replay_preserves_exact_versions() {
             key: Key::new_kv(ns.clone(), "beta"),
             value: Value::I64(222),
             version: 2000,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -362,6 +382,8 @@ fn test_replay_preserves_exact_versions() {
             key: Key::new_kv(ns.clone(), "gamma"),
             value: Value::I64(333),
             version: 3000,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -426,6 +448,8 @@ fn test_replay_version_ordering_preserved() {
             key: Key::new_kv(ns.clone(), "key_z"),
             value: Value::Bool(true),
             version: 50,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -434,6 +458,8 @@ fn test_replay_version_ordering_preserved() {
             key: Key::new_kv(ns.clone(), "key_a"),
             value: Value::Bool(false),
             version: 10,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -442,6 +468,8 @@ fn test_replay_version_ordering_preserved() {
             key: Key::new_kv(ns.clone(), "key_m"),
             value: Value::Bool(true),
             version: 30,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -513,6 +541,8 @@ fn test_replay_write_then_delete_same_key() {
             key: Key::new_kv(ns.clone(), "temp"),
             value: Value::Bytes(b"created".to_vec()),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -611,6 +641,8 @@ fn test_replay_multiple_writes_same_key() {
             key: Key::new_kv(ns.clone(), "counter"),
             value: Value::I64(1),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -619,6 +651,8 @@ fn test_replay_multiple_writes_same_key() {
             key: Key::new_kv(ns.clone(), "counter"),
             value: Value::I64(2),
             version: 2,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -627,6 +661,8 @@ fn test_replay_multiple_writes_same_key() {
             key: Key::new_kv(ns.clone(), "counter"),
             value: Value::I64(3),
             version: 3,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -709,6 +745,8 @@ fn test_replay_different_value_types() {
             key: Key::new_kv(ns.clone(), "string"),
             value: Value::String("hello".to_string()),
             version: 1,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -717,6 +755,8 @@ fn test_replay_different_value_types() {
             key: Key::new_kv(ns.clone(), "i64"),
             value: Value::I64(-42),
             version: 2,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -725,6 +765,8 @@ fn test_replay_different_value_types() {
             key: Key::new_kv(ns.clone(), "bool"),
             value: Value::Bool(true),
             version: 3,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -733,6 +775,8 @@ fn test_replay_different_value_types() {
             key: Key::new_kv(ns.clone(), "bytes"),
             value: Value::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF]),
             version: 4,
+            timestamp: 0,
+            ttl: None,
         })
         .unwrap();
 
@@ -807,6 +851,8 @@ fn test_replay_deterministic_order() {
                 key: Key::new_kv(ns.clone(), format!("k{}", i)),
                 value: Value::I64(i as i64),
                 version: i,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
             wal.append(&WALEntry::CommitTxn { txn_id: i, run_id })

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -21,3 +21,4 @@ tracing = { workspace = true }
 tempfile = { workspace = true }
 proptest = { workspace = true }
 chrono = { workspace = true }
+in-mem-primitives = { path = "../primitives" }

--- a/crates/engine/tests/crash_simulation_test.rs
+++ b/crates/engine/tests/crash_simulation_test.rs
@@ -101,6 +101,8 @@ fn test_crash_after_begin_and_write() {
                 key: Key::new_kv(ns.clone(), "crash_key"),
                 value: Value::Bytes(b"never_committed".to_vec()),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -153,6 +155,8 @@ fn test_crash_after_commit_strict_mode() {
                 key: Key::new_kv(ns.clone(), "durable_key"),
                 value: Value::Bytes(b"durable_value".to_vec()),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -223,6 +227,8 @@ fn test_crash_batched_mode_may_lose_recent() {
                 key: Key::new_kv(ns.clone(), "maybe_lost"),
                 value: Value::Bytes(b"might_not_be_durable".to_vec()),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -284,6 +290,8 @@ fn test_multiple_incomplete_transactions() {
                     key: Key::new_kv(ns.clone(), format!("incomplete_{}", i)),
                     value: Value::Bytes(format!("value_{}", i).into_bytes()),
                     version: i + 1,
+                    timestamp: 0,
+                    ttl: None,
                 })
                 .unwrap();
 
@@ -346,6 +354,8 @@ fn test_mixed_committed_and_incomplete() {
                 key: Key::new_kv(ns.clone(), "committed_1"),
                 value: Value::Bytes(b"c1".to_vec()),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
         wal_guard
@@ -366,6 +376,8 @@ fn test_mixed_committed_and_incomplete() {
                 key: Key::new_kv(ns.clone(), "incomplete_2"),
                 value: Value::Bytes(b"i2".to_vec()),
                 version: 2,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
         // NO CommitTxn
@@ -384,6 +396,8 @@ fn test_mixed_committed_and_incomplete() {
                 key: Key::new_kv(ns.clone(), "committed_3"),
                 value: Value::Bytes(b"c3".to_vec()),
                 version: 3,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
         wal_guard
@@ -404,6 +418,8 @@ fn test_mixed_committed_and_incomplete() {
                 key: Key::new_kv(ns.clone(), "incomplete_4"),
                 value: Value::Bytes(b"i4".to_vec()),
                 version: 4,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
         // NO CommitTxn
@@ -483,6 +499,8 @@ fn test_recovery_after_clean_shutdown() {
                     key: Key::new_kv(ns.clone(), format!("key_{}", i)),
                     value: Value::Bytes(format!("value_{}", i).into_bytes()),
                     version: i + 1,
+                    timestamp: 0,
+                    ttl: None,
                 })
                 .unwrap();
             wal_guard
@@ -555,6 +573,8 @@ fn test_recovery_with_large_wal() {
                     key: Key::new_kv(ns.clone(), format!("k{}", i)),
                     value: Value::Bytes(vec![i as u8]),
                     version: i + 1,
+                    timestamp: 0,
+                    ttl: None,
                 })
                 .unwrap();
             wal_guard
@@ -626,6 +646,8 @@ fn test_crash_with_aborted_transaction() {
                 key: Key::new_kv(ns.clone(), "aborted_key"),
                 value: Value::Bytes(b"aborted_value".to_vec()),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -681,6 +703,8 @@ fn test_crash_multi_write_transaction() {
                     key: Key::new_kv(ns.clone(), format!("multi_key_{}", i)),
                     value: Value::I64(i),
                     version: (i + 1) as u64,
+                    timestamp: 0,
+                    ttl: None,
                 })
                 .unwrap();
         }
@@ -740,6 +764,8 @@ fn test_crash_with_delete_operation() {
                 key: Key::new_kv(ns.clone(), "to_delete"),
                 value: Value::Bytes(b"original".to_vec()),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -835,6 +861,8 @@ fn test_crash_interleaved_run_ids() {
                 key: Key::new_kv(ns1.clone(), "run1_committed"),
                 value: Value::Bytes(b"r1c".to_vec()),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
         wal_guard
@@ -858,6 +886,8 @@ fn test_crash_interleaved_run_ids() {
                 key: Key::new_kv(ns2.clone(), "run2_incomplete"),
                 value: Value::Bytes(b"r2i".to_vec()),
                 version: 2,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
         // NO CommitTxn for run 2
@@ -876,6 +906,8 @@ fn test_crash_interleaved_run_ids() {
                 key: Key::new_kv(ns1.clone(), "run1_incomplete"),
                 value: Value::Bytes(b"r1i".to_vec()),
                 version: 3,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
         // NO CommitTxn for run 1 txn 3

--- a/crates/engine/tests/database_open_test.rs
+++ b/crates/engine/tests/database_open_test.rs
@@ -53,6 +53,8 @@ fn test_database_lifecycle() {
                 key: Key::new_kv(ns.clone(), "user:1"),
                 value: Value::String("Alice".to_string()),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -62,6 +64,8 @@ fn test_database_lifecycle() {
                 key: Key::new_kv(ns.clone(), "user:2"),
                 value: Value::String("Bob".to_string()),
                 version: 2,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -112,6 +116,8 @@ fn test_database_lifecycle() {
                 key: Key::new_kv(ns.clone(), "user:3"),
                 value: Value::String("Charlie".to_string()),
                 version: 3,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -184,6 +190,8 @@ fn test_crash_recovery() {
                 key: Key::new_kv(ns.clone(), "committed_key"),
                 value: Value::I64(42),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -206,6 +214,8 @@ fn test_crash_recovery() {
                 key: Key::new_kv(ns.clone(), "uncommitted_key"),
                 value: Value::I64(999),
                 version: 2,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -279,6 +289,8 @@ fn test_multiple_run_ids() {
                 key: Key::new_kv(ns1.clone(), "run1_key"),
                 value: Value::String("run1_value".to_string()),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -304,6 +316,8 @@ fn test_multiple_run_ids() {
                 key: Key::new_kv(ns2.clone(), "run2_key"),
                 value: Value::String("run2_value".to_string()),
                 version: 2,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -375,6 +389,8 @@ fn test_delete_operations() {
                 key: Key::new_kv(ns.clone(), "to_delete"),
                 value: Value::String("temp_value".to_string()),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -454,6 +470,8 @@ fn test_durability_modes() {
                 key: Key::new_kv(ns.clone(), "strict_key"),
                 value: Value::I64(1),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -502,6 +520,8 @@ fn test_durability_modes() {
                 key: Key::new_kv(ns.clone(), "batched_key"),
                 value: Value::I64(2),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -560,6 +580,8 @@ fn test_large_transaction() {
                     key: Key::new_kv(ns.clone(), format!("key_{}", i)),
                     value: Value::I64(i as i64),
                     version: (i + 1) as u64,
+                    timestamp: 0,
+                    ttl: None,
                 })
                 .unwrap();
         }
@@ -625,6 +647,8 @@ fn test_aborted_transaction_discarded() {
                 key: Key::new_kv(ns.clone(), "committed"),
                 value: Value::Bool(true),
                 version: 1,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 
@@ -647,6 +671,8 @@ fn test_aborted_transaction_discarded() {
                 key: Key::new_kv(ns.clone(), "aborted"),
                 value: Value::Bool(false),
                 version: 2,
+                timestamp: 0,
+                ttl: None,
             })
             .unwrap();
 

--- a/crates/engine/tests/integration_test.rs
+++ b/crates/engine/tests/integration_test.rs
@@ -1,0 +1,619 @@
+//! M1 Integration Tests
+//!
+//! These tests validate the complete M1 foundation works end-to-end:
+//! - Database initialization and recovery
+//! - Run lifecycle (begin_run, end_run)
+//! - WAL logging and replay
+//! - Storage operations
+//! - KV primitive facade
+//!
+//! Success = M1 Foundation Complete
+
+use in_mem_core::types::RunId;
+use in_mem_engine::Database;
+use in_mem_primitives::KVStore;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::TempDir;
+
+/// Test: Write via KV → restart → read via KV → data restored
+#[test]
+fn test_end_to_end_write_restart_read() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("e2e_db");
+
+    let run_id = RunId::new();
+
+    // Phase 1: Write data
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+
+        // Begin run with tags
+        db.begin_run(
+            run_id,
+            vec![
+                ("env".to_string(), "test".to_string()),
+                ("agent".to_string(), "test-agent".to_string()),
+            ],
+        )
+        .unwrap();
+
+        // Write KV data
+        kv.put(run_id, "greeting", b"Hello, World!".to_vec())
+            .unwrap();
+        kv.put(run_id, "count", b"42".to_vec()).unwrap();
+        kv.put(run_id, "status", b"running".to_vec()).unwrap();
+
+        // End run
+        db.end_run(run_id).unwrap();
+
+        // Ensure flushed
+        db.flush().unwrap();
+    }
+
+    // Phase 2: Reopen and verify
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+
+        // Verify KV data restored
+        assert_eq!(
+            kv.get(run_id, "greeting").unwrap().unwrap(),
+            b"Hello, World!"
+        );
+        assert_eq!(kv.get(run_id, "count").unwrap().unwrap(), b"42");
+        assert_eq!(kv.get(run_id, "status").unwrap().unwrap(), b"running");
+
+        // Verify run metadata restored
+        let metadata = db.get_run(run_id).unwrap().unwrap();
+        assert_eq!(metadata.run_id, run_id);
+        assert_eq!(metadata.status, "completed");
+        assert_eq!(metadata.tags.len(), 2);
+    }
+}
+
+/// Test: Multiple runs maintain isolation across restart
+#[test]
+fn test_multiple_runs_isolation_across_restart() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("multi_run_db");
+
+    let run1 = RunId::new();
+    let run2 = RunId::new();
+    let run3 = RunId::new();
+
+    // Write data for 3 runs
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+
+        // Run 1
+        db.begin_run(run1, vec![("name".to_string(), "run1".to_string())])
+            .unwrap();
+        kv.put(run1, "key", b"run1_value".to_vec()).unwrap();
+        kv.put(run1, "run1_specific", b"data1".to_vec()).unwrap();
+        db.end_run(run1).unwrap();
+
+        // Run 2
+        db.begin_run(run2, vec![("name".to_string(), "run2".to_string())])
+            .unwrap();
+        kv.put(run2, "key", b"run2_value".to_vec()).unwrap();
+        kv.put(run2, "run2_specific", b"data2".to_vec()).unwrap();
+        db.end_run(run2).unwrap();
+
+        // Run 3
+        db.begin_run(run3, vec![("name".to_string(), "run3".to_string())])
+            .unwrap();
+        kv.put(run3, "key", b"run3_value".to_vec()).unwrap();
+        kv.put(run3, "run3_specific", b"data3".to_vec()).unwrap();
+        db.end_run(run3).unwrap();
+
+        db.flush().unwrap();
+    }
+
+    // Reopen and verify isolation
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db);
+
+        // Each run should see its own data
+        assert_eq!(kv.get(run1, "key").unwrap().unwrap(), b"run1_value");
+        assert_eq!(kv.get(run2, "key").unwrap().unwrap(), b"run2_value");
+        assert_eq!(kv.get(run3, "key").unwrap().unwrap(), b"run3_value");
+
+        // Run-specific keys should only be visible to their run
+        assert!(kv.get(run1, "run1_specific").unwrap().is_some());
+        assert!(kv.get(run1, "run2_specific").unwrap().is_none());
+
+        assert!(kv.get(run2, "run2_specific").unwrap().is_some());
+        assert!(kv.get(run2, "run3_specific").unwrap().is_none());
+
+        assert!(kv.get(run3, "run3_specific").unwrap().is_some());
+        assert!(kv.get(run3, "run1_specific").unwrap().is_none());
+    }
+}
+
+/// Test: Large dataset (1000 keys) survives restart
+#[test]
+fn test_large_dataset_survives_restart() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("large_db");
+
+    let run_id = RunId::new();
+    let entry_count = 1000;
+
+    // Write 1000 entries
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+
+        db.begin_run(run_id, vec![]).unwrap();
+
+        for i in 0..entry_count {
+            let key = format!("key_{:04}", i);
+            let value = format!("value_{:04}", i);
+            kv.put(run_id, key.as_bytes(), value.as_bytes().to_vec())
+                .unwrap();
+        }
+
+        db.end_run(run_id).unwrap();
+        db.flush().unwrap();
+    }
+
+    // Reopen and verify all entries
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db);
+
+        for i in 0..entry_count {
+            let key = format!("key_{:04}", i);
+            let expected = format!("value_{:04}", i);
+
+            let actual = kv.get(run_id, key.as_bytes()).unwrap();
+            assert!(actual.is_some(), "Key {} not found after restart", key);
+            assert_eq!(
+                actual.unwrap(),
+                expected.as_bytes(),
+                "Mismatch at key_{:04}",
+                i
+            );
+        }
+    }
+}
+
+/// Test: TTL expiration works correctly across restart
+/// Note: Uses 1-second TTL (minimum supported by second-level precision)
+#[test]
+fn test_ttl_across_restart() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("ttl_db");
+
+    let run_id = RunId::new();
+
+    // Write with short and long TTL
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+
+        db.begin_run(run_id, vec![]).unwrap();
+
+        // Short TTL (1 second - minimum supported)
+        kv.put_with_ttl(
+            run_id,
+            "short_lived",
+            b"expires_soon".to_vec(),
+            Duration::from_secs(1),
+        )
+        .unwrap();
+
+        // Long TTL (won't expire during test)
+        kv.put_with_ttl(
+            run_id,
+            "long_lived",
+            b"persists".to_vec(),
+            Duration::from_secs(3600),
+        )
+        .unwrap();
+
+        db.end_run(run_id).unwrap();
+        db.flush().unwrap();
+    }
+
+    // Wait for short TTL to expire
+    std::thread::sleep(Duration::from_millis(1100));
+
+    // Reopen and verify TTL behavior
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db);
+
+        // Short-lived should be expired
+        assert!(
+            kv.get(run_id, "short_lived").unwrap().is_none(),
+            "Short-lived key should have expired"
+        );
+
+        // Long-lived should still exist
+        assert_eq!(
+            kv.get(run_id, "long_lived").unwrap().unwrap(),
+            b"persists",
+            "Long-lived key should still exist"
+        );
+    }
+}
+
+/// Test: Run metadata fully persists and restores
+#[test]
+fn test_run_metadata_completeness() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("metadata_db");
+
+    let run_id = RunId::new();
+
+    // Create run with metadata
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+
+        db.begin_run(
+            run_id,
+            vec![
+                ("user".to_string(), "alice".to_string()),
+                ("task".to_string(), "data_processing".to_string()),
+                ("priority".to_string(), "high".to_string()),
+            ],
+        )
+        .unwrap();
+
+        // Do some work
+        kv.put(run_id, "result", b"success".to_vec()).unwrap();
+
+        db.end_run(run_id).unwrap();
+        db.flush().unwrap();
+    }
+
+    // Reopen and verify metadata
+    {
+        let db = Database::open(&db_path).unwrap();
+        let metadata = db.get_run(run_id).unwrap().unwrap();
+
+        // Check all fields
+        assert_eq!(metadata.run_id, run_id);
+        assert_eq!(metadata.status, "completed");
+        assert!(metadata.created_at > 0);
+        assert!(metadata.completed_at.is_some());
+        assert!(metadata.completed_at.unwrap() >= metadata.created_at);
+
+        // Check tags
+        assert_eq!(metadata.tags.len(), 3);
+        assert!(metadata
+            .tags
+            .contains(&("user".to_string(), "alice".to_string())));
+        assert!(metadata
+            .tags
+            .contains(&("task".to_string(), "data_processing".to_string())));
+        assert!(metadata
+            .tags
+            .contains(&("priority".to_string(), "high".to_string())));
+    }
+}
+
+/// Test: List operations work after recovery
+#[test]
+fn test_list_operations_across_restart() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("list_db");
+
+    let run_id = RunId::new();
+
+    // Write data with prefixes
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+
+        db.begin_run(run_id, vec![]).unwrap();
+
+        kv.put(run_id, "user:alice:name", b"Alice".to_vec())
+            .unwrap();
+        kv.put(run_id, "user:alice:age", b"30".to_vec()).unwrap();
+        kv.put(run_id, "user:bob:name", b"Bob".to_vec()).unwrap();
+        kv.put(run_id, "user:bob:age", b"25".to_vec()).unwrap();
+        kv.put(run_id, "config:timeout", b"60".to_vec()).unwrap();
+        kv.put(run_id, "config:retries", b"3".to_vec()).unwrap();
+
+        db.end_run(run_id).unwrap();
+        db.flush().unwrap();
+    }
+
+    // Reopen and verify list operations
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db);
+
+        // List all user: entries
+        let user_entries = kv.list(run_id, "user:").unwrap();
+        assert_eq!(user_entries.len(), 4, "Should have 4 user entries");
+
+        // List alice entries
+        let alice_entries = kv.list(run_id, "user:alice:").unwrap();
+        assert_eq!(alice_entries.len(), 2, "Should have 2 alice entries");
+
+        // List config entries
+        let config_entries = kv.list(run_id, "config:").unwrap();
+        assert_eq!(config_entries.len(), 2, "Should have 2 config entries");
+
+        // Verify specific values
+        let alice_name = kv.get(run_id, "user:alice:name").unwrap().unwrap();
+        assert_eq!(alice_name, b"Alice");
+    }
+}
+
+/// Test: Delete operations persist across restart
+#[test]
+fn test_delete_operations_across_restart() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("delete_db");
+
+    let run_id = RunId::new();
+
+    // Write and delete data
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+
+        db.begin_run(run_id, vec![]).unwrap();
+
+        // Write 3 keys
+        kv.put(run_id, "keep1", b"value1".to_vec()).unwrap();
+        kv.put(run_id, "delete_me", b"goodbye".to_vec()).unwrap();
+        kv.put(run_id, "keep2", b"value2".to_vec()).unwrap();
+
+        // Delete one
+        let deleted = kv.delete(run_id, "delete_me").unwrap();
+        assert_eq!(deleted.unwrap(), b"goodbye");
+
+        db.end_run(run_id).unwrap();
+        db.flush().unwrap();
+    }
+
+    // Reopen and verify deletion persisted
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db);
+
+        // Kept keys should exist
+        assert_eq!(kv.get(run_id, "keep1").unwrap().unwrap(), b"value1");
+        assert_eq!(kv.get(run_id, "keep2").unwrap().unwrap(), b"value2");
+
+        // Deleted key should be gone
+        assert!(kv.get(run_id, "delete_me").unwrap().is_none());
+    }
+}
+
+/// Test: Complete M1 workflow - the final validation test
+#[test]
+fn test_m1_complete_workflow() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("m1_complete");
+
+    println!("=== M1 Integration Test: Complete Workflow ===");
+
+    let run_id = RunId::new();
+
+    // Phase 1: Initialize and write
+    println!("Phase 1: Writing data...");
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+
+        // Begin run
+        db.begin_run(
+            run_id,
+            vec![("test".to_string(), "m1_integration".to_string())],
+        )
+        .unwrap();
+
+        // Write various data
+        kv.put(run_id, "agent_state", b"initialized".to_vec())
+            .unwrap();
+        kv.put(run_id, "tool_output", b"weather: 72F".to_vec())
+            .unwrap();
+        kv.put(run_id, "decision", b"umbrella_not_needed".to_vec())
+            .unwrap();
+
+        // Update state
+        kv.put(run_id, "agent_state", b"completed".to_vec())
+            .unwrap();
+
+        // End run
+        db.end_run(run_id).unwrap();
+        db.flush().unwrap();
+
+        println!("  Wrote 3 KV pairs, ended run");
+    }
+
+    // Phase 2: Simulate crash/restart
+    println!("Phase 2: Simulating restart...");
+
+    // Phase 3: Recover and verify
+    println!("Phase 3: Recovering...");
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+
+        println!("  Recovery complete");
+
+        // Verify data
+        assert_eq!(
+            kv.get(run_id, "agent_state").unwrap().unwrap(),
+            b"completed",
+            "Agent state should be 'completed'"
+        );
+        assert_eq!(
+            kv.get(run_id, "tool_output").unwrap().unwrap(),
+            b"weather: 72F",
+            "Tool output should be preserved"
+        );
+        assert_eq!(
+            kv.get(run_id, "decision").unwrap().unwrap(),
+            b"umbrella_not_needed",
+            "Decision should be preserved"
+        );
+
+        println!("  All data verified");
+
+        // Verify run metadata
+        let metadata = db.get_run(run_id).unwrap().unwrap();
+        assert_eq!(metadata.status, "completed");
+        assert!(metadata
+            .tags
+            .contains(&("test".to_string(), "m1_integration".to_string())));
+
+        println!("  Run metadata verified");
+    }
+
+    println!("=== M1 Integration Test: PASSED ===");
+}
+
+/// Test: Concurrent writes from multiple KVStore instances
+#[test]
+fn test_concurrent_kv_writes() {
+    use std::thread;
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("concurrent_db");
+
+    let db = Arc::new(Database::open(&db_path).unwrap());
+    let run_id = RunId::new();
+
+    db.begin_run(run_id, vec![]).unwrap();
+
+    let mut handles = vec![];
+
+    // Spawn 10 threads, each writing 100 keys
+    for thread_id in 0..10 {
+        let kv = KVStore::new(db.clone());
+        let handle = thread::spawn(move || {
+            for i in 0..100 {
+                let key = format!("thread_{}_key_{}", thread_id, i);
+                let value = format!("thread_{}_value_{}", thread_id, i);
+                kv.put(run_id, key.as_bytes(), value.as_bytes().to_vec())
+                    .unwrap();
+            }
+        });
+        handles.push(handle);
+    }
+
+    // Wait for all threads
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    db.end_run(run_id).unwrap();
+    db.flush().unwrap();
+
+    // Drop and reopen
+    drop(db);
+
+    let db = Arc::new(Database::open(&db_path).unwrap());
+    let kv = KVStore::new(db);
+
+    // Verify all data
+    for thread_id in 0..10 {
+        for i in 0..100 {
+            let key = format!("thread_{}_key_{}", thread_id, i);
+            let expected = format!("thread_{}_value_{}", thread_id, i);
+            let actual = kv.get(run_id, key.as_bytes()).unwrap().unwrap();
+            assert_eq!(actual, expected.as_bytes());
+        }
+    }
+}
+
+/// Test: Multiple sequential restarts
+///
+/// Tests that data written in session N survives restart and is readable in session N+1.
+/// Uses separate runs for each session to avoid run tracking complexity.
+#[test]
+fn test_multiple_restarts() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("restart_db");
+
+    // Use separate runs for each session
+    let run1 = RunId::new();
+    let run2 = RunId::new();
+    let run3 = RunId::new();
+
+    // First session
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+        db.begin_run(run1, vec![("session".to_string(), "1".to_string())])
+            .unwrap();
+        kv.put(run1, "key", b"data1".to_vec()).unwrap();
+        db.end_run(run1).unwrap();
+        db.flush().unwrap();
+    }
+
+    // Second session - verify previous and add more
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+        // Verify previous data
+        assert_eq!(kv.get(run1, "key").unwrap().unwrap(), b"data1");
+        // Add more in a new run
+        db.begin_run(run2, vec![("session".to_string(), "2".to_string())])
+            .unwrap();
+        kv.put(run2, "key", b"data2".to_vec()).unwrap();
+        db.end_run(run2).unwrap();
+        db.flush().unwrap();
+    }
+
+    // Third session - verify all previous and add more
+    {
+        // Debug: Check WAL entries before opening database
+        use in_mem_durability::wal::{DurabilityMode, WAL};
+        let wal = WAL::open(db_path.join("wal/current.wal"), DurabilityMode::Strict).unwrap();
+        let entries = wal.read_all().unwrap();
+        println!("DEBUG: Before session 3, WAL has {} entries", entries.len());
+        drop(wal);
+
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+
+        // Debug: Check what's recovered
+        let run1_data = kv.get(run1, "key").unwrap();
+        let run2_data = kv.get(run2, "key").unwrap();
+        println!(
+            "DEBUG: run1 data: {:?}, run2 data: {:?}",
+            run1_data.as_ref().map(|d| String::from_utf8_lossy(d)),
+            run2_data.as_ref().map(|d| String::from_utf8_lossy(d))
+        );
+
+        // Verify all previous data
+        assert!(run1_data.is_some(), "run1 data should exist");
+        assert_eq!(run1_data.unwrap(), b"data1");
+        assert!(run2_data.is_some(), "run2 data should exist");
+        assert_eq!(run2_data.unwrap(), b"data2");
+        // Add more in a new run
+        db.begin_run(run3, vec![("session".to_string(), "3".to_string())])
+            .unwrap();
+        kv.put(run3, "key", b"data3".to_vec()).unwrap();
+        db.end_run(run3).unwrap();
+        db.flush().unwrap();
+    }
+
+    // Final verification
+    {
+        let db = Arc::new(Database::open(&db_path).unwrap());
+        let kv = KVStore::new(db.clone());
+        assert_eq!(kv.get(run1, "key").unwrap().unwrap(), b"data1");
+        assert_eq!(kv.get(run2, "key").unwrap().unwrap(), b"data2");
+        assert_eq!(kv.get(run3, "key").unwrap().unwrap(), b"data3");
+
+        // Verify all runs completed
+        assert_eq!(db.get_run(run1).unwrap().unwrap().status, "completed");
+        assert_eq!(db.get_run(run2).unwrap().unwrap().status, "completed");
+        assert_eq!(db.get_run(run3).unwrap().unwrap().status, "completed");
+    }
+}


### PR DESCRIPTION
## Summary

- Add comprehensive integration test suite (10 tests) validating all M1 components work together after database restart
- Fix transaction ID collision bug that caused data loss across database sessions
- Add TTL/timestamp preservation during WAL recovery

## Details

### Integration Tests

The test suite validates:
- Basic durability (write → restart → read)
- Run isolation across restarts
- Large dataset recovery (1000 keys - verifies Issue #59 fix)
- TTL metadata preservation
- Run metadata completeness
- List operations after recovery
- Delete operations durability
- Concurrent write safety
- Multiple consecutive restarts (verifies Issue #60 area)
- Complete M1 workflow

### Bug Fixes

**Transaction ID Collision (Issue #60)**
- `next_txn_id` was always reset to 1 on database open
- This caused session 2's transactions to overwrite session 1's during recovery
- Fixed by tracking `max_txn_id` in `ReplayStats` and initializing from it

**TTL Preservation**
- Added `timestamp` and `ttl` fields to `WALEntry::Write`
- Updated recovery to use `put_with_version_and_ttl` for full metadata restoration

## Test plan

- [x] `cargo test -p in-mem-engine --test integration_test` - all 10 tests pass
- [x] `cargo test --all` - all tests pass
- [x] `cargo clippy --all` - no warnings
- [x] `cargo fmt --check` - formatting clean

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)