### PR TITLE
Rename durability modes: None→Cache, Batched→Standard, Strict→Always (#975)

### DIFF
--- a/audit-tests/tests/issue_838.rs
+++ b/audit-tests/tests/issue_838.rs
@@ -20,7 +20,7 @@ use strata_engine::primitives::state::StateCell;
 /// or silently replaced with Null.
 #[test]
 fn issue_838_state_to_stored_value_nan_causes_silent_null() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let sc = StateCell::new(db.clone());
     let branch_id = BranchId::new();
 
@@ -77,7 +77,7 @@ fn issue_838_state_to_stored_value_nan_causes_silent_null() {
 /// stored as Null, corrupting the hash chain.
 #[test]
 fn issue_838_event_to_stored_value_corruption() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let log = EventLog::new(db.clone());
     let branch_id = BranchId::new();
 

--- a/audit-tests/tests/issue_843.rs
+++ b/audit-tests/tests/issue_843.rs
@@ -21,7 +21,7 @@ fn payload(key: &str, value: Value) -> Value {
 /// This serves as the baseline -- the EventLog's own hash computation is self-consistent.
 #[test]
 fn issue_843_eventlog_hash_chain_baseline() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let log = EventLog::new(db.clone());
     let branch_id = BranchId::new();
 

--- a/audit-tests/tests/issue_845.rs
+++ b/audit-tests/tests/issue_845.rs
@@ -19,7 +19,7 @@ fn payload(key: &str, value: Value) -> Value {
 /// This baseline test confirms the happy path works.
 #[test]
 fn issue_845_baseline_event_metadata_correct() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let log = EventLog::new(db.clone());
     let branch_id = BranchId::new();
 
@@ -66,7 +66,7 @@ fn issue_845_baseline_event_metadata_correct() {
 ///   - Race conditions during concurrent writes
 #[test]
 fn issue_845_metadata_corruption_leads_to_sequence_reset() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let log = EventLog::new(db.clone());
     let branch_id = BranchId::new();
 

--- a/audit-tests/tests/issue_850.rs
+++ b/audit-tests/tests/issue_850.rs
@@ -9,7 +9,7 @@ use strata_engine::Database;
 use strata_executor::{Command, Executor, Value};
 
 fn setup() -> Executor {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     Executor::new(db)
 }
 

--- a/audit-tests/tests/issue_851.rs
+++ b/audit-tests/tests/issue_851.rs
@@ -9,7 +9,7 @@ use strata_engine::Database;
 use strata_executor::{Command, Executor, Output, Value};
 
 fn setup() -> Executor {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     Executor::new(db)
 }
 

--- a/audit-tests/tests/issue_852.rs
+++ b/audit-tests/tests/issue_852.rs
@@ -12,7 +12,7 @@ use strata_engine::Database;
 use strata_executor::{Command, DistanceMetric, Executor, FilterOp, MetadataFilter, Output, Value};
 
 fn setup() -> Executor {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     Executor::new(db)
 }
 

--- a/audit-tests/tests/issue_853.rs
+++ b/audit-tests/tests/issue_853.rs
@@ -8,7 +8,7 @@ use strata_engine::Database;
 use strata_executor::{BranchId, Command, Output, Session};
 
 fn setup() -> Session {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     Session::new(db)
 }
 

--- a/audit-tests/tests/issue_856.rs
+++ b/audit-tests/tests/issue_856.rs
@@ -9,7 +9,7 @@ use strata_engine::Database;
 
 #[test]
 fn issue_856_closure_api_blocked_after_shutdown() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
 
     // Shutdown the database
     db.shutdown().unwrap();
@@ -25,7 +25,7 @@ fn issue_856_closure_api_blocked_after_shutdown() {
 
 #[test]
 fn issue_856_begin_transaction_allowed_after_shutdown() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
 
     // Verify database is open
     assert!(db.is_open(), "Database should be open initially");

--- a/audit-tests/tests/issue_864.rs
+++ b/audit-tests/tests/issue_864.rs
@@ -42,17 +42,17 @@ fn issue_864_all_databases_share_same_uuid_in_wal() {
 }
 
 #[test]
-fn issue_864_ephemeral_databases_also_have_no_unique_id() {
-    // Even if ephemeral databases don't write WAL, the Database struct
+fn issue_864_cache_databases_also_have_no_unique_id() {
+    // Even if cache databases don't write WAL, the Database struct
     // has no database_id field at all -- there's no unique identifier.
-    let db1 = Database::ephemeral().unwrap();
-    let db2 = Database::ephemeral().unwrap();
+    let db1 = Database::cache().unwrap();
+    let db2 = Database::cache().unwrap();
 
     // Both are different instances (not registered in registry)
     assert!(!std::sync::Arc::ptr_eq(&db1, &db2));
 
     // BUG: Neither database has a unique identifier.
-    // For ephemeral databases this is less critical since there's no WAL,
+    // For cache databases this is less critical since there's no WAL,
     // but for disk-backed databases the hardcoded UUID is a real concern
     // for cross-contamination detection.
 }

--- a/audit-tests/tests/issue_917.rs
+++ b/audit-tests/tests/issue_917.rs
@@ -15,7 +15,7 @@ use strata_executor::{Command, Output, Session};
 /// deserialized Value::Object (not raw bytes or internal struct fields).
 #[test]
 fn issue_917_json_get_root_path_in_transaction() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let mut session = Session::new(db);
 
     let branch = strata_executor::BranchId::from("default");
@@ -94,7 +94,7 @@ fn issue_917_json_get_root_path_in_transaction() {
 /// Confirm that JSON root path works correctly OUTSIDE a transaction too.
 #[test]
 fn issue_917_json_get_root_path_outside_transaction_works() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let mut session = Session::new(db);
 
     let branch = strata_executor::BranchId::from("default");

--- a/audit-tests/tests/issue_918.rs
+++ b/audit-tests/tests/issue_918.rs
@@ -20,7 +20,7 @@ use strata_executor::{Command, Output};
 /// despite using different internal serialization formats.
 #[test]
 fn issue_918_all_primitives_store_and_retrieve_successfully() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = strata_executor::Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");

--- a/audit-tests/tests/issue_919.rs
+++ b/audit-tests/tests/issue_919.rs
@@ -17,7 +17,7 @@ use strata_executor::{Command, Output};
 /// After initializing a state cell, the only option is to overwrite its value.
 #[test]
 fn issue_919_no_state_delete_command() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = strata_executor::Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");
@@ -93,7 +93,7 @@ fn issue_919_no_state_delete_command() {
 /// You cannot enumerate state cells for a branch.
 #[test]
 fn issue_919_no_state_list_command() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = strata_executor::Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");

--- a/audit-tests/tests/issue_921.rs
+++ b/audit-tests/tests/issue_921.rs
@@ -19,7 +19,7 @@ use strata_executor::{Command, Output};
 /// Demonstrate that JsonList supports cursor-based pagination.
 #[test]
 fn issue_921_json_list_has_cursor_pagination() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = strata_executor::Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");
@@ -97,7 +97,7 @@ fn issue_921_json_list_has_cursor_pagination() {
 /// Demonstrate that EventReadByType returns ALL matching events with no pagination.
 #[test]
 fn issue_921_event_read_by_type_no_pagination() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = strata_executor::Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");
@@ -149,7 +149,7 @@ fn issue_921_event_read_by_type_no_pagination() {
 /// Demonstrate that KvList returns ALL keys with no pagination mechanism.
 #[test]
 fn issue_921_kv_list_no_pagination() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = strata_executor::Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");

--- a/audit-tests/tests/issue_922.rs
+++ b/audit-tests/tests/issue_922.rs
@@ -22,7 +22,7 @@ use strata_executor::{Command, Output};
 /// observable through the executor API, but we can verify the append succeeds.
 #[test]
 fn issue_922_event_append_succeeds() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = strata_executor::Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");
@@ -66,7 +66,7 @@ fn issue_922_event_append_succeeds() {
 /// State does not have 200 retries -- it uses the default retry count.
 #[test]
 fn issue_922_state_cas_works_without_retries() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = strata_executor::Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");

--- a/audit-tests/tests/issue_923.rs
+++ b/audit-tests/tests/issue_923.rs
@@ -14,7 +14,7 @@ use strata_executor::{Command, DistanceMetric, Output};
 /// instead of silently auto-creating with Cosine metric.
 #[test]
 fn issue_923_upsert_without_create_fails() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = strata_executor::Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");
@@ -40,7 +40,7 @@ fn issue_923_upsert_without_create_fails() {
 /// and that VectorUpsert respects the explicitly created collection.
 #[test]
 fn issue_923_explicit_create_preserves_metric() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = strata_executor::Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");
@@ -93,7 +93,7 @@ fn issue_923_explicit_create_preserves_metric() {
 /// Verify that VectorUpsert works correctly with an explicitly created DotProduct collection.
 #[test]
 fn issue_923_explicit_dotproduct_collection() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = strata_executor::Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");

--- a/audit-tests/tests/issue_924.rs
+++ b/audit-tests/tests/issue_924.rs
@@ -14,7 +14,7 @@ use strata_executor::{Command, Output};
 /// Demonstrate that EventReadByType scans all events and returns only matching ones.
 #[test]
 fn issue_924_event_read_by_type_filters_correctly() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = strata_executor::Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");

--- a/audit-tests/tests/issue_925.rs
+++ b/audit-tests/tests/issue_925.rs
@@ -26,7 +26,7 @@ use strata_executor::{Command, Output};
 /// Verify that branch delete removes data from all primitive types.
 #[test]
 fn issue_925_branch_delete_removes_all_data() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = strata_executor::Executor::new(db);
 
     // Create a non-default branch

--- a/audit-tests/tests/issue_926.rs
+++ b/audit-tests/tests/issue_926.rs
@@ -22,7 +22,7 @@ use strata_executor::{Command, Executor, Output};
 /// Demonstrate that CAS with correct expected counter succeeds.
 #[test]
 fn issue_926_state_cas_correct_counter_succeeds() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");
@@ -60,7 +60,7 @@ fn issue_926_state_cas_correct_counter_succeeds() {
 /// Demonstrate that CAS with wrong expected counter returns None.
 #[test]
 fn issue_926_state_cas_wrong_counter_returns_none() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");
@@ -111,7 +111,7 @@ fn issue_926_state_cas_wrong_counter_returns_none() {
 /// ```
 #[test]
 fn issue_926_state_cas_swallows_errors_as_cas_failure() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");
@@ -172,7 +172,7 @@ fn issue_926_state_cas_swallows_errors_as_cas_failure() {
 /// Demonstrate the init path also swallows errors.
 #[test]
 fn issue_926_state_cas_init_path_swallows_errors() {
-    let db = strata_engine::database::Database::ephemeral().unwrap();
+    let db = strata_engine::database::Database::cache().unwrap();
     let executor = Executor::new(db);
 
     let branch = strata_executor::BranchId::from("default");

--- a/audit-tests/tests/issue_927.rs
+++ b/audit-tests/tests/issue_927.rs
@@ -26,7 +26,7 @@ use strata_executor::{BranchId, Command, Executor, Output, Session, Value};
 /// handled inside the transaction, but StateSet is not.
 #[test]
 fn issue_927_state_set_bypasses_transaction_but_kv_put_does_not() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let mut session = Session::new(db.clone());
 
     let branch = BranchId::from("default");
@@ -102,7 +102,7 @@ fn issue_927_state_set_bypasses_transaction_but_kv_put_does_not() {
 /// different conversion paths depending on whether a transaction is active.
 #[test]
 fn issue_927_error_paths_differ_for_session_vs_executor() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db.clone());
     let mut session = Session::new(db);
 

--- a/audit-tests/tests/issue_931.rs
+++ b/audit-tests/tests/issue_931.rs
@@ -28,7 +28,7 @@ use strata_executor::{BranchId, Command, Error, Executor, Output, Session, Value
 /// ALL errors, not just conflicts, produce this same error type.
 #[test]
 fn issue_931_commit_always_returns_transaction_conflict() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let mut session = Session::new(db.clone());
     let executor = Executor::new(db.clone());
 

--- a/audit-tests/tests/issue_932.rs
+++ b/audit-tests/tests/issue_932.rs
@@ -12,7 +12,7 @@ use strata_executor::{BranchId, Command, DistanceMetric, Executor};
 /// Without VectorCreateCollection, upsert returns CollectionNotFound.
 #[test]
 fn issue_932_vector_upsert_requires_explicit_collection() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     let branch = BranchId::from("default");
@@ -36,7 +36,7 @@ fn issue_932_vector_upsert_requires_explicit_collection() {
 /// when the collection is explicitly created first.
 #[test]
 fn issue_932_repeated_upsert_with_explicit_collection() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     let branch = BranchId::from("default");
@@ -81,7 +81,7 @@ fn issue_932_repeated_upsert_with_explicit_collection() {
 /// collection fails with a dimension mismatch at the insert step.
 #[test]
 fn issue_932_dimension_mismatch_error() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     let branch = BranchId::from("default");

--- a/audit-tests/tests/issue_934.rs
+++ b/audit-tests/tests/issue_934.rs
@@ -30,7 +30,7 @@ use strata_executor::{Command, Executor, Output, Value};
 /// so passing None for branch works correctly through the public API.
 #[test]
 fn issue_934_executor_execute_resolves_none_branch() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     // Pass None branch — Executor::execute() calls resolve_default_branch
@@ -87,7 +87,7 @@ fn issue_934_expect_message_is_consistent() {
     // This test simply verifies that the public API works correctly
     // (None branches are resolved).
 
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     // Various commands with None branch all work through execute()

--- a/audit-tests/tests/issue_936.rs
+++ b/audit-tests/tests/issue_936.rs
@@ -25,7 +25,7 @@ use strata_executor::{BranchId, Command, DistanceMetric, Executor, Output, Value
 /// if not exists", the TOCTOU check would be unreliable.
 #[test]
 fn issue_936_sequential_duplicate_upsert_succeeds() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     let branch = BranchId::from("default");

--- a/audit-tests/tests/issue_937.rs
+++ b/audit-tests/tests/issue_937.rs
@@ -26,7 +26,7 @@ use strata_executor::{BranchId, Command, DistanceMetric, Executor, Output};
 /// steps succeed. The bug manifests only on failure between the steps.
 #[test]
 fn issue_937_normal_case_backend_and_kv_consistent() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     let branch = BranchId::from("default");

--- a/audit-tests/tests/issue_938.rs
+++ b/audit-tests/tests/issue_938.rs
@@ -16,7 +16,7 @@ use strata_executor::{BranchId, Command, DistanceMetric, Error, Session};
 /// Verifies that vector upsert is now blocked inside a transaction.
 #[test]
 fn issue_938_vector_writes_bypass_transaction() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let mut session = Session::new(db);
     let branch = BranchId::from("default");
 
@@ -70,7 +70,7 @@ fn issue_938_vector_writes_bypass_transaction() {
 /// Verifies that vector delete is now blocked inside a transaction.
 #[test]
 fn issue_938_vector_delete_bypasses_transaction() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let mut session = Session::new(db);
     let branch = BranchId::from("default");
 

--- a/audit-tests/tests/issue_939.rs
+++ b/audit-tests/tests/issue_939.rs
@@ -16,7 +16,7 @@ use strata_executor::{BranchId, Command, Error, Session};
 /// Verifies that BranchCreate is now blocked inside a transaction.
 #[test]
 fn issue_939_branch_create_bypasses_transaction() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let mut session = Session::new(db);
     let branch = BranchId::from("default");
 
@@ -57,7 +57,7 @@ fn issue_939_branch_create_bypasses_transaction() {
 /// Verifies that BranchDelete is now blocked inside a transaction.
 #[test]
 fn issue_939_branch_delete_bypasses_transaction() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let mut session = Session::new(db);
     let branch = BranchId::from("default");
 

--- a/audit-tests/tests/issue_940.rs
+++ b/audit-tests/tests/issue_940.rs
@@ -25,7 +25,7 @@ use strata_executor::{BranchId, Command, Output, Session, Value};
 /// not see events appended within the same transaction.
 #[test]
 fn issue_940_event_read_by_type_misses_uncommitted() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let mut session = Session::new(db);
     let branch = BranchId::from("default");
 
@@ -84,7 +84,7 @@ fn issue_940_event_read_by_type_misses_uncommitted() {
 /// JsonList is in the "non-transactional commands" match arm.
 #[test]
 fn issue_940_json_list_routed_through_executor() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let mut session = Session::new(db);
     let branch = BranchId::from("default");
 
@@ -169,7 +169,7 @@ fn issue_940_json_list_routed_through_executor() {
 /// version history changes made within the transaction.
 #[test]
 fn issue_940_kv_getv_bypasses_transaction() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let mut session = Session::new(db);
     let branch = BranchId::from("default");
 

--- a/audit-tests/tests/issue_941.rs
+++ b/audit-tests/tests/issue_941.rs
@@ -45,7 +45,7 @@ use strata_executor::{Command, Session};
 /// the command variant exists and routes through the session without panicking.
 #[test]
 fn issue_941_branch_export_routes_through_session() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let mut session = Session::new(db);
 
     // BranchExport requires a valid branch_id and path.
@@ -69,7 +69,7 @@ fn issue_941_branch_export_routes_through_session() {
 /// Verify that BranchBundleValidate command routes through session.
 #[test]
 fn issue_941_branch_bundle_validate_routes_through_session() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let mut session = Session::new(db);
 
     let result = session.execute(Command::BranchBundleValidate {
@@ -91,7 +91,7 @@ fn issue_941_branch_bundle_validate_routes_through_session() {
 /// through execute_in_txn -> catch-all -> executor.execute().
 #[test]
 fn issue_941_branch_export_during_active_transaction() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let mut session = Session::new(db);
 
     // Begin a transaction

--- a/audit-tests/tests/issue_942.rs
+++ b/audit-tests/tests/issue_942.rs
@@ -30,7 +30,7 @@ use strata_executor::{Command, Executor, Output};
 /// the engine layer, which is the semantic bug.
 #[test]
 fn issue_942_vector_version_type_mismatch() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 

--- a/audit-tests/tests/issue_943.rs
+++ b/audit-tests/tests/issue_943.rs
@@ -40,7 +40,7 @@ use strata_executor::{Command, Executor, Output};
 /// Currently both work because events use Sequence versions, but the code paths differ.
 #[test]
 fn issue_943_event_read_by_type_version_extraction_inconsistency() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -142,7 +142,7 @@ fn issue_943_event_read_by_type_version_extraction_inconsistency() {
 /// but documents the inconsistency for future reference.
 #[test]
 fn issue_943_documents_fragile_version_pattern() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 

--- a/audit-tests/tests/issue_944.rs
+++ b/audit-tests/tests/issue_944.rs
@@ -60,7 +60,7 @@ fn issue_944_commit_locks_never_removed_on_branch_delete() {
     use strata_executor::BranchId;
     use strata_executor::{Command, Executor, Output};
 
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     // Create and delete multiple branches

--- a/audit-tests/tests/issue_945.rs
+++ b/audit-tests/tests/issue_945.rs
@@ -22,7 +22,7 @@ use strata_executor::{Command, Executor, Output};
 /// 3. The latest value is still accessible after GC
 #[test]
 fn issue_945_version_chain_gc_never_invoked() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 

--- a/audit-tests/tests/issue_946.rs
+++ b/audit-tests/tests/issue_946.rs
@@ -34,7 +34,7 @@ use strata_executor::{BranchId, Command, DistanceMetric, Executor, Output};
 /// the branch is gone but vector backend state may linger.
 #[test]
 fn issue_946_branch_delete_leaves_vector_data() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     // Create a branch

--- a/audit-tests/tests/issue_948.rs
+++ b/audit-tests/tests/issue_948.rs
@@ -11,7 +11,7 @@ use strata_executor::{BranchId, Command, DistanceMetric, Executor};
 /// Verify that NaN values in vector embeddings are rejected.
 #[test]
 fn issue_948_nan_vector_rejected() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -47,7 +47,7 @@ fn issue_948_nan_vector_rejected() {
 /// Verify that Infinity values in vector embeddings are rejected.
 #[test]
 fn issue_948_infinity_vector_rejected() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -77,7 +77,7 @@ fn issue_948_infinity_vector_rejected() {
 /// Verify that negative infinity is also rejected.
 #[test]
 fn issue_948_neg_infinity_vector_rejected() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -107,7 +107,7 @@ fn issue_948_neg_infinity_vector_rejected() {
 /// Verify that valid embeddings still work after the validation was added.
 #[test]
 fn issue_948_valid_vector_still_accepted() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 

--- a/audit-tests/tests/issue_949.rs
+++ b/audit-tests/tests/issue_949.rs
@@ -41,7 +41,7 @@ use strata_executor::{BranchId, Command, DistanceMetric, Executor};
 /// current validation only checks for dimension > 0.
 #[test]
 fn issue_949_no_vector_dimension_upper_bound() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -68,7 +68,7 @@ fn issue_949_no_vector_dimension_upper_bound() {
 /// which could be astronomically large.
 #[test]
 fn issue_949_dimension_as_u64_allows_extreme_values() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 

--- a/audit-tests/tests/issue_950.rs
+++ b/audit-tests/tests/issue_950.rs
@@ -34,7 +34,7 @@ use strata_executor::{Command, Executor, Output};
 /// Demonstrates that an empty branch name is accepted without validation.
 #[test]
 fn issue_950_empty_branch_name_accepted() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     let result = executor.execute(Command::BranchCreate {
@@ -66,7 +66,7 @@ fn issue_950_empty_branch_name_accepted() {
 /// Demonstrates that whitespace-only branch names are accepted.
 #[test]
 fn issue_950_whitespace_branch_name_accepted() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     let result = executor.execute(Command::BranchCreate {
@@ -87,7 +87,7 @@ fn issue_950_whitespace_branch_name_accepted() {
 /// Demonstrates that branch names with special characters are accepted.
 #[test]
 fn issue_950_special_chars_branch_name_accepted() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     // Try various problematic names

--- a/audit-tests/tests/issue_951.rs
+++ b/audit-tests/tests/issue_951.rs
@@ -32,7 +32,7 @@ use strata_executor::{BranchId, Command, Executor, Output};
 /// Demonstrates that writing to a deleted branch succeeds, creating orphaned data.
 #[test]
 fn issue_951_ops_on_deleted_branch() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     // Create a branch
@@ -116,7 +116,7 @@ fn issue_951_ops_on_deleted_branch() {
 /// Demonstrates that event append on a deleted branch may succeed.
 #[test]
 fn issue_951_event_append_on_deleted_branch() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     // Create and delete a branch
@@ -159,7 +159,7 @@ fn issue_951_event_append_on_deleted_branch() {
 /// Demonstrates that state operations on a deleted branch may succeed.
 #[test]
 fn issue_951_state_set_on_deleted_branch() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     // Create and delete a branch

--- a/audit-tests/tests/issue_953.rs
+++ b/audit-tests/tests/issue_953.rs
@@ -21,7 +21,7 @@ use strata_executor::{BranchId, Command, Executor};
 /// KV rejects empty keys but vector accepts them.
 #[test]
 fn issue_953_vector_accepts_empty_key_while_kv_rejects() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -55,7 +55,7 @@ fn issue_953_vector_accepts_empty_key_while_kv_rejects() {
 /// KV rejects keys with NUL bytes but vector accepts them.
 #[test]
 fn issue_953_vector_accepts_nul_byte_key_while_kv_rejects() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -90,7 +90,7 @@ fn issue_953_vector_accepts_nul_byte_key_while_kv_rejects() {
 /// KV rejects keys with _strata/ prefix but vector accepts them.
 #[test]
 fn issue_953_vector_accepts_reserved_prefix_key_while_kv_rejects() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -128,7 +128,7 @@ fn issue_953_vector_accepts_reserved_prefix_key_while_kv_rejects() {
 /// KV rejects oversized keys but vector accepts them.
 #[test]
 fn issue_953_vector_accepts_oversized_key_while_kv_rejects() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -166,7 +166,7 @@ fn issue_953_vector_accepts_oversized_key_while_kv_rejects() {
 /// VectorGet and VectorDelete also lack key validation.
 #[test]
 fn issue_953_vector_get_and_delete_also_skip_key_validation() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 

--- a/audit-tests/tests/issue_954.rs
+++ b/audit-tests/tests/issue_954.rs
@@ -15,7 +15,7 @@ use strata_executor::{BranchId, Command, Executor, Output};
 /// Verify that KvGet now returns Output::MaybeVersioned as documented.
 #[test]
 fn issue_954_kvget_returns_maybe_versioned() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -47,7 +47,7 @@ fn issue_954_kvget_returns_maybe_versioned() {
 /// Verify that KvGet for a missing key returns MaybeVersioned(None).
 #[test]
 fn issue_954_kvget_missing_key_returns_maybe_versioned_none() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 

--- a/audit-tests/tests/issue_955.rs
+++ b/audit-tests/tests/issue_955.rs
@@ -13,7 +13,7 @@ use strata_executor::{BranchId, Command, Executor, Output};
 /// KvGet now preserves version metadata.
 #[test]
 fn issue_955_kvget_preserves_version() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -54,7 +54,7 @@ fn issue_955_kvget_preserves_version() {
 /// StateRead now preserves version metadata.
 #[test]
 fn issue_955_state_read_preserves_version() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -90,7 +90,7 @@ fn issue_955_state_read_preserves_version() {
 /// JsonGet now preserves version metadata.
 #[test]
 fn issue_955_json_get_preserves_version() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -128,7 +128,7 @@ fn issue_955_json_get_preserves_version() {
 /// Contrast: the version-history commands (KvGetv, StateReadv) DO preserve versions.
 #[test]
 fn issue_955_version_history_commands_do_preserve_versions() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 

--- a/audit-tests/tests/issue_956.rs
+++ b/audit-tests/tests/issue_956.rs
@@ -14,7 +14,7 @@ use strata_executor::{BranchId, Command, Executor, Output};
 /// BranchGet returns MaybeBranchInfo(Some(...)) for explicitly created branches.
 #[test]
 fn issue_956_branch_get_existing_returns_maybe_branch_info_some() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     // Create a branch explicitly so it has metadata
@@ -46,7 +46,7 @@ fn issue_956_branch_get_existing_returns_maybe_branch_info_some() {
 /// BranchGet returns MaybeBranchInfo(None) for non-existent branches.
 #[test]
 fn issue_956_branch_get_missing_returns_maybe_branch_info_none() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     // Get non-existent branch
@@ -66,7 +66,7 @@ fn issue_956_branch_get_missing_returns_maybe_branch_info_none() {
 /// Both found and not-found now use the same Output variant.
 #[test]
 fn issue_956_branch_get_consistent_output_variants() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     // Create a branch explicitly
@@ -111,12 +111,12 @@ fn issue_956_branch_get_consistent_output_variants() {
 }
 
 /// Note: the "default" branch exists implicitly for data operations but does NOT
-/// have formal BranchMetadata in the engine's branch index for ephemeral databases.
-/// BranchGet for "default" on an ephemeral DB returns MaybeBranchInfo(None), the
+/// have formal BranchMetadata in the engine's branch index for cache databases.
+/// BranchGet for "default" on a cache DB returns MaybeBranchInfo(None), the
 /// same as for a truly non-existent branch.
 #[test]
-fn issue_956_default_branch_has_no_metadata_in_ephemeral_db() {
-    let db = Database::ephemeral().unwrap();
+fn issue_956_default_branch_has_no_metadata_in_cache_db() {
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
 
     let result = executor
@@ -130,7 +130,7 @@ fn issue_956_default_branch_has_no_metadata_in_ephemeral_db() {
     // BranchMetadata record.
     assert!(
         matches!(result, Output::MaybeBranchInfo(None)),
-        "Default branch returns MaybeBranchInfo(None) from BranchGet in ephemeral DB. Got: {:?}",
+        "Default branch returns MaybeBranchInfo(None) from BranchGet in cache DB. Got: {:?}",
         result
     );
 }

--- a/audit-tests/tests/issue_957.rs
+++ b/audit-tests/tests/issue_957.rs
@@ -28,7 +28,7 @@ use strata_executor::{BranchId, Command, Executor, Output};
 /// In normal operation (no corrupt data), all versions should be present.
 #[test]
 fn issue_957_json_getv_returns_version_history() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -88,7 +88,7 @@ fn issue_957_json_getv_returns_version_history() {
 /// Verify that JsonGetv for a non-existent key returns None.
 #[test]
 fn issue_957_json_getv_nonexistent_returns_none() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -111,7 +111,7 @@ fn issue_957_json_getv_nonexistent_returns_none() {
 /// so deserialization errors in KV history would propagate rather than be silently dropped.
 #[test]
 fn issue_957_kvgetv_does_not_use_filter_map() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 

--- a/audit-tests/tests/issue_959.rs
+++ b/audit-tests/tests/issue_959.rs
@@ -25,7 +25,7 @@ use strata_executor::{BranchId, Command, Executor, Output};
 /// Deleting a non-existent document at root returns Uint(0) — correct.
 #[test]
 fn issue_959_json_delete_root_nonexistent_returns_zero() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -47,7 +47,7 @@ fn issue_959_json_delete_root_nonexistent_returns_zero() {
 /// Deleting an existing document at root returns Uint(1) — correct.
 #[test]
 fn issue_959_json_delete_root_existing_returns_one() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -82,7 +82,7 @@ fn issue_959_json_delete_root_existing_returns_one() {
 /// Deleting a non-existent path within an existing doc always returns Uint(1) — BUG.
 #[test]
 fn issue_959_json_delete_nonroot_nonexistent_path_returns_one() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 
@@ -130,7 +130,7 @@ fn issue_959_json_delete_nonroot_nonexistent_path_returns_one() {
 /// from the non-existent path case due to the bug).
 #[test]
 fn issue_959_json_delete_nonroot_existing_path_returns_one() {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db);
     let branch = BranchId::from("default");
 

--- a/audit-tests/tests/issue_963.rs
+++ b/audit-tests/tests/issue_963.rs
@@ -22,7 +22,7 @@
 //!    is minimized even if the application crashes
 //! 2. The performance difference between flush-on-commit and periodic-flush
 //!    depends heavily on the workload and storage hardware
-//! 3. Users who chose `DurabilityMode::None` may be surprised that their
+//! 3. Users who chose `DurabilityMode::Cache` may be surprised that their
 //!    writes are still being flushed, but this errs on the side of safety
 //! 4. Separating flush from fsync is a valid design: flush pushes data to
 //!    the OS page cache, fsync pushes it to stable storage. Skipping flush

--- a/audit-tests/tests/issue_971.rs
+++ b/audit-tests/tests/issue_971.rs
@@ -22,7 +22,7 @@ fn branch_switch_produces_no_wal_writes() {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::builder()
         .path(dir.path())
-        .strict()
+        .always()
         .open()
         .expect("open db");
 
@@ -49,7 +49,7 @@ fn repeated_branch_switches_produce_no_wal_writes() {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::builder()
         .path(dir.path())
-        .strict()
+        .always()
         .open()
         .expect("open db");
 
@@ -80,7 +80,7 @@ fn branch_exists_check_produces_no_wal_writes() {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::builder()
         .path(dir.path())
-        .strict()
+        .always()
         .open()
         .expect("open db");
 

--- a/audit-tests/tests/issue_972.rs
+++ b/audit-tests/tests/issue_972.rs
@@ -1,6 +1,6 @@
 //! Audit test for issue #972: Event append 100x slower than KV put in Cache mode
 //!
-//! Event append in NoDurability (Cache) mode takes ~1ms p50 — orders of magnitude
+//! Event append in Cache mode takes ~1ms p50 — orders of magnitude
 //! slower than KV put (~1µs). The root cause is that EventLogMeta stores a
 //! `sequences: Vec<u64>` per stream type that grows linearly with every append.
 //! Each append must deserialize and re-serialize this growing metadata, making
@@ -18,7 +18,7 @@ use strata_engine::primitives::EventLog;
 use strata_engine::Database;
 use tempfile::TempDir;
 
-/// Helper: create an ephemeral (NoDurability/Cache) database.
+/// Helper: create a cache-mode database.
 fn cache_db() -> (std::sync::Arc<Database>, TempDir) {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::open(dir.path()).expect("open db");

--- a/audit-tests/tests/issue_973.rs
+++ b/audit-tests/tests/issue_973.rs
@@ -23,7 +23,7 @@ fn json_set_root_new_doc_produces_one_wal_write() {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::builder()
         .path(dir.path())
-        .strict()
+        .always()
         .open()
         .expect("open db");
     let strata = Strata::from_database(db).expect("strata");
@@ -55,7 +55,7 @@ fn json_set_path_new_doc_produces_one_wal_write() {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::builder()
         .path(dir.path())
-        .strict()
+        .always()
         .open()
         .expect("open db");
     let strata = Strata::from_database(db).expect("strata");
@@ -88,7 +88,7 @@ fn json_set_path_existing_doc_produces_one_wal_write() {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::builder()
         .path(dir.path())
-        .strict()
+        .always()
         .open()
         .expect("open db");
     let strata = Strata::from_database(db).expect("strata");
@@ -131,7 +131,7 @@ fn json_set_data_integrity_after_fix() {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::builder()
         .path(dir.path())
-        .strict()
+        .always()
         .open()
         .expect("open db");
     let strata = Strata::from_database(db).expect("strata");

--- a/audit-tests/tests/issue_974.rs
+++ b/audit-tests/tests/issue_974.rs
@@ -24,7 +24,7 @@ fn branch_delete_empty_branch_produces_one_wal_write() {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::builder()
         .path(dir.path())
-        .strict()
+        .always()
         .open()
         .expect("open db");
     let strata = Strata::from_database(db).expect("strata");
@@ -56,7 +56,7 @@ fn branch_delete_with_data_produces_one_wal_write() {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::builder()
         .path(dir.path())
-        .strict()
+        .always()
         .open()
         .expect("open db");
     let strata = Strata::from_database(db).expect("strata");
@@ -104,7 +104,7 @@ fn branch_delete_actually_removes_data() {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::builder()
         .path(dir.path())
-        .strict()
+        .always()
         .open()
         .expect("open db");
     let strata = Strata::from_database(db).expect("strata");

--- a/audit-tests/tests/issue_976.rs
+++ b/audit-tests/tests/issue_976.rs
@@ -24,7 +24,7 @@ fn kv_delete_existing_key_produces_one_wal_write() {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::builder()
         .path(dir.path())
-        .strict()
+        .always()
         .open()
         .expect("open db");
     let strata = Strata::from_database(db).expect("strata");
@@ -65,7 +65,7 @@ fn kv_delete_nonexistent_key_produces_no_wal_writes() {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::builder()
         .path(dir.path())
-        .strict()
+        .always()
         .open()
         .expect("open db");
     let strata = Strata::from_database(db).expect("strata");
@@ -99,7 +99,7 @@ fn kv_delete_default_branch_produces_one_wal_write() {
     let dir = TempDir::new().expect("tempdir");
     let db = Database::builder()
         .path(dir.path())
-        .strict()
+        .always()
         .open()
         .expect("open db");
     let strata = Strata::from_database(db).expect("strata");

--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -162,7 +162,7 @@ impl TransactionManager {
     /// * `txn` - Transaction to commit (must be in Active state)
     /// * `store` - Storage to validate against and apply writes to
     /// * `wal` - Optional WAL for durability. Pass `None` for ephemeral databases
-    ///           or when durability is not required (DurabilityMode::None).
+    ///           or when durability is not required (DurabilityMode::Cache).
     ///
     /// # Returns
     /// - Ok(commit_version) on success
@@ -320,7 +320,7 @@ mod tests {
         WalWriter::new(
             dir.to_path_buf(),
             [0u8; 16],
-            DurabilityMode::Strict,
+            DurabilityMode::Always,
             WalConfig::for_testing(),
             Box::new(IdentityCodec),
         )

--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -249,7 +249,7 @@ mod tests {
         WalWriter::new(
             dir.to_path_buf(),
             [0u8; 16],
-            DurabilityMode::Strict,
+            DurabilityMode::Always,
             WalConfig::for_testing(),
             Box::new(IdentityCodec),
         )

--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate handles everything that touches disk:
 //!
 //! - WAL: Segmented write-ahead log with one record per committed transaction
-//! - Durability modes: Strict, Batched (default), None
+//! - Durability modes: Always, Standard (default), Cache
 //! - Snapshot creation and loading
 //! - Recovery: Coordinator-based recovery (MANIFEST + snapshot + WAL)
 //! - Binary on-disk formats (segmented WAL, snapshots, manifest)

--- a/crates/durability/src/recovery/coordinator.rs
+++ b/crates/durability/src/recovery/coordinator.rs
@@ -167,8 +167,8 @@ impl RecoveryCoordinator {
     ///
     /// This is safe because:
     /// - Partial records mean the transaction wasn't committed
-    /// - In Strict mode, committed transactions are fsynced
-    /// - In Buffered mode, some data loss is expected on crash
+    /// - In Always mode, committed transactions are fsynced
+    /// - In Standard mode, some data loss is expected on crash
     pub fn truncate_partial_records(&self, wal_dir: &Path) -> Result<u64, RecoveryError> {
         let reader = crate::wal::WalReader::new(clone_codec(self.codec.as_ref())?);
 
@@ -318,7 +318,7 @@ mod tests {
         let mut writer = WalWriter::new(
             wal_dir,
             test_uuid(),
-            DurabilityMode::Strict,
+            DurabilityMode::Always,
             WalConfig::for_testing(),
             make_codec(),
         )

--- a/crates/durability/src/recovery/replayer.rs
+++ b/crates/durability/src/recovery/replayer.rs
@@ -230,7 +230,7 @@ mod tests {
         let mut writer = WalWriter::new(
             wal_dir.to_path_buf(),
             [1u8; 16],
-            DurabilityMode::Strict,
+            DurabilityMode::Always,
             WalConfig::for_testing(),
             make_codec(),
         )

--- a/crates/durability/src/wal/config.rs
+++ b/crates/durability/src/wal/config.rs
@@ -10,9 +10,9 @@ pub struct WalConfig {
     /// When a segment exceeds this size, a new segment is created.
     pub segment_size: u64,
 
-    /// Bytes between fsyncs in Buffered/Batched mode (default: 4MB).
+    /// Bytes between fsyncs in Standard mode (default: 4MB).
     ///
-    /// For Batched durability mode, fsync is triggered when this many
+    /// For Standard durability mode, fsync is triggered when this many
     /// bytes have been written since the last fsync.
     pub buffered_sync_bytes: u64,
 }

--- a/crates/durability/src/wal/mod.rs
+++ b/crates/durability/src/wal/mod.rs
@@ -1,6 +1,6 @@
 //! WAL (Write-Ahead Log) module
 //!
-//! - `mode`: DurabilityMode (None, Strict, Batched)
+//! - `mode`: DurabilityMode (Cache, Always, Standard)
 //! - `config`: WAL configuration (WalConfig, WalConfigError)
 //! - `writer`: Segmented WAL writer (WalWriter)
 //! - `reader`: Segmented WAL reader (WalReader)

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -330,7 +330,7 @@ mod tests {
         let mut writer = WalWriter::new(
             wal_dir.to_path_buf(),
             [1u8; 16],
-            DurabilityMode::Strict,
+            DurabilityMode::Always,
             WalConfig::for_testing(),
             make_codec(),
         )

--- a/crates/engine/src/primitives/json.rs
+++ b/crates/engine/src/primitives/json.rs
@@ -156,7 +156,7 @@ impl JsonDoc {
 /// use strata_core::types::BranchId;
 /// use strata_core::primitives::json::JsonValue;
 ///
-/// let db = Database::ephemeral()?;
+/// let db = Database::cache()?;
 /// let json = JsonStore::new(db);
 /// let branch_id = BranchId::new();
 ///
@@ -773,7 +773,7 @@ mod tests {
 
     #[test]
     fn test_jsonstore_is_clone() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store1 = JsonStore::new(db.clone());
         let store2 = store1.clone();
         assert!(Arc::ptr_eq(store1.database(), store2.database()));
@@ -787,7 +787,7 @@ mod tests {
 
     #[test]
     fn test_key_for_branch_isolation() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
 
         let branch1 = BranchId::new();
@@ -803,7 +803,7 @@ mod tests {
 
     #[test]
     fn test_key_for_same_branch() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
 
         let branch_id = BranchId::new();
@@ -871,7 +871,7 @@ mod tests {
 
     #[test]
     fn test_serialize_deserialize_roundtrip() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let _store = JsonStore::new(db);
 
         let doc = JsonDoc::new("test-doc", JsonValue::from("test value"));
@@ -888,7 +888,7 @@ mod tests {
 
     #[test]
     fn test_serialize_complex_document() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let _store = JsonStore::new(db);
 
         let value: JsonValue = serde_json::json!({
@@ -913,7 +913,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_invalid_type() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let _store = JsonStore::new(db);
 
         // Try to deserialize a non-bytes value
@@ -925,7 +925,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_invalid_bytes() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let _store = JsonStore::new(db);
 
         // Try to deserialize garbage bytes
@@ -937,7 +937,7 @@ mod tests {
 
     #[test]
     fn test_serialized_size_is_compact() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let _store = JsonStore::new(db);
 
         let doc = JsonDoc::new("test-doc", JsonValue::from(42i64));
@@ -960,7 +960,7 @@ mod tests {
 
     #[test]
     fn test_create_document() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -973,7 +973,7 @@ mod tests {
 
     #[test]
     fn test_create_object_document() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -990,7 +990,7 @@ mod tests {
 
     #[test]
     fn test_create_duplicate_fails() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1007,7 +1007,7 @@ mod tests {
 
     #[test]
     fn test_create_different_docs() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
 
@@ -1027,7 +1027,7 @@ mod tests {
 
     #[test]
     fn test_create_branch_isolation() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
 
         let branch1 = BranchId::new();
@@ -1048,7 +1048,7 @@ mod tests {
 
     #[test]
     fn test_create_null_value() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1061,7 +1061,7 @@ mod tests {
 
     #[test]
     fn test_create_empty_object() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1074,7 +1074,7 @@ mod tests {
 
     #[test]
     fn test_create_empty_array() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1091,7 +1091,7 @@ mod tests {
 
     #[test]
     fn test_get_root() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1106,7 +1106,7 @@ mod tests {
 
     #[test]
     fn test_get_at_path() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1135,7 +1135,7 @@ mod tests {
 
     #[test]
     fn test_get_nested_path() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1162,7 +1162,7 @@ mod tests {
 
     #[test]
     fn test_get_array_element() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1185,7 +1185,7 @@ mod tests {
 
     #[test]
     fn test_get_missing_document() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1196,7 +1196,7 @@ mod tests {
 
     #[test]
     fn test_get_missing_path() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1213,7 +1213,7 @@ mod tests {
 
     #[test]
     fn test_exists() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1229,7 +1229,7 @@ mod tests {
 
     #[test]
     fn test_exists_branch_isolation() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
 
         let branch1 = BranchId::new();
@@ -1251,7 +1251,7 @@ mod tests {
 
     #[test]
     fn test_set_at_root() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1276,7 +1276,7 @@ mod tests {
 
     #[test]
     fn test_set_at_path() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1306,7 +1306,7 @@ mod tests {
 
     #[test]
     fn test_set_nested_path() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1337,7 +1337,7 @@ mod tests {
 
     #[test]
     fn test_set_increments_version() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1370,7 +1370,7 @@ mod tests {
 
     #[test]
     fn test_set_missing_document() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1386,7 +1386,7 @@ mod tests {
 
     #[test]
     fn test_set_overwrites_value() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1414,7 +1414,7 @@ mod tests {
 
     #[test]
     fn test_set_array_element() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1443,7 +1443,7 @@ mod tests {
 
     #[test]
     fn test_delete_at_path() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1477,7 +1477,7 @@ mod tests {
 
     #[test]
     fn test_delete_at_nested_path() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1517,7 +1517,7 @@ mod tests {
 
     #[test]
     fn test_delete_at_path_array_element() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1547,7 +1547,7 @@ mod tests {
 
     #[test]
     fn test_delete_at_path_increments_version() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1574,7 +1574,7 @@ mod tests {
 
     #[test]
     fn test_delete_at_path_missing_document() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1585,7 +1585,7 @@ mod tests {
 
     #[test]
     fn test_delete_at_path_missing_path() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1607,7 +1607,7 @@ mod tests {
 
     #[test]
     fn test_destroy_existing_document() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1624,7 +1624,7 @@ mod tests {
 
     #[test]
     fn test_destroy_nonexistent_document() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1635,7 +1635,7 @@ mod tests {
 
     #[test]
     fn test_destroy_branch_isolation() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
 
         let branch1 = BranchId::new();
@@ -1660,7 +1660,7 @@ mod tests {
 
     #[test]
     fn test_destroy_then_recreate() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1683,7 +1683,7 @@ mod tests {
 
     #[test]
     fn test_destroy_complex_document() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
@@ -1709,7 +1709,7 @@ mod tests {
 
     #[test]
     fn test_destroy_idempotent() {
-        let db = Database::ephemeral().unwrap();
+        let db = Database::cache().unwrap();
         let store = JsonStore::new(db);
         let branch_id = BranchId::new();
         let doc_id = "test-doc";

--- a/crates/engine/tests/critical_audit_tests.rs
+++ b/crates/engine/tests/critical_audit_tests.rs
@@ -15,7 +15,7 @@
 //! - #596: Lock poisoning cascade (RwLock)
 //! - #597: SystemTime panic on clock backwards
 //! - #598: WAL Mutex unwrap cascade
-//! - #599: Buffered durability silent failure
+//! - #599: Standard durability silent failure
 //! - #600: Wire encoding precision loss (u64 > 2^53)
 //! - #601: Recovery crashes on invariant violation
 //! - #602: Incomplete WAL entry detection
@@ -302,11 +302,11 @@ fn test_issue_598_mutex_poisoning_cascade() {
 // Issue #599: Buffered Durability Silent Failure
 // ============================================================================
 
-/// This test documents that the buffered durability mode silently ignores
+/// This test documents that the standard durability mode silently ignores
 /// flush errors.
 #[test]
-fn test_issue_599_buffered_durability_pattern() {
-    // The problematic pattern in buffered.rs is:
+fn test_issue_599_standard_durability_pattern() {
+    // The problematic pattern in standard.rs is:
     //
     // if let Err(e) = flush_result {
     //     eprintln!("Flush error: {}", e);  // Just prints!
@@ -321,7 +321,7 @@ fn test_issue_599_buffered_durability_pattern() {
     let _expected = "Flush errors should be propagated to callers";
     let _actual = "Flush errors are printed to stderr and ignored";
 
-    println!("Issue #599: Buffered durability silently ignores flush errors");
+    println!("Issue #599: Standard durability silently ignores flush errors");
 }
 
 // ============================================================================
@@ -446,7 +446,7 @@ fn test_all_critical_issues_documented() {
         ("596", "RwLock poisoning cascade"),
         ("597", "SystemTime panic"),
         ("598", "WAL mutex cascade"),
-        ("599", "Buffered durability failure"),
+        ("599", "Standard durability failure"),
         ("600", "Wire encoding precision loss"),
         ("601", "Recovery crash on invariant violation"),
         ("602", "Incomplete WAL entry detection"),

--- a/crates/engine/tests/database_open_test.rs
+++ b/crates/engine/tests/database_open_test.rs
@@ -438,11 +438,11 @@ fn test_durability_modes() {
         branch_id,
     );
 
-    // Test with Strict mode
+    // Test with Always mode
     {
         let db_path = temp_dir.path().join("strict_db");
-        let db = Database::open_with_mode(&db_path, DurabilityMode::Strict)
-            .expect("Failed to open with Strict mode");
+        let db = Database::open_with_mode(&db_path, DurabilityMode::Always)
+            .expect("Failed to open with Always mode");
 
         let wal = db.wal().unwrap();
         let mut wal_guard = wal.lock();
@@ -480,17 +480,17 @@ fn test_durability_modes() {
             .is_some());
     }
 
-    // Test with Batched mode
+    // Test with Standard mode
     {
         let db_path = temp_dir.path().join("batched_db");
         let db = Database::open_with_mode(
             &db_path,
-            DurabilityMode::Batched {
+            DurabilityMode::Standard {
                 interval_ms: 100,
                 batch_size: 10,
             },
         )
-        .expect("Failed to open with Batched mode");
+        .expect("Failed to open with Standard mode");
 
         let wal = db.wal().unwrap();
         let mut wal_guard = wal.lock();
@@ -731,7 +731,7 @@ fn test_multiple_crash_cycles_with_high_level_api() {
     for cycle in 0..NUM_CYCLES {
         // Open database and write keys
         {
-            let db = Database::open_with_mode(&db_path, DurabilityMode::Strict)
+            let db = Database::open_with_mode(&db_path, DurabilityMode::Always)
                 .expect("Failed to open database");
 
             for i in 0..KEYS_PER_CYCLE {
@@ -744,7 +744,7 @@ fn test_multiple_crash_cycles_with_high_level_api() {
 
         // Reopen and verify ALL previous data survived
         {
-            let db = Database::open_with_mode(&db_path, DurabilityMode::Strict)
+            let db = Database::open_with_mode(&db_path, DurabilityMode::Always)
                 .expect("Failed to reopen database");
 
             // Verify all keys from all cycles up to and including current cycle
@@ -793,7 +793,7 @@ fn test_twenty_sequential_puts_recover() {
 
     // Write 20 keys using high-level API
     {
-        let db = Database::open_with_mode(&db_path, DurabilityMode::Strict)
+        let db = Database::open_with_mode(&db_path, DurabilityMode::Always)
             .expect("Failed to open database");
 
         for i in 0..NUM_PUTS {
@@ -802,12 +802,12 @@ fn test_twenty_sequential_puts_recover() {
                 .expect("Put should succeed");
         }
 
-        // No explicit flush - relies on Strict mode
+        // No explicit flush - relies on Always mode
     }
 
     // Reopen and verify
     {
-        let db = Database::open_with_mode(&db_path, DurabilityMode::Strict)
+        let db = Database::open_with_mode(&db_path, DurabilityMode::Always)
             .expect("Failed to reopen database");
 
         let mut recovered_count = 0;

--- a/crates/engine/tests/versioned_conformance_tests.rs
+++ b/crates/engine/tests/versioned_conformance_tests.rs
@@ -42,7 +42,7 @@ fn int_payload(v: i64) -> Value {
 }
 
 fn setup() -> (Arc<Database>, BranchId) {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let branch_id = BranchId::new();
     (db, branch_id)
 }

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -126,8 +126,8 @@ impl Strata {
     /// ```
     pub fn open_temp() -> Result<Self> {
         ensure_vector_recovery();
-        let db = Database::ephemeral().map_err(|e| Error::Internal {
-            reason: format!("Failed to open ephemeral database: {}", e),
+        let db = Database::cache().map_err(|e| Error::Internal {
+            reason: format!("Failed to open cache database: {}", e),
         })?;
         let executor = Executor::new(db);
 

--- a/crates/executor/src/tests/determinism.rs
+++ b/crates/executor/src/tests/determinism.rs
@@ -10,7 +10,7 @@ use strata_engine::Database;
 
 /// Create a test executor.
 fn create_test_executor() -> Executor {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     Executor::new(db)
 }
 

--- a/crates/executor/src/tests/execute_many.rs
+++ b/crates/executor/src/tests/execute_many.rs
@@ -7,11 +7,11 @@ use crate::types::*;
 use crate::Value;
 use crate::{Command, Executor, Output};
 
-/// Create a test executor with an ephemeral in-memory database.
+/// Create a test executor with a cache in-memory database.
 fn create_test_executor() -> Executor {
     use strata_engine::Database;
 
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     Executor::new(db)
 }
 

--- a/crates/executor/src/tests/parity.rs
+++ b/crates/executor/src/tests/parity.rs
@@ -12,7 +12,7 @@ use strata_engine::Database;
 
 /// Create a test executor with shared primitives for parity comparisons.
 fn create_test_environment() -> (Executor, Arc<Primitives>) {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     let executor = Executor::new(db.clone());
     let primitives = Arc::new(Primitives::new(db));
     (executor, primitives)

--- a/crates/executor/src/tests/search.rs
+++ b/crates/executor/src/tests/search.rs
@@ -10,7 +10,7 @@ use crate::{Command, Executor, Output};
 use strata_engine::Database;
 
 fn create_executor() -> Executor {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     Executor::new(db)
 }
 

--- a/crates/executor/src/tests/session.rs
+++ b/crates/executor/src/tests/session.rs
@@ -4,9 +4,9 @@ use crate::Value;
 use crate::{Command, Error, Output, Session};
 use strata_engine::Database;
 
-/// Create a test session with an ephemeral in-memory database.
+/// Create a test session with a cache in-memory database.
 fn create_test_session() -> Session {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     Session::new(db)
 }
 

--- a/crates/intelligence/src/hybrid.rs
+++ b/crates/intelligence/src/hybrid.rs
@@ -267,7 +267,7 @@ mod tests {
     use strata_core::value::Value;
 
     fn test_db() -> Arc<Database> {
-        Database::ephemeral().expect("Failed to create test database")
+        Database::cache().expect("Failed to create test database")
     }
 
     #[test]

--- a/crates/intelligence/src/lib.rs
+++ b/crates/intelligence/src/lib.rs
@@ -55,7 +55,7 @@ pub use tokenizer::{tokenize, tokenize_unique};
 /// use strata_intelligence::DatabaseSearchExt;
 /// use std::sync::Arc;
 ///
-/// let db = Database::ephemeral()?;
+/// let db = Database::cache()?;
 /// let hybrid = db.hybrid();
 /// let response = hybrid.search(&request)?;
 /// ```
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn test_database_search_ext() {
-        let db = Database::ephemeral().expect("Failed to create test database");
+        let db = Database::cache().expect("Failed to create test database");
 
         let hybrid = db.hybrid();
         let branch_id = BranchId::new();

--- a/docs/architecture/crash-recovery-audit.md
+++ b/docs/architecture/crash-recovery-audit.md
@@ -159,7 +159,7 @@ let should_sync = self.writes_since_sync >= batch_size
 ```
 WalWriter::append(record)
 │
-├─ [1] Skip if DurabilityMode::None                      (writer.rs:141-143)
+├─ [1] Skip if DurabilityMode::Cache                     (writer.rs:141-143)
 │
 ├─ [2] record.to_bytes()                                 (writer.rs:151)
 │      [Length(4)] + [FormatVer(1) + TxnId(8) + BranchId(16)
@@ -461,7 +461,7 @@ pub fn sync_if_overdue(&mut self) -> std::io::Result<bool> {
     if !self.has_unsynced_data {
         return Ok(false);
     }
-    if let DurabilityMode::Batched { interval_ms, .. } = self.durability {
+    if let DurabilityMode::Standard { interval_ms, .. } = self.durability {
         if self.last_sync_time.elapsed().as_millis() as u64 >= interval_ms {
             // ... sync ...
         }

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -4,18 +4,18 @@
 
 | Mode | Enum Value | Description | Data Loss on Crash |
 |------|-----------|-------------|-------------------|
-| **None** | `DurabilityMode::None` | No persistence | All data |
-| **Batched** | `DurabilityMode::Batched` | Periodic fsync (~100ms / ~1000 writes) | Last ~100ms |
-| **Strict** | `DurabilityMode::Strict` | Immediate fsync per commit | None |
+| **Cache** | `DurabilityMode::Cache` | No persistence | All data |
+| **Standard** | `DurabilityMode::Standard` | Periodic fsync (~100ms / ~1000 writes) | Last ~100ms |
+| **Always** | `DurabilityMode::Always` | Immediate fsync per commit | None |
 
-Default: `Batched`
+Default: `Standard`
 
 ## Opening Methods
 
 | Method | Durability | Disk Files | Use Case |
 |--------|-----------|------------|----------|
 | `Strata::open(path)` | Configurable | Yes | Production |
-| `Strata::open_temp()` | None (in-memory) | No | Testing |
+| `Strata::open_temp()` | Cache (in-memory) | No | Testing |
 | `Strata::from_database(db)` | Inherited | Depends | Shared DB |
 
 ## Database Info

--- a/tests/AUDIT.md
+++ b/tests/AUDIT.md
@@ -102,7 +102,7 @@ The recovery invariant tests catch bugs like "recovery invents phantom keys" or 
    - Update vector helper signatures to match current `VectorStore::insert()` API
    - Remove/update search helper imports (`strata_intelligence::SearchRequest` etc.)
    - Verify `TestDb` wrapper methods match current `Database`/`DatabaseBuilder` API
-   - Remove references to `DatabaseBuilder::open_temp()` (doesn't exist — use `Database::ephemeral()`)
+   - Remove references to `DatabaseBuilder::open_temp()` (doesn't exist — use `Database::cache()`)
 2. Fix `acid_properties.rs`:
    - `Database::shutdown()` is `pub(crate)` — either make public or use `drop()`
    - `KVStoreExt`, `EventLogExt`, `StateCellExt` all exist and match

--- a/tests/durability/mode_equivalence.rs
+++ b/tests/durability/mode_equivalence.rs
@@ -1,6 +1,6 @@
 //! Durability Mode Equivalence Tests
 //!
-//! Verifies that in-memory, buffered, and strict modes produce
+//! Verifies that in-memory, standard, and always modes produce
 //! semantically identical results for the same workload.
 
 use crate::common::*;
@@ -96,8 +96,8 @@ fn delete_semantics_equivalent_across_modes() {
 }
 
 #[test]
-fn buffered_mode_recovers_after_restart() {
-    let mut test_db = TestDb::new(); // buffered mode
+fn standard_mode_recovers_after_restart() {
+    let mut test_db = TestDb::new(); // standard mode
     let branch_id = test_db.branch_id;
 
     let kv = test_db.kv();
@@ -115,12 +115,12 @@ fn buffered_mode_recovers_after_restart() {
     assert_states_equal(
         &state_before,
         &state_after,
-        "Buffered mode should recover all data",
+        "Standard mode should recover all data",
     );
 }
 
 #[test]
-fn strict_mode_recovers_after_restart() {
+fn always_mode_recovers_after_restart() {
     let mut test_db = TestDb::new_strict();
     let branch_id = test_db.branch_id;
 
@@ -138,6 +138,6 @@ fn strict_mode_recovers_after_restart() {
     assert_states_equal(
         &state_before,
         &state_after,
-        "Strict mode should recover all data",
+        "Always mode should recover all data",
     );
 }

--- a/tests/engine/database/lifecycle.rs
+++ b/tests/engine/database/lifecycle.rs
@@ -5,12 +5,12 @@
 use crate::common::*;
 
 // ============================================================================
-// Ephemeral Database
+// Cache Database
 // ============================================================================
 
 #[test]
-fn ephemeral_database_is_functional() {
-    let db = Database::ephemeral().expect("ephemeral database");
+fn cache_database_is_functional() {
+    let db = Database::cache().expect("cache database");
 
     let branch_id = BranchId::new();
     let kv = KVStore::new(db);
@@ -23,19 +23,19 @@ fn ephemeral_database_is_functional() {
 }
 
 #[test]
-fn ephemeral_database_data_is_lost_on_drop() {
+fn cache_database_data_is_lost_on_drop() {
     let branch_id = BranchId::new();
     let key = unique_key();
 
     // Write data
     {
-        let db = Database::ephemeral().expect("ephemeral database");
+        let db = Database::cache().expect("cache database");
         let kv = KVStore::new(db);
         kv.put(&branch_id, &key, Value::Int(42)).unwrap();
     }
 
-    // New ephemeral database has no data
-    let db = Database::ephemeral().expect("ephemeral database");
+    // New cache database has no data
+    let db = Database::cache().expect("cache database");
     let kv = KVStore::new(db);
     let result = kv.get(&branch_id, &key).unwrap();
 
@@ -55,7 +55,7 @@ fn persistent_database_creates_directory() {
 
     let _db = Database::builder()
         .path(&db_path)
-        .buffered()
+        .standard()
         .open()
         .expect("create database");
 
@@ -116,13 +116,13 @@ fn persistent_database_multiple_reopens() {
 // ============================================================================
 
 #[test]
-fn builder_no_durability_with_temp_path_uses_temp_files() {
-    // builder with a temp path and no_durability still creates files on disk
-    // It's NOT truly ephemeral
+fn builder_cache_durability_with_temp_path_uses_temp_files() {
+    // builder with a temp path and cache durability still creates files on disk
+    // It's NOT truly cache
     let temp_dir = tempfile::tempdir().unwrap();
     let db = Database::builder()
         .path(temp_dir.path())
-        .no_durability()
+        .cache()
         .open()
         .unwrap();
 
@@ -130,9 +130,9 @@ fn builder_no_durability_with_temp_path_uses_temp_files() {
 }
 
 #[test]
-fn database_ephemeral_is_truly_ephemeral() {
-    // Database::ephemeral() creates a purely in-memory database
-    let db = Database::ephemeral().expect("ephemeral database");
+fn database_cache_is_truly_cache() {
+    // Database::cache() creates a purely in-memory database
+    let db = Database::cache().expect("cache database");
     assert!(db.is_ephemeral());
 }
 
@@ -142,7 +142,7 @@ fn builder_creates_persistent_with_path() {
 
     let db = Database::builder()
         .path(temp_dir.path())
-        .buffered()
+        .standard()
         .open()
         .unwrap();
 
@@ -150,12 +150,12 @@ fn builder_creates_persistent_with_path() {
 }
 
 #[test]
-fn builder_strict_mode() {
+fn builder_always_mode() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let db = Database::builder()
         .path(temp_dir.path())
-        .strict()
+        .always()
         .open()
         .unwrap();
 
@@ -167,12 +167,12 @@ fn builder_strict_mode() {
 }
 
 #[test]
-fn builder_buffered_mode() {
+fn builder_standard_mode() {
     let temp_dir = tempfile::tempdir().unwrap();
 
     let db = Database::builder()
         .path(temp_dir.path())
-        .buffered()
+        .standard()
         .open()
         .unwrap();
 
@@ -203,7 +203,7 @@ fn is_open_reflects_state() {
 
     let db = Database::builder()
         .path(temp_dir.path())
-        .buffered()
+        .standard()
         .open()
         .unwrap();
 

--- a/tests/executor/common.rs
+++ b/tests/executor/common.rs
@@ -6,7 +6,7 @@ use strata_executor::{Executor, Output, Session, Strata};
 
 /// Create an executor with an in-memory database
 pub fn create_executor() -> Executor {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     Executor::new(db)
 }
 
@@ -17,13 +17,13 @@ pub fn create_strata() -> Strata {
 
 /// Create a Session with an in-memory database
 pub fn create_session() -> Session {
-    let db = Database::ephemeral().unwrap();
+    let db = Database::cache().unwrap();
     Session::new(db)
 }
 
 /// Create a database for shared use
 pub fn create_db() -> Arc<Database> {
-    Database::ephemeral().unwrap()
+    Database::cache().unwrap()
 }
 
 /// Helper to create an event payload (must be an Object)


### PR DESCRIPTION
## Summary

- Renames `DurabilityMode` enum variants for clarity: `None`→`Cache`, `Batched`→`Standard`, `Strict`→`Always`
- Renames builder methods: `.no_durability()`→`.cache()`, `.buffered()`→`.standard()`, `.strict()`→`.always()`
- Renames `Database::ephemeral()`→`Database::cache()` and `buffered_default()`→`standard_default()`
- Updates all 87 files across source, tests, audit tests, and documentation

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test --workspace` — all 124 test suites pass, zero failures
- [x] Verified no remaining references to old names via `grep` across all source and test files
- [x] Documentation updated (configuration-reference.md, crash-recovery-audit.md, AUDIT.md)

Closes #975

🤖 Generated with [Claude Code](https://claude.com/claude-code)