### PR TITLE
Add extended roadmap: benchmarks, security, intelligence, SDKs, websites

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -1,12 +1,12 @@
-# StrataDB Feature Roadmap
+# StrataDB Roadmap
 
 StrataDB is an embedded database designed for AI agents, providing six primitives (KV, Event, State, JSON, Vector, Branch) with ACID transactions, snapshot isolation, and crash-safe durability.
 
 **Current release**: v0.1.0 (embedded library)
 
-**Direction**: Embedded-first, with an optional server mode planned for multi-process access.
+**Direction**: Embedded-first, with intelligence features, server mode, and multi-language SDKs planned.
 
-## Milestones
+## Feature milestones
 
 | Version | Theme | Status |
 |---------|-------|--------|
@@ -18,6 +18,42 @@ StrataDB is an embedded database designed for AI agents, providing six primitive
 | [v0.7](v0.7-observability.md) | Observability | Planned |
 | [v1.0](v1.0-stable.md) | Stable release | Planned |
 | [Future](future.md) | Post-1.0 exploration | Planned |
+
+## Cross-cutting initiatives
+
+These are not versioned milestones — they cut across releases and have their own sequencing.
+
+| Initiative | Summary |
+|------------|---------|
+| [Performance characterization](performance-characterization.md) | Benchmark suite (all primitives x all durability modes) and hardware scaling study (RPi to Xeon) |
+| [Engine & storage optimization](engine-storage-optimization.md) | Data-driven rewrites based on benchmark results |
+| [strata-security](strata-security.md) | Access control crate — read-only/read-write now, per-connection auth for server mode later |
+| [Intelligence: Indexing](intelligence-indexing.md) | Reduce search latency through indexing (index type TBD, tracking SOTA) |
+| [Intelligence: Internal graph](intelligence-graph.md) | Internal graph structure for relationship-aware queries across primitives |
+| [Intelligence: Embedded inference](intelligence-inference.md) | Nano inference runtime — MiniLM for auto-embedding, Qwen3 for natural language search |
+| [SDKs and MCP server](sdks-and-mcp.md) | Python SDK (PyO3), Node SDK (NAPI-RS), MCP server — thin wrappers over Command/Output |
+| [Websites](websites.md) | stratadb.org (docs, benchmarks) and stratadb.ai (live WASM demos) |
+
+## Sequencing
+
+```
+Black-box tests
+    │
+    ▼
+Performance characterization ──→ Engine & storage optimization
+    │
+    ▼
+strata-security (phase 1)
+    │
+    ├──→ Intelligence: Indexing ──→ Intelligence: Graph
+    │                                    │
+    │                                    ▼
+    │                           Intelligence: Inference
+    │
+    ├──→ SDKs and MCP server
+    │
+    └──→ Websites: stratadb.org ──→ WASM build ──→ stratadb.ai
+```
 
 ## What shipped in v0.1.0
 
@@ -33,10 +69,10 @@ StrataDB is an embedded database designed for AI agents, providing six primitive
 
 ## How to read this roadmap
 
-Each milestone file describes:
-- **Theme**: The unifying goal for that release
-- **Features**: What will be built, with references to existing code where applicable
-- **Context**: Why this ordering makes sense
-- **Dependencies**: What must ship before this milestone
+Each document describes:
+- **Theme**: The unifying goal
+- **Features/Scope**: What will be built, with references to existing code where applicable
+- **Dependencies**: What must ship first
+- **Open questions**: What we don't know yet
 
 Milestones are ordered by priority but not committed to specific dates. Features may shift between milestones as development progresses.

--- a/roadmap/engine-storage-optimization.md
+++ b/roadmap/engine-storage-optimization.md
@@ -1,0 +1,24 @@
+# Engine & Storage Optimization
+
+**Theme**: Data-driven rewrites based on benchmark and scaling study results.
+
+## Context
+
+The [performance characterization](performance-characterization.md) work will produce throughput curves across hardware tiers (Raspberry Pi to Xeon), concurrency levels, and dataset sizes. Those curves will reveal where the current engine and storage layers hit their limits.
+
+This milestone is intentionally left open until that data exists. The specific optimizations, their priority, and their scope will be determined by what the benchmarks show — not by speculation.
+
+## Known areas to watch
+
+- ShardedStore concurrency scaling
+- WAL write serialization under high core counts
+- Memory allocation pressure on constrained devices
+- Vector search performance vs. collection size
+
+## Scope
+
+Partial rewrites of `strata-engine` and `strata-storage` internals. Public API (`strata-executor`) should remain unchanged.
+
+## Dependencies
+
+- Performance characterization (benchmark suite + hardware scaling study) must complete first

