### PR TITLE
Fix c_char type mismatch on aarch64 Linux

### DIFF
--- a/crates/intelligence/src/runtime/cuda/ffi.rs
+++ b/crates/intelligence/src/runtime/cuda/ffi.rs
@@ -6,7 +6,7 @@
 //! and cached for the lifetime of the process.
 
 use std::ffi::CStr;
-use std::os::raw::c_void;
+use std::os::raw::{c_char, c_void};
 
 use super::super::dl::DynLib;
 
@@ -50,7 +50,7 @@ type FnCuMemcpyDtoH =
 type FnCuModuleLoadData =
     unsafe extern "C" fn(module: *mut CUmodule, image: *const c_void) -> CUresult;
 type FnCuModuleGetFunction =
-    unsafe extern "C" fn(func: *mut CUfunction, module: CUmodule, name: *const i8) -> CUresult;
+    unsafe extern "C" fn(func: *mut CUfunction, module: CUmodule, name: *const c_char) -> CUresult;
 type FnCuLaunchKernel = unsafe extern "C" fn(
     f: CUfunction,
     grid_x: u32,

--- a/crates/intelligence/src/runtime/dl.rs
+++ b/crates/intelligence/src/runtime/dl.rs
@@ -4,7 +4,7 @@
 //! runtime. Used by the CUDA backend to load `libcuda.so.1` / `nvcuda.dll`.
 
 use std::ffi::CStr;
-use std::os::raw::c_void;
+use std::os::raw::{c_char, c_void};
 
 /// Handle to a dynamically loaded shared library.
 pub struct DynLib {
@@ -122,17 +122,17 @@ const RTLD_LOCAL: i32 = 0;
 
 #[cfg(unix)]
 extern "C" {
-    fn dlopen(filename: *const i8, flags: i32) -> *mut c_void;
-    fn dlsym(handle: *mut c_void, symbol: *const i8) -> *mut c_void;
+    fn dlopen(filename: *const c_char, flags: i32) -> *mut c_void;
+    fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
     fn dlclose(handle: *mut c_void) -> i32;
-    fn dlerror() -> *const i8;
+    fn dlerror() -> *const c_char;
 }
 
 // --- Windows bindings ---
 
 #[cfg(windows)]
 extern "system" {
-    fn LoadLibraryA(name: *const i8) -> *mut c_void;
-    fn GetProcAddress(module: *mut c_void, name: *const i8) -> *mut c_void;
+    fn LoadLibraryA(name: *const c_char) -> *mut c_void;
+    fn GetProcAddress(module: *mut c_void, name: *const c_char) -> *mut c_void;
     fn FreeLibrary(module: *mut c_void) -> i32;
 }


### PR DESCRIPTION
## Summary
- Use `c_char` instead of hardcoded `i8` in `dl.rs` and `cuda/ffi.rs` FFI signatures
- On `aarch64-unknown-linux-gnu`, `c_char` is `u8` (not `i8`), causing compile failures in the manylinux aarch64 wheel build

## Test plan
- [x] `cargo check --features embed-cuda` passes on x86_64
- [x] All 181 intelligence crate tests pass
- [ ] aarch64 Linux cross-compile / CI build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)