### PR TITLE
Remove unused functions from executor crate

### DIFF
--- a/crates/executor/src/bridge.rs
+++ b/crates/executor/src/bridge.rs
@@ -349,18 +349,6 @@ fn value_to_json_scalar(value: &Value) -> strata_engine::JsonScalar {
 // RunStatus Conversion
 // =============================================================================
 
-/// Convert executor RunStatus to engine RunStatus.
-pub fn to_engine_run_status(status: crate::types::RunStatus) -> strata_engine::RunStatus {
-    match status {
-        crate::types::RunStatus::Active => strata_engine::RunStatus::Active,
-        crate::types::RunStatus::Completed => strata_engine::RunStatus::Completed,
-        crate::types::RunStatus::Failed => strata_engine::RunStatus::Failed,
-        crate::types::RunStatus::Cancelled => strata_engine::RunStatus::Cancelled,
-        crate::types::RunStatus::Paused => strata_engine::RunStatus::Paused,
-        crate::types::RunStatus::Archived => strata_engine::RunStatus::Archived,
-    }
-}
-
 /// Convert engine RunStatus to executor RunStatus.
 pub fn from_engine_run_status(status: strata_engine::RunStatus) -> crate::types::RunStatus {
     match status {

--- a/crates/executor/src/json.rs
+++ b/crates/executor/src/json.rs
@@ -193,21 +193,6 @@ impl From<CanonicalValue> for Value {
     }
 }
 
-/// Convert a Command to canonical JSON string.
-pub fn to_json_string<T: Serialize>(value: &T) -> Result<String, serde_json::Error> {
-    serde_json::to_string(value)
-}
-
-/// Convert a Command to canonical pretty-printed JSON string.
-pub fn to_json_string_pretty<T: Serialize>(value: &T) -> Result<String, serde_json::Error> {
-    serde_json::to_string_pretty(value)
-}
-
-/// Parse a Command from JSON string.
-pub fn from_json_str<'a, T: Deserialize<'a>>(s: &'a str) -> Result<T, serde_json::Error> {
-    serde_json::from_str(s)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Delete `to_engine_run_status()` from bridge.rs (the reverse `from_engine_run_status()` is still used)
- Delete `to_json_string()`, `to_json_string_pretty()`, `from_json_str()` from json.rs

These functions were never called and generated compiler warnings.

## Test plan

- [x] All 157 executor tests pass
- [x] Crate compiles without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)