### PR TITLE
Story #98: Database Transaction API

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -81,7 +81,7 @@ impl TransactionManager {
     /// Allocate next commit version (increment global version)
     ///
     /// Per spec Section 6.1: Version incremented ONCE for the whole transaction.
-    fn allocate_commit_version(&self) -> u64 {
+    pub fn allocate_version(&self) -> u64 {
         self.version.fetch_add(1, Ordering::SeqCst) + 1
     }
 
@@ -126,7 +126,7 @@ impl TransactionManager {
         // but NOT yet durable (not in WAL)
 
         // Step 2: Allocate commit version
-        let commit_version = self.allocate_commit_version();
+        let commit_version = self.allocate_version();
 
         // Step 3-5: Write to WAL (durability)
         let txn_id = self.next_txn_id();
@@ -286,10 +286,10 @@ mod tests {
     }
 
     #[test]
-    fn test_allocate_commit_version() {
+    fn test_allocate_version() {
         let manager = TransactionManager::new(10);
-        assert_eq!(manager.allocate_commit_version(), 11);
-        assert_eq!(manager.allocate_commit_version(), 12);
+        assert_eq!(manager.allocate_version(), 11);
+        assert_eq!(manager.allocate_version(), 12);
         assert_eq!(manager.current_version(), 12);
     }
 


### PR DESCRIPTION
## Summary

- Adds transaction API to Database struct per Epic 10 spec
- Integrates TransactionManager with RecoveryCoordinator for proper startup
- Implements transaction() closure API with automatic commit/abort
- Adds begin_transaction() and commit_transaction() for manual control
- Adds TransactionConflict error variant with is_conflict() helper

## Changes

### Core Error (`crates/core/src/error.rs`)
- Add `TransactionConflict(String)` error variant
- Add `is_conflict()` method for retry logic support

### TransactionManager (`crates/concurrency/src/manager.rs`)
- Make `allocate_version()` public (renamed from `allocate_commit_version`)

### Database (`crates/engine/src/database.rs`)
- Add `txn_manager: TransactionManager` to Database struct
- Update `open_with_mode()` to use `RecoveryCoordinator` instead of `replay_wal`
- Add `transaction<F, T>(run_id, closure)` closure API
- Add `begin_transaction(run_id)` for manual control
- Add `commit_transaction(txn)` for manual commit
- Add `txn_manager()` accessor

## Test Plan

- [x] Transaction closure API works (test_transaction_closure_api)
- [x] Transaction returns closure value (test_transaction_returns_closure_value)
- [x] Read-your-writes works (test_transaction_read_your_writes)
- [x] Abort on closure error (test_transaction_aborts_on_closure_error)
- [x] Manual begin/commit works (test_begin_and_commit_manual)
- [x] WAL logging survives restart (test_transaction_wal_logging)
- [x] Version allocation is monotonic (test_transaction_version_allocation)
- [x] Multi-key same version (test_transaction_multi_key)
- [x] Delete operations work (test_transaction_with_delete)
- [x] All 38 engine tests pass
- [x] All workspace tests pass
- [x] Clippy clean
- [x] Formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)