### PR TITLE
test(engine): bring strata-engine to A- test coverage with 343 tests

### DIFF
--- a/crates/engine/src/recovery_participant.rs
+++ b/crates/engine/src/recovery_participant.rs
@@ -120,3 +120,289 @@ pub fn clear_recovery_registry() {
     let mut registry = RECOVERY_REGISTRY.write();
     registry.clear();
 }
+
+/// Get the number of registered participants (for testing only)
+#[cfg(test)]
+pub fn recovery_registry_count() -> usize {
+    let registry = RECOVERY_REGISTRY.read();
+    registry.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use parking_lot::Mutex;
+
+    // Use a mutex to serialize tests that modify the global registry
+    static TEST_LOCK: once_cell::sync::Lazy<Mutex<()>> = once_cell::sync::Lazy::new(|| Mutex::new(()));
+
+    // Mock recovery function that succeeds
+    fn mock_recovery_success(_db: &super::super::Database) -> Result<()> {
+        Ok(())
+    }
+
+    #[test]
+    fn test_recovery_participant_new() {
+        let participant = RecoveryParticipant::new("test", mock_recovery_success);
+        assert_eq!(participant.name, "test");
+    }
+
+    #[test]
+    fn test_recovery_participant_debug() {
+        let participant = RecoveryParticipant::new("vector", mock_recovery_success);
+        let debug_str = format!("{:?}", participant);
+        assert!(debug_str.contains("RecoveryParticipant"));
+        assert!(debug_str.contains("vector"));
+    }
+
+    #[test]
+    fn test_recovery_participant_clone() {
+        let participant = RecoveryParticipant::new("test", mock_recovery_success);
+        let cloned = participant.clone();
+        assert_eq!(participant.name, cloned.name);
+    }
+
+    #[test]
+    fn test_register_and_count() {
+        let _lock = TEST_LOCK.lock();
+        clear_recovery_registry();
+
+        assert_eq!(recovery_registry_count(), 0);
+
+        register_recovery_participant(RecoveryParticipant::new("p1", mock_recovery_success));
+        assert_eq!(recovery_registry_count(), 1);
+
+        register_recovery_participant(RecoveryParticipant::new("p2", mock_recovery_success));
+        assert_eq!(recovery_registry_count(), 2);
+
+        register_recovery_participant(RecoveryParticipant::new("p3", mock_recovery_success));
+        assert_eq!(recovery_registry_count(), 3);
+    }
+
+    #[test]
+    fn test_duplicate_registration_prevented() {
+        let _lock = TEST_LOCK.lock();
+        clear_recovery_registry();
+
+        register_recovery_participant(RecoveryParticipant::new("dup_name", mock_recovery_success));
+        assert_eq!(recovery_registry_count(), 1);
+
+        // Same name should be ignored
+        register_recovery_participant(RecoveryParticipant::new("dup_name", mock_recovery_success));
+        assert_eq!(recovery_registry_count(), 1);
+
+        // Different name should work
+        register_recovery_participant(RecoveryParticipant::new("other_name", mock_recovery_success));
+        assert_eq!(recovery_registry_count(), 2);
+    }
+
+    #[test]
+    fn test_clear_recovery_registry() {
+        let _lock = TEST_LOCK.lock();
+
+        register_recovery_participant(RecoveryParticipant::new("clear_test", mock_recovery_success));
+        assert!(recovery_registry_count() > 0);
+
+        clear_recovery_registry();
+        assert_eq!(recovery_registry_count(), 0);
+    }
+
+    #[test]
+    fn test_recover_empty_registry() {
+        use tempfile::tempdir;
+
+        let _lock = TEST_LOCK.lock();
+        clear_recovery_registry();
+
+        let dir = tempdir().unwrap();
+        let db = super::super::Database::open(dir.path()).unwrap();
+
+        let result = recover_all_participants(&db);
+        assert!(result.is_ok(), "Empty registry should succeed");
+
+        db.close().unwrap();
+    }
+
+    #[test]
+    fn test_recover_calls_participant() {
+        use tempfile::tempdir;
+
+        let _lock = TEST_LOCK.lock();
+        clear_recovery_registry();
+
+        static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+        fn counting_recovery(_db: &super::super::Database) -> Result<()> {
+            CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        CALL_COUNT.store(0, Ordering::SeqCst);
+
+        let dir = tempdir().unwrap();
+        let db = super::super::Database::open(dir.path()).unwrap();
+
+        register_recovery_participant(RecoveryParticipant::new("counter", counting_recovery));
+
+        let result = recover_all_participants(&db);
+        assert!(result.is_ok());
+        assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 1, "Recovery should be called exactly once");
+
+        db.close().unwrap();
+    }
+
+    #[test]
+    fn test_recover_calls_in_order() {
+        use tempfile::tempdir;
+
+        let _lock = TEST_LOCK.lock();
+        clear_recovery_registry();
+
+        static ORDER: once_cell::sync::Lazy<Mutex<Vec<&'static str>>> =
+            once_cell::sync::Lazy::new(|| Mutex::new(Vec::new()));
+
+        fn first_recovery(_db: &super::super::Database) -> Result<()> {
+            ORDER.lock().push("first");
+            Ok(())
+        }
+
+        fn second_recovery(_db: &super::super::Database) -> Result<()> {
+            ORDER.lock().push("second");
+            Ok(())
+        }
+
+        fn third_recovery(_db: &super::super::Database) -> Result<()> {
+            ORDER.lock().push("third");
+            Ok(())
+        }
+
+        ORDER.lock().clear();
+
+        let dir = tempdir().unwrap();
+        let db = super::super::Database::open(dir.path()).unwrap();
+
+        register_recovery_participant(RecoveryParticipant::new("first", first_recovery));
+        register_recovery_participant(RecoveryParticipant::new("second", second_recovery));
+        register_recovery_participant(RecoveryParticipant::new("third", third_recovery));
+
+        let result = recover_all_participants(&db);
+        assert!(result.is_ok());
+
+        let order = ORDER.lock();
+        assert_eq!(order.as_slice(), &["first", "second", "third"], "Should call in registration order");
+
+        db.close().unwrap();
+    }
+
+    #[test]
+    fn test_recover_error_stops_execution() {
+        use tempfile::tempdir;
+
+        let _lock = TEST_LOCK.lock();
+        clear_recovery_registry();
+
+        static CALLED: once_cell::sync::Lazy<Mutex<Vec<&'static str>>> =
+            once_cell::sync::Lazy::new(|| Mutex::new(Vec::new()));
+
+        fn success_recovery(_db: &super::super::Database) -> Result<()> {
+            CALLED.lock().push("success");
+            Ok(())
+        }
+
+        fn failing_recovery(_db: &super::super::Database) -> Result<()> {
+            CALLED.lock().push("failing");
+            Err(strata_core::error::Error::Corruption("test failure".to_string()))
+        }
+
+        fn should_not_run(_db: &super::super::Database) -> Result<()> {
+            CALLED.lock().push("should_not_run");
+            Ok(())
+        }
+
+        CALLED.lock().clear();
+
+        let dir = tempdir().unwrap();
+        let db = super::super::Database::open(dir.path()).unwrap();
+
+        register_recovery_participant(RecoveryParticipant::new("success", success_recovery));
+        register_recovery_participant(RecoveryParticipant::new("failing", failing_recovery));
+        register_recovery_participant(RecoveryParticipant::new("never", should_not_run));
+
+        let result = recover_all_participants(&db);
+        assert!(result.is_err(), "Should return error");
+
+        let called = CALLED.lock();
+        assert_eq!(called.len(), 2, "Should stop after failure");
+        assert!(called.contains(&"success"));
+        assert!(called.contains(&"failing"));
+        assert!(!called.contains(&"should_not_run"), "Should not call participant after failure");
+
+        db.close().unwrap();
+    }
+
+    #[test]
+    fn test_concurrent_registration_no_data_race() {
+        use std::thread;
+
+        let _lock = TEST_LOCK.lock();
+        clear_recovery_registry();
+
+        let barrier = Arc::new(std::sync::Barrier::new(10));
+        let handles: Vec<_> = (0..10)
+            .map(|i| {
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    // Each thread registers with a unique static name
+                    let name: &'static str = match i {
+                        0 => "concurrent_0",
+                        1 => "concurrent_1",
+                        2 => "concurrent_2",
+                        3 => "concurrent_3",
+                        4 => "concurrent_4",
+                        5 => "concurrent_5",
+                        6 => "concurrent_6",
+                        7 => "concurrent_7",
+                        8 => "concurrent_8",
+                        _ => "concurrent_9",
+                    };
+                    register_recovery_participant(RecoveryParticipant::new(name, mock_recovery_success));
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        assert_eq!(recovery_registry_count(), 10, "All 10 unique participants should be registered");
+    }
+
+    #[test]
+    fn test_concurrent_duplicate_registration_safe() {
+        use std::thread;
+
+        let _lock = TEST_LOCK.lock();
+        clear_recovery_registry();
+
+        let barrier = Arc::new(std::sync::Barrier::new(10));
+        let handles: Vec<_> = (0..10)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    // All threads try same name
+                    register_recovery_participant(RecoveryParticipant::new("same_name", mock_recovery_success));
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        assert_eq!(recovery_registry_count(), 1, "Only one should be registered despite concurrent attempts");
+    }
+}

--- a/crates/engine/src/transaction_ops.rs
+++ b/crates/engine/src/transaction_ops.rs
@@ -191,12 +191,296 @@ pub trait TransactionOps {
 mod tests {
     use super::*;
 
-    // Verify trait is object-safe (can be used as dyn TransactionOps)
-    fn _assert_object_safe(_: &dyn TransactionOps) {}
+    /// Mock implementation of TransactionOps for testing trait properties
+    struct MockTransactionOps {
+        kv_data: std::collections::HashMap<String, Value>,
+        event_count: u64,
+    }
+
+    impl MockTransactionOps {
+        fn new() -> Self {
+            Self {
+                kv_data: std::collections::HashMap::new(),
+                event_count: 0,
+            }
+        }
+    }
+
+    impl TransactionOps for MockTransactionOps {
+        fn kv_get(&self, key: &str) -> Result<Option<Versioned<Value>>, StrataError> {
+            Ok(self.kv_data.get(key).map(|v| Versioned::new(v.clone(), Version::txn(1))))
+        }
+
+        fn kv_put(&mut self, key: &str, value: Value) -> Result<Version, StrataError> {
+            self.kv_data.insert(key.to_string(), value);
+            Ok(Version::txn(1))
+        }
+
+        fn kv_delete(&mut self, key: &str) -> Result<bool, StrataError> {
+            Ok(self.kv_data.remove(key).is_some())
+        }
+
+        fn kv_exists(&self, key: &str) -> Result<bool, StrataError> {
+            Ok(self.kv_data.contains_key(key))
+        }
+
+        fn kv_list(&self, prefix: Option<&str>) -> Result<Vec<String>, StrataError> {
+            let keys: Vec<_> = self.kv_data.keys()
+                .filter(|k| prefix.is_none() || k.starts_with(prefix.unwrap()))
+                .cloned()
+                .collect();
+            Ok(keys)
+        }
+
+        fn event_append(&mut self, _event_type: &str, _payload: Value) -> Result<Version, StrataError> {
+            self.event_count += 1;
+            Ok(Version::seq(self.event_count))
+        }
+
+        fn event_read(&self, sequence: u64) -> Result<Option<Versioned<Event>>, StrataError> {
+            // Return None for simplicity - Event struct is complex
+            if sequence == 0 || sequence > self.event_count {
+                return Ok(None);
+            }
+            // For testing purposes, we'll return None rather than construct a complex Event
+            // The trait behavior is still tested through event_append and event_len
+            Ok(None)
+        }
+
+        fn event_range(&self, _start: u64, _end: u64) -> Result<Vec<Versioned<Event>>, StrataError> {
+            // Return empty for simplicity
+            Ok(Vec::new())
+        }
+
+        fn event_len(&self) -> Result<u64, StrataError> {
+            Ok(self.event_count)
+        }
+
+        // State operations - return not implemented error for mock
+        fn state_read(&self, _name: &str) -> Result<Option<Versioned<State>>, StrataError> {
+            Err(StrataError::Internal { message: "state_read not implemented in mock".to_string() })
+        }
+
+        fn state_init(&mut self, _name: &str, _value: Value) -> Result<Version, StrataError> {
+            Err(StrataError::Internal { message: "state_init not implemented in mock".to_string() })
+        }
+
+        fn state_cas(&mut self, _name: &str, _expected: u64, _value: Value) -> Result<Version, StrataError> {
+            Err(StrataError::Internal { message: "state_cas not implemented in mock".to_string() })
+        }
+
+        fn state_delete(&mut self, _name: &str) -> Result<bool, StrataError> {
+            Err(StrataError::Internal { message: "state_delete not implemented in mock".to_string() })
+        }
+
+        fn state_exists(&self, _name: &str) -> Result<bool, StrataError> {
+            Err(StrataError::Internal { message: "state_exists not implemented in mock".to_string() })
+        }
+
+        // Json operations
+        fn json_create(&mut self, _doc_id: &JsonDocId, _value: JsonValue) -> Result<Version, StrataError> {
+            Err(StrataError::Internal { message: "json_create not implemented in mock".to_string() })
+        }
+
+        fn json_get(&self, _doc_id: &JsonDocId) -> Result<Option<Versioned<JsonValue>>, StrataError> {
+            Err(StrataError::Internal { message: "json_get not implemented in mock".to_string() })
+        }
+
+        fn json_get_path(&self, _doc_id: &JsonDocId, _path: &JsonPath) -> Result<Option<JsonValue>, StrataError> {
+            Err(StrataError::Internal { message: "json_get_path not implemented in mock".to_string() })
+        }
+
+        fn json_set(&mut self, _doc_id: &JsonDocId, _path: &JsonPath, _value: JsonValue) -> Result<Version, StrataError> {
+            Err(StrataError::Internal { message: "json_set not implemented in mock".to_string() })
+        }
+
+        fn json_delete(&mut self, _doc_id: &JsonDocId) -> Result<bool, StrataError> {
+            Err(StrataError::Internal { message: "json_delete not implemented in mock".to_string() })
+        }
+
+        fn json_exists(&self, _doc_id: &JsonDocId) -> Result<bool, StrataError> {
+            Err(StrataError::Internal { message: "json_exists not implemented in mock".to_string() })
+        }
+
+        fn json_destroy(&mut self, _doc_id: &JsonDocId) -> Result<bool, StrataError> {
+            Err(StrataError::Internal { message: "json_destroy not implemented in mock".to_string() })
+        }
+
+        // Vector operations
+        fn vector_insert(&mut self, _collection: &str, _key: &str, _embedding: &[f32], _metadata: Option<Value>) -> Result<Version, StrataError> {
+            Err(StrataError::Internal { message: "vector_insert not implemented in mock".to_string() })
+        }
+
+        fn vector_get(&self, _collection: &str, _key: &str) -> Result<Option<Versioned<VectorEntry>>, StrataError> {
+            Err(StrataError::Internal { message: "vector_get not implemented in mock".to_string() })
+        }
+
+        fn vector_delete(&mut self, _collection: &str, _key: &str) -> Result<bool, StrataError> {
+            Err(StrataError::Internal { message: "vector_delete not implemented in mock".to_string() })
+        }
+
+        fn vector_search(&self, _collection: &str, _query: &[f32], _k: usize, _filter: Option<MetadataFilter>) -> Result<Vec<VectorMatch>, StrataError> {
+            Err(StrataError::Internal { message: "vector_search not implemented in mock".to_string() })
+        }
+
+        fn vector_exists(&self, _collection: &str, _key: &str) -> Result<bool, StrataError> {
+            Err(StrataError::Internal { message: "vector_exists not implemented in mock".to_string() })
+        }
+
+        // Run operations
+        fn run_metadata(&self) -> Result<Option<Versioned<RunMetadata>>, StrataError> {
+            Err(StrataError::Internal { message: "run_metadata not implemented in mock".to_string() })
+        }
+
+        fn run_update_status(&mut self, _status: RunStatus) -> Result<Version, StrataError> {
+            Err(StrataError::Internal { message: "run_update_status not implemented in mock".to_string() })
+        }
+    }
+
+    // ========== Object Safety Tests ==========
+
+    /// Verify trait is object-safe by creating a trait object
+    fn accept_dyn_transaction_ops(_ops: &dyn TransactionOps) {}
+
+    fn accept_mut_dyn_transaction_ops(_ops: &mut dyn TransactionOps) {}
+
+    fn accept_boxed_dyn_transaction_ops(_ops: Box<dyn TransactionOps>) {}
 
     #[test]
-    fn test_trait_compiles() {
-        // This test verifies the trait compiles with all methods
-        // Actual implementation tests are in the Transaction impl
+    fn test_trait_is_object_safe_ref() {
+        let ops = MockTransactionOps::new();
+        accept_dyn_transaction_ops(&ops);
+    }
+
+    #[test]
+    fn test_trait_is_object_safe_mut_ref() {
+        let mut ops = MockTransactionOps::new();
+        accept_mut_dyn_transaction_ops(&mut ops);
+    }
+
+    #[test]
+    fn test_trait_is_object_safe_boxed() {
+        let ops = MockTransactionOps::new();
+        accept_boxed_dyn_transaction_ops(Box::new(ops));
+    }
+
+    // ========== Read Operations Through Trait Object ==========
+
+    #[test]
+    fn test_kv_operations_through_trait_object() {
+        let mut ops: Box<dyn TransactionOps> = Box::new(MockTransactionOps::new());
+
+        // Put through trait object
+        let version = ops.kv_put("key1", Value::Int(42)).unwrap();
+        assert_eq!(version.as_u64(), 1);
+
+        // Get through trait object
+        let result = ops.kv_get("key1").unwrap();
+        assert!(result.is_some());
+        let versioned = result.unwrap();
+        assert_eq!(versioned.value, Value::Int(42));
+
+        // Exists through trait object
+        assert!(ops.kv_exists("key1").unwrap());
+        assert!(!ops.kv_exists("nonexistent").unwrap());
+
+        // Delete through trait object
+        let deleted = ops.kv_delete("key1").unwrap();
+        assert!(deleted);
+        assert!(!ops.kv_exists("key1").unwrap());
+    }
+
+    #[test]
+    fn test_event_operations_through_trait_object() {
+        let mut ops: Box<dyn TransactionOps> = Box::new(MockTransactionOps::new());
+
+        // Append events
+        let v1 = ops.event_append("UserCreated", Value::String("alice".into())).unwrap();
+        let v2 = ops.event_append("UserUpdated", Value::String("bob".into())).unwrap();
+
+        // Check versions are sequential
+        assert_eq!(v1.as_u64(), 1);
+        assert_eq!(v2.as_u64(), 2);
+
+        // Check length
+        assert_eq!(ops.event_len().unwrap(), 2);
+
+        // Non-existent event (beyond the event count)
+        assert!(ops.event_read(999).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_kv_list_through_trait_object() {
+        let mut ops: Box<dyn TransactionOps> = Box::new(MockTransactionOps::new());
+
+        ops.kv_put("user:1", Value::Int(1)).unwrap();
+        ops.kv_put("user:2", Value::Int(2)).unwrap();
+        ops.kv_put("config:a", Value::Int(3)).unwrap();
+
+        // List all
+        let all_keys = ops.kv_list(None).unwrap();
+        assert_eq!(all_keys.len(), 3);
+
+        // List with prefix
+        let user_keys = ops.kv_list(Some("user:")).unwrap();
+        assert_eq!(user_keys.len(), 2);
+        assert!(user_keys.iter().all(|k| k.starts_with("user:")));
+    }
+
+    // ========== Unimplemented Operations Return Proper Errors ==========
+
+    #[test]
+    fn test_unimplemented_operations_return_errors() {
+        let ops: Box<dyn TransactionOps> = Box::new(MockTransactionOps::new());
+
+        // State operations should return unimplemented error
+        let result = ops.state_read("test");
+        assert!(result.is_err());
+
+        let result = ops.state_exists("test");
+        assert!(result.is_err());
+
+        // Json operations should return unimplemented error
+        let doc_id = JsonDocId::new();
+        let result = ops.json_get(&doc_id);
+        assert!(result.is_err());
+
+        // Vector operations should return unimplemented error
+        let result = ops.vector_exists("collection", "key");
+        assert!(result.is_err());
+
+        // Run operations should return unimplemented error
+        let result = ops.run_metadata();
+        assert!(result.is_err());
+    }
+
+    // ========== Trait Method Signatures ==========
+
+    #[test]
+    fn test_read_methods_take_shared_ref() {
+        // This test verifies that read methods use &self (not &mut self)
+        // by calling them on an immutable reference
+        let ops = MockTransactionOps::new();
+        let ops_ref: &dyn TransactionOps = &ops;
+
+        // All these should compile with &self
+        let _ = ops_ref.kv_get("key");
+        let _ = ops_ref.kv_exists("key");
+        let _ = ops_ref.kv_list(None);
+        let _ = ops_ref.event_read(1);
+        let _ = ops_ref.event_range(1, 10);
+        let _ = ops_ref.event_len();
+    }
+
+    #[test]
+    fn test_write_methods_take_mutable_ref() {
+        // This test verifies that write methods use &mut self
+        let mut ops = MockTransactionOps::new();
+        let ops_mut: &mut dyn TransactionOps = &mut ops;
+
+        // All these should compile with &mut self
+        let _ = ops_mut.kv_put("key", Value::Int(1));
+        let _ = ops_mut.kv_delete("key");
+        let _ = ops_mut.event_append("test", Value::Null);
     }
 }


### PR DESCRIPTION
## Summary

- Add 12 recovery_participant tests for registration, dispatch, error handling, and concurrent safety
- Add 10 coordinator wait_for_idle tests for shutdown behavior and timeout handling
- Add 9 transaction_ops behavioral tests with MockTransactionOps
- Add 10 durability/traits CommitData tests
- Add 4 replay invariant tests (P2 self-contained, P5 determinism, P6 idempotency)
- Fix race condition in test_active_count_accuracy_under_concurrent_load (barrier 20→10)

## Test Coverage

| Area | Before | After |
|------|--------|-------|
| recovery_participant.rs | 0 tests | 12 tests |
| coordinator wait_for_idle | 0 tests | 10 tests |
| transaction_ops.rs | 1 test (compilation-only) | 9 tests |
| durability/traits CommitData | 0 tests | 10 tests |
| replay.rs invariants | partial | P2, P5, P6 covered |
| **Total lib tests** | ~150 | **200** |
| **Integration tests** | 143 | 143 |
| **Grand total** | ~293 | **343** |

## Test plan
- [x] All 200 lib tests pass (`cargo test -p strata-engine --lib`)
- [x] All 143 integration tests pass (`cargo test -p strata-engine --test '*'`)
- [x] No race conditions (fixed barrier bug)
- [x] Updated TESTING_AUDIT_REPORT.md grade: B- → A-

🤖 Generated with [Claude Code](https://claude.com/claude-code)