### PR TITLE
Fix remaining old durability names in config.rs and modes.rs (#975)

### DIFF
--- a/crates/durability/src/database/config.rs
+++ b/crates/durability/src/database/config.rs
@@ -31,21 +31,21 @@ impl Default for DatabaseConfig {
 }
 
 impl DatabaseConfig {
-    /// Create config with strict durability (default)
+    /// Create config with always durability (default)
     ///
     /// Every commit is fsynced before returning.
-    pub fn strict() -> Self {
+    pub fn always() -> Self {
         DatabaseConfig {
             durability: DurabilityMode::Always,
             ..Default::default()
         }
     }
 
-    /// Create config with batched durability
+    /// Create config with standard durability
     ///
     /// Commits are batched and fsynced periodically.
     /// Some committed transactions may be lost on crash.
-    pub fn batched() -> Self {
+    pub fn standard() -> Self {
         DatabaseConfig {
             durability: DurabilityMode::standard_default(),
             ..Default::default()
@@ -119,14 +119,14 @@ mod tests {
     }
 
     #[test]
-    fn test_strict_config() {
-        let config = DatabaseConfig::strict();
+    fn test_always_config() {
+        let config = DatabaseConfig::always();
         assert!(matches!(config.durability, DurabilityMode::Always));
     }
 
     #[test]
-    fn test_batched_config() {
-        let config = DatabaseConfig::batched();
+    fn test_standard_config() {
+        let config = DatabaseConfig::standard();
         assert!(matches!(config.durability, DurabilityMode::Standard { .. }));
     }
 
@@ -158,8 +158,8 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_valid_config_batched() {
-        let config = DatabaseConfig::batched();
+    fn test_validate_valid_config_standard() {
+        let config = DatabaseConfig::standard();
         let result = config.validate();
         assert!(result.is_ok(), "Standard config should be valid");
         assert!(matches!(config.durability, DurabilityMode::Standard { .. }));


### PR DESCRIPTION
## Summary

Second pass on the durability mode rename (#975). The initial PR #988 missed:

- `DatabaseConfig::strict()` → `DatabaseConfig::always()` and `DatabaseConfig::batched()` → `DatabaseConfig::standard()` in `crates/durability/src/database/config.rs`
- `create_ephemeral()` → `create_cache()`, `create_persistent_no_durability()` → `create_persistent_cache()`, and `ephemeral_*` test function names → `cache_*` in `tests/integration/modes.rs`

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test --workspace` — all 124 test suites pass, zero failures
- [x] Final grep confirms zero remaining references to old names in `.rs` files

Closes #975

🤖 Generated with [Claude Code](https://claude.com/claude-code)