### PR TITLE
Make Database::executor() public for SDK access

### DIFF
--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -312,8 +312,8 @@ impl Strata {
         }
     }
 
-    /// Get the underlying executor (crate-internal only).
-    pub(crate) fn executor(&self) -> &Executor {
+    /// Get the underlying executor.
+    pub fn executor(&self) -> &Executor {
         &self.executor
     }
 


### PR DESCRIPTION
## Summary
- Changes `Database::executor()` from `pub(crate)` to `pub` so the Python SDK (strata-python) can call it from outside the crate
- Required for strata-python to build against latest strata-core main

## Test plan
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)