### PR TITLE
Update reference docs for unified config and SDK changes

### DIFF
--- a/docs/reference/api-quick-reference.md
+++ b/docs/reference/api-quick-reference.md
@@ -7,13 +7,25 @@ Every method on the `Strata` struct, grouped by category.
 | Method | Signature | Returns |
 |--------|-----------|---------|
 | `open` | `(path: impl AsRef<Path>) -> Result<Self>` | New Strata instance |
+| `open_with` | `(path: impl AsRef<Path>, opts: OpenOptions) -> Result<Self>` | New Strata instance with options |
 | `cache` | `() -> Result<Self>` | Ephemeral in-memory instance |
 | `new_handle` | `() -> Result<Self>` | Independent handle to same database |
 | `ping` | `() -> Result<String>` | Version string |
 | `info` | `() -> Result<DatabaseInfo>` | Database statistics |
 | `flush` | `() -> Result<()>` | Flushes pending writes |
 | `compact` | `() -> Result<()>` | Triggers compaction |
-| `time_range` | `(branch: Option<&str>) -> Result<Option<(u64, u64)>>` | Oldest/latest timestamps | Time-travel window |
+| `time_range` | `(branch: Option<&str>) -> Result<Option<(u64, u64)>>` | Oldest/latest timestamps |
+
+## Configuration
+
+| Method | Signature | Returns | Notes |
+|--------|-----------|---------|-------|
+| `config` | `() -> StrataConfig` | Current config snapshot | Read-only clone |
+| `configure_model` | `(endpoint: &str, model: &str, api_key: Option<&str>, timeout_ms: Option<u64>) -> Result<()>` | | Persisted to `strata.toml` |
+| `auto_embed_enabled` | `() -> bool` | Whether auto-embed is on | |
+| `set_auto_embed` | `(enabled: bool) -> Result<()>` | | Persisted to `strata.toml` |
+| `access_mode` | `() -> AccessMode` | ReadWrite or ReadOnly | |
+| `durability_counters` | `() -> Option<WalCounters>` | WAL stats | `None` for cache databases |
 
 ## Branch Context
 

--- a/docs/reference/command-reference.md
+++ b/docs/reference/command-reference.md
@@ -19,7 +19,7 @@ This reference is primarily for SDK builders and contributors. Most users should
 | Retention | 3 | Retention policy |
 | Database | 5 | Database-level operations |
 | Bundle | 3 | Branch export/import |
-| Intelligence | 1 | Cross-primitive search |
+| Intelligence | 2 | Cross-primitive search and model config |
 
 ## KV Commands
 
@@ -135,6 +135,7 @@ This reference is primarily for SDK builders and contributors. Most users should
 | Command | Fields | Output |
 |---------|--------|--------|
 | `Search` | `branch?`, `space?`, `search: SearchQuery` | `SearchResults(Vec<SearchResultHit>)` |
+| `ConfigureModel` | `endpoint`, `model`, `api_key?`, `timeout_ms?` | `Unit` |
 
 ### SearchQuery Object
 
@@ -156,6 +157,17 @@ The `search` field is a structured `SearchQuery` object:
 |-------|------|-------------|
 | `start` | string | Range start (inclusive), ISO 8601 datetime |
 | `end` | string | Range end (inclusive), ISO 8601 datetime |
+
+### ConfigureModel Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `endpoint` | string | *required* | OpenAI-compatible API endpoint URL |
+| `model` | string | *required* | Model name (e.g. `"qwen3:1.7b"`) |
+| `api_key` | string? | none | Optional bearer token |
+| `timeout_ms` | integer? | 5000 | Request timeout in milliseconds |
+
+The model configuration is persisted to `strata.toml` and survives database restarts.
 
 ## Branch Field Convention
 
@@ -182,5 +194,7 @@ All commands implement `Serialize` and `Deserialize` with `deny_unknown_fields`.
 {"Search": {"search": {"query": "error handling", "k": 10}}}
 {"Search": {"search": {"query": "errors", "time_range": {"start": "2026-02-07T00:00:00Z", "end": "2026-02-09T00:00:00Z"}}}}
 {"TimeRange": {"branch": "default"}}
