### PR TITLE
Story #101: Transaction Error Handling & Retry

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -20,4 +20,4 @@ pub mod database;
 // pub mod run;          // Story #29
 
 pub use coordinator::{TransactionCoordinator, TransactionMetrics};
-pub use database::Database;
+pub use database::{Database, RetryConfig};


### PR DESCRIPTION
## Summary
- Add `RetryConfig` struct for configurable retry behavior
- Add `transaction_with_retry()` method with exponential backoff
- Only conflict errors (`Error::TransactionConflict`) are retried
- Non-conflict errors are returned immediately without retry
- Builder pattern for `RetryConfig` with sensible defaults (3 retries, 10ms base delay)

## Test plan
- [x] `test_retry_config_default` - Default values are correct
- [x] `test_retry_config_builder` - Builder pattern works
- [x] `test_retry_config_no_retry` - No-retry configuration
- [x] `test_retry_config_delay_calculation` - Exponential backoff is correct
- [x] `test_transaction_with_retry_success` - Basic success case
- [x] `test_transaction_with_retry_non_conflict_error_not_retried` - Non-conflicts fail immediately
- [x] `test_transaction_with_retry_conflict_is_retried` - Conflicts are retried
- [x] `test_transaction_with_retry_max_retries_exceeded` - Max retries enforced
- [x] `test_transaction_with_retry_no_retry_config` - Zero retries works
- [x] `test_transaction_with_retry_returns_value` - Closure return values work
- [x] `test_transaction_with_retry_read_modify_write` - Full read-modify-write scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)