### PR TITLE
Simplify Event primitive to MVP methods

### DIFF
--- a/crates/executor/src/api/event.rs
+++ b/crates/executor/src/api/event.rs
@@ -1,4 +1,6 @@
-//! Event log / stream operations.
+//! Event log operations (4 MVP).
+//!
+//! MVP: append, read, read_by_type, len
 
 use super::Strata;
 use crate::{Command, Error, Output, Result, Value};
@@ -6,14 +8,14 @@ use crate::types::*;
 
 impl Strata {
     // =========================================================================
-    // Event Operations (11)
+    // Event Operations (4 MVP)
     // =========================================================================
 
-    /// Append an event to a stream.
-    pub fn event_append(&self, stream: &str, payload: Value) -> Result<u64> {
+    /// Append an event to the log.
+    pub fn event_append(&self, event_type: &str, payload: Value) -> Result<u64> {
         match self.executor.execute(Command::EventAppend {
             run: self.run_id(),
-            stream: stream.to_string(),
+            event_type: event_type.to_string(),
             payload,
         })? {
             Output::Version(v) => Ok(v),
@@ -23,46 +25,10 @@ impl Strata {
         }
     }
 
-    /// Append multiple events atomically.
-    pub fn event_append_batch(&self, events: Vec<(String, Value)>) -> Result<Vec<u64>> {
-        match self.executor.execute(Command::EventAppendBatch {
-            run: self.run_id(),
-            events,
-        })? {
-            Output::Versions(versions) => Ok(versions),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for EventAppendBatch".into(),
-            }),
-        }
-    }
-
-    /// Get events from a stream in a range.
-    pub fn event_range(
-        &self,
-        stream: &str,
-        start: Option<u64>,
-        end: Option<u64>,
-        limit: Option<u64>,
-    ) -> Result<Vec<VersionedValue>> {
-        match self.executor.execute(Command::EventRange {
-            run: self.run_id(),
-            stream: stream.to_string(),
-            start,
-            end,
-            limit,
-        })? {
-            Output::VersionedValues(events) => Ok(events),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for EventRange".into(),
-            }),
-        }
-    }
-
-    /// Get a specific event by sequence number.
-    pub fn event_read(&self, stream: &str, sequence: u64) -> Result<Option<VersionedValue>> {
+    /// Read a specific event by sequence number.
+    pub fn event_read(&self, sequence: u64) -> Result<Option<VersionedValue>> {
         match self.executor.execute(Command::EventRead {
             run: self.run_id(),
-            stream: stream.to_string(),
             sequence,
         })? {
             Output::MaybeVersioned(v) => Ok(v),
@@ -72,100 +38,27 @@ impl Strata {
         }
     }
 
-    /// Get the count of events in a stream.
-    pub fn event_len(&self, stream: &str) -> Result<u64> {
+    /// Read all events of a specific type.
+    pub fn event_read_by_type(&self, event_type: &str) -> Result<Vec<VersionedValue>> {
+        match self.executor.execute(Command::EventReadByType {
+            run: self.run_id(),
+            event_type: event_type.to_string(),
+        })? {
+            Output::VersionedValues(events) => Ok(events),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for EventReadByType".into(),
+            }),
+        }
+    }
+
+    /// Get the total count of events in the log.
+    pub fn event_len(&self) -> Result<u64> {
         match self.executor.execute(Command::EventLen {
             run: self.run_id(),
-            stream: stream.to_string(),
         })? {
             Output::Uint(len) => Ok(len),
             _ => Err(Error::Internal {
                 reason: "Unexpected output for EventLen".into(),
-            }),
-        }
-    }
-
-    /// Get the latest sequence number in a stream.
-    pub fn event_latest_sequence(&self, stream: &str) -> Result<Option<u64>> {
-        match self.executor.execute(Command::EventLatestSequence {
-            run: self.run_id(),
-            stream: stream.to_string(),
-        })? {
-            Output::MaybeVersion(seq) => Ok(seq),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for EventLatestSequence".into(),
-            }),
-        }
-    }
-
-    /// Get stream metadata.
-    pub fn event_stream_info(&self, stream: &str) -> Result<StreamInfo> {
-        match self.executor.execute(Command::EventStreamInfo {
-            run: self.run_id(),
-            stream: stream.to_string(),
-        })? {
-            Output::StreamInfo(info) => Ok(info),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for EventStreamInfo".into(),
-            }),
-        }
-    }
-
-    /// Read events from a stream in descending order (newest first).
-    pub fn event_rev_range(
-        &self,
-        stream: &str,
-        start: Option<u64>,
-        end: Option<u64>,
-        limit: Option<u64>,
-    ) -> Result<Vec<VersionedValue>> {
-        match self.executor.execute(Command::EventRevRange {
-            run: self.run_id(),
-            stream: stream.to_string(),
-            start,
-            end,
-            limit,
-        })? {
-            Output::VersionedValues(events) => Ok(events),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for EventRevRange".into(),
-            }),
-        }
-    }
-
-    /// List all event streams.
-    pub fn event_streams(&self) -> Result<Vec<String>> {
-        match self.executor.execute(Command::EventStreams {
-            run: self.run_id(),
-        })? {
-            Output::Strings(streams) => Ok(streams),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for EventStreams".into(),
-            }),
-        }
-    }
-
-    /// Get the latest event (head) of a stream.
-    pub fn event_head(&self, stream: &str) -> Result<Option<VersionedValue>> {
-        match self.executor.execute(Command::EventHead {
-            run: self.run_id(),
-            stream: stream.to_string(),
-        })? {
-            Output::MaybeVersioned(v) => Ok(v),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for EventHead".into(),
-            }),
-        }
-    }
-
-    /// Verify the hash chain integrity of the event log.
-    pub fn event_verify_chain(&self) -> Result<ChainVerificationResult> {
-        match self.executor.execute(Command::EventVerifyChain {
-            run: self.run_id(),
-        })? {
-            Output::ChainVerification(result) => Ok(result),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for EventVerifyChain".into(),
             }),
         }
     }

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -417,7 +417,7 @@ mod tests {
             [("value".to_string(), Value::Int(2))].into_iter().collect()
         )).unwrap();
 
