### PR TITLE
Route all operations through Command enum + public executor API

### DIFF
--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -317,9 +317,8 @@ impl Strata {
         }
     }
 
-    /// Get the underlying executor.
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) fn executor(&self) -> &Executor {
+    /// Get the underlying executor for direct command execution.
+    pub fn executor(&self) -> &Executor {
         &self.executor
     }
 


### PR DESCRIPTION
## Summary
- Routes all database operations through the unified `Command` enum with full `Output` variant coverage (#1200, #1205)
- Makes `Strata::executor()` public for use by SDK bindings (strata-python, strata-mcp)
- Adds maintenance design document

## Test plan
- [x] All existing tests pass
- [x] strata-python compiles against these changes
- [x] strata-mcp compiles against these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)