### PR TITLE
Simplify Vector primitive to MVP methods

### DIFF
--- a/crates/executor/src/api/vector.rs
+++ b/crates/executor/src/api/vector.rs
@@ -1,4 +1,6 @@
-//! Vector store operations.
+//! Vector store operations (7 MVP).
+//!
+//! MVP: upsert, get, delete, search, create_collection, delete_collection, list_collections
 
 use super::Strata;
 use crate::{Command, Error, Output, Result, Value};
@@ -6,7 +8,7 @@ use crate::types::*;
 
 impl Strata {
     // =========================================================================
-    // Vector Operations (17)
+    // Vector Operations (7 MVP)
     // =========================================================================
 
     /// Create a vector collection.
@@ -25,6 +27,31 @@ impl Strata {
             Output::Version(v) => Ok(v),
             _ => Err(Error::Internal {
                 reason: "Unexpected output for VectorCreateCollection".into(),
+            }),
+        }
+    }
+
+    /// Delete a collection.
+    pub fn vector_delete_collection(&self, collection: &str) -> Result<bool> {
+        match self.executor.execute(Command::VectorDeleteCollection {
+            run: self.run_id(),
+            collection: collection.to_string(),
+        })? {
+            Output::Bool(dropped) => Ok(dropped),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for VectorDeleteCollection".into(),
+            }),
+        }
+    }
+
+    /// List all collections.
+    pub fn vector_list_collections(&self) -> Result<Vec<CollectionInfo>> {
+        match self.executor.execute(Command::VectorListCollections {
+            run: self.run_id(),
+        })? {
+            Output::VectorCollectionList(infos) => Ok(infos),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for VectorListCollections".into(),
             }),
         }
     }
