### PR TITLE
Fix state_cas(None) after idempotent init change

### DIFF
--- a/crates/executor/src/handlers/state.rs
+++ b/crates/executor/src/handlers/state.rs
@@ -76,6 +76,10 @@ pub fn state_cas(
     match expected_counter {
         None => {
             // Init semantics: create only if cell doesn't exist.
+            // Check existence first since init() is idempotent.
+            if convert_result(p.state.read(&branch_id, &cell))?.is_some() {
+                return Ok(Output::MaybeVersion(None));
+            }
             match p.state.init(&branch_id, &cell, value) {
                 Ok(versioned) => Ok(Output::MaybeVersion(Some(bridge::extract_version(&versioned.version)))),
                 Err(_) => Ok(Output::MaybeVersion(None)),


### PR DESCRIPTION
## Summary

- Fix regression from #823 (idempotent `state_init`): `state_cas` with `expected_counter=None` now correctly rejects existing cells
- The CAS handler delegates to `init()` for "create only if not exists" semantics. Since `init()` is now idempotent, an explicit existence check is needed before calling it.

## Test plan

- [x] All strata-core workspace tests pass
- [x] `cas_based_lock` pattern works correctly (second acquire fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)