--- a/roadmap/intelligence-graph.md
+++ b/roadmap/intelligence-graph.md
@@ -1,0 +1,46 @@
+# Intelligence: Internal Graph Primitive
+
+**Theme**: Relationship-aware queries powered by an internal graph structure.
+
+## Motivation
+
+The existing primitives store entities but not the relationships between them. A KV entry can reference another key by convention, but there's no way to ask "what is connected to X?" or "find all entities within 2 hops of Y" without the caller implementing traversal logic themselves.
+
+A graph structure inside `strata-intelligence` can represent relationships across primitives — connecting KV entries to their related events, JSON documents to their vector embeddings, branches to their lineage — and make those relationships queryable. This makes the intelligence layer meaningfully smarter than a search index.
+
+## Scope: internal only
+
+This is **not** a new public primitive. It is an internal data structure within `strata-intelligence` that the intelligence layer uses to improve its own query capabilities. Users interact with it indirectly through richer search results, not through a `graph_add_edge` API.
+
+Reasons to keep it internal:
+
+- Exposing a full graph API invites scope creep toward a general-purpose graph database
+- The value is in what the intelligence layer can *do* with relationships, not in letting users manage edges manually
+- Internal means we can change the representation without breaking the public API
+
+## What it enables
+
+- **Cross-primitive correlation**: "Find events related to this KV entry" without the caller knowing the connection scheme
+- **Relationship-weighted search**: Boost search results that are closely connected to the query context
+- **Lineage queries**: Track how data flows across branches (e.g., which branch was forked from which)
+- **Neighborhood context**: When retrieving an entity, optionally include its nearest neighbors in the graph
+
+## What it is NOT
+
+- Not NetworkX. No general-purpose graph algorithms library, no pagerank, no community detection, no visualization.
+- Not a public primitive. No `graph_add_edge`, `graph_query`, or `graph_traverse` in the Strata API.
+- Not a graph database. No Cypher, no SPARQL, no property graph query language.
+
+The graph is a backing structure — like how an inverted index backs text search without being a user-facing primitive.
+
+## Open questions
+
+- **Edge population**: Are edges inferred automatically (e.g., shared keys, temporal proximity, embedding similarity) or do internal callers register them explicitly?
+- **Persistence**: Does the graph persist, or is it rebuilt on startup from the existing primitives?
+- **Representation**: Adjacency list, CSR, or something else? Depends on query patterns (traversal-heavy vs. lookup-heavy).
+- **Scale**: How many edges per branch is realistic? This determines whether an in-memory representation is viable.
+
+## Dependencies
+
+- Intelligence indexing (the graph is one possible index structure, or works alongside indexes)
+- Engine & storage optimization (graph traversal performance depends on underlying storage speed)

--- a/roadmap/intelligence-indexing.md
+++ b/roadmap/intelligence-indexing.md
@@ -1,0 +1,31 @@
+# Intelligence: Indexing
+
+**Theme**: Reduce search latency across all primitives through indexing.
+
+## Context
+
+Today, searches in `strata-intelligence` scan data at query time. As dataset sizes grow, this becomes the dominant cost. An indexing layer that maintains precomputed structures can drop search latency by orders of magnitude.
+
+The right index type is an open question. The embedded database space and the AI retrieval space are both moving fast — B-trees, LSM trees, HNSW, IVF, graph indexes, learned indexes, and hybrid structures all have trade-offs that depend on workload shape, update frequency, and hardware constraints.
+
+## What we know
+
+- Indexing needs to cover all searchable primitives: KV (prefix/range), JSON (path + text), Event (type + time), Vector (similarity), and cross-primitive hybrid search
+- Indexes must be branch-scoped (consistent with data isolation model)
+- Indexes must survive crash recovery (rebuilt from WAL/snapshots, or persisted alongside data)
+- Write amplification matters — index maintenance cannot make writes dramatically slower
+
+## What we don't know
+
+- Which index structures best fit each primitive's access patterns
+- Whether one general-purpose index (e.g., an LSM-backed inverted index) covers most cases, or whether each primitive needs a specialized structure
+- How SOTA evolves — learned indexes, quantization-aware structures, and GPU-accelerated search are all active research areas
+
+## Approach
+
+Track state of the art. Let the benchmark and scaling data (from [performance characterization](performance-characterization.md)) quantify the current search latency baseline, then evaluate index structures against that baseline with real workload profiles.
+
+## Dependencies
+
+- Performance characterization (establishes the latency baseline to improve against)
+- Engine & storage optimization (indexing builds on top of a stable, performant storage layer)

