### PR TITLE
Add BTreeSet index for O(log n + k) prefix scans

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ members = [
     "crates/engine",
     "crates/intelligence",
     "crates/executor",
-    "audit-tests",
 ]
 
 [workspace.package]


### PR DESCRIPTION
## Summary

- Adds a parallel `BTreeSet<Key>` index (`ordered_keys`) to each `Shard` alongside the existing `FxHashMap`, eliminating O(n) full-shard scans in all prefix-based and list queries
- Rewrites `scan_prefix`, `list_by_prefix`, `list_branch`, `list_by_type`, and `count_by_type` for both `ShardedStore` and `ShardedSnapshot` to use BTreeSet range iteration
- Removes all post-sort calls since BTreeSet iteration is already ordered
- Removes stale `audit-tests` workspace member from `Cargo.toml`

| Operation | Before | After |
|-----------|--------|-------|
| scan_prefix | O(n) | O(log n + k) |
| list_by_prefix | O(n) | O(log n + k) |
| list_branch | O(n) + sort | O(n) no sort |
| get / put | O(1) | O(1) / O(log n) new keys only |

Memory overhead: ~130 bytes/key for duplicated Key in BTreeSet. At 250K keys ≈ 32 MB — acceptable for an in-memory DB.

Closes #1002, closes #1006, closes #1007

## Test plan

- [x] All 108 strata-storage tests pass (104 existing + 4 new)
- [x] All 472 strata-engine tests pass
- [x] All 68 strata-concurrency tests pass
- [x] New test: `test_ordered_keys_consistent_with_data` — verifies BTreeSet/HashMap stay in sync
- [x] New test: `test_prefix_scan_sorted_without_explicit_sort` — verifies sorted output
- [x] New test: `test_prefix_scan_with_tombstones` — verifies MVCC tombstone visibility
- [x] New test: `test_prefix_scan_scales_with_matches` — 10K keys, verifies prefix isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)