### PR TITLE
cleanup(primitives): remove internal development markers

### DIFF
--- a/crates/primitives/benches/primitive_benchmarks.rs
+++ b/crates/primitives/benches/primitive_benchmarks.rs
@@ -1,6 +1,6 @@
-//! Primitive Performance Benchmarks (Story #200)
+//! Primitive Performance Benchmarks
 //!
-//! Performance targets from M3_ARCHITECTURE.md Section 14:
+//! Performance targets from architecture documentation:
 //! - KV put: >10K ops/sec
 //! - KV get: >20K ops/sec
 //! - EventLog append: >5K ops/sec

--- a/crates/primitives/src/event_log.rs
+++ b/crates/primitives/src/event_log.rs
@@ -320,7 +320,7 @@ impl EventLog {
         Namespace::for_run(*run_id)
     }
 
-    // ========== Append Operation (Story #175) ==========
+    // ========== Append Operation ==========
 
     /// Append a new event to the log
     ///
@@ -532,7 +532,7 @@ impl EventLog {
             })
     }
 
-    // ========== Read Operations (Story #176) ==========
+    // ========== Read Operations ==========
 
     /// Read a single event by sequence number (FAST PATH)
     ///
@@ -714,7 +714,7 @@ impl EventLog {
         Ok(self.len(run_id)? == 0)
     }
 
-    // ========== Chain Verification (Story #177) ==========
+    // ========== Chain Verification ==========
 
     /// Verify chain integrity from start to end
     ///
@@ -889,7 +889,7 @@ impl EventLog {
         Ok(meta.streams.keys().cloned().collect())
     }
 
-    // ========== Query by Type (Story #178) ==========
+    // ========== Query by Type ==========
 
     /// Read events filtered by type
     ///
@@ -951,7 +951,7 @@ impl EventLog {
         })
     }
 
-    // ========== Search API (M6) ==========
+    // ========== Search API ==========
 
     /// Search events
     ///
@@ -1050,7 +1050,7 @@ impl EventLog {
     }
 }
 
