### PR TITLE
Simplify JSON primitive to MVP methods

### DIFF
--- a/crates/executor/src/api/json.rs
+++ b/crates/executor/src/api/json.rs
@@ -1,15 +1,59 @@
-//! JSON document store operations.
+//! JSON document store operations (MVP).
+//!
+//! Provides document storage with path-based access.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use strata_executor::Strata;
+//!
+//! let db = Strata::open("/path/to/data")?;
+//!
+//! // Create/update a document
+//! db.json_set("user:123", "$", json!({"name": "Alice", "age": 30}))?;
+//!
+//! // Get a value at a path
+//! let name = db.json_get("user:123", "$.name")?;
+//!
+//! // Delete a document
+//! db.json_delete("user:123", "$")?;
+//!
+//! // List documents
+//! let (keys, cursor) = db.json_list(Some("user:".into()), None, 100)?;
+//! ```
 
 use super::Strata;
 use crate::{Command, Error, Output, Result, Value};
-use crate::types::*;
 
 impl Strata {
     // =========================================================================
-    // JSON Operations (17)
+    // JSON Operations (4 MVP)
     // =========================================================================
 
     /// Set a JSON value at a path.
+    ///
+    /// Creates the document if it doesn't exist, or updates the value at the
+    /// specified path. Use "$" as the path for the root document.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - Document identifier
+    /// * `path` - JSONPath to the value (use "$" for root)
+    /// * `value` - Value to set
+    ///
+    /// # Returns
+    ///
+    /// The new version number.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Create a new document
+    /// db.json_set("config", "$", json!({"debug": true}))?;
+    ///
+    /// // Update a nested path
+    /// db.json_set("config", "$.debug", false)?;
+    /// ```
     pub fn json_set(&self, key: &str, path: &str, value: impl Into<Value>) -> Result<u64> {
         match self.executor.execute(Command::JsonSet {
             run: self.run_id(),
@@ -25,7 +69,26 @@ impl Strata {
     }
 
     /// Get a JSON value at a path.
-    pub fn json_get(&self, key: &str, path: &str) -> Result<Option<VersionedValue>> {
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - Document identifier
+    /// * `path` - JSONPath to the value (use "$" for root)
+    ///
+    /// # Returns
+    ///
+    /// The versioned value if found, None otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Get the whole document
+    /// let doc = db.json_get("config", "$")?;
+    ///
+    /// // Get a nested value
+    /// let debug = db.json_get("config", "$.debug")?;
+    /// ```
+    pub fn json_get(&self, key: &str, path: &str) -> Result<Option<crate::types::VersionedValue>> {
         match self.executor.execute(Command::JsonGet {
             run: self.run_id(),
             key: key.to_string(),
@@ -38,7 +101,28 @@ impl Strata {
         }
     }
 
-    /// Delete a value at a path from a JSON document.
+    /// Delete a JSON document or value at a path.
+    ///
+    /// Use "$" as the path to delete the entire document.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - Document identifier
+    /// * `path` - JSONPath to delete (use "$" for whole document)
+    ///
+    /// # Returns
+    ///
+    /// The new version number (0 if document was deleted entirely).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Delete a nested value
+    /// db.json_delete("config", "$.deprecated_field")?;
+    ///
+    /// // Delete entire document
+    /// db.json_delete("config", "$")?;
+    /// ```
     pub fn json_delete(&self, key: &str, path: &str) -> Result<u64> {
         match self.executor.execute(Command::JsonDelete {
             run: self.run_id(),
@@ -52,82 +136,29 @@ impl Strata {
         }
     }
 
-    /// Merge a value at a path (RFC 7396 JSON Merge Patch).
-    pub fn json_merge(&self, key: &str, path: &str, patch: impl Into<Value>) -> Result<u64> {
-        match self.executor.execute(Command::JsonMerge {
-            run: self.run_id(),
-            key: key.to_string(),
-            path: path.to_string(),
-            patch: patch.into(),
-        })? {
-            Output::Version(v) => Ok(v),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for JsonMerge".into(),
-            }),
-        }
-    }
-
-    /// Get version history for a JSON document.
-    pub fn json_history(
-        &self,
-        key: &str,
-        limit: Option<u64>,
-        before: Option<u64>,
-    ) -> Result<Vec<VersionedValue>> {
-        match self.executor.execute(Command::JsonHistory {
-            run: self.run_id(),
-            key: key.to_string(),
-            limit,
-            before,
-        })? {
-            Output::VersionedValues(vals) => Ok(vals),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for JsonHistory".into(),
-            }),
-        }
-    }
-
-    /// Check if a JSON document exists.
-    pub fn json_exists(&self, key: &str) -> Result<bool> {
-        match self.executor.execute(Command::JsonExists {
-            run: self.run_id(),
-            key: key.to_string(),
-        })? {
-            Output::Bool(exists) => Ok(exists),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for JsonExists".into(),
-            }),
-        }
-    }
-
-    /// Get the current version of a JSON document.
-    pub fn json_get_version(&self, key: &str) -> Result<Option<u64>> {
-        match self.executor.execute(Command::JsonGetVersion {
-            run: self.run_id(),
-            key: key.to_string(),
-        })? {
-            Output::MaybeVersion(v) => Ok(v),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for JsonGetVersion".into(),
-            }),
-        }
-    }
-
-    /// Full-text search across JSON documents.
-    pub fn json_search(&self, query: &str, k: u64) -> Result<Vec<JsonSearchHit>> {
-        match self.executor.execute(Command::JsonSearch {
-            run: self.run_id(),
-            query: query.to_string(),
-            k,
-        })? {
-            Output::JsonSearchHits(hits) => Ok(hits),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for JsonSearch".into(),
-            }),
-        }
-    }
-
     /// List JSON documents with cursor-based pagination.
