### PR TITLE
Story #86: CAS Validation

### DIFF
--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -15,7 +15,9 @@ pub mod validation;
 
 pub use snapshot::ClonedSnapshotView;
 pub use transaction::{CASOperation, TransactionContext, TransactionStatus};
-pub use validation::{validate_read_set, validate_write_set, ConflictType, ValidationResult};
+pub use validation::{
+    validate_cas_set, validate_read_set, validate_write_set, ConflictType, ValidationResult,
+};
 
 // Re-export the SnapshotView trait from core for convenience
 pub use in_mem_core::traits::SnapshotView;


### PR DESCRIPTION
Implements #86

## Changes
- Add `validate_cas_set` function for detecting CAS conflicts
- Compare expected_version against current storage version
- Return CASConflict if versions don't match
- expected_version=0 means "key must not exist"
- CAS does NOT add to read_set (validated separately)

## M2 Spec Compliance
- [x] Code complies with `docs/architecture/M2_TRANSACTION_SEMANTICS.md`
- [x] CAS conflict: expected_version != current_version -> ABORT (Section 3.1)
- [x] CAS validated separately from read-set (Section 3.4)
- [x] Does not auto-add to read_set
- [x] expected_version=0 means key must not exist

## Testing
- [x] Tests pass: `cargo test --all`
- [x] Formatting: `cargo fmt --all -- --check`
- [x] Linting: `cargo clippy --all -- -D warnings`

## Checklist
- [x] Code written
- [x] Tests added
- [x] Documentation updated
- [x] CI ready to pass