### PR TITLE
Wire Flush and Compact executor commands to engine substrate

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -649,7 +649,7 @@ impl Database {
     /// be called manually to ensure durability at a specific point.
     ///
     /// For ephemeral databases, this is a no-op.
-    pub(crate) fn flush(&self) -> StrataResult<()> {
+    pub fn flush(&self) -> StrataResult<()> {
         if let Some(ref wal) = self.wal_writer {
             let mut wal = wal.lock();
             wal.flush().map_err(StrataError::from)

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -124,11 +124,11 @@ impl Executor {
                 }))
             }
             Command::Flush => {
-                // TODO: Call substrate flush
+                convert_result(self.primitives.db.flush())?;
                 Ok(Output::Unit)
             }
             Command::Compact => {
-                // TODO: Call substrate compact
+                convert_result(self.primitives.db.compact())?;
                 Ok(Output::Unit)
             }
 

--- a/crates/executor/src/tests/execute_many.rs
+++ b/crates/executor/src/tests/execute_many.rs
@@ -210,13 +210,13 @@ fn test_execute_many_all_database_commands() {
     ]);
 
     assert_eq!(results.len(), 4);
-    assert!(results.iter().all(|r| r.is_ok()));
 
     // Verify specific outputs
     matches!(&results[0], Ok(Output::Pong { .. }));
     matches!(&results[1], Ok(Output::DatabaseInfo(_)));
     matches!(&results[2], Ok(Output::Unit));
-    matches!(&results[3], Ok(Output::Unit));
+    // Compact correctly delegates to db.compact(), which is not yet implemented
+    assert!(results[3].is_err(), "Compact should propagate the engine error");
 }
 
 #[test]

--- a/crates/executor/src/tests/parity.rs
+++ b/crates/executor/src/tests/parity.rs
@@ -481,14 +481,19 @@ fn test_info_parity() {
 
 #[test]
 fn test_flush_compact_parity() {
-    let (executor, _p) = create_test_environment();
+    let (executor, p) = create_test_environment();
 
-    // These should not error
+    // Flush should delegate to db.flush() and succeed (no-op on ephemeral)
     let flush_result = executor.execute(Command::Flush);
     assert!(flush_result.is_ok());
 
-    let compact_result = executor.execute(Command::Compact);
-    assert!(compact_result.is_ok());
+    // The executor result for Compact must match the engine result.
+    // db.compact() returns an error ("not yet implemented"), so the
+    // executor must also return an error — not silently succeed.
+    let engine_result = p.db.compact();
+    let executor_result = executor.execute(Command::Compact);
+    assert_eq!(engine_result.is_err(), executor_result.is_err(),
+        "Executor Compact result must match engine compact() result");
 }
 
 // =============================================================================

--- a/tests/executor/command_dispatch.rs
+++ b/tests/executor/command_dispatch.rs
@@ -48,11 +48,12 @@ fn flush_returns_unit() {
 }
 
 #[test]
-fn compact_returns_unit() {
+fn compact_returns_error() {
     let executor = create_executor();
 
-    let output = executor.execute(Command::Compact).unwrap();
-    assert!(matches!(output, Output::Unit));
+    // Compact correctly delegates to the engine, which is not yet implemented
+    let result = executor.execute(Command::Compact);
+    assert!(result.is_err());
 }
 
 // ============================================================================

--- a/tests/executor/strata_api.rs
+++ b/tests/executor/strata_api.rs
@@ -38,10 +38,11 @@ fn flush_succeeds() {
 }
 
 #[test]
-fn compact_succeeds() {
+fn compact_returns_not_implemented() {
     let db = create_strata();
 
-    db.compact().unwrap();
+    // compact() correctly delegates to the engine, which is not yet implemented
+    assert!(db.compact().is_err());
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #1044

- **Flush**: Wires `Command::Flush` to `db.flush()`, which flushes WAL to disk for durable databases and is a no-op for ephemeral/cache databases
- **Compact**: Wires `Command::Compact` to `db.compact()`, which currently returns a "not yet implemented" error — this is correct behavior instead of silently returning success
- Promotes `Database::flush()` from `pub(crate)` to `pub` so the executor crate can call it
- Updates 4 test files to verify executor results match engine behavior (parity test, execute_many, command_dispatch, strata_api)

## Test plan

- [x] Regression test confirms bug: executor Compact returned `Ok` while engine returned `Err`
- [x] After fix: parity test verifies executor and engine agree on both Flush and Compact
- [x] All 187 executor unit tests pass
- [x] All 126 executor integration tests pass
- [x] Engine test suite passes with visibility change

🤖 Generated with [Claude Code](https://claude.com/claude-code)