+    ///
+    /// # Arguments
+    ///
+    /// * `prefix` - Optional key prefix filter
+    /// * `cursor` - Optional cursor for pagination (from previous call)
+    /// * `limit` - Maximum number of keys to return
+    ///
+    /// # Returns
+    ///
+    /// Tuple of (keys, next_cursor). If next_cursor is Some, there are more results.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // List all documents with prefix
+    /// let (keys, cursor) = db.json_list(Some("user:".into()), None, 100)?;
+    ///
+    /// // Get next page if there are more
+    /// if let Some(c) = cursor {
+    ///     let (more_keys, _) = db.json_list(Some("user:".into()), Some(c), 100)?;
+    /// }
+    /// ```
     pub fn json_list(
         &self,
         prefix: Option<String>,
@@ -143,125 +174,6 @@ impl Strata {
             Output::JsonListResult { keys, cursor } => Ok((keys, cursor)),
             _ => Err(Error::Internal {
                 reason: "Unexpected output for JsonList".into(),
-            }),
-        }
-    }
-
-    /// Compare-and-swap: update if version matches.
-    pub fn json_cas(
-        &self,
-        key: &str,
-        expected_version: u64,
-        path: &str,
-        value: impl Into<Value>,
-    ) -> Result<u64> {
-        match self.executor.execute(Command::JsonCas {
-            run: self.run_id(),
-            key: key.to_string(),
-            expected_version,
-            path: path.to_string(),
-            value: value.into(),
-        })? {
-            Output::Version(v) => Ok(v),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for JsonCas".into(),
-            }),
-        }
-    }
-
-    /// Query documents by exact field match.
-    pub fn json_query(&self, path: &str, value: impl Into<Value>, limit: u64) -> Result<Vec<String>> {
-        match self.executor.execute(Command::JsonQuery {
-            run: self.run_id(),
-            path: path.to_string(),
-            value: value.into(),
-            limit,
-        })? {
-            Output::Keys(keys) => Ok(keys),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for JsonQuery".into(),
-            }),
-        }
-    }
-
-    /// Count JSON documents in the store.
-    pub fn json_count(&self) -> Result<u64> {
-        match self.executor.execute(Command::JsonCount {
-            run: self.run_id(),
-        })? {
-            Output::Uint(count) => Ok(count),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for JsonCount".into(),
-            }),
-        }
-    }
-
-    /// Batch get multiple JSON documents.
-    pub fn json_batch_get(&self, keys: Vec<String>) -> Result<Vec<Option<VersionedValue>>> {
-        match self.executor.execute(Command::JsonBatchGet {
-            run: self.run_id(),
-            keys,
-        })? {
-            Output::Values(vals) => Ok(vals),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for JsonBatchGet".into(),
-            }),
-        }
-    }
-
-    /// Batch create multiple JSON documents atomically.
-    pub fn json_batch_create(&self, docs: Vec<(String, Value)>) -> Result<Vec<u64>> {
-        match self.executor.execute(Command::JsonBatchCreate {
-            run: self.run_id(),
-            docs,
-        })? {
-            Output::Versions(versions) => Ok(versions),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for JsonBatchCreate".into(),
-            }),
-        }
-    }
-
-    /// Atomically push values to an array at path.
-    pub fn json_array_push(&self, key: &str, path: &str, values: Vec<Value>) -> Result<u64> {
-        match self.executor.execute(Command::JsonArrayPush {
-            run: self.run_id(),
-            key: key.to_string(),
-            path: path.to_string(),
-            values,
-        })? {
-            Output::Uint(len) => Ok(len),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for JsonArrayPush".into(),
-            }),
-        }
-    }
-
-    /// Atomically increment a numeric value at path.
-    pub fn json_increment(&self, key: &str, path: &str, delta: f64) -> Result<f64> {
-        match self.executor.execute(Command::JsonIncrement {
-            run: self.run_id(),
-            key: key.to_string(),
-            path: path.to_string(),
-            delta,
-        })? {
-            Output::Float(val) => Ok(val),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for JsonIncrement".into(),
-            }),
-        }
-    }
-
-    /// Atomically pop a value from an array at path.
-    pub fn json_array_pop(&self, key: &str, path: &str) -> Result<Option<Value>> {
-        match self.executor.execute(Command::JsonArrayPop {
-            run: self.run_id(),
-            key: key.to_string(),
-            path: path.to_string(),
-        })? {
-            Output::Maybe(val) => Ok(val),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for JsonArrayPop".into(),
             }),
         }
     }

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -100,7 +100,7 @@ pub enum Command {
         prefix: Option<String>,
     },
 
