### PR TITLE
Raise default embed_batch_size from 64 to 512

### DIFF
--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -73,7 +73,8 @@ pub struct StrataConfig {
     /// Optional model configuration for query expansion and re-ranking.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<ModelConfig>,
-    /// Embedding batch size for auto-embed (default: 64).
+    /// Embedding batch size for auto-embed.
+    /// When opened via `OpenOptions`, defaults to 512.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embed_batch_size: Option<usize>,
 }
@@ -123,9 +124,9 @@ durability = "standard"
 # Requires the "embed" feature to be compiled in.
 auto_embed = false
 
-# Embedding batch size for auto-embed (default: 64).
+# Embedding batch size for auto-embed (default: 512 via OpenOptions).
 # Increase for bulk ingestion, decrease for interactive use.
-# embed_batch_size = 64
+# embed_batch_size = 512
 
 # Model configuration for query expansion and re-ranking.
 # Uncomment and configure to enable intelligent search features.

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -718,7 +718,7 @@ impl Database {
         });
     }
 
-    /// Get the embedding batch size (reads config, defaults to 64).
+    /// Get the embedding batch size (reads config).
     pub fn embed_batch_size(&self) -> usize {
         self.config.read().embed_batch_size.unwrap_or(64)
     }

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -175,9 +175,9 @@ impl Strata {
                 model.timeout_ms = ms;
             }
         }
-        if let Some(bs) = opts.embed_batch_size {
-            cfg.embed_batch_size = Some(bs);
-        }
+        cfg.embed_batch_size = Some(opts.embed_batch_size.unwrap_or(
+            cfg.embed_batch_size.unwrap_or(512),
+        ));
 
         let db = Database::open_with_config(&data_dir, cfg).map_err(|e| Error::Internal {
             reason: format!("Failed to open database: {}", e),

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -48,7 +48,7 @@ pub struct OpenOptions {
     /// Override model request timeout in milliseconds.
     pub model_timeout_ms: Option<u64>,
     /// Override embedding batch size for auto-embed.
-    /// `None` means "use the config file default" (64).
+    /// `None` means "use the config file value, or 512 if unset".
     pub embed_batch_size: Option<usize>,
 }
 


### PR DESCRIPTION
## Summary

- Default `embed_batch_size` raised from 64 to 512 via `OpenOptions` to improve bulk ingestion throughput
- `OpenOptions` now applies the 512 default when neither the caller nor config file specifies a value
- Updated doc comments across config, API, and security crates to reflect the new default
- Fixed `embed_hook` test to use dynamic `batch_size` from config instead of hardcoded 64

## Test plan

- [x] `cargo test -p strata-engine` passes
- [x] `cargo test -p strata-executor` — embed_hook test updated to match new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)