### PR TITLE
Optimize transaction commit path with fast paths (#993, #1004, #1005)

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -873,7 +873,10 @@ impl Database {
         txn: &mut TransactionContext,
         durability: DurabilityMode,
     ) -> StrataResult<u64> {
-        let mut wal_guard = if durability.requires_wal() {
+        let needs_wal = durability.requires_wal()
+            && (!txn.is_read_only() || !txn.json_writes().is_empty());
+
+        let mut wal_guard = if needs_wal {
             self.wal_writer.as_ref().map(|w| w.lock())
         } else {
             None


### PR DESCRIPTION
## Summary

- **Read-only fast path**: transactions with no writes skip lock, validation, version allocation, WAL, and apply entirely
- **Blind-write validation skip**: writes with no prior reads skip OCC validation (no-op), still hold per-branch lock for ordering
- **WAL lock skip**: read-only transactions skip WAL mutex at engine layer (defense-in-depth)
- **Add `TransactionContext::get_versioned()`**: snapshot-isolated reads preserving version metadata
- **Fix `KVStore::get_versioned()`**: route through transaction layer instead of bypassing with direct storage access

## Test plan

- [x] `cargo test -p strata-concurrency` — 68 passed, 0 failed
- [x] `cargo test -p strata-engine` — 472 passed, 0 failed
- [x] `cargo test` — full workspace passes, 0 failures
- [ ] Run `cargo bench --bench kv` to verify read performance improvement

Closes #993
Closes #1004
Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)