### PR TITLE
Simplify State primitive to MVP methods

### DIFF
--- a/crates/engine/src/primitives/state_cell.rs
+++ b/crates/engine/src/primitives/state_cell.rs
@@ -4,22 +4,11 @@
 //!
 //! 1. **Versioned Updates**: Every update increments the version.
 //! 2. **CAS Semantics**: Compare-and-swap ensures safe concurrent updates.
-//! 3. **Purity Requirement**: Transition closures MUST be pure functions.
 //!
-//! ## Naming Note
+//! ## API
 //!
-//! This is "StateCell" not "StateMachine". Currently, this is a simple CAS cell.
-//! Full state machine semantics (transitions, guards) may come in future versions.
-//!
-//! ## Purity Requirement
-//!
-//! The `transition()` closure may be called multiple times due to OCC retries.
-//! Closures MUST be pure functions:
-//! - Pure function of inputs (result depends only on &State argument)
-//! - No I/O (no file, network, console operations)
-//! - No external mutation (don't modify variables outside closure scope)
-//! - No irreversible effects (no logging, metrics, API calls)
-//! - Idempotent (same input produces same output)
+//! All operations go through `db.transaction()` for consistency:
+//! - `init`, `read`, `set`, `cas`
 //!
 //! ## Key Design
 //!
@@ -33,7 +22,7 @@ use strata_core::error::Result;
 use strata_core::types::{Key, Namespace, RunId};
 use strata_core::value::Value;
 use strata_core::Timestamp;
