### PR TITLE
Re-export Database/DurabilityMode, make executor() pub(crate)

### DIFF
--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -312,8 +312,8 @@ impl Strata {
         }
     }
 
-    /// Get the underlying executor.
-    pub fn executor(&self) -> &Executor {
+    /// Get the underlying executor (crate-internal only).
+    pub(crate) fn executor(&self) -> &Executor {
         &self.executor
     }
 

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -94,5 +94,9 @@ pub use strata_engine::WalCounters;
 // Re-export configuration types so users don't need strata-engine directly
 pub use strata_engine::{ModelConfig, StrataConfig};
 
+// Re-export Database and DurabilityMode so users can open/create databases
+// and create sessions without depending on strata-engine directly
+pub use strata_engine::{Database, DurabilityMode};
+
 /// Result type for executor operations
 pub type Result<T> = std::result::Result<T, Error>;

--- a/tests/executor/strata_api.rs
+++ b/tests/executor/strata_api.rs
@@ -350,9 +350,6 @@ fn session_from_strata() {
     let db = create_db();
     let strata = strata_executor::Strata::from_database(db.clone()).unwrap();
 
-    // Strata provides executor access
-    let _executor = strata.executor();
-
     // Session can be created from the strata instance
     let _session = strata.session();
 }


### PR DESCRIPTION
## Summary
- Re-export `Database` and `DurabilityMode` from `strata-executor` so downstream crates (benchmarks, SDKs) don't need `strata-engine` directly
- Make `Strata::executor()` `pub(crate)` to prevent bypassing the typed API — only 1 smoke test was affected

## Test plan
- [x] `cargo test --workspace` — all 2,862 tests pass
- [x] No external code should depend on `Strata::executor()` (only internal tests used it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)