### PR TITLE
Fix m4 regression tests for EventLog object payload validation

### DIFF
--- a/tests/m4_regression_tests/main.rs
+++ b/tests/m4_regression_tests/main.rs
@@ -4,11 +4,28 @@
 //! across different durability modes.
 
 use strata_core::types::RunId;
+use strata_core::value::Value;
 use strata_durability::wal::DurabilityMode;
 use strata_engine::Database;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+/// Helper to create Value::Object from key-value pairs
+/// Usage: `obj([("key", Value::Int(1))])`
+pub fn obj<I>(pairs: I) -> Value
+where
+    I: IntoIterator<Item = (&'static str, Value)>,
+{
+    Value::Object(pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+}
+
+/// Helper to wrap a value in an object with a "value" key
+/// Usage: `wrap_payload(Value::Int(42))` -> `{"value": 42}`
+pub fn wrap_payload(v: Value) -> Value {
+    obj([("value", v)])
+}
 
 // Test modules in priority order
 pub mod aba_detection;

--- a/tests/m4_regression_tests/snapshot_monotonicity.rs
+++ b/tests/m4_regression_tests/snapshot_monotonicity.rs
@@ -228,7 +228,7 @@ fn eventlog_sequence_stability() {
 
         // Append some events
         for i in 0..10 {
-            events.append(&run_id, "test", Value::Int(i)).unwrap();
+            events.append(&run_id, "test", wrap_payload(Value::Int(i))).unwrap();
         }
 
         // Read range multiple times
@@ -272,7 +272,7 @@ fn eventlog_no_sequence_regression() {
             thread::spawn(move || {
                 barrier.wait();
                 for i in 0..100 {
-                    let _ = events.append(&run_id, &format!("writer_{}", writer_id), Value::Int(i));
+                    let _ = events.append(&run_id, &format!("writer_{}", writer_id), wrap_payload(Value::Int(i)));
                 }
             })
         })


### PR DESCRIPTION
## Summary

Fix m4 regression tests to use object payloads for EventLog, matching the validation requirement that EventLog payloads must be JSON objects.

## Changes

- Add `obj()` and `wrap_payload()` helpers to test harness
- Update `eventlog_semantics.rs`: wrap all append payloads and assertions
- Update `cross_primitive.rs`: wrap EventLog payloads
- Update `snapshot_monotonicity.rs`: wrap EventLog payloads
- Fix `mixed_primitive_sequence` assertion (3 events, not 4)

## Test Results

- **83 passed**, 1 failed (pre-existing performance test `red_flag_facade_tax_b_a1`)
- All 17 EventLog-related tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)