### PR TITLE
Add getv methods to API quick reference

### DIFF
--- a/docs/reference/api-quick-reference.md
+++ b/docs/reference/api-quick-reference.md
@@ -46,6 +46,7 @@ Every method on the `Strata` struct, grouped by category.
 | `kv_put` | `(key: &str, value: impl Into<Value>) -> Result<u64>` | Version | Creates or overwrites |
 | `kv_get` | `(key: &str) -> Result<Option<Value>>` | Value or None | |
 | `kv_get_at` | `(key: &str, as_of_ts: u64) -> Result<Option<Value>>` | Historical value or None | Time-travel read |
+| `kv_getv` | `(key: &str) -> Result<Option<Vec<VersionedValue>>>` | Version history or None | Newest first |
 | `kv_delete` | `(key: &str) -> Result<bool>` | Whether key existed | |
 | `kv_list` | `(prefix: Option<&str>) -> Result<Vec<String>>` | Key names | |
 | `kv_list_at` | `(prefix: Option<&str>, as_of_ts: u64) -> Result<Vec<String>>` | Historical key names | Time-travel list |
@@ -67,6 +68,7 @@ Every method on the `Strata` struct, grouped by category.
 | `state_set` | `(cell: &str, value: impl Into<Value>) -> Result<u64>` | Version | Unconditional write |
 | `state_get` | `(cell: &str) -> Result<Option<Value>>` | Value or None | |
 | `state_get_at` | `(cell: &str, as_of_ts: u64) -> Result<Option<Value>>` | Historical value or None | Time-travel read |
+| `state_getv` | `(cell: &str) -> Result<Option<Vec<VersionedValue>>>` | Version history or None | Newest first |
 | `state_init` | `(cell: &str, value: impl Into<Value>) -> Result<u64>` | Version | Only if absent |
 | `state_cas` | `(cell: &str, expected: Option<u64>, value: impl Into<Value>) -> Result<Option<u64>>` | New version or None | CAS |
 
@@ -77,6 +79,7 @@ Every method on the `Strata` struct, grouped by category.
 | `json_set` | `(key: &str, path: &str, value: impl Into<Value>) -> Result<u64>` | Version | Use "$" for root |
 | `json_get` | `(key: &str, path: &str) -> Result<Option<Value>>` | Value or None | |
 | `json_get_at` | `(key: &str, as_of_ts: u64) -> Result<Option<Value>>` | Historical value or None | Time-travel read |
+| `json_getv` | `(key: &str) -> Result<Option<Vec<VersionedValue>>>` | Version history or None | Newest first |
 | `json_delete` | `(key: &str, path: &str) -> Result<u64>` | Count deleted | |
 | `json_list` | `(prefix: Option<String>, cursor: Option<String>, limit: u64) -> Result<(Vec<String>, Option<String>)>` | Keys + cursor | |
 


### PR DESCRIPTION
## Summary
- Add `kv_getv`, `state_getv`, and `json_getv` version history methods to the KV Store, State Cell, and JSON Store sections of the API quick reference

## Test plan
- [ ] Verify signatures match the implementations in `crates/executor/src/api/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)