### PR TITLE
Implement Redis-inspired CLI crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/durability",
     "crates/engine",
     "crates/intelligence",
+    "crates/cli",
     "crates/security",
     "crates/executor",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "strata-cli"
+version = "0.5.2"
+edition = "2021"
+description = "Redis-inspired CLI for the Strata database"
+publish = false
+
+[[bin]]
+name = "strata"
+path = "src/main.rs"
+
+[dependencies]
+strata-executor = { path = "../executor" }
+clap = { version = "4", features = ["string"] }
+rustyline = { version = "15", features = ["with-file-history"] }
+shlex = "1"
+serde_json = { workspace = true }

--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -1,0 +1,621 @@
+//! Output → human/json/raw string formatting.
+//!
+//! Three modes:
+//! - **Human** (default on TTY): Redis-style, e.g. `"value"`, `(integer) 42`, `(nil)`
+//! - **JSON** (`--json`): `serde_json::to_string_pretty`
+//! - **Raw** (`--raw`): Bare values, no quotes, no type prefixes
+
+use strata_executor::{
+    BranchDiffResult, Error, ForkInfo, MergeInfo, Output, Value,
+};
+
+/// Output formatting mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputMode {
+    Human,
+    Json,
+    Raw,
+}
+
+/// Format a successful output.
+pub fn format_output(output: &Output, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Json => format_json(output),
+        OutputMode::Raw => format_raw(output),
+        OutputMode::Human => format_human(output),
+    }
+}
+
+/// Format an error.
+pub fn format_error(err: &Error, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Json => {
+            serde_json::to_string_pretty(&serde_json::json!({
+                "error": format!("{}", err)
+            }))
+            .unwrap_or_else(|_| format!("{{\"error\": \"{}\"}}", err))
+        }
+        OutputMode::Raw => format!("{}", err),
+        OutputMode::Human => format!("(error) {}", err),
+    }
+}
+
+/// Format branch fork info.
+pub fn format_fork_info(info: &ForkInfo, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Json => serde_json::to_string_pretty(&serde_json::json!({
+            "source": info.source,
+            "destination": info.destination,
+            "keys_copied": info.keys_copied,
+            "spaces_copied": info.spaces_copied,
+        }))
+        .unwrap(),
+        OutputMode::Raw => format!("{}", info.keys_copied),
+        OutputMode::Human => format!(
+            "Forked \"{}\" -> \"{}\" ({} keys, {} spaces)",
+            info.source, info.destination, info.keys_copied, info.spaces_copied
+        ),
+    }
+}
+
+/// Format branch diff result.
+pub fn format_diff(diff: &BranchDiffResult, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Json => serde_json::to_string_pretty(&serde_json::json!({
+            "branch_a": diff.branch_a,
+            "branch_b": diff.branch_b,
+            "summary": {
+                "total_added": diff.summary.total_added,
+                "total_removed": diff.summary.total_removed,
+                "total_modified": diff.summary.total_modified,
+            },
+            "spaces": diff.spaces.iter().map(|sd| serde_json::json!({
+                "space": sd.space,
+                "added": sd.added.len(),
+                "removed": sd.removed.len(),
+                "modified": sd.modified.len(),
+            })).collect::<Vec<_>>(),
+        }))
+        .unwrap(),
+        OutputMode::Raw => format!(
+            "{}\t{}\t{}",
+            diff.summary.total_added, diff.summary.total_removed, diff.summary.total_modified
+        ),
+        OutputMode::Human => {
+            let mut lines = Vec::new();
+            lines.push(format!(
+                "Branch \"{}\" vs \"{}\":",
+                diff.branch_a, diff.branch_b
+            ));
+            lines.push(format!(
+                "  +{} added, -{} removed, ~{} modified",
+                diff.summary.total_added,
+                diff.summary.total_removed,
+                diff.summary.total_modified
+            ));
+            for sd in &diff.spaces {
+                if !sd.added.is_empty() || !sd.removed.is_empty() || !sd.modified.is_empty() {
+                    lines.push(format!("  Space \"{}\":", sd.space));
+                    for entry in &sd.added {
+                        lines.push(format!("    + {} ({})", entry.key, entry.primitive));
+                    }
+                    for entry in &sd.removed {
+                        lines.push(format!("    - {} ({})", entry.key, entry.primitive));
+                    }
+                    for entry in &sd.modified {
+                        lines.push(format!("    ~ {} ({})", entry.key, entry.primitive));
+                    }
+                }
+            }
+            lines.join("\n")
+        }
+    }
+}
+
+/// Format merge info.
+pub fn format_merge_info(info: &MergeInfo, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Json => serde_json::to_string_pretty(&serde_json::json!({
+            "source": info.source,
+            "target": info.target,
+            "keys_applied": info.keys_applied,
+            "conflicts": info.conflicts.len(),
+            "spaces_merged": info.spaces_merged,
+        }))
+        .unwrap(),
+        OutputMode::Raw => format!("{}", info.keys_applied),
+        OutputMode::Human => {
+            let conflict_note = if info.conflicts.is_empty() {
+                String::new()
+            } else {
+                format!(", {} conflicts resolved", info.conflicts.len())
+            };
+            format!(
+                "Merged \"{}\" -> \"{}\" ({} keys, {} spaces{})",
+                info.source, info.target, info.keys_applied, info.spaces_merged, conflict_note
+            )
+        }
+    }
+}
+
+// =========================================================================
+// JSON mode
+// =========================================================================
+
+fn format_json(output: &Output) -> String {
+    serde_json::to_string_pretty(output).unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+}
+
+// =========================================================================
+// Raw mode
+// =========================================================================
+
+fn format_raw(output: &Output) -> String {
+    match output {
+        Output::Unit => String::new(),
+        Output::Maybe(None) => String::new(),
+        Output::Maybe(Some(v)) => format_value_raw(v),
+        Output::MaybeVersioned(None) => String::new(),
+        Output::MaybeVersioned(Some(vv)) => format_value_raw(&vv.value),
+        Output::MaybeVersion(None) => String::new(),
+        Output::MaybeVersion(Some(v)) => v.to_string(),
+        Output::Version(v) => v.to_string(),
+        Output::Bool(b) => {
+            if *b {
+                "1".to_string()
+            } else {
+                "0".to_string()
+            }
+        }
+        Output::Uint(n) => n.to_string(),
+        Output::VersionedValues(vals) => vals
+            .iter()
+            .map(|vv| format_value_raw(&vv.value))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Output::VersionHistory(None) => String::new(),
+        Output::VersionHistory(Some(vals)) => vals
+            .iter()
+            .map(|vv| format_value_raw(&vv.value))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Output::Keys(keys) => keys.join("\n"),
+        Output::JsonListResult { keys, .. } => keys.join("\n"),
+        Output::VectorMatches(matches) => matches
+            .iter()
+            .map(|m| format!("{}\t{}", m.key, m.score))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Output::VectorData(None) => String::new(),
+        Output::VectorData(Some(vd)) => format!("{:?}", vd.data.embedding),
+        Output::VectorCollectionList(colls) => colls
+            .iter()
+            .map(|c| c.name.clone())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Output::Versions(vs) => vs
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Output::MaybeBranchInfo(None) => String::new(),
+        Output::MaybeBranchInfo(Some(bi)) => bi.info.id.0.clone(),
+        Output::BranchInfoList(branches) => branches
+            .iter()
+            .map(|b| b.info.id.0.clone())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Output::BranchWithVersion { info, version } => {
+            format!("{}\t{}", info.id, version)
+        }
+        Output::TxnInfo(None) => String::new(),
+        Output::TxnInfo(Some(info)) => info.id.clone(),
+        Output::TxnBegun => "OK".to_string(),
+        Output::TxnCommitted { version } => version.to_string(),
+        Output::TxnAborted => "OK".to_string(),
+        Output::DatabaseInfo(info) => {
+            format!(
+                "{}\t{}\t{}\t{}",
+                info.version, info.uptime_secs, info.branch_count, info.total_keys
+            )
+        }
+        Output::Pong { version } => version.clone(),
+        Output::SearchResults(hits) => hits
+            .iter()
+            .map(|h| format!("{}\t{}\t{}", h.entity, h.primitive, h.score))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Output::SpaceList(spaces) => spaces.join("\n"),
+        Output::BranchExported(r) => format!("{}\t{}", r.path, r.entry_count),
+        Output::BranchImported(r) => format!("{}\t{}", r.branch_id, r.keys_written),
+        Output::BundleValidated(r) => {
+            if r.checksums_valid {
+                "1".to_string()
+            } else {
+                "0".to_string()
+            }
+        }
+    }
+}
+
+fn format_value_raw(v: &Value) -> String {
+    match v {
+        Value::Null => String::new(),
+        Value::Bool(b) => {
+            if *b {
+                "1".to_string()
+            } else {
+                "0".to_string()
+            }
+        }
+        Value::Int(i) => i.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::String(s) => s.clone(),
+        Value::Bytes(b) => base64_encode(b),
+        Value::Array(arr) => arr
+            .iter()
+            .map(format_value_raw)
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Value::Object(obj) => serde_json::to_string(obj).unwrap_or_default(),
+    }
+}
+
+// =========================================================================
+// Human mode
+// =========================================================================
+
+fn format_human(output: &Output) -> String {
+    match output {
+        Output::Unit => "OK".to_string(),
+        Output::Maybe(None) => "(nil)".to_string(),
+        Output::Maybe(Some(v)) => format_value_human(v),
+        Output::MaybeVersioned(None) => "(nil)".to_string(),
+        Output::MaybeVersioned(Some(vv)) => format_value_human(&vv.value),
+        Output::MaybeVersion(None) => "(nil)".to_string(),
+        Output::MaybeVersion(Some(v)) => format!("(version) {}", v),
+        Output::Version(v) => format!("(version) {}", v),
+        Output::Bool(b) => format!("(boolean) {}", b),
+        Output::Uint(n) => format!("(integer) {}", n),
+        Output::VersionedValues(vals) => {
+            if vals.is_empty() {
+                "(empty list)".to_string()
+            } else {
+                vals.iter()
+                    .enumerate()
+                    .map(|(i, vv)| {
+                        format!("{}) {} (v{})", i + 1, format_value_human(&vv.value), vv.version)
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        Output::VersionHistory(None) => "(nil)".to_string(),
+        Output::VersionHistory(Some(vals)) => {
+            if vals.is_empty() {
+                "(empty list)".to_string()
+            } else {
+                // Show newest first
+                let mut sorted = vals.clone();
+                sorted.sort_by(|a, b| b.version.cmp(&a.version));
+                sorted
+                    .iter()
+                    .enumerate()
+                    .map(|(i, vv)| {
+                        format!("{}) v{}: {}", i + 1, vv.version, format_value_human(&vv.value))
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        Output::Keys(keys) => format_string_list(keys),
+        Output::JsonListResult { keys, cursor } => {
+            let mut out = format_string_list(keys);
+            if let Some(c) = cursor {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                out.push_str(&format!("(cursor) {}", c));
+            }
+            out
+        }
+        Output::VectorMatches(matches) => {
+            if matches.is_empty() {
+                "(empty list)".to_string()
+            } else {
+                matches
+                    .iter()
+                    .enumerate()
+                    .map(|(i, m)| format!("{}) \"{}\" (score: {:.3})", i + 1, m.key, m.score))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        Output::VectorData(None) => "(nil)".to_string(),
+        Output::VectorData(Some(vd)) => {
+            let mut lines = vec![
+                format!("key: \"{}\"", vd.key),
+                format!("embedding: {:?}", vd.data.embedding),
+                format!("version: {}", vd.version),
+            ];
+            if let Some(meta) = &vd.data.metadata {
+                lines.push(format!("metadata: {}", format_value_human(meta)));
+            }
+            lines.join("\n")
+        }
+        Output::VectorCollectionList(colls) => {
+            if colls.is_empty() {
+                "(empty list)".to_string()
+            } else {
+                colls
+                    .iter()
+                    .enumerate()
+                    .map(|(i, c)| {
+                        format!(
+                            "{}) \"{}\" (dim: {}, metric: {:?}, count: {})",
+                            i + 1,
+                            c.name,
+                            c.dimension,
+                            c.metric,
+                            c.count
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        Output::Versions(vs) => {
+            if vs.is_empty() {
+                "(empty list)".to_string()
+            } else {
+                vs.iter()
+                    .enumerate()
+                    .map(|(i, v)| format!("{}) (version) {}", i + 1, v))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        Output::MaybeBranchInfo(None) => "(nil)".to_string(),
+        Output::MaybeBranchInfo(Some(bi)) => {
+            let mut lines = vec![
+                format!("id: \"{}\"", bi.info.id),
+                format!("status: {:?}", bi.info.status),
+                format!("version: {}", bi.version),
+                format!("created_at: {}", bi.info.created_at),
+                format!("updated_at: {}", bi.info.updated_at),
+            ];
+            if let Some(parent) = &bi.info.parent_id {
+                lines.push(format!("parent: \"{}\"", parent));
+            }
+            lines.join("\n")
+        }
+        Output::BranchInfoList(branches) => {
+            if branches.is_empty() {
+                "(empty list)".to_string()
+            } else {
+                branches
+                    .iter()
+                    .enumerate()
+                    .map(|(i, b)| format!("{}) \"{}\"", i + 1, b.info.id))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        Output::BranchWithVersion { info, version } => {
+            format!("Branch \"{}\" created (v{})", info.id, version)
+        }
+        Output::TxnInfo(None) => "(nil)".to_string(),
+        Output::TxnInfo(Some(info)) => {
+            format!(
+                "id: {}\nstatus: {:?}\nstarted_at: {}",
+                info.id, info.status, info.started_at
+            )
+        }
+        Output::TxnBegun => "OK".to_string(),
+        Output::TxnCommitted { version } => format!("Committed (v{})", version),
+        Output::TxnAborted => "OK".to_string(),
+        Output::DatabaseInfo(info) => {
+            format!(
+                "version: {}\nuptime_secs: {}\nbranches: {}\ntotal_keys: {}",
+                info.version, info.uptime_secs, info.branch_count, info.total_keys
+            )
+        }
+        Output::Pong { version } => format!("PONG {}", version),
+        Output::SearchResults(hits) => {
+            if hits.is_empty() {
+                "(empty list)".to_string()
+            } else {
+                hits.iter()
+                    .enumerate()
+                    .map(|(i, h)| {
+                        let snippet = h
+                            .snippet
+                            .as_deref()
+                            .map(|s| format!(" - {}", s))
+                            .unwrap_or_default();
+                        format!(
+                            "{}) \"{}\" [{}] (score: {:.3}){}",
+                            i + 1,
+                            h.entity,
+                            h.primitive,
+                            h.score,
+                            snippet
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        Output::SpaceList(spaces) => format_string_list(spaces),
+        Output::BranchExported(r) => {
+            format!(
+                "Exported branch \"{}\" to {} ({} entries, {} bytes)",
+                r.branch_id, r.path, r.entry_count, r.bundle_size
+            )
+        }
+        Output::BranchImported(r) => {
+            format!(
+                "Imported branch \"{}\" ({} transactions, {} keys)",
+                r.branch_id, r.transactions_applied, r.keys_written
+            )
+        }
+        Output::BundleValidated(r) => {
+            format!(
+                "Bundle valid: branch=\"{}\", format_version={}, entries={}, checksums={}",
+                r.branch_id,
+                r.format_version,
+                r.entry_count,
+                if r.checksums_valid { "OK" } else { "FAILED" }
+            )
+        }
+    }
+}
+
+fn format_value_human(v: &Value) -> String {
+    match v {
+        Value::Null => "(nil)".to_string(),
+        Value::Bool(b) => format!("(boolean) {}", b),
+        Value::Int(i) => format!("(integer) {}", i),
+        Value::Float(f) => format!("(float) {}", f),
+        Value::String(s) => format!("\"{}\"", s),
+        Value::Bytes(b) => format!("(bytes) {}", base64_encode(b)),
+        Value::Array(arr) => {
+            if arr.is_empty() {
+                "(empty array)".to_string()
+            } else {
+                arr.iter()
+                    .enumerate()
+                    .map(|(i, v)| format!("{}) {}", i + 1, format_value_human(v)))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        Value::Object(obj) => {
+            if obj.is_empty() {
+                "(empty object)".to_string()
+            } else {
+                let mut entries: Vec<_> = obj.iter().collect();
+                entries.sort_by_key(|(k, _): &(&String, &Value)| (*k).clone());
+                entries
+                    .iter()
+                    .map(|(k, v)| format!("{}: {}", k, format_value_human(v)))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+    }
+}
+
+fn format_string_list(items: &[String]) -> String {
+    if items.is_empty() {
+        "(empty list)".to_string()
+    } else {
+        items
+            .iter()
+            .enumerate()
+            .map(|(i, s)| format!("{}) \"{}\"", i + 1, s))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+fn base64_encode(data: &[u8]) -> String {
+    // Simple base64 encoding without external dependency
+    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut result = String::new();
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };
+        let b2 = if chunk.len() > 2 { chunk[2] as u32 } else { 0 };
+        let triple = (b0 << 16) | (b1 << 8) | b2;
+        result.push(CHARS[((triple >> 18) & 0x3F) as usize] as char);
+        result.push(CHARS[((triple >> 12) & 0x3F) as usize] as char);
+        if chunk.len() > 1 {
+            result.push(CHARS[((triple >> 6) & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
+        if chunk.len() > 2 {
+            result.push(CHARS[(triple & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use strata_executor::VersionedValue;
+
+    #[test]
+    fn test_format_unit() {
+        assert_eq!(format_output(&Output::Unit, OutputMode::Human), "OK");
+        assert_eq!(format_output(&Output::Unit, OutputMode::Raw), "");
+    }
+
+    #[test]
+    fn test_format_version() {
+        assert_eq!(
+            format_output(&Output::Version(3), OutputMode::Human),
+            "(version) 3"
+        );
+        assert_eq!(format_output(&Output::Version(3), OutputMode::Raw), "3");
+    }
+
+    #[test]
+    fn test_format_bool() {
+        assert_eq!(
+            format_output(&Output::Bool(true), OutputMode::Human),
+            "(boolean) true"
+        );
+        assert_eq!(format_output(&Output::Bool(true), OutputMode::Raw), "1");
+    }
+
+    #[test]
+    fn test_format_nil() {
+        assert_eq!(
+            format_output(&Output::MaybeVersioned(None), OutputMode::Human),
+            "(nil)"
+        );
+        assert_eq!(
+            format_output(&Output::MaybeVersioned(None), OutputMode::Raw),
+            ""
+        );
+    }
+
+    #[test]
+    fn test_format_versioned_value() {
+        let vv = VersionedValue {
+            value: Value::String("hello".into()),
+            version: 1,
+            timestamp: 0,
+        };
+        assert_eq!(
+            format_output(&Output::MaybeVersioned(Some(vv)), OutputMode::Human),
+            "\"hello\""
+        );
+    }
+
+    #[test]
+    fn test_format_keys() {
+        let keys = vec!["key1".to_string(), "key2".to_string()];
+        assert_eq!(
+            format_output(&Output::Keys(keys.clone()), OutputMode::Human),
+            "1) \"key1\"\n2) \"key2\""
+        );
+        assert_eq!(
+            format_output(&Output::Keys(keys), OutputMode::Raw),
+            "key1\nkey2"
+        );
+    }
+
+    #[test]
+    fn test_format_pong() {
+        let pong = Output::Pong {
+            version: "0.5.2".to_string(),
+        };
+        assert_eq!(format_output(&pong, OutputMode::Human), "PONG 0.5.2");
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,0 +1,161 @@
+//! Strata CLI — Redis-inspired CLI for the Strata database.
+//!
+//! Two modes:
+//! - **Shell mode**: `strata [flags] COMMAND` — single command, exit
+//! - **REPL mode**: `strata [flags]` — interactive prompt (if stdin is TTY)
+//! - **Pipe mode**: `echo "kv put k v" | strata` — line-by-line from stdin
+
+mod commands;
+mod format;
+mod parse;
+mod repl;
+mod state;
+mod value;
+
+use std::io::IsTerminal;
+use std::process;
+
+use strata_executor::{AccessMode, OpenOptions, Strata};
+
+use commands::build_cli;
+use format::{
+    format_diff, format_error, format_fork_info, format_merge_info, format_output, OutputMode,
+};
+use parse::{matches_to_action, BranchOp, CliAction};
+use state::SessionState;
+
+fn main() {
+    let cli = build_cli();
+    let matches = cli.get_matches();
+
+    // Determine output mode
+    let output_mode = if matches.get_flag("json") {
+        OutputMode::Json
+    } else if matches.get_flag("raw") {
+        OutputMode::Raw
+    } else {
+        OutputMode::Human
+    };
+
+    // Open database
+    let db = match open_database(&matches) {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("{}", e);
+            process::exit(1);
+        }
+    };
+
+    // Initial branch/space
+    let initial_branch = matches
+        .get_one::<String>("branch")
+        .cloned()
+        .unwrap_or_else(|| "default".to_string());
+    let initial_space = matches
+        .get_one::<String>("space")
+        .cloned()
+        .unwrap_or_else(|| "default".to_string());
+
+    let mut state = SessionState::new(db, initial_branch, initial_space);
+
+    // Dispatch mode
+    if matches.subcommand().is_some() {
+        // Shell mode: parse, execute, format, exit
+        let exit_code = run_shell_mode(&matches, &mut state, output_mode);
+        process::exit(exit_code);
+    } else if std::io::stdin().is_terminal() {
+        // REPL mode
+        repl::run_repl(&mut state, output_mode);
+    } else {
+        // Pipe mode
+        let exit_code = repl::run_pipe(&mut state, output_mode);
+        process::exit(exit_code);
+    }
+}
+
+fn open_database(matches: &clap::ArgMatches) -> Result<Strata, String> {
+    let read_only = matches.get_flag("read-only");
+    let use_cache = matches.get_flag("cache");
+
+    if use_cache {
+        Strata::cache().map_err(|e| format!("Failed to open cache database: {}", e))
+    } else {
+        let path = matches
+            .get_one::<String>("db")
+            .map(|s| s.as_str())
+            .unwrap_or(".strata");
+
+        if read_only {
+            let opts = OpenOptions::new().access_mode(AccessMode::ReadOnly);
+            Strata::open_with(path, opts)
+                .map_err(|e| format!("Failed to open database (read-only): {}", e))
+        } else {
+            Strata::open(path).map_err(|e| format!("Failed to open database: {}", e))
+        }
+    }
+}
+
+fn run_shell_mode(
+    matches: &clap::ArgMatches,
+    state: &mut SessionState,
+    mode: OutputMode,
+) -> i32 {
+    match matches_to_action(matches, state) {
+        Ok(CliAction::Execute(cmd)) => match state.execute(cmd) {
+            Ok(output) => {
+                let formatted = format_output(&output, mode);
+                if !formatted.is_empty() {
+                    println!("{}", formatted);
+                }
+                0
+            }
+            Err(e) => {
+                eprintln!("{}", format_error(&e, mode));
+                1
+            }
+        },
+        Ok(CliAction::BranchOp(op)) => match op {
+            BranchOp::Fork { destination } => match state.fork_branch(&destination) {
+                Ok(info) => {
+                    println!("{}", format_fork_info(&info, mode));
+                    0
+                }
+                Err(e) => {
+                    eprintln!("{}", format_error(&e, mode));
+                    1
+                }
+            },
+            BranchOp::Diff {
+                branch_a,
+                branch_b,
+            } => match state.diff_branches(&branch_a, &branch_b) {
+                Ok(diff) => {
+                    println!("{}", format_diff(&diff, mode));
+                    0
+                }
+                Err(e) => {
+                    eprintln!("{}", format_error(&e, mode));
+                    1
+                }
+            },
+            BranchOp::Merge { source, strategy } => match state.merge_branch(&source, strategy) {
+                Ok(info) => {
+                    println!("{}", format_merge_info(&info, mode));
+                    0
+                }
+                Err(e) => {
+                    eprintln!("{}", format_error(&e, mode));
+                    1
+                }
+            },
+        },
+        Ok(CliAction::Meta(_)) => {
+            eprintln!("(error) Meta-commands are only available in REPL mode");
+            1
+        }
+        Err(e) => {
+            eprintln!("(error) {}", e);
+            1
+        }
+    }
+}

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -1,0 +1,671 @@
+//! ArgMatches → Command/BranchOp/MetaCommand conversion.
+//!
+//! Translates clap's parsed arguments into the appropriate action:
+//! - Standard commands → `CliAction::Execute(Command)`
+//! - Branch power ops → `CliAction::BranchOp`
+//! - REPL meta-commands → `CliAction::Meta`
+
+use clap::ArgMatches;
+use strata_executor::{
+    BranchId, BatchVectorEntry, Command, DistanceMetric, MergeStrategy, MetadataFilter, TxnOptions,
+};
+
+use crate::state::SessionState;
+use crate::value::{parse_json_value, parse_value, parse_vector};
+
+/// The result of parsing user input.
+#[allow(dead_code)]
+pub enum CliAction {
+    /// A standard command to execute via Session.
+    Execute(Command),
+    /// A branch power-API operation (fork/diff/merge).
+    BranchOp(BranchOp),
+    /// A REPL-only meta-command.
+    Meta(MetaCommand),
+}
+
+/// Branch operations that bypass the Command enum.
+pub enum BranchOp {
+    Fork { destination: String },
+    Diff { branch_a: String, branch_b: String },
+    Merge { source: String, strategy: MergeStrategy },
+}
+
+/// REPL meta-commands.
+pub enum MetaCommand {
+    Use { branch: String, space: Option<String> },
+    Help { command: Option<String> },
+    Quit,
+    Clear,
+}
+
+/// Check for REPL meta-commands before delegating to clap.
+///
+/// Returns `Some(MetaCommand)` if the line is a meta-command, `None` otherwise.
+pub fn check_meta_command(line: &str) -> Option<MetaCommand> {
+    let trimmed = line.trim();
+    let mut parts = trimmed.splitn(3, char::is_whitespace);
+    let cmd = parts.next()?;
+
+    match cmd {
+        "quit" | "exit" => Some(MetaCommand::Quit),
+        "clear" => Some(MetaCommand::Clear),
+        "help" => {
+            let command = parts.next().map(|s| s.trim().to_string());
+            Some(MetaCommand::Help { command })
+        }
+        "use" => {
+            let branch = parts.next()?.trim().to_string();
+            let space = parts.next().map(|s| s.trim().to_string());
+            Some(MetaCommand::Use { branch, space })
+        }
+        _ => None,
+    }
+}
+
+/// Convert clap ArgMatches into a CliAction.
+pub fn matches_to_action(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, String> {
+    let (sub_name, sub_matches) = matches
+        .subcommand()
+        .ok_or_else(|| "No command provided".to_string())?;
+
+    match sub_name {
+        "kv" => parse_kv(sub_matches, state),
+        "json" => parse_json(sub_matches, state),
+        "event" => parse_event(sub_matches, state),
+        "state" => parse_state(sub_matches, state),
+        "vector" => parse_vector_cmd(sub_matches, state),
+        "branch" => parse_branch(sub_matches, state),
+        "space" => parse_space(sub_matches, state),
+        "begin" => parse_begin(sub_matches, state),
+        "commit" => Ok(CliAction::Execute(Command::TxnCommit)),
+        "rollback" => Ok(CliAction::Execute(Command::TxnRollback)),
+        "txn" => parse_txn(sub_matches),
+        "ping" => Ok(CliAction::Execute(Command::Ping)),
+        "info" => Ok(CliAction::Execute(Command::Info)),
+        "flush" => Ok(CliAction::Execute(Command::Flush)),
+        "compact" => Ok(CliAction::Execute(Command::Compact)),
+        "search" => parse_search(sub_matches, state),
+        other => Err(format!("Unknown command: {}", other)),
+    }
+}
+
+// =========================================================================
+// Branch/space helpers
+// =========================================================================
+
+fn branch(state: &SessionState) -> Option<BranchId> {
+    Some(BranchId::from(state.branch()))
+}
+
+fn space(state: &SessionState) -> Option<String> {
+    Some(state.space().to_string())
+}
+
+// =========================================================================
+// KV
+// =========================================================================
+
+fn parse_kv(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, String> {
+    let (sub, m) = matches.subcommand().ok_or("No kv subcommand")?;
+    match sub {
+        "put" => {
+            let key = m.get_one::<String>("key").unwrap().clone();
+            let raw = m.get_one::<String>("value").unwrap();
+            let value = parse_value(raw);
+            Ok(CliAction::Execute(Command::KvPut {
+                branch: branch(state),
+                space: space(state),
+                key,
+                value,
+            }))
+        }
+        "get" => {
+            let key = m.get_one::<String>("key").unwrap().clone();
+            Ok(CliAction::Execute(Command::KvGet {
+                branch: branch(state),
+                space: space(state),
+                key,
+            }))
+        }
+        "del" => {
+            let key = m.get_one::<String>("key").unwrap().clone();
+            Ok(CliAction::Execute(Command::KvDelete {
+                branch: branch(state),
+                space: space(state),
+                key,
+            }))
+        }
+        "list" => {
+            let prefix = m.get_one::<String>("prefix").cloned();
+            let limit = m
+                .get_one::<String>("limit")
+                .map(|s| s.parse::<u64>())
+                .transpose()
+                .map_err(|e| format!("Invalid limit: {}", e))?;
+            let cursor = m.get_one::<String>("cursor").cloned();
+            Ok(CliAction::Execute(Command::KvList {
+                branch: branch(state),
+                space: space(state),
+                prefix,
+                cursor,
+                limit,
+            }))
+        }
+        "history" => {
+            let key = m.get_one::<String>("key").unwrap().clone();
+            Ok(CliAction::Execute(Command::KvGetv {
+                branch: branch(state),
+                space: space(state),
+                key,
+            }))
+        }
+        other => Err(format!("Unknown kv subcommand: {}", other)),
+    }
+}
+
+// =========================================================================
+// JSON
+// =========================================================================
+
+fn parse_json(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, String> {
+    let (sub, m) = matches.subcommand().ok_or("No json subcommand")?;
+    match sub {
+        "set" => {
+            let key = m.get_one::<String>("key").unwrap().clone();
+            let path = m.get_one::<String>("path").unwrap().clone();
+            let raw = m.get_one::<String>("value").unwrap();
+            let value = parse_json_value(raw)?;
+            Ok(CliAction::Execute(Command::JsonSet {
+                branch: branch(state),
+                space: space(state),
+                key,
+                path,
+                value,
+            }))
+        }
+        "get" => {
+            let key = m.get_one::<String>("key").unwrap().clone();
+            let path = m.get_one::<String>("path").unwrap().clone();
+            Ok(CliAction::Execute(Command::JsonGet {
+                branch: branch(state),
+                space: space(state),
+                key,
+                path,
+            }))
+        }
+        "del" => {
+            let key = m.get_one::<String>("key").unwrap().clone();
+            let path = m.get_one::<String>("path").unwrap().clone();
+            Ok(CliAction::Execute(Command::JsonDelete {
+                branch: branch(state),
+                space: space(state),
+                key,
+                path,
+            }))
+        }
+        "list" => {
+            let prefix = m.get_one::<String>("prefix").cloned();
+            let cursor = m.get_one::<String>("cursor").cloned();
+            let limit = m
+                .get_one::<String>("limit")
+                .map(|s| s.parse::<u64>())
+                .transpose()
+                .map_err(|e| format!("Invalid limit: {}", e))?
+                .unwrap_or(100);
+            Ok(CliAction::Execute(Command::JsonList {
+                branch: branch(state),
+                space: space(state),
+                prefix,
+                cursor,
+                limit,
+            }))
+        }
+        "history" => {
+            let key = m.get_one::<String>("key").unwrap().clone();
+            Ok(CliAction::Execute(Command::JsonGetv {
+                branch: branch(state),
+                space: space(state),
+                key,
+            }))
+        }
+        other => Err(format!("Unknown json subcommand: {}", other)),
+    }
+}
+
+// =========================================================================
+// Event
+// =========================================================================
+
+fn parse_event(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, String> {
+    let (sub, m) = matches.subcommand().ok_or("No event subcommand")?;
+    match sub {
+        "append" => {
+            let event_type = m.get_one::<String>("type").unwrap().clone();
+            let raw = m.get_one::<String>("payload").unwrap();
+            let payload = parse_json_value(raw)?;
+            Ok(CliAction::Execute(Command::EventAppend {
+                branch: branch(state),
+                space: space(state),
+                event_type,
+                payload,
+            }))
+        }
+        "get" => {
+            let sequence = m
+                .get_one::<String>("sequence")
+                .unwrap()
+                .parse::<u64>()
+                .map_err(|e| format!("Invalid sequence: {}", e))?;
+            Ok(CliAction::Execute(Command::EventGet {
+                branch: branch(state),
+                space: space(state),
+                sequence,
+            }))
+        }
+        "list" => {
+            let event_type = m.get_one::<String>("type").unwrap().clone();
+            let limit = m
+                .get_one::<String>("limit")
+                .map(|s| s.parse::<u64>())
+                .transpose()
+                .map_err(|e| format!("Invalid limit: {}", e))?;
+            let after_sequence = m
+                .get_one::<String>("after")
+                .map(|s| s.parse::<u64>())
+                .transpose()
+                .map_err(|e| format!("Invalid after: {}", e))?;
+            Ok(CliAction::Execute(Command::EventGetByType {
+                branch: branch(state),
+                space: space(state),
+                event_type,
+                limit,
+                after_sequence,
+            }))
+        }
+        "len" => Ok(CliAction::Execute(Command::EventLen {
+            branch: branch(state),
+            space: space(state),
+        })),
+        other => Err(format!("Unknown event subcommand: {}", other)),
+    }
+}
+
+// =========================================================================
+// State
+// =========================================================================
+
+fn parse_state(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, String> {
+    let (sub, m) = matches.subcommand().ok_or("No state subcommand")?;
+    match sub {
+        "set" => {
+            let cell = m.get_one::<String>("cell").unwrap().clone();
+            let raw = m.get_one::<String>("value").unwrap();
+            let value = parse_value(raw);
+            Ok(CliAction::Execute(Command::StateSet {
+                branch: branch(state),
+                space: space(state),
+                cell,
+                value,
+            }))
+        }
+        "get" => {
+            let cell = m.get_one::<String>("cell").unwrap().clone();
+            Ok(CliAction::Execute(Command::StateGet {
+                branch: branch(state),
+                space: space(state),
+                cell,
+            }))
+        }
+        "del" => {
+            let cell = m.get_one::<String>("cell").unwrap().clone();
+            Ok(CliAction::Execute(Command::StateDelete {
+                branch: branch(state),
+                space: space(state),
+                cell,
+            }))
+        }
+        "init" => {
+            let cell = m.get_one::<String>("cell").unwrap().clone();
+            let raw = m.get_one::<String>("value").unwrap();
+            let value = parse_value(raw);
+            Ok(CliAction::Execute(Command::StateInit {
+                branch: branch(state),
+                space: space(state),
+                cell,
+                value,
+            }))
+        }
+        "cas" => {
+            let cell = m.get_one::<String>("cell").unwrap().clone();
+            let expected_str = m.get_one::<String>("expected").unwrap();
+            let expected_counter = if expected_str == "none" {
+                None
+            } else {
+                Some(
+                    expected_str
+                        .parse::<u64>()
+                        .map_err(|e| format!("Invalid expected version: {}", e))?,
+                )
+            };
+            let raw = m.get_one::<String>("value").unwrap();
+            let value = parse_value(raw);
+            Ok(CliAction::Execute(Command::StateCas {
+                branch: branch(state),
+                space: space(state),
+                cell,
+                expected_counter,
+                value,
+            }))
+        }
+        "list" => {
+            let prefix = m.get_one::<String>("prefix").cloned();
+            Ok(CliAction::Execute(Command::StateList {
+                branch: branch(state),
+                space: space(state),
+                prefix,
+            }))
+        }
+        "history" => {
+            let cell = m.get_one::<String>("cell").unwrap().clone();
+            Ok(CliAction::Execute(Command::StateGetv {
+                branch: branch(state),
+                space: space(state),
+                cell,
+            }))
+        }
+        other => Err(format!("Unknown state subcommand: {}", other)),
+    }
+}
+
+// =========================================================================
+// Vector
+// =========================================================================
+
+fn parse_metric(s: &str) -> Result<DistanceMetric, String> {
+    match s.to_lowercase().as_str() {
+        "cosine" => Ok(DistanceMetric::Cosine),
+        "euclidean" => Ok(DistanceMetric::Euclidean),
+        "dotproduct" | "dot_product" | "dot" => Ok(DistanceMetric::DotProduct),
+        other => Err(format!("Unknown metric: {}. Use cosine, euclidean, or dotproduct", other)),
+    }
+}
+
+fn parse_vector_cmd(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, String> {
+    let (sub, m) = matches.subcommand().ok_or("No vector subcommand")?;
+    match sub {
+        "upsert" => {
+            let collection = m.get_one::<String>("collection").unwrap().clone();
+            let key = m.get_one::<String>("key").unwrap().clone();
+            let vector = parse_vector(m.get_one::<String>("vector").unwrap())?;
+            let metadata = m
+                .get_one::<String>("metadata")
+                .map(|s| parse_json_value(s))
+                .transpose()?;
+            Ok(CliAction::Execute(Command::VectorUpsert {
+                branch: branch(state),
+                space: space(state),
+                collection,
+                key,
+                vector,
+                metadata,
+            }))
+        }
+        "get" => {
+            let collection = m.get_one::<String>("collection").unwrap().clone();
+            let key = m.get_one::<String>("key").unwrap().clone();
+            Ok(CliAction::Execute(Command::VectorGet {
+                branch: branch(state),
+                space: space(state),
+                collection,
+                key,
+            }))
+        }
+        "del" => {
+            let collection = m.get_one::<String>("collection").unwrap().clone();
+            let key = m.get_one::<String>("key").unwrap().clone();
+            Ok(CliAction::Execute(Command::VectorDelete {
+                branch: branch(state),
+                space: space(state),
+                collection,
+                key,
+            }))
+        }
+        "search" => {
+            let collection = m.get_one::<String>("collection").unwrap().clone();
+            let query = parse_vector(m.get_one::<String>("query").unwrap())?;
+            let k = m
+                .get_one::<String>("k")
+                .unwrap()
+                .parse::<u64>()
+                .map_err(|e| format!("Invalid k: {}", e))?;
+            let metric = m
+                .get_one::<String>("metric")
+                .map(|s| parse_metric(s))
+                .transpose()?;
+            let filter = m
+                .get_one::<String>("filter")
+                .map(|s| -> Result<Vec<MetadataFilter>, String> {
+                    serde_json::from_str(s).map_err(|e| format!("Invalid filter JSON: {}", e))
+                })
+                .transpose()?;
+            Ok(CliAction::Execute(Command::VectorSearch {
+                branch: branch(state),
+                space: space(state),
+                collection,
+                query,
+                k,
+                filter,
+                metric,
+            }))
+        }
+        "create" => {
+            let collection = m.get_one::<String>("name").unwrap().clone();
+            let dimension = m
+                .get_one::<String>("dim")
+                .unwrap()
+                .parse::<u64>()
+                .map_err(|e| format!("Invalid dimension: {}", e))?;
+            let metric = parse_metric(m.get_one::<String>("metric").unwrap())?;
+            Ok(CliAction::Execute(Command::VectorCreateCollection {
+                branch: branch(state),
+                space: space(state),
+                collection,
+                dimension,
+                metric,
+            }))
+        }
+        "drop" => {
+            let collection = m.get_one::<String>("name").unwrap().clone();
+            Ok(CliAction::Execute(Command::VectorDeleteCollection {
+                branch: branch(state),
+                space: space(state),
+                collection,
+            }))
+        }
+        "collections" => Ok(CliAction::Execute(Command::VectorListCollections {
+            branch: branch(state),
+            space: space(state),
+        })),
+        "stats" => {
+            let collection = m.get_one::<String>("collection").unwrap().clone();
+            Ok(CliAction::Execute(Command::VectorCollectionStats {
+                branch: branch(state),
+                space: space(state),
+                collection,
+            }))
+        }
+        "batch-upsert" => {
+            let collection = m.get_one::<String>("collection").unwrap().clone();
+            let raw = m.get_one::<String>("json").unwrap();
+            let entries: Vec<BatchVectorEntry> =
+                serde_json::from_str(raw).map_err(|e| format!("Invalid batch JSON: {}", e))?;
+            Ok(CliAction::Execute(Command::VectorBatchUpsert {
+                branch: branch(state),
+                space: space(state),
+                collection,
+                entries,
+            }))
+        }
+        other => Err(format!("Unknown vector subcommand: {}", other)),
+    }
+}
+
+// =========================================================================
+// Branch
+// =========================================================================
+
+fn parse_branch(matches: &ArgMatches, _state: &SessionState) -> Result<CliAction, String> {
+    let (sub, m) = matches.subcommand().ok_or("No branch subcommand")?;
+    match sub {
+        "create" => {
+            let branch_id = m.get_one::<String>("name").cloned();
+            Ok(CliAction::Execute(Command::BranchCreate {
+                branch_id,
+                metadata: None,
+            }))
+        }
+        "info" => {
+            let name = m.get_one::<String>("name").unwrap().clone();
+            Ok(CliAction::Execute(Command::BranchGet {
+                branch: BranchId::from(name),
+            }))
+        }
+        "list" => {
+            let limit = m
+                .get_one::<String>("limit")
+                .map(|s| s.parse::<u64>())
+                .transpose()
+                .map_err(|e| format!("Invalid limit: {}", e))?;
+            Ok(CliAction::Execute(Command::BranchList {
+                state: None,
+                limit,
+                offset: None,
+            }))
+        }
+        "exists" => {
+            let name = m.get_one::<String>("name").unwrap().clone();
+            Ok(CliAction::Execute(Command::BranchExists {
+                branch: BranchId::from(name),
+            }))
+        }
+        "del" => {
+            let name = m.get_one::<String>("name").unwrap().clone();
+            Ok(CliAction::Execute(Command::BranchDelete {
+                branch: BranchId::from(name),
+            }))
+        }
+        "fork" => {
+            let destination = m.get_one::<String>("dest").unwrap().clone();
+            Ok(CliAction::BranchOp(BranchOp::Fork { destination }))
+        }
+        "diff" => {
+            let branch_a = m.get_one::<String>("a").unwrap().clone();
+            let branch_b = m.get_one::<String>("b").unwrap().clone();
+            Ok(CliAction::BranchOp(BranchOp::Diff { branch_a, branch_b }))
+        }
+        "merge" => {
+            let source = m.get_one::<String>("source").unwrap().clone();
+            let strategy = match m.get_one::<String>("strategy").map(|s| s.as_str()) {
+                Some("strict") => MergeStrategy::Strict,
+                _ => MergeStrategy::LastWriterWins,
+            };
+            Ok(CliAction::BranchOp(BranchOp::Merge { source, strategy }))
+        }
+        "export" => {
+            let branch_id = m.get_one::<String>("branch").unwrap().clone();
+            let path = m.get_one::<String>("path").unwrap().clone();
+            Ok(CliAction::Execute(Command::BranchExport { branch_id, path }))
+        }
+        "import" => {
+            let path = m.get_one::<String>("path").unwrap().clone();
+            Ok(CliAction::Execute(Command::BranchImport { path }))
+        }
+        "validate" => {
+            let path = m.get_one::<String>("path").unwrap().clone();
+            Ok(CliAction::Execute(Command::BranchBundleValidate { path }))
+        }
+        other => Err(format!("Unknown branch subcommand: {}", other)),
+    }
+}
+
+// =========================================================================
+// Space
+// =========================================================================
+
+fn parse_space(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, String> {
+    let (sub, m) = matches.subcommand().ok_or("No space subcommand")?;
+    match sub {
+        "list" => Ok(CliAction::Execute(Command::SpaceList {
+            branch: branch(state),
+        })),
+        "create" => {
+            let name = m.get_one::<String>("name").unwrap().clone();
+            Ok(CliAction::Execute(Command::SpaceCreate {
+                branch: branch(state),
+                space: name,
+            }))
+        }
+        "del" => {
+            let name = m.get_one::<String>("name").unwrap().clone();
+            let force = m.get_flag("force");
+            Ok(CliAction::Execute(Command::SpaceDelete {
+                branch: branch(state),
+                space: name,
+                force,
+            }))
+        }
+        "exists" => {
+            let name = m.get_one::<String>("name").unwrap().clone();
+            Ok(CliAction::Execute(Command::SpaceExists {
+                branch: branch(state),
+                space: name,
+            }))
+        }
+        other => Err(format!("Unknown space subcommand: {}", other)),
+    }
+}
+
+// =========================================================================
+// Transaction
+// =========================================================================
+
+fn parse_begin(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, String> {
+    let read_only = matches.get_flag("txn-read-only");
+    Ok(CliAction::Execute(Command::TxnBegin {
+        branch: branch(state),
+        options: Some(TxnOptions { read_only }),
+    }))
+}
+
+fn parse_txn(matches: &ArgMatches) -> Result<CliAction, String> {
+    let (sub, _) = matches.subcommand().ok_or("No txn subcommand")?;
+    match sub {
+        "info" => Ok(CliAction::Execute(Command::TxnInfo)),
+        "active" => Ok(CliAction::Execute(Command::TxnIsActive)),
+        other => Err(format!("Unknown txn subcommand: {}", other)),
+    }
+}
+
+// =========================================================================
+// Search
+// =========================================================================
+
+fn parse_search(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, String> {
+    let query = matches.get_one::<String>("query").unwrap().clone();
+    let k = matches
+        .get_one::<String>("k")
+        .map(|s| s.parse::<u64>())
+        .transpose()
+        .map_err(|e| format!("Invalid k: {}", e))?;
+    let primitives = matches
+        .get_one::<String>("primitives")
+        .map(|s| s.split(',').map(|p| p.trim().to_string()).collect());
+    Ok(CliAction::Execute(Command::Search {
+        branch: branch(state),
+        space: space(state),
+        query,
+        k,
+        primitives,
+    }))
+}

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -1,0 +1,393 @@
+//! REPL loop with rustyline.
+//!
+//! Interactive mode: prompt, meta-commands, history, TAB completion.
+//! Pipe mode: read lines from stdin, execute each.
+
+use std::io::{self, BufRead};
+
+use rustyline::completion::{Completer, Pair};
+use rustyline::error::ReadlineError;
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::validate::Validator;
+use rustyline::{CompletionType, Config, Context, Editor, Helper};
+
+use crate::commands::build_repl_cmd;
+use crate::format::{
+    format_diff, format_error, format_fork_info, format_merge_info, format_output, OutputMode,
+};
+use crate::parse::{check_meta_command, matches_to_action, BranchOp, CliAction, MetaCommand};
+use crate::state::SessionState;
+
+/// Run the interactive REPL.
+pub fn run_repl(state: &mut SessionState, mode: OutputMode) {
+    let config = Config::builder()
+        .history_ignore_space(true)
+        .completion_type(CompletionType::List)
+        .build();
+
+    let helper = StrataHelper::new();
+    let mut rl: Editor<StrataHelper, _> = Editor::with_config(config).unwrap();
+    rl.set_helper(Some(helper));
+
+    // Load history
+    let history_path = history_file();
+    if let Some(ref path) = history_path {
+        let _ = rl.load_history(path);
+    }
+
+    loop {
+        let prompt = state.prompt();
+        match rl.readline(&prompt) {
+            Ok(line) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+
+                let _ = rl.add_history_entry(trimmed);
+
+                // Check meta-commands first
+                if let Some(meta) = check_meta_command(trimmed) {
+                    match meta {
+                        MetaCommand::Quit => break,
+                        MetaCommand::Clear => {
+                            // ANSI clear screen
+                            print!("\x1B[2J\x1B[1;1H");
+                        }
+                        MetaCommand::Help { command } => {
+                            print_help(command.as_deref());
+                        }
+                        MetaCommand::Use { branch, space } => {
+                            match state.set_branch(&branch) {
+                                Ok(()) => {
+                                    if let Some(s) = space {
+                                        state.set_space(&s);
+                                    } else {
+                                        state.set_space("default");
+                                    }
+                                }
+                                Err(e) => {
+                                    eprintln!("{}", format_error(&e, mode));
+                                }
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                // Tokenize with shlex (respects quotes)
+                let tokens = match shlex::split(trimmed) {
+                    Some(t) => t,
+                    None => {
+                        eprintln!("(error) Invalid quoting");
+                        continue;
+                    }
+                };
+
+                if tokens.is_empty() {
+                    continue;
+                }
+
+                // Parse via clap
+                let cmd = build_repl_cmd();
+                let matches = match cmd.try_get_matches_from(tokens) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        // clap error — show help text
+                        eprintln!("{}", e);
+                        continue;
+                    }
+                };
+
+                execute_action(&matches, state, mode);
+            }
+            Err(ReadlineError::Interrupted) => {
+                // Ctrl-C — just show new prompt
+                continue;
+            }
+            Err(ReadlineError::Eof) => {
+                // Ctrl-D — exit
+                break;
+            }
+            Err(err) => {
+                eprintln!("(error) {:?}", err);
+                break;
+            }
+        }
+    }
+
+    // Save history
+    if let Some(ref path) = history_path {
+        let _ = rl.save_history(path);
+    }
+}
+
+/// Run in pipe mode: read lines from stdin, execute each.
+pub fn run_pipe(state: &mut SessionState, mode: OutputMode) -> i32 {
+    let stdin = io::stdin();
+    let mut exit_code = 0;
+
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let tokens = match shlex::split(trimmed) {
+            Some(t) => t,
+            None => {
+                eprintln!("(error) Invalid quoting: {}", trimmed);
+                exit_code = 1;
+                continue;
+            }
+        };
+
+        if tokens.is_empty() {
+            continue;
+        }
+
+        let cmd = build_repl_cmd();
+        let matches = match cmd.try_get_matches_from(tokens) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("{}", e);
+                exit_code = 1;
+                continue;
+            }
+        };
+
+        if !execute_action(&matches, state, mode) {
+            exit_code = 1;
+        }
+    }
+
+    exit_code
+}
+
+/// Execute a parsed action. Returns true on success, false on error.
+fn execute_action(
+    matches: &clap::ArgMatches,
+    state: &mut SessionState,
+    mode: OutputMode,
+) -> bool {
+    match matches_to_action(matches, state) {
+        Ok(CliAction::Execute(cmd)) => match state.execute(cmd) {
+            Ok(output) => {
+                let formatted = format_output(&output, mode);
+                if !formatted.is_empty() {
+                    println!("{}", formatted);
+                }
+                true
+            }
+            Err(e) => {
+                eprintln!("{}", format_error(&e, mode));
+                false
+            }
+        },
+        Ok(CliAction::BranchOp(op)) => match op {
+            BranchOp::Fork { destination } => match state.fork_branch(&destination) {
+                Ok(info) => {
+                    println!("{}", format_fork_info(&info, mode));
+                    true
+                }
+                Err(e) => {
+                    eprintln!("{}", format_error(&e, mode));
+                    false
+                }
+            },
+            BranchOp::Diff {
+                branch_a,
+                branch_b,
+            } => match state.diff_branches(&branch_a, &branch_b) {
+                Ok(diff) => {
+                    println!("{}", format_diff(&diff, mode));
+                    true
+                }
+                Err(e) => {
+                    eprintln!("{}", format_error(&e, mode));
+                    false
+                }
+            },
+            BranchOp::Merge { source, strategy } => match state.merge_branch(&source, strategy) {
+                Ok(info) => {
+                    println!("{}", format_merge_info(&info, mode));
+                    true
+                }
+                Err(e) => {
+                    eprintln!("{}", format_error(&e, mode));
+                    false
+                }
+            },
+        },
+        Ok(CliAction::Meta(_)) => {
+            // Meta-commands should have been handled before reaching here
+            true
+        }
+        Err(e) => {
+            eprintln!("(error) {}", e);
+            false
+        }
+    }
+}
+
+fn history_file() -> Option<String> {
+    std::env::var("HOME")
+        .ok()
+        .map(|h| format!("{}/.strata_history", h))
+}
+
+fn print_help(command: Option<&str>) {
+    if let Some(cmd) = command {
+        // Show help for a specific command
+        let cli = build_repl_cmd();
+        match cli.try_get_matches_from(vec![cmd, "--help"]) {
+            Ok(_) => {}
+            Err(e) => println!("{}", e),
+        }
+    } else {
+        println!("Available commands:");
+        println!("  kv          Key-value operations (put, get, del, list, history)");
+        println!("  json        JSON document operations (set, get, del, list, history)");
+        println!("  event       Event log operations (append, get, list, len)");
+        println!("  state       State cell operations (set, get, del, init, cas, list, history)");
+        println!("  vector      Vector store operations (upsert, get, del, search, create, ...)");
+        println!("  branch      Branch operations (create, info, list, fork, diff, merge, ...)");
+        println!("  space       Space operations (list, create, del, exists)");
+        println!("  begin       Begin a transaction");
+        println!("  commit      Commit a transaction");
+        println!("  rollback    Rollback a transaction");
+        println!("  txn         Transaction info (info, active)");
+        println!("  ping        Ping the database");
+        println!("  info        Database information");
+        println!("  flush       Flush writes to disk");
+        println!("  compact     Trigger compaction");
+        println!("  search      Search across primitives");
+        println!();
+        println!("Meta-commands:");
+        println!("  use <branch> [space]   Switch branch/space context");
+        println!("  help [command]         Show help");
+        println!("  quit / exit            Exit REPL");
+        println!("  clear                  Clear screen");
+    }
+}
+
+// =========================================================================
+// TAB Completion
+// =========================================================================
+
+/// Known top-level commands for TAB completion.
+const TOP_LEVEL_COMMANDS: &[&str] = &[
+    "kv", "json", "event", "state", "vector", "branch", "space", "begin", "commit", "rollback",
+    "txn", "ping", "info", "flush", "compact", "search", "use", "help", "quit", "exit", "clear",
+];
+
+/// Known subcommands for each top-level command.
+fn subcommands_for(cmd: &str) -> &'static [&'static str] {
+    match cmd {
+        "kv" => &["put", "get", "del", "list", "history"],
+        "json" => &["set", "get", "del", "list", "history"],
+        "event" => &["append", "get", "list", "len"],
+        "state" => &["set", "get", "del", "init", "cas", "list", "history"],
+        "vector" => &[
+            "upsert",
+            "get",
+            "del",
+            "search",
+            "create",
+            "drop",
+            "collections",
+            "stats",
+            "batch-upsert",
+        ],
+        "branch" => &[
+            "create", "info", "list", "exists", "del", "fork", "diff", "merge", "export",
+            "import", "validate",
+        ],
+        "space" => &["list", "create", "del", "exists"],
+        "txn" => &["info", "active"],
+        _ => &[],
+    }
+}
+
+struct StrataHelper;
+
+impl StrataHelper {
+    fn new() -> Self {
+        Self
+    }
+}
+
+impl Helper for StrataHelper {}
+impl Validator for StrataHelper {}
+impl Highlighter for StrataHelper {}
+impl Hinter for StrataHelper {
+    type Hint = String;
+
+    fn hint(&self, _line: &str, _pos: usize, _ctx: &Context<'_>) -> Option<String> {
+        None
+    }
+}
+
+impl Completer for StrataHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        let line_to_pos = &line[..pos];
+        let parts: Vec<&str> = line_to_pos.split_whitespace().collect();
+
+        // Determine if we're completing a partial word or starting a new word
+        let trailing_space = line_to_pos.ends_with(' ');
+
+        if parts.is_empty() || (parts.len() == 1 && !trailing_space) {
+            // Completing top-level command
+            let prefix = parts.first().copied().unwrap_or("");
+            let start = pos - prefix.len();
+            let candidates: Vec<Pair> = TOP_LEVEL_COMMANDS
+                .iter()
+                .filter(|cmd| cmd.starts_with(prefix))
+                .map(|cmd| Pair {
+                    display: cmd.to_string(),
+                    replacement: cmd.to_string(),
+                })
+                .collect();
+            Ok((start, candidates))
+        } else if parts.len() == 1 && trailing_space {
+            // Just typed the top-level command, completing subcommand
+            let subs = subcommands_for(parts[0]);
+            let candidates: Vec<Pair> = subs
+                .iter()
+                .map(|s| Pair {
+                    display: s.to_string(),
+                    replacement: s.to_string(),
+                })
+                .collect();
+            Ok((pos, candidates))
+        } else if parts.len() == 2 && !trailing_space {
+            // Completing partial subcommand
+            let subs = subcommands_for(parts[0]);
+            let prefix = parts[1];
+            let start = pos - prefix.len();
+            let candidates: Vec<Pair> = subs
+                .iter()
+                .filter(|s| s.starts_with(prefix))
+                .map(|s| Pair {
+                    display: s.to_string(),
+                    replacement: s.to_string(),
+                })
+                .collect();
+            Ok((start, candidates))
+        } else {
+            Ok((pos, vec![]))
+        }
+    }
+}

--- a/crates/cli/src/state.rs
+++ b/crates/cli/src/state.rs
@@ -1,0 +1,118 @@
+//! Session wrapper with branch/space context.
+//!
+//! Holds both a `Strata` handle (for branch power API) and a `Session`
+//! (for transactional command execution). Both share the same underlying
+//! `Arc<Database>`.
+
+use strata_executor::{
+    BranchDiffResult, Branches, Command, Error, ForkInfo, MergeInfo, MergeStrategy, Output,
+    Result, Session, Strata,
+};
+
+/// Wraps the database handles and tracks current context.
+pub struct SessionState {
+    db: Strata,
+    session: Session,
+    branch: String,
+    space: String,
+    in_transaction: bool,
+}
+
+impl SessionState {
+    /// Create a new SessionState from a Strata handle.
+    pub fn new(db: Strata, branch: String, space: String) -> Self {
+        let session = db.session();
+        Self {
+            db,
+            session,
+            branch,
+            space,
+            in_transaction: false,
+        }
+    }
+
+    /// Execute a command via the session.
+    pub fn execute(&mut self, cmd: Command) -> Result<Output> {
+        let output = self.session.execute(cmd)?;
+        // Track transaction state changes
+        match &output {
+            Output::TxnBegun => self.in_transaction = true,
+            Output::TxnCommitted { .. } | Output::TxnAborted => self.in_transaction = false,
+            _ => {}
+        }
+        Ok(output)
+    }
+
+    /// Get a Branches handle for fork/diff/merge.
+    #[allow(dead_code)]
+    pub fn branches(&self) -> Branches<'_> {
+        self.db.branches()
+    }
+
+    /// Fork the current branch.
+    pub fn fork_branch(&self, destination: &str) -> Result<ForkInfo> {
+        self.db.branches().fork(&self.branch, destination)
+    }
+
+    /// Diff two branches.
+    pub fn diff_branches(&self, branch_a: &str, branch_b: &str) -> Result<BranchDiffResult> {
+        self.db.branches().diff(branch_a, branch_b)
+    }
+
+    /// Merge a source branch into the current branch.
+    pub fn merge_branch(&self, source: &str, strategy: MergeStrategy) -> Result<MergeInfo> {
+        self.db.branches().merge(source, &self.branch, strategy)
+    }
+
+    /// Current branch name.
+    pub fn branch(&self) -> &str {
+        &self.branch
+    }
+
+    /// Current space name.
+    pub fn space(&self) -> &str {
+        &self.space
+    }
+
+    /// Switch branch context.
+    pub fn set_branch(&mut self, name: &str) -> Result<()> {
+        // Verify branch exists
+        let exists = match self.session.execute(Command::BranchExists {
+            branch: name.into(),
+        })? {
+            Output::Bool(b) => b,
+            _ => {
+                return Err(Error::Internal {
+                    reason: "Unexpected output".into(),
+                })
+            }
+        };
+        if !exists {
+            return Err(Error::BranchNotFound {
+                branch: name.to_string(),
+            });
+        }
+        self.branch = name.to_string();
+        Ok(())
+    }
+
+    /// Switch space context.
+    pub fn set_space(&mut self, name: &str) {
+        self.space = name.to_string();
+    }
+
+    /// Whether a transaction is currently active.
+    #[allow(dead_code)]
+    pub fn in_transaction(&self) -> bool {
+        self.in_transaction
+    }
+
+    /// Generate the REPL prompt string.
+    pub fn prompt(&self) -> String {
+        if self.in_transaction {
+            format!("strata:{}/{}(txn)> ", self.branch, self.space)
+        } else {
+            format!("strata:{}/{}> ", self.branch, self.space)
+        }
+    }
+}

--- a/crates/cli/src/value.rs
+++ b/crates/cli/src/value.rs
@@ -1,0 +1,182 @@
+//! String → Value parsing rules.
+//!
+//! User input is parsed into `Value` using auto-detect logic:
+//! 1. JSON structures (`{`, `[`, `"`) → parse as JSON
+//! 2. `null` → Value::Null
+//! 3. `true` / `false` → Value::Bool
+//! 4. Integer pattern → Value::Int
+//! 5. Float pattern → Value::Float
+//! 6. Everything else → Value::String
+
+use strata_executor::Value;
+
+/// Auto-detect value type from a user-supplied string.
+///
+/// Rules applied in order:
+/// 1. If starts with `{`, `[`, or `"` → parse as JSON, convert via `From<serde_json::Value>`
+/// 2. `null` → `Value::Null`
+/// 3. `true` / `false` → `Value::Bool`
+/// 4. Matches `^-?[0-9]+$` and fits i64 → `Value::Int`
+/// 5. Matches float pattern → `Value::Float`
+/// 6. Everything else → `Value::String`
+pub fn parse_value(s: &str) -> Value {
+    // Rule 1: JSON structures
+    if s.starts_with('{') || s.starts_with('[') || s.starts_with('"') {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(s) {
+            return Value::from(json);
+        }
+        // If JSON parse fails, fall through to string
+    }
+
+    // Rule 2: null
+    if s == "null" {
+        return Value::Null;
+    }
+
+    // Rule 3: booleans
+    if s == "true" {
+        return Value::Bool(true);
+    }
+    if s == "false" {
+        return Value::Bool(false);
+    }
+
+    // Rule 4: integers
+    if is_integer(s) {
+        if let Ok(i) = s.parse::<i64>() {
+            return Value::Int(i);
+        }
+    }
+
+    // Rule 5: floats
+    if is_float(s) {
+        if let Ok(f) = s.parse::<f64>() {
+            return Value::Float(f);
+        }
+    }
+
+    // Rule 6: everything else is a string
+    Value::String(s.to_string())
+}
+
+/// Strict JSON parsing — input must be valid JSON.
+pub fn parse_json_value(s: &str) -> Result<Value, String> {
+    let json: serde_json::Value =
+        serde_json::from_str(s).map_err(|e| format!("Invalid JSON: {}", e))?;
+    Ok(Value::from(json))
+}
+
+/// Parse a vector literal like `[1.0, 2.0, 3.0]`.
+pub fn parse_vector(s: &str) -> Result<Vec<f32>, String> {
+    let json: serde_json::Value =
+        serde_json::from_str(s).map_err(|e| format!("Invalid vector literal: {}", e))?;
+    match json {
+        serde_json::Value::Array(arr) => {
+            let mut result = Vec::with_capacity(arr.len());
+            for (i, v) in arr.iter().enumerate() {
+                match v.as_f64() {
+                    Some(f) => result.push(f as f32),
+                    None => return Err(format!("Element {} is not a number", i)),
+                }
+            }
+            Ok(result)
+        }
+        _ => Err("Expected a JSON array of numbers".to_string()),
+    }
+}
+
+fn is_integer(s: &str) -> bool {
+    let s = if let Some(rest) = s.strip_prefix('-') {
+        rest
+    } else {
+        s
+    };
+    !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
+}
+
+fn is_float(s: &str) -> bool {
+    let s = if let Some(rest) = s.strip_prefix('-') {
+        rest
+    } else {
+        s
+    };
+    if s.is_empty() {
+        return false;
+    }
+    // Must contain a dot or exponent
+    if !s.contains('.') && !s.contains('e') && !s.contains('E') {
+        return false;
+    }
+    // All characters must be digits, dot, e, E, +, -
+    s.bytes()
+        .all(|b| b.is_ascii_digit() || b == b'.' || b == b'e' || b == b'E' || b == b'+' || b == b'-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_null() {
+        assert_eq!(parse_value("null"), Value::Null);
+    }
+
+    #[test]
+    fn test_parse_booleans() {
+        assert_eq!(parse_value("true"), Value::Bool(true));
+        assert_eq!(parse_value("false"), Value::Bool(false));
+    }
+
+    #[test]
+    fn test_parse_integers() {
+        assert_eq!(parse_value("42"), Value::Int(42));
+        assert_eq!(parse_value("-1"), Value::Int(-1));
+        assert_eq!(parse_value("0"), Value::Int(0));
+    }
+
+    #[test]
+    fn test_parse_floats() {
+        assert_eq!(parse_value("3.14"), Value::Float(3.14));
+        assert_eq!(parse_value("-0.5"), Value::Float(-0.5));
+        assert_eq!(parse_value("1.0e10"), Value::Float(1.0e10));
+    }
+
+    #[test]
+    fn test_parse_strings() {
+        assert_eq!(parse_value("hello"), Value::String("hello".into()));
+        assert_eq!(parse_value("foo bar"), Value::String("foo bar".into()));
+    }
+
+    #[test]
+    fn test_parse_json_object() {
+        match parse_value(r#"{"name":"Alice"}"#) {
+            Value::Object(map) => {
+                assert_eq!(
+                    map.get("name"),
+                    Some(&Value::String("Alice".into()))
+                );
+            }
+            other => panic!("Expected Object, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_json_array() {
+        match parse_value("[1,2,3]") {
+            Value::Array(arr) => assert_eq!(arr.len(), 3),
+            other => panic!("Expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_vector() {
+        let v = parse_vector("[1.0, 2.0, 3.0]").unwrap();
+        assert_eq!(v, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn test_parse_json_value_strict() {
+        assert!(parse_json_value("not json").is_err());
+        assert!(parse_json_value(r#"{"a":1}"#).is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `strata-cli` crate with a `strata` binary providing shell, interactive REPL, and pipe modes
- Implements all command categories: KV, JSON, Event, State, Vector, Branch (including fork/diff/merge via Branches power API), Space, Transaction, Database, and Search
- Three output modes: human (Redis-style conventions), JSON (`--json`), and raw (`--raw`) for shell scripting
- REPL features: rustyline with history, TAB completion, `use` context switching, transaction-aware prompt
- 16 unit tests covering value parsing and output formatting

## Test plan

- [x] `cargo build -p strata-cli` — zero warnings
- [x] `cargo test -p strata-cli` — 16/16 pass
- [x] `cargo build --workspace` — clean
- [x] Smoke test: shell mode KV put/get, state set/get, branch list, ping, info
- [x] Smoke test: pipe mode with `--cache` flag
- [x] Smoke test: `begin --read-only` / `rollback` transaction flow
- [ ] Manual REPL session: context switching with `use`, transaction prompt indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)