### PR TITLE
Fix 16 critical and high severity bugs from architectural audit

### DIFF
--- a/crates/durability/src/recovery/replayer.rs
+++ b/crates/durability/src/recovery/replayer.rs
@@ -93,7 +93,7 @@ impl WalReplayer {
         stats.segments_read = segments.len();
 
         for segment_number in segments {
-            let (records, _valid_end) = self
+            let (records, _valid_end, _stop_reason) = self
                 .reader
                 .read_segment(&self.wal_dir, segment_number)
                 .map_err(WalReplayError::from)?;

--- a/crates/durability/src/wal/mod.rs
+++ b/crates/durability/src/wal/mod.rs
@@ -15,5 +15,5 @@ pub use mode::DurabilityMode;
 
 // Segmented WAL types (primary API)
 pub use config::{WalConfig, WalConfigError};
-pub use reader::{TruncateInfo, WalReader, WalReaderError};
+pub use reader::{ReadStopReason, TruncateInfo, WalReader, WalReaderError};
 pub use writer::WalWriter;

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -164,11 +164,10 @@ impl BranchMetadata {
 // ========== Serialization Helpers ==========
 
 /// Serialize a struct to Value::String for storage
-fn to_stored_value<T: Serialize>(v: &T) -> Value {
-    match serde_json::to_string(v) {
-        Ok(s) => Value::String(s),
-        Err(_) => Value::Null,
-    }
+fn to_stored_value<T: Serialize>(v: &T) -> StrataResult<Value> {
+    serde_json::to_string(v)
+        .map(Value::String)
+        .map_err(|e| StrataError::serialization(e.to_string()))
 }
 
 /// Deserialize from Value::String storage
@@ -250,7 +249,7 @@ impl BranchIndex {
             }
 
             let branch_meta = BranchMetadata::new(branch_id);
-            txn.put(key, to_stored_value(&branch_meta))?;
+            txn.put(key, to_stored_value(&branch_meta)?)?;
 
             Ok(branch_meta.into_versioned())
         })

--- a/tests/concurrency/cas_operations.rs
+++ b/tests/concurrency/cas_operations.rs
@@ -41,7 +41,7 @@ fn cas_succeeds_when_version_matches() {
         new_value: Value::Int(200),
     }];
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(result.is_valid(), "CAS should succeed when version matches");
 }
 
@@ -60,7 +60,7 @@ fn cas_create_succeeds_when_key_absent() {
         new_value: Value::Int(42),
     }];
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(result.is_valid(), "CAS create should succeed when key absent");
 }
 
@@ -88,7 +88,7 @@ fn cas_fails_when_version_stale() {
         new_value: Value::Int(3),
     }];
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(!result.is_valid(), "CAS should fail when version is stale");
 
     match &result.conflicts[0] {
@@ -120,7 +120,7 @@ fn cas_create_fails_when_key_exists() {
         new_value: Value::Int(200),
     }];
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(!result.is_valid(), "CAS create should fail when key exists");
 }
 
@@ -142,7 +142,7 @@ fn cas_fails_when_key_deleted() {
         new_value: Value::Int(200),
     }];
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(!result.is_valid(), "CAS should fail when key was deleted");
 }
 
@@ -195,7 +195,7 @@ fn cas_validated_separately_from_reads() {
     Storage::put(&*store, read_key.clone(), Value::Int(10), None).unwrap();
 
     // Validation should fail on read_key (ReadWriteConflict), not on CAS
-    let result = validate_transaction(&txn, &*store);
+    let result = validate_transaction(&txn, &*store).unwrap();
     assert!(!result.is_valid());
 
     // Should have ReadWriteConflict, not CASConflict
@@ -233,7 +233,7 @@ fn multiple_cas_all_succeed() {
         })
         .collect();
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(result.is_valid(), "All CAS should succeed");
 }
 
@@ -276,7 +276,7 @@ fn multiple_cas_one_fails() {
         },
     ];
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(!result.is_valid(), "Should fail due to key2");
     assert_eq!(result.conflict_count(), 1, "Only key2 should conflict");
 }
@@ -305,7 +305,7 @@ fn cas_in_full_transaction() {
 
     // Validate
     let result = validate_transaction(&txn, &*store);
-    assert!(result.is_valid());
+    assert!(result.unwrap().is_valid());
 }
 
 #[test]
@@ -329,7 +329,7 @@ fn cas_with_read_of_same_key() {
 
     // Both should pass (version matches)
     let result = validate_transaction(&txn, &*store);
-    assert!(result.is_valid());
+    assert!(result.unwrap().is_valid());
 }
 
 // ============================================================================
