### PR TITLE
Add Strata::new_handle() for multi-threaded usage

### DIFF
--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -140,6 +140,26 @@ impl Strata {
         })
     }
 
+    /// Create a new independent handle to the same database.
+    ///
+    /// Each handle has its own branch context (starting on "default") and can
+    /// be moved to a separate thread. This is the standard way to use Strata
+    /// from multiple threads.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let db = Strata::open("/data/myapp")?;
+    /// let handle = db.new_handle()?;
+    /// std::thread::spawn(move || {
+    ///     handle.kv_put("key", Value::Int(1)).unwrap();
+    /// });
+    /// ```
+    pub fn new_handle(&self) -> Result<Self> {
+        let db = self.executor.primitives().db.clone();
+        Self::from_database(db)
+    }
+
     /// Create a new Strata instance from an existing database.
     ///
     /// Use this when you need more control over database configuration.

--- a/docs/reference/api-quick-reference.md
+++ b/docs/reference/api-quick-reference.md
@@ -8,6 +8,7 @@ Every method on the `Strata` struct, grouped by category.
 |--------|-----------|---------|
 | `open` | `(path: impl AsRef<Path>) -> Result<Self>` | New Strata instance |
 | `cache` | `() -> Result<Self>` | Ephemeral in-memory instance |
+| `new_handle` | `() -> Result<Self>` | Independent handle to same database |
 | `ping` | `() -> Result<String>` | Version string |
 | `info` | `() -> Result<DatabaseInfo>` | Database statistics |
 | `flush` | `() -> Result<()>` | Flushes pending writes |


### PR DESCRIPTION
## Summary

Add `Strata::new_handle()` method that creates an independent handle to the same database. Each handle has its own branch context and can be moved to a separate thread.

This is needed after #998 removed `Database` from public exports — external code can no longer clone `Arc<Database>` and call `from_database()`. `new_handle()` provides the same capability through the public API.

```rust
let db = Strata::open("/data/myapp")?;
let handle = db.new_handle()?;
std::thread::spawn(move || {
    handle.kv_put("key", Value::Int(1)).unwrap();
});
```

## Test plan

- [x] `cargo build --workspace` — compiles cleanly
- [x] Method delegates to existing `from_database()` which is well-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)