### PR TITLE
Simplify MVP API: Database opening and primitives

### DIFF
--- a/crates/engine/src/durability/mod.rs
+++ b/crates/engine/src/durability/mod.rs
@@ -18,20 +18,16 @@
 //!
 //! ```ignore
 //! use strata_engine::Database;
-//! use strata_durability::wal::DurabilityMode;
 //!
-//! // InMemory mode for fastest performance
-//! let db = Database::builder()
-//!     .in_memory()
-//!     .open_temp()?;
+//! // Ephemeral mode for testing (no disk files)
+//! let db = Database::ephemeral()?;
 //!
-//! // Buffered mode for production (default)
-//! let db = Database::builder()
-//!     .buffered()
-//!     .open()?;
+//! // Simple open with buffered durability (default)
+//! let db = Database::open("/data/mydb")?;
 //!
 //! // Strict mode for maximum durability
 //! let db = Database::builder()
+//!     .path("/data/mydb")
 //!     .strict()
 //!     .open()?;
 //! ```

--- a/crates/engine/src/primitives/json_store.rs
+++ b/crates/engine/src/primitives/json_store.rs
@@ -154,7 +154,7 @@ impl JsonDoc {
 /// use strata_core::types::RunId;
 /// use strata_core::primitives::json::JsonValue;
 ///
-/// let db = Database::builder().in_memory().open_temp()?;
+/// let db = Database::ephemeral()?;
 /// let json = JsonStore::new(db);
 /// let run_id = RunId::new();
 ///
@@ -657,7 +657,7 @@ mod tests {
 
     #[test]
     fn test_jsonstore_is_clone() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store1 = JsonStore::new(db.clone());
         let store2 = store1.clone();
         assert!(Arc::ptr_eq(store1.database(), store2.database()));
@@ -671,7 +671,7 @@ mod tests {
 
     #[test]
     fn test_key_for_run_isolation() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
 
         let run1 = RunId::new();
@@ -687,7 +687,7 @@ mod tests {
 
     #[test]
     fn test_key_for_same_run() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
 
         let run_id = RunId::new();
@@ -755,7 +755,7 @@ mod tests {
 
     #[test]
     fn test_serialize_deserialize_roundtrip() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let _store = JsonStore::new(db);
 
         let doc = JsonDoc::new("test-doc", JsonValue::from("test value"));
@@ -772,7 +772,7 @@ mod tests {
 
     #[test]
     fn test_serialize_complex_document() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let _store = JsonStore::new(db);
 
         let value: JsonValue = serde_json::json!({
@@ -797,7 +797,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_invalid_type() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let _store = JsonStore::new(db);
 
         // Try to deserialize a non-bytes value
@@ -809,7 +809,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_invalid_bytes() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let _store = JsonStore::new(db);
 
         // Try to deserialize garbage bytes
@@ -821,7 +821,7 @@ mod tests {
 
     #[test]
     fn test_serialized_size_is_compact() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let _store = JsonStore::new(db);
 
         let doc = JsonDoc::new("test-doc", JsonValue::from(42i64));
@@ -844,7 +844,7 @@ mod tests {
 
     #[test]
     fn test_create_document() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -857,7 +857,7 @@ mod tests {
 
     #[test]
     fn test_create_object_document() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -874,7 +874,7 @@ mod tests {
 
     #[test]
     fn test_create_duplicate_fails() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -891,7 +891,7 @@ mod tests {
 
     #[test]
     fn test_create_different_docs() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
 
@@ -907,7 +907,7 @@ mod tests {
 
     #[test]
     fn test_create_run_isolation() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
 
         let run1 = RunId::new();
@@ -924,7 +924,7 @@ mod tests {
 
     #[test]
     fn test_create_null_value() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -935,7 +935,7 @@ mod tests {
 
     #[test]
     fn test_create_empty_object() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -946,7 +946,7 @@ mod tests {
 
     #[test]
     fn test_create_empty_array() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -961,7 +961,7 @@ mod tests {
 
     #[test]
     fn test_get_root() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -976,7 +976,7 @@ mod tests {
 
     #[test]
     fn test_get_at_path() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1005,7 +1005,7 @@ mod tests {
 
     #[test]
     fn test_get_nested_path() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1032,7 +1032,7 @@ mod tests {
 
     #[test]
     fn test_get_array_element() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1055,7 +1055,7 @@ mod tests {
 
     #[test]
     fn test_get_missing_document() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1066,7 +1066,7 @@ mod tests {
 
     #[test]
     fn test_get_missing_path() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1081,7 +1081,7 @@ mod tests {
 
     #[test]
     fn test_exists() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1097,7 +1097,7 @@ mod tests {
 
     #[test]
     fn test_exists_run_isolation() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
 
         let run1 = RunId::new();
@@ -1119,7 +1119,7 @@ mod tests {
 
     #[test]
     fn test_set_at_root() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1139,7 +1139,7 @@ mod tests {
 
     #[test]
     fn test_set_at_path() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1167,7 +1167,7 @@ mod tests {
 
     #[test]
     fn test_set_nested_path() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1196,7 +1196,7 @@ mod tests {
 
     #[test]
     fn test_set_increments_version() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1227,7 +1227,7 @@ mod tests {
 
     #[test]
     fn test_set_missing_document() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1243,7 +1243,7 @@ mod tests {
 
     #[test]
     fn test_set_overwrites_value() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1271,7 +1271,7 @@ mod tests {
 
     #[test]
     fn test_set_array_element() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1300,7 +1300,7 @@ mod tests {
 
     #[test]
     fn test_delete_at_path() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1335,7 +1335,7 @@ mod tests {
 
     #[test]
     fn test_delete_at_nested_path() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1376,7 +1376,7 @@ mod tests {
 
     #[test]
     fn test_delete_at_path_array_element() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1407,7 +1407,7 @@ mod tests {
 
     #[test]
     fn test_delete_at_path_increments_version() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1434,7 +1434,7 @@ mod tests {
 
     #[test]
     fn test_delete_at_path_missing_document() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1445,7 +1445,7 @@ mod tests {
 
     #[test]
     fn test_delete_at_path_missing_path() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1465,7 +1465,7 @@ mod tests {
 
     #[test]
     fn test_destroy_existing_document() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1482,7 +1482,7 @@ mod tests {
 
     #[test]
     fn test_destroy_nonexistent_document() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1493,7 +1493,7 @@ mod tests {
 
     #[test]
     fn test_destroy_run_isolation() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
 
         let run1 = RunId::new();
@@ -1514,7 +1514,7 @@ mod tests {
 
     #[test]
     fn test_destroy_then_recreate() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1537,7 +1537,7 @@ mod tests {
 
     #[test]
     fn test_destroy_complex_document() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";
@@ -1563,7 +1563,7 @@ mod tests {
 
     #[test]
     fn test_destroy_idempotent() {
-        let db = Database::builder().in_memory().open_temp().unwrap();
+        let db = Database::ephemeral().unwrap();
         let store = JsonStore::new(db);
         let run_id = RunId::new();
         let doc_id = "test-doc";

--- a/crates/engine/tests/versioned_conformance_tests.rs
+++ b/crates/engine/tests/versioned_conformance_tests.rs
@@ -39,7 +39,7 @@ fn int_payload(v: i64) -> Value {
 }
 
 fn setup() -> (Arc<Database>, RunId) {
-    let db = Database::builder().in_memory().open_temp().unwrap();
+    let db = Database::ephemeral().unwrap();
     let run_id = RunId::new();
     (db, run_id)
 }

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -102,9 +102,9 @@ impl Strata {
         })
     }
 
-    /// Open a temporary in-memory database.
+    /// Open an ephemeral in-memory database.
     ///
-    /// Useful for testing. Data is not persisted.
+    /// Useful for testing. Data is not persisted and no disk files are created.
     ///
     /// # Example
     ///
@@ -113,11 +113,9 @@ impl Strata {
     /// db.kv_put("key", Value::Int(42))?;
     /// ```
     pub fn open_temp() -> Result<Self> {
-        let db = Database::builder()
-            .no_durability()
-            .open_temp()
+        let db = Database::ephemeral()
             .map_err(|e| Error::Internal {
-                reason: format!("Failed to open temp database: {}", e),
+                reason: format!("Failed to open ephemeral database: {}", e),
             })?;
         let executor = Executor::new(db);
 

--- a/crates/executor/src/tests/determinism.rs
+++ b/crates/executor/src/tests/determinism.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 /// Create a test executor.
 fn create_test_executor() -> Executor {
-    let db = Database::builder().no_durability().open_temp().unwrap();
+    let db = Database::ephemeral().unwrap();
     Executor::new(db)
 }
 

--- a/crates/executor/src/tests/execute_many.rs
+++ b/crates/executor/src/tests/execute_many.rs
@@ -8,11 +8,11 @@ use crate::{Command, Executor, Output};
 use crate::Value;
 use std::sync::Arc;
 
-/// Create a test executor with an in-memory database.
+/// Create a test executor with an ephemeral in-memory database.
 fn create_test_executor() -> Executor {
     use strata_engine::Database;
 
-    let db = Database::builder().no_durability().open_temp().unwrap();
+    let db = Database::ephemeral().unwrap();
     Executor::new(db)
 }
 

--- a/crates/executor/src/tests/parity.rs
+++ b/crates/executor/src/tests/parity.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 /// Create a test executor with shared primitives for parity comparisons.
 fn create_test_environment() -> (Executor, Arc<Primitives>) {
-    let db = Database::builder().no_durability().open_temp().unwrap();
+    let db = Database::ephemeral().unwrap();
     let executor = Executor::new(db.clone());
     let primitives = Arc::new(Primitives::new(db));
     (executor, primitives)

--- a/crates/executor/src/tests/search.rs
+++ b/crates/executor/src/tests/search.rs
@@ -11,7 +11,7 @@ use strata_engine::Database;
 use std::sync::Arc;
 
 fn create_executor() -> Executor {
-    let db = Database::builder().no_durability().open_temp().unwrap();
+    let db = Database::ephemeral().unwrap();
     Executor::new(db)
 }
 

--- a/crates/executor/src/tests/session.rs
+++ b/crates/executor/src/tests/session.rs
@@ -7,13 +7,13 @@ use std::sync::Arc;
 
 /// Create a test session with an ephemeral in-memory database.
 fn create_test_session() -> Session {
-    let db = Database::builder().no_durability().open_temp().unwrap();
+    let db = Database::ephemeral().unwrap();
     Session::new(db)
 }
 
 /// Create a test session, returning the db handle too (for multi-session tests).
 fn create_test_db_and_session() -> (Arc<Database>, Session) {
-    let db = Database::builder().no_durability().open_temp().unwrap();
+    let db = Database::ephemeral().unwrap();
     let session = Session::new(db.clone());
     (db, session)
 }

--- a/crates/intelligence/src/hybrid.rs
+++ b/crates/intelligence/src/hybrid.rs
@@ -267,9 +267,7 @@ mod tests {
     use strata_core::value::Value;
 
     fn test_db() -> Arc<Database> {
-        Database::builder()
-            .no_durability()
-            .open_temp()
+        Database::ephemeral()
             .expect("Failed to create test database")
     }
 

--- a/crates/intelligence/src/lib.rs
+++ b/crates/intelligence/src/lib.rs
@@ -55,7 +55,7 @@ pub use tokenizer::{tokenize, tokenize_unique};
 /// use strata_intelligence::DatabaseSearchExt;
 /// use std::sync::Arc;
 ///
-/// let db = Arc::new(Database::builder().in_memory().open_temp()?);
+/// let db = Database::ephemeral()?;
 /// let hybrid = db.hybrid();
 /// let response = hybrid.search(&request)?;
 /// ```
@@ -80,12 +80,8 @@ mod tests {
 
     #[test]
     fn test_database_search_ext() {
-        let db = Arc::new(
-            Database::builder()
-                .in_memory()
-                .open_temp()
-                .expect("Failed to create test database"),
-        );
+        let db = Database::ephemeral()
+            .expect("Failed to create test database");
 
         let hybrid = db.hybrid();
         let run_id = RunId::new();


### PR DESCRIPTION
## Summary

- Simplify Database/DatabaseBuilder API to three clear opening methods
- Simplify all primitives (KV, State, JSON, Event, Vector) to MVP methods
- Clean up tests to use the new simplified API

### Database API Changes

The API now provides three clear ways to open a database:

```rust
// 1. Simple open with sensible defaults (buffered durability)
let db = Database::open("/data/mydb")?;

// 2. Builder for custom durability
let db = Database::builder()
    .path("/data/mydb")
    .strict()  // or .buffered() or .no_durability()
    .open()?;

// 3. Ephemeral (no files, testing)
let db = Database::ephemeral()?;
```

### Key Changes

- `Database::open(path)` now uses buffered durability by default (was strict)
- `DatabaseBuilder::open()` now requires a path (errors if none set)
- Removed `DatabaseBuilder::open_temp()` - use `Database::ephemeral()` instead
- Removed `DatabaseBuilder::in_memory()` - was deprecated
- Removed `DatabaseBuilder::get_durability()` - internal detail
- Updated `Strata::open_temp()` to use `Database::ephemeral()`

## Test plan

- [x] All strata-engine tests pass (576 tests)
- [x] All strata-executor tests pass (157 tests)
- [x] All strata-intelligence tests pass (23 tests)
- [x] Full workspace tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)