### PR TITLE
Fix v0.7 auto-embed gaps for hybrid search readiness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,8 @@ perf-trace = []  # Enable per-layer timing instrumentation for M4
 comparison-benchmarks = ["dep:redb", "dep:heed", "dep:rusqlite"]
 # Enable USearch for vector comparisons (requires C++ build tools)
 usearch-enabled = ["dep:usearch"]
+# Enable auto-embedding (MiniLM-L6-v2 inference runtime)
+embed = ["strata-executor/embed"]
 
 [dependencies]
 strata-executor = { path = "crates/executor" }

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -60,6 +60,13 @@ pub fn build_cli() -> Command {
                 .action(clap::ArgAction::SetTrue)
                 .global(true),
         )
+        .arg(
+            Arg::new("auto-embed")
+                .long("auto-embed")
+                .help("Enable automatic text embedding for semantic search")
+                .action(clap::ArgAction::SetTrue)
+                .global(true),
+        )
         .subcommand(build_kv())
         .subcommand(build_json())
         .subcommand(build_event())

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -77,6 +77,7 @@ fn main() {
 fn open_database(matches: &clap::ArgMatches) -> Result<Strata, String> {
     let read_only = matches.get_flag("read-only");
     let use_cache = matches.get_flag("cache");
+    let auto_embed = matches.get_flag("auto-embed");
 
     if use_cache {
         Strata::cache().map_err(|e| format!("Failed to open cache database: {}", e))
@@ -86,13 +87,17 @@ fn open_database(matches: &clap::ArgMatches) -> Result<Strata, String> {
             .map(|s| s.as_str())
             .unwrap_or(".strata");
 
+        let mut opts = OpenOptions::new();
+
         if read_only {
-            let opts = OpenOptions::new().access_mode(AccessMode::ReadOnly);
-            Strata::open_with(path, opts)
-                .map_err(|e| format!("Failed to open database (read-only): {}", e))
-        } else {
-            Strata::open(path).map_err(|e| format!("Failed to open database: {}", e))
+            opts = opts.access_mode(AccessMode::ReadOnly);
         }
+        if auto_embed {
+            opts = opts.auto_embed(true);
+        }
+
+        Strata::open_with(path, opts)
+            .map_err(|e| format!("Failed to open database: {}", e))
     }
 }
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 [features]
 default = []
 perf-trace = []  # Enable per-layer timing instrumentation for M4
+embed = []       # Marker feature: auto-embed runtime is available
 
 [dependencies]
 strata-core = { path = "../core" }

--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -27,6 +27,9 @@ pub struct StrataConfig {
     /// Durability mode: `"standard"` or `"always"`.
     #[serde(default = "default_durability_str")]
     pub durability: String,
+    /// Enable automatic text embedding for semantic search.
+    #[serde(default)]
+    pub auto_embed: bool,
 }
 
 fn default_durability_str() -> String {
@@ -37,6 +40,7 @@ impl Default for StrataConfig {
     fn default() -> Self {
         Self {
             durability: default_durability_str(),
+            auto_embed: false,
         }
     }
 }
@@ -66,6 +70,10 @@ impl StrataConfig {
 #   "standard" = periodic fsync (~100ms), may lose last interval on crash
 #   "always"   = fsync every commit, zero data loss
 durability = "standard"
+
+# Auto-embed: automatically generate embeddings for text data (default: false)
+# Requires the "embed" feature to be compiled in.
+auto_embed = false
 "#
     }
 

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -9,6 +9,10 @@ repository.workspace = true
 publish = false
 description = "Command execution layer for Strata database"
 
+[features]
+default = []
+embed = ["strata-intelligence/embed", "strata-engine/embed"]
+
 [dependencies]
 # Internal crates
 strata-core = { path = "../core" }

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -126,6 +126,18 @@ impl Strata {
         let db = Database::open(path).map_err(|e| Error::Internal {
             reason: format!("Failed to open database: {}", e),
         })?;
+
+        // Override auto_embed if explicitly set in OpenOptions
+        if let Some(enabled) = opts.auto_embed {
+            if enabled {
+                #[cfg(not(feature = "embed"))]
+                return Err(Error::Internal {
+                    reason: "auto_embed requires the 'embed' feature to be compiled in".into(),
+                });
+            }
+            db.set_auto_embed(enabled);
+        }
+
         let access_mode = opts.access_mode;
         let executor = Executor::new_with_mode(db, access_mode);
 

--- a/crates/executor/src/handlers/embed_hook.rs
+++ b/crates/executor/src/handlers/embed_hook.rs
@@ -1,0 +1,198 @@
+//! Auto-embed hook called from write handlers.
+//!
+//! When auto-embedding is enabled and the `embed` feature is compiled in,
+//! this module generates embeddings for text values and stores them in
+//! shadow vector collections.
+
+use std::sync::Arc;
+
+use crate::bridge::Primitives;
+
+/// Shadow collection names for each primitive type.
+pub const SHADOW_KV: &str = "_system_embed_kv";
+pub const SHADOW_JSON: &str = "_system_embed_json";
+pub const SHADOW_EVENT: &str = "_system_embed_event";
+pub const SHADOW_STATE: &str = "_system_embed_state";
+
+/// Separator for composite shadow keys (ASCII Unit Separator).
+/// Avoids ambiguity since "/" is allowed in both space and key names.
+#[cfg(feature = "embed")]
+const SHADOW_KEY_SEP: char = '\x1f';
+
+/// Attempt to embed text and store in a shadow vector collection.
+///
+/// Best-effort: failures are logged, never propagated to the caller.
+/// The `source_ref` traces the shadow embedding back to the originating record.
+#[cfg(feature = "embed")]
+pub fn maybe_embed_text(
+    p: &Arc<Primitives>,
+    branch_id: strata_core::types::BranchId,
+    space: &str,
+    shadow_collection: &str,
+    key: &str,
+    text: &str,
+    source_ref: strata_core::EntityRef,
+) {
+    use strata_intelligence::embed::EmbedModelState;
+
+    if !p.db.auto_embed_enabled() {
+        return;
+    }
+
+    let model_dir = p.db.model_dir();
+    let embed_state = p.db.extension::<EmbedModelState>();
+
+    let model = match embed_state.get_or_load(&model_dir) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(target: "strata::embed", error = %e, "Failed to load embedding model");
+            return;
+        }
+    };
+
+    let embedding = model.embed(text);
+
+    // Ensure shadow collection exists (384-dim cosine)
+    ensure_shadow_collection(p, branch_id, shadow_collection);
+
+    // Build composite key: "{space}\x1f{key}"
+    let composite_key = format!("{}{}{}", space, SHADOW_KEY_SEP, key);
+
+    // Build source metadata
+    let metadata = serde_json::json!({
+        "source_space": space,
+        "source_key": key,
+    });
+
+    if let Err(e) = p.vector.system_insert_with_source(
+        branch_id,
+        shadow_collection,
+        &composite_key,
+        &embedding,
+        Some(metadata),
+        source_ref,
+    ) {
+        tracing::warn!(
+            target: "strata::embed",
+            collection = shadow_collection,
+            key = composite_key,
+            error = %e,
+            "Failed to insert embedding"
+        );
+    }
+}
+
+/// No-op when the embed feature is not compiled in.
+#[cfg(not(feature = "embed"))]
+pub fn maybe_embed_text(
+    _p: &Arc<Primitives>,
+    _branch_id: strata_core::types::BranchId,
+    _space: &str,
+    _shadow_collection: &str,
+    _key: &str,
+    _text: &str,
+    _source_ref: strata_core::EntityRef,
+) {
+}
+
+/// Remove a shadow embedding entry on delete.
+///
+/// Best-effort: failures are logged, never propagated to the caller.
+#[cfg(feature = "embed")]
+pub fn maybe_remove_embedding(
+    p: &Arc<Primitives>,
+    branch_id: strata_core::types::BranchId,
+    space: &str,
+    shadow_collection: &str,
+    key: &str,
+) {
+    if !p.db.auto_embed_enabled() {
+        return;
+    }
+
+    let composite_key = format!("{}{}{}", space, SHADOW_KEY_SEP, key);
+
+    if let Err(e) = p
+        .vector
+        .system_delete(branch_id, shadow_collection, &composite_key)
+    {
+        // Collection may not exist yet (no embeds were ever created), that's fine.
+        let msg = e.to_string();
+        if !msg.contains("not found") && !msg.contains("does not exist") {
+            tracing::warn!(
+                target: "strata::embed",
+                collection = shadow_collection,
+                key = composite_key,
+                error = %e,
+                "Failed to remove shadow embedding"
+            );
+        }
+    }
+}
+
+/// No-op when the embed feature is not compiled in.
+#[cfg(not(feature = "embed"))]
+pub fn maybe_remove_embedding(
+    _p: &Arc<Primitives>,
+    _branch_id: strata_core::types::BranchId,
+    _space: &str,
+    _shadow_collection: &str,
+    _key: &str,
+) {
+}
+
+/// Extract embeddable text from a Value.
+#[cfg(feature = "embed")]
+pub fn extract_text(value: &strata_core::Value) -> Option<String> {
+    strata_intelligence::embed::extract::extract_text(value)
+}
+
+/// No-op when the embed feature is not compiled in.
+#[cfg(not(feature = "embed"))]
+pub fn extract_text(_value: &strata_core::Value) -> Option<String> {
+    None
+}
+
+/// Ensure a shadow collection exists, swallowing AlreadyExists errors.
+///
+/// Uses a per-Database cache to avoid repeated creation attempts on every write.
+#[cfg(feature = "embed")]
+fn ensure_shadow_collection(
+    p: &Arc<Primitives>,
+    branch_id: strata_core::types::BranchId,
+    name: &str,
+) {
+    use strata_core::primitives::vector::VectorConfig;
+    use strata_engine::database::AutoEmbedState;
+
+    let cache_key = format!("{:?}{}{}", branch_id.as_bytes(), SHADOW_KEY_SEP, name);
+    let state = p.db.extension::<AutoEmbedState>();
+
+    // Fast path: already created in this process lifetime
+    if state.shadow_collections_created.contains_key(&cache_key) {
+        return;
+    }
+
+    let config = VectorConfig::for_minilm();
+
+    match p.vector.create_system_collection(branch_id, name, config) {
+        Ok(_) => {
+            tracing::info!(target: "strata::embed", collection = name, "Created shadow embedding collection");
+            state.shadow_collections_created.insert(cache_key, ());
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("already exists") {
+                // Already exists from a previous process run — mark as created
+                state.shadow_collections_created.insert(cache_key, ());
+            } else {
+                tracing::warn!(
+                    target: "strata::embed",
+                    collection = name,
+                    error = %e,
+                    "Failed to create shadow collection"
+                );
+            }
+        }
+    }
+}

--- a/crates/executor/src/handlers/mod.rs
+++ b/crates/executor/src/handlers/mod.rs
@@ -15,6 +15,7 @@
 //! | `database` | 4 | Database-level |
 
 pub mod branch;
+pub mod embed_hook;
 pub mod event;
 pub mod json;
 pub mod kv;

--- a/crates/intelligence/Cargo.toml
+++ b/crates/intelligence/Cargo.toml
@@ -4,10 +4,14 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
-license.workspace = true
+license = "BUSL-1.1"
 repository.workspace = true
 publish = false
 description = "Intelligence layer for Strata — derived operations over primitives"
+
+[features]
+default = []
+embed = []
 
 [dependencies]
 strata-core = { path = "../core" }
@@ -16,6 +20,7 @@ dashmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
+once_cell = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/intelligence/LICENSE
+++ b/crates/intelligence/LICENSE
@@ -1,0 +1,10 @@
+Business Source License 1.1 (BUSL-1.1)
+
+Licensor: Strata contributors
+Licensed Work: strata-intelligence crate
+Change Date: 4 years from each release
+Change License: Apache-2.0
+Additional Use Grant: May be used in production for internal use; restricted from
+offering as a commercial hosted database service.
+
+Full license text to be added before release.

--- a/crates/intelligence/src/embed/extract.rs
+++ b/crates/intelligence/src/embed/extract.rs
@@ -1,0 +1,197 @@
+//! Value → embeddable text extraction.
+
+use strata_core::Value;
+
+/// Maximum text length sent to the tokenizer (≈256 tokens).
+const MAX_TEXT_LEN: usize = 1024;
+
+/// Maximum recursion depth for nested Array/Object values.
+const MAX_DEPTH: usize = 16;
+
+/// Extract embeddable text from a Value.
+///
+/// Returns `None` for values that are not meaningful to embed (Null, Bytes).
+/// Nested structures are traversed up to `MAX_DEPTH` levels to prevent
+/// stack overflow on pathologically deep documents.
+pub fn extract_text(value: &Value) -> Option<String> {
+    let text = extract_text_inner(value, 0)?;
+
+    if text.len() > MAX_TEXT_LEN {
+        // Find the last char boundary at or before MAX_TEXT_LEN to avoid
+        // panicking on multi-byte UTF-8 characters.
+        let mut end = MAX_TEXT_LEN;
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        Some(text[..end].to_string())
+    } else {
+        Some(text)
+    }
+}
+
+fn extract_text_inner(value: &Value, depth: usize) -> Option<String> {
+    match value {
+        Value::String(s) => {
+            if s.is_empty() {
+                return None;
+            }
+            Some(s.clone())
+        }
+        Value::Int(n) => Some(n.to_string()),
+        Value::Float(f) => Some(f.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Null => None,
+        Value::Bytes(_) => None,
+        Value::Array(arr) => {
+            if depth >= MAX_DEPTH {
+                return None;
+            }
+            let parts: Vec<String> = arr
+                .iter()
+                .filter_map(|v| extract_text_inner(v, depth + 1))
+                .collect();
+            if parts.is_empty() {
+                return None;
+            }
+            Some(parts.join(" "))
+        }
+        Value::Object(map) => {
+            if depth >= MAX_DEPTH {
+                return None;
+            }
+            let mut parts: Vec<String> = Vec::new();
+            // Sort keys for deterministic output
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            for key in keys {
+                if let Some(val_text) = extract_text_inner(&map[key], depth + 1) {
+                    parts.push(format!("{}: {}", key, val_text));
+                }
+            }
+            if parts.is_empty() {
+                return None;
+            }
+            Some(parts.join(" "))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_string() {
+        assert_eq!(
+            extract_text(&Value::String("hello".into())),
+            Some("hello".into())
+        );
+    }
+
+    #[test]
+    fn test_empty_string() {
+        assert_eq!(extract_text(&Value::String("".into())), None);
+    }
+
+    #[test]
+    fn test_int() {
+        assert_eq!(extract_text(&Value::Int(42)), Some("42".into()));
+    }
+
+    #[test]
+    fn test_float() {
+        assert_eq!(extract_text(&Value::Float(3.14)), Some("3.14".into()));
+    }
+
+    #[test]
+    fn test_bool() {
+        assert_eq!(extract_text(&Value::Bool(true)), Some("true".into()));
+    }
+
+    #[test]
+    fn test_null() {
+        assert_eq!(extract_text(&Value::Null), None);
+    }
+
+    #[test]
+    fn test_bytes() {
+        assert_eq!(extract_text(&Value::Bytes(vec![1, 2, 3])), None);
+    }
+
+    #[test]
+    fn test_array() {
+        let arr = Value::Array(vec![
+            Value::String("hello".into()),
+            Value::Int(42),
+            Value::Null,
+        ]);
+        assert_eq!(extract_text(&arr), Some("hello 42".into()));
+    }
+
+    #[test]
+    fn test_object() {
+        let mut map = HashMap::new();
+        map.insert("name".to_string(), Value::String("Alice".into()));
+        map.insert("age".to_string(), Value::Int(30));
+        let obj = Value::Object(map);
+        let text = extract_text(&obj).unwrap();
+        assert!(text.contains("age: 30"));
+        assert!(text.contains("name: Alice"));
+    }
+
+    #[test]
+    fn test_truncation() {
+        let long_str = Value::String("a".repeat(2000));
+        let text = extract_text(&long_str).unwrap();
+        assert_eq!(text.len(), MAX_TEXT_LEN);
+    }
+
+    #[test]
+    fn test_empty_array() {
+        assert_eq!(extract_text(&Value::Array(vec![])), None);
+    }
+
+    #[test]
+    fn test_truncation_multibyte_safe() {
+        // Each '😀' is 4 bytes. Fill past MAX_TEXT_LEN to ensure we don't panic
+        // on a multi-byte char boundary.
+        let emoji_str = "😀".repeat(300); // 300 * 4 = 1200 bytes > 1024
+        let text = extract_text(&Value::String(emoji_str)).unwrap();
+        assert!(text.len() <= MAX_TEXT_LEN);
+        // Must be valid UTF-8 (no panic, no partial chars)
+        assert!(text.is_char_boundary(text.len()));
+    }
+
+    #[test]
+    fn test_array_all_null() {
+        assert_eq!(
+            extract_text(&Value::Array(vec![Value::Null, Value::Null])),
+            None
+        );
+    }
+
+    #[test]
+    fn test_depth_limit() {
+        // Build a deeply nested structure exceeding MAX_DEPTH
+        let mut value = Value::String("deep".into());
+        for _ in 0..20 {
+            value = Value::Array(vec![value]);
+        }
+        // The leaf "deep" is at depth 20, which exceeds MAX_DEPTH (16).
+        // extract_text should return None because the recursion stops before reaching it.
+        assert_eq!(extract_text(&value), None);
+    }
+
+    #[test]
+    fn test_depth_at_limit() {
+        // Build a nested structure exactly at MAX_DEPTH (16 levels of nesting)
+        let mut value = Value::String("found".into());
+        for _ in 0..15 {
+            value = Value::Array(vec![value]);
+        }
+        // 15 levels of Array wrapping: depths 0..14 are Array, depth 15 is String.
+        // All within MAX_DEPTH (16), so the text should be extractable.
+        assert_eq!(extract_text(&value), Some("found".into()));
+    }
+}

--- a/crates/intelligence/src/embed/mod.rs
+++ b/crates/intelligence/src/embed/mod.rs
@@ -1,0 +1,63 @@
+//! Auto-embedding module: MiniLM-L6-v2 text embeddings.
+//!
+//! Provides a lazy-loading model lifecycle via [`EmbedModelState`] and
+//! text extraction from Strata [`Value`] types.
+
+pub mod extract;
+pub mod model;
+pub mod tokenizer;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use model::EmbedModel;
+
+/// Lazy-loading model state stored as a Database extension.
+///
+/// On first use, loads the MiniLM-L6-v2 model from the model directory.
+/// If model files are missing, stores the error and never retries.
+pub struct EmbedModelState {
+    model: once_cell::sync::OnceCell<Result<Arc<EmbedModel>, String>>,
+}
+
+impl Default for EmbedModelState {
+    fn default() -> Self {
+        Self {
+            model: once_cell::sync::OnceCell::new(),
+        }
+    }
+}
+
+impl EmbedModelState {
+    /// Get or load the embedding model.
+    ///
+    /// Loads from `model_dir/model.safetensors` and `model_dir/vocab.txt`.
+    /// Caches the result (success or failure) so filesystem is probed at most once.
+    pub fn get_or_load(&self, model_dir: &Path) -> Result<Arc<EmbedModel>, String> {
+        self.model
+            .get_or_init(|| {
+                let safetensors_path = model_dir.join("model.safetensors");
+                let vocab_path = model_dir.join("vocab.txt");
+
+                let safetensors_bytes = std::fs::read(&safetensors_path).map_err(|e| {
+                    format!(
+                        "Failed to read model file '{}': {}",
+                        safetensors_path.display(),
+                        e
+                    )
+                })?;
+
+                let vocab_text = std::fs::read_to_string(&vocab_path).map_err(|e| {
+                    format!(
+                        "Failed to read vocab file '{}': {}",
+                        vocab_path.display(),
+                        e
+                    )
+                })?;
+
+                let model = EmbedModel::load(&safetensors_bytes, &vocab_text)?;
+                Ok(Arc::new(model))
+            })
+            .clone()
+    }
+}

--- a/crates/intelligence/src/embed/model.rs
+++ b/crates/intelligence/src/embed/model.rs
@@ -1,0 +1,347 @@
+//! MiniLM-L6-v2 encoder architecture and forward pass.
+
+use crate::runtime::safetensors::SafeTensors;
+use crate::runtime::tensor::Tensor;
+
+use super::tokenizer::{TokenizedInput, WordPieceTokenizer};
+
+const HIDDEN_SIZE: usize = 384;
+const NUM_HEADS: usize = 12;
+const HEAD_DIM: usize = HIDDEN_SIZE / NUM_HEADS; // 32
+const NUM_LAYERS: usize = 6;
+const VOCAB_SIZE: usize = 30522;
+const LAYER_NORM_EPS: f32 = 1e-12;
+
+/// A single transformer encoder layer.
+struct TransformerLayer {
+    q_weight: Tensor,
+    q_bias: Vec<f32>,
+    k_weight: Tensor,
+    k_bias: Vec<f32>,
+    v_weight: Tensor,
+    v_bias: Vec<f32>,
+    attn_output_weight: Tensor,
+    attn_output_bias: Vec<f32>,
+    attn_ln_weight: Vec<f32>,
+    attn_ln_bias: Vec<f32>,
+    intermediate_weight: Tensor,
+    intermediate_bias: Vec<f32>,
+    output_weight: Tensor,
+    output_bias: Vec<f32>,
+    output_ln_weight: Vec<f32>,
+    output_ln_bias: Vec<f32>,
+}
+
+/// The MiniLM-L6-v2 embedding model.
+pub struct EmbedModel {
+    tokenizer: WordPieceTokenizer,
+    word_embeddings: Tensor,
+    position_embeddings: Tensor,
+    token_type_embeddings: Tensor,
+    embed_ln_weight: Vec<f32>,
+    embed_ln_bias: Vec<f32>,
+    layers: Vec<TransformerLayer>,
+}
+
+impl EmbedModel {
+    /// Load model weights from SafeTensors bytes and vocabulary text.
+    pub fn load(safetensors_bytes: &[u8], vocab_text: &str) -> Result<Self, String> {
+        let st = SafeTensors::from_bytes(safetensors_bytes)?;
+        let tokenizer = WordPieceTokenizer::from_vocab(vocab_text);
+
+        let word_embeddings = st
+            .tensor("bert.embeddings.word_embeddings.weight")
+            .ok_or("Missing word_embeddings")?;
+
+        if word_embeddings.rows != VOCAB_SIZE || word_embeddings.cols != HIDDEN_SIZE {
+            return Err(format!(
+                "word_embeddings shape mismatch: expected {}x{}, got {}x{}",
+                VOCAB_SIZE, HIDDEN_SIZE, word_embeddings.rows, word_embeddings.cols
+            ));
+        }
+
+        let position_embeddings = st
+            .tensor("bert.embeddings.position_embeddings.weight")
+            .ok_or("Missing position_embeddings")?;
+
+        let token_type_embeddings = st
+            .tensor("bert.embeddings.token_type_embeddings.weight")
+            .ok_or("Missing token_type_embeddings")?;
+
+        let embed_ln_weight = st
+            .tensor_1d("bert.embeddings.LayerNorm.weight")
+            .ok_or("Missing embeddings LayerNorm weight")?;
+
+        let embed_ln_bias = st
+            .tensor_1d("bert.embeddings.LayerNorm.bias")
+            .ok_or("Missing embeddings LayerNorm bias")?;
+
+        let mut layers = Vec::with_capacity(NUM_LAYERS);
+        for i in 0..NUM_LAYERS {
+            let prefix = format!("bert.encoder.layer.{}", i);
+            let layer = TransformerLayer {
+                q_weight: st
+                    .tensor(&format!("{}.attention.self.query.weight", prefix))
+                    .ok_or_else(|| format!("Missing {}.attention.self.query.weight", prefix))?,
+                q_bias: st
+                    .tensor_1d(&format!("{}.attention.self.query.bias", prefix))
+                    .ok_or_else(|| format!("Missing {}.attention.self.query.bias", prefix))?,
+                k_weight: st
+                    .tensor(&format!("{}.attention.self.key.weight", prefix))
+                    .ok_or_else(|| format!("Missing {}.attention.self.key.weight", prefix))?,
+                k_bias: st
+                    .tensor_1d(&format!("{}.attention.self.key.bias", prefix))
+                    .ok_or_else(|| format!("Missing {}.attention.self.key.bias", prefix))?,
+                v_weight: st
+                    .tensor(&format!("{}.attention.self.value.weight", prefix))
+                    .ok_or_else(|| format!("Missing {}.attention.self.value.weight", prefix))?,
+                v_bias: st
+                    .tensor_1d(&format!("{}.attention.self.value.bias", prefix))
+                    .ok_or_else(|| format!("Missing {}.attention.self.value.bias", prefix))?,
+                attn_output_weight: st
+                    .tensor(&format!("{}.attention.output.dense.weight", prefix))
+                    .ok_or_else(|| {
+                        format!("Missing {}.attention.output.dense.weight", prefix)
+                    })?,
+                attn_output_bias: st
+                    .tensor_1d(&format!("{}.attention.output.dense.bias", prefix))
+                    .ok_or_else(|| {
+                        format!("Missing {}.attention.output.dense.bias", prefix)
+                    })?,
+                attn_ln_weight: st
+                    .tensor_1d(&format!("{}.attention.output.LayerNorm.weight", prefix))
+                    .ok_or_else(|| {
+                        format!("Missing {}.attention.output.LayerNorm.weight", prefix)
+                    })?,
+                attn_ln_bias: st
+                    .tensor_1d(&format!("{}.attention.output.LayerNorm.bias", prefix))
+                    .ok_or_else(|| {
+                        format!("Missing {}.attention.output.LayerNorm.bias", prefix)
+                    })?,
+                intermediate_weight: st
+                    .tensor(&format!("{}.intermediate.dense.weight", prefix))
+                    .ok_or_else(|| {
+                        format!("Missing {}.intermediate.dense.weight", prefix)
+                    })?,
+                intermediate_bias: st
+                    .tensor_1d(&format!("{}.intermediate.dense.bias", prefix))
+                    .ok_or_else(|| {
+                        format!("Missing {}.intermediate.dense.bias", prefix)
+                    })?,
+                output_weight: st
+                    .tensor(&format!("{}.output.dense.weight", prefix))
+                    .ok_or_else(|| format!("Missing {}.output.dense.weight", prefix))?,
+                output_bias: st
+                    .tensor_1d(&format!("{}.output.dense.bias", prefix))
+                    .ok_or_else(|| format!("Missing {}.output.dense.bias", prefix))?,
+                output_ln_weight: st
+                    .tensor_1d(&format!("{}.output.LayerNorm.weight", prefix))
+                    .ok_or_else(|| format!("Missing {}.output.LayerNorm.weight", prefix))?,
+                output_ln_bias: st
+                    .tensor_1d(&format!("{}.output.LayerNorm.bias", prefix))
+                    .ok_or_else(|| format!("Missing {}.output.LayerNorm.bias", prefix))?,
+            };
+            layers.push(layer);
+        }
+
+        Ok(Self {
+            tokenizer,
+            word_embeddings,
+            position_embeddings,
+            token_type_embeddings,
+            embed_ln_weight,
+            embed_ln_bias,
+            layers,
+        })
+    }
+
+    /// Embed a text string into a 384-dimensional vector.
+    pub fn embed(&self, text: &str) -> Vec<f32> {
+        let input = self.tokenizer.tokenize(text);
+        let seq_len = input.input_ids.len();
+
+        // 1. Gather embeddings
+        let hidden = self.gather_embeddings(&input, seq_len);
+
+        // 2. Layer norm
+        let mut hidden = hidden.layer_norm(&self.embed_ln_weight, &self.embed_ln_bias, LAYER_NORM_EPS);
+
+        // 3. Transformer layers
+        for layer in &self.layers {
+            hidden = self.transformer_layer(layer, &hidden, &input.attention_mask);
+        }
+
+        // 4. Mean pooling (exclude padding)
+        let pooled = self.mean_pool(&hidden, &input.attention_mask);
+
+        // 5. L2 normalize
+        l2_normalize(&pooled)
+    }
+
+    fn gather_embeddings(&self, input: &TokenizedInput, seq_len: usize) -> Tensor {
+        let mut data = vec![0.0f32; seq_len * HIDDEN_SIZE];
+
+        for (pos, (&token_id, &type_id)) in input
+            .input_ids
+            .iter()
+            .zip(input.token_type_ids.iter())
+            .enumerate()
+        {
+            let word_row = self.word_embeddings.row(token_id as usize);
+            let pos_row = self.position_embeddings.row(pos);
+            let type_row = self.token_type_embeddings.row(type_id as usize);
+
+            let offset = pos * HIDDEN_SIZE;
+            for i in 0..HIDDEN_SIZE {
+                data[offset + i] = word_row[i] + pos_row[i] + type_row[i];
+            }
+        }
+
+        Tensor::from_slice(&data, seq_len, HIDDEN_SIZE)
+    }
+
+    fn transformer_layer(
+        &self,
+        layer: &TransformerLayer,
+        hidden: &Tensor,
+        attention_mask: &[u32],
+    ) -> Tensor {
+        let seq_len = hidden.rows;
+
+        // Self-attention
+        // Q, K, V projections: hidden × Wᵀ + b
+        // BERT stores weights transposed: shape is (out, in), so we use matmul_transpose
+        let mut q = hidden.matmul_transpose(&layer.q_weight);
+        q.add_bias(&layer.q_bias);
+        let mut k = hidden.matmul_transpose(&layer.k_weight);
+        k.add_bias(&layer.k_bias);
+        let mut v = hidden.matmul_transpose(&layer.v_weight);
+        v.add_bias(&layer.v_bias);
+
+        // Multi-head attention
+        let scale = 1.0 / (HEAD_DIM as f32).sqrt();
+        let mut attn_output_data = vec![0.0f32; seq_len * HIDDEN_SIZE];
+
+        for head in 0..NUM_HEADS {
+            let head_offset = head * HEAD_DIM;
+
+            // Extract Q, K, V slices for this head
+            let mut q_head = Tensor::zeros(seq_len, HEAD_DIM);
+            let mut k_head = Tensor::zeros(seq_len, HEAD_DIM);
+            let mut v_head = Tensor::zeros(seq_len, HEAD_DIM);
+
+            for s in 0..seq_len {
+                for d in 0..HEAD_DIM {
+                    q_head.data[s * HEAD_DIM + d] = q.data[s * HIDDEN_SIZE + head_offset + d];
+                    k_head.data[s * HEAD_DIM + d] = k.data[s * HIDDEN_SIZE + head_offset + d];
+                    v_head.data[s * HEAD_DIM + d] = v.data[s * HIDDEN_SIZE + head_offset + d];
+                }
+            }
+
+            // Attention scores: Q × Kᵀ / √d_k
+            let mut scores = q_head.matmul_transpose(&k_head);
+            scores.scale(scale);
+
+            // Apply attention mask (set padding positions to -10000)
+            for i in 0..seq_len {
+                for j in 0..seq_len {
+                    if attention_mask[j] == 0 {
+                        scores.data[i * seq_len + j] = -10000.0;
+                    }
+                }
+            }
+
+            scores.softmax_rows();
+
+            // Weighted sum: scores × V
+            let context = scores.matmul(&v_head);
+
+            // Copy back to full hidden dim
+            for s in 0..seq_len {
+                for d in 0..HEAD_DIM {
+                    attn_output_data[s * HIDDEN_SIZE + head_offset + d] =
+                        context.data[s * HEAD_DIM + d];
+                }
+            }
+        }
+
+        let attn_output = Tensor::from_slice(&attn_output_data, seq_len, HIDDEN_SIZE);
+
+        // Output projection
+        let mut projected = attn_output.matmul_transpose(&layer.attn_output_weight);
+        projected.add_bias(&layer.attn_output_bias);
+
+        // Residual + LayerNorm
+        let post_attn = projected.add_tensor(hidden);
+        let normed_attn =
+            post_attn.layer_norm(&layer.attn_ln_weight, &layer.attn_ln_bias, LAYER_NORM_EPS);
+
+        // FFN: intermediate
+        let mut intermediate = normed_attn.matmul_transpose(&layer.intermediate_weight);
+        intermediate.add_bias(&layer.intermediate_bias);
+        let intermediate = intermediate.gelu();
+
+        // FFN: output
+        let mut output = intermediate.matmul_transpose(&layer.output_weight);
+        output.add_bias(&layer.output_bias);
+
+        // Residual + LayerNorm
+        let post_ffn = output.add_tensor(&normed_attn);
+        post_ffn.layer_norm(&layer.output_ln_weight, &layer.output_ln_bias, LAYER_NORM_EPS)
+    }
+
+    fn mean_pool(&self, hidden: &Tensor, attention_mask: &[u32]) -> Vec<f32> {
+        let seq_len = hidden.rows;
+        let mut sum = vec![0.0f32; HIDDEN_SIZE];
+        let mut count = 0.0f32;
+
+        for s in 0..seq_len {
+            if attention_mask[s] == 1 {
+                let row = hidden.row(s);
+                for i in 0..HIDDEN_SIZE {
+                    sum[i] += row[i];
+                }
+                count += 1.0;
+            }
+        }
+
+        if count > 0.0 {
+            for v in sum.iter_mut() {
+                *v /= count;
+            }
+        }
+
+        sum
+    }
+}
+
+fn l2_normalize(v: &[f32]) -> Vec<f32> {
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        v.iter().map(|x| x / norm).collect()
+    } else {
+        v.to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_l2_normalize() {
+        let v = vec![3.0, 4.0];
+        let n = l2_normalize(&v);
+        assert!((n[0] - 0.6).abs() < 1e-6);
+        assert!((n[1] - 0.8).abs() < 1e-6);
+        let norm: f32 = n.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_l2_normalize_zero() {
+        let v = vec![0.0, 0.0];
+        let n = l2_normalize(&v);
+        assert_eq!(n, vec![0.0, 0.0]);
+    }
+}

--- a/crates/intelligence/src/embed/tokenizer.rs
+++ b/crates/intelligence/src/embed/tokenizer.rs
@@ -1,0 +1,234 @@
+//! WordPiece tokenizer for BERT-family models.
+
+use std::collections::HashMap;
+
+const CLS_ID: u32 = 101;
+const SEP_ID: u32 = 102;
+const UNK_ID: u32 = 100;
+
+/// A WordPiece tokenizer compatible with BERT/MiniLM vocabulary.
+pub struct WordPieceTokenizer {
+    vocab: HashMap<String, u32>,
+    max_seq_len: usize,
+}
+
+/// Tokenized input ready for the model.
+pub struct TokenizedInput {
+    /// Token IDs (vocabulary indices).
+    pub input_ids: Vec<u32>,
+    /// Attention mask (1 for real tokens, 0 for padding).
+    pub attention_mask: Vec<u32>,
+    /// Token type IDs (0 for single-sentence input).
+    pub token_type_ids: Vec<u32>,
+}
+
+impl WordPieceTokenizer {
+    /// Build a tokenizer from a vocab.txt file (one token per line).
+    pub fn from_vocab(vocab_text: &str) -> Self {
+        let vocab: HashMap<String, u32> = vocab_text
+            .lines()
+            .enumerate()
+            .map(|(i, line)| (line.to_string(), i as u32))
+            .collect();
+
+        Self {
+            vocab,
+            max_seq_len: 256,
+        }
+    }
+
+    /// Tokenize a text string.
+    pub fn tokenize(&self, text: &str) -> TokenizedInput {
+        let lower = text.to_lowercase();
+        let words = basic_split(&lower);
+
+        let mut tokens = vec![CLS_ID];
+
+        for word in &words {
+            self.wordpiece_tokenize(word, &mut tokens);
+            if tokens.len() >= self.max_seq_len - 1 {
+                tokens.truncate(self.max_seq_len - 1);
+                break;
+            }
+        }
+
+        tokens.push(SEP_ID);
+
+        let len = tokens.len();
+        let attention_mask = vec![1u32; len];
+        let token_type_ids = vec![0u32; len];
+
+        TokenizedInput {
+            input_ids: tokens,
+            attention_mask,
+            token_type_ids,
+        }
+    }
+
+    fn wordpiece_tokenize(&self, word: &str, tokens: &mut Vec<u32>) {
+        if word.is_empty() {
+            return;
+        }
+
+        // Try the whole word first
+        if let Some(&id) = self.vocab.get(word) {
+            tokens.push(id);
+            return;
+        }
+
+        // WordPiece subword tokenization
+        let chars: Vec<char> = word.chars().collect();
+        let mut start = 0;
+        let mut is_first = true;
+
+        while start < chars.len() {
+            let mut end = chars.len();
+            let mut found = false;
+
+            while start < end {
+                let substr: String = if is_first {
+                    chars[start..end].iter().collect()
+                } else {
+                    format!("##{}", chars[start..end].iter().collect::<String>())
+                };
+
+                if let Some(&id) = self.vocab.get(&substr) {
+                    tokens.push(id);
+                    found = true;
+                    start = end;
+                    is_first = false;
+                    break;
+                }
+
+                end -= 1;
+            }
+
+            if !found {
+                tokens.push(UNK_ID);
+                start += 1;
+                is_first = false;
+            }
+        }
+    }
+}
+
+/// Basic tokenization: split on whitespace and punctuation.
+fn basic_split(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            if !current.is_empty() {
+                tokens.push(std::mem::take(&mut current));
+            }
+        } else if is_punctuation(ch) {
+            if !current.is_empty() {
+                tokens.push(std::mem::take(&mut current));
+            }
+            tokens.push(ch.to_string());
+        } else {
+            current.push(ch);
+        }
+    }
+
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    tokens
+}
+
+fn is_punctuation(ch: char) -> bool {
+    matches!(
+        ch,
+        '!' | '"'
+            | '#'
+            | '$'
+            | '%'
+            | '&'
+            | '\''
+            | '('
+            | ')'
+            | '*'
+            | '+'
+            | ','
+            | '-'
+            | '.'
+            | '/'
+            | ':'
+            | ';'
+            | '<'
+            | '='
+            | '>'
+            | '?'
+            | '@'
+            | '['
+            | '\\'
+            | ']'
+            | '^'
+            | '_'
+            | '`'
+            | '{'
+            | '|'
+            | '}'
+            | '~'
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_vocab() -> String {
+        // Minimal vocab for testing
+        let mut lines = vec!["[PAD]"; 101]; // 0..100 = pad/unused
+        lines[0] = "[PAD]";
+        lines[100] = "[UNK]";
+        lines.push("[CLS]"); // 101
+        lines.push("[SEP]"); // 102
+        lines.push("hello"); // 103
+        lines.push("world"); // 104
+        lines.push("##ing"); // 105
+        lines.push("test"); // 106
+        lines.join("\n")
+    }
+
+    #[test]
+    fn test_basic_tokenization() {
+        let vocab = test_vocab();
+        let tok = WordPieceTokenizer::from_vocab(&vocab);
+        let result = tok.tokenize("hello world");
+        // [CLS]=101, hello=103, world=104, [SEP]=102
+        assert_eq!(result.input_ids[0], CLS_ID);
+        assert_eq!(result.input_ids[1], 103); // hello
+        assert_eq!(result.input_ids[2], 104); // world
+        assert_eq!(*result.input_ids.last().unwrap(), SEP_ID);
+        assert_eq!(result.attention_mask.len(), result.input_ids.len());
+        assert!(result.attention_mask.iter().all(|&v| v == 1));
+    }
+
+    #[test]
+    fn test_unknown_word() {
+        let vocab = test_vocab();
+        let tok = WordPieceTokenizer::from_vocab(&vocab);
+        let result = tok.tokenize("xyz");
+        // [CLS], [UNK], [SEP]
+        assert_eq!(result.input_ids[1], UNK_ID);
+    }
+
+    #[test]
+    fn test_basic_split_punctuation() {
+        let tokens = basic_split("hello, world!");
+        assert_eq!(tokens, vec!["hello", ",", "world", "!"]);
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let vocab = test_vocab();
+        let tok = WordPieceTokenizer::from_vocab(&vocab);
+        let result = tok.tokenize("");
+        // [CLS], [SEP]
+        assert_eq!(result.input_ids, vec![CLS_ID, SEP_ID]);
+    }
+}

--- a/crates/intelligence/src/lib.rs
+++ b/crates/intelligence/src/lib.rs
@@ -30,6 +30,12 @@ pub mod index;
 pub mod scorer;
 pub mod tokenizer;
 
+#[cfg(feature = "embed")]
+pub mod runtime;
+
+#[cfg(feature = "embed")]
+pub mod embed;
+
 use std::sync::Arc;
 use strata_engine::Database;
 

--- a/crates/intelligence/src/runtime/mod.rs
+++ b/crates/intelligence/src/runtime/mod.rs
@@ -1,0 +1,6 @@
+//! Shared inference runtime foundation.
+//!
+//! Provides tensor operations and weight loading used by all inference backends.
+
+pub mod safetensors;
+pub mod tensor;

--- a/crates/intelligence/src/runtime/safetensors.rs
+++ b/crates/intelligence/src/runtime/safetensors.rs
@@ -1,0 +1,221 @@
+//! SafeTensors binary format parser.
+//!
+//! Parses the SafeTensors file format: 8-byte header length (u64 LE),
+//! JSON header describing tensor metadata, then raw tensor data.
+
+use super::tensor::Tensor;
+use std::collections::HashMap;
+
+/// Parsed tensor metadata from the SafeTensors header.
+#[derive(Debug, Clone)]
+struct TensorInfo {
+    dtype: String,
+    shape: Vec<usize>,
+    data_offsets: [usize; 2],
+}
+
+/// A parsed SafeTensors file.
+pub struct SafeTensors {
+    tensors: HashMap<String, TensorInfo>,
+    data: Vec<u8>,
+}
+
+impl SafeTensors {
+    /// Parse a SafeTensors file from raw bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
+        if bytes.len() < 8 {
+            return Err("SafeTensors file too short".into());
+        }
+
+        let header_len = u64::from_le_bytes(
+            bytes[..8]
+                .try_into()
+                .map_err(|_| "Failed to read header length")?,
+        ) as usize;
+
+        if 8 + header_len > bytes.len() {
+            return Err(format!(
+                "Header length {} exceeds file size {}",
+                header_len,
+                bytes.len()
+            ));
+        }
+
+        let header_json = std::str::from_utf8(&bytes[8..8 + header_len])
+            .map_err(|e| format!("Invalid UTF-8 in header: {}", e))?;
+
+        let header: HashMap<String, serde_json::Value> = serde_json::from_str(header_json)
+            .map_err(|e| format!("Failed to parse header JSON: {}", e))?;
+
+        let mut tensors = HashMap::new();
+
+        for (name, meta) in &header {
+            // Skip the __metadata__ key
+            if name == "__metadata__" {
+                continue;
+            }
+
+            let obj = meta
+                .as_object()
+                .ok_or_else(|| format!("Tensor '{}' metadata is not an object", name))?;
+
+            let dtype = obj
+                .get("dtype")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| format!("Tensor '{}' missing dtype", name))?
+                .to_string();
+
+            let shape: Vec<usize> = obj
+                .get("shape")
+                .and_then(|v| v.as_array())
+                .ok_or_else(|| format!("Tensor '{}' missing shape", name))?
+                .iter()
+                .map(|v| v.as_u64().unwrap_or(0) as usize)
+                .collect();
+
+            let offsets = obj
+                .get("data_offsets")
+                .and_then(|v| v.as_array())
+                .ok_or_else(|| format!("Tensor '{}' missing data_offsets", name))?;
+
+            if offsets.len() != 2 {
+                return Err(format!("Tensor '{}' has invalid data_offsets", name));
+            }
+
+            let start = offsets[0].as_u64().unwrap_or(0) as usize;
+            let end = offsets[1].as_u64().unwrap_or(0) as usize;
+
+            tensors.insert(
+                name.clone(),
+                TensorInfo {
+                    dtype,
+                    shape,
+                    data_offsets: [start, end],
+                },
+            );
+        }
+
+        Ok(Self {
+            tensors,
+            data: bytes[8 + header_len..].to_vec(),
+        })
+    }
+
+    /// Extract a named tensor as a 2D Tensor.
+    pub fn tensor(&self, name: &str) -> Option<Tensor> {
+        let info = self.tensors.get(name)?;
+
+        if info.dtype != "F32" {
+            return None;
+        }
+
+        let start = info.data_offsets[0];
+        let end = info.data_offsets[1];
+
+        if end > self.data.len() {
+            return None;
+        }
+
+        let raw = &self.data[start..end];
+        let floats: Vec<f32> = raw
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+
+        let (rows, cols) = match info.shape.len() {
+            1 => (1, info.shape[0]),
+            2 => (info.shape[0], info.shape[1]),
+            _ => return None,
+        };
+
+        Some(Tensor::from_slice(&floats, rows, cols))
+    }
+
+    /// Extract a named 1D tensor as a Vec<f32>.
+    pub fn tensor_1d(&self, name: &str) -> Option<Vec<f32>> {
+        let info = self.tensors.get(name)?;
+
+        if info.dtype != "F32" {
+            return None;
+        }
+
+        let start = info.data_offsets[0];
+        let end = info.data_offsets[1];
+
+        if end > self.data.len() {
+            return None;
+        }
+
+        let raw = &self.data[start..end];
+        let floats: Vec<f32> = raw
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+
+        Some(floats)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal synthetic SafeTensors file with one 2x3 F32 tensor.
+    fn build_synthetic_safetensors() -> Vec<u8> {
+        let header = r#"{"test_tensor":{"dtype":"F32","shape":[2,3],"data_offsets":[0,24]}}"#;
+        let header_bytes = header.as_bytes();
+        let header_len = header_bytes.len() as u64;
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&header_len.to_le_bytes());
+        buf.extend_from_slice(header_bytes);
+
+        // 6 floats: 1.0, 2.0, 3.0, 4.0, 5.0, 6.0
+        for &v in &[1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0] {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+
+        buf
+    }
+
+    #[test]
+    fn test_parse_synthetic() {
+        let data = build_synthetic_safetensors();
+        let st = SafeTensors::from_bytes(&data).unwrap();
+        let t = st.tensor("test_tensor").unwrap();
+        assert_eq!(t.rows, 2);
+        assert_eq!(t.cols, 3);
+        assert_eq!(t.data, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn test_tensor_1d() {
+        let header = r#"{"bias":{"dtype":"F32","shape":[3],"data_offsets":[0,12]}}"#;
+        let header_bytes = header.as_bytes();
+        let header_len = header_bytes.len() as u64;
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&header_len.to_le_bytes());
+        buf.extend_from_slice(header_bytes);
+        for &v in &[0.1f32, 0.2, 0.3] {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+
+        let st = SafeTensors::from_bytes(&buf).unwrap();
+        let bias = st.tensor_1d("bias").unwrap();
+        assert_eq!(bias.len(), 3);
+        assert!((bias[0] - 0.1).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_missing_tensor() {
+        let data = build_synthetic_safetensors();
+        let st = SafeTensors::from_bytes(&data).unwrap();
+        assert!(st.tensor("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_too_short() {
+        assert!(SafeTensors::from_bytes(&[0; 4]).is_err());
+    }
+}

--- a/crates/intelligence/src/runtime/tensor.rs
+++ b/crates/intelligence/src/runtime/tensor.rs
@@ -1,0 +1,301 @@
+//! Minimal 2D tensor with matmul, GELU, LayerNorm, softmax.
+
+/// A 2D row-major tensor of f32 values.
+#[derive(Debug, Clone)]
+pub struct Tensor {
+    /// Flat row-major data buffer.
+    pub data: Vec<f32>,
+    /// Number of rows.
+    pub rows: usize,
+    /// Number of columns.
+    pub cols: usize,
+}
+
+impl Tensor {
+    /// Create a tensor of zeros.
+    pub fn zeros(rows: usize, cols: usize) -> Self {
+        Self {
+            data: vec![0.0; rows * cols],
+            rows,
+            cols,
+        }
+    }
+
+    /// Create a tensor from a flat slice.
+    pub fn from_slice(data: &[f32], rows: usize, cols: usize) -> Self {
+        assert_eq!(data.len(), rows * cols, "data length mismatch");
+        Self {
+            data: data.to_vec(),
+            rows,
+            cols,
+        }
+    }
+
+    /// Get a single row as a slice.
+    pub fn row(&self, r: usize) -> &[f32] {
+        let start = r * self.cols;
+        &self.data[start..start + self.cols]
+    }
+
+    /// Slice a range of rows into a new tensor.
+    pub fn slice_rows(&self, start: usize, end: usize) -> Self {
+        let s = start * self.cols;
+        let e = end * self.cols;
+        Self {
+            data: self.data[s..e].to_vec(),
+            rows: end - start,
+            cols: self.cols,
+        }
+    }
+
+    /// Matrix multiply: (M,K) × (K,N) → (M,N)
+    pub fn matmul(&self, other: &Tensor) -> Tensor {
+        assert_eq!(self.cols, other.rows, "matmul dimension mismatch");
+        let m = self.rows;
+        let k = self.cols;
+        let n = other.cols;
+        let mut out = vec![0.0f32; m * n];
+
+        for i in 0..m {
+            let a_row = i * k;
+            let o_row = i * n;
+            for p in 0..k {
+                let a_val = self.data[a_row + p];
+                let b_row = p * n;
+                for j in 0..n {
+                    out[o_row + j] += a_val * other.data[b_row + j];
+                }
+            }
+        }
+
+        Tensor {
+            data: out,
+            rows: m,
+            cols: n,
+        }
+    }
+
+    /// Matrix multiply with transpose: (M,K) × (N,K)ᵀ → (M,N)
+    pub fn matmul_transpose(&self, other: &Tensor) -> Tensor {
+        assert_eq!(self.cols, other.cols, "matmul_transpose dimension mismatch");
+        let m = self.rows;
+        let k = self.cols;
+        let n = other.rows;
+        let mut out = vec![0.0f32; m * n];
+
+        for i in 0..m {
+            let a_row = i * k;
+            let o_row = i * n;
+            for j in 0..n {
+                let b_row = j * k;
+                let mut sum = 0.0f32;
+                for p in 0..k {
+                    sum += self.data[a_row + p] * other.data[b_row + p];
+                }
+                out[o_row + j] = sum;
+            }
+        }
+
+        Tensor {
+            data: out,
+            rows: m,
+            cols: n,
+        }
+    }
+
+    /// Broadcast row-add: add a 1D bias to each row.
+    pub fn add_bias(&mut self, bias: &[f32]) {
+        assert_eq!(bias.len(), self.cols, "bias length mismatch");
+        for r in 0..self.rows {
+            let start = r * self.cols;
+            for c in 0..self.cols {
+                self.data[start + c] += bias[c];
+            }
+        }
+    }
+
+    /// Element-wise add (residual connections).
+    pub fn add_tensor(&self, other: &Tensor) -> Tensor {
+        assert_eq!(self.data.len(), other.data.len(), "add_tensor size mismatch");
+        let data: Vec<f32> = self
+            .data
+            .iter()
+            .zip(other.data.iter())
+            .map(|(a, b)| a + b)
+            .collect();
+        Tensor {
+            data,
+            rows: self.rows,
+            cols: self.cols,
+        }
+    }
+
+    /// Fast GELU approximation: x * 0.5 * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x³)))
+    pub fn gelu(&self) -> Tensor {
+        const SQRT_2_OVER_PI: f32 = 0.797_884_56; // sqrt(2/π)
+        let data: Vec<f32> = self
+            .data
+            .iter()
+            .map(|&x| {
+                let inner = SQRT_2_OVER_PI * (x + 0.044715 * x * x * x);
+                0.5 * x * (1.0 + inner.tanh())
+            })
+            .collect();
+        Tensor {
+            data,
+            rows: self.rows,
+            cols: self.cols,
+        }
+    }
+
+    /// Layer normalization per row.
+    pub fn layer_norm(&self, weight: &[f32], bias: &[f32], eps: f32) -> Tensor {
+        assert_eq!(weight.len(), self.cols);
+        assert_eq!(bias.len(), self.cols);
+        let mut out = vec![0.0f32; self.data.len()];
+
+        for r in 0..self.rows {
+            let start = r * self.cols;
+            let row = &self.data[start..start + self.cols];
+
+            // Mean
+            let mean: f32 = row.iter().sum::<f32>() / self.cols as f32;
+
+            // Variance
+            let var: f32 =
+                row.iter().map(|&x| (x - mean) * (x - mean)).sum::<f32>() / self.cols as f32;
+            let inv_std = 1.0 / (var + eps).sqrt();
+
+            for c in 0..self.cols {
+                out[start + c] = (row[c] - mean) * inv_std * weight[c] + bias[c];
+            }
+        }
+
+        Tensor {
+            data: out,
+            rows: self.rows,
+            cols: self.cols,
+        }
+    }
+
+    /// Per-row softmax with max-subtraction for numerical stability.
+    pub fn softmax_rows(&mut self) {
+        for r in 0..self.rows {
+            let start = r * self.cols;
+            let row = &mut self.data[start..start + self.cols];
+
+            let max = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let mut sum = 0.0f32;
+            for v in row.iter_mut() {
+                *v = (*v - max).exp();
+                sum += *v;
+            }
+            if sum > 0.0 {
+                for v in row.iter_mut() {
+                    *v /= sum;
+                }
+            }
+        }
+    }
+
+    /// Scalar multiply.
+    pub fn scale(&mut self, factor: f32) {
+        for v in self.data.iter_mut() {
+            *v *= factor;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zeros() {
+        let t = Tensor::zeros(2, 3);
+        assert_eq!(t.data, vec![0.0; 6]);
+    }
+
+    #[test]
+    fn test_matmul_2x3_times_3x2() {
+        // [[1,2,3],[4,5,6]] × [[7,8],[9,10],[11,12]]
+        let a = Tensor::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
+        let b = Tensor::from_slice(&[7.0, 8.0, 9.0, 10.0, 11.0, 12.0], 3, 2);
+        let c = a.matmul(&b);
+        assert_eq!(c.rows, 2);
+        assert_eq!(c.cols, 2);
+        // [1*7+2*9+3*11, 1*8+2*10+3*12] = [58, 64]
+        // [4*7+5*9+6*11, 4*8+5*10+6*12] = [139, 154]
+        assert_eq!(c.data, vec![58.0, 64.0, 139.0, 154.0]);
+    }
+
+    #[test]
+    fn test_matmul_transpose() {
+        // A=(2,3), B=(2,3) → A × Bᵀ = (2,2)
+        let a = Tensor::from_slice(&[1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 2, 3);
+        let b = Tensor::from_slice(&[1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 2, 3);
+        let c = a.matmul_transpose(&b);
+        assert_eq!(c.rows, 2);
+        assert_eq!(c.cols, 2);
+        assert_eq!(c.data, vec![1.0, 0.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn test_add_bias() {
+        let mut t = Tensor::from_slice(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        t.add_bias(&[10.0, 20.0]);
+        assert_eq!(t.data, vec![11.0, 22.0, 13.0, 24.0]);
+    }
+
+    #[test]
+    fn test_add_tensor() {
+        let a = Tensor::from_slice(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let b = Tensor::from_slice(&[10.0, 20.0, 30.0, 40.0], 2, 2);
+        let c = a.add_tensor(&b);
+        assert_eq!(c.data, vec![11.0, 22.0, 33.0, 44.0]);
+    }
+
+    #[test]
+    fn test_gelu_zero() {
+        let t = Tensor::from_slice(&[0.0], 1, 1);
+        let g = t.gelu();
+        assert!((g.data[0]).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_layer_norm() {
+        // Simple case: [1, 3] → mean=2, var=1, normalized [-1, 1]
+        let t = Tensor::from_slice(&[1.0, 3.0], 1, 2);
+        let w = vec![1.0, 1.0];
+        let b = vec![0.0, 0.0];
+        let n = t.layer_norm(&w, &b, 1e-5);
+        assert!((n.data[0] - (-1.0)).abs() < 1e-4);
+        assert!((n.data[1] - 1.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_softmax_rows() {
+        let mut t = Tensor::from_slice(&[1.0, 2.0, 3.0], 1, 3);
+        t.softmax_rows();
+        let sum: f32 = t.data.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-5);
+        // Values should be monotonically increasing
+        assert!(t.data[0] < t.data[1]);
+        assert!(t.data[1] < t.data[2]);
+    }
+
+    #[test]
+    fn test_scale() {
+        let mut t = Tensor::from_slice(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        t.scale(2.0);
+        assert_eq!(t.data, vec![2.0, 4.0, 6.0, 8.0]);
+    }
+
+    #[test]
+    fn test_slice_rows() {
+        let t = Tensor::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let s = t.slice_rows(1, 3);
+        assert_eq!(s.rows, 2);
+        assert_eq!(s.data, vec![3.0, 4.0, 5.0, 6.0]);
+    }
+}

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -30,6 +30,9 @@ pub enum AccessMode {
 pub struct OpenOptions {
     /// The access mode for the database.
     pub access_mode: AccessMode,
+    /// Enable automatic text embedding for semantic search.
+    /// `None` means "use the config file default".
+    pub auto_embed: Option<bool>,
 }
 
 impl OpenOptions {
@@ -43,12 +46,19 @@ impl OpenOptions {
         self.access_mode = mode;
         self
     }
+
+    /// Enable or disable automatic text embedding.
+    pub fn auto_embed(mut self, enabled: bool) -> Self {
+        self.auto_embed = Some(enabled);
+        self
+    }
 }
 
 impl Default for OpenOptions {
     fn default() -> Self {
         Self {
             access_mode: AccessMode::ReadWrite,
+            auto_embed: None,
         }
     }
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-The StrataDB CLI (`strata`) provides a Redis-inspired command-line interface for interacting with StrataDB databases.
+The StrataDB CLI (`strata`) provides an interactive command-line interface for interacting with StrataDB databases.
 
 ## Installation
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,7 +4,7 @@ Complete specifications for the StrataDB API.
 
 ## SDK & Interface References
 
-- **[CLI Reference](cli.md)** — Redis-inspired command-line interface
+- **[CLI Reference](cli.md)** — Interactive command-line interface
 - **[MCP Server Reference](mcp.md)** — Model Context Protocol server for AI assistants
 - **[Python SDK Reference](python-sdk.md)** — Native Python bindings via PyO3
 - **[Node.js SDK Reference](node-sdk.md)** — Native Node.js bindings via NAPI-RS


### PR DESCRIPTION
## Summary

- **P0 — source_ref on shadow inserts**: Extract `insert_inner()` in VectorStore, add `system_insert_with_source()`, and pass `EntityRef` from all 4 handler call sites (KV, JSON, Event, State) so hybrid search can trace shadow embeddings back to source records
- **P1 — non-ambiguous key separator**: Replace `/` with `\x1f` (ASCII Unit Separator) in composite shadow keys to prevent collisions when spaces or keys contain `/`
- **P1 — cfg-gated config warning**: When `auto_embed=true` in `strata.toml` but the `embed` feature is not compiled, log a warning and force `auto_embed=false` instead of silently no-oping. Adds `embed` marker feature to engine crate, forwarded from executor.
- **P2 — recursion depth limit**: Cap `extract_text` at 16 levels of nested Array/Object to prevent stack overflow on pathological documents
- **Cleanup — event key simplification**: Use `sequence.to_string()` instead of `"{type}/{seq}"` since `EntityRef::event` now carries the structured back-reference

## Test plan

- [x] `cargo check` — compiles without embed feature (no warnings)
- [x] `cargo check --features embed` — compiles with embed feature (no warnings)
- [x] `cargo test` — all existing tests pass (584 passed, 0 failed)
- [x] `cargo test -p strata-engine` — 514 passed
- [x] `cargo test -p strata-intelligence --features embed -- extract` — 15 passed (includes 2 new depth-limit tests)
- [x] No `/` separators remain in embed_hook composite keys
- [x] cfg-gated warning message verified in compiled output

🤖 Generated with [Claude Code](https://claude.com/claude-code)