### PR TITLE
Replace .lock().unwrap() with parking_lot::Mutex to prevent cascading panics (#1047)

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -311,7 +311,7 @@ impl Database {
         // Hold lock for entire operation to prevent TOCTOU race condition
         // This ensures only one thread creates a database for a given path.
         // For the common case (database already open), this is still fast.
-        let mut registry = OPEN_DATABASES.lock().unwrap();
+        let mut registry = OPEN_DATABASES.lock();
 
         // Check registry for existing instance
         if let Some(weak) = registry.get(&canonical_path) {
@@ -1270,9 +1270,8 @@ impl Drop for Database {
 
         // Remove from registry if we're disk-backed
         if self.persistence_mode == PersistenceMode::Disk && !self.data_dir.as_os_str().is_empty() {
-            if let Ok(mut registry) = OPEN_DATABASES.lock() {
-                registry.remove(&self.data_dir);
-            }
+            let mut registry = OPEN_DATABASES.lock();
+            registry.remove(&self.data_dir);
         }
     }
 }

--- a/crates/engine/src/database/registry.rs
+++ b/crates/engine/src/database/registry.rs
@@ -4,9 +4,10 @@
 //! Uses weak references to allow cleanup when all references are dropped.
 
 use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Mutex, Weak};
+use std::sync::Weak;
 
 use super::Database;
 
@@ -21,6 +22,9 @@ use super::Database;
 //   3. Consistent behavior across the process
 //
 // The registry uses weak references so databases are cleaned up when dropped.
+//
+// Uses parking_lot::Mutex instead of std::sync::Mutex to avoid cascading
+// panics from mutex poisoning (issue #1047).
 
 /// Global registry of open databases (path -> weak reference)
 pub static OPEN_DATABASES: Lazy<Mutex<HashMap<PathBuf, Weak<Database>>>> =


### PR DESCRIPTION
## Summary
- Switch `OPEN_DATABASES` registry from `std::sync::Mutex` to `parking_lot::Mutex` — eliminates cascading panic risk when a thread panics while holding the registry lock
- Replace `std::sync::Mutex` with `parking_lot::Mutex` in coordinator test code (result collection mutexes) to prevent test cascading failures
- Remove `.lock().unwrap()` calls from production code (registry lock in `Database::open()` and `Drop`)
- Add 3 new tests: one proving `std::sync::Mutex` poisons on panic, one proving `parking_lot::Mutex` does not, and one verifying the coordinator's concurrent collection pattern survives thread panics

## Test plan
- [x] `test_issue_1047_std_mutex_does_poison` — confirms the bug: `std::sync::Mutex` cascades panics via poisoning
- [x] `test_issue_1047_parking_lot_no_poisoning` — confirms the fix: `parking_lot::Mutex` survives thread panics
- [x] `test_issue_1047_concurrent_collection_survives_thread_panic` — verifies coordinator test pattern works despite worker panic
- [x] All 520 engine tests pass
- [x] All 187 executor tests pass
- [x] All 126 integration tests pass

Closes #1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)