-        let events = db.event_range("stream", None, None, None).unwrap();
+        let events = db.event_read_by_type("stream").unwrap();
         assert_eq!(events.len(), 2);
     }
 
@@ -586,7 +586,7 @@ mod tests {
         // None of the data should exist in this run
         assert!(db.kv_get("kv-key").unwrap().is_none());
         assert!(db.state_read("state-cell").unwrap().is_none());
-        assert_eq!(db.event_len("stream").unwrap(), 0);
+        assert_eq!(db.event_len().unwrap(), 0);
     }
 
     // =========================================================================

--- a/crates/executor/src/bridge.rs
+++ b/crates/executor/src/bridge.rs
@@ -23,7 +23,6 @@ use strata_engine::{
 };
 
 use crate::types::RunId;
-use crate::Error;
 
 // =============================================================================
 // Primitives
@@ -132,25 +131,6 @@ pub fn validate_key(key: &str) -> StrataResult<()> {
     }
     Ok(())
 }
-
-/// Validate an event stream name (must be non-empty).
-pub fn validate_stream_name(stream: &str) -> StrataResult<()> {
-    if stream.is_empty() {
-        return Err(StrataError::invalid_input("Stream name must not be empty"));
-    }
-    Ok(())
-}
-
-/// Validate an event payload (must be an Object).
-pub fn validate_event_payload(payload: &Value) -> StrataResult<()> {
-    if !matches!(payload, Value::Object(_)) {
-        return Err(StrataError::invalid_input(
-            "Event payload must be an Object"
-        ));
-    }
-    Ok(())
-}
-
 /// Check if a collection name is internal (starts with `_`).
 pub fn is_internal_collection(name: &str) -> bool {
     name.starts_with('_')

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -129,70 +129,26 @@ impl Executor {
                 crate::handlers::json::json_list(&self.primitives, run, prefix, cursor, limit)
             }
 
-            // Event commands
+            // Event commands (4 MVP)
             Command::EventAppend {
                 run,
-                stream,
+                event_type,
                 payload,
             } => {
                 let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::event::event_append(&self.primitives, run, stream, payload)
+                crate::handlers::event::event_append(&self.primitives, run, event_type, payload)
             }
-            Command::EventAppendBatch { run, events } => {
+            Command::EventRead { run, sequence } => {
                 let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::event::event_append_batch(&self.primitives, run, events)
+                crate::handlers::event::event_read(&self.primitives, run, sequence)
             }
-            Command::EventRange {
-                run,
-                stream,
-                start,
-                end,
-                limit,
-            } => {
+            Command::EventReadByType { run, event_type } => {
                 let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::event::event_range(&self.primitives, run, stream, start, end, limit)
+                crate::handlers::event::event_read_by_type(&self.primitives, run, event_type)
             }
-            Command::EventRead {
-                run,
-                stream,
-                sequence,
-            } => {
+            Command::EventLen { run } => {
                 let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::event::event_read(&self.primitives, run, stream, sequence)
-            }
-            Command::EventLen { run, stream } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::event::event_len(&self.primitives, run, stream)
-            }
-            Command::EventLatestSequence { run, stream } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::event::event_latest_sequence(&self.primitives, run, stream)
-            }
-            Command::EventStreamInfo { run, stream } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::event::event_stream_info(&self.primitives, run, stream)
-            }
-            Command::EventRevRange {
-                run,
-                stream,
-                start,
-                end,
-                limit,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::event::event_rev_range(&self.primitives, run, stream, start, end, limit)
-            }
-            Command::EventStreams { run } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::event::event_streams(&self.primitives, run)
-            }
-            Command::EventHead { run, stream } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::event::event_head(&self.primitives, run, stream)
-            }
-            Command::EventVerifyChain { run } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::event::event_verify_chain(&self.primitives, run)
+                crate::handlers::event::event_len(&self.primitives, run)
             }
 
             // State commands (4 MVP)

