### PR TITLE
Clean up intelligence crate: deduplicate, fix gating, centralize constants

### DIFF
--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -9,6 +9,19 @@ use std::path::Path;
 use strata_core::{StrataError, StrataResult};
 use strata_durability::wal::DurabilityMode;
 
+// ============================================================================
+// Shadow Collection Names
+// ============================================================================
+
+/// Shadow vector collection name for KV store auto-embeddings.
+pub const SHADOW_KV: &str = "_system_embed_kv";
+/// Shadow vector collection name for JSON store auto-embeddings.
+pub const SHADOW_JSON: &str = "_system_embed_json";
+/// Shadow vector collection name for event log auto-embeddings.
+pub const SHADOW_EVENT: &str = "_system_embed_event";
+/// Shadow vector collection name for state cell auto-embeddings.
+pub const SHADOW_STATE: &str = "_system_embed_state";
+
 /// Config file name placed in the database data directory.
 pub const CONFIG_FILE_NAME: &str = "strata.toml";
 
@@ -159,9 +172,8 @@ auto_embed = false
 
     /// Serialize this config to TOML and write it to the given path.
     pub fn write_to_file(&self, path: &Path) -> StrataResult<()> {
-        let content = toml::to_string_pretty(self).map_err(|e| {
-            StrataError::internal(format!("Failed to serialize config: {}", e))
-        })?;
+        let content = toml::to_string_pretty(self)
+            .map_err(|e| StrataError::internal(format!("Failed to serialize config: {}", e)))?;
         std::fs::write(path, content).map_err(|e| {
             StrataError::internal(format!(
                 "Failed to write config file '{}': {}",

--- a/crates/engine/src/primitives/json.rs
+++ b/crates/engine/src/primitives/json.rs
@@ -1860,12 +1860,7 @@ mod tests {
         let root = JsonPath::root();
 
         store
-            .create(
-                &branch_id,
-                "default",
-                doc_id,
-                JsonValue::from("v1"),
-            )
+            .create(&branch_id, "default", doc_id, JsonValue::from("v1"))
             .unwrap();
 
         // Capture the timestamp returned by get_versioned

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -130,8 +130,7 @@ impl Strata {
         })?;
 
         // Read existing config (or defaults)
-        let config_path =
-            data_dir.join(strata_engine::database::config::CONFIG_FILE_NAME);
+        let config_path = data_dir.join(strata_engine::database::config::CONFIG_FILE_NAME);
         strata_engine::database::config::StrataConfig::write_default_if_missing(&config_path)
             .map_err(|e| Error::Internal {
                 reason: format!("Failed to write default config: {}", e),
@@ -177,10 +176,9 @@ impl Strata {
             }
         }
 
-        let db =
-            Database::open_with_config(&data_dir, cfg).map_err(|e| Error::Internal {
-                reason: format!("Failed to open database: {}", e),
-            })?;
+        let db = Database::open_with_config(&data_dir, cfg).map_err(|e| Error::Internal {
+            reason: format!("Failed to open database: {}", e),
+        })?;
 
         let access_mode = opts.access_mode;
         let executor = Executor::new_with_mode(db, access_mode);

--- a/crates/intelligence/src/expand/api.rs
+++ b/crates/intelligence/src/expand/api.rs
@@ -4,13 +4,12 @@
 //! parses the response into typed queries.
 
 use super::parser::parse_expansion_with_filter;
-use super::prompt::build_messages;
 use super::{ExpandError, ExpandedQueries, QueryExpander};
-use tracing::warn;
 
 /// Query expander that calls an OpenAI-compatible chat completions endpoint.
 ///
 /// Works with Ollama, vLLM, llama.cpp server, OpenAI, and other compatible providers.
+#[allow(dead_code)] // fields used behind #[cfg(feature = "expand")]
 pub struct ApiExpander {
     /// Full URL to the chat completions endpoint
     url: String,
@@ -20,7 +19,16 @@ pub struct ApiExpander {
     api_key: Option<String>,
     /// Request timeout
     timeout: std::time::Duration,
+    /// Sampling temperature (default: 0.7)
+    temperature: f32,
+    /// Maximum response tokens (default: 600)
+    max_tokens: u32,
 }
+
+/// Default expansion temperature — moderate creativity for query variations.
+const DEFAULT_EXPAND_TEMPERATURE: f32 = 0.7;
+/// Default max tokens for expansion responses.
+const DEFAULT_EXPAND_MAX_TOKENS: u32 = 600;
 
 impl ApiExpander {
     /// Create a new ApiExpander.
@@ -35,127 +43,63 @@ impl ApiExpander {
             model: model.to_string(),
             api_key: api_key.map(|s| s.to_string()),
             timeout: std::time::Duration::from_millis(timeout_ms),
+            temperature: DEFAULT_EXPAND_TEMPERATURE,
+            max_tokens: DEFAULT_EXPAND_MAX_TOKENS,
         }
+    }
+
+    /// Override the sampling temperature.
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.temperature = temperature;
+        self
+    }
+
+    /// Override the maximum response tokens.
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = max_tokens;
+        self
     }
 
     /// Make the HTTP call and return the raw response text.
     #[cfg(feature = "expand")]
     fn call_api(&self, query: &str) -> Result<String, ExpandError> {
+        use super::prompt::build_messages;
+
         let body = serde_json::json!({
             "model": self.model,
             "messages": build_messages(query),
-            "temperature": 0.7,
-            "max_tokens": 600,
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
         });
 
-        let body_bytes = serde_json::to_vec(&body)
-            .map_err(|e| ExpandError::Parse(format!("failed to serialize request: {}", e)))?;
-
-        let config = ureq::Agent::config_builder()
-            .timeout_global(Some(self.timeout))
-            .build();
-        let agent = ureq::Agent::new_with_config(config);
-
-        let mut request = agent
-            .post(&self.url)
-            .header("Content-Type", "application/json");
-
-        if let Some(ref key) = self.api_key {
-            request = request.header("Authorization", &format!("Bearer {}", key));
-        }
-
-        let mut response = request.send(&body_bytes[..]).map_err(|e| {
-            let msg = e.to_string();
-            if msg.contains("timed out") || msg.contains("Timeout") {
-                ExpandError::Timeout
-            } else {
-                ExpandError::Network(msg)
-            }
-        })?;
-
-        let response_text = response
-            .body_mut()
-            .read_to_string()
-            .map_err(|e| ExpandError::Network(format!("failed to read response: {}", e)))?;
-
-        // Parse the OpenAI-format response to extract the content
-        let json: serde_json::Value = serde_json::from_str(&response_text)
-            .map_err(|e| ExpandError::Parse(format!("invalid JSON response: {}", e)))?;
-
-        let content = json
-            .get("choices")
-            .and_then(|c| c.get(0))
-            .and_then(|c| c.get("message"))
-            .and_then(|m| m.get("content"))
-            .and_then(|c| c.as_str())
-            .ok_or_else(|| {
-                ExpandError::Parse(format!(
-                    "unexpected response format: {}",
-                    &response_text[..response_text.len().min(200)]
-                ))
-            })?;
-
-        Ok(content.to_string())
+        crate::llm_client::call_chat_completions(
+            &self.url,
+            self.api_key.as_deref(),
+            self.timeout,
+            &body,
+        )
     }
 
     /// Placeholder for when the `expand` feature is not enabled.
     #[cfg(not(feature = "expand"))]
     fn call_api(&self, _query: &str) -> Result<String, ExpandError> {
-        Err(ExpandError::Network(
-            "expand feature not enabled".to_string(),
-        ))
+        Err(ExpandError::FeatureDisabled("expand"))
     }
 }
 
 impl QueryExpander for ApiExpander {
     fn expand(&self, query: &str) -> Result<ExpandedQueries, ExpandError> {
-        // First attempt
-        match self.call_api(query) {
-            Ok(text) => {
-                let result = parse_expansion_with_filter(&text, Some(query));
-                if !result.queries.is_empty() {
-                    return Ok(result);
-                }
-                // Zero valid lines — retry once
-                warn!(
-                    target: "strata::expand",
-                    "First expansion returned no valid lines, retrying"
-                );
-            }
-            Err(e) => {
-                warn!(
-                    target: "strata::expand",
-                    error = %e,
-                    "First expansion call failed, retrying"
-                );
-            }
-        }
-
-        // Retry once
-        match self.call_api(query) {
-            Ok(text) => {
-                let result = parse_expansion_with_filter(&text, Some(query));
-                if result.queries.is_empty() {
-                    warn!(
-                        target: "strata::expand",
-                        "Retry also returned no valid lines, falling back"
-                    );
-                    Err(ExpandError::Parse(
-                        "model returned no valid expansion lines after retry".to_string(),
-                    ))
-                } else {
-                    Ok(result)
-                }
-            }
-            Err(e) => {
-                warn!(
-                    target: "strata::expand",
-                    error = %e,
-                    "Retry also failed, falling back"
-                );
-                Err(e)
-            }
-        }
+        crate::llm_client::retry_once(
+            || self.call_api(query),
+            |text| parse_expansion_with_filter(text, Some(query)),
+            |result| result.queries.is_empty(),
+            || {
+                ExpandError::Parse(
+                    "model returned no valid expansion lines after retry".to_string(),
+                )
+            },
+            "strata::expand",
+        )
     }
 }
 

--- a/crates/intelligence/src/expand/error.rs
+++ b/crates/intelligence/src/expand/error.rs
@@ -1,29 +1,4 @@
-//! Error types for query expansion
-
-use std::fmt;
+//! Error types for query expansion — type alias for shared LlmClientError
 
 /// Errors that can occur during query expansion
-#[derive(Debug)]
-pub enum ExpandError {
-    /// HTTP request failed (network unreachable, connection refused, etc.)
-    Network(String),
-    /// Failed to parse model response into valid expansions
-    Parse(String),
-    /// Model request timed out
-    Timeout,
-    /// Model returned an error response
-    Model(String),
-}
-
-impl fmt::Display for ExpandError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ExpandError::Network(msg) => write!(f, "network error: {}", msg),
-            ExpandError::Parse(msg) => write!(f, "parse error: {}", msg),
-            ExpandError::Timeout => write!(f, "model request timed out"),
-            ExpandError::Model(msg) => write!(f, "model error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for ExpandError {}
+pub type ExpandError = crate::llm_client::LlmClientError;

--- a/crates/intelligence/src/expand/mod.rs
+++ b/crates/intelligence/src/expand/mod.rs
@@ -15,13 +15,14 @@
 
 pub mod api;
 pub mod error;
-pub mod mock;
 pub mod parser;
 pub mod prompt;
 
+#[cfg(test)]
+pub(crate) mod mock;
+
 pub use api::ApiExpander;
 pub use error::ExpandError;
-pub use mock::MockExpander;
 
 /// Type of expanded query — determines how it is searched.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,7 +58,6 @@ pub struct ExpandedQueries {
 ///
 /// # Implementations
 ///
-/// - `MockExpander` — deterministic expansions for testing
 /// - `ApiExpander` — calls an OpenAI-compatible endpoint
 pub trait QueryExpander: Send + Sync {
     /// Expand a query into multiple typed search variants.
@@ -67,6 +67,7 @@ pub trait QueryExpander: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::expand::mock::MockExpander;
     use std::sync::Arc;
 
     #[test]

--- a/crates/intelligence/src/index.rs
+++ b/crates/intelligence/src/index.rs
@@ -1,6 +1,0 @@
-//! InvertedIndex — re-exported from strata_engine::search
-//!
-//! The InvertedIndex has been moved to the engine crate so that primitives
-//! can use it on write paths. This module re-exports for backward compatibility.
-
-pub use strata_engine::search::{InvertedIndex, PostingEntry, PostingList};

--- a/crates/intelligence/src/lib.rs
+++ b/crates/intelligence/src/lib.rs
@@ -5,13 +5,10 @@
 //! vector indexing, and other composite intelligence.
 //!
 //! This crate provides:
-//! - Scorer trait for pluggable scoring algorithms
-//! - ScorerContext for corpus-level statistics
-//! - BM25LiteScorer default implementation
-//! - Basic tokenizer
-//! - Fuser trait for result fusion
+//! - Fuser trait for result fusion (SimpleFuser, RRFFuser)
 //! - HybridSearch for composite search orchestration
 //! - DatabaseSearchExt extension trait for db.hybrid() accessor
+//! - Query expansion and re-ranking via external LLM endpoints
 //!
 //! # Usage
 //!
@@ -27,10 +24,8 @@
 pub mod expand;
 pub mod fuser;
 pub mod hybrid;
-pub mod index;
+pub mod llm_client;
 pub mod rerank;
-pub mod scorer;
-pub mod tokenizer;
 
 #[cfg(feature = "embed")]
 pub mod runtime;
@@ -44,9 +39,6 @@ use strata_engine::Database;
 // Re-export commonly used types
 pub use fuser::{weighted_rrf_fuse, FusedResult, Fuser, RRFFuser, SimpleFuser};
 pub use hybrid::HybridSearch;
-pub use index::{InvertedIndex, PostingEntry, PostingList};
-pub use scorer::{BM25LiteScorer, Scorer, ScorerContext, SearchDoc};
-pub use tokenizer::{tokenize, tokenize_unique};
 
 // ============================================================================
 // Database Extension

--- a/crates/intelligence/src/llm_client.rs
+++ b/crates/intelligence/src/llm_client.rs
@@ -1,0 +1,174 @@
+//! Shared LLM client infrastructure for expand and rerank modules
+//!
+//! Provides a unified error type, HTTP call helper, and retry logic
+//! to avoid duplication between ApiExpander and ApiReranker.
+
+use std::fmt;
+
+// ============================================================================
+// Unified Error Type
+// ============================================================================
+
+/// Errors that can occur when calling an external LLM endpoint
+#[derive(Debug)]
+pub enum LlmClientError {
+    /// HTTP request failed (network unreachable, connection refused, etc.)
+    Network(String),
+    /// Failed to parse model response
+    Parse(String),
+    /// Model request timed out
+    Timeout,
+    /// Required cargo feature (expand/rerank) is not enabled
+    FeatureDisabled(&'static str),
+}
+
+impl fmt::Display for LlmClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LlmClientError::Network(msg) => write!(f, "network error: {}", msg),
+            LlmClientError::Parse(msg) => write!(f, "parse error: {}", msg),
+            LlmClientError::Timeout => write!(f, "model request timed out"),
+            LlmClientError::FeatureDisabled(feat) => {
+                write!(f, "feature '{}' not enabled", feat)
+            }
+        }
+    }
+}
+
+impl std::error::Error for LlmClientError {}
+
+// ============================================================================
+// Shared HTTP Client
+// ============================================================================
+
+/// Call an OpenAI-compatible chat completions endpoint and extract the response content.
+///
+/// Handles:
+/// - ureq agent construction with timeout
+/// - Bearer token auth header
+/// - Sending the request body
+/// - Parsing `choices[0].message.content` from the response
+///
+/// Returns the extracted content string on success.
+#[cfg(any(feature = "expand", feature = "rerank"))]
+pub fn call_chat_completions(
+    url: &str,
+    api_key: Option<&str>,
+    timeout: std::time::Duration,
+    body: &serde_json::Value,
+) -> Result<String, LlmClientError> {
+    let body_bytes = serde_json::to_vec(body)
+        .map_err(|e| LlmClientError::Parse(format!("failed to serialize request: {}", e)))?;
+
+    let config = ureq::Agent::config_builder()
+        .timeout_global(Some(timeout))
+        .build();
+    let agent = ureq::Agent::new_with_config(config);
+
+    let mut request = agent.post(url).header("Content-Type", "application/json");
+
+    if let Some(key) = api_key {
+        request = request.header("Authorization", &format!("Bearer {}", key));
+    }
+
+    let mut response = request.send(&body_bytes[..]).map_err(|e| {
+        let msg = e.to_string();
+        if msg.contains("timed out") || msg.contains("Timeout") {
+            LlmClientError::Timeout
+        } else {
+            LlmClientError::Network(msg)
+        }
+    })?;
+
+    let response_text = response
+        .body_mut()
+        .read_to_string()
+        .map_err(|e| LlmClientError::Network(format!("failed to read response: {}", e)))?;
+
+    let json: serde_json::Value = serde_json::from_str(&response_text)
+        .map_err(|e| LlmClientError::Parse(format!("invalid JSON response: {}", e)))?;
+
+    let content = json
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("message"))
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_str())
+        .ok_or_else(|| {
+            LlmClientError::Parse(format!(
+                "unexpected response format: {}",
+                &response_text[..response_text.len().min(200)]
+            ))
+        })?;
+
+    Ok(content.to_string())
+}
+
+// ============================================================================
+// Retry Helper
+// ============================================================================
+
+/// Execute an LLM call with a single retry on failure or empty results.
+///
+/// 1. Calls `call_fn()` to get raw text
+/// 2. Calls `parse_fn()` to parse it
+/// 3. If parsing succeeds but `is_empty_fn()` returns true, retries once
+/// 4. If the call itself fails, retries once
+///
+/// `operation` is a label for tracing messages (e.g. "expand" or "rerank").
+pub fn retry_once<T>(
+    call_fn: impl Fn() -> Result<String, LlmClientError>,
+    parse_fn: impl Fn(&str) -> T,
+    is_empty_fn: impl Fn(&T) -> bool,
+    on_empty_err: impl Fn() -> LlmClientError,
+    operation: &str,
+) -> Result<T, LlmClientError> {
+    // First attempt
+    match call_fn() {
+        Ok(text) => {
+            let result = parse_fn(&text);
+            if !is_empty_fn(&result) {
+                return Ok(result);
+            }
+            tracing::warn!(
+                target: "strata::llm_client",
+                op = operation,
+                "First call returned no valid results, retrying"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "strata::llm_client",
+                op = operation,
+                error = %e,
+                "First call failed, retrying"
+            );
+        }
+    }
+
+    // Retry once
+    match call_fn() {
+        Ok(text) => {
+            let result = parse_fn(&text);
+            if is_empty_fn(&result) {
+                tracing::warn!(
+                    target: "strata::llm_client",
+                    op = operation,
+                    "Retry also returned no valid results, falling back"
+                );
+                Err(on_empty_err())
+            } else {
+                Ok(result)
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "strata::llm_client",
+                op = operation,
+                error = %e,
+                "Retry also failed, falling back"
+            );
+            Err(e)
+        }
+    }
+}

--- a/crates/intelligence/src/rerank/error.rs
+++ b/crates/intelligence/src/rerank/error.rs
@@ -1,26 +1,4 @@
-//! Error types for re-ranking
-
-use std::fmt;
+//! Error types for re-ranking — type alias for shared LlmClientError
 
 /// Errors that can occur during re-ranking
-#[derive(Debug)]
-pub enum RerankError {
-    /// HTTP request failed (network unreachable, connection refused, etc.)
-    Network(String),
-    /// Failed to parse model response into valid scores
-    Parse(String),
-    /// Model request timed out
-    Timeout,
-}
-
-impl fmt::Display for RerankError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RerankError::Network(msg) => write!(f, "network error: {}", msg),
-            RerankError::Parse(msg) => write!(f, "parse error: {}", msg),
-            RerankError::Timeout => write!(f, "rerank request timed out"),
-        }
-    }
-}
-
-impl std::error::Error for RerankError {}
+pub type RerankError = crate::llm_client::LlmClientError;

