### PR TITLE
fix(storage): replace unwrap() with proper error handling in codec cloning

### DIFF
--- a/crates/storage/src/database/handle.rs
+++ b/crates/storage/src/database/handle.rs
@@ -81,13 +81,13 @@ impl DatabaseHandle {
             database_uuid,
             config.durability,
             config.wal_config.clone(),
-            clone_codec(codec.as_ref()),
+            clone_codec(codec.as_ref())?,
         )?;
 
         // Create checkpoint coordinator
         let checkpoint_coordinator = CheckpointCoordinator::new(
             paths.snapshots_dir(),
-            clone_codec(codec.as_ref()),
+            clone_codec(codec.as_ref())?,
             database_uuid,
         )?;
 
@@ -137,7 +137,7 @@ impl DatabaseHandle {
             database_uuid,
             config.durability,
             config.wal_config.clone(),
-            clone_codec(codec.as_ref()),
+            clone_codec(codec.as_ref())?,
         )?;
 
         // Create checkpoint coordinator with existing watermark
@@ -153,7 +153,7 @@ impl DatabaseHandle {
 
         let checkpoint_coordinator = CheckpointCoordinator::with_watermark(
             paths.snapshots_dir(),
-            clone_codec(codec.as_ref()),
+            clone_codec(codec.as_ref())?,
             database_uuid,
             watermark,
         )?;
@@ -198,7 +198,7 @@ impl DatabaseHandle {
     {
         let coordinator = RecoveryCoordinator::new(
             self.paths.root().to_path_buf(),
-            clone_codec(self.codec.as_ref()),
+            clone_codec(self.codec.as_ref())?,
         );
 
         coordinator.recover(on_snapshot, on_record)
@@ -373,8 +373,8 @@ fn generate_uuid() -> [u8; 16] {
 }
 
 /// Clone a boxed codec
-fn clone_codec(codec: &dyn StorageCodec) -> Box<dyn StorageCodec> {
-    get_codec(codec.codec_id()).unwrap()
+fn clone_codec(codec: &dyn StorageCodec) -> Result<Box<dyn StorageCodec>, crate::codec::CodecError> {
+    get_codec(codec.codec_id())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Change `clone_codec()` to return `Result` instead of using `unwrap()`
- Add `CodecError` variant to `RecoveryError` for proper error propagation
- Replace `segments.last().unwrap()` with pattern matching
- Update all call sites to use `?` operator for error propagation

## Files Changed
- `crates/storage/src/recovery/mod.rs` - Fixed unwrap at lines 184 and 289
- `crates/storage/src/database/handle.rs` - Fixed unwrap at line 377

## Test plan
- [x] `cargo check -p strata-storage` passes
- [ ] Run full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)