### PR TITLE
Fix db.extension() calls to handle Result return type

### DIFF
--- a/crates/executor/src/handlers/embed_hook.rs
+++ b/crates/executor/src/handlers/embed_hook.rs
@@ -40,7 +40,13 @@ pub fn maybe_embed_text(
     }
 
     let model_dir = p.db.model_dir();
-    let embed_state = p.db.extension::<EmbedModelState>();
+    let embed_state = match p.db.extension::<EmbedModelState>() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(target: "strata::embed", error = %e, "Failed to get embed model state");
+            return;
+        }
+    };
 
     let model = match embed_state.get_or_load(&model_dir) {
         Ok(m) => m,
@@ -175,7 +181,13 @@ fn ensure_shadow_collection(
     use strata_engine::database::AutoEmbedState;
 
     let cache_key = format!("{:?}{}{}", branch_id.as_bytes(), SHADOW_KEY_SEP, name);
-    let state = p.db.extension::<AutoEmbedState>();
+    let state = match p.db.extension::<AutoEmbedState>() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(target: "strata::embed", error = %e, "Failed to get auto-embed state");
+            return;
+        }
+    };
 
     // Fast path: already created in this process lifetime
     if state.shadow_collections_created.contains_key(&cache_key) {

--- a/crates/intelligence/src/embed/mod.rs
+++ b/crates/intelligence/src/embed/mod.rs
@@ -70,7 +70,13 @@ impl EmbedModelState {
 /// or embedding fails. This is a best-effort helper for hybrid search.
 pub fn embed_query(db: &strata_engine::Database, text: &str) -> Option<Vec<f32>> {
     let model_dir = db.model_dir();
-    let state = db.extension::<EmbedModelState>();
+    let state = match db.extension::<EmbedModelState>() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(target: "strata::hybrid", error = %e, "Failed to get embed model state");
+            return None;
+        }
+    };
     let model = match state.get_or_load(&model_dir) {
         Ok(m) => m,
         Err(e) => {


### PR DESCRIPTION
## Summary
- Fix 3 call sites in `embed_hook.rs` and `embed/mod.rs` that call `db.extension::<T>()` without handling the `Result` return type
- The `extension()` method was changed to return `StrataResult<Arc<T>>` in #1071 (security audit hardening), but these call sites were not updated
- All three are best-effort embed hooks, so we log warnings and return early on failure

## Test plan
- [x] `cargo build --features embed` compiles cleanly
- [x] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)