### PR TITLE
Add comprehensive API reference documentation for all 4 surfaces

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,831 @@
+# CLI Reference
+
+The StrataDB CLI (`strata`) provides a Redis-inspired command-line interface for interacting with StrataDB databases.
+
+## Installation
+
+```bash
+# From crates.io
+cargo install strata-cli
+
+# From source
+git clone https://github.com/stratadb-labs/strata-core
+cd strata-core
+cargo install --path crates/cli
+```
+
+## Quick Start
+
+```bash
+# Open a database
+strata /path/to/data
+
+# Or use an in-memory database
+strata --memory
+
+# Run a single command
+strata /path/to/data -c "kv put greeting hello"
+```
+
+## Command Line Options
+
+| Option | Description |
+|--------|-------------|
+| `<PATH>` | Path to the database directory |
+| `--memory` | Use ephemeral in-memory database |
+| `-c, --command <CMD>` | Execute command and exit |
+| `--json` | Output in JSON format |
+| `--raw` | Output raw values (no formatting) |
+| `-h, --help` | Show help |
+| `-V, --version` | Show version |
+
+---
+
+## Database Commands
+
+### ping
+
+Check database connectivity.
+
+```
+ping
+```
+
+**Returns:** `PONG` with version string
+
+### info
+
+Get database information.
+
+```
+info
+```
+
+**Returns:** Database statistics including version, uptime, branch count, and total keys.
+
+### flush
+
+Flush pending writes to disk.
+
+```
+flush
+```
+
+### compact
+
+Trigger database compaction.
+
+```
+compact
+```
+
+---
+
+## KV Store Commands
+
+### kv put
+
+Store one or more key-value pairs.
+
+```
+kv put <key> <value> [<key> <value> ...]
+```
+
+**Examples:**
+```bash
+kv put name "Alice"
+kv put counter 42
+kv put config '{"debug": true}'
+kv put a 1 b 2 c 3  # Multiple pairs
+```
+
+**Returns:** Version number(s)
+
+### kv get
+
+Get one or more values by key.
+
+```
+kv get <key> [<key> ...]
+kv get <key> --with-version
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--with-version`, `-v` | Include version and timestamp |
+
+**Examples:**
+```bash
+kv get name
+kv get a b c
+kv get config --with-version
+```
+
+**Returns:** Value(s) or `(nil)` if not found
+
+### kv del
+
+Delete one or more keys.
+
+```
+kv del <key> [<key> ...]
+```
+
+**Examples:**
+```bash
+kv del name
+kv del a b c
+```
+
+**Returns:** `(integer) 1` if deleted, `(integer) 0` if not found
+
+### kv list
+
+List keys with optional prefix filter.
+
+```
+kv list [--prefix <prefix>] [--limit <n>] [--cursor <cursor>] [--all]
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--prefix`, `-p` | Filter keys by prefix |
+| `--limit`, `-n` | Maximum keys to return |
+| `--cursor`, `-c` | Pagination cursor |
+| `--all`, `-a` | Fetch all keys (auto-pagination) |
+
+**Examples:**
+```bash
+kv list
+kv list --prefix "user:"
+kv list --prefix "session:" --limit 100
+kv list --all
+```
+
+### kv history
+
+Get version history for a key.
+
+```
+kv history <key>
+```
+
+**Returns:** Array of versioned values with timestamps
+
+---
+
+## State Cell Commands
+
+### state set
+
+Set a state cell value.
+
+```
+state set <cell> <value>
+```
+
+**Examples:**
+```bash
+state set counter 0
+state set config '{"mode": "production"}'
+```
+
+**Returns:** Version number
+
+### state get
+
+Get a state cell value.
+
+```
+state get <cell>
+state get <cell> --with-version
+```
+
+**Returns:** Value or `(nil)` if not found
+
+### state init
+
+Initialize a state cell only if it doesn't exist.
+
+```
+state init <cell> <value>
+```
+
+**Returns:** Version number (same version if already exists)
+
+### state cas
+
+Compare-and-swap update based on version.
+
+```
+state cas <cell> <new_value> [--expect <version>]
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--expect`, `-e` | Expected current version (omit for "must not exist") |
+
+**Examples:**
+```bash
+state cas counter 1 --expect 0
+state cas lock "acquired"  # Only if doesn't exist
+```
+
+**Returns:** New version if successful, error if CAS failed
+
+### state del
+
+Delete a state cell.
+
+```
+state del <cell>
+```
+
+**Returns:** `(integer) 1` if deleted, `(integer) 0` if not found
+
+### state list
+
+List state cell names.
+
+```
+state list [--prefix <prefix>]
+```
+
+### state history
+
+Get version history for a state cell.
+
+```
+state history <cell>
+```
+
+---
+
+## Event Log Commands
+
+### event append
+
+Append an event to the log.
+
+```
+event append <type> <payload>
+event append <type> --file <path>
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--file`, `-f` | Read payload from JSON file (use `-` for stdin) |
+
+**Examples:**
+```bash
+event append user_action '{"action": "click", "target": "button"}'
+event append order_placed --file order.json
+echo '{"data": 123}' | event append sensor_reading -f -
+```
+
+**Returns:** Sequence number
+
+### event get
+
+Get an event by sequence number.
+
+```
+event get <sequence>
+```
+
+**Returns:** Event with type, payload, and timestamp
+
+### event list
+
+List events by type.
+
+```
+event list <type> [--limit <n>] [--after <seq>]
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--limit`, `-n` | Maximum events to return |
+| `--after`, `-a` | Return events after this sequence number |
+
+**Examples:**
+```bash
+event list user_action
+event list sensor_reading --limit 100 --after 500
+```
+
+### event len
+
+Get total event count.
+
+```
+event len
+```
+
+**Returns:** Number of events in the log
+
+---
+
+## JSON Store Commands
+
+### json set
+
+Set a value at a JSONPath.
+
+```
+json set <key> <path> <value>
+json set <key> <path> --file <path>
+```
+
+**Examples:**
+```bash
+json set user:123 $ '{"name": "Alice", "age": 30}'
+json set user:123 $.email "alice@example.com"
+json set config $ --file config.json
+```
+
+**Returns:** Version number
+
+### json get
+
+Get a value at a JSONPath.
+
+```
+json get <key> <path>
+json get <key> <path> --with-version
+```
+
+**Examples:**
+```bash
+json get user:123 $
+json get user:123 $.name
+json get user:123 $.address.city
+```
+
+### json del
+
+Delete a value at a JSONPath.
+
+```
+json del <key> <path>
+```
+
+**Returns:** Count of elements removed
+
+### json list
+
+List JSON document keys.
+
+```
+json list [--prefix <prefix>] [--limit <n>] [--cursor <cursor>]
+```
+
+### json history
+
+Get version history for a JSON document.
+
+```
+json history <key>
+```
+
+---
+
+## Vector Store Commands
+
+### vector create
+
+Create a vector collection.
+
+```
+vector create <collection> <dimension> [--metric <metric>]
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--metric`, `-m` | Distance metric: `cosine` (default), `euclidean`, `dot_product` |
+
+**Examples:**
+```bash
+vector create embeddings 384
+vector create images 512 --metric euclidean
+```
+
+### vector drop
+
+Delete a vector collection.
+
+```
+vector drop <collection>
+```
+
+Alias: `vector del-collection`
+
+### vector list
+
+List all vector collections.
+
+```
+vector list
+```
+
+**Returns:** Collection info including dimension, metric, count, memory usage
+
+### vector stats
+
+Get detailed statistics for a collection.
+
+```
+vector stats <collection>
+```
+
+### vector upsert
+
+Insert or update a vector.
+
+```
+vector upsert <collection> <key> <vector> [--metadata <json>]
+```
+
+**Examples:**
+```bash
+vector upsert embeddings doc-1 "[0.1, 0.2, 0.3, ...]"
+vector upsert embeddings doc-2 "[...]" --metadata '{"title": "Hello"}'
+```
+
+### vector get
+
+Get a vector by key.
+
+```
+vector get <collection> <key>
+```
+
+**Returns:** Vector embedding, metadata, version, timestamp
+
+### vector del
+
+Delete a vector.
+
+```
+vector del <collection> <key>
+```
+
+### vector search
+
+Search for similar vectors.
+
+```
+vector search <collection> <query> <k> [--metric <metric>] [--filter <json>]
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--metric`, `-m` | Override distance metric for this search |
+| `--filter`, `-f` | Metadata filter (JSON array) |
+
+**Filter operators:** `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `contains`
+
+**Examples:**
+```bash
+vector search embeddings "[0.1, 0.2, ...]" 10
+vector search embeddings "[...]" 5 --filter '[{"field": "category", "op": "eq", "value": "science"}]'
+```
+
+**Returns:** Top-k matches with key, score, and metadata
+
+### vector batch-upsert
+
+Batch insert/update multiple vectors.
+
+```
+vector batch-upsert <collection> --file <path>
+```
+
+**File format:** JSON array of `{key, vector, metadata?}` objects
+
+---
+
+## Branch Commands
+
+### branch create
+
+Create a new empty branch.
+
+```
+branch create <name>
+```
+
+### branch info
+
+Get branch metadata.
+
+```
+branch info <name>
+```
+
+Alias: `branch get`
+
+### branch list
+
+List all branches.
+
+```
+branch list
+```
+
+### branch exists
+
+Check if a branch exists.
+
+```
+branch exists <name>
+```
+
+**Returns:** `(integer) 1` if exists, `(integer) 0` if not
+
+### branch del
+
+Delete a branch.
+
+```
+branch del <name>
+```
+
+### branch fork
+
+Fork a branch with all its data.
+
+```
+branch fork <source> <destination>
+```
+
+**Returns:** Fork info with keys copied count
+
+### branch diff
+
+Compare two branches.
+
+```
+branch diff <branch_a> <branch_b>
+```
+
+**Returns:** Diff summary with added, removed, modified counts
+
+### branch merge
+
+Merge a branch into another.
+
+```
+branch merge <source> <target> [--strategy <strategy>]
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--strategy`, `-s` | `last_writer_wins` (default) or `strict` |
+
+### branch use
+
+Switch to a different branch.
+
+```
+branch use <name>
+```
+
+Alias: `use <name>`
+
+### branch export
+
+Export a branch to a bundle file.
+
+```
+branch export <name> <path>
+```
+
+### branch import
+
+Import a branch from a bundle file.
+
+```
+branch import <path>
+```
+
+### branch validate
+
+Validate a bundle file without importing.
+
+```
+branch validate <path>
+```
+
+---
+
+## Space Commands
+
+### space create
+
+Create a new space.
+
+```
+space create <name>
+```
+
+### space list
+
+List all spaces in current branch.
+
+```
+space list
+```
+
+### space exists
+
+Check if a space exists.
+
+```
+space exists <name>
+```
+
+### space del
+
+Delete an empty space.
+
+```
+space del <name>
+```
+
+### space del-force
+
+Delete a space and all its data.
+
+```
+space del-force <name>
+```
+
+### space use
+
+Switch to a different space.
+
+```
+space use <name>
+```
+
+---
+
+## Transaction Commands
+
+### txn begin
+
+Begin a new transaction.
+
+```
+txn begin [--read-only]
+```
+
+### txn commit
+
+Commit the current transaction.
+
+```
+txn commit
+```
+
+**Returns:** Commit version number
+
+### txn rollback
+
+Rollback the current transaction.
+
+```
+txn rollback
+```
+
+### txn info
+
+Get current transaction info.
+
+```
+txn info
+```
+
+### txn active
+
+Check if a transaction is active.
+
+```
+txn active
+```
+
+---
+
+## Search Commands
+
+### search
+
+Search across multiple primitives.
+
+```
+search <query> [--k <n>] [--primitives <list>]
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--k`, `-k` | Maximum results (default: 10) |
+| `--primitives`, `-p` | Comma-separated list: `kv,json,events,state` |
+
+**Examples:**
+```bash
+search "hello world"
+search "error" --k 20 --primitives kv,json
+```
+
+**Returns:** Hits with entity, primitive, score, rank, snippet
+
+---
+
+## REPL Commands
+
+These commands are only available in interactive mode:
+
+| Command | Description |
+|---------|-------------|
+| `help [command]` | Show help for a command |
+| `clear` | Clear the screen |
+| `quit` / `exit` | Exit the REPL |
+
+### Tab Completion
+
+Press `TAB` to autocomplete:
+- Command names
+- Subcommand names
+- Flag names
+- Branch names (after `branch use`)
+- Space names (after `space use`)
+
+---
+
+## Output Formats
+
+### Human (default)
+
+Redis-style output optimized for readability:
+
+```
+> kv put name "Alice"
+(integer) 1
+
+> kv get name
+"Alice"
+
+> kv list
+1) "name"
+```
+
+### JSON (`--json`)
+
+Machine-readable JSON output:
+
+```bash
+strata /data --json -c "kv get name"
+# {"value": "Alice"}
+```
+
+### Raw (`--raw`)
+
+Unformatted values only:
+
+```bash
+strata /data --raw -c "kv get name"
+# Alice
+```
+
+---
+
+## Error Handling
+
+Errors are displayed with descriptive messages:
+
+```
+> kv get nonexistent
+(nil)
+
+> branch use nonexistent
+(error) Branch not found: nonexistent
+
+> state cas counter 10 --expect 5
+(error) CAS failed: expected version 5, found 7
+```
+
+In JSON mode, errors include an `error` field:
+
+```json
+{"error": "Branch not found: nonexistent"}
+```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,8 +2,17 @@
 
 Complete specifications for the StrataDB API.
 
+## SDK & Interface References
+
+- **[CLI Reference](cli.md)** — Redis-inspired command-line interface
+- **[MCP Server Reference](mcp.md)** — Model Context Protocol server for AI assistants
+- **[Python SDK Reference](python-sdk.md)** — Native Python bindings via PyO3
+- **[Node.js SDK Reference](node-sdk.md)** — Native Node.js bindings via NAPI-RS
+
+## Core API References
+
 - **[API Quick Reference](api-quick-reference.md)** — every `Strata` method at a glance
+- **[Command Reference](command-reference.md)** — the `Command` and `Output` enums
 - **[Value Type Reference](value-type-reference.md)** — all 8 variants, all conversions
 - **[Error Reference](error-reference.md)** — every error variant and when it occurs
-- **[Command Reference](command-reference.md)** — the `Command` and `Output` enums
 - **[Configuration Reference](configuration-reference.md)** — durability modes and database options

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -1,0 +1,755 @@
+# MCP Server Reference
+
+The StrataDB MCP (Model Context Protocol) server exposes StrataDB as a tool provider for AI assistants like Claude.
+
+## Installation
+
+```bash
+# From crates.io
+cargo install strata-mcp
+
+# From source
+git clone https://github.com/stratadb-labs/strata-core
+cd strata-core
+cargo install --path crates/mcp
+```
+
+## Configuration
+
+### Claude Desktop
+
+Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "stratadb": {
+      "command": "strata-mcp",
+      "args": ["/path/to/data"]
+    }
+  }
+}
+```
+
+### In-Memory Mode
+
+For ephemeral databases:
+
+```json
+{
+  "mcpServers": {
+    "stratadb": {
+      "command": "strata-mcp",
+      "args": ["--memory"]
+    }
+  }
+}
+```
+
+## Command Line Options
+
+| Option | Description |
+|--------|-------------|
+| `<PATH>` | Path to the database directory |
+| `--memory` | Use ephemeral in-memory database |
+| `-h, --help` | Show help |
+| `-V, --version` | Show version |
+
+---
+
+## Tools
+
+The MCP server exposes the following tools to AI assistants:
+
+### Database Tools
+
+#### strata_ping
+
+Check database connectivity.
+
+**Parameters:** None
+
+**Returns:**
+```json
+{"version": "0.5.1"}
+```
+
+#### strata_info
+
+Get database information.
+
+**Parameters:** None
+
+**Returns:**
+```json
+{
+  "version": "0.5.1",
+  "uptime_secs": 3600,
+  "branch_count": 3,
+  "total_keys": 1500
+}
+```
+
+#### strata_flush
+
+Flush pending writes to disk.
+
+**Parameters:** None
+
+#### strata_compact
+
+Trigger database compaction.
+
+**Parameters:** None
+
+---
+
+### KV Store Tools
+
+#### strata_kv_put
+
+Store a key-value pair.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `key` | string | Yes | The key to store |
+| `value` | any | Yes | The value (string, number, boolean, object, array) |
+
+**Returns:** `{"version": 1}`
+
+#### strata_kv_get
+
+Get a value by key.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `key` | string | Yes | The key to retrieve |
+
+**Returns:** The value, or `null` if not found
+
+#### strata_kv_delete
+
+Delete a key.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `key` | string | Yes | The key to delete |
+
+**Returns:** `{"deleted": true}` or `{"deleted": false}`
+
+#### strata_kv_list
+
+List keys with optional prefix filter.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `prefix` | string | No | Filter keys by prefix |
+| `limit` | number | No | Maximum keys to return |
+| `cursor` | string | No | Pagination cursor |
+
+**Returns:** `{"keys": ["key1", "key2", ...]}`
+
+#### strata_kv_history
+
+Get version history for a key.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `key` | string | Yes | The key |
+
+**Returns:** Array of `{value, version, timestamp}`
+
+---
+
+### State Cell Tools
+
+#### strata_state_set
+
+Set a state cell value.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `cell` | string | Yes | The cell name |
+| `value` | any | Yes | The value to set |
+
+**Returns:** `{"version": 1}`
+
+#### strata_state_get
+
+Get a state cell value.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `cell` | string | Yes | The cell name |
+
+**Returns:** The value, or `null` if not found
+
+#### strata_state_init
+
+Initialize a state cell only if it doesn't exist.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `cell` | string | Yes | The cell name |
+| `value` | any | Yes | The initial value |
+
+**Returns:** `{"version": 1}`
+
+#### strata_state_cas
+
+Compare-and-swap update.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `cell` | string | Yes | The cell name |
+| `value` | any | Yes | The new value |
+| `expected_version` | number | No | Expected current version |
+
+**Returns:** `{"version": 2}` on success, `{"failed": true}` on CAS failure
+
+#### strata_state_delete
+
+Delete a state cell.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `cell` | string | Yes | The cell name |
+
+**Returns:** `{"deleted": true}` or `{"deleted": false}`
+
+#### strata_state_list
+
+List state cell names.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `prefix` | string | No | Filter by prefix |
+
+**Returns:** `{"cells": ["cell1", "cell2", ...]}`
+
+---
+
+### Event Log Tools
+
+#### strata_event_append
+
+Append an event to the log.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `event_type` | string | Yes | The event type |
+| `payload` | object | Yes | The event payload (must be an object) |
+
+**Returns:** `{"sequence": 0}`
+
+#### strata_event_get
+
+Get an event by sequence number.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sequence` | number | Yes | The sequence number |
+
+**Returns:** `{value, version, timestamp}` or `null`
+
+#### strata_event_list
+
+List events by type.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `event_type` | string | Yes | The event type |
+| `limit` | number | No | Maximum events |
+| `after` | number | No | Return events after this sequence |
+
+**Returns:** Array of events
+
+#### strata_event_len
+
+Get total event count.
+
+**Parameters:** None
+
+**Returns:** `{"count": 100}`
+
+---
+
+### JSON Store Tools
+
+#### strata_json_set
+
+Set a value at a JSONPath.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `key` | string | Yes | The document key |
+| `path` | string | Yes | JSONPath (use `$` for root) |
+| `value` | any | Yes | The value to set |
+
+**Returns:** `{"version": 1}`
+
+#### strata_json_get
+
+Get a value at a JSONPath.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `key` | string | Yes | The document key |
+| `path` | string | Yes | JSONPath |
+
+**Returns:** The value, or `null` if not found
+
+#### strata_json_delete
+
+Delete a value at a JSONPath.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `key` | string | Yes | The document key |
+| `path` | string | Yes | JSONPath |
+
+**Returns:** `{"deleted": 1}`
+
+#### strata_json_list
+
+List JSON document keys.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `prefix` | string | No | Filter by prefix |
+| `limit` | number | Yes | Maximum keys |
+| `cursor` | string | No | Pagination cursor |
+
+**Returns:** `{"keys": [...], "cursor": "..."}`
+
+---
+
+### Vector Store Tools
+
+#### strata_vector_create_collection
+
+Create a vector collection.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `collection` | string | Yes | Collection name |
+| `dimension` | number | Yes | Vector dimension |
+| `metric` | string | No | `cosine` (default), `euclidean`, `dot_product` |
+
+**Returns:** `{"version": 1}`
+
+#### strata_vector_delete_collection
+
+Delete a vector collection.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `collection` | string | Yes | Collection name |
+
+**Returns:** `{"deleted": true}`
+
+#### strata_vector_list_collections
+
+List all vector collections.
+
+**Parameters:** None
+
+**Returns:** Array of collection info
+
+#### strata_vector_upsert
+
+Insert or update a vector.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `collection` | string | Yes | Collection name |
+| `key` | string | Yes | Vector key |
+| `vector` | number[] | Yes | Vector embedding |
+| `metadata` | object | No | Optional metadata |
+
+**Returns:** `{"version": 1}`
+
+#### strata_vector_get
+
+Get a vector by key.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `collection` | string | Yes | Collection name |
+| `key` | string | Yes | Vector key |
+
+**Returns:** `{key, embedding, metadata, version, timestamp}` or `null`
+
+#### strata_vector_delete
+
+Delete a vector.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `collection` | string | Yes | Collection name |
+| `key` | string | Yes | Vector key |
+
+**Returns:** `{"deleted": true}`
+
+#### strata_vector_search
+
+Search for similar vectors.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `collection` | string | Yes | Collection name |
+| `query` | number[] | Yes | Query vector |
+| `k` | number | Yes | Number of results |
+| `metric` | string | No | Override distance metric |
+| `filter` | object[] | No | Metadata filters |
+
+**Filter format:**
+```json
+[
+  {"field": "category", "op": "eq", "value": "science"},
+  {"field": "year", "op": "gte", "value": 2020}
+]
+```
+
+**Filter operators:** `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `contains`
+
+**Returns:** Array of `{key, score, metadata}`
+
+#### strata_vector_batch_upsert
+
+Batch insert/update vectors.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `collection` | string | Yes | Collection name |
+| `entries` | object[] | Yes | Array of `{key, vector, metadata?}` |
+
+**Returns:** `{"versions": [1, 2, 3, ...]}`
+
+---
+
+### Branch Tools
+
+#### strata_branch_create
+
+Create a new empty branch.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | Yes | Branch name |
+
+#### strata_branch_get
+
+Get branch metadata.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | Yes | Branch name |
+
+**Returns:** Branch info or `null`
+
+#### strata_branch_list
+
+List all branches.
+
+**Parameters:** None
+
+**Returns:** `{"branches": ["default", "feature", ...]}`
+
+#### strata_branch_exists
+
+Check if a branch exists.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | Yes | Branch name |
+
+**Returns:** `{"exists": true}`
+
+#### strata_branch_delete
+
+Delete a branch.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | Yes | Branch name |
+
+#### strata_branch_fork
+
+Fork a branch with all its data.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `source` | string | Yes | Source branch |
+| `destination` | string | Yes | New branch name |
+
+**Returns:** `{"source", "destination", "keys_copied"}`
+
+#### strata_branch_diff
+
+Compare two branches.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `branch_a` | string | Yes | First branch |
+| `branch_b` | string | Yes | Second branch |
+
+**Returns:** Diff summary
+
+#### strata_branch_merge
+
+Merge branches.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `source` | string | Yes | Source branch |
+| `target` | string | Yes | Target branch |
+| `strategy` | string | No | `last_writer_wins` (default) or `strict` |
+
+**Returns:** Merge result with conflicts
+
+#### strata_branch_use
+
+Switch current branch context.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | Yes | Branch name |
+
+#### strata_current_branch
+
+Get current branch name.
+
+**Parameters:** None
+
+**Returns:** `{"branch": "default"}`
+
+---
+
+### Space Tools
+
+#### strata_space_create
+
+Create a new space.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | Yes | Space name |
+
+#### strata_space_list
+
+List all spaces.
+
+**Parameters:** None
+
+**Returns:** `{"spaces": ["default", ...]}`
+
+#### strata_space_exists
+
+Check if a space exists.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | Yes | Space name |
+
+**Returns:** `{"exists": true}`
+
+#### strata_space_delete
+
+Delete an empty space.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | Yes | Space name |
+
+#### strata_space_use
+
+Switch current space context.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | Yes | Space name |
+
+#### strata_current_space
+
+Get current space name.
+
+**Parameters:** None
+
+**Returns:** `{"space": "default"}`
+
+---
+
+### Transaction Tools
+
+#### strata_txn_begin
+
+Begin a new transaction.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `read_only` | boolean | No | Read-only transaction |
+
+#### strata_txn_commit
+
+Commit the current transaction.
+
+**Parameters:** None
+
+**Returns:** `{"version": 5}`
+
+#### strata_txn_rollback
+
+Rollback the current transaction.
+
+**Parameters:** None
+
+#### strata_txn_info
+
+Get current transaction info.
+
+**Parameters:** None
+
+**Returns:** `{id, status, started_at}` or `null`
+
+#### strata_txn_is_active
+
+Check if a transaction is active.
+
+**Parameters:** None
+
+**Returns:** `{"active": true}`
+
+---
+
+### Search Tools
+
+#### strata_search
+
+Search across multiple primitives.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `query` | string | Yes | Search query |
+| `k` | number | No | Maximum results |
+| `primitives` | string[] | No | Primitives to search |
+
+**Returns:** Array of `{entity, primitive, score, rank, snippet}`
+
+---
+
+### Bundle Tools
+
+#### strata_branch_export
+
+Export a branch to a bundle file.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `branch` | string | Yes | Branch name |
+| `path` | string | Yes | Output file path |
+
+**Returns:** Export result
+
+#### strata_branch_import
+
+Import a branch from a bundle file.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | Yes | Bundle file path |
+
+**Returns:** Import result
+
+#### strata_branch_validate
+
+Validate a bundle file.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | Yes | Bundle file path |
+
+**Returns:** Validation result
+
+---
+
+## Error Handling
+
+Tool errors are returned in the standard MCP error format:
+
+```json
+{
+  "error": {
+    "code": -32000,
+    "message": "Branch not found: nonexistent"
+  }
+}
+```
+
+Common error codes:
+- `-32000`: Application error (invalid operation, not found, etc.)
+- `-32602`: Invalid parameters
+- `-32603`: Internal error
+
+---
+
+## Usage with Claude
+
+Once configured, Claude can use StrataDB tools naturally:
+
+**User:** "Store my name as Alice"
+
+**Claude:** I'll store that for you.
+*[Calls strata_kv_put with key="name", value="Alice"]*
+
+Done! I've stored your name as "Alice" in the database.
+
+**User:** "Create a branch called 'experiment' and switch to it"
+
+**Claude:** I'll create that branch and switch to it.
+*[Calls strata_branch_create with name="experiment"]*
+*[Calls strata_branch_use with name="experiment"]*
+
+Done! Created the "experiment" branch and switched to it. Any data operations will now happen on this branch.

