### PR TITLE
Fix release workflow: use macos-latest for x86_64 Darwin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
             runner: ubuntu-latest
             archive: tar.gz
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
             archive: tar.gz
           - target: aarch64-apple-darwin
             runner: macos-latest


### PR DESCRIPTION
## Summary
- `macos-13` runner is not available for the org — the x86_64-apple-darwin build failed in the v0.5.1-rc1 test run
- Switch to `macos-latest` (ARM64) which can cross-compile x86_64 via Rust's target system

## Test plan
- [ ] Merge, re-tag, verify all 5 builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)