### PR TITLE
fix(core): remove tautology in JsonPath::to_path_string

### DIFF
--- a/crates/core/src/json.rs
+++ b/crates/core/src/json.rs
@@ -653,7 +653,7 @@ impl JsonPath {
         for seg in &self.segments {
             match seg {
                 PathSegment::Key(k) => {
-                    if !result.is_empty() || result.is_empty() {
+                    if !result.is_empty() {
                         result.push('.');
                     }
                     result.push_str(k);
@@ -664,10 +664,6 @@ impl JsonPath {
                     result.push(']');
                 }
             }
-        }
-        // Remove leading dot if it starts with one
-        if result.starts_with('.') {
-            result.remove(0);
         }
         result
     }


### PR DESCRIPTION
## Summary

- Remove tautology `!result.is_empty() || result.is_empty()` which was always true
- Remove compensating code that stripped leading dots

## The Bug

The condition at line 656 was:
```rust
if !result.is_empty() || result.is_empty() {
    result.push('.');
}
```

This is always true (A OR NOT A = true), so a dot was added before every key. The code then compensated by removing the leading dot at the end.

## The Fix

Simplified to only add a dot when the result is not empty:
```rust
if !result.is_empty() {
    result.push('.');
}
```

This is more efficient and semantically correct.

## Test plan
- [x] All 451 strata-core tests pass
- [x] All path-related tests (33 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)