### PR TITLE
Fix all clippy warnings across workspace

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -162,7 +162,7 @@ impl TransactionManager {
     /// * `txn` - Transaction to commit (must be in Active state)
     /// * `store` - Storage to validate against and apply writes to
     /// * `wal` - Optional WAL for durability. Pass `None` for ephemeral databases
-    ///           or when durability is not required (DurabilityMode::Cache).
+    ///   or when durability is not required (DurabilityMode::Cache).
     ///
     /// # Returns
     /// - Ok(commit_version) on success

--- a/crates/core/src/contract/versioned_history.rs
+++ b/crates/core/src/contract/versioned_history.rs
@@ -50,6 +50,11 @@ impl<T> VersionedHistory<T> {
         self.versions.len()
     }
 
+    /// Returns `false` — a `VersionedHistory` is always non-empty.
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
     /// Get the version identifier of the latest entry.
     pub fn version(&self) -> Version {
         self.versions[0].version

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -137,7 +137,7 @@ impl TransactionCoordinator {
     /// * `txn` - Transaction to commit (must be in Active state)
     /// * `store` - Storage to validate against and apply writes to
     /// * `wal` - Optional WAL for durability. Pass `None` for ephemeral databases
-    ///           or when durability is not required.
+    ///   or when durability is not required.
     ///
     /// # Returns
     /// * `Ok(commit_version)` - Transaction committed successfully

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -69,7 +69,7 @@ use tracing::{info, warn};
 /// - **Disk + Cache**: Integration tests (fast, isolated, but files exist)
 /// - **Disk + Standard**: Production workloads
 /// - **Disk + Always**: Audit logs, critical data
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum PersistenceMode {
     /// No disk files at all - data exists only in memory
     ///
@@ -85,13 +85,8 @@ pub(crate) enum PersistenceMode {
     ///
     /// Creates directories and WAL file. Data can survive crashes
     /// depending on the `DurabilityMode`.
+    #[default]
     Disk,
-}
-
-impl Default for PersistenceMode {
-    fn default() -> Self {
-        PersistenceMode::Disk
-    }
 }
 
 // ============================================================================

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -71,9 +71,10 @@ fn global_namespace() -> Namespace {
 ///
 /// All branches are Active. Additional statuses will be added when
 /// lifecycle transitions are implemented.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 pub enum BranchStatus {
     /// Branch is currently active
+    #[default]
     Active,
 }
 
@@ -83,12 +84,6 @@ impl BranchStatus {
         match self {
             BranchStatus::Active => "Active",
         }
-    }
-}
-
-impl Default for BranchStatus {
-    fn default() -> Self {
-        BranchStatus::Active
     }
 }
 

--- a/crates/engine/src/primitives/event.rs
+++ b/crates/engine/src/primitives/event.rs
@@ -133,18 +133,18 @@ pub fn compute_event_hash(
     let mut hasher = Sha256::new();
 
     // Sequence (8 bytes, little-endian)
-    hasher.update(&sequence.to_le_bytes());
+    hasher.update(sequence.to_le_bytes());
 
     // Event type with length prefix (4 bytes length + content)
-    hasher.update(&(event_type.len() as u32).to_le_bytes());
+    hasher.update((event_type.len() as u32).to_le_bytes());
     hasher.update(event_type.as_bytes());
 
     // Timestamp (8 bytes, little-endian)
-    hasher.update(&timestamp.to_le_bytes());
+    hasher.update(timestamp.to_le_bytes());
 
     // Payload as canonical JSON with length prefix
     let payload_bytes = serde_json::to_vec(payload).unwrap_or_default();
-    hasher.update(&(payload_bytes.len() as u32).to_le_bytes());
+    hasher.update((payload_bytes.len() as u32).to_le_bytes());
     hasher.update(&payload_bytes);
 
     // Previous hash (32 bytes)

--- a/crates/engine/src/primitives/vector/brute_force.rs
+++ b/crates/engine/src/primitives/vector/brute_force.rs
@@ -139,10 +139,10 @@ impl VectorIndexBackend for BruteForceBackend {
     fn memory_usage(&self) -> usize {
         // Each active vector: dimension * 4 bytes (f32) for embedding data
         // Plus overhead for BTreeMap entries and free_slots
-        let embedding_bytes = self.heap.raw_data().len() * std::mem::size_of::<f32>();
+        let embedding_bytes = std::mem::size_of_val(self.heap.raw_data());
         let map_overhead =
             self.heap.len() * (std::mem::size_of::<VectorId>() + std::mem::size_of::<usize>() + 64); // BTreeMap node overhead estimate
-        let free_slots_bytes = self.heap.free_slots().len() * std::mem::size_of::<usize>();
+        let free_slots_bytes = std::mem::size_of_val(self.heap.free_slots());
         embedding_bytes + map_overhead + free_slots_bytes
     }
 

--- a/crates/engine/src/primitives/vector/hnsw.rs
+++ b/crates/engine/src/primitives/vector/hnsw.rs
@@ -193,8 +193,7 @@ impl HnswBackend {
         let uniform = (hash as f64) / (u64::MAX as f64);
         // Clamp to avoid log(0)
         let uniform = uniform.max(1e-15);
-        let level = (-uniform.ln() * self.config.ml) as usize;
-        level
+        (-uniform.ln() * self.config.ml) as usize
     }
 
     /// SplitMix64 hash function for deterministic PRNG
@@ -822,7 +821,7 @@ impl VectorIndexBackend for HnswBackend {
 
     fn memory_usage(&self) -> usize {
         // Embedding storage
-        let embedding_bytes = self.heap.raw_data().len() * std::mem::size_of::<f32>();
+        let embedding_bytes = std::mem::size_of_val(self.heap.raw_data());
         // Graph structure: each node has neighbor lists
         let graph_bytes: usize = self
             .nodes
@@ -838,7 +837,7 @@ impl VectorIndexBackend for HnswBackend {
             .sum();
         let heap_overhead =
             self.heap.len() * (std::mem::size_of::<VectorId>() + std::mem::size_of::<usize>() + 64);
-        let free_slots_bytes = self.heap.free_slots().len() * std::mem::size_of::<usize>();
+        let free_slots_bytes = std::mem::size_of_val(self.heap.free_slots());
 
         embedding_bytes + graph_bytes + heap_overhead + free_slots_bytes
     }

--- a/crates/engine/src/primitives/vector/store.rs
+++ b/crates/engine/src/primitives/vector/store.rs
@@ -1166,6 +1166,7 @@ impl VectorStore {
     /// Note: `_key`, `_metadata`, and `_source_ref` parameters are not used here because
     /// they are stored in the KV layer (via VectorRecord), which has its own WAL entries.
     /// This method only replays the embedding into the VectorHeap backend.
+    #[allow(clippy::too_many_arguments)]
     pub fn replay_upsert(
         &self,
         branch_id: BranchId,
@@ -1223,6 +1224,7 @@ impl VectorStore {
     /// Create a system collection (internal use only, bypasses `_` prefix check)
     ///
     /// System collections must have names starting with `_system_`.
+    #[allow(dead_code)]
     pub(crate) fn create_system_collection(
         &self,
         branch_id: BranchId,
@@ -1276,6 +1278,7 @@ impl VectorStore {
     }
 
     /// Insert into a system collection (internal use only)
+    #[allow(dead_code)]
     pub(crate) fn system_insert(
         &self,
         branch_id: BranchId,
@@ -1291,6 +1294,7 @@ impl VectorStore {
     }
 
     /// Search a system collection (internal use only)
+    #[allow(dead_code)]
     pub(crate) fn system_search(
         &self,
         branch_id: BranchId,

--- a/crates/engine/src/transaction/context.rs
+++ b/crates/engine/src/transaction/context.rs
@@ -181,7 +181,7 @@ impl<'a> TransactionOps for Transaction<'a> {
         let full_key = self.kv_key(key);
 
         // Use the ctx.put() method which handles all the bookkeeping
-        self.ctx.put(full_key, value).map_err(StrataError::from)?;
+        self.ctx.put(full_key, value)?;
 
         Ok(Version::txn(self.ctx.txn_id))
     }
@@ -193,7 +193,7 @@ impl<'a> TransactionOps for Transaction<'a> {
         let existed = self.kv_exists(key)?;
 
         // Use the ctx.delete() method
-        self.ctx.delete(full_key).map_err(StrataError::from)?;
+        self.ctx.delete(full_key)?;
 
         Ok(existed)
     }
@@ -276,7 +276,7 @@ impl<'a> TransactionOps for Transaction<'a> {
         })?;
         self.ctx
             .put(event_key, Value::String(event_json))
-            .map_err(StrataError::from)?;
+            ?;
 
         // Write EventLogMeta so EventLog::len() and other readers see the update after commit
         let meta_key = Key::new_event_meta(self.namespace.clone());
@@ -291,7 +291,7 @@ impl<'a> TransactionOps for Transaction<'a> {
         })?;
         self.ctx
             .put(meta_key, Value::String(meta_json))
-            .map_err(StrataError::from)?;
+            ?;
 
         // Update TransactionContext event state for cross-Transaction continuity
         self.ctx.set_event_state(
@@ -394,7 +394,7 @@ impl<'a> TransactionOps for Transaction<'a> {
 
         self.ctx
             .put(full_key, Value::String(state_json))
-            .map_err(StrataError::from)?;
+            ?;
 
         Ok(version)
     }
@@ -442,7 +442,7 @@ impl<'a> TransactionOps for Transaction<'a> {
 
         self.ctx
             .put(full_key, Value::String(state_json))
-            .map_err(StrataError::from)?;
+            ?;
 
         Ok(new_version)
     }
@@ -472,7 +472,7 @@ impl<'a> TransactionOps for Transaction<'a> {
         // Create the document by setting at root path
         self.ctx
             .json_set(&full_key, &JsonPath::root(), value)
-            .map_err(StrataError::from)?;
+            ?;
 
         Ok(Version::txn(self.ctx.txn_id))
     }
@@ -560,7 +560,7 @@ impl<'a> TransactionOps for Transaction<'a> {
         // Call ctx.json_set (same pattern as kv_put calling ctx.put)
         self.ctx
             .json_set(&full_key, path, value)
-            .map_err(StrataError::from)?;
+            ?;
 
         Ok(Version::txn(self.ctx.txn_id))
     }
@@ -574,7 +574,7 @@ impl<'a> TransactionOps for Transaction<'a> {
         // Delete the entire document by deleting at root path
         self.ctx
             .json_delete(&full_key, &JsonPath::root())
-            .map_err(StrataError::from)?;
+            ?;
 
         Ok(existed)
     }

--- a/crates/executor/src/handlers/vector.rs
+++ b/crates/executor/src/handlers/vector.rs
@@ -34,7 +34,7 @@ fn to_versioned_vector_data(
         .clone()
         .map(serde_json_to_value_public)
         .transpose()
-        .map_err(|e| crate::Error::from(e))?;
+        .map_err(crate::Error::from)?;
     Ok(VersionedVectorData {
         key: entry.key.clone(),
         data: VectorData {
@@ -52,7 +52,7 @@ fn to_vector_match(m: strata_engine::VectorMatch) -> Result<VectorMatch> {
         .metadata
         .map(serde_json_to_value_public)
         .transpose()
-        .map_err(|e| crate::Error::from(e))?;
+        .map_err(crate::Error::from)?;
     Ok(VectorMatch {
         key: m.key,
         score: m.score,
@@ -81,7 +81,7 @@ pub fn vector_upsert(
     let json_metadata = metadata
         .map(value_to_serde_json_public)
         .transpose()
-        .map_err(|e| crate::Error::from(e))?;
+        .map_err(crate::Error::from)?;
     let version = convert_vector_result(p.vector.insert(
         branch_id,
         &space,
@@ -133,6 +133,7 @@ pub fn vector_delete(
 }
 
 /// Handle VectorSearch command.
+#[allow(clippy::too_many_arguments)]
 pub fn vector_search(
     p: &Arc<Primitives>,
     branch: BranchId,
@@ -287,7 +288,7 @@ pub fn vector_batch_upsert(
             .metadata
             .map(value_to_serde_json_public)
             .transpose()
-            .map_err(|e| crate::Error::from(e))?;
+            .map_err(crate::Error::from)?;
         engine_entries.push((entry.key, entry.vector, json_metadata));
     }
 
@@ -298,7 +299,7 @@ pub fn vector_batch_upsert(
         engine_entries,
     ))?;
 
-    let version_nums: Vec<u64> = versions.iter().map(|v| extract_version(v)).collect();
+    let version_nums: Vec<u64> = versions.iter().map(extract_version).collect();
     Ok(Output::Versions(version_nums))
 }
 

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -16,11 +16,13 @@ use strata_core::Value;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct BranchId(pub String);
 
-impl BranchId {
-    /// Create a BranchId for the default branch.
-    pub fn default() -> Self {
+impl Default for BranchId {
+    fn default() -> Self {
         BranchId("default".to_string())
     }
+}
+
+impl BranchId {
 
     /// Check if this is the default branch.
     pub fn is_default(&self) -> bool {
@@ -30,12 +32,6 @@ impl BranchId {
     /// Get the string value.
     pub fn as_str(&self) -> &str {
         &self.0
-    }
-}
-
-impl Default for BranchId {
-    fn default() -> Self {
-        Self::default()
     }
 }
 
@@ -99,18 +95,13 @@ pub struct VersionedValue {
 // =============================================================================
 
 /// Distance metric for vector similarity search
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DistanceMetric {
+    #[default]
     Cosine,
     Euclidean,
     DotProduct,
-}
-
-impl Default for DistanceMetric {
-    fn default() -> Self {
-        DistanceMetric::Cosine
-    }
 }
 
 /// Metadata filter for vector search

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -6,16 +6,11 @@
 use serde::{Deserialize, Serialize};
 
 /// Controls whether the database allows writes or is read-only.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum AccessMode {
+    #[default]
     ReadWrite,
     ReadOnly,
-}
-
-impl Default for AccessMode {
-    fn default() -> Self {
-        AccessMode::ReadWrite
-    }
 }
 
 /// Options for opening a database.

--- a/crates/storage/src/sharded.rs
+++ b/crates/storage/src/sharded.rs
@@ -414,8 +414,8 @@ impl ShardedStore {
         self.shards
             .get(&branch_id)
             .map(|shard| {
-                shard.data.get(key).map_or(false, |chain| {
-                    chain.latest().map_or(false, |sv| !sv.is_tombstone())
+                shard.data.get(key).is_some_and(|chain| {
+                    chain.latest().is_some_and(|sv| !sv.is_tombstone())
                 })
             })
             .unwrap_or(false)
@@ -439,6 +439,7 @@ impl ShardedStore {
     ///
     /// Captures timestamp once per batch instead of per-write to avoid
     /// repeated syscalls. All writes in a transaction share the same timestamp.
+    #[allow(clippy::type_complexity)]
     pub fn apply_batch(
         &self,
         writes: &[(Key, strata_core::value::Value)],
@@ -558,7 +559,7 @@ impl ShardedStore {
                             .data
                             .get(*k)
                             .and_then(|chain| chain.latest())
-                            .map_or(false, |sv| !sv.is_tombstone())
+                            .is_some_and(|sv| !sv.is_tombstone())
                     })
                     .cloned()
                     .collect()
@@ -615,7 +616,7 @@ impl ShardedStore {
                             .data
                             .get(*k)
                             .and_then(|chain| chain.latest())
-                            .map_or(false, |sv| !sv.is_tombstone())
+                            .is_some_and(|sv| !sv.is_tombstone())
                     })
                     .cloned()
                     .collect()
@@ -673,7 +674,7 @@ impl ShardedStore {
                             .data
                             .get(*k)
                             .and_then(|chain| chain.latest())
-                            .map_or(false, |sv| !sv.is_tombstone())
+                            .is_some_and(|sv| !sv.is_tombstone())
                     })
                     .cloned()
                     .collect()
@@ -718,7 +719,7 @@ impl ShardedStore {
                                 .data
                                 .get(*k)
                                 .and_then(|chain| chain.latest())
-                                .map_or(false, |sv| !sv.is_tombstone())
+                                .is_some_and(|sv| !sv.is_tombstone())
                     })
                     .count()
             })


### PR DESCRIPTION
## Summary

- Fix all clippy warnings that would fail CI with `-D warnings`
- 14 files across 7 crates, zero behavior changes
- All tests pass

### Changes by lint

| Lint | Fix | Files |
|------|-----|-------|
| `derivable_impls` | Use `#[derive(Default)]` + `#[default]` | security, engine (2), executor |
| `len_without_is_empty` | Add `is_empty()` to `VersionedHistory` | core |
| `unnecessary_map_or` | `map_or(false, …)` → `is_some_and(…)` | storage (7 sites) |
| `useless_conversion` | Remove `.map_err(StrataError::from)` | engine/transaction (9 sites) |
| `needless_borrows_for_generic_args` | Remove `&` on `.to_le_bytes()` | engine/event |
| `manual_slice_size_calculation` | Use `size_of_val()` | engine/vector (4 sites) |
| `let_and_return` | Inline expression | engine/hnsw |
| `redundant_closure` | Use function reference directly | executor/vector (5 sites) |
| `should_implement_trait` | Move `BranchId::default()` to `Default` impl | executor/types |
| `doc_overindented_list_items` | Fix doc indent | concurrency, engine |
| `dead_code` | `#[allow]` on forward-planned system methods | engine/vector |
| `too_many_arguments` | `#[allow]` on `replay_upsert`, `vector_search` | engine, executor |
| `type_complexity` | `#[allow]` on `apply_batch` | storage |

## Test plan

- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — all suites pass, zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)