### PR TITLE
Update reference docs for M2 transactions

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -12,13 +12,13 @@ Complete reference documentation for **in-mem** - a fast, durable, embedded data
 
 ### For Developers
 
-- **[M1 Architecture Spec](../architecture/M1_ARCHITECTURE.md)** - Detailed technical specification
+- **[M1 Architecture Spec](../architecture/M1_ARCHITECTURE.md)** - Storage layer specification
+- **[M2 Transaction Semantics](../architecture/M2_TRANSACTION_SEMANTICS.md)** - OCC and snapshot isolation specification
 - **[Development Workflow](../development/DEVELOPMENT_WORKFLOW.md)** - Git workflow
 - **[TDD Methodology](../development/TDD_METHODOLOGY.md)** - Testing approach
 
 ### Project Information
 
-- **[Project Status](../milestones/PROJECT_STATUS.md)** - Current development status
 - **[Milestones](../milestones/MILESTONES.md)** - Roadmap M1-M5
 - **[GitHub Repository](https://github.com/anibjoshi/in-mem)** - Source code
 
@@ -32,7 +32,8 @@ docs/
 │   └── architecture.md     # Architecture overview
 │
 ├── architecture/           # Technical specifications
-│   └── M1_ARCHITECTURE.md  # M1 detailed spec
+│   ├── M1_ARCHITECTURE.md  # Storage layer spec
+│   └── M2_TRANSACTION_SEMANTICS.md  # OCC & snapshot isolation spec
 │
 ├── development/            # Developer guides
 │   ├── GETTING_STARTED.md  # Developer onboarding
@@ -43,8 +44,7 @@ docs/
 │   └── m1-architecture.md  # Visual diagrams
 │
 └── milestones/             # Project management
-    ├── MILESTONES.md       # Roadmap
-    └── PROJECT_STATUS.md   # Current status
+    └── MILESTONES.md       # Roadmap
 ```
 
 ## What is in-mem?
@@ -56,14 +56,16 @@ docs/
 - **Durable by Default**: Write-ahead log with configurable fsync modes
 - **Embedded Library**: Zero-copy in-process API (network layer in M7)
 
-### Current Status: M1 Foundation Complete ✅
+### Current Status: M2 Transactions Complete ✅
 
-- ✅ 297 tests (95.45% coverage)
-- ✅ 20,564 txns/sec recovery (10x over target)
-- ✅ Zero compiler warnings
-- ✅ Production-ready embedded database
+- ✅ 630+ tests
+- ✅ OCC with snapshot isolation
+- ✅ Multi-key atomic transactions
+- ✅ Compare-and-swap (CAS) operations
+- ✅ 37K txns/s (canonical agent workload)
+- ✅ >95% success rate under contention
 
-See [Project Status](../milestones/PROJECT_STATUS.md) for details.
+See [Milestones](../milestones/MILESTONES.md) for roadmap.
 
 ## Quick Start
 
@@ -76,11 +78,19 @@ let db = Database::open("./my-agent-db")?;
 // Begin a run
 let run_id = db.begin_run();
 
-// Store data
-db.put(run_id, b"key", b"value")?;
+// Simple operations
+db.put(run_id, &key, value)?;
+let value = db.get(run_id, &key)?;
 
-// Retrieve data
-let value = db.get(run_id, b"key")?;
+// Atomic transactions (M2)
+db.transaction(run_id, |txn| {
+    let val = txn.get(&key)?;
+    txn.put(key.clone(), new_value)?;
+    Ok(())
+})?;
+
+// Compare-and-swap (M2)
+db.cas(run_id, key, expected_version, new_value)?;
 
 // End run
 db.end_run(run_id)?;
@@ -100,5 +110,5 @@ See [Getting Started](getting-started.md) for full guide.
 
 ---
 
-**Version**: 0.1.0 (M1 Foundation)
-**Last Updated**: 2026-01-11
+**Version**: 0.2.0 (M2 Transactions)
+**Last Updated**: 2026-01-14


### PR DESCRIPTION
## Summary

Update docs/reference/ to include M2 transaction entities and reflect M2 completion.

### Changes

**api-reference.md**:
- Add `transaction()`, `transaction_with_retry()`, `transaction_with_timeout()` methods
- Add `cas()` (compare-and-swap) method
- Add `TransactionContext` type with `get`, `put`, `delete`, `cas` methods
- Add `RetryConfig` type
- Update `Error` enum with M2 variants (`TransactionConflict`, `TransactionTimeout`, `InvalidState`)
- Update version history with M2 release
- Update concurrency model description

**architecture.md**:
- Replace M1 RwLock section with M2 OCC implementation details
- Add transaction lifecycle diagram
- Add conflict detection explanation
- Add first-committer-wins semantics
- Update performance characteristics with M2 benchmark results
- Update known limitations (resolved vs remaining)
- Update roadmap (M2 marked complete)

**README.md**:
- Update status from M1 to M2 complete
- Add M2 Transaction Semantics spec link
- Update documentation structure
- Add transaction and CAS examples to Quick Start
- Update version to 0.2.0

## Test plan
- [x] All documentation links are valid
- [x] Code examples are syntactically correct
- [x] Version numbers are consistent across files

🤖 Generated with [Claude Code](https://claude.ai/code)