### PR TITLE
Remove dead code from concurrency crate per audit

### DIFF
--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -13,33 +13,19 @@
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 
-pub mod conflict;
+pub(crate) mod conflict;
 pub mod manager;
 pub mod recovery;
 pub mod snapshot;
 pub mod transaction;
-pub mod validation;
+pub(crate) mod validation;
 pub mod wal_writer;
 
 pub use manager::TransactionManager;
 pub use recovery::{RecoveryCoordinator, RecoveryResult, RecoveryStats};
 pub use snapshot::ClonedSnapshotView;
-pub use transaction::{
-    ApplyResult, CASOperation, CommitError, JsonPatchEntry, JsonPathRead, JsonStoreExt,
-    PendingOperations, TransactionContext, TransactionStatus,
-};
-pub use validation::{
-    validate_cas_set, validate_json_paths, validate_json_set, validate_read_set,
-    validate_transaction, validate_write_set, ConflictType, ValidationResult,
-};
+pub use transaction::{CommitError, JsonStoreExt, TransactionContext, TransactionStatus};
 pub use wal_writer::TransactionWALWriter;
-
-// JSON conflict detection
-pub use conflict::{
-    check_all_conflicts, check_read_write_conflicts, check_version_conflicts,
-    check_write_write_conflicts, find_first_read_write_conflict, find_first_version_conflict,
-    find_first_write_write_conflict, ConflictResult, JsonConflictError,
-};
 
 // Re-export the SnapshotView trait from core for convenience
 pub use strata_core::traits::SnapshotView;

