### PR TITLE
Story #85: Write-Set Validation

### DIFF
--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -15,7 +15,7 @@ pub mod validation;
 
 pub use snapshot::ClonedSnapshotView;
 pub use transaction::{CASOperation, TransactionContext, TransactionStatus};
-pub use validation::{validate_read_set, ConflictType, ValidationResult};
+pub use validation::{validate_read_set, validate_write_set, ConflictType, ValidationResult};
 
 // Re-export the SnapshotView trait from core for convenience
 pub use in_mem_core::traits::SnapshotView;


### PR DESCRIPTION
Implements #85

## Changes
- Add `validate_write_set` function that always returns OK per spec
- Blind writes (write without read) do NOT conflict
- First-committer-wins is based on READ-SET, not write-set
- Write-write conflicts only detected via read-set when key was also read

## M2 Spec Compliance
- [x] Code complies with `docs/architecture/M2_TRANSACTION_SEMANTICS.md`
- [x] Blind writes (Section 3.2) do NOT conflict
- [x] First-committer-wins based on read-set, not write-set
- [x] Write-write conflicts detected by validate_read_set when key was also read

## Testing
- [x] Tests pass: `cargo test --all`
- [x] Formatting: `cargo fmt --all -- --check`
- [x] Linting: `cargo clippy --all -- -D warnings`

## Checklist
- [x] Code written
- [x] Tests added
- [x] Documentation updated
- [x] CI ready to pass