### PR TITLE
Add ontology layer design and Palantir architecture study

### DIFF
--- a/docs/architecture/ontology.md
+++ b/docs/architecture/ontology.md
@@ -1,0 +1,321 @@
+# Ontology Layer
+
+**Extends:** `strata-graph` PRD
+**Status:** Draft
+**Principle:** Strata stores, indexes, and retrieves. It never decides, acts, or interprets. The AI defines the ontology and creates instances. Strata makes that structure queryable.
+
+---
+
+## 1. What This Is
+
+The ontology is a **user-defined type system** for the graph. It gives nodes and edges meaning — not just "a string ID with properties" but "a Patient with a date_of_birth and an mrn, linked to Lab Results via HAS_LAB_RESULT."
+
+The graph PRD provides the mechanical layer: nodes, edges, traversal, branching. The ontology provides the semantic layer: what the nodes and edges *are*, what properties they carry, what relationships are valid, and what constraints apply.
+
+Without the ontology, the graph is a bag of strings. With it, the graph becomes a typed knowledge structure that Strata can index, validate, and retrieve intelligently.
+
+### What the Ontology Is Not
+
+- **Not an agent.** Strata doesn't decide what object types exist or what relationships to create. The AI or user defines the ontology; Strata stores and enforces it.
+- **Not a business logic layer.** No Actions, no Functions, no side effects, no orchestration. The AI calls graph operations directly. Strata validates them against the ontology.
+- **Not a query language.** No Cypher, no SPARQL, no GraphQL. The existing graph API (neighbors, BFS, subgraph) works against typed nodes and edges. The ontology makes those queries return structured, typed results instead of raw property bags.
+- **Not mandatory.** Untyped graphs (as described in the graph PRD) continue to work. The ontology is opt-in per graph.
+
+---
+
+## 2. Core Concepts
+
+### Object Types
+
+An object type is a named schema for a category of nodes. It defines what properties instances must or may have.
+
+```json
+{
+  "name": "Patient",
+  "properties": {
+    "mrn": { "type": "string", "required": true },
+    "date_of_birth": { "type": "string" },
+    "department": { "type": "string" }
+  }
+}
+```
+
+Object types are stored in the graph's meta namespace:
+
+```
+_graph_/{graph_name}/__types__/object/{type_name} → schema (JSON)
+```
+
+When a node declares an object type, Strata validates its properties against the schema on write. Missing required properties are rejected. Unknown properties are allowed (open schema by default) or rejected (closed schema, opt-in per type).
+
+### Link Types
+
+A link type is a named schema for a category of edges. It defines which object types it connects, its cardinality, and what properties the edge may carry.
+
+```json
+{
+  "name": "HAS_LAB_RESULT",
+  "source": "Patient",
+  "target": "LabResult",
+  "cardinality": "one_to_many",
+  "properties": {
+    "ordered_by": { "type": "string" },
+    "ordered_date": { "type": "string" }
+  }
+}
+```
+
+Stored at:
+
+```
+_graph_/{graph_name}/__types__/link/{type_name} → schema (JSON)
+```
+
+When an edge is created with a declared link type, Strata validates that the source and target nodes match the expected object types, and that edge properties conform to the schema. This prevents structural nonsense — a LabResult DIAGNOSED_WITH a Medication — without Strata needing to understand what any of it means.
+
+### Cardinality
+
+Link types declare cardinality constraints:
+
+| Cardinality | Meaning | Enforcement |
+|-------------|---------|-------------|
+| `one_to_one` | Source has at most one target of this link type | Reject duplicate edges from same source |
+| `one_to_many` | Source can have many targets | No constraint on target count |
+| `many_to_one` | Many sources can link to one target | No constraint on source count |
+| `many_to_many` | No constraints | Default if cardinality is omitted |
+
+Cardinality is enforced on write. The AI decides the cardinality when defining the link type. Strata enforces it.
+
+### Instances
+
+A typed node is an instance of an object type. In the graph API, this means:
+
+```python
+graph.add_node("patient-4821", object_type="Patient", properties={
+    "mrn": "4821",
+    "date_of_birth": "1974-03-15",
+    "department": "endocrinology"
+}, entity_ref="json://main/patient-4821")
+```
+
+The `object_type` field in node metadata links the node to its schema. If the graph has an ontology with a `Patient` type, the properties are validated against it. If there's no ontology or no matching type, the node is stored as an untyped node (backward compatible with the graph PRD).
+
+A typed edge is an instance of a link type:
+
+```python
+graph.add_edge("patient-4821", "lab:HbA1c", "HAS_LAB_RESULT",
+    properties={"ordered_by": "Dr. Chen", "ordered_date": "2026-01-15"})
+```
+
+If `HAS_LAB_RESULT` is a declared link type, Strata validates that the source is a Patient and the target is a LabResult, and that the edge properties match the schema.
+
+---
+
+## 3. The Ontology Is Data
+
+The ontology itself is stored in Strata, as KV entries within the graph's key namespace. This means:
+
+**Versioned.** Every change to the ontology is a versioned write. You can see how the type system evolved over time via `as_of` queries on the schema entries.
+
+**Branchable.** Fork the branch, modify the ontology on the fork (add a property, change a cardinality), test it, merge or discard. The ontology participates in branching exactly like data does. This is what makes schema evolution safe — you never modify the production ontology in place.
+
+**Time-travelable.** Query the ontology as it was at any past timestamp. Combined with time-travel on the data itself, you can see what the type system looked like when a particular piece of data was stored.
+
+**Diffable.** Branch diff on `_graph_/{g}/__types__/` shows exactly what changed in the ontology between two branches.
+
+No separate ontology management system. No migration tooling. The ontology is data, and Strata already knows how to version, branch, and diff data.
+
+---
+
+## 4. Schema Evolution
+
+Because the ontology is branchable, schema evolution follows the same workflow as data experimentation:
+
+1. **Fork** the current branch
+2. **Modify** the ontology on the fork — add a property, change a cardinality, add a new object type
+3. **Test** — create instances against the new schema, verify queries work
+4. **Merge** or **discard**
+
+### Adding Properties
+
+Adding a new optional property to an object type is non-breaking. Existing nodes don't have the property and that's fine — it's optional.
+
+Adding a new required property is breaking. Existing nodes will fail validation on the next write. The AI (not Strata) is responsible for deciding how to handle this — backfill the property, make it optional, or accept that existing nodes are grandfathered.
+
+### Removing Properties
+
+Removing a property from the schema doesn't delete it from existing nodes. The property data persists in KV; it just isn't part of the schema anymore. This is consistent with Strata's principle that nothing is ever lost.
+
+### Changing Types or Cardinality
+
+These are breaking changes. The recommended workflow is: fork, modify, validate, merge. Strata doesn't automatically migrate data — the AI does that if it needs to.
+
+---
+
+## 5. Ontology-Grounded Retrieval
+
+The ontology changes what search returns. Without it, `strata_search` returns `{ key, score, snippet }` — flat results. With it, search can return **typed objects with their relationships**.
+
+### How It Works
+
+When a search hit matches a node that has an `object_type`, the search result can be enriched:
+
+1. The node's object type tells Strata what this result *is* (a Patient, a LabResult, a Diagnosis)
+2. The link types tell Strata what's connected to it and how
+3. The result includes not just the matching data but its typed context — the object type, its properties, and its immediate relationships
+
+This is the difference between returning `{ key: "patient-4821", score: 0.92, snippet: "..." }` and returning:
+
+```json
+{
+  "key": "patient-4821",
+  "score": 0.92,
+  "object_type": "Patient",
+  "properties": { "mrn": "4821", "department": "endocrinology" },
+  "links": {
+    "HAS_LAB_RESULT": ["lab:HbA1c", "lab:eGFR"],
+    "DIAGNOSED_WITH": ["ICD:E11.9"]
+  }
+}
+```
+
+The AI receives structured, typed context instead of text snippets. This is what Palantir calls Ontology-Augmented Generation — passing typed objects to the LLM rather than raw chunks. Strata provides the structure; the AI reasons over it.
+
+### Depth Control
+
+How much context to include is controlled by the caller:
+
+- `depth: 0` — just the matching node with its type and properties (default)
+- `depth: 1` — include immediate neighbors with their types
+- `depth: 2` — include 2-hop neighborhood
+
+Strata doesn't decide what depth is appropriate. The AI does.
+
+---
+
+## 6. Storage Model
+
+The ontology extends the graph's existing KV key namespace:
+
+```
+_graph_/{graph_name}/__types__/object/{type_name}   → object type schema (JSON)
+_graph_/{graph_name}/__types__/link/{type_name}      → link type schema (JSON)
+```
+
+Node metadata gains an optional `object_type` field:
+
+```json
+{
+  "object_type": "Patient",
+  "entity_ref": "json://main/patient-4821",
+  "properties": {
+    "mrn": "4821",
+    "date_of_birth": "1974-03-15"
+  }
+}
+```
+
+Edge payloads are unchanged from the graph PRD. The edge type string (e.g., `HAS_LAB_RESULT`) is matched against declared link types for validation. If no matching link type is declared, the edge is untyped (backward compatible).
+
+### Indexes
+
+Object type membership is implicitly indexed by the existing node metadata. To efficiently query "all Patients," prefix scan on `_graph_/{g}/n/` and filter by `object_type`. If this becomes a bottleneck, a secondary index can be added:
+
+```
+_graph_/{graph_name}/__by_type__/{object_type}/{node_id} → ""
+```
+
+This follows the same pattern as the reverse EntityRef index in the graph PRD.
+
+---
+
+## 7. API Surface
+
+### Ontology Management
+
+```python
+# Define object types
+graph.define_object_type("Patient", properties={
+    "mrn": {"type": "string", "required": True},
+    "date_of_birth": {"type": "string"},
+    "department": {"type": "string"},
+})
+
+graph.define_object_type("LabResult", properties={
+    "test_name": {"type": "string", "required": True},
+    "value": {"type": "string", "required": True},
+    "unit": {"type": "string"},
+    "reference_range": {"type": "string"},
+})
+
+# Define link types
+graph.define_link_type("HAS_LAB_RESULT",
+    source="Patient", target="LabResult",
+    cardinality="one_to_many",
+    properties={"ordered_by": {"type": "string"}})
+
+# List types
+graph.object_types()   # → ["Patient", "LabResult", ...]
+graph.link_types()     # → ["HAS_LAB_RESULT", ...]
+
+# Get type schema
+graph.get_object_type("Patient")  # → schema JSON
+graph.get_link_type("HAS_LAB_RESULT")  # → schema JSON
+```
+
+### Typed Node and Edge Operations
+
+```python
+# Create a typed node (validated against Patient schema)
+graph.add_node("patient-4821", object_type="Patient", properties={
+    "mrn": "4821",
+    "date_of_birth": "1974-03-15",
+    "department": "endocrinology",
+}, entity_ref="json://main/patient-4821")
+
+# Create a typed edge (validated against HAS_LAB_RESULT schema)
+graph.add_edge("patient-4821", "lab:HbA1c", "HAS_LAB_RESULT",
+    properties={"ordered_by": "Dr. Chen"})
+
+# Query by object type
+graph.nodes_by_type("Patient")  # → all Patient nodes
+graph.nodes_by_type("LabResult", filter={"test_name": "HbA1c"})
+```
+
+### Untyped Operations (Backward Compatible)
+
+All existing graph PRD operations work unchanged. Nodes without `object_type` are untyped. Edges with undeclared edge types are untyped. The ontology is additive — it enhances graphs that use it without breaking graphs that don't.
+
+---
+
+## 8. What the AI Does vs. What Strata Does
+
+| Responsibility | Who |
+|---------------|-----|
+| Decide what object types exist | AI / user |
+| Define properties and constraints | AI / user |
+| Decide what link types exist and their cardinality | AI / user |
+| Create, update, delete instances | AI / user |
+| Decide when to evolve the schema | AI / user |
+| Decide what to store and how to structure it | AI / user |
+| Decide what depth of context to retrieve | AI / user |
+| Store type definitions as versioned data | Strata |
+| Validate instances against declared schemas on write | Strata |
+| Enforce cardinality constraints | Strata |
+| Index nodes by object type for efficient queries | Strata |
+| Enrich search results with typed context and relationships | Strata |
+| Branch, version, time-travel the ontology like any other data | Strata |
+
+Strata is the filing system. A very good filing system that understands the structure of what's filed, validates it, indexes it, and retrieves it with context. But it doesn't decide what to file or why.
+
+---
+
+## 9. Relationship to Cognitive Architecture Layers
+
+The ontology spans layers 2 and 3 of the cognitive architecture:
+
+**Layer 2 contribution:** The ontology gives the graph structure meaning. Typed nodes and edges with schemas and cardinality constraints turn the raw wiring into a semantic structure. This is the mechanical foundation — without it, the graph is just strings pointing at strings.
+
+**Layer 3 contribution:** Ontology-grounded retrieval changes what search returns. Instead of flat results, the AI receives typed objects with their relationships. This is what enables the AI to reason over structure rather than text. The ontology also provides the vocabulary for automatic association — when layer 3 infers relationships, it does so in terms of declared link types with known cardinality, not arbitrary string edges.
+
+**Layer 4 implication:** When the cognitive interface matures, the ontology is what makes "what do we know about patient 4821?" return a structured answer traversing typed relationships, rather than a list of keyword matches. The AI defines the ontology; the ontology structures what Strata returns; the AI reasons over the structure. The loop is: cortex defines → hippocampus stores and organizes → cortex retrieves and reasons.

