### PR TITLE
Add embed_status() API to track async embedding progress

### DIFF
--- a/crates/executor/src/api/db.rs
+++ b/crates/executor/src/api/db.rs
@@ -1,6 +1,7 @@
 //! Database operations: ping, info, flush, compact, configuration.
 
 use super::Strata;
+use crate::output::EmbedStatusInfo;
 use crate::types::*;
 use crate::{Command, Error, Output, Result};
 use strata_engine::{ModelConfig, StrataConfig};
@@ -130,6 +131,16 @@ impl Strata {
                 });
             })
             .map_err(Error::from)
+    }
+
+    /// Get a snapshot of the embedding pipeline status.
+    pub fn embed_status(&self) -> Result<EmbedStatusInfo> {
+        match self.executor.execute(Command::EmbedStatus)? {
+            Output::EmbedStatus(info) => Ok(info),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for EmbedStatus".into(),
+            }),
+        }
     }
 
     /// Check whether auto-embedding is enabled.

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -747,6 +747,10 @@ pub enum Command {
         space: String,
     },
 
+    /// Get embedding pipeline status.
+    /// Returns: `Output::EmbedStatus`
+    EmbedStatus,
+
     /// Delete a space (must be empty unless force=true).
     /// Returns: `Output::Unit`
     SpaceDelete {
@@ -868,6 +872,7 @@ impl Command {
             Command::BranchBundleValidate { .. } => "BranchBundleValidate",
             Command::ConfigureModel { .. } => "ConfigureModel",
             Command::Search { .. } => "Search",
+            Command::EmbedStatus => "EmbedStatus",
             Command::SpaceList { .. } => "SpaceList",
             Command::SpaceCreate { .. } => "SpaceCreate",
             Command::SpaceDelete { .. } => "SpaceDelete",
@@ -969,6 +974,7 @@ impl Command {
             | Command::Info
             | Command::Flush
             | Command::Compact
+            | Command::EmbedStatus
             | Command::BranchExport { .. }
             | Command::BranchImport { .. }
             | Command::BranchBundleValidate { .. }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -195,6 +195,10 @@ impl Executor {
                 convert_result(self.primitives.db.compact())?;
                 Ok(Output::Unit)
             }
+            Command::EmbedStatus => {
+                let info = crate::handlers::embed_hook::embed_status(&self.primitives);
+                Ok(Output::EmbedStatus(info))
+            }
             Command::TimeRange { branch } => {
                 let branch = branch.ok_or(Error::InvalidInput {
                     reason: "Branch must be specified or resolved to default".into(),

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -78,7 +78,7 @@ pub use api::{
 pub use command::Command;
 pub use error::Error;
 pub use executor::Executor;
-pub use output::Output;
+pub use output::{EmbedStatusInfo, Output};
 pub use session::Session;
 pub use types::*;
 

--- a/crates/executor/src/output.rs
+++ b/crates/executor/src/output.rs
@@ -151,4 +151,34 @@ pub enum Output {
         /// Latest timestamp, or None if branch has no data.
         latest_ts: Option<u64>,
     },
+
+    /// Embedding pipeline status
+    EmbedStatus(EmbedStatusInfo),
+}
+
+/// Snapshot of the embedding pipeline status.
+///
+/// Returned by [`Command::EmbedStatus`](crate::Command::EmbedStatus).
+/// Users can derive:
+/// - **Progress:** `total_embedded / total_queued`
+/// - **In-flight:** `total_queued - total_embedded - total_failed`
+/// - **Is idle:** `pending == 0 && scheduler_active_tasks == 0 && scheduler_queue_depth == 0`
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EmbedStatusInfo {
+    /// Whether auto-embedding is currently enabled.
+    pub auto_embed: bool,
+    /// Configured batch size for embedding.
+    pub batch_size: usize,
+    /// Number of items currently waiting in the buffer.
+    pub pending: usize,
+    /// Cumulative count of items pushed into the buffer.
+    pub total_queued: u64,
+    /// Cumulative count of items successfully embedded.
+    pub total_embedded: u64,
+    /// Cumulative count of items that failed embedding.
+    pub total_failed: u64,
+    /// Number of tasks waiting in the scheduler queue.
+    pub scheduler_queue_depth: usize,
+    /// Number of tasks currently being executed by scheduler workers.
+    pub scheduler_active_tasks: usize,
 }

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -141,6 +141,7 @@ impl Session {
             | Command::Info
             | Command::Flush
             | Command::Compact
+            | Command::EmbedStatus
             | Command::RetentionApply { .. }
             | Command::RetentionStats { .. }
             | Command::RetentionPreview { .. }


### PR DESCRIPTION
## Summary
- Adds atomic counters (`total_queued`, `total_embedded`, `total_failed`) to `EmbedBuffer` for tracking embedding pipeline throughput
- Adds `Command::EmbedStatus` → `Output::EmbedStatus(EmbedStatusInfo)` for querying pipeline state
- Exposes via `Strata::embed_status()` high-level API for SDK consumption
- Users can derive progress (`total_embedded / total_queued`), in-flight count, and idle state

## Files Changed
| File | Changes |
|------|---------|
| `crates/executor/src/handlers/embed_hook.rs` | `AtomicU64` counters on `EmbedBuffer`, increment in push/flush, `embed_status()` fn, 2 new tests |
| `crates/executor/src/command.rs` | `Command::EmbedStatus` variant |
| `crates/executor/src/output.rs` | `EmbedStatusInfo` struct, `Output::EmbedStatus` variant |
| `crates/executor/src/executor.rs` | Handle `Command::EmbedStatus` |
| `crates/executor/src/session.rs` | Delegate `EmbedStatus` to executor |
| `crates/executor/src/api/db.rs` | `Strata::embed_status()` high-level method |
| `crates/executor/src/lib.rs` | Re-export `EmbedStatusInfo` |

## Test plan
- [x] `cargo test -p strata-executor --features embed` — all 210 tests pass (including 2 new)
- [x] `cargo build -p strata-executor` — clean build without embed feature
- [x] New test: push N items, flush, verify `total_queued == N` and `total_embedded + total_failed == N`
- [x] New test: verify `embed_status()` returns correct values through executor command path

🤖 Generated with [Claude Code](https://claude.com/claude-code)