-    // ==================== JSON (17) ====================
+    // ==================== JSON (4 MVP) ====================
     /// Set a value at a path in a JSON document.
     /// Returns: `Output::Version`
     JsonSet {
@@ -129,51 +129,6 @@ pub enum Command {
         path: String,
     },
 
-    /// Merge a value at a path (RFC 7396 JSON Merge Patch).
-    /// Returns: `Output::Version`
-    JsonMerge {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        key: String,
-        path: String,
-        patch: Value,
-    },
-
-    /// Get version history for a JSON document.
-    /// Returns: `Output::VersionedValues`
-    JsonHistory {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        key: String,
-        limit: Option<u64>,
-        before: Option<u64>,
-    },
-
-    /// Check if a JSON document exists.
-    /// Returns: `Output::Bool`
-    JsonExists {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        key: String,
-    },
-
-    /// Get the current version of a JSON document.
-    /// Returns: `Output::MaybeUint`
-    JsonGetVersion {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        key: String,
-    },
-
-    /// Full-text search across JSON documents.
-    /// Returns: `Output::JsonSearchHits`
-    JsonSearch {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        query: String,
-        k: u64,
-    },
-
     /// List JSON documents with cursor-based pagination.
     /// Returns: `Output::JsonListResult`
     JsonList {
@@ -182,79 +137,6 @@ pub enum Command {
         prefix: Option<String>,
         cursor: Option<String>,
         limit: u64,
-    },
-
-    /// Compare-and-swap: update if version matches.
-    /// Returns: `Output::Version`
-    JsonCas {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        key: String,
-        expected_version: u64,
-        path: String,
-        value: Value,
-    },
-
-    /// Query documents by exact field match.
-    /// Returns: `Output::Keys`
-    JsonQuery {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        path: String,
-        value: Value,
-        limit: u64,
-    },
-
-    /// Count JSON documents in the store.
-    /// Returns: `Output::Uint`
-    JsonCount {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-    },
-
-    /// Batch get multiple JSON documents.
-    /// Returns: `Output::MaybeVersionedValues`
-    JsonBatchGet {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        keys: Vec<String>,
-    },
-
-    /// Batch create multiple JSON documents atomically.
-    /// Returns: `Output::Versions`
-    JsonBatchCreate {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        docs: Vec<(String, Value)>,
-    },
-
-    /// Atomically push values to an array at path.
-    /// Returns: `Output::Uint` (new array length)
-    JsonArrayPush {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        key: String,
-        path: String,
-        values: Vec<Value>,
-    },
-
-    /// Atomically increment a numeric value at path.
-    /// Returns: `Output::Float`
-    JsonIncrement {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        key: String,
-        path: String,
-        delta: f64,
-    },
-
-    /// Atomically pop a value from an array at path.
-    /// Returns: `Output::Maybe` (the popped value)
-    JsonArrayPop {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        key: String,
-        path: String,
     },
 
     // ==================== Event (11) ====================
@@ -720,20 +602,7 @@ impl Command {
             | Command::JsonSet { run, .. }
             | Command::JsonGet { run, .. }
             | Command::JsonDelete { run, .. }
-            | Command::JsonMerge { run, .. }
-            | Command::JsonHistory { run, .. }
-            | Command::JsonExists { run, .. }
-            | Command::JsonGetVersion { run, .. }
-            | Command::JsonSearch { run, .. }
             | Command::JsonList { run, .. }
-            | Command::JsonCas { run, .. }
-            | Command::JsonQuery { run, .. }
-            | Command::JsonCount { run, .. }
-            | Command::JsonBatchGet { run, .. }
-            | Command::JsonBatchCreate { run, .. }
-            | Command::JsonArrayPush { run, .. }
-            | Command::JsonIncrement { run, .. }
-            | Command::JsonArrayPop { run, .. }
             // Event
             | Command::EventAppend { run, .. }
             | Command::EventAppendBatch { run, .. }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -101,7 +101,7 @@ impl Executor {
                 crate::handlers::kv::kv_list(&self.primitives, run, prefix)
             }
 
-            // JSON commands
+            // JSON commands (4 MVP)
             Command::JsonSet {
                 run,
                 key,
@@ -119,36 +119,6 @@ impl Executor {
                 let run = run.expect("resolved by resolve_default_run");
                 crate::handlers::json::json_delete(&self.primitives, run, key, path)
             }
-            Command::JsonMerge {
-                run,
-                key,
-                path,
-                patch,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::json::json_merge(&self.primitives, run, key, path, patch)
-            }
-            Command::JsonHistory {
-                run,
-                key,
-                limit,
-                before,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::json::json_history(&self.primitives, run, key, limit, before)
-            }
-            Command::JsonExists { run, key } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::json::json_exists(&self.primitives, run, key)
-            }
-            Command::JsonGetVersion { run, key } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::json::json_get_version(&self.primitives, run, key)
-            }
-            Command::JsonSearch { run, query, k } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::json::json_search(&self.primitives, run, query, k)
-            }
             Command::JsonList {
                 run,
                 prefix,
@@ -157,66 +127,6 @@ impl Executor {
             } => {
                 let run = run.expect("resolved by resolve_default_run");
                 crate::handlers::json::json_list(&self.primitives, run, prefix, cursor, limit)
-            }
-            Command::JsonCas {
-                run,
-                key,
-                expected_version,
-                path,
-                value,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::json::json_cas(
-                    &self.primitives,
-                    run,
-                    key,
-                    expected_version,
-                    path,
-                    value,
-                )
-            }
-            Command::JsonQuery {
-                run,
-                path,
-                value,
-                limit,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::json::json_query(&self.primitives, run, path, value, limit)
-            }
-            Command::JsonCount { run } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::json::json_count(&self.primitives, run)
-            }
-            Command::JsonBatchGet { run, keys } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::json::json_batch_get(&self.primitives, run, keys)
-            }
-            Command::JsonBatchCreate { run, docs } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::json::json_batch_create(&self.primitives, run, docs)
-            }
-            Command::JsonArrayPush {
-                run,
-                key,
-                path,
-                values,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::json::json_array_push(&self.primitives, run, key, path, values)
-            }
-            Command::JsonIncrement {
-                run,
-                key,
-                path,
-                delta,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::json::json_increment(&self.primitives, run, key, path, delta)
-            }
-            Command::JsonArrayPop { run, key, path } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::json::json_array_pop(&self.primitives, run, key, path)
             }
 
             // Event commands

