### PR TITLE
Fix 3 ignored test bugs (#781, session events, serialization)

### DIFF
--- a/crates/engine/src/primitives/event.rs
+++ b/crates/engine/src/primitives/event.rs
@@ -51,7 +51,7 @@ use std::sync::Arc;
 pub use strata_core::primitives::Event;
 
 /// Hash version constants
-const HASH_VERSION_SHA256: u8 = 1; // SHA-256
+pub(crate) const HASH_VERSION_SHA256: u8 = 1; // SHA-256
 
 /// Per-stream metadata for O(1) access to stream statistics
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/IGNORED_TESTS.md
+++ b/tests/IGNORED_TESTS.md
@@ -1,6 +1,6 @@
 # Ignored Tests Registry
 
-**Total: 64 ignored tests across 6 suites**
+**Total: 61 ignored tests across 6 suites**
 
 This document tracks every `#[ignore]` test so none are forgotten. Tests fall into
 three categories: **API gaps** (need new methods), **known bugs** (need fixes), and
@@ -100,35 +100,6 @@ ensures related events are written atomically.
 
 **Why this matters:** Run forking enables branching agent execution — try
 different strategies from the same starting state without re-running setup.
-
----
-
-## Known Bug Tests (1 test)
-
-### Run Deletion Data Cleanup
-
-**File:** `tests/executor/run_invariants.rs`
-
-| Test | Bug | What It Validates |
-|------|-----|-------------------|
-| `run_delete_removes_all_data` | Issue #781 | Deleting a run should cascade-delete all KV, State, and Event data |
-
-**Current behavior:** `RunDelete` removes the run metadata but data persists.
-Recreating a run with the same name sees stale data. See
-`run_delete_currently_does_not_remove_data` (not ignored) which documents this.
-
----
-
-## Implementation-Pending Tests (2 tests)
-
-### Session Transaction Gaps
-
-**File:** `tests/executor/session_transactions.rs`
-
-| Test | Issue | What It Validates |
-|------|-------|-------------------|
-| `read_your_writes_event` | EventAppend in transactions pending review | Events written in a transaction are readable before commit |
-| `cross_primitive_transaction` | State/Event serialization issues | Single transaction spans KV + State + Event atomically |
 
 ---
 

--- a/tests/executor/run_invariants.rs
+++ b/tests/executor/run_invariants.rs
@@ -78,9 +78,7 @@ fn run_data_is_isolated() {
 // ============================================================================
 
 /// Deleting a run should remove all its data (KV, State, Events)
-/// BUG: Currently data persists after run deletion - see issue #781
 #[test]
-#[ignore] // Enable when run deletion properly cleans up data
 fn run_delete_removes_all_data() {
     let executor = create_executor();
 
@@ -145,9 +143,9 @@ fn run_delete_removes_all_data() {
         "Data should not persist after run deletion and recreation");
 }
 
-/// Document current behavior: run delete does NOT remove data (bug)
+/// Verify run delete properly cleans up data (issue #781 fixed)
 #[test]
-fn run_delete_currently_does_not_remove_data() {
+fn run_delete_cleans_up_data() {
     let executor = create_executor();
 
     let run_id = match executor.execute(Command::RunCreate {
@@ -176,15 +174,14 @@ fn run_delete_currently_does_not_remove_data() {
         metadata: None,
     }).unwrap();
 
-    // BUG: Data still exists! This should be None.
+    // Data should be gone after deletion
     let output = executor.execute(Command::KvGet {
         run: Some(run_id),
         key: "persistent_key".into(),
     }).unwrap();
 
-    // Documenting current (broken) behavior
-    assert!(matches!(output, Output::Maybe(Some(_))),
-        "Current behavior: data persists after run deletion (see issue #781)");
+    assert!(matches!(output, Output::Maybe(None)),
+        "Data should not persist after run deletion (issue #781)");
 }
 
 // ============================================================================

--- a/tests/executor/session_transactions.rs
+++ b/tests/executor/session_transactions.rs
@@ -171,7 +171,6 @@ fn read_your_writes_state() {
 }
 
 #[test]
-#[ignore] // EventAppend in Session transactions pending implementation review
 fn read_your_writes_event() {
     let mut session = create_session();
 
@@ -477,7 +476,6 @@ fn multiple_kv_operations_in_transaction() {
 }
 
 #[test]
-#[ignore] // State/Event in Session transactions have serialization issues pending fix
 fn cross_primitive_transaction() {
     let db = create_db();
     let mut session = Session::new(db.clone());


### PR DESCRIPTION
## Summary

Fixes 3 bugs tracked in `tests/IGNORED_TESTS.md`, reducing ignored test count from 64 to 61:

- **Bug #781 — RunDelete cascade**: `delete_run()` now resolves run names to the same deterministic UUID v5 the executor uses, and also cleans up data stored under the metadata's random UUID. Previously, the namespace mismatch meant data survived deletion.
- **Session event read-your-writes**: Added `event_sequence_count` and `event_last_hash` tracking to `TransactionContext` (lazy-allocated, following the existing JSON field pattern). `Transaction::new()` reads state from the context; `event_append()` writes it back. This ensures multiple `Transaction` instances within a session share event continuity.
- **Serialization alignment**: Transaction event and state operations now use `Value::String(serde_json::to_string)` matching EventLog and StateCell primitive formats (previously used `Value::Bytes(serde_json::to_vec)`). Also writes `EventLogMeta` on `event_append()` so `EventLog::len()` sees committed events.

### Files changed

| File | Change |
|------|--------|
| `crates/concurrency/src/transaction.rs` | Add event state fields, accessors, reset clearing |
| `crates/engine/src/primitives/event.rs` | Make `HASH_VERSION_SHA256` `pub(crate)` |
| `crates/engine/src/primitives/run/index.rs` | Fix `delete_run()` to resolve both namespace RunIds |
| `crates/engine/src/transaction/context.rs` | Fix serialization format, add EventLogMeta writes, read event state from ctx |
| `tests/executor/run_invariants.rs` | Un-ignore `run_delete_removes_all_data`, update companion test |
| `tests/executor/session_transactions.rs` | Un-ignore `read_your_writes_event` and `cross_primitive_transaction` |
| `tests/IGNORED_TESTS.md` | Remove fixed entries, update count 64 → 61 |

## Test plan

- [x] `run_delete_removes_all_data` — passes (was ignored)
- [x] `run_delete_cleans_up_data` — passes (updated from bug-documenting test)
- [x] `read_your_writes_event` — passes (was ignored)
- [x] `cross_primitive_transaction` — passes (was ignored)
- [x] `cargo test --test executor` — 24/24 pass
- [x] `cargo test --test engine --test executor --test concurrency --test durability --test integration --test storage` — all pass
- [x] `cargo test -p strata-engine --lib --tests` — 55/55 pass
- [x] `cargo test -p strata-concurrency --lib --tests` — 69/69 pass
- [x] `cargo test -p strata-engine --test recovery_tests` — 12/12 pass (including `test_run_delete_survives_recovery`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)