### PR TITLE
Add graph & ontology documentation

### DIFF
--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -8,3 +8,4 @@ Real-world patterns and recipes for building with StrataDB.
 - **[Deterministic Replay](deterministic-replay.md)** — record nondeterministic inputs, replay later
 - **[Intelligent Search](intelligent-search.md)** — time-scoped cross-primitive search with expansion and reranking
 - **[A/B Testing with Branches](ab-testing-with-branches.md)** — run two strategies, compare results
+- **[Knowledge Graph](knowledge-graph.md)** — typed knowledge graph with ontology validation and bulk loading

--- a/docs/cookbook/knowledge-graph.md
+++ b/docs/cookbook/knowledge-graph.md
@@ -1,0 +1,270 @@
+# Knowledge Graph with Schema Validation
+
+Build a typed knowledge graph with ontology-driven validation and bulk loading.
+
+## Pattern
+
+Combine the graph store with the ontology layer to create a structured knowledge graph:
+- **Graph** holds entities (nodes) and relationships (edges)
+- **Ontology** defines the allowed types and validates writes after freezing
+- **Bulk insert** loads large datasets efficiently
+
+## Scenario
+
+A healthcare knowledge graph tracking patients, lab results, diagnoses, and treatments. The ontology enforces that lab results belong to patients and diagnoses link to supporting evidence.
+
+## Implementation
+
+### Step 1: Create the Graph
+
+```rust
+use serde_json::json;
+
+let db = Strata::cache()?;
+db.graph_create("medical")?;
+```
+
+### Step 2: Define the Ontology
+
+Define four object types with required properties:
+
+```rust
+// Patient
+db.graph_define_object_type("medical", json!({
+    "name": "Patient",
+    "properties": {
+        "full_name": { "type": "string", "required": true },
+        "date_of_birth": { "type": "string", "required": true },
+        "blood_type": { "type": "string" }
+    }
+}))?;
+
+// LabResult
+db.graph_define_object_type("medical", json!({
+    "name": "LabResult",
+    "properties": {
+        "test_name": { "type": "string", "required": true },
+        "value": { "type": "number", "required": true },
+        "unit": { "type": "string", "required": true },
+        "collected_at": { "type": "string" }
+    }
+}))?;
+
+// Diagnosis
+db.graph_define_object_type("medical", json!({
+    "name": "Diagnosis",
+    "properties": {
+        "code": { "type": "string", "required": true },
+        "description": { "type": "string", "required": true },
+        "severity": { "type": "string" }
+    }
+}))?;
+
+// Treatment
+db.graph_define_object_type("medical", json!({
+    "name": "Treatment",
+    "properties": {
+        "name": { "type": "string", "required": true },
+        "dosage": { "type": "string" },
+        "start_date": { "type": "string", "required": true }
+    }
+}))?;
+```
+
+Define four link types with source/target constraints:
+
+```rust
+db.graph_define_link_type("medical", json!({
+    "name": "HAS_LAB_RESULT",
+    "source": "Patient",
+    "target": "LabResult",
+    "cardinality": "one_to_many"
+}))?;
+
+db.graph_define_link_type("medical", json!({
+    "name": "DIAGNOSED_WITH",
+    "source": "Patient",
+    "target": "Diagnosis",
+    "cardinality": "one_to_many"
+}))?;
+
+db.graph_define_link_type("medical", json!({
+    "name": "SUPPORTS",
+    "source": "LabResult",
+    "target": "Diagnosis",
+    "cardinality": "many_to_many"
+}))?;
+
+db.graph_define_link_type("medical", json!({
+    "name": "TREATED_WITH",
+    "source": "Diagnosis",
+    "target": "Treatment",
+    "cardinality": "one_to_many"
+}))?;
+```
+
+### Step 3: Freeze the Ontology
+
+Freezing locks the schema and enables validation on all subsequent writes:
+
+```rust
+db.graph_freeze_ontology("medical")?;
+
+let status = db.graph_ontology_status("medical")?;
+// Some({"status": "frozen", ...})
+```
+
+### Step 4: Bulk Load Data
+
+Use `graph_bulk_insert` to load nodes and edges in a single call:
+
+```rust
+let nodes: Vec<(&str, Option<&str>, Option<serde_json::Value>)> = vec![
+    // Patients
+    ("patient-jane", None, Some(json!({"full_name": "Jane Doe", "date_of_birth": "1990-05-15", "blood_type": "A+"}))),
+    ("patient-john", None, Some(json!({"full_name": "John Smith", "date_of_birth": "1985-03-20", "blood_type": "O-"}))),
+    ("patient-maria", None, Some(json!({"full_name": "Maria Garcia", "date_of_birth": "1978-11-02"}))),
+
+    // Lab results
+    ("lab-001", None, Some(json!({"test_name": "HbA1c", "value": 7.2, "unit": "%", "collected_at": "2025-01-10"}))),
+    ("lab-002", None, Some(json!({"test_name": "Fasting Glucose", "value": 142.0, "unit": "mg/dL", "collected_at": "2025-01-10"}))),
+    ("lab-003", None, Some(json!({"test_name": "LDL Cholesterol", "value": 165.0, "unit": "mg/dL", "collected_at": "2025-01-12"}))),
+    ("lab-004", None, Some(json!({"test_name": "Blood Pressure", "value": 145.0, "unit": "mmHg", "collected_at": "2025-01-15"}))),
+    ("lab-005", None, Some(json!({"test_name": "HbA1c", "value": 5.4, "unit": "%", "collected_at": "2025-01-11"}))),
+
+    // Diagnoses
+    ("dx-diabetes", None, Some(json!({"code": "E11.9", "description": "Type 2 Diabetes", "severity": "moderate"}))),
+    ("dx-hyperlipidemia", None, Some(json!({"code": "E78.5", "description": "Hyperlipidemia", "severity": "mild"}))),
+    ("dx-hypertension", None, Some(json!({"code": "I10", "description": "Essential Hypertension", "severity": "moderate"}))),
+
+    // Treatments
+    ("tx-metformin", None, Some(json!({"name": "Metformin", "dosage": "500mg twice daily", "start_date": "2025-01-15"}))),
+    ("tx-atorvastatin", None, Some(json!({"name": "Atorvastatin", "dosage": "20mg daily", "start_date": "2025-01-16"}))),
+    ("tx-lisinopril", None, Some(json!({"name": "Lisinopril", "dosage": "10mg daily", "start_date": "2025-01-17"}))),
+];
+
+let edges: Vec<(&str, &str, &str, Option<f64>, Option<serde_json::Value>)> = vec![
+    // Jane's lab results
+    ("patient-jane", "lab-001", "HAS_LAB_RESULT", None, None),
+    ("patient-jane", "lab-002", "HAS_LAB_RESULT", None, None),
+    ("patient-jane", "lab-003", "HAS_LAB_RESULT", None, None),
+
+    // John's lab results
+    ("patient-john", "lab-004", "HAS_LAB_RESULT", None, None),
+    ("patient-john", "lab-005", "HAS_LAB_RESULT", None, None),
+
+    // Diagnoses
+    ("patient-jane", "dx-diabetes",       "DIAGNOSED_WITH", None, None),
+    ("patient-jane", "dx-hyperlipidemia", "DIAGNOSED_WITH", None, None),
+    ("patient-john", "dx-hypertension",   "DIAGNOSED_WITH", None, None),
+
+    // Lab results supporting diagnoses
+    ("lab-001", "dx-diabetes",       "SUPPORTS", Some(0.95), None),
+    ("lab-002", "dx-diabetes",       "SUPPORTS", Some(0.88), None),
+    ("lab-003", "dx-hyperlipidemia", "SUPPORTS", Some(0.91), None),
+    ("lab-004", "dx-hypertension",   "SUPPORTS", Some(0.85), None),
+
+    // Treatments for diagnoses
+    ("dx-diabetes",       "tx-metformin",    "TREATED_WITH", None, None),
+    ("dx-hyperlipidemia", "tx-atorvastatin", "TREATED_WITH", None, None),
+    ("dx-hypertension",   "tx-lisinopril",   "TREATED_WITH", None, None),
+];
+
+let (n, e) = db.graph_bulk_insert("medical", &nodes, &edges)?;
+assert_eq!(n, 15);
+assert_eq!(e, 15);
+```
+
+### Step 5: Query the Graph
+
+Find all of Jane's lab results:
+
+```rust
+let labs = db.graph_neighbors("medical", "patient-jane", "outgoing", Some("HAS_LAB_RESULT"))?;
+// 3 results: lab-001, lab-002, lab-003
+
+for hit in &labs {
+    println!("{} (weight: {})", hit.node_id, hit.weight);
+}
+```
+
+Find everything reachable from Jane within 3 hops:
+
+```rust
+let result = db.graph_bfs("medical", "patient-jane", 3, None, None, Some("outgoing"))?;
+// visited: ["patient-jane", "lab-001", "lab-002", "lab-003",
+//           "dx-diabetes", "dx-hyperlipidemia",
+//           "tx-metformin", "tx-atorvastatin"]
+// depths:  patient-jane=0, lab-*=1, dx-*=2, tx-*=3
+
+for node_id in &result.visited {
+    let depth = result.depths.get(node_id).unwrap_or(&0);
+    println!("  depth {}: {}", depth, node_id);
+}
+```
+
+List all patients by type:
+
+```rust
+let patients = db.graph_nodes_by_type("medical", "Patient")?;
+// ["patient-jane", "patient-john", "patient-maria"]
+```
+
+### Step 6: Introspect the Schema
+
+Use `graph_ontology_summary` for a complete view of the schema and instance counts:
+
+```rust
+let summary = db.graph_ontology_summary("medical")?;
+println!("{}", serde_json::to_string_pretty(&summary)?);
+// {
+//   "status": "frozen",
+//   "object_types": [
+//     { "name": "Patient", "properties": {...}, "node_count": 3 },
+//     { "name": "LabResult", "properties": {...}, "node_count": 5 },
+//     { "name": "Diagnosis", "properties": {...}, "node_count": 3 },
+//     { "name": "Treatment", "properties": {...}, "node_count": 3 }
+//   ],
+//   "link_types": [
+//     { "name": "HAS_LAB_RESULT", "source": "Patient", "target": "LabResult" },
+//     { "name": "DIAGNOSED_WITH", "source": "Patient", "target": "Diagnosis" },
+//     { "name": "SUPPORTS", "source": "LabResult", "target": "Diagnosis" },
+//     { "name": "TREATED_WITH", "source": "Diagnosis", "target": "Treatment" }
+//   ]
+// }
+```
+
+### Step 7: Entity Reference Binding
+
+Link a graph node to a JSON document for richer data:
+
+```rust
+// Store detailed patient record in the JSON store
+db.json_set("patient:jane:record", "$", json!({
+    "insurance": "BlueCross #12345",
+    "emergency_contact": {"name": "Bob Doe", "phone": "555-0123"},
+    "allergies": ["penicillin"]
+}))?;
+
+// Bind the graph node to the JSON document
+db.graph_add_node("medical", "patient-jane", Some("json://default/patient:jane:record"), Some(json!({
+    "full_name": "Jane Doe",
+    "date_of_birth": "1990-05-15",
+    "blood_type": "A+"
+})))?;
+
+// The node now carries both graph properties and a reference to the full record
+let node = db.graph_get_node("medical", "patient-jane")?;
+```
+
+## Cleanup
+
+```rust
+db.graph_delete("medical")?;
+```
+
+## See Also
+
+- [Graph Store Guide](../guides/graph.md) — node/edge CRUD, traversal, bulk loading
+- [Ontology Guide](../guides/ontology.md) — typed schemas with validation
+- [API Quick Reference](../reference/api-quick-reference.md) — all method signatures

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -1,0 +1,303 @@
+# Graph Store Guide
+
+Model relationships between entities using a property graph with typed nodes and edges.
+
+## API Overview
+
+### Lifecycle
+
+| Method | Signature | Returns |
+|--------|-----------|---------|
+| `graph_create` | `(graph: &str) -> Result<()>` | |
+| `graph_create_with_policy` | `(graph: &str, cascade_policy: Option<&str>) -> Result<()>` | |
+| `graph_delete` | `(graph: &str) -> Result<()>` | |
+| `graph_list` | `() -> Result<Vec<String>>` | Graph names |
+| `graph_get_meta` | `(graph: &str) -> Result<Option<Value>>` | Graph metadata or None |
+
+### Node CRUD
+
+| Method | Signature | Returns |
+|--------|-----------|---------|
+| `graph_add_node` | `(graph, node_id, entity_ref?, properties?) -> Result<()>` | |
+| `graph_add_node_typed` | `(graph, node_id, entity_ref?, properties?, object_type?) -> Result<()>` | |
+| `graph_get_node` | `(graph, node_id) -> Result<Option<Value>>` | Node data or None |
+| `graph_remove_node` | `(graph, node_id) -> Result<()>` | |
+| `graph_list_nodes` | `(graph) -> Result<Vec<String>>` | Node IDs |
+
+### Edge CRUD
+
+| Method | Signature | Returns |
+|--------|-----------|---------|
+| `graph_add_edge` | `(graph, src, dst, edge_type, weight?, properties?) -> Result<()>` | |
+| `graph_remove_edge` | `(graph, src, dst, edge_type) -> Result<()>` | |
+
+### Bulk
+
+| Method | Signature | Returns |
+|--------|-----------|---------|
+| `graph_bulk_insert` | `(graph, nodes, edges) -> Result<(u64, u64)>` | (nodes_inserted, edges_inserted) |
+
+### Traversal
+
+| Method | Signature | Returns |
+|--------|-----------|---------|
+| `graph_neighbors` | `(graph, node_id, direction, edge_type?) -> Result<Vec<GraphNeighborHit>>` | Neighbor list |
+| `graph_bfs` | `(graph, start, max_depth, max_nodes?, edge_types?, direction?) -> Result<GraphBfsResult>` | BFS result |
+
+## Creating a Graph
+
+Use `graph_create` to create a new empty graph on the current branch:
+
+```rust
+let db = Strata::cache()?;
+
+db.graph_create("social")?;
+
+// Verify it exists
+let graphs = db.graph_list()?;
+assert!(graphs.contains(&"social".to_string()));
+```
+
+### Cascade Policy
+
+`graph_create_with_policy` lets you control what happens to edges when a node is removed:
+
+```rust
+// "cascade" — removing a node also removes all its edges (default-like behavior)
+db.graph_create_with_policy("social", Some("cascade"))?;
+
+// "detach" — edges are silently detached when a node is removed
+db.graph_create_with_policy("links", Some("detach"))?;
+
+// "ignore" — no special edge handling
+db.graph_create_with_policy("tags", Some("ignore"))?;
+```
+
+## Adding Nodes
+
+Add nodes with `graph_add_node`. Each node has an ID and optional properties:
+
+```rust
+use serde_json::json;
+
+let db = Strata::cache()?;
+db.graph_create("social")?;
+
+// Simple node with no properties
+db.graph_add_node("social", "alice", None, None)?;
+
+// Node with properties
+db.graph_add_node("social", "bob", None, Some(json!({
+    "name": "Bob",
+    "age": 30
+})))?;
+
+db.graph_add_node("social", "carol", None, Some(json!({
+    "name": "Carol",
+    "age": 25
+})))?;
+```
+
+### Entity References
+
+Bind a node to an existing KV or JSON document using `entity_ref`:
+
+```rust
+db.kv_put("user:alice", json!({"email": "alice@example.com"}))?;
+
+// Bind the graph node to the KV entry
+db.graph_add_node("social", "alice", Some("kv://default/user:alice"), Some(json!({
+    "name": "Alice"
+})))?;
+```
+
+### Typed Nodes
+
+Use `graph_add_node_typed` to associate nodes with an ontology object type (see the [Ontology Guide](ontology.md)):
+
+```rust
+db.graph_add_node_typed(
+    "social", "alice", None,
+    Some(json!({"name": "Alice"})),
+    Some("Person"),
+)?;
+```
+
+## Adding Edges
+
+Edges are directed and typed. Each edge connects a source node to a destination node:
+
+```rust
+let db = Strata::cache()?;
+db.graph_create("social")?;
+
+db.graph_add_node("social", "alice", None, None)?;
+db.graph_add_node("social", "bob", None, None)?;
+db.graph_add_node("social", "carol", None, None)?;
+
+// alice follows bob
+db.graph_add_edge("social", "alice", "bob", "FOLLOWS", None, None)?;
+
+// bob follows carol
+db.graph_add_edge("social", "bob", "carol", "FOLLOWS", None, None)?;
+
+// alice follows carol
+db.graph_add_edge("social", "alice", "carol", "FOLLOWS", None, None)?;
+
+// alice likes bob's post — with a weight and properties
+db.graph_add_edge("social", "alice", "bob", "LIKES", Some(0.9), Some(json!({
+    "timestamp": "2025-01-15T10:30:00Z"
+})))?;
+```
+
+## Querying
+
+### Get a Node
+
+```rust
+let node = db.graph_get_node("social", "bob")?;
+// Returns the node's properties, entity_ref, etc. as a Value
+```
+
+### List All Nodes
+
+```rust
+let nodes = db.graph_list_nodes("social")?;
+// ["alice", "bob", "carol"]
+```
+
+### Neighbors
+
+`graph_neighbors` returns the immediate neighbors of a node. The `direction` parameter controls which edges to follow:
+
+- `"outgoing"` — nodes this node points to
+- `"incoming"` — nodes that point to this node
+- `"both"` — all connected nodes
+
+```rust
+// Who does alice follow?
+let following = db.graph_neighbors("social", "alice", "outgoing", Some("FOLLOWS"))?;
+// [GraphNeighborHit { node_id: "bob", edge_type: "FOLLOWS", weight: 1.0 },
+//  GraphNeighborHit { node_id: "carol", edge_type: "FOLLOWS", weight: 1.0 }]
+
+// Who follows carol?
+let followers = db.graph_neighbors("social", "carol", "incoming", Some("FOLLOWS"))?;
+// [GraphNeighborHit { node_id: "alice", ... }, GraphNeighborHit { node_id: "bob", ... }]
+
+// All connections for bob (any edge type)
+let all = db.graph_neighbors("social", "bob", "both", None)?;
+```
+
+### BFS Traversal
+
+`graph_bfs` performs a breadth-first search from a start node, returning all reachable nodes up to a given depth:
+
+```rust
+let result = db.graph_bfs("social", "alice", 3, None, None, None)?;
+
+// result.visited — node IDs in BFS order: ["alice", "bob", "carol"]
+// result.depths  — depth map: {"alice": 0, "bob": 1, "carol": 1}
+// result.edges   — edges traversed: [("alice","bob","FOLLOWS"), ("alice","carol","FOLLOWS")]
+```
+
+You can filter by edge type, limit the number of nodes, or restrict direction:
+
+```rust
+// Only follow FOLLOWS edges, max 10 nodes, outgoing only
+let result = db.graph_bfs(
+    "social",
+    "alice",
+    5,                                        // max_depth
+    Some(10),                                 // max_nodes
+    Some(vec!["FOLLOWS".to_string()]),        // edge_types
+    Some("outgoing"),                         // direction
+)?;
+```
+
+## Bulk Loading
+
+For loading large datasets, `graph_bulk_insert` is significantly faster than individual `graph_add_node`/`graph_add_edge` calls. It uses chunked transactions internally to handle large payloads efficiently.
+
+```rust
+let db = Strata::cache()?;
+db.graph_create("social")?;
+
+let nodes = vec![
+    ("alice", None, Some(json!({"name": "Alice"}))),
+    ("bob",   None, Some(json!({"name": "Bob"}))),
+    ("carol", None, Some(json!({"name": "Carol"}))),
+];
+
+let edges = vec![
+    ("alice", "bob",   "FOLLOWS", None, None),
+    ("bob",   "carol", "FOLLOWS", None, None),
+    ("alice", "carol", "FOLLOWS", None, None),
+];
+
+let (nodes_inserted, edges_inserted) = db.graph_bulk_insert("social", &nodes, &edges)?;
+assert_eq!(nodes_inserted, 3);
+assert_eq!(edges_inserted, 3);
+```
+
+## Removing Data
+
+### Remove a Node
+
+Removing a node also removes all its incident edges (regardless of direction):
+
+```rust
+db.graph_remove_node("social", "bob")?;
+
+// bob is gone, and so are all edges to/from bob
+let nodes = db.graph_list_nodes("social")?;
+assert!(!nodes.contains(&"bob".to_string()));
+```
+
+### Remove an Edge
+
+Remove a specific edge by source, destination, and type:
+
+```rust
+db.graph_remove_edge("social", "alice", "carol", "FOLLOWS")?;
+```
+
+### Delete a Graph
+
+Delete the entire graph and all its data:
+
+```rust
+db.graph_delete("social")?;
+```
+
+## Branch Isolation (Not Space-Scoped)
+
+Graph data is **branch-scoped only** — unlike KV, JSON, and other primitives, graphs are not isolated by space. All graphs on a branch are visible regardless of which space is active. This is intentional: graphs model cross-cutting relationships across your data, and entity refs can point into any space (e.g. `kv://default/key`, `json://other-space/doc`). Graph names serve as the namespace boundary within a branch.
+
+Each branch has its own independent copy of graph state, and graphs created on one branch are not visible on others:
+
+```rust
+let db = Strata::cache()?;
+
+db.graph_create("social")?;
+db.graph_add_node("social", "alice", None, None)?;
+
+// Fork to a new branch
+db.fork_branch("experiment")?;
+db.set_branch("experiment")?;
+
+// The forked branch inherits all graph data
+let nodes = db.graph_list_nodes("social")?;
+assert!(nodes.contains(&"alice".to_string()));
+
+// Changes on the fork don't affect the original branch
+db.graph_add_node("social", "dave", None, None)?;
+db.set_branch("default")?;
+let nodes = db.graph_list_nodes("social")?;
+assert!(!nodes.contains(&"dave".to_string()));
+```
+
+## Next
+
+- [Ontology Guide](ontology.md) — define typed schemas with validation
+- [Knowledge Graph Cookbook](../cookbook/knowledge-graph.md) — end-to-end recipe combining graph + ontology
+- [API Quick Reference](../reference/api-quick-reference.md) — all method signatures

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,6 +9,8 @@ Detailed walkthroughs for each StrataDB feature.
 - **[State Cell](state-cell.md)** — mutable state with CAS, coordination patterns
 - **[JSON Store](json-store.md)** — structured documents with path-level access
 - **[Vector Store](vector-store.md)** — collections, similarity search, metadata filtering