--- a/crates/executor/src/handlers/json.rs
+++ b/crates/executor/src/handlers/json.rs
@@ -1,19 +1,17 @@
-//! JSON command handlers.
+//! JSON command handlers (MVP).
 //!
-//! This module implements handlers for all JSON commands by dispatching
-//! directly to engine primitives via `bridge::Primitives`.
+//! This module implements handlers for the 4 MVP JSON commands.
 
 use std::sync::Arc;
 
 use strata_core::{Value, Versioned};
-use strata_engine::SearchRequest;
 
 use crate::bridge::{
     extract_version, json_to_value, parse_path, to_core_run_id, validate_key, value_to_json,
     Primitives,
 };
 use crate::convert::convert_result;
-use crate::types::{JsonSearchHit, RunId, VersionedValue};
+use crate::types::{RunId, VersionedValue};
 use crate::{Output, Result};
 
 // =============================================================================
@@ -34,7 +32,7 @@ fn json_versioned_to_versioned_value(
 }
 
 // =============================================================================
-// Individual Handlers
+// MVP Handlers (4)
 // =============================================================================
 
 /// Handle JsonSet command.
@@ -114,108 +112,6 @@ pub fn json_delete(
     }
 }
 
-/// Handle JsonMerge command.
-pub fn json_merge(
-    p: &Arc<Primitives>,
-    run: RunId,
-    key: String,
-    path: String,
-    patch: Value,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_key(&key))?;
-    let json_path = convert_result(parse_path(&path))?;
-    let patch_json = convert_result(value_to_json(patch))?;
-
-    let version = convert_result(p.json.merge(&run_id, &key, &json_path, patch_json))?;
-    Ok(Output::Version(extract_version(&version)))
-}
-
-/// Handle JsonHistory command.
-pub fn json_history(
-    p: &Arc<Primitives>,
-    run: RunId,
-    key: String,
-    limit: Option<u64>,
-    before: Option<u64>,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_key(&key))?;
-
-    let history = convert_result(p.json.history(
-        &run_id,
-        &key,
-        limit.map(|l| l as usize),
-        before,
-    ))?;
-
-    // Convert Vec<Versioned<JsonDoc>> to Vec<VersionedValue>
-    let values: Vec<VersionedValue> = history
-        .into_iter()
-        .map(|v| {
-            let val = convert_result(json_to_value(v.value.value))?;
-            Ok(VersionedValue {
-                value: val,
-                version: extract_version(&v.version),
-                timestamp: v.timestamp.into(),
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    Ok(Output::VersionedValues(values))
-}
-
-/// Handle JsonExists command.
-pub fn json_exists(
-    p: &Arc<Primitives>,
-    run: RunId,
-    key: String,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_key(&key))?;
-
-    let exists = convert_result(p.json.exists(&run_id, &key))?;
-    Ok(Output::Bool(exists))
-}
-
-/// Handle JsonGetVersion command.
-pub fn json_get_version(
-    p: &Arc<Primitives>,
-    run: RunId,
-    key: String,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_key(&key))?;
-
-    let version = convert_result(p.json.get_version(&run_id, &key))?;
-    Ok(Output::MaybeVersion(version))
-}
-
-/// Handle JsonSearch command.
-pub fn json_search(
-    p: &Arc<Primitives>,
-    run: RunId,
-    query: String,
-    k: u64,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-
-    let request = SearchRequest::new(run_id, &query).with_k(k as usize);
-    let response = convert_result(p.json.search(&request))?;
-
-    let search_hits: Vec<JsonSearchHit> = response
-        .hits
-        .into_iter()
-        .map(|hit| JsonSearchHit {
-            key: hit.doc_ref.to_string(),
-            score: hit.score,
-            highlights: vec![],
-        })
-        .collect();
-
-    Ok(Output::JsonSearchHits(search_hits))
-}
-
 /// Handle JsonList command.
 pub fn json_list(
     p: &Arc<Primitives>,
@@ -237,163 +133,6 @@ pub fn json_list(
         keys: result.doc_ids,
         cursor: result.next_cursor,
     })
-}
-
-/// Handle JsonCas command.
-pub fn json_cas(
-    p: &Arc<Primitives>,
-    run: RunId,
-    key: String,
-    expected_version: u64,
-    path: String,
-    value: Value,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_key(&key))?;
-    let json_path = convert_result(parse_path(&path))?;
-    let json_value = convert_result(value_to_json(value))?;
-
-    let version = convert_result(p.json.cas(
-        &run_id,
-        &key,
-        expected_version,
-        &json_path,
-        json_value,
-    ))?;
-    Ok(Output::Version(extract_version(&version)))
-}
-
-/// Handle JsonQuery command.
-pub fn json_query(
-    p: &Arc<Primitives>,
-    run: RunId,
-    path: String,
-    value: Value,
-    limit: u64,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    let json_path = convert_result(parse_path(&path))?;
-    let json_value = convert_result(value_to_json(value))?;
-
-    let keys = convert_result(p.json.query(&run_id, &json_path, &json_value, limit as usize))?;
-    Ok(Output::Keys(keys))
-}
-
-/// Handle JsonCount command.
-pub fn json_count(p: &Arc<Primitives>, run: RunId) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    let count = convert_result(p.json.count(&run_id))?;
-    Ok(Output::Uint(count))
-}
-
-/// Handle JsonBatchGet command.
-pub fn json_batch_get(
-    p: &Arc<Primitives>,
-    run: RunId,
-    keys: Vec<String>,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-
-    let results = convert_result(p.json.batch_get(&run_id, &key_refs))?;
-
-    // Convert Vec<Option<Versioned<JsonDoc>>> to Vec<Option<VersionedValue>>
-    let values: Vec<Option<VersionedValue>> = results
-        .into_iter()
-        .map(|opt| {
-            opt.map(|v| {
-                let val = convert_result(json_to_value(v.value.value))?;
-                Ok(VersionedValue {
-                    value: val,
-                    version: extract_version(&v.version),
-                    timestamp: v.timestamp.into(),
-                })
-            })
-            .transpose()
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    Ok(Output::Values(values))
-}
-
-/// Handle JsonBatchCreate command.
-pub fn json_batch_create(
-    p: &Arc<Primitives>,
-    run: RunId,
-    docs: Vec<(String, Value)>,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-
-    let json_docs: Vec<(String, strata_core::primitives::json::JsonValue)> = docs
-        .into_iter()
-        .map(|(k, v)| {
-            let jv = convert_result(value_to_json(v))?;
-            Ok((k, jv))
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    let versions = convert_result(p.json.batch_create(&run_id, json_docs))?;
-    let version_nums: Vec<u64> = versions.into_iter().map(|v| extract_version(&v)).collect();
-    Ok(Output::Versions(version_nums))
-}
-
-/// Handle JsonArrayPush command.
-pub fn json_array_push(
-    p: &Arc<Primitives>,
-    run: RunId,
-    key: String,
-    path: String,
-    values: Vec<Value>,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_key(&key))?;
-    let json_path = convert_result(parse_path(&path))?;
-
-    let json_values: Vec<strata_core::primitives::json::JsonValue> = values
-        .into_iter()
-        .map(|v| convert_result(value_to_json(v)))
-        .collect::<Result<Vec<_>>>()?;
-
-    let (_version, new_len) =
-        convert_result(p.json.array_push(&run_id, &key, &json_path, json_values))?;
-    Ok(Output::Uint(new_len as u64))
-}
-
-/// Handle JsonIncrement command.
-pub fn json_increment(
-    p: &Arc<Primitives>,
-    run: RunId,
-    key: String,
-    path: String,
-    delta: f64,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_key(&key))?;
-    let json_path = convert_result(parse_path(&path))?;
-
-    let (_version, new_value) =
-        convert_result(p.json.increment(&run_id, &key, &json_path, delta))?;
-    Ok(Output::Float(new_value))
-}
-
-/// Handle JsonArrayPop command.
-pub fn json_array_pop(
-    p: &Arc<Primitives>,
-    run: RunId,
-    key: String,
-    path: String,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_key(&key))?;
-    let json_path = convert_result(parse_path(&path))?;
-
-    let (_version, popped_json) =
-        convert_result(p.json.array_pop(&run_id, &key, &json_path))?;
-
-    let popped = popped_json
-        .map(|jv| convert_result(json_to_value(jv)))
-        .transpose()?;
-    Ok(Output::Maybe(popped))
 }
 
 #[cfg(test)]

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -338,10 +338,6 @@ impl Session {
                 let deleted = txn.json_delete(&key).map_err(Error::from)?;
                 Ok(Output::Uint(if deleted { 1 } else { 0 }))
             }
-            Command::JsonExists { key, .. } => {
-                let exists = txn.json_exists(&key).map_err(Error::from)?;
-                Ok(Output::Bool(exists))
-            }
 
             // Commands not directly mapped to TransactionOps — delegate to executor.
             // This includes batch operations, history, CAS, scan, incr, etc.

--- a/crates/executor/src/tests/serialization.rs
+++ b/crates/executor/src/tests/serialization.rs
@@ -121,25 +121,6 @@ fn test_command_json_get() {
     });
 }
 
