### PR TITLE
Add workflow to dispatch docs updates to stratadb.org

### DIFF
--- a/.github/workflows/docs-dispatch.yml
+++ b/.github/workflows/docs-dispatch.yml
@@ -1,0 +1,19 @@
+name: Dispatch docs update
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger stratadb.org rebuild
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+          repository: strata-systems/stratadb.org
+          event-type: docs-update
+          client-payload: '{"source": "strata-core", "ref": "${{ github.sha }}"}'


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/docs-dispatch.yml` that sends a `repository_dispatch` event to `strata-systems/stratadb.org` whenever `docs/**` changes on `main`
- This triggers an automatic rebuild of the docs site with the latest content from strata-core
- Part of the automated docs sync pipeline (counterpart already deployed to stratadb.org)

## Setup required
A `DOCS_DISPATCH_TOKEN` secret must be added to this repo — a GitHub PAT with permission to dispatch to `strata-systems/stratadb.org`.

## Test plan
- [ ] Verify workflow YAML is valid (appears in Actions tab after merge)
- [ ] Add `DOCS_DISPATCH_TOKEN` secret to repo settings
- [ ] Push a docs change to main and confirm stratadb.org rebuild triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)