@@ -97,226 +124,6 @@ impl Strata {
             Output::VectorMatches(matches) => Ok(matches),
             _ => Err(Error::Internal {
                 reason: "Unexpected output for VectorSearch".into(),
-            }),
-        }
-    }
-
-    /// Search for similar vectors with filter and metric options.
-    pub fn vector_search_filtered(
-        &self,
-        collection: &str,
-        query: Vec<f32>,
-        k: u64,
-        filter: Option<Vec<MetadataFilter>>,
-        metric: Option<DistanceMetric>,
-    ) -> Result<Vec<VectorMatch>> {
-        match self.executor.execute(Command::VectorSearch {
-            run: self.run_id(),
-            collection: collection.to_string(),
-            query,
-            k,
-            filter,
-            metric,
-        })? {
-            Output::VectorMatches(matches) => Ok(matches),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorSearch".into(),
-            }),
-        }
-    }
-
-    /// Get collection information.
-    pub fn vector_get_collection(&self, collection: &str) -> Result<Option<CollectionInfo>> {
-        match self.executor.execute(Command::VectorGetCollection {
-            run: self.run_id(),
-            collection: collection.to_string(),
-        })? {
-            Output::VectorGetCollection(info) => Ok(info),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorGetCollection".into(),
-            }),
-        }
-    }
-
-    /// Delete a collection.
-    pub fn vector_delete_collection(&self, collection: &str) -> Result<bool> {
-        match self.executor.execute(Command::VectorDeleteCollection {
-            run: self.run_id(),
-            collection: collection.to_string(),
-        })? {
-            Output::Bool(dropped) => Ok(dropped),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorDeleteCollection".into(),
-            }),
-        }
-    }
-
-    /// List all collections.
-    pub fn vector_list_collections(&self) -> Result<Vec<CollectionInfo>> {
-        match self.executor.execute(Command::VectorListCollections {
-            run: self.run_id(),
-        })? {
-            Output::VectorCollectionList(infos) => Ok(infos),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorListCollections".into(),
-            }),
-        }
-    }
-
-    /// Check if a collection exists.
-    pub fn vector_collection_exists(&self, collection: &str) -> Result<bool> {
-        match self.executor.execute(Command::VectorCollectionExists {
-            run: self.run_id(),
-            collection: collection.to_string(),
-        })? {
-            Output::Bool(exists) => Ok(exists),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorCollectionExists".into(),
-            }),
-        }
-    }
-
-    /// Get the count of vectors in a collection.
-    pub fn vector_count(&self, collection: &str) -> Result<u64> {
-        match self.executor.execute(Command::VectorCount {
-            run: self.run_id(),
-            collection: collection.to_string(),
-        })? {
-            Output::Uint(count) => Ok(count),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorCount".into(),
-            }),
-        }
-    }
-
-    /// Batch insert or update vectors.
-    pub fn vector_upsert_batch(
-        &self,
-        collection: &str,
-        vectors: Vec<VectorEntry>,
-    ) -> Result<Vec<VectorBatchEntry>> {
-        match self.executor.execute(Command::VectorUpsertBatch {
-            run: self.run_id(),
-            collection: collection.to_string(),
-            vectors,
-        })? {
-            Output::VectorBatchResult(results) => Ok(results),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorUpsertBatch".into(),
-            }),
-        }
-    }
-
-    /// Batch get vectors.
-    pub fn vector_get_batch(
-        &self,
-        collection: &str,
-        keys: Vec<String>,
-    ) -> Result<Vec<Option<VersionedVectorData>>> {
-        match self.executor.execute(Command::VectorGetBatch {
-            run: self.run_id(),
-            collection: collection.to_string(),
-            keys,
-        })? {
-            Output::VectorDataList(data) => Ok(data),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorGetBatch".into(),
-            }),
-        }
-    }
-
-    /// Batch delete vectors.
-    pub fn vector_delete_batch(&self, collection: &str, keys: Vec<String>) -> Result<Vec<bool>> {
-        match self.executor.execute(Command::VectorDeleteBatch {
-            run: self.run_id(),
-            collection: collection.to_string(),
-            keys,
-        })? {
-            Output::Bools(results) => Ok(results),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorDeleteBatch".into(),
-            }),
-        }
-    }
-
-    /// Get version history for a vector.
-    pub fn vector_history(
-        &self,
-        collection: &str,
-        key: &str,
-        limit: Option<u64>,
-        before_version: Option<u64>,
-    ) -> Result<Vec<VersionedVectorData>> {
-        match self.executor.execute(Command::VectorHistory {
-            run: self.run_id(),
-            collection: collection.to_string(),
-            key: key.to_string(),
-            limit,
-            before_version,
-        })? {
-            Output::VectorDataHistory(history) => Ok(history),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorHistory".into(),
-            }),
-        }
-    }
-
-    /// Get a vector at a specific version.
-    pub fn vector_get_at(
-        &self,
-        collection: &str,
-        key: &str,
-        version: u64,
-    ) -> Result<Option<VersionedVectorData>> {
-        match self.executor.execute(Command::VectorGetAt {
-            run: self.run_id(),
-            collection: collection.to_string(),
-            key: key.to_string(),
-            version,
-        })? {
-            Output::VectorData(data) => Ok(data),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorGetAt".into(),
-            }),
-        }
-    }
-
-    /// List all vector keys in a collection.
-    pub fn vector_list_keys(
-        &self,
-        collection: &str,
-        limit: Option<u64>,
-        cursor: Option<String>,
-    ) -> Result<Vec<String>> {
-        match self.executor.execute(Command::VectorListKeys {
-            run: self.run_id(),
-            collection: collection.to_string(),
-            limit,
-            cursor,
-        })? {
-            Output::Keys(keys) => Ok(keys),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorListKeys".into(),
-            }),
-        }
-    }
-
-    /// Scan vectors in a collection.
-    pub fn vector_scan(
-        &self,
-        collection: &str,
-        limit: Option<u64>,
-        cursor: Option<String>,
-    ) -> Result<Vec<(String, VectorData)>> {
-        match self.executor.execute(Command::VectorScan {
-            run: self.run_id(),
-            collection: collection.to_string(),
-            limit,
-            cursor,
-        })? {
-            Output::VectorKeyValues(entries) => Ok(entries),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorScan".into(),
             }),
         }
     }

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -27,7 +27,7 @@ use crate::types::*;
 /// | JSON | 17 | JSON document operations |
 /// | Event | 4 | Event log operations (MVP) |
 /// | State | 4 | State cell operations (MVP) |
-/// | Vector | 19 | Vector store operations |
+/// | Vector | 7 | Vector store operations (MVP) |
 /// | Run | 5 | Run lifecycle operations (MVP) |
 /// | Transaction | 5 | Transaction control |
 /// | Retention | 3 | Retention policy |
@@ -213,7 +213,9 @@ pub enum Command {
         value: Value,
     },
 