-#[test]
-fn test_command_json_search() {
-    test_command_round_trip(Command::JsonSearch {
-        run: Some(RunId::from("default")),
-        query: "alice".to_string(),
-        k: 10,
-    });
-}
-
-#[test]
-fn test_command_json_array_push() {
-    test_command_round_trip(Command::JsonArrayPush {
-        run: Some(RunId::from("default")),
-        key: "doc1".to_string(),
-        path: "$.items".to_string(),
-        values: vec![Value::Int(1), Value::Int(2)],
-    });
-}
-
 // =============================================================================
 // Event Command Tests
 // =============================================================================


### PR DESCRIPTION
## Summary
- Simplify JSON engine primitive from 18 methods to 7 MVP methods
- Change all JSON methods to use `db.transaction()` instead of direct snapshot access
- Reduce executor JSON API from 17 to 4 composite methods
- Remove ~1,600 lines of code

## Changes

### Engine Layer (JsonStore)
**Removed methods (11):**
- `get_doc`, `get_version`, `history`, `merge`, `cas`
- `count`, `batch_get`, `batch_create`
- `array_push`, `increment`, `array_pop`

**Kept MVP methods (7):**
- `create`, `get`, `exists`, `set`, `delete_at_path`, `destroy`, `list`

**Architecture improvement:**
- All methods now go through `db.transaction()` for consistency
- No direct storage/snapshot access

### Executor Layer
**4 MVP commands:** `JsonSet`, `JsonGet`, `JsonDelete`, `JsonList`

**Composite API:**
- `json_set` = exists + create/set (auto-creates documents)
- `json_delete` = destroy/delete_at_path (based on path)

## Test plan
- [x] All 48 json_store unit tests pass
- [x] All 159 executor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)