--- a/docs/architecture/palantir-study.md
+++ b/docs/architecture/palantir-study.md
@@ -1,0 +1,161 @@
+# Palantir Ontology: Architecture Study
+
+**Purpose:** Understand Palantir's Ontology system and map its concepts to Strata's cognitive architecture. Not everything applies today — Strata is the hippocampus, not the cortex — but the full picture informs where the system can evolve.
+
+---
+
+## 1. What Palantir Built
+
+Palantir's Ontology is a **typed, operational semantic layer** over data. It has four dimensions:
+
+1. **Data Layer** — unifies disparate sources (ERPs, CRMs, sensors, document stores) into coherent objects, properties, and links. Every object type is backed by one or more datasets. The Ontology doesn't replace the data — it indexes and projects from it.
+
+2. **Logic Layer** — computation ranging from simple business rules to ML models to LLM-driven functions. Implemented as TypeScript/Python Functions that read objects, traverse links, and return results or edits.
+
+3. **Action Layer** — structured mutations. Every write flows through a parameterized, validated, permissioned Action Type — not raw SQL. Actions are auditable, governable, and attachable to side effects.
+
+4. **Security Layer** — row-level, column-level, and cell-level permissions embedded in the Ontology itself, enforced through to the AI layer.
+
+The system is both the type system AND the runtime. Type definitions drive indexing (the "Funnel" service reads backing datasets and indexes objects), querying (the Object Set Service handles all reads), code generation (the OSDK generates type-safe clients), security enforcement, and AI grounding.
+
+---
+
+## 2. Key Design Decisions
+
+### Abstraction Over Storage, Not Replacement
+
+The Ontology does not store the canonical data. It indexes data from backing datasets. Upstream data pipelines continue to work; the Ontology is an indexed, queryable, semantic view over them. A single object type can aggregate columns from up to 70 different datasets, joined by primary key.
+
+**Strata parallel:** The ontology layer (as drafted in `ontology.md`) is a semantic view over Strata's storage primitives. Object types don't replace KV, JSON, events, or vectors — they project from them via EntityRef bindings. A Patient node bound to `json://main/patient-4821` is a typed view over a JSON document.
+
+### Separated Edit Layer
+
+User modifications through Actions are stored in separate writeback datasets, preserving the original backing data. This is event sourcing — the original data and the edits are maintained independently and merged at query time. Conflict resolution is configurable: "user edits always win" or "most recent value wins."
+
+**Strata parallel:** Strata's versioning model already provides this. Every write creates a new version; nothing is overwritten. The edit history is the version history. Branch-level isolation provides even stronger separation — fork, edit, merge — without needing a separate writeback dataset.
+
+### Entirely User-Defined Types
+
+Object types, properties, link types, cardinality constraints — all defined by the user (or AI), not predefined by the system. No fixed categories like "People, Organizations, Projects." Whatever the domain needs.
+
+**Strata parallel:** Directly adopted in the ontology layer. Object types and link types are user-defined schemas stored as data within the graph. The AI defines the ontology; Strata stores and enforces it.
+
+### Schema as Runtime
+
+Type definitions aren't documentation. They drive:
+- **Indexing** — when a type definition changes, the system re-indexes affected objects
+- **Querying** — the Object Set Service filters, searches, and aggregates against typed objects
+- **Code generation** — the OSDK produces per-application type-safe clients
+- **Security** — permissions are defined in terms of object types and properties
+- **AI grounding** — structured objects (not text chunks) are passed to LLMs
+
+**Strata parallel today:** The ontology layer enables schema-driven validation on write and typed context in search results. Schema-driven indexing (secondary indexes by object type) is planned.
+
+**Strata parallel future:** Code generation (SDK producing typed clients from the ontology) and AI grounding (search returning typed objects with relationships instead of snippets) are natural extensions.
+
+### Git-Like Schema Governance
+
+Ontology changes go through a branching, proposal, review, and merge workflow. Breaking changes trigger automatic detection. Schema migrations handle user edit preservation across versions.
+
+**Strata parallel:** This is native. The ontology is stored as versioned KV entries within the graph. Fork the branch, modify the ontology, test, merge or discard. Breaking change detection would be: compare the old schema to the new schema and report which existing nodes would fail validation.
+
+### Interfaces (Polymorphism)
+
+Interfaces define shared property sets and link constraints that multiple object types can implement. An interface "Location" might be implemented by Airport, Plant, and Warehouse — enabling generic operations across all of them.
+
+**Strata today:** Not in scope for the initial ontology layer. Object types are standalone.
+
+**Strata future:** Interfaces are a natural extension. A "Searchable" interface requiring a `title` and `description` property could enable generic search enrichment across any conforming object type. Worth considering once the base ontology is stable.
+
+---
+
+## 3. What Strata Adopts
+
+These concepts map directly to Strata's architecture and are adopted in the ontology layer:
+
+| Palantir Concept | Strata Equivalent |
+|-----------------|-------------------|
+| Object types with typed properties | `define_object_type()` — user-defined schemas stored as graph metadata |
+| Link types with cardinality | `define_link_type()` — source/target type constraints, cardinality enforcement |
+| Backing datasources | EntityRef bindings — nodes project from KV, JSON, events, vectors |
+| Schema versioning | Ontology stored as KV entries — versioned, branchable, diffable automatically |
+| Schema branching and governance | Fork the branch, modify the ontology, test, merge/discard |
+| Ontology-grounded retrieval | Search returns typed objects with relationships instead of flat results |
+
+---
+
+## 4. What Strata Defers
+
+These concepts are part of Palantir's full stack but belong to the cortex (the AI), not the hippocampus (Strata). They're documented here because the architecture should not prevent them from being built later — by Strata, by the AI, or by an application layer on top.
+
+### Actions (Governed Mutations)
+
+Palantir routes all mutations through parameterized, validated Action Types with permissions, submission criteria, and side effects. Every write is auditable and governable.
+
+**Why Strata defers this:** Strata is passive infrastructure. The AI calls `graph.add_node()` and `graph.add_edge()` directly. Strata validates against the ontology (type checking, cardinality) but doesn't impose additional governance. The AI or an application layer above Strata could implement governed mutations — Strata's event log already provides the audit trail, and the ontology provides the type constraints that Actions would validate against.
+
+**What Strata should not prevent:** An application layer that intercepts graph writes, validates them against business rules, logs them as events, and only commits if all rules pass. The ontology's type constraints are the foundation this would build on.
+
+### Functions (Logic Layer)
+
+Palantir embeds TypeScript/Python Functions as first-class computation within the Ontology. Functions read objects, traverse links, and return structured results or edits.
+
+**Why Strata defers this:** Computation belongs to the cortex. Strata stores and retrieves; it doesn't compute. The AI can read objects from Strata, compute over them, and write results back.
+
+**What Strata should not prevent:** An extension that registers named computations (e.g., "compute patient risk score from lab results and diagnoses") that run over graph snapshots. The `GraphAlgorithm` trait in the graph PRD is the extensibility point — Functions would be a higher-level version of the same pattern.
+
+### AIP Agent Studio (Orchestration)
+
+Palantir's Agent Studio combines LLMs, the Ontology, documents, tools, and state variables into interactive assistants.
+
+**Why Strata defers this:** Agent orchestration is a cortex concern. Strata doesn't orchestrate agents — it provides the state layer that agents orchestrate over.
+
+**What Strata should not prevent:** An agent framework that uses Strata as its state backend, defining its workflow state as typed objects, its decision history as events, and its knowledge as an ontology-typed graph. Strata's 8 MCP tools are already designed for this — the ontology makes the state structure explicit and queryable.
+
+### Security Model
+
+Palantir embeds row-level, column-level, and cell-level security into the Ontology, enforced through to the AI layer.
+
+**Why Strata defers this:** Strata's security model (`crates/security/`) operates at the branch and space level. Object-level and property-level security is not currently in scope.
+
+**What Strata should not prevent:** The ontology's type system is the natural place to attach permission metadata. A future extension could add `read_access` and `write_access` fields to object type and property definitions, enforced at the graph operation level.
+
+---
+
+## 5. What Strata Does Differently
+
+### Embedded, Not Distributed
+
+Palantir's Ontology is a distributed system with dedicated microservices (OMS, OSS, Funnel, Actions Service). Strata is a single embedded process. The ontology is stored in the same KV primitive as everything else. This is a deliberate architectural choice — cognitive infrastructure should be as simple to deploy as SQLite, not as complex as Kubernetes.
+
+### Branching as a First-Class Primitive
+
+Palantir supports ontology branching and proposals, but it's a governance workflow — review, approve, merge. In Strata, branching is a data primitive. Fork, modify, test, merge/discard — in milliseconds, programmatically, by the AI. This makes schema evolution something an agent can do mid-task, not a deployment ceremony.
+
+### The Ontology Is the Data
+
+In Palantir, the Ontology Manager is a separate system from the backing datasets. Type definitions live in OMS; data lives in Foundry datasets; the Funnel indexes one into the other. In Strata, the ontology is stored as KV entries in the same namespace as the graph data. There's no separate metadata service — the type system is versioned, branched, and time-traveled alongside the data it describes. When you fork a branch, you fork the ontology too.
+
+### No Edit Layer Separation
+
+Palantir separates backing data from user edits in writeback datasets. Strata doesn't need this — every write is a new version of the same key. The version history IS the edit history. There's nothing to reconcile because writes never overwrite.
+
+---
+
+## 6. The Long View
+
+Palantir's full stack — Ontology + Functions + Actions + AIP — is a complete operational platform. Strata is not trying to be that. Strata is the persistence layer that makes such a platform possible.
+
+But the architecture should be designed so that each Palantir capability has a natural extension point in Strata:
+
+| Palantir Capability | Strata Extension Point |
+|--------------------|----------------------|
+| Object types and link types | Ontology layer (adopted) |
+| Ontology-grounded retrieval | Search enrichment with typed context (adopted) |
+| Schema governance | Branch + merge on ontology data (native) |
+| Actions (governed mutations) | Event log + ontology validation (foundation exists, governance layer deferred) |
+| Functions (computation) | `GraphAlgorithm` trait + graph snapshots (extension point exists) |
+| Agent orchestration | MCP tools + ontology-typed state (interface exists) |
+| Security | Branch/space-level security (exists), object-level (deferred) |
+
+The principle is: Strata builds the hippocampus correctly. The cortex — whether it's an AI agent, an application framework, or something that doesn't exist yet — builds on top. Nothing in Strata's design should prevent the cortex from being built. Everything in Strata's design should make the cortex's job easier.


### PR DESCRIPTION
## Summary
- `docs/architecture/ontology.md` — Ontology layer extending strata-graph with user-defined object types, link types, cardinality constraints, and ontology-grounded retrieval. Strata validates and indexes; the AI defines and decides.
- `docs/architecture/palantir-study.md` — Architecture study mapping Palantir's Ontology/AIP stack to Strata's cognitive layers, with explicit boundaries on what Strata adopts vs defers to the cortex.

Key principle throughout: Strata is the hippocampus. It stores, validates, indexes, and retrieves. It never decides, acts, or interprets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)