--- a/roadmap/intelligence-inference.md
+++ b/roadmap/intelligence-inference.md
@@ -1,0 +1,172 @@
+# Intelligence: Embedded Inference Runtime
+
+**Theme**: A minimal inference runtime inside `strata-intelligence`, fixed to two models, turning StrataDB from a storage engine into a storage engine that understands its own data.
+
+## Vision
+
+Two models, two jobs:
+
+| Model | Parameters | Role |
+|-------|-----------|------|
+| **all-MiniLM-L6-v2** | ~22M | Auto-embedding generation on insert |
+| **Qwen3-1.3B** | ~1.3B | Natural language query interface for search and retrieval |
+
+This is not a general-purpose inference server. It is a nano inference runtime — borrowing key ideas from vLLM (batched inference, KV cache reuse) — hardcoded to exactly these two models. No model zoo, no dynamic loading, no serving API.
+
+## Auto-embedding pipeline
+
+When data is inserted into any text-bearing primitive (KV string values, JSON documents, event payloads), the intelligence layer can automatically generate embeddings via MiniLM and populate a shadow vector collection.
+
+```
+User calls: db.kv_put("doc:123", "The agent completed the search task")
+                │
+                ▼
+        ┌───────────────┐
+        │ KV primitive   │  (stores the value)
+        └───────┬───────┘
+                │ if auto_embed is enabled
+                ▼
+        ┌───────────────┐
+        │ MiniLM-L6-v2  │  (generates 384-dim embedding)
+        └───────┬───────┘
+                │
+                ▼
+        ┌───────────────┐
+        │ Vector         │  (upserts to shadow collection)
+        │ primitive      │
+        └───────────────┘
+```
+
+### Configuration
+
+Auto-embedding is opt-in, configurable per database or per branch:
+
+```rust
+let db = Strata::builder()
+    .path("/data")
+    .auto_embed(true)       // enable auto-embedding
+    .embed_primitives(&[    // which primitives to embed
+        "kv", "json", "event"
+    ])
+    .open()?;
+```
+
+When disabled, StrataDB behaves exactly as it does today — zero model overhead.
+
+### Shadow collections
+
+Auto-generated embeddings live in internal vector collections (e.g., `__auto_kv`, `__auto_json`) that are:
+- Branch-scoped (same isolation as user data)
+- Transparent to the user (search uses them automatically)
+- Managed by the intelligence layer (created/deleted with the branch lifecycle)
+
+## LLM-powered search
+
+Qwen3-1.3B sits at the front of the search pipeline, turning natural language queries into multi-primitive search operations and synthesizing results.
+
+### Query pipeline
+
+```
+User calls: db.search("what tools did the agent use in the last hour?")
+                │
+                ▼
+        ┌───────────────┐
+        │ Qwen3-1.3B    │  query understanding
+        │                │  → decompose into sub-queries:
+        │                │    1. event search: type=tool_call, recent
+        │                │    2. KV search: prefix "agent:tool:"
+        │                │    3. vector search: semantic similarity
+        └───────┬───────┘
+                │
+                ▼
+        ┌───────────────┐
+        │ Multi-primitive│  (existing hybrid search + auto-embed vectors)
+        │ search         │
+        └───────┬───────┘
+                │
+                ▼
+        ┌───────────────┐
+        │ Qwen3-1.3B    │  result synthesis
+        │                │  → re-rank, filter, summarize
+        └───────┬───────┘
+                │
+                ▼
+        Structured search results with relevance explanations
+```
+
+### What Qwen3 enables
+
+- **Query decomposition**: Parse natural language into typed sub-queries across primitives
+- **Result re-ranking**: Use language understanding to re-score results beyond BM25/cosine
+- **Answer synthesis**: Combine results from multiple primitives into a coherent response
+- **Temporal reasoning**: Understand "last hour", "before the error", "most recent" in query context
+
+## Nano inference runtime
+
+Key ideas borrowed from vLLM, implemented minimally:
+
+### What to take from vLLM
+
+- **Continuous batching**: If multiple embedding requests arrive (e.g., bulk insert), batch them through MiniLM in one forward pass instead of one-at-a-time
+- **KV cache management**: For Qwen3, reuse key-value cache across the query-understanding and result-synthesis phases (same conversation context)
+- **Quantization**: Run Qwen3 in Q4/Q8 quantization to fit in ~1-2GB RAM instead of ~2.6GB at f16
+
+### What NOT to take from vLLM
+
+- No PagedAttention (overkill for single-user embedded inference)
+- No multi-GPU scheduling
+- No HTTP serving layer
+- No dynamic model loading
+- No speculative decoding
+
+### Runtime options
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **candle** (Rust-native) | Pure Rust, no C++ deps, compiles with cargo | Younger ecosystem, fewer optimized kernels |
+| **llama.cpp** (via bindings) | Battle-tested, excellent quantization, broad hardware support | C++ build dependency, FFI complexity |
+| **ONNX Runtime** (via bindings) | Mature, good MiniLM support, hardware abstraction | Large dependency, less suited for LLM generation |
+
+The choice depends on how well each handles both the embedding model (MiniLM, encoder-only) and the generative model (Qwen3, decoder-only). A split approach (ONNX for MiniLM, llama.cpp for Qwen3) is also viable.
+
+### Model distribution
+
+- Models are **not** bundled in the crate (too large for crates.io)
+- Downloaded on first use to a local cache directory (e.g., `~/.stratadb/models/`)
+- Checksum-verified after download
+- If models are not available, auto-embed and LLM search features are disabled — the database still works, just without intelligence features
+
+## Memory footprint
+
+| Component | RAM |
+|-----------|-----|
+| MiniLM-L6-v2 (f32) | ~80 MB |
+| Qwen3-1.3B (Q4) | ~1 GB |
+| Qwen3-1.3B (Q8) | ~1.5 GB |
+| KV cache (Qwen3, short context) | ~100-200 MB |
+| **Total (Q4 Qwen3)** | **~1.4 GB** |
+
+This fits on every hardware tier from the scaling study except possibly a 2GB Raspberry Pi. Feature flags can disable the LLM components to run on constrained devices.
+
+## Feature flags
+
+```toml
+[features]
+default = []
+intelligence-embed = []    # MiniLM auto-embedding only (~80MB RAM)
+intelligence-llm = []      # Qwen3 search interface (~1-1.5GB additional RAM)
+intelligence-full = ["intelligence-embed", "intelligence-llm"]
+```
+
+## Open questions
+
+- **Sync vs. async inference**: Should embedding generation block the insert call, or happen asynchronously in a background thread? Async is better for write throughput but introduces eventual consistency for search.
+- **Context window**: How much context to feed Qwen3 for query understanding — just the query string, or also recent conversation/search history?
+- **Fine-tuning**: Are the off-the-shelf models good enough, or will Strata-specific fine-tuning be needed for query decomposition?
+- **Model updates**: When better small models ship (there will be better ones), what's the upgrade path?
+
+## Dependencies
+
+- Intelligence indexing (auto-embeddings need efficient vector indexes to be useful at scale)
+- Performance characterization (need to understand the latency budget — if a KV put takes 3us today, adding 1ms of embedding time is a 300x regression that must be async)
+- Engine & storage optimization (inference puts sustained memory pressure on the system)

