### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stratadb"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 description = "Production-grade embedded database for AI agents"
 
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Strata contributors"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-cli"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 description = "Redis-inspired CLI for the Strata database"
 publish = false

--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -932,8 +932,8 @@ mod tests {
     #[test]
     fn test_format_pong() {
         let pong = Output::Pong {
-            version: "0.5.2".to_string(),
+            version: "0.6.0".to_string(),
         };
-        assert_eq!(format_output(&pong, OutputMode::Human), "PONG 0.5.2");
+        assert_eq!(format_output(&pong, OutputMode::Human), "PONG 0.6.0");
     }
 }

--- a/distribution/homebrew/strata.rb
+++ b/distribution/homebrew/strata.rb
@@ -1,7 +1,7 @@
 class Strata < Formula
   desc "Production-grade embedded database for AI agents"
   homepage "https://stratadb.org"
-  version "0.5.1"
+  version "0.6.0"
   license "Apache-2.0"
 
   on_macos do

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -71,7 +71,7 @@ Check database connectivity.
 
 **Returns:**
 ```json
-{"pong": true, "version": "0.5.1"}
+{"pong": true, "version": "0.6.0"}
 ```
 
 #### strata_db_info
@@ -83,7 +83,7 @@ Get database information.
 **Returns:**
 ```json
 {
-  "version": "0.5.1",
+  "version": "0.6.0",
   "uptime_secs": 3600,
   "branch_count": 3,
   "total_keys": 1500


### PR DESCRIPTION
## Summary
- Workspace version: `0.5.1` → `0.6.0`
- CLI crate version: `0.5.2` → `0.6.0`
- Homebrew formula template: `0.5.1` → `0.6.0`
- MCP docs version references: `0.5.1` → `0.6.0`
- Test fixtures updated

## Files changed
- `Cargo.toml` (root package + workspace.package)
- `crates/cli/Cargo.toml`
- `crates/cli/src/format.rs`
- `distribution/homebrew/strata.rb`
- `docs/reference/mcp.md`

## Test plan
- [x] `cargo check --workspace` passes
- [ ] CI passes
- [ ] After merge, tag `v0.6.0` and release

🤖 Generated with [Claude Code](https://claude.com/claude-code)