### PR TITLE
Fix M7 Durability issues: #437, #439, #444, #447

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -20,6 +20,7 @@ dashmap = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }


### PR DESCRIPTION
## Summary

This PR addresses four M7 (Durability, Snapshots, Replay & Storage Stabilization) issues:

- **#437**: Expose `replay_run()` and `diff_runs()` APIs on Database - CRITICAL API contract fix
- **#439**: Fix snapshot header size documentation mismatch (38 vs 39 bytes)
- **#444**: Implement proper ReadOnlyView with EventLog integration - HIGH priority
- **#447**: Unify snapshot serialization traits - HIGH priority architecture fix

### Issue #437: replay_run() and diff_runs() APIs

Added the missing public APIs to Database struct:
- `replay_run(run_id)` - Returns ReadOnlyView for a run
- `diff_runs(run_a, run_b)` - Returns RunDiff comparing two runs

These implement M7 Stories #314 and #315 per DURABILITY_REPLAY_CONTRACT.md.

### Issue #439: Snapshot Header Size

Updated SNAPSHOT_FORMAT.md to clarify:
- Fixed header is 38 bytes (Magic + Version + Timestamp + WAL Offset + Tx Count)
- Prim Count (1 byte) is written separately at offset 38
- Minimum snapshot size is 43 bytes (38 header + 1 prim count + 4 CRC32)

The implementation was already correct; only the spec documentation needed updating.

### Issue #444: ReadOnlyView EventLog Integration

Enhanced `replay_run()` to properly handle all entry types:
- Separates entries by TypeTag (KV, Event, State, etc.)
- Parses Event entries from JSON storage format
- Adds events to ReadOnlyView via `append_event()`
- Skips metadata keys (`__meta__`)
- Satisfies P1 invariant: replay is a pure function over (Snapshot, WAL, EventLog)

### Issue #447: Unified Snapshot Serialization

Deprecated `SnapshotSerializable` trait in favor of `PrimitiveStorageExt`:
- Added `#[deprecated]` annotation with migration guidance
- Added blanket impl: `PrimitiveStorageExt` automatically implements `SnapshotSerializable`
- Added `#[allow(deprecated)]` to internal usage
- Single trait for all primitives going forward

## Test plan

- [x] Engine crate builds successfully
- [x] All 123 engine unit tests pass
- [x] All 15 replay_invariants integration tests pass
- [x] All 2 run_lifecycle_tests pass
- [x] Workspace builds successfully

## Closes

Closes #437
Closes #439
Closes #444
Closes #447

🤖 Generated with [Claude Code](https://claude.ai/code)