### PR TITLE
Fix six bugs (#821, #822, #823, #824, #825, #831)

### DIFF
--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -39,7 +39,7 @@ const BRANCH_NAMESPACE: Uuid = Uuid::from_bytes([
 /// - "default" → nil UUID (all zeros)
 /// - Valid UUID string → parsed directly
 /// - Any other string → deterministic UUID v5 from name
-fn resolve_branch_name(name: &str) -> BranchId {
+pub fn resolve_branch_name(name: &str) -> BranchId {
     if name == "default" {
         BranchId::from_bytes([0u8; 16])
     } else if let Ok(u) = Uuid::parse_str(name) {

--- a/crates/engine/src/primitives/branch/mod.rs
+++ b/crates/engine/src/primitives/branch/mod.rs
@@ -7,5 +7,5 @@
 mod index;
 mod handle;
 
-pub use index::{BranchIndex, BranchMetadata, BranchStatus};
+pub use index::{BranchIndex, BranchMetadata, BranchStatus, resolve_branch_name};
 pub use handle::{BranchHandle, EventHandle, JsonHandle, KvHandle, StateHandle, VectorHandle};

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -416,9 +416,11 @@ mod tests {
         kv.put(&branch_id, "bool", Value::Bool(true)).unwrap();
         assert_eq!(kv.get(&branch_id, "bool").unwrap(), Some(Value::Bool(true)));
 
-        // Null - Note: Value::Null is a tombstone, so storing it is equivalent to delete
+        // Null - Value::Null should be storable and round-trip correctly
         kv.put(&branch_id, "null", Value::Null).unwrap();
-        assert_eq!(kv.get(&branch_id, "null").unwrap(), None);
+        let result = kv.get(&branch_id, "null").unwrap();
+        assert!(result.is_some(), "Value::Null should be storable");
+        assert_eq!(result.unwrap(), Value::Null);
 
         // Bytes
         kv.put(&branch_id, "bytes", Value::Bytes(vec![1, 2, 3]))

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -66,11 +66,13 @@ impl Executor {
                 version: env!("CARGO_PKG_VERSION").to_string(),
             }),
             Command::Info => {
-                // TODO: Implement properly
+                let branch_count = self.primitives.branch.list_branches()
+                    .map(|ids| ids.len() as u64)
+                    .unwrap_or(0);
                 Ok(Output::DatabaseInfo(crate::types::DatabaseInfo {
                     version: env!("CARGO_PKG_VERSION").to_string(),
                     uptime_secs: 0,
-                    branch_count: 0,
+                    branch_count,
                     total_keys: 0,
                 }))
             }


### PR DESCRIPTION
## Summary

- **#821 — JSON path `$.field` syntax**: Strip `$` prefix in `parse_path()` before delegating to core parser, so `$.name` and `$[0]` work correctly
- **#822 — Vector data doesn't persist across reopen**: Register vector recovery participant via `Once`-guarded `ensure_vector_recovery()` in all `Strata` constructors
- **#823 — `state_init` not idempotent**: Return existing version silently instead of erroring when cell already exists
- **#824 — `DatabaseInfo.branch_count` hardcoded to 0**: Call `list_branches()` and use actual count
- **#825 — `Value::Null` acts as silent tombstone**: Add `is_tombstone: bool` flag to `StoredValue`; use flag (not value type) to identify deletions across all 12 check sites in sharded storage
- **#831 — Bundle export scans wrong namespace**: Replace `BranchId::from_string()` with `resolve_branch_name()` at all 4 call sites in `bundle.rs`

## Test plan

- [x] All existing tests pass (`cargo test --workspace` — 0 failures)
- [x] Updated `test_init_already_exists` → `test_init_is_idempotent` (engine unit test)
- [x] Updated `init_fails_if_exists` → `init_is_idempotent` (integration test)
- [x] Updated `null_value_treated_as_deletion` → `null_value_is_storable` (adversarial test)
- [x] Updated KV `Value::Null` round-trip test to assert `Some(Null)` instead of `None`

Closes #821, #822, #823, #824, #825, #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)