### PR TITLE
Wire shadow vectors into hybrid search via RRF

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -122,6 +122,7 @@ pub use primitives::{
     VectorId,
     VectorIndexBackend,
     VectorMatch,
+    VectorMatchWithSource,
     VectorRecord,
     VectorResult,
     VectorStore,

--- a/crates/engine/src/primitives/mod.rs
+++ b/crates/engine/src/primitives/mod.rs
@@ -61,7 +61,8 @@ pub use vector::{
     CollectionId, CollectionInfo, CollectionRecord, DistanceMetric, FilterCondition, FilterOp,
     HnswBackend, HnswConfig, IndexBackendFactory, JsonScalar, MetadataFilter, StorageDtype,
     VectorBackendState, VectorConfig, VectorConfigSerde, VectorEntry, VectorError, VectorHeap,
-    VectorId, VectorIndexBackend, VectorMatch, VectorRecord, VectorResult, VectorStore,
+    VectorId, VectorIndexBackend, VectorMatch, VectorMatchWithSource, VectorRecord, VectorResult,
+    VectorStore,
 };
 
 // Re-export search types for convenience (from search module)


### PR DESCRIPTION
## Summary

- When `SearchMode::Hybrid` is requested, embed the query text with MiniLM, search all 4 shadow vector collections (`_system_embed_kv`, `_system_embed_json`, `_system_embed_event`, `_system_embed_state`), convert matches back to `SearchHit`s via their `source_ref`, and fuse with BM25 results using `RRFFuser`
- Adds `system_search_with_sources()` to `VectorStore` that returns `VectorMatchWithSource` (includes `source_ref` + `version`) for tracing shadow embeddings back to originating records
- Adds `embed_query()` convenience function to the intelligence crate (feature-gated with `embed`) that loads/caches the MiniLM model and embeds query text
- Vector hits from all 4 shadow collections are sorted by score globally before rank assignment, ensuring RRF ranks reflect true relevance rather than collection iteration order
- Compiles cleanly with and without `embed` feature; all existing tests pass

## Test plan

- [x] `cargo check --workspace` — compiles without `embed` feature
- [x] `cargo check --workspace --features embed` — compiles with `embed` feature
- [x] `cargo test -p strata-engine` — 514 tests pass
- [x] `cargo test -p strata-intelligence` — 23 tests pass (without `embed`)
- [x] `cargo test -p strata-intelligence --features embed` — 110 tests pass (with `embed`)
- [ ] Manual integration test: create a database with auto-embed enabled, write several KV entries, call `hybrid.search()` with `SearchMode::Hybrid` — verify semantically similar entries surface even when keywords don't match

🤖 Generated with [Claude Code](https://claude.com/claude-code)