### PR TITLE
Story #84: Read-Set Validation

### DIFF
--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -15,7 +15,7 @@ pub mod validation;
 
 pub use snapshot::ClonedSnapshotView;
 pub use transaction::{CASOperation, TransactionContext, TransactionStatus};
-pub use validation::{ConflictType, ValidationResult};
+pub use validation::{validate_read_set, ConflictType, ValidationResult};
 
 // Re-export the SnapshotView trait from core for convenience
 pub use in_mem_core::traits::SnapshotView;


### PR DESCRIPTION
Implements #84

## Changes
- Add `validate_read_set` function for detecting read-write conflicts
- Compare each key's read version against current storage version
- Handle non-existent keys (version 0) correctly
- Accumulate all conflicts (no early exit)

## M2 Spec Compliance
- [x] Code complies with `docs/architecture/M2_TRANSACTION_SEMANTICS.md`
- [x] Read-write conflict: key read at version V, current version V' != V
- [x] Version 0 means "key did not exist when read"
- [x] Key created after read (0 -> X) is a conflict
- [x] Key deleted after read (X -> 0) is a conflict

## Testing
- [x] Tests pass: `cargo test --all`
- [x] Formatting: `cargo fmt --all -- --check`
- [x] Linting: `cargo clippy --all -- -D warnings`

## Checklist
- [x] Code written
- [x] Tests added
- [x] Documentation updated
- [x] CI ready to pass