### PR TITLE
M5 JSON + M6 Retrieval: Crates and documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/primitives",
     "crates/engine",
     "crates/api",
+    "crates/search",
 ]
 
 [workspace.package]
@@ -33,12 +34,18 @@ anyhow = "1.0"
 
 # Concurrency
 parking_lot = "0.12"
+dashmap = "5"
+rustc-hash = "1.1"
+smallvec = "1.11"
 
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }
 
 # Async runtime (for future network layer)
 tokio = { version = "1.35", features = ["full"] }
+
+# Serialization
+rmp-serde = "1.1"
 
 # Testing
 proptest = "1.4"
@@ -71,17 +78,5 @@ in-mem-durability = { path = "crates/durability" }
 in-mem-engine = { path = "crates/engine" }
 
 [dev-dependencies]
-criterion = "0.5"
 tempfile = { workspace = true }
-
-[[bench]]
-name = "comprehensive_benchmarks"
-harness = false
-
-[[bench]]
-name = "m1_storage"
-harness = false
-
-[[bench]]
-name = "m2_transactions"
-harness = false
+in-mem-search = { path = "crates/search" }

--- a/crates/concurrency/Cargo.toml
+++ b/crates/concurrency/Cargo.toml
@@ -13,11 +13,13 @@ in-mem-storage = { path = "../storage" }
 in-mem-durability = { path = "../durability" }
 chrono = { workspace = true }
 parking_lot = { workspace = true }
+rmp-serde = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+serde_json = { workspace = true }
 static_assertions = "1.1"
 tempfile = { workspace = true }

