### PR TITLE
Standardize API naming: read→get, State returns bare Version

### DIFF
--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -612,11 +612,11 @@ impl TransactionContext {
         }
 
         // 3. Read from snapshot with version info
-        self.read_versioned_from_snapshot(key)
+        self.get_versioned_from_snapshot(key)
     }
 
     /// Read from snapshot preserving version metadata, and track in read_set
-    fn read_versioned_from_snapshot(&mut self, key: &Key) -> StrataResult<Option<VersionedValue>> {
+    fn get_versioned_from_snapshot(&mut self, key: &Key) -> StrataResult<Option<VersionedValue>> {
         let snapshot = self.snapshot.as_ref().ok_or_else(|| {
             StrataError::invalid_input("Transaction has no snapshot for reads".to_string())
         })?;

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -302,7 +302,7 @@ impl Key {
 
     /// Create an event type index key
     ///
-    /// Stores a per-type sequence index entry for efficient `read_by_type` lookups.
+    /// Stores a per-type sequence index entry for efficient `get_by_type` lookups.
     /// Key format: `__tidx__{event_type}\0{sequence_be_bytes}`
     ///
     /// The null byte separator ensures correct prefix scanning: scanning
@@ -319,7 +319,7 @@ impl Key {
 
     /// Create a prefix key for scanning all type index entries of a given event type
     ///
-    /// Used by `read_by_type` to find all sequence numbers for a specific event type.
+    /// Used by `get_by_type` to find all sequence numbers for a specific event type.
     pub fn new_event_type_idx_prefix(namespace: Namespace, event_type: &str) -> Self {
         let mut user_key = Vec::with_capacity(8 + event_type.len() + 1);
         user_key.extend_from_slice(b"__tidx__");

--- a/crates/engine/benches/primitive_benchmarks.rs
+++ b/crates/engine/benches/primitive_benchmarks.rs
@@ -105,7 +105,7 @@ fn bench_state_cas(c: &mut Criterion) {
     group.bench_function("cas", |b| {
         b.iter(|| {
             let current = state_cell
-                .read_versioned(&branch_id, "bench_cell")
+                .get_versioned(&branch_id, "bench_cell")
                 .unwrap()
                 .unwrap();
             let val = match current.value {
@@ -156,7 +156,7 @@ fn bench_cross_primitive_transaction(c: &mut Criterion) {
 }
 
 /// Benchmark EventLog read operations
-fn bench_event_read(c: &mut Criterion) {
+fn bench_event_get(c: &mut Criterion) {
     let (db, _temp, branch_id) = setup_db();
     let event_log = EventLog::new(db.clone());
 
@@ -174,14 +174,14 @@ fn bench_event_read(c: &mut Criterion) {
     group.bench_function("read", |b| {
         b.iter(|| {
             let i = counter.fetch_add(1, Ordering::SeqCst) % 1000;
-            event_log.read(&branch_id, i).unwrap()
+            event_log.get(&branch_id, i).unwrap()
         })
     });
     group.finish();
 }
 
 /// Benchmark StateCell read operations
-fn bench_state_read(c: &mut Criterion) {
+fn bench_state_get(c: &mut Criterion) {
     let (db, _temp, branch_id) = setup_db();
     let state_cell = StateCell::new(db.clone());
 
@@ -194,7 +194,7 @@ fn bench_state_read(c: &mut Criterion) {
     group.throughput(Throughput::Elements(1));
 
     group.bench_function("read", |b| {
-        b.iter(|| state_cell.read(&branch_id, "default", "read_cell").unwrap())
+        b.iter(|| state_cell.get(&branch_id, "default", "read_cell").unwrap())
     });
     group.finish();
 }
@@ -233,9 +233,9 @@ criterion_group!(
     bench_kv_get,
     bench_kv_list,
     bench_event_append,
-    bench_event_read,
+    bench_event_get,
     bench_state_cas,
-    bench_state_read,
+    bench_state_get,
     bench_cross_primitive_transaction,
 );
 criterion_main!(benches);

--- a/crates/engine/src/primitives/branch/handle.rs
+++ b/crates/engine/src/primitives/branch/handle.rs
@@ -218,10 +218,10 @@ impl EventHandle {
             .transaction(self.branch_id, |txn| txn.event_append(event_type, payload))
     }
 
-    /// Read an event by sequence number
-    pub fn read(&self, sequence: u64) -> StrataResult<Option<Value>> {
+    /// Get an event by sequence number
+    pub fn get(&self, sequence: u64) -> StrataResult<Option<Value>> {
         self.db
-            .transaction(self.branch_id, |txn| txn.event_read(sequence))
+            .transaction(self.branch_id, |txn| txn.event_get(sequence))
     }
 }
 
@@ -242,10 +242,10 @@ impl StateHandle {
         Self { db, branch_id }
     }
 
-    /// Read current state
-    pub fn read(&self, name: &str) -> StrataResult<Option<Value>> {
+    /// Get current state
+    pub fn get(&self, name: &str) -> StrataResult<Option<Value>> {
         self.db
-            .transaction(self.branch_id, |txn| txn.state_read(name))
+            .transaction(self.branch_id, |txn| txn.state_get(name))
     }
 
     /// Compare-and-swap update

--- a/crates/engine/src/primitives/extensions.rs
+++ b/crates/engine/src/primitives/extensions.rs
@@ -65,7 +65,7 @@ pub trait EventLogExt {
     fn event_append(&mut self, event_type: &str, payload: Value) -> StrataResult<u64>;
 
     /// Read an event by sequence number
-    fn event_read(&mut self, sequence: u64) -> StrataResult<Option<Value>>;
+    fn event_get(&mut self, sequence: u64) -> StrataResult<Option<Value>>;
 }
 
 /// State cell operations within a transaction
@@ -73,7 +73,7 @@ pub trait EventLogExt {
 /// Implemented in `state_cell.rs`
 pub trait StateCellExt {
     /// Read current state
-    fn state_read(&mut self, name: &str) -> StrataResult<Option<Value>>;
+    fn state_get(&mut self, name: &str) -> StrataResult<Option<Value>>;
 
     /// Compare-and-swap update, returns new version
     fn state_cas(

--- a/crates/engine/src/transaction_ops.rs
+++ b/crates/engine/src/transaction_ops.rs
@@ -75,7 +75,7 @@ pub trait TransactionOps {
     fn event_append(&mut self, event_type: &str, payload: Value) -> Result<Version, StrataError>;
 
     /// Read an event by sequence number
-    fn event_read(&self, sequence: u64) -> Result<Option<Versioned<Event>>, StrataError>;
+    fn event_get(&self, sequence: u64) -> Result<Option<Versioned<Event>>, StrataError>;
 
     /// Read a range of events [start, end)
     fn event_range(&self, start: u64, end: u64) -> Result<Vec<Versioned<Event>>, StrataError>;
@@ -88,7 +88,7 @@ pub trait TransactionOps {
     // =========================================================================
 
     /// Read a state cell
-    fn state_read(&self, name: &str) -> Result<Option<Versioned<State>>, StrataError>;
+    fn state_get(&self, name: &str) -> Result<Option<Versioned<State>>, StrataError>;
 
     /// Initialize a state cell (fails if exists)
     fn state_init(&mut self, name: &str, value: Value) -> Result<Version, StrataError>;
@@ -240,7 +240,7 @@ mod tests {
             Ok(Version::seq(self.event_count))
         }
 
-        fn event_read(&self, sequence: u64) -> Result<Option<Versioned<Event>>, StrataError> {
+        fn event_get(&self, sequence: u64) -> Result<Option<Versioned<Event>>, StrataError> {
             // Return None for simplicity - Event struct is complex
             if sequence == 0 || sequence > self.event_count {
                 return Ok(None);
@@ -264,9 +264,9 @@ mod tests {
         }
 
         // State operations - return not implemented error for mock
-        fn state_read(&self, _name: &str) -> Result<Option<Versioned<State>>, StrataError> {
+        fn state_get(&self, _name: &str) -> Result<Option<Versioned<State>>, StrataError> {
             Err(StrataError::Internal {
-                message: "state_read not implemented in mock".to_string(),
+                message: "state_get not implemented in mock".to_string(),
             })
         }
 
@@ -477,7 +477,7 @@ mod tests {
         assert_eq!(ops.event_len().unwrap(), 2);
 
         // Non-existent event (beyond the event count)
-        assert!(ops.event_read(999).unwrap().is_none());
+        assert!(ops.event_get(999).unwrap().is_none());
     }
 
     #[test]
@@ -505,7 +505,7 @@ mod tests {
         let ops: Box<dyn TransactionOps> = Box::new(MockTransactionOps::new());
 
         // State operations should return unimplemented error
-        let result = ops.state_read("test");
+        let result = ops.state_get("test");
         assert!(result.is_err());
 
         // Json operations should return unimplemented error
@@ -534,7 +534,7 @@ mod tests {
         let _ = ops_ref.kv_get("key");
         let _ = ops_ref.kv_exists("key");
         let _ = ops_ref.kv_list(None);
-        let _ = ops_ref.event_read(1);
+        let _ = ops_ref.event_get(1);
         let _ = ops_ref.event_range(1, 10);
         let _ = ops_ref.event_len();
     }

--- a/crates/engine/tests/adversarial_tests.rs
+++ b/crates/engine/tests/adversarial_tests.rs
@@ -605,7 +605,7 @@ fn test_statecell_transition_retries_under_contention() {
     }
 
     // All increments should have been applied
-    let final_state = state_cell.read(&branch_id, "default", "counter").unwrap().unwrap();
+    let final_state = state_cell.get(&branch_id, "default", "counter").unwrap().unwrap();
     let expected = (num_threads * increments_per_thread) as i64;
     assert_eq!(
         final_state.value.value,
@@ -1068,12 +1068,12 @@ fn test_branch_isolation_comprehensive() {
     );
 
     assert_eq!(
-        state_cell.read(&branch_a, "default", "cell").unwrap().unwrap().value,
+        state_cell.get(&branch_a, "default", "cell").unwrap().unwrap().value,
         Value::Int(100),
         "Branch A should see its own state"
     );
     assert_eq!(
-        state_cell.read(&branch_b, "default", "cell").unwrap().unwrap().value,
+        state_cell.get(&branch_b, "default", "cell").unwrap().unwrap().value,
         Value::Int(200),
         "Branch B should see its own state"
     );
@@ -1131,7 +1131,7 @@ fn test_persistence_across_reopen() {
         assert_eq!(event_count, 1, "Event should persist across reopen");
 
         // StateCell should persist
-        let state = state_cell.read(&branch_id, "default", "persistent_cell").unwrap().unwrap();
+        let state = state_cell.get(&branch_id, "default", "persistent_cell").unwrap().unwrap();
         assert_eq!(
             state.value.value,
             Value::Int(999),

--- a/crates/engine/tests/branch_isolation_tests.rs
+++ b/crates/engine/tests/branch_isolation_tests.rs
@@ -129,11 +129,11 @@ fn test_state_cell_isolation() {
 
     // Each branch sees its own value
     let state1 = state_cell
-        .read(&branch1, "default", "counter")
+        .get(&branch1, "default", "counter")
         .unwrap()
         .unwrap();
     let state2 = state_cell
-        .read(&branch2, "default", "counter")
+        .get(&branch2, "default", "counter")
         .unwrap()
         .unwrap();
 
@@ -152,11 +152,11 @@ fn test_state_cell_isolation() {
         .unwrap();
 
     let state1 = state_cell
-        .read(&branch1, "default", "counter")
+        .get(&branch1, "default", "counter")
         .unwrap()
         .unwrap();
     let state2 = state_cell
-        .read(&branch2, "default", "counter")
+        .get(&branch2, "default", "counter")
         .unwrap()
         .unwrap();
 
@@ -238,14 +238,14 @@ fn test_cross_branch_query_isolation() {
     // Actually both have overlapping key names, but different values
     assert_eq!(
         state_cell
-            .read(&branch1, "default", "state")
+            .get(&branch1, "default", "state")
             .unwrap()
             .unwrap(),
         Value::String("branch1".into())
     );
     assert_eq!(
         state_cell
-            .read(&branch2, "default", "state")
+            .get(&branch2, "default", "state")
             .unwrap()
             .unwrap(),
         Value::String("branch2".into())
@@ -298,7 +298,7 @@ fn test_branch_delete_isolation() {
     assert!(kv.get(&branch1, "default", "key").unwrap().is_none());
     assert_eq!(event_log.len(&branch1, "default").unwrap(), 0);
     assert!(state_cell
-        .read(&branch1, "default", "cell")
+        .get(&branch1, "default", "cell")
         .unwrap()
         .is_none());
 
@@ -309,7 +309,7 @@ fn test_branch_delete_isolation() {
     );
     assert_eq!(event_log.len(&branch2, "default").unwrap(), 1);
     assert!(state_cell
-        .read(&branch2, "default", "cell")
+        .get(&branch2, "default", "cell")
         .unwrap()
         .is_some());
 }
@@ -381,11 +381,11 @@ fn test_state_cell_cas_isolation() {
 
     // Both have been updated
     let s1 = state_cell
-        .read(&branch1, "default", "cell")
+        .get(&branch1, "default", "cell")
         .unwrap()
         .unwrap();
     let s2 = state_cell
-        .read(&branch2, "default", "cell")
+        .get(&branch2, "default", "cell")
         .unwrap()
         .unwrap();
 
@@ -422,14 +422,14 @@ fn test_event_log_chain_isolation() {
         .unwrap();
 
     // Read events to get hashes
-    let event1_0 = event_log.read(&branch1, "default", 0).unwrap().unwrap();
-    let event2_0 = event_log.read(&branch2, "default", 0).unwrap().unwrap();
+    let event1_0 = event_log.get(&branch1, "default", 0).unwrap().unwrap();
+    let event2_0 = event_log.get(&branch2, "default", 0).unwrap().unwrap();
 
     // Chains have different hashes (different content)
     assert_ne!(event1_0.value.hash, event2_0.value.hash);
 
     // Read event from branch1 - prev_hash links within branch1 only
-    let event1_1 = event_log.read(&branch1, "default", 1).unwrap().unwrap();
+    let event1_1 = event_log.get(&branch1, "default", 1).unwrap().unwrap();
     assert_eq!(event1_1.value.prev_hash, event1_0.value.hash);
 
     // Note: verify_chain() removed in MVP simplification

--- a/crates/engine/tests/primitives_cross_tests.rs
+++ b/crates/engine/tests/primitives_cross_tests.rs
@@ -80,7 +80,7 @@ fn test_kv_event_state_atomic() {
     assert_eq!(event_log.len(&branch_id, "default").unwrap(), 1);
 
     let state = state_cell
-        .read(&branch_id, "default", "workflow")
+        .get(&branch_id, "default", "workflow")
         .unwrap()
         .unwrap();
     assert_eq!(state, Value::String("step1".into()));
@@ -128,7 +128,7 @@ fn test_cross_primitive_rollback() {
 
     // Verify StateCell unchanged
     let state = state_cell
-        .read(&branch_id, "default", "cell")
+        .get(&branch_id, "default", "cell")
         .unwrap()
         .unwrap();
     assert_eq!(state, Value::Int(100));
@@ -170,7 +170,7 @@ fn test_all_extension_traits_compose() {
     assert!(kv.get(&branch_id, "default", "config").unwrap().is_some());
     assert_eq!(event_log.len(&branch_id, "default").unwrap(), 1);
     assert!(state_cell
-        .read(&branch_id, "default", "counter")
+        .get(&branch_id, "default", "counter")
         .unwrap()
         .is_some());
 }
@@ -214,7 +214,7 @@ fn test_partial_failure_full_rollback() {
     assert_eq!(event_log.len(&branch_id, "default").unwrap(), 0);
 
     let state = state_cell
-        .read(&branch_id, "default", "state")
+        .get(&branch_id, "default", "state")
         .unwrap()
         .unwrap();
     assert_eq!(state, Value::Int(0)); // Unchanged
@@ -259,13 +259,13 @@ fn test_nested_primitive_operations() {
 
     // Verify causal chain worked
     let event_log = EventLog::new(db.clone());
-    let event = event_log.read(&branch_id, "default", 0).unwrap().unwrap();
+    let event = event_log.get(&branch_id, "default", 0).unwrap().unwrap();
     // Payload is now wrapped: {"from_kv": 42}
     let expected_payload = Value::Object(HashMap::from([("from_kv".to_string(), Value::Int(42))]));
     assert_eq!(event.value.payload, expected_payload);
 
     let state = state_cell
-        .read(&branch_id, "default", "sequence_tracker")
+        .get(&branch_id, "default", "sequence_tracker")
         .unwrap()
         .unwrap();
     assert_eq!(state, Value::Int(0)); // Sequence number (starts at 0)
@@ -311,7 +311,7 @@ fn test_multiple_transactions_consistency() {
 
     // Counter at 10
     let state = state_cell
-        .read(&branch_id, "default", "counter")
+        .get(&branch_id, "default", "counter")
         .unwrap()
         .unwrap();
     assert_eq!(state, Value::Int(10));
@@ -364,7 +364,7 @@ fn test_read_only_transaction() {
         let kv_val = txn.kv_get("existing")?;
         assert_eq!(kv_val, Some(Value::Int(100)));
 
-        let state_val = txn.state_read("cell")?;
+        let state_val = txn.state_get("cell")?;
         assert!(state_val.is_some());
 
         Ok(())
@@ -378,7 +378,7 @@ fn test_read_only_transaction() {
         Some(Value::Int(100))
     );
     let state = state_cell
-        .read(&branch_id, "default", "cell")
+        .get(&branch_id, "default", "cell")
         .unwrap()
         .unwrap();
     assert_eq!(state, Value::Int(50));

--- a/crates/engine/tests/recovery_tests.rs
+++ b/crates/engine/tests/recovery_tests.rs
@@ -163,9 +163,9 @@ fn test_event_log_chain_survives_recovery() {
         .unwrap();
 
     // Read to get hashes before crash
-    let pre_event0 = event_log.read(&branch_id, "default", 0).unwrap().unwrap();
-    let pre_event1 = event_log.read(&branch_id, "default", 1).unwrap().unwrap();
-    let pre_event2 = event_log.read(&branch_id, "default", 2).unwrap().unwrap();
+    let pre_event0 = event_log.get(&branch_id, "default", 0).unwrap().unwrap();
+    let pre_event1 = event_log.get(&branch_id, "default", 1).unwrap().unwrap();
+    let pre_event2 = event_log.get(&branch_id, "default", 2).unwrap().unwrap();
 
     let hash0 = pre_event0.value.hash;
     let hash1 = pre_event1.value.hash;
@@ -186,16 +186,16 @@ fn test_event_log_chain_survives_recovery() {
     assert_eq!(event_log.len(&branch_id, "default").unwrap(), 3);
 
     // Events readable with correct hashes
-    let event0 = event_log.read(&branch_id, "default", 0).unwrap().unwrap();
+    let event0 = event_log.get(&branch_id, "default", 0).unwrap().unwrap();
     assert_eq!(event0.value.event_type, "event1");
     assert_eq!(event0.value.payload, string_payload("payload1"));
     assert_eq!(event0.value.hash, hash0);
 
-    let event2 = event_log.read(&branch_id, "default", 2).unwrap().unwrap();
+    let event2 = event_log.get(&branch_id, "default", 2).unwrap().unwrap();
     assert_eq!(event2.value.hash, hash2);
 
     // Hash chaining preserved - event1 prev_hash points to event0's hash
-    let event1 = event_log.read(&branch_id, "default", 1).unwrap().unwrap();
+    let event1 = event_log.get(&branch_id, "default", 1).unwrap().unwrap();
     assert_eq!(event1.value.prev_hash, hash0);
     assert_eq!(event1.value.hash, hash1);
 
@@ -236,7 +236,7 @@ fn test_event_log_multiple_events_survives_recovery() {
     assert_eq!(event_log.len(&branch_id, "default").unwrap(), 5);
     assert_eq!(
         event_log
-            .read(&branch_id, "default", 1)
+            .get(&branch_id, "default", 1)
             .unwrap()
             .unwrap()
             .value
@@ -245,7 +245,7 @@ fn test_event_log_multiple_events_survives_recovery() {
     );
     assert_eq!(
         event_log
-            .read(&branch_id, "default", 2)
+            .get(&branch_id, "default", 2)
             .unwrap()
             .unwrap()
             .value
@@ -254,7 +254,7 @@ fn test_event_log_multiple_events_survives_recovery() {
     );
     assert_eq!(
         event_log
-            .read(&branch_id, "default", 3)
+            .get(&branch_id, "default", 3)
             .unwrap()
             .unwrap()
             .value
@@ -307,7 +307,7 @@ fn test_state_cell_version_survives_recovery() {
 
     // Verify before crash
     let state = state_cell
-        .read(&branch_id, "default", "counter")
+        .get(&branch_id, "default", "counter")
         .unwrap()
         .unwrap();
     assert_eq!(state, Value::Int(30));
@@ -322,7 +322,7 @@ fn test_state_cell_version_survives_recovery() {
 
     // Value is correct
     let state = state_cell
-        .read(&branch_id, "default", "counter")
+        .get(&branch_id, "default", "counter")
         .unwrap()
         .unwrap();
     assert_eq!(state, Value::Int(30));
@@ -337,7 +337,7 @@ fn test_state_cell_version_survives_recovery() {
             Value::Int(40),
         )
         .unwrap();
-    assert_eq!(new_versioned.value, Version::counter(5));
+    assert_eq!(new_versioned, Version::counter(5));
 
     // CAS with old version fails
     let result = state_cell.cas(
@@ -386,7 +386,7 @@ fn test_state_cell_set_survives_recovery() {
 
     // Value preserved
     let state = state_cell
-        .read(&branch_id, "default", "status")
+        .get(&branch_id, "default", "status")
         .unwrap()
         .unwrap();
     assert_eq!(state, Value::String("updated".into()));
@@ -541,7 +541,7 @@ fn test_cross_primitive_transaction_survives_recovery() {
     );
     assert_eq!(event_log.len(&branch_id, "default").unwrap(), 1);
     let state = state_cell
-        .read(&branch_id, "default", "txn_state")
+        .get(&branch_id, "default", "txn_state")
         .unwrap()
         .unwrap();
     assert_eq!(state, Value::Int(42));
@@ -684,12 +684,12 @@ fn test_all_primitives_recover_together() {
 
         // EventLog
         assert_eq!(event_log.len(&branch_id, "default").unwrap(), 1);
-        let event = event_log.read(&branch_id, "default", 0).unwrap().unwrap();
+        let event = event_log.get(&branch_id, "default", 0).unwrap().unwrap();
         assert_eq!(event.value.payload, int_payload(999));
 
         // StateCell
         let state = state_cell
-            .read(&branch_id, "default", "full_state")
+            .get(&branch_id, "default", "full_state")
             .unwrap()
             .unwrap();
         assert_eq!(state, Value::Int(100));

--- a/crates/executor/src/api/event.rs
+++ b/crates/executor/src/api/event.rs
@@ -1,6 +1,6 @@
 //! Event log operations (4 MVP).
 //!
-//! MVP: append, read, read_by_type, len
+//! MVP: append, read, get_by_type, len
 
 use super::Strata;
 use crate::types::*;
@@ -27,22 +27,22 @@ impl Strata {
     }
 
     /// Read a specific event by sequence number.
-    pub fn event_read(&self, sequence: u64) -> Result<Option<VersionedValue>> {
-        match self.executor.execute(Command::EventRead {
+    pub fn event_get(&self, sequence: u64) -> Result<Option<VersionedValue>> {
+        match self.executor.execute(Command::EventGet {
             branch: self.branch_id(),
             space: self.space_id(),
             sequence,
         })? {
             Output::MaybeVersioned(v) => Ok(v),
             _ => Err(Error::Internal {
-                reason: "Unexpected output for EventRead".into(),
+                reason: "Unexpected output for EventGet".into(),
             }),
         }
     }
 
     /// Read all events of a specific type.
-    pub fn event_read_by_type(&self, event_type: &str) -> Result<Vec<VersionedValue>> {
-        match self.executor.execute(Command::EventReadByType {
+    pub fn event_get_by_type(&self, event_type: &str) -> Result<Vec<VersionedValue>> {
+        match self.executor.execute(Command::EventGetByType {
             branch: self.branch_id(),
             space: self.space_id(),
             event_type: event_type.to_string(),
@@ -51,7 +51,7 @@ impl Strata {
         })? {
             Output::VersionedValues(events) => Ok(events),
             _ => Err(Error::Internal {
-                reason: "Unexpected output for EventReadByType".into(),
+                reason: "Unexpected output for EventGetByType".into(),
             }),
         }
     }

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -599,7 +599,7 @@ mod tests {
 
         // Simplified API: just pass &str directly
         db.state_set("cell", "state").unwrap();
-        let value = db.state_read("cell").unwrap();
+        let value = db.state_get("cell").unwrap();
         assert!(value.is_some());
         assert_eq!(value.unwrap(), Value::String("state".into()));
     }
@@ -620,7 +620,7 @@ mod tests {
         )
         .unwrap();
 
-        let events = db.event_read_by_type("stream").unwrap();
+        let events = db.event_get_by_type("stream").unwrap();
         assert_eq!(events.len(), 2);
     }
 
@@ -797,7 +797,7 @@ mod tests {
 
         // None of the data should exist in this branch
         assert!(db.kv_get("kv-key").unwrap().is_none());
-        assert!(db.state_read("state-cell").unwrap().is_none());
+        assert!(db.state_get("state-cell").unwrap().is_none());
         assert_eq!(db.event_len().unwrap(), 0);
     }
 

--- a/crates/executor/src/api/state.rs
+++ b/crates/executor/src/api/state.rs
@@ -26,8 +26,8 @@ impl Strata {
     }
 
     /// Read a state cell value.
-    pub fn state_read(&self, cell: &str) -> Result<Option<Value>> {
-        match self.executor.execute(Command::StateRead {
+    pub fn state_get(&self, cell: &str) -> Result<Option<Value>> {
+        match self.executor.execute(Command::StateGet {
             branch: self.branch_id(),
             space: self.space_id(),
             cell: cell.to_string(),
@@ -35,7 +35,7 @@ impl Strata {
             Output::MaybeVersioned(v) => Ok(v.map(|vv| vv.value)),
             Output::Maybe(v) => Ok(v),
             _ => Err(Error::Internal {
-                reason: "Unexpected output for StateRead".into(),
+                reason: "Unexpected output for StateGet".into(),
             }),
         }
     }
@@ -44,15 +44,15 @@ impl Strata {
     ///
     /// Returns all versions of the cell, newest first, or None if the cell
     /// doesn't exist.
-    pub fn state_readv(&self, cell: &str) -> Result<Option<Vec<crate::types::VersionedValue>>> {
-        match self.executor.execute(Command::StateReadv {
+    pub fn state_getv(&self, cell: &str) -> Result<Option<Vec<crate::types::VersionedValue>>> {
+        match self.executor.execute(Command::StateGetv {
             branch: self.branch_id(),
             space: self.space_id(),
             cell: cell.to_string(),
         })? {
             Output::VersionHistory(h) => Ok(h),
             _ => Err(Error::Internal {
-                reason: "Unexpected output for StateReadv".into(),
+                reason: "Unexpected output for StateGetv".into(),
             }),
         }
     }

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -179,7 +179,7 @@ pub enum Command {
     },
 
     // ==================== Event (4 MVP) ====================
-    // MVP: append, read, read_by_type, len
+    // MVP: append, read, get_by_type, len
     /// Append an event to the log.
     /// Returns: `Output::Version`
     EventAppend {
@@ -193,7 +193,7 @@ pub enum Command {
 
     /// Read a specific event by sequence number.
     /// Returns: `Output::MaybeVersioned`
-    EventRead {
+    EventGet {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         branch: Option<BranchId>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -203,7 +203,7 @@ pub enum Command {
 
     /// Read all events of a specific type.
     /// Returns: `Output::VersionedValues`
-    EventReadByType {
+    EventGetByType {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         branch: Option<BranchId>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -239,7 +239,7 @@ pub enum Command {
 
     /// Read a state cell value.
     /// Returns: `Output::MaybeVersioned`
-    StateRead {
+    StateGet {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         branch: Option<BranchId>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -261,7 +261,7 @@ pub enum Command {
 
     /// Get full version history for a state cell.
     /// Returns: `Output::VersionHistory`
-    StateReadv {
+    StateGetv {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         branch: Option<BranchId>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -610,13 +610,13 @@ impl Command {
             Command::JsonGetv { .. } => "JsonGetv",
             Command::JsonList { .. } => "JsonList",
             Command::EventAppend { .. } => "EventAppend",
-            Command::EventRead { .. } => "EventRead",
-            Command::EventReadByType { .. } => "EventReadByType",
+            Command::EventGet { .. } => "EventGet",
+            Command::EventGetByType { .. } => "EventGetByType",
             Command::EventLen { .. } => "EventLen",
             Command::StateSet { .. } => "StateSet",
-            Command::StateRead { .. } => "StateRead",
+            Command::StateGet { .. } => "StateGet",
             Command::StateCas { .. } => "StateCas",
-            Command::StateReadv { .. } => "StateReadv",
+            Command::StateGetv { .. } => "StateGetv",
             Command::StateInit { .. } => "StateInit",
             Command::StateDelete { .. } => "StateDelete",
             Command::StateList { .. } => "StateList",
@@ -692,13 +692,13 @@ impl Command {
             | Command::JsonList { branch, space, .. }
             // Event (4 MVP)
             | Command::EventAppend { branch, space, .. }
-            | Command::EventRead { branch, space, .. }
-            | Command::EventReadByType { branch, space, .. }
+            | Command::EventGet { branch, space, .. }
+            | Command::EventGetByType { branch, space, .. }
             | Command::EventLen { branch, space, .. }
             // State
             | Command::StateSet { branch, space, .. }
-            | Command::StateRead { branch, space, .. }
-            | Command::StateReadv { branch, space, .. }
+            | Command::StateGet { branch, space, .. }
+            | Command::StateGetv { branch, space, .. }
             | Command::StateCas { branch, space, .. }
             | Command::StateInit { branch, space, .. }
             | Command::StateDelete { branch, space, .. }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -270,7 +270,7 @@ impl Executor {
                     payload,
                 )
             }
-            Command::EventRead {
+            Command::EventGet {
                 branch,
                 space,
                 sequence,
@@ -279,9 +279,9 @@ impl Executor {
                     reason: "Branch must be specified or resolved to default".into(),
                 })?;
                 let space = space.unwrap_or_else(|| "default".to_string());
-                crate::handlers::event::event_read(&self.primitives, branch, space, sequence)
+                crate::handlers::event::event_get(&self.primitives, branch, space, sequence)
             }
-            Command::EventReadByType {
+            Command::EventGetByType {
                 branch,
                 space,
                 event_type,
@@ -292,7 +292,7 @@ impl Executor {
                     reason: "Branch must be specified or resolved to default".into(),
                 })?;
                 let space = space.unwrap_or_else(|| "default".to_string());
-                crate::handlers::event::event_read_by_type(
+                crate::handlers::event::event_get_by_type(
                     &self.primitives,
                     branch,
                     space,
@@ -323,7 +323,7 @@ impl Executor {
                 self.ensure_space_registered(&branch, &space)?;
                 crate::handlers::state::state_set(&self.primitives, branch, space, cell, value)
             }
-            Command::StateRead {
+            Command::StateGet {
                 branch,
                 space,
                 cell,
@@ -332,9 +332,9 @@ impl Executor {
                     reason: "Branch must be specified or resolved to default".into(),
                 })?;
                 let space = space.unwrap_or_else(|| "default".to_string());
-                crate::handlers::state::state_read(&self.primitives, branch, space, cell)
+                crate::handlers::state::state_get(&self.primitives, branch, space, cell)
             }
-            Command::StateReadv {
+            Command::StateGetv {
                 branch,
                 space,
                 cell,
@@ -343,7 +343,7 @@ impl Executor {
                     reason: "Branch must be specified or resolved to default".into(),
                 })?;
                 let space = space.unwrap_or_else(|| "default".to_string());
-                crate::handlers::state::state_readv(&self.primitives, branch, space, cell)
+                crate::handlers::state::state_getv(&self.primitives, branch, space, cell)
             }
             Command::StateCas {
                 branch,

--- a/crates/executor/src/handlers/event.rs
+++ b/crates/executor/src/handlers/event.rs
@@ -1,6 +1,6 @@
 //! Event command handlers (4 MVP).
 //!
-//! MVP: append, read, read_by_type, len
+//! MVP: append, read, get_by_type, len
 
 use std::sync::Arc;
 
@@ -48,15 +48,15 @@ pub fn event_append(
     Ok(Output::Version(bridge::extract_version(&version)))
 }
 
-/// Handle EventRead command.
-pub fn event_read(
+/// Handle EventGet command.
+pub fn event_get(
     p: &Arc<Primitives>,
     branch: BranchId,
     space: String,
     sequence: u64,
 ) -> Result<Output> {
     let core_branch_id = bridge::to_core_branch_id(&branch)?;
-    let event = convert_result(p.event.read(&core_branch_id, &space, sequence))?;
+    let event = convert_result(p.event.get(&core_branch_id, &space, sequence))?;
 
     let result = event.map(|e| VersionedValue {
         value: e.value.payload,
@@ -67,8 +67,8 @@ pub fn event_read(
     Ok(Output::MaybeVersioned(result))
 }
 
-/// Handle EventReadByType command.
-pub fn event_read_by_type(
+/// Handle EventGetByType command.
+pub fn event_get_by_type(
     p: &Arc<Primitives>,
     branch: BranchId,
     space: String,
@@ -77,7 +77,7 @@ pub fn event_read_by_type(
     after_sequence: Option<u64>,
 ) -> Result<Output> {
     let core_branch_id = bridge::to_core_branch_id(&branch)?;
-    let events = convert_result(p.event.read_by_type(&core_branch_id, &space, &event_type))?;
+    let events = convert_result(p.event.get_by_type(&core_branch_id, &space, &event_type))?;
 
     // Apply after_sequence filter
     let filtered: Vec<_> = if let Some(after_seq) = after_sequence {

--- a/crates/executor/src/tests/access_mode.rs
+++ b/crates/executor/src/tests/access_mode.rs
@@ -215,12 +215,12 @@ fn test_read_only_allows_all_reads() {
             cursor: None,
             limit: 10,
         },
-        Command::EventRead {
+        Command::EventGet {
             branch: None,
             space: None,
             sequence: 0,
         },
-        Command::EventReadByType {
+        Command::EventGetByType {
             branch: None,
             space: None,
             event_type: "t".into(),
@@ -231,12 +231,12 @@ fn test_read_only_allows_all_reads() {
             branch: None,
             space: None,
         },
-        Command::StateRead {
+        Command::StateGet {
             branch: None,
             space: None,
             cell: "c".into(),
         },
-        Command::StateReadv {
+        Command::StateGetv {
             branch: None,
             space: None,
             cell: "c".into(),
@@ -497,12 +497,12 @@ fn test_is_write_classification() {
             cursor: None,
             limit: 10,
         },
-        Command::EventRead {
+        Command::EventGet {
             branch: None,
             space: None,
             sequence: 0,
         },
-        Command::EventReadByType {
+        Command::EventGetByType {
             branch: None,
             space: None,
             event_type: "".into(),
@@ -513,12 +513,12 @@ fn test_is_write_classification() {
             branch: None,
             space: None,
         },
-        Command::StateRead {
+        Command::StateGet {
             branch: None,
             space: None,
             cell: "".into(),
         },
-        Command::StateReadv {
+        Command::StateGetv {
             branch: None,
             space: None,
             cell: "".into(),

--- a/crates/executor/src/tests/determinism.rs
+++ b/crates/executor/src/tests/determinism.rs
@@ -133,7 +133,7 @@ fn test_state_write_read_determinism() {
     // Read it multiple times - should always get same result
     let results: Vec<_> = (0..5)
         .map(|_| {
-            executor.execute(Command::StateRead {
+            executor.execute(Command::StateGet {
                 branch: Some(BranchId::from("default")),
                 space: None,
                 cell: "counter".to_string(),
@@ -348,7 +348,7 @@ fn test_vector_search_determinism() {
 // =============================================================================
 
 #[test]
-fn test_event_read_by_type_determinism() {
+fn test_event_get_by_type_determinism() {
     let executor = create_test_executor();
 
     // Append some events
@@ -366,7 +366,7 @@ fn test_event_read_by_type_determinism() {
     // ReadByType query multiple times - should get same results
     let results: Vec<_> = (0..5)
         .map(|_| {
-            executor.execute(Command::EventReadByType {
+            executor.execute(Command::EventGetByType {
                 branch: Some(BranchId::from("default")),
                 space: None,
                 event_type: "events".to_string(),

--- a/crates/executor/src/tests/parity.rs
+++ b/crates/executor/src/tests/parity.rs
@@ -212,7 +212,7 @@ fn test_json_set_get_parity() {
 // =============================================================================
 
 #[test]
-fn test_event_append_read_by_type_parity() {
+fn test_event_append_get_by_type_parity() {
     let (executor, p) = create_test_environment();
     let branch_id = strata_core::types::BranchId::from_bytes([0u8; 16]);
 
@@ -250,7 +250,7 @@ fn test_event_append_read_by_type_parity() {
         .unwrap();
 
     // ReadByType query via executor
-    let read_result = executor.execute(Command::EventReadByType {
+    let read_result = executor.execute(Command::EventGetByType {
         branch: None,
         space: None,
         event_type: "events".to_string(),
@@ -289,7 +289,7 @@ fn test_state_set_get_parity() {
     };
 
     // Get via direct primitive
-    let direct_get = p.state.read(&branch_id, "default", "cell1").unwrap();
+    let direct_get = p.state.get(&branch_id, "default", "cell1").unwrap();
     assert!(direct_get.is_some());
     assert_eq!(direct_get.unwrap(), Value::Int(100));
 
@@ -301,10 +301,10 @@ fn test_state_set_get_parity() {
 
     // Both should have counter 1 (first write to each cell)
     assert_eq!(counter1, 1);
-    assert_eq!(bridge::extract_version(&versioned2.version), 1);
+    assert_eq!(bridge::extract_version(&versioned2), 1);
 
     // Get cell2 via executor
-    let exec_get = executor.execute(Command::StateRead {
+    let exec_get = executor.execute(Command::StateGet {
         branch: None,
         space: None,
         cell: "cell2".to_string(),

--- a/crates/executor/src/tests/serialization.rs
+++ b/crates/executor/src/tests/serialization.rs
@@ -148,8 +148,8 @@ fn test_command_event_append() {
 }
 
 #[test]
-fn test_command_event_read() {
-    test_command_round_trip(Command::EventRead {
+fn test_command_event_get() {
+    test_command_round_trip(Command::EventGet {
         branch: Some(BranchId::from("default")),
         space: None,
         sequence: 42,
@@ -157,8 +157,8 @@ fn test_command_event_read() {
 }
 
 #[test]
-fn test_command_event_read_by_type() {
-    test_command_round_trip(Command::EventReadByType {
+fn test_command_event_get_by_type() {
+    test_command_round_trip(Command::EventGetByType {
         branch: Some(BranchId::from("default")),
         space: None,
         event_type: "events".to_string(),

--- a/crates/executor/src/tests/spaces.rs
+++ b/crates/executor/src/tests/spaces.rs
@@ -170,19 +170,19 @@ fn test_state_isolation_across_spaces() {
 
     // Switch to another space — cell should not be visible
     db.set_space("delta").unwrap();
-    let result = db.state_read("counter").unwrap();
+    let result = db.state_get("counter").unwrap();
     assert_eq!(result, None);
 
     // Set same cell with different value in delta
     db.state_set("counter", 20i64).unwrap();
 
     // Verify delta sees its own value
-    let v = db.state_read("counter").unwrap().unwrap();
+    let v = db.state_get("counter").unwrap().unwrap();
     assert_eq!(v, Value::Int(20));
 
     // Default still has its original value
     db.set_space("default").unwrap();
-    let v = db.state_read("counter").unwrap().unwrap();
+    let v = db.state_get("counter").unwrap().unwrap();
     assert_eq!(v, Value::Int(10));
 }
 

--- a/docs/architecture/event-primitive.md
+++ b/docs/architecture/event-primitive.md
@@ -200,7 +200,7 @@ Client               Handler             Engine (EventLog)    Transaction       
 
 **Steps:**
 
-1. **Handler**: Converts branch. Calls `primitives.event.read(&branch_id, sequence)`. Maps the returned `Versioned<Event>` to `VersionedValue { value: event.payload, version: sequence, timestamp }`.
+1. **Handler**: Converts branch. Calls `primitives.event.get(&branch_id, sequence)`. Maps the returned `Versioned<Event>` to `VersionedValue { value: event.payload, version: sequence, timestamp }`.
 2. **Engine (EventLog)**: Constructs `Key::new_event(ns, sequence)` (sequence as big-endian 8 bytes). Opens transaction. Calls `txn.get()`. Deserializes the JSON string back to `Event` struct. Wraps in `Versioned::with_timestamp(event, Version::Sequence(seq), Timestamp)`.
 3. **Transaction/Storage**: Standard read path through write set -> delete set -> snapshot.
 
@@ -245,7 +245,7 @@ Client               Handler             Engine (EventLog)    Transaction       
 
 **Steps:**
 
-1. **Handler**: Converts branch. Calls `primitives.event.read_by_type()`. Maps each `Versioned<Event>` to `VersionedValue { value: event.payload, version: sequence, timestamp }`.
+1. **Handler**: Converts branch. Calls `primitives.event.get_by_type()`. Maps each `Versioned<Event>` to `VersionedValue { value: event.payload, version: sequence, timestamp }`.
 2. **Engine (EventLog)**: Opens transaction. Reads `EventLogMeta` to get `next_sequence` (total event count). Iterates through ALL events from sequence 0 to N-1. For each event, deserializes and checks if `event.event_type == target_type`. Collects matching events.
 3. **Performance note**: This is an O(N) scan over all events in the branch. The `EventLogMeta.streams` map tracks per-type metadata but is not currently used to optimize the scan.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@
 //! | Primitive | Purpose | Key Methods |
 //! |-----------|---------|-------------|
 //! | **KV Store** | Working memory, config | `kv_put`, `kv_get`, `kv_delete`, `kv_list` |
-//! | **Event Log** | Immutable audit trail | `event_append`, `event_read`, `event_read_by_type` |
-//! | **State Cell** | CAS-based coordination | `state_set`, `state_read`, `state_cas` |
+//! | **Event Log** | Immutable audit trail | `event_append`, `event_get`, `event_get_by_type` |
+//! | **State Cell** | CAS-based coordination | `state_set`, `state_get`, `state_cas` |
 //! | **JSON Store** | Structured documents | `json_set`, `json_get`, `json_delete` |
 //! | **Vector Store** | Embeddings, similarity search | `vector_upsert`, `vector_search` |
 //! | **Branch** | Data isolation | `create_branch`, `set_branch`, `list_branches` |

--- a/tests/durability/cross_primitive_recovery.rs
+++ b/tests/durability/cross_primitive_recovery.rs
@@ -56,11 +56,11 @@ fn all_six_primitives_recover_together() {
 
     let events = p
         .event
-        .read_by_type(&branch_id, "default", "stream")
+        .get_by_type(&branch_id, "default", "stream")
         .unwrap();
     assert_eq!(events.len(), 1, "EventLog should recover");
 
-    let state_val = p.state.read(&branch_id, "default", "cell").unwrap();
+    let state_val = p.state.get(&branch_id, "default", "cell").unwrap();
     let state_val = state_val.expect("StateCell should recover");
     assert_eq!(state_val, Value::String("initial".into()));
 
@@ -97,7 +97,7 @@ fn interleaved_writes_recover_correctly() {
     }
 
     let events = event
-        .read_by_type(&branch_id, "default", "interleaved")
+        .get_by_type(&branch_id, "default", "interleaved")
         .unwrap();
     assert_eq!(events.len(), 50, "All 50 events should recover");
 }

--- a/tests/durability/mode_equivalence.rs
+++ b/tests/durability/mode_equivalence.rs
@@ -58,7 +58,7 @@ fn event_operations_equivalent_across_modes() {
             .append(&branch_id, "default", "stream", int_payload(3))
             .unwrap();
 
-        let events = event.read_by_type(&branch_id, "default", "stream").unwrap();
+        let events = event.get_by_type(&branch_id, "default", "stream").unwrap();
         events.len() as u64
     });
 }
@@ -73,10 +73,10 @@ fn statecell_cas_equivalent_across_modes() {
             .init(&branch_id, "default", "counter", Value::Int(0))
             .unwrap();
         state
-            .cas(&branch_id, "default", "counter", v.value, Value::Int(1))
+            .cas(&branch_id, "default", "counter", v, Value::Int(1))
             .unwrap();
 
-        let val = state.read(&branch_id, "default", "counter").unwrap();
+        let val = state.get(&branch_id, "default", "counter").unwrap();
         val.map(|v| format!("{:?}", v))
     });
 }

--- a/tests/durability/recovery_invariants.rs
+++ b/tests/durability/recovery_invariants.rs
@@ -66,7 +66,7 @@ fn committed_event_data_survives_restart() {
 
     let event = test_db.event();
     let events = event
-        .read_by_type(&branch_id, "default", "test_stream")
+        .get_by_type(&branch_id, "default", "test_stream")
         .unwrap();
     assert_eq!(events.len(), 10, "All events should survive restart");
 }
@@ -81,13 +81,13 @@ fn committed_statecell_survives_restart() {
         .init(&branch_id, "default", "counter", Value::Int(0))
         .unwrap();
     state
-        .cas(&branch_id, "default", "counter", v.value, Value::Int(42))
+        .cas(&branch_id, "default", "counter", v, Value::Int(42))
         .unwrap();
 
     test_db.reopen();
 
     let state = test_db.state();
-    let val = state.read(&branch_id, "default", "counter").unwrap();
+    let val = state.get(&branch_id, "default", "counter").unwrap();
     assert!(val.is_some());
     assert_eq!(val.unwrap(), Value::Int(42));
 }

--- a/tests/engine/acid_properties.rs
+++ b/tests/engine/acid_properties.rs
@@ -130,7 +130,7 @@ fn consistency_invariants_maintained() {
     // Increment counter using read + cas (ensures atomic read-modify-write)
     for _ in 0..10 {
         let current = state
-            .readv(&branch_id, "default", "counter")
+            .getv(&branch_id, "default", "counter")
             .unwrap()
             .unwrap();
         let version = current.version();
@@ -145,7 +145,7 @@ fn consistency_invariants_maintained() {
 
     // Counter should be exactly 10
     let result = state
-        .read(&branch_id, "default", "counter")
+        .get(&branch_id, "default", "counter")
         .unwrap()
         .unwrap();
     assert_eq!(result, Value::Int(10));
@@ -161,7 +161,7 @@ fn consistency_cas_prevents_invalid_state() {
         .init(&branch_id, "default", "balance", Value::Int(100))
         .unwrap();
     let version = state
-        .readv(&branch_id, "default", "balance")
+        .getv(&branch_id, "default", "balance")
         .unwrap()
         .unwrap()
         .version();
@@ -177,7 +177,7 @@ fn consistency_cas_prevents_invalid_state() {
 
     // Balance should be 90, not 80
     let balance = state
-        .read(&branch_id, "default", "balance")
+        .get(&branch_id, "default", "balance")
         .unwrap()
         .unwrap();
     assert_eq!(balance, Value::Int(90));
@@ -380,11 +380,11 @@ fn acid_transfer_between_accounts() {
 
     // Transfer 30 from A to B using readv + cas
     let a_val = state
-        .readv(&branch_id, "default", "account_a")
+        .getv(&branch_id, "default", "account_a")
         .unwrap()
         .unwrap();
     let b_val = state
-        .readv(&branch_id, "default", "account_b")
+        .getv(&branch_id, "default", "account_b")
         .unwrap()
         .unwrap();
 
@@ -399,7 +399,7 @@ fn acid_transfer_between_accounts() {
             )
             .unwrap();
         let b_val2 = state
-            .readv(&branch_id, "default", "account_b")
+            .getv(&branch_id, "default", "account_b")
             .unwrap()
             .unwrap();
         state
@@ -415,11 +415,11 @@ fn acid_transfer_between_accounts() {
 
     // Verify balances
     let a = state
-        .read(&branch_id, "default", "account_a")
+        .get(&branch_id, "default", "account_a")
         .unwrap()
         .unwrap();
     let b = state
-        .read(&branch_id, "default", "account_b")
+        .get(&branch_id, "default", "account_b")
         .unwrap()
         .unwrap();
 

--- a/tests/engine/adversarial.rs
+++ b/tests/engine/adversarial.rs
@@ -82,7 +82,7 @@ fn cross_primitive_rollback_leaves_no_trace() {
     // - existing_cell should be unchanged
     assert_eq!(
         state
-            .read(&branch_id, "default", "existing_cell")
+            .get(&branch_id, "default", "existing_cell")
             .unwrap()
             .unwrap(),
         Value::Int(200),
@@ -419,7 +419,7 @@ fn versions_monotonically_increase() {
 
     let mut last_version = 0u64;
     for i in 1..=10 {
-        let current = state.readv(&branch_id, "default", "key").unwrap().unwrap();
+        let current = state.getv(&branch_id, "default", "key").unwrap().unwrap();
         let current_version = current.version().as_u64();
         state
             .cas(
@@ -480,7 +480,7 @@ fn statecell_cas_version_ordering() {
 
     // Get initial version
     let v1 = state
-        .readv(&branch_id, "default", "cell")
+        .getv(&branch_id, "default", "cell")
         .unwrap()
         .unwrap()
         .version();
@@ -496,7 +496,7 @@ fn statecell_cas_version_ordering() {
 
     // Value should be 1 (from successful CAS), not 2
     assert_eq!(
-        state.read(&branch_id, "default", "cell").unwrap().unwrap(),
+        state.get(&branch_id, "default", "cell").unwrap().unwrap(),
         Value::Int(1)
     );
 }

--- a/tests/engine/adversarial_deep.rs
+++ b/tests/engine/adversarial_deep.rs
@@ -269,7 +269,7 @@ fn atomicity_on_operation_failure() {
         .init(&branch_id, "default", "cell", Value::Int(200))
         .unwrap();
     let version = state
-        .readv(&branch_id, "default", "cell")
+        .getv(&branch_id, "default", "cell")
         .unwrap()
         .unwrap()
         .version();

--- a/tests/engine/branch_isolation.rs
+++ b/tests/engine/branch_isolation.rs
@@ -172,8 +172,8 @@ fn eventlog_independent_per_branch() {
     assert_eq!(event.len(&branch_b, "default").unwrap(), 5);
 
     // Events should be readable independently
-    let a_event = event.read(&branch_a, "default", 0).unwrap();
-    let b_event = event.read(&branch_b, "default", 0).unwrap();
+    let a_event = event.get(&branch_a, "default", 0).unwrap();
+    let b_event = event.get(&branch_b, "default", 0).unwrap();
     assert_eq!(a_event.as_ref().unwrap().value.event_type, "type");
     assert_eq!(b_event.as_ref().unwrap().value.event_type, "type");
 }
@@ -199,11 +199,11 @@ fn statecell_branches_are_isolated() {
         .unwrap();
 
     assert_eq!(
-        state.read(&branch_a, "default", "cell").unwrap().unwrap(),
+        state.get(&branch_a, "default", "cell").unwrap().unwrap(),
         Value::Int(1)
     );
     assert_eq!(
-        state.read(&branch_b, "default", "cell").unwrap().unwrap(),
+        state.get(&branch_b, "default", "cell").unwrap().unwrap(),
         Value::Int(2)
     );
 }
@@ -224,12 +224,12 @@ fn statecell_cas_isolated() {
         .unwrap();
 
     let version_a = state
-        .readv(&branch_a, "default", "cell")
+        .getv(&branch_a, "default", "cell")
         .unwrap()
         .unwrap()
         .version();
     let version_b = state
-        .readv(&branch_b, "default", "cell")
+        .getv(&branch_b, "default", "cell")
         .unwrap()
         .unwrap()
         .version();
@@ -241,7 +241,7 @@ fn statecell_cas_isolated() {
 
     // Branch B unchanged
     assert_eq!(
-        state.read(&branch_b, "default", "cell").unwrap().unwrap(),
+        state.get(&branch_b, "default", "cell").unwrap().unwrap(),
         Value::Int(0)
     );
 
@@ -252,11 +252,11 @@ fn statecell_cas_isolated() {
 
     // Both have their own values
     assert_eq!(
-        state.read(&branch_a, "default", "cell").unwrap().unwrap(),
+        state.get(&branch_a, "default", "cell").unwrap().unwrap(),
         Value::Int(100)
     );
     assert_eq!(
-        state.read(&branch_b, "default", "cell").unwrap().unwrap(),
+        state.get(&branch_b, "default", "cell").unwrap().unwrap(),
         Value::Int(200)
     );
 }
@@ -462,7 +462,7 @@ fn all_primitives_isolated_by_branch() {
     assert_eq!(prims.event.len(&branch_b, "default").unwrap(), 0);
     assert!(prims
         .state
-        .read(&branch_b, "default", "cell")
+        .get(&branch_b, "default", "cell")
         .unwrap()
         .is_none());
     assert!(!prims.json.exists(&branch_b, "default", "doc").unwrap());

--- a/tests/engine/cross_primitive.rs
+++ b/tests/engine/cross_primitive.rs
@@ -73,10 +73,7 @@ fn kv_and_statecell_atomic() {
         Some(Value::Int(1234567890))
     );
 
-    let current = state
-        .read(&branch_id, "default", "status")
-        .unwrap()
-        .unwrap();
+    let current = state.get(&branch_id, "default", "status").unwrap().unwrap();
     assert_eq!(current, Value::String("completed".into()));
 }
 
@@ -116,7 +113,7 @@ fn three_primitives_atomic() {
     assert_eq!(event.len(&branch_id, "default").unwrap(), 1);
 
     let counter = state
-        .read(&branch_id, "default", "counter")
+        .get(&branch_id, "default", "counter")
         .unwrap()
         .unwrap();
     assert_eq!(counter, Value::Int(1));
@@ -234,10 +231,7 @@ fn read_from_one_write_to_another() {
         })
         .unwrap();
 
-    let copied = state
-        .read(&branch_id, "default", "copied")
-        .unwrap()
-        .unwrap();
+    let copied = state.get(&branch_id, "default", "copied").unwrap().unwrap();
     assert_eq!(copied, Value::Int(42));
 }
 
@@ -288,7 +282,7 @@ fn saga_pattern_all_steps_complete() {
     assert_eq!(event.len(&branch_id, "default").unwrap(), 1);
     assert_eq!(
         state
-            .read(&branch_id, "default", "order:1:status")
+            .get(&branch_id, "default", "order:1:status")
             .unwrap()
             .unwrap(),
         Value::String("processing".into())

--- a/tests/engine/database/durability_modes.rs
+++ b/tests/engine/database/durability_modes.rs
@@ -63,7 +63,7 @@ fn eventlog_append_same_across_modes() {
             )
             .unwrap();
         let len = event.len(&branch_id, "default").unwrap();
-        let first = event.read(&branch_id, "default", 0).unwrap();
+        let first = event.get(&branch_id, "default", 0).unwrap();
 
         (len, first.map(|e| e.value.event_type.clone()))
     });
@@ -78,7 +78,7 @@ fn statecell_cas_same_across_modes() {
         state
             .init(&branch_id, "default", "cell", Value::Int(1))
             .unwrap();
-        let read = state.readv(&branch_id, "default", "cell").unwrap();
+        let read = state.getv(&branch_id, "default", "cell").unwrap();
         let version = read
             .as_ref()
             .map(|v| v.version())
@@ -88,7 +88,7 @@ fn statecell_cas_same_across_modes() {
 
         (
             cas_result.is_ok(),
-            state.read(&branch_id, "default", "cell").unwrap(),
+            state.get(&branch_id, "default", "cell").unwrap(),
         )
     });
 }

--- a/tests/engine/primitives/eventlog.rs
+++ b/tests/engine/primitives/eventlog.rs
@@ -53,7 +53,7 @@ fn empty_log_head_is_none() {
         // empty log, head is none
         assert_eq!(len, 0);
     } else {
-        let head = event.read(&test_db.branch_id, "default", len - 1).unwrap();
+        let head = event.get(&test_db.branch_id, "default", len - 1).unwrap();
         assert!(head.is_some());
     }
 }
@@ -128,7 +128,7 @@ fn read_returns_appended_event() {
         )
         .unwrap();
 
-    let read = event.read(&test_db.branch_id, "default", 0).unwrap();
+    let read = event.get(&test_db.branch_id, "default", 0).unwrap();
     assert!(read.is_some());
 
     let e = read.unwrap().value;
@@ -141,7 +141,7 @@ fn read_nonexistent_returns_none() {
     let test_db = TestDb::new();
     let event = test_db.event();
 
-    let read = event.read(&test_db.branch_id, "default", 999).unwrap();
+    let read = event.get(&test_db.branch_id, "default", 999).unwrap();
     assert!(read.is_none());
 }
 
@@ -163,7 +163,7 @@ fn head_returns_last_event() {
     // head rewritten using len() + read(len-1)
     let len = event.len(&test_db.branch_id, "default").unwrap();
     let head = event
-        .read(&test_db.branch_id, "default", len - 1)
+        .get(&test_db.branch_id, "default", len - 1)
         .unwrap()
         .unwrap();
     assert_eq!(head.value.payload, payload_int(3));
@@ -183,7 +183,7 @@ fn read_range_returns_events_in_order() {
     // read_range rewritten using loop of read() calls
     let mut range = Vec::new();
     for seq in 1..4 {
-        if let Some(e) = event.read(&test_db.branch_id, "default", seq).unwrap() {
+        if let Some(e) = event.get(&test_db.branch_id, "default", seq).unwrap() {
             range.push(e);
         }
     }
@@ -206,7 +206,7 @@ fn read_range_empty_when_start_equals_end() {
     // read_range(0, 0) means empty range; rewritten using loop with 0..0
     let mut range = Vec::new();
     for seq in 0u64..0u64 {
-        if let Some(e) = event.read(&test_db.branch_id, "default", seq).unwrap() {
+        if let Some(e) = event.get(&test_db.branch_id, "default", seq).unwrap() {
             range.push(e);
         }
     }
@@ -245,7 +245,7 @@ fn events_have_hash_field() {
         .unwrap();
 
     let e = event
-        .read(&test_db.branch_id, "default", 0)
+        .get(&test_db.branch_id, "default", 0)
         .unwrap()
         .unwrap();
     // Hash should be non-empty
@@ -265,11 +265,11 @@ fn events_have_prev_hash_field() {
         .unwrap();
 
     let e0 = event
-        .read(&test_db.branch_id, "default", 0)
+        .get(&test_db.branch_id, "default", 0)
         .unwrap()
         .unwrap();
     let e1 = event
-        .read(&test_db.branch_id, "default", 1)
+        .get(&test_db.branch_id, "default", 1)
         .unwrap()
         .unwrap();
 
@@ -298,10 +298,10 @@ fn multiple_event_types() {
 
     // Verify both types exist by reading by type
     let type_a = event
-        .read_by_type(&test_db.branch_id, "default", "type_a")
+        .get_by_type(&test_db.branch_id, "default", "type_a")
         .unwrap();
     let type_b = event
-        .read_by_type(&test_db.branch_id, "default", "type_b")
+        .get_by_type(&test_db.branch_id, "default", "type_b")
         .unwrap();
     assert_eq!(type_a.len(), 2);
     assert_eq!(type_b.len(), 1);
@@ -325,24 +325,24 @@ fn len_by_type() {
         .append(&test_db.branch_id, "default", "type_a", payload_int(4))
         .unwrap();
 
-    // len_by_type rewritten using read_by_type().len()
+    // len_by_type rewritten using get_by_type().len()
     assert_eq!(
         event
-            .read_by_type(&test_db.branch_id, "default", "type_a")
+            .get_by_type(&test_db.branch_id, "default", "type_a")
             .unwrap()
             .len(),
         3
     );
     assert_eq!(
         event
-            .read_by_type(&test_db.branch_id, "default", "type_b")
+            .get_by_type(&test_db.branch_id, "default", "type_b")
             .unwrap()
             .len(),
         1
     );
     assert_eq!(
         event
-            .read_by_type(&test_db.branch_id, "default", "type_c")
+            .get_by_type(&test_db.branch_id, "default", "type_c")
             .unwrap()
             .len(),
         0
@@ -350,7 +350,7 @@ fn len_by_type() {
 }
 
 #[test]
-fn read_by_type() {
+fn get_by_type() {
     let test_db = TestDb::new();
     let event = test_db.event();
 
@@ -365,7 +365,7 @@ fn read_by_type() {
         .unwrap();
 
     let orders = event
-        .read_by_type(&test_db.branch_id, "default", "orders")
+        .get_by_type(&test_db.branch_id, "default", "orders")
         .unwrap();
     assert_eq!(orders.len(), 2);
     assert_eq!(orders[0].value.payload, payload_int(100));
@@ -415,7 +415,7 @@ fn large_payload() {
         .unwrap();
 
     let read = event
-        .read(&test_db.branch_id, "default", 0)
+        .get(&test_db.branch_id, "default", 0)
         .unwrap()
         .unwrap();
     assert_eq!(read.value.payload, payload_str(&large_string));

--- a/tests/engine/stress.rs
+++ b/tests/engine/stress.rs
@@ -322,7 +322,7 @@ fn stress_eventlog_append() {
     // Verify all events are readable
     let verify_start = Instant::now();
     for i in 0..10_000u64 {
-        let ev = event.read(&branch_id, "default", i).unwrap();
+        let ev = event.get(&branch_id, "default", i).unwrap();
         assert!(ev.is_some(), "Event at sequence {} should exist", i);
     }
     let verify_time = verify_start.elapsed();

--- a/tests/executor/branch_invariants.rs
+++ b/tests/executor/branch_invariants.rs
@@ -71,7 +71,7 @@ fn branch_data_is_isolated() {
     );
 
     let output = executor
-        .execute(Command::StateRead {
+        .execute(Command::StateGet {
             branch: Some(branch_b.clone()),
             space: None,
             cell: "state".into(),

--- a/tests/executor/command_dispatch.rs
+++ b/tests/executor/command_dispatch.rs
@@ -231,7 +231,7 @@ fn state_set_read_cycle() {
     assert!(matches!(output, Output::Version(_)));
 
     let output = executor
-        .execute(Command::StateRead {
+        .execute(Command::StateGet {
             branch: None,
             space: None,
             cell: "status".into(),

--- a/tests/executor/error_handling.rs
+++ b/tests/executor/error_handling.rs
@@ -332,11 +332,11 @@ fn concurrent_sessions_independent_transactions() {
 // ============================================================================
 
 #[test]
-fn state_read_nonexistent_returns_none() {
+fn state_get_nonexistent_returns_none() {
     let executor = create_executor();
 
     let result = executor
-        .execute(Command::StateRead {
+        .execute(Command::StateGet {
             branch: None,
             space: None,
             cell: "nonexistent".into(),

--- a/tests/executor/session_transactions.rs
+++ b/tests/executor/session_transactions.rs
@@ -180,7 +180,7 @@ fn read_your_writes_state() {
         .unwrap();
 
     let output = session
-        .execute(Command::StateRead {
+        .execute(Command::StateGet {
             branch: None,
             space: None,
             cell: "cell".into(),
@@ -308,7 +308,7 @@ fn rollback_discards_state_writes() {
     // Verify not visible
     let executor = strata_executor::Executor::new(db);
     let output = executor
-        .execute(Command::StateRead {
+        .execute(Command::StateGet {
             branch: None,
             space: None,
             cell: "rollback_cell".into(),
@@ -642,7 +642,7 @@ fn cross_primitive_transaction() {
     ));
 
     let state_out = executor
-        .execute(Command::StateRead {
+        .execute(Command::StateGet {
             branch: None,
             space: None,
             cell: "state_cell".into(),

--- a/tests/executor/strata_api.rs
+++ b/tests/executor/strata_api.rs
@@ -95,7 +95,7 @@ fn state_set_and_read() {
     let db = create_strata();
 
     db.state_set("cell", Value::String("state".into())).unwrap();
-    let value = db.state_read("cell").unwrap();
+    let value = db.state_get("cell").unwrap();
     assert!(value.is_some());
     assert_eq!(value.unwrap(), Value::String("state".into()));
 }
@@ -105,7 +105,7 @@ fn state_set_and_read() {
 // ============================================================================
 
 #[test]
-fn event_append_and_read_by_type() {
+fn event_append_and_get_by_type() {
     let db = create_strata();
 
     // Event payloads must be Objects
@@ -114,7 +114,7 @@ fn event_append_and_read_by_type() {
     db.event_append("stream", event_payload("value", Value::Int(2)))
         .unwrap();
 
-    let events = db.event_read_by_type("stream").unwrap();
+    let events = db.event_get_by_type("stream").unwrap();
     assert_eq!(events.len(), 2);
 }
 
@@ -330,7 +330,7 @@ fn use_all_primitives() {
         Some(Value::String("enabled".into()))
     );
     assert_eq!(
-        db.state_read("status").unwrap().unwrap(),
+        db.state_get("status").unwrap().unwrap(),
         Value::String("running".into())
     );
     assert_eq!(db.event_len().unwrap(), 1);

--- a/tests/integration/branching.rs
+++ b/tests/integration/branching.rs
@@ -128,16 +128,16 @@ fn all_primitives_isolated_between_branches() {
     );
 
     assert_eq!(
-        p.state.read(&branch_a, "default", "s").unwrap().unwrap(),
+        p.state.get(&branch_a, "default", "s").unwrap().unwrap(),
         Value::Int(1)
     );
     assert_eq!(
-        p.state.read(&branch_b, "default", "s").unwrap().unwrap(),
+        p.state.get(&branch_b, "default", "s").unwrap().unwrap(),
         Value::Int(2)
     );
 
-    let events_a = p.event.read_by_type(&branch_a, "default", "e").unwrap();
-    let events_b = p.event.read_by_type(&branch_b, "default", "e").unwrap();
+    let events_a = p.event.get_by_type(&branch_a, "default", "e").unwrap();
+    let events_b = p.event.get_by_type(&branch_b, "default", "e").unwrap();
     assert_eq!(events_a.len(), 1);
     assert_eq!(events_b.len(), 1);
 
@@ -301,14 +301,14 @@ fn event_streams_isolated_per_branch() {
 
     assert_eq!(
         event
-            .read_by_type(&branch_a, "default", "audit")
+            .get_by_type(&branch_a, "default", "audit")
             .unwrap()
             .len(),
         2
     );
     assert_eq!(
         event
-            .read_by_type(&branch_b, "default", "audit")
+            .get_by_type(&branch_b, "default", "audit")
             .unwrap()
             .len(),
         1

--- a/tests/integration/modes.rs
+++ b/tests/integration/modes.rs
@@ -65,7 +65,7 @@ fn cache_all_primitives() {
         .init(&branch_id, "default", "s", Value::Int(2))
         .unwrap();
     assert_eq!(
-        state.read(&branch_id, "default", "s").unwrap().unwrap(),
+        state.get(&branch_id, "default", "s").unwrap().unwrap(),
         Value::Int(2)
     );
 
@@ -253,7 +253,7 @@ fn always_mode_all_primitives_survive_reopen() {
         let state = StateCell::new(db.clone());
         assert_eq!(
             state
-                .read(&branch_id, "default", "state_cell")
+                .get(&branch_id, "default", "state_cell")
                 .unwrap()
                 .unwrap(),
             Value::Int(42)

--- a/tests/integration/primitives.rs
+++ b/tests/integration/primitives.rs
@@ -110,7 +110,7 @@ mod state_single {
             .init(&branch_id, "default", "counter", Value::Int(0))
             .unwrap();
         let val = state
-            .read(&branch_id, "default", "counter")
+            .get(&branch_id, "default", "counter")
             .unwrap()
             .unwrap();
         assert_eq!(val, Value::Int(0));
@@ -133,7 +133,7 @@ mod state_single {
             .unwrap();
 
         let val = state
-            .read(&branch_id, "default", "counter")
+            .get(&branch_id, "default", "counter")
             .unwrap()
             .unwrap();
         assert_eq!(val, Value::Int(2));
@@ -149,7 +149,7 @@ mod state_single {
             .init(&branch_id, "default", "counter", Value::Int(0))
             .unwrap();
         let current = state
-            .readv(&branch_id, "default", "counter")
+            .getv(&branch_id, "default", "counter")
             .unwrap()
             .unwrap();
 
@@ -164,7 +164,7 @@ mod state_single {
             .unwrap();
 
         let updated = state
-            .read(&branch_id, "default", "counter")
+            .get(&branch_id, "default", "counter")
             .unwrap()
             .unwrap();
         assert_eq!(updated, Value::Int(1));
@@ -180,7 +180,7 @@ mod state_single {
             .init(&branch_id, "default", "counter", Value::Int(0))
             .unwrap();
         let current = state
-            .readv(&branch_id, "default", "counter")
+            .getv(&branch_id, "default", "counter")
             .unwrap()
             .unwrap();
         let stale_version = current.version();
@@ -202,7 +202,7 @@ mod state_single {
 
         // Value should remain at 1
         let final_val = state
-            .read(&branch_id, "default", "counter")
+            .get(&branch_id, "default", "counter")
             .unwrap()
             .unwrap();
         assert_eq!(final_val, Value::Int(1));
@@ -231,7 +231,7 @@ mod event_single {
         assert!(seq2 > seq1);
         assert!(seq3 > seq2);
 
-        let events = event.read_by_type(&branch_id, "default", "audit").unwrap();
+        let events = event.get_by_type(&branch_id, "default", "audit").unwrap();
         assert_eq!(events.len(), 3);
     }
 
@@ -253,14 +253,14 @@ mod event_single {
 
         assert_eq!(
             event
-                .read_by_type(&branch_id, "default", "stream_a")
+                .get_by_type(&branch_id, "default", "stream_a")
                 .unwrap()
                 .len(),
             2
         );
         assert_eq!(
             event
-                .read_by_type(&branch_id, "default", "stream_b")
+                .get_by_type(&branch_id, "default", "stream_b")
                 .unwrap()
                 .len(),
             1
@@ -279,7 +279,7 @@ mod event_single {
 
         // Events can only be appended, not modified or deleted
         // The API doesn't provide update/delete methods for events
-        let events = event.read_by_type(&branch_id, "default", "audit").unwrap();
+        let events = event.get_by_type(&branch_id, "default", "audit").unwrap();
         assert_eq!(events.len(), 1);
     }
 }
@@ -545,7 +545,7 @@ fn all_six_primitives_together() {
     );
     assert_eq!(
         p.state
-            .read(&branch_id, "default", "status")
+            .get(&branch_id, "default", "status")
             .unwrap()
             .unwrap(),
         Value::String("running".into())
@@ -671,21 +671,21 @@ fn cross_primitive_workflow_agent_memory() {
     // Verify final state
     let status = p
         .state
-        .read(&branch_id, "default", "agent:status")
+        .get(&branch_id, "default", "agent:status")
         .unwrap()
         .unwrap();
     assert_eq!(status, Value::String("completed".into()));
 
     assert_eq!(
         p.event
-            .read_by_type(&branch_id, "default", "agent:turns")
+            .get_by_type(&branch_id, "default", "agent:turns")
             .unwrap()
             .len(),
         3
     );
     assert_eq!(
         p.event
-            .read_by_type(&branch_id, "default", "agent:lifecycle")
+            .get_by_type(&branch_id, "default", "agent:lifecycle")
             .unwrap()
             .len(),
         2
@@ -735,7 +735,7 @@ fn delete_in_one_primitive_doesnt_affect_others() {
     assert!(p.kv.get(&branch_id, "default", "shared").unwrap().is_none());
     assert_eq!(
         p.state
-            .read(&branch_id, "default", "shared")
+            .get(&branch_id, "default", "shared")
             .unwrap()
             .unwrap(),
         Value::String("state".into())

--- a/tests/integration/scale.rs
+++ b/tests/integration/scale.rs
@@ -119,7 +119,7 @@ mod event_scale {
         // Count
         measure(&format!("Count {} events", count), || {
             let len = event
-                .read_by_type(&branch_id, "default", "scale_test")
+                .get_by_type(&branch_id, "default", "scale_test")
                 .unwrap()
                 .len() as u64;
             assert_eq!(len, count as u64);
@@ -128,7 +128,7 @@ mod event_scale {
         // Read all
         measure(&format!("Read {} events", count), || {
             let events = event
-                .read_by_type(&branch_id, "default", "scale_test")
+                .get_by_type(&branch_id, "default", "scale_test")
                 .unwrap();
             assert_eq!(events.len(), count);
         });
@@ -338,7 +338,7 @@ fn cross_primitive_scale_1k() {
     );
     assert_eq!(
         p.event
-            .read_by_type(&branch_id, "default", "items")
+            .get_by_type(&branch_id, "default", "items")
             .unwrap()
             .len() as u64,
         count as u64


### PR DESCRIPTION
## Summary

- **Rename `read()` → `get()` on Event and State primitives** to match KV, JSON, and Vector. All five primitives now use `get()` consistently for read operations. Includes `read_by_type()` → `get_by_type()`, `read_versioned()` → `get_versioned()`, `readv()` → `getv()`, and all corresponding extension traits, handles, Command enum variants, handlers, and API methods.
- **StateCell `init()`/`set()`/`cas()` now return bare `Version`** instead of `Versioned<Version>`. The wrapper was redundant (`.value` and `.version` were identical, `.timestamp` was never accessed by any caller). This aligns with the extension traits and StateHandle which already returned bare `Version`.

50 files changed across engine, executor, and test layers.

## Test plan

- [x] All 2,664 workspace tests pass (0 failures)
- [x] `cargo clippy --workspace --tests` clean (no errors)
- [x] `cargo fmt --check` clean
- [x] Doc-tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)