### PR TITLE
test(storage): bring strata-storage to A+ test coverage

### DIFF
--- a/crates/storage/src/codec/traits.rs
+++ b/crates/storage/src/codec/traits.rs
@@ -59,7 +59,89 @@ pub enum CodecError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codec::IdentityCodec;
 
     // Test that trait is object-safe
     fn _accepts_box_dyn_codec(_codec: Box<dyn StorageCodec>) {}
+
+    #[test]
+    fn test_codec_trait_object_safe() {
+        // Verify we can create and use a boxed trait object
+        let codec: Box<dyn StorageCodec> = Box::new(IdentityCodec);
+
+        // Test encode/decode through trait object
+        let data = b"test data";
+        let encoded = codec.encode(data);
+        let decoded = codec.decode(&encoded).unwrap();
+
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn test_codec_trait_codec_id() {
+        let codec: Box<dyn StorageCodec> = Box::new(IdentityCodec);
+        assert_eq!(codec.codec_id(), "identity");
+    }
+
+    #[test]
+    fn test_codec_error_display() {
+        let err = CodecError::DecodeError("test error".to_string());
+        assert!(err.to_string().contains("test error"));
+
+        let err = CodecError::UnknownCodec("mystery".to_string());
+        assert!(err.to_string().contains("mystery"));
+
+        let err = CodecError::CodecMismatch {
+            expected: "aes256".to_string(),
+            actual: "identity".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("aes256"));
+        assert!(msg.contains("identity"));
+    }
+
+    #[test]
+    fn test_codec_error_equality() {
+        let err1 = CodecError::DecodeError("error".to_string());
+        let err2 = CodecError::DecodeError("error".to_string());
+        let err3 = CodecError::DecodeError("different".to_string());
+
+        assert_eq!(err1, err2);
+        assert_ne!(err1, err3);
+    }
+
+    #[test]
+    fn test_codec_roundtrip_empty_data() {
+        let codec: Box<dyn StorageCodec> = Box::new(IdentityCodec);
+
+        let data = b"";
+        let encoded = codec.encode(data);
+        let decoded = codec.decode(&encoded).unwrap();
+
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn test_codec_roundtrip_large_data() {
+        let codec: Box<dyn StorageCodec> = Box::new(IdentityCodec);
+
+        // 1MB of data
+        let data: Vec<u8> = (0..1_000_000).map(|i| (i % 256) as u8).collect();
+        let encoded = codec.encode(&data);
+        let decoded = codec.decode(&encoded).unwrap();
+
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn test_codec_roundtrip_binary_data() {
+        let codec: Box<dyn StorageCodec> = Box::new(IdentityCodec);
+
+        // Data with all byte values including null bytes
+        let data: Vec<u8> = (0..=255).collect();
+        let encoded = codec.encode(&data);
+        let decoded = codec.decode(&encoded).unwrap();
+
+        assert_eq!(decoded, data);
+    }
 }


### PR DESCRIPTION
## Summary
- Add comprehensive tests to fill identified gaps in strata-storage
- Bring strata-storage from B grade to A+ test coverage
- Total: 503+ tests (429 lib + 25 compaction + 19 crash + 29 integration)

## Tests Added

### codec/traits.rs (7 tests)
- Runtime behavior tests for StorageCodec trait
- Roundtrip tests for empty, large, and binary data
- Error equality and codec ID verification

### database/config.rs (4 tests)
- Strengthen test_validate_valid_config to verify config contents
- Add tests for batched mode, custom config, and invalid WAL config

### database/handle.rs (2 tests)
- Fix test_codec_invalid to check specific error type
- Add test_create_with_invalid_codec

### sharded.rs (5 tests)
- MVCC get_at_version() tests covering:
  - Single version retrieval
  - Multiple versions in chain
  - Between-versions lookup
  - Snapshot isolation

### recovery/mod.rs (4 tests)
- Corrupted snapshot recovery tests:
  - CRC mismatch detection
  - Missing snapshot file handling
  - Invalid magic bytes detection
  - Callback error propagation

### compaction_tests.rs (3 tests)
- Truly concurrent compaction tests with Barrier synchronization:
  - Concurrent WAL writes during compaction
  - Active segment protection
  - Idempotent concurrent compactors

## Test plan
- [x] All 429 library tests pass
- [x] All 25 compaction tests pass
- [x] All 19 crash scenario tests pass
- [x] All 29 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)