-use crate::database::{Database, RetryConfig};
+use crate::database::Database;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -79,16 +68,13 @@ fn from_stored_value<T: for<'de> Deserialize<'de>>(
 ///
 /// // Read current state
 /// let state = sc.read(&run_id, "counter")?.unwrap();
-/// assert_eq!(state.version, 1);
+/// assert_eq!(state.value.version, Version::counter(1));
 ///
-/// // CAS update
-/// sc.cas(&run_id, "counter", 1, Value::Int(1))?;
+/// // CAS update (only succeeds if version matches)
+/// sc.cas(&run_id, "counter", Version::counter(1), Value::Int(1))?;
 ///
-/// // Transition with automatic retry
-/// sc.transition(&run_id, "counter", |state| {
-///     let current = state.value.as_i64().unwrap_or(0);
-///     Ok((Value::Int(current + 1), current + 1))
-/// })?;
+/// // Unconditional set
+/// sc.set(&run_id, "counter", Value::Int(10))?;
 /// ```
 #[derive(Clone)]
 pub struct StateCell {
@@ -101,11 +87,6 @@ impl StateCell {
         Self { db }
     }
 
-    /// Get the underlying database reference
-    pub fn database(&self) -> &Arc<Database> {
-        &self.db
-    }
-
     /// Build namespace for run-scoped operations
     fn namespace_for_run(&self, run_id: &RunId) -> Namespace {
         Namespace::for_run(*run_id)
@@ -116,7 +97,7 @@ impl StateCell {
         Key::new_state(self.namespace_for_run(run_id), name)
     }
 
-    // ========== Read/Init/Delete Operations ==========
+    // ========== Read/Init Operations ==========
 
     /// Initialize a cell with a value (only if it doesn't exist)
     ///
@@ -143,45 +124,17 @@ impl StateCell {
         })
     }
 
-    /// Read current state (FAST PATH)
-    ///
-    /// Bypasses full transaction overhead for read-only access.
-    /// Uses direct snapshot read which maintains snapshot isolation.
+    /// Read current state.
     ///
     /// Returns `Versioned<State>` with `Version::Counter` type.
-    ///
-    /// # StateCell Versioned Returns
     pub fn read(&self, run_id: &RunId, name: &str) -> Result<Option<Versioned<State>>> {
-        use strata_core::traits::SnapshotView;
-
-        let snapshot = self.db.storage().create_snapshot();
         let key = self.key_for(run_id, name);
 
-        match snapshot.get(&key)? {
-            Some(vv) => {
-                let state: State = from_stored_value(&vv.value)
-                    .map_err(|e| strata_core::StrataError::serialization(e.to_string()))?;
-                let version = state.version;
-                let timestamp = Timestamp::from_micros(state.updated_at);
-                Ok(Some(Versioned::with_timestamp(state, version, timestamp)))
-            }
-            None => Ok(None),
-        }
-    }
-
-    /// Read current state (with full transaction)
-    ///
-    /// Use this when you need transaction semantics.
-    ///
-    /// # StateCell Versioned Returns
-    pub fn read_in_transaction(&self, run_id: &RunId, name: &str) -> Result<Option<Versioned<State>>> {
         self.db.transaction(*run_id, |txn| {
-            let key = self.key_for(run_id, name);
             match txn.get(&key)? {
                 Some(v) => {
-                    let state: State = from_stored_value(&v).map_err(|e| {
-                        strata_core::StrataError::serialization(e.to_string())
-                    })?;
+                    let state: State = from_stored_value(&v)
+                        .map_err(|e| strata_core::StrataError::serialization(e.to_string()))?;
                     let version = state.version;
                     let timestamp = Timestamp::from_micros(state.updated_at);
                     Ok(Some(Versioned::with_timestamp(state, version, timestamp)))
@@ -189,131 +142,6 @@ impl StateCell {
                 None => Ok(None),
             }
         })
-    }
-
-    /// Delete a cell
-    ///
-    /// Returns true if deleted, false if didn't exist
-    pub fn delete(&self, run_id: &RunId, name: &str) -> Result<bool> {
-        let deleted = self.db.transaction(*run_id, |txn| {
-            let key = self.key_for(run_id, name);
-
-            if txn.get(&key)?.is_none() {
-                return Ok(false);
-            }
-
-            txn.delete(key)?;
-            Ok(true)
-        })?;
-
-        if deleted {
-            let index = self.db.extension::<crate::primitives::index::InvertedIndex>();
-            if index.is_enabled() {
-                let entity_ref = crate::search_types::EntityRef::State {
-                    run_id: *run_id,
-                    name: name.to_string(),
-                };
-                index.remove_document(&entity_ref);
-            }
-        }
-
-        Ok(deleted)
-    }
-
-    /// Check if a cell exists (FAST PATH)
-    ///
-    /// Uses direct snapshot read which maintains snapshot isolation.
-    pub fn exists(&self, run_id: &RunId, name: &str) -> Result<bool> {
-        use strata_core::traits::SnapshotView;
-
-        let snapshot = self.db.storage().create_snapshot();
-        let key = self.key_for(run_id, name);
-        Ok(snapshot.get(&key)?.is_some())
-    }
-
-    /// List all cell names in run
-    pub fn list(&self, run_id: &RunId) -> Result<Vec<String>> {
-        self.db.transaction(*run_id, |txn| {
-            let ns = self.namespace_for_run(run_id);
-            let prefix = Key::new_state(ns, "");
-            let results = txn.scan_prefix(&prefix)?;
-            Ok(results
-                .into_iter()
-                .map(|(key, _)| String::from_utf8_lossy(&key.user_key).to_string())
-                .collect())
-        })
-    }
-
-    /// Get version history for a cell
-    ///
-    /// Returns historical versions newest first.
-    /// Each entry contains the value and counter version at that point in time.
-    ///
-    /// ## Parameters
-    ///
-    /// - `limit`: Maximum number of versions to return
-    /// - `before_counter`: Only return versions with counter < this value
-    ///
-    /// ## Example
-    ///
-    /// ```ignore
-    /// // Get last 10 versions
-    /// let history = sc.history(&run_id, "cell", Some(10), None)?;
-    ///
-    /// // Paginate: get next 10 after counter 50
-    /// let page2 = sc.history(&run_id, "cell", Some(10), Some(50))?;
-    /// ```
-    pub fn history(
-        &self,
-        run_id: &RunId,
-        name: &str,
-        limit: Option<usize>,
-        before_counter: Option<u64>,
-    ) -> Result<Vec<Versioned<Value>>> {
-        use strata_core::traits::Storage;
-
-        let key = self.key_for(run_id, name);
-
-        // Get raw history from storage layer
-        // Storage uses transaction versions, but StateCell stores counter inside State struct
-        let raw_history = self.db.storage().get_history(&key, limit, None)?;
-
-        // Convert storage entries to StateCell format
-        // Each stored value is a serialized State struct containing counter version
-        let mut results: Vec<Versioned<Value>> = Vec::new();
-
-        for versioned_value in raw_history {
-            // Deserialize the State struct from storage
-            let state: State = match from_stored_value(&versioned_value.value) {
-                Ok(s) => s,
-                Err(_) => continue, // Skip malformed entries
-            };
-
-            // Apply before_counter filter (based on cell's internal counter, not txn version)
-            if let Some(before) = before_counter {
-                if state.version.as_u64() >= before {
-                    continue;
-                }
-            }
-
-            // Build Versioned<Value> with counter-based version
-            let versioned = Versioned::with_timestamp(
-                state.value,
-                state.version,
-                Timestamp::from_micros(state.updated_at),
-            );
-
-            results.push(versioned);
-
-            // Apply limit after filtering
-            if let Some(max) = limit {
-                if results.len() >= max {
-                    break;
-                }
-            }
-        }
-
-        Ok(results)
     }
 
     // ========== CAS & Set Operations ==========
@@ -409,197 +237,6 @@ impl StateCell {
         Ok(result)
     }
 
-    // ========== Transition Closure Pattern ==========
-
-    /// Apply a transition function with automatic retry on conflict
-    ///
-    /// Returns `(user_result, Versioned<u64>)` tuple. The version is the version
-    /// number after the transition commits, useful for tracking without a separate read.
-    ///
-    /// ## Purity Requirement
-    ///
-    /// The closure `f` MAY BE CALLED MULTIPLE TIMES due to OCC retries.
-    /// It MUST be a pure function:
-    /// - No I/O (file, network, console)
-    /// - No external mutation
-    /// - No irreversible effects (logging, metrics)
-    /// - Idempotent (same input -> same output)
-    ///
-    /// ## Implementation Note
-    ///
-    /// This method performs read + closure + write in a SINGLE TRANSACTION
-    /// to ensure atomic OCC validation. The entire transaction retries on
-    /// conflict, not just the CAS operation.
-    ///
-    /// ## Example
-    ///
-    /// ```rust,ignore
-    /// let (incremented, versioned) = sc.transition(run_id, "counter", |state| {
-    ///     let current = state.value.as_i64().unwrap_or(0);
-    ///     Ok((Value::Int(current + 1), current + 1))
-    /// })?;
-    /// ```
-    ///
-    /// # StateCell Versioned Returns
-    pub fn transition<F, T>(&self, run_id: &RunId, name: &str, f: F) -> Result<(T, Versioned<Version>)>
-    where
-        F: Fn(&State) -> Result<(Value, T)>,
-    {
-        // Use high retry count for contention scenarios
-        // With N concurrent threads on single key, worst case needs N retries per op
-        // 200 retries with fast backoff handles 100+ concurrent threads reliably
-        let retry_config = RetryConfig::default()
-            .with_max_retries(200)
-            .with_base_delay_ms(1)
-            .with_max_delay_ms(50);
-
-        let key = self.key_for(run_id, name);
-        let name_owned = name.to_string();
-
-        // Perform read + closure + write in a SINGLE transaction
-        // This ensures atomic OCC validation at commit time
-        self.db
-            .transaction_with_retry(*run_id, retry_config, |txn| {
-                // Read current state within the transaction
-                let current: State = match txn.get(&key)? {
-                    Some(v) => from_stored_value(&v).map_err(|e| {
-                        strata_core::StrataError::serialization(e.to_string())
-                    })?,
-                    None => {
-                        return Err(strata_core::StrataError::invalid_input(format!(
-                            "StateCell '{}' not found",
-                            name_owned
-                        )))
-                    }
-                };
-
-                // Compute new value (closure may be called multiple times!)
-                let (new_value, result) = f(&current)?;
-
-                // Write new state with incremented version
-                let new_version = current.version.increment();
-                let new_state = State {
-                    value: new_value,
-                    version: new_version,
-                    updated_at: State::now(),
-                };
-
-                txn.put(key.clone(), to_stored_value(&new_state))?;
-                Ok((result, Versioned::new(new_version, new_version)))
-            })
-    }
-
-    /// Apply transition or initialize if cell doesn't exist
-    ///
-    /// First attempts to initialize the cell with `initial` value,
-    /// then applies the transition function.
-    ///
-    /// Returns `(user_result, Versioned<Version>)` tuple.
-    ///
-    /// # StateCell Versioned Returns
-    pub fn transition_or_init<F, T>(
-        &self,
-        run_id: &RunId,
-        name: &str,
-        initial: Value,
-        f: F,
-    ) -> Result<(T, Versioned<Version>)>
-    where
-        F: Fn(&State) -> Result<(Value, T)>,
-    {
-        // Try to init first (ignore AlreadyExists error)
-        let _ = self.init(run_id, name, initial);
-
-        // Then transition
-        self.transition(run_id, name, f)
-    }
-
-    // ========== Search API ==========
-
-    /// Search state cells
-    ///
-    /// Searches cell names and values. Respects budget constraints.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// use crate::SearchRequest;
-    ///
-    /// let response = state.search(&SearchRequest::new(run_id, "counter"))?;
-    /// for hit in response.hits {
-    ///     println!("Found state {:?} with score {}", hit.doc_ref, hit.score);
-    /// }
-    /// ```
-    pub fn search(
-        &self,
-        req: &crate::SearchRequest,
-    ) -> strata_core::error::Result<crate::SearchResponse> {
-        use crate::primitives::searchable::{build_search_response, SearchCandidate};
-        use crate::search_types::EntityRef;
-        use strata_core::traits::SnapshotView;
-        use std::time::Instant;
-
-        let start = Instant::now();
-        let snapshot = self.db.storage().create_snapshot();
-        let ns = self.namespace_for_run(&req.run_id);
-        let scan_prefix = Key::new_state(ns, "");
-
-        let mut candidates = Vec::new();
-        let mut truncated = false;
-
-        // Scan all state cells for this run
-        for (key, versioned_value) in snapshot.scan_prefix(&scan_prefix)? {
-            // Check budget constraints
-            if start.elapsed().as_micros() as u64 >= req.budget.max_wall_time_micros {
-                truncated = true;
-                break;
-            }
-            if candidates.len() >= req.budget.max_candidates_per_primitive {
-                truncated = true;
-                break;
-            }
-
-            // Deserialize state
-            let state: State = match from_stored_value(&versioned_value.value) {
-                Ok(s) => s,
-                Err(_) => continue,
-            };
-
-            // Time range filter
-            if let Some((start_ts, end_ts)) = req.time_range {
-                if state.updated_at < start_ts || state.updated_at > end_ts {
-                    continue;
-                }
-            }
-
-            // Extract searchable text: cell name + value
-            let cell_name = key.user_key_string().unwrap_or_default();
-            let text = self.extract_state_text(&cell_name, &state);
-
-            candidates.push(SearchCandidate::new(
-                EntityRef::State { run_id: req.run_id, name: cell_name },
-                text,
-                Some(state.updated_at),
-            ));
-        }
-
-        Ok(build_search_response(
-            candidates,
-            &req.query,
-            req.k,
-            truncated,
-            start.elapsed().as_micros() as u64,
-        ))
-    }
-
-    /// Extract searchable text from a state cell
-    fn extract_state_text(&self, name: &str, state: &State) -> String {
-        let mut parts = vec![name.to_string()];
-        if let Ok(s) = serde_json::to_string(&state.value) {
-            parts.push(s);
-        }
-        parts.join(" ")
-    }
 }
 
 // ========== Searchable Trait Implementation ==========
@@ -607,9 +244,10 @@ impl StateCell {
 impl crate::primitives::searchable::Searchable for StateCell {
     fn search(
         &self,
-        req: &crate::SearchRequest,
+        _req: &crate::SearchRequest,
     ) -> strata_core::error::Result<crate::SearchResponse> {
-        self.search(req)
+        // StateCell does not support search in MVP
+        Ok(crate::SearchResponse::empty())
     }
 
     fn primitive_kind(&self) -> strata_core::PrimitiveType {
@@ -723,13 +361,6 @@ mod tests {
     }
 
     #[test]
-    fn test_statecell_creation() {
-        let (_temp, _db, sc) = setup();
-        // Just verify we can get the database reference
-        let _db_ref = sc.database();
-    }
-
-    #[test]
     fn test_statecell_is_clone() {
         let (_temp, _db, sc) = setup();
         let _sc2 = sc.clone();
@@ -741,7 +372,7 @@ mod tests {
         assert_send_sync::<StateCell>();
     }
 
-    // ========== Read/Init/Delete Tests ==========
+    // ========== Read/Init Tests ==========
 
     #[test]
     fn test_init_and_read() {
@@ -775,54 +406,6 @@ mod tests {
 
         let result = sc.read(&run_id, "nonexistent").unwrap();
         assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_delete() {
-        let (_temp, _db, sc) = setup();
-        let run_id = RunId::new();
-
-        sc.init(&run_id, "temp", Value::Null).unwrap();
-        assert!(sc.exists(&run_id, "temp").unwrap());
-
-        let deleted = sc.delete(&run_id, "temp").unwrap();
-        assert!(deleted);
-        assert!(!sc.exists(&run_id, "temp").unwrap());
-    }
-
-    #[test]
-    fn test_delete_nonexistent() {
-        let (_temp, _db, sc) = setup();
-        let run_id = RunId::new();
-
-        let deleted = sc.delete(&run_id, "nonexistent").unwrap();
-        assert!(!deleted);
-    }
-
-    #[test]
-    fn test_exists() {
-        let (_temp, _db, sc) = setup();
-        let run_id = RunId::new();
-
-        assert!(!sc.exists(&run_id, "cell").unwrap());
-        sc.init(&run_id, "cell", Value::Null).unwrap();
-        assert!(sc.exists(&run_id, "cell").unwrap());
-    }
-
-    #[test]
-    fn test_list() {
-        let (_temp, _db, sc) = setup();
-        let run_id = RunId::new();
-
-        sc.init(&run_id, "alpha", Value::Null).unwrap();
-        sc.init(&run_id, "beta", Value::Null).unwrap();
-        sc.init(&run_id, "gamma", Value::Null).unwrap();
-
-        let names = sc.list(&run_id).unwrap();
-        assert_eq!(names.len(), 3);
-        assert!(names.contains(&"alpha".to_string()));
-        assert!(names.contains(&"beta".to_string()));
-        assert!(names.contains(&"gamma".to_string()));
     }
 
     #[test]
@@ -925,112 +508,6 @@ mod tests {
         assert_eq!(state.value.version, Version::counter(11));
     }
 
-    // ========== Transition Tests ==========
-
-    #[test]
-    fn test_transition_increment() {
-        let (_temp, _db, sc) = setup();
-        let run_id = RunId::new();
-
-        sc.init(&run_id, "counter", Value::Int(0)).unwrap();
-
-        let (result, new_versioned) = sc
-            .transition(&run_id, "counter", |state| {
-                let current = match &state.value {
-                    Value::Int(n) => *n,
-                    _ => 0,
-                };
-                Ok((Value::Int(current + 1), current + 1))
-            })
-            .unwrap();
-
-        assert_eq!(result, 1);
-        assert_eq!(new_versioned.value, Version::counter(2));
-        assert!(new_versioned.version.is_counter());
-
-        let state = sc.read(&run_id, "counter").unwrap().unwrap();
-        assert_eq!(state.value.value, Value::Int(1));
-        assert_eq!(state.value.version, Version::counter(2));
-    }
-
-    #[test]
-    fn test_transition_not_found() {
-        let (_temp, _db, sc) = setup();
-        let run_id = RunId::new();
-
-        let result = sc.transition(&run_id, "nonexistent", |_state| Ok((Value::Null, ())));
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_transition_or_init_creates() {
-        let (_temp, _db, sc) = setup();
-        let run_id = RunId::new();
-
-        // Cell doesn't exist, should init then transition
-        let (result, _versioned) = sc
-            .transition_or_init(&run_id, "new-counter", Value::Int(0), |state| {
-                let current = match &state.value {
-                    Value::Int(n) => *n,
-                    _ => 0,
-                };
-                Ok((Value::Int(current + 10), current + 10))
-            })
-            .unwrap();
-
-        assert_eq!(result, 10);
-
-        let state = sc.read(&run_id, "new-counter").unwrap().unwrap();
-        assert_eq!(state.value.value, Value::Int(10));
-    }
-
-    #[test]
-    fn test_transition_or_init_existing() {
-        let (_temp, _db, sc) = setup();
-        let run_id = RunId::new();
-
-        // Init first
-        sc.init(&run_id, "counter", Value::Int(5)).unwrap();
-
-        // transition_or_init should use existing value
-        let (result, _versioned) = sc
-            .transition_or_init(&run_id, "counter", Value::Int(0), |state| {
-                let current = match &state.value {
-                    Value::Int(n) => *n,
-                    _ => 0,
-                };
-                Ok((Value::Int(current + 1), current + 1))
-            })
-            .unwrap();
-
-        assert_eq!(result, 6);
-    }
-
-    #[test]
-    fn test_multiple_transitions() {
-        let (_temp, _db, sc) = setup();
-        let run_id = RunId::new();
-
-        sc.init(&run_id, "counter", Value::Int(0)).unwrap();
-
-        for expected in 1..=5 {
-            let (result, _versioned) = sc
-                .transition(&run_id, "counter", |state| {
-                    let current = match &state.value {
-                        Value::Int(n) => *n,
-                        _ => 0,
-                    };
-                    Ok((Value::Int(current + 1), current + 1))
-                })
-                .unwrap();
-            assert_eq!(result, expected);
-        }
-
-        let state = sc.read(&run_id, "counter").unwrap().unwrap();
-        assert_eq!(state.value.value, Value::Int(5));
-        assert_eq!(state.value.version, Version::counter(6));
-    }
-
     // ========== StateCellExt Tests ==========
 
     #[test]
@@ -1120,10 +597,10 @@ mod tests {
         assert_eq!(state.value.value, Value::Int(1));
     }
 
-    // ========== Fast Path Tests ==========
+    // ========== Read Tests ==========
 
     #[test]
-    fn test_fast_read_returns_correct_value() {
+    fn test_read_returns_correct_value() {
         let (_temp, _db, sc) = setup();
         let run_id = RunId::new();
 
@@ -1136,7 +613,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fast_read_returns_none_for_missing() {
+    fn test_read_returns_none_for_missing() {
         let (_temp, _db, sc) = setup();
         let run_id = RunId::new();
 
@@ -1145,35 +622,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fast_read_equals_transaction_read() {
-        let (_temp, _db, sc) = setup();
-        let run_id = RunId::new();
-
-        sc.init(&run_id, "cell", Value::String("test".into()))
-            .unwrap();
-
-        let fast = sc.read(&run_id, "cell").unwrap();
-        let txn = sc.read_in_transaction(&run_id, "cell").unwrap();
-
-        // Compare the inner values (timestamp may differ slightly)
-        assert_eq!(fast.as_ref().map(|v| &v.value), txn.as_ref().map(|v| &v.value));
-        assert_eq!(fast.as_ref().map(|v| v.version.clone()), txn.as_ref().map(|v| v.version.clone()));
-    }
-
-    #[test]
-    fn test_fast_exists_uses_fast_path() {
-        let (_temp, _db, sc) = setup();
-        let run_id = RunId::new();
-
-        assert!(!sc.exists(&run_id, "cell").unwrap());
-
-        sc.init(&run_id, "cell", Value::Null).unwrap();
-
-        assert!(sc.exists(&run_id, "cell").unwrap());
-    }
-
-    #[test]
-    fn test_fast_read_run_isolation() {
+    fn test_read_run_isolation() {
         let (_temp, _db, sc) = setup();
         let run1 = RunId::new();
         let run2 = RunId::new();

--- a/crates/engine/src/transaction_ops.rs
+++ b/crates/engine/src/transaction_ops.rs
@@ -84,7 +84,7 @@ pub trait TransactionOps {
     fn event_len(&self) -> Result<u64, StrataError>;
 
     // =========================================================================
-    // State Operations (Phase 3)
+    // State Operations (4 MVP)
     // =========================================================================
 
     /// Read a state cell
@@ -100,12 +100,6 @@ pub trait TransactionOps {
         expected_version: Version,
         value: Value,
     ) -> Result<Version, StrataError>;
-
-    /// Delete a state cell
-    fn state_delete(&mut self, name: &str) -> Result<bool, StrataError>;
-
-    /// Check if a state cell exists
-    fn state_exists(&self, name: &str) -> Result<bool, StrataError>;
 
     // =========================================================================
     // Json Operations (Phase 4)
@@ -269,14 +263,6 @@ mod tests {
             Err(StrataError::Internal { message: "state_cas not implemented in mock".to_string() })
         }
 
-        fn state_delete(&mut self, _name: &str) -> Result<bool, StrataError> {
-            Err(StrataError::Internal { message: "state_delete not implemented in mock".to_string() })
-        }
-
-        fn state_exists(&self, _name: &str) -> Result<bool, StrataError> {
-            Err(StrataError::Internal { message: "state_exists not implemented in mock".to_string() })
-        }
-
         // Json operations
         fn json_create(&mut self, _doc_id: &str, _value: JsonValue) -> Result<Version, StrataError> {
             Err(StrataError::Internal { message: "json_create not implemented in mock".to_string() })
@@ -435,9 +421,6 @@ mod tests {
 
         // State operations should return unimplemented error
         let result = ops.state_read("test");
-        assert!(result.is_err());
-
-        let result = ops.state_exists("test");
         assert!(result.is_err());
 
         // Json operations should return unimplemented error

--- a/crates/executor/src/api/state.rs
+++ b/crates/executor/src/api/state.rs
@@ -1,4 +1,6 @@
-//! State cell operations.
+//! State cell operations (4 MVP).
+//!
+//! MVP: set, read, cas, init
 
 use super::Strata;
 use crate::{Command, Error, Output, Result, Value};
@@ -6,10 +8,10 @@ use crate::types::*;
 
 impl Strata {
     // =========================================================================
-    // State Operations (8)
+    // State Operations (4 MVP)
     // =========================================================================
 
-    /// Set a state cell value.
+    /// Set a state cell value (unconditional write).
     pub fn state_set(&self, cell: &str, value: impl Into<Value>) -> Result<u64> {
         match self.executor.execute(Command::StateSet {
             run: self.run_id(),
@@ -23,7 +25,7 @@ impl Strata {
         }
     }
 
-    /// Get a state cell value.
+    /// Read a state cell value.
     pub fn state_read(&self, cell: &str) -> Result<Option<VersionedValue>> {
         match self.executor.execute(Command::StateRead {
             run: self.run_id(),
@@ -56,52 +58,6 @@ impl Strata {
         }
     }
 
-    /// Delete a state cell.
-    pub fn state_delete(&self, cell: &str) -> Result<bool> {
-        match self.executor.execute(Command::StateDelete {
-            run: self.run_id(),
-            cell: cell.to_string(),
-        })? {
-            Output::Bool(deleted) => Ok(deleted),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for StateDelete".into(),
-            }),
-        }
-    }
-
-    /// Check if a state cell exists.
-    pub fn state_exists(&self, cell: &str) -> Result<bool> {
-        match self.executor.execute(Command::StateExists {
-            run: self.run_id(),
-            cell: cell.to_string(),
-        })? {
-            Output::Bool(exists) => Ok(exists),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for StateExists".into(),
-            }),
-        }
-    }
-
-    /// Get version history for a state cell.
-    pub fn state_history(
-        &self,
-        cell: &str,
-        limit: Option<u64>,
-        before: Option<u64>,
-    ) -> Result<Vec<VersionedValue>> {
-        match self.executor.execute(Command::StateHistory {
-            run: self.run_id(),
-            cell: cell.to_string(),
-            limit,
-            before,
-        })? {
-            Output::VersionedValues(vals) => Ok(vals),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for StateHistory".into(),
-            }),
-        }
-    }
-
     /// Initialize a state cell (only if it doesn't exist).
     pub fn state_init(&self, cell: &str, value: impl Into<Value>) -> Result<u64> {
         match self.executor.execute(Command::StateInit {
@@ -112,18 +68,6 @@ impl Strata {
             Output::Version(v) => Ok(v),
             _ => Err(Error::Internal {
                 reason: "Unexpected output for StateInit".into(),
-            }),
-        }
-    }
-
-    /// List all state cell names.
-    pub fn state_list(&self) -> Result<Vec<String>> {
-        match self.executor.execute(Command::StateList {
-            run: self.run_id(),
-        })? {
-            Output::Strings(names) => Ok(names),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for StateList".into(),
             }),
         }
     }

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -26,7 +26,7 @@ use crate::types::*;
 /// | KV | 4 | Key-value operations |
 /// | JSON | 17 | JSON document operations |
 /// | Event | 11 | Event log operations |
-/// | State | 8 | State cell operations |
+/// | State | 4 | State cell operations (MVP) |
 /// | Vector | 19 | Vector store operations |
 /// | Run | 5 | Run lifecycle operations (MVP) |
 /// | Transaction | 5 | Transaction control |
@@ -234,11 +234,10 @@ pub enum Command {
         run: Option<RunId>,
     },
 
-    // ==================== State (8) ====================
-    // Note: state_transition, state_transition_or_init, state_get_or_init
-    // are excluded as they require closures
+    // ==================== State (4 MVP) ====================
+    // MVP: set, read, cas, init
 
-    /// Set a state cell value.
+    /// Set a state cell value (unconditional write).
     /// Returns: `Output::Version`
     StateSet {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -247,7 +246,7 @@ pub enum Command {
         value: Value,
     },
 
-    /// Get a state cell value.
+    /// Read a state cell value.
     /// Returns: `Output::MaybeVersioned`
     StateRead {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -265,32 +264,6 @@ pub enum Command {
         value: Value,
     },
 
-    /// Delete a state cell.
-    /// Returns: `Output::Bool`
-    StateDelete {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        cell: String,
-    },
-
-    /// Check if a state cell exists.
-    /// Returns: `Output::Bool`
-    StateExists {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        cell: String,
-    },
-
-    /// Get version history for a state cell.
-    /// Returns: `Output::VersionedValues`
-    StateHistory {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        cell: String,
-        limit: Option<u64>,
-        before: Option<u64>,
-    },
-
     /// Initialize a state cell (only if it doesn't exist).
     /// Returns: `Output::Version`
     StateInit {
@@ -298,13 +271,6 @@ pub enum Command {
         run: Option<RunId>,
         cell: String,
         value: Value,
-    },
-
-    /// List all state cell names.
-    /// Returns: `Output::Strings`
-    StateList {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
     },
 
     // ==================== Vector (19) ====================
@@ -615,15 +581,11 @@ impl Command {
             | Command::EventStreams { run, .. }
             | Command::EventHead { run, .. }
             | Command::EventVerifyChain { run, .. }
-            // State
+            // State (4 MVP)
             | Command::StateSet { run, .. }
             | Command::StateRead { run, .. }
             | Command::StateCas { run, .. }
-            | Command::StateDelete { run, .. }
-            | Command::StateExists { run, .. }
-            | Command::StateHistory { run, .. }
             | Command::StateInit { run, .. }
-            | Command::StateList { run, .. }
             // Vector
             | Command::VectorUpsert { run, .. }
             | Command::VectorGet { run, .. }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -195,7 +195,7 @@ impl Executor {
                 crate::handlers::event::event_verify_chain(&self.primitives, run)
             }
 
-            // State commands
+            // State commands (4 MVP)
             Command::StateSet { run, cell, value } => {
                 let run = run.expect("resolved by resolve_default_run");
                 crate::handlers::state::state_set(&self.primitives, run, cell, value)
@@ -213,30 +213,9 @@ impl Executor {
                 let run = run.expect("resolved by resolve_default_run");
                 crate::handlers::state::state_cas(&self.primitives, run, cell, expected_counter, value)
             }
-            Command::StateDelete { run, cell } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::state::state_delete(&self.primitives, run, cell)
-            }
-            Command::StateExists { run, cell } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::state::state_exists(&self.primitives, run, cell)
-            }
-            Command::StateHistory {
-                run,
-                cell,
-                limit,
-                before,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::state::state_history(&self.primitives, run, cell, limit, before)
-            }
             Command::StateInit { run, cell, value } => {
                 let run = run.expect("resolved by resolve_default_run");
                 crate::handlers::state::state_init(&self.primitives, run, cell, value)
-            }
-            Command::StateList { run } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::state::state_list(&self.primitives, run)
             }
 
             // Vector commands

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -286,14 +286,6 @@ impl Session {
                 let version = txn.state_cas(&cell, expected, value).map_err(Error::from)?;
                 Ok(Output::MaybeVersion(Some(extract_version(&version))))
             }
-            Command::StateDelete { cell, .. } => {
-                let deleted = txn.state_delete(&cell).map_err(Error::from)?;
-                Ok(Output::Bool(deleted))
-            }
-            Command::StateExists { cell, .. } => {
-                let exists = txn.state_exists(&cell).map_err(Error::from)?;
-                Ok(Output::Bool(exists))
-            }
 
             // === JSON ===
             Command::JsonSet {


### PR DESCRIPTION
## Summary
- Simplify State primitive from 8+ methods to 4 MVP methods
- Ensure all operations go through `db.transaction()` (no direct storage access)

## Engine Layer Changes
- **state_cell.rs**: Keep `init`, `read`, `set`, `cas`; remove `transition`, `transition_or_init`, `delete`, `exists`, `list`, `history`, `search`
- **TransactionOps trait**: Remove `state_delete`, `state_exists`
- **Transaction impl**: Remove deleted method implementations

## Executor Layer Changes
- **Commands**: Reduce from 8 to 4: `StateSet`, `StateRead`, `StateCas`, `StateInit`
- **Removed**: `StateDelete`, `StateExists`, `StateHistory`, `StateList`
- **Handlers, session, API**: Updated to match

## Test plan
- [x] 558 engine tests pass
- [x] 159 executor tests pass
- [x] 25 StateCell unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)