### PR TITLE
Update documentation for v0.4 vector enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to StrataDB are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.0] - 2026-02-03
+
+### Added
+
+- **HNSW index backend**: O(log n) approximate nearest neighbor search built from scratch, verified against the Malkov & Yashunin paper (arXiv:1603.09320). Configurable M, ef_construction, ef_search parameters. Selectable per collection via `IndexBackendFactory`.
+- **Advanced metadata filters**: 8 filter operators (Eq, Ne, Gt, Gte, Lt, Lte, In, Contains) with `FilterCondition` and `FilterOp` types in core. Full executor bridge support.
+- **Batch vector upsert**: `VectorBatchUpsert` command and `vector_batch_upsert()` API for atomic bulk vector insertion in a single transaction.
+- **Collection statistics**: `VectorCollectionStats` command and `vector_collection_stats()` API. CollectionInfo now includes `index_type` and `memory_bytes` fields. Backed by `index_type_name()` and `memory_usage()` on the `VectorIndexBackend` trait.
+- **Reserved internal vector namespace**: `_system_*` collections for the intelligence layer with `validate_system_collection_name()` and internal `system_insert`/`system_search` methods. Hidden from `vector_list_collections`.
+- **Shared distance functions**: Extracted distance computation into `distance.rs` module shared by both BruteForce and HNSW backends (cosine, euclidean, dot product).
+- **strata-security crate**: Read-only access mode for database connections (from PR #1012).
+
 ## [0.1.0] - 2026-01-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ db.state_cas("lock", None, "acquired")?;
 | **Event Log** | Immutable audit trail, tool call history | `event_append`, `event_read`, `event_read_by_type` |
 | **State Cell** | CAS-based coordination, counters, locks | `state_set`, `state_read`, `state_cas`, `state_init` |
 | **JSON Store** | Structured documents with path-level mutations | `json_set`, `json_get`, `json_delete`, `json_list` |
-| **Vector Store** | Embeddings and similarity search | `vector_upsert`, `vector_search`, `vector_create_collection` |
+| **Vector Store** | Embeddings and similarity search (brute-force + HNSW) | `vector_upsert`, `vector_search`, `vector_batch_upsert` |
 | **Branch** | Data isolation (like git branches) | `create_branch`, `set_branch`, `list_branches`, `delete_branch` |
 
 ## Installation
@@ -63,6 +63,39 @@ fn main() -> stratadb::Result<()> {
 }
 ```
 
+## Vector Search
+
+StrataDB includes a built-in vector store with two index backends for similarity search:
+
+| Backend | Complexity | Best For |
+|---------|-----------|----------|
+| **Brute Force** | O(n) exact search | Small collections (< 10K vectors) |
+| **HNSW** | O(log n) approximate search | Large collections (10K+ vectors) |
+
+```rust
+use stratadb::{Strata, DistanceMetric};
+
+let db = Strata::cache()?;
+
+// Create a collection with cosine similarity
+db.vector_create_collection("embeddings", 384, DistanceMetric::Cosine)?;
+
+// Upsert vectors with metadata
+db.vector_upsert("embeddings", "doc-1", embedding, Some(metadata))?;
+
+// Batch upsert for bulk loading
+db.vector_batch_upsert("embeddings", entries)?;
+
+// Similarity search
+let results = db.vector_search("embeddings", query_embedding, 10)?;
+
+// Collection statistics
+let stats = db.vector_collection_stats("embeddings")?;
+println!("{} vectors, {} bytes, index: {}", stats.count, stats.memory_bytes, stats.index_type);
+```
+
+**Metadata filtering** supports 8 operators: `Eq`, `Ne`, `Gt`, `Gte`, `Lt`, `Lte`, `In`, `Contains`.
+
 ## Durability
 
 Choose your speed/safety trade-off:
@@ -77,7 +110,7 @@ Choose your speed/safety trade-off:
 
 ```
 +-----------------------------------------------------------+
-|  Strata API (KV, Event, State, JSON, Vector, Branch)         |
+|  Strata API (KV, Event, State, JSON, Vector, Branch)      |
 +-----------------------------------------------------------+
 |  Executor (Command dispatch) / Session (Transactions)     |
 +-----------------------------------------------------------+
@@ -89,10 +122,10 @@ Choose your speed/safety trade-off:
 | (OCC, CAS)  |  |  (WAL, Snapshots)     |  | (Search,BM25)|
 +-------------+  +----------+------------+  +--------------+
                              |
-                   +---------v---------+
-                   |  Storage          |
-                   |  (ShardedStore)   |
-                   +-------------------+
+                   +---------v---------+  +--------------+
+                   |  Storage          |  |  Security    |
+                   |  (ShardedStore)   |  |  (Access)    |
+                   +-------------------+  +--------------+
 ```
 
 **Key design choices:**
@@ -101,6 +134,7 @@ Choose your speed/safety trade-off:
 - **Branch-tagged keys** — every key includes its branch ID, making replay O(branch size)
 - **Optimistic concurrency** — lock-free transactions via compare-and-swap; agents rarely conflict
 - **Batched durability** — fsync batched by default; losing 100ms of work is acceptable for most agents
+- **Pluggable vector indexing** — swap between brute-force O(n) and HNSW O(log n) per collection
 
 ## Documentation
 

--- a/docs/architecture/crate-structure.md
+++ b/docs/architecture/crate-structure.md
@@ -1,6 +1,6 @@
 # Crate Structure
 
-StrataDB is a Rust workspace with 7 member crates. Dependencies flow downward — higher-level crates depend on lower-level ones.
+StrataDB is a Rust workspace with 8 member crates. Dependencies flow downward — higher-level crates depend on lower-level ones.
 
 ## Dependency Graph
 
@@ -15,9 +15,11 @@ stratadb (root)
         │     │           └── strata-core
         │     ├── strata-storage
         │     └── strata-durability
-        └── strata-intelligence
-              ├── strata-core
-              └── strata-engine
+        ├── strata-intelligence
+        │     ├── strata-core
+        │     └── strata-engine
+        └── strata-security
+              └── strata-core
 ```
 
 ## Crate Descriptions
@@ -100,6 +102,17 @@ stratadb (root)
 
 **Dependencies:** strata-core, strata-engine, dashmap, serde
 
+### `strata-security`
+
+**Purpose:** Access control and security policies.
+
+**Key responsibilities:**
+- Read-only access mode for database connections
+- Per-connection access control (read-write vs read-only)
+- Future: role-based access control, authentication
+
+**Dependencies:** strata-core
+
 ### `strata-executor`
 
 **Purpose:** Public API and command dispatch. **This is the only crate users import.**
@@ -108,12 +121,12 @@ stratadb (root)
 - `Strata` — the main user-facing API with typed methods
 - `Session` — stateful transaction support
 - `Executor` — command dispatcher
-- `Command` — all operations as enum variants
+- `Command` — all operations as enum variants (47 commands across 11 categories)
 - `Output` — all results as enum variants
 - `Error` — structured error type
 - Re-exports `Value` from strata-core
 
-**Dependencies:** strata-core, strata-engine, strata-intelligence
+**Dependencies:** strata-core, strata-engine, strata-intelligence, strata-security
 
 ## Root Crate: `stratadb`
 

--- a/docs/concepts/primitives.md
+++ b/docs/concepts/primitives.md
@@ -10,7 +10,7 @@ StrataDB provides **six data primitives** — purpose-built data structures that
 | **[Event Log](../guides/event-log.md)** | Append-only sequence of typed events | Audit trails, tool call history, decision logs |
 | **[State Cell](../guides/state-cell.md)** | Named cell with CAS | Coordination, counters, locks, state machines |
 | **[JSON Store](../guides/json-store.md)** | Key → JSON document with path access | Structured config, conversation history |
-| **[Vector Store](../guides/vector-store.md)** | Collection of keyed embeddings | Similarity search, RAG context, agent memory |
+| **[Vector Store](../guides/vector-store.md)** | Collection of keyed embeddings with pluggable indexing (brute-force or HNSW) | Similarity search, RAG context, agent memory |
 | **[Branch](../guides/branch-management.md)** | Named isolated namespace | Session isolation, experiments, multi-tenancy |
 
 ## Choosing the Right Primitive
@@ -23,7 +23,7 @@ StrataDB provides **six data primitives** — purpose-built data structures that
 
 **"I need a structured document I can update at specific paths"** → JSON Store. You can read and write at JSON paths like `$.config.temperature` without replacing the whole document.
 
-**"I need to store and search embeddings"** → Vector Store. Create collections with a fixed dimension and distance metric, then search by similarity.
+**"I need to store and search embeddings"** → Vector Store. Create collections with a fixed dimension and distance metric, then search by similarity. Supports brute-force (exact) and HNSW (approximate) indexing, batch upsert for bulk loading, and 8 metadata filter operators.
 
 **"I need to isolate data between sessions or experiments"** → Branches. Every other primitive is scoped to a branch.
 

--- a/docs/reference/api-quick-reference.md
+++ b/docs/reference/api-quick-reference.md
@@ -69,10 +69,12 @@ Every method on the `Strata` struct, grouped by category.
 | `vector_create_collection` | `(name: &str, dimension: u64, metric: DistanceMetric) -> Result<u64>` | Version | |
 | `vector_delete_collection` | `(name: &str) -> Result<bool>` | Whether it existed | |
 | `vector_list_collections` | `() -> Result<Vec<CollectionInfo>>` | All collections | |
+| `vector_collection_stats` | `(collection: &str) -> Result<CollectionInfo>` | Collection details | Includes `index_type`, `memory_bytes` |
 | `vector_upsert` | `(collection: &str, key: &str, vector: Vec<f32>, metadata: Option<Value>) -> Result<u64>` | Version | |
+| `vector_batch_upsert` | `(collection: &str, entries: Vec<BatchVectorEntry>) -> Result<Vec<u64>>` | Versions | Atomic bulk insert |
 | `vector_get` | `(collection: &str, key: &str) -> Result<Option<VersionedVectorData>>` | Vector data or None | |
 | `vector_delete` | `(collection: &str, key: &str) -> Result<bool>` | Whether it existed | |
-| `vector_search` | `(collection: &str, query: Vec<f32>, k: u64) -> Result<Vec<VectorMatch>>` | Top-k matches | |
+| `vector_search` | `(collection: &str, query: Vec<f32>, k: u64) -> Result<Vec<VectorMatch>>` | Top-k matches | 8 metadata filter operators |
 
 ## Branch Operations (Low-Level)
 

--- a/docs/reference/command-reference.md
+++ b/docs/reference/command-reference.md
@@ -12,7 +12,7 @@ This reference is primarily for SDK builders and contributors. Most users should
 | JSON | 5 | JSON document operations |
 | Event | 4 | Event log operations |
 | State | 5 | State cell operations |
-| Vector | 7 | Vector store operations |
+| Vector | 9 | Vector store operations |
 | Branch | 5 | Branch lifecycle operations |
 | Transaction | 5 | Transaction control |
 | Retention | 3 | Retention policy |
@@ -66,7 +66,9 @@ This reference is primarily for SDK builders and contributors. Most users should
 | `VectorCreateCollection` | `branch?`, `collection`, `dimension`, `metric` | `Version(u64)` |
 | `VectorDeleteCollection` | `branch?`, `collection` | `Bool(existed)` |
 | `VectorListCollections` | `branch?` | `VectorCollectionList(Vec<CollectionInfo>)` |
+| `VectorCollectionStats` | `branch?`, `collection` | `VectorCollectionList(Vec<CollectionInfo>)` |
 | `VectorUpsert` | `branch?`, `collection`, `key`, `vector`, `metadata?` | `Version(u64)` |
+| `VectorBatchUpsert` | `branch?`, `collection`, `entries` | `Versions(Vec<u64>)` |
 | `VectorGet` | `branch?`, `collection`, `key` | `VectorData(Option<VersionedVectorData>)` |
 | `VectorDelete` | `branch?`, `collection`, `key` | `Bool(existed)` |
 | `VectorSearch` | `branch?`, `collection`, `query`, `k`, `filter?`, `metric?` | `VectorMatches(Vec<VectorMatch>)` |

--- a/roadmap/v0.4-vector-enhancements.md
+++ b/roadmap/v0.4-vector-enhancements.md
@@ -2,65 +2,80 @@
 
 **Theme**: Vector search at scale.
 
-v0.1 ships brute-force vector search, which is correct but O(n) per query. v0.4 adds approximate nearest neighbor indexing and storage optimizations to handle larger vector collections.
+**Status**: Implemented (2026-02-03)
 
-## Features
+v0.1 shipped brute-force vector search, which is correct but O(n) per query. v0.4 adds approximate nearest neighbor indexing, advanced metadata filtering, batch operations, collection statistics, and a reserved internal namespace for the intelligence layer.
+
+## Implemented Features
 
 ### HNSW Index Backend
 
-Add Hierarchical Navigable Small World graph indexing for sub-linear vector search.
+Added Hierarchical Navigable Small World graph indexing for sub-linear vector search, built from scratch and verified against the Malkov & Yashunin paper (arXiv:1603.09320).
 
-- `IndexBackendFactory` trait already exists in `crates/engine/src/primitives/vector/`
-- `VectorIndexBackend` trait defines the interface: `insert`, `remove`, `search`, `len`
-- `BruteForceBackend` is the current implementation
-- Add `HnswBackend` as a new backend, selectable per collection at creation time
-- Consider wrapping an existing HNSW library (e.g., `instant-distance` or `hnsw_rs`)
-
-### F16 Half-Precision Storage
-
-Store vectors in 16-bit floating point to halve memory usage.
-
-- `StorageDtype` enum in `crates/core/src/primitives/vector.rs` already reserves byte value `1` for F16
-- Currently only `F32` (value `0`) is implemented
-- Add conversion between F32 (compute) and F16 (storage)
-- Quantization happens at storage time; search uses F32 internally
-
-### Int8 Scalar Quantization
-
-Store vectors as 8-bit integers for 4x memory reduction vs F32.
-
-- `StorageDtype` reserves byte value `2` for Int8
-- Requires calibration step to determine scale/offset per collection
-- Higher compression, lower accuracy -- suitable for large-scale retrieval
+- `HnswBackend` implements `VectorIndexBackend` trait in `crates/engine/src/primitives/vector/hnsw.rs`
+- `IndexBackendFactory::Hnsw(HnswConfig)` variant for per-collection backend selection
+- Configurable parameters: M (16), ef_construction (200), ef_search (50)
+- Deterministic: seeded PRNG (SplitMix64), BTreeMap nodes, BTreeSet neighbors
+- Full snapshot serialization/deserialization of graph state
+- `rebuild_graph()` for post-recovery reconstruction
+- 17 unit tests including multi-query recall validation (>= 0.95 average)
 
 ### Advanced Metadata Filters
 
-Extend metadata filtering beyond simple equality.
+Extended metadata filtering beyond simple equality to 8 operators.
 
-- `MetadataFilter` type exists in `crates/core/src/primitives/vector.rs`
-- `JsonScalar` supports basic scalar types
-- Add: range filters (`gt`, `lt`, `gte`, `lte`), `in` operator, nested path access
-- Filters applied during search to prune candidates before distance computation
+- `FilterCondition` and `FilterOp` types in `crates/core/src/primitives/vector.rs`
+- Operators: Eq, Ne, Gt, Gte, Lt, Lte, In, Contains
+- Full executor bridge support in `bridge.rs`
+- Builder methods on `MetadataFilter`: `.ne()`, `.gt()`, `.gte()`, `.lt()`, `.lte()`, `.in_values()`, `.contains()`
 
 ### Batch Vector Upsert
 
-Insert/update multiple vectors in a single operation.
+Insert/update multiple vectors in a single atomic operation.
 
-- Currently each upsert is a separate command
-- Batch API reduces transaction overhead for bulk ingestion
-- Important for RAG pipelines that embed documents in chunks
+- `VectorBatchUpsert` command in executor
+- `vector_batch_upsert()` API method
+- `batch_insert()` engine method with single write lock
+- Validates all entries before committing (no partial writes)
 
 ### Collection Statistics
 
-Expose per-collection metrics.
+Per-collection metrics exposed through the API.
 
-- Add: vector count, dimension, index type, storage size, dtype distribution
-- Useful for monitoring and capacity planning
+- `VectorCollectionStats` command
+- `vector_collection_stats()` API method
+- `CollectionInfo` now includes `index_type` ("brute_force" or "hnsw") and `memory_bytes`
+- Backed by `index_type_name()` and `memory_usage()` on `VectorIndexBackend` trait
+
+### Reserved Internal Vector Namespace
+
+`_system_*` collections for the intelligence layer.
+
+- `validate_system_collection_name()` in `collection.rs`
+- `create_system_collection()`, `system_insert()`, `system_search()` internal methods in `store.rs`
+- `vector_list_collections` filters out `_`-prefixed collections from user results
+
+### Shared Distance Functions
+
+Extracted distance computation into a shared module.
+
+- `distance.rs` with `compute_similarity()`, `cosine_similarity()`, `euclidean_similarity()`, `dot_product()`, `l2_norm()`, `euclidean_distance()`
+- Both BruteForceBackend and HnswBackend import from this shared module
+
+## Deferred Features
+
+### F16 Half-Precision Storage
+
+Deferred as premature optimization. `StorageDtype` reserves byte value `1` for F16.
+
+### Int8 Scalar Quantization
+
+Deferred as premature optimization. `StorageDtype` reserves byte value `2` for Int8.
 
 ## Context
 
-Vector search is central to AI agent workloads (RAG, memory retrieval, similarity matching). Brute-force works for <10K vectors but real applications often need 100K+. Index backends and quantization unlock these scales.
+Vector search is central to AI agent workloads (RAG, memory retrieval, similarity matching). Brute-force works for <10K vectors but real applications often need 100K+. The HNSW index backend unlocks these scales with ~95%+ recall at O(log n) search complexity.
 
 ## Dependencies
 
-None -- builds on v0.1 vector infrastructure.
+None — builds on v0.1 vector infrastructure.


### PR DESCRIPTION
## Summary
- Rewrite README with vector search section, HNSW backend comparison, and updated architecture diagram
- Add v0.4.0 entry to CHANGELOG covering HNSW, advanced filters, batch upsert, collection stats, internal namespace, and strata-security
- Rewrite vector-store guide with index backends, batch upsert, collection stats, and 8 metadata filter operators
- Rewrite vector-primitive architecture doc with both backends, HNSW internals, distance functions, and new operation flows
- Update api-quick-reference and command-reference with `vector_collection_stats` and `vector_batch_upsert`
- Update crate-structure to reflect 8 crates (add strata-security)
- Update primitives concept doc and RAG cookbook for pluggable indexing and batch operations
- Rewrite v0.4 roadmap as implemented with detailed notes

## Test plan
- [ ] Verify all markdown renders correctly on GitHub
- [ ] Verify all internal doc links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)