-    // ==================== Vector (19) ====================
+    // ==================== Vector (7 MVP) ====================
+    // MVP: upsert, get, delete, search, create_collection, delete_collection, list_collections
+
     /// Insert or update a vector.
     /// Returns: `Output::Version`
     VectorUpsert {
@@ -255,14 +257,6 @@ pub enum Command {
         metric: Option<DistanceMetric>,
     },
 
-    /// Get collection information.
-    /// Returns: `Output::MaybeCollectionInfo`
-    VectorGetCollection {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        collection: String,
-    },
-
     /// Create a collection with explicit configuration.
     /// Returns: `Output::Version`
     VectorCreateCollection {
@@ -282,94 +276,10 @@ pub enum Command {
     },
 
     /// List all collections in a run.
-    /// Returns: `Output::CollectionInfos`
+    /// Returns: `Output::VectorCollectionList`
     VectorListCollections {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         run: Option<RunId>,
-    },
-
-    /// Check if a collection exists.
-    /// Returns: `Output::Bool`
-    VectorCollectionExists {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        collection: String,
-    },
-
-    /// Get the count of vectors in a collection.
-    /// Returns: `Output::Uint`
-    VectorCount {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        collection: String,
-    },
-
-    /// Batch insert or update vectors.
-    /// Returns: `Output::VectorBatchResults`
-    VectorUpsertBatch {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        collection: String,
-        vectors: Vec<VectorEntry>,
-    },
-
-    /// Batch get vectors.
-    /// Returns: `Output::MaybeVectorDatas`
-    VectorGetBatch {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        collection: String,
-        keys: Vec<String>,
-    },
-
-    /// Batch delete vectors.
-    /// Returns: `Output::Bools`
-    VectorDeleteBatch {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        collection: String,
-        keys: Vec<String>,
-    },
-
-    /// Get version history for a vector.
-    /// Returns: `Output::VectorHistoryResult`
-    VectorHistory {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        collection: String,
-        key: String,
-        limit: Option<u64>,
-        before_version: Option<u64>,
-    },
-
-    /// Get a vector at a specific version.
-    /// Returns: `Output::MaybeVectorData`
-    VectorGetAt {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        collection: String,
-        key: String,
-        version: u64,
-    },
-
-    /// List all vector keys in a collection.
-    /// Returns: `Output::Keys`
-    VectorListKeys {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        collection: String,
-        limit: Option<u64>,
-        cursor: Option<String>,
-    },
-
-    /// Scan vectors in a collection.
-    /// Returns: `Output::VectorScanResult`
-    VectorScan {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        run: Option<RunId>,
-        collection: String,
-        limit: Option<u64>,
-        cursor: Option<String>,
     },
 
     // ==================== Run (5 MVP) ====================
@@ -519,24 +429,14 @@ impl Command {
             | Command::StateRead { run, .. }
             | Command::StateCas { run, .. }
             | Command::StateInit { run, .. }
-            // Vector
+            // Vector (7 MVP)
             | Command::VectorUpsert { run, .. }
             | Command::VectorGet { run, .. }
             | Command::VectorDelete { run, .. }
             | Command::VectorSearch { run, .. }
-            | Command::VectorGetCollection { run, .. }
             | Command::VectorCreateCollection { run, .. }
             | Command::VectorDeleteCollection { run, .. }
             | Command::VectorListCollections { run, .. }
-            | Command::VectorCollectionExists { run, .. }
-            | Command::VectorCount { run, .. }
-            | Command::VectorUpsertBatch { run, .. }
-            | Command::VectorGetBatch { run, .. }
-            | Command::VectorDeleteBatch { run, .. }
-            | Command::VectorHistory { run, .. }
-            | Command::VectorGetAt { run, .. }
-            | Command::VectorListKeys { run, .. }
-            | Command::VectorScan { run, .. }
             // Retention
             | Command::RetentionApply { run, .. }
             | Command::RetentionStats { run, .. }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -227,10 +227,6 @@ impl Executor {
                     metric,
                 )
             }
-            Command::VectorGetCollection { run, collection } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::vector::vector_get_collection(&self.primitives, run, collection)
-            }
             Command::VectorCreateCollection {
                 run,
                 collection,
@@ -253,82 +249,6 @@ impl Executor {
             Command::VectorListCollections { run } => {
                 let run = run.expect("resolved by resolve_default_run");
                 crate::handlers::vector::vector_list_collections(&self.primitives, run)
-            }
-            Command::VectorCollectionExists { run, collection } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::vector::vector_collection_exists(&self.primitives, run, collection)
-            }
-            Command::VectorCount { run, collection } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::vector::vector_count(&self.primitives, run, collection)
-            }
-            Command::VectorUpsertBatch {
-                run,
-                collection,
-                vectors,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::vector::vector_upsert_batch(&self.primitives, run, collection, vectors)
-            }
-            Command::VectorGetBatch {
-                run,
-                collection,
-                keys,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::vector::vector_get_batch(&self.primitives, run, collection, keys)
-            }
-            Command::VectorDeleteBatch {
-                run,
-                collection,
-                keys,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::vector::vector_delete_batch(&self.primitives, run, collection, keys)
-            }
-            Command::VectorHistory {
-                run,
-                collection,
-                key,
-                limit,
-                before_version,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::vector::vector_history(
-                    &self.primitives,
-                    run,
-                    collection,
-                    key,
-                    limit,
-                    before_version,
-                )
-            }
-            Command::VectorGetAt {
-                run,
-                collection,
-                key,
-                version,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::vector::vector_get_at(&self.primitives, run, collection, key, version)
-            }
-            Command::VectorListKeys {
-                run,
-                collection,
-                limit,
-                cursor,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::vector::vector_list_keys(&self.primitives, run, collection, limit, cursor)
-            }
-            Command::VectorScan {
-                run,
-                collection,
-                limit,
-                cursor,
-            } => {
-                let run = run.expect("resolved by resolve_default_run");
-                crate::handlers::vector::vector_scan(&self.primitives, run, collection, limit, cursor)
             }
 
             // Run commands (5 MVP)

--- a/crates/executor/src/handlers/vector.rs
+++ b/crates/executor/src/handlers/vector.rs
@@ -1,11 +1,10 @@
-//! Vector command handlers.
+//! Vector command handlers (7 MVP).
 //!
-//! This module implements handlers for all vector commands by dispatching
-//! directly to engine primitives via `bridge::Primitives`.
+//! MVP: upsert, get, delete, search, create_collection, delete_collection, list_collections
 
 use std::sync::Arc;
 
-use strata_core::{StrataError, Value, Version};
+use strata_core::{StrataError, Value};
 
 use crate::bridge::{
     extract_version, from_engine_metric, is_internal_collection, to_core_run_id, to_engine_filter,
@@ -14,14 +13,12 @@ use crate::bridge::{
 };
 use crate::convert::convert_result;
 use crate::types::{
-    CollectionInfo, DistanceMetric, MetadataFilter, RunId, VectorBatchEntry, VectorData,
-    VectorEntry, VectorMatch, VersionedVectorData,
+    CollectionInfo, DistanceMetric, MetadataFilter, RunId, VectorData,
+    VectorMatch, VersionedVectorData,
 };
 use crate::{Output, Result};
 
 /// Convert an engine `VectorResult<T>` to an executor `Result<T>`.
-///
-/// Maps `VectorError` → `StrataError` → executor `Error`.
 fn convert_vector_result<T>(
     r: std::result::Result<T, strata_engine::VectorError>,
 ) -> Result<T> {
@@ -66,7 +63,7 @@ fn to_vector_match(m: strata_engine::VectorMatch) -> Result<VectorMatch> {
 }
 
 // =============================================================================
-// Individual Handlers
+// Individual Handlers (7 MVP)
 // =============================================================================
 
 /// Handle VectorUpsert command.
@@ -158,24 +155,6 @@ pub fn vector_search(
     Ok(Output::VectorMatches(results?))
 }
 
-/// Handle VectorGetCollection command.
-pub fn vector_get_collection(
-    p: &Arc<Primitives>,
-    run: RunId,
-    collection: String,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_not_internal_collection(&collection))?;
-
-    let info = convert_vector_result(p.vector.get_collection(run_id, &collection))?;
-    Ok(Output::VectorGetCollection(info.map(|i| CollectionInfo {
-        name: collection,
-        dimension: i.value.config.dimension,
-        metric: from_engine_metric(i.value.config.metric),
-        count: i.value.count as u64,
-    })))
-}
-
 /// Handle VectorCreateCollection command.
 pub fn vector_create_collection(
     p: &Arc<Primitives>,
@@ -229,266 +208,6 @@ pub fn vector_list_collections(p: &Arc<Primitives>, run: RunId) -> Result<Output
         })
         .collect();
     Ok(Output::VectorCollectionList(infos))
-}
-
-/// Handle VectorCollectionExists command.
-pub fn vector_collection_exists(
-    p: &Arc<Primitives>,
-    run: RunId,
-    collection: String,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_not_internal_collection(&collection))?;
-    let exists = convert_vector_result(p.vector.collection_exists(run_id, &collection))?;
-    Ok(Output::Bool(exists))
-}
-
-/// Handle VectorCount command.
-pub fn vector_count(
-    p: &Arc<Primitives>,
-    run: RunId,
-    collection: String,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_not_internal_collection(&collection))?;
-
-    // Return 0 if collection doesn't exist
-    let exists = convert_vector_result(p.vector.collection_exists(run_id, &collection))?;
-    if !exists {
-        return Ok(Output::Uint(0));
-    }
-
-    let count = convert_vector_result(p.vector.count(run_id, &collection))?;
-    Ok(Output::Uint(count as u64))
-}
-
-/// Handle VectorUpsertBatch command.
-pub fn vector_upsert_batch(
-    p: &Arc<Primitives>,
-    run: RunId,
-    collection: String,
-    vectors: Vec<VectorEntry>,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_not_internal_collection(&collection))?;
-
-    if vectors.is_empty() {
-        return Ok(Output::VectorBatchResult(Vec::new()));
-    }
-
-    // Auto-create collection if it doesn't exist (dimension from first vector)
-    let exists = convert_vector_result(p.vector.collection_exists(run_id, &collection))?;
-    if !exists {
-        if let Some(first) = vectors.iter().find(|e| !e.embedding.is_empty()) {
-            let config = convert_result(strata_core::primitives::VectorConfig::new(
-                first.embedding.len(),
-                strata_engine::DistanceMetric::Cosine,
-            ))?;
-            convert_vector_result(p.vector.create_collection(run_id, &collection, config))?;
-        }
-    }
-
-    // Convert metadata from Value to serde_json::Value
-    let mut primitive_vectors: Vec<(&str, &[f32], Option<serde_json::Value>)> =
-        Vec::with_capacity(vectors.len());
-    let mut json_metadata_store: Vec<Option<serde_json::Value>> =
-        Vec::with_capacity(vectors.len());
-
-    for entry in &vectors {
-        let json_meta = entry
-            .metadata
-            .clone()
-            .map(value_to_serde_json_public)
-            .transpose()
-            .map_err(|e| crate::Error::from(e))?;
-        json_metadata_store.push(json_meta);
-    }
-    for (i, entry) in vectors.iter().enumerate() {
-        primitive_vectors.push((
-            entry.key.as_str(),
-            entry.embedding.as_slice(),
-            json_metadata_store[i].clone(),
-        ));
-    }
-
-    let results =
-        convert_vector_result(p.vector.insert_batch(run_id, &collection, primitive_vectors))?;
-
-    let entries: Vec<VectorBatchEntry> = results
-        .into_iter()
-        .zip(vectors.iter())
-        .map(|(r, v)| VectorBatchEntry {
-            key: v.key.clone(),
-            result: r
-                .map(|(_, version)| extract_version(&version))
-                .map_err(|e| StrataError::from(e).to_string()),
-        })
-        .collect();
-    Ok(Output::VectorBatchResult(entries))
-}
-
-/// Handle VectorGetBatch command.
-pub fn vector_get_batch(
-    p: &Arc<Primitives>,
-    run: RunId,
-    collection: String,
-    keys: Vec<String>,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_not_internal_collection(&collection))?;
-
-    if keys.is_empty() {
-        return Ok(Output::VectorDataList(Vec::new()));
-    }
-
-    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-    let results = convert_vector_result(p.vector.get_batch(run_id, &collection, &key_refs))?;
-
-    let data: Result<Vec<Option<VersionedVectorData>>> = results
-        .into_iter()
-        .map(|opt| {
-            opt.map(|versioned| {
-                let version = extract_version(&versioned.version);
-                let timestamp: u64 = versioned.timestamp.into();
-                to_versioned_vector_data(&versioned.value, version, timestamp)
-            })
-            .transpose()
-        })
-        .collect();
-    Ok(Output::VectorDataList(data?))
-}
-
-/// Handle VectorDeleteBatch command.
-pub fn vector_delete_batch(
-    p: &Arc<Primitives>,
-    run: RunId,
-    collection: String,
-    keys: Vec<String>,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_not_internal_collection(&collection))?;
-
-    if keys.is_empty() {
-        return Ok(Output::Bools(Vec::new()));
-    }
-
-    let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-    let results = convert_vector_result(p.vector.delete_batch(run_id, &collection, &key_refs))?;
-    Ok(Output::Bools(results))
-}
-
-/// Handle VectorHistory command.
-pub fn vector_history(
-    p: &Arc<Primitives>,
-    run: RunId,
-    collection: String,
-    key: String,
-    limit: Option<u64>,
-    before_version: Option<u64>,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_not_internal_collection(&collection))?;
-
-    let history = convert_vector_result(p.vector.history(
-        run_id,
-        &collection,
-        &key,
-        limit.map(|l| l as usize),
-        before_version,
-    ))?;
-
-    let data: Result<Vec<VersionedVectorData>> = history
-        .into_iter()
-        .map(|versioned| {
-            let version = extract_version(&versioned.version);
-            let timestamp: u64 = versioned.timestamp.into();
-            to_versioned_vector_data(&versioned.value, version, timestamp)
-        })
-        .collect();
-    Ok(Output::VectorDataHistory(data?))
-}
-
-/// Handle VectorGetAt command.
-pub fn vector_get_at(
-    p: &Arc<Primitives>,
-    run: RunId,
-    collection: String,
-    key: String,
-    version: u64,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_not_internal_collection(&collection))?;
-
-    let result = convert_vector_result(
-        p.vector
-            .get_at(run_id, &collection, &key, Version::txn(version)),
-    )?;
-    match result {
-        Some(versioned) => {
-            let ver = extract_version(&versioned.version);
-            let timestamp: u64 = versioned.timestamp.into();
-            let data = to_versioned_vector_data(&versioned.value, ver, timestamp)?;
-            Ok(Output::VectorData(Some(data)))
-        }
-        None => Ok(Output::VectorData(None)),
-    }
-}
-
-/// Handle VectorListKeys command.
-pub fn vector_list_keys(
-    p: &Arc<Primitives>,
-    run: RunId,
-    collection: String,
-    limit: Option<u64>,
-    cursor: Option<String>,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_not_internal_collection(&collection))?;
-
-    let keys = convert_vector_result(p.vector.list_keys(
-        run_id,
-        &collection,
-        limit.map(|l| l as usize),
-        cursor.as_deref(),
-    ))?;
-    Ok(Output::Keys(keys))
-}
-
-/// Handle VectorScan command.
-pub fn vector_scan(
-    p: &Arc<Primitives>,
-    run: RunId,
-    collection: String,
-    limit: Option<u64>,
-    cursor: Option<String>,
-) -> Result<Output> {
-    let run_id = to_core_run_id(&run)?;
-    convert_result(validate_not_internal_collection(&collection))?;
-
-    let results = convert_vector_result(p.vector.scan(
-        run_id,
-        &collection,
-        limit.map(|l| l as usize),
-        cursor.as_deref(),
-    ))?;
-
-    let data: Result<Vec<(String, VectorData)>> = results
-        .into_iter()
-        .map(|(key, embedding, metadata, _version)| {
-            let meta = metadata
-                .map(serde_json_to_value_public)
-                .transpose()
-                .map_err(|e| crate::Error::from(e))?;
-            Ok((
-                key,
-                VectorData {
-                    embedding,
-                    metadata: meta,
-                },
-            ))
-        })
-        .collect();
-    Ok(Output::VectorKeyValues(data?))
 }
 
 #[cfg(test)]

