### PR TITLE
Security audit hardening: enforce limits, file locking, safe recovery

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod branch_types; // Branch lifecycle types
 pub mod contract; // contract types
 pub mod error;
+pub mod limits; // Size limits for keys, values, and vectors
 pub mod primitive_ext; // extension trait for primitives to integrate with storage/durability
 pub mod primitives; // primitive types (Event, State, Vector, JSON types)
 pub mod search_types; // search types (EntityRef/PrimitiveType re-exports only; types moved to engine)
@@ -30,6 +31,7 @@ pub use branch_types::{BranchEventOffsets, BranchMetadata, BranchStatus};
 pub use error::{
     ConstraintReason, DetailValue, ErrorCode, ErrorDetails, StrataError, StrataResult,
 };
+pub use limits::{LimitError, Limits};
 pub use traits::{SnapshotView, Storage};
 pub use types::{validate_space_name, BranchId, Key, Namespace, TypeTag};
 pub use value::Value;

--- a/crates/core/src/limits.rs
+++ b/crates/core/src/limits.rs
@@ -267,6 +267,28 @@ impl LimitError {
             LimitError::VectorDimMismatch { .. } => "vector_dim_mismatch",
         }
     }
+
+    /// Get the actual value that exceeded the limit.
+    pub fn actual(&self) -> usize {
+        match self {
+            LimitError::KeyTooLong { actual, .. }
+            | LimitError::ValueTooLarge { actual, .. }
+            | LimitError::NestingTooDeep { actual, .. }
+            | LimitError::VectorDimExceeded { actual, .. } => *actual,
+            LimitError::VectorDimMismatch { actual, .. } => *actual,
+        }
+    }
+
+    /// Get the maximum allowed value.
+    pub fn max(&self) -> usize {
+        match self {
+            LimitError::KeyTooLong { max, .. }
+            | LimitError::ValueTooLarge { max, .. }
+            | LimitError::NestingTooDeep { max, .. }
+            | LimitError::VectorDimExceeded { max, .. } => *max,
+            LimitError::VectorDimMismatch { expected, .. } => *expected,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
+fs2 = "0.4"
 sha2 = "0.10.9"
 base64 = { workspace = true }
 byteorder = { workspace = true }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -707,8 +707,13 @@ impl Executor {
     }
 }
 
-// SAFETY: Executor is Send+Sync because:
-// - primitives: Arc<Primitives> is Send+Sync (all fields are Arc<Database>)
-// - access_mode: AccessMode is a Copy enum (trivially Send+Sync)
-unsafe impl Send for Executor {}
-unsafe impl Sync for Executor {}
+// Static assertion: Executor must remain Send+Sync.
+// If a future refactor adds a non-Send/Sync field, this will fail at compile time.
+const _: () = {
+    fn _assert_send<T: Send>() {}
+    fn _assert_sync<T: Sync>() {}
+    fn _check() {
+        _assert_send::<Executor>();
+        _assert_sync::<Executor>();
+    }
+};

--- a/crates/executor/src/handlers/event.rs
+++ b/crates/executor/src/handlers/event.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use crate::bridge::{self, Primitives};
+use crate::bridge::{self, validate_value, Primitives};
 use crate::convert::convert_result;
 use crate::types::{BranchId, VersionedValue};
 use crate::{Error, Output, Result};
@@ -41,6 +41,7 @@ pub fn event_append(
 ) -> Result<Output> {
     require_branch_exists(p, &branch)?;
     let core_branch_id = bridge::to_core_branch_id(&branch)?;
+    convert_result(validate_value(&payload, &p.limits))?;
 
     // Extract text before payload is consumed
     let text = super::embed_hook::extract_text(&payload);

--- a/crates/executor/src/handlers/json.rs
+++ b/crates/executor/src/handlers/json.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use strata_core::Value;
 
 use crate::bridge::{
-    extract_version, json_to_value, parse_path, to_core_branch_id, validate_key, value_to_json,
-    Primitives,
+    extract_version, json_to_value, parse_path, to_core_branch_id, validate_key, validate_value,
+    value_to_json, Primitives,
 };
 use crate::convert::convert_result;
 use crate::types::{BranchId, VersionedValue};
@@ -82,6 +82,7 @@ pub fn json_set(
     require_branch_exists(p, &branch)?;
     let branch_id = to_core_branch_id(&branch)?;
     convert_result(validate_key(&key))?;
+    convert_result(validate_value(&value, &p.limits))?;
 
     let json_path = convert_result(parse_path(&path))?;
     let json_value = convert_result(value_to_json(value))?;

--- a/crates/executor/src/handlers/kv.rs
+++ b/crates/executor/src/handlers/kv.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 use strata_core::Value;
 
 use crate::bridge::{
-    extract_version, to_core_branch_id, to_versioned_value, validate_key, Primitives,
+    extract_version, to_core_branch_id, to_versioned_value, validate_key, validate_value,
+    Primitives,
 };
 use crate::convert::convert_result;
 use crate::types::BranchId;
@@ -67,6 +68,7 @@ pub fn kv_put(
     require_branch_exists(p, &branch)?;
     let branch_id = to_core_branch_id(&branch)?;
     convert_result(validate_key(&key))?;
+    convert_result(validate_value(&value, &p.limits))?;
 
     // Extract text before the value is consumed by put()
     let text = super::embed_hook::extract_text(&value);

--- a/crates/executor/src/handlers/state.rs
+++ b/crates/executor/src/handlers/state.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use strata_core::{Value, Version};
 
-use crate::bridge::{self, Primitives};
+use crate::bridge::{self, validate_value, Primitives};
 use crate::convert::convert_result;
 use crate::types::BranchId;
 use crate::{Error, Output, Result};
@@ -68,6 +68,7 @@ pub fn state_set(
     require_branch_exists(p, &branch)?;
     let branch_id = bridge::to_core_branch_id(&branch)?;
     convert_result(bridge::validate_key(&cell))?;
+    convert_result(validate_value(&value, &p.limits))?;
 
     // Extract text before value is consumed
     let text = super::embed_hook::extract_text(&value);
@@ -119,6 +120,7 @@ pub fn state_cas(
     require_branch_exists(p, &branch)?;
     let branch_id = bridge::to_core_branch_id(&branch)?;
     convert_result(bridge::validate_key(&cell))?;
+    convert_result(validate_value(&value, &p.limits))?;
 
     // Extract text before value is consumed
     let text = super::embed_hook::extract_text(&value);
@@ -195,6 +197,7 @@ pub fn state_init(
     require_branch_exists(p, &branch)?;
     let branch_id = bridge::to_core_branch_id(&branch)?;
     convert_result(bridge::validate_key(&cell))?;
+    convert_result(validate_value(&value, &p.limits))?;
 
     // Extract text before value is consumed
     let text = super::embed_hook::extract_text(&value);

--- a/crates/executor/src/handlers/vector.rs
+++ b/crates/executor/src/handlers/vector.rs
@@ -9,7 +9,7 @@ use strata_core::Value;
 use crate::bridge::{
     extract_version, from_engine_metric, is_internal_collection, serde_json_to_value_public,
     to_core_branch_id, to_engine_filter, to_engine_metric, validate_key,
-    validate_not_internal_collection, value_to_serde_json_public, Primitives,
+    validate_not_internal_collection, validate_vector, value_to_serde_json_public, Primitives,
 };
 use crate::convert::convert_result;
 use crate::types::{
@@ -83,6 +83,7 @@ pub fn vector_upsert(
     let branch_id = to_core_branch_id(&branch)?;
     convert_result(validate_key(&key))?;
     convert_result(validate_not_internal_collection(&collection))?;
+    convert_result(validate_vector(&vector, &p.limits))?;
 
     let json_metadata = metadata
         .map(value_to_serde_json_public)
@@ -300,6 +301,7 @@ pub fn vector_batch_upsert(
     let mut engine_entries = Vec::with_capacity(entries.len());
     for entry in entries {
         convert_result(validate_key(&entry.key))?;
+        convert_result(validate_vector(&entry.vector, &p.limits))?;
         let json_metadata = entry
             .metadata
             .map(value_to_serde_json_public)


### PR DESCRIPTION
## Summary

Addresses 7 issues identified during a security audit, re-evaluated against the embedded database threat model (where the caller is the application itself, and the OS boundary provides protection).

- **#1059** — Wire orphaned `core::Limits` module into executor handlers, enforcing key length, value size, and vector dimension limits at the API boundary
- **#1060** — Add `fs2` exclusive file lock at `Database::open()` to prevent multi-process WAL corruption
- **#1061** — Replace WAL recovery's corrupted-length-based skip with a byte-by-byte scan for the next valid record (bounded by 1 MB window)
- **#1063** — Remove `unsafe impl Send/Sync for Executor`; replace with a compile-time static assertion
- **#1065** — Add allocation bounds checks in vector snapshot deserialization (1 MB header, 64 KB key, 64 MB metadata)
- **#1066** — Collapse two-phase `list_branch`/`list_by_prefix`/`list_by_type` into single-lock reads to eliminate TOCTOU races
- **#1067** — Replace SafeTensors `unwrap_or(0)` with proper error propagation via `ok_or_else()`

### Crates touched
`core`, `storage`, `durability`, `engine`, `executor`, `intelligence`

### Key design decisions
- Limits are developer guardrails (not security boundaries) given the embedded model — enforced at the executor layer via `Limits::default()`
- File lock acquired **after** the in-process registry check to avoid blocking same-process re-opens
- WAL scan uses `WalRecord::from_bytes()` at each candidate offset — CRC32 validation ensures negligible false-positive rate (~1 in 4 billion per position)
- TOCTOU fix uses the simpler single-lock approach rather than restructuring to MVCC snapshots

## Test plan

- [x] `cargo test -p strata-core` — 24 limits tests pass
- [x] `cargo test -p strata-storage` — 108 storage tests pass
- [x] `cargo test -p strata-durability` — 384 durability tests pass
- [x] `cargo test -p strata-engine` — 528+ engine tests pass (including 11 snapshot tests)
- [x] `cargo test -p strata-executor` — 187 executor tests pass
- [x] `cargo test -p strata-intelligence` — SafeTensors tests pass

Closes #1059, closes #1060, closes #1061, closes #1063, closes #1065, closes #1066, closes #1067

🤖 Generated with [Claude Code](https://claude.com/claude-code)