### PR TITLE
Fix: WAL recovery data loss when txn_ids are reused across sessions

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -60,11 +60,24 @@ impl TransactionManager {
     /// Create a new transaction manager
     ///
     /// # Arguments
-    /// * `initial_version` - Starting version (typically from storage.current_version())
+    /// * `initial_version` - Starting version (typically from recovery's final_version)
     pub fn new(initial_version: u64) -> Self {
+        Self::with_txn_id(initial_version, 0)
+    }
+
+    /// Create a new transaction manager with specific starting txn_id
+    ///
+    /// This is used during recovery to ensure new transactions get unique IDs
+    /// that don't conflict with transactions already in the WAL.
+    ///
+    /// # Arguments
+    /// * `initial_version` - Starting version (from recovery's final_version)
+    /// * `max_txn_id` - Maximum txn_id seen in WAL (new transactions start at max_txn_id + 1)
+    pub fn with_txn_id(initial_version: u64, max_txn_id: u64) -> Self {
         TransactionManager {
             version: AtomicU64::new(initial_version),
-            next_txn_id: AtomicU64::new(1),
+            // Start next_txn_id at max_txn_id + 1 to avoid conflicts
+            next_txn_id: AtomicU64::new(max_txn_id + 1),
         }
     }
 

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -197,6 +197,7 @@ mod tests {
             writes_applied: 10,
             deletes_applied: 2,
             final_version: 100,
+            max_txn_id: 6,
             from_checkpoint: false,
         };
 


### PR DESCRIPTION
## Summary

- Fixed critical bug where WAL recovery lost data when database was reopened multiple times
- Root cause: `txn_id` values were reused across sessions, causing HashMap collisions during replay
- Two-part fix: (1) replay uses internal IDs for grouping, (2) TransactionManager tracks max_txn_id

## Test plan

- [x] Added regression test `test_multiple_crash_cycles_with_high_level_api` (5 cycles, 50 keys)
- [x] Added `test_twenty_sequential_puts_recover` 
- [x] Added WAL-level tests for multi-session replay
- [x] All 655 existing tests pass

## Root Cause Analysis

When the database reopened after a crash:
1. `TransactionManager.next_txn_id` was always initialized to 1
2. New transactions got the same `txn_id` values as transactions already in the WAL
3. During replay, the HashMap used `txn_id` as the key
4. Later transactions overwrote earlier ones with the same ID
5. Result: Only the most recent session's transactions were recovered

## Changes

### `crates/durability/src/recovery.rs`
- Added `max_txn_id` to `ReplayStats`
- Refactored `replay_wal_with_options` to use internal sequential IDs for transaction grouping
- This handles WALs that already have duplicate txn_ids from multiple sessions

### `crates/concurrency/src/recovery.rs`
- Added `max_txn_id` to `RecoveryStats`
- Recovery now initializes `TransactionManager` with max_txn_id

### `crates/concurrency/src/manager.rs`
- Added `TransactionManager::with_txn_id()` method
- Allows recovery to set starting txn_id to prevent future collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)