--- a/crates/executor/src/output.rs
+++ b/crates/executor/src/output.rs
@@ -79,9 +79,6 @@ pub enum Output {
     /// List of strings (tags, stream names, etc.)
     Strings(Vec<String>),
 
-    /// List of booleans (batch delete results)
-    Bools(Vec<bool>),
-
     // ==================== Scan Results ====================
     /// KV scan result with cursor
     KvScanResult {
@@ -111,21 +108,6 @@ pub enum Output {
     // ==================== Vector-specific ====================
     /// Single vector data
     VectorData(Option<VersionedVectorData>),
-
-    /// Multiple vector data
-    VectorDataList(Vec<Option<VersionedVectorData>>),
-
-    /// Vector history
-    VectorDataHistory(Vec<VersionedVectorData>),
-
-    /// Vector scan result
-    VectorKeyValues(Vec<(String, VectorData)>),
-
-    /// Vector batch upsert result
-    VectorBatchResult(Vec<VectorBatchEntry>),
-
-    /// Vector collection info
-    VectorGetCollection(Option<CollectionInfo>),
 
     /// List of vector collections
     VectorCollectionList(Vec<CollectionInfo>),

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -85,19 +85,9 @@ impl Session {
             | Command::VectorGet { .. }
             | Command::VectorDelete { .. }
             | Command::VectorSearch { .. }
-            | Command::VectorGetCollection { .. }
             | Command::VectorCreateCollection { .. }
             | Command::VectorDeleteCollection { .. }
             | Command::VectorListCollections { .. }
-            | Command::VectorCollectionExists { .. }
-            | Command::VectorCount { .. }
-            | Command::VectorUpsertBatch { .. }
-            | Command::VectorGetBatch { .. }
-            | Command::VectorDeleteBatch { .. }
-            | Command::VectorHistory { .. }
-            | Command::VectorGetAt { .. }
-            | Command::VectorListKeys { .. }
-            | Command::VectorScan { .. }
             | Command::Ping
             | Command::Info
             | Command::Flush

--- a/crates/executor/src/tests/serialization.rs
+++ b/crates/executor/src/tests/serialization.rs
@@ -345,11 +345,6 @@ fn test_output_strings() {
 }
 
 #[test]
-fn test_output_bools() {
-    test_output_round_trip(Output::Bools(vec![true, false, true]));
-}
-
-#[test]
 fn test_output_versions() {
     test_output_round_trip(Output::Versions(vec![1, 2, 3, 4, 5]));
 }
@@ -392,16 +387,6 @@ fn test_output_vector_matches() {
         score: 0.95,
         metadata: Some(Value::String("test".to_string())),
     }]));
-}
-
-#[test]
-fn test_output_vector_get_collection() {
-    test_output_round_trip(Output::VectorGetCollection(Some(CollectionInfo {
-        name: "embeddings".to_string(),
-        dimension: 384,
-        metric: DistanceMetric::Cosine,
-        count: 1000,
-    })));
 }
 
 #[test]

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -166,21 +166,6 @@ pub struct VectorMatch {
     pub metadata: Option<Value>,
 }
 