--- a/crates/executor/src/handlers/event.rs
+++ b/crates/executor/src/handlers/event.rs
@@ -1,238 +1,75 @@
-//! Event command handlers.
+//! Event command handlers (4 MVP).
 //!
-//! This module implements handlers for all 11 Event commands by calling
-//! engine primitives directly via `bridge::Primitives`.
+//! MVP: append, read, read_by_type, len
 
 use std::sync::Arc;
 
-use strata_core::{Value, Version};
+use strata_core::Version;
 
 use crate::bridge::{self, Primitives};
 use crate::convert::convert_result;
-use crate::types::{ChainVerificationResult, RunId, StreamInfo, VersionedValue};
+use crate::types::{RunId, VersionedValue};
 use crate::{Output, Result};
 
 // =============================================================================
-// Individual Handlers
+// Individual Handlers (4 MVP)
 // =============================================================================
 
 /// Handle EventAppend command.
 pub fn event_append(
     p: &Arc<Primitives>,
     run: RunId,
-    stream: String,
-    payload: Value,
+    event_type: String,
+    payload: strata_core::Value,
 ) -> Result<Output> {
     let core_run = bridge::to_core_run_id(&run)?;
-    let version = convert_result(p.event.append(&core_run, &stream, payload))?;
+    let version = convert_result(p.event.append(&core_run, &event_type, payload))?;
     Ok(Output::Version(bridge::extract_version(&version)))
 }
 