@@ -341,7 +341,7 @@ fn cas_empty_set_validates() {
     let store = Arc::new(ShardedStore::new());
     let cas_set: Vec<CASOperation> = Vec::new();
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(result.is_valid());
 }
 
@@ -376,7 +376,7 @@ fn cas_conflict_reports_correct_key() {
         new_value: Value::Int(100),
     }];
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
 
     match &result.conflicts[0] {
         ConflictType::CASConflict { key: k, .. } => {

--- a/tests/concurrency/concurrent_transactions.rs
+++ b/tests/concurrency/concurrent_transactions.rs
@@ -61,7 +61,7 @@ fn parallel_commits_different_runs_no_contention() {
 
                     // Validate
                     let result = validate_transaction(&txn, &*store);
-                    if result.is_valid() {
+                    if result.unwrap().is_valid() {
                         Storage::put(&*store, key.clone(), Value::Int(i), None).unwrap();
                         commits.fetch_add(1, Ordering::Relaxed);
                     }
@@ -144,7 +144,7 @@ fn high_contention_single_key() {
 
                         // Validate
                         let result = validate_transaction(&txn, &*store);
-                        if result.is_valid() {
+                        if result.unwrap().is_valid() {
                             Storage::put(
                                 &*store,
                                 key.clone(),
@@ -206,8 +206,8 @@ fn interleaved_disjoint_operations_both_commit() {
     let result1 = validate_transaction(&t1, &*store);
     let result2 = validate_transaction(&t2, &*store);
 
-    assert!(result1.is_valid(), "T1 should commit (reads A, writes B)");
-    assert!(result2.is_valid(), "T2 should commit (reads B, writes A)");
+    assert!(result1.unwrap().is_valid(), "T1 should commit (reads A, writes B)");
+    assert!(result2.unwrap().is_valid(), "T2 should commit (reads B, writes A)");
 }
 
 // ============================================================================
@@ -338,7 +338,7 @@ fn concurrent_empty_transactions() {
                 // Empty transaction (read-only)
                 let txn = TransactionContext::new(i as u64, branch_id, 1);
                 let result = validate_transaction(&txn, &*store);
-                result.is_valid()
+                result.unwrap().is_valid()
             })
         })
         .collect();

--- a/tests/concurrency/conflict_detection.rs
+++ b/tests/concurrency/conflict_detection.rs
@@ -45,7 +45,7 @@ fn read_write_conflict_version_increased() {
     Storage::put(&*store, key.clone(), Value::Int(2), None).unwrap();
 
     // Validate
-    let result = validate_read_set(&read_set, &*store);
+    let result = validate_read_set(&read_set, &*store).unwrap();
     assert!(!result.is_valid());
     assert!(matches!(
         &result.conflicts[0],
@@ -71,7 +71,7 @@ fn read_write_conflict_key_deleted() {
     Storage::delete(&*store, &key).unwrap();
 
     // Validate - should conflict (version changed to 0)
-    let result = validate_read_set(&read_set, &*store);
+    let result = validate_read_set(&read_set, &*store).unwrap();
     assert!(!result.is_valid());
 }
 
@@ -89,7 +89,7 @@ fn read_write_conflict_key_created() {
     Storage::put(&*store, key.clone(), Value::Int(1), None).unwrap();
 
     // Validate - should conflict (version changed from 0)
-    let result = validate_read_set(&read_set, &*store);
+    let result = validate_read_set(&read_set, &*store).unwrap();
     assert!(!result.is_valid());
 }
 
@@ -110,7 +110,7 @@ fn no_read_write_conflict_version_same() {
     // No changes
 
     // Validate - should pass
-    let result = validate_read_set(&read_set, &*store);
+    let result = validate_read_set(&read_set, &*store).unwrap();
     assert!(result.is_valid());
 }
 
@@ -138,7 +138,7 @@ fn cas_conflict_version_mismatch() {
         new_value: Value::Int(300),
     }];
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(!result.is_valid());
     match &result.conflicts[0] {
         ConflictType::CASConflict {
@@ -169,7 +169,7 @@ fn cas_create_conflict_key_exists() {
         new_value: Value::Int(200),
     }];
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(!result.is_valid());
     match &result.conflicts[0] {
         ConflictType::CASConflict {
@@ -198,7 +198,7 @@ fn cas_success_version_matches() {
         new_value: Value::Int(200),
     }];
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(result.is_valid());
 }
 
@@ -217,7 +217,7 @@ fn cas_create_success_key_not_exists() {
         new_value: Value::Int(100),
     }];
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(result.is_valid());
 }
 
@@ -250,7 +250,7 @@ fn multiple_cas_operations() {
         },
     ];
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(!result.is_valid());
     assert_eq!(result.conflict_count(), 1); // Only key2 conflicts
 }
@@ -285,7 +285,7 @@ fn transaction_validation_combines_all_checks() {
     Storage::put(&*store, key2.clone(), Value::Int(20), None).unwrap();
 
     // Validate - should have both conflicts
-    let result = validate_transaction(&txn, &*store);
+    let result = validate_transaction(&txn, &*store).unwrap();
     assert!(!result.is_valid());
     // Read-write conflict on key1, CAS conflict on key2
     assert!(result.conflict_count() >= 1);
@@ -300,7 +300,7 @@ fn empty_read_set_validates() {
     let store = Arc::new(ShardedStore::new());
     let read_set = HashMap::new();
 
-    let result = validate_read_set(&read_set, &*store);
+    let result = validate_read_set(&read_set, &*store).unwrap();
     assert!(result.is_valid());
 }
 
@@ -309,7 +309,7 @@ fn empty_cas_set_validates() {
     let store = Arc::new(ShardedStore::new());
     let cas_set: Vec<CASOperation> = Vec::new();
 
-    let result = validate_cas_set(&cas_set, &*store);
+    let result = validate_cas_set(&cas_set, &*store).unwrap();
     assert!(result.is_valid());
 }
 
@@ -344,7 +344,7 @@ fn large_read_set_validation() {
     }
 
     // All versions match - should validate
-    let result = validate_read_set(&read_set, &*store);
+    let result = validate_read_set(&read_set, &*store).unwrap();
     assert!(result.is_valid());
 }
 
@@ -367,7 +367,7 @@ fn large_read_set_with_one_conflict() {
     Storage::put(&*store, modified_key, Value::Int(500), None).unwrap();
 
     // Should have exactly one conflict
-    let result = validate_read_set(&read_set, &*store);
+    let result = validate_read_set(&read_set, &*store).unwrap();
     assert!(!result.is_valid());
     assert_eq!(result.conflict_count(), 1);
 }

--- a/tests/concurrency/stress.rs
+++ b/tests/concurrency/stress.rs
@@ -66,7 +66,7 @@ fn stress_concurrent_read_write() {
                             .insert(key.clone(), Value::Int((thread_id * 1000 + iter) as i64));
 
                         let result = validate_transaction(&txn, &*store);
-                        if result.is_valid() {
+                        if result.unwrap().is_valid() {
                             Storage::put(
                                 &*store,
                                 key.clone(),
@@ -130,7 +130,7 @@ fn stress_transaction_throughput() {
         }
 
         let result = validate_transaction(&txn, &*store);
-        if result.is_valid() {
+        if result.unwrap().is_valid() {
             if let Value::Int(v) = current.value {
                 Storage::put(&*store, key.clone(), Value::Int(v + 1), None).unwrap();
             }
@@ -184,7 +184,7 @@ fn stress_large_transaction() {
         txn.pending_operations().puts
     );
 
-    assert!(result.is_valid());
+    assert!(result.unwrap().is_valid());
     assert_eq!(txn.pending_operations().puts, 10_000);
 }
 
@@ -216,7 +216,7 @@ fn stress_many_branches() {
                     txn.write_set.insert(key.clone(), Value::Int(i));
 
                     let result = validate_transaction(&txn, &*store);
-                    if result.is_valid() {
+                    if result.unwrap().is_valid() {
                         Storage::put(&*store, key.clone(), Value::Int(i), None).unwrap();
                         commits.fetch_add(1, Ordering::Relaxed);
                     }
@@ -272,7 +272,7 @@ fn stress_long_running_transaction() {
     writer.join().unwrap();
 
     // Should conflict due to concurrent modifications
-    assert!(!result.is_valid(), "Long-running transaction should conflict");
+    assert!(!result.unwrap().is_valid(), "Long-running transaction should conflict");
 }
 
 /// Sustained mixed workload
@@ -321,7 +321,7 @@ fn stress_sustained_workload() {
                         txn.write_set.insert(key.clone(), Value::Int(thread_id as i64));
 
                         let result = validate_transaction(&txn, &*store);
-                        if result.is_valid() {
+                        if result.unwrap().is_valid() {
                             Storage::put(&*store, key, Value::Int(thread_id as i64), None).unwrap();
                         }
                     } else {

--- a/tests/concurrency/transaction_lifecycle.rs
+++ b/tests/concurrency/transaction_lifecycle.rs
@@ -39,7 +39,7 @@ fn begin_commit_makes_writes_permanent() {
     // Validate
     txn.mark_validating().unwrap();
     let result = validate_transaction(&txn, &*store);
-    assert!(result.is_valid());
+    assert!(result.unwrap().is_valid());
 
     // Commit
     txn.mark_committed().unwrap();
@@ -129,7 +129,7 @@ fn validation_failure_leads_to_abort() {
 
     // Validate - should fail
     txn.mark_validating().unwrap();
-    let result = validate_transaction(&txn, &*store);
+    let result = validate_transaction(&txn, &*store).unwrap();
     assert!(!result.is_valid());
 
     // Abort
@@ -257,7 +257,7 @@ fn read_modify_write_workflow() {
     // Validate and commit
     txn.mark_validating().unwrap();
     let result = validate_transaction(&txn, &*store);
-    assert!(result.is_valid());
+    assert!(result.unwrap().is_valid());
 
     txn.mark_committed().unwrap();
 
@@ -296,7 +296,7 @@ fn multi_key_transaction_workflow() {
     // Validate
     txn.mark_validating().unwrap();
     let result = validate_transaction(&txn, &*store);
-    assert!(result.is_valid());
+    assert!(result.unwrap().is_valid());
 
     txn.mark_committed().unwrap();
 
@@ -327,7 +327,7 @@ fn delete_workflow() {
     // Validate
     txn.mark_validating().unwrap();
     let result = validate_transaction(&txn, &*store);
-    assert!(result.is_valid());
+    assert!(result.unwrap().is_valid());
 
     txn.mark_committed().unwrap();
 
@@ -351,7 +351,7 @@ fn empty_transaction_commits() {
 
     txn.mark_validating().unwrap();
     let result = validate_transaction(&txn, &*store);
-    assert!(result.is_valid());
+    assert!(result.unwrap().is_valid());
 
     txn.mark_committed().unwrap();
     assert!(txn.is_committed());
@@ -374,7 +374,7 @@ fn many_sequential_transactions() {
 
         txn.mark_validating().unwrap();
         let result = validate_transaction(&txn, &*store);
-        assert!(result.is_valid(), "Transaction {} should validate", i);
+        assert!(result.unwrap().is_valid(), "Transaction {} should validate", i);
 
         txn.mark_committed().unwrap();
         Storage::put(&*store, key.clone(), Value::Int(i), None).unwrap();


### PR DESCRIPTION
## Summary

Fixes all 3 **CRITICAL** and 13 **HIGH** severity bugs identified during the architectural audit (issues #838-#914).

### Critical Fixes
- **#838/#845**: `to_stored_value` silently returned null on serialization failure — now returns `StrataResult`
- **#874/#882**: DashMap shard lock contention in list operations — two-phase approach (collect keys under lock, read values individually)
- **#847**: `list_branch`/`list_by_prefix`/`list_by_type`/`count_by_type`/`contains` did not filter tombstones in non-snapshot paths

### High Fixes
- **#839**: 5 commands (`KvGetv`, `StateReadv`, `JsonGetv`, `JsonList`, `EventReadByType`) fell through catch-all instead of being explicitly non-transactional
- **#843**: Transaction event hash used divergent algorithm (big-endian, no length prefix) vs EventLog canonical hash — now uses shared `compute_event_hash`
- **#844**: Transaction reads (`KvGet`, `KvList`, `StateRead`, `JsonGet`) returned `None` for pre-existing data — now fall through to snapshot via `ctx.get()`
- **#846**: Bundle export collapsed all entries to version 1 — now preserves version history using storage layer's `get_history`
- **#878**: `validate_transaction` silently treated storage errors as version 0 — now returns `StrataResult` and propagates errors
- **#883**: `apply_batch` acquired/released shard lock per operation — now groups by branch_id for per-branch atomicity
- **#887**: Batched fsync only checked on write, could exceed `interval_ms` — added `sync_if_overdue()` and `Drop` impl
- **#893**: WAL reader returned no diagnostic info on parse failure — added `ReadStopReason` enum with `ChecksumMismatch` and `ParseError`
- **#895**: Codec decode errors had no context — `DecodeError` now carries `codec_id` and `data_len`

## Test plan
- [x] `cargo build` compiles with zero warnings
- [x] `cargo test` passes all 578 tests (0 failures)
- [ ] Review each fix for correctness
- [ ] Run integration tests in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)