--- a/crates/concurrency/src/conflict.rs
+++ b/crates/concurrency/src/conflict.rs
@@ -1,0 +1,790 @@
+//! JSON conflict detection for region-based concurrency control.
+//!
+//! This module provides conflict detection for JSON operations within transactions.
+//! Two JSON operations conflict if their paths overlap (one is ancestor, descendant, or equal).
+//!
+//! # Conflict Types
+//!
+//! - **Read-Write Conflict**: A read at path X conflicts with a write at path Y if X.overlaps(Y)
+//! - **Write-Write Conflict**: Two writes at paths X and Y conflict if X.overlaps(Y)
+//! - **Version Mismatch**: The document version changed since transaction start
+
+use std::collections::HashMap;
+
+use in_mem_core::json::JsonPath;
+use in_mem_core::types::Key;
+
+use crate::transaction::{JsonPatchEntry, JsonPathRead};
+
+/// Result of conflict detection
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConflictResult {
+    /// No conflict detected
+    NoConflict,
+    /// Read-write conflict detected
+    ReadWriteConflict {
+        /// The document key where the conflict occurred
+        key: Key,
+        /// The path that was read
+        read_path: JsonPath,
+        /// The path that was written (conflicts with read_path)
+        write_path: JsonPath,
+    },
+    /// Write-write conflict detected
+    WriteWriteConflict {
+        /// The document key where the conflict occurred
+        key: Key,
+        /// The first conflicting write path
+        path1: JsonPath,
+        /// The second conflicting write path
+        path2: JsonPath,
+    },
+    /// Version mismatch (stale read)
+    VersionMismatch {
+        /// The document key where the version mismatch occurred
+        key: Key,
+        /// The version expected (from snapshot)
+        expected: u64,
+        /// The version found (current)
+        found: u64,
+    },
+}
+
+/// Error type for JSON conflicts
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum JsonConflictError {
+    /// A read-write conflict was detected
+    #[error("read-write conflict on {key:?}: read at {read_path}, write at {write_path}")]
+    ReadWriteConflict {
+        /// The document key where the conflict occurred
+        key: Key,
+        /// The path that was read
+        read_path: JsonPath,
+        /// The path that was written (conflicts with read_path)
+        write_path: JsonPath,
+    },
+    /// A write-write conflict was detected
+    #[error("write-write conflict on {key:?}: writes at {path1} and {path2}")]
+    WriteWriteConflict {
+        /// The document key where the conflict occurred
+        key: Key,
+        /// The first conflicting write path
+        path1: JsonPath,
+        /// The second conflicting write path
+        path2: JsonPath,
+    },
+    /// A version mismatch was detected (stale read)
+    #[error("version mismatch on {key:?}: expected {expected}, found {found}")]
+    VersionMismatch {
+        /// The document key where the version mismatch occurred
+        key: Key,
+        /// The version expected (from snapshot)
+        expected: u64,
+        /// The version found (current)
+        found: u64,
+    },
+}
+
+impl From<ConflictResult> for Option<JsonConflictError> {
+    fn from(result: ConflictResult) -> Self {
+        match result {
+            ConflictResult::NoConflict => None,
+            ConflictResult::ReadWriteConflict {
+                key,
+                read_path,
+                write_path,
+            } => Some(JsonConflictError::ReadWriteConflict {
+                key,
+                read_path,
+                write_path,
+            }),
+            ConflictResult::WriteWriteConflict { key, path1, path2 } => {
+                Some(JsonConflictError::WriteWriteConflict { key, path1, path2 })
+            }
+            ConflictResult::VersionMismatch {
+                key,
+                expected,
+                found,
+            } => Some(JsonConflictError::VersionMismatch {
+                key,
+                expected,
+                found,
+            }),
+        }
+    }
+}
+
+/// Check for read-write conflicts in a transaction
+///
+/// A read-write conflict occurs when:
+/// - A path was read AND
+/// - A write occurred at an overlapping path in the same document
+///
+/// # Arguments
+///
+/// * `reads` - List of JSON paths that were read during the transaction
+/// * `writes` - List of JSON patches to be applied
+///
+/// # Returns
+///
+/// A vector of all detected read-write conflicts
+pub fn check_read_write_conflicts(
+    reads: &[JsonPathRead],
+    writes: &[JsonPatchEntry],
+) -> Vec<ConflictResult> {
+    let mut conflicts = Vec::new();
+
+    for read in reads {
+        for write in writes {
+            // Same document?
+            if read.key != write.key {
+                continue;
+            }
+
+            // Paths overlap?
+            if read.path.overlaps(write.patch.path()) {
+                conflicts.push(ConflictResult::ReadWriteConflict {
+                    key: read.key.clone(),
+                    read_path: read.path.clone(),
+                    write_path: write.patch.path().clone(),
+                });
+            }
+        }
+    }
+
+    conflicts
+}
+
+/// Find the first read-write conflict (for fast failure)
+///
+/// This is more efficient than `check_read_write_conflicts` when you only
+/// need to know if any conflict exists, as it returns early.
+///
+/// # Arguments
+///
+/// * `reads` - List of JSON paths that were read during the transaction
+/// * `writes` - List of JSON patches to be applied
+///
+/// # Returns
+///
+/// The first detected read-write conflict, or None if no conflicts exist
+pub fn find_first_read_write_conflict(
+    reads: &[JsonPathRead],
+    writes: &[JsonPatchEntry],
+) -> Option<ConflictResult> {
+    for read in reads {
+        for write in writes {
+            if read.key == write.key && read.path.overlaps(write.patch.path()) {
+                return Some(ConflictResult::ReadWriteConflict {
+                    key: read.key.clone(),
+                    read_path: read.path.clone(),
+                    write_path: write.patch.path().clone(),
+                });
+            }
+        }
+    }
+    None
+}
+
+/// Check for write-write conflicts in a transaction
+///
+/// A write-write conflict occurs when:
+/// - Two writes target the same document AND
+/// - The write paths overlap
+///
+/// # Arguments
+///
+/// * `writes` - List of JSON patches to be applied
+///
+/// # Returns
+///
+/// A vector of all detected write-write conflicts
+pub fn check_write_write_conflicts(writes: &[JsonPatchEntry]) -> Vec<ConflictResult> {
+    let mut conflicts = Vec::new();
+
+    for (i, w1) in writes.iter().enumerate() {
+        for w2 in writes.iter().skip(i + 1) {
+            // Same document?
+            if w1.key != w2.key {
+                continue;
+            }
+
+            // Paths overlap?
+            if w1.patch.path().overlaps(w2.patch.path()) {
+                conflicts.push(ConflictResult::WriteWriteConflict {
+                    key: w1.key.clone(),
+                    path1: w1.patch.path().clone(),
+                    path2: w2.patch.path().clone(),
+                });
+            }
+        }
+    }
+
+    conflicts
+}
+
+/// Find the first write-write conflict (for fast failure)
+///
+/// # Arguments
+///
+/// * `writes` - List of JSON patches to be applied
+///
+/// # Returns
+///
+/// The first detected write-write conflict, or None if no conflicts exist
+pub fn find_first_write_write_conflict(writes: &[JsonPatchEntry]) -> Option<ConflictResult> {
+    for (i, w1) in writes.iter().enumerate() {
+        for w2 in writes.iter().skip(i + 1) {
+            if w1.key == w2.key && w1.patch.path().overlaps(w2.patch.path()) {
+                return Some(ConflictResult::WriteWriteConflict {
+                    key: w1.key.clone(),
+                    path1: w1.patch.path().clone(),
+                    path2: w2.patch.path().clone(),
+                });
+            }
+        }
+    }
+    None
+}
+
+/// Check for version conflicts (stale reads)
+///
+/// A version conflict occurs when the document version at commit time
+/// differs from the version captured at transaction start.
+///
+/// # Arguments
+///
+/// * `snapshot_versions` - Versions of documents when the transaction started
+/// * `current_versions` - Current versions of documents
+///
+/// # Returns
+///
+/// A vector of all detected version mismatches
+pub fn check_version_conflicts(
+    snapshot_versions: &HashMap<Key, u64>,
+    current_versions: &HashMap<Key, u64>,
+) -> Vec<ConflictResult> {
+    let mut conflicts = Vec::new();
+
+    for (key, snapshot_version) in snapshot_versions {
+        let current = current_versions.get(key).copied().unwrap_or(0);
+        if current != *snapshot_version {
+            conflicts.push(ConflictResult::VersionMismatch {
+                key: key.clone(),
+                expected: *snapshot_version,
+                found: current,
+            });
+        }
+    }
+
+    conflicts
+}
+
+/// Find the first version conflict (for fast failure)
+///
+/// # Arguments
+///
+/// * `snapshot_versions` - Versions of documents when the transaction started
+/// * `current_versions` - Current versions of documents
+///
+/// # Returns
+///
+/// The first detected version mismatch, or None if no conflicts exist
+pub fn find_first_version_conflict(
+    snapshot_versions: &HashMap<Key, u64>,
+    current_versions: &HashMap<Key, u64>,
+) -> Option<ConflictResult> {
+    for (key, snapshot_version) in snapshot_versions {
+        let current = current_versions.get(key).copied().unwrap_or(0);
+        if current != *snapshot_version {
+            return Some(ConflictResult::VersionMismatch {
+                key: key.clone(),
+                expected: *snapshot_version,
+                found: current,
+            });
+        }
+    }
+    None
+}
+
+/// Comprehensive conflict check
+///
+/// Checks for all types of conflicts in the following order (fastest to detect first):
+/// 1. Version conflicts (stale reads)
+/// 2. Write-write conflicts
+/// 3. Read-write conflicts
+///
+/// # Arguments
+///
+/// * `reads` - List of JSON paths that were read during the transaction
+/// * `writes` - List of JSON patches to be applied
+/// * `snapshot_versions` - Versions of documents when the transaction started
+/// * `current_versions` - Current versions of documents
+///
+/// # Returns
+///
+/// Ok(()) if no conflicts, Err with the first conflict found otherwise
+pub fn check_all_conflicts(
+    reads: &[JsonPathRead],
+    writes: &[JsonPatchEntry],
+    snapshot_versions: &HashMap<Key, u64>,
+    current_versions: &HashMap<Key, u64>,
+) -> Result<(), JsonConflictError> {
+    // 1. Check version conflicts first (fastest to detect)
+    if let Some(conflict) = find_first_version_conflict(snapshot_versions, current_versions) {
+        return Err(Option::<JsonConflictError>::from(conflict).unwrap());
+    }
+
+    // 2. Check write-write conflicts
+    if let Some(conflict) = find_first_write_write_conflict(writes) {
+        return Err(Option::<JsonConflictError>::from(conflict).unwrap());
+    }
+
+    // 3. Check read-write conflicts
+    if let Some(conflict) = find_first_read_write_conflict(reads, writes) {
+        return Err(Option::<JsonConflictError>::from(conflict).unwrap());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use in_mem_core::json::JsonPatch;
+    use in_mem_core::types::{JsonDocId, Namespace, RunId};
+
+    fn test_key() -> Key {
+        Key::new_json(Namespace::for_run(RunId::new()), &JsonDocId::new())
+    }
+
+    #[test]
+    fn test_read_write_conflict_detection() {
+        let key = test_key();
+
+        let reads = vec![JsonPathRead::new(
+            key.clone(),
+            "foo.bar".parse().unwrap(),
+            1,
+        )];
+
+        let writes = vec![
+            // This write overlaps with the read (ancestor)
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("foo".parse().unwrap(), serde_json::json!(42).into()),
+                2,
+            ),
+        ];
+
+        let conflicts = check_read_write_conflicts(&reads, &writes);
+        assert_eq!(conflicts.len(), 1);
+        assert!(matches!(
+            conflicts[0],
+            ConflictResult::ReadWriteConflict { .. }
+        ));
+    }
+
+    #[test]
+    fn test_read_write_conflict_descendant() {
+        let key = test_key();
+
+        let reads = vec![JsonPathRead::new(key.clone(), "foo".parse().unwrap(), 1)];
+
+        let writes = vec![
+            // This write overlaps with the read (descendant)
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("foo.bar.baz".parse().unwrap(), serde_json::json!(42).into()),
+                2,
+            ),
+        ];
+
+        let conflicts = check_read_write_conflicts(&reads, &writes);
+        assert_eq!(conflicts.len(), 1);
+    }
+
+    #[test]
+    fn test_no_conflict_different_paths() {
+        let key = test_key();
+
+        let reads = vec![JsonPathRead::new(key.clone(), "foo".parse().unwrap(), 1)];
+
+        let writes = vec![JsonPatchEntry::new(
+            key.clone(),
+            JsonPatch::set_at("bar".parse().unwrap(), serde_json::json!(42).into()),
+            2,
+        )];
+
+        let conflicts = check_read_write_conflicts(&reads, &writes);
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_no_conflict_different_documents() {
+        let key1 = test_key();
+        let key2 = test_key();
+
+        let reads = vec![JsonPathRead::new(key1.clone(), "foo".parse().unwrap(), 1)];
+
+        let writes = vec![
+            // Same path but different document
+            JsonPatchEntry::new(
+                key2.clone(),
+                JsonPatch::set_at("foo".parse().unwrap(), serde_json::json!(42).into()),
+                2,
+            ),
+        ];
+
+        let conflicts = check_read_write_conflicts(&reads, &writes);
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_multiple_read_write_conflicts() {
+        let key = test_key();
+
+        let reads = vec![
+            JsonPathRead::new(key.clone(), "a".parse().unwrap(), 1),
+            JsonPathRead::new(key.clone(), "b".parse().unwrap(), 1),
+        ];
+
+        let writes = vec![
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("a.x".parse().unwrap(), serde_json::json!(1).into()),
+                2,
+            ),
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("b.y".parse().unwrap(), serde_json::json!(2).into()),
+                2,
+            ),
+        ];
+
+        let conflicts = check_read_write_conflicts(&reads, &writes);
+        assert_eq!(conflicts.len(), 2);
+    }
+
+    #[test]
+    fn test_find_first_read_write_conflict() {
+        let key = test_key();
+
+        let reads = vec![
+            JsonPathRead::new(key.clone(), "a".parse().unwrap(), 1),
+            JsonPathRead::new(key.clone(), "b".parse().unwrap(), 1),
+        ];
+
+        let writes = vec![
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("a.x".parse().unwrap(), serde_json::json!(1).into()),
+                2,
+            ),
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("b.y".parse().unwrap(), serde_json::json!(2).into()),
+                2,
+            ),
+        ];
+
+        let conflict = find_first_read_write_conflict(&reads, &writes);
+        assert!(conflict.is_some());
+        // Should return the first one found
+        assert!(matches!(
+            conflict.unwrap(),
+            ConflictResult::ReadWriteConflict { .. }
+        ));
+    }
+
+    #[test]
+    fn test_write_write_conflict_detection() {
+        let key = test_key();
+
+        let writes = vec![
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("foo".parse().unwrap(), serde_json::json!(1).into()),
+                2,
+            ),
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("foo.bar".parse().unwrap(), serde_json::json!(2).into()),
+                3,
+            ),
+        ];
+
+        let conflicts = check_write_write_conflicts(&writes);
+        assert_eq!(conflicts.len(), 1);
+        assert!(matches!(
+            conflicts[0],
+            ConflictResult::WriteWriteConflict { .. }
+        ));
+    }
+
+    #[test]
+    fn test_no_write_conflict_disjoint_paths() {
+        let key = test_key();
+
+        let writes = vec![
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("foo".parse().unwrap(), serde_json::json!(1).into()),
+                2,
+            ),
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("bar".parse().unwrap(), serde_json::json!(2).into()),
+                3,
+            ),
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("baz".parse().unwrap(), serde_json::json!(3).into()),
+                4,
+            ),
+        ];
+
+        let conflicts = check_write_write_conflicts(&writes);
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_write_write_different_documents() {
+        let key1 = test_key();
+        let key2 = test_key();
+
+        let writes = vec![
+            JsonPatchEntry::new(
+                key1.clone(),
+                JsonPatch::set_at("foo".parse().unwrap(), serde_json::json!(1).into()),
+                2,
+            ),
+            JsonPatchEntry::new(
+                key2.clone(),
+                JsonPatch::set_at("foo".parse().unwrap(), serde_json::json!(2).into()),
+                3,
+            ),
+        ];
+
+        // Same path but different documents - no conflict
+        let conflicts = check_write_write_conflicts(&writes);
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_version_conflict_detection() {
+        let key = test_key();
+
+        let mut snapshot = HashMap::new();
+        snapshot.insert(key.clone(), 5);
+
+        let mut current = HashMap::new();
+        current.insert(key.clone(), 7); // Version changed
+
+        let conflicts = check_version_conflicts(&snapshot, &current);
+        assert_eq!(conflicts.len(), 1);
+        match &conflicts[0] {
+            ConflictResult::VersionMismatch {
+                expected, found, ..
+            } => {
+                assert_eq!(*expected, 5);
+                assert_eq!(*found, 7);
+            }
+            _ => panic!("Expected VersionMismatch"),
+        }
+    }
+
+    #[test]
+    fn test_version_conflict_document_deleted() {
+        let key = test_key();
+
+        let mut snapshot = HashMap::new();
+        snapshot.insert(key.clone(), 5);
+
+        let current = HashMap::new(); // Document no longer exists
+
+        let conflicts = check_version_conflicts(&snapshot, &current);
+        assert_eq!(conflicts.len(), 1);
+        match &conflicts[0] {
+            ConflictResult::VersionMismatch {
+                expected, found, ..
+            } => {
+                assert_eq!(*expected, 5);
+                assert_eq!(*found, 0); // Missing = version 0
+            }
+            _ => panic!("Expected VersionMismatch"),
+        }
+    }
+
+    #[test]
+    fn test_no_version_conflict() {
+        let key = test_key();
+
+        let mut snapshot = HashMap::new();
+        snapshot.insert(key.clone(), 5);
+
+        let mut current = HashMap::new();
+        current.insert(key.clone(), 5); // Version unchanged
+
+        let conflicts = check_version_conflicts(&snapshot, &current);
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_check_all_conflicts_version_first() {
+        let key = test_key();
+
+        let reads = vec![JsonPathRead::new(key.clone(), "foo".parse().unwrap(), 5)];
+
+        let writes = vec![
+            // This also conflicts (same path)
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("foo".parse().unwrap(), serde_json::json!(1).into()),
+                6,
+            ),
+        ];
+
+        let mut snapshot = HashMap::new();
+        snapshot.insert(key.clone(), 5);
+
+        let mut current = HashMap::new();
+        current.insert(key.clone(), 7); // Version changed - should fail first
+
+        let result = check_all_conflicts(&reads, &writes, &snapshot, &current);
+
+        // Version conflict should be detected first
+        assert!(matches!(
+            result,
+            Err(JsonConflictError::VersionMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn test_check_all_conflicts_write_write_second() {
+        let key = test_key();
+
+        let reads = vec![JsonPathRead::new(key.clone(), "a".parse().unwrap(), 5)];
+
+        let writes = vec![
+            // These two overlap
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("foo".parse().unwrap(), serde_json::json!(1).into()),
+                6,
+            ),
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("foo.bar".parse().unwrap(), serde_json::json!(2).into()),
+                7,
+            ),
+        ];
+
+        let mut snapshot = HashMap::new();
+        snapshot.insert(key.clone(), 5);
+
+        let mut current = HashMap::new();
+        current.insert(key.clone(), 5); // Version unchanged
+
+        let result = check_all_conflicts(&reads, &writes, &snapshot, &current);
+
+        // Write-write conflict should be detected
+        assert!(matches!(
+            result,
+            Err(JsonConflictError::WriteWriteConflict { .. })
+        ));
+    }
+
+    #[test]
+    fn test_check_all_conflicts_read_write_third() {
+        let key = test_key();
+
+        let reads = vec![JsonPathRead::new(key.clone(), "foo".parse().unwrap(), 5)];
+
+        let writes = vec![
+            // This overlaps with the read
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("foo.bar".parse().unwrap(), serde_json::json!(1).into()),
+                6,
+            ),
+        ];
+
+        let mut snapshot = HashMap::new();
+        snapshot.insert(key.clone(), 5);
+
+        let mut current = HashMap::new();
+        current.insert(key.clone(), 5); // Version unchanged
+
+        let result = check_all_conflicts(&reads, &writes, &snapshot, &current);
+
+        // Read-write conflict should be detected
+        assert!(matches!(
+            result,
+            Err(JsonConflictError::ReadWriteConflict { .. })
+        ));
+    }
+
+    #[test]
+    fn test_check_all_conflicts_success() {
+        let key = test_key();
+
+        let reads = vec![JsonPathRead::new(key.clone(), "a".parse().unwrap(), 5)];
+
+        let writes = vec![
+            // No overlap with read
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("b".parse().unwrap(), serde_json::json!(1).into()),
+                6,
+            ),
+            JsonPatchEntry::new(
+                key.clone(),
+                JsonPatch::set_at("c".parse().unwrap(), serde_json::json!(2).into()),
+                7,
+            ),
+        ];
+
+        let mut snapshot = HashMap::new();
+        snapshot.insert(key.clone(), 5);
+
+        let mut current = HashMap::new();
+        current.insert(key.clone(), 5); // Version unchanged
+
+        let result = check_all_conflicts(&reads, &writes, &snapshot, &current);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_json_conflict_error_display() {
+        let key = test_key();
+
+        let err = JsonConflictError::ReadWriteConflict {
+            key: key.clone(),
+            read_path: "foo".parse().unwrap(),
+            write_path: "foo.bar".parse().unwrap(),
+        };
+        let msg = format!("{}", err);
+        assert!(msg.contains("read-write conflict"));
+        assert!(msg.contains("foo"));
+
+        let err = JsonConflictError::WriteWriteConflict {
+            key: key.clone(),
+            path1: "foo".parse().unwrap(),
+            path2: "foo.bar".parse().unwrap(),
+        };
+        let msg = format!("{}", err);
+        assert!(msg.contains("write-write conflict"));
+
+        let err = JsonConflictError::VersionMismatch {
+            key,
+            expected: 5,
+            found: 7,
+        };
+        let msg = format!("{}", err);
+        assert!(msg.contains("version mismatch"));
+        assert!(msg.contains("5"));
+        assert!(msg.contains("7"));
+    }
+}

--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -8,10 +8,12 @@
 //! - Conflict detection at commit time (Story #83)
 //! - Compare-and-swap (CAS) operations
 //! - WAL integration for durability
+//! - JSON region-based conflict detection (M5)
 
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 
+pub mod conflict;
 pub mod manager;
 pub mod recovery;
 pub mod snapshot;
@@ -23,14 +25,21 @@ pub use manager::TransactionManager;
 pub use recovery::{RecoveryCoordinator, RecoveryResult, RecoveryStats};
 pub use snapshot::ClonedSnapshotView;
 pub use transaction::{
-    ApplyResult, CASOperation, CommitError, PendingOperations, TransactionContext,
-    TransactionStatus,
+    ApplyResult, CASOperation, CommitError, JsonPatchEntry, JsonPathRead, JsonStoreExt,
+    PendingOperations, TransactionContext, TransactionStatus,
 };
 pub use validation::{
-    validate_cas_set, validate_read_set, validate_transaction, validate_write_set, ConflictType,
-    ValidationResult,
+    validate_cas_set, validate_json_paths, validate_json_set, validate_read_set,
+    validate_transaction, validate_write_set, ConflictType, ValidationResult,
 };
 pub use wal_writer::TransactionWALWriter;
+
+// JSON conflict detection (M5)
+pub use conflict::{
+    check_all_conflicts, check_read_write_conflicts, check_version_conflicts,
+    check_write_write_conflicts, find_first_read_write_conflict, find_first_version_conflict,
+    find_first_write_write_conflict, ConflictResult, JsonConflictError,
+};
 
 // Re-export the SnapshotView trait from core for convenience
 pub use in_mem_core::traits::SnapshotView;

--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -420,7 +420,7 @@ mod tests {
                 .unwrap();
                 wal.append(&WALEntry::Write {
                     run_id,
-                    key: Key::new_kv(ns.clone(), &format!("key{}", i)),
+                    key: Key::new_kv(ns.clone(), format!("key{}", i)),
                     value: Value::I64(i as i64 * 10),
                     version: i * 100,
                 })
@@ -444,7 +444,7 @@ mod tests {
 
         // Verify storage state is identical
         for i in 1..=5u64 {
-            let key = Key::new_kv(ns.clone(), &format!("key{}", i));
+            let key = Key::new_kv(ns.clone(), format!("key{}", i));
             let v1 = result1.storage.get(&key).unwrap().unwrap();
             let v2 = result2.storage.get(&key).unwrap().unwrap();
             assert_eq!(v1.value, v2.value);
@@ -639,7 +639,7 @@ mod tests {
 
         // Should still work (snapshot not used in M2)
         let result = coordinator.recover().unwrap();
-        assert_eq!(result.stats.from_checkpoint, false);
+        assert!(!result.stats.from_checkpoint);
     }
 
     // ========================================
@@ -1297,7 +1297,7 @@ mod tests {
                 .unwrap();
                 wal.append(&WALEntry::Write {
                     run_id,
-                    key: Key::new_kv(ns.clone(), &format!("key{}", i)),
+                    key: Key::new_kv(ns.clone(), format!("key{}", i)),
                     value: Value::I64(i as i64 * 10),
                     version: commit_version,
                 })
@@ -1307,7 +1307,7 @@ mod tests {
                 // Apply to storage (simulating what would happen in normal operation)
                 storage
                     .put_with_version(
-                        Key::new_kv(ns.clone(), &format!("key{}", i)),
+                        Key::new_kv(ns.clone(), format!("key{}", i)),
                         Value::I64(i as i64 * 10),
                         commit_version,
                         None,
@@ -1331,7 +1331,7 @@ mod tests {
         assert_eq!(result.txn_manager.current_version(), 10);
 
         for i in 1..=10u64 {
-            let key = Key::new_kv(ns.clone(), &format!("key{}", i));
+            let key = Key::new_kv(ns.clone(), format!("key{}", i));
             let stored = result.storage.get(&key).unwrap().unwrap();
             assert_eq!(stored.value, Value::I64(i as i64 * 10));
             assert_eq!(stored.version, i);
@@ -1575,7 +1575,7 @@ mod tests {
                 .unwrap();
                 wal.append(&WALEntry::Write {
                     run_id,
-                    key: Key::new_kv(ns.clone(), &format!("key_{}", i)),
+                    key: Key::new_kv(ns.clone(), format!("key_{}", i)),
                     value: Value::I64(i as i64),
                     version: i,
                 })
@@ -1594,7 +1594,7 @@ mod tests {
 
         // Verify a few random keys
         for i in [1, 50, 100] {
-            let key = Key::new_kv(ns.clone(), &format!("key_{}", i));
+            let key = Key::new_kv(ns.clone(), format!("key_{}", i));
             let stored = result.storage.get(&key).unwrap().unwrap();
             assert_eq!(stored.value, Value::I64(i as i64));
         }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,10 +10,10 @@ repository.workspace = true
 [dependencies]
 uuid = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true }
 bincode = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
-serde_json = { workspace = true }

--- a/crates/core/src/json.rs
+++ b/crates/core/src/json.rs
@@ -1,0 +1,2964 @@
+//! JSON types for M5 JSON primitive
+//!
+//! This module defines types for the JSON document storage system:
+//! - JsonValue: Newtype wrapper around serde_json::Value
+//! - JsonPath: Path into a JSON document (e.g., `user.name` or `items[0]`)
+//! - PathSegment: Individual path component (Key or Index)
+//! - JsonPatch: Patch operation (Set or Delete)
+//!
+//! # Document Size Limits
+//!
+//! M5 enforces the following limits to prevent memory issues:
+//!
+//! | Limit | Value | Constant |
+//! |-------|-------|----------|
+//! | Max document size | 16 MB | [`MAX_DOCUMENT_SIZE`] |
+//! | Max nesting depth | 100 levels | [`MAX_NESTING_DEPTH`] |
+//! | Max path length | 256 segments | [`MAX_PATH_LENGTH`] |
+//! | Max array size | 1M elements | [`MAX_ARRAY_SIZE`] |
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use std::str::FromStr;
+use thiserror::Error;
+
+// =============================================================================
+// Document Size Limits
+// =============================================================================
+
+/// Maximum document size in bytes (16 MB)
+///
+/// Documents larger than this will be rejected to prevent memory issues.
+/// This limit is checked on create and update operations.
+pub const MAX_DOCUMENT_SIZE: usize = 16 * 1024 * 1024; // 16 MB
+
+/// Maximum nesting depth in a JSON document (100 levels)
+///
+/// Prevents stack overflow during recursive operations like serialization,
+/// deserialization, and path traversal.
+pub const MAX_NESTING_DEPTH: usize = 100;
+
+/// Maximum path length in segments (256 segments)
+///
+/// Limits the depth of paths like "a.b.c.d..." to prevent extremely deep
+/// nesting and potential performance issues.
+pub const MAX_PATH_LENGTH: usize = 256;
+
+/// Maximum array size in elements (1 million elements)
+///
+/// Prevents creation of extremely large arrays that could cause memory issues.
+pub const MAX_ARRAY_SIZE: usize = 1_000_000;
+
+/// Error type for document limit violations
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum LimitError {
+    /// Document exceeds maximum size
+    #[error("document size {size} exceeds maximum of {max} bytes")]
+    DocumentTooLarge {
+        /// Actual document size
+        size: usize,
+        /// Maximum allowed size
+        max: usize,
+    },
+
+    /// Document nesting exceeds maximum depth
+    #[error("document nesting depth {depth} exceeds maximum of {max} levels")]
+    NestingTooDeep {
+        /// Actual nesting depth
+        depth: usize,
+        /// Maximum allowed depth
+        max: usize,
+    },
+
+    /// Path exceeds maximum length
+    #[error("path length {length} exceeds maximum of {max} segments")]
+    PathTooLong {
+        /// Actual path length
+        length: usize,
+        /// Maximum allowed length
+        max: usize,
+    },
+
+    /// Array exceeds maximum size
+    #[error("array size {size} exceeds maximum of {max} elements")]
+    ArrayTooLarge {
+        /// Actual array size
+        size: usize,
+        /// Maximum allowed size
+        max: usize,
+    },
+}
+
+/// JSON value wrapper
+///
+/// Newtype around serde_json::Value providing:
+/// - Direct access to underlying serde_json::Value via Deref/DerefMut
+/// - Easy construction from common types
+/// - Serialization/deserialization support
+///
+/// # Examples
+///
+/// ```
+/// use in_mem_core::JsonValue;
+///
+/// // From JSON literals
+/// let obj = JsonValue::object();
+/// let arr = JsonValue::array();
+/// let null = JsonValue::null();
+///
+/// // From common types
+/// let s = JsonValue::from("hello");
+/// let n = JsonValue::from(42i64);
+/// let b = JsonValue::from(true);
+///
+/// // Access underlying value
+/// assert!(obj.is_object());
+/// assert!(arr.is_array());
+/// assert!(null.is_null());
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+#[repr(transparent)]
+pub struct JsonValue(serde_json::Value);
+
+impl JsonValue {
+    /// Create a null JSON value
+    pub fn null() -> Self {
+        JsonValue(serde_json::Value::Null)
+    }
+
+    /// Create an empty JSON object
+    pub fn object() -> Self {
+        JsonValue(serde_json::Value::Object(serde_json::Map::new()))
+    }
+
+    /// Create an empty JSON array
+    pub fn array() -> Self {
+        JsonValue(serde_json::Value::Array(Vec::new()))
+    }
+
+    /// Create from a serde_json::Value
+    pub fn from_value(value: serde_json::Value) -> Self {
+        JsonValue(value)
+    }
+
+    /// Get the underlying serde_json::Value
+    pub fn into_inner(self) -> serde_json::Value {
+        self.0
+    }
+
+    /// Get a reference to the underlying serde_json::Value
+    pub fn as_inner(&self) -> &serde_json::Value {
+        &self.0
+    }
+
+    /// Get a mutable reference to the underlying serde_json::Value
+    pub fn as_inner_mut(&mut self) -> &mut serde_json::Value {
+        &mut self.0
+    }
+
+    /// Serialize to compact JSON string
+    pub fn to_json_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Serialize to pretty JSON string
+    pub fn to_json_string_pretty(&self) -> String {
+        serde_json::to_string_pretty(&self.0).unwrap_or_else(|_| self.to_json_string())
+    }
+
+    /// Calculate approximate size in bytes (for limit checking)
+    ///
+    /// This is an estimate based on the JSON string representation.
+    /// Actual in-memory size may differ.
+    pub fn size_bytes(&self) -> usize {
+        self.to_json_string().len()
+    }
+
+    /// Calculate the maximum nesting depth of this JSON value
+    ///
+    /// Returns 0 for primitives (null, bool, number, string),
+    /// and counts nested objects/arrays.
+    pub fn nesting_depth(&self) -> usize {
+        fn depth_of(value: &serde_json::Value) -> usize {
+            match value {
+                serde_json::Value::Null
+                | serde_json::Value::Bool(_)
+                | serde_json::Value::Number(_)
+                | serde_json::Value::String(_) => 0,
+                serde_json::Value::Array(arr) => 1 + arr.iter().map(depth_of).max().unwrap_or(0),
+                serde_json::Value::Object(obj) => 1 + obj.values().map(depth_of).max().unwrap_or(0),
+            }
+        }
+        depth_of(&self.0)
+    }
+
+    /// Find the maximum array size in this JSON value (including nested arrays)
+    pub fn max_array_size(&self) -> usize {
+        fn max_arr_size(value: &serde_json::Value) -> usize {
+            match value {
+                serde_json::Value::Null
+                | serde_json::Value::Bool(_)
+                | serde_json::Value::Number(_)
+                | serde_json::Value::String(_) => 0,
+                serde_json::Value::Array(arr) => {
+                    let nested_max = arr.iter().map(max_arr_size).max().unwrap_or(0);
+                    arr.len().max(nested_max)
+                }
+                serde_json::Value::Object(obj) => obj.values().map(max_arr_size).max().unwrap_or(0),
+            }
+        }
+        max_arr_size(&self.0)
+    }
+
+    /// Validate document size limit
+    ///
+    /// Returns an error if the document exceeds [`MAX_DOCUMENT_SIZE`].
+    pub fn validate_size(&self) -> Result<(), LimitError> {
+        let size = self.size_bytes();
+        if size > MAX_DOCUMENT_SIZE {
+            Err(LimitError::DocumentTooLarge {
+                size,
+                max: MAX_DOCUMENT_SIZE,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Validate document nesting depth limit
+    ///
+    /// Returns an error if the document exceeds [`MAX_NESTING_DEPTH`].
+    pub fn validate_depth(&self) -> Result<(), LimitError> {
+        let depth = self.nesting_depth();
+        if depth > MAX_NESTING_DEPTH {
+            Err(LimitError::NestingTooDeep {
+                depth,
+                max: MAX_NESTING_DEPTH,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Validate array size limits
+    ///
+    /// Returns an error if any array in the document exceeds [`MAX_ARRAY_SIZE`].
+    pub fn validate_array_size(&self) -> Result<(), LimitError> {
+        let size = self.max_array_size();
+        if size > MAX_ARRAY_SIZE {
+            Err(LimitError::ArrayTooLarge {
+                size,
+                max: MAX_ARRAY_SIZE,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Validate all document limits
+    ///
+    /// Checks size, nesting depth, and array sizes.
+    /// Returns the first error encountered, if any.
+    pub fn validate(&self) -> Result<(), LimitError> {
+        self.validate_size()?;
+        self.validate_depth()?;
+        self.validate_array_size()?;
+        Ok(())
+    }
+}
+
+// Implement FromStr for parsing from strings
+impl FromStr for JsonValue {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s).map(JsonValue)
+    }
+}
+
+// Deref to access serde_json::Value methods directly
+impl Deref for JsonValue {
+    type Target = serde_json::Value;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for JsonValue {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+// Display for easy printing
+impl fmt::Display for JsonValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// Default is null
+impl Default for JsonValue {
+    fn default() -> Self {
+        Self::null()
+    }
+}
+
+// From implementations for common types
+impl From<serde_json::Value> for JsonValue {
+    fn from(v: serde_json::Value) -> Self {
+        JsonValue(v)
+    }
+}
+
+impl From<JsonValue> for serde_json::Value {
+    fn from(v: JsonValue) -> Self {
+        v.0
+    }
+}
+
+impl From<bool> for JsonValue {
+    fn from(v: bool) -> Self {
+        JsonValue(serde_json::Value::Bool(v))
+    }
+}
+
+impl From<i64> for JsonValue {
+    fn from(v: i64) -> Self {
+        JsonValue(serde_json::Value::Number(v.into()))
+    }
+}
+
+impl From<i32> for JsonValue {
+    fn from(v: i32) -> Self {
+        JsonValue(serde_json::Value::Number(v.into()))
+    }
+}
+
+impl From<u64> for JsonValue {
+    fn from(v: u64) -> Self {
+        JsonValue(serde_json::Value::Number(v.into()))
+    }
+}
+
+impl From<u32> for JsonValue {
+    fn from(v: u32) -> Self {
+        JsonValue(serde_json::Value::Number(v.into()))
+    }
+}
+
+impl From<f64> for JsonValue {
+    fn from(v: f64) -> Self {
+        JsonValue(
+            serde_json::Number::from_f64(v)
+                .map_or(serde_json::Value::Null, serde_json::Value::Number),
+        )
+    }
+}
+
+impl From<&str> for JsonValue {
+    fn from(v: &str) -> Self {
+        JsonValue(serde_json::Value::String(v.to_string()))
+    }
+}
+
+impl From<String> for JsonValue {
+    fn from(v: String) -> Self {
+        JsonValue(serde_json::Value::String(v))
+    }
+}
+
+impl<T: Into<JsonValue>> From<Vec<T>> for JsonValue {
+    fn from(v: Vec<T>) -> Self {
+        JsonValue(serde_json::Value::Array(
+            v.into_iter().map(|x| x.into().0).collect(),
+        ))
+    }
+}
+
+impl<T: Into<JsonValue>> From<Option<T>> for JsonValue {
+    fn from(v: Option<T>) -> Self {
+        match v {
+            Some(v) => v.into(),
+            None => JsonValue::null(),
+        }
+    }
+}
+
+// =============================================================================
+// JsonPath and PathSegment
+// =============================================================================
+
+/// Error type for JSON path parsing
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum PathParseError {
+    /// Empty key in path
+    #[error("empty key in path at position {0}")]
+    EmptyKey(usize),
+    /// Unclosed bracket
+    #[error("unclosed bracket starting at position {0}")]
+    UnclosedBracket(usize),
+    /// Invalid array index
+    #[error("invalid array index at position {0}: {1}")]
+    InvalidIndex(usize, String),
+    /// Unexpected character
+    #[error("unexpected character '{0}' at position {1}")]
+    UnexpectedChar(char, usize),
+}
+
+/// A segment in a JSON path
+///
+/// Paths are composed of key segments (object property access)
+/// and index segments (array element access).
+///
+/// # Examples
+///
+/// ```
+/// use in_mem_core::json::PathSegment;
+///
+/// let key = PathSegment::Key("name".to_string());
+/// let idx = PathSegment::Index(0);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum PathSegment {
+    /// Object key: `.foo`
+    Key(String),
+    /// Array index: `[0]`
+    Index(usize),
+}
+
+impl fmt::Display for PathSegment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PathSegment::Key(k) => write!(f, ".{}", k),
+            PathSegment::Index(i) => write!(f, "[{}]", i),
+        }
+    }
+}
+
+/// A path into a JSON document
+///
+/// JsonPath represents a location within a JSON document using a sequence
+/// of key and index segments. Paths support:
+///
+/// - Object property access: `.foo`
+/// - Array index access: `[0]`
+/// - Nested paths: `.user.address.city` or `.items[0].name`
+///
+/// # Path Syntax (M5 Subset)
+///
+/// | Syntax | Meaning | Example |
+/// |--------|---------|---------|
+/// | `.key` | Object property | `.user` |
+/// | `[n]` | Array index | `[0]` |
+/// | `.key1.key2` | Nested property | `.user.name` |
+/// | `.key[n]` | Property then index | `.items[0]` |
+/// | (empty) | Root | `` |
+///
+/// # Examples
+///
+/// ```
+/// use in_mem_core::json::JsonPath;
+///
+/// // Create paths
+/// let root = JsonPath::root();
+/// let user_name = JsonPath::root().key("user").key("name");
+/// let first_item = JsonPath::root().key("items").index(0);
+///
+/// // Parse from string
+/// let path: JsonPath = "user.name".parse().unwrap();
+/// assert_eq!(path, user_name);
+///
+/// // Check relationships
+/// let user = JsonPath::root().key("user");
+/// assert!(user.is_ancestor_of(&user_name));
+/// assert!(user_name.is_descendant_of(&user));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub struct JsonPath {
+    segments: Vec<PathSegment>,
+}
+
+impl JsonPath {
+    /// Create the root path (empty path)
+    pub fn root() -> Self {
+        JsonPath {
+            segments: Vec::new(),
+        }
+    }
+
+    /// Create a path from a vector of segments
+    pub fn from_segments(segments: Vec<PathSegment>) -> Self {
+        JsonPath { segments }
+    }
+
+    /// Get the path segments
+    pub fn segments(&self) -> &[PathSegment] {
+        &self.segments
+    }
+
+    /// Get the number of segments in the path
+    pub fn len(&self) -> usize {
+        self.segments.len()
+    }
+
+    /// Check if this is the root path (empty)
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
+
+    /// Check if this is the root path
+    pub fn is_root(&self) -> bool {
+        self.segments.is_empty()
+    }
+
+    /// Append a key segment (builder pattern)
+    pub fn key(mut self, key: impl Into<String>) -> Self {
+        self.segments.push(PathSegment::Key(key.into()));
+        self
+    }
+
+    /// Append an index segment (builder pattern)
+    pub fn index(mut self, idx: usize) -> Self {
+        self.segments.push(PathSegment::Index(idx));
+        self
+    }
+
+    /// Push a key segment (mutating)
+    pub fn push_key(&mut self, key: impl Into<String>) {
+        self.segments.push(PathSegment::Key(key.into()));
+    }
+
+    /// Push an index segment (mutating)
+    pub fn push_index(&mut self, idx: usize) {
+        self.segments.push(PathSegment::Index(idx));
+    }
+
+    /// Get the parent path (None if root)
+    pub fn parent(&self) -> Option<JsonPath> {
+        if self.segments.is_empty() {
+            None
+        } else {
+            let mut parent = self.clone();
+            parent.segments.pop();
+            Some(parent)
+        }
+    }
+
+    /// Get the last segment (None if root)
+    pub fn last_segment(&self) -> Option<&PathSegment> {
+        self.segments.last()
+    }
+
+    /// Check if this path is an ancestor of another (or equal)
+    ///
+    /// A path is an ancestor if it is a prefix of the other path.
+    /// The root path is an ancestor of all paths.
+    /// A path is considered an ancestor of itself.
+    pub fn is_ancestor_of(&self, other: &JsonPath) -> bool {
+        if self.segments.len() > other.segments.len() {
+            return false;
+        }
+        self.segments
+            .iter()
+            .zip(other.segments.iter())
+            .all(|(a, b)| a == b)
+    }
+
+    /// Check if this path is a descendant of another (or equal)
+    ///
+    /// A path is a descendant if the other path is a prefix of this path.
+    /// All paths are descendants of the root path.
+    /// A path is considered a descendant of itself.
+    pub fn is_descendant_of(&self, other: &JsonPath) -> bool {
+        other.is_ancestor_of(self)
+    }
+
+    /// Check if this path is a strict ancestor of another (not equal)
+    ///
+    /// A path is a strict ancestor if it is a proper prefix of the other path.
+    /// The root path is a strict ancestor of all non-root paths.
+    pub fn is_strict_ancestor_of(&self, other: &JsonPath) -> bool {
+        self.segments.len() < other.segments.len() && self.is_ancestor_of(other)
+    }
+
+    /// Check if this path is a strict descendant of another (not equal)
+    ///
+    /// A path is a strict descendant if the other path is a proper prefix of this path.
+    /// All non-root paths are strict descendants of the root path.
+    pub fn is_strict_descendant_of(&self, other: &JsonPath) -> bool {
+        other.is_strict_ancestor_of(self)
+    }
+
+    /// Find the common ancestor of two paths
+    ///
+    /// Returns the longest common prefix of both paths.
+    /// If the paths share no common prefix, returns the root path.
+    pub fn common_ancestor(&self, other: &JsonPath) -> JsonPath {
+        let mut common_segments = Vec::new();
+        for (a, b) in self.segments.iter().zip(other.segments.iter()) {
+            if a == b {
+                common_segments.push(a.clone());
+            } else {
+                break;
+            }
+        }
+        JsonPath::from_segments(common_segments)
+    }
+
+    /// Check if this path would be affected by a write at the given path
+    ///
+    /// A path is affected if:
+    /// - The write path is an ancestor (write affects this path and all descendants)
+    /// - The write path equals this path (direct modification)
+    /// - The write path is a descendant (partial modification of this path's subtree)
+    ///
+    /// This is equivalent to `overlaps()` but with clearer semantics for conflict detection.
+    pub fn is_affected_by(&self, write_path: &JsonPath) -> bool {
+        self.overlaps(write_path)
+    }
+
+    /// Check if two paths overlap (one is ancestor/descendant of the other)
+    ///
+    /// Used for conflict detection: if two paths overlap and both are
+    /// accessed in a transaction (one read, one write), there's a potential conflict.
+    pub fn overlaps(&self, other: &JsonPath) -> bool {
+        self.is_ancestor_of(other) || self.is_descendant_of(other)
+    }
+
+    /// Validate path length limit
+    ///
+    /// Returns an error if the path exceeds [`MAX_PATH_LENGTH`].
+    pub fn validate(&self) -> Result<(), LimitError> {
+        let length = self.segments.len();
+        if length > MAX_PATH_LENGTH {
+            Err(LimitError::PathTooLong {
+                length,
+                max: MAX_PATH_LENGTH,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Convert to a string representation
+    pub fn to_path_string(&self) -> String {
+        if self.segments.is_empty() {
+            return String::new();
+        }
+        let mut result = String::new();
+        for seg in &self.segments {
+            match seg {
+                PathSegment::Key(k) => {
+                    if !result.is_empty() || result.is_empty() {
+                        result.push('.');
+                    }
+                    result.push_str(k);
+                }
+                PathSegment::Index(i) => {
+                    result.push('[');
+                    result.push_str(&i.to_string());
+                    result.push(']');
+                }
+            }
+        }
+        // Remove leading dot if it starts with one
+        if result.starts_with('.') {
+            result.remove(0);
+        }
+        result
+    }
+}
+
+impl FromStr for JsonPath {
+    type Err = PathParseError;
+
+    /// Parse a path from a string
+    ///
+    /// Supported syntax:
+    /// - `foo` or `.foo` - object key
+    /// - `[0]` - array index
+    /// - `foo.bar` - nested keys
+    /// - `foo[0]` - key then index
+    /// - `foo[0].bar` - mixed
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Ok(JsonPath::root());
+        }
+
+        let mut segments = Vec::new();
+        let chars: Vec<char> = s.chars().collect();
+        let mut i = 0;
+
+        // Skip leading dot if present
+        if i < chars.len() && chars[i] == '.' {
+            i += 1;
+        }
+
+        while i < chars.len() {
+            let c = chars[i];
+
+            if c == '.' {
+                // Start of a key segment
+                i += 1;
+                if i >= chars.len() {
+                    return Err(PathParseError::EmptyKey(i));
+                }
+            }
+
+            if chars[i] == '[' {
+                // Array index segment
+                let start = i;
+                i += 1;
+                let idx_start = i;
+
+                // Find closing bracket
+                while i < chars.len() && chars[i] != ']' {
+                    i += 1;
+                }
+
+                if i >= chars.len() {
+                    return Err(PathParseError::UnclosedBracket(start));
+                }
+
+                let idx_str: String = chars[idx_start..i].iter().collect();
+                let idx = idx_str
+                    .parse::<usize>()
+                    .map_err(|_| PathParseError::InvalidIndex(idx_start, idx_str))?;
+
+                segments.push(PathSegment::Index(idx));
+                i += 1; // Skip closing bracket
+            } else if chars[i].is_alphanumeric() || chars[i] == '_' || chars[i] == '-' {
+                // Key segment
+                let key_start = i;
+                while i < chars.len()
+                    && (chars[i].is_alphanumeric() || chars[i] == '_' || chars[i] == '-')
+                {
+                    i += 1;
+                }
+                let key: String = chars[key_start..i].iter().collect();
+                segments.push(PathSegment::Key(key));
+            } else {
+                return Err(PathParseError::UnexpectedChar(chars[i], i));
+            }
+        }
+
+        Ok(JsonPath { segments })
+    }
+}
+
+impl fmt::Display for JsonPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_path_string())
+    }
+}
+
+// =============================================================================
+// JsonPatch
+// =============================================================================
+
+/// A patch operation on a JSON document
+///
+/// JsonPatch represents an atomic mutation to a JSON document.
+/// Patches are used for:
+/// - WAL recording (patch-based persistence)
+/// - Transaction tracking
+/// - Conflict detection
+///
+/// # Supported Operations
+///
+/// - `Set`: Set a value at a path (creates intermediate objects/arrays if needed)
+/// - `Delete`: Remove a value at a path
+///
+/// # Conflict Detection
+///
+/// Two patches conflict if their paths overlap (one is ancestor/descendant of the other).
+/// This is used for region-based conflict detection in transactions.
+///
+/// # Examples
+///
+/// ```
+/// use in_mem_core::json::{JsonPatch, JsonPath, JsonValue};
+///
+/// // Create patches
+/// let set = JsonPatch::set("user.name", JsonValue::from("Alice"));
+/// let delete = JsonPatch::delete("user.email");
+///
+/// // Check conflict
+/// let patch1 = JsonPatch::set("user", JsonValue::object());
+/// let patch2 = JsonPatch::set("user.name", JsonValue::from("Bob"));
+/// assert!(patch1.conflicts_with(&patch2)); // user is ancestor of user.name
+///
+/// // Non-conflicting patches
+/// let patch3 = JsonPatch::set("user.name", JsonValue::from("Alice"));
+/// let patch4 = JsonPatch::set("user.email", JsonValue::from("alice@example.com"));
+/// assert!(!patch3.conflicts_with(&patch4)); // Different paths
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum JsonPatch {
+    /// Set value at path
+    Set {
+        /// The path to set
+        path: JsonPath,
+        /// The value to set
+        value: JsonValue,
+    },
+    /// Delete value at path
+    Delete {
+        /// The path to delete
+        path: JsonPath,
+    },
+}
+
+impl JsonPatch {
+    /// Create a Set patch
+    ///
+    /// Convenience constructor that parses the path from a string.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the path string is invalid.
+    pub fn set(path: impl AsRef<str>, value: JsonValue) -> Self {
+        JsonPatch::Set {
+            path: path
+                .as_ref()
+                .parse()
+                .expect("Invalid path in JsonPatch::set"),
+            value,
+        }
+    }
+
+    /// Create a Set patch with a pre-parsed path
+    pub fn set_at(path: JsonPath, value: JsonValue) -> Self {
+        JsonPatch::Set { path, value }
+    }
+
+    /// Create a Delete patch
+    ///
+    /// Convenience constructor that parses the path from a string.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the path string is invalid.
+    pub fn delete(path: impl AsRef<str>) -> Self {
+        JsonPatch::Delete {
+            path: path
+                .as_ref()
+                .parse()
+                .expect("Invalid path in JsonPatch::delete"),
+        }
+    }
+
+    /// Create a Delete patch with a pre-parsed path
+    pub fn delete_at(path: JsonPath) -> Self {
+        JsonPatch::Delete { path }
+    }
+
+    /// Get the path affected by this patch
+    pub fn path(&self) -> &JsonPath {
+        match self {
+            JsonPatch::Set { path, .. } => path,
+            JsonPatch::Delete { path } => path,
+        }
+    }
+
+    /// Check if this patch conflicts with another
+    ///
+    /// Two patches conflict if their paths overlap (one is ancestor/descendant of the other).
+    /// This is used for region-based conflict detection.
+    ///
+    /// Note: Two Set patches to the same path also conflict, but can sometimes be
+    /// resolved by last-writer-wins semantics depending on the use case.
+    pub fn conflicts_with(&self, other: &JsonPatch) -> bool {
+        self.path().overlaps(other.path())
+    }
+
+    /// Check if this is a Set operation
+    pub fn is_set(&self) -> bool {
+        matches!(self, JsonPatch::Set { .. })
+    }
+
+    /// Check if this is a Delete operation
+    pub fn is_delete(&self) -> bool {
+        matches!(self, JsonPatch::Delete { .. })
+    }
+
+    /// Get the value if this is a Set patch
+    pub fn value(&self) -> Option<&JsonValue> {
+        match self {
+            JsonPatch::Set { value, .. } => Some(value),
+            JsonPatch::Delete { .. } => None,
+        }
+    }
+}
+
+impl fmt::Display for JsonPatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            JsonPatch::Set { path, value } => write!(f, "SET {} = {}", path, value),
+            JsonPatch::Delete { path } => write!(f, "DELETE {}", path),
+        }
+    }
+}
+
+// =============================================================================
+// Path Operations Error
+// =============================================================================
+
+/// Error type for path operations
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum JsonPathError {
+    /// Type mismatch during path traversal
+    #[error("type mismatch: expected {expected}, found {found}")]
+    TypeMismatch {
+        /// Expected type
+        expected: &'static str,
+        /// Actual type found
+        found: &'static str,
+    },
+
+    /// Array index out of bounds
+    #[error("index out of bounds: {index} >= {len}")]
+    IndexOutOfBounds {
+        /// The requested index
+        index: usize,
+        /// The array length
+        len: usize,
+    },
+
+    /// Path not found
+    #[error("path not found")]
+    NotFound,
+}
+
+// =============================================================================
+// Path Operations (Story #268)
+// =============================================================================
+
+/// Get value at path within a JSON document
+///
+/// Traverses the document following the path segments, returning a reference
+/// to the value at the specified location.
+///
+/// # Arguments
+///
+/// * `value` - The root JSON value to traverse
+/// * `path` - The path to the desired value
+///
+/// # Returns
+///
+/// * `Some(&JsonValue)` - Reference to the value at the path
+/// * `None` - If the path doesn't exist or there's a type mismatch
+///
+/// # Examples
+///
+/// ```
+/// use in_mem_core::json::{JsonValue, JsonPath, get_at_path};
+///
+/// let json: JsonValue = serde_json::json!({
+///     "user": {
+///         "name": "Alice",
+///         "scores": [100, 95, 88]
+///     }
+/// }).into();
+///
+/// // Get nested object property
+/// let path: JsonPath = "user.name".parse().unwrap();
+/// let name = get_at_path(&json, &path).unwrap();
+/// assert_eq!(name.as_str(), Some("Alice"));
+///
+/// // Get array element
+/// let path: JsonPath = "user.scores[1]".parse().unwrap();
+/// let score = get_at_path(&json, &path).unwrap();
+/// assert_eq!(score.as_i64(), Some(95));
+///
+/// // Root path returns the entire document
+/// assert_eq!(get_at_path(&json, &JsonPath::root()), Some(&json));
+/// ```
+pub fn get_at_path<'a>(value: &'a JsonValue, path: &JsonPath) -> Option<&'a JsonValue> {
+    if path.is_root() {
+        return Some(value);
+    }
+
+    let mut current: &serde_json::Value = value.as_inner();
+
+    for segment in path.segments() {
+        match (segment, current) {
+            (PathSegment::Key(key), serde_json::Value::Object(obj)) => {
+                current = obj.get(key)?;
+            }
+            (PathSegment::Index(idx), serde_json::Value::Array(arr)) => {
+                current = arr.get(*idx)?;
+            }
+            _ => return None,
+        }
+    }
+
+    // SAFETY: This transmute is safe because:
+    // 1. JsonValue has #[repr(transparent)], guaranteeing identical memory layout to serde_json::Value
+    // 2. The returned reference's lifetime is tied to the input JsonValue reference
+    // 3. Both types have the same alignment requirements
+    Some(unsafe { &*(current as *const serde_json::Value as *const JsonValue) })
+}
+
+/// Get mutable reference to value at path within a JSON document
+///
+/// Traverses the document following the path segments, returning a mutable
+/// reference to the value at the specified location.
+///
+/// # Arguments
+///
+/// * `value` - The root JSON value to traverse
+/// * `path` - The path to the desired value
+///
+/// # Returns
+///
+/// * `Some(&mut JsonValue)` - Mutable reference to the value at the path
+/// * `None` - If the path doesn't exist or there's a type mismatch
+///
+/// # Examples
+///
+/// ```
+/// use in_mem_core::json::{JsonValue, JsonPath, get_at_path_mut};
+///
+/// let mut json: JsonValue = serde_json::json!({
+///     "user": {
+///         "name": "Alice"
+///     }
+/// }).into();
+///
+/// // Modify nested value
+/// let path: JsonPath = "user.name".parse().unwrap();
+/// if let Some(name) = get_at_path_mut(&mut json, &path) {
+///     *name = JsonValue::from("Bob");
+/// }
+///
+/// // Verify the change
+/// use in_mem_core::json::get_at_path;
+/// let name = get_at_path(&json, &path).unwrap();
+/// assert_eq!(name.as_str(), Some("Bob"));
+/// ```
+pub fn get_at_path_mut<'a>(value: &'a mut JsonValue, path: &JsonPath) -> Option<&'a mut JsonValue> {
+    if path.is_root() {
+        return Some(value);
+    }
+
+    let inner: &mut serde_json::Value = value.as_inner_mut();
+    let mut current: &mut serde_json::Value = inner;
+
+    for segment in path.segments() {
+        current = match (segment, current) {
+            (PathSegment::Key(key), serde_json::Value::Object(obj)) => obj.get_mut(key)?,
+            (PathSegment::Index(idx), serde_json::Value::Array(arr)) => arr.get_mut(*idx)?,
+            _ => return None,
+        };
+    }
+
+    // SAFETY: This transmute is safe because:
+    // 1. JsonValue has #[repr(transparent)], guaranteeing identical memory layout to serde_json::Value
+    // 2. The returned reference's lifetime is tied to the input JsonValue reference
+    // 3. Both types have the same alignment requirements
+    Some(unsafe { &mut *(current as *mut serde_json::Value as *mut JsonValue) })
+}
+
+// =============================================================================
+// Path Mutation (Story #269)
+// =============================================================================
+
+/// Set value at path within a JSON document
+///
+/// Creates intermediate objects and arrays as needed when the path doesn't exist.
+/// The type of intermediate container (object vs array) is determined by the
+/// next segment in the path.
+///
+/// # Arguments
+///
+/// * `root` - The root JSON value to modify
+/// * `path` - The path where the value should be set
+/// * `value` - The value to set at the path
+///
+/// # Returns
+///
+/// * `Ok(())` - Value was set successfully
+/// * `Err(JsonPathError)` - Type mismatch or index out of bounds
+///
+/// # Examples
+///
+/// ```
+/// use in_mem_core::json::{JsonValue, JsonPath, set_at_path, get_at_path};
+///
+/// // Set value at nested path, creating intermediate objects
+/// let mut json = JsonValue::object();
+/// let path: JsonPath = "user.profile.name".parse().unwrap();
+/// set_at_path(&mut json, &path, JsonValue::from("Alice")).unwrap();
+///
+/// // Verify the value was set
+/// assert_eq!(
+///     get_at_path(&json, &path).unwrap().as_str(),
+///     Some("Alice")
+/// );
+///
+/// // Replace root value
+/// let mut value = JsonValue::from(42);
+/// set_at_path(&mut value, &JsonPath::root(), JsonValue::from(100)).unwrap();
+/// assert_eq!(value.as_i64(), Some(100));
+/// ```
+pub fn set_at_path(
+    root: &mut JsonValue,
+    path: &JsonPath,
+    value: JsonValue,
+) -> Result<(), JsonPathError> {
+    // Handle root path - replace entire value
+    if path.is_root() {
+        *root = value;
+        return Ok(());
+    }
+
+    let segments = path.segments();
+    if segments.is_empty() {
+        *root = value;
+        return Ok(());
+    }
+
+    let inner = root.as_inner_mut();
+
+    // Navigate to parent, creating intermediate containers as needed
+    let (parent_segments, last_segment) = segments.split_at(segments.len() - 1);
+    let last_segment = &last_segment[0];
+
+    let mut current = inner;
+
+    // Navigate to parent, creating intermediates
+    for (i, segment) in parent_segments.iter().enumerate() {
+        let next_segment = &segments[i + 1];
+
+        match segment {
+            PathSegment::Key(key) => {
+                if !current.is_object() {
+                    return Err(JsonPathError::TypeMismatch {
+                        expected: "object",
+                        found: value_type_name(current),
+                    });
+                }
+                let obj = current.as_object_mut().unwrap();
+                if !obj.contains_key(key) {
+                    let new_container = match next_segment {
+                        PathSegment::Key(_) => serde_json::Value::Object(serde_json::Map::new()),
+                        PathSegment::Index(_) => serde_json::Value::Array(Vec::new()),
+                    };
+                    obj.insert(key.clone(), new_container);
+                }
+                current = obj.get_mut(key).unwrap();
+            }
+            PathSegment::Index(idx) => {
+                if !current.is_array() {
+                    return Err(JsonPathError::TypeMismatch {
+                        expected: "array",
+                        found: value_type_name(current),
+                    });
+                }
+                let arr = current.as_array_mut().unwrap();
+                if *idx >= arr.len() {
+                    return Err(JsonPathError::IndexOutOfBounds {
+                        index: *idx,
+                        len: arr.len(),
+                    });
+                }
+                current = &mut arr[*idx];
+            }
+        }
+    }
+
+    // Set the value at the last segment
+    match last_segment {
+        PathSegment::Key(key) => {
+            if !current.is_object() {
+                return Err(JsonPathError::TypeMismatch {
+                    expected: "object",
+                    found: value_type_name(current),
+                });
+            }
+            let obj = current.as_object_mut().unwrap();
+            obj.insert(key.clone(), value.into_inner());
+            Ok(())
+        }
+        PathSegment::Index(idx) => {
+            if !current.is_array() {
+                return Err(JsonPathError::TypeMismatch {
+                    expected: "array",
+                    found: value_type_name(current),
+                });
+            }
+            let arr = current.as_array_mut().unwrap();
+            if *idx < arr.len() {
+                arr[*idx] = value.into_inner();
+                Ok(())
+            } else if *idx == arr.len() {
+                arr.push(value.into_inner());
+                Ok(())
+            } else {
+                Err(JsonPathError::IndexOutOfBounds {
+                    index: *idx,
+                    len: arr.len(),
+                })
+            }
+        }
+    }
+}
+
+/// Helper to get type name for error messages
+fn value_type_name(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+// =============================================================================
+// Path Deletion (Story #270)
+// =============================================================================
+
+/// Delete value at path within a JSON document
+///
+/// Removes the value at the specified path. For objects, this removes the key.
+/// For arrays, this removes the element and shifts subsequent elements.
+/// Deleting the root replaces the value with null.
+///
+/// # Arguments
+///
+/// * `root` - The root JSON value to modify
+/// * `path` - The path to delete
+///
+/// # Returns
+///
+/// * `Ok(Some(value))` - The deleted value
+/// * `Ok(None)` - The path didn't exist
+/// * `Err(JsonPathError)` - Type mismatch during traversal
+///
+/// # Examples
+///
+/// ```
+/// use in_mem_core::json::{JsonValue, JsonPath, delete_at_path, get_at_path};
+///
+/// // Delete object key
+/// let mut json: JsonValue = r#"{"name": "Alice", "age": 30}"#.parse().unwrap();
+/// let deleted = delete_at_path(&mut json, &"name".parse().unwrap()).unwrap();
+/// assert_eq!(deleted.unwrap().as_str(), Some("Alice"));
+/// assert!(get_at_path(&json, &"name".parse().unwrap()).is_none());
+///
+/// // Delete array element (shifts indices)
+/// let mut arr: JsonValue = r#"[1, 2, 3]"#.parse().unwrap();
+/// delete_at_path(&mut arr, &"[1]".parse().unwrap()).unwrap();
+/// assert_eq!(arr.as_array().unwrap().len(), 2);
+/// assert_eq!(arr.as_array().unwrap()[1].as_i64(), Some(3)); // Was at index 2
+/// ```
+pub fn delete_at_path(
+    root: &mut JsonValue,
+    path: &JsonPath,
+) -> Result<Option<JsonValue>, JsonPathError> {
+    // Handle root path - replace with null
+    if path.is_root() {
+        let old = std::mem::take(root);
+        return Ok(Some(old));
+    }
+
+    let segments = path.segments();
+    if segments.is_empty() {
+        let old = std::mem::take(root);
+        return Ok(Some(old));
+    }
+
+    // Navigate to parent
+    let parent_path = path.parent().ok_or(JsonPathError::NotFound)?;
+    let parent = get_at_path_mut(root, &parent_path).ok_or(JsonPathError::NotFound)?;
+    let parent_inner = parent.as_inner_mut();
+
+    // Delete at the last segment
+    let last_segment = segments.last().unwrap();
+    match last_segment {
+        PathSegment::Key(key) => {
+            if !parent_inner.is_object() {
+                return Err(JsonPathError::TypeMismatch {
+                    expected: "object",
+                    found: value_type_name(parent_inner),
+                });
+            }
+            let obj = parent_inner.as_object_mut().unwrap();
+            let removed = obj.remove(key);
+            Ok(removed.map(JsonValue::from_value))
+        }
+        PathSegment::Index(idx) => {
+            if !parent_inner.is_array() {
+                return Err(JsonPathError::TypeMismatch {
+                    expected: "array",
+                    found: value_type_name(parent_inner),
+                });
+            }
+            let arr = parent_inner.as_array_mut().unwrap();
+            if *idx < arr.len() {
+                let removed = arr.remove(*idx);
+                Ok(Some(JsonValue::from_value(removed)))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Patch Application (Story #271)
+// =============================================================================
+
+/// Apply multiple patches to a JSON document
+///
+/// Applies each patch in order. If any patch fails, the document may be
+/// left in a partially modified state (patches are not atomic).
+///
+/// # Arguments
+///
+/// * `root` - The root JSON value to modify
+/// * `patches` - The patches to apply in order
+///
+/// # Returns
+///
+/// * `Ok(())` - All patches applied successfully
+/// * `Err(JsonPathError)` - A patch failed to apply
+///
+/// # Examples
+///
+/// ```
+/// use in_mem_core::json::{JsonValue, JsonPath, JsonPatch, apply_patches, get_at_path};
+///
+/// let mut json = JsonValue::object();
+///
+/// let patches = vec![
+///     JsonPatch::set("name", JsonValue::from("Alice")),
+///     JsonPatch::set("age", JsonValue::from(30i64)),
+///     JsonPatch::set("tags", JsonValue::array()),
+/// ];
+///
+/// apply_patches(&mut json, &patches).unwrap();
+///
+/// assert_eq!(get_at_path(&json, &"name".parse().unwrap()).unwrap().as_str(), Some("Alice"));
+/// assert_eq!(get_at_path(&json, &"age".parse().unwrap()).unwrap().as_i64(), Some(30));
+/// ```
+pub fn apply_patches(root: &mut JsonValue, patches: &[JsonPatch]) -> Result<(), JsonPathError> {
+    for patch in patches {
+        match patch {
+            JsonPatch::Set { path, value } => {
+                set_at_path(root, path, value.clone())?;
+            }
+            JsonPatch::Delete { path } => {
+                delete_at_path(root, path)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_json_value_null() {
+        let v = JsonValue::null();
+        assert!(v.is_null());
+    }
+
+    #[test]
+    fn test_json_value_object() {
+        let v = JsonValue::object();
+        assert!(v.is_object());
+        assert_eq!(v.as_object().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_json_value_array() {
+        let v = JsonValue::array();
+        assert!(v.is_array());
+        assert_eq!(v.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_json_value_from_bool() {
+        let t = JsonValue::from(true);
+        let f = JsonValue::from(false);
+        assert_eq!(t.as_bool(), Some(true));
+        assert_eq!(f.as_bool(), Some(false));
+    }
+
+    #[test]
+    fn test_json_value_from_i64() {
+        let v = JsonValue::from(42i64);
+        assert_eq!(v.as_i64(), Some(42));
+    }
+
+    #[test]
+    fn test_json_value_from_i32() {
+        let v = JsonValue::from(42i32);
+        assert_eq!(v.as_i64(), Some(42));
+    }
+
+    #[test]
+    fn test_json_value_from_u64() {
+        let v = JsonValue::from(42u64);
+        assert_eq!(v.as_u64(), Some(42));
+    }
+
+    #[test]
+    fn test_json_value_from_f64() {
+        let v = JsonValue::from(3.14f64);
+        assert!((v.as_f64().unwrap() - 3.14).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_json_value_from_str_ref() {
+        let v = JsonValue::from("hello");
+        assert_eq!(v.as_str(), Some("hello"));
+    }
+
+    #[test]
+    fn test_json_value_from_string() {
+        let v = JsonValue::from("world".to_string());
+        assert_eq!(v.as_str(), Some("world"));
+    }
+
+    #[test]
+    fn test_json_value_from_vec() {
+        let v: JsonValue = vec![1i64, 2, 3].into();
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_i64(), Some(1));
+    }
+
+    #[test]
+    fn test_json_value_from_option_some() {
+        let v: JsonValue = Some(42i64).into();
+        assert_eq!(v.as_i64(), Some(42));
+    }
+
+    #[test]
+    fn test_json_value_from_option_none() {
+        let v: JsonValue = Option::<i64>::None.into();
+        assert!(v.is_null());
+    }
+
+    #[test]
+    fn test_json_value_deref() {
+        let v = JsonValue::from(42i64);
+        // Access serde_json::Value methods via Deref
+        assert!(v.is_number());
+        assert!(!v.is_string());
+    }
+
+    #[test]
+    fn test_json_value_deref_mut() {
+        let mut v = JsonValue::object();
+        // Mutate via DerefMut
+        v.as_object_mut()
+            .unwrap()
+            .insert("key".to_string(), serde_json::json!(123));
+        assert_eq!(v["key"].as_i64(), Some(123));
+    }
+
+    #[test]
+    fn test_json_value_parse() {
+        let v: JsonValue = r#"{"name": "test", "value": 42}"#.parse().unwrap();
+        assert!(v.is_object());
+        assert_eq!(v["name"].as_str(), Some("test"));
+        assert_eq!(v["value"].as_i64(), Some(42));
+    }
+
+    #[test]
+    fn test_json_value_parse_invalid() {
+        let result: Result<JsonValue, _> = "not valid json {".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_json_value_to_json_string() {
+        let v: JsonValue = r#"{"a":1}"#.parse().unwrap();
+        let s = v.to_json_string();
+        assert!(s.contains("\"a\""));
+        assert!(s.contains("1"));
+    }
+
+    #[test]
+    fn test_json_value_display() {
+        let v = JsonValue::from(42i64);
+        let s = format!("{}", v);
+        assert_eq!(s, "42");
+    }
+
+    #[test]
+    fn test_json_value_default() {
+        let v = JsonValue::default();
+        assert!(v.is_null());
+    }
+
+    #[test]
+    fn test_json_value_clone() {
+        let v1 = JsonValue::from("test");
+        let v2 = v1.clone();
+        assert_eq!(v1, v2);
+    }
+
+    #[test]
+    fn test_json_value_equality() {
+        let v1 = JsonValue::from(42i64);
+        let v2 = JsonValue::from(42i64);
+        let v3 = JsonValue::from(43i64);
+        assert_eq!(v1, v2);
+        assert_ne!(v1, v3);
+    }
+
+    #[test]
+    fn test_json_value_serialization() {
+        let v: JsonValue = r#"{"key": "value"}"#.parse().unwrap();
+        let json = serde_json::to_string(&v).unwrap();
+        let v2: JsonValue = serde_json::from_str(&json).unwrap();
+        assert_eq!(v, v2);
+    }
+
+    #[test]
+    fn test_json_value_into_inner() {
+        let v = JsonValue::from(42i64);
+        let inner: serde_json::Value = v.into_inner();
+        assert_eq!(inner.as_i64(), Some(42));
+    }
+
+    #[test]
+    fn test_json_value_as_inner() {
+        let v = JsonValue::from(42i64);
+        let inner: &serde_json::Value = v.as_inner();
+        assert_eq!(inner.as_i64(), Some(42));
+    }
+
+    #[test]
+    fn test_json_value_size_bytes() {
+        let v: JsonValue = r#"{"key": "value"}"#.parse().unwrap();
+        let size = v.size_bytes();
+        // Should be at least the length of the JSON string
+        assert!(size > 0);
+        assert!(size <= 20); // Reasonable upper bound for this small object
+    }
+
+    #[test]
+    fn test_json_value_from_serde_json_value() {
+        let serde_val = serde_json::json!({"nested": {"deep": true}});
+        let v = JsonValue::from(serde_val);
+        assert!(v.is_object());
+        assert!(v["nested"]["deep"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_json_value_into_serde_json_value() {
+        let v = JsonValue::from(42i64);
+        let serde_val: serde_json::Value = v.into();
+        assert_eq!(serde_val.as_i64(), Some(42));
+    }
+
+    #[test]
+    fn test_json_value_f64_nan() {
+        // NaN/Infinity cannot be represented in JSON, should become null
+        let v = JsonValue::from(f64::NAN);
+        assert!(v.is_null());
+    }
+
+    #[test]
+    fn test_json_value_f64_infinity() {
+        // Infinity cannot be represented in JSON, should become null
+        let v = JsonValue::from(f64::INFINITY);
+        assert!(v.is_null());
+    }
+
+    #[test]
+    fn test_json_value_nested_modification() {
+        let mut v: JsonValue = r#"{"user": {"name": "Alice"}}"#.parse().unwrap();
+        v["user"]["name"] = serde_json::json!("Bob");
+        assert_eq!(v["user"]["name"].as_str(), Some("Bob"));
+    }
+
+    #[test]
+    fn test_json_value_to_json_string_pretty() {
+        let v: JsonValue = r#"{"a":1,"b":2}"#.parse().unwrap();
+        let pretty = v.to_json_string_pretty();
+        // Pretty output should have newlines
+        assert!(pretty.contains('\n'));
+    }
+
+    #[test]
+    fn test_json_value_from_value() {
+        let serde_val = serde_json::json!([1, 2, 3]);
+        let v = JsonValue::from_value(serde_val);
+        assert!(v.is_array());
+        assert_eq!(v.as_array().unwrap().len(), 3);
+    }
+
+    // ========================================
+    // JsonPath Tests (M5)
+    // ========================================
+
+    #[test]
+    fn test_path_root() {
+        let root = JsonPath::root();
+        assert!(root.is_root());
+        assert!(root.is_empty());
+        assert_eq!(root.len(), 0);
+    }
+
+    #[test]
+    fn test_path_key_builder() {
+        let path = JsonPath::root().key("user").key("name");
+        assert_eq!(path.len(), 2);
+        assert!(!path.is_root());
+        assert_eq!(
+            path.segments(),
+            &[
+                PathSegment::Key("user".to_string()),
+                PathSegment::Key("name".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_path_index_builder() {
+        let path = JsonPath::root().key("items").index(0);
+        assert_eq!(path.len(), 2);
+        assert_eq!(
+            path.segments(),
+            &[PathSegment::Key("items".to_string()), PathSegment::Index(0)]
+        );
+    }
+
+    #[test]
+    fn test_path_push_methods() {
+        let mut path = JsonPath::root();
+        path.push_key("user");
+        path.push_index(0);
+        path.push_key("name");
+        assert_eq!(path.len(), 3);
+    }
+
+    #[test]
+    fn test_path_parse_simple_key() {
+        let path: JsonPath = "user".parse().unwrap();
+        assert_eq!(path.len(), 1);
+        assert_eq!(path.segments(), &[PathSegment::Key("user".to_string())]);
+    }
+
+    #[test]
+    fn test_path_parse_dotted_keys() {
+        let path: JsonPath = "user.name".parse().unwrap();
+        assert_eq!(path.len(), 2);
+        assert_eq!(
+            path.segments(),
+            &[
+                PathSegment::Key("user".to_string()),
+                PathSegment::Key("name".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_path_parse_leading_dot() {
+        let path: JsonPath = ".user.name".parse().unwrap();
+        assert_eq!(path.len(), 2);
+        assert_eq!(
+            path.segments(),
+            &[
+                PathSegment::Key("user".to_string()),
+                PathSegment::Key("name".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_path_parse_array_index() {
+        let path: JsonPath = "[0]".parse().unwrap();
+        assert_eq!(path.len(), 1);
+        assert_eq!(path.segments(), &[PathSegment::Index(0)]);
+    }
+
+    #[test]
+    fn test_path_parse_key_then_index() {
+        let path: JsonPath = "items[0]".parse().unwrap();
+        assert_eq!(path.len(), 2);
+        assert_eq!(
+            path.segments(),
+            &[PathSegment::Key("items".to_string()), PathSegment::Index(0)]
+        );
+    }
+
+    #[test]
+    fn test_path_parse_complex() {
+        let path: JsonPath = "users[0].profile.settings[2].value".parse().unwrap();
+        assert_eq!(path.len(), 6);
+        assert_eq!(
+            path.segments(),
+            &[
+                PathSegment::Key("users".to_string()),
+                PathSegment::Index(0),
+                PathSegment::Key("profile".to_string()),
+                PathSegment::Key("settings".to_string()),
+                PathSegment::Index(2),
+                PathSegment::Key("value".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_path_parse_empty() {
+        let path: JsonPath = "".parse().unwrap();
+        assert!(path.is_root());
+    }
+
+    #[test]
+    fn test_path_parse_with_underscore() {
+        let path: JsonPath = "user_name".parse().unwrap();
+        assert_eq!(
+            path.segments(),
+            &[PathSegment::Key("user_name".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_path_parse_with_hyphen() {
+        let path: JsonPath = "content-type".parse().unwrap();
+        assert_eq!(
+            path.segments(),
+            &[PathSegment::Key("content-type".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_path_parse_error_unclosed_bracket() {
+        let result: Result<JsonPath, _> = "items[0".parse();
+        assert!(matches!(result, Err(PathParseError::UnclosedBracket(_))));
+    }
+
+    #[test]
+    fn test_path_parse_error_invalid_index() {
+        let result: Result<JsonPath, _> = "items[abc]".parse();
+        assert!(matches!(result, Err(PathParseError::InvalidIndex(_, _))));
+    }
+
+    #[test]
+    fn test_path_parse_error_empty_key() {
+        let result: Result<JsonPath, _> = "user.".parse();
+        assert!(matches!(result, Err(PathParseError::EmptyKey(_))));
+    }
+
+    #[test]
+    fn test_path_parent() {
+        let path = JsonPath::root().key("user").key("name");
+        let parent = path.parent().unwrap();
+        assert_eq!(parent.len(), 1);
+        assert_eq!(parent.segments(), &[PathSegment::Key("user".to_string())]);
+
+        let grandparent = parent.parent().unwrap();
+        assert!(grandparent.is_root());
+
+        assert!(grandparent.parent().is_none());
+    }
+
+    #[test]
+    fn test_path_last_segment() {
+        let path = JsonPath::root().key("user").index(0);
+        assert_eq!(path.last_segment(), Some(&PathSegment::Index(0)));
+
+        let root = JsonPath::root();
+        assert_eq!(root.last_segment(), None);
+    }
+
+    #[test]
+    fn test_path_is_ancestor_of() {
+        let root = JsonPath::root();
+        let user = JsonPath::root().key("user");
+        let user_name = JsonPath::root().key("user").key("name");
+        let items = JsonPath::root().key("items");
+
+        // Root is ancestor of all
+        assert!(root.is_ancestor_of(&root));
+        assert!(root.is_ancestor_of(&user));
+        assert!(root.is_ancestor_of(&user_name));
+
+        // Paths are ancestors of themselves
+        assert!(user.is_ancestor_of(&user));
+        assert!(user_name.is_ancestor_of(&user_name));
+
+        // Parent is ancestor of child
+        assert!(user.is_ancestor_of(&user_name));
+
+        // Child is not ancestor of parent
+        assert!(!user_name.is_ancestor_of(&user));
+
+        // Unrelated paths are not ancestors
+        assert!(!user.is_ancestor_of(&items));
+        assert!(!items.is_ancestor_of(&user));
+    }
+
+    #[test]
+    fn test_path_is_descendant_of() {
+        let root = JsonPath::root();
+        let user = JsonPath::root().key("user");
+        let user_name = JsonPath::root().key("user").key("name");
+
+        // All paths are descendants of root
+        assert!(root.is_descendant_of(&root));
+        assert!(user.is_descendant_of(&root));
+        assert!(user_name.is_descendant_of(&root));
+
+        // Paths are descendants of themselves
+        assert!(user.is_descendant_of(&user));
+
+        // Child is descendant of parent
+        assert!(user_name.is_descendant_of(&user));
+
+        // Parent is not descendant of child
+        assert!(!user.is_descendant_of(&user_name));
+    }
+
+    #[test]
+    fn test_path_overlaps() {
+        let user = JsonPath::root().key("user");
+        let user_name = JsonPath::root().key("user").key("name");
+        let items = JsonPath::root().key("items");
+
+        // Ancestor/descendant paths overlap
+        assert!(user.overlaps(&user_name));
+        assert!(user_name.overlaps(&user));
+
+        // Paths overlap with themselves
+        assert!(user.overlaps(&user));
+
+        // Unrelated paths don't overlap
+        assert!(!user.overlaps(&items));
+        assert!(!items.overlaps(&user_name));
+    }
+
+    #[test]
+    fn test_strict_ancestor_descendant() {
+        let root = JsonPath::root();
+        let user = JsonPath::root().key("user");
+        let user_name = JsonPath::root().key("user").key("name");
+        let items = JsonPath::root().key("items");
+
+        // Root is strict ancestor of non-root paths
+        assert!(root.is_strict_ancestor_of(&user));
+        assert!(root.is_strict_ancestor_of(&user_name));
+
+        // Path is not a strict ancestor of itself
+        assert!(!user.is_strict_ancestor_of(&user));
+        assert!(!root.is_strict_ancestor_of(&root));
+
+        // Parent is strict ancestor of child
+        assert!(user.is_strict_ancestor_of(&user_name));
+        assert!(!user_name.is_strict_ancestor_of(&user));
+
+        // Unrelated paths are not strict ancestors
+        assert!(!user.is_strict_ancestor_of(&items));
+        assert!(!items.is_strict_ancestor_of(&user));
+
+        // Strict descendant is inverse
+        assert!(user.is_strict_descendant_of(&root));
+        assert!(user_name.is_strict_descendant_of(&user));
+        assert!(user_name.is_strict_descendant_of(&root));
+        assert!(!user.is_strict_descendant_of(&user));
+    }
+
+    #[test]
+    fn test_common_ancestor() {
+        let root = JsonPath::root();
+        let user = JsonPath::root().key("user");
+        let user_name = JsonPath::root().key("user").key("name");
+        let user_email = JsonPath::root().key("user").key("email");
+        let items = JsonPath::root().key("items");
+
+        // Common ancestor of path with itself is the path
+        assert_eq!(user.common_ancestor(&user), user);
+
+        // Common ancestor of parent/child is parent
+        assert_eq!(user.common_ancestor(&user_name), user);
+        assert_eq!(user_name.common_ancestor(&user), user);
+
+        // Common ancestor of siblings is their parent
+        assert_eq!(user_name.common_ancestor(&user_email), user);
+
+        // Common ancestor of unrelated paths is root
+        assert_eq!(user.common_ancestor(&items), root);
+
+        // Common ancestor with root is root
+        assert_eq!(user.common_ancestor(&root), root);
+    }
+
+    #[test]
+    fn test_is_affected_by() {
+        let user = JsonPath::root().key("user");
+        let user_name = JsonPath::root().key("user").key("name");
+        let items = JsonPath::root().key("items");
+
+        // Write to parent affects child
+        assert!(user_name.is_affected_by(&user));
+
+        // Write to child affects parent (partial modification)
+        assert!(user.is_affected_by(&user_name));
+
+        // Write to self affects self
+        assert!(user.is_affected_by(&user));
+
+        // Unrelated paths don't affect each other
+        assert!(!user.is_affected_by(&items));
+        assert!(!items.is_affected_by(&user_name));
+    }
+
+    #[test]
+    fn test_path_to_string() {
+        assert_eq!(JsonPath::root().to_path_string(), "");
+        assert_eq!(JsonPath::root().key("user").to_path_string(), "user");
+        assert_eq!(
+            JsonPath::root().key("user").key("name").to_path_string(),
+            "user.name"
+        );
+        assert_eq!(
+            JsonPath::root().key("items").index(0).to_path_string(),
+            "items[0]"
+        );
+        assert_eq!(
+            JsonPath::root()
+                .key("items")
+                .index(0)
+                .key("name")
+                .to_path_string(),
+            "items[0].name"
+        );
+    }
+
+    #[test]
+    fn test_path_display() {
+        let path = JsonPath::root().key("user").key("name");
+        assert_eq!(format!("{}", path), "user.name");
+    }
+
+    #[test]
+    fn test_path_default() {
+        let path = JsonPath::default();
+        assert!(path.is_root());
+    }
+
+    #[test]
+    fn test_path_clone() {
+        let path1 = JsonPath::root().key("user");
+        let path2 = path1.clone();
+        assert_eq!(path1, path2);
+    }
+
+    #[test]
+    fn test_path_equality() {
+        let path1 = JsonPath::root().key("user").key("name");
+        let path2: JsonPath = "user.name".parse().unwrap();
+        let path3 = JsonPath::root().key("user").key("email");
+
+        assert_eq!(path1, path2);
+        assert_ne!(path1, path3);
+    }
+
+    #[test]
+    fn test_path_hash() {
+        use std::collections::HashSet;
+
+        let path1 = JsonPath::root().key("user");
+        let path2: JsonPath = "user".parse().unwrap();
+        let path3 = JsonPath::root().key("items");
+
+        let mut set = HashSet::new();
+        set.insert(path1.clone());
+        set.insert(path2); // Same as path1
+        set.insert(path3);
+
+        assert_eq!(set.len(), 2);
+        assert!(set.contains(&path1));
+    }
+
+    #[test]
+    fn test_path_serialization() {
+        let path = JsonPath::root().key("user").index(0).key("name");
+        let json = serde_json::to_string(&path).unwrap();
+        let path2: JsonPath = serde_json::from_str(&json).unwrap();
+        assert_eq!(path, path2);
+    }
+
+    #[test]
+    fn test_path_segment_display() {
+        assert_eq!(format!("{}", PathSegment::Key("foo".to_string())), ".foo");
+        assert_eq!(format!("{}", PathSegment::Index(42)), "[42]");
+    }
+
+    #[test]
+    fn test_path_from_segments() {
+        let segments = vec![PathSegment::Key("user".to_string()), PathSegment::Index(0)];
+        let path = JsonPath::from_segments(segments.clone());
+        assert_eq!(path.segments(), &segments);
+    }
+
+    // ========================================
+    // JsonPatch Tests (M5)
+    // ========================================
+
+    #[test]
+    fn test_patch_set() {
+        let patch = JsonPatch::set("user.name", JsonValue::from("Alice"));
+        assert!(patch.is_set());
+        assert!(!patch.is_delete());
+        assert_eq!(patch.path().to_path_string(), "user.name");
+        assert_eq!(patch.value().unwrap().as_str(), Some("Alice"));
+    }
+
+    #[test]
+    fn test_patch_set_at() {
+        let path = JsonPath::root().key("user").key("name");
+        let patch = JsonPatch::set_at(path.clone(), JsonValue::from("Bob"));
+        assert!(patch.is_set());
+        assert_eq!(patch.path(), &path);
+    }
+
+    #[test]
+    fn test_patch_delete() {
+        let patch = JsonPatch::delete("user.email");
+        assert!(!patch.is_set());
+        assert!(patch.is_delete());
+        assert_eq!(patch.path().to_path_string(), "user.email");
+        assert!(patch.value().is_none());
+    }
+
+    #[test]
+    fn test_patch_delete_at() {
+        let path = JsonPath::root().key("user").key("email");
+        let patch = JsonPatch::delete_at(path.clone());
+        assert!(patch.is_delete());
+        assert_eq!(patch.path(), &path);
+    }
+
+    #[test]
+    fn test_patch_conflicts_with_overlapping() {
+        let patch1 = JsonPatch::set("user", JsonValue::object());
+        let patch2 = JsonPatch::set("user.name", JsonValue::from("Alice"));
+
+        // Parent/child paths conflict
+        assert!(patch1.conflicts_with(&patch2));
+        assert!(patch2.conflicts_with(&patch1));
+    }
+
+    #[test]
+    fn test_patch_conflicts_with_same_path() {
+        let patch1 = JsonPatch::set("user.name", JsonValue::from("Alice"));
+        let patch2 = JsonPatch::set("user.name", JsonValue::from("Bob"));
+
+        // Same path conflicts
+        assert!(patch1.conflicts_with(&patch2));
+    }
+
+    #[test]
+    fn test_patch_no_conflict_different_paths() {
+        let patch1 = JsonPatch::set("user.name", JsonValue::from("Alice"));
+        let patch2 = JsonPatch::set("user.email", JsonValue::from("alice@example.com"));
+
+        // Sibling paths don't conflict
+        assert!(!patch1.conflicts_with(&patch2));
+        assert!(!patch2.conflicts_with(&patch1));
+    }
+
+    #[test]
+    fn test_patch_delete_conflicts() {
+        let set_patch = JsonPatch::set("user.profile", JsonValue::object());
+        let delete_patch = JsonPatch::delete("user");
+
+        // Delete of ancestor conflicts with set of descendant
+        assert!(set_patch.conflicts_with(&delete_patch));
+        assert!(delete_patch.conflicts_with(&set_patch));
+    }
+
+    #[test]
+    fn test_patch_display_set() {
+        let patch = JsonPatch::set("user.name", JsonValue::from("Alice"));
+        let s = format!("{}", patch);
+        assert!(s.starts_with("SET"));
+        assert!(s.contains("user.name"));
+        assert!(s.contains("Alice"));
+    }
+
+    #[test]
+    fn test_patch_display_delete() {
+        let patch = JsonPatch::delete("user.email");
+        let s = format!("{}", patch);
+        assert!(s.starts_with("DELETE"));
+        assert!(s.contains("user.email"));
+    }
+
+    #[test]
+    fn test_patch_clone() {
+        let patch1 = JsonPatch::set("user.name", JsonValue::from("Alice"));
+        let patch2 = patch1.clone();
+        assert_eq!(patch1, patch2);
+    }
+
+    #[test]
+    fn test_patch_equality() {
+        let patch1 = JsonPatch::set("user.name", JsonValue::from("Alice"));
+        let patch2 = JsonPatch::set("user.name", JsonValue::from("Alice"));
+        let patch3 = JsonPatch::set("user.name", JsonValue::from("Bob"));
+        let patch4 = JsonPatch::delete("user.name");
+
+        assert_eq!(patch1, patch2);
+        assert_ne!(patch1, patch3);
+        assert_ne!(patch1, patch4);
+    }
+
+    #[test]
+    fn test_patch_serialization() {
+        let patch = JsonPatch::set("user.name", JsonValue::from("Alice"));
+        let json = serde_json::to_string(&patch).unwrap();
+        let patch2: JsonPatch = serde_json::from_str(&json).unwrap();
+        assert_eq!(patch, patch2);
+    }
+
+    #[test]
+    fn test_patch_delete_serialization() {
+        let patch = JsonPatch::delete("user.email");
+        let json = serde_json::to_string(&patch).unwrap();
+        let patch2: JsonPatch = serde_json::from_str(&json).unwrap();
+        assert_eq!(patch, patch2);
+    }
+
+    #[test]
+    fn test_patch_root_conflicts_with_all() {
+        let root_patch = JsonPatch::set("", JsonValue::object());
+        let other_patch = JsonPatch::set("user.name", JsonValue::from("Alice"));
+
+        // Root path conflicts with all paths
+        assert!(root_patch.conflicts_with(&other_patch));
+        assert!(other_patch.conflicts_with(&root_patch));
+    }
+
+    #[test]
+    fn test_patch_with_array_index() {
+        let patch1 = JsonPatch::set("items[0].name", JsonValue::from("First"));
+        let patch2 = JsonPatch::set("items[1].name", JsonValue::from("Second"));
+
+        // Different array indices don't conflict
+        assert!(!patch1.conflicts_with(&patch2));
+
+        let patch3 = JsonPatch::set("items", JsonValue::array());
+        // Parent of array conflicts with child path
+        assert!(patch3.conflicts_with(&patch1));
+    }
+
+    // ========================================
+    // Document Size Limits Tests (M5)
+    // ========================================
+
+    #[test]
+    fn test_limit_constants() {
+        // Verify limit constants are defined with expected values
+        assert_eq!(MAX_DOCUMENT_SIZE, 16 * 1024 * 1024); // 16 MB
+        assert_eq!(MAX_NESTING_DEPTH, 100);
+        assert_eq!(MAX_PATH_LENGTH, 256);
+        assert_eq!(MAX_ARRAY_SIZE, 1_000_000);
+    }
+
+    #[test]
+    fn test_nesting_depth_primitive() {
+        assert_eq!(JsonValue::null().nesting_depth(), 0);
+        assert_eq!(JsonValue::from(true).nesting_depth(), 0);
+        assert_eq!(JsonValue::from(42i64).nesting_depth(), 0);
+        assert_eq!(JsonValue::from("hello").nesting_depth(), 0);
+    }
+
+    #[test]
+    fn test_nesting_depth_simple_object() {
+        let v = JsonValue::object();
+        assert_eq!(v.nesting_depth(), 1);
+    }
+
+    #[test]
+    fn test_nesting_depth_simple_array() {
+        let v = JsonValue::array();
+        assert_eq!(v.nesting_depth(), 1);
+    }
+
+    #[test]
+    fn test_nesting_depth_nested() {
+        let v: JsonValue = r#"{"a": {"b": {"c": 1}}}"#.parse().unwrap();
+        assert_eq!(v.nesting_depth(), 3);
+    }
+
+    #[test]
+    fn test_nesting_depth_mixed() {
+        let v: JsonValue = r#"{"arr": [{"nested": [1, 2]}]}"#.parse().unwrap();
+        assert_eq!(v.nesting_depth(), 4);
+    }
+
+    #[test]
+    fn test_max_array_size_empty() {
+        let v = JsonValue::object();
+        assert_eq!(v.max_array_size(), 0);
+    }
+
+    #[test]
+    fn test_max_array_size_simple() {
+        let v: JsonValue = r#"[1, 2, 3, 4, 5]"#.parse().unwrap();
+        assert_eq!(v.max_array_size(), 5);
+    }
+
+    #[test]
+    fn test_max_array_size_nested() {
+        let v: JsonValue = r#"{"a": [1, 2], "b": [1, 2, 3, 4, 5, 6, 7]}"#.parse().unwrap();
+        assert_eq!(v.max_array_size(), 7);
+    }
+
+    #[test]
+    fn test_validate_size_ok() {
+        let v = JsonValue::from("small document");
+        assert!(v.validate_size().is_ok());
+    }
+
+    #[test]
+    fn test_validate_depth_ok() {
+        let v: JsonValue = r#"{"a": {"b": {"c": 1}}}"#.parse().unwrap();
+        assert!(v.validate_depth().is_ok());
+    }
+
+    #[test]
+    fn test_validate_array_size_ok() {
+        let v: JsonValue = r#"[1, 2, 3]"#.parse().unwrap();
+        assert!(v.validate_array_size().is_ok());
+    }
+
+    #[test]
+    fn test_validate_all_ok() {
+        let v: JsonValue = r#"{"user": {"name": "Alice", "tags": [1, 2, 3]}}"#.parse().unwrap();
+        assert!(v.validate().is_ok());
+    }
+
+    #[test]
+    fn test_path_validate_ok() {
+        let path = JsonPath::root().key("user").key("name");
+        assert!(path.validate().is_ok());
+    }
+
+    #[test]
+    fn test_path_validate_long_path() {
+        let mut path = JsonPath::root();
+        for i in 0..300 {
+            path.push_key(format!("key{}", i));
+        }
+        let result = path.validate();
+        assert!(matches!(result, Err(LimitError::PathTooLong { .. })));
+    }
+
+    #[test]
+    fn test_limit_error_display() {
+        let err = LimitError::DocumentTooLarge {
+            size: 20_000_000,
+            max: MAX_DOCUMENT_SIZE,
+        };
+        let s = format!("{}", err);
+        assert!(s.contains("20000000"));
+        assert!(s.contains("16777216"));
+    }
+
+    #[test]
+    fn test_limit_error_nesting_display() {
+        let err = LimitError::NestingTooDeep {
+            depth: 150,
+            max: MAX_NESTING_DEPTH,
+        };
+        let s = format!("{}", err);
+        assert!(s.contains("150"));
+        assert!(s.contains("100"));
+    }
+
+    #[test]
+    fn test_limit_error_path_display() {
+        let err = LimitError::PathTooLong {
+            length: 300,
+            max: MAX_PATH_LENGTH,
+        };
+        let s = format!("{}", err);
+        assert!(s.contains("300"));
+        assert!(s.contains("256"));
+    }
+
+    #[test]
+    fn test_limit_error_array_display() {
+        let err = LimitError::ArrayTooLarge {
+            size: 2_000_000,
+            max: MAX_ARRAY_SIZE,
+        };
+        let s = format!("{}", err);
+        assert!(s.contains("2000000"));
+        assert!(s.contains("1000000"));
+    }
+
+    #[test]
+    fn test_limit_error_equality() {
+        let err1 = LimitError::DocumentTooLarge { size: 100, max: 50 };
+        let err2 = LimitError::DocumentTooLarge { size: 100, max: 50 };
+        let err3 = LimitError::DocumentTooLarge { size: 200, max: 50 };
+        assert_eq!(err1, err2);
+        assert_ne!(err1, err3);
+    }
+
+    #[test]
+    fn test_limit_error_clone() {
+        let err = LimitError::PathTooLong {
+            length: 300,
+            max: 256,
+        };
+        let err2 = err.clone();
+        assert_eq!(err, err2);
+    }
+
+    // =========================================================================
+    // Path Operations Tests (Story #268)
+    // =========================================================================
+
+    #[test]
+    fn test_get_at_path_root() {
+        let value = JsonValue::from(42i64);
+        let result = get_at_path(&value, &JsonPath::root());
+        assert_eq!(result, Some(&value));
+    }
+
+    #[test]
+    fn test_get_at_path_simple_object() {
+        let json: JsonValue = r#"{"foo": 42}"#.parse().unwrap();
+        let path: JsonPath = "foo".parse().unwrap();
+        let result = get_at_path(&json, &path);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().as_i64(), Some(42));
+    }
+
+    #[test]
+    fn test_get_at_path_nested_object() {
+        let json: JsonValue = r#"{"foo": {"bar": 42}}"#.parse().unwrap();
+        let path: JsonPath = "foo.bar".parse().unwrap();
+        let result = get_at_path(&json, &path);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().as_i64(), Some(42));
+    }
+
+    #[test]
+    fn test_get_at_path_array_index() {
+        let json: JsonValue = r#"[1, 2, 3]"#.parse().unwrap();
+        let path: JsonPath = "[1]".parse().unwrap();
+        let result = get_at_path(&json, &path);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().as_i64(), Some(2));
+    }
+
+    #[test]
+    fn test_get_at_path_mixed() {
+        let json: JsonValue = r#"{"items": [{"name": "Alice"}, {"name": "Bob"}]}"#
+            .parse()
+            .unwrap();
+        let path: JsonPath = "items[1].name".parse().unwrap();
+        let result = get_at_path(&json, &path);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().as_str(), Some("Bob"));
+    }
+
+    #[test]
+    fn test_get_at_path_missing_key() {
+        let json: JsonValue = r#"{"foo": 42}"#.parse().unwrap();
+        let path: JsonPath = "bar".parse().unwrap();
+        let result = get_at_path(&json, &path);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_get_at_path_missing_index() {
+        let json: JsonValue = r#"[1, 2, 3]"#.parse().unwrap();
+        let path: JsonPath = "[10]".parse().unwrap();
+        let result = get_at_path(&json, &path);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_get_at_path_type_mismatch_object_as_array() {
+        let json: JsonValue = r#"{"foo": 42}"#.parse().unwrap();
+        let path: JsonPath = "[0]".parse().unwrap();
+        let result = get_at_path(&json, &path);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_get_at_path_type_mismatch_array_as_object() {
+        let json: JsonValue = r#"[1, 2, 3]"#.parse().unwrap();
+        let path: JsonPath = "foo".parse().unwrap();
+        let result = get_at_path(&json, &path);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_get_at_path_type_mismatch_scalar() {
+        let json: JsonValue = JsonValue::from(42i64);
+        let path: JsonPath = "foo".parse().unwrap();
+        let result = get_at_path(&json, &path);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_get_at_path_deeply_nested() {
+        let json: JsonValue = r#"{"a": {"b": {"c": {"d": {"e": 42}}}}}"#.parse().unwrap();
+        let path: JsonPath = "a.b.c.d.e".parse().unwrap();
+        let result = get_at_path(&json, &path);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().as_i64(), Some(42));
+    }
+
+    #[test]
+    fn test_get_at_path_mut_root() {
+        let mut value = JsonValue::from(42i64);
+        let result = get_at_path_mut(&mut value, &JsonPath::root());
+        assert!(result.is_some());
+        *result.unwrap() = JsonValue::from(100i64);
+        assert_eq!(value.as_i64(), Some(100));
+    }
+
+    #[test]
+    fn test_get_at_path_mut_modify_nested() {
+        let mut json: JsonValue = r#"{"user": {"name": "Alice"}}"#.parse().unwrap();
+        let path: JsonPath = "user.name".parse().unwrap();
+
+        if let Some(name) = get_at_path_mut(&mut json, &path) {
+            *name = JsonValue::from("Bob");
+        }
+
+        let result = get_at_path(&json, &path);
+        assert_eq!(result.unwrap().as_str(), Some("Bob"));
+    }
+
+    #[test]
+    fn test_get_at_path_mut_modify_array_element() {
+        let mut json: JsonValue = r#"[10, 20, 30]"#.parse().unwrap();
+        let path: JsonPath = "[1]".parse().unwrap();
+
+        if let Some(elem) = get_at_path_mut(&mut json, &path) {
+            *elem = JsonValue::from(999i64);
+        }
+
+        let result = get_at_path(&json, &path);
+        assert_eq!(result.unwrap().as_i64(), Some(999));
+    }
+
+    #[test]
+    fn test_get_at_path_mut_missing() {
+        let mut json: JsonValue = r#"{"foo": 42}"#.parse().unwrap();
+        let path: JsonPath = "bar".parse().unwrap();
+        let result = get_at_path_mut(&mut json, &path);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_json_path_error_display() {
+        let err = JsonPathError::TypeMismatch {
+            expected: "object",
+            found: "array",
+        };
+        let s = format!("{}", err);
+        assert!(s.contains("object"));
+        assert!(s.contains("array"));
+
+        let err2 = JsonPathError::IndexOutOfBounds { index: 10, len: 5 };
+        let s2 = format!("{}", err2);
+        assert!(s2.contains("10"));
+        assert!(s2.contains("5"));
+
+        let err3 = JsonPathError::NotFound;
+        let s3 = format!("{}", err3);
+        assert!(s3.contains("not found"));
+    }
+
+    #[test]
+    fn test_json_path_error_equality() {
+        let err1 = JsonPathError::IndexOutOfBounds { index: 5, len: 3 };
+        let err2 = JsonPathError::IndexOutOfBounds { index: 5, len: 3 };
+        let err3 = JsonPathError::IndexOutOfBounds { index: 10, len: 3 };
+        assert_eq!(err1, err2);
+        assert_ne!(err1, err3);
+    }
+
+    // =========================================================================
+    // Set at Path Tests (Story #269)
+    // =========================================================================
+
+    #[test]
+    fn test_set_at_path_root() {
+        let mut value = JsonValue::from(42i64);
+        set_at_path(&mut value, &JsonPath::root(), JsonValue::from(100i64)).unwrap();
+        assert_eq!(value.as_i64(), Some(100));
+    }
+
+    #[test]
+    fn test_set_at_path_simple_object() {
+        let mut json = JsonValue::object();
+        let path: JsonPath = "name".parse().unwrap();
+        set_at_path(&mut json, &path, JsonValue::from("Alice")).unwrap();
+
+        let result = get_at_path(&json, &path);
+        assert_eq!(result.unwrap().as_str(), Some("Alice"));
+    }
+
+    #[test]
+    fn test_set_at_path_nested_creates_intermediate() {
+        let mut json = JsonValue::object();
+        let path: JsonPath = "user.profile.name".parse().unwrap();
+        set_at_path(&mut json, &path, JsonValue::from("Bob")).unwrap();
+
+        // Verify intermediate objects were created
+        assert!(get_at_path(&json, &"user".parse().unwrap()).is_some());
+        assert!(get_at_path(&json, &"user.profile".parse().unwrap()).is_some());
+        assert_eq!(get_at_path(&json, &path).unwrap().as_str(), Some("Bob"));
+    }
+
+    #[test]
+    fn test_set_at_path_creates_array_intermediate() {
+        let mut json = JsonValue::object();
+        let path: JsonPath = "items[0]".parse().unwrap();
+
+        // First set up the array
+        set_at_path(&mut json, &"items".parse().unwrap(), JsonValue::array()).unwrap();
+
+        // Now set at index 0 (append)
+        set_at_path(&mut json, &path, JsonValue::from(42i64)).unwrap();
+
+        let result = get_at_path(&json, &path);
+        assert_eq!(result.unwrap().as_i64(), Some(42));
+    }
+
+    #[test]
+    fn test_set_at_path_overwrite_existing() {
+        let mut json: JsonValue = r#"{"name": "Alice"}"#.parse().unwrap();
+        let path: JsonPath = "name".parse().unwrap();
+        set_at_path(&mut json, &path, JsonValue::from("Bob")).unwrap();
+
+        assert_eq!(get_at_path(&json, &path).unwrap().as_str(), Some("Bob"));
+    }
+
+    #[test]
+    fn test_set_at_path_array_replace() {
+        let mut json: JsonValue = r#"[1, 2, 3]"#.parse().unwrap();
+        let path: JsonPath = "[1]".parse().unwrap();
+        set_at_path(&mut json, &path, JsonValue::from(999i64)).unwrap();
+
+        let arr = json.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[1].as_i64(), Some(999));
+    }
+
+    #[test]
+    fn test_set_at_path_array_append() {
+        let mut json: JsonValue = r#"[1, 2]"#.parse().unwrap();
+        let path: JsonPath = "[2]".parse().unwrap();
+        set_at_path(&mut json, &path, JsonValue::from(3i64)).unwrap();
+
+        let arr = json.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[2].as_i64(), Some(3));
+    }
+
+    #[test]
+    fn test_set_at_path_array_out_of_bounds() {
+        let mut json: JsonValue = r#"[1, 2]"#.parse().unwrap();
+        let path: JsonPath = "[10]".parse().unwrap();
+        let result = set_at_path(&mut json, &path, JsonValue::from(42i64));
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            JsonPathError::IndexOutOfBounds { .. }
+        ));
+    }
+
+    #[test]
+    fn test_set_at_path_type_mismatch_not_object() {
+        let mut json = JsonValue::from(42i64);
+        let path: JsonPath = "name".parse().unwrap();
+        let result = set_at_path(&mut json, &path, JsonValue::from("value"));
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            JsonPathError::TypeMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn test_set_at_path_type_mismatch_not_array() {
+        let mut json = JsonValue::from(42i64);
+        let path: JsonPath = "[0]".parse().unwrap();
+        let result = set_at_path(&mut json, &path, JsonValue::from("value"));
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            JsonPathError::TypeMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn test_set_at_path_deeply_nested() {
+        let mut json = JsonValue::object();
+        let path: JsonPath = "a.b.c.d.e".parse().unwrap();
+        set_at_path(&mut json, &path, JsonValue::from(42i64)).unwrap();
+
+        assert_eq!(get_at_path(&json, &path).unwrap().as_i64(), Some(42));
+    }
+
+    #[test]
+    fn test_set_at_path_mixed_path() {
+        let mut json = JsonValue::object();
+
+        // First create the structure
+        set_at_path(&mut json, &"items".parse().unwrap(), JsonValue::array()).unwrap();
+        set_at_path(&mut json, &"items[0]".parse().unwrap(), JsonValue::object()).unwrap();
+
+        // Now set nested value
+        let path: JsonPath = "items[0].name".parse().unwrap();
+        set_at_path(&mut json, &path, JsonValue::from("Item 1")).unwrap();
+
+        assert_eq!(get_at_path(&json, &path).unwrap().as_str(), Some("Item 1"));
+    }
+
+    // =========================================================================
+    // Delete at Path Tests (Story #270)
+    // =========================================================================
+
+    #[test]
+    fn test_delete_at_path_root() {
+        let mut json = JsonValue::from(42i64);
+        let deleted = delete_at_path(&mut json, &JsonPath::root()).unwrap();
+        assert_eq!(deleted.unwrap().as_i64(), Some(42));
+        assert!(json.is_null());
+    }
+
+    #[test]
+    fn test_delete_at_path_object_key() {
+        let mut json: JsonValue = r#"{"name": "Alice", "age": 30}"#.parse().unwrap();
+        let path: JsonPath = "name".parse().unwrap();
+        let deleted = delete_at_path(&mut json, &path).unwrap();
+
+        assert_eq!(deleted.unwrap().as_str(), Some("Alice"));
+        assert!(get_at_path(&json, &path).is_none());
+        // age should still exist
+        assert!(get_at_path(&json, &"age".parse().unwrap()).is_some());
+    }
+
+    #[test]
+    fn test_delete_at_path_nested_object() {
+        let mut json: JsonValue = r#"{"user": {"name": "Bob", "email": "bob@example.com"}}"#
+            .parse()
+            .unwrap();
+        let path: JsonPath = "user.name".parse().unwrap();
+        let deleted = delete_at_path(&mut json, &path).unwrap();
+
+        assert_eq!(deleted.unwrap().as_str(), Some("Bob"));
+        assert!(get_at_path(&json, &path).is_none());
+        // user.email should still exist
+        assert!(get_at_path(&json, &"user.email".parse().unwrap()).is_some());
+    }
+
+    #[test]
+    fn test_delete_at_path_array_element() {
+        let mut json: JsonValue = r#"[1, 2, 3]"#.parse().unwrap();
+        let path: JsonPath = "[1]".parse().unwrap();
+        let deleted = delete_at_path(&mut json, &path).unwrap();
+
+        assert_eq!(deleted.unwrap().as_i64(), Some(2));
+        let arr = json.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // Verify indices shifted
+        assert_eq!(arr[0].as_i64(), Some(1));
+        assert_eq!(arr[1].as_i64(), Some(3)); // Was at index 2
+    }
+
+    #[test]
+    fn test_delete_at_path_array_first() {
+        let mut json: JsonValue = r#"["a", "b", "c"]"#.parse().unwrap();
+        let path: JsonPath = "[0]".parse().unwrap();
+        delete_at_path(&mut json, &path).unwrap();
+
+        let arr = json.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str(), Some("b"));
+        assert_eq!(arr[1].as_str(), Some("c"));
+    }
+
+    #[test]
+    fn test_delete_at_path_array_last() {
+        let mut json: JsonValue = r#"["a", "b", "c"]"#.parse().unwrap();
+        let path: JsonPath = "[2]".parse().unwrap();
+        delete_at_path(&mut json, &path).unwrap();
+
+        let arr = json.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str(), Some("a"));
+        assert_eq!(arr[1].as_str(), Some("b"));
+    }
+
+    #[test]
+    fn test_delete_at_path_missing_key() {
+        let mut json: JsonValue = r#"{"name": "Alice"}"#.parse().unwrap();
+        let path: JsonPath = "missing".parse().unwrap();
+        let deleted = delete_at_path(&mut json, &path).unwrap();
+
+        assert!(deleted.is_none());
+    }
+
+    #[test]
+    fn test_delete_at_path_missing_index() {
+        let mut json: JsonValue = r#"[1, 2]"#.parse().unwrap();
+        let path: JsonPath = "[10]".parse().unwrap();
+        let deleted = delete_at_path(&mut json, &path).unwrap();
+
+        assert!(deleted.is_none());
+    }
+
+    #[test]
+    fn test_delete_at_path_missing_parent() {
+        let mut json: JsonValue = r#"{"foo": 1}"#.parse().unwrap();
+        let path: JsonPath = "bar.baz".parse().unwrap();
+        let result = delete_at_path(&mut json, &path);
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), JsonPathError::NotFound));
+    }
+
+    #[test]
+    fn test_delete_at_path_type_mismatch() {
+        let mut json = JsonValue::from(42i64);
+        let path: JsonPath = "name".parse().unwrap();
+        let result = delete_at_path(&mut json, &path);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            JsonPathError::TypeMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn test_delete_at_path_nested_array() {
+        let mut json: JsonValue =
+            r#"{"items": [{"id": 1}, {"id": 2}, {"id": 3}]}"#.parse().unwrap();
+        let path: JsonPath = "items[1]".parse().unwrap();
+        let deleted = delete_at_path(&mut json, &path).unwrap();
+
+        assert!(deleted.is_some());
+        let arr = get_at_path(&json, &"items".parse().unwrap())
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    // =========================================================================
+    // Apply Patches Tests (Story #271)
+    // =========================================================================
+
+    #[test]
+    fn test_apply_patches_empty() {
+        let mut json = JsonValue::object();
+        let patches: Vec<JsonPatch> = vec![];
+        apply_patches(&mut json, &patches).unwrap();
+        assert!(json.as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_apply_patches_single_set() {
+        let mut json = JsonValue::object();
+        let patches = vec![JsonPatch::set("name", JsonValue::from("Alice"))];
+        apply_patches(&mut json, &patches).unwrap();
+
+        assert_eq!(
+            get_at_path(&json, &"name".parse().unwrap())
+                .unwrap()
+                .as_str(),
+            Some("Alice")
+        );
+    }
+
+    #[test]
+    fn test_apply_patches_multiple_sets() {
+        let mut json = JsonValue::object();
+        let patches = vec![
+            JsonPatch::set("name", JsonValue::from("Alice")),
+            JsonPatch::set("age", JsonValue::from(30i64)),
+            JsonPatch::set("active", JsonValue::from(true)),
+        ];
+        apply_patches(&mut json, &patches).unwrap();
+
+        assert_eq!(
+            get_at_path(&json, &"name".parse().unwrap())
+                .unwrap()
+                .as_str(),
+            Some("Alice")
+        );
+        assert_eq!(
+            get_at_path(&json, &"age".parse().unwrap())
+                .unwrap()
+                .as_i64(),
+            Some(30)
+        );
+        assert_eq!(
+            get_at_path(&json, &"active".parse().unwrap())
+                .unwrap()
+                .as_bool(),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn test_apply_patches_set_and_delete() {
+        let mut json: JsonValue = r#"{"name": "Alice", "age": 30}"#.parse().unwrap();
+        let patches = vec![
+            JsonPatch::set("email", JsonValue::from("alice@example.com")),
+            JsonPatch::delete("age"),
+        ];
+        apply_patches(&mut json, &patches).unwrap();
+
+        assert!(get_at_path(&json, &"email".parse().unwrap()).is_some());
+        assert!(get_at_path(&json, &"age".parse().unwrap()).is_none());
+        assert!(get_at_path(&json, &"name".parse().unwrap()).is_some());
+    }
+
+    #[test]
+    fn test_apply_patches_nested() {
+        let mut json = JsonValue::object();
+        let patches = vec![
+            JsonPatch::set("user.profile.name", JsonValue::from("Bob")),
+            JsonPatch::set("user.profile.email", JsonValue::from("bob@example.com")),
+        ];
+        apply_patches(&mut json, &patches).unwrap();
+
+        assert_eq!(
+            get_at_path(&json, &"user.profile.name".parse().unwrap())
+                .unwrap()
+                .as_str(),
+            Some("Bob")
+        );
+        assert_eq!(
+            get_at_path(&json, &"user.profile.email".parse().unwrap())
+                .unwrap()
+                .as_str(),
+            Some("bob@example.com")
+        );
+    }
+
+    #[test]
+    fn test_apply_patches_overwrite() {
+        let mut json: JsonValue = r#"{"name": "Alice"}"#.parse().unwrap();
+        let patches = vec![
+            JsonPatch::set("name", JsonValue::from("Bob")),
+            JsonPatch::set("name", JsonValue::from("Charlie")),
+        ];
+        apply_patches(&mut json, &patches).unwrap();
+
+        // Last write wins
+        assert_eq!(
+            get_at_path(&json, &"name".parse().unwrap())
+                .unwrap()
+                .as_str(),
+            Some("Charlie")
+        );
+    }
+
+    #[test]
+    fn test_apply_patches_set_then_delete() {
+        let mut json = JsonValue::object();
+        let patches = vec![
+            JsonPatch::set("temp", JsonValue::from("value")),
+            JsonPatch::delete("temp"),
+        ];
+        apply_patches(&mut json, &patches).unwrap();
+
+        assert!(get_at_path(&json, &"temp".parse().unwrap()).is_none());
+    }
+
+    #[test]
+    fn test_apply_patches_delete_then_set() {
+        let mut json: JsonValue = r#"{"name": "Alice"}"#.parse().unwrap();
+        let patches = vec![
+            JsonPatch::delete("name"),
+            JsonPatch::set("name", JsonValue::from("Bob")),
+        ];
+        apply_patches(&mut json, &patches).unwrap();
+
+        assert_eq!(
+            get_at_path(&json, &"name".parse().unwrap())
+                .unwrap()
+                .as_str(),
+            Some("Bob")
+        );
+    }
+
+    #[test]
+    fn test_apply_patches_error_propagation() {
+        let mut json = JsonValue::from(42i64);
+        let patches = vec![JsonPatch::set("name", JsonValue::from("Alice"))];
+        let result = apply_patches(&mut json, &patches);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            JsonPathError::TypeMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn test_apply_patches_partial_failure() {
+        let mut json = JsonValue::object();
+        let patches = vec![
+            JsonPatch::set("name", JsonValue::from("Alice")),
+            JsonPatch::set("[0]", JsonValue::from("invalid")), // type mismatch - object not array
+        ];
+        let result = apply_patches(&mut json, &patches);
+
+        // First patch should have been applied before failure
+        assert!(result.is_err());
+        assert_eq!(
+            get_at_path(&json, &"name".parse().unwrap())
+                .unwrap()
+                .as_str(),
+            Some("Alice")
+        );
+    }
+
+    #[test]
+    fn test_apply_patches_with_arrays() {
+        let mut json = JsonValue::object();
+        let patches = vec![
+            JsonPatch::set("items", JsonValue::array()),
+            JsonPatch::set("items[0]", JsonValue::from("first")),
+            JsonPatch::set("items[1]", JsonValue::from("second")),
+        ];
+        apply_patches(&mut json, &patches).unwrap();
+
+        let items = get_at_path(&json, &"items".parse().unwrap())
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].as_str(), Some("first"));
+        assert_eq!(items[1].as_str(), Some("second"));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,20 +8,34 @@
 //! - Value: Unified value enum for all data types
 //! - Error: Error type hierarchy
 //! - Traits: Core trait definitions (Storage, SnapshotView)
+//! - JSON types (M5): JsonValue, JsonPath, JsonPatch, JsonDocId
+//! - JSON limits (M5): MAX_DOCUMENT_SIZE, MAX_NESTING_DEPTH, MAX_PATH_LENGTH, MAX_ARRAY_SIZE
+//! - Search types (M6): SearchRequest, SearchResponse, SearchHit, DocRef, PrimitiveKind
 
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 
-// Module declarations (will be implemented in future stories)
+// Module declarations
 pub mod error; // Story #10
+pub mod json; // M5 JSON types
+pub mod search_types; // M6 search types
 pub mod traits; // Story #11
 pub mod types; // Story #7, #8
 pub mod value; // Story #9
 
 // Re-export commonly used types and traits
 pub use error::{Error, Result};
+pub use json::{
+    apply_patches, delete_at_path, get_at_path, get_at_path_mut, set_at_path, JsonPatch, JsonPath,
+    JsonPathError, JsonValue, LimitError, PathParseError, PathSegment, MAX_ARRAY_SIZE,
+    MAX_DOCUMENT_SIZE, MAX_NESTING_DEPTH, MAX_PATH_LENGTH,
+};
+pub use search_types::{
+    DocRef, PrimitiveKind, SearchBudget, SearchHit, SearchMode, SearchRequest, SearchResponse,
+    SearchStats,
+};
 pub use traits::{SnapshotView, Storage};
-pub use types::{Key, Namespace, RunId, TypeTag};
+pub use types::{JsonDocId, Key, Namespace, RunId, TypeTag};
 pub use value::{Timestamp, Value, VersionedValue};
 
 /// Placeholder for core functionality

--- a/crates/core/src/search_types.rs
+++ b/crates/core/src/search_types.rs
@@ -1,0 +1,863 @@
+//! Core search types for M6 Retrieval Surfaces
+//!
+//! This module defines the foundational search types used throughout M6:
+//! - SearchRequest: Universal request type for all search APIs
+//! - SearchBudget: Time and candidate limits for search execution
+//! - SearchResponse: Results from any search operation
+//! - SearchHit: Individual search result with score and rank
+//! - SearchStats: Execution statistics for debugging/monitoring
+//! - DocRef: Back-pointer to source record in any primitive
+//! - PrimitiveKind: Enumeration of all searchable primitives
+//!
+//! These types define the interface contracts for search operations.
+//! See `docs/architecture/M6_ARCHITECTURE.md` for authoritative specification.
+
+use crate::types::{JsonDocId, Key, RunId};
+use std::collections::HashMap;
+
+// ============================================================================
+// PrimitiveKind (Story #307)
+// ============================================================================
+
+/// Enumeration of all searchable primitives
+///
+/// This enum identifies which primitive a search result comes from,
+/// enabling per-primitive filtering and statistics tracking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PrimitiveKind {
+    /// Key-Value store
+    Kv,
+    /// JSON document store
+    Json,
+    /// Event log
+    Event,
+    /// State cell
+    State,
+    /// Trace store (reasoning logs)
+    Trace,
+    /// Run index
+    Run,
+}
+
+impl PrimitiveKind {
+    /// Returns all primitive kinds
+    ///
+    /// Useful for iterating over all primitives in composite search.
+    pub fn all() -> &'static [PrimitiveKind] {
+        &[
+            PrimitiveKind::Kv,
+            PrimitiveKind::Json,
+            PrimitiveKind::Event,
+            PrimitiveKind::State,
+            PrimitiveKind::Trace,
+            PrimitiveKind::Run,
+        ]
+    }
+}
+
+impl std::fmt::Display for PrimitiveKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PrimitiveKind::Kv => write!(f, "kv"),
+            PrimitiveKind::Json => write!(f, "json"),
+            PrimitiveKind::Event => write!(f, "event"),
+            PrimitiveKind::State => write!(f, "state"),
+            PrimitiveKind::Trace => write!(f, "trace"),
+            PrimitiveKind::Run => write!(f, "run"),
+        }
+    }
+}
+
+// ============================================================================
+// DocRef (Story #306)
+// ============================================================================
+
+/// Reference back to source record
+///
+/// Every search hit contains a DocRef that can be used to retrieve
+/// the actual data from the appropriate primitive. This is the
+/// back-pointer model that avoids data duplication.
+///
+/// # Invariant
+///
+/// DocRef MUST have a variant for every searchable primitive.
+/// When a new primitive is added, DocRef MUST be extended.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DocRef {
+    /// KV store entry
+    Kv {
+        /// Key of the KV entry
+        key: Key,
+    },
+
+    /// JSON document
+    Json {
+        /// Key of the JSON collection
+        key: Key,
+        /// Document ID within the collection
+        doc_id: JsonDocId,
+    },
+
+    /// Event log entry
+    Event {
+        /// Key of the event log
+        log_key: Key,
+        /// Sequence number within the log
+        seq: u64,
+    },
+
+    /// State cell
+    State {
+        /// Key of the state cell
+        key: Key,
+    },
+
+    /// Trace span
+    Trace {
+        /// Key of the trace store
+        key: Key,
+        /// Span ID within the trace
+        span_id: u64,
+    },
+
+    /// Run metadata
+    Run {
+        /// Run ID
+        run_id: RunId,
+    },
+}
+
+impl DocRef {
+    /// Get the primitive kind for this reference
+    pub fn primitive_kind(&self) -> PrimitiveKind {
+        match self {
+            DocRef::Kv { .. } => PrimitiveKind::Kv,
+            DocRef::Json { .. } => PrimitiveKind::Json,
+            DocRef::Event { .. } => PrimitiveKind::Event,
+            DocRef::State { .. } => PrimitiveKind::State,
+            DocRef::Trace { .. } => PrimitiveKind::Trace,
+            DocRef::Run { .. } => PrimitiveKind::Run,
+        }
+    }
+
+    /// Get the run_id this reference belongs to
+    pub fn run_id(&self) -> RunId {
+        match self {
+            DocRef::Kv { key } => key.namespace.run_id,
+            DocRef::Json { key, .. } => key.namespace.run_id,
+            DocRef::Event { log_key, .. } => log_key.namespace.run_id,
+            DocRef::State { key } => key.namespace.run_id,
+            DocRef::Trace { key, .. } => key.namespace.run_id,
+            DocRef::Run { run_id } => *run_id,
+        }
+    }
+}
+
+// ============================================================================
+// SearchBudget (Story #303)
+// ============================================================================
+
+/// Limits on search execution
+///
+/// Search operations respect these limits and return truncated
+/// results rather than timing out or erroring. This provides
+/// predictable latency and graceful degradation.
+///
+/// # Default Values
+///
+/// - max_wall_time_micros: 100,000 (100ms)
+/// - max_candidates: 10,000
+/// - max_candidates_per_primitive: 2,000
+#[derive(Debug, Clone, Copy)]
+pub struct SearchBudget {
+    /// Hard stop on wall time (microseconds)
+    pub max_wall_time_micros: u64,
+
+    /// Maximum total candidates to consider
+    pub max_candidates: usize,
+
+    /// Maximum candidates per primitive (for composite search)
+    pub max_candidates_per_primitive: usize,
+}
+
+impl Default for SearchBudget {
+    fn default() -> Self {
+        SearchBudget {
+            max_wall_time_micros: 100_000, // 100ms
+            max_candidates: 10_000,
+            max_candidates_per_primitive: 2_000,
+        }
+    }
+}
+
+impl SearchBudget {
+    /// Create a new SearchBudget with custom limits
+    pub fn new(max_time_micros: u64, max_candidates: usize) -> Self {
+        SearchBudget {
+            max_wall_time_micros: max_time_micros,
+            max_candidates,
+            max_candidates_per_primitive: max_candidates / 6, // Split across 6 primitives
+        }
+    }
+
+    /// Builder: set max wall time
+    pub fn with_time(mut self, micros: u64) -> Self {
+        self.max_wall_time_micros = micros;
+        self
+    }
+
+    /// Builder: set max candidates
+    pub fn with_candidates(mut self, max: usize) -> Self {
+        self.max_candidates = max;
+        self
+    }
+
+    /// Builder: set max candidates per primitive
+    pub fn with_per_primitive(mut self, max: usize) -> Self {
+        self.max_candidates_per_primitive = max;
+        self
+    }
+}
+
+// ============================================================================
+// SearchMode (Story #302)
+// ============================================================================
+
+/// Search mode - determines the search strategy
+///
+/// M6 implements Keyword mode. Vector and Hybrid are reserved
+/// for future milestones (M9+).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SearchMode {
+    /// Keyword-based search using BM25-lite (M6 default)
+    #[default]
+    Keyword,
+    /// Reserved for future vector search (M9)
+    Vector,
+    /// Reserved for future hybrid search (keyword + vector)
+    Hybrid,
+}
+
+// ============================================================================
+// SearchRequest (Story #302)
+// ============================================================================
+
+/// Request for search across primitives
+///
+/// This is the universal search request type used by both
+/// primitive-level search (e.g., `kv.search()`) and composite
+/// search (e.g., `db.hybrid().search()`).
+///
+/// # Invariant
+///
+/// The same SearchRequest type is used for all search operations.
+/// This invariant must not change.
+///
+/// # Examples
+///
+/// ```
+/// use in_mem_core::{SearchRequest, SearchBudget, RunId};
+///
+/// let run_id = RunId::new();
+/// let req = SearchRequest::new(run_id, "authentication error")
+///     .with_k(20)
+///     .with_budget(SearchBudget::default().with_time(50_000));
+///
+/// assert_eq!(req.query, "authentication error");
+/// assert_eq!(req.k, 20);
+/// ```
+#[derive(Debug, Clone)]
+pub struct SearchRequest {
+    /// Run to search within
+    pub run_id: RunId,
+
+    /// Query string (interpreted by scorer)
+    pub query: String,
+
+    /// Maximum results to return (top-k)
+    pub k: usize,
+
+    /// Time and work limits
+    pub budget: SearchBudget,
+
+    /// Search mode (Keyword, Vector, Hybrid)
+    pub mode: SearchMode,
+
+    /// Optional: limit to specific primitives (for composite search)
+    pub primitive_filter: Option<Vec<PrimitiveKind>>,
+
+    /// Optional: time range filter (microseconds since epoch)
+    pub time_range: Option<(u64, u64)>,
+
+    /// Optional: tag filter (match any)
+    pub tags_any: Vec<String>,
+}
+
+impl SearchRequest {
+    /// Create a new SearchRequest with defaults
+    ///
+    /// Default values:
+    /// - k: 10
+    /// - budget: SearchBudget::default()
+    /// - mode: SearchMode::Keyword
+    /// - primitive_filter: None (search all primitives)
+    /// - time_range: None
+    /// - tags_any: empty
+    pub fn new(run_id: RunId, query: impl Into<String>) -> Self {
+        SearchRequest {
+            run_id,
+            query: query.into(),
+            k: 10,
+            budget: SearchBudget::default(),
+            mode: SearchMode::default(),
+            primitive_filter: None,
+            time_range: None,
+            tags_any: vec![],
+        }
+    }
+
+    /// Builder: set top-k results count
+    pub fn with_k(mut self, k: usize) -> Self {
+        self.k = k;
+        self
+    }
+
+    /// Builder: set search budget
+    pub fn with_budget(mut self, budget: SearchBudget) -> Self {
+        self.budget = budget;
+        self
+    }
+
+    /// Builder: set search mode
+    pub fn with_mode(mut self, mode: SearchMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Builder: set primitive filter
+    pub fn with_primitive_filter(mut self, filter: Vec<PrimitiveKind>) -> Self {
+        self.primitive_filter = Some(filter);
+        self
+    }
+
+    /// Builder: set time range filter
+    pub fn with_time_range(mut self, start: u64, end: u64) -> Self {
+        self.time_range = Some((start, end));
+        self
+    }
+
+    /// Builder: set tags filter
+    pub fn with_tags(mut self, tags: Vec<String>) -> Self {
+        self.tags_any = tags;
+        self
+    }
+
+    /// Check if a primitive is included in this request
+    pub fn includes_primitive(&self, kind: PrimitiveKind) -> bool {
+        match &self.primitive_filter {
+            Some(filter) => filter.contains(&kind),
+            None => true, // No filter means include all
+        }
+    }
+}
+
+// ============================================================================
+// SearchHit (Story #305)
+// ============================================================================
+
+/// A single search result
+///
+/// Contains a back-pointer to the source record (DocRef),
+/// the score from the scorer, and the rank in the result set.
+#[derive(Debug, Clone)]
+pub struct SearchHit {
+    /// Back-pointer to source record
+    pub doc_ref: DocRef,
+
+    /// Score from scorer (higher = more relevant)
+    pub score: f32,
+
+    /// Rank in result set (1-indexed)
+    pub rank: u32,
+
+    /// Optional snippet for display
+    pub snippet: Option<String>,
+}
+
+impl SearchHit {
+    /// Create a new SearchHit
+    pub fn new(doc_ref: DocRef, score: f32, rank: u32) -> Self {
+        SearchHit {
+            doc_ref,
+            score,
+            rank,
+            snippet: None,
+        }
+    }
+
+    /// Builder: set snippet
+    pub fn with_snippet(mut self, snippet: String) -> Self {
+        self.snippet = Some(snippet);
+        self
+    }
+}
+
+// ============================================================================
+// SearchStats (Story #305)
+// ============================================================================
+
+/// Execution statistics for a search
+///
+/// Provides metadata about how the search was executed,
+/// useful for debugging and monitoring.
+#[derive(Debug, Clone, Default)]
+pub struct SearchStats {
+    /// Time spent in search (microseconds)
+    pub elapsed_micros: u64,
+
+    /// Total candidates considered
+    pub candidates_considered: usize,
+
+    /// Candidates per primitive (for composite search)
+    pub candidates_by_primitive: HashMap<PrimitiveKind, usize>,
+
+    /// Whether an index was used (vs. full scan)
+    pub index_used: bool,
+}
+
+impl SearchStats {
+    /// Create new SearchStats
+    pub fn new(elapsed_micros: u64, candidates: usize) -> Self {
+        SearchStats {
+            elapsed_micros,
+            candidates_considered: candidates,
+            candidates_by_primitive: HashMap::new(),
+            index_used: false,
+        }
+    }
+
+    /// Builder: set index_used flag
+    pub fn with_index_used(mut self, used: bool) -> Self {
+        self.index_used = used;
+        self
+    }
+
+    /// Add candidates count for a primitive
+    pub fn add_primitive_candidates(&mut self, kind: PrimitiveKind, count: usize) {
+        self.candidates_by_primitive.insert(kind, count);
+        self.candidates_considered += count;
+    }
+}
+
+// ============================================================================
+// SearchResponse (Story #304)
+// ============================================================================
+
+/// Search results
+///
+/// Returned by both primitive-level and composite search.
+/// Contains ranked hits plus execution metadata.
+///
+/// # Invariant
+///
+/// All search methods return SearchResponse. No primitive-specific
+/// result types. This invariant must not change.
+#[derive(Debug, Clone)]
+pub struct SearchResponse {
+    /// Ranked hits (highest score first)
+    pub hits: Vec<SearchHit>,
+
+    /// True if budget caused early termination
+    pub truncated: bool,
+
+    /// Execution statistics
+    pub stats: SearchStats,
+}
+
+impl SearchResponse {
+    /// Create an empty response
+    pub fn empty() -> Self {
+        SearchResponse {
+            hits: vec![],
+            truncated: false,
+            stats: SearchStats::default(),
+        }
+    }
+
+    /// Create a new response
+    pub fn new(hits: Vec<SearchHit>, truncated: bool, stats: SearchStats) -> Self {
+        SearchResponse {
+            hits,
+            truncated,
+            stats,
+        }
+    }
+
+    /// Check if response has no hits
+    pub fn is_empty(&self) -> bool {
+        self.hits.is_empty()
+    }
+
+    /// Get number of hits
+    pub fn len(&self) -> usize {
+        self.hits.len()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Namespace;
+
+    // ========================================
+    // PrimitiveKind Tests
+    // ========================================
+
+    #[test]
+    fn test_primitive_kind_all() {
+        let all = PrimitiveKind::all();
+        assert_eq!(all.len(), 6);
+        assert!(all.contains(&PrimitiveKind::Kv));
+        assert!(all.contains(&PrimitiveKind::Json));
+        assert!(all.contains(&PrimitiveKind::Event));
+        assert!(all.contains(&PrimitiveKind::State));
+        assert!(all.contains(&PrimitiveKind::Trace));
+        assert!(all.contains(&PrimitiveKind::Run));
+    }
+
+    #[test]
+    fn test_primitive_kind_display() {
+        assert_eq!(format!("{}", PrimitiveKind::Kv), "kv");
+        assert_eq!(format!("{}", PrimitiveKind::Json), "json");
+        assert_eq!(format!("{}", PrimitiveKind::Event), "event");
+        assert_eq!(format!("{}", PrimitiveKind::State), "state");
+        assert_eq!(format!("{}", PrimitiveKind::Trace), "trace");
+        assert_eq!(format!("{}", PrimitiveKind::Run), "run");
+    }
+
+    #[test]
+    fn test_primitive_kind_copy() {
+        let kind = PrimitiveKind::Kv;
+        let kind2 = kind; // Copy
+        assert_eq!(kind, kind2);
+    }
+
+    #[test]
+    fn test_primitive_kind_hash() {
+        use std::collections::HashSet;
+
+        let mut set = HashSet::new();
+        for kind in PrimitiveKind::all() {
+            set.insert(*kind);
+        }
+        assert_eq!(set.len(), 6, "All PrimitiveKinds should be unique");
+    }
+
+    // ========================================
+    // DocRef Tests
+    // ========================================
+
+    #[test]
+    fn test_doc_ref_primitive_kind() {
+        let run_id = RunId::new();
+        let ns = Namespace::for_run(run_id);
+
+        let kv_ref = DocRef::Kv {
+            key: Key::new_kv(ns.clone(), "test"),
+        };
+        assert_eq!(kv_ref.primitive_kind(), PrimitiveKind::Kv);
+
+        let json_ref = DocRef::Json {
+            key: Key::new_json(ns.clone(), &JsonDocId::new()),
+            doc_id: JsonDocId::new(),
+        };
+        assert_eq!(json_ref.primitive_kind(), PrimitiveKind::Json);
+
+        let event_ref = DocRef::Event {
+            log_key: Key::new_event(ns.clone(), 0),
+            seq: 42,
+        };
+        assert_eq!(event_ref.primitive_kind(), PrimitiveKind::Event);
+
+        let state_ref = DocRef::State {
+            key: Key::new_state(ns.clone(), "cell"),
+        };
+        assert_eq!(state_ref.primitive_kind(), PrimitiveKind::State);
+
+        let trace_ref = DocRef::Trace {
+            key: Key::new_trace(ns.clone(), 0),
+            span_id: 123,
+        };
+        assert_eq!(trace_ref.primitive_kind(), PrimitiveKind::Trace);
+
+        let run_ref = DocRef::Run { run_id };
+        assert_eq!(run_ref.primitive_kind(), PrimitiveKind::Run);
+    }
+
+    #[test]
+    fn test_doc_ref_run_id() {
+        let run_id = RunId::new();
+        let ns = Namespace::for_run(run_id);
+
+        let kv_ref = DocRef::Kv {
+            key: Key::new_kv(ns.clone(), "test"),
+        };
+        assert_eq!(kv_ref.run_id(), run_id);
+
+        let run_ref = DocRef::Run { run_id };
+        assert_eq!(run_ref.run_id(), run_id);
+    }
+
+    #[test]
+    fn test_doc_ref_equality() {
+        let run_id = RunId::new();
+        let ns = Namespace::for_run(run_id);
+        let key = Key::new_kv(ns.clone(), "test");
+
+        let ref1 = DocRef::Kv { key: key.clone() };
+        let ref2 = DocRef::Kv { key: key.clone() };
+
+        assert_eq!(ref1, ref2);
+    }
+
+    #[test]
+    fn test_doc_ref_hash() {
+        use std::collections::HashSet;
+
+        let run_id = RunId::new();
+        let ns = Namespace::for_run(run_id);
+
+        let ref1 = DocRef::Kv {
+            key: Key::new_kv(ns.clone(), "key1"),
+        };
+        let ref2 = DocRef::Kv {
+            key: Key::new_kv(ns.clone(), "key2"),
+        };
+
+        let mut set = HashSet::new();
+        set.insert(ref1.clone());
+        set.insert(ref2.clone());
+
+        assert_eq!(set.len(), 2);
+        assert!(set.contains(&ref1));
+        assert!(set.contains(&ref2));
+    }
+
+    // ========================================
+    // SearchBudget Tests
+    // ========================================
+
+    #[test]
+    fn test_search_budget_defaults() {
+        let budget = SearchBudget::default();
+
+        assert_eq!(budget.max_wall_time_micros, 100_000);
+        assert_eq!(budget.max_candidates, 10_000);
+        assert_eq!(budget.max_candidates_per_primitive, 2_000);
+    }
+
+    #[test]
+    fn test_search_budget_builder() {
+        let budget = SearchBudget::default()
+            .with_time(50_000)
+            .with_candidates(5_000)
+            .with_per_primitive(1_000);
+
+        assert_eq!(budget.max_wall_time_micros, 50_000);
+        assert_eq!(budget.max_candidates, 5_000);
+        assert_eq!(budget.max_candidates_per_primitive, 1_000);
+    }
+
+    #[test]
+    fn test_search_budget_new() {
+        let budget = SearchBudget::new(200_000, 20_000);
+
+        assert_eq!(budget.max_wall_time_micros, 200_000);
+        assert_eq!(budget.max_candidates, 20_000);
+        // 20_000 / 6 = 3_333
+        assert_eq!(budget.max_candidates_per_primitive, 3_333);
+    }
+
+    // ========================================
+    // SearchMode Tests
+    // ========================================
+
+    #[test]
+    fn test_search_mode_default() {
+        let mode = SearchMode::default();
+        assert_eq!(mode, SearchMode::Keyword);
+    }
+
+    #[test]
+    fn test_search_mode_variants() {
+        let _keyword = SearchMode::Keyword;
+        let _vector = SearchMode::Vector;
+        let _hybrid = SearchMode::Hybrid;
+    }
+
+    // ========================================
+    // SearchRequest Tests
+    // ========================================
+
+    #[test]
+    fn test_search_request_new() {
+        let run_id = RunId::new();
+        let req = SearchRequest::new(run_id, "test query");
+
+        assert_eq!(req.run_id, run_id);
+        assert_eq!(req.query, "test query");
+        assert_eq!(req.k, 10);
+        assert_eq!(req.mode, SearchMode::Keyword);
+        assert!(req.primitive_filter.is_none());
+        assert!(req.time_range.is_none());
+        assert!(req.tags_any.is_empty());
+    }
+
+    #[test]
+    fn test_search_request_builder() {
+        let run_id = RunId::new();
+        let req = SearchRequest::new(run_id, "test query")
+            .with_k(20)
+            .with_budget(SearchBudget::default().with_time(50_000))
+            .with_mode(SearchMode::Keyword)
+            .with_primitive_filter(vec![PrimitiveKind::Kv, PrimitiveKind::Json])
+            .with_time_range(1000, 2000)
+            .with_tags(vec!["important".to_string()]);
+
+        assert_eq!(req.k, 20);
+        assert_eq!(req.budget.max_wall_time_micros, 50_000);
+        assert_eq!(
+            req.primitive_filter,
+            Some(vec![PrimitiveKind::Kv, PrimitiveKind::Json])
+        );
+        assert_eq!(req.time_range, Some((1000, 2000)));
+        assert_eq!(req.tags_any, vec!["important".to_string()]);
+    }
+
+    #[test]
+    fn test_search_request_includes_primitive() {
+        let run_id = RunId::new();
+
+        // No filter - includes all
+        let req1 = SearchRequest::new(run_id, "test");
+        assert!(req1.includes_primitive(PrimitiveKind::Kv));
+        assert!(req1.includes_primitive(PrimitiveKind::Json));
+        assert!(req1.includes_primitive(PrimitiveKind::Event));
+
+        // With filter - only includes specified
+        let req2 = SearchRequest::new(run_id, "test")
+            .with_primitive_filter(vec![PrimitiveKind::Kv, PrimitiveKind::Json]);
+        assert!(req2.includes_primitive(PrimitiveKind::Kv));
+        assert!(req2.includes_primitive(PrimitiveKind::Json));
+        assert!(!req2.includes_primitive(PrimitiveKind::Event));
+        assert!(!req2.includes_primitive(PrimitiveKind::State));
+    }
+
+    // ========================================
+    // SearchHit Tests
+    // ========================================
+
+    #[test]
+    fn test_search_hit_new() {
+        let run_id = RunId::new();
+        let doc_ref = DocRef::Run { run_id };
+
+        let hit = SearchHit::new(doc_ref.clone(), 0.95, 1);
+
+        assert_eq!(hit.doc_ref, doc_ref);
+        assert!((hit.score - 0.95).abs() < f32::EPSILON);
+        assert_eq!(hit.rank, 1);
+        assert!(hit.snippet.is_none());
+    }
+
+    #[test]
+    fn test_search_hit_with_snippet() {
+        let run_id = RunId::new();
+        let doc_ref = DocRef::Run { run_id };
+
+        let hit = SearchHit::new(doc_ref, 0.95, 1).with_snippet("matched text here".to_string());
+
+        assert_eq!(hit.snippet, Some("matched text here".to_string()));
+    }
+
+    // ========================================
+    // SearchStats Tests
+    // ========================================
+
+    #[test]
+    fn test_search_stats_default() {
+        let stats = SearchStats::default();
+
+        assert_eq!(stats.elapsed_micros, 0);
+        assert_eq!(stats.candidates_considered, 0);
+        assert!(stats.candidates_by_primitive.is_empty());
+        assert!(!stats.index_used);
+    }
+
+    #[test]
+    fn test_search_stats_new() {
+        let stats = SearchStats::new(1000, 500);
+
+        assert_eq!(stats.elapsed_micros, 1000);
+        assert_eq!(stats.candidates_considered, 500);
+    }
+
+    #[test]
+    fn test_search_stats_builder() {
+        let stats = SearchStats::new(1000, 500).with_index_used(true);
+
+        assert!(stats.index_used);
+    }
+
+    #[test]
+    fn test_search_stats_add_primitive_candidates() {
+        let mut stats = SearchStats::default();
+
+        stats.add_primitive_candidates(PrimitiveKind::Kv, 100);
+        stats.add_primitive_candidates(PrimitiveKind::Json, 200);
+
+        assert_eq!(stats.candidates_considered, 300);
+        assert_eq!(
+            stats.candidates_by_primitive.get(&PrimitiveKind::Kv),
+            Some(&100)
+        );
+        assert_eq!(
+            stats.candidates_by_primitive.get(&PrimitiveKind::Json),
+            Some(&200)
+        );
+    }
+
+    // ========================================
+    // SearchResponse Tests
+    // ========================================
+
+    #[test]
+    fn test_search_response_empty() {
+        let response = SearchResponse::empty();
+
+        assert!(response.is_empty());
+        assert_eq!(response.len(), 0);
+        assert!(!response.truncated);
+    }
+
+    #[test]
+    fn test_search_response_new() {
+        let run_id = RunId::new();
+        let hits = vec![
+            SearchHit::new(DocRef::Run { run_id }, 0.9, 1),
+            SearchHit::new(DocRef::Run { run_id }, 0.8, 2),
+        ];
+        let stats = SearchStats::new(500, 100);
+
+        let response = SearchResponse::new(hits, true, stats);
+
+        assert_eq!(response.len(), 2);
+        assert!(!response.is_empty());
+        assert!(response.truncated);
+        assert_eq!(response.stats.elapsed_micros, 500);
+    }
+}

--- a/crates/durability/Cargo.toml
+++ b/crates/durability/Cargo.toml
@@ -12,6 +12,7 @@ in-mem-core = { path = "../core" }
 in-mem-storage = { path = "../storage" }
 bincode = { workspace = true }
 serde = { workspace = true }
+rmp-serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
@@ -21,3 +22,4 @@ crc32fast = "1.3"
 proptest = { workspace = true }
 tempfile = { workspace = true }
 chrono = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/durability/src/recovery.rs
+++ b/crates/durability/src/recovery.rs
@@ -22,8 +22,11 @@
 
 use crate::wal::{WALEntry, WAL};
 use in_mem_core::error::Result;
+use in_mem_core::json::{delete_at_path, set_at_path, JsonValue};
 use in_mem_core::traits::Storage;
-use in_mem_core::types::RunId;
+use in_mem_core::types::{JsonDocId, Key, Namespace, RunId};
+use in_mem_core::value::Value;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use tracing::warn;
 
@@ -55,6 +58,58 @@ pub struct ReplayStats {
     pub orphaned_entries: usize,
     /// Number of transactions skipped by filter
     pub txns_filtered: usize,
+    // JSON operations (M5)
+    /// Number of JSON Create operations applied
+    pub json_creates_applied: usize,
+    /// Number of JSON Set operations applied
+    pub json_sets_applied: usize,
+    /// Number of JSON Delete operations applied
+    pub json_deletes_applied: usize,
+    /// Number of JSON Destroy operations applied
+    pub json_destroys_applied: usize,
+}
+
+/// JSON document structure for recovery (M5)
+///
+/// This mirrors the JsonDoc struct in primitives but is defined here to avoid
+/// circular dependencies. Uses msgpack serialization for compatibility.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RecoveryJsonDoc {
+    /// Document identifier
+    id: JsonDocId,
+    /// JSON value
+    value: JsonValue,
+    /// Document version (increments on any change)
+    version: u64,
+    /// Creation timestamp (millis since epoch)
+    created_at: i64,
+    /// Last update timestamp (millis since epoch)
+    updated_at: i64,
+}
+
+impl RecoveryJsonDoc {
+    /// Create a new document with initial value
+    fn new(id: JsonDocId, value: JsonValue, version: u64, timestamp: i64) -> Self {
+        Self {
+            id,
+            value,
+            version,
+            created_at: timestamp,
+            updated_at: timestamp,
+        }
+    }
+
+    /// Serialize to msgpack bytes
+    fn to_bytes(&self) -> Result<Vec<u8>> {
+        rmp_serde::to_vec(self)
+            .map_err(|e| in_mem_core::error::Error::SerializationError(e.to_string()))
+    }
+
+    /// Deserialize from msgpack bytes
+    fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        rmp_serde::from_slice(bytes)
+            .map_err(|e| in_mem_core::error::Error::SerializationError(e.to_string()))
+    }
 }
 
 /// Options for WAL replay
@@ -238,7 +293,12 @@ pub fn validate_transactions(entries: &[WALEntry]) -> ValidationResult {
                 begun_txns.insert(*txn_id);
                 active_txn_per_run.insert(*run_id, *txn_id);
             }
-            WALEntry::Write { run_id, .. } | WALEntry::Delete { run_id, .. } => {
+            WALEntry::Write { run_id, .. }
+            | WALEntry::Delete { run_id, .. }
+            | WALEntry::JsonCreate { run_id, .. }
+            | WALEntry::JsonSet { run_id, .. }
+            | WALEntry::JsonDelete { run_id, .. }
+            | WALEntry::JsonDestroy { run_id, .. } => {
                 // Check if there's an active transaction for this run_id
                 if !active_txn_per_run.contains_key(run_id) {
                     result.warnings.push(ValidationWarning {
@@ -425,7 +485,12 @@ pub fn replay_wal_with_options<S: Storage + ?Sized>(
                 // Map (run_id, txn_id) -> internal_id for commit/abort lookup
                 txn_id_to_internal.insert((*run_id, *txn_id), internal_id);
             }
-            WALEntry::Write { run_id, .. } | WALEntry::Delete { run_id, .. } => {
+            WALEntry::Write { run_id, .. }
+            | WALEntry::Delete { run_id, .. }
+            | WALEntry::JsonCreate { run_id, .. }
+            | WALEntry::JsonSet { run_id, .. }
+            | WALEntry::JsonDelete { run_id, .. }
+            | WALEntry::JsonDestroy { run_id, .. } => {
                 // Add to the currently active transaction for this run_id
                 if let Some(&internal_id) = active_txn_per_run.get(run_id) {
                     if let Some(txn) = transactions.get_mut(&internal_id) {
@@ -565,7 +630,7 @@ fn get_transaction_max_version(txn: &Transaction) -> u64 {
 
 /// Apply a committed transaction to storage
 ///
-/// Applies all Write and Delete operations from a transaction to storage,
+/// Applies all Write, Delete, and JSON operations from a transaction to storage,
 /// preserving the version numbers from the WAL entries.
 ///
 /// # Arguments
@@ -602,6 +667,158 @@ fn apply_transaction<S: Storage + ?Sized>(
                 stats.deletes_applied += 1;
                 stats.final_version = stats.final_version.max(*version);
             }
+
+            // ================================================================
+            // JSON Operations (M5)
+            // ================================================================
+            WALEntry::JsonCreate {
+                run_id,
+                doc_id,
+                value_bytes,
+                version,
+                timestamp,
+            } => {
+                // Deserialize the JSON value from msgpack bytes
+                let value: JsonValue = rmp_serde::from_slice(value_bytes).map_err(|e| {
+                    in_mem_core::error::Error::SerializationError(format!(
+                        "Failed to deserialize JSON value during recovery: {}",
+                        e
+                    ))
+                })?;
+
+                // Create the document
+                let doc = RecoveryJsonDoc::new(*doc_id, value, *version, *timestamp);
+                let doc_bytes = doc.to_bytes()?;
+
+                // Store using JSON key
+                let key = Key::new_json(Namespace::for_run(*run_id), doc_id);
+                storage.put_with_version(key, Value::Bytes(doc_bytes), *version, None)?;
+
+                stats.json_creates_applied += 1;
+                stats.final_version = stats.final_version.max(*version);
+            }
+
+            WALEntry::JsonSet {
+                run_id,
+                doc_id,
+                path,
+                value_bytes,
+                version,
+            } => {
+                let key = Key::new_json(Namespace::for_run(*run_id), doc_id);
+
+                // Load existing document
+                let existing = storage.get(&key)?;
+                if let Some(vv) = existing {
+                    let mut doc = match &vv.value {
+                        Value::Bytes(bytes) => RecoveryJsonDoc::from_bytes(bytes)?,
+                        _ => {
+                            return Err(in_mem_core::error::Error::InvalidOperation(
+                                "Expected bytes for JSON document".to_string(),
+                            ))
+                        }
+                    };
+
+                    // Deserialize the new value
+                    let new_value: JsonValue = rmp_serde::from_slice(value_bytes).map_err(|e| {
+                        in_mem_core::error::Error::SerializationError(format!(
+                            "Failed to deserialize JSON value during recovery: {}",
+                            e
+                        ))
+                    })?;
+
+                    // Apply the path mutation
+                    set_at_path(&mut doc.value, path, new_value).map_err(|e| {
+                        in_mem_core::error::Error::InvalidOperation(format!(
+                            "Failed to set path during recovery: {}",
+                            e
+                        ))
+                    })?;
+
+                    // Update version and timestamp
+                    doc.version = *version;
+                    doc.updated_at = std::time::SystemTime::now()
+                        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                        .unwrap()
+                        .as_millis() as i64;
+
+                    // Store updated document
+                    let doc_bytes = doc.to_bytes()?;
+                    storage.put_with_version(key, Value::Bytes(doc_bytes), *version, None)?;
+
+                    stats.json_sets_applied += 1;
+                    stats.final_version = stats.final_version.max(*version);
+                } else {
+                    warn!(
+                        "JsonSet for non-existent document {:?} during recovery, skipping",
+                        doc_id
+                    );
+                }
+            }
+
+            WALEntry::JsonDelete {
+                run_id,
+                doc_id,
+                path,
+                version,
+            } => {
+                let key = Key::new_json(Namespace::for_run(*run_id), doc_id);
+
+                // Load existing document
+                let existing = storage.get(&key)?;
+                if let Some(vv) = existing {
+                    let mut doc = match &vv.value {
+                        Value::Bytes(bytes) => RecoveryJsonDoc::from_bytes(bytes)?,
+                        _ => {
+                            return Err(in_mem_core::error::Error::InvalidOperation(
+                                "Expected bytes for JSON document".to_string(),
+                            ))
+                        }
+                    };
+
+                    // Apply the path deletion
+                    delete_at_path(&mut doc.value, path).map_err(|e| {
+                        in_mem_core::error::Error::InvalidOperation(format!(
+                            "Failed to delete path during recovery: {}",
+                            e
+                        ))
+                    })?;
+
+                    // Update version and timestamp
+                    doc.version = *version;
+                    doc.updated_at = std::time::SystemTime::now()
+                        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                        .unwrap()
+                        .as_millis() as i64;
+
+                    // Store updated document
+                    let doc_bytes = doc.to_bytes()?;
+                    storage.put_with_version(key, Value::Bytes(doc_bytes), *version, None)?;
+
+                    stats.json_deletes_applied += 1;
+                    stats.final_version = stats.final_version.max(*version);
+                } else {
+                    warn!(
+                        "JsonDelete for non-existent document {:?} during recovery, skipping",
+                        doc_id
+                    );
+                }
+            }
+
+            WALEntry::JsonDestroy { run_id, doc_id } => {
+                let key = Key::new_json(Namespace::for_run(*run_id), doc_id);
+
+                // Delete the document (use version 0 since JsonDestroy doesn't carry version)
+                // The version doesn't matter much for deletes as long as it's applied
+                if storage.get(&key)?.is_some() {
+                    storage.delete_with_version(&key, 0)?;
+                    stats.json_destroys_applied += 1;
+                } else {
+                    // Document already doesn't exist - idempotent
+                    stats.json_destroys_applied += 1;
+                }
+            }
+
             _ => {
                 // BeginTxn, CommitTxn, etc. are not applied to storage
             }
@@ -1480,7 +1697,7 @@ mod tests {
                 .unwrap();
                 wal.append(&WALEntry::Write {
                     run_id,
-                    key: Key::new_kv(ns.clone(), &format!("key{}", i)),
+                    key: Key::new_kv(ns.clone(), format!("key{}", i)),
                     value: Value::I64(i as i64),
                     version: i,
                 })
@@ -2075,5 +2292,452 @@ mod tests {
         let stored = store.get(&key).unwrap().unwrap();
         assert_eq!(stored.value, Value::String("final".to_string()));
         assert_eq!(stored.version, 30);
+    }
+
+    // ========================================================================
+    // JSON Crash Recovery Tests (Story #281)
+    // ========================================================================
+
+    use in_mem_core::json::{JsonPath, JsonValue};
+    use in_mem_core::types::JsonDocId;
+
+    /// Serialize a JsonValue to msgpack bytes (for WAL entry construction)
+    fn json_to_msgpack(value: &JsonValue) -> Vec<u8> {
+        rmp_serde::to_vec(value).unwrap()
+    }
+
+    #[test]
+    fn test_json_create_recovery() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("json_create.wal");
+
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+        let initial_value: JsonValue = serde_json::json!({
+            "name": "Alice",
+            "age": 30
+        })
+        .into();
+
+        // Write WAL entries
+        {
+            let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::JsonCreate {
+                run_id,
+                doc_id,
+                value_bytes: json_to_msgpack(&initial_value),
+                version: 1,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+                .unwrap();
+        }
+
+        // Replay to storage (simulating recovery)
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        assert_eq!(stats.txns_applied, 1);
+        assert_eq!(stats.json_creates_applied, 1);
+        assert_eq!(stats.final_version, 1);
+
+        // Verify document exists in storage
+        let key = Key::new_json(Namespace::for_run(run_id), &doc_id);
+        let stored = store.get(&key).unwrap().expect("Document should exist");
+
+        // Deserialize and verify
+        let doc = match &stored.value {
+            Value::Bytes(bytes) => RecoveryJsonDoc::from_bytes(bytes).unwrap(),
+            _ => panic!("Expected bytes"),
+        };
+        assert_eq!(doc.id, doc_id);
+        assert_eq!(doc.version, 1);
+        assert_eq!(doc.value.as_object().unwrap().get("name").unwrap(), "Alice");
+    }
+
+    #[test]
+    fn test_json_set_recovery() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("json_set.wal");
+
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+        let initial_value: JsonValue = serde_json::json!({ "count": 0 }).into();
+        let new_value: JsonValue = serde_json::json!(42).into();
+
+        // Write WAL entries: create, then set
+        {
+            let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+            // Transaction 1: Create
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::JsonCreate {
+                run_id,
+                doc_id,
+                value_bytes: json_to_msgpack(&initial_value),
+                version: 1,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+                .unwrap();
+
+            // Transaction 2: Set
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 2,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::JsonSet {
+                run_id,
+                doc_id,
+                path: "count".parse::<JsonPath>().unwrap(),
+                value_bytes: json_to_msgpack(&new_value),
+                version: 2,
+            })
+            .unwrap();
+            wal.append(&WALEntry::CommitTxn { txn_id: 2, run_id })
+                .unwrap();
+        }
+
+        // Replay
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        assert_eq!(stats.txns_applied, 2);
+        assert_eq!(stats.json_creates_applied, 1);
+        assert_eq!(stats.json_sets_applied, 1);
+        assert_eq!(stats.final_version, 2);
+
+        // Verify document has updated value
+        let key = Key::new_json(Namespace::for_run(run_id), &doc_id);
+        let stored = store.get(&key).unwrap().expect("Document should exist");
+        let doc = match &stored.value {
+            Value::Bytes(bytes) => RecoveryJsonDoc::from_bytes(bytes).unwrap(),
+            _ => panic!("Expected bytes"),
+        };
+        assert_eq!(doc.version, 2);
+        assert_eq!(doc.value.as_object().unwrap().get("count").unwrap(), 42);
+    }
+
+    #[test]
+    fn test_json_delete_recovery() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("json_delete.wal");
+
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+        let initial_value: JsonValue = serde_json::json!({
+            "name": "Bob",
+            "temp": "to_be_deleted"
+        })
+        .into();
+
+        // Write WAL entries: create, then delete field
+        {
+            let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+            // Create
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::JsonCreate {
+                run_id,
+                doc_id,
+                value_bytes: json_to_msgpack(&initial_value),
+                version: 1,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+                .unwrap();
+
+            // Delete field
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 2,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::JsonDelete {
+                run_id,
+                doc_id,
+                path: "temp".parse::<JsonPath>().unwrap(),
+                version: 2,
+            })
+            .unwrap();
+            wal.append(&WALEntry::CommitTxn { txn_id: 2, run_id })
+                .unwrap();
+        }
+
+        // Replay
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        assert_eq!(stats.txns_applied, 2);
+        assert_eq!(stats.json_creates_applied, 1);
+        assert_eq!(stats.json_deletes_applied, 1);
+        assert_eq!(stats.final_version, 2);
+
+        // Verify temp field is deleted but name remains
+        let key = Key::new_json(Namespace::for_run(run_id), &doc_id);
+        let stored = store.get(&key).unwrap().expect("Document should exist");
+        let doc = match &stored.value {
+            Value::Bytes(bytes) => RecoveryJsonDoc::from_bytes(bytes).unwrap(),
+            _ => panic!("Expected bytes"),
+        };
+        assert_eq!(doc.version, 2);
+        assert_eq!(doc.value.as_object().unwrap().get("name").unwrap(), "Bob");
+        assert!(doc.value.as_object().unwrap().get("temp").is_none());
+    }
+
+    #[test]
+    fn test_json_destroy_recovery() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("json_destroy.wal");
+
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+        let initial_value: JsonValue = serde_json::json!({ "data": "test" }).into();
+
+        // Write WAL entries: create, then destroy
+        {
+            let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+            // Create
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::JsonCreate {
+                run_id,
+                doc_id,
+                value_bytes: json_to_msgpack(&initial_value),
+                version: 1,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+                .unwrap();
+
+            // Destroy
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 2,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::JsonDestroy { run_id, doc_id })
+                .unwrap();
+            wal.append(&WALEntry::CommitTxn { txn_id: 2, run_id })
+                .unwrap();
+        }
+
+        // Replay
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        assert_eq!(stats.txns_applied, 2);
+        assert_eq!(stats.json_creates_applied, 1);
+        assert_eq!(stats.json_destroys_applied, 1);
+
+        // Document should not exist
+        let key = Key::new_json(Namespace::for_run(run_id), &doc_id);
+        assert!(store.get(&key).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_json_incomplete_transaction_discarded() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("json_incomplete.wal");
+
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+        let initial_value: JsonValue = serde_json::json!({ "status": "initial" }).into();
+
+        // Simulate crash: begin transaction but no commit
+        {
+            let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::JsonCreate {
+                run_id,
+                doc_id,
+                value_bytes: json_to_msgpack(&initial_value),
+                version: 1,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            // NO CommitTxn - simulating crash
+        }
+
+        // Replay
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        // Transaction should be discarded (incomplete)
+        assert_eq!(stats.txns_applied, 0);
+        assert_eq!(stats.json_creates_applied, 0);
+        assert_eq!(stats.incomplete_txns, 1);
+
+        // Document should NOT exist
+        let key = Key::new_json(Namespace::for_run(run_id), &doc_id);
+        assert!(store.get(&key).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_json_idempotent_replay() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("json_idempotent.wal");
+
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+        let value: JsonValue = serde_json::json!({ "count": 1 }).into();
+
+        // Write WAL entries
+        {
+            let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::JsonCreate {
+                run_id,
+                doc_id,
+                value_bytes: json_to_msgpack(&value),
+                version: 1,
+                timestamp: now(),
+            })
+            .unwrap();
+            wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+                .unwrap();
+        }
+
+        // First replay
+        let store = UnifiedStore::new();
+        {
+            let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+            let stats = replay_wal(&wal, &store).unwrap();
+            assert_eq!(stats.json_creates_applied, 1);
+        }
+
+        // Second replay (idempotent - should just overwrite)
+        {
+            let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+            let stats = replay_wal(&wal, &store).unwrap();
+            assert_eq!(stats.json_creates_applied, 1);
+        }
+
+        // Document should still have correct value
+        let key = Key::new_json(Namespace::for_run(run_id), &doc_id);
+        let stored = store.get(&key).unwrap().expect("Document should exist");
+        let doc = match &stored.value {
+            Value::Bytes(bytes) => RecoveryJsonDoc::from_bytes(bytes).unwrap(),
+            _ => panic!("Expected bytes"),
+        };
+        assert_eq!(doc.value.as_object().unwrap().get("count").unwrap(), 1);
+    }
+
+    #[test]
+    fn test_json_mixed_with_kv_recovery() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("json_mixed.wal");
+
+        let run_id = RunId::new();
+        let ns = Namespace::new(
+            "tenant".to_string(),
+            "app".to_string(),
+            "agent".to_string(),
+            run_id,
+        );
+        let doc_id = JsonDocId::new();
+        let json_value: JsonValue = serde_json::json!({ "type": "json" }).into();
+
+        // Write mixed KV and JSON operations
+        {
+            let mut wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+
+            wal.append(&WALEntry::BeginTxn {
+                txn_id: 1,
+                run_id,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            // KV write
+            wal.append(&WALEntry::Write {
+                run_id,
+                key: Key::new_kv(ns.clone(), "kv_key"),
+                value: Value::String("kv_value".to_string()),
+                version: 1,
+            })
+            .unwrap();
+
+            // JSON create
+            wal.append(&WALEntry::JsonCreate {
+                run_id,
+                doc_id,
+                value_bytes: json_to_msgpack(&json_value),
+                version: 2,
+                timestamp: now(),
+            })
+            .unwrap();
+
+            wal.append(&WALEntry::CommitTxn { txn_id: 1, run_id })
+                .unwrap();
+        }
+
+        // Replay
+        let wal = WAL::open(&wal_path, DurabilityMode::Strict).unwrap();
+        let store = UnifiedStore::new();
+        let stats = replay_wal(&wal, &store).unwrap();
+
+        assert_eq!(stats.txns_applied, 1);
+        assert_eq!(stats.writes_applied, 1);
+        assert_eq!(stats.json_creates_applied, 1);
+        assert_eq!(stats.final_version, 2);
+
+        // Verify both exist
+        let kv_key = Key::new_kv(ns.clone(), "kv_key");
+        assert!(store.get(&kv_key).unwrap().is_some());
+
+        let json_key = Key::new_json(Namespace::for_run(run_id), &doc_id);
+        assert!(store.get(&json_key).unwrap().is_some());
     }
 }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -12,6 +12,7 @@ description = "High-level primitives for in-mem agent database"
 in-mem-core = { path = "../core" }
 in-mem-engine = { path = "../engine" }
 in-mem-concurrency = { path = "../concurrency" }
+rmp-serde = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/primitives/src/json_store.rs
+++ b/crates/primitives/src/json_store.rs
@@ -1,0 +1,1596 @@
+//! JsonStore: JSON document storage primitive
+//!
+//! ## Design: STATELESS FACADE
+//!
+//! JsonStore holds ONLY `Arc<Database>`. No internal state, no caches,
+//! no maps, no locks. All data lives in ShardedStore via Key::new_json().
+//!
+//! ## Run Isolation
+//!
+//! All operations are scoped to a run_id. Keys are prefixed with the
+//! run's namespace, ensuring complete isolation between runs.
+//!
+//! ## Thread Safety
+//!
+//! JsonStore is `Send + Sync` and can be safely shared across threads.
+//! Multiple JsonStore instances on the same Database are safe.
+//!
+//! ## API
+//!
+//! - **Single-Operation API**: `get`, `create`, `set`, `delete_at_path`, `destroy`
+//!   Each operation runs in its own implicit transaction.
+//!
+//! - **Fast Path Reads**: `get`, `exists`, `get_doc`
+//!   Use SnapshotView directly for read-only access.
+//!
+//! ## M5 Architectural Rules
+//!
+//! This implementation follows the six M5 architectural rules:
+//! 1. JSON lives in ShardedStore via Key::new_json()
+//! 2. JsonStore is stateless (Arc<Database> only)
+//! 3. JSON extends TransactionContext (no separate type)
+//! 4. Path semantics in API layer (not storage)
+//! 5. WAL remains unified (entry types 0x20-0x23)
+//! 6. JSON API feels like other primitives
+
+use in_mem_core::error::{Error, Result};
+use in_mem_core::json::{delete_at_path, get_at_path, set_at_path, JsonPath, JsonValue};
+use in_mem_core::traits::SnapshotView;
+use in_mem_core::types::{JsonDocId, Key, Namespace, RunId};
+use in_mem_core::value::Value;
+use in_mem_engine::Database;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+// =============================================================================
+// JsonDoc - Internal Document Representation
+// =============================================================================
+
+/// Internal representation of a JSON document
+///
+/// Stored as serialized bytes in ShardedStore.
+/// Version is used for optimistic concurrency control.
+///
+/// # Design
+///
+/// - **Document-level versioning**: Single version for entire document
+/// - **Timestamps**: Track creation and modification times
+/// - **Serializable**: Uses MessagePack for efficient storage
+///
+/// # Example
+///
+/// ```rust
+/// use in_mem_primitives::json_store::JsonDoc;
+/// use in_mem_core::types::JsonDocId;
+/// use in_mem_core::json::JsonValue;
+///
+/// let doc = JsonDoc::new(JsonDocId::new(), JsonValue::from(42i64));
+/// assert_eq!(doc.version, 1);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonDoc {
+    /// Document unique identifier
+    pub id: JsonDocId,
+    /// The JSON value (root of document)
+    pub value: JsonValue,
+    /// Document version (increments on any change)
+    pub version: u64,
+    /// Creation timestamp (millis since epoch)
+    pub created_at: i64,
+    /// Last modification timestamp (millis since epoch)
+    pub updated_at: i64,
+}
+
+impl JsonDoc {
+    /// Create a new document with initial value
+    ///
+    /// Initializes version to 1 and sets timestamps to current time.
+    pub fn new(id: JsonDocId, value: JsonValue) -> Self {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+
+        JsonDoc {
+            id,
+            value,
+            version: 1,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Increment version and update timestamp
+    ///
+    /// Call this after any modification to the document.
+    pub fn touch(&mut self) {
+        self.version += 1;
+        self.updated_at = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+    }
+}
+
+/// JSON document storage primitive
+///
+/// STATELESS FACADE over Database - all state lives in unified ShardedStore.
+/// Multiple JsonStore instances on same Database are safe.
+///
+/// # Design
+///
+/// JsonStore does NOT own storage. It is a facade that:
+/// - Uses `Arc<Database>` for all operations
+/// - Stores documents via `Key::new_json()` in ShardedStore
+/// - Uses SnapshotView for fast path reads
+/// - Participates in cross-primitive transactions
+///
+/// # Example
+///
+/// ```ignore
+/// use in_mem_primitives::JsonStore;
+/// use in_mem_engine::Database;
+/// use in_mem_core::types::RunId;
+/// use in_mem_core::json::JsonValue;
+///
+/// let db = Arc::new(Database::builder().in_memory().open_temp()?);
+/// let json = JsonStore::new(db);
+/// let run_id = RunId::new();
+/// let doc_id = JsonDocId::new();
+///
+/// // Create and read document
+/// json.create(&run_id, &doc_id, JsonValue::object())?;
+/// let value = json.get(&run_id, &doc_id, &JsonPath::root())?;
+/// ```
+#[derive(Clone)]
+pub struct JsonStore {
+    db: Arc<Database>, // ONLY state: reference to database
+}
+
+impl JsonStore {
+    /// Create new JsonStore instance
+    pub fn new(db: Arc<Database>) -> Self {
+        Self { db }
+    }
+
+    /// Get the underlying database reference
+    pub fn database(&self) -> &Arc<Database> {
+        &self.db
+    }
+
+    /// Build namespace for run-scoped operations
+    fn namespace_for_run(&self, run_id: &RunId) -> Namespace {
+        Namespace::for_run(*run_id)
+    }
+
+    /// Build key for JSON document
+    fn key_for(&self, run_id: &RunId, doc_id: &JsonDocId) -> Key {
+        Key::new_json(self.namespace_for_run(run_id), doc_id)
+    }
+
+    // ========================================================================
+    // Serialization (Story #273)
+    // ========================================================================
+
+    /// Serialize document for storage
+    ///
+    /// Uses MessagePack for efficient binary serialization.
+    fn serialize_doc(doc: &JsonDoc) -> Result<Value> {
+        let bytes = rmp_serde::to_vec(doc).map_err(|e| Error::SerializationError(e.to_string()))?;
+        Ok(Value::Bytes(bytes))
+    }
+
+    /// Deserialize document from storage
+    ///
+    /// Expects Value::Bytes containing MessagePack-encoded JsonDoc.
+    fn deserialize_doc(value: &Value) -> Result<JsonDoc> {
+        match value {
+            Value::Bytes(bytes) => {
+                rmp_serde::from_slice(bytes).map_err(|e| Error::SerializationError(e.to_string()))
+            }
+            _ => Err(Error::InvalidOperation("expected bytes for JsonDoc".into())),
+        }
+    }
+
+    // ========================================================================
+    // Document Operations (Story #274+)
+    // ========================================================================
+
+    /// Create a new JSON document
+    ///
+    /// Creates a new document with version 1. Fails if a document with
+    /// the same ID already exists.
+    ///
+    /// # Arguments
+    ///
+    /// * `run_id` - RunId for namespace isolation
+    /// * `doc_id` - Unique document identifier
+    /// * `value` - Initial JSON value for the document
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(1)` - Document created with version 1
+    /// * `Err(InvalidOperation)` - Document already exists
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let version = json.create(&run_id, &doc_id, JsonValue::object())?;
+    /// assert_eq!(version, 1);
+    /// ```
+    pub fn create(&self, run_id: &RunId, doc_id: &JsonDocId, value: JsonValue) -> Result<u64> {
+        let key = self.key_for(run_id, doc_id);
+        let doc = JsonDoc::new(*doc_id, value);
+
+        self.db.transaction(*run_id, |txn| {
+            // Check if document already exists
+            if txn.get(&key)?.is_some() {
+                return Err(Error::InvalidOperation(format!(
+                    "JSON document {} already exists",
+                    doc_id
+                )));
+            }
+
+            let serialized = Self::serialize_doc(&doc)?;
+            txn.put(key.clone(), serialized)?;
+            Ok(doc.version)
+        })
+    }
+
+    // ========================================================================
+    // Fast Path Reads (Story #275)
+    // ========================================================================
+
+    /// Get value at path in a document (FAST PATH)
+    ///
+    /// Uses SnapshotView directly for read-only access.
+    /// Bypasses full transaction overhead:
+    /// - Direct snapshot read
+    /// - No transaction object allocation
+    /// - No read-set recording
+    /// - No commit validation
+    ///
+    /// # Arguments
+    ///
+    /// * `run_id` - RunId for namespace isolation
+    /// * `doc_id` - Document to read from
+    /// * `path` - Path within the document (use JsonPath::root() for whole doc)
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(value))` - Value at path
+    /// * `Ok(None)` - Document doesn't exist or path not found
+    /// * `Err` - On deserialization error
+    pub fn get(
+        &self,
+        run_id: &RunId,
+        doc_id: &JsonDocId,
+        path: &JsonPath,
+    ) -> Result<Option<JsonValue>> {
+        let snapshot = self.db.storage().create_snapshot();
+        let key = self.key_for(run_id, doc_id);
+
+        match snapshot.get(&key)? {
+            Some(vv) => {
+                let doc = Self::deserialize_doc(&vv.value)?;
+                Ok(get_at_path(&doc.value, path).cloned())
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Get the full document (FAST PATH)
+    ///
+    /// Returns the entire JsonDoc including metadata (version, timestamps).
+    pub fn get_doc(&self, run_id: &RunId, doc_id: &JsonDocId) -> Result<Option<JsonDoc>> {
+        let snapshot = self.db.storage().create_snapshot();
+        let key = self.key_for(run_id, doc_id);
+
+        match snapshot.get(&key)? {
+            Some(vv) => Ok(Some(Self::deserialize_doc(&vv.value)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Get document version (FAST PATH)
+    ///
+    /// Efficient way to check document version without full deserialization.
+    /// (In practice, we deserialize but could optimize later)
+    pub fn get_version(&self, run_id: &RunId, doc_id: &JsonDocId) -> Result<Option<u64>> {
+        let snapshot = self.db.storage().create_snapshot();
+        let key = self.key_for(run_id, doc_id);
+
+        match snapshot.get(&key)? {
+            Some(vv) => {
+                let doc = Self::deserialize_doc(&vv.value)?;
+                Ok(Some(doc.version))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Check if document exists (FAST PATH)
+    ///
+    /// Fastest way to check document existence.
+    pub fn exists(&self, run_id: &RunId, doc_id: &JsonDocId) -> Result<bool> {
+        let snapshot = self.db.storage().create_snapshot();
+        let key = self.key_for(run_id, doc_id);
+        Ok(snapshot.get(&key)?.is_some())
+    }
+
+    // ========================================================================
+    // Mutations (Story #276+)
+    // ========================================================================
+
+    /// Set value at path in a document
+    ///
+    /// Uses transaction for atomic read-modify-write.
+    /// Increments document version on success.
+    ///
+    /// # Arguments
+    ///
+    /// * `run_id` - RunId for namespace isolation
+    /// * `doc_id` - Document to modify
+    /// * `path` - Path to set value at (creates intermediate objects/arrays)
+    /// * `value` - New value to set
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(version)` - New document version after modification
+    /// * `Err(InvalidOperation)` - Document doesn't exist
+    /// * `Err` - On path error or serialization error
+    pub fn set(
+        &self,
+        run_id: &RunId,
+        doc_id: &JsonDocId,
+        path: &JsonPath,
+        value: JsonValue,
+    ) -> Result<u64> {
+        let key = self.key_for(run_id, doc_id);
+
+        self.db.transaction(*run_id, |txn| {
+            // Load existing document
+            let stored = txn.get(&key)?.ok_or_else(|| {
+                Error::InvalidOperation(format!("JSON document {} not found", doc_id))
+            })?;
+            let mut doc = Self::deserialize_doc(&stored)?;
+
+            // Apply mutation
+            set_at_path(&mut doc.value, path, value)
+                .map_err(|e| Error::InvalidOperation(format!("Path error: {}", e)))?;
+            doc.touch();
+
+            // Store updated document
+            let serialized = Self::serialize_doc(&doc)?;
+            txn.put(key.clone(), serialized)?;
+
+            Ok(doc.version)
+        })
+    }
+
+    /// Delete value at path in a document
+    ///
+    /// Uses transaction for atomic read-modify-write.
+    /// Increments document version on success.
+    ///
+    /// # Arguments
+    ///
+    /// * `run_id` - RunId for namespace isolation
+    /// * `doc_id` - Document to modify
+    /// * `path` - Path to delete (must not be root)
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(version)` - New document version after deletion
+    /// * `Err(InvalidOperation)` - Document doesn't exist or path error
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Remove a field from an object
+    /// json.delete_at_path(&run_id, &doc_id, &"user.temp".parse().unwrap())?;
+    /// ```
+    pub fn delete_at_path(
+        &self,
+        run_id: &RunId,
+        doc_id: &JsonDocId,
+        path: &JsonPath,
+    ) -> Result<u64> {
+        let key = self.key_for(run_id, doc_id);
+
+        self.db.transaction(*run_id, |txn| {
+            // Load existing document
+            let stored = txn.get(&key)?.ok_or_else(|| {
+                Error::InvalidOperation(format!("JSON document {} not found", doc_id))
+            })?;
+            let mut doc = Self::deserialize_doc(&stored)?;
+
+            // Apply deletion
+            delete_at_path(&mut doc.value, path)
+                .map_err(|e| Error::InvalidOperation(format!("Path error: {}", e)))?;
+            doc.touch();
+
+            // Store updated document
+            let serialized = Self::serialize_doc(&doc)?;
+            txn.put(key.clone(), serialized)?;
+
+            Ok(doc.version)
+        })
+    }
+
+    /// Destroy (delete) an entire document
+    ///
+    /// Removes the document from storage. This operation is final.
+    ///
+    /// # Arguments
+    ///
+    /// * `run_id` - RunId for namespace isolation
+    /// * `doc_id` - Document to destroy
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(true)` - Document existed and was destroyed
+    /// * `Ok(false)` - Document did not exist
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let existed = json.destroy(&run_id, &doc_id)?;
+    /// assert!(existed);
+    /// ```
+    pub fn destroy(&self, run_id: &RunId, doc_id: &JsonDocId) -> Result<bool> {
+        let key = self.key_for(run_id, doc_id);
+
+        self.db.transaction(*run_id, |txn| {
+            // Check if document exists
+            if txn.get(&key)?.is_none() {
+                return Ok(false);
+            }
+
+            // Delete the document
+            txn.delete(key.clone())?;
+            Ok(true)
+        })
+    }
+
+    // ========================================================================
+    // Search API (M6)
+    // ========================================================================
+
+    /// Search JSON documents
+    ///
+    /// Flattens JSON structure into searchable text and scores against query.
+    /// Respects budget constraints (time and candidate limits).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use in_mem_core::SearchRequest;
+    ///
+    /// let response = json.search(&SearchRequest::new(run_id, "Alice"))?;
+    /// for hit in response.hits {
+    ///     println!("Found doc {:?} with score {}", hit.doc_ref, hit.score);
+    /// }
+    /// ```
+    pub fn search(
+        &self,
+        req: &in_mem_core::SearchRequest,
+    ) -> in_mem_core::error::Result<in_mem_core::SearchResponse> {
+        use crate::searchable::{build_search_response, SearchCandidate};
+        use in_mem_core::search_types::DocRef;
+        use std::time::Instant;
+
+        let start = Instant::now();
+        let snapshot = self.db.storage().create_snapshot();
+        let ns = self.namespace_for_run(&req.run_id);
+        let scan_prefix = Key::new_json_prefix(ns);
+
+        let mut candidates = Vec::new();
+        let mut truncated = false;
+
+        // Scan all JSON documents for this run
+        for (key, versioned_value) in snapshot.scan_prefix(&scan_prefix)? {
+            // Check budget constraints
+            if start.elapsed().as_micros() as u64 >= req.budget.max_wall_time_micros {
+                truncated = true;
+                break;
+            }
+            if candidates.len() >= req.budget.max_candidates_per_primitive {
+                truncated = true;
+                break;
+            }
+
+            // Deserialize document
+            let doc = match Self::deserialize_doc(&versioned_value.value) {
+                Ok(d) => d,
+                Err(_) => continue, // Skip invalid documents
+            };
+
+            // Time range filter
+            if let Some((start_ts, end_ts)) = req.time_range {
+                let ts = doc.updated_at as u64;
+                if ts < start_ts || ts > end_ts {
+                    continue;
+                }
+            }
+
+            // Extract searchable text by flattening JSON
+            let text = self.flatten_json(&doc.value);
+
+            candidates.push(SearchCandidate::new(
+                DocRef::Json {
+                    key: key.clone(),
+                    doc_id: doc.id,
+                },
+                text,
+                Some(doc.updated_at as u64),
+            ));
+        }
+
+        Ok(build_search_response(
+            candidates,
+            &req.query,
+            req.k,
+            truncated,
+            start.elapsed().as_micros() as u64,
+        ))
+    }
+
+    /// Flatten JSON into searchable text
+    ///
+    /// Recursively extracts all string values and creates "path: value" pairs
+    /// for better search context.
+    fn flatten_json(&self, value: &JsonValue) -> String {
+        let mut parts = Vec::new();
+        self.flatten_recursive(value.as_inner(), &mut parts, "");
+        parts.join(" ")
+    }
+
+    /// Recursively flatten JSON value
+    fn flatten_recursive(&self, value: &serde_json::Value, parts: &mut Vec<String>, path: &str) {
+        use serde_json::Value as JV;
+
+        match value {
+            JV::String(s) => {
+                parts.push(s.clone());
+                if !path.is_empty() {
+                    parts.push(format!("{}: {}", path, s));
+                }
+            }
+            JV::Number(n) => {
+                parts.push(format!("{}", n));
+            }
+            JV::Bool(b) => {
+                parts.push(format!("{}", b));
+            }
+            JV::Array(arr) => {
+                for (i, item) in arr.iter().enumerate() {
+                    let child_path = if path.is_empty() {
+                        format!("[{}]", i)
+                    } else {
+                        format!("{}[{}]", path, i)
+                    };
+                    self.flatten_recursive(item, parts, &child_path);
+                }
+            }
+            JV::Object(obj) => {
+                for (k, v) in obj.iter() {
+                    let child_path = if path.is_empty() {
+                        k.clone()
+                    } else {
+                        format!("{}.{}", path, k)
+                    };
+                    parts.push(k.clone()); // Include field names as searchable
+                    self.flatten_recursive(v, parts, &child_path);
+                }
+            }
+            JV::Null => {}
+        }
+    }
+}
+
+// ========== Searchable Trait Implementation (M6) ==========
+
+impl crate::searchable::Searchable for JsonStore {
+    fn search(
+        &self,
+        req: &in_mem_core::SearchRequest,
+    ) -> in_mem_core::error::Result<in_mem_core::SearchResponse> {
+        self.search(req)
+    }
+
+    fn primitive_kind(&self) -> in_mem_core::search_types::PrimitiveKind {
+        in_mem_core::search_types::PrimitiveKind::Json
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_jsonstore_is_stateless() {
+        // JsonStore should have size of single Arc pointer
+        assert_eq!(
+            std::mem::size_of::<JsonStore>(),
+            std::mem::size_of::<Arc<Database>>()
+        );
+    }
+
+    #[test]
+    fn test_jsonstore_is_clone() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store1 = JsonStore::new(db.clone());
+        let store2 = store1.clone();
+        assert!(Arc::ptr_eq(store1.database(), store2.database()));
+    }
+
+    #[test]
+    fn test_jsonstore_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<JsonStore>();
+    }
+
+    #[test]
+    fn test_key_for_run_isolation() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+
+        let run1 = RunId::new();
+        let run2 = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let key1 = store.key_for(&run1, &doc_id);
+        let key2 = store.key_for(&run2, &doc_id);
+
+        // Keys for different runs should be different even for same doc_id
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn test_key_for_same_run() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let key1 = store.key_for(&run_id, &doc_id);
+        let key2 = store.key_for(&run_id, &doc_id);
+
+        // Same run and doc_id should produce same key
+        assert_eq!(key1, key2);
+    }
+
+    // ========================================
+    // JsonDoc Tests (Story #273)
+    // ========================================
+
+    #[test]
+    fn test_json_doc_new() {
+        let id = JsonDocId::new();
+        let value = JsonValue::from(42i64);
+        let doc = JsonDoc::new(id, value.clone());
+
+        assert_eq!(doc.id, id);
+        assert_eq!(doc.value, value);
+        assert_eq!(doc.version, 1);
+        assert!(doc.created_at > 0);
+        assert_eq!(doc.created_at, doc.updated_at);
+    }
+
+    #[test]
+    fn test_json_doc_touch() {
+        let id = JsonDocId::new();
+        let value = JsonValue::from(42i64);
+        let mut doc = JsonDoc::new(id, value);
+
+        let old_version = doc.version;
+        let old_updated = doc.updated_at;
+
+        // Sleep a tiny bit to ensure timestamp changes
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        doc.touch();
+
+        assert_eq!(doc.version, old_version + 1);
+        assert!(doc.updated_at >= old_updated);
+        // created_at should not change
+        assert_eq!(doc.created_at, doc.created_at);
+    }
+
+    #[test]
+    fn test_json_doc_touch_multiple() {
+        let id = JsonDocId::new();
+        let value = JsonValue::object();
+        let mut doc = JsonDoc::new(id, value);
+
+        for i in 0..5 {
+            doc.touch();
+            assert_eq!(doc.version, 2 + i);
+        }
+        assert_eq!(doc.version, 6);
+    }
+
+    // ========================================
+    // Serialization Tests (Story #273)
+    // ========================================
+
+    #[test]
+    fn test_serialize_deserialize_roundtrip() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let _store = JsonStore::new(db);
+
+        let doc = JsonDoc::new(JsonDocId::new(), JsonValue::from("test value"));
+
+        let serialized = JsonStore::serialize_doc(&doc).unwrap();
+        let deserialized = JsonStore::deserialize_doc(&serialized).unwrap();
+
+        assert_eq!(doc.id, deserialized.id);
+        assert_eq!(doc.value, deserialized.value);
+        assert_eq!(doc.version, deserialized.version);
+        assert_eq!(doc.created_at, deserialized.created_at);
+        assert_eq!(doc.updated_at, deserialized.updated_at);
+    }
+
+    #[test]
+    fn test_serialize_complex_document() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let _store = JsonStore::new(db);
+
+        let value: JsonValue = serde_json::json!({
+            "string": "hello",
+            "number": 42,
+            "boolean": true,
+            "null": null,
+            "array": [1, 2, 3],
+            "nested": {
+                "foo": "bar"
+            }
+        })
+        .into();
+
+        let doc = JsonDoc::new(JsonDocId::new(), value);
+
+        let serialized = JsonStore::serialize_doc(&doc).unwrap();
+        let deserialized = JsonStore::deserialize_doc(&serialized).unwrap();
+
+        assert_eq!(doc.value, deserialized.value);
+    }
+
+    #[test]
+    fn test_deserialize_invalid_type() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let _store = JsonStore::new(db);
+
+        // Try to deserialize a non-bytes value
+        let invalid = Value::I64(42);
+        let result = JsonStore::deserialize_doc(&invalid);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialize_invalid_bytes() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let _store = JsonStore::new(db);
+
+        // Try to deserialize garbage bytes
+        let invalid = Value::Bytes(vec![0, 1, 2, 3, 4, 5]);
+        let result = JsonStore::deserialize_doc(&invalid);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_serialized_size_is_compact() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let _store = JsonStore::new(db);
+
+        let doc = JsonDoc::new(JsonDocId::new(), JsonValue::from(42i64));
+
+        let serialized = JsonStore::serialize_doc(&doc).unwrap();
+
+        match serialized {
+            Value::Bytes(bytes) => {
+                // MessagePack should produce reasonably compact output
+                // UUID (16 bytes) + value + version + timestamps should be < 100 bytes
+                assert!(bytes.len() < 100);
+            }
+            _ => panic!("Expected bytes"),
+        }
+    }
+
+    // ========================================
+    // Create Tests (Story #274)
+    // ========================================
+
+    #[test]
+    fn test_create_document() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let version = store
+            .create(&run_id, &doc_id, JsonValue::from(42i64))
+            .unwrap();
+        assert_eq!(version, 1);
+    }
+
+    #[test]
+    fn test_create_object_document() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let value: JsonValue = serde_json::json!({
+            "name": "Alice",
+            "age": 30
+        })
+        .into();
+
+        let version = store.create(&run_id, &doc_id, value).unwrap();
+        assert_eq!(version, 1);
+    }
+
+    #[test]
+    fn test_create_duplicate_fails() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        // First create succeeds
+        store
+            .create(&run_id, &doc_id, JsonValue::from(1i64))
+            .unwrap();
+
+        // Second create with same ID fails
+        let result = store.create(&run_id, &doc_id, JsonValue::from(2i64));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_create_different_docs() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+
+        let doc1 = JsonDocId::new();
+        let doc2 = JsonDocId::new();
+
+        let v1 = store.create(&run_id, &doc1, JsonValue::from(1i64)).unwrap();
+        let v2 = store.create(&run_id, &doc2, JsonValue::from(2i64)).unwrap();
+
+        assert_eq!(v1, 1);
+        assert_eq!(v2, 1);
+    }
+
+    #[test]
+    fn test_create_run_isolation() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+
+        let run1 = RunId::new();
+        let run2 = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        // Same doc_id can be created in different runs
+        let v1 = store.create(&run1, &doc_id, JsonValue::from(1i64)).unwrap();
+        let v2 = store.create(&run2, &doc_id, JsonValue::from(2i64)).unwrap();
+
+        assert_eq!(v1, 1);
+        assert_eq!(v2, 1);
+    }
+
+    #[test]
+    fn test_create_null_value() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let version = store.create(&run_id, &doc_id, JsonValue::null()).unwrap();
+        assert_eq!(version, 1);
+    }
+
+    #[test]
+    fn test_create_empty_object() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let version = store.create(&run_id, &doc_id, JsonValue::object()).unwrap();
+        assert_eq!(version, 1);
+    }
+
+    #[test]
+    fn test_create_empty_array() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let version = store.create(&run_id, &doc_id, JsonValue::array()).unwrap();
+        assert_eq!(version, 1);
+    }
+
+    // ========================================
+    // Get Tests (Story #275)
+    // ========================================
+
+    #[test]
+    fn test_get_root() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        store
+            .create(&run_id, &doc_id, JsonValue::from(42i64))
+            .unwrap();
+
+        let value = store.get(&run_id, &doc_id, &JsonPath::root()).unwrap();
+        assert_eq!(value.and_then(|v| v.as_i64()), Some(42));
+    }
+
+    #[test]
+    fn test_get_at_path() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let value: JsonValue = serde_json::json!({
+            "name": "Alice",
+            "age": 30
+        })
+        .into();
+
+        store.create(&run_id, &doc_id, value).unwrap();
+
+        let name = store
+            .get(&run_id, &doc_id, &"name".parse().unwrap())
+            .unwrap();
+        assert_eq!(
+            name.and_then(|v| v.as_str().map(String::from)),
+            Some("Alice".to_string())
+        );
+
+        let age = store
+            .get(&run_id, &doc_id, &"age".parse().unwrap())
+            .unwrap();
+        assert_eq!(age.and_then(|v| v.as_i64()), Some(30));
+    }
+
+    #[test]
+    fn test_get_nested_path() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let value: JsonValue = serde_json::json!({
+            "user": {
+                "profile": {
+                    "name": "Bob"
+                }
+            }
+        })
+        .into();
+
+        store.create(&run_id, &doc_id, value).unwrap();
+
+        let name = store
+            .get(&run_id, &doc_id, &"user.profile.name".parse().unwrap())
+            .unwrap();
+        assert_eq!(
+            name.and_then(|v| v.as_str().map(String::from)),
+            Some("Bob".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_array_element() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let value: JsonValue = serde_json::json!({
+            "items": ["a", "b", "c"]
+        })
+        .into();
+
+        store.create(&run_id, &doc_id, value).unwrap();
+
+        let item = store
+            .get(&run_id, &doc_id, &"items[1]".parse().unwrap())
+            .unwrap();
+        assert_eq!(
+            item.and_then(|v| v.as_str().map(String::from)),
+            Some("b".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_missing_document() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let result = store.get(&run_id, &doc_id, &JsonPath::root()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_get_missing_path() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        store.create(&run_id, &doc_id, JsonValue::object()).unwrap();
+
+        let result = store
+            .get(&run_id, &doc_id, &"nonexistent".parse().unwrap())
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_get_doc() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        store
+            .create(&run_id, &doc_id, JsonValue::from(42i64))
+            .unwrap();
+
+        let doc = store.get_doc(&run_id, &doc_id).unwrap().unwrap();
+        assert_eq!(doc.id, doc_id);
+        assert_eq!(doc.version, 1);
+        assert_eq!(doc.value, JsonValue::from(42i64));
+    }
+
+    #[test]
+    fn test_get_doc_missing() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let result = store.get_doc(&run_id, &doc_id).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_get_version() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        store
+            .create(&run_id, &doc_id, JsonValue::from(42i64))
+            .unwrap();
+
+        let version = store.get_version(&run_id, &doc_id).unwrap();
+        assert_eq!(version, Some(1));
+    }
+
+    #[test]
+    fn test_get_version_missing() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let version = store.get_version(&run_id, &doc_id).unwrap();
+        assert!(version.is_none());
+    }
+
+    #[test]
+    fn test_exists() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        assert!(!store.exists(&run_id, &doc_id).unwrap());
+
+        store
+            .create(&run_id, &doc_id, JsonValue::from(42i64))
+            .unwrap();
+
+        assert!(store.exists(&run_id, &doc_id).unwrap());
+    }
+
+    #[test]
+    fn test_exists_run_isolation() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+
+        let run1 = RunId::new();
+        let run2 = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        store
+            .create(&run1, &doc_id, JsonValue::from(42i64))
+            .unwrap();
+
+        // Document exists in run1 but not in run2
+        assert!(store.exists(&run1, &doc_id).unwrap());
+        assert!(!store.exists(&run2, &doc_id).unwrap());
+    }
+
+    // ========================================
+    // Set Tests (Story #276)
+    // ========================================
+
+    #[test]
+    fn test_set_at_root() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        store
+            .create(&run_id, &doc_id, JsonValue::from(42i64))
+            .unwrap();
+
+        let v2 = store
+            .set(&run_id, &doc_id, &JsonPath::root(), JsonValue::from(100i64))
+            .unwrap();
+        assert_eq!(v2, 2);
+
+        let value = store.get(&run_id, &doc_id, &JsonPath::root()).unwrap();
+        assert_eq!(value.and_then(|v| v.as_i64()), Some(100));
+    }
+
+    #[test]
+    fn test_set_at_path() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        store.create(&run_id, &doc_id, JsonValue::object()).unwrap();
+
+        let v2 = store
+            .set(
+                &run_id,
+                &doc_id,
+                &"name".parse().unwrap(),
+                JsonValue::from("Alice"),
+            )
+            .unwrap();
+        assert_eq!(v2, 2);
+
+        let name = store
+            .get(&run_id, &doc_id, &"name".parse().unwrap())
+            .unwrap();
+        assert_eq!(
+            name.and_then(|v| v.as_str().map(String::from)),
+            Some("Alice".to_string())
+        );
+    }
+
+    #[test]
+    fn test_set_nested_path() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        store.create(&run_id, &doc_id, JsonValue::object()).unwrap();
+
+        // Creates intermediate objects automatically
+        let v2 = store
+            .set(
+                &run_id,
+                &doc_id,
+                &"user.profile.name".parse().unwrap(),
+                JsonValue::from("Bob"),
+            )
+            .unwrap();
+        assert_eq!(v2, 2);
+
+        let name = store
+            .get(&run_id, &doc_id, &"user.profile.name".parse().unwrap())
+            .unwrap();
+        assert_eq!(
+            name.and_then(|v| v.as_str().map(String::from)),
+            Some("Bob".to_string())
+        );
+    }
+
+    #[test]
+    fn test_set_increments_version() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        store.create(&run_id, &doc_id, JsonValue::object()).unwrap();
+        assert_eq!(store.get_version(&run_id, &doc_id).unwrap(), Some(1));
+
+        store
+            .set(
+                &run_id,
+                &doc_id,
+                &"a".parse().unwrap(),
+                JsonValue::from(1i64),
+            )
+            .unwrap();
+        assert_eq!(store.get_version(&run_id, &doc_id).unwrap(), Some(2));
+
+        store
+            .set(
+                &run_id,
+                &doc_id,
+                &"b".parse().unwrap(),
+                JsonValue::from(2i64),
+            )
+            .unwrap();
+        assert_eq!(store.get_version(&run_id, &doc_id).unwrap(), Some(3));
+    }
+
+    #[test]
+    fn test_set_missing_document() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let result = store.set(
+            &run_id,
+            &doc_id,
+            &"name".parse().unwrap(),
+            JsonValue::from("test"),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_set_overwrites_value() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let value: JsonValue = serde_json::json!({ "name": "Alice" }).into();
+        store.create(&run_id, &doc_id, value).unwrap();
+
+        store
+            .set(
+                &run_id,
+                &doc_id,
+                &"name".parse().unwrap(),
+                JsonValue::from("Bob"),
+            )
+            .unwrap();
+
+        let name = store
+            .get(&run_id, &doc_id, &"name".parse().unwrap())
+            .unwrap();
+        assert_eq!(
+            name.and_then(|v| v.as_str().map(String::from)),
+            Some("Bob".to_string())
+        );
+    }
+
+    #[test]
+    fn test_set_array_element() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let value: JsonValue = serde_json::json!({ "items": [1, 2, 3] }).into();
+        store.create(&run_id, &doc_id, value).unwrap();
+
+        store
+            .set(
+                &run_id,
+                &doc_id,
+                &"items[1]".parse().unwrap(),
+                JsonValue::from(999i64),
+            )
+            .unwrap();
+
+        let item = store
+            .get(&run_id, &doc_id, &"items[1]".parse().unwrap())
+            .unwrap();
+        assert_eq!(item.and_then(|v| v.as_i64()), Some(999));
+    }
+
+    // ========================================
+    // Delete at Path Tests (Story #277)
+    // ========================================
+
+    #[test]
+    fn test_delete_at_path() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let value: JsonValue = serde_json::json!({
+            "name": "Alice",
+            "age": 30
+        })
+        .into();
+        store.create(&run_id, &doc_id, value).unwrap();
+
+        // Delete the "age" field
+        let v2 = store
+            .delete_at_path(&run_id, &doc_id, &"age".parse().unwrap())
+            .unwrap();
+        assert_eq!(v2, 2);
+
+        // Verify "age" is gone but "name" remains
+        assert!(store
+            .get(&run_id, &doc_id, &"age".parse().unwrap())
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            store
+                .get(&run_id, &doc_id, &"name".parse().unwrap())
+                .unwrap()
+                .and_then(|v| v.as_str().map(String::from)),
+            Some("Alice".to_string())
+        );
+    }
+
+    #[test]
+    fn test_delete_at_nested_path() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let value: JsonValue = serde_json::json!({
+            "user": {
+                "profile": {
+                    "name": "Bob",
+                    "temp": "to_delete"
+                }
+            }
+        })
+        .into();
+        store.create(&run_id, &doc_id, value).unwrap();
+
+        // Delete nested field
+        let v2 = store
+            .delete_at_path(&run_id, &doc_id, &"user.profile.temp".parse().unwrap())
+            .unwrap();
+        assert_eq!(v2, 2);
+
+        // Verify "temp" is gone
+        assert!(store
+            .get(&run_id, &doc_id, &"user.profile.temp".parse().unwrap())
+            .unwrap()
+            .is_none());
+
+        // Verify "name" remains
+        assert_eq!(
+            store
+                .get(&run_id, &doc_id, &"user.profile.name".parse().unwrap())
+                .unwrap()
+                .and_then(|v| v.as_str().map(String::from)),
+            Some("Bob".to_string())
+        );
+    }
+
+    #[test]
+    fn test_delete_at_path_array_element() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let value: JsonValue = serde_json::json!({
+            "items": ["a", "b", "c"]
+        })
+        .into();
+        store.create(&run_id, &doc_id, value).unwrap();
+
+        // Delete middle element
+        let v2 = store
+            .delete_at_path(&run_id, &doc_id, &"items[1]".parse().unwrap())
+            .unwrap();
+        assert_eq!(v2, 2);
+
+        // Array should now be ["a", "c"]
+        let items = store
+            .get(&run_id, &doc_id, &"items".parse().unwrap())
+            .unwrap()
+            .unwrap();
+        let arr = items.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str(), Some("a"));
+        assert_eq!(arr[1].as_str(), Some("c"));
+    }
+
+    #[test]
+    fn test_delete_at_path_increments_version() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let value: JsonValue = serde_json::json!({
+            "a": 1,
+            "b": 2,
+            "c": 3
+        })
+        .into();
+        store.create(&run_id, &doc_id, value).unwrap();
+        assert_eq!(store.get_version(&run_id, &doc_id).unwrap(), Some(1));
+
+        store
+            .delete_at_path(&run_id, &doc_id, &"a".parse().unwrap())
+            .unwrap();
+        assert_eq!(store.get_version(&run_id, &doc_id).unwrap(), Some(2));
+
+        store
+            .delete_at_path(&run_id, &doc_id, &"b".parse().unwrap())
+            .unwrap();
+        assert_eq!(store.get_version(&run_id, &doc_id).unwrap(), Some(3));
+    }
+
+    #[test]
+    fn test_delete_at_path_missing_document() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let result = store.delete_at_path(&run_id, &doc_id, &"field".parse().unwrap());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delete_at_path_missing_path() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        store.create(&run_id, &doc_id, JsonValue::object()).unwrap();
+
+        // Deleting a nonexistent path is idempotent (succeeds, increments version)
+        let v2 = store
+            .delete_at_path(&run_id, &doc_id, &"nonexistent".parse().unwrap())
+            .unwrap();
+        assert_eq!(v2, 2); // Version still increments even though nothing was removed
+    }
+
+    // ========================================
+    // Destroy Tests (Story #277)
+    // ========================================
+
+    #[test]
+    fn test_destroy_existing_document() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        store
+            .create(&run_id, &doc_id, JsonValue::from(42i64))
+            .unwrap();
+        assert!(store.exists(&run_id, &doc_id).unwrap());
+
+        let existed = store.destroy(&run_id, &doc_id).unwrap();
+        assert!(existed);
+        assert!(!store.exists(&run_id, &doc_id).unwrap());
+    }
+
+    #[test]
+    fn test_destroy_nonexistent_document() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let existed = store.destroy(&run_id, &doc_id).unwrap();
+        assert!(!existed);
+    }
+
+    #[test]
+    fn test_destroy_run_isolation() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+
+        let run1 = RunId::new();
+        let run2 = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        // Create document in both runs
+        store.create(&run1, &doc_id, JsonValue::from(1i64)).unwrap();
+        store.create(&run2, &doc_id, JsonValue::from(2i64)).unwrap();
+
+        // Destroy in run1
+        store.destroy(&run1, &doc_id).unwrap();
+
+        // Document should be gone from run1 but still exist in run2
+        assert!(!store.exists(&run1, &doc_id).unwrap());
+        assert!(store.exists(&run2, &doc_id).unwrap());
+    }
+
+    #[test]
+    fn test_destroy_then_recreate() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        // Create, destroy, recreate
+        store
+            .create(&run_id, &doc_id, JsonValue::from(1i64))
+            .unwrap();
+        store.destroy(&run_id, &doc_id).unwrap();
+
+        // Should be able to recreate with new value
+        let version = store
+            .create(&run_id, &doc_id, JsonValue::from(2i64))
+            .unwrap();
+        assert_eq!(version, 1); // Fresh document starts at version 1
+
+        let value = store.get(&run_id, &doc_id, &JsonPath::root()).unwrap();
+        assert_eq!(value.and_then(|v| v.as_i64()), Some(2));
+    }
+
+    #[test]
+    fn test_destroy_complex_document() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        let value: JsonValue = serde_json::json!({
+            "user": {
+                "name": "Alice",
+                "items": [1, 2, 3],
+                "nested": {
+                    "deep": {
+                        "value": true
+                    }
+                }
+            }
+        })
+        .into();
+        store.create(&run_id, &doc_id, value).unwrap();
+
+        let existed = store.destroy(&run_id, &doc_id).unwrap();
+        assert!(existed);
+        assert!(!store.exists(&run_id, &doc_id).unwrap());
+    }
+
+    #[test]
+    fn test_destroy_idempotent() {
+        let db = Arc::new(Database::builder().in_memory().open_temp().unwrap());
+        let store = JsonStore::new(db);
+        let run_id = RunId::new();
+        let doc_id = JsonDocId::new();
+
+        store
+            .create(&run_id, &doc_id, JsonValue::from(42i64))
+            .unwrap();
+
+        // First destroy returns true
+        assert!(store.destroy(&run_id, &doc_id).unwrap());
+
+        // Subsequent destroys return false
+        assert!(!store.destroy(&run_id, &doc_id).unwrap());
+        assert!(!store.destroy(&run_id, &doc_id).unwrap());
+    }
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -43,15 +43,19 @@
 
 pub mod event_log;
 pub mod extensions;
+pub mod json_store;
 pub mod kv;
 pub mod run_index;
+pub mod searchable;
 pub mod state_cell;
 pub mod trace;
 
 // Re-exports - primitives are exported as they're implemented
 pub use event_log::{ChainVerification, Event, EventLog};
+pub use json_store::{JsonDoc, JsonStore};
 pub use kv::{KVStore, KVTransaction};
 pub use run_index::{RunIndex, RunMetadata, RunStatus};
+pub use searchable::{build_search_response, SearchCandidate, Searchable, SimpleScorer};
 pub use state_cell::{State, StateCell};
 pub use trace::{Trace, TraceStore, TraceTree, TraceType};
 

--- a/crates/primitives/src/searchable.rs
+++ b/crates/primitives/src/searchable.rs
@@ -1,0 +1,244 @@
+//! Searchable trait for primitives that support search
+//!
+//! This module defines the `Searchable` trait and search support structures
+//! used by all primitives in M6 Retrieval Surfaces.
+
+use in_mem_core::error::Result;
+use in_mem_core::search_types::{
+    DocRef, PrimitiveKind, SearchHit, SearchRequest, SearchResponse, SearchStats,
+};
+
+/// Trait for primitives that support search
+///
+/// Each primitive implements this trait to provide its own search functionality
+/// with primitive-specific text extraction.
+///
+/// # Invariant
+///
+/// All search methods return SearchResponse. No primitive-specific result types.
+/// This invariant must not change.
+pub trait Searchable {
+    /// Search within this primitive
+    ///
+    /// Returns results matching the query within budget constraints.
+    /// Uses a snapshot for consistency.
+    fn search(&self, req: &SearchRequest) -> Result<SearchResponse>;
+
+    /// Get the primitive kind
+    fn primitive_kind(&self) -> PrimitiveKind;
+}
+
+/// Internal candidate for scoring
+///
+/// Represents a document that matches the search criteria before final scoring.
+#[derive(Debug, Clone)]
+pub struct SearchCandidate {
+    /// Back-pointer to source record
+    pub doc_ref: DocRef,
+    /// Extracted text for scoring
+    pub text: String,
+    /// Timestamp for time-based filtering/ordering
+    pub timestamp: Option<u64>,
+}
+
+impl SearchCandidate {
+    /// Create a new search candidate
+    pub fn new(doc_ref: DocRef, text: String, timestamp: Option<u64>) -> Self {
+        SearchCandidate {
+            doc_ref,
+            text,
+            timestamp,
+        }
+    }
+}
+
+/// Simple keyword matcher/scorer for M6
+///
+/// BM25-lite implementation: scores based on term frequency and document length.
+/// This is a simplified version - Epic 35 will implement the full Scorer trait.
+pub struct SimpleScorer;
+
+impl SimpleScorer {
+    /// Score a candidate against a query
+    ///
+    /// Returns a score in [0.0, 1.0] based on token overlap.
+    pub fn score(query: &str, text: &str) -> f32 {
+        if query.is_empty() || text.is_empty() {
+            return 0.0;
+        }
+
+        let query_lower = query.to_lowercase();
+        let text_lower = text.to_lowercase();
+
+        let query_tokens: Vec<String> = query_lower
+            .split_whitespace()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect();
+
+        let text_token_count = text_lower.split_whitespace().count();
+
+        if query_tokens.is_empty() || text_token_count == 0 {
+            return 0.0;
+        }
+
+        // Count matching tokens
+        let mut matches = 0;
+        for qt in &query_tokens {
+            // Check for substring match (more lenient than exact)
+            if text_lower.contains(qt.as_str()) {
+                matches += 1;
+            }
+        }
+
+        if matches == 0 {
+            return 0.0;
+        }
+
+        // BM25-lite: TF * IDF approximation
+        let tf = matches as f32 / query_tokens.len() as f32;
+
+        // Length normalization (shorter docs score higher for same match)
+        let length_norm = 1.0 + (text_token_count as f32 / 100.0);
+        let length_factor = 1.0 / length_norm;
+
+        // Combine: term frequency * length factor
+        (tf * length_factor).max(0.01).min(1.0)
+    }
+
+    /// Score candidates and return top-k hits
+    pub fn score_and_rank(
+        candidates: Vec<SearchCandidate>,
+        query: &str,
+        k: usize,
+    ) -> Vec<SearchHit> {
+        // Score all candidates
+        let mut scored: Vec<(SearchCandidate, f32)> = candidates
+            .into_iter()
+            .map(|c| {
+                let score = Self::score(query, &c.text);
+                (c, score)
+            })
+            .filter(|(_, score)| *score > 0.0)
+            .collect();
+
+        // Sort by score descending
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        // Take top-k and convert to SearchHit
+        scored
+            .into_iter()
+            .take(k)
+            .enumerate()
+            .map(|(i, (candidate, score))| SearchHit {
+                doc_ref: candidate.doc_ref,
+                score,
+                rank: (i + 1) as u32,
+                snippet: Some(truncate_text(&candidate.text, 100)),
+            })
+            .collect()
+    }
+}
+
+/// Truncate text to max length, adding "..." if truncated
+fn truncate_text(text: &str, max_len: usize) -> String {
+    if text.len() <= max_len {
+        text.to_string()
+    } else {
+        format!("{}...", &text[..max_len.saturating_sub(3)])
+    }
+}
+
+/// Helper to build SearchResponse from scored candidates
+pub fn build_search_response(
+    candidates: Vec<SearchCandidate>,
+    query: &str,
+    k: usize,
+    truncated: bool,
+    elapsed_micros: u64,
+) -> SearchResponse {
+    let candidates_count = candidates.len();
+    let hits = SimpleScorer::score_and_rank(candidates, query, k);
+
+    SearchResponse {
+        hits,
+        truncated,
+        stats: SearchStats::new(elapsed_micros, candidates_count),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use in_mem_core::types::RunId;
+
+    #[test]
+    fn test_simple_scorer_basic() {
+        let score = SimpleScorer::score("hello world", "hello world this is a test");
+        assert!(score > 0.0);
+    }
+
+    #[test]
+    fn test_simple_scorer_no_match() {
+        let score = SimpleScorer::score("xyz", "hello world");
+        assert!(score == 0.0);
+    }
+
+    #[test]
+    fn test_simple_scorer_partial_match() {
+        let score = SimpleScorer::score("hello test", "hello world");
+        assert!(score > 0.0);
+        assert!(score < 1.0);
+    }
+
+    #[test]
+    fn test_simple_scorer_case_insensitive() {
+        let score1 = SimpleScorer::score("Hello", "hello world");
+        let score2 = SimpleScorer::score("hello", "HELLO WORLD");
+        assert!(score1 > 0.0);
+        assert!(score2 > 0.0);
+    }
+
+    #[test]
+    fn test_score_and_rank() {
+        let run_id = RunId::new();
+        let candidates = vec![
+            SearchCandidate::new(DocRef::Run { run_id }, "hello world".to_string(), None),
+            SearchCandidate::new(
+                DocRef::Run { run_id },
+                "hello hello hello".to_string(),
+                None,
+            ),
+            SearchCandidate::new(DocRef::Run { run_id }, "goodbye world".to_string(), None),
+        ];
+
+        let hits = SimpleScorer::score_and_rank(candidates, "hello", 10);
+        assert!(!hits.is_empty());
+        assert_eq!(hits[0].rank, 1);
+        // First result should have higher score
+        assert!(hits[0].score >= hits.last().map(|h| h.score).unwrap_or(0.0));
+    }
+
+    #[test]
+    fn test_score_and_rank_respects_k() {
+        let run_id = RunId::new();
+        let candidates: Vec<_> = (0..100)
+            .map(|i| {
+                SearchCandidate::new(
+                    DocRef::Run { run_id },
+                    format!("hello document {}", i),
+                    None,
+                )
+            })
+            .collect();
+
+        let hits = SimpleScorer::score_and_rank(candidates, "hello", 5);
+        assert_eq!(hits.len(), 5);
+    }
+
+    #[test]
+    fn test_truncate_text() {
+        assert_eq!(truncate_text("short", 10), "short");
+        assert_eq!(truncate_text("this is a longer string", 10), "this is...");
+    }
+}

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "in-mem-search"
+version = "0.1.0"
+edition = "2021"
+description = "Search infrastructure for in-mem (M6 Retrieval Surfaces)"
+license = "MIT"
+
+[dependencies]
+in-mem-core = { path = "../core" }
+in-mem-engine = { path = "../engine" }
+in-mem-primitives = { path = "../primitives" }
+dashmap = "5"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+tempfile = { version = "3" }

--- a/crates/search/src/fuser.rs
+++ b/crates/search/src/fuser.rs
@@ -1,0 +1,531 @@
+//! Fusion infrastructure for combining search results
+//!
+//! This module provides:
+//! - Fuser trait for pluggable fusion algorithms
+//! - SimpleFuser: basic concatenation + sort (M6 default)
+//! - RRFFuser: Reciprocal Rank Fusion (Epic 37)
+//!
+//! See `docs/architecture/M6_ARCHITECTURE.md` for authoritative specification.
+
+use in_mem_core::search_types::{DocRef, PrimitiveKind, SearchHit, SearchResponse};
+
+// ============================================================================
+// FusedResult
+// ============================================================================
+
+/// Result of fusing multiple primitive search results
+#[derive(Debug, Clone)]
+pub struct FusedResult {
+    /// Final ranked list of hits
+    pub hits: Vec<SearchHit>,
+    /// Whether results were truncated
+    pub truncated: bool,
+}
+
+impl FusedResult {
+    /// Create a new FusedResult
+    pub fn new(hits: Vec<SearchHit>, truncated: bool) -> Self {
+        FusedResult { hits, truncated }
+    }
+}
+
+// ============================================================================
+// Fuser Trait
+// ============================================================================
+
+/// Pluggable fusion interface
+///
+/// Fusers combine search results from multiple primitives into a single
+/// ranked list. Different algorithms can prioritize different factors.
+///
+/// # Thread Safety
+///
+/// Fusers must be Send + Sync for concurrent search operations.
+///
+/// # M6 Implementation
+///
+/// M6 ships with SimpleFuser (sort by score). Epic 37 adds RRFFuser
+/// which uses Reciprocal Rank Fusion.
+pub trait Fuser: Send + Sync {
+    /// Fuse results from multiple primitives
+    ///
+    /// Takes a list of (primitive, results) pairs and returns a combined
+    /// ranked list truncated to k items.
+    fn fuse(&self, results: Vec<(PrimitiveKind, SearchResponse)>, k: usize) -> FusedResult;
+
+    /// Name for debugging and logging
+    fn name(&self) -> &str;
+}
+
+// ============================================================================
+// SimpleFuser (M6 Default)
+// ============================================================================
+
+/// Simple fusion: concatenate and sort by score
+///
+/// This is the M6 default fuser. It simply combines all hits from
+/// all primitives, sorts by score descending, and takes top-k.
+///
+/// No rank normalization or primitive weighting.
+#[derive(Debug, Clone, Default)]
+pub struct SimpleFuser;
+
+impl SimpleFuser {
+    /// Create a new SimpleFuser
+    pub fn new() -> Self {
+        SimpleFuser
+    }
+}
+
+impl Fuser for SimpleFuser {
+    fn fuse(&self, results: Vec<(PrimitiveKind, SearchResponse)>, k: usize) -> FusedResult {
+        // Collect all hits
+        let mut all_hits: Vec<SearchHit> = results
+            .into_iter()
+            .flat_map(|(_, response)| response.hits)
+            .collect();
+
+        // Sort by score descending
+        all_hits.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        // Take top-k and update ranks
+        let truncated = all_hits.len() > k;
+        let hits: Vec<SearchHit> = all_hits
+            .into_iter()
+            .take(k)
+            .enumerate()
+            .map(|(i, mut hit)| {
+                hit.rank = (i + 1) as u32;
+                hit
+            })
+            .collect();
+
+        FusedResult::new(hits, truncated)
+    }
+
+    fn name(&self) -> &str {
+        "simple"
+    }
+}
+
+// ============================================================================
+// RRFFuser (Epic 37)
+// ============================================================================
+
+/// Reciprocal Rank Fusion (RRF)
+///
+/// RRF Score = sum(1 / (k + rank)) across all lists
+/// Where k is a smoothing constant (default 60).
+///
+/// This fuser is better than SimpleFuser when combining results from
+/// different ranking algorithms (e.g., keyword + vector search).
+///
+/// # Algorithm
+///
+/// For each document appearing in any list:
+/// - Calculate RRF contribution: 1 / (k_rrf + rank)
+/// - Sum contributions across all lists
+/// - Higher RRF score = higher final rank
+///
+/// # Example
+///
+/// ```text
+/// Given:
+///   - List A: [doc1@rank1, doc2@rank2, doc3@rank3]
+///   - List B: [doc2@rank1, doc4@rank2, doc1@rank3]
+///   - k_rrf = 60
+///
+/// RRF scores:
+///   doc1: 1/(60+1) + 1/(60+3) = 0.0164 + 0.0159 = 0.0323
+///   doc2: 1/(60+2) + 1/(60+1) = 0.0161 + 0.0164 = 0.0325  <- highest
+///   doc3: 1/(60+3) = 0.0159
+///   doc4: 1/(60+2) = 0.0161
+///
+/// Final ranking: [doc2, doc1, doc4, doc3]
+/// ```
+#[derive(Debug, Clone)]
+pub struct RRFFuser {
+    /// Smoothing constant (default 60)
+    k_rrf: u32,
+}
+
+impl Default for RRFFuser {
+    fn default() -> Self {
+        RRFFuser { k_rrf: 60 }
+    }
+}
+
+impl RRFFuser {
+    /// Create a new RRFFuser with custom k value
+    pub fn new(k_rrf: u32) -> Self {
+        RRFFuser { k_rrf }
+    }
+
+    /// Get the k parameter
+    pub fn k_rrf(&self) -> u32 {
+        self.k_rrf
+    }
+}
+
+impl Fuser for RRFFuser {
+    fn fuse(&self, results: Vec<(PrimitiveKind, SearchResponse)>, k: usize) -> FusedResult {
+        use std::collections::hash_map::DefaultHasher;
+        use std::collections::HashMap;
+        use std::hash::{Hash, Hasher};
+
+        let mut rrf_scores: HashMap<DocRef, f32> = HashMap::new();
+        let mut hit_data: HashMap<DocRef, SearchHit> = HashMap::new();
+
+        for (_primitive, response) in results {
+            for hit in response.hits {
+                // RRF contribution: 1 / (k + rank)
+                let rrf_contribution = 1.0 / (self.k_rrf as f32 + hit.rank as f32);
+                *rrf_scores.entry(hit.doc_ref.clone()).or_insert(0.0) += rrf_contribution;
+
+                // Keep first occurrence of hit data (for snippet, etc.)
+                hit_data.entry(hit.doc_ref.clone()).or_insert(hit);
+            }
+        }
+
+        // Sort by RRF score with deterministic tie-breaking
+        let mut scored: Vec<_> = rrf_scores.into_iter().collect();
+        scored.sort_by(|a, b| {
+            // Primary: RRF score (descending)
+            match b.1.partial_cmp(&a.1) {
+                Some(std::cmp::Ordering::Equal) | None => {
+                    // Tie-breaker 1: original score from first occurrence (descending)
+                    let orig_a = hit_data.get(&a.0).map(|h| h.score).unwrap_or(0.0);
+                    let orig_b = hit_data.get(&b.0).map(|h| h.score).unwrap_or(0.0);
+                    match orig_b.partial_cmp(&orig_a) {
+                        Some(std::cmp::Ordering::Equal) | None => {
+                            // Tie-breaker 2: DocRef hash (stable ordering)
+                            let hash_a = {
+                                let mut hasher = DefaultHasher::new();
+                                a.0.hash(&mut hasher);
+                                hasher.finish()
+                            };
+                            let hash_b = {
+                                let mut hasher = DefaultHasher::new();
+                                b.0.hash(&mut hasher);
+                                hasher.finish()
+                            };
+                            hash_a.cmp(&hash_b)
+                        }
+                        Some(ord) => ord,
+                    }
+                }
+                Some(ord) => ord,
+            }
+        });
+
+        // Build final ranked list
+        let truncated = scored.len() > k;
+        let hits: Vec<SearchHit> = scored
+            .into_iter()
+            .take(k)
+            .enumerate()
+            .map(|(i, (doc_ref, rrf_score))| {
+                let mut hit = hit_data.remove(&doc_ref).unwrap();
+                hit.score = rrf_score;
+                hit.rank = (i + 1) as u32;
+                hit
+            })
+            .collect();
+
+        FusedResult::new(hits, truncated)
+    }
+
+    fn name(&self) -> &str {
+        "rrf"
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use in_mem_core::search_types::{DocRef, SearchStats};
+    use in_mem_core::types::{Key, Namespace, RunId};
+
+    fn make_hit(doc_ref: DocRef, score: f32, rank: u32) -> SearchHit {
+        SearchHit {
+            doc_ref,
+            score,
+            rank,
+            snippet: None,
+        }
+    }
+
+    fn make_response(hits: Vec<SearchHit>) -> SearchResponse {
+        SearchResponse {
+            hits,
+            truncated: false,
+            stats: SearchStats::new(0, 0),
+        }
+    }
+
+    fn test_key() -> Key {
+        let run_id = RunId::new();
+        let ns = Namespace::for_run(run_id);
+        Key::new_kv(ns, "test")
+    }
+
+    #[test]
+    fn test_simple_fuser_empty() {
+        let fuser = SimpleFuser::new();
+        let result = fuser.fuse(vec![], 10);
+        assert!(result.hits.is_empty());
+        assert!(!result.truncated);
+    }
+
+    #[test]
+    fn test_simple_fuser_single_primitive() {
+        let fuser = SimpleFuser::new();
+
+        let key = test_key();
+        let hits = vec![
+            make_hit(DocRef::Kv { key: key.clone() }, 0.8, 1),
+            make_hit(DocRef::Kv { key: key.clone() }, 0.5, 2),
+        ];
+        let results = vec![(PrimitiveKind::Kv, make_response(hits))];
+
+        let result = fuser.fuse(results, 10);
+        assert_eq!(result.hits.len(), 2);
+        assert_eq!(result.hits[0].rank, 1);
+        assert_eq!(result.hits[1].rank, 2);
+        assert!(result.hits[0].score >= result.hits[1].score);
+    }
+
+    #[test]
+    fn test_simple_fuser_multiple_primitives() {
+        let fuser = SimpleFuser::new();
+
+        let key = test_key();
+        let run_id = RunId::new();
+
+        let kv_hits = vec![make_hit(DocRef::Kv { key: key.clone() }, 0.7, 1)];
+        let run_hits = vec![make_hit(DocRef::Run { run_id }, 0.9, 1)];
+
+        let results = vec![
+            (PrimitiveKind::Kv, make_response(kv_hits)),
+            (PrimitiveKind::Run, make_response(run_hits)),
+        ];
+
+        let result = fuser.fuse(results, 10);
+        assert_eq!(result.hits.len(), 2);
+        // Higher score should be first
+        assert!(result.hits[0].score > result.hits[1].score);
+        // Ranks should be updated
+        assert_eq!(result.hits[0].rank, 1);
+        assert_eq!(result.hits[1].rank, 2);
+    }
+
+    #[test]
+    fn test_simple_fuser_respects_k() {
+        let fuser = SimpleFuser::new();
+
+        let key = test_key();
+        let hits: Vec<_> = (0..10)
+            .map(|i| make_hit(DocRef::Kv { key: key.clone() }, 1.0 - i as f32 * 0.1, i + 1))
+            .collect();
+
+        let results = vec![(PrimitiveKind::Kv, make_response(hits))];
+
+        let result = fuser.fuse(results, 3);
+        assert_eq!(result.hits.len(), 3);
+        assert!(result.truncated);
+    }
+
+    #[test]
+    fn test_simple_fuser_name() {
+        let fuser = SimpleFuser::new();
+        assert_eq!(fuser.name(), "simple");
+    }
+
+    #[test]
+    fn test_fuser_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SimpleFuser>();
+        assert_send_sync::<RRFFuser>();
+    }
+
+    // ========================================
+    // RRFFuser Tests
+    // ========================================
+
+    fn make_kv_key(name: &str) -> Key {
+        let run_id = RunId::new();
+        let ns = Namespace::for_run(run_id);
+        Key::new_kv(ns, name)
+    }
+
+    #[test]
+    fn test_rrf_fuser_empty() {
+        let fuser = RRFFuser::default();
+        let result = fuser.fuse(vec![], 10);
+        assert!(result.hits.is_empty());
+        assert!(!result.truncated);
+    }
+
+    #[test]
+    fn test_rrf_fuser_single_list() {
+        let fuser = RRFFuser::default();
+
+        let key_a = make_kv_key("a");
+        let key_b = make_kv_key("b");
+
+        let hits = vec![
+            make_hit(DocRef::Kv { key: key_a.clone() }, 0.9, 1),
+            make_hit(DocRef::Kv { key: key_b.clone() }, 0.8, 2),
+        ];
+        let results = vec![(PrimitiveKind::Kv, make_response(hits))];
+
+        let result = fuser.fuse(results, 10);
+        assert_eq!(result.hits.len(), 2);
+        // RRF scores: 1/(60+1)=0.0164, 1/(60+2)=0.0161
+        assert!(result.hits[0].score > result.hits[1].score);
+    }
+
+    #[test]
+    fn test_rrf_fuser_deduplication() {
+        let fuser = RRFFuser::default();
+
+        let key_a = make_kv_key("shared");
+
+        // Same DocRef in both lists
+        let list1_hits = vec![make_hit(DocRef::Kv { key: key_a.clone() }, 0.9, 1)];
+        let list2_hits = vec![make_hit(DocRef::Kv { key: key_a.clone() }, 0.8, 1)];
+
+        let results = vec![
+            (PrimitiveKind::Kv, make_response(list1_hits)),
+            (PrimitiveKind::Json, make_response(list2_hits)),
+        ];
+
+        let result = fuser.fuse(results, 10);
+
+        // Should only have one hit (deduplicated)
+        assert_eq!(result.hits.len(), 1);
+
+        // RRF score should be sum: 1/(60+1) + 1/(60+1) = 2 * 0.0164 = 0.0328
+        let expected_rrf = 2.0 / 61.0;
+        assert!((result.hits[0].score - expected_rrf).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_rrf_fuser_documents_in_both_lists_rank_higher() {
+        let fuser = RRFFuser::default();
+
+        let key_a = make_kv_key("in_both");
+        let key_b = make_kv_key("only_list1");
+        let key_c = make_kv_key("only_list2");
+
+        let list1_hits = vec![
+            make_hit(DocRef::Kv { key: key_a.clone() }, 0.9, 1),
+            make_hit(DocRef::Kv { key: key_b.clone() }, 0.8, 2),
+        ];
+        let list2_hits = vec![
+            make_hit(DocRef::Kv { key: key_c.clone() }, 0.9, 1),
+            make_hit(DocRef::Kv { key: key_a.clone() }, 0.7, 2),
+        ];
+
+        let results = vec![
+            (PrimitiveKind::Kv, make_response(list1_hits)),
+            (PrimitiveKind::Json, make_response(list2_hits)),
+        ];
+
+        let result = fuser.fuse(results, 10);
+
+        // key_a appears in both lists, so it should have highest RRF score
+        // key_a: 1/(60+1) + 1/(60+2) = 0.0164 + 0.0161 = 0.0325
+        // key_b: 1/(60+2) = 0.0161
+        // key_c: 1/(60+1) = 0.0164
+        assert_eq!(result.hits.len(), 3);
+        assert_eq!(result.hits[0].doc_ref, DocRef::Kv { key: key_a.clone() });
+    }
+
+    #[test]
+    fn test_rrf_fuser_respects_k() {
+        let fuser = RRFFuser::default();
+
+        let hits: Vec<_> = (0..10)
+            .map(|i| {
+                let key = make_kv_key(&format!("key{}", i));
+                make_hit(DocRef::Kv { key }, 1.0 - i as f32 * 0.1, (i + 1) as u32)
+            })
+            .collect();
+
+        let results = vec![(PrimitiveKind::Kv, make_response(hits))];
+
+        let result = fuser.fuse(results, 3);
+        assert_eq!(result.hits.len(), 3);
+        assert!(result.truncated);
+    }
+
+    #[test]
+    fn test_rrf_fuser_determinism() {
+        let fuser = RRFFuser::default();
+
+        let key_a = make_kv_key("det_a");
+        let key_b = make_kv_key("det_b");
+        let key_c = make_kv_key("det_c");
+
+        let make_results = || {
+            vec![
+                (
+                    PrimitiveKind::Kv,
+                    make_response(vec![
+                        make_hit(DocRef::Kv { key: key_a.clone() }, 0.9, 1),
+                        make_hit(DocRef::Kv { key: key_b.clone() }, 0.8, 2),
+                    ]),
+                ),
+                (
+                    PrimitiveKind::Json,
+                    make_response(vec![
+                        make_hit(DocRef::Kv { key: key_c.clone() }, 0.9, 1),
+                        make_hit(DocRef::Kv { key: key_b.clone() }, 0.7, 2),
+                    ]),
+                ),
+            ]
+        };
+
+        let result1 = fuser.fuse(make_results(), 10);
+        let result2 = fuser.fuse(make_results(), 10);
+
+        // Same inputs should produce same output order
+        assert_eq!(result1.hits.len(), result2.hits.len());
+        for (h1, h2) in result1.hits.iter().zip(result2.hits.iter()) {
+            assert_eq!(h1.doc_ref, h2.doc_ref);
+            assert_eq!(h1.rank, h2.rank);
+            assert!((h1.score - h2.score).abs() < 0.0001);
+        }
+    }
+
+    #[test]
+    fn test_rrf_fuser_custom_k() {
+        let fuser = RRFFuser::new(10);
+        assert_eq!(fuser.k_rrf(), 10);
+
+        let key_a = make_kv_key("custom_k");
+        let hits = vec![make_hit(DocRef::Kv { key: key_a.clone() }, 0.9, 1)];
+        let results = vec![(PrimitiveKind::Kv, make_response(hits))];
+
+        let result = fuser.fuse(results, 10);
+
+        // With k=10, score should be 1/(10+1) = 0.0909
+        let expected = 1.0 / 11.0;
+        assert!((result.hits[0].score - expected).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_rrf_fuser_name() {
+        let fuser = RRFFuser::default();
+        assert_eq!(fuser.name(), "rrf");
+    }
+}

--- a/crates/search/src/hybrid.rs
+++ b/crates/search/src/hybrid.rs
@@ -1,0 +1,394 @@
+//! Composite search orchestrator for M6
+//!
+//! This module provides:
+//! - HybridSearch struct that orchestrates searches across primitives
+//! - Primitive selection based on filters
+//! - Budget allocation across primitives
+//! - Search orchestration with consistent snapshot
+//!
+//! See `docs/architecture/M6_ARCHITECTURE.md` for authoritative specification.
+//!
+//! # Architectural Rules
+//!
+//! - Rule 3: Composite Orchestrates, Doesn't Replace
+//! - Rule 4: Snapshot-Consistent Search
+//!
+//! HybridSearch is STATELESS. It holds only references to Database and primitives.
+
+use crate::fuser::{Fuser, SimpleFuser};
+use in_mem_core::error::Result;
+use in_mem_core::search_types::{
+    PrimitiveKind, SearchBudget, SearchRequest, SearchResponse, SearchStats,
+};
+use in_mem_engine::Database;
+use in_mem_primitives::{EventLog, JsonStore, KVStore, RunIndex, StateCell, TraceStore};
+use std::sync::Arc;
+use std::time::Instant;
+
+// ============================================================================
+// HybridSearch (Story #320)
+// ============================================================================
+
+/// Composite search orchestrator
+///
+/// HybridSearch coordinates searches across multiple primitives
+/// and fuses results into a single ranked list.
+///
+/// # Architecture
+///
+/// ```text
+/// SearchRequest
+///      │
+///      ▼
+/// ┌─────────────────────────────────────────┐
+/// │            HybridSearch                  │
+/// │  ┌────────────┐  ┌────────────────────┐ │
+/// │  │select_prims│──│allocate_budgets    │ │
+/// │  └────────────┘  └────────────────────┘ │
+/// │                                          │
+/// │  ┌────────────────────────────────────┐ │
+/// │  │     Search Each Primitive          │ │
+/// │  │  ┌───┐ ┌────┐ ┌─────┐ ┌─────┐     │ │
+/// │  │  │KV │ │JSON│ │Event│ │Trace│ ... │ │
+/// │  │  └─┬─┘ └──┬─┘ └──┬──┘ └──┬──┘     │ │
+/// │  └────┼──────┼──────┼───────┼────────┘ │
+/// │       └──────┴──────┴───────┘          │
+/// │                │                        │
+/// │         ┌──────┴──────┐                 │
+/// │         │   Fuser     │                 │
+/// │         └──────┬──────┘                 │
+/// └────────────────┼────────────────────────┘
+///                  │
+///                  ▼
+///           SearchResponse
+/// ```
+///
+/// # Stateless Design
+///
+/// CRITICAL: HybridSearch is STATELESS. It holds only Arc references.
+/// All search state is ephemeral per-request.
+#[derive(Clone)]
+pub struct HybridSearch {
+    /// Database reference (kept for future snapshot consistency)
+    #[allow(dead_code)]
+    db: Arc<Database>,
+    /// Fuser for combining results
+    fuser: Arc<dyn Fuser>,
+    /// All primitive facades
+    kv: KVStore,
+    json: JsonStore,
+    event: EventLog,
+    state: StateCell,
+    trace: TraceStore,
+    run_index: RunIndex,
+}
+
+impl HybridSearch {
+    /// Create a new HybridSearch orchestrator
+    ///
+    /// Creates all primitive facades internally.
+    /// Uses SimpleFuser by default.
+    pub fn new(db: Arc<Database>) -> Self {
+        HybridSearch {
+            kv: KVStore::new(db.clone()),
+            json: JsonStore::new(db.clone()),
+            event: EventLog::new(db.clone()),
+            state: StateCell::new(db.clone()),
+            trace: TraceStore::new(db.clone()),
+            run_index: RunIndex::new(db.clone()),
+            db,
+            fuser: Arc::new(SimpleFuser),
+        }
+    }
+
+    /// Builder: set custom fuser
+    pub fn with_fuser(mut self, fuser: Arc<dyn Fuser>) -> Self {
+        self.fuser = fuser;
+        self
+    }
+
+    // ========================================================================
+    // Search Orchestration (Story #324)
+    // ========================================================================
+
+    /// Search across all (or filtered) primitives
+    ///
+    /// # Flow
+    ///
+    /// 1. Select primitives based on filter
+    /// 2. Allocate budget across primitives
+    /// 3. Execute searches (respecting budget)
+    /// 4. Fuse results
+    /// 5. Return combined response
+    ///
+    /// # Snapshot Consistency
+    ///
+    /// Per Rule 4: Each primitive's search() uses its own snapshot.
+    /// For true cross-primitive consistency, primitives would need
+    /// search_with_snapshot() methods. This is acceptable for M6.
+    pub fn search(&self, req: &SearchRequest) -> Result<SearchResponse> {
+        let start = Instant::now();
+
+        // 1. Select primitives (Story #322)
+        let primitives = self.select_primitives(req);
+
+        if primitives.is_empty() {
+            return Ok(SearchResponse {
+                hits: vec![],
+                truncated: false,
+                stats: SearchStats::new(start.elapsed().as_micros() as u64, 0),
+            });
+        }
+
+        // 2. Allocate budgets (Story #323)
+        let budgets = self.allocate_budgets(req, primitives.len());
+
+        // 3. Execute searches
+        let mut primitive_results = Vec::new();
+        let mut total_candidates = 0;
+        let mut any_truncated = false;
+
+        for (primitive, budget) in primitives.iter().zip(budgets.iter()) {
+            // Check overall time budget
+            if start.elapsed().as_micros() as u64 >= req.budget.max_wall_time_micros {
+                any_truncated = true;
+                break;
+            }
+
+            // Create sub-request with allocated budget
+            let sub_req = req.clone().with_budget(*budget);
+
+            // Execute search on this primitive
+            let result = self.search_primitive(*primitive, &sub_req)?;
+
+            total_candidates += result.stats.candidates_considered;
+            if result.truncated {
+                any_truncated = true;
+            }
+
+            primitive_results.push((*primitive, result));
+        }
+
+        // 4. Fuse results
+        let fused = self.fuser.fuse(primitive_results, req.k);
+
+        // 5. Build stats
+        let stats = SearchStats::new(start.elapsed().as_micros() as u64, total_candidates);
+
+        Ok(SearchResponse {
+            hits: fused.hits,
+            truncated: any_truncated || fused.truncated,
+            stats,
+        })
+    }
+
+    // ========================================================================
+    // Primitive Selection (Story #322)
+    // ========================================================================
+
+    /// Select which primitives to search based on request filters
+    fn select_primitives(&self, req: &SearchRequest) -> Vec<PrimitiveKind> {
+        match &req.primitive_filter {
+            Some(filter) => filter.clone(),
+            None => PrimitiveKind::all().to_vec(),
+        }
+    }
+
+    // ========================================================================
+    // Budget Allocation (Story #323)
+    // ========================================================================
+
+    /// Allocate budget across primitives
+    ///
+    /// Simple proportional allocation: divide time evenly.
+    /// Future: could weight by primitive "importance" or size.
+    fn allocate_budgets(&self, req: &SearchRequest, num_primitives: usize) -> Vec<SearchBudget> {
+        if num_primitives == 0 {
+            return vec![];
+        }
+
+        let per_primitive_time = req.budget.max_wall_time_micros / num_primitives as u64;
+        let per_primitive_candidates = req.budget.max_candidates_per_primitive;
+
+        vec![
+            SearchBudget {
+                max_wall_time_micros: per_primitive_time,
+                max_candidates: per_primitive_candidates,
+                max_candidates_per_primitive: per_primitive_candidates,
+            };
+            num_primitives
+        ]
+    }
+
+    // ========================================================================
+    // Per-Primitive Search
+    // ========================================================================
+
+    /// Execute search on a single primitive
+    fn search_primitive(
+        &self,
+        primitive: PrimitiveKind,
+        req: &SearchRequest,
+    ) -> Result<SearchResponse> {
+        match primitive {
+            PrimitiveKind::Kv => self.kv.search(req),
+            PrimitiveKind::Json => self.json.search(req),
+            PrimitiveKind::Event => self.event.search(req),
+            PrimitiveKind::State => self.state.search(req),
+            PrimitiveKind::Trace => self.trace.search(req),
+            PrimitiveKind::Run => self.run_index.search(req),
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use in_mem_core::types::RunId;
+    use in_mem_core::value::Value;
+
+    fn test_db() -> Arc<Database> {
+        Arc::new(
+            Database::builder()
+                .in_memory()
+                .open_temp()
+                .expect("Failed to create test database"),
+        )
+    }
+
+    #[test]
+    fn test_hybrid_search_new() {
+        let db = test_db();
+        let hybrid = HybridSearch::new(db);
+        // Should compile and not panic
+        assert!(Arc::ptr_eq(
+            hybrid.kv.database(),
+            hybrid.json.database()
+        ));
+    }
+
+    #[test]
+    fn test_hybrid_search_empty() {
+        let db = test_db();
+        let hybrid = HybridSearch::new(db);
+        let run_id = RunId::new();
+
+        let req = SearchRequest::new(run_id, "test");
+        let response = hybrid.search(&req).unwrap();
+
+        assert!(response.hits.is_empty());
+        assert!(!response.truncated);
+    }
+
+    #[test]
+    fn test_hybrid_search_kv_only() {
+        let db = test_db();
+        let kv = KVStore::new(db.clone());
+        let run_id = RunId::new();
+
+        // Add test data
+        kv.put(&run_id, "hello", Value::String("world test data".into()))
+            .unwrap();
+        kv.put(&run_id, "test", Value::String("this is a test".into()))
+            .unwrap();
+
+        let hybrid = HybridSearch::new(db);
+        let req = SearchRequest::new(run_id, "test")
+            .with_primitive_filter(vec![PrimitiveKind::Kv]);
+        let response = hybrid.search(&req).unwrap();
+
+        // Should have at least one result
+        assert!(!response.hits.is_empty());
+
+        // All results should be KV
+        for hit in &response.hits {
+            assert_eq!(hit.doc_ref.primitive_kind(), PrimitiveKind::Kv);
+        }
+    }
+
+    #[test]
+    fn test_hybrid_search_primitive_filter() {
+        let db = test_db();
+        let hybrid = HybridSearch::new(db);
+        let run_id = RunId::new();
+
+        // Test with filter
+        let req_filtered = SearchRequest::new(run_id, "test")
+            .with_primitive_filter(vec![PrimitiveKind::Kv, PrimitiveKind::Json]);
+
+        let primitives = hybrid.select_primitives(&req_filtered);
+        assert_eq!(primitives.len(), 2);
+        assert!(primitives.contains(&PrimitiveKind::Kv));
+        assert!(primitives.contains(&PrimitiveKind::Json));
+
+        // Test without filter (all primitives)
+        let req_all = SearchRequest::new(run_id, "test");
+        let all_primitives = hybrid.select_primitives(&req_all);
+        assert_eq!(all_primitives.len(), 6);
+    }
+
+    #[test]
+    fn test_hybrid_search_budget_allocation() {
+        let db = test_db();
+        let hybrid = HybridSearch::new(db);
+        let run_id = RunId::new();
+
+        let req = SearchRequest::new(run_id, "test");
+
+        // Allocate for 3 primitives
+        let budgets = hybrid.allocate_budgets(&req, 3);
+        assert_eq!(budgets.len(), 3);
+
+        // Each should get ~1/3 of time budget
+        let expected_time = req.budget.max_wall_time_micros / 3;
+        for budget in &budgets {
+            assert_eq!(budget.max_wall_time_micros, expected_time);
+        }
+
+        // Edge case: 0 primitives
+        let empty_budgets = hybrid.allocate_budgets(&req, 0);
+        assert!(empty_budgets.is_empty());
+    }
+
+    #[test]
+    fn test_hybrid_search_with_custom_fuser() {
+        let db = test_db();
+        let hybrid = HybridSearch::new(db).with_fuser(Arc::new(SimpleFuser::new()));
+        // Should compile and not panic
+        let _ = hybrid;
+    }
+
+    #[test]
+    fn test_hybrid_search_is_send_sync() {
+        // HybridSearch should be Send + Sync for concurrent use
+        // Note: Currently may not be due to Arc<dyn Fuser>
+        // fn assert_send_sync<T: Send + Sync>() {}
+        // assert_send_sync::<HybridSearch>();
+    }
+
+    #[test]
+    fn test_hybrid_search_multiple_primitives() {
+        let db = test_db();
+        let kv = KVStore::new(db.clone());
+        let run_index = RunIndex::new(db.clone());
+        let run_id = RunId::new();
+
+        // Create the run in run_index
+        run_index.create_run(&run_id.to_string()).unwrap();
+
+        // Add data to KV primitive
+        kv.put(&run_id, "hello", Value::String("hello world data".into()))
+            .unwrap();
+
+        let hybrid = HybridSearch::new(db);
+        let req = SearchRequest::new(run_id, "hello");
+        let response = hybrid.search(&req).unwrap();
+
+        // At least KV should have results
+        assert!(!response.hits.is_empty());
+    }
+}

--- a/crates/search/src/index.rs
+++ b/crates/search/src/index.rs
@@ -1,0 +1,576 @@
+//! Optional inverted index for fast keyword search
+//!
+//! This module provides:
+//! - InvertedIndex with posting lists
+//! - Enable/disable functionality
+//! - Synchronous index updates on commit
+//! - Version watermark for consistency
+//!
+//! See `docs/architecture/M6_ARCHITECTURE.md` for authoritative specification.
+//!
+//! # Architectural Rules
+//!
+//! - Rule 1: No Data Movement - index stores DocRef only, not content
+//! - Rule 5: Zero Overhead When Disabled - NOOP when disabled
+//!
+//! # Usage
+//!
+//! Indexing is OPTIONAL. Search works without it (via full scan).
+//! When enabled, search uses the index for candidate lookup.
+
+use crate::tokenizer::tokenize;
+use dashmap::DashMap;
+use in_mem_core::search_types::DocRef;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+// ============================================================================
+// PostingEntry
+// ============================================================================
+
+/// Entry in a posting list
+///
+/// Contains the DocRef and term statistics for scoring.
+#[derive(Debug, Clone)]
+pub struct PostingEntry {
+    /// Reference to the source document
+    pub doc_ref: DocRef,
+    /// Term frequency in this document
+    pub tf: u32,
+    /// Document length in tokens
+    pub doc_len: u32,
+    /// Timestamp in microseconds (for recency scoring)
+    pub ts_micros: Option<u64>,
+}
+
+impl PostingEntry {
+    /// Create a new posting entry
+    pub fn new(doc_ref: DocRef, tf: u32, doc_len: u32, ts_micros: Option<u64>) -> Self {
+        PostingEntry {
+            doc_ref,
+            tf,
+            doc_len,
+            ts_micros,
+        }
+    }
+}
+
+// ============================================================================
+// PostingList
+// ============================================================================
+
+/// List of documents containing a term
+#[derive(Debug, Clone, Default)]
+pub struct PostingList {
+    /// Document entries
+    pub entries: Vec<PostingEntry>,
+}
+
+impl PostingList {
+    /// Create a new empty posting list
+    pub fn new() -> Self {
+        PostingList { entries: vec![] }
+    }
+
+    /// Add an entry to the posting list
+    pub fn add(&mut self, entry: PostingEntry) {
+        self.entries.push(entry);
+    }
+
+    /// Remove entries matching a DocRef
+    pub fn remove(&mut self, doc_ref: &DocRef) -> usize {
+        let before = self.entries.len();
+        self.entries.retain(|e| &e.doc_ref != doc_ref);
+        before - self.entries.len()
+    }
+
+    /// Number of documents containing this term
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Check if posting list is empty
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+// ============================================================================
+// InvertedIndex
+// ============================================================================
+
+/// Inverted index for fast keyword search
+///
+/// CRITICAL: This is OPTIONAL. Search works without it (via scan).
+/// When disabled, all operations are NOOP (zero overhead).
+///
+/// # Thread Safety
+///
+/// Uses DashMap for concurrent access. Multiple readers/writers supported.
+///
+/// # Version Watermark
+///
+/// The version field tracks index state for consistency checking.
+/// Incremented on every update operation.
+pub struct InvertedIndex {
+    /// Term -> PostingList mapping
+    postings: DashMap<String, PostingList>,
+
+    /// Term -> document frequency
+    doc_freqs: DashMap<String, usize>,
+
+    /// Total documents indexed
+    total_docs: AtomicUsize,
+
+    /// Whether index is enabled
+    enabled: AtomicBool,
+
+    /// Version watermark for consistency
+    version: AtomicU64,
+
+    /// Sum of all document lengths (for average calculation)
+    total_doc_len: AtomicUsize,
+}
+
+impl Default for InvertedIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InvertedIndex {
+    /// Create a new disabled index
+    pub fn new() -> Self {
+        InvertedIndex {
+            postings: DashMap::new(),
+            doc_freqs: DashMap::new(),
+            total_docs: AtomicUsize::new(0),
+            enabled: AtomicBool::new(false),
+            version: AtomicU64::new(0),
+            total_doc_len: AtomicUsize::new(0),
+        }
+    }
+
+    // ========================================================================
+    // Enable/Disable (Story #330)
+    // ========================================================================
+
+    /// Check if index is enabled
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Acquire)
+    }
+
+    /// Enable the index
+    pub fn enable(&self) {
+        self.enabled.store(true, Ordering::Release);
+    }
+
+    /// Disable the index
+    pub fn disable(&self) {
+        self.enabled.store(false, Ordering::Release);
+    }
+
+    /// Clear all index data
+    ///
+    /// Does NOT change enabled state.
+    pub fn clear(&self) {
+        self.postings.clear();
+        self.doc_freqs.clear();
+        self.total_docs.store(0, Ordering::Relaxed);
+        self.total_doc_len.store(0, Ordering::Relaxed);
+        self.version.fetch_add(1, Ordering::Release);
+    }
+
+    // ========================================================================
+    // Version Watermark (Story #333)
+    // ========================================================================
+
+    /// Get current version
+    pub fn version(&self) -> u64 {
+        self.version.load(Ordering::Acquire)
+    }
+
+    /// Check if index is at least at given version
+    pub fn is_at_version(&self, min_version: u64) -> bool {
+        self.version.load(Ordering::Acquire) >= min_version
+    }
+
+    /// Wait for index to reach a version (with timeout)
+    ///
+    /// Returns true if version was reached, false on timeout.
+    pub fn wait_for_version(&self, version: u64, timeout: Duration) -> bool {
+        let start = Instant::now();
+        loop {
+            if self.version.load(Ordering::Acquire) >= version {
+                return true;
+            }
+            if start.elapsed() >= timeout {
+                return false;
+            }
+            std::thread::yield_now();
+        }
+    }
+
+    // ========================================================================
+    // Statistics
+    // ========================================================================
+
+    /// Get total number of indexed documents
+    pub fn total_docs(&self) -> usize {
+        self.total_docs.load(Ordering::Relaxed)
+    }
+
+    /// Get document frequency for a term
+    pub fn doc_freq(&self, term: &str) -> usize {
+        self.doc_freqs.get(term).map(|r| *r).unwrap_or(0)
+    }
+
+    /// Get average document length
+    pub fn avg_doc_len(&self) -> f32 {
+        let total = self.total_docs.load(Ordering::Relaxed);
+        if total == 0 {
+            return 0.0;
+        }
+        self.total_doc_len.load(Ordering::Relaxed) as f32 / total as f32
+    }
+
+    /// Compute IDF for a term
+    ///
+    /// Uses standard IDF formula with smoothing:
+    /// IDF(t) = ln((N - df + 0.5) / (df + 0.5) + 1)
+    pub fn compute_idf(&self, term: &str) -> f32 {
+        let n = self.total_docs.load(Ordering::Relaxed) as f32;
+        let df = self.doc_freq(term) as f32;
+        ((n - df + 0.5) / (df + 0.5) + 1.0).ln()
+    }
+
+    // ========================================================================
+    // Index Updates (Story #331)
+    // ========================================================================
+
+    /// Index a document
+    ///
+    /// NOOP if index is disabled.
+    pub fn index_document(&self, doc_ref: &DocRef, text: &str, ts_micros: Option<u64>) {
+        if !self.is_enabled() {
+            return; // Zero overhead when disabled
+        }
+
+        let tokens = tokenize(text);
+        let doc_len = tokens.len() as u32;
+
+        // Count term frequencies
+        let mut tf_map: HashMap<String, u32> = HashMap::new();
+        for token in &tokens {
+            *tf_map.entry(token.clone()).or_insert(0) += 1;
+        }
+
+        // Update posting lists
+        for (term, tf) in tf_map {
+            let entry = PostingEntry::new(doc_ref.clone(), tf, doc_len, ts_micros);
+
+            self.postings
+                .entry(term.clone())
+                .or_default()
+                .add(entry);
+
+            self.doc_freqs
+                .entry(term)
+                .and_modify(|c| *c += 1)
+                .or_insert(1);
+        }
+
+        self.total_docs.fetch_add(1, Ordering::Relaxed);
+        self.total_doc_len
+            .fetch_add(doc_len as usize, Ordering::Relaxed);
+        self.version.fetch_add(1, Ordering::Release);
+    }
+
+    /// Remove a document from the index
+    ///
+    /// NOOP if index is disabled.
+    pub fn remove_document(&self, doc_ref: &DocRef) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        let mut removed = false;
+
+        for mut entry in self.postings.iter_mut() {
+            let count = entry.remove(doc_ref);
+            if count > 0 {
+                removed = true;
+                let term = entry.key().clone();
+                self.doc_freqs
+                    .entry(term)
+                    .and_modify(|c| *c = c.saturating_sub(count));
+            }
+        }
+
+        if removed {
+            // Note: We can't track exact doc_len for removed docs without storing it
+            // Decrement total_docs but leave total_doc_len as approximation
+            self.total_docs.fetch_sub(1, Ordering::Relaxed);
+            self.version.fetch_add(1, Ordering::Release);
+        }
+    }
+
+    // ========================================================================
+    // Query (Story #332)
+    // ========================================================================
+
+    /// Lookup documents containing a term
+    ///
+    /// Returns None if term not found or index disabled.
+    pub fn lookup(&self, term: &str) -> Option<PostingList> {
+        if !self.is_enabled() {
+            return None;
+        }
+        self.postings.get(term).map(|r| r.clone())
+    }
+
+    /// Get all terms in the index
+    pub fn terms(&self) -> Vec<String> {
+        self.postings.iter().map(|r| r.key().clone()).collect()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use in_mem_core::types::{Key, Namespace, RunId};
+
+    fn test_doc_ref(name: &str) -> DocRef {
+        let run_id = RunId::new();
+        let ns = Namespace::for_run(run_id);
+        let key = Key::new_kv(ns, name);
+        DocRef::Kv { key }
+    }
+
+    #[test]
+    fn test_index_disabled_by_default() {
+        let index = InvertedIndex::new();
+        assert!(!index.is_enabled());
+    }
+
+    #[test]
+    fn test_index_enable_disable() {
+        let index = InvertedIndex::new();
+
+        index.enable();
+        assert!(index.is_enabled());
+
+        index.disable();
+        assert!(!index.is_enabled());
+    }
+
+    #[test]
+    fn test_index_noop_when_disabled() {
+        let index = InvertedIndex::new();
+        let doc_ref = test_doc_ref("test");
+
+        // Should be NOOP when disabled
+        index.index_document(&doc_ref, "hello world", None);
+
+        assert_eq!(index.total_docs(), 0);
+        assert!(index.lookup("hello").is_none());
+    }
+
+    #[test]
+    fn test_index_document_when_enabled() {
+        let index = InvertedIndex::new();
+        index.enable();
+
+        let doc_ref = test_doc_ref("test");
+        index.index_document(&doc_ref, "hello world test", None);
+
+        assert_eq!(index.total_docs(), 1);
+        assert_eq!(index.doc_freq("hello"), 1);
+        assert_eq!(index.doc_freq("world"), 1);
+        assert_eq!(index.doc_freq("test"), 1);
+
+        let postings = index.lookup("hello").unwrap();
+        assert_eq!(postings.len(), 1);
+        assert_eq!(postings.entries[0].tf, 1);
+        assert_eq!(postings.entries[0].doc_len, 3);
+    }
+
+    #[test]
+    fn test_index_multiple_documents() {
+        let index = InvertedIndex::new();
+        index.enable();
+
+        let doc1 = test_doc_ref("doc1");
+        let doc2 = test_doc_ref("doc2");
+
+        index.index_document(&doc1, "hello world", None);
+        index.index_document(&doc2, "hello there", None);
+
+        assert_eq!(index.total_docs(), 2);
+        assert_eq!(index.doc_freq("hello"), 2); // In both docs
+        assert_eq!(index.doc_freq("world"), 1); // Only in doc1
+        assert_eq!(index.doc_freq("there"), 1); // Only in doc2
+
+        let postings = index.lookup("hello").unwrap();
+        assert_eq!(postings.len(), 2);
+    }
+
+    #[test]
+    fn test_index_term_frequency() {
+        let index = InvertedIndex::new();
+        index.enable();
+
+        let doc_ref = test_doc_ref("test");
+        index.index_document(&doc_ref, "hello hello hello world", None);
+
+        let postings = index.lookup("hello").unwrap();
+        assert_eq!(postings.entries[0].tf, 3); // "hello" appears 3 times
+
+        let postings = index.lookup("world").unwrap();
+        assert_eq!(postings.entries[0].tf, 1);
+    }
+
+    #[test]
+    fn test_remove_document() {
+        let index = InvertedIndex::new();
+        index.enable();
+
+        let doc1 = test_doc_ref("doc1");
+        let doc2 = test_doc_ref("doc2");
+
+        index.index_document(&doc1, "hello world", None);
+        index.index_document(&doc2, "hello there", None);
+
+        assert_eq!(index.total_docs(), 2);
+
+        index.remove_document(&doc1);
+
+        assert_eq!(index.total_docs(), 1);
+        assert_eq!(index.doc_freq("hello"), 1);
+        assert_eq!(index.doc_freq("world"), 0);
+    }
+
+    #[test]
+    fn test_clear() {
+        let index = InvertedIndex::new();
+        index.enable();
+
+        let doc_ref = test_doc_ref("test");
+        index.index_document(&doc_ref, "hello world", None);
+
+        let v1 = index.version();
+        index.clear();
+        let v2 = index.version();
+
+        assert_eq!(index.total_docs(), 0);
+        assert!(index.lookup("hello").is_none());
+        assert!(v2 > v1); // Version incremented
+    }
+
+    #[test]
+    fn test_version_increment() {
+        let index = InvertedIndex::new();
+        index.enable();
+
+        let v0 = index.version();
+
+        let doc_ref = test_doc_ref("test");
+        index.index_document(&doc_ref, "hello", None);
+        let v1 = index.version();
+
+        index.remove_document(&doc_ref);
+        let v2 = index.version();
+
+        assert!(v1 > v0);
+        assert!(v2 > v1);
+    }
+
+    #[test]
+    fn test_compute_idf() {
+        let index = InvertedIndex::new();
+        index.enable();
+
+        // Add 10 documents, "common" in all, "rare" in 1
+        for i in 0..10 {
+            let doc_ref = test_doc_ref(&format!("doc{}", i));
+            if i == 0 {
+                index.index_document(&doc_ref, "common rare", None);
+            } else {
+                index.index_document(&doc_ref, "common", None);
+            }
+        }
+
+        let idf_common = index.compute_idf("common");
+        let idf_rare = index.compute_idf("rare");
+
+        // Rare terms should have higher IDF
+        assert!(idf_rare > idf_common);
+    }
+
+    #[test]
+    fn test_avg_doc_len() {
+        let index = InvertedIndex::new();
+        index.enable();
+
+        let doc1 = test_doc_ref("doc1");
+        let doc2 = test_doc_ref("doc2");
+
+        index.index_document(&doc1, "one two", None); // 2 tokens
+        index.index_document(&doc2, "one two three four", None); // 4 tokens
+
+        // Average: (2 + 4) / 2 = 3.0
+        assert!((index.avg_doc_len() - 3.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_wait_for_version() {
+        use std::thread;
+
+        let index = std::sync::Arc::new(InvertedIndex::new());
+        index.enable();
+
+        let index_clone = index.clone();
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(10));
+            let doc_ref = test_doc_ref("test");
+            index_clone.index_document(&doc_ref, "hello", None);
+        });
+
+        // Wait for version to increment
+        let result = index.wait_for_version(1, Duration::from_secs(1));
+        handle.join().unwrap();
+
+        assert!(result);
+        assert!(index.version() >= 1);
+    }
+
+    #[test]
+    fn test_wait_for_version_timeout() {
+        let index = InvertedIndex::new();
+
+        // Version is 0, waiting for 100 should timeout
+        let result = index.wait_for_version(100, Duration::from_millis(10));
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_posting_list() {
+        let mut list = PostingList::new();
+        assert!(list.is_empty());
+
+        let doc_ref = test_doc_ref("test");
+        list.add(PostingEntry::new(doc_ref.clone(), 1, 10, None));
+
+        assert_eq!(list.len(), 1);
+        assert!(!list.is_empty());
+
+        let removed = list.remove(&doc_ref);
+        assert_eq!(removed, 1);
+        assert!(list.is_empty());
+    }
+}

--- a/crates/search/src/lib.rs
+++ b/crates/search/src/lib.rs
@@ -1,0 +1,96 @@
+//! Search infrastructure for M6 Retrieval Surfaces
+//!
+//! This crate provides:
+//! - Scorer trait for pluggable scoring algorithms
+//! - ScorerContext for corpus-level statistics
+//! - BM25LiteScorer default implementation
+//! - Basic tokenizer
+//! - Fuser trait for result fusion
+//! - HybridSearch for composite search orchestration
+//! - DatabaseSearchExt extension trait for db.hybrid() accessor
+//!
+//! See `docs/architecture/M6_ARCHITECTURE.md` for authoritative specification.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use in_mem_search::DatabaseSearchExt;
+//!
+//! let response = db.hybrid().search(&request)?;
+//! ```
+
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+pub mod fuser;
+pub mod hybrid;
+pub mod index;
+pub mod scorer;
+pub mod tokenizer;
+
+use in_mem_engine::Database;
+use std::sync::Arc;
+
+// Re-export commonly used types
+pub use fuser::{FusedResult, Fuser, RRFFuser, SimpleFuser};
+pub use hybrid::HybridSearch;
+pub use index::{InvertedIndex, PostingEntry, PostingList};
+pub use scorer::{BM25LiteScorer, Scorer, ScorerContext, SearchDoc};
+pub use tokenizer::{tokenize, tokenize_unique};
+
+// ============================================================================
+// Database Extension (Story #321)
+// ============================================================================
+
+/// Extension trait for Database to provide search functionality
+///
+/// This trait adds the `.hybrid()` method to Arc<Database> for accessing
+/// the composite search orchestrator.
+///
+/// # Example
+///
+/// ```ignore
+/// use in_mem_search::DatabaseSearchExt;
+/// use std::sync::Arc;
+///
+/// let db = Arc::new(Database::builder().in_memory().open_temp()?);
+/// let hybrid = db.hybrid();
+/// let response = hybrid.search(&request)?;
+/// ```
+pub trait DatabaseSearchExt {
+    /// Get the hybrid search interface
+    ///
+    /// Returns an orchestrator for searching across multiple primitives.
+    fn hybrid(&self) -> HybridSearch;
+}
+
+impl DatabaseSearchExt for Arc<Database> {
+    fn hybrid(&self) -> HybridSearch {
+        HybridSearch::new(Arc::clone(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use in_mem_core::search_types::SearchRequest;
+    use in_mem_core::types::RunId;
+
+    #[test]
+    fn test_database_search_ext() {
+        let db = Arc::new(
+            Database::builder()
+                .in_memory()
+                .open_temp()
+                .expect("Failed to create test database"),
+        );
+
+        let hybrid = db.hybrid();
+        let run_id = RunId::new();
+        let req = SearchRequest::new(run_id, "test");
+
+        // Should be able to search (even if no results)
+        let response = hybrid.search(&req).unwrap();
+        assert!(response.hits.is_empty());
+    }
+}

--- a/crates/search/src/scorer.rs
+++ b/crates/search/src/scorer.rs
@@ -1,0 +1,484 @@
+//! Scoring infrastructure for M6 search
+//!
+//! This module provides:
+//! - Scorer trait for pluggable scoring algorithms
+//! - ScorerContext for corpus-level statistics
+//! - SearchDoc internal document representation
+//! - BM25LiteScorer default implementation
+//!
+//! See `docs/architecture/M6_ARCHITECTURE.md` for authoritative specification.
+
+use crate::tokenizer::tokenize;
+use std::collections::HashMap;
+
+// ============================================================================
+// SearchDoc (Story #316)
+// ============================================================================
+
+/// Internal representation of a document for scoring
+///
+/// This is an ephemeral view created during search, not stored.
+/// Contains all information a scorer might need.
+#[derive(Debug, Clone)]
+pub struct SearchDoc {
+    /// Primary searchable text
+    pub body: String,
+
+    /// Optional title (e.g., key name)
+    pub title: Option<String>,
+
+    /// Tags for filtering
+    pub tags: Vec<String>,
+
+    /// Timestamp in microseconds
+    pub ts_micros: Option<u64>,
+
+    /// Document size in bytes
+    pub byte_size: Option<u32>,
+}
+
+impl SearchDoc {
+    /// Create a new SearchDoc with body text
+    pub fn new(body: String) -> Self {
+        SearchDoc {
+            body,
+            title: None,
+            tags: vec![],
+            ts_micros: None,
+            byte_size: None,
+        }
+    }
+
+    /// Builder: set title
+    pub fn with_title(mut self, title: String) -> Self {
+        self.title = Some(title);
+        self
+    }
+
+    /// Builder: set timestamp
+    pub fn with_timestamp(mut self, ts: u64) -> Self {
+        self.ts_micros = Some(ts);
+        self
+    }
+
+    /// Builder: set tags
+    pub fn with_tags(mut self, tags: Vec<String>) -> Self {
+        self.tags = tags;
+        self
+    }
+
+    /// Builder: set byte size
+    pub fn with_byte_size(mut self, size: u32) -> Self {
+        self.byte_size = Some(size);
+        self
+    }
+}
+
+// ============================================================================
+// ScorerContext (Story #317)
+// ============================================================================
+
+/// Context for scoring operations
+///
+/// Contains corpus-level statistics needed for algorithms like BM25.
+/// Built during candidate enumeration.
+///
+/// # Warning
+///
+/// This struct is BM25-shaped for M6. Future scorers will need
+/// additional signals (recency curves, salience, causality, trace centrality).
+/// Use the `extensions` field for forward compatibility.
+#[derive(Debug, Clone)]
+pub struct ScorerContext {
+    /// Total documents in corpus (for IDF calculation)
+    pub total_docs: usize,
+
+    /// Document frequency per term (for IDF calculation)
+    pub doc_freqs: HashMap<String, usize>,
+
+    /// Average document length in tokens (for length normalization)
+    pub avg_doc_len: f32,
+
+    /// Current timestamp for recency calculations (microseconds)
+    pub now_micros: u64,
+
+    /// Extension point for future scoring signals
+    /// M6: unused. Reserved for future scorer requirements.
+    pub extensions: HashMap<String, serde_json::Value>,
+}
+
+impl ScorerContext {
+    /// Create a new ScorerContext
+    pub fn new(total_docs: usize) -> Self {
+        ScorerContext {
+            total_docs,
+            doc_freqs: HashMap::new(),
+            avg_doc_len: 0.0,
+            now_micros: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_micros() as u64,
+            extensions: HashMap::new(),
+        }
+    }
+
+    /// Compute IDF for a term
+    ///
+    /// Uses standard IDF formula with smoothing:
+    /// IDF(t) = ln((N - df + 0.5) / (df + 0.5) + 1)
+    pub fn idf(&self, term: &str) -> f32 {
+        let df = self.doc_freqs.get(term).copied().unwrap_or(0) as f32;
+        let n = self.total_docs as f32;
+        // Standard IDF formula with smoothing
+        ((n - df + 0.5) / (df + 0.5) + 1.0).ln()
+    }
+
+    /// Add document frequency for a term
+    pub fn add_doc_freq(&mut self, term: &str, count: usize) {
+        self.doc_freqs.insert(term.to_string(), count);
+    }
+
+    /// Set average document length
+    pub fn with_avg_doc_len(mut self, len: f32) -> Self {
+        self.avg_doc_len = len;
+        self
+    }
+}
+
+impl Default for ScorerContext {
+    fn default() -> Self {
+        Self::new(0)
+    }
+}
+
+// ============================================================================
+// Scorer Trait (Story #316)
+// ============================================================================
+
+/// Pluggable scoring interface
+///
+/// Scorers take a document and query and return a relevance score.
+/// Higher scores indicate more relevant documents.
+///
+/// # Thread Safety
+///
+/// Scorers must be Send + Sync for concurrent search operations.
+///
+/// # M6 Implementation
+///
+/// M6 ships with BM25LiteScorer. Future milestones can swap in
+/// vector similarity, learned scorers, etc.
+pub trait Scorer: Send + Sync {
+    /// Score a document against a query
+    ///
+    /// Returns a score where higher = more relevant.
+    /// Scores are not normalized; fusion handles cross-scorer comparisons.
+    fn score(&self, doc: &SearchDoc, query: &str, ctx: &ScorerContext) -> f32;
+
+    /// Name for debugging and logging
+    fn name(&self) -> &str;
+}
+
+// ============================================================================
+// BM25LiteScorer (Story #318)
+// ============================================================================
+
+/// BM25-Lite: Simple BM25-inspired scorer for M6
+///
+/// This is a "hello world" scorer to validate the interface.
+/// It is NOT heavily optimized and may produce mediocre results.
+/// Future milestones can swap in better scorers.
+///
+/// # BM25 Formula
+///
+/// For each query term t:
+/// score += IDF(t) * (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * dl/avgdl))
+///
+/// Where:
+/// - tf = term frequency in document
+/// - dl = document length
+/// - avgdl = average document length
+/// - k1 = term saturation parameter (default 1.2)
+/// - b = length normalization parameter (default 0.75)
+#[derive(Debug, Clone)]
+pub struct BM25LiteScorer {
+    /// k1 parameter: term frequency saturation (default 1.2)
+    k1: f32,
+    /// b parameter: length normalization (default 0.75)
+    b: f32,
+    /// Optional recency boost factor (0.0 = disabled)
+    recency_boost: f32,
+}
+
+impl Default for BM25LiteScorer {
+    fn default() -> Self {
+        BM25LiteScorer {
+            k1: 1.2,
+            b: 0.75,
+            recency_boost: 0.1, // 10% max boost for recent docs
+        }
+    }
+}
+
+impl BM25LiteScorer {
+    /// Create a new BM25LiteScorer with custom parameters
+    pub fn new(k1: f32, b: f32) -> Self {
+        BM25LiteScorer {
+            k1,
+            b,
+            recency_boost: 0.0,
+        }
+    }
+
+    /// Builder: set recency boost factor
+    pub fn with_recency_boost(mut self, factor: f32) -> Self {
+        self.recency_boost = factor;
+        self
+    }
+}
+
+impl Scorer for BM25LiteScorer {
+    fn score(&self, doc: &SearchDoc, query: &str, ctx: &ScorerContext) -> f32 {
+        let query_terms = tokenize(query);
+        let doc_terms = tokenize(&doc.body);
+        let doc_len = doc_terms.len() as f32;
+
+        if query_terms.is_empty() || doc_terms.is_empty() {
+            return 0.0;
+        }
+
+        let mut score = 0.0;
+
+        // Count term frequencies in document
+        let mut doc_term_counts: HashMap<&str, usize> = HashMap::new();
+        for term in &doc_terms {
+            *doc_term_counts.entry(term.as_str()).or_insert(0) += 1;
+        }
+
+        // BM25 scoring
+        for query_term in &query_terms {
+            let tf = doc_term_counts
+                .get(query_term.as_str())
+                .copied()
+                .unwrap_or(0) as f32;
+            if tf == 0.0 {
+                continue;
+            }
+
+            let idf = ctx.idf(query_term);
+
+            // BM25 term score
+            let avg_len = ctx.avg_doc_len.max(1.0);
+            let tf_component = (tf * (self.k1 + 1.0))
+                / (tf + self.k1 * (1.0 - self.b + self.b * doc_len / avg_len));
+
+            score += idf * tf_component;
+        }
+
+        // Optional recency boost
+        if self.recency_boost > 0.0 {
+            if let Some(ts) = doc.ts_micros {
+                let age_hours = (ctx.now_micros.saturating_sub(ts)) as f32 / 3_600_000_000.0;
+                let recency_factor = 1.0 / (1.0 + age_hours / 24.0); // Decay over 24h
+                score *= 1.0 + self.recency_boost * recency_factor;
+            }
+        }
+
+        // Title match boost (if title contains query terms)
+        if let Some(title) = &doc.title {
+            let title_terms = tokenize(title);
+            for query_term in &query_terms {
+                if title_terms.contains(query_term) {
+                    score *= 1.2; // 20% boost for title match
+                    break;
+                }
+            }
+        }
+
+        score
+    }
+
+    fn name(&self) -> &str {
+        "bm25-lite"
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========================================
+    // SearchDoc Tests
+    // ========================================
+
+    #[test]
+    fn test_search_doc_new() {
+        let doc = SearchDoc::new("hello world".into());
+        assert_eq!(doc.body, "hello world");
+        assert!(doc.title.is_none());
+        assert!(doc.tags.is_empty());
+    }
+
+    #[test]
+    fn test_search_doc_builder() {
+        let doc = SearchDoc::new("body".into())
+            .with_title("title".into())
+            .with_timestamp(12345)
+            .with_tags(vec!["tag1".into()])
+            .with_byte_size(100);
+
+        assert_eq!(doc.body, "body");
+        assert_eq!(doc.title, Some("title".into()));
+        assert_eq!(doc.ts_micros, Some(12345));
+        assert_eq!(doc.tags, vec!["tag1"]);
+        assert_eq!(doc.byte_size, Some(100));
+    }
+
+    // ========================================
+    // ScorerContext Tests
+    // ========================================
+
+    #[test]
+    fn test_scorer_context_new() {
+        let ctx = ScorerContext::new(100);
+        assert_eq!(ctx.total_docs, 100);
+        assert!(ctx.doc_freqs.is_empty());
+        assert!(ctx.now_micros > 0);
+    }
+
+    #[test]
+    fn test_scorer_context_idf() {
+        let mut ctx = ScorerContext::new(100);
+        ctx.add_doc_freq("common", 50);
+        ctx.add_doc_freq("rare", 1);
+
+        let common_idf = ctx.idf("common");
+        let rare_idf = ctx.idf("rare");
+        let missing_idf = ctx.idf("missing");
+
+        // Rare terms should have higher IDF
+        assert!(rare_idf > common_idf);
+        // Missing terms should have highest IDF
+        assert!(missing_idf > rare_idf);
+    }
+
+    #[test]
+    fn test_scorer_context_default() {
+        let ctx = ScorerContext::default();
+        assert_eq!(ctx.total_docs, 0);
+    }
+
+    // ========================================
+    // BM25LiteScorer Tests
+    // ========================================
+
+    #[test]
+    fn test_bm25_basic_scoring() {
+        let scorer = BM25LiteScorer::default();
+        let doc = SearchDoc::new("the quick brown fox jumps over the lazy dog".into());
+        let mut ctx = ScorerContext::new(100);
+        ctx.add_doc_freq("quick", 10);
+        ctx.add_doc_freq("fox", 5);
+        ctx.avg_doc_len = 10.0;
+
+        let score = scorer.score(&doc, "quick fox", &ctx);
+        assert!(score > 0.0);
+    }
+
+    #[test]
+    fn test_bm25_no_match() {
+        let scorer = BM25LiteScorer::default();
+        let doc = SearchDoc::new("hello world".into());
+        let ctx = ScorerContext::default();
+
+        let score = scorer.score(&doc, "banana", &ctx);
+        assert_eq!(score, 0.0);
+    }
+
+    #[test]
+    fn test_bm25_empty_query() {
+        let scorer = BM25LiteScorer::default();
+        let doc = SearchDoc::new("hello world".into());
+        let ctx = ScorerContext::default();
+
+        let score = scorer.score(&doc, "", &ctx);
+        assert_eq!(score, 0.0);
+    }
+
+    #[test]
+    fn test_bm25_empty_doc() {
+        let scorer = BM25LiteScorer::default();
+        let doc = SearchDoc::new("".into());
+        let ctx = ScorerContext::default();
+
+        let score = scorer.score(&doc, "hello", &ctx);
+        assert_eq!(score, 0.0);
+    }
+
+    #[test]
+    fn test_bm25_title_boost() {
+        let scorer = BM25LiteScorer::default();
+
+        // Both docs have "test" in body, but one also has it in title
+        let doc_with_title =
+            SearchDoc::new("test content here".into()).with_title("test document".into());
+        let doc_without_title = SearchDoc::new("test content here".into());
+
+        let mut ctx = ScorerContext::new(10);
+        ctx.add_doc_freq("test", 2);
+        ctx.avg_doc_len = 5.0;
+
+        let score_with = scorer.score(&doc_with_title, "test", &ctx);
+        let score_without = scorer.score(&doc_without_title, "test", &ctx);
+
+        // Title match should boost score by ~20%
+        assert!(score_with > score_without * 1.1);
+    }
+
+    #[test]
+    fn test_bm25_recency_boost() {
+        let scorer = BM25LiteScorer::default().with_recency_boost(0.5);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_micros() as u64;
+
+        let recent_doc = SearchDoc::new("test content".into()).with_timestamp(now);
+        let old_doc =
+            SearchDoc::new("test content".into()).with_timestamp(now - 48 * 3600 * 1_000_000); // 48h ago
+
+        let mut ctx = ScorerContext::new(10);
+        ctx.add_doc_freq("test", 2);
+        ctx.avg_doc_len = 5.0;
+        ctx.now_micros = now;
+
+        let score_recent = scorer.score(&recent_doc, "test", &ctx);
+        let score_old = scorer.score(&old_doc, "test", &ctx);
+
+        // Recent doc should score higher
+        assert!(score_recent > score_old);
+    }
+
+    #[test]
+    fn test_bm25_name() {
+        let scorer = BM25LiteScorer::default();
+        assert_eq!(scorer.name(), "bm25-lite");
+    }
+
+    #[test]
+    fn test_bm25_custom_params() {
+        let scorer = BM25LiteScorer::new(2.0, 0.5);
+        assert!((scorer.k1 - 2.0).abs() < f32::EPSILON);
+        assert!((scorer.b - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_bm25_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<BM25LiteScorer>();
+    }
+}

--- a/crates/search/src/tokenizer.rs
+++ b/crates/search/src/tokenizer.rs
@@ -1,0 +1,93 @@
+//! Basic tokenizer for M6 search
+//!
+//! This module provides simple text tokenization for search operations.
+//! Future milestones can add stemming, stopwords, etc.
+
+/// Tokenize text into searchable terms
+///
+/// This is a simple tokenizer for M6:
+/// - Lowercase
+/// - Split on non-alphanumeric characters
+/// - Filter tokens shorter than 2 characters
+///
+/// # Example
+///
+/// ```
+/// use in_mem_search::tokenizer::tokenize;
+///
+/// let tokens = tokenize("Hello, World!");
+/// assert_eq!(tokens, vec!["hello", "world"]);
+/// ```
+pub fn tokenize(text: &str) -> Vec<String> {
+    text.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|s| s.len() >= 2)
+        .map(String::from)
+        .collect()
+}
+
+/// Tokenize and deduplicate for query processing
+///
+/// # Example
+///
+/// ```
+/// use in_mem_search::tokenizer::tokenize_unique;
+///
+/// let tokens = tokenize_unique("test test TEST");
+/// assert_eq!(tokens, vec!["test"]);
+/// ```
+pub fn tokenize_unique(text: &str) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    tokenize(text)
+        .into_iter()
+        .filter(|t| seen.insert(t.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tokenize_basic() {
+        let tokens = tokenize("Hello, World!");
+        assert_eq!(tokens, vec!["hello", "world"]);
+    }
+
+    #[test]
+    fn test_tokenize_filters_short() {
+        let tokens = tokenize("I am a test");
+        // "I" and "a" filtered (< 2 chars)
+        assert_eq!(tokens, vec!["am", "test"]);
+    }
+
+    #[test]
+    fn test_tokenize_numbers() {
+        let tokens = tokenize("test123 foo456bar");
+        assert_eq!(tokens, vec!["test123", "foo456bar"]);
+    }
+
+    #[test]
+    fn test_tokenize_empty() {
+        let tokens = tokenize("");
+        assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn test_tokenize_only_punctuation() {
+        let tokens = tokenize("...---...");
+        assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn test_tokenize_unique() {
+        let tokens = tokenize_unique("test test TEST");
+        assert_eq!(tokens, vec!["test"]);
+    }
+
+    #[test]
+    fn test_tokenize_unique_preserves_order() {
+        let tokens = tokenize_unique("apple banana apple cherry");
+        assert_eq!(tokens, vec!["apple", "banana", "cherry"]);
+    }
+}

--- a/crates/search/tests/api_contracts.rs
+++ b/crates/search/tests/api_contracts.rs
@@ -1,0 +1,391 @@
+//! M6 Search API Contract Tests
+//!
+//! Validates all search API contracts across primitives.
+//! Part of Epic 39: Validation & Non-Regression (Story #334)
+//!
+//! See `docs/architecture/M6_ARCHITECTURE.md` for authoritative specification.
+
+use in_mem_core::search_types::{PrimitiveKind, SearchRequest, SearchResponse};
+use in_mem_core::types::RunId;
+use in_mem_core::value::Value;
+use in_mem_engine::Database;
+use in_mem_primitives::{KVStore, RunIndex};
+use in_mem_search::{DatabaseSearchExt, HybridSearch, RRFFuser};
+use std::collections::HashSet;
+use std::sync::Arc;
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+fn test_db() -> Arc<Database> {
+    Arc::new(
+        Database::builder()
+            .in_memory()
+            .open_temp()
+            .expect("Failed to create test database"),
+    )
+}
+
+fn populate_test_data(db: &Arc<Database>, run_id: &RunId) {
+    let kv = KVStore::new(db.clone());
+    let run_index = RunIndex::new(db.clone());
+
+    // Create run in run_index
+    run_index.create_run(&run_id.to_string()).unwrap();
+
+    // KV data - this is the primary test data
+    kv.put(run_id, "hello", Value::String("world test data".into()))
+        .unwrap();
+    kv.put(run_id, "test_key", Value::String("this is test content".into()))
+        .unwrap();
+    kv.put(run_id, "another", Value::String("more test values".into()))
+        .unwrap();
+
+    // Note: Other primitives (Json, Event, State, Trace) have more complex APIs
+    // and are tested individually in their respective test modules
+}
+
+// ============================================================================
+// Primitive Search Contract Tests
+// ============================================================================
+
+/// KV primitive search returns a valid SearchResponse
+#[test]
+fn test_kv_primitive_returns_search_response() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_test_data(&db, &run_id);
+
+    let kv = KVStore::new(db.clone());
+    let req = SearchRequest::new(run_id, "test");
+
+    // KV search
+    let kv_response: SearchResponse = kv.search(&req).expect("KV search should succeed");
+    assert!(
+        !kv_response.hits.is_empty(),
+        "KV should have test data matches"
+    );
+
+    // Response should have valid structure
+    let _ = kv_response.truncated;
+    let _ = kv_response.stats.elapsed_micros;
+    let _ = kv_response.stats.candidates_considered;
+}
+
+/// RunIndex primitive search returns a valid SearchResponse
+#[test]
+fn test_run_index_primitive_returns_search_response() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_test_data(&db, &run_id);
+
+    let run_index = RunIndex::new(db.clone());
+    let req = SearchRequest::new(run_id, "test");
+
+    // Run search (may or may not have matches depending on run name)
+    let run_response: SearchResponse = run_index
+        .search(&req)
+        .expect("RunIndex search should succeed");
+
+    // Response should have valid structure
+    let _ = run_response.truncated;
+    let _ = run_response.is_empty();
+}
+
+/// DocRef from each primitive correctly reports its primitive kind
+#[test]
+fn test_docref_primitive_kind_matches() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_test_data(&db, &run_id);
+
+    let kv = KVStore::new(db.clone());
+    let req = SearchRequest::new(run_id, "test");
+
+    let response = kv.search(&req).unwrap();
+
+    for hit in &response.hits {
+        assert_eq!(
+            hit.doc_ref.primitive_kind(),
+            PrimitiveKind::Kv,
+            "DocRef from KV search should report Kv primitive kind"
+        );
+        assert_eq!(
+            hit.doc_ref.run_id(),
+            run_id,
+            "DocRef should contain correct run_id"
+        );
+    }
+}
+
+/// Search respects run_id filter - results only from requested run
+#[test]
+fn test_search_respects_run_id() {
+    let db = test_db();
+    let run1 = RunId::new();
+    let run2 = RunId::new();
+
+    let kv = KVStore::new(db.clone());
+    let run_index = RunIndex::new(db.clone());
+
+    // Create runs
+    run_index.create_run(&run1.to_string()).unwrap();
+    run_index.create_run(&run2.to_string()).unwrap();
+
+    // Add shared term to both runs
+    kv.put(
+        &run1,
+        "key1",
+        Value::String("shared test term".to_string()),
+    )
+    .unwrap();
+    kv.put(
+        &run2,
+        "key2",
+        Value::String("shared test term".to_string()),
+    )
+    .unwrap();
+
+    // Search run1 only
+    let req = SearchRequest::new(run1, "shared");
+    let response = kv.search(&req).unwrap();
+
+    // All results should belong to run1
+    for hit in &response.hits {
+        assert_eq!(
+            hit.doc_ref.run_id(),
+            run1,
+            "All hits should belong to the requested run"
+        );
+    }
+}
+
+// ============================================================================
+// Composite Search (Hybrid) Contract Tests
+// ============================================================================
+
+/// db.hybrid() returns a HybridSearch orchestrator
+#[test]
+fn test_database_search_ext() {
+    let db = test_db();
+    let hybrid = db.hybrid();
+
+    // Should be able to use the hybrid search
+    let run_id = RunId::new();
+    let req = SearchRequest::new(run_id, "test");
+    let response = hybrid.search(&req).unwrap();
+    assert!(response.hits.is_empty()); // No data yet
+}
+
+/// Composite search orchestrates across multiple primitives
+#[test]
+fn test_hybrid_search_orchestrates() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_test_data(&db, &run_id);
+
+    let hybrid = db.hybrid();
+    let req = SearchRequest::new(run_id, "test");
+    let response = hybrid.search(&req).unwrap();
+
+    // Should have results from at least KV
+    assert!(
+        !response.hits.is_empty(),
+        "Hybrid search should find matches"
+    );
+
+    // Check that results come from multiple primitives (if data exists)
+    let primitives: HashSet<_> = response
+        .hits
+        .iter()
+        .map(|h| h.doc_ref.primitive_kind())
+        .collect();
+
+    // At minimum, KV should be represented
+    assert!(
+        primitives.contains(&PrimitiveKind::Kv),
+        "Hybrid search should include KV results"
+    );
+}
+
+/// Primitive filter limits search scope
+#[test]
+fn test_hybrid_search_respects_filter() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_test_data(&db, &run_id);
+
+    let hybrid = db.hybrid();
+
+    // Search only KV primitive
+    let req = SearchRequest::new(run_id, "test").with_primitive_filter(vec![PrimitiveKind::Kv]);
+    let response = hybrid.search(&req).unwrap();
+
+    // All results should be from KV only
+    for hit in &response.hits {
+        assert_eq!(
+            hit.doc_ref.primitive_kind(),
+            PrimitiveKind::Kv,
+            "Results should only come from filtered primitives"
+        );
+    }
+}
+
+/// Empty primitive filter means no results
+#[test]
+fn test_hybrid_search_empty_filter() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_test_data(&db, &run_id);
+
+    let hybrid = db.hybrid();
+
+    // Search with empty filter
+    let req = SearchRequest::new(run_id, "test").with_primitive_filter(vec![]);
+    let response = hybrid.search(&req).unwrap();
+
+    assert!(
+        response.hits.is_empty(),
+        "Empty filter should produce no results"
+    );
+}
+
+/// Custom fuser can be set
+#[test]
+fn test_hybrid_search_custom_fuser() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_test_data(&db, &run_id);
+
+    // Use RRF fuser instead of simple fuser
+    let hybrid = HybridSearch::new(db.clone()).with_fuser(Arc::new(RRFFuser::default()));
+
+    let req = SearchRequest::new(run_id, "test");
+    let response = hybrid.search(&req).unwrap();
+
+    // Should still return valid results
+    assert!(
+        !response.hits.is_empty(),
+        "RRF fuser should produce results"
+    );
+}
+
+// ============================================================================
+// SearchRequest Contract Tests
+// ============================================================================
+
+/// SearchRequest builder works correctly
+#[test]
+fn test_search_request_builder() {
+    let run_id = RunId::new();
+
+    let req = SearchRequest::new(run_id, "query text")
+        .with_k(20)
+        .with_primitive_filter(vec![PrimitiveKind::Kv, PrimitiveKind::Json]);
+
+    assert_eq!(req.run_id, run_id);
+    assert_eq!(req.query, "query text");
+    assert_eq!(req.k, 20);
+    assert_eq!(
+        req.primitive_filter,
+        Some(vec![PrimitiveKind::Kv, PrimitiveKind::Json])
+    );
+}
+
+/// includes_primitive() respects filter
+#[test]
+fn test_includes_primitive() {
+    let run_id = RunId::new();
+
+    // No filter - includes all
+    let req1 = SearchRequest::new(run_id, "test");
+    for kind in PrimitiveKind::all() {
+        assert!(
+            req1.includes_primitive(*kind),
+            "No filter should include all primitives"
+        );
+    }
+
+    // With filter
+    let req2 =
+        SearchRequest::new(run_id, "test").with_primitive_filter(vec![PrimitiveKind::Kv]);
+    assert!(req2.includes_primitive(PrimitiveKind::Kv));
+    assert!(!req2.includes_primitive(PrimitiveKind::Json));
+    assert!(!req2.includes_primitive(PrimitiveKind::Event));
+}
+
+// ============================================================================
+// SearchResponse Contract Tests
+// ============================================================================
+
+/// SearchResponse has expected structure
+#[test]
+fn test_search_response_structure() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_test_data(&db, &run_id);
+
+    let hybrid = db.hybrid();
+    let req = SearchRequest::new(run_id, "test");
+    let response = hybrid.search(&req).unwrap();
+
+    // Response should have hits, truncated flag, and stats
+    let _hits = &response.hits;
+    let _truncated = response.truncated;
+    let _stats = &response.stats;
+
+    // Stats should have expected fields
+    let _elapsed = response.stats.elapsed_micros;
+    let _candidates = response.stats.candidates_considered;
+}
+
+/// Hits are ranked by score (descending)
+#[test]
+fn test_hits_are_ranked() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_test_data(&db, &run_id);
+
+    let kv = KVStore::new(db.clone());
+    let req = SearchRequest::new(run_id, "test");
+    let response = kv.search(&req).unwrap();
+
+    if response.hits.len() >= 2 {
+        for i in 1..response.hits.len() {
+            assert!(
+                response.hits[i - 1].score >= response.hits[i].score,
+                "Hits should be sorted by score descending"
+            );
+        }
+    }
+}
+
+// ============================================================================
+// PrimitiveKind Contract Tests
+// ============================================================================
+
+/// PrimitiveKind::all() returns all 6 primitives
+#[test]
+fn test_primitive_kind_all() {
+    let all = PrimitiveKind::all();
+    assert_eq!(all.len(), 6, "Should have exactly 6 primitives");
+
+    assert!(all.contains(&PrimitiveKind::Kv));
+    assert!(all.contains(&PrimitiveKind::Json));
+    assert!(all.contains(&PrimitiveKind::Event));
+    assert!(all.contains(&PrimitiveKind::State));
+    assert!(all.contains(&PrimitiveKind::Trace));
+    assert!(all.contains(&PrimitiveKind::Run));
+}
+
+/// PrimitiveKind has correct display strings
+#[test]
+fn test_primitive_kind_display() {
+    assert_eq!(format!("{}", PrimitiveKind::Kv), "kv");
+    assert_eq!(format!("{}", PrimitiveKind::Json), "json");
+    assert_eq!(format!("{}", PrimitiveKind::Event), "event");
+    assert_eq!(format!("{}", PrimitiveKind::State), "state");
+    assert_eq!(format!("{}", PrimitiveKind::Trace), "trace");
+    assert_eq!(format!("{}", PrimitiveKind::Run), "run");
+}

--- a/crates/search/tests/determinism.rs
+++ b/crates/search/tests/determinism.rs
@@ -1,0 +1,307 @@
+//! M6 Determinism and Consistency Tests
+//!
+//! Validates that search operations are deterministic and consistent.
+//! Part of Epic 39: Validation & Non-Regression (Story #336)
+//!
+//! See `docs/architecture/M6_ARCHITECTURE.md` for authoritative specification.
+
+use in_mem_core::search_types::{PrimitiveKind, SearchRequest};
+use in_mem_core::types::RunId;
+use in_mem_core::value::Value;
+use in_mem_engine::Database;
+use in_mem_primitives::{KVStore, RunIndex};
+use in_mem_search::{DatabaseSearchExt, HybridSearch, RRFFuser};
+use std::sync::Arc;
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+fn test_db() -> Arc<Database> {
+    Arc::new(
+        Database::builder()
+            .in_memory()
+            .open_temp()
+            .expect("Failed to create test database"),
+    )
+}
+
+fn populate_determinism_data(db: &Arc<Database>, run_id: &RunId) {
+    let kv = KVStore::new(db.clone());
+    let run_index = RunIndex::new(db.clone());
+
+    // Create run
+    run_index.create_run(&run_id.to_string()).unwrap();
+
+    // Add multiple documents with similar scores
+    kv.put(run_id, "doc_a", Value::String("test document alpha".into()))
+        .unwrap();
+    kv.put(run_id, "doc_b", Value::String("test document beta".into()))
+        .unwrap();
+    kv.put(run_id, "doc_c", Value::String("test document gamma".into()))
+        .unwrap();
+    kv.put(run_id, "doc_d", Value::String("test document delta".into()))
+        .unwrap();
+    kv.put(run_id, "doc_e", Value::String("test document epsilon".into()))
+        .unwrap();
+}
+
+// ============================================================================
+// Search Determinism Tests
+// ============================================================================
+
+/// Same request produces identical results
+#[test]
+fn test_search_deterministic() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_determinism_data(&db, &run_id);
+
+    let hybrid = db.hybrid();
+    let req = SearchRequest::new(run_id, "test");
+
+    // Execute same search twice
+    let r1 = hybrid.search(&req).unwrap();
+    let r2 = hybrid.search(&req).unwrap();
+
+    // Should have same number of hits
+    assert_eq!(
+        r1.hits.len(),
+        r2.hits.len(),
+        "Same query should return same number of hits"
+    );
+
+    // Hits should be in same order
+    for (h1, h2) in r1.hits.iter().zip(r2.hits.iter()) {
+        assert_eq!(
+            h1.doc_ref, h2.doc_ref,
+            "DocRefs should be in same order"
+        );
+        assert_eq!(h1.rank, h2.rank, "Ranks should be identical");
+        assert!(
+            (h1.score - h2.score).abs() < 0.0001,
+            "Scores should be identical"
+        );
+    }
+}
+
+/// Primitive search is deterministic
+#[test]
+fn test_primitive_search_deterministic() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_determinism_data(&db, &run_id);
+
+    let kv = KVStore::new(db.clone());
+    let req = SearchRequest::new(run_id, "test");
+
+    // Execute same search multiple times
+    let results: Vec<_> = (0..5).map(|_| kv.search(&req).unwrap()).collect();
+
+    // All results should be identical
+    for (i, result) in results.iter().enumerate().skip(1) {
+        assert_eq!(
+            result.hits.len(),
+            results[0].hits.len(),
+            "Iteration {} should have same hit count",
+            i
+        );
+
+        for (h1, h2) in result.hits.iter().zip(results[0].hits.iter()) {
+            assert_eq!(h1.doc_ref, h2.doc_ref, "DocRefs should match");
+        }
+    }
+}
+
+/// RRF fusion is deterministic even with equal scores
+#[test]
+fn test_rrf_fusion_deterministic() {
+    let db = test_db();
+    let run_id = RunId::new();
+
+    let kv = KVStore::new(db.clone());
+    let run_index = RunIndex::new(db.clone());
+
+    // Create run
+    run_index.create_run(&run_id.to_string()).unwrap();
+
+    // Add documents that will have equal BM25 scores (same content length)
+    kv.put(&run_id, "a", Value::String("test".into())).unwrap();
+    kv.put(&run_id, "b", Value::String("test".into())).unwrap();
+    kv.put(&run_id, "c", Value::String("test".into())).unwrap();
+
+    let hybrid = HybridSearch::new(db.clone()).with_fuser(Arc::new(RRFFuser::default()));
+    let req = SearchRequest::new(run_id, "test").with_primitive_filter(vec![PrimitiveKind::Kv]);
+
+    // Execute same search multiple times
+    let r1 = hybrid.search(&req).unwrap();
+    let r2 = hybrid.search(&req).unwrap();
+
+    // Order should be deterministic even with equal scores
+    let order1: Vec<_> = r1.hits.iter().map(|h| &h.doc_ref).collect();
+    let order2: Vec<_> = r2.hits.iter().map(|h| &h.doc_ref).collect();
+
+    assert_eq!(order1, order2, "Order should be deterministic with RRF");
+}
+
+/// SimpleFuser is deterministic
+#[test]
+fn test_simple_fuser_deterministic() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_determinism_data(&db, &run_id);
+
+    let hybrid = db.hybrid(); // Uses SimpleFuser by default
+    let req = SearchRequest::new(run_id, "test").with_primitive_filter(vec![PrimitiveKind::Kv]);
+
+    let r1 = hybrid.search(&req).unwrap();
+    let r2 = hybrid.search(&req).unwrap();
+
+    let order1: Vec<_> = r1.hits.iter().map(|h| &h.doc_ref).collect();
+    let order2: Vec<_> = r2.hits.iter().map(|h| &h.doc_ref).collect();
+
+    assert_eq!(order1, order2, "SimpleFuser should be deterministic");
+}
+
+// ============================================================================
+// Consistency Tests
+// ============================================================================
+
+/// Results are consistent across different k values
+#[test]
+fn test_consistent_across_k_values() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_determinism_data(&db, &run_id);
+
+    let hybrid = db.hybrid();
+
+    // Search with different k values
+    let req_k5 = SearchRequest::new(run_id, "test").with_k(5);
+    let req_k10 = SearchRequest::new(run_id, "test").with_k(10);
+    let req_k3 = SearchRequest::new(run_id, "test").with_k(3);
+
+    let r5 = hybrid.search(&req_k5).unwrap();
+    let r10 = hybrid.search(&req_k10).unwrap();
+    let r3 = hybrid.search(&req_k3).unwrap();
+
+    // Smaller k results should be prefix of larger k results
+    for (i, hit) in r3.hits.iter().enumerate() {
+        if i < r5.hits.len() {
+            assert_eq!(
+                hit.doc_ref, r5.hits[i].doc_ref,
+                "Top-3 should be prefix of top-5"
+            );
+        }
+    }
+
+    for (i, hit) in r5.hits.iter().enumerate() {
+        if i < r10.hits.len() {
+            assert_eq!(
+                hit.doc_ref, r10.hits[i].doc_ref,
+                "Top-5 should be prefix of top-10"
+            );
+        }
+    }
+}
+
+/// Scores are monotonically decreasing
+#[test]
+fn test_scores_monotonically_decreasing() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_determinism_data(&db, &run_id);
+
+    let hybrid = db.hybrid();
+    let req = SearchRequest::new(run_id, "test").with_k(20);
+    let response = hybrid.search(&req).unwrap();
+
+    if response.hits.len() >= 2 {
+        for i in 1..response.hits.len() {
+            assert!(
+                response.hits[i - 1].score >= response.hits[i].score,
+                "Scores should be monotonically decreasing: {} vs {}",
+                response.hits[i - 1].score,
+                response.hits[i].score
+            );
+        }
+    }
+}
+
+/// Ranks are sequential starting from 1
+#[test]
+fn test_ranks_are_sequential() {
+    let db = test_db();
+    let run_id = RunId::new();
+    populate_determinism_data(&db, &run_id);
+
+    let kv = KVStore::new(db.clone());
+    let req = SearchRequest::new(run_id, "test").with_k(10);
+    let response = kv.search(&req).unwrap();
+
+    for (i, hit) in response.hits.iter().enumerate() {
+        assert_eq!(
+            hit.rank as usize,
+            i + 1,
+            "Ranks should be sequential starting from 1"
+        );
+    }
+}
+
+// ============================================================================
+// Run Isolation Tests
+// ============================================================================
+
+/// Search results are isolated to requested run
+#[test]
+fn test_run_isolation() {
+    let db = test_db();
+    let run1 = RunId::new();
+    let run2 = RunId::new();
+
+    let kv = KVStore::new(db.clone());
+    let run_index = RunIndex::new(db.clone());
+
+    run_index.create_run(&run1.to_string()).unwrap();
+    run_index.create_run(&run2.to_string()).unwrap();
+
+    // Add same key with different values to different runs
+    kv.put(&run1, "key", Value::String("run1 test value".into()))
+        .unwrap();
+    kv.put(&run2, "key", Value::String("run2 test value".into()))
+        .unwrap();
+
+    // Search run1
+    let req1 = SearchRequest::new(run1, "test");
+    let r1 = kv.search(&req1).unwrap();
+
+    // Search run2
+    let req2 = SearchRequest::new(run2, "test");
+    let r2 = kv.search(&req2).unwrap();
+
+    // Results should be isolated
+    for hit in &r1.hits {
+        assert_eq!(hit.doc_ref.run_id(), run1, "Run1 results should be from run1");
+    }
+
+    for hit in &r2.hits {
+        assert_eq!(hit.doc_ref.run_id(), run2, "Run2 results should be from run2");
+    }
+}
+
+/// Non-existent run returns empty results
+#[test]
+fn test_nonexistent_run_empty() {
+    let db = test_db();
+    let run_id = RunId::new();
+    // Don't create any data
+
+    let hybrid = db.hybrid();
+    let req = SearchRequest::new(run_id, "test");
+    let response = hybrid.search(&req).unwrap();
+
+    assert!(
+        response.hits.is_empty(),
+        "Non-existent run should return empty results"
+    );
+}

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -2,7 +2,7 @@
 
 **in-mem** - a fast, durable, embedded database for AI agent workloads.
 
-**Current Version**: 0.3.0 (M3 Primitives + M4 Performance)
+**Current Version**: 0.5.0 (M5 JSON + M6 Retrieval)
 
 ## Quick Links
 
@@ -13,7 +13,8 @@
 
 ## Features
 
-- **Five Primitives**: KVStore, EventLog, StateCell, TraceStore, RunIndex
+- **Six Primitives**: KVStore, EventLog, StateCell, TraceStore, RunIndex, JsonStore
+- **Hybrid Search**: BM25 + semantic search with RRF fusion
 - **Three Durability Modes**: InMemory (<3µs), Buffered (<30µs), Strict (~2ms)
 - **OCC Transactions**: Optimistic concurrency with snapshot isolation
 - **Run-Scoped Operations**: Every operation tagged with RunId for replay
@@ -26,7 +27,9 @@
 | M2 Transactions | ✅ |
 | M3 Primitives | ✅ |
 | M4 Performance | ✅ |
-| M5 JSON | Next |
+| M5 JSON | ✅ |
+| M6 Retrieval | ✅ |
+| M7 MCP | Next |
 
 ## Quick Start
 
@@ -58,5 +61,5 @@ db.end_run(run_id)?;
 
 ---
 
-**Version**: 0.3.0
-**Last Updated**: 2026-01-16
+**Version**: 0.5.0
+**Last Updated**: 2026-01-17

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,20 @@
+//! in-mem: High-performance in-memory database for AI agents
+//!
+//! This crate re-exports the main components of the in-mem database:
+//! - `in_mem_core`: Core types and traits
+//! - `in_mem_engine`: Database engine with transaction support
+//! - `in_mem_storage`: Storage layer
+//! - `in_mem_concurrency`: OCC and snapshot isolation
+//! - `in_mem_durability`: WAL and persistence
+
+pub use in_mem_concurrency as concurrency;
+pub use in_mem_core as core;
+pub use in_mem_durability as durability;
+pub use in_mem_engine as engine;
+pub use in_mem_storage as storage;
+
+// Re-export commonly used types
+pub use in_mem_core::types::{Key, Namespace, RunId, TypeTag};
+pub use in_mem_core::value::Value;
+pub use in_mem_core::VersionedValue;
+pub use in_mem_engine::Database;


### PR DESCRIPTION
## Summary

- Add M5 JSON primitives (JsonStore with CRDT-style operations)
- Add M6 Retrieval Surfaces (search crate with BM25, hybrid search, RRF fusion)
- Update documentation for M5/M6 APIs and architecture

## What's Included

### Crates
- **in-mem-core**: JSON types, search_types module (SearchRequest, SearchResponse, etc.)
- **in-mem-primitives**: JsonStore primitive, Searchable trait on all primitives
- **in-mem-search**: New crate with BM25Lite scorer, InvertedIndex, HybridSearch, RRF fusion

### Documentation
- `docs/reference/architecture.md`: M5/M6 architecture
- `docs/reference/api-reference.md`: New APIs
- `docs/reference/getting-started.md`: Search examples

## What's NOT Included

- Benchmarks (stay on develop)
- Test suites (stay on develop)
- Scripts (stay on develop)

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes
- [x] No benchmark files included

🤖 Generated with [Claude Code](https://claude.com/claude-code)