-/// Handle EventAppendBatch command.
-pub fn event_append_batch(
-    p: &Arc<Primitives>,
-    run: RunId,
-    events: Vec<(String, Value)>,
-) -> Result<Output> {
-    let core_run = bridge::to_core_run_id(&run)?;
-    // Convert Vec<(String, Value)> to Vec<(&str, Value)>
-    let event_refs: Vec<(&str, Value)> = events
-        .iter()
-        .map(|(s, v): &(String, Value)| (s.as_str(), v.clone()))
-        .collect();
-    let versions = convert_result(p.event.append_batch(&core_run, &event_refs))?;
-    let version_nums: Vec<u64> = versions.iter().map(|v| bridge::extract_version(v)).collect();
-    Ok(Output::Versions(version_nums))
-}
-
-/// Handle EventRange command.
-pub fn event_range(
-    p: &Arc<Primitives>,
-    run: RunId,
-    stream: String,
-    start: Option<u64>,
-    end: Option<u64>,
-    limit: Option<u64>,
-) -> Result<Output> {
-    let core_run = bridge::to_core_run_id(&run)?;
-    convert_result(bridge::validate_stream_name(&stream))?;
-
-    // Read all events of this type, then filter by range and limit
-    let events = convert_result(p.event.read_by_type(&core_run, &stream))?;
-
-    let filtered: Vec<VersionedValue> = events
-        .into_iter()
-        .filter(|e| {
-            let seq = match e.version {
-                Version::Sequence(s) => s,
-                _ => return false,
-            };
-            start.map_or(true, |s| seq >= s) && end.map_or(true, |e| seq <= e)
-        })
-        .take(limit.unwrap_or(u64::MAX) as usize)
-        .map(|e| VersionedValue {
-            value: e.value.payload.clone(),
-            version: bridge::extract_version(&e.version),
-            timestamp: strata_core::Timestamp::from_micros(e.value.timestamp).into(),
-        })
-        .collect();
-
-    Ok(Output::VersionedValues(filtered))
-}
-
 /// Handle EventRead command.
