### PR TITLE
Story #99: Transaction Coordinator

### DIFF
--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -1,0 +1,328 @@
+//! Transaction coordinator for managing transaction lifecycle
+//!
+//! Per spec Section 6.1:
+//! - Single monotonic counter for the entire database
+//! - Incremented on each COMMIT (not each write)
+//!
+//! The TransactionCoordinator wraps TransactionManager and adds:
+//! - Active transaction tracking
+//! - Transaction metrics (started, committed, aborted)
+//! - Commit rate calculation
+
+use in_mem_concurrency::{RecoveryResult, TransactionContext, TransactionManager};
+use in_mem_core::types::RunId;
+use in_mem_storage::UnifiedStore;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Transaction coordinator for the database
+///
+/// Manages transaction lifecycle, ID allocation, version tracking, and metrics.
+/// Per spec Section 6.1: Single monotonic counter for the entire database.
+pub struct TransactionCoordinator {
+    /// Transaction manager for ID/version allocation
+    manager: TransactionManager,
+    /// Active transaction count (for metrics)
+    active_count: AtomicU64,
+    /// Total transactions started
+    total_started: AtomicU64,
+    /// Total transactions committed
+    total_committed: AtomicU64,
+    /// Total transactions aborted
+    total_aborted: AtomicU64,
+}
+
+impl TransactionCoordinator {
+    /// Create new coordinator with initial version
+    ///
+    /// # Arguments
+    /// * `initial_version` - Starting version (typically from storage or recovery)
+    pub fn new(initial_version: u64) -> Self {
+        Self {
+            manager: TransactionManager::new(initial_version),
+            active_count: AtomicU64::new(0),
+            total_started: AtomicU64::new(0),
+            total_committed: AtomicU64::new(0),
+            total_aborted: AtomicU64::new(0),
+        }
+    }
+
+    /// Create coordinator from recovery result
+    ///
+    /// Initializes the coordinator with the version from recovery,
+    /// ensuring new transactions get monotonically increasing versions.
+    ///
+    /// # Arguments
+    /// * `result` - Recovery result containing final version
+    pub fn from_recovery(result: &RecoveryResult) -> Self {
+        Self::new(result.stats.final_version)
+    }
+
+    /// Start a new transaction
+    ///
+    /// Creates a TransactionContext with a snapshot of the current storage state.
+    /// Increments active count and total started metrics.
+    ///
+    /// # Arguments
+    /// * `run_id` - RunId for namespace isolation
+    /// * `storage` - Storage to create snapshot from
+    ///
+    /// # Returns
+    /// * `TransactionContext` - Active transaction ready for operations
+    pub fn start_transaction(&self, run_id: RunId, storage: &UnifiedStore) -> TransactionContext {
+        let txn_id = self.manager.next_txn_id();
+        let snapshot = storage.create_snapshot();
+
+        self.active_count.fetch_add(1, Ordering::Relaxed);
+        self.total_started.fetch_add(1, Ordering::Relaxed);
+
+        TransactionContext::with_snapshot(txn_id, run_id, Box::new(snapshot))
+    }
+
+    /// Allocate commit version
+    ///
+    /// Per spec Section 6.1: Version incremented ONCE for the whole transaction.
+    /// All keys in a transaction get the same commit version.
+    pub fn allocate_commit_version(&self) -> u64 {
+        self.manager.allocate_version()
+    }
+
+    /// Record transaction commit
+    ///
+    /// Decrements active count and increments committed count.
+    pub fn record_commit(&self) {
+        self.active_count.fetch_sub(1, Ordering::Relaxed);
+        self.total_committed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record transaction abort
+    ///
+    /// Decrements active count and increments aborted count.
+    pub fn record_abort(&self) {
+        self.active_count.fetch_sub(1, Ordering::Relaxed);
+        self.total_aborted.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Get current global version
+    pub fn current_version(&self) -> u64 {
+        self.manager.current_version()
+    }
+
+    /// Get next transaction ID (for internal use)
+    pub fn next_txn_id(&self) -> u64 {
+        self.manager.next_txn_id()
+    }
+
+    /// Get transaction metrics
+    ///
+    /// Returns current snapshot of transaction statistics.
+    pub fn metrics(&self) -> TransactionMetrics {
+        let started = self.total_started.load(Ordering::Relaxed);
+        let committed = self.total_committed.load(Ordering::Relaxed);
+
+        TransactionMetrics {
+            active_count: self.active_count.load(Ordering::Relaxed),
+            total_started: started,
+            total_committed: committed,
+            total_aborted: self.total_aborted.load(Ordering::Relaxed),
+            commit_rate: if started > 0 {
+                committed as f64 / started as f64
+            } else {
+                0.0
+            },
+        }
+    }
+}
+
+/// Transaction metrics
+///
+/// Provides statistics about transaction lifecycle.
+#[derive(Debug, Clone)]
+pub struct TransactionMetrics {
+    /// Number of currently active transactions
+    pub active_count: u64,
+    /// Total number of transactions started
+    pub total_started: u64,
+    /// Total number of transactions committed
+    pub total_committed: u64,
+    /// Total number of transactions aborted
+    pub total_aborted: u64,
+    /// Commit success rate (committed / started)
+    pub commit_rate: f64,
+}
+
+impl TransactionMetrics {
+    /// Total transactions that completed (committed + aborted)
+    pub fn total_completed(&self) -> u64 {
+        self.total_committed + self.total_aborted
+    }
+
+    /// Abort rate (aborted / started)
+    pub fn abort_rate(&self) -> f64 {
+        if self.total_started > 0 {
+            self.total_aborted as f64 / self.total_started as f64
+        } else {
+            0.0
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_storage() -> UnifiedStore {
+        UnifiedStore::new()
+    }
+
+    #[test]
+    fn test_coordinator_new() {
+        let coordinator = TransactionCoordinator::new(0);
+        assert_eq!(coordinator.current_version(), 0);
+
+        let metrics = coordinator.metrics();
+        assert_eq!(metrics.active_count, 0);
+        assert_eq!(metrics.total_started, 0);
+        assert_eq!(metrics.total_committed, 0);
+        assert_eq!(metrics.total_aborted, 0);
+    }
+
+    #[test]
+    fn test_coordinator_from_recovery() {
+        use in_mem_concurrency::RecoveryStats;
+
+        let stats = RecoveryStats {
+            txns_replayed: 5,
+            incomplete_txns: 1,
+            aborted_txns: 0,
+            writes_applied: 10,
+            deletes_applied: 2,
+            final_version: 100,
+            from_checkpoint: false,
+        };
+
+        let result = RecoveryResult {
+            storage: UnifiedStore::new(),
+            txn_manager: TransactionManager::new(100),
+            stats,
+        };
+
+        let coordinator = TransactionCoordinator::from_recovery(&result);
+        assert_eq!(coordinator.current_version(), 100);
+    }
+
+    #[test]
+    fn test_start_transaction_updates_metrics() {
+        let coordinator = TransactionCoordinator::new(0);
+        let storage = create_test_storage();
+        let run_id = RunId::new();
+
+        let _txn1 = coordinator.start_transaction(run_id, &storage);
+        let _txn2 = coordinator.start_transaction(run_id, &storage);
+
+        let metrics = coordinator.metrics();
+        assert_eq!(metrics.total_started, 2);
+        assert_eq!(metrics.active_count, 2);
+    }
+
+    #[test]
+    fn test_record_commit_updates_metrics() {
+        let coordinator = TransactionCoordinator::new(0);
+        let storage = create_test_storage();
+        let run_id = RunId::new();
+
+        let _txn = coordinator.start_transaction(run_id, &storage);
+        coordinator.record_commit();
+
+        let metrics = coordinator.metrics();
+        assert_eq!(metrics.total_started, 1);
+        assert_eq!(metrics.total_committed, 1);
+        assert_eq!(metrics.active_count, 0);
+        assert_eq!(metrics.commit_rate, 1.0);
+    }
+
+    #[test]
+    fn test_record_abort_updates_metrics() {
+        let coordinator = TransactionCoordinator::new(0);
+        let storage = create_test_storage();
+        let run_id = RunId::new();
+
+        let _txn = coordinator.start_transaction(run_id, &storage);
+        coordinator.record_abort();
+
+        let metrics = coordinator.metrics();
+        assert_eq!(metrics.total_started, 1);
+        assert_eq!(metrics.total_aborted, 1);
+        assert_eq!(metrics.active_count, 0);
+        assert_eq!(metrics.commit_rate, 0.0);
+    }
+
+    #[test]
+    fn test_version_monotonic() {
+        let coordinator = TransactionCoordinator::new(100);
+
+        let v1 = coordinator.allocate_commit_version();
+        let v2 = coordinator.allocate_commit_version();
+        let v3 = coordinator.allocate_commit_version();
+
+        assert!(v1 < v2);
+        assert!(v2 < v3);
+        assert_eq!(v1, 101);
+        assert_eq!(v2, 102);
+        assert_eq!(v3, 103);
+    }
+
+    #[test]
+    fn test_metrics_helpers() {
+        let coordinator = TransactionCoordinator::new(0);
+        let storage = create_test_storage();
+        let run_id = RunId::new();
+
+        // Start 4 transactions
+        for _ in 0..4 {
+            let _txn = coordinator.start_transaction(run_id, &storage);
+        }
+
+        // 3 commit, 1 abort
+        coordinator.record_commit();
+        coordinator.record_commit();
+        coordinator.record_commit();
+        coordinator.record_abort();
+
+        let metrics = coordinator.metrics();
+        assert_eq!(metrics.total_completed(), 4);
+        assert_eq!(metrics.abort_rate(), 0.25);
+        assert_eq!(metrics.commit_rate, 0.75);
+    }
+
+    #[test]
+    fn test_mixed_transactions() {
+        let coordinator = TransactionCoordinator::new(0);
+        let storage = create_test_storage();
+        let run_id = RunId::new();
+
+        // Simulate realistic usage
+        let _txn1 = coordinator.start_transaction(run_id, &storage);
+        let _txn2 = coordinator.start_transaction(run_id, &storage);
+
+        assert_eq!(coordinator.metrics().active_count, 2);
+
+        coordinator.record_commit(); // txn1 commits
+
+        assert_eq!(coordinator.metrics().active_count, 1);
+        assert_eq!(coordinator.metrics().total_committed, 1);
+
+        let _txn3 = coordinator.start_transaction(run_id, &storage);
+
+        assert_eq!(coordinator.metrics().active_count, 2);
+        assert_eq!(coordinator.metrics().total_started, 3);
+
+        coordinator.record_abort(); // txn2 aborts
+        coordinator.record_commit(); // txn3 commits
+
+        let metrics = coordinator.metrics();
+        assert_eq!(metrics.active_count, 0);
+        assert_eq!(metrics.total_started, 3);
+        assert_eq!(metrics.total_committed, 2);
+        assert_eq!(metrics.total_aborted, 1);
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -15,8 +15,9 @@
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 
+pub mod coordinator;
 pub mod database;
 // pub mod run;          // Story #29
-// pub mod coordinator;  // M4
 
+pub use coordinator::{TransactionCoordinator, TransactionMetrics};
 pub use database::Database;


### PR DESCRIPTION
## Summary

- Adds TransactionCoordinator for lifecycle management and metrics
- Updates Database to use TransactionCoordinator instead of TransactionManager
- Provides transaction statistics via metrics() method

## Changes

### New: TransactionCoordinator (`crates/engine/src/coordinator.rs`)
- Wraps TransactionManager with metrics tracking
- Tracks active_count, total_started, total_committed, total_aborted
- Provides commit_rate and abort_rate calculations
- `from_recovery()` for version continuity after restart

### TransactionMetrics
- `active_count` - currently active transactions
- `total_started` - total transactions started
- `total_committed` - total committed
- `total_aborted` - total aborted
- `commit_rate` - success rate
- Helper: `total_completed()`, `abort_rate()`

### Database Updates
- Use TransactionCoordinator instead of raw TransactionManager
- Track commit/abort in transaction() closure API
- Add `coordinator()` accessor
- Add `metrics()` method

## Test Plan

- [x] TransactionCoordinator creation (test_coordinator_new)
- [x] from_recovery initializes correctly (test_coordinator_from_recovery)
- [x] start_transaction updates metrics (test_start_transaction_updates_metrics)
- [x] record_commit updates metrics (test_record_commit_updates_metrics)
- [x] record_abort updates metrics (test_record_abort_updates_metrics)
- [x] Version allocation is monotonic (test_version_monotonic)
- [x] Metrics helpers work (test_metrics_helpers)
- [x] Mixed transactions scenario (test_mixed_transactions)
- [x] Database coordinator accessor (test_coordinator_accessor)
- [x] Database metrics integration (test_transaction_metrics)
- [x] All 27 engine tests pass
- [x] All workspace tests pass
- [x] Clippy clean
- [x] Formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)