### PR TITLE
Implement unified configuration system with StrataConfig

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -31,7 +31,7 @@ pub mod transaction;
 pub mod transaction_ops; // TransactionOps Trait Definition
 
 pub use coordinator::{TransactionCoordinator, TransactionMetrics};
-pub use database::{Database, RetryConfig, StrataConfig};
+pub use database::{Database, ModelConfig, RetryConfig, StrataConfig};
 pub use instrumentation::PerfTrace;
 pub use recovery::{
     diff_views, recover_all_participants, register_recovery_participant, BranchDiff, BranchError,

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -19,12 +19,15 @@ pub enum AccessMode {
 
 /// Options for opening a database.
 ///
-/// Use the builder pattern to configure options:
+/// Use the builder pattern to configure options. Any field set to `Some`
+/// overrides the corresponding value in `strata.toml`.
 ///
 /// ```ignore
 /// use strata_security::{OpenOptions, AccessMode};
 ///
-/// let opts = OpenOptions::new().access_mode(AccessMode::ReadOnly);
+/// let opts = OpenOptions::new()
+///     .access_mode(AccessMode::ReadOnly)
+///     .durability("always");
 /// ```
 #[derive(Debug, Clone)]
 pub struct OpenOptions {
@@ -33,6 +36,17 @@ pub struct OpenOptions {
     /// Enable automatic text embedding for semantic search.
     /// `None` means "use the config file default".
     pub auto_embed: Option<bool>,
+    /// Override durability mode: `"standard"` or `"always"`.
+    /// `None` means "use the config file default".
+    pub durability: Option<String>,
+    /// Override model endpoint (OpenAI-compatible URL).
+    pub model_endpoint: Option<String>,
+    /// Override model name.
+    pub model_name: Option<String>,
+    /// Override model API key.
+    pub model_api_key: Option<String>,
+    /// Override model request timeout in milliseconds.
+    pub model_timeout_ms: Option<u64>,
 }
 
 impl OpenOptions {
@@ -52,6 +66,31 @@ impl OpenOptions {
         self.auto_embed = Some(enabled);
         self
     }
+
+    /// Set the durability mode (`"standard"` or `"always"`).
+    pub fn durability(mut self, mode: &str) -> Self {
+        self.durability = Some(mode.to_string());
+        self
+    }
+
+    /// Set the model endpoint and name for query expansion / re-ranking.
+    pub fn model(mut self, endpoint: &str, name: &str) -> Self {
+        self.model_endpoint = Some(endpoint.to_string());
+        self.model_name = Some(name.to_string());
+        self
+    }
+
+    /// Set the model API key.
+    pub fn model_api_key(mut self, key: &str) -> Self {
+        self.model_api_key = Some(key.to_string());
+        self
+    }
+
+    /// Set the model request timeout in milliseconds.
+    pub fn model_timeout_ms(mut self, ms: u64) -> Self {
+        self.model_timeout_ms = Some(ms);
+        self
+    }
 }
 
 impl Default for OpenOptions {
@@ -59,6 +98,11 @@ impl Default for OpenOptions {
         Self {
             access_mode: AccessMode::ReadWrite,
             auto_embed: None,
+            durability: None,
+            model_endpoint: None,
+            model_name: None,
+            model_api_key: None,
+            model_timeout_ms: None,
         }
     }
 }

--- a/tests/engine/database/durability_modes.rs
+++ b/tests/engine/database/durability_modes.rs
@@ -142,8 +142,7 @@ fn standard_mode_is_persistent() {
 #[test]
 fn always_mode_is_persistent() {
     let temp_dir = tempfile::tempdir().unwrap();
-    write_always_config(temp_dir.path());
-    let db = Database::open(temp_dir.path()).expect("always database");
+    let db = Database::open_with_config(temp_dir.path(), always_config()).expect("always database");
 
     assert!(!db.is_cache());
 }
@@ -206,8 +205,7 @@ fn transaction_atomicity_standard() {
 #[test]
 fn transaction_atomicity_always() {
     let temp_dir = tempfile::tempdir().unwrap();
-    write_always_config(temp_dir.path());
-    let db = Database::open(temp_dir.path()).expect("always database");
+    let db = Database::open_with_config(temp_dir.path(), always_config()).expect("always database");
     let branch_id = BranchId::new();
 
     db.transaction(branch_id, |txn| {

--- a/tests/engine/database/lifecycle.rs
+++ b/tests/engine/database/lifecycle.rs
@@ -133,9 +133,8 @@ fn open_creates_persistent_database() {
 #[test]
 fn open_with_always_config() {
     let temp_dir = tempfile::tempdir().unwrap();
-    write_always_config(temp_dir.path());
 
-    let db = Database::open(temp_dir.path()).unwrap();
+    let db = Database::open_with_config(temp_dir.path(), always_config()).unwrap();
 
     // Verify it works
     let branch_id = BranchId::new();

--- a/tests/integration/modes.rs
+++ b/tests/integration/modes.rs
@@ -21,8 +21,7 @@ fn create_persistent_standard(dir: &TempDir) -> Arc<Database> {
 }
 
 fn create_persistent_always(dir: &TempDir) -> Arc<Database> {
-    write_always_config(dir.path());
-    Database::open(dir.path()).expect("always db")
+    Database::open_with_config(dir.path(), always_config()).expect("always db")
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Consolidate 4 disconnected config mechanisms (`strata.toml`, `OpenOptions`, `ModelConfigState` extension, builder pattern) into a single `StrataConfig` struct in `engine/config.rs`
- Add `Database::open_with_config(path, StrataConfig)` for programmatic configuration, eliminating temp `strata.toml` file writing in tests
- `ModelConfig` now persists to `strata.toml` via `ConfigureModel` command, surviving restarts
- Expand `OpenOptions` with `durability`, `model_endpoint`, `model_name`, `model_api_key`, `model_timeout_ms` fields that merge into `StrataConfig`
- Add `Database::config()` accessor and `update_config()` mutator with durability-change rejection and auto-persist to disk

### Files changed

| File | Change |
|------|--------|
| `crates/engine/src/database/config.rs` | Add `ModelConfig` struct, expand `StrataConfig`, add `write_to_file()`, 5 new tests |
| `crates/engine/src/database/mod.rs` | Add config `RwLock` to Database, `open_with_config`/`update_config` APIs, delete `ModelConfigState`, simplify `AutoEmbedState` |
| `crates/engine/src/lib.rs` | Re-export `ModelConfig` |
| `crates/security/src/lib.rs` | Add durability + model fields to `OpenOptions` with builder methods |
| `crates/executor/src/api/mod.rs` | Rewrite `open_with()` with config merge logic |
| `crates/executor/src/handlers/configure_model.rs` | Use `update_config()` instead of extension (config now persists) |
| `crates/executor/src/handlers/search.rs` | Read model from `db.config()` instead of extension |
| `tests/common/mod.rs` | Replace `write_always_config()` with `always_config()` + `open_with_config` |
| `tests/engine/database/{lifecycle,durability_modes}.rs`, `tests/integration/modes.rs` | Update callers |

## Test plan

- [x] `cargo build --workspace` — clean compilation
- [x] `cargo test --workspace` — all existing tests pass
- [x] `cargo test --workspace --features embed,expand,rerank` — feature-gated tests pass
- [x] New unit tests in config.rs: TOML round-trip with/without model, backward compat, default timeout, file round-trip
- [x] `TestDb::new_strict()` works without writing temp files
- [ ] Verify `ConfigureModel` persists to strata.toml and survives `TestDb::reopen()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)