-pub fn event_read(
-    p: &Arc<Primitives>,
-    run: RunId,
-    stream: String,
-    sequence: u64,
-) -> Result<Output> {
+pub fn event_read(p: &Arc<Primitives>, run: RunId, sequence: u64) -> Result<Output> {
     let core_run = bridge::to_core_run_id(&run)?;
-    convert_result(bridge::validate_stream_name(&stream))?;
-
-    // Read the event at this sequence
     let event = convert_result(p.event.read(&core_run, sequence))?;
 
-    // Check if it matches the requested stream (event_type)
-    let result = match event {
-        Some(e) if e.value.event_type == stream => Some(VersionedValue {
-            value: e.value.payload,
-            version: bridge::extract_version(&e.version),
-            timestamp: strata_core::Timestamp::from_micros(e.value.timestamp).into(),
-        }),
-        _ => None,
-    };
+    let result = event.map(|e| VersionedValue {
+        value: e.value.payload,
+        version: bridge::extract_version(&e.version),
+        timestamp: strata_core::Timestamp::from_micros(e.value.timestamp).into(),
+    });
 
     Ok(Output::MaybeVersioned(result))
 }
 
-/// Handle EventLen command.
-pub fn event_len(
+/// Handle EventReadByType command.
+pub fn event_read_by_type(
     p: &Arc<Primitives>,
     run: RunId,
-    stream: String,
+    event_type: String,
 ) -> Result<Output> {
     let core_run = bridge::to_core_run_id(&run)?;
-    convert_result(bridge::validate_stream_name(&stream))?;
-    let count = convert_result(p.event.len_by_type(&core_run, &stream))?;
-    Ok(Output::Uint(count))
-}
+    let events = convert_result(p.event.read_by_type(&core_run, &event_type))?;
 
-/// Handle EventLatestSequence command.
-pub fn event_latest_sequence(
-    p: &Arc<Primitives>,
-    run: RunId,
-    stream: String,
-) -> Result<Output> {
-    let core_run = bridge::to_core_run_id(&run)?;
-    convert_result(bridge::validate_stream_name(&stream))?;
-    let sequence = convert_result(p.event.latest_sequence_by_type(&core_run, &stream))?;
-    // Use MaybeVersion since it's Option<u64> - sequence numbers are version-like
-    Ok(Output::MaybeVersion(sequence))
-}
-
-/// Handle EventStreamInfo command.
-pub fn event_stream_info(
-    p: &Arc<Primitives>,
-    run: RunId,
-    stream: String,
-) -> Result<Output> {
-    let core_run = bridge::to_core_run_id(&run)?;
-    convert_result(bridge::validate_stream_name(&stream))?;
-    let info = convert_result(p.event.stream_info(&core_run, &stream))?;
-    let stream_info = match info {
-        Some(meta) => StreamInfo {
-            name: stream,
-            length: meta.count,
-            first_sequence: Some(meta.first_sequence),
-            last_sequence: Some(meta.last_sequence),
-        },
-        None => StreamInfo {
-            name: stream,
-            length: 0,
-            first_sequence: None,
-            last_sequence: None,
-        },
-    };
-    Ok(Output::StreamInfo(stream_info))
-}
-
-/// Handle EventRevRange command.
-pub fn event_rev_range(
-    p: &Arc<Primitives>,
-    run: RunId,
-    stream: String,
-    start: Option<u64>,
-    end: Option<u64>,
-    limit: Option<u64>,
-) -> Result<Output> {
-    let core_run = bridge::to_core_run_id(&run)?;
-    convert_result(bridge::validate_stream_name(&stream))?;
-
-    // Read all events of this type, then filter by reversed range and limit
-    let events = convert_result(p.event.read_by_type(&core_run, &stream))?;
-
-    // For rev_range: start is the high bound, end is the low bound
-    let mut filtered: Vec<VersionedValue> = events
+    let versioned: Vec<VersionedValue> = events
         .into_iter()
-        .filter(|e| {
-            let seq = match e.version {
-                Version::Sequence(s) => s,
-                _ => return false,
-            };
-            start.map_or(true, |s| seq <= s) && end.map_or(true, |e| seq >= e)
-        })
         .map(|e| VersionedValue {
             value: e.value.payload.clone(),
-            version: bridge::extract_version(&e.version),
+            version: match e.version {
+                Version::Sequence(s) => s,
+                _ => 0,
+            },
             timestamp: strata_core::Timestamp::from_micros(e.value.timestamp).into(),
         })
         .collect();
 
-    // Reverse to get newest first
-    filtered.reverse();
-
-    // Apply limit
-    if let Some(n) = limit {
-        filtered.truncate(n as usize);
-    }
-
-    Ok(Output::VersionedValues(filtered))
+    Ok(Output::VersionedValues(versioned))
 }
 
-/// Handle EventStreams command.
-pub fn event_streams(p: &Arc<Primitives>, run: RunId) -> Result<Output> {
+/// Handle EventLen command.
+pub fn event_len(p: &Arc<Primitives>, run: RunId) -> Result<Output> {
     let core_run = bridge::to_core_run_id(&run)?;
-    let streams = convert_result(p.event.stream_names(&core_run))?;
-    Ok(Output::Strings(streams))
-}
-
-/// Handle EventHead command.
-pub fn event_head(
-    p: &Arc<Primitives>,
-    run: RunId,
-    stream: String,
-) -> Result<Output> {
-    let core_run = bridge::to_core_run_id(&run)?;
-    convert_result(bridge::validate_stream_name(&stream))?;
-    let result = convert_result(p.event.head_by_type(&core_run, &stream))?;
-    let versioned = result.map(|e| VersionedValue {
-        value: e.value.payload.clone(),
-        version: bridge::extract_version(&e.version),
-        timestamp: strata_core::Timestamp::from_micros(e.value.timestamp).into(),
-    });
-    Ok(Output::MaybeVersioned(versioned))
-}
-
-/// Handle EventVerifyChain command.
-pub fn event_verify_chain(p: &Arc<Primitives>, run: RunId) -> Result<Output> {
-    let core_run = bridge::to_core_run_id(&run)?;
-    let verification = convert_result(p.event.verify_chain(&core_run))?;
-    Ok(Output::ChainVerification(ChainVerificationResult {
-        valid: verification.is_valid,
-        checked_count: verification.length,
-        error: verification.error,
-    }))
+    let count = convert_result(p.event.len(&core_run))?;
+    Ok(Output::Uint(count))
 }
 
 #[cfg(test)]

--- a/crates/executor/src/output.rs
+++ b/crates/executor/src/output.rs
@@ -130,13 +130,6 @@ pub enum Output {
     /// List of vector collections
     VectorCollectionList(Vec<CollectionInfo>),
 
-    // ==================== Event-specific ====================
-    /// Event stream info
-    StreamInfo(StreamInfo),
-
-    /// Chain verification result
-    ChainVerification(ChainVerificationResult),
-
     // ==================== Run-specific ====================
     /// Single run info (unversioned)
     RunInfo(RunInfo),

--- a/crates/executor/src/tests/determinism.rs
+++ b/crates/executor/src/tests/determinism.rs
@@ -337,7 +337,7 @@ fn test_vector_search_determinism() {
 // =============================================================================
 
 #[test]
-fn test_event_range_determinism() {
+fn test_event_read_by_type_determinism() {
     let executor = create_test_executor();
 
     // Append some events
@@ -345,7 +345,7 @@ fn test_event_range_determinism() {
         executor
             .execute(Command::EventAppend {
                 run: Some(RunId::from("default")),
-                stream: "events".to_string(),
+                event_type: "events".to_string(),
                 payload: Value::Object(
                     [("seq".to_string(), Value::Int(i))]
                         .into_iter()
@@ -355,15 +355,12 @@ fn test_event_range_determinism() {
             .unwrap();
     }
 
-    // Range query multiple times - should get same results
+    // ReadByType query multiple times - should get same results
     let results: Vec<_> = (0..5)
         .map(|_| {
-            executor.execute(Command::EventRange {
+            executor.execute(Command::EventReadByType {
                 run: Some(RunId::from("default")),
-                stream: "events".to_string(),
-                start: None,
-                end: None,
-                limit: None,
+                event_type: "events".to_string(),
             })
         })
         .collect();

--- a/crates/executor/src/tests/parity.rs
+++ b/crates/executor/src/tests/parity.rs
@@ -186,14 +186,14 @@ fn test_json_set_get_parity() {
 // =============================================================================
 
 #[test]
-fn test_event_append_range_parity() {
+fn test_event_append_read_by_type_parity() {
     let (executor, p) = create_test_environment();
     let run_id = strata_core::types::RunId::from_bytes([0u8; 16]);
 
     // Append via executor - EventAppend returns Version
     let result1 = executor.execute(Command::EventAppend {
         run: None,
-        stream: "events".to_string(),
+        event_type: "events".to_string(),
         payload: Value::Object(
             [("type".to_string(), Value::String("click".into()))]
                 .into_iter()
@@ -219,16 +219,13 @@ fn test_event_append_range_parity() {
     )
     .unwrap();
 
-    // Range query via executor
-    let range_result = executor.execute(Command::EventRange {
+    // ReadByType query via executor
+    let read_result = executor.execute(Command::EventReadByType {
         run: None,
-        stream: "events".to_string(),
-        start: None,
-        end: None,
-        limit: None,
+        event_type: "events".to_string(),
     });
 
-    match range_result {
+    match read_result {
         Ok(Output::VersionedValues(events)) => {
             assert_eq!(events.len(), 2);
         }

--- a/crates/executor/src/tests/serialization.rs
+++ b/crates/executor/src/tests/serialization.rs
@@ -122,14 +122,14 @@ fn test_command_json_get() {
 }
 
 // =============================================================================
-// Event Command Tests
+// Event Command Tests (4 MVP)
 // =============================================================================
 
 #[test]
 fn test_command_event_append() {
     test_command_round_trip(Command::EventAppend {
         run: Some(RunId::from("default")),
-        stream: "events".to_string(),
+        event_type: "events".to_string(),
         payload: Value::Object(
             [("type".to_string(), Value::String("click".to_string()))]
                 .into_iter()
@@ -139,19 +139,24 @@ fn test_command_event_append() {
 }
 
 #[test]
-fn test_command_event_range() {
-    test_command_round_trip(Command::EventRange {
+fn test_command_event_read() {
+    test_command_round_trip(Command::EventRead {
         run: Some(RunId::from("default")),
-        stream: "events".to_string(),
-        start: Some(0),
-        end: Some(100),
-        limit: Some(50),
+        sequence: 42,
     });
 }
 
 #[test]
-fn test_command_event_streams() {
-    test_command_round_trip(Command::EventStreams {
+fn test_command_event_read_by_type() {
+    test_command_round_trip(Command::EventReadByType {
+        run: Some(RunId::from("default")),
+        event_type: "events".to_string(),
+    });
+}
+
+#[test]
+fn test_command_event_len() {
+    test_command_round_trip(Command::EventLen {
         run: Some(RunId::from("default")),
     });
 }
@@ -397,16 +402,6 @@ fn test_output_vector_get_collection() {
         metric: DistanceMetric::Cosine,
         count: 1000,
     })));
-}
-
-#[test]
-fn test_output_stream_info() {
-    test_output_round_trip(Output::StreamInfo(StreamInfo {
-        name: "events".to_string(),
-        length: 100,
-        first_sequence: Some(1),
-        last_sequence: Some(100),
-    }));
 }
 
 #[test]

--- a/crates/executor/src/tests/session.rs
+++ b/crates/executor/src/tests/session.rs
@@ -393,8 +393,10 @@ fn test_event_append_in_txn() {
 
     let result = session.execute(Command::EventAppend {
         run: None,
-        stream: "test_stream".to_string(),
-        payload: Value::String("event_data".into()),
+        event_type: "test_stream".to_string(),
+        payload: Value::Object(std::collections::HashMap::from([
+            ("data".to_string(), Value::String("event_data".into())),
+        ])),
     });
     assert!(result.is_ok(), "EventAppend should succeed in txn");
 

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -193,25 +193,6 @@ pub struct CollectionInfo {
 // =============================================================================
 // Event Types
 // =============================================================================
-
-/// Event stream information
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct StreamInfo {
-    pub name: String,
-    pub length: u64,
-    pub first_sequence: Option<u64>,
-    pub last_sequence: Option<u64>,
-}
-
-/// Chain verification result
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ChainVerificationResult {
-    pub valid: bool,
-    pub checked_count: u64,
-    pub error: Option<String>,
-}
-
-// =============================================================================
 // JSON Types
 // =============================================================================
 


### PR DESCRIPTION
## Summary
- Reduce Event commands from 11 to 4 MVP operations per `docs/design/primitive-api-mvp.md`
- Simplify Event API to match JSON and State MVP patterns
- Remove unused types and bridge validation functions

## MVP Commands (4)
| Command | Description |
|---------|-------------|
| `EventAppend` | Append event with event_type and payload |
| `EventRead` | Read event by global sequence (no stream filter) |
| `EventReadByType` | Read all events of a type |
| `EventLen` | Get total event count (no stream filter) |

## Removed Commands (7)
- `EventAppendBatch` - Batch operations not MVP
- `EventLatestSequence` - Convenience, not MVP
- `EventStreamInfo` - Metadata, not MVP
- `EventRevRange` - Convenience, not MVP
- `EventStreams` - Use application-level tracking
- `EventHead` - Convenience, not MVP
- `EventVerifyChain` - Advanced integrity check, not MVP

## Test plan
- [x] All 160 executor tests pass
- [x] All 57 EventLog engine unit tests pass
- [x] Event serialization tests updated for new command structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)