-// ========== Searchable Trait Implementation (M6) ==========
+// ========== Searchable Trait Implementation ==========
 
 impl crate::searchable::Searchable for EventLog {
     fn search(
@@ -1065,7 +1065,7 @@ impl crate::searchable::Searchable for EventLog {
     }
 }
 
-// ========== EventLogExt Implementation (Story #179) ==========
+// ========== EventLogExt Implementation ==========
 
 impl EventLogExt for TransactionContext {
     fn event_append(&mut self, event_type: &str, payload: Value) -> Result<u64> {
@@ -1168,7 +1168,7 @@ mod tests {
         payload_with("value", Value::Int(v))
     }
 
-    // ========== Core Structure Tests (Story #174) ==========
+    // ========== Core Structure Tests ==========
 
     #[test]
     fn test_event_serialization() {
@@ -1304,7 +1304,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    // ========== Append Tests (Story #175) ==========
+    // ========== Append Tests ==========
 
     #[test]
     fn test_append_first_event() {
@@ -1382,7 +1382,7 @@ mod tests {
         assert_eq!(run2_events[0].value.event_type, "run2_event");
     }
 
-    // ========== Read Tests (Story #176) ==========
+    // ========== Read Tests ==========
 
     #[test]
     fn test_read_single_event() {
@@ -1464,7 +1464,7 @@ mod tests {
         assert_eq!(log.len(&run_id).unwrap(), 3);
     }
 
-    // ========== Chain Verification Tests (Story #177) ==========
+    // ========== Chain Verification Tests ==========
 
     #[test]
     fn test_verify_empty_chain() {
@@ -1645,7 +1645,7 @@ mod tests {
         assert!(non_zero_after_8 > 0, "SHA-256 should use all 32 bytes");
     }
 
-    // ========== Query by Type Tests (Story #178) ==========
+    // ========== Query by Type Tests ==========
 
     #[test]
     fn test_read_by_type() {
@@ -1688,7 +1688,7 @@ mod tests {
         assert!(types.contains(&"type_c".to_string()));
     }
 
-    // ========== EventLogExt Tests (Story #179) ==========
+    // ========== EventLogExt Tests ==========
 
     #[test]
     fn test_eventlog_ext_append() {
@@ -1978,7 +1978,7 @@ mod tests {
         }
     }
 
-    // ========== Fast Path Tests (Story #238) ==========
+    // ========== Fast Path Tests ==========
 
     #[test]
     fn test_fast_read_returns_correct_value() {

--- a/crates/primitives/src/extensions.rs
+++ b/crates/primitives/src/extensions.rs
@@ -45,7 +45,7 @@ use strata_core::{Result, Value};
 
 /// KV operations within a transaction
 ///
-/// Implemented in `kv.rs` (Story #173)
+/// Implemented in `kv.rs`
 pub trait KVStoreExt {
     /// Get a value by key
     fn kv_get(&mut self, key: &str) -> Result<Option<Value>>;
@@ -59,7 +59,7 @@ pub trait KVStoreExt {
 
 /// Event log operations within a transaction
 ///
-/// Implemented in `event_log.rs` (Story #179)
+/// Implemented in `event_log.rs`
 pub trait EventLogExt {
     /// Append an event and return sequence number
     fn event_append(&mut self, event_type: &str, payload: Value) -> Result<u64>;
@@ -70,7 +70,7 @@ pub trait EventLogExt {
 
 /// State cell operations within a transaction
 ///
-/// Implemented in `state_cell.rs` (Story #184)
+/// Implemented in `state_cell.rs`
 pub trait StateCellExt {
     /// Read current state
     fn state_read(&mut self, name: &str) -> Result<Option<Value>>;
@@ -84,7 +84,7 @@ pub trait StateCellExt {
 
 /// JSON store operations within a transaction
 ///
-/// Implemented in `json_store.rs` (Story #477)
+/// Implemented in `json_store.rs`
 pub trait JsonStoreExt {
     /// Get value at path in a document
     fn json_get(&mut self, doc_id: &str, path: &JsonPath) -> Result<Option<JsonValue>>;
@@ -102,7 +102,7 @@ pub trait JsonStoreExt {
 /// the backend state management complexity. Only basic read/write ops
 /// are supported.
 ///
-/// Implemented in `vector/store.rs` (Story #477)
+/// Implemented in `vector/store.rs`
 pub trait VectorStoreExt {
     /// Get a vector by key
     fn vector_get(&mut self, collection: &str, key: &str) -> Result<Option<Vec<f32>>>;

--- a/crates/primitives/src/json_store.rs
+++ b/crates/primitives/src/json_store.rs
@@ -23,9 +23,9 @@
 //! - **Fast Path Reads**: `get`, `exists`, `get_doc`
 //!   Use SnapshotView directly for read-only access.
 //!
-//! ## M5 Architectural Rules
+//! ## Architectural Rules
 //!
-//! This implementation follows the six M5 architectural rules:
+//! This implementation follows the architectural rules:
 //! 1. JSON lives in ShardedStore via Key::new_json()
 //! 2. JsonStore is stateless (Arc<Database> only)
 //! 3. JSON extends TransactionContext (no separate type)
@@ -193,7 +193,7 @@ impl JsonStore {
     }
 
     // ========================================================================
-    // Serialization (Story #273)
+    // Serialization
     // ========================================================================
 
     /// Serialize document for storage
@@ -217,7 +217,7 @@ impl JsonStore {
     }
 
     // ========================================================================
-    // Document Operations (Story #274+)
+    // Document Operations
     // ========================================================================
 
     /// Create a new JSON document
@@ -265,7 +265,7 @@ impl JsonStore {
     }
 
     // ========================================================================
-    // Fast Path Reads (Story #275)
+    // Fast Path Reads
     // ========================================================================
 
     /// Get value at path in a document (FAST PATH)
@@ -475,7 +475,7 @@ impl JsonStore {
     }
 
     // ========================================================================
-    // Mutations (Story #276+)
+    // Mutations
     // ========================================================================
 
     /// Set value at path in a document
@@ -617,7 +617,7 @@ impl JsonStore {
     }
 
     // ========================================================================
-    // Atomic Merge (M11B)
+    // Atomic Merge
     // ========================================================================
 
     /// Atomically merge a patch into a document using RFC 7396 JSON Merge Patch
@@ -720,7 +720,7 @@ impl JsonStore {
     }
 
     // ========================================================================
-    // Compare-and-Swap (M11B)
+    // Compare-and-Swap
     // ========================================================================
 
     /// Compare-and-swap: atomically update if version matches
@@ -802,7 +802,7 @@ impl JsonStore {
     }
 
     // ========================================================================
-    // Introspection (M11B)
+    // Introspection
     // ========================================================================
 
     /// List documents in the store with cursor-based pagination
@@ -1077,7 +1077,7 @@ impl JsonStore {
     }
 
     // ========================================================================
-    // Array Operations (M11B Tier 3)
+    // Array Operations
     // ========================================================================
 
     /// Atomically push values to an array at path
@@ -1429,7 +1429,7 @@ impl JsonStore {
     }
 
     // ========================================================================
-    // Search API (M6)
+    // Search API
     // ========================================================================
 
     /// Search JSON documents
@@ -1564,7 +1564,7 @@ impl JsonStore {
     }
 }
 
-// ========== Searchable Trait Implementation (M6) ==========
+// ========== Searchable Trait Implementation ==========
 
 impl crate::searchable::Searchable for JsonStore {
     fn search(
@@ -1580,7 +1580,7 @@ impl crate::searchable::Searchable for JsonStore {
 }
 
 // =============================================================================
-// JsonStoreExt Implementation (Story #477)
+// JsonStoreExt Implementation
 // =============================================================================
 //
 // Extension trait implementation for cross-primitive transactions.
@@ -1752,7 +1752,7 @@ mod tests {
     }
 
     // ========================================
-    // JsonDoc Tests (Story #273)
+    // JsonDoc Tests
     // ========================================
 
     #[test]
@@ -1801,7 +1801,7 @@ mod tests {
     }
 
     // ========================================
-    // Serialization Tests (Story #273)
+    // Serialization Tests
     // ========================================
 
     #[test]
@@ -1890,7 +1890,7 @@ mod tests {
     }
 
     // ========================================
-    // Create Tests (Story #274)
+    // Create Tests
     // ========================================
 
     #[test]
@@ -2007,7 +2007,7 @@ mod tests {
     }
 
     // ========================================
-    // Get Tests (Story #275)
+    // Get Tests
     // ========================================
 
     #[test]
@@ -2220,7 +2220,7 @@ mod tests {
     }
 
     // ========================================
-    // Set Tests (Story #276)
+    // Set Tests
     // ========================================
 
     #[test]
@@ -2401,7 +2401,7 @@ mod tests {
     }
 
     // ========================================
-    // Delete at Path Tests (Story #277)
+    // Delete at Path Tests
     // ========================================
 
     #[test]
@@ -2566,7 +2566,7 @@ mod tests {
     }
 
     // ========================================
-    // Destroy Tests (Story #277)
+    // Destroy Tests
     // ========================================
 
     #[test]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -46,7 +46,7 @@ pub mod event_log;
 pub mod extensions;
 pub mod json_store;
 pub mod kv;
-pub mod run_handle; // Story #478: RunHandle Pattern Implementation
+pub mod run_handle;
 pub mod run_index;
 pub mod searchable;
 pub mod state_cell;

--- a/crates/primitives/src/run_handle.rs
+++ b/crates/primitives/src/run_handle.rs
@@ -25,7 +25,7 @@
 //! })?;
 //! ```
 //!
-//! ## Story #478: RunHandle Pattern Implementation
+//! ## RunHandle Pattern Implementation
 
 use crate::extensions::{
     EventLogExt, JsonStoreExt, KVStoreExt, StateCellExt, VectorStoreExt,

--- a/crates/primitives/src/run_index.rs
+++ b/crates/primitives/src/run_index.rs
@@ -59,7 +59,7 @@ fn global_namespace() -> Namespace {
     Namespace::for_run(global_run_id())
 }
 
-// ========== RunStatus Enum (Story #191) ==========
+// ========== RunStatus Enum ==========
 
 /// Run lifecycle status
 ///
@@ -140,7 +140,7 @@ impl RunStatus {
     }
 }
 
-// ========== RunMetadata Struct (Story #191) ==========
+// ========== RunMetadata Struct ==========
 
 /// Metadata about a run
 ///
@@ -245,7 +245,7 @@ fn from_stored_value<T: for<'de> Deserialize<'de>>(
     }
 }
 
-// ========== RunIndex Core (Story #191) ==========
+// ========== RunIndex Core ==========
 
 /// Run lifecycle management primitive
 ///
@@ -302,7 +302,7 @@ impl RunIndex {
         Key::new_run_with_id(global_namespace(), run_id)
     }
 
-    // ========== Create & Get Operations (Story #192) ==========
+    // ========== Create & Get Operations ==========
 
     /// Create a new run
     ///
@@ -418,7 +418,7 @@ impl RunIndex {
         Ok(self.list_runs()?.len())
     }
 
-    // ========== Status Update & Transitions (Story #193) ==========
+    // ========== Status Update & Transitions ==========
 
     /// Update run status with transition validation
     ///
@@ -524,7 +524,7 @@ impl RunIndex {
         self.update_status(run_id, RunStatus::Cancelled)
     }
 
-    // ========== Secondary Indices (Story #194) ==========
+    // ========== Secondary Indices ==========
 
     /// Write secondary indices for a run
     fn write_indices_internal(txn: &mut TransactionContext, meta: &RunMetadata) -> Result<()> {
@@ -618,7 +618,7 @@ impl RunIndex {
         Ok(runs)
     }
 
-    // ========== Delete & Archive Operations (Story #195) ==========
+    // ========== Delete & Archive Operations ==========
 
     /// Archive a run (soft delete - status change to Archived)
     ///
@@ -825,7 +825,7 @@ impl RunIndex {
         })
     }
 
-    // ========== Search API (M6) ==========
+    // ========== Search API ==========
 
     /// Search runs
     ///
@@ -1459,7 +1459,7 @@ fn json_to_value(json: &serde_json::Value) -> Value {
     }
 }
 
-// ========== Searchable Trait Implementation (M6) ==========
+// ========== Searchable Trait Implementation ==========
 
 impl crate::searchable::Searchable for RunIndex {
     fn search(
@@ -1492,7 +1492,7 @@ mod tests {
         Value::Object(std::collections::HashMap::new())
     }
 
-    // ========== Story #191 Tests: RunStatus ==========
+    // ========== Tests: RunStatus ==========
 
     #[test]
     fn test_status_active_can_go_anywhere() {
@@ -1563,7 +1563,7 @@ mod tests {
         assert_eq!(status, restored);
     }
 
-    // ========== Story #191 Tests: RunMetadata ==========
+    // ========== Tests: RunMetadata ==========
 
     #[test]
     fn test_run_metadata_creation() {
@@ -1587,7 +1587,7 @@ mod tests {
         assert_eq!(meta, restored);
     }
 
-    // ========== Story #191 Tests: RunIndex Core ==========
+    // ========== Tests: RunIndex Core ==========
 
     #[test]
     fn test_runindex_new() {
@@ -1596,7 +1596,7 @@ mod tests {
         assert!(Arc::ptr_eq(ri.database(), &db));
     }
 
-    // ========== Story #192 Tests: Create & Get ==========
+    // ========== Tests: Create & Get ==========
 
     #[test]
     fn test_create_run() {
@@ -1736,7 +1736,7 @@ mod tests {
         assert_eq!(ri.count().unwrap(), 2);
     }
 
-    // ========== Story #193 Tests: Status Transitions ==========
+    // ========== Tests: Status Transitions ==========
 
     #[test]
     fn test_complete_run() {
@@ -1815,7 +1815,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ========== Story #194 Tests: Query Operations ==========
+    // ========== Tests: Query Operations ==========
 
     #[test]
     fn test_query_by_status() {
@@ -1873,7 +1873,7 @@ mod tests {
         assert_eq!(children.len(), 2);
     }
 
-    // ========== Story #195 Tests: Delete & Archive ==========
+    // ========== Tests: Delete & Archive ==========
 
     #[test]
     fn test_archive_run() {
@@ -2018,7 +2018,7 @@ mod tests {
             .is_err());
     }
 
-    // ========== Story #196 Tests: Integration ==========
+    // ========== Tests: Integration ==========
 
     mod integration_tests {
         use super::*;
@@ -2081,7 +2081,7 @@ mod tests {
                 .unwrap();
 
             // Verify isolation
-            // M9: get() returns Versioned<Value>
+            // get() returns Versioned<Value>
             assert_eq!(
                 kv.get(&run_id1, "key").unwrap().map(|v| v.value),
                 Some(Value::String("run1-value".into()))

--- a/crates/primitives/src/searchable.rs
+++ b/crates/primitives/src/searchable.rs
@@ -1,7 +1,7 @@
 //! Searchable trait for primitives that support search
 //!
 //! This module defines the `Searchable` trait and search support structures
-//! used by all primitives in M6 Retrieval Surfaces.
+//! used by all primitives for retrieval operations.
 
 use strata_core::error::Result;
 use strata_core::search_types::{
@@ -53,10 +53,10 @@ impl SearchCandidate {
     }
 }
 
-/// Simple keyword matcher/scorer for M6
+/// Simple keyword matcher/scorer for search
 ///
 /// BM25-lite implementation: scores based on term frequency and document length.
-/// This is a simplified version - Epic 35 will implement the full Scorer trait.
+/// This is a simplified version - Future versions will implement the full Scorer trait.
 pub struct SimpleScorer;
 
 impl SimpleScorer {

--- a/crates/primitives/src/vector/backend.rs
+++ b/crates/primitives/src/vector/backend.rs
@@ -1,19 +1,19 @@
 //! Vector Index Backend trait
 //!
 //! Defines the interface for swappable vector index implementations.
-//! M8: BruteForceBackend (O(n) search)
-//! M9: HnswBackend (O(log n) search) - reserved
+//! BruteForceBackend (O(n) search)
+//! HnswBackend (O(log n) search) - reserved
 
 use crate::vector::{DistanceMetric, VectorConfig, VectorError, VectorId};
 
 /// Trait for swappable vector index implementations
 ///
-/// M8: BruteForceBackend (O(n) search)
-/// M9: HnswBackend (O(log n) search)
+/// BruteForceBackend (O(n) search)
+/// HnswBackend (O(log n) search)
 ///
 /// IMPORTANT: This trait is designed to work for BOTH brute-force and HNSW.
 /// Do NOT add methods that assume brute-force semantics (like get_all_vectors).
-/// See Evolution Warning A in M8_ARCHITECTURE.md.
+/// See Evolution Warning A in architecture documentation.
 pub trait VectorIndexBackend: Send + Sync {
     /// Allocate a new VectorId (monotonically increasing, per-collection)
     ///
@@ -75,7 +75,7 @@ pub trait VectorIndexBackend: Send + Sync {
     fn contains(&self, id: VectorId) -> bool;
 
     // ========================================================================
-    // Snapshot Methods (Epic 55 Story #359)
+    // Snapshot Methods
     // ========================================================================
 
     /// Get all VectorIds in deterministic order
@@ -99,14 +99,14 @@ pub trait VectorIndexBackend: Send + Sync {
 
 /// Factory for creating index backends
 ///
-/// This abstraction allows switching between BruteForce (M8) and HNSW (M9)
+/// This abstraction allows switching between BruteForce and HNSW
 /// without changing the VectorStore code.
 #[derive(Clone, Default)]
 pub enum IndexBackendFactory {
     /// Brute-force O(n) search
     #[default]
     BruteForce,
-    // Hnsw(HnswConfig),  // Reserved for M9
+    // Hnsw(HnswConfig),  // Reserved for future use
 }
 
 impl IndexBackendFactory {

--- a/crates/primitives/src/vector/brute_force.rs
+++ b/crates/primitives/src/vector/brute_force.rs
@@ -1,10 +1,10 @@
 //! Brute-Force Vector Search Backend
 //!
-//! Simple O(n) implementation for M8.
+//! Simple O(n) brute-force implementation.
 //! Sufficient for datasets < 10K vectors.
 //! Performance degrades linearly with dataset size.
 //!
-//! Switch threshold: P95 > 100ms at 50K vectors triggers M9/HNSW priority.
+//! Switch threshold: P95 > 100ms at 50K vectors triggers HNSW priority.
 
 use std::cmp::Ordering;
 
@@ -13,11 +13,11 @@ use crate::vector::{DistanceMetric, VectorConfig, VectorError, VectorHeap, Vecto
 
 /// Brute-force vector search backend
 ///
-/// Simple O(n) implementation for M8.
+/// Simple O(n) brute-force implementation.
 /// Sufficient for datasets < 10K vectors.
 /// Performance degrades linearly with dataset size.
 ///
-/// Switch threshold: P95 > 100ms at 50K vectors triggers M9/HNSW priority.
+/// Switch threshold: P95 > 100ms at 50K vectors triggers HNSW priority.
 pub struct BruteForceBackend {
     /// Vector heap (contiguous storage)
     heap: VectorHeap,

--- a/crates/primitives/src/vector/error.rs
+++ b/crates/primitives/src/vector/error.rs
@@ -135,7 +135,7 @@ impl VectorError {
 pub type VectorResult<T> = Result<T, VectorError>;
 
 // =============================================================================
-// Conversion to StrataError (M9)
+// Conversion to StrataError
 // =============================================================================
 
 impl From<VectorError> for StrataError {

--- a/crates/primitives/src/vector/snapshot.rs
+++ b/crates/primitives/src/vector/snapshot.rs
@@ -29,7 +29,7 @@
 //! 2. **Critical State**: next_id and free_slots MUST be persisted and restored
 //!    to maintain VectorId uniqueness across restarts (Invariant T4).
 //!
-//! 3. **Embedding Format**: Raw f32 LE for efficiency. No compression in M8.
+//! 3. **Embedding Format**: Raw f32 LE for efficiency. No compression currently.
 
 use crate::vector::{
     CollectionId, DistanceMetric, IndexBackendFactory, StorageDtype, VectorConfig, VectorError,
@@ -254,7 +254,7 @@ impl VectorStore {
                 })
                 .map_err(|e| VectorError::Database(e.to_string()))?;
 
-            // Create backend using factory (M8: hardcoded to BruteForce)
+            // Create backend using factory (hardcoded to BruteForce)
             let factory = IndexBackendFactory::default();
             let mut backend = factory.create(&config);
 

--- a/crates/primitives/src/vector/types.rs
+++ b/crates/primitives/src/vector/types.rs
@@ -18,7 +18,7 @@ pub use strata_core::EntityRef;
 pub use strata_core::types::RunId;
 
 // ============================================================================
-// Story #339: VectorRecord and CollectionRecord (Implementation types)
+// VectorRecord and CollectionRecord (Implementation types)
 // ============================================================================
 
 use serde::{Deserialize, Serialize};

--- a/crates/primitives/src/vector/wal.rs
+++ b/crates/primitives/src/vector/wal.rs
@@ -9,9 +9,9 @@
 //!    and respects transaction ordering. The vector replayer does NOT need to check
 //!    transaction boundaries.
 //!
-//! 2. **Embedding Storage**: TEMPORARY M8 FORMAT - Full embeddings are stored in WAL
-//!    payloads. This bloats WAL size (~3KB per 768-dim vector) but is correct for M8.
-//!    M9 may optimize with external embedding storage or delta encoding.
+//! 2. **Embedding Storage**: TEMPORARY FORMAT - Full embeddings are stored in WAL
+//!    payloads. This bloats WAL size (~3KB per 768-dim vector) but is correct.
+//!    future versions may optimize with external embedding storage or delta encoding.
 //!
 //! 3. **Replay vs Normal Operations**: replay_* methods do NOT write to WAL (they are
 //!    replaying from WAL). Normal operations use the VectorStore methods which write WAL.
@@ -50,14 +50,14 @@ pub struct WalVectorCollectionDelete {
 
 /// WAL payload for vector upsert
 ///
-/// WARNING: TEMPORARY M8 FORMAT
+/// WARNING: TEMPORARY FORMAT
 /// This payload contains the full embedding, which:
 /// - Bloats WAL size significantly (~3KB per 768-dim vector)
 /// - Slows down recovery proportionally
 ///
-/// This is acceptable for M8 (correctness over performance).
+/// This is acceptable (correctness over performance).
 ///
-/// M9 MAY change this to:
+/// Future versions may change this to:
 /// - Store embeddings in separate segment
 /// - Use delta encoding for updates
 /// - Reference external embedding storage
@@ -256,7 +256,7 @@ pub fn create_wal_delete(
 }
 
 // ============================================================================
-// VectorWalReplayer (Story #360)
+// VectorWalReplayer
 // ============================================================================
 
 use crate::vector::{DistanceMetric, VectorStore};

--- a/crates/primitives/tests/cross_primitive_tests.rs
+++ b/crates/primitives/tests/cross_primitive_tests.rs
@@ -1,4 +1,4 @@
-//! Cross-Primitive Transaction Tests (Story #197)
+//! Cross-Primitive Transaction Tests
 //!
 //! Tests verifying that multiple primitives can participate in atomic transactions.
 

--- a/crates/primitives/tests/m4_fast_path_equivalence.rs
+++ b/crates/primitives/tests/m4_fast_path_equivalence.rs
@@ -1,4 +1,4 @@
-//! M4 Fast Path Observational Equivalence Tests
+//! Fast Path Observational Equivalence Tests
 //!
 //! Verifies that fast-path reads are observationally equivalent
 //! to transaction-based reads. This is a CRITICAL invariant:

--- a/crates/primitives/tests/recovery_tests.rs
+++ b/crates/primitives/tests/recovery_tests.rs
@@ -1,4 +1,4 @@
-//! Primitive Recovery Tests (Story #199)
+//! Primitive Recovery Tests
 //!
 //! Tests verifying that ALL primitives survive crash + WAL replay.
 //! The recovery contract ensures:

--- a/crates/primitives/tests/run_isolation_tests.rs
+++ b/crates/primitives/tests/run_isolation_tests.rs
@@ -1,4 +1,4 @@
-//! Run Isolation Integration Tests (Story #198)
+//! Run Isolation Integration Tests
 //!
 //! Tests verifying that different runs are completely isolated from each other.
 //! Each run has its own namespace and cannot see or affect other runs' data.

--- a/crates/primitives/tests/versioned_conformance_tests.rs
+++ b/crates/primitives/tests/versioned_conformance_tests.rs
@@ -1,4 +1,4 @@
-//! M9 Conformance Tests: Verifying All 6 Primitives Against All 7 Invariants
+//! Conformance Tests: Verifying All 6 Primitives Against All 7 Invariants
 //!
 //! This test suite verifies that all primitives conform to the Seven Invariants
 //! defined in PRIMITIVE_CONTRACT.md:


### PR DESCRIPTION
## Summary
Remove internal milestone and story/epic markers from strata_primitives crate to prepare for production.

## Changes
- Remove `(Story #NNN)` and `(Epic NNN)` suffixes from comments and section headers
- Replace M3-M9 milestone references with generic descriptions:
  - "M9 will..." → "future versions may..."
  - "in M8" → "currently"
  - "per M9 spec" → removed
- Generalize architecture document references (M8_ARCHITECTURE.md → architecture documentation)
- Clean up section headers

## Files Changed
- 22 files in `crates/primitives/`

## Test plan
- [x] `cargo check -p strata-primitives` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)