+- **[Graph Store](graph.md)** — property graph with typed nodes, edges, and traversal
+- **[Ontology](ontology.md)** — typed schemas for graphs with validation
 - **[Branch Management](branch-management.md)** — creating, switching, listing, and deleting branches
 - **[Spaces](spaces.md)** — organizing data within branches using spaces
 

--- a/docs/guides/ontology.md
+++ b/docs/guides/ontology.md
@@ -1,0 +1,260 @@
+# Ontology Guide
+
+Define a typed schema for your graph with object types, link types, and validation.
+
+## API Overview
+
+### Object Types
+
+| Method | Signature | Returns |
+|--------|-----------|---------|
+| `graph_define_object_type` | `(graph: &str, definition: Value) -> Result<()>` | |
+| `graph_get_object_type` | `(graph: &str, name: &str) -> Result<Option<Value>>` | Definition or None |
+| `graph_list_object_types` | `(graph: &str) -> Result<Vec<String>>` | Type names |
+| `graph_delete_object_type` | `(graph: &str, name: &str) -> Result<()>` | |
+
+### Link Types
+
+| Method | Signature | Returns |
+|--------|-----------|---------|
+| `graph_define_link_type` | `(graph: &str, definition: Value) -> Result<()>` | |
+| `graph_get_link_type` | `(graph: &str, name: &str) -> Result<Option<Value>>` | Definition or None |
+| `graph_list_link_types` | `(graph: &str) -> Result<Vec<String>>` | Type names |
+| `graph_delete_link_type` | `(graph: &str, name: &str) -> Result<()>` | |
+
+### Lifecycle
+
+| Method | Signature | Returns |
+|--------|-----------|---------|
+| `graph_freeze_ontology` | `(graph: &str) -> Result<()>` | |
+| `graph_ontology_status` | `(graph: &str) -> Result<Option<Value>>` | Status or None |
+
+### Queries
+
+| Method | Signature | Returns |
+|--------|-----------|---------|
+| `graph_ontology_summary` | `(graph: &str) -> Result<Option<Value>>` | Full summary or None |
+| `graph_nodes_by_type` | `(graph: &str, object_type: &str) -> Result<Vec<String>>` | Node IDs |
+
+## Defining Object Types
+
+An object type defines a category of nodes in your graph. Each type has a name and optional property definitions:
+
+```rust
+use serde_json::json;
+
+let db = Strata::cache()?;
+db.graph_create("healthcare")?;
+
+// Define a Patient type with required and optional properties
+db.graph_define_object_type("healthcare", json!({
+    "name": "Patient",
+    "properties": {
+        "full_name": { "type": "string", "required": true },
+        "date_of_birth": { "type": "string", "required": true },
+        "blood_type": { "type": "string" }
+    }
+}))?;
+
+// Define a LabResult type
+db.graph_define_object_type("healthcare", json!({
+    "name": "LabResult",
+    "properties": {
+        "test_name": { "type": "string", "required": true },
+        "value": { "type": "number", "required": true },
+        "unit": { "type": "string", "required": true },
+        "collected_at": { "type": "string" }
+    }
+}))?;
+
+// Define a Diagnosis type
+db.graph_define_object_type("healthcare", json!({
+    "name": "Diagnosis",
+    "properties": {
+        "code": { "type": "string", "required": true },
+        "description": { "type": "string", "required": true },
+        "severity": { "type": "string" }
+    }
+}))?;
+```
+
+### Retrieving a Type Definition
+
+```rust
+let patient_type = db.graph_get_object_type("healthcare", "Patient")?;
+// Returns the full definition as a Value
+
+let all_types = db.graph_list_object_types("healthcare")?;
+// ["Diagnosis", "LabResult", "Patient"]
+```
+
+### Deleting a Type (Draft Only)
+
+While the ontology is in draft mode, you can remove types:
+
+```rust
+db.graph_delete_object_type("healthcare", "LabResult")?;
+```
+
+## Defining Link Types
+
+A link type defines a category of edges, including which object types it can connect and its cardinality:
+
+```rust
+// A Patient can have many LabResults
+db.graph_define_link_type("healthcare", json!({
+    "name": "HAS_LAB_RESULT",
+    "source": "Patient",
+    "target": "LabResult",
+    "cardinality": "one_to_many"
+}))?;
+
+// A Patient can have many Diagnoses
+db.graph_define_link_type("healthcare", json!({
+    "name": "DIAGNOSED_WITH",
+    "source": "Patient",
+    "target": "Diagnosis",
+    "cardinality": "one_to_many"
+}))?;
+
+// A LabResult can support a Diagnosis
+db.graph_define_link_type("healthcare", json!({
+    "name": "SUPPORTS",
+    "source": "LabResult",
+    "target": "Diagnosis",
+    "cardinality": "many_to_many"
+}))?;
+```
+
+### Retrieving a Link Type
+
+```rust
+let link = db.graph_get_link_type("healthcare", "HAS_LAB_RESULT")?;
+
+let all_links = db.graph_list_link_types("healthcare")?;
+// ["DIAGNOSED_WITH", "HAS_LAB_RESULT", "SUPPORTS"]
+```
+
+### Deleting a Link Type (Draft Only)
+
+```rust
+db.graph_delete_link_type("healthcare", "SUPPORTS")?;
+```
+
+## Draft vs Frozen
+
+Every ontology starts in **draft** mode. In draft mode you can freely add, modify, and delete type definitions. No validation is enforced on node or edge writes.
+
+Once the schema is ready, **freeze** it to enable validation:
+
+```rust
+// Check current status
+let status = db.graph_ontology_status("healthcare")?;
+// Some({"status": "draft", ...})
+
+// Freeze the ontology
+db.graph_freeze_ontology("healthcare")?;
+
+let status = db.graph_ontology_status("healthcare")?;
+// Some({"status": "frozen", ...})
+```
+
+After freezing:
+
+- You **cannot** add, modify, or delete type definitions
+- Typed node writes are **validated** against the schema
+- Edge writes with a defined link type are **validated** for source/target type constraints
+
+## Validation After Freeze
+
+Once frozen, the following checks are enforced on writes:
+
+**Validated:**
+- Required properties must be present on typed nodes
+- Edge source and target nodes must have the correct object types for the link type
+
+**Not validated (by design):**
+- Property value types are not checked at write time
+- Cardinality limits are not enforced at write time
+
+```rust
+db.graph_freeze_ontology("healthcare")?;
+
+// This succeeds — all required properties present
+db.graph_add_node_typed(
+    "healthcare", "patient-1", None,
+    Some(json!({
+        "full_name": "Jane Doe",
+        "date_of_birth": "1990-05-15"
+    })),
+    Some("Patient"),
+)?;
+
+// This fails — missing required property "full_name"
+let result = db.graph_add_node_typed(
+    "healthcare", "patient-2", None,
+    Some(json!({
+        "date_of_birth": "1985-03-20"
+    })),
+    Some("Patient"),
+);
+assert!(result.is_err());
+```
+
+## Querying by Type
+
+Retrieve all nodes of a given object type:
+
+```rust
+db.graph_add_node_typed("healthcare", "patient-1", None,
+    Some(json!({"full_name": "Jane Doe", "date_of_birth": "1990-05-15"})),
+    Some("Patient"))?;
+db.graph_add_node_typed("healthcare", "patient-2", None,
+    Some(json!({"full_name": "John Smith", "date_of_birth": "1985-03-20"})),
+    Some("Patient"))?;
+
+let patients = db.graph_nodes_by_type("healthcare", "Patient")?;
+// ["patient-1", "patient-2"]
+```
+
+## Schema Introspection
+
+`graph_ontology_summary` returns the full ontology with type definitions and instance counts. This is the recommended way for AI agents to orient themselves in a graph:
+
+```rust
+let summary = db.graph_ontology_summary("healthcare")?;
+// Returns a Value like:
+// {
+//   "status": "frozen",
+//   "object_types": [
+//     { "name": "Patient", "properties": {...}, "node_count": 2 },
+//     { "name": "LabResult", "properties": {...}, "node_count": 5 },
+//     ...
+//   ],
+//   "link_types": [
+//     { "name": "HAS_LAB_RESULT", "source": "Patient", "target": "LabResult", ... },
+//     ...
+//   ]
+// }
+```
+
+## Schema Evolution
+
+Ontologies cannot be unfrozen. To evolve a schema, fork the branch and redefine the ontology on the new branch:
+
+```rust
+// Original branch has a frozen ontology
+db.fork_branch("schema-v2")?;
+db.set_branch("schema-v2")?;
+
+// The forked branch inherits the frozen ontology
+// Create a new graph with the updated schema, or work with the inherited data
+```
+
+This approach preserves the original data and schema while letting you iterate on the new version independently.
+
+## Next
+
+- [Graph Store Guide](graph.md) — node/edge CRUD, traversal, bulk loading
+- [Knowledge Graph Cookbook](../cookbook/knowledge-graph.md) — end-to-end recipe combining graph + ontology
+- [API Quick Reference](../reference/api-quick-reference.md) — all method signatures