-/// Vector batch entry (for batch operations)
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct VectorEntry {
-    pub key: String,
-    pub embedding: Vec<f32>,
-    pub metadata: Option<Value>,
-}
-
-/// Vector batch result entry
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct VectorBatchEntry {
-    pub key: String,
-    pub result: Result<u64, String>, // version or error message
-}
-
 /// Vector collection information
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CollectionInfo {


### PR DESCRIPTION
## Summary
Reduce Vector commands from 17 to 7 MVP operations per `docs/design/primitive-api-mvp.md`.

## MVP Commands (7)
| Command | Description |
|---------|-------------|
| `VectorUpsert` | Insert or update a vector |
| `VectorGet` | Get vector by key |
| `VectorDelete` | Delete a vector |
| `VectorSearch` | KNN search |
| `VectorCreateCollection` | Create collection |
| `VectorDeleteCollection` | Delete collection |
| `VectorListCollections` | List all collections |

## Removed Commands (10)
- `VectorGetCollection` - Use list_collections
- `VectorCollectionExists` - Use list_collections
- `VectorCount` - Use application tracking
- `VectorUpsertBatch` - Batch not MVP
- `VectorGetBatch` - Batch not MVP
- `VectorDeleteBatch` - Batch not MVP
- `VectorHistory` - Version history not MVP
- `VectorGetAt` - Historical access not MVP
- `VectorListKeys` - Use application tracking
- `VectorScan` - Cursor pagination not MVP

## Cleanup
Also removed unused types and output variants:
- `VectorEntry`, `VectorBatchEntry` types
- `Bools`, `VectorDataList`, `VectorDataHistory`, `VectorKeyValues`, `VectorBatchResult`, `VectorGetCollection` output variants

## Stats
- 8 files changed
- 41 insertions, 753 deletions

## Test plan
- [x] All 157 executor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)