--- a/roadmap/performance-characterization.md
+++ b/roadmap/performance-characterization.md
@@ -1,0 +1,134 @@
+# Performance Characterization
+
+**Theme**: Understand StrataDB's performance envelope before optimizing.
+
+This is a characterization effort, not a feature milestone. The goal is to establish baselines, identify bottlenecks, and understand how performance scales with hardware — before committing to optimization work.
+
+## 1. Comprehensive Benchmark Suite
+
+Systematic benchmarks across all primitives and durability modes.
+
+### Matrix
+
+Every cell in this matrix gets a benchmark:
+
+|                        | InMemory | Buffered | Strict |
+|------------------------|----------|----------|--------|
+| **KV put**             |          |          |        |
+| **KV get**             |          |          |        |
+| **KV delete**          |          |          |        |
+| **KV list (prefix)**   |          |          |        |
+| **State set**          |          |          |        |
+| **State read**         |          |          |        |
+| **State CAS**          |          |          |        |
+| **Event append**       |          |          |        |
+| **Event read**         |          |          |        |
+| **Event read by type** |          |          |        |
+| **JSON set (root)**    |          |          |        |
+| **JSON set (path)**    |          |          |        |
+| **JSON get**           |          |          |        |
+| **JSON list**          |          |          |        |
+| **Vector upsert**      |          |          |        |
+| **Vector search**      |          |          |        |
+| **Vector get**         |          |          |        |
+| **Branch create**      |          |          |        |
+| **Branch switch**      |          |          |        |
+| **Branch delete**      |          |          |        |
+
+### Metrics per cell
+
+- **Throughput**: ops/sec (single-threaded)
+- **Latency**: p50, p95, p99 (microseconds)
+- **Memory**: RSS delta per 10K operations
+
+### Workload parameters
+
+- KV: 100-byte keys, 1KB values
+- Events: 512-byte JSON payloads
+- JSON: 10-field documents, 3-level nesting
+- Vectors: 128-dimensional, cosine similarity, 10K collection size
+- State: 64-byte values
+- All benchmarks run with 10K warmup operations, then 100K measured operations
+
+### Performance target
+
+**InMemory mode should achieve Redis-class throughput**: 100K+ ops/sec for KV get/put on commodity hardware. Redis single-threaded GET/SET benchmarks at ~100-150K ops/sec — StrataDB's InMemory mode should be in the same ballpark since both are in-process data structure operations with no I/O.
+
+### Comparison baselines
+
+The `comparison-benchmarks` feature flag already supports redb, LMDB, and SQLite. Benchmarks should include these for KV workloads to contextualize StrataDB's numbers:
+
+- **redb**: Rust-native embedded DB (closest competitor)
+- **LMDB**: Memory-mapped B-tree (gold standard for read-heavy embedded)
+- **SQLite**: Ubiquitous baseline
+
+### Implementation
+
+- Extend existing `criterion` benchmarks in `crates/engine/benches/`
+- One benchmark file per primitive: `benches/kv_bench.rs`, `benches/event_bench.rs`, etc.
+- Shared harness that parameterizes durability mode
+- Output as JSON for downstream analysis and plotting
+- CI integration: run on every merge to main, alert on >10% regression
+
+## 2. Hardware Scaling Study
+
+Characterize how StrataDB performance scales across hardware tiers — from resource-constrained edge devices to high-core-count servers.
+
+### Goal
+
+Plot performance curves (ops/sec) as a function of:
+- CPU cores (1 to 64+)
+- Available memory (512MB to 256GB+)
+- Storage speed (SD card to NVMe)
+
+This is observational. The goal is to understand the scaling curve, not to change the architecture.
+
+### Hardware tiers
+
+| Tier | Representative hardware | Cores | RAM | Storage |
+|------|------------------------|-------|-----|---------|
+| **Edge** | Raspberry Pi 4 | 4 (ARM Cortex-A72) | 4 GB | microSD |
+| **Laptop** | M-series MacBook / Ryzen laptop | 8-12 | 16-32 GB | NVMe SSD |
+| **Workstation** | Desktop Ryzen 9 / i9 | 16-24 | 64 GB | NVMe SSD |
+| **Server** | Xeon / EPYC rack server | 48-128 | 256+ GB | NVMe array |
+
+### What to measure at each tier
+
+1. **Single-threaded throughput**: Same benchmark suite from Section 1, run on each hardware tier. This reveals how raw single-core performance scales (clock speed, cache hierarchy, memory bandwidth).
+
+2. **Concurrent throughput**: Run N threads issuing operations against the same database, sweep N from 1 to (2 * core count). Measure aggregate ops/sec. This reveals:
+   - Whether the OCC transaction model scales with cores
+   - Where lock contention appears (DashMap shards, WAL writer, etc.)
+   - The concurrency sweet spot per hardware tier
+
+3. **Working set vs. memory**: Load increasing amounts of data (1K, 10K, 100K, 1M, 10M keys) and measure read throughput. This reveals when the working set exceeds cache/memory and performance degrades.
+
+4. **Storage-bound workloads**: For Buffered and Strict modes, measure how storage speed affects write throughput. Compare microSD vs. SATA SSD vs. NVMe.
+
+### Expected outcome
+
+A set of charts:
+- **ops/sec vs. core count** (one line per primitive, one chart per durability mode)
+- **ops/sec vs. concurrent clients** (saturation curves)
+- **ops/sec vs. dataset size** (memory pressure curves)
+- **write latency vs. storage tier** (for Buffered and Strict modes)
+
+These charts inform future optimization priorities: if the bottleneck at scale is OCC contention, that's different work than if it's WAL write throughput or memory allocation pressure.
+
+### Execution approach
+
+- Use the same benchmark binary from Section 1, parameterized by thread count and dataset size
+- Run on actual hardware (not VMs) for tiers where possible
+- For server-tier, cloud instances (e.g., `c7i.16xlarge` or `c7g.16xlarge`) are acceptable proxies
+- Automate with a runner script that sweeps parameters and collects results
+- Results stored as CSV/JSON, visualized with a simple plotting script (Python matplotlib or similar)
+
+## Ordering
+
+1. **Benchmark suite first** — this can run on any single machine and establishes the baseline
+2. **Hardware scaling study second** — requires access to multiple hardware tiers and more setup
+
+## Dependencies
+
+- Black-box test suite should be complete first (validates correctness before measuring performance)
+- No code changes required — this is measurement of the existing v0.1 codebase