--- a/docs/reference/api-quick-reference.md
+++ b/docs/reference/api-quick-reference.md
@@ -111,6 +111,43 @@ Every method on the `Strata` struct, grouped by category.
 | `vector_search` | `(collection: &str, query: Vec<f32>, k: u64) -> Result<Vec<VectorMatch>>` | Top-k matches | 8 metadata filter operators |
 | `vector_search_at` | `(collection: &str, query: Vec<f32>, k: u64, as_of_ts: u64) -> Result<Vec<VectorMatch>>` | Historical top-k matches | Temporal HNSW filtering |
 
+## Graph Store
+
+| Method | Signature | Returns | Notes |
+|--------|-----------|---------|-------|
+| `graph_create` | `(graph: &str) -> Result<()>` | | Creates empty graph |
+| `graph_create_with_policy` | `(graph: &str, cascade_policy: Option<&str>) -> Result<()>` | | `"cascade"`, `"detach"`, or `"ignore"` |
+| `graph_delete` | `(graph: &str) -> Result<()>` | | Deletes graph + all data |
+| `graph_list` | `() -> Result<Vec<String>>` | Graph names | |
+| `graph_get_meta` | `(graph: &str) -> Result<Option<Value>>` | Metadata or None | |
+| `graph_add_node` | `(graph: &str, node_id: &str, entity_ref: Option<&str>, properties: Option<Value>) -> Result<()>` | | Creates or updates |
+| `graph_add_node_typed` | `(graph: &str, node_id: &str, entity_ref: Option<&str>, properties: Option<Value>, object_type: Option<&str>) -> Result<()>` | | With ontology type |
+| `graph_get_node` | `(graph: &str, node_id: &str) -> Result<Option<Value>>` | Node data or None | |
+| `graph_remove_node` | `(graph: &str, node_id: &str) -> Result<()>` | | Cascades to edges |
+| `graph_list_nodes` | `(graph: &str) -> Result<Vec<String>>` | Node IDs | |
+| `graph_add_edge` | `(graph: &str, src: &str, dst: &str, edge_type: &str, weight: Option<f64>, properties: Option<Value>) -> Result<()>` | | Directed typed edge |
+| `graph_remove_edge` | `(graph: &str, src: &str, dst: &str, edge_type: &str) -> Result<()>` | | |
+| `graph_bulk_insert` | `(graph: &str, nodes: &[...], edges: &[...]) -> Result<(u64, u64)>` | (nodes, edges) inserted | Chunked transactions |
+| `graph_neighbors` | `(graph: &str, node_id: &str, direction: &str, edge_type: Option<&str>) -> Result<Vec<GraphNeighborHit>>` | Neighbor list | Direction: `"outgoing"`, `"incoming"`, `"both"` |
+| `graph_bfs` | `(graph: &str, start: &str, max_depth: usize, max_nodes: Option<usize>, edge_types: Option<Vec<String>>, direction: Option<&str>) -> Result<GraphBfsResult>` | BFS result | visited + depths + edges |
+
+## Graph Ontology
+
+| Method | Signature | Returns | Notes |
+|--------|-----------|---------|-------|
+| `graph_define_object_type` | `(graph: &str, definition: Value) -> Result<()>` | | Draft mode only |
+| `graph_get_object_type` | `(graph: &str, name: &str) -> Result<Option<Value>>` | Definition or None | |
+| `graph_list_object_types` | `(graph: &str) -> Result<Vec<String>>` | Type names | |
+| `graph_delete_object_type` | `(graph: &str, name: &str) -> Result<()>` | | Draft mode only |
+| `graph_define_link_type` | `(graph: &str, definition: Value) -> Result<()>` | | Draft mode only |
+| `graph_get_link_type` | `(graph: &str, name: &str) -> Result<Option<Value>>` | Definition or None | |
+| `graph_list_link_types` | `(graph: &str) -> Result<Vec<String>>` | Type names | |
+| `graph_delete_link_type` | `(graph: &str, name: &str) -> Result<()>` | | Draft mode only |
+| `graph_freeze_ontology` | `(graph: &str) -> Result<()>` | | Enables validation |
+| `graph_ontology_status` | `(graph: &str) -> Result<Option<Value>>` | Status or None | `"draft"` or `"frozen"` |
+| `graph_ontology_summary` | `(graph: &str) -> Result<Option<Value>>` | Full summary or None | Types + counts |
+| `graph_nodes_by_type` | `(graph: &str, object_type: &str) -> Result<Vec<String>>` | Node IDs | |
+
 ## Search
 
 | Method | Signature | Returns | Notes |


### PR DESCRIPTION
## Summary
- Adds `docs/guides/graph.md` — Graph Store guide (social network examples, all 15 API methods)
- Adds `docs/guides/ontology.md` — Ontology guide (healthcare examples, all 12 API methods)
- Adds `docs/cookbook/knowledge-graph.md` — end-to-end recipe (bulk load, traverse, introspect)
- Updates `docs/reference/api-quick-reference.md` with Graph Store (15 methods) and Graph Ontology (12 methods) sections
- Updates guide and cookbook index files

## Test plan
- [ ] Verify all method names/signatures match `crates/executor/src/api/graph.rs`
- [ ] Verify cross-references between the 3 new docs and the API reference resolve correctly
- [ ] Verify API reference table format matches existing sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)