### PR TITLE
fix(wire): replace unwrap with safe default in encode_response

### DIFF
--- a/crates/wire/src/json/envelope.rs
+++ b/crates/wire/src/json/envelope.rs
@@ -134,7 +134,13 @@ pub fn encode_response(response: &Response) -> String {
             encode_json(response.result.as_ref().unwrap_or(&Value::Null)),
         )
     } else {
-        let error = response.error.as_ref().unwrap();
+        // Default error for malformed responses (ok=false but no error provided)
+        let default_error = ApiError {
+            code: "Internal".to_string(),
+            message: "Unknown error".to_string(),
+            details: None,
+        };
+        let error = response.error.as_ref().unwrap_or(&default_error);
         format!(
             r#"{{"id":{},"ok":false,"error":{{"code":{},"message":{},"details":{}}}}}"#,
             encode_string(&response.id),


### PR DESCRIPTION
## Summary
Replace `response.error.as_ref().unwrap()` with `unwrap_or()` that provides a sensible default error for malformed responses.

## Change
When `ok=false` but `error` is `None` (which shouldn't happen per the API contract), instead of panicking, we now provide a default error:
```rust
ApiError {
    code: "Internal",
    message: "Unknown error",
    details: None,
}
```

This eliminates a panic path in favor of graceful degradation.

## Test plan
- [x] `cargo check -p strata-wire` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)