--- a/docs/reference/node-sdk.md
+++ b/docs/reference/node-sdk.md
@@ -1,0 +1,1071 @@
+# Node.js SDK Reference
+
+The StrataDB Node.js SDK provides native bindings via NAPI-RS with full TypeScript support.
+
+## Installation
+
+```bash
+npm install stratadb
+# or
+yarn add stratadb
+```
+
+## Quick Start
+
+```typescript
+import { Strata } from 'stratadb';
+
+// Open a database
+const db = Strata.open('/path/to/data');
+
+// Store and retrieve data
+db.kvPut('greeting', 'Hello, World!');
+console.log(db.kvGet('greeting'));  // "Hello, World!"
+
+// Use transactions
+db.begin();
+try {
+  db.kvPut('a', 1);
+  db.kvPut('b', 2);
+  db.commit();
+} catch (e) {
+  db.rollback();
+  throw e;
+}
+
+// Vector search
+db.vectorCreateCollection('embeddings', 384);
+db.vectorUpsert('embeddings', 'doc-1', new Array(384).fill(0.1));
+const results = db.vectorSearch('embeddings', new Array(384).fill(0.1), 5);
+```
+
+---
+
+## Opening a Database
+
+### Strata.open(path)
+
+Open a database at the given path.
+
+```typescript
+const db = Strata.open('/path/to/data');
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `path` | string | Path to the database directory |
+
+**Returns:** `Strata` instance
+
+**Throws:** Error if the database cannot be opened
+
+### Strata.cache()
+
+Create an ephemeral in-memory database.
+
+```typescript
+const db = Strata.cache();
+```
+
+**Returns:** `Strata` instance
+
+---
+
+## KV Store
+
+### kvPut(key, value)
+
+Store a key-value pair.
+
+```typescript
+const version = db.kvPut('user:123', { name: 'Alice', age: 30 });
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `key` | string | The key |
+| `value` | JsonValue | The value |
+
+**Returns:** `number` - Version number
+
+### kvGet(key)
+
+Get a value by key.
+
+```typescript
+const value = db.kvGet('user:123');
+if (value !== null) {
+  console.log(value.name);
+}
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `key` | string | The key |
+
+**Returns:** `JsonValue` - Value or `null` if not found
+
+### kvDelete(key)
+
+Delete a key.
+
+```typescript
+const deleted = db.kvDelete('user:123');
+```
+
+**Returns:** `boolean` - True if the key existed
+
+### kvList(prefix?)
+
+List keys with optional prefix filter.
+
+```typescript
+const allKeys = db.kvList();
+const userKeys = db.kvList('user:');
+```
+
+**Returns:** `string[]` - Key names
+
+### kvHistory(key)
+
+Get version history for a key.
+
+```typescript
+const history = db.kvHistory('user:123');
+if (history) {
+  for (const entry of history) {
+    console.log(`v${entry.version}: ${entry.value}`);
+  }
+}
+```
+
+**Returns:** `VersionedValue[] | null`
+
+### kvGetVersioned(key)
+
+Get a value with version info.
+
+```typescript
+const result = db.kvGetVersioned('user:123');
+if (result) {
+  console.log(`Value: ${result.value}, Version: ${result.version}`);
+}
+```
+
+**Returns:** `VersionedValue | null`
+
+### kvListPaginated(prefix?, limit?, cursor?)
+
+List keys with pagination.
+
+```typescript
+const result = db.kvListPaginated('user:', 100);
+console.log(result.keys);
+```
+
+**Returns:** `KvListResult` with `keys` array
+
+---
+
+## State Cell
+
+### stateSet(cell, value)
+
+Set a state cell value.
+
+```typescript
+const version = db.stateSet('counter', 0);
+```
+
+**Returns:** `number` - Version number
+
+### stateGet(cell)
+
+Get a state cell value.
+
+```typescript
+const value = db.stateGet('counter');
+```
+
+**Returns:** `JsonValue` - Value or `null`
+
+### stateInit(cell, value)
+
+Initialize a state cell only if it doesn't exist.
+
+```typescript
+const version = db.stateInit('counter', 0);
+```
+
+**Returns:** `number` - Version number
+
+### stateCas(cell, newValue, expectedVersion?)
+
+Compare-and-swap update.
+
+```typescript
+// Only update if version is 5
+const newVersion = db.stateCas('counter', 10, 5);
+if (newVersion === null) {
+  console.log('CAS failed - version mismatch');
+}
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `cell` | string | The cell name |
+| `newValue` | JsonValue | The new value |
+| `expectedVersion` | number? | Expected current version |
+
+**Returns:** `number | null` - New version or null if CAS failed
+
+### stateDelete(cell)
+
+Delete a state cell.
+
+```typescript
+const deleted = db.stateDelete('counter');
+```
+
+**Returns:** `boolean`
+
+### stateList(prefix?)
+
+List state cell names.
+
+```typescript
+const cells = db.stateList();
+const configCells = db.stateList('config:');
+```
+
+**Returns:** `string[]`
+
+### stateHistory(cell)
+
+Get version history for a state cell.
+
+```typescript
+const history = db.stateHistory('counter');
+```
+
+**Returns:** `VersionedValue[] | null`
+
+### stateGetVersioned(cell)
+
+Get a state cell with version info.
+
+```typescript
+const result = db.stateGetVersioned('counter');
+```
+
+**Returns:** `VersionedValue | null`
+
+---
+
+## Event Log
+
+### eventAppend(eventType, payload)
+
+Append an event to the log.
+
+```typescript
+const seq = db.eventAppend('user_action', { action: 'click', target: 'button' });
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `eventType` | string | The event type |
+| `payload` | JsonValue | The event payload |
+
+**Returns:** `number` - Sequence number
+
+### eventGet(sequence)
+
+Get an event by sequence number.
+
+```typescript
+const event = db.eventGet(0);
+if (event) {
+  console.log(event.value);
+}
+```
+
+**Returns:** `VersionedValue | null`
+
+### eventList(eventType)
+
+List events by type.
+
+```typescript
+const events = db.eventList('user_action');
+for (const event of events) {
+  console.log(event.value);
+}
+```
+
+**Returns:** `VersionedValue[]`
+
+### eventLen()
+
+Get total event count.
+
+```typescript
+const count = db.eventLen();
+```
+
+**Returns:** `number`
+
+### eventListPaginated(eventType, limit?, after?)
+
+List events with pagination.
+
+```typescript
+const events = db.eventListPaginated('user_action', 100, 500);
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `eventType` | string | The event type |
+| `limit` | number? | Maximum events |
+| `after` | number? | Return events after this sequence |
+
+**Returns:** `VersionedValue[]`
+
+---
+
+## JSON Store
+
+### jsonSet(key, path, value)
+
+Set a value at a JSONPath.
+
+```typescript
+// Set entire document
+db.jsonSet('user:123', '$', { name: 'Alice', age: 30 });
+
+// Set nested field
+db.jsonSet('user:123', '$.email', 'alice@example.com');
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `key` | string | Document key |
+| `path` | string | JSONPath (use `$` for root) |
+| `value` | JsonValue | The value |
+
+**Returns:** `number` - Version number
+
+### jsonGet(key, path)
+
+Get a value at a JSONPath.
+
+```typescript
+const doc = db.jsonGet('user:123', '$');
+const name = db.jsonGet('user:123', '$.name');
+```
+
+**Returns:** `JsonValue` - Value or `null`
+
+### jsonDelete(key, path)
+
+Delete a value at a JSONPath.
+
+```typescript
+const deletedCount = db.jsonDelete('user:123', '$.email');
+```
+
+**Returns:** `number` - Count of elements deleted
+
+### jsonList(limit, prefix?, cursor?)
+
+List JSON document keys with pagination.
+
+```typescript
+const result = db.jsonList(100, 'user:');
+const { keys, cursor } = result;
+```
+
+**Returns:** `JsonListResult` with `keys` and optional `cursor`
+
+### jsonHistory(key)
+
+Get version history for a JSON document.
+
+```typescript
+const history = db.jsonHistory('user:123');
+```
+
+**Returns:** `VersionedValue[] | null`
+
+### jsonGetVersioned(key)
+
+Get a JSON document with version info.
+
+```typescript
+const result = db.jsonGetVersioned('user:123');
+```
+
+**Returns:** `VersionedValue | null`
+
+---
+
+## Vector Store
+
+### vectorCreateCollection(collection, dimension, metric?)
+
+Create a vector collection.
+
+```typescript
+db.vectorCreateCollection('embeddings', 384);
+db.vectorCreateCollection('images', 512, 'euclidean');
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `collection` | string | Collection name |
+| `dimension` | number | Vector dimension |
+| `metric` | string? | `cosine` (default), `euclidean`, `dot_product` |
+
+**Returns:** `number` - Version number
+
+### vectorDeleteCollection(collection)
+
+Delete a vector collection.
+
+```typescript
+const deleted = db.vectorDeleteCollection('embeddings');
+```
+
+**Returns:** `boolean`
+
+### vectorListCollections()
+
+List all vector collections.
+
+```typescript
+const collections = db.vectorListCollections();
+for (const c of collections) {
+  console.log(`${c.name}: ${c.count} vectors`);
+}
+```
+
+**Returns:** `CollectionInfo[]`
+
+### vectorUpsert(collection, key, vector, metadata?)
+
+Insert or update a vector.
+
+```typescript
+const embedding = new Array(384).fill(0).map(() => Math.random());
+db.vectorUpsert('embeddings', 'doc-1', embedding, { title: 'Hello' });
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `collection` | string | Collection name |
+| `key` | string | Vector key |
+| `vector` | number[] | Vector embedding |
+| `metadata` | JsonValue? | Optional metadata |
+
+**Returns:** `number` - Version number
+
+### vectorGet(collection, key)
+
+Get a vector by key.
+
+```typescript
+const result = db.vectorGet('embeddings', 'doc-1');
+if (result) {
+  console.log(result.embedding);
+  console.log(result.metadata);
+}
+```
+
+**Returns:** `VectorData | null`
+
+### vectorDelete(collection, key)
+
+Delete a vector.
+
+```typescript
+const deleted = db.vectorDelete('embeddings', 'doc-1');
+```
+
+**Returns:** `boolean`
+
+### vectorSearch(collection, query, k)
+
+Search for similar vectors.
+
+```typescript
+const query = new Array(384).fill(0.1);
+const matches = db.vectorSearch('embeddings', query, 10);
+for (const match of matches) {
+  console.log(`${match.key}: ${match.score}`);
+}
+```
+
+**Returns:** `SearchMatch[]` with `key`, `score`, `metadata`
+
+### vectorSearchFiltered(collection, query, k, metric?, filter?)
+
+Search with filter and metric override.
+
+```typescript
+const matches = db.vectorSearchFiltered(
+  'embeddings',
+  query,
+  10,
+  'euclidean',
+  [
+    { field: 'category', op: 'eq', value: 'science' },
+    { field: 'year', op: 'gte', value: 2020 }
+  ]
+);
+```
+
+**Filter operators:** `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `contains`
+
+**Returns:** `SearchMatch[]`
+
+### vectorCollectionStats(collection)
+
+Get detailed collection statistics.
+
+```typescript
+const stats = db.vectorCollectionStats('embeddings');
+console.log(`Count: ${stats.count}, Memory: ${stats.memoryBytes} bytes`);
+```
+
+**Returns:** `CollectionInfo`
+
+### vectorBatchUpsert(collection, vectors)
+
+Batch insert/update vectors.
+
+```typescript
+const vectors = [
+  { key: 'doc-1', vector: [...], metadata: { title: 'A' } },
+  { key: 'doc-2', vector: [...] },
+];
+const versions = db.vectorBatchUpsert('embeddings', vectors);
+```
+
+**Returns:** `number[]` - Version numbers
+
+---
+
+## Branches
+
+### currentBranch()
+
+Get the current branch name.
+
+```typescript
+const branch = db.currentBranch();
+```
+
+**Returns:** `string`
+
+### setBranch(branch)
+
+Switch to a different branch.
+
+```typescript
+db.setBranch('feature');
+```
+
+### createBranch(branch)
+
+Create a new empty branch.
+
+```typescript
+db.createBranch('experiment');
+```
+
+### listBranches()
+
+List all branches.
+
+```typescript
+const branches = db.listBranches();
+```
+
+**Returns:** `string[]`
+
+### deleteBranch(branch)
+
+Delete a branch.
+
+```typescript
+db.deleteBranch('experiment');
+```
+
+### branchExists(name)
+
+Check if a branch exists.
+
+```typescript
+const exists = db.branchExists('feature');
+```
+
+**Returns:** `boolean`
+
+### branchGet(name)
+
+Get branch metadata.
+
+```typescript
+const info = db.branchGet('default');
+if (info) {
+  console.log(`Created: ${info.createdAt}, Version: ${info.version}`);
+}
+```
+
+**Returns:** `BranchInfo | null`
+
+### forkBranch(destination)
+
+Fork the current branch with all its data.
+
+```typescript
+const result = db.forkBranch('experiment-copy');
+console.log(`Copied ${result.keysCopied} keys`);
+```
+
+**Returns:** `ForkResult`
+
+### diffBranches(branchA, branchB)
+
+Compare two branches.
+
+```typescript
+const diff = db.diffBranches('default', 'feature');
+console.log(`Added: ${diff.summary.totalAdded}`);
+```
+
+**Returns:** `DiffResult`
+
+### mergeBranches(source, strategy?)
+
+Merge a branch into the current branch.
+
+```typescript
+const result = db.mergeBranches('feature', 'last_writer_wins');
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `source` | string | Source branch |
+| `strategy` | string? | `last_writer_wins` (default) or `strict` |
+
+**Returns:** `MergeResult`
+
+---
+
+## Spaces
+
+### currentSpace()
+
+Get the current space name.
+
+```typescript
+const space = db.currentSpace();
+```
+
+**Returns:** `string`
+
+### setSpace(space)
+
+Switch to a different space.
+
+```typescript
+db.setSpace('conversations');
+```
+
+### listSpaces()
+
+List all spaces.
+
+```typescript
+const spaces = db.listSpaces();
+```
+
+**Returns:** `string[]`
+
+### deleteSpace(space)
+
+Delete an empty space.
+
+```typescript
+db.deleteSpace('old-space');
+```
+
+### deleteSpaceForce(space)
+
+Delete a space and all its data.
+
+```typescript
+db.deleteSpaceForce('old-space');
+```
+
+### spaceCreate(space)
+
+Create a new space explicitly.
+
+```typescript
+db.spaceCreate('archive');
+```
+
+### spaceExists(space)
+
+Check if a space exists.
+
+```typescript
+const exists = db.spaceExists('archive');
+```
+
+**Returns:** `boolean`
+
+---
+
+## Transactions
+
+### begin(readOnly?)
+
+Begin a new transaction.
+
+```typescript
+db.begin();
+// or read-only
+db.begin(true);
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `readOnly` | boolean? | Read-only transaction |
+
+### commit()
+
+Commit the current transaction.
+
+```typescript
+const version = db.commit();
+```
+
+**Returns:** `number` - Commit version
+
+### rollback()
+
+Rollback the current transaction.
+
+```typescript
+db.rollback();
+```
+
+### txnInfo()
+
+Get current transaction info.
+
+```typescript
+const info = db.txnInfo();
+if (info) {
+  console.log(`Transaction ${info.id} is ${info.status}`);
+}
+```
+
+**Returns:** `TransactionInfo | null`
+
+### txnIsActive()
+
+Check if a transaction is active.
+
+```typescript
+const active = db.txnIsActive();
+```
+
+**Returns:** `boolean`
+
+### Transaction Pattern
+
+```typescript
+db.begin();
+try {
+  db.kvPut('a', 1);
+  db.kvPut('b', 2);
+  db.commit();
+} catch (e) {
+  db.rollback();
+  throw e;
+}
+```
+
+---
+
+## Search
+
+### search(query, k?, primitives?)
+
+Search across multiple primitives.
+
+```typescript
+const results = db.search('hello world', 10, ['kv', 'json']);
+for (const hit of results) {
+  console.log(`${hit.entity} (${hit.primitive}): ${hit.score}`);
+}
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `query` | string | Search query |
+| `k` | number? | Maximum results |
+| `primitives` | string[]? | Primitives to search |
+
+**Returns:** `SearchHit[]` with `entity`, `primitive`, `score`, `rank`, `snippet`
+
+---
+
+## Database Operations
+
+### ping()
+
+Check database connectivity.
+
+```typescript
+const version = db.ping();
+```
+
+**Returns:** `string` - Version string
+
+### info()
+
+Get database information.
+
+```typescript
+const info = db.info();
+console.log(`Version: ${info.version}`);
+console.log(`Total keys: ${info.totalKeys}`);
+```
+
+**Returns:** `DatabaseInfo`
+
+### flush()
+
+Flush pending writes to disk.
+
+```typescript
+db.flush();
+```
+
+### compact()
+
+Trigger database compaction.
+
+```typescript
+db.compact();
+```
+
+---
+
+## Bundle Operations
+
+### branchExport(branch, path)
+
+Export a branch to a bundle file.
+
+```typescript
+const result = db.branchExport('default', '/tmp/backup.bundle');
+console.log(`Exported ${result.entryCount} entries`);
+```
+
+**Returns:** `BranchExportResult`
+
+### branchImport(path)
+
+Import a branch from a bundle file.
+
+```typescript
+const result = db.branchImport('/tmp/backup.bundle');
+console.log(`Imported to branch ${result.branchId}`);
+```
+
+**Returns:** `BranchImportResult`
+
+### branchValidateBundle(path)
+
+Validate a bundle file without importing.
+
+```typescript
+const result = db.branchValidateBundle('/tmp/backup.bundle');
+console.log(`Valid: ${result.checksumsValid}`);
+```
+
+**Returns:** `BundleValidateResult`
+
+---
+
+## Error Handling
+
+All methods may throw errors for database operations:
+
+```typescript
+try {
+  db.setBranch('nonexistent');
+} catch (e) {
+  console.log(`Error: ${e.message}`);
+}
+```
+
+Common errors:
+- Branch not found
+- Collection not found
+- CAS version mismatch
+- Transaction already active
+- Invalid input
+
+---
+
+## TypeScript Types
+
+### JsonValue
+
+```typescript
+type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+```
+
+### VersionedValue
+
+```typescript
+interface VersionedValue {
+  value: JsonValue;
+  version: number;
+  timestamp: number;
+}
+```
+
+### CollectionInfo
+
+```typescript
+interface CollectionInfo {
+  name: string;
+  dimension: number;
+  metric: string;
+  count: number;
+  indexType: string;
+  memoryBytes: number;
+}
+```
+
+### VectorData
+
+```typescript
+interface VectorData {
+  key: string;
+  embedding: number[];
+  metadata?: JsonValue;
+  version: number;
+  timestamp: number;
+}
+```
+
+### SearchMatch
+
+```typescript
+interface SearchMatch {
+  key: string;
+  score: number;
+  metadata?: JsonValue;
+}
+```
+
+### MetadataFilter
+
+```typescript
+interface MetadataFilter {
+  field: string;
+  op: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'contains';
+  value: JsonValue;
+}
+```
+
+### SearchHit
+
+```typescript
+interface SearchHit {
+  entity: string;
+  primitive: string;
+  score: number;
+  rank: number;
+  snippet?: string;
+}
+```
+
+### TransactionInfo
+
+```typescript
+interface TransactionInfo {
+  id: string;
+  status: string;
+  startedAt: number;
+}
+```
+
+### BranchInfo
+
+```typescript
+interface BranchInfo {
+  id: string;
+  status: string;
+  createdAt: number;
+  updatedAt: number;
+  parentId?: string;
+  version: number;
+  timestamp: number;
+}
+```
+
+### DatabaseInfo
+
+```typescript
+interface DatabaseInfo {
+  version: string;
+  uptimeSecs: number;
+  branchCount: number;
+  totalKeys: number;
+}
+```
+
+---
+
+## Synchronous API
+
+All methods in the Node.js SDK are **synchronous**. This is because StrataDB is an embedded database with no network I/O, making synchronous operations efficient.
+
+For async patterns, wrap in promises:
+
+```typescript
+async function getData(key: string): Promise<JsonValue> {
+  return db.kvGet(key);
+}
+
+// Or use worker threads for heavy operations
+import { Worker } from 'worker_threads';
+```

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,0 +1,974 @@
+# Python SDK Reference
+
+The StrataDB Python SDK provides native Python bindings via PyO3.
+
+## Installation
+
+```bash
+pip install stratadb
+```
+
+## Quick Start
+
+```python
+from stratadb import Strata
+
+# Open a database
+db = Strata.open("/path/to/data")
+
+# Store and retrieve data
+db.kv_put("greeting", "Hello, World!")
+print(db.kv_get("greeting"))  # "Hello, World!"
+
+# Use transactions
+with db.transaction():
+    db.kv_put("a", 1)
+    db.kv_put("b", 2)
+# Auto-commits on success, auto-rollbacks on exception
+
+# Use vector search with NumPy
+import numpy as np
+embedding = np.random.rand(384).astype(np.float32)
+db.vector_create_collection("docs", 384)
+db.vector_upsert("docs", "doc-1", embedding)
+results = db.vector_search("docs", embedding, k=5)
+```
+
+---
+
+## Opening a Database
+
+### Strata.open(path)
+
+Open a database at the given path.
+
+```python
+db = Strata.open("/path/to/data")
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `path` | str | Path to the database directory |
+
+**Returns:** `Strata` instance
+
+**Raises:** `RuntimeError` if the database cannot be opened
+
+### Strata.cache()
+
+Create an ephemeral in-memory database.
+
+```python
+db = Strata.cache()
+```
+
+**Returns:** `Strata` instance
+
+---
+
+## KV Store
+
+### kv_put(key, value)
+
+Store a key-value pair.
+
+```python
+version = db.kv_put("user:123", {"name": "Alice", "age": 30})
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `key` | str | The key |
+| `value` | any | The value (str, int, float, bool, list, dict, bytes, None) |
+
+**Returns:** `int` - Version number
+
+### kv_get(key)
+
+Get a value by key.
+
+```python
+value = db.kv_get("user:123")
+if value is not None:
+    print(value["name"])
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `key` | str | The key |
+
+**Returns:** Value or `None` if not found
+
+### kv_delete(key)
+
+Delete a key.
+
+```python
+deleted = db.kv_delete("user:123")
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `key` | str | The key |
+
+**Returns:** `bool` - True if the key existed
+
+### kv_list(prefix=None)
+
+List keys with optional prefix filter.
+
+```python
+all_keys = db.kv_list()
+user_keys = db.kv_list(prefix="user:")
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `prefix` | str, optional | Filter keys by prefix |
+
+**Returns:** `list[str]` - Key names
+
+### kv_history(key)
+
+Get version history for a key.
+
+```python
+history = db.kv_history("user:123")
+for entry in history:
+    print(f"v{entry['version']}: {entry['value']}")
+```
+
+**Returns:** `list[dict]` with `value`, `version`, `timestamp`, or `None`
+
+### kv_get_versioned(key)
+
+Get a value with version info.
+
+```python
+result = db.kv_get_versioned("user:123")
+if result:
+    print(f"Value: {result['value']}, Version: {result['version']}")
+```
+
+**Returns:** `dict` with `value`, `version`, `timestamp`, or `None`
+
+### kv_list_paginated(prefix=None, limit=None, cursor=None)
+
+List keys with pagination.
+
+```python
+result = db.kv_list_paginated(prefix="user:", limit=100)
+print(result["keys"])
+```
+
+**Returns:** `dict` with `keys` list
+
+---
+
+## State Cell
+
+### state_set(cell, value)
+
+Set a state cell value.
+
+```python
+version = db.state_set("counter", 0)
+```
+
+**Returns:** `int` - Version number
+
+### state_get(cell)
+
+Get a state cell value.
+
+```python
+value = db.state_get("counter")
+```
+
+**Returns:** Value or `None`
+
+### state_init(cell, value)
+
+Initialize a state cell only if it doesn't exist.
+
+```python
+version = db.state_init("counter", 0)
+```
+
+**Returns:** `int` - Version number
+
+### state_cas(cell, new_value, expected_version=None)
+
+Compare-and-swap update.
+
+```python
+# Only update if version is 5
+new_version = db.state_cas("counter", 10, expected_version=5)
+if new_version is None:
+    print("CAS failed - version mismatch")
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `cell` | str | The cell name |
+| `new_value` | any | The new value |
+| `expected_version` | int, optional | Expected current version |
+
+**Returns:** `int` (new version) or `None` if CAS failed
+
+### state_delete(cell)
+
+Delete a state cell.
+
+```python
+deleted = db.state_delete("counter")
+```
+
+**Returns:** `bool` - True if the cell existed
+
+### state_list(prefix=None)
+
+List state cell names.
+
+```python
+cells = db.state_list()
+cells = db.state_list(prefix="config:")
+```
+
+**Returns:** `list[str]`
+
+### state_history(cell)
+
+Get version history for a state cell.
+
+```python
+history = db.state_history("counter")
+```
+
+**Returns:** `list[dict]` or `None`
+
+### state_get_versioned(cell)
+
+Get a state cell with version info.
+
+```python
+result = db.state_get_versioned("counter")
+```
+
+**Returns:** `dict` with `value`, `version`, `timestamp`, or `None`
+
+---
+
+## Event Log
+
+### event_append(event_type, payload)
+
+Append an event to the log.
+
+```python
+seq = db.event_append("user_action", {"action": "click", "target": "button"})
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `event_type` | str | The event type |
+| `payload` | any | The event payload |
+
+**Returns:** `int` - Sequence number
+
+### event_get(sequence)
+
+Get an event by sequence number.
+
+```python
+event = db.event_get(0)
+if event:
+    print(event["value"])
+```
+
+**Returns:** `dict` with `value`, `version`, `timestamp`, or `None`
+
+### event_list(event_type)
+
+List events by type.
+
+```python
+events = db.event_list("user_action")
+for event in events:
+    print(event["value"])
+```
+
+**Returns:** `list[dict]`
+
+### event_len()
+
+Get total event count.
+
+```python
+count = db.event_len()
+```
+
+**Returns:** `int`
+
+### event_list_paginated(event_type, limit=None, after=None)
+
+List events with pagination.
+
+```python
+events = db.event_list_paginated("user_action", limit=100, after=500)
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `event_type` | str | The event type |
+| `limit` | int, optional | Maximum events |
+| `after` | int, optional | Return events after this sequence |
+
+**Returns:** `list[dict]`
+
+---
+
+## JSON Store
+
+### json_set(key, path, value)
+
+Set a value at a JSONPath.
+
+```python
+# Set entire document
+db.json_set("user:123", "$", {"name": "Alice", "age": 30})
+
+# Set nested field
+db.json_set("user:123", "$.email", "alice@example.com")
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `key` | str | Document key |
+| `path` | str | JSONPath (use `$` for root) |
+| `value` | any | The value |
+
+**Returns:** `int` - Version number
+
+### json_get(key, path)
+
+Get a value at a JSONPath.
+
+```python
+doc = db.json_get("user:123", "$")
+name = db.json_get("user:123", "$.name")
+```
+
+**Returns:** Value or `None`
+
+### json_delete(key, path)
+
+Delete a value at a JSONPath.
+
+```python
+deleted_count = db.json_delete("user:123", "$.email")
+```
+
+**Returns:** `int` - Count of elements deleted
+
+### json_list(limit, prefix=None, cursor=None)
+
+List JSON document keys with pagination.
+
+```python
+result = db.json_list(100, prefix="user:")
+keys = result["keys"]
+next_cursor = result.get("cursor")
+```
+
+**Returns:** `dict` with `keys` and optional `cursor`
+
+### json_history(key)
+
+Get version history for a JSON document.
+
+```python
+history = db.json_history("user:123")
+```
+
+**Returns:** `list[dict]` or `None`
+
+### json_get_versioned(key)
+
+Get a JSON document with version info.
+
+```python
+result = db.json_get_versioned("user:123")
+```
+
+**Returns:** `dict` with `value`, `version`, `timestamp`, or `None`
+
+---
+
+## Vector Store
+
+### vector_create_collection(collection, dimension, metric=None)
+
+Create a vector collection.
+
+```python
+db.vector_create_collection("embeddings", 384)
+db.vector_create_collection("images", 512, metric="euclidean")
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `collection` | str | Collection name |
+| `dimension` | int | Vector dimension |
+| `metric` | str, optional | `cosine` (default), `euclidean`, `dot_product` |
+
+**Returns:** `int` - Version number
+
+### vector_delete_collection(collection)
+
+Delete a vector collection.
+
+```python
+deleted = db.vector_delete_collection("embeddings")
+```
+
+**Returns:** `bool`
+
+### vector_list_collections()
+
+List all vector collections.
+
+```python
+collections = db.vector_list_collections()
+for c in collections:
+    print(f"{c['name']}: {c['count']} vectors")
+```
+
+**Returns:** `list[dict]` with `name`, `dimension`, `metric`, `count`, `index_type`, `memory_bytes`
+
+### vector_upsert(collection, key, vector, metadata=None)
+
+Insert or update a vector.
+
+```python
+import numpy as np
+
+embedding = np.random.rand(384).astype(np.float32)
+db.vector_upsert("embeddings", "doc-1", embedding, {"title": "Hello"})
+
+# Also accepts lists
+db.vector_upsert("embeddings", "doc-2", [0.1, 0.2, 0.3, ...])
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `collection` | str | Collection name |
+| `key` | str | Vector key |
+| `vector` | ndarray or list | Vector embedding |
+| `metadata` | dict, optional | Metadata |
+
+**Returns:** `int` - Version number
+
+### vector_get(collection, key)
+
+Get a vector by key.
+
+```python
+result = db.vector_get("embeddings", "doc-1")
+if result:
+    print(result["embedding"])  # NumPy array
+    print(result["metadata"])
+```
+
+**Returns:** `dict` with `key`, `embedding`, `metadata`, `version`, `timestamp`, or `None`
+
+### vector_delete(collection, key)
+
+Delete a vector.
+
+```python
+deleted = db.vector_delete("embeddings", "doc-1")
+```
+
+**Returns:** `bool`
+
+### vector_search(collection, query, k)
+
+Search for similar vectors.
+
+```python
+query = np.random.rand(384).astype(np.float32)
+matches = db.vector_search("embeddings", query, k=10)
+for match in matches:
+    print(f"{match['key']}: {match['score']}")
+```
+
+**Returns:** `list[dict]` with `key`, `score`, `metadata`
+
+### vector_search_filtered(collection, query, k, metric=None, filter=None)
+
+Search with filter and metric override.
+
+```python
+matches = db.vector_search_filtered(
+    "embeddings",
+    query,
+    k=10,
+    metric="euclidean",
+    filter=[
+        {"field": "category", "op": "eq", "value": "science"},
+        {"field": "year", "op": "gte", "value": 2020}
+    ]
+)
+```
+
+**Filter operators:** `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `contains`
+
+**Returns:** `list[dict]` with `key`, `score`, `metadata`
+
+### vector_collection_stats(collection)
+
+Get detailed collection statistics.
+
+```python
+stats = db.vector_collection_stats("embeddings")
+print(f"Count: {stats['count']}, Memory: {stats['memory_bytes']} bytes")
+```
+
+**Returns:** `dict`
+
+### vector_batch_upsert(collection, vectors)
+
+Batch insert/update vectors.
+
+```python
+vectors = [
+    {"key": "doc-1", "vector": [0.1, 0.2, ...], "metadata": {"title": "A"}},
+    {"key": "doc-2", "vector": [0.3, 0.4, ...]},
+]
+versions = db.vector_batch_upsert("embeddings", vectors)
+```
+
+**Returns:** `list[int]` - Version numbers
+
+---
+
+## Branches
+
+### current_branch()
+
+Get the current branch name.
+
+```python
+branch = db.current_branch()
+```
+
+**Returns:** `str`
+
+### set_branch(branch)
+
+Switch to a different branch.
+
+```python
+db.set_branch("feature")
+```
+
+### create_branch(branch)
+
+Create a new empty branch.
+
+```python
+db.create_branch("experiment")
+```
+
+### list_branches()
+
+List all branches.
+
+```python
+branches = db.list_branches()
+```
+
+**Returns:** `list[str]`
+
+### delete_branch(branch)
+
+Delete a branch.
+
+```python
+db.delete_branch("experiment")
+```
+
+### branch_exists(name)
+
+Check if a branch exists.
+
+```python
+exists = db.branch_exists("feature")
+```
+
+**Returns:** `bool`
+
+### branch_get(name)
+
+Get branch metadata.
+
+```python
+info = db.branch_get("default")
+if info:
+    print(f"Created: {info['created_at']}, Version: {info['version']}")
+```
+
+**Returns:** `dict` or `None`
+
+### fork_branch(destination)
+
+Fork the current branch with all its data.
+
+```python
+result = db.fork_branch("experiment-copy")
+print(f"Copied {result['keys_copied']} keys")
+```
+
+**Returns:** `dict` with `source`, `destination`, `keys_copied`
+
+### diff_branches(branch_a, branch_b)
+
+Compare two branches.
+
+```python
+diff = db.diff_branches("default", "feature")
+print(f"Added: {diff['summary']['total_added']}")
+```
+
+**Returns:** `dict` with diff details
+
+### merge_branches(source, strategy=None)
+
+Merge a branch into the current branch.
+
+```python
+result = db.merge_branches("feature", strategy="last_writer_wins")
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `source` | str | Source branch |
+| `strategy` | str, optional | `last_writer_wins` (default) or `strict` |
+
+**Returns:** `dict` with merge results
+
+---
+
+## Spaces
+
+### current_space()
+
+Get the current space name.
+
+```python
+space = db.current_space()
+```
+
+**Returns:** `str`
+
+### set_space(space)
+
+Switch to a different space.
+
+```python
+db.set_space("conversations")
+```
+
+### list_spaces()
+
+List all spaces.
+
+```python
+spaces = db.list_spaces()
+```
+
+**Returns:** `list[str]`
+
+### delete_space(space)
+
+Delete an empty space.
+
+```python
+db.delete_space("old-space")
+```
+
+### delete_space_force(space)
+
+Delete a space and all its data.
+
+```python
+db.delete_space_force("old-space")
+```
+
+### space_create(space)
+
+Create a new space explicitly.
+
+```python
+db.space_create("archive")
+```
+
+### space_exists(space)
+
+Check if a space exists.
+
+```python
+exists = db.space_exists("archive")
+```
+
+**Returns:** `bool`
+
+---
+
+## Transactions
+
+### transaction(read_only=False)
+
+Get a transaction context manager.
+
+```python
+# Read-write transaction
+with db.transaction():
+    db.kv_put("a", 1)
+    db.kv_put("b", 2)
+# Auto-commits on success
+
+# Read-only transaction
+with db.transaction(read_only=True):
+    a = db.kv_get("a")
+    b = db.kv_get("b")
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `read_only` | bool | Read-only transaction |
+
+### begin(read_only=None)
+
+Begin a transaction manually.
+
+```python
+db.begin()
+try:
+    db.kv_put("a", 1)
+    db.commit()
+except Exception:
+    db.rollback()
+    raise
+```
+
+### commit()
+
+Commit the current transaction.
+
+```python
+version = db.commit()
+```
+
+**Returns:** `int` - Commit version
+
+### rollback()
+
+Rollback the current transaction.
+
+```python
+db.rollback()
+```
+
+### txn_info()
+
+Get current transaction info.
+
+```python
+info = db.txn_info()
+if info:
+    print(f"Transaction {info['id']} is {info['status']}")
+```
+
+**Returns:** `dict` with `id`, `status`, `started_at`, or `None`
+
+### txn_is_active()
+
+Check if a transaction is active.
+
+```python
+active = db.txn_is_active()
+```
+
+**Returns:** `bool`
+
+---
+
+## Search
+
+### search(query, k=None, primitives=None)
+
+Search across multiple primitives.
+
+```python
+results = db.search("hello world", k=10, primitives=["kv", "json"])
+for hit in results:
+    print(f"{hit['entity']} ({hit['primitive']}): {hit['score']}")
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `query` | str | Search query |
+| `k` | int, optional | Maximum results |
+| `primitives` | list[str], optional | Primitives to search |
+
+**Returns:** `list[dict]` with `entity`, `primitive`, `score`, `rank`, `snippet`
+
+---
+
+## Database Operations
+
+### ping()
+
+Check database connectivity.
+
+```python
+version = db.ping()
+```
+
+**Returns:** `str` - Version string
+
+### info()
+
+Get database information.
+
+```python
+info = db.info()
+print(f"Version: {info['version']}")
+print(f"Total keys: {info['total_keys']}")
+```
+
+**Returns:** `dict` with `version`, `uptime_secs`, `branch_count`, `total_keys`
+
+### flush()
+
+Flush pending writes to disk.
+
+```python
+db.flush()
+```
+
+### compact()
+
+Trigger database compaction.
+
+```python
+db.compact()
+```
+
+---
+
+## Bundle Operations
+
+### branch_export(branch, path)
+
+Export a branch to a bundle file.
+
+```python
+result = db.branch_export("default", "/tmp/backup.bundle")
+print(f"Exported {result['entry_count']} entries")
+```
+
+**Returns:** `dict` with export details
+
+### branch_import(path)
+
+Import a branch from a bundle file.
+
+```python
+result = db.branch_import("/tmp/backup.bundle")
+print(f"Imported to branch {result['branch_id']}")
+```
+
+**Returns:** `dict` with import details
+
+### branch_validate_bundle(path)
+
+Validate a bundle file without importing.
+
+```python
+result = db.branch_validate_bundle("/tmp/backup.bundle")
+print(f"Valid: {result['checksums_valid']}")
+```
+
+**Returns:** `dict` with validation details
+
+---
+
+## Error Handling
+
+All methods may raise `RuntimeError` for database errors:
+
+```python
+try:
+    db.set_branch("nonexistent")
+except RuntimeError as e:
+    print(f"Error: {e}")
+```
+
+Common errors:
+- Branch not found
+- Collection not found
+- CAS version mismatch
+- Transaction already active
+- Invalid input
+
+---
+
+## Type Reference
+
+### Value Types
+
+Python types map to StrataDB values:
+
+| Python Type | StrataDB Type |
+|-------------|---------------|
+| `None` | Null |
+| `bool` | Bool |
+| `int` | Int |
+| `float` | Float |
+| `str` | String |
+| `bytes` | Bytes |
+| `list` | Array |
+| `dict` | Object |
+
+### NumPy Support
+
+Vector operations accept NumPy arrays:
+
+```python
+import numpy as np
+
+# Use np.float32 for best performance
+embedding = np.random.rand(384).astype(np.float32)
+db.vector_upsert("coll", "key", embedding)
+
+# Retrieved embeddings are NumPy arrays
+result = db.vector_get("coll", "key")
+embedding = result["embedding"]  # np.ndarray
+```


### PR DESCRIPTION
## Summary

Create official API reference documentation for the stratadb website, covering all 4 public interfaces.

## New Documentation

### CLI Reference (`docs/reference/cli.md`)
- All database, KV, state, event, JSON, vector, branch, space, transaction, and search commands
- Command options and flags
- Output formats (human, JSON, raw)
- REPL commands and tab completion
- Examples for every command

### MCP Server Reference (`docs/reference/mcp.md`)
- Installation and Claude Desktop configuration
- All 50+ tools with parameters and return types
- Filter operators for vector search
- Error handling
- Usage examples with Claude

### Python SDK Reference (`docs/reference/python-sdk.md`)
- Complete API documentation for all methods
- Type information and return values
- NumPy support for vectors
- Transaction context manager pattern
- Error handling

### Node.js SDK Reference (`docs/reference/node-sdk.md`)
- Full TypeScript type definitions
- All methods with parameters and returns
- Transaction patterns
- Complete interface definitions

## Index Update

Reorganized `docs/reference/index.md` into:
- **SDK & Interface References** - CLI, MCP, Python, Node.js
- **Core API References** - Quick reference, commands, types, errors, config

## Test plan

- [x] All markdown renders correctly
- [x] Internal links work
- [x] Code examples are syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)