--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -55,7 +55,7 @@ impl RecoveryCoordinator {
     ///
     /// Note: Snapshot-based recovery is not implemented in M2.
     /// This method is provided for future extensibility.
-    pub fn with_snapshot_path(mut self, path: PathBuf) -> Self {
+    pub(crate) fn with_snapshot_path(mut self, path: PathBuf) -> Self {
         self.snapshot_path = Some(path);
         self
     }

--- a/crates/concurrency/src/snapshot.rs
+++ b/crates/concurrency/src/snapshot.rs
@@ -93,7 +93,7 @@ impl ClonedSnapshotView {
     /// Create a snapshot from an existing Arc (for sharing between snapshots)
     ///
     /// This is useful when multiple transactions need the same snapshot data.
-    pub fn from_arc(version: u64, data: Arc<BTreeMap<Key, VersionedValue>>) -> Self {
+    pub(crate) fn from_arc(version: u64, data: Arc<BTreeMap<Key, VersionedValue>>) -> Self {
         ClonedSnapshotView { version, data }
     }
 

--- a/docs/architecture/CONCURRENCY_CRATE_AUDIT.md
+++ b/docs/architecture/CONCURRENCY_CRATE_AUDIT.md
@@ -1,6 +1,6 @@
 # Concurrency Crate Audit
 
-## Status: Findings documented, action pending
+## Status: All findings resolved
 
 ## Date: 2026-01-29
 
@@ -10,6 +10,8 @@ After consolidating the commit protocol (see `COMMIT_PROTOCOL_CONSOLIDATION.md`)
 the concurrency crate was re-audited. The crate is well-structured overall (83 tests,
 clean architecture, no circular dependencies), but the consolidation exposed dead
 code both within the concurrency crate and in the engine's durability module.
+
+All findings have been resolved.
 
 ---
 
@@ -23,111 +25,43 @@ The WAL's `append()` method handles all fsync behavior internally based on its
 
 ---
 
-## MEDIUM PRIORITY: Dead Public Exports from Concurrency Crate
+## ~~MEDIUM PRIORITY: Dead Public Exports from Concurrency Crate~~ RESOLVED
 
-These items are exported from `crates/concurrency/src/lib.rs` but have zero
-external callers. They should be removed from `pub use` (made `pub(crate)` or removed).
+**Resolved**: Trimmed `pub use` in `crates/concurrency/src/lib.rs` to only
+re-export items with external callers. Made `conflict` and `validation` modules
+`pub(crate)`. Removed `abort()` and `commit_or_rollback()` from
+`TransactionManager`. Demoted `RecoveryCoordinator::with_snapshot_path()` and
+`ClonedSnapshotView::from_arc()` to `pub(crate)`.
 
-### Manager methods
-
-| Item | File | Notes |
-|------|------|-------|
-| `commit_or_rollback()` | manager.rs:281 | Never called. Engine uses `TransactionCoordinator::commit()` which handles errors itself. |
-| `TransactionManager::abort()` | manager.rs:272 | Only called in a test. Engine calls `txn.mark_aborted()` directly. |
-
-### Transaction types
-
-| Item | File | Notes |
-|------|------|-------|
-| `ApplyResult` | transaction.rs:77 | Return type of `apply_writes()` but always discarded by `TransactionManager::commit()`. |
-| `PendingOperations` | transaction.rs:97 | Debugging struct returned by `pending_operations()`. Zero external callers. |
-| `CASOperation` | transaction.rs | Only used internally by validation. |
-| `JsonPathRead`, `JsonPatchEntry` | transaction.rs | Only used internally by validation/conflict. |
-
-### Validation functions (all 6)
-
-| Item | File | Notes |
-|------|------|-------|
-| `validate_transaction` | validation.rs | Only called internally by `TransactionContext::commit()`. |
-| `validate_read_set` | validation.rs | Only called internally by `validate_transaction()`. |
-| `validate_write_set` | validation.rs | No-op function (always returns ok). |
-| `validate_cas_set` | validation.rs | Only called internally. |
-| `validate_json_set` | validation.rs | Only called internally. |
-| `validate_json_paths` | validation.rs | Only called internally. |
-| `ConflictType` | validation.rs | Only used internally. |
-| `ValidationResult` | validation.rs | Only used internally. Engine converts via `StrataError::from(CommitError)`. |
-
-### Conflict module (all 9 items)
-
-| Item | File | Notes |
-|------|------|-------|
-| `check_all_conflicts` | conflict.rs | Never called. |
-| `check_read_write_conflicts` | conflict.rs | Never called. |
-| `check_version_conflicts` | conflict.rs | Never called. |
-| `check_write_write_conflicts` | conflict.rs | Only called internally by `validate_json_paths`. |
-| `find_first_read_write_conflict` | conflict.rs | Only called by `check_all_conflicts` (which is itself never called). |
-| `find_first_version_conflict` | conflict.rs | Only called by `check_all_conflicts`. |
-| `find_first_write_write_conflict` | conflict.rs | Only called by `check_all_conflicts`. |
-| `ConflictResult` | conflict.rs | Only used internally. |
-| `JsonConflictError` | conflict.rs | Only used internally. |
-
-### Recovery and snapshot methods
-
-| Item | File | Notes |
-|------|------|-------|
-| `RecoveryCoordinator::with_snapshot_path()` | recovery.rs:58 | Only called in a test. Documented as "M3+ feature". |
-| `ClonedSnapshotView::from_arc()` | snapshot.rs:96 | Only called in tests. |
-
-**Action**: Remove all items above from `pub use` in `lib.rs`. Make them
-`pub(crate)` where they're still used internally, or remove entirely if unused.
+Remaining exports: `TransactionManager`, `TransactionContext`, `CommitError`,
+`JsonStoreExt`, `TransactionStatus`, `RecoveryCoordinator`, `RecoveryResult`,
+`RecoveryStats`, `ClonedSnapshotView`, `TransactionWALWriter`, `SnapshotView`.
 
 ---
 
-## MEDIUM PRIORITY: Dead WAL Writer Methods
+## ~~MEDIUM PRIORITY: Dead WAL Writer Methods~~ RESOLVED
 
-**Location**: `crates/concurrency/src/wal_writer.rs`
-
-| Method | Lines | Callers |
-|--------|-------|---------|
-| `write_abort()` | 128-135 | Only in wal_writer tests. Spec says aborted transactions don't need WAL entries. |
-| `write_vector_collection_create()` | 158-178 | Zero callers anywhere. |
-| `write_vector_collection_delete()` | 181-201 | Zero callers anywhere. |
-| `write_vector_upsert()` | 205-233 | Zero callers anywhere. |
-| `write_vector_delete()` | 236-252 | Zero callers anywhere. |
-
-The 4 vector WAL methods were built for future vector WAL integration but were
-never connected. The vector store in the engine does not use WAL for its operations.
-
-**Action**: Remove all 5 methods and their tests.
+**Resolved**: Removed `write_abort()` and all 4 vector WAL methods
+(`write_vector_collection_create`, `write_vector_collection_delete`,
+`write_vector_upsert`, `write_vector_delete`) from `TransactionWALWriter`,
+along with the `write_abort` test.
 
 ---
 
-## LOW PRIORITY: No-Op Validation Function
+## ~~LOW PRIORITY: No-Op Validation Function~~ RESOLVED
 
-**Location**: `crates/concurrency/src/validation.rs:195`
-
-`validate_write_set()` always returns `ValidationResult::ok()`. It's called on
-every commit via `validate_transaction()` but does nothing. A comment explains
-that blind writes don't conflict (by design), so write-set validation is a no-op.
-
-**Action**: Remove the function and its call in `validate_transaction()`. The
-design rationale (blind writes don't conflict) is already documented elsewhere.
+**Resolved**: Removed `validate_write_set()` and its call in
+`validate_transaction()`. The design rationale (blind writes don't conflict,
+per spec Section 3.2) is documented in `validate_transaction()`'s doc comment.
 
 ---
 
-## LOW PRIORITY: Field Access Inconsistency
+## ~~LOW PRIORITY: Field Access Inconsistency~~ RESOLVED
 
-The engine accesses `TransactionContext` internal fields directly
-(`txn.write_set`, `txn.delete_set`, `txn.cas_set`) rather than using the
-accessor methods (`write_count()`, `delete_count()`, `cas_count()`). This
-makes the accessor methods dead code externally.
-
-**Location**: `crates/engine/src/durability/traits.rs:170-173` (this file is
-itself dead code per the high-priority finding above)
-
-**Action**: Once the durability module is removed, verify no other engine code
-accesses these fields directly. If the fields are only accessed internally by
-the concurrency crate, consider making them `pub(crate)` instead of `pub`.
+**Resolved**: The only location that accessed `TransactionContext` fields
+directly from the engine was `crates/engine/src/durability/traits.rs`, which
+was removed as part of the HIGH PRIORITY fix. No other engine code accesses
+these fields directly (verified via grep).
 
 ---
 
@@ -148,16 +82,3 @@ For reference, these concurrency crate exports are actively used:
 | `JsonStoreExt` | engine transaction context, json primitive, extensions, run handle |
 | `TransactionStatus` | concurrency internal (via `txn.status` public field) |
 | `SnapshotView` (re-export) | engine, storage |
-
----
-
-## Estimated Cleanup Impact
-
-| Action | Lines removed | Files affected |
-|--------|--------------|----------------|
-| Remove engine durability module | ~500 | 5 (4 files + mod.rs) |
-| Trim concurrency public exports | ~0 (just `pub use` changes) | 1 (lib.rs) |
-| Remove dead WAL writer methods | ~130 | 1 (wal_writer.rs) |
-| Remove `validate_write_set` no-op | ~20 | 1 (validation.rs) |
-| Remove `commit_or_rollback` | ~15 | 1 (manager.rs) |
-| **Total** | **~665 lines** | **9 files** |


### PR DESCRIPTION
## Summary

- **Trim 26 dead public exports** from `crates/concurrency/src/lib.rs`; make `conflict` and `validation` modules `pub(crate)`
- **Remove `TransactionManager::abort()` and `commit_or_rollback()`** — zero external callers
- **Remove 5 dead WAL writer methods** — `write_abort()` and 4 vector methods with zero callers
- **Remove no-op `validate_write_set()`** — always returned ok, called on every commit but did nothing
- **Demote `with_snapshot_path()` and `from_arc()`** to `pub(crate)` (only used in tests)
- **Mark all audit findings as resolved** in `CONCURRENCY_CRATE_AUDIT.md`

Net: -335 lines across 7 files. All remaining exports are verified to have external callers.

## Test plan

- [x] `cargo check --workspace` compiles cleanly
- [x] `cargo test -p strata-concurrency --lib` — 81 tests pass (2 removed with their dead methods)
- [x] `cargo test --workspace --lib` — 1,875 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)