### PR TITLE
Implement multi-process WAL coordination (#1228)

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -313,6 +313,126 @@ impl TransactionManager {
     pub fn remove_branch_lock(&self, branch_id: &BranchId) {
         self.commit_locks.remove(branch_id);
     }
+
+    /// Advance the version counter to at least `v`.
+    ///
+    /// Used during multi-process refresh to ensure the local version counter
+    /// reflects writes applied from other processes' WAL entries.
+    /// Uses `fetch_max` so the counter never goes backward.
+    pub fn catch_up_version(&self, v: u64) {
+        self.version.fetch_max(v, Ordering::SeqCst);
+    }
+
+    /// Advance the next_txn_id counter to at least `id + 1`.
+    ///
+    /// Used during multi-process refresh to ensure locally-allocated transaction
+    /// IDs never collide with IDs already used by other processes.
+    pub fn catch_up_txn_id(&self, id: u64) {
+        self.next_txn_id.fetch_max(id + 1, Ordering::SeqCst);
+    }
+
+    /// Commit a transaction with an externally-allocated version.
+    ///
+    /// Similar to `commit()` but does NOT allocate a version from the local
+    /// counter — instead, uses the provided `version`. This is used by the
+    /// coordinated commit path where version allocation happens under the
+    /// WAL file lock via the shared counter file.
+    ///
+    /// The per-branch commit lock is still acquired for thread safety.
+    pub fn commit_with_version<S: Storage>(
+        &self,
+        txn: &mut TransactionContext,
+        store: &S,
+        mut wal: Option<&mut WalWriter>,
+        version: u64,
+    ) -> std::result::Result<u64, CommitError> {
+        // Fast path: read-only transactions
+        if txn.is_read_only() && txn.json_writes().is_empty() {
+            if !txn.is_active() {
+                return Err(CommitError::InvalidState(format!(
+                    "Cannot commit transaction {} from {:?} state - must be Active",
+                    txn.txn_id, txn.status
+                )));
+            }
+            txn.status = TransactionStatus::Committed;
+            return Ok(version);
+        }
+
+        // Acquire per-branch commit lock
+        let branch_lock = self
+            .commit_locks
+            .entry(txn.branch_id)
+            .or_insert_with(|| Mutex::new(()));
+        let _commit_guard = branch_lock.lock();
+
+        // Validate
+        let can_skip_validation = txn.read_set.is_empty()
+            && txn.cas_set.is_empty()
+            && txn.json_snapshot_versions().map_or(true, |v| v.is_empty())
+            && txn.json_writes().is_empty();
+
+        if can_skip_validation {
+            if !txn.is_active() {
+                return Err(CommitError::InvalidState(format!(
+                    "Cannot commit transaction {} from {:?} state - must be Active",
+                    txn.txn_id, txn.status
+                )));
+            }
+            txn.status = TransactionStatus::Committed;
+        } else {
+            txn.commit(store)?;
+        }
+
+        // Use the externally-provided version (do NOT allocate from local counter)
+        let commit_version = version;
+
+        // Advance local counter so it stays in sync
+        self.version.fetch_max(commit_version, Ordering::SeqCst);
+
+        // Write to WAL
+        let has_mutations = !txn.is_read_only() || !txn.json_writes().is_empty();
+        if has_mutations {
+            if let Some(wal) = wal.as_mut() {
+                let payload = TransactionPayload::from_transaction(txn, commit_version);
+                let record = WalRecord::new(
+                    txn.txn_id,
+                    *txn.branch_id.as_bytes(),
+                    now_micros(),
+                    payload.to_bytes(),
+                );
+
+                if let Err(e) = wal.append(&record) {
+                    txn.status = TransactionStatus::Aborted {
+                        reason: format!("WAL write failed: {}", e),
+                    };
+                    return Err(CommitError::WALError(e.to_string()));
+                }
+            }
+        }
+
+        // Apply to storage
+        if let Err(e) = txn.apply_writes(store, commit_version) {
+            if wal.is_some() {
+                tracing::error!(
+                    target: "strata::txn",
+                    txn_id = txn.txn_id,
+                    commit_version = commit_version,
+                    error = %e,
+                    "Storage application failed after WAL commit - will be recovered on restart"
+                );
+            } else {
+                txn.status = TransactionStatus::Aborted {
+                    reason: format!("Storage application failed: {}", e),
+                };
+                return Err(CommitError::WALError(format!(
+                    "Storage application failed (no WAL): {}",
+                    e
+                )));
+            }
+        }
+
+        Ok(commit_version)
+    }
 }
 
 impl Default for TransactionManager {

--- a/crates/durability/Cargo.toml
+++ b/crates/durability/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 crc32fast = "1.3"
+fs2 = "0.4"
 
 # RunBundle support
 tar = { workspace = true }

--- a/crates/durability/src/coordination.rs
+++ b/crates/durability/src/coordination.rs
@@ -1,0 +1,219 @@
+//! WAL coordination primitives for multi-process access.
+//!
+//! Provides two types for inter-process coordination:
+//!
+//! - [`WalFileLock`]: Exclusive file lock on `{wal_dir}/.wal-lock` for serializing
+//!   WAL writes across processes.
+//! - [`CounterFile`]: Atomic read/write of `(max_version, max_txn_id)` at
+//!   `{wal_dir}/counters` for globally-unique version and txn_id allocation.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+/// Exclusive file lock on `{wal_dir}/.wal-lock`.
+///
+/// Only one process can hold this lock at a time. Used to serialize the
+/// critical section of coordinated commits: refresh → validate → allocate
+/// version → WAL append → update counters.
+///
+/// The lock is released when the value is dropped.
+pub struct WalFileLock {
+    _file: File,
+}
+
+impl WalFileLock {
+    /// Acquire the WAL file lock, blocking until available.
+    pub fn acquire(wal_dir: &Path) -> io::Result<Self> {
+        let lock_path = wal_dir.join(".wal-lock");
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)?;
+        fs2::FileExt::lock_exclusive(&file)?;
+        Ok(WalFileLock { _file: file })
+    }
+
+    /// Try to acquire the WAL file lock without blocking.
+    ///
+    /// Returns `Ok(Some(lock))` if acquired, `Ok(None)` if another process
+    /// holds the lock.
+    pub fn try_acquire(wal_dir: &Path) -> io::Result<Option<Self>> {
+        let lock_path = wal_dir.join(".wal-lock");
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)?;
+        match fs2::FileExt::try_lock_exclusive(&file) {
+            Ok(()) => Ok(Some(WalFileLock { _file: file })),
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => Ok(None),
+            // On some platforms, try_lock returns EAGAIN (11) or EACCES (13)
+            // which may not map to WouldBlock.
+            Err(ref e)
+                if e.raw_os_error() == Some(11)
+                    || e.raw_os_error() == Some(13)
+                    || e.raw_os_error() == Some(35) =>
+            {
+                // 11=EAGAIN (Linux), 13=EACCES (Windows), 35=EAGAIN (macOS)
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+// fs2 file locks are released on drop (when the File is closed).
+
+/// Atomic read/write of `(max_version, max_txn_id)` stored at `{wal_dir}/counters`.
+///
+/// The file format is 16 bytes: two little-endian u64 values.
+/// Reads and writes should only be performed while holding [`WalFileLock`].
+pub struct CounterFile {
+    path: PathBuf,
+}
+
+/// Size of the counter file in bytes: two u64 values.
+const COUNTER_FILE_SIZE: usize = 16;
+
+impl CounterFile {
+    /// Open (or create) a counter file at `{wal_dir}/counters`.
+    pub fn new(wal_dir: &Path) -> Self {
+        CounterFile {
+            path: wal_dir.join("counters"),
+        }
+    }
+
+    /// Read the current `(max_version, max_txn_id)` from the file.
+    ///
+    /// Returns an error if the file exists but has invalid contents.
+    pub fn read(&self) -> io::Result<(u64, u64)> {
+        let mut file = File::open(&self.path)?;
+        let mut buf = [0u8; COUNTER_FILE_SIZE];
+        file.read_exact(&mut buf)?;
+        let max_version = u64::from_le_bytes(buf[0..8].try_into().unwrap());
+        let max_txn_id = u64::from_le_bytes(buf[8..16].try_into().unwrap());
+        Ok((max_version, max_txn_id))
+    }
+
+    /// Read the counters, returning `(0, 0)` if the file does not exist.
+    pub fn read_or_default(&self) -> io::Result<(u64, u64)> {
+        match self.read() {
+            Ok(v) => Ok(v),
+            Err(ref e) if e.kind() == io::ErrorKind::NotFound => Ok((0, 0)),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Write `(max_version, max_txn_id)` atomically.
+    ///
+    /// Writes to the file and fsyncs to ensure durability.
+    pub fn write(&self, max_version: u64, max_txn_id: u64) -> io::Result<()> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .read(true)
+            .open(&self.path)?;
+        let mut buf = [0u8; COUNTER_FILE_SIZE];
+        buf[0..8].copy_from_slice(&max_version.to_le_bytes());
+        buf[8..16].copy_from_slice(&max_txn_id.to_le_bytes());
+        file.seek(SeekFrom::Start(0))?;
+        file.write_all(&buf)?;
+        file.sync_all()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_wal_lock_acquire_and_release() {
+        let dir = tempdir().unwrap();
+        let lock = WalFileLock::acquire(dir.path());
+        assert!(lock.is_ok());
+        // Lock file should exist
+        assert!(dir.path().join(".wal-lock").exists());
+    }
+
+    #[test]
+    fn test_wal_lock_second_acquire_blocks() {
+        let dir = tempdir().unwrap();
+        let _lock1 = WalFileLock::acquire(dir.path()).unwrap();
+
+        // try_acquire should return None (lock is held)
+        let lock2 = WalFileLock::try_acquire(dir.path()).unwrap();
+        assert!(lock2.is_none(), "Second lock should not be acquired");
+    }
+
+    #[test]
+    fn test_wal_lock_released_on_drop() {
+        let dir = tempdir().unwrap();
+        {
+            let _lock = WalFileLock::acquire(dir.path()).unwrap();
+            // Lock is held
+        }
+        // Lock should be released after drop
+        let lock2 = WalFileLock::try_acquire(dir.path()).unwrap();
+        assert!(lock2.is_some(), "Lock should be available after drop");
+    }
+
+    #[test]
+    fn test_counter_file_read_write_roundtrip() {
+        let dir = tempdir().unwrap();
+        let cf = CounterFile::new(dir.path());
+
+        cf.write(42, 100).unwrap();
+        let (v, t) = cf.read().unwrap();
+        assert_eq!(v, 42);
+        assert_eq!(t, 100);
+    }
+
+    #[test]
+    fn test_counter_file_missing_returns_default() {
+        let dir = tempdir().unwrap();
+        let cf = CounterFile::new(dir.path());
+
+        let (v, t) = cf.read_or_default().unwrap();
+        assert_eq!(v, 0);
+        assert_eq!(t, 0);
+    }
+
+    #[test]
+    fn test_counter_file_survives_reopen() {
+        let dir = tempdir().unwrap();
+
+        // Write with one instance
+        {
+            let cf = CounterFile::new(dir.path());
+            cf.write(999, 888).unwrap();
+        }
+
+        // Read with a new instance
+        {
+            let cf = CounterFile::new(dir.path());
+            let (v, t) = cf.read().unwrap();
+            assert_eq!(v, 999);
+            assert_eq!(t, 888);
+        }
+    }
+
+    #[test]
+    fn test_counter_file_overwrite() {
+        let dir = tempdir().unwrap();
+        let cf = CounterFile::new(dir.path());
+
+        cf.write(1, 1).unwrap();
+        cf.write(2, 2).unwrap();
+
+        let (v, t) = cf.read().unwrap();
+        assert_eq!(v, 2);
+        assert_eq!(t, 2);
+    }
+}

--- a/crates/durability/src/format/wal_record.rs
+++ b/crates/durability/src/format/wal_record.rs
@@ -445,6 +445,17 @@ impl WalSegment {
         self.file.seek(SeekFrom::Start(position))
     }
 
+    /// Flush any buffered data and seek to the end of the file.
+    ///
+    /// Used in multi-process mode: after another process has appended to the
+    /// same segment, this re-positions the write cursor at the true end of file.
+    pub fn seek_to_end(&mut self) -> std::io::Result<()> {
+        self.file.flush()?;
+        let end = self.file.seek(SeekFrom::End(0))?;
+        self.write_position = end;
+        Ok(())
+    }
+
     /// Truncate segment at the given position.
     ///
     /// Used during recovery to remove partial records.

--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -32,6 +32,9 @@ pub mod format; // Binary on-disk formats (WAL segments, snapshots, manifest, wr
 pub mod retention; // Version retention policies (KeepAll, KeepLast, KeepFor, Composite)
 pub mod testing; // Crash test harness and reference model
 
+// === Multi-process WAL coordination ===
+pub mod coordination; // WAL file lock + counter file for multi-process access
+
 // === Phase 2: Database lifecycle coordination ===
 pub mod database; // Database handle, config, paths (DatabaseHandle, DatabaseConfig, etc.)
 

--- a/crates/durability/src/wal/writer.rs
+++ b/crates/durability/src/wal/writer.rs
@@ -444,6 +444,102 @@ impl WalWriter {
         Ok(segments)
     }
 
+    /// Re-sync with the WAL directory in case another process has written.
+    ///
+    /// Call this under the WAL file lock before appending in multi-process mode.
+    /// If another process rotated the segment or appended to the current one,
+    /// this method updates the local writer state accordingly.
+    pub fn reopen_if_needed(&mut self) -> std::io::Result<()> {
+        if !self.durability.requires_wal() {
+            return Ok(());
+        }
+
+        let latest = Self::find_latest_segment(&self.wal_dir);
+        match latest {
+            Some(num) if num > self.current_segment_number => {
+                // Another process rotated — write .meta for our old segment, then
+                // open the new one for appending.
+                if let Some(ref meta) = self.current_segment_meta {
+                    if !meta.is_empty() {
+                        let _ = meta.write_to_file(&self.wal_dir);
+                    }
+                }
+                match WalSegment::open_append(&self.wal_dir, num) {
+                    Ok(seg) => {
+                        self.segment = Some(seg);
+                        self.current_segment_number = num;
+                        self.current_segment_meta =
+                            Self::rebuild_meta_for_segment(&self.wal_dir, num);
+                    }
+                    Err(_) => {
+                        // If we can't open it, create a new one after it
+                        let new_num = num + 1;
+                        let seg = WalSegment::create(
+                            &self.wal_dir,
+                            new_num,
+                            self.database_uuid,
+                        )?;
+                        self.segment = Some(seg);
+                        self.current_segment_number = new_num;
+                        self.current_segment_meta =
+                            Some(SegmentMeta::new_empty(new_num));
+                    }
+                }
+            }
+            _ => {
+                // Same segment — seek to end to pick up writes from other processes.
+                if let Some(ref mut seg) = self.segment {
+                    seg.seek_to_end()?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Append a record and immediately flush for multi-process safety.
+    ///
+    /// This method:
+    /// 1. Calls `reopen_if_needed()` to pick up other processes' writes
+    /// 2. Serializes and writes the record
+    /// 3. Forces a flush + fsync so the record is visible to other processes
+    ///
+    /// Should be called while holding the WAL file lock.
+    pub fn append_and_flush(&mut self, record: &WalRecord) -> std::io::Result<()> {
+        if !self.durability.requires_wal() {
+            return Ok(());
+        }
+
+        self.reopen_if_needed()?;
+
+        let segment = self
+            .segment
+            .as_mut()
+            .expect("Segment should exist for non-Cache mode");
+
+        let record_bytes = record.to_bytes();
+        let encoded = self.codec.encode(&record_bytes);
+
+        // Check if rotation is needed
+        if segment.size() + encoded.len() as u64 > self.config.segment_size {
+            self.rotate_segment()?;
+        }
+
+        let segment = self.segment.as_mut().unwrap();
+        segment.write(&encoded)?;
+
+        if let Some(ref mut meta) = self.current_segment_meta {
+            meta.track_record(record.txn_id, record.timestamp);
+        }
+
+        self.total_wal_appends += 1;
+        self.total_bytes_written += encoded.len() as u64;
+
+        // Immediately flush for cross-process visibility
+        self.flush()?;
+
+        Ok(())
+    }
+
     /// Close the writer, ensuring all data is flushed.
     pub fn close(mut self) -> std::io::Result<()> {
         self.flush()?;
@@ -610,6 +706,153 @@ mod tests {
         // Should have appended to existing or created new
         let writer = make_writer(&wal_dir, DurabilityMode::Always);
         assert!(writer.current_segment() >= 1);
+    }
+
+    // ========================================================================
+    // Phase 2: Multi-process writer tests
+    // ========================================================================
+
+    #[test]
+    fn test_two_writers_same_wal_dir_no_corruption() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+
+        // Writer A writes records 1..5
+        {
+            let mut writer_a = make_writer(&wal_dir, DurabilityMode::Always);
+            for i in 1..=5 {
+                writer_a.append_and_flush(&make_record(i)).unwrap();
+            }
+        }
+
+        // Writer B opens the same dir and writes records 6..10
+        {
+            let mut writer_b = make_writer(&wal_dir, DurabilityMode::Always);
+            for i in 6..=10 {
+                writer_b.append_and_flush(&make_record(i)).unwrap();
+            }
+        }
+
+        // Read all records — should see all 10 in order
+        let reader = crate::wal::WalReader::new(Box::new(IdentityCodec));
+        let result = reader.read_all(&wal_dir).unwrap();
+        let ids: Vec<u64> = result.records.iter().map(|r| r.txn_id).collect();
+        assert_eq!(ids, (1..=10).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_writer_sees_other_writers_records_after_reopen() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+
+        // Writer A writes record 1
+        let mut writer_a = make_writer(&wal_dir, DurabilityMode::Always);
+        writer_a.append_and_flush(&make_record(1)).unwrap();
+
+        // Writer B writes record 2 (opens same dir)
+        {
+            let mut writer_b = make_writer(&wal_dir, DurabilityMode::Always);
+            writer_b.append_and_flush(&make_record(2)).unwrap();
+        }
+
+        // Writer A calls reopen_if_needed then writes record 3
+        writer_a.reopen_if_needed().unwrap();
+        writer_a.append_and_flush(&make_record(3)).unwrap();
+
+        // All 3 records should be readable
+        let reader = crate::wal::WalReader::new(Box::new(IdentityCodec));
+        let result = reader.read_all(&wal_dir).unwrap();
+        let ids: Vec<u64> = result.records.iter().map(|r| r.txn_id).collect();
+        assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_writer_handles_segment_rotation_by_other() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+
+        // Use small segments to force rotation
+        let config = WalConfig::new()
+            .with_segment_size(100)
+            .with_buffered_sync_bytes(50);
+
+        let mut writer_a = WalWriter::new(
+            wal_dir.clone(),
+            [1u8; 16],
+            DurabilityMode::Always,
+            config.clone(),
+            Box::new(IdentityCodec),
+        )
+        .unwrap();
+
+        // Writer A writes one record
+        writer_a
+            .append_and_flush(&WalRecord::new(1, [1u8; 16], 0, vec![0; 50]))
+            .unwrap();
+        let seg_a = writer_a.current_segment();
+
+        // Writer B opens same dir and writes enough to rotate segments
+        {
+            let mut writer_b = WalWriter::new(
+                wal_dir.clone(),
+                [1u8; 16],
+                DurabilityMode::Always,
+                config,
+                Box::new(IdentityCodec),
+            )
+            .unwrap();
+            for i in 2..=5 {
+                writer_b
+                    .append_and_flush(&WalRecord::new(i, [1u8; 16], 0, vec![0; 50]))
+                    .unwrap();
+            }
+            assert!(
+                writer_b.current_segment() > seg_a,
+                "Writer B should have rotated"
+            );
+        }
+
+        // Writer A should detect the new segment after reopen
+        writer_a.reopen_if_needed().unwrap();
+        writer_a
+            .append_and_flush(&WalRecord::new(99, [1u8; 16], 0, vec![0; 10]))
+            .unwrap();
+
+        // All records should be readable
+        let reader = crate::wal::WalReader::new(Box::new(IdentityCodec));
+        let result = reader.read_all(&wal_dir).unwrap();
+        assert!(
+            result.records.len() >= 6,
+            "Should have at least 6 records, got {}",
+            result.records.len()
+        );
+        // Record 99 should be last
+        assert_eq!(result.records.last().unwrap().txn_id, 99);
+    }
+
+    #[test]
+    fn test_reader_reads_interleaved_records_in_order() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+
+        // Create alternating writes from two writers
+        let mut writer_a = make_writer(&wal_dir, DurabilityMode::Always);
+        writer_a.append_and_flush(&make_record(1)).unwrap();
+
+        // Writer B opens, writes, closes
+        {
+            let mut writer_b = make_writer(&wal_dir, DurabilityMode::Always);
+            writer_b.append_and_flush(&make_record(2)).unwrap();
+        }
+
+        // Writer A reopens and writes again
+        writer_a.reopen_if_needed().unwrap();
+        writer_a.append_and_flush(&make_record(3)).unwrap();
+
+        let reader = crate::wal::WalReader::new(Box::new(IdentityCodec));
+        let result = reader.read_all(&wal_dir).unwrap();
+        let ids: Vec<u64> = result.records.iter().map(|r| r.txn_id).collect();
+        assert_eq!(ids, vec![1, 2, 3]);
     }
 
     #[test]

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -215,6 +215,45 @@ impl TransactionCoordinator {
         self.manager.remove_branch_lock(branch_id);
     }
 
+    /// Advance the version counter to at least `v`.
+    ///
+    /// Used during multi-process refresh to catch up with other processes.
+    pub fn catch_up_version(&self, v: u64) {
+        self.manager.catch_up_version(v);
+    }
+
+    /// Advance the txn_id counter to at least `id + 1`.
+    ///
+    /// Used during multi-process refresh to avoid ID collisions.
+    pub fn catch_up_txn_id(&self, id: u64) {
+        self.manager.catch_up_txn_id(id);
+    }
+
+    /// Commit a transaction with an externally-allocated version.
+    ///
+    /// Used by the coordinated commit path where versions are allocated
+    /// from the shared counter file under the WAL file lock.
+    pub fn commit_with_version<S: Storage>(
+        &self,
+        txn: &mut TransactionContext,
+        store: &S,
+        wal: Option<&mut WalWriter>,
+        version: u64,
+    ) -> StrataResult<u64> {
+        match self.manager.commit_with_version(txn, store, wal, version) {
+            Ok(v) => {
+                self.record_commit();
+                info!(target: "strata::txn", version = v, "Coordinated commit succeeded");
+                Ok(v)
+            }
+            Err(e) => {
+                self.record_abort();
+                warn!(target: "strata::txn", error = %e, "Coordinated commit aborted");
+                Err(StrataError::from(e))
+            }
+        }
+    }
+
     /// Get transaction metrics
     ///
     /// Returns current snapshot of transaction statistics.

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -51,6 +51,7 @@ use strata_durability::{
     ManifestManager, WalOnlyCompactor,
 };
 use strata_storage::ShardedStore;
+use std::sync::atomic::AtomicU64;
 use tracing::{info, warn};
 
 // ============================================================================
@@ -187,6 +188,15 @@ pub struct Database {
     /// Held for the lifetime of the Database. Dropped automatically when the
     /// Database is dropped, releasing the lock. None for ephemeral databases.
     _lock_file: Option<std::fs::File>,
+
+    /// WAL directory path (for multi-process refresh).
+    wal_dir: PathBuf,
+
+    /// Max txn_id applied to local storage from WAL (multi-process watermark).
+    wal_watermark: AtomicU64,
+
+    /// Whether this database uses multi-process coordination.
+    multi_process: bool,
 }
 
 impl Database {
@@ -333,6 +343,29 @@ impl Database {
         durability_mode: DurabilityMode,
         cfg: StrataConfig,
     ) -> StrataResult<Arc<Self>> {
+        Self::open_internal(path, durability_mode, cfg, false)
+    }
+
+    /// Open database in multi-process mode with specific durability and config.
+    ///
+    /// When multi-process mode is enabled, the database uses a shared file lock
+    /// instead of an exclusive lock, allowing multiple processes to access the
+    /// same database directory concurrently. Commits are coordinated through
+    /// the WAL file lock.
+    pub fn open_multi_process<P: AsRef<Path>>(
+        path: P,
+        durability_mode: DurabilityMode,
+        cfg: StrataConfig,
+    ) -> StrataResult<Arc<Self>> {
+        Self::open_internal(path, durability_mode, cfg, true)
+    }
+
+    fn open_internal<P: AsRef<Path>>(
+        path: P,
+        durability_mode: DurabilityMode,
+        cfg: StrataConfig,
+        multi_process: bool,
+    ) -> StrataResult<Arc<Self>> {
         // Create directory first so we can canonicalize the path
         let data_dir = path.as_ref().to_path_buf();
         std::fs::create_dir_all(&data_dir).map_err(StrataError::from)?;
@@ -340,23 +373,53 @@ impl Database {
         // Canonicalize path for consistent registry keys
         let canonical_path = data_dir.canonicalize().map_err(StrataError::from)?;
 
-        // Hold lock for entire operation to prevent TOCTOU race condition
-        // This ensures only one thread creates a database for a given path.
-        // For the common case (database already open), this is still fast.
-        let mut registry = OPEN_DATABASES.lock();
+        if !multi_process {
+            // Single-process mode: use registry and exclusive lock
+            let mut registry = OPEN_DATABASES.lock();
 
-        // Check registry for existing instance
-        if let Some(weak) = registry.get(&canonical_path) {
-            if let Some(db) = weak.upgrade() {
-                info!(target: "strata::db", path = ?canonical_path, "Returning existing database instance");
-                return Ok(db);
+            if let Some(weak) = registry.get(&canonical_path) {
+                if let Some(db) = weak.upgrade() {
+                    info!(target: "strata::db", path = ?canonical_path, "Returning existing database instance");
+                    return Ok(db);
+                }
             }
+
+            let lock_path = canonical_path.join(".lock");
+            let lock_file = std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(&lock_path)
+                .map_err(|e| StrataError::storage(format!("failed to open lock file: {}", e)))?;
+            fs2::FileExt::try_lock_exclusive(&lock_file).map_err(|_| {
+                StrataError::storage(format!(
+                    "database at '{}' is already in use by another process",
+                    canonical_path.display()
+                ))
+            })?;
+
+            let db = Self::open_finish(
+                canonical_path.clone(),
+                durability_mode,
+                cfg,
+                multi_process,
+                Some(lock_file),
+            )?;
+
+            registry.insert(canonical_path, Arc::downgrade(&db));
+            drop(registry);
+
+            crate::recovery::recover_all_participants(&db)?;
+            let index = db.extension::<crate::search::InvertedIndex>()?;
+            if !index.is_enabled() {
+                index.enable();
+            }
+
+            return Ok(db);
         }
 
-        // Not in registry (or expired) - create new instance
-        // Acquire an exclusive filesystem lock to prevent concurrent process access.
-        // This protects against multiple processes opening the same database directory,
-        // which would corrupt WAL files via interleaved writes.
+        // Multi-process mode: shared lock, skip registry singleton
         let lock_path = canonical_path.join(".lock");
         let lock_file = std::fs::OpenOptions::new()
             .create(true)
@@ -365,14 +428,37 @@ impl Database {
             .write(true)
             .open(&lock_path)
             .map_err(|e| StrataError::storage(format!("failed to open lock file: {}", e)))?;
-        fs2::FileExt::try_lock_exclusive(&lock_file).map_err(|_| {
-            StrataError::storage(format!(
-                "database at '{}' is already in use by another process",
-                canonical_path.display()
-            ))
+        fs2::FileExt::lock_shared(&lock_file).map_err(|e| {
+            StrataError::storage(format!("failed to acquire shared lock: {}", e))
         })?;
+
+        let db = Self::open_finish(
+            canonical_path,
+            durability_mode,
+            cfg,
+            multi_process,
+            Some(lock_file),
+        )?;
+
+        crate::recovery::recover_all_participants(&db)?;
+        let index = db.extension::<crate::search::InvertedIndex>()?;
+        if !index.is_enabled() {
+            index.enable();
+        }
+
+        Ok(db)
+    }
+
+    /// Shared tail of database open: recovery, WAL writer, coordinator, flush thread.
+    fn open_finish(
+        canonical_path: PathBuf,
+        durability_mode: DurabilityMode,
+        cfg: StrataConfig,
+        multi_process: bool,
+        lock_file: Option<std::fs::File>,
+    ) -> StrataResult<Arc<Self>> {
         // Create WAL directory
-        let wal_dir = data_dir.join("wal");
+        let wal_dir = canonical_path.join("wal");
         std::fs::create_dir_all(&wal_dir).map_err(StrataError::from)?;
 
         // Use RecoveryCoordinator for proper transaction-aware recovery
@@ -401,12 +487,40 @@ impl Database {
 
         // Open segmented WAL writer for appending
         let wal_writer = WalWriter::new(
-            wal_dir,
+            wal_dir.clone(),
             [0u8; 16], // database UUID placeholder
             durability_mode,
             WalConfig::default(),
             Box::new(IdentityCodec),
         )?;
+
+        let wal_watermark = AtomicU64::new(result.stats.max_txn_id);
+
+        // In multi-process mode, seed the counter file from recovery results.
+        // This ensures that if the counter file is missing (first multi-process open)
+        // or stale (crash between WAL write and counter update), the first coordinated
+        // commit will see correct starting values.
+        if multi_process {
+            use strata_durability::coordination::CounterFile;
+            let counter_file = CounterFile::new(&wal_dir);
+            let (cf_version, cf_txn_id) = counter_file.read_or_default().map_err(|e| {
+                StrataError::storage(format!("Failed to read counter file: {}", e))
+            })?;
+
+            // Only update if recovery found higher values (never go backward)
+            let recovered_version = result.stats.final_version;
+            let recovered_txn_id = result.stats.max_txn_id;
+            if recovered_version > cf_version || recovered_txn_id > cf_txn_id {
+                counter_file
+                    .write(
+                        recovered_version.max(cf_version),
+                        recovered_txn_id.max(cf_txn_id),
+                    )
+                    .map_err(|e| {
+                        StrataError::storage(format!("Failed to seed counter file: {}", e))
+                    })?;
+            }
+        }
 
         // Create coordinator from recovery result (preserves version continuity)
         let coordinator = TransactionCoordinator::from_recovery(&result);
@@ -453,28 +567,11 @@ impl Database {
             flush_shutdown,
             flush_handle: ParkingMutex::new(flush_handle),
             scheduler: BackgroundScheduler::new(2, 4096),
-            _lock_file: Some(lock_file),
+            _lock_file: lock_file,
+            wal_dir,
+            wal_watermark,
+            multi_process,
         });
-
-        // Register in global registry (lock already held)
-        registry.insert(canonical_path, Arc::downgrade(&db));
-
-        // Release lock before running primitive recovery (may be slow)
-        drop(registry);
-
-        // Run primitive recovery (e.g., VectorStore, Search Index)
-        // This must happen AFTER KV recovery completes, as primitives may
-        // depend on config data stored in KV.
-        crate::recovery::recover_all_participants(&db)?;
-
-        // Ensure the inverted index is enabled. If the search recovery
-        // participant was registered, it already loaded state and enabled it.
-        // If not (e.g., unit tests that don't register participants), we
-        // enable it here as a fallback.
-        let index = db.extension::<crate::search::InvertedIndex>()?;
-        if !index.is_enabled() {
-            index.enable();
-        }
 
         Ok(db)
     }
@@ -539,6 +636,9 @@ impl Database {
             flush_handle: ParkingMutex::new(None),
             scheduler: BackgroundScheduler::new(2, 4096),
             _lock_file: None, // No lock for ephemeral databases
+            wal_dir: PathBuf::new(),
+            wal_watermark: AtomicU64::new(0),
+            multi_process: false,
         });
 
         // Note: Ephemeral databases are NOT registered in the global registry
@@ -799,6 +899,90 @@ impl Database {
     /// Should be called after `BranchIndex::delete_branch()` succeeds.
     pub fn remove_branch_lock(&self, branch_id: &BranchId) {
         self.coordinator.remove_branch_lock(branch_id);
+    }
+
+    // ========================================================================
+    // Multi-Process Refresh
+    // ========================================================================
+
+    /// Refresh local storage by tailing new WAL entries from other processes.
+    ///
+    /// In multi-process mode, other processes may have appended new WAL records
+    /// since this instance last read the WAL. `refresh()` reads any new records
+    /// and applies them to local in-memory storage, bringing this instance
+    /// up-to-date with all committed writes.
+    ///
+    /// Returns the number of new records applied.
+    ///
+    /// For non-multi-process databases, this is a no-op returning 0.
+    pub fn refresh(&self) -> StrataResult<usize> {
+        if !self.multi_process || self.persistence_mode == PersistenceMode::Ephemeral {
+            return Ok(0);
+        }
+
+        let watermark = self.wal_watermark.load(std::sync::atomic::Ordering::SeqCst);
+
+        // Read all WAL records after our watermark
+        let reader = strata_durability::wal::WalReader::new(Box::new(
+            strata_durability::codec::IdentityCodec,
+        ));
+        let records = reader
+            .read_all_after_watermark(&self.wal_dir, watermark)
+            .map_err(|e| StrataError::storage(format!("WAL refresh read failed: {}", e)))?;
+
+        if records.is_empty() {
+            return Ok(0);
+        }
+
+        let mut applied = 0usize;
+        let mut max_version = 0u64;
+        let mut max_txn_id = watermark;
+
+        for record in &records {
+            max_txn_id = max_txn_id.max(record.txn_id);
+
+            let payload =
+                strata_concurrency::TransactionPayload::from_bytes(&record.writeset).map_err(
+                    |e| {
+                        StrataError::storage(format!(
+                            "Failed to decode WAL payload for txn {}: {}",
+                            record.txn_id, e
+                        ))
+                    },
+                )?;
+
+            max_version = max_version.max(payload.version);
+
+            // Apply puts
+            for (key, value) in &payload.puts {
+                use strata_core::traits::Storage;
+                Storage::put_with_version(
+                    self.storage.as_ref(),
+                    key.clone(),
+                    value.clone(),
+                    payload.version,
+                    None,
+                )?;
+            }
+
+            // Apply deletes
+            for key in &payload.deletes {
+                use strata_core::traits::Storage;
+                Storage::delete_with_version(self.storage.as_ref(), key, payload.version)?;
+            }
+
+            applied += 1;
+        }
+
+        // Advance local counters so new transactions get unique IDs/versions
+        self.coordinator.catch_up_version(max_version);
+        self.coordinator.catch_up_txn_id(max_txn_id);
+
+        // Update watermark
+        self.wal_watermark
+            .store(max_txn_id, std::sync::atomic::Ordering::SeqCst);
+
+        Ok(applied)
     }
 
     // ========================================================================
@@ -1345,6 +1529,10 @@ impl Database {
         txn: &mut TransactionContext,
         durability: DurabilityMode,
     ) -> StrataResult<u64> {
+        if self.multi_process {
+            return self.commit_coordinated(txn, durability);
+        }
+
         let needs_wal =
             durability.requires_wal() && (!txn.is_read_only() || !txn.json_writes().is_empty());
 
@@ -1356,6 +1544,108 @@ impl Database {
         let wal_ref = wal_guard.as_deref_mut();
 
         self.coordinator.commit(txn, self.storage.as_ref(), wal_ref)
+    }
+
+    /// Coordinated commit for multi-process mode.
+    ///
+    /// Critical section (under WAL file lock):
+    /// 1. Refresh — tail new WAL entries into local storage
+    /// 2. Read counters — get (max_version, max_txn_id)
+    /// 3. Allocate — new_version = max_version + 1, new_txn_id = max_txn_id + 1
+    /// 4. Validate against refreshed storage (OCC re-validation)
+    /// 5. WAL append + flush
+    /// 6. Update counters
+    /// 7. Drop WAL file lock
+    /// 8. Apply to local storage + update watermark
+    fn commit_coordinated(
+        &self,
+        txn: &mut TransactionContext,
+        durability: DurabilityMode,
+    ) -> StrataResult<u64> {
+        use strata_durability::coordination::{CounterFile, WalFileLock};
+
+        // Read-only transactions skip coordination entirely
+        if txn.is_read_only() && txn.json_writes().is_empty() {
+            return self.coordinator.commit(txn, self.storage.as_ref(), None);
+        }
+
+        // Acquire WAL file lock (blocks until available)
+        let _wal_lock = WalFileLock::acquire(&self.wal_dir).map_err(|e| {
+            StrataError::storage(format!("Failed to acquire WAL file lock: {}", e))
+        })?;
+
+        // Step 1: Refresh from WAL (apply other processes' writes)
+        self.refresh()?;
+
+        // Step 2: Read counters — take max of counter file and local state.
+        //
+        // The counter file may be stale if:
+        // - This is the first multi-process open (counter file doesn't exist yet)
+        // - A previous process crashed after WAL write but before counter update
+        // - The database was converted from single-process to multi-process mode
+        //
+        // The local coordinator already reflects WAL reality (from recovery + refresh),
+        // so we take the max to ensure we never allocate a duplicate version/txn_id.
+        let counter_file = CounterFile::new(&self.wal_dir);
+        let (cf_version, cf_txn_id) = counter_file.read_or_default().map_err(|e| {
+            StrataError::storage(format!("Failed to read counter file: {}", e))
+        })?;
+
+        let local_version = self.coordinator.current_version();
+        let local_max_txn_id = self.wal_watermark.load(std::sync::atomic::Ordering::SeqCst);
+
+        let max_version = cf_version.max(local_version);
+        let max_txn_id = cf_txn_id.max(local_max_txn_id);
+
+        // Step 3: Allocate new version and txn_id
+        let new_version = max_version + 1;
+        let new_txn_id = max_txn_id + 1;
+
+        // Override the transaction's txn_id with the globally-unique one
+        txn.txn_id = new_txn_id;
+
+        // Step 4: Validate + WAL append using commit_with_version
+        let needs_wal =
+            durability.requires_wal() && (!txn.is_read_only() || !txn.json_writes().is_empty());
+
+        let mut wal_guard = if needs_wal {
+            self.wal_writer.as_ref().map(|w| w.lock())
+        } else {
+            None
+        };
+
+        // If we have a WAL writer, ensure it sees the latest segment
+        if let Some(ref mut wal) = wal_guard {
+            wal.reopen_if_needed()
+                .map_err(|e| StrataError::storage(format!("WAL reopen failed: {}", e)))?;
+        }
+
+        let wal_ref = wal_guard.as_deref_mut();
+
+        // Use append_and_flush via commit_with_version to ensure immediate visibility
+        let commit_version = self.coordinator.commit_with_version(
+            txn,
+            self.storage.as_ref(),
+            wal_ref,
+            new_version,
+        )?;
+
+        // Flush WAL for cross-process visibility
+        if let Some(ref mut wal) = wal_guard {
+            wal.flush().map_err(StrataError::from)?;
+        }
+
+        // Step 5: Update counter file
+        counter_file.write(new_version, new_txn_id).map_err(|e| {
+            StrataError::storage(format!("Failed to update counter file: {}", e))
+        })?;
+
+        // Step 6: Update local watermark
+        self.wal_watermark
+            .store(new_txn_id, std::sync::atomic::Ordering::SeqCst);
+
+        // WAL file lock is dropped here (end of scope)
+        Ok(commit_version)
     }
 
     // ========================================================================
@@ -1501,8 +1791,12 @@ impl Drop for Database {
         // Freeze search index to disk for fast recovery
         self.freeze_search_index();
 
-        // Remove from registry if we're disk-backed
-        if self.persistence_mode == PersistenceMode::Disk && !self.data_dir.as_os_str().is_empty() {
+        // Remove from registry if we're disk-backed (skip in multi-process mode:
+        // multi-process instances are not registered in the singleton registry).
+        if self.persistence_mode == PersistenceMode::Disk
+            && !self.data_dir.as_os_str().is_empty()
+            && !self.multi_process
+        {
             let mut registry = OPEN_DATABASES.lock();
             registry.remove(&self.data_dir);
         }

--- a/crates/engine/tests/multi_process_tests.rs
+++ b/crates/engine/tests/multi_process_tests.rs
@@ -1,0 +1,806 @@
+//! Integration tests for multi-process WAL coordination (Phases 3–5).
+//!
+//! These tests verify:
+//! - Two Database instances can open the same directory concurrently
+//! - WAL refresh brings one instance up-to-date with another's writes
+//! - Coordinated commit detects conflicts across instances
+//! - Crash recovery preserves both instances' committed data
+
+use std::sync::Arc;
+use strata_core::types::{BranchId, Key, Namespace};
+use strata_core::value::Value;
+use strata_engine::database::config::StrataConfig;
+use strata_engine::Database;
+use tempfile::TempDir;
+
+fn create_test_namespace(branch_id: BranchId) -> Namespace {
+    Namespace::new(
+        "tenant".to_string(),
+        "app".to_string(),
+        "agent".to_string(),
+        branch_id,
+        "default".to_string(),
+    )
+}
+
+/// Read a key value through a read-only transaction.
+fn read_key(db: &Database, branch_id: BranchId, key: &Key) -> Option<Value> {
+    db.transaction(branch_id, |txn| Ok(txn.get(key)?))
+        .unwrap()
+}
+
+// ============================================================================
+// Phase 3: Multi-Instance Database Open
+// ============================================================================
+
+#[test]
+fn test_multi_process_two_instances_same_path() {
+    let dir = TempDir::new().unwrap();
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    // Distinct instances (not the same Arc)
+    assert!(!Arc::ptr_eq(&db1, &db2));
+    assert!(db1.is_open());
+    assert!(db2.is_open());
+}
+
+#[test]
+fn test_multi_process_both_read_after_recovery() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    let key = Key::new_kv(ns.clone(), "shared_key");
+
+    // Write data with instance 1
+    {
+        let cfg = StrataConfig::default();
+        let mode = cfg.durability_mode().unwrap();
+        let db = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+        db.transaction(branch_id, |txn| {
+            txn.put(key.clone(), Value::Int(42))?;
+            Ok(())
+        })
+        .unwrap();
+        db.flush().unwrap();
+    }
+
+    // Both new instances should see the data after recovery
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    let val1 = read_key(&db1, branch_id, &key);
+    assert_eq!(val1, Some(Value::Int(42)));
+
+    let val2 = read_key(&db2, branch_id, &key);
+    assert_eq!(val2, Some(Value::Int(42)));
+}
+
+#[test]
+fn test_default_mode_still_exclusive_lock() {
+    let dir = TempDir::new().unwrap();
+
+    let db1 = Database::open(dir.path()).unwrap();
+    let db2 = Database::open(dir.path()).unwrap();
+
+    // Same Arc from registry
+    assert!(Arc::ptr_eq(&db1, &db2));
+}
+
+// ============================================================================
+// Phase 4: WAL Refresh
+// ============================================================================
+
+#[test]
+fn test_refresh_sees_other_instance_writes() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    let key = Key::new_kv(ns.clone(), "from_db1");
+
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    // Write via db1
+    db1.transaction(branch_id, |txn| {
+        txn.put(key.clone(), Value::Int(100))?;
+        Ok(())
+    })
+    .unwrap();
+    db1.flush().unwrap();
+
+    // After refresh, db2 should see it
+    let applied = db2.refresh().unwrap();
+    assert!(applied > 0, "Should have applied new records");
+
+    let val = read_key(&db2, branch_id, &key);
+    assert_eq!(val, Some(Value::Int(100)));
+}
+
+#[test]
+fn test_refresh_updates_version_counter() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    let v_before = db2.current_version();
+
+    db1.transaction(branch_id, |txn| {
+        txn.put(Key::new_kv(ns.clone(), "key"), Value::Int(1))?;
+        Ok(())
+    })
+    .unwrap();
+    db1.flush().unwrap();
+
+    db2.refresh().unwrap();
+
+    let v_after = db2.current_version();
+    assert!(
+        v_after > v_before,
+        "Version should advance after refresh: {} -> {}",
+        v_before,
+        v_after
+    );
+}
+
+#[test]
+fn test_refresh_idempotent_no_new_records() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    db1.transaction(branch_id, |txn| {
+        txn.put(Key::new_kv(ns.clone(), "key"), Value::Int(1))?;
+        Ok(())
+    })
+    .unwrap();
+    db1.flush().unwrap();
+
+    let applied1 = db2.refresh().unwrap();
+    assert!(applied1 > 0);
+
+    let applied2 = db2.refresh().unwrap();
+    assert_eq!(applied2, 0, "Second refresh should find no new records");
+}
+
+#[test]
+fn test_refresh_multiple_records() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    for i in 1..=5i64 {
+        db1.transaction(branch_id, |txn| {
+            txn.put(Key::new_kv(ns.clone(), format!("key{}", i)), Value::Int(i))?;
+            Ok(())
+        })
+        .unwrap();
+    }
+    db1.flush().unwrap();
+
+    let applied = db2.refresh().unwrap();
+    assert_eq!(applied, 5, "Should apply all 5 records");
+
+    for i in 1..=5i64 {
+        let key = Key::new_kv(ns.clone(), format!("key{}", i));
+        let val = read_key(&db2, branch_id, &key);
+        assert_eq!(val, Some(Value::Int(i)));
+    }
+}
+
+// ============================================================================
+// Phase 5: Coordinated Commit
+// ============================================================================
+
+#[test]
+fn test_coordinated_commit_basic() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    let key = Key::new_kv(ns.clone(), "key");
+
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    db.transaction(branch_id, |txn| {
+        txn.put(key.clone(), Value::Int(42))?;
+        Ok(())
+    })
+    .unwrap();
+
+    let val = read_key(&db, branch_id, &key);
+    assert_eq!(val, Some(Value::Int(42)));
+}
+
+#[test]
+fn test_coordinated_commit_conflict_detected() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    let key = Key::new_kv(ns.clone(), "conflict_key");
+
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    // Write initial value via db1
+    db1.transaction(branch_id, |txn| {
+        txn.put(key.clone(), Value::Int(1))?;
+        Ok(())
+    })
+    .unwrap();
+    db1.flush().unwrap();
+
+    // db2 refreshes to see the initial value
+    db2.refresh().unwrap();
+
+    // db1 updates the key (read-modify-write)
+    db1.transaction(branch_id, |txn| {
+        let _ = txn.get(&key)?;
+        txn.put(key.clone(), Value::Int(2))?;
+        Ok(())
+    })
+    .unwrap();
+    db1.flush().unwrap();
+
+    // db2 tries read-modify-write on same key.
+    // The coordinated commit refreshes WAL and re-validates,
+    // detecting that the key was modified since db2's snapshot.
+    let result = db2.transaction(branch_id, |txn| {
+        let _ = txn.get(&key)?;
+        txn.put(key.clone(), Value::Int(3))?;
+        Ok(())
+    });
+
+    assert!(
+        result.is_err(),
+        "Should detect conflict: db1 updated key between db2's read and commit"
+    );
+}
+
+#[test]
+fn test_coordinated_commit_blind_writes_no_conflict() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    // Both write different keys blindly (no reads) — no conflict
+    db1.transaction(branch_id, |txn| {
+        txn.put(Key::new_kv(ns.clone(), "from_db1"), Value::Int(1))?;
+        Ok(())
+    })
+    .unwrap();
+    db1.flush().unwrap();
+
+    db2.transaction(branch_id, |txn| {
+        txn.put(Key::new_kv(ns.clone(), "from_db2"), Value::Int(2))?;
+        Ok(())
+    })
+    .unwrap();
+    db2.flush().unwrap();
+
+    // Both keys should be present after refresh
+    db1.refresh().unwrap();
+    db2.refresh().unwrap();
+
+    let k1 = Key::new_kv(ns.clone(), "from_db1");
+    let k2 = Key::new_kv(ns.clone(), "from_db2");
+
+    assert_eq!(read_key(&db1, branch_id, &k1), Some(Value::Int(1)));
+    assert_eq!(read_key(&db1, branch_id, &k2), Some(Value::Int(2)));
+    assert_eq!(read_key(&db2, branch_id, &k1), Some(Value::Int(1)));
+    assert_eq!(read_key(&db2, branch_id, &k2), Some(Value::Int(2)));
+}
+
+#[test]
+fn test_coordinated_commit_versions_monotonic_across_instances() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    // Alternate commits between instances and track versions
+    let v0 = db1.current_version();
+
+    db1.transaction(branch_id, |txn| {
+        txn.put(Key::new_kv(ns.clone(), "a"), Value::Int(1))?;
+        Ok(())
+    })
+    .unwrap();
+    db1.flush().unwrap();
+    let v1 = db1.current_version();
+
+    db2.transaction(branch_id, |txn| {
+        txn.put(Key::new_kv(ns.clone(), "b"), Value::Int(2))?;
+        Ok(())
+    })
+    .unwrap();
+    db2.flush().unwrap();
+    let v2 = db2.current_version();
+
+    db1.transaction(branch_id, |txn| {
+        txn.put(Key::new_kv(ns.clone(), "c"), Value::Int(3))?;
+        Ok(())
+    })
+    .unwrap();
+    let v3 = db1.current_version();
+
+    assert!(v0 < v1, "v0={} should be < v1={}", v0, v1);
+    assert!(v1 < v2, "v1={} should be < v2={}", v1, v2);
+    assert!(v2 < v3, "v2={} should be < v3={}", v2, v3);
+}
+
+#[test]
+fn test_two_instances_interleaved_commits() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    for i in 0..5i64 {
+        let db = if i % 2 == 0 { &db1 } else { &db2 };
+        db.transaction(branch_id, |txn| {
+            txn.put(Key::new_kv(ns.clone(), format!("key{}", i)), Value::Int(i))?;
+            Ok(())
+        })
+        .unwrap();
+        db.flush().unwrap();
+    }
+
+    db1.refresh().unwrap();
+    db2.refresh().unwrap();
+
+    for i in 0..5i64 {
+        let key = Key::new_kv(ns.clone(), format!("key{}", i));
+        assert_eq!(
+            read_key(&db1, branch_id, &key),
+            Some(Value::Int(i)),
+            "db1 should see key{}",
+            i
+        );
+        assert_eq!(
+            read_key(&db2, branch_id, &key),
+            Some(Value::Int(i)),
+            "db2 should see key{}",
+            i
+        );
+    }
+}
+
+#[test]
+fn test_coordinated_commit_crash_recovery_preserves_both() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    {
+        let cfg = StrataConfig::default();
+        let mode = cfg.durability_mode().unwrap();
+        let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+        let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+        db1.transaction(branch_id, |txn| {
+            txn.put(Key::new_kv(ns.clone(), "from_db1"), Value::Int(100))?;
+            Ok(())
+        })
+        .unwrap();
+        db1.flush().unwrap();
+
+        db2.transaction(branch_id, |txn| {
+            txn.put(Key::new_kv(ns.clone(), "from_db2"), Value::Int(200))?;
+            Ok(())
+        })
+        .unwrap();
+        db2.flush().unwrap();
+    }
+
+    // Reopen — all data should be recovered
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    let k1 = Key::new_kv(ns.clone(), "from_db1");
+    let k2 = Key::new_kv(ns.clone(), "from_db2");
+
+    assert_eq!(read_key(&db, branch_id, &k1), Some(Value::Int(100)));
+    assert_eq!(read_key(&db, branch_id, &k2), Some(Value::Int(200)));
+}
+
+#[test]
+fn test_coordinated_commit_different_branches_both_succeed() {
+    let dir = TempDir::new().unwrap();
+    let branch_a = BranchId::new();
+    let branch_b = BranchId::new();
+    let ns_a = create_test_namespace(branch_a);
+    let ns_b = create_test_namespace(branch_b);
+
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    db1.transaction(branch_a, |txn| {
+        txn.put(Key::new_kv(ns_a.clone(), "key"), Value::Int(1))?;
+        Ok(())
+    })
+    .unwrap();
+    db1.flush().unwrap();
+
+    db2.transaction(branch_b, |txn| {
+        txn.put(Key::new_kv(ns_b.clone(), "key"), Value::Int(2))?;
+        Ok(())
+    })
+    .unwrap();
+    db2.flush().unwrap();
+
+    db1.refresh().unwrap();
+
+    let ka = Key::new_kv(ns_a, "key");
+    let kb = Key::new_kv(ns_b, "key");
+
+    assert_eq!(read_key(&db1, branch_a, &ka), Some(Value::Int(1)));
+    assert_eq!(read_key(&db1, branch_b, &kb), Some(Value::Int(2)));
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+/// Verifies that opening a database in multi-process mode after prior single-process
+/// usage correctly initializes the counter file from recovery, preventing version
+/// collisions.
+#[test]
+fn test_single_to_multi_process_conversion() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    let key_old = Key::new_kv(ns.clone(), "old_data");
+    let key_new = Key::new_kv(ns.clone(), "new_data");
+
+    // Phase 1: Write data in single-process mode
+    let version_after_single;
+    {
+        let db = Database::open(dir.path()).unwrap();
+        for i in 1..=10i64 {
+            db.transaction(branch_id, |txn| {
+                txn.put(Key::new_kv(ns.clone(), format!("key{}", i)), Value::Int(i))?;
+                Ok(())
+            })
+            .unwrap();
+        }
+        db.transaction(branch_id, |txn| {
+            txn.put(key_old.clone(), Value::Int(999))?;
+            Ok(())
+        })
+        .unwrap();
+        version_after_single = db.current_version();
+        db.flush().unwrap();
+    }
+
+    // Phase 2: Reopen in multi-process mode and write new data
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    // Old data must be recovered
+    assert_eq!(read_key(&db, branch_id, &key_old), Some(Value::Int(999)));
+
+    // New commit must get a version HIGHER than any single-process version
+    db.transaction(branch_id, |txn| {
+        txn.put(key_new.clone(), Value::Int(123))?;
+        Ok(())
+    })
+    .unwrap();
+
+    let version_after_multi = db.current_version();
+    assert!(
+        version_after_multi > version_after_single,
+        "Multi-process version {} must exceed single-process version {}",
+        version_after_multi,
+        version_after_single
+    );
+
+    // Both old and new data must be readable
+    assert_eq!(read_key(&db, branch_id, &key_old), Some(Value::Int(999)));
+    assert_eq!(read_key(&db, branch_id, &key_new), Some(Value::Int(123)));
+}
+
+/// Simulates the counter file being stale (e.g., crash between WAL write and
+/// counter update) and verifies that the next commit still allocates unique
+/// version/txn_id values by cross-referencing with local coordinator state.
+#[test]
+fn test_stale_counter_file_recovery() {
+    use strata_durability::coordination::CounterFile;
+
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    // Open and write several transactions to establish versions
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    {
+        let db = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+
+        for i in 1..=5i64 {
+            db.transaction(branch_id, |txn| {
+                txn.put(Key::new_kv(ns.clone(), format!("key{}", i)), Value::Int(i))?;
+                Ok(())
+            })
+            .unwrap();
+        }
+        db.flush().unwrap();
+    }
+
+    // Corrupt the counter file to simulate a crash gap:
+    // Reset it to (0, 0), as if the last counter update never happened.
+    let wal_dir = dir.path().join("wal");
+    let counter_file = CounterFile::new(&wal_dir);
+    counter_file.write(0, 0).unwrap();
+
+    // Reopen — recovery should fix the counter file
+    let db = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    // The counter file should have been reseeded from recovery
+    let (cf_ver, cf_txn) = counter_file.read().unwrap();
+    assert!(cf_ver >= 5, "Counter file version should be >= 5, got {}", cf_ver);
+    assert!(cf_txn >= 5, "Counter file txn_id should be >= 5, got {}", cf_txn);
+
+    // A new commit should get a version higher than anything before
+    let key_new = Key::new_kv(ns.clone(), "after_recovery");
+    db.transaction(branch_id, |txn| {
+        txn.put(key_new.clone(), Value::Int(42))?;
+        Ok(())
+    })
+    .unwrap();
+
+    let new_version = db.current_version();
+    assert!(
+        new_version > 5,
+        "New version {} must be > 5 (pre-crash version)",
+        new_version
+    );
+
+    // All old data must still be readable
+    for i in 1..=5i64 {
+        let key = Key::new_kv(ns.clone(), format!("key{}", i));
+        assert_eq!(read_key(&db, branch_id, &key), Some(Value::Int(i)));
+    }
+    assert_eq!(read_key(&db, branch_id, &key_new), Some(Value::Int(42)));
+}
+
+/// Verifies that deletes propagate correctly through WAL refresh.
+#[test]
+fn test_refresh_propagates_deletes() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    let key = Key::new_kv(ns.clone(), "to_delete");
+
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    // db1 writes a key
+    db1.transaction(branch_id, |txn| {
+        txn.put(key.clone(), Value::Int(42))?;
+        Ok(())
+    })
+    .unwrap();
+    db1.flush().unwrap();
+
+    // db2 refreshes and sees it
+    db2.refresh().unwrap();
+    assert_eq!(read_key(&db2, branch_id, &key), Some(Value::Int(42)));
+
+    // db1 deletes the key
+    db1.transaction(branch_id, |txn| {
+        txn.delete(key.clone())?;
+        Ok(())
+    })
+    .unwrap();
+    db1.flush().unwrap();
+
+    // db2 refreshes and should see the deletion
+    db2.refresh().unwrap();
+    assert_eq!(
+        read_key(&db2, branch_id, &key),
+        None,
+        "Deleted key should be None after refresh"
+    );
+}
+
+/// Both instances blindly overwrite the same key. Both commits should succeed
+/// (no read set → no conflict), and the final value should be the later writer's.
+#[test]
+fn test_same_key_blind_overwrite_both_succeed() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    let key = Key::new_kv(ns.clone(), "shared");
+
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    // db1 blindly writes
+    db1.transaction(branch_id, |txn| {
+        txn.put(key.clone(), Value::Int(100))?;
+        Ok(())
+    })
+    .unwrap();
+    db1.flush().unwrap();
+
+    // db2 blindly writes the same key (no read → no conflict)
+    db2.transaction(branch_id, |txn| {
+        txn.put(key.clone(), Value::Int(200))?;
+        Ok(())
+    })
+    .unwrap();
+    db2.flush().unwrap();
+
+    // After both refresh, the later write (db2's 200) should win
+    // because it has a higher version number
+    db1.refresh().unwrap();
+    db2.refresh().unwrap();
+
+    assert_eq!(read_key(&db1, branch_id, &key), Some(Value::Int(200)));
+    assert_eq!(read_key(&db2, branch_id, &key), Some(Value::Int(200)));
+}
+
+/// Read-only transactions in multi-process mode should not acquire
+/// the WAL file lock and should complete without coordination overhead.
+#[test]
+fn test_read_only_transaction_skips_coordination() {
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    let key = Key::new_kv(ns.clone(), "data");
+
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+    let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    // Write some data
+    db1.transaction(branch_id, |txn| {
+        txn.put(key.clone(), Value::Int(42))?;
+        Ok(())
+    })
+    .unwrap();
+    db1.flush().unwrap();
+
+    db2.refresh().unwrap();
+
+    // A read-only transaction on db2 should work even without coordination
+    let val: Option<Value> = db2
+        .transaction(branch_id, |txn| Ok(txn.get(&key)?))
+        .unwrap();
+    assert_eq!(val, Some(Value::Int(42)));
+
+    // A purely read-only transaction should also work on db1
+    let val: Option<Value> = db1
+        .transaction(branch_id, |txn| Ok(txn.get(&key)?))
+        .unwrap();
+    assert_eq!(val, Some(Value::Int(42)));
+}
+
+/// After crash recovery, both instances' data should be present and the
+/// counter file should be correctly seeded so new commits get unique versions.
+#[test]
+fn test_crash_recovery_counter_file_consistency() {
+    use strata_durability::coordination::CounterFile;
+
+    let dir = TempDir::new().unwrap();
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    // Two instances write data and close (simulating crash)
+    {
+        let cfg = StrataConfig::default();
+        let mode = cfg.durability_mode().unwrap();
+        let db1 = Database::open_multi_process(dir.path(), mode, cfg.clone()).unwrap();
+        let db2 = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+        db1.transaction(branch_id, |txn| {
+            txn.put(Key::new_kv(ns.clone(), "from_1"), Value::Int(1))?;
+            Ok(())
+        })
+        .unwrap();
+        db1.flush().unwrap();
+
+        db2.transaction(branch_id, |txn| {
+            txn.put(Key::new_kv(ns.clone(), "from_2"), Value::Int(2))?;
+            Ok(())
+        })
+        .unwrap();
+        db2.flush().unwrap();
+    }
+
+    // Check counter file state before reopen
+    let wal_dir = dir.path().join("wal");
+    let cf = CounterFile::new(&wal_dir);
+    let (ver_before, txn_before) = cf.read().unwrap();
+
+    // Reopen single instance — counter file should be consistent
+    let cfg = StrataConfig::default();
+    let mode = cfg.durability_mode().unwrap();
+    let db = Database::open_multi_process(dir.path(), mode, cfg).unwrap();
+
+    let (ver_after, txn_after) = cf.read().unwrap();
+    assert!(
+        ver_after >= ver_before,
+        "Counter version should not go backward: {} -> {}",
+        ver_before,
+        ver_after
+    );
+    assert!(
+        txn_after >= txn_before,
+        "Counter txn_id should not go backward: {} -> {}",
+        txn_before,
+        txn_after
+    );
+
+    // New commit should get version higher than anything before
+    db.transaction(branch_id, |txn| {
+        txn.put(Key::new_kv(ns.clone(), "after_reopen"), Value::Int(3))?;
+        Ok(())
+    })
+    .unwrap();
+
+    let new_version = db.current_version();
+    assert!(new_version > ver_before, "New version must exceed pre-crash version");
+
+    // All data readable
+    assert_eq!(
+        read_key(&db, branch_id, &Key::new_kv(ns.clone(), "from_1")),
+        Some(Value::Int(1))
+    );
+    assert_eq!(
+        read_key(&db, branch_id, &Key::new_kv(ns.clone(), "from_2")),
+        Some(Value::Int(2))
+    );
+    assert_eq!(
+        read_key(&db, branch_id, &Key::new_kv(ns.clone(), "after_reopen")),
+        Some(Value::Int(3))
+    );
+}

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -182,9 +182,23 @@ impl Strata {
                 .unwrap_or(cfg.embed_batch_size.unwrap_or(512)),
         );
 
-        let db = Database::open_with_config(&data_dir, cfg).map_err(|e| Error::Internal {
-            reason: format!("Failed to open database: {}", e),
-        })?;
+        let db = if opts.multi_process {
+            let mode = cfg.durability_mode().map_err(|e| Error::Internal {
+                reason: format!("Failed to parse durability mode: {}", e),
+            })?;
+            // Write config to strata.toml so restarts pick it up
+            let config_path = data_dir.join(strata_engine::database::config::CONFIG_FILE_NAME);
+            cfg.write_to_file(&config_path).map_err(|e| Error::Internal {
+                reason: format!("Failed to write config: {}", e),
+            })?;
+            Database::open_multi_process(&data_dir, mode, cfg).map_err(|e| Error::Internal {
+                reason: format!("Failed to open database (multi-process): {}", e),
+            })?
+        } else {
+            Database::open_with_config(&data_dir, cfg).map_err(|e| Error::Internal {
+                reason: format!("Failed to open database: {}", e),
+            })?
+        };
 
         let access_mode = opts.access_mode;
         let executor = Executor::new_with_mode(db, access_mode);

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -50,6 +50,14 @@ pub struct OpenOptions {
     /// Override embedding batch size for auto-embed.
     /// `None` means "use the config file value, or 512 if unset".
     pub embed_batch_size: Option<usize>,
+    /// Enable multi-process coordination mode.
+    ///
+    /// When `true`, multiple processes can open the same database directory
+    /// concurrently. A shared file lock is used instead of an exclusive one,
+    /// and commits are coordinated through the WAL.
+    ///
+    /// Default: `false` (exclusive single-process access).
+    pub multi_process: bool,
 }
 
 impl OpenOptions {
@@ -100,6 +108,15 @@ impl OpenOptions {
         self.embed_batch_size = Some(size);
         self
     }
+
+    /// Enable multi-process coordination mode.
+    ///
+    /// When enabled, multiple processes can open the same database directory
+    /// concurrently. Commits are coordinated through the WAL file lock.
+    pub fn multi_process(mut self, enabled: bool) -> Self {
+        self.multi_process = enabled;
+        self
+    }
 }
 
 impl Default for OpenOptions {
@@ -113,6 +130,7 @@ impl Default for OpenOptions {
             model_api_key: None,
             model_timeout_ms: None,
             embed_batch_size: None,
+            multi_process: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Enable multiple processes to safely read/write the same Strata database concurrently by coordinating through the WAL
- Add `WalFileLock` and `CounterFile` primitives for inter-process coordination via short-lived exclusive locks and atomic counter allocation
- Add `Database::open_multi_process()` with shared file locking (vs exclusive in default mode), `Database::refresh()` for incremental WAL tailing, and coordinated commit path with OCC re-validation
- Counter file is seeded from recovery results on open and cross-referenced with local coordinator state on commit to prevent version collisions from crash gaps or mode conversion
- Default single-process mode is completely unchanged; multi-process is opt-in via `OpenOptions::multi_process(true)`

### Crates modified
| Crate | Changes |
|-------|---------|
| `strata-durability` | New `coordination.rs` (WalFileLock, CounterFile); `WalWriter::reopen_if_needed()` + `append_and_flush()`; `WalSegment::seek_to_end()` |
| `strata-concurrency` | `TransactionManager::catch_up_version/txn_id()`, `commit_with_version()` |
| `strata-engine` | `Database::open_multi_process()`, `refresh()`, `commit_coordinated()`; counter file seeding in `open_finish()` |
| `strata-executor` | Thread `multi_process` from `OpenOptions` to `Database` |
| `strata-security` | `OpenOptions::multi_process` flag |

## Test plan

- [x] 20 integration tests in `crates/engine/tests/multi_process_tests.rs`
- [x] Two instances open same directory concurrently
- [x] WAL refresh propagates writes and deletes across instances
- [x] Coordinated commit detects read-write conflicts
- [x] Blind writes to different keys succeed without conflict
- [x] Same-key blind overwrite: higher version wins
- [x] Version monotonicity across alternating instance commits
- [x] Crash recovery preserves both instances' data
- [x] Single→multi-process conversion: no version collisions
- [x] Stale counter file (simulated crash gap): correctly reseeded from recovery
- [x] Counter file consistency after reopen
- [x] Read-only transactions skip WAL coordination
- [x] Default mode still uses exclusive lock + registry singleton
- [x] `cargo test --workspace` — all tests pass, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)