--- a/roadmap/sdks-and-mcp.md
+++ b/roadmap/sdks-and-mcp.md
@@ -1,0 +1,176 @@
+# SDKs and MCP Server
+
+**Theme**: Thin client SDKs and an MCP server, all powered by the Command/Output protocol.
+
+## Why the SDKs are boring (by design)
+
+The `strata-executor` crate defines a `Command` enum (53 variants) and an `Output` enum. Every operation in StrataDB — across all six primitives — is a serializable command in, serializable output out. There is no business logic outside this boundary.
+
+This means every SDK is the same pattern:
+
+1. Accept typed method call from the user
+2. Serialize it into a `Command`
+3. Send it to the engine (FFI, network, or stdio)
+4. Deserialize the `Output`
+5. Return typed result to the user
+
+No SDK reimplements validation, transaction coordination, branch resolution, or error handling. That all lives in the executor.
+
+## Python SDK
+
+### Transport: PyO3 FFI
+
+Embed the Rust library directly in a Python native extension via PyO3. No network hop, no serialization overhead beyond the Python↔Rust boundary.
+
+```python
+from stratadb import Strata
+
+db = Strata.open("/path/to/data")
+db.kv_put("user:123", "Alice")
+value = db.kv_get("user:123")
+
+db.create_branch("experiment")
+db.set_branch("experiment")
+
+results = db.search("what tools were used?")
+```
+
+### Scope
+
+- Pythonic API: context managers for transactions, iterators for list/scan operations, type hints throughout
+- 1:1 mapping to the Strata public API — no Python-only features
+- NumPy integration for vector operations (accept/return `np.ndarray` for embeddings)
+- pip-installable with prebuilt wheels (manylinux, macOS, Windows)
+- Async variant via `asyncio` wrappers (if demand warrants it)
+
+### Crate
+
+```
+sdks/python/
+├── Cargo.toml        # PyO3 dependency, links strata-executor
+├── src/
+│   └── lib.rs        # PyO3 module: #[pyclass] Strata, #[pymethods]
+├── python/
+│   └── stratadb/
+│       ├── __init__.py
+│       └── py.typed   # PEP 561 marker
+├── pyproject.toml
+└── tests/
+    └── test_strata.py
+```
+
+## Node.js SDK
+
+### Transport: NAPI-RS FFI
+
+Same approach as Python — embed the Rust library as a native addon via NAPI-RS. No network hop.
+
+```typescript
+import { Strata } from 'stratadb';
+
+const db = await Strata.open('/path/to/data');
+await db.kvPut('user:123', 'Alice');
+const value = await db.kvGet('user:123');
+
+await db.createBranch('experiment');
+await db.setBranch('experiment');
+
+const results = await db.search('what tools were used?');
+```
+
+### Scope
+
+- TypeScript-first: full type definitions, no `any`
+- Async/await API (Node native addons run on the libuv thread pool)
+- camelCase method names (JS convention) mapping to snake_case Rust methods
+- `Buffer` support for binary values
+- npm-installable with prebuilt binaries (via `@napi-rs/cli`)
+
+### Package
+
+```
+sdks/node/
+├── Cargo.toml          # napi-rs dependency, links strata-executor
+├── src/
+│   └── lib.rs          # NAPI module
+├── index.d.ts          # TypeScript definitions
+├── package.json
+└── __tests__/
+    └── strata.test.ts
+```
+
+## MCP Server
+
+### What
+
+A Model Context Protocol server that exposes StrataDB as a tool provider for AI agents (Claude, GPT, etc.). The agent calls tools like `kv_put`, `search`, `create_branch` through the MCP protocol, and the server translates them into `Command` variants.
+
+### Transport: stdio
+
+MCP servers communicate over stdin/stdout with JSON-RPC. The server is a small Rust binary that:
+
+1. Opens a StrataDB instance
+2. Reads JSON-RPC requests from stdin
+3. Maps MCP tool calls to `Command` variants
+4. Executes via the executor
+5. Maps `Output` to JSON-RPC responses on stdout
+
+### Tool definitions
+
+Each public Strata method becomes an MCP tool:
+
+```json
+{
+  "name": "kv_put",
+  "description": "Store a key-value pair in the current branch",
+  "parameters": {
+    "key": { "type": "string" },
+    "value": { "type": "string" }
+  }
+}
+```
+
+The full tool set mirrors the Strata public API. Tools are grouped by primitive for discoverability.
+
+### Scope
+
+- All 6 primitives exposed as tools
+- Branch management tools (create, switch, list, delete)
+- Search tool (natural language, backed by intelligence layer)
+- Transaction tools (begin, commit, rollback)
+- Read-only mode support (via `strata-security` AccessMode)
+
+### Binary
+
+```
+sdks/mcp/
+├── Cargo.toml          # depends on strata-executor, serde_json
+├── src/
+│   ├── main.rs         # stdio loop, JSON-RPC dispatch
+│   ├── tools.rs        # MCP tool definitions
+│   └── convert.rs      # MCP params ↔ Command/Output mapping
+└── tests/
+    └── mcp_tests.rs
+```
+
+## Shared testing strategy
+
+All three SDKs and the MCP server are thin wrappers around the same executor. The test strategy reflects this:
+
+- **Rust-side correctness**: Already covered by the existing 2,500+ test suite
+- **SDK tests**: Verify the binding layer works — types cross the FFI boundary correctly, errors propagate, async behaves properly
+- **Black-box tests**: The same black-box test scenarios can be implemented in Python, TypeScript, and MCP tool calls to verify parity across all interfaces
+
+## Dependencies
+
+- `strata-executor` public API must be stable before SDKs ship (breaking API changes ripple into every SDK)
+- `strata-security` (SDKs should support `AccessMode` from day one)
+- For MCP: no additional dependencies beyond what the executor already provides
+- For Python: PyO3, maturin (build tool)
+- For Node: napi-rs, @napi-rs/cli (build tool)
+
+## Ordering
+
+1. **MCP server first** — smallest surface area, highest immediate value for AI agent use cases, validates the Command/Output serialization path
+2. **Python SDK second** — largest potential user base (AI/ML ecosystem)
+3. **Node SDK third** — web and server-side JS ecosystem