+{"ConfigureModel": {"endpoint": "http://localhost:11434/v1", "model": "qwen3:1.7b"}}
+{"ConfigureModel": {"endpoint": "http://localhost:11434/v1", "model": "qwen3:1.7b", "api_key": "sk-...", "timeout_ms": 10000}}
 {"TxnCommit": null}
 ```

--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -43,6 +43,12 @@ pub enum Error {
     TransactionAlreadyActive,
     TransactionConflict { reason: String },
 
+    // Access
+    AccessDenied { command: String },
+
+    // History
+    HistoryUnavailable { requested_ts: u64, oldest_available_ts: u64 },
+
     // System
     Io { reason: String },
     Serialization { reason: String },
@@ -218,6 +224,26 @@ pub enum Error {
 **Fields:** `reason: String`
 
 **When:** Commit-time validation detects conflicts with concurrent transactions.
+
+## Access Errors
+
+### `AccessDenied`
+
+**Fields:** `command: String`
+
+**When:** A write command is rejected because the database was opened in read-only mode (via `OpenOptions { access_mode: ReadOnly, .. }`).
+
+**Handle:** Re-open the database without `read_only` if writes are needed.
+
+## History Errors
+
+### `HistoryUnavailable`
+
+**Fields:** `requested_ts: u64`, `oldest_available_ts: u64`
+
+**When:** A time-travel read requests a timestamp older than the oldest data available. This differs from `HistoryTrimmed` (which is for version-based retention); `HistoryUnavailable` is for timestamp-based queries where no data exists yet at the requested point.
+
+**Handle:** Use `db.time_range()` to discover the valid time window before issuing time-travel reads.
 
 ## System Errors
 

--- a/docs/reference/node-sdk.md
+++ b/docs/reference/node-sdk.md
@@ -65,6 +65,11 @@ const db = Strata.open('/path/to/data', { readOnly: true });
 |------|------|-------------|
 | `autoEmbed` | boolean? | Enable automatic text embedding |
 | `readOnly` | boolean? | Open in read-only mode |
+| `durability` | string? | `"standard"` or `"always"` |
+| `modelEndpoint` | string? | Override model endpoint URL |
+| `modelName` | string? | Override model name |
+| `modelApiKey` | string? | Override model API key |
+| `modelTimeoutMs` | number? | Override model request timeout |
 
 **Returns:** `Strata` instance
 
@@ -910,6 +915,70 @@ const active = await db.txnIsActive(); // boolean
 
 ---
 
+## Configuration
+
+### config()
+
+Get the current database configuration as a snapshot.
+
+```typescript
+const cfg = db.config();
+console.log(cfg.durability);   // "standard"
+console.log(cfg.autoEmbed);    // false
+if (cfg.model) {
+  console.log(cfg.model.endpoint);
+}
+```
+
+**Returns:** `StrataConfig` — `{ durability: string, autoEmbed: boolean, model?: ModelConfig }`
+
+### configureModel(endpoint, model, options?)
+
+Configure an inference model endpoint for query expansion and reranking. Persisted to `strata.toml`.
+
+```typescript
+db.configureModel('http://localhost:11434/v1', 'qwen3:1.7b');
+db.configureModel('https://api.example.com/v1', 'gpt-4', {
+  apiKey: 'sk-...',
+  timeoutMs: 10000,
+});
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `endpoint` | string | OpenAI-compatible API endpoint URL |
+| `model` | string | Model name |
+| `options.apiKey` | string? | Bearer token |
+| `options.timeoutMs` | number? | Request timeout in milliseconds (default: 5000) |
+
+### autoEmbedEnabled()
+
+Check whether automatic text embedding is enabled.
+
+```typescript
+if (db.autoEmbedEnabled()) {
+  console.log('Auto-embedding is on');
+}
+```
+
+**Returns:** `boolean`
+
+### setAutoEmbed(enabled)
+
+Enable or disable automatic text embedding. Persisted to `strata.toml`.
+
+```typescript
+db.setAutoEmbed(true);
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `enabled` | boolean | Whether to enable auto-embed |
+
+---
+
 ## Database Operations
 
 ### ping()
@@ -1124,6 +1193,19 @@ interface SearchHit {
 interface TimeRangeInput {
   start: string;  // ISO 8601 datetime
   end: string;    // ISO 8601 datetime
+}
+
+interface StrataConfig {
+  durability: string;
+  autoEmbed: boolean;
+  model?: ModelConfig;
+}
+
+interface ModelConfig {
+  endpoint: string;
+  model: string;
+  apiKey?: string;
+  timeoutMs: number;
 }
 
 interface SearchOptions {

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -954,9 +954,38 @@ results = db.search("database issues", rerank=True)
 
 When `expand` or `rerank` are not specified, they are automatically enabled if a model is configured via `configure_model`. Set to `False` to force off, or `True` to force on (silently skipped if no model).
 
+---
+
+## Configuration
+
+### db.config()
+
+Get the current database configuration as a snapshot.
+
+```python
+cfg = db.config()
+print(cfg["durability"])    # "standard"
+print(cfg["auto_embed"])    # False
+if cfg["model"]:
+    print(cfg["model"]["endpoint"])
+```
+
+**Returns:** `dict` with `"durability"` (str), `"auto_embed"` (bool), `"model"` (dict or `None`). Model dict has `"endpoint"`, `"model"`, `"api_key"`, `"timeout_ms"`.
+
+### db.auto_embed_enabled
+
+Whether automatic text embedding is currently enabled (read-only property).
+
+```python
+if db.auto_embed_enabled:
+    print("Auto-embedding is on")
+```
+
+**Returns:** `bool`
+
 ### db.configure_model(endpoint, model, api_key=None, timeout_ms=None)
 
-Configure an inference model endpoint for intelligent search.
+Configure an inference model endpoint for query expansion and reranking. Persisted to `strata.toml`.
 
 ```python
 db.configure_model(
@@ -974,6 +1003,21 @@ db.configure_model(
 | `model` | str | Model name |
 | `api_key` | str, optional | Bearer token |
 | `timeout_ms` | int, optional | Request timeout in milliseconds (default: 5000) |
+
+### db.set_auto_embed(enabled)
+
+Enable or disable automatic text embedding. Persisted to `strata.toml`.
+
+```python
+db.set_auto_embed(True)
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `enabled` | bool | Whether to enable auto-embed |
+
+**Raises:** `IoError` if config cannot be written
 
 ---
 


### PR DESCRIPTION
## Summary
- **api-quick-reference.md**: Added Configuration section with `config()`, `configure_model`, `auto_embed_enabled`, `set_auto_embed`, `access_mode`, `durability_counters`
- **configuration-reference.md**: Added `auto_embed` and `[model]` to strata.toml example, `OpenOptions` table, programmatic config section, `embed`/`expand`/`rerank` feature flags
- **command-reference.md**: Added `ConfigureModel` command with fields table and JSON serialization examples
- **error-reference.md**: Added `AccessDenied` and `HistoryUnavailable` error variants with descriptions
- **python-sdk.md**: Added Configuration section (`config()`, `auto_embed_enabled`, `set_auto_embed`, `configure_model`), fixed dict-access syntax for `config()` return value
- **node-sdk.md**: Added Configuration section (`config()`, `configureModel()`, `autoEmbedEnabled()`, `setAutoEmbed()`), `StrataConfig`/`ModelConfig` TypeScript interfaces, expanded `OpenOptions`

## Test plan
- [x] All docs are consistent with strata-core API (PR #1154)
- [x] Python SDK docs verified against strata-python implementation
- [x] Node.js SDK docs verified against strata-node implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)