--- a/crates/intelligence/src/scorer.rs
+++ b/crates/intelligence/src/scorer.rs
@@ -1,7 +1,0 @@
-//! Scoring infrastructure — re-exported from strata_engine::search
-//!
-//! The scorer types have been moved to the engine crate so that
-//! `build_search_response()` can use BM25 scoring directly.
-//! This module re-exports for backward compatibility.
-
-pub use strata_engine::search::{BM25LiteScorer, Scorer, ScorerContext, SearchDoc};

--- a/crates/intelligence/src/tokenizer.rs
+++ b/crates/intelligence/src/tokenizer.rs
@@ -1,6 +1,0 @@
-//! Tokenizer — re-exported from strata_engine::search
-//!
-//! The tokenizer has been moved to the engine crate so that primitives
-//! can use it on write paths. This module re-exports for backward compatibility.
-
-pub use strata_engine::search::{tokenize, tokenize_unique};

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -70,8 +70,8 @@ impl TestDb {
         ensure_recovery_registered();
         let dir = tempfile::tempdir().expect("Failed to create temp dir");
         let config = always_config();
-        let db = Database::open_with_config(dir.path(), config)
-            .expect("Failed to create test database");
+        let db =
+            Database::open_with_config(dir.path(), config).expect("Failed to create test database");
         let branch_id = BranchId::new();
         TestDb { db, dir, branch_id }
     }