--- a/roadmap/strata-security.md
+++ b/roadmap/strata-security.md
@@ -1,0 +1,268 @@
+# strata-security: Access Control
+
+**Theme**: A dedicated crate for access control, starting simple and growing with the architecture.
+
+## Why a separate crate
+
+Security policy should live in one place. Today the scope is small (read-only vs read-write), but server mode (v0.6) will need per-connection access modes, API key validation, and per-branch permissions. Building `strata-security` as a standalone crate now means:
+
+- The command classification and policy enforcement APIs stabilize early
+- Server mode imports and extends the crate rather than yanking control flow out of the executor
+- Security logic is testable in isolation, without standing up a database
+
+The crate sits between the public API (`strata-executor`) and the engine — it inspects commands and either allows or rejects them before they reach dispatch.
+
+```
+  Strata API (strata-executor)
+        │
+        ▼
+  ┌─────────────┐
+  │  strata-     │  ← policy check: is this command allowed?
+  │  security    │
+  └──────┬──────┘
+         │
+         ▼
+  Executor dispatch → Engine → Storage
+```
+
+## Phase 1: Access Mode (embedded, pre-server)
+
+### AccessMode enum
+
+```rust
+// crates/security/src/lib.rs
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessMode {
+    ReadOnly,
+    ReadWrite,
+}
+```
+
+Set once at open time. Immutable for the lifetime of the handle.
+
+### Command classification
+
+The crate owns the classification of every `Command` variant as read or write.
+
+```rust
+// crates/security/src/classify.rs
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandAccess {
+    Read,
+    Write,
+}
+
+pub fn classify(cmd: &Command) -> CommandAccess { ... }
+```
+
+**Read commands** (allowed in both modes):
+
+| Primitive | Commands |
+|-----------|----------|
+| KV | `KvGet`, `KvList`, `KvGetv` |
+| JSON | `JsonGet`, `JsonGetv`, `JsonList` |
+| Event | `EventRead`, `EventReadByType`, `EventLen` |
+| State | `StateRead`, `StateReadv` |
+| Vector | `VectorGet`, `VectorSearch`, `VectorListCollections` |
+| Branch | `BranchGet`, `BranchList`, `BranchExists` |
+| Transaction | `TxnInfo`, `TxnIsActive` |
+| Retention | `RetentionStats`, `RetentionPreview` |
+| Database | `Ping`, `Info` |
+| Intelligence | `Search` |
+| Bundle | `BranchBundleValidate` |
+
+**Write commands** (rejected in read-only mode):
+
+| Primitive | Commands |
+|-----------|----------|
+| KV | `KvPut`, `KvDelete` |
+| JSON | `JsonSet`, `JsonDelete` |
+| Event | `EventAppend` |
+| State | `StateSet`, `StateCas`, `StateInit` |
+| Vector | `VectorUpsert`, `VectorDelete`, `VectorCreateCollection`, `VectorDeleteCollection` |
+| Branch | `BranchCreate`, `BranchDelete` |
+| Transaction | `TxnBegin`, `TxnCommit`, `TxnRollback` |
+| Retention | `RetentionApply` |
+| Database | `Flush`, `Compact` |
+| Bundle | `BranchExport`, `BranchImport` |
+
+### Policy guard
+
+```rust
+// crates/security/src/guard.rs
+
+pub struct PolicyGuard {
+    mode: AccessMode,
+}
+
+impl PolicyGuard {
+    pub fn new(mode: AccessMode) -> Self { ... }
+
+    /// Returns Ok(()) if the command is allowed, Err if rejected.
+    pub fn check(&self, cmd: &Command) -> Result<(), AccessDenied> {
+        if self.mode == AccessMode::ReadOnly && classify(cmd) == CommandAccess::Write {
+            return Err(AccessDenied {
+                command: cmd.name(),
+                reason: "database opened in read-only mode",
+            });
+        }
+        Ok(())
+    }
+}
+```
+
+### Integration with Strata
+
+The executor's `Strata` struct holds a `PolicyGuard` and calls `check()` before dispatch:
+
+```rust
+// In crates/executor/src/api/mod.rs
+
+pub struct Strata {
+    executor: Executor,
+    current_branch: BranchId,
+    guard: PolicyGuard,  // from strata-security
+}
+
+// All command dispatch goes through this internal method
+fn execute_checked(&self, cmd: Command) -> Result<Output> {
+    self.guard.check(&cmd)?;
+    self.executor.execute(cmd)
+}
+```
+
+### Public API
+
+```rust
+// Read-write (default, same as today)
+let db = Strata::open("/path/to/data")?;
+
+// Explicit read-only
+let db = Strata::open_read_only("/path/to/data")?;
+
+// Via builder
+let db = Strata::builder()
+    .path("/path/to/data")
+    .access_mode(AccessMode::ReadOnly)
+    .open()?;
+```
+
+### Error type
+
+```rust
+// crates/security/src/error.rs
+
+#[derive(Debug, thiserror::Error)]
+#[error("access denied: {command} rejected — {reason}")]
+pub struct AccessDenied {
+    pub command: String,
+    pub reason: &'static str,
+}
+```
+
+The executor's `Error` enum gets a new variant that wraps this:
+
+```rust
+pub enum Error {
+    // ... existing variants ...
+    AccessDenied(strata_security::AccessDenied),
+}
+```
+
+## Phase 2: Server mode extensions (v0.6+)
+
+When the TCP server ships, `strata-security` grows to handle multi-connection concerns. These are sketched here to show the crate's trajectory — not committed to implementation.
+
+### Per-connection access mode
+
+Each network connection gets its own `PolicyGuard`. The server assigns the mode based on authentication:
+
+```rust
+// Future: per-connection policy
+let guard = PolicyGuard::new(connection.access_mode());
+guard.check(&cmd)?;
+```
+
+### API key authentication
+
+```rust
+// crates/security/src/auth.rs (future)
+
+pub struct ApiKey {
+    pub key_id: String,
+    pub access_mode: AccessMode,
+    pub allowed_branches: Option<Vec<String>>,  // None = all branches
+}
+
+pub struct Authenticator {
+    keys: HashMap<String, ApiKey>,
+}
+
+impl Authenticator {
+    pub fn validate(&self, token: &str) -> Result<&ApiKey, AuthError> { ... }
+}
+```
+
+### Per-branch permissions
+
+Extend `PolicyGuard` to also check branch scope:
+
+```rust
+// Future: branch-scoped access
+pub struct PolicyGuard {
+    mode: AccessMode,
+    allowed_branches: Option<HashSet<String>>,  // None = unrestricted
+}
+```
+
+### Audit logging
+
+Optional command-level audit trail:
+
+```rust
+// Future: audit log
+pub trait AuditSink {
+    fn record(&self, event: AuditEvent);
+}
+
+pub struct AuditEvent {
+    pub timestamp: u64,
+    pub command: String,
+    pub branch: Option<String>,
+    pub result: AuditResult,  // Allowed | Denied
+}
+```
+
+## What this is NOT
+
+- **Not RBAC/RCAC**: No roles, row-level, or column-level access control. The permission model is flat: a handle is either read-only or read-write.
+- **Not encryption**: No data-at-rest or data-in-transit encryption.
+- **Not a firewall**: In embedded mode, the caller IS the process. The crate prevents programming errors, not adversaries with process-level access.
+
+## Crate structure
+
+```
+crates/security/
+├── Cargo.toml          # depends on strata-executor (for Command type)
+├── src/
+│   ├── lib.rs          # AccessMode, re-exports
+│   ├── classify.rs     # Command → Read/Write classification
+│   ├── guard.rs        # PolicyGuard
+│   └── error.rs        # AccessDenied
+└── tests/
+    ├── classify_tests.rs   # every command variant is classified
+    └── guard_tests.rs      # read-only mode rejects writes, allows reads
+```
+
+## Dependencies
+
+- `strata-executor` (for `Command` type) — or `strata-core` if `Command` moves to core
+- `thiserror` (for error derive)
+- No other dependencies. The crate is deliberately lightweight.
+
+## Ordering
+
+- Phase 1 can ship independently of any milestone
+- Phase 2 ships with or after v0.6 (server mode)

