### PR TITLE
Revert: Remove unnecessary API wrapper methods

### DIFF
--- a/crates/executor/src/api/event.rs
+++ b/crates/executor/src/api/event.rs
@@ -68,28 +68,4 @@ impl Strata {
             }),
         }
     }
-
-    /// Read events of a specific type with pagination support.
-    ///
-    /// - `limit`: Maximum number of events to return
-    /// - `after_sequence`: Only return events after this sequence number
-    pub fn event_get_by_type_paginated(
-        &self,
-        event_type: &str,
-        limit: Option<u64>,
-        after_sequence: Option<u64>,
-    ) -> Result<Vec<VersionedValue>> {
-        match self.executor.execute(Command::EventGetByType {
-            branch: self.branch_id(),
-            space: self.space_id(),
-            event_type: event_type.to_string(),
-            limit,
-            after_sequence,
-        })? {
-            Output::VersionedValues(events) => Ok(events),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for EventGetByType".into(),
-            }),
-        }
-    }
 }

--- a/crates/executor/src/api/kv.rs
+++ b/crates/executor/src/api/kv.rs
@@ -126,40 +126,4 @@ impl Strata {
             }),
         }
     }
-
-    /// List keys with pagination support.
-    ///
-    /// Returns a tuple of (keys, next_cursor). If next_cursor is Some, there are more keys
-    /// to fetch by calling with that cursor value.
-    pub fn kv_list_paginated(
-        &self,
-        prefix: Option<&str>,
-        cursor: Option<&str>,
-        limit: Option<u64>,
-    ) -> Result<(Vec<String>, Option<String>)> {
-        match self.executor.execute(Command::KvList {
-            branch: self.branch_id(),
-            space: self.space_id(),
-            prefix: prefix.map(|s| s.to_string()),
-            cursor: cursor.map(|s| s.to_string()),
-            limit,
-        })? {
-            Output::Keys(keys) => {
-                // If we got exactly `limit` keys, the last key is the cursor for the next page
-                let next_cursor = if let Some(lim) = limit {
-                    if keys.len() == lim as usize {
-                        keys.last().cloned()
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-                Ok((keys, next_cursor))
-            }
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for KvList".into(),
-            }),
-        }
-    }
 }

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -523,58 +523,6 @@ impl Strata {
             }),
         }
     }
-
-    /// Create a new space explicitly.
-    ///
-    /// Spaces are auto-created on first write, but this allows pre-creation
-    /// for organizational purposes.
-    pub fn space_create(&self, space: &str) -> Result<()> {
-        match self.executor.execute(Command::SpaceCreate {
-            branch: self.branch_id(),
-            space: space.to_string(),
-        })? {
-            Output::Unit => Ok(()),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for SpaceCreate".into(),
-            }),
-        }
-    }
-
-    /// Check if a space exists in the current branch.
-    pub fn space_exists(&self, space: &str) -> Result<bool> {
-        match self.executor.execute(Command::SpaceExists {
-            branch: self.branch_id(),
-            space: space.to_string(),
-        })? {
-            Output::Bool(exists) => Ok(exists),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for SpaceExists".into(),
-            }),
-        }
-    }
-
-    /// Search across multiple primitives for matching content.
-    ///
-    /// Returns ranked results with entity, primitive type, score, rank, and optional snippet.
-    pub fn search(
-        &self,
-        query: &str,
-        k: Option<u64>,
-        primitives: Option<Vec<String>>,
-    ) -> Result<Vec<crate::types::SearchResultHit>> {
-        match self.executor.execute(Command::Search {
-            branch: self.branch_id(),
-            space: self.space_id(),
-            query: query.to_string(),
-            k,
-            primitives,
-        })? {
-            Output::SearchResults(results) => Ok(results),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for Search".into(),
-            }),
-        }
-    }
 }
 
 // =============================================================================

--- a/crates/executor/src/api/state.rs
+++ b/crates/executor/src/api/state.rs
@@ -92,34 +92,4 @@ impl Strata {
             }),
         }
     }
-
-    /// Delete a state cell.
-    ///
-    /// Returns `true` if the cell existed and was deleted, `false` if it didn't exist.
-    pub fn state_delete(&self, cell: &str) -> Result<bool> {
-        match self.executor.execute(Command::StateDelete {
-            branch: self.branch_id(),
-            space: self.space_id(),
-            cell: cell.to_string(),
-        })? {
-            Output::Bool(deleted) => Ok(deleted),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for StateDelete".into(),
-            }),
-        }
-    }
-
-    /// List state cell names with optional prefix filter.
-    pub fn state_list(&self, prefix: Option<&str>) -> Result<Vec<String>> {
-        match self.executor.execute(Command::StateList {
-            branch: self.branch_id(),
-            space: self.space_id(),
-            prefix: prefix.map(|s| s.to_string()),
-        })? {
-            Output::Keys(keys) => Ok(keys),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for StateList".into(),
-            }),
-        }
-    }
 }

--- a/crates/executor/src/api/vector.rs
+++ b/crates/executor/src/api/vector.rs
@@ -169,29 +169,4 @@ impl Strata {
             }),
         }
     }
-
-    /// Search for similar vectors with optional filter and metric override.
-    pub fn vector_search_filtered(
-        &self,
-        collection: &str,
-        query: Vec<f32>,
-        k: u64,
-        filter: Option<Vec<MetadataFilter>>,
-        metric: Option<DistanceMetric>,
-    ) -> Result<Vec<VectorMatch>> {
-        match self.executor.execute(Command::VectorSearch {
-            branch: self.branch_id(),
-            space: self.space_id(),
-            collection: collection.to_string(),
-            query,
-            k,
-            filter,
-            metric,
-        })? {
-            Output::VectorMatches(matches) => Ok(matches),
-            _ => Err(Error::Internal {
-                reason: "Unexpected output for VectorSearch".into(),
-            }),
-        }
-    }
 }


### PR DESCRIPTION
## Summary

Reverts #1037 which added unnecessary wrapper methods to the Strata API.

The Command enum already has all the variants needed (StateDelete, StateList, SpaceCreate, SpaceExists, Search, etc.) and the executor handles them. SDKs should use the executor/session directly with Command variants, not high-level wrapper methods.

This keeps the API consistent with how MCP and CLI work - they call `session.execute(Command::...)` directly.

The Python SDK will be updated to use the executor pattern instead.

## Test plan

- [x] All tests pass (the methods weren't tested, just the underlying commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)