--- a/tests/intelligence/architectural_invariants.rs
+++ b/tests/intelligence/architectural_invariants.rs
@@ -173,7 +173,7 @@ fn test_tier1_rule4_snapshot_consistent() {
 /// Index is disabled by default
 #[test]
 fn test_tier1_rule5_index_disabled_by_default() {
-    use strata_intelligence::InvertedIndex;
+    use strata_engine::search::InvertedIndex;
 
     let index = InvertedIndex::new();
     assert!(!index.is_enabled(), "Index should be disabled by default");
@@ -183,7 +183,7 @@ fn test_tier1_rule5_index_disabled_by_default() {
 #[test]
 fn test_tier1_rule5_no_overhead_when_disabled() {
     use strata_core::search_types::DocRef;
-    use strata_intelligence::InvertedIndex;
+    use strata_engine::search::InvertedIndex;
 
     let index = InvertedIndex::new();
     let branch_id = BranchId::new();

--- a/tests/intelligence/indexing.rs
+++ b/tests/intelligence/indexing.rs
@@ -4,7 +4,7 @@
 
 use strata_core::search_types::DocRef;
 use strata_core::types::BranchId;
-use strata_intelligence::InvertedIndex;
+use strata_engine::search::InvertedIndex;
 
 // ============================================================================
 // Index Enable/Disable Tests


### PR DESCRIPTION
## Summary

Comprehensive cleanup of the `strata-intelligence` crate addressing 19 open issues (#1128, #1131, #1134-#1139, #1141-#1147, #1149, #1151).

**Deduplication (-160 lines net)**
- Unified `ExpandError`/`RerankError` into shared `LlmClientError` (new `llm_client.rs`)
- Extracted `call_chat_completions()` and `retry_once()` shared helpers
- Deduplicated fuser sort logic into `sort_rrf_scored()` + `build_ranked_result()`
- Removed dead re-export shim modules (`scorer.rs`, `tokenizer.rs`, `index.rs`)

**Architecture fixes**
- Centralized shadow collection constants (`SHADOW_KV`, etc.) in `engine::database::config` — single source of truth for both intelligence and executor
- Moved `AutoEmbedState` from engine to executor (its sole consumer)
- Changed default fuser from `SimpleFuser` to `RRFFuser`; `with_fuser()` is now respected
- Added `FeatureDisabled` error variant for clean feature-gate stubs

**Quality improvements**
- Made LLM `temperature`/`max_tokens` configurable via builder methods on `ApiExpander`/`ApiReranker`
- Fixed compiler warnings (unused imports, dead code annotations)
- Replaced hollow tests with honest orchestration tests + a real fuser verification test
- Gated `MockExpander` behind `#[cfg(test)]`
- Uncommented Send+Sync assertions

## Issues closed

#1128, #1131, #1134, #1135, #1136, #1137, #1138, #1139, #1141, #1142, #1143, #1144, #1145, #1146, #1147, #1149, #1151

Also closed as duplicates/resolved: #1129, #1130, #1133, #1148, #1150, #1152

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo check --workspace --features embed,expand,rerank` — clean
- [x] `cargo test -p strata-intelligence` — 69 tests pass
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo fmt --all` — formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)