### PR TITLE
Story #87: Full Transaction Validation

### DIFF
--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -16,7 +16,8 @@ pub mod validation;
 pub use snapshot::ClonedSnapshotView;
 pub use transaction::{CASOperation, TransactionContext, TransactionStatus};
 pub use validation::{
-    validate_cas_set, validate_read_set, validate_write_set, ConflictType, ValidationResult,
+    validate_cas_set, validate_read_set, validate_transaction, validate_write_set, ConflictType,
+    ValidationResult,
 };
 
 // Re-export the SnapshotView trait from core for convenience


### PR DESCRIPTION
Implements #87

## Changes
- Add `validate_transaction` function that orchestrates all validation phases:
  1. Read-set validation (read-write conflicts)
  2. Write-set validation (no-op per spec - blind writes OK)
  3. CAS validation (CAS conflicts)
- All conflicts are accumulated and returned together
- Added comprehensive integration tests

## M2 Spec Compliance
- [x] Code complies with `docs/architecture/M2_TRANSACTION_SEMANTICS.md`
- [x] First-committer-wins based on read-set (Section 3)
- [x] Blind writes/deletes do NOT conflict (Section 3.2)
- [x] CAS validated separately from read-set (Section 3.4)
- [x] Write skew is ALLOWED by design

## Testing
- [x] Tests pass: `cargo test --all`
- [x] Formatting: `cargo fmt --all -- --check`
- [x] Linting: `cargo clippy --all -- -D warnings`

## Checklist
- [x] Code written
- [x] Tests added
- [x] Documentation updated
- [x] CI ready to pass

## Epic 7 Complete
This story completes Epic 7: Transaction Semantics. All validation functions are now implemented:
- Story #83: ConflictType, ValidationResult
- Story #84: validate_read_set
- Story #85: validate_write_set
- Story #86: validate_cas_set
- Story #87: validate_transaction (orchestrator)