--- a/roadmap/websites.md
+++ b/roadmap/websites.md
@@ -1,0 +1,133 @@
+# Websites: stratadb.org and stratadb.ai
+
+**Theme**: Two domains, two audiences, one database.
+
+## stratadb.org — The Engine
+
+The authoritative home for StrataDB as an open-source embedded database.
+
+### Purpose
+
+Convince a senior engineer in 30 seconds that StrataDB is worth evaluating. Then give them everything they need to go from `cargo add` to production.
+
+### Content
+
+- **Landing page**: What it is, the six primitives table, the durability modes table, a code sample, install instructions
+- **Documentation**: The `docs/` folder rendered as a proper doc site (getting started, concepts, guides, cookbook, API reference, architecture)
+- **Benchmarks**: Published results from the performance characterization — throughput tables, latency percentiles, comparison charts against redb/LMDB/SQLite
+- **Roadmap**: The `roadmap/` folder rendered as a timeline/status page
+- **Blog**: Release notes, design decisions, benchmark deep-dives
+- **GitHub link**: Prominent, not buried
+
+### Tech
+
+- Static site generator (mdBook, Docusaurus, or similar)
+- Content sourced directly from the repo's `docs/` and `roadmap/` markdown
+- Deployed on a CDN (Cloudflare Pages, Netlify, or similar)
+- No backend, no database (ironic but correct — static is the right choice for docs)
+
+## stratadb.ai — The Intelligence Layer
+
+A live, interactive demo of what makes StrataDB different from every other embedded database.
+
+### The headline
+
+> This page is running a live instance of StrataDB.
+
+The database runs in the browser via WebAssembly. Not a mock, not a simulation, not a proxy to a server. The actual Rust engine compiled to WASM, executing in the user's browser tab.
+
+### What the user experiences
+
+1. **Live REPL**: Type Strata commands and see results immediately. Pre-loaded with a sample dataset (agent conversation logs, tool call history, embeddings).
+
+2. **Auto-embedding demo**: Insert a piece of text, watch the MiniLM embedding get generated and the shadow vector collection update in real time. Show the embedding dimensions, the similarity scores against existing data.
+
+3. **Natural language search**: Type a question in plain English. Show the query decomposition (what Qwen3 does), the multi-primitive search fan-out, the result re-ranking, and the final synthesized answer. Make the pipeline visible, not just the result.
+
+4. **Branch isolation demo**: Create a branch, mutate data, switch back, show isolation. Visual diff between branches.
+
+5. **Performance counter**: A live ops/sec counter running in the corner while the user interacts. "Your browser just executed 50,000 KV operations per second."
+
+### WASM build
+
+The Rust codebase compiles to `wasm32-unknown-unknown` with some constraints:
+
+- **InMemory mode only** (no filesystem access in the browser)
+- **No std::fs, no WAL, no snapshots** — feature-gated out for the WASM target
+- **Intelligence layer**: MiniLM can run in WASM (ONNX Runtime has a WASM backend, or use candle's WASM support). Qwen3 in-browser is harder — may need to proxy to a lightweight backend or use a smaller model for the demo.
+- **Target size**: The WASM binary should be under 5MB (before gzip). The engine without intelligence features is likely well under this. With MiniLM, the model weights add ~80MB — loaded lazily after page load.
+
+```toml
+# Cargo.toml for WASM build
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+stratadb = { path = "../..", default-features = false, features = ["wasm"] }
+wasm-bindgen = "0.2"
+```
+
+### Architecture
+
+```
+Browser tab
+├── stratadb.wasm          (~2-5MB, the database engine)
+├── minilm.onnx            (~80MB, loaded lazily for embedding demo)
+├── UI (React/Svelte/vanilla)
+│   ├── REPL component
+│   ├── Embedding visualizer
+│   ├── Search pipeline visualizer
+│   ├── Branch diff viewer
+│   └── Performance counter
+└── JS glue (wasm-bindgen)
+    └── Maps JS calls → Strata Command/Output
+```
+
+### Qwen3 in the demo
+
+Running 1.3B parameters in a browser tab is possible but heavy. Options:
+
+| Approach | Tradeoff |
+|----------|----------|
+| **Full in-browser** (WebGPU + llama.cpp WASM) | Impressive demo, requires WebGPU-capable browser, slow on older hardware |
+| **Thin backend proxy** | Fast, reliable, but "running in your browser" claim is partially false |
+| **Smaller model substitute** (Qwen3-0.6B or similar) | Honest in-browser, reduced quality |
+
+The right choice depends on what's available when we build it. WebGPU adoption is accelerating.
+
+### What stratadb.ai is NOT
+
+- Not a hosted StrataDB service (the database runs client-side)
+- Not a playground with a server backend pretending to be local
+- Not a marketing site with screenshots (every demo is live)
+
+## Shared concerns
+
+### Domain separation
+
+| | stratadb.org | stratadb.ai |
+|--|-------------|-------------|
+| **Audience** | Engineers evaluating a database | Anyone curious about AI-native databases |
+| **Tone** | Technical, precise, referential | Interactive, visual, exploratory |
+| **Content** | Docs, benchmarks, architecture | Live demos, visualizations |
+| **Backend** | None (static) | None (WASM) or minimal (Qwen3 proxy) |
+| **Update cadence** | Every release | When demos change |
+
+### Cross-linking
+
+- stratadb.org links to stratadb.ai for "try it live"
+- stratadb.ai links to stratadb.org for "read the docs"
+- Both link to GitHub
+
+## Dependencies
+
+- WASM build target requires feature-gating filesystem-dependent code (WAL, snapshots, durability)
+- Intelligence inference runtime must support WASM (at least for MiniLM)
+- The core engine and public API should be stable before building SDK/WASM wrappers around them
+- Performance characterization must complete before publishing benchmark pages on stratadb.org
+
+## Ordering
+
+1. **stratadb.org first** — static doc site, can ship as soon as docs are stable
+2. **WASM build target** — get the engine compiling to WASM with InMemory mode
+3. **stratadb.ai** — build the interactive demos on top of the WASM build


### PR DESCRIPTION
## Summary

- **Performance characterization**: Benchmark suite (20 operations x 3 durability modes, Redis-class target for InMemory) and hardware scaling study (RPi to Xeon)
- **strata-security**: Dedicated access control crate — read-only/read-write for embedded mode now, per-connection auth and per-branch permissions for server mode later
- **Engine & storage optimization**: Placeholder for data-driven rewrites after benchmarks reveal bottlenecks
- **Intelligence: Indexing**: Search latency reduction through indexing (structure TBD, tracking SOTA)
- **Intelligence: Internal graph**: Internal graph primitive for relationship-aware cross-primitive queries
- **Intelligence: Embedded inference**: Nano inference runtime with MiniLM (auto-embedding) and Qwen3 (natural language search)
- **SDKs and MCP server**: Python (PyO3), Node (NAPI-RS), MCP server — thin wrappers over Command/Output
- **Websites**: stratadb.org (docs/benchmarks) and stratadb.ai (live WASM demos running StrataDB in the browser)
- Updated roadmap README with cross-cutting initiatives table and sequencing diagram

## Test plan

- [ ] All markdown links resolve correctly
- [ ] Roadmap README renders properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)