### PR TITLE
Fix cargo fmt formatting across workspace

### DIFF
--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -1204,9 +1204,7 @@ mod tests {
         assert!(filtered.is_empty());
 
         // Watermark=u64::MAX: extreme case
-        let filtered = reader
-            .read_all_after_watermark(&wal_dir, u64::MAX)
-            .unwrap();
+        let filtered = reader.read_all_after_watermark(&wal_dir, u64::MAX).unwrap();
         assert!(filtered.is_empty());
     }
 

--- a/crates/durability/src/wal/writer.rs
+++ b/crates/durability/src/wal/writer.rs
@@ -474,15 +474,10 @@ impl WalWriter {
                     Err(_) => {
                         // If we can't open it, create a new one after it
                         let new_num = num + 1;
-                        let seg = WalSegment::create(
-                            &self.wal_dir,
-                            new_num,
-                            self.database_uuid,
-                        )?;
+                        let seg = WalSegment::create(&self.wal_dir, new_num, self.database_uuid)?;
                         self.segment = Some(seg);
                         self.current_segment_number = new_num;
-                        self.current_segment_meta =
-                            Some(SegmentMeta::new_empty(new_num));
+                        self.current_segment_meta = Some(SegmentMeta::new_empty(new_num));
                     }
                 }
             }

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -34,6 +34,7 @@ use dashmap::DashMap;
 use parking_lot::Mutex as ParkingMutex;
 use std::any::{Any, TypeId};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use strata_concurrency::{RecoveryCoordinator, TransactionContext};
@@ -51,7 +52,6 @@ use strata_durability::{
     ManifestManager, WalOnlyCompactor,
 };
 use strata_storage::ShardedStore;
-use std::sync::atomic::AtomicU64;
 use tracing::{info, warn};
 
 // ============================================================================
@@ -428,9 +428,8 @@ impl Database {
             .write(true)
             .open(&lock_path)
             .map_err(|e| StrataError::storage(format!("failed to open lock file: {}", e)))?;
-        fs2::FileExt::lock_shared(&lock_file).map_err(|e| {
-            StrataError::storage(format!("failed to acquire shared lock: {}", e))
-        })?;
+        fs2::FileExt::lock_shared(&lock_file)
+            .map_err(|e| StrataError::storage(format!("failed to acquire shared lock: {}", e)))?;
 
         let db = Self::open_finish(
             canonical_path,
@@ -503,9 +502,9 @@ impl Database {
         if multi_process {
             use strata_durability::coordination::CounterFile;
             let counter_file = CounterFile::new(&wal_dir);
-            let (cf_version, cf_txn_id) = counter_file.read_or_default().map_err(|e| {
-                StrataError::storage(format!("Failed to read counter file: {}", e))
-            })?;
+            let (cf_version, cf_txn_id) = counter_file
+                .read_or_default()
+                .map_err(|e| StrataError::storage(format!("Failed to read counter file: {}", e)))?;
 
             // Only update if recovery found higher values (never go backward)
             let recovered_version = result.stats.final_version;
@@ -947,19 +946,16 @@ impl Database {
             .extension::<crate::primitives::vector::store::VectorBackendState>()
             .ok();
 
-
         for record in &records {
             max_txn_id = max_txn_id.max(record.txn_id);
 
-            let payload =
-                strata_concurrency::TransactionPayload::from_bytes(&record.writeset).map_err(
-                    |e| {
-                        StrataError::storage(format!(
-                            "Failed to decode WAL payload for txn {}: {}",
-                            record.txn_id, e
-                        ))
-                    },
-                )?;
+            let payload = strata_concurrency::TransactionPayload::from_bytes(&record.writeset)
+                .map_err(|e| {
+                    StrataError::storage(format!(
+                        "Failed to decode WAL payload for txn {}: {}",
+                        record.txn_id, e
+                    ))
+                })?;
 
             max_version = max_version.max(payload.version);
 
@@ -987,7 +983,6 @@ impl Database {
                 }
             }
 
-
             // Apply puts
             for (key, value) in &payload.puts {
                 use strata_core::traits::Storage;
@@ -1014,20 +1009,18 @@ impl Database {
                     let branch_id = key.namespace.branch_id;
                     match key.type_tag {
                         TypeTag::KV => {
-                            if let Some(text) =
-                                crate::search::extract_indexable_text(value)
-                            {
+                            if let Some(text) = crate::search::extract_indexable_text(value) {
                                 if let Some(user_key) = key.user_key_string() {
-                                    let entity_ref =
-                                        strata_core::EntityRef::Kv { branch_id, key: user_key };
+                                    let entity_ref = strata_core::EntityRef::Kv {
+                                        branch_id,
+                                        key: user_key,
+                                    };
                                     index.index_document(&entity_ref, &text, None);
                                 }
                             }
                         }
                         TypeTag::State => {
-                            if let Some(text) =
-                                crate::search::extract_indexable_text(value)
-                            {
+                            if let Some(text) = crate::search::extract_indexable_text(value) {
                                 if let Some(name) = key.user_key_string() {
                                     let entity_ref =
                                         strata_core::EntityRef::State { branch_id, name };
@@ -1036,20 +1029,19 @@ impl Database {
                             }
                         }
                         TypeTag::Event => {
-                            if key.user_key == b"__meta__"
-                                || key.user_key.starts_with(b"__tidx__")
+                            if key.user_key == b"__meta__" || key.user_key.starts_with(b"__tidx__")
                             {
                                 continue;
                             }
-                            if let Some(text) =
-                                crate::search::extract_indexable_text(value)
-                            {
+                            if let Some(text) = crate::search::extract_indexable_text(value) {
                                 if key.user_key.len() == 8 {
                                     let sequence = u64::from_be_bytes(
                                         key.user_key.as_slice().try_into().unwrap_or([0; 8]),
                                     );
-                                    let entity_ref =
-                                        strata_core::EntityRef::Event { branch_id, sequence };
+                                    let entity_ref = strata_core::EntityRef::Event {
+                                        branch_id,
+                                        sequence,
+                                    };
                                     index.index_document(&entity_ref, &text, None);
                                 }
                             }
@@ -1063,21 +1055,21 @@ impl Database {
                     match key.type_tag {
                         TypeTag::KV => {
                             if let Some(user_key) = key.user_key_string() {
-                                let entity_ref =
-                                    strata_core::EntityRef::Kv { branch_id, key: user_key };
+                                let entity_ref = strata_core::EntityRef::Kv {
+                                    branch_id,
+                                    key: user_key,
+                                };
                                 index.remove_document(&entity_ref);
                             }
                         }
                         TypeTag::State => {
                             if let Some(name) = key.user_key_string() {
-                                let entity_ref =
-                                    strata_core::EntityRef::State { branch_id, name };
+                                let entity_ref = strata_core::EntityRef::State { branch_id, name };
                                 index.remove_document(&entity_ref);
                             }
                         }
                         TypeTag::Event => {
-                            if key.user_key == b"__meta__"
-                                || key.user_key.starts_with(b"__tidx__")
+                            if key.user_key == b"__meta__" || key.user_key.starts_with(b"__tidx__")
                             {
                                 continue;
                             }
@@ -1086,8 +1078,10 @@ impl Database {
                                     key.user_key.as_slice().try_into().unwrap_or([0; 8]),
                                 );
                                 let branch_id = key.namespace.branch_id;
-                                let entity_ref =
-                                    strata_core::EntityRef::Event { branch_id, sequence };
+                                let entity_ref = strata_core::EntityRef::Event {
+                                    branch_id,
+                                    sequence,
+                                };
                                 index.remove_document(&entity_ref);
                             }
                         }
@@ -1109,12 +1103,11 @@ impl Database {
                         strata_core::value::Value::Bytes(b) => b,
                         _ => continue,
                     };
-                    let record = match crate::primitives::vector::types::VectorRecord::from_bytes(
-                        bytes,
-                    ) {
-                        Ok(r) => r,
-                        Err(_) => continue,
-                    };
+                    let record =
+                        match crate::primitives::vector::types::VectorRecord::from_bytes(bytes) {
+                            Ok(r) => r,
+                            Err(_) => continue,
+                        };
                     let user_key_str = match key.user_key_string() {
                         Some(s) => s,
                         None => continue,
@@ -1775,9 +1768,8 @@ impl Database {
         }
 
         // Acquire WAL file lock (blocks until available)
-        let _wal_lock = WalFileLock::acquire(&self.wal_dir).map_err(|e| {
-            StrataError::storage(format!("Failed to acquire WAL file lock: {}", e))
-        })?;
+        let _wal_lock = WalFileLock::acquire(&self.wal_dir)
+            .map_err(|e| StrataError::storage(format!("Failed to acquire WAL file lock: {}", e)))?;
 
         // Step 1: Refresh from WAL (apply other processes' writes)
         self.refresh()?;
@@ -1792,9 +1784,9 @@ impl Database {
         // The local coordinator already reflects WAL reality (from recovery + refresh),
         // so we take the max to ensure we never allocate a duplicate version/txn_id.
         let counter_file = CounterFile::new(&self.wal_dir);
-        let (cf_version, cf_txn_id) = counter_file.read_or_default().map_err(|e| {
-            StrataError::storage(format!("Failed to read counter file: {}", e))
-        })?;
+        let (cf_version, cf_txn_id) = counter_file
+            .read_or_default()
+            .map_err(|e| StrataError::storage(format!("Failed to read counter file: {}", e)))?;
 
         let local_version = self.coordinator.current_version();
         let local_max_txn_id = self.wal_watermark.load(std::sync::atomic::Ordering::SeqCst);
@@ -1841,9 +1833,9 @@ impl Database {
         }
 
         // Step 5: Update counter file
-        counter_file.write(new_version, new_txn_id).map_err(|e| {
-            StrataError::storage(format!("Failed to update counter file: {}", e))
-        })?;
+        counter_file
+            .write(new_version, new_txn_id)
+            .map_err(|e| StrataError::storage(format!("Failed to update counter file: {}", e)))?;
 
         // Step 6: Update local watermark
         self.wal_watermark

--- a/crates/engine/src/graph/keys.rs
+++ b/crates/engine/src/graph/keys.rs
@@ -268,9 +268,7 @@ pub fn validate_type_name(name: &str) -> StrataResult<()> {
         return Err(StrataError::invalid_input("Type name must not be empty"));
     }
     if name.contains(SEP) {
-        return Err(StrataError::invalid_input(
-            "Type name must not contain '/'",
-        ));
+        return Err(StrataError::invalid_input("Type name must not contain '/'"));
     }
     if name.starts_with("__") {
         return Err(StrataError::invalid_input(

--- a/crates/engine/src/graph/mod.rs
+++ b/crates/engine/src/graph/mod.rs
@@ -172,7 +172,6 @@ impl GraphStore {
             }
         }
 
-
         let node_json =
             serde_json::to_string(&data).map_err(|e| StrataError::serialization(e.to_string()))?;
         let user_key = keys::node_key(graph, node_id);
@@ -366,7 +365,6 @@ impl GraphStore {
                 self.validate_edge(branch_id, graph, src, dst, edge_type)?;
             }
         }
-
 
         let edge_json =
             serde_json::to_string(&data).map_err(|e| StrataError::serialization(e.to_string()))?;
@@ -615,7 +613,6 @@ impl GraphStore {
             .and_then(|m| m.ontology_status)
             == Some(types::OntologyStatus::Frozen);
 
-
         let chunk_size = std::cmp::max(1, chunk_size.unwrap_or(Self::DEFAULT_BULK_CHUNK_SIZE));
         let empty_json = "{}";
         let default_edge_json = "{\"weight\":1.0}";
@@ -640,14 +637,15 @@ impl GraphStore {
                 let user_key = keys::node_key(graph, node_id);
                 let sk = keys::storage_key(branch_id, &user_key);
 
-                let json =
-                    if data.entity_ref.is_none() && data.properties.is_none() && data.object_type.is_none()
-                    {
-                        empty_json.to_string()
-                    } else {
-                        serde_json::to_string(data)
-                            .map_err(|e| StrataError::serialization(e.to_string()))?
-                    };
+                let json = if data.entity_ref.is_none()
+                    && data.properties.is_none()
+                    && data.object_type.is_none()
+                {
+                    empty_json.to_string()
+                } else {
+                    serde_json::to_string(data)
+                        .map_err(|e| StrataError::serialization(e.to_string()))?
+                };
 
                 entries.push((sk, json));
 
@@ -681,7 +679,6 @@ impl GraphStore {
                     }
                 }
 
-
                 for (sk, json) in &entries {
                     txn.put(sk.clone(), Value::String(json.clone()))?;
                 }
@@ -713,7 +710,6 @@ impl GraphStore {
                 if is_frozen {
                     self.validate_edge(branch_id, graph, src, dst, edge_type)?;
                 }
-
 
                 let fwd = keys::forward_edge_key(graph, src, edge_type, dst);
                 let rev = keys::reverse_edge_key(graph, dst, edge_type, src);
@@ -852,20 +848,8 @@ mod tests {
         let branch = default_branch();
 
         gs.create_graph(branch, "dg", None).unwrap();
-        gs.add_node(
-            branch,
-            "dg",
-            "A",
-            NodeData::default(),
-        )
-        .unwrap();
-        gs.add_node(
-            branch,
-            "dg",
-            "B",
-            NodeData::default(),
-        )
-        .unwrap();
+        gs.add_node(branch, "dg", "A", NodeData::default()).unwrap();
+        gs.add_node(branch, "dg", "B", NodeData::default()).unwrap();
         gs.add_edge(branch, "dg", "A", "B", "KNOWS", EdgeData::default())
             .unwrap();
 
@@ -941,13 +925,8 @@ mod tests {
         let branch = default_branch();
 
         gs.create_graph(branch, "ng", None).unwrap();
-        gs.add_node(
-            branch,
-            "ng",
-            "n1",
-            NodeData::default(),
-        )
-        .unwrap();
+        gs.add_node(branch, "ng", "n1", NodeData::default())
+            .unwrap();
 
         let node = gs.get_node(branch, "ng", "n1").unwrap().unwrap();
         assert!(node.entity_ref.is_none());
@@ -960,13 +939,7 @@ mod tests {
 
         gs.create_graph(branch, "ng", None).unwrap();
         for id in &["a", "b", "c"] {
-            gs.add_node(
-                branch,
-                "ng",
-                id,
-                NodeData::default(),
-            )
-            .unwrap();
+            gs.add_node(branch, "ng", id, NodeData::default()).unwrap();
         }
 
         let mut nodes = gs.list_nodes(branch, "ng").unwrap();
@@ -980,13 +953,8 @@ mod tests {
         let branch = default_branch();
 
         gs.create_graph(branch, "ng", None).unwrap();
-        gs.add_node(
-            branch,
-            "ng",
-            "n1",
-            NodeData::default(),
-        )
-        .unwrap();
+        gs.add_node(branch, "ng", "n1", NodeData::default())
+            .unwrap();
         gs.remove_node(branch, "ng", "n1").unwrap();
         assert!(gs.get_node(branch, "ng", "n1").unwrap().is_none());
     }
@@ -998,13 +966,7 @@ mod tests {
 
         gs.create_graph(branch, "ng", None).unwrap();
         for id in &["A", "B", "C"] {
-            gs.add_node(
-                branch,
-                "ng",
-                id,
-                NodeData::default(),
-            )
-            .unwrap();
+            gs.add_node(branch, "ng", id, NodeData::default()).unwrap();
         }
         gs.add_edge(branch, "ng", "A", "B", "E1", EdgeData::default())
             .unwrap();
@@ -1027,14 +989,7 @@ mod tests {
         let branch = default_branch();
 
         gs.create_graph(branch, "ng", None).unwrap();
-        assert!(gs
-            .add_node(
-                branch,
-                "ng",
-                "",
-                NodeData::default(),
-            )
-            .is_err());
+        assert!(gs.add_node(branch, "ng", "", NodeData::default(),).is_err());
     }
 
     // =========================================================================
@@ -1155,20 +1110,10 @@ mod tests {
 
         gs.create_graph(branch, "gA", None).unwrap();
         gs.create_graph(branch, "gB", None).unwrap();
-        gs.add_node(
-            branch,
-            "gA",
-            "n1",
-            NodeData::default(),
-        )
-        .unwrap();
-        gs.add_node(
-            branch,
-            "gB",
-            "n1",
-            NodeData::default(),
-        )
-        .unwrap();
+        gs.add_node(branch, "gA", "n1", NodeData::default())
+            .unwrap();
+        gs.add_node(branch, "gB", "n1", NodeData::default())
+            .unwrap();
 
         gs.delete_graph(branch, "gA").unwrap();
 
@@ -1282,13 +1227,8 @@ mod tests {
         let branch = default_branch();
 
         gs.create_graph(branch, "rg", None).unwrap();
-        gs.add_node(
-            branch,
-            "rg",
-            "n1",
-            NodeData::default(),
-        )
-        .unwrap();
+        gs.add_node(branch, "rg", "n1", NodeData::default())
+            .unwrap();
 
         let refs = gs.nodes_for_entity(branch, "kv://main/key1").unwrap();
         assert!(refs.is_empty());
@@ -1557,13 +1497,8 @@ mod tests {
         .unwrap();
 
         // Update with entity_ref=None
-        gs.add_node(
-            branch,
-            "rg",
-            "n1",
-            NodeData::default(),
-        )
-        .unwrap();
+        gs.add_node(branch, "rg", "n1", NodeData::default())
+            .unwrap();
 
         let refs = gs.nodes_for_entity(branch, "kv://main/key1").unwrap();
         assert!(refs.is_empty());
@@ -1581,18 +1516,9 @@ mod tests {
         gs.create_graph(branch, "bg", None).unwrap();
 
         let nodes: Vec<(String, NodeData)> = vec![
-            (
-                "A".into(),
-                NodeData::default(),
-            ),
-            (
-                "B".into(),
-                NodeData::default(),
-            ),
-            (
-                "C".into(),
-                NodeData::default(),
-            ),
+            ("A".into(), NodeData::default()),
+            ("B".into(), NodeData::default()),
+            ("C".into(), NodeData::default()),
         ];
         let edges: Vec<(String, String, String, EdgeData)> = vec![
             ("A".into(), "B".into(), "KNOWS".into(), EdgeData::default()),
@@ -1663,10 +1589,7 @@ mod tests {
                     ..Default::default()
                 },
             ),
-            (
-                "n3".into(),
-                NodeData::default(),
-            ),
+            ("n3".into(), NodeData::default()),
             (
                 "n4".into(),
                 NodeData {
@@ -1750,14 +1673,8 @@ mod tests {
         gs.create_graph(branch, "bg", None).unwrap();
 
         let nodes: Vec<(String, NodeData)> = vec![
-            (
-                "A".into(),
-                NodeData::default(),
-            ),
-            (
-                "B".into(),
-                NodeData::default(),
-            ),
+            ("A".into(), NodeData::default()),
+            ("B".into(), NodeData::default()),
         ];
         let edges: Vec<(String, String, String, EdgeData)> =
             vec![("A".into(), "B".into(), "E".into(), EdgeData::default())];
@@ -1851,10 +1768,7 @@ mod tests {
 
         gs.create_graph(branch, "bg", None).unwrap();
 
-        let nodes: Vec<(String, NodeData)> = vec![(
-            "A".into(),
-            NodeData::default(),
-        )];
+        let nodes: Vec<(String, NodeData)> = vec![("A".into(), NodeData::default())];
 
         // chunk_size=0 should be clamped to 1, not panic
         let (ni, _) = gs.bulk_insert(branch, "bg", &nodes, &[], Some(0)).unwrap();
@@ -1870,14 +1784,8 @@ mod tests {
         gs.create_graph(branch, "bg", None).unwrap();
 
         let nodes: Vec<(String, NodeData)> = vec![
-            (
-                "A".into(),
-                NodeData::default(),
-            ),
-            (
-                "B".into(),
-                NodeData::default(),
-            ),
+            ("A".into(), NodeData::default()),
+            ("B".into(), NodeData::default()),
         ];
         let edges: Vec<(String, String, String, EdgeData)> =
             vec![("A".into(), "B".into(), "E".into(), EdgeData::default())];
@@ -1900,18 +1808,9 @@ mod tests {
         gs.create_graph(branch, "bg", None).unwrap();
 
         let nodes: Vec<(String, NodeData)> = vec![
-            (
-                "good1".into(),
-                NodeData::default(),
-            ),
-            (
-                "".into(),
-                NodeData::default(),
-            ), // invalid
-            (
-                "good2".into(),
-                NodeData::default(),
-            ),
+            ("good1".into(), NodeData::default()),
+            ("".into(), NodeData::default()), // invalid
+            ("good2".into(), NodeData::default()),
         ];
 
         let result = gs.bulk_insert(branch, "bg", &nodes, &[], None);
@@ -1991,22 +1890,10 @@ mod tests {
 
         // Build a small graph: A -> B -> C -> D
         let nodes: Vec<(String, NodeData)> = vec![
-            (
-                "A".into(),
-                NodeData::default(),
-            ),
-            (
-                "B".into(),
-                NodeData::default(),
-            ),
-            (
-                "C".into(),
-                NodeData::default(),
-            ),
-            (
-                "D".into(),
-                NodeData::default(),
-            ),
+            ("A".into(), NodeData::default()),
+            ("B".into(), NodeData::default()),
+            ("C".into(), NodeData::default()),
+            ("D".into(), NodeData::default()),
         ];
         let edges: Vec<(String, String, String, EdgeData)> = vec![
             ("A".into(), "B".into(), "NEXT".into(), EdgeData::default()),
@@ -2108,14 +1995,8 @@ mod tests {
         gs.create_graph(branch, "bg", None).unwrap();
 
         let nodes: Vec<(String, NodeData)> = vec![
-            (
-                "A".into(),
-                NodeData::default(),
-            ),
-            (
-                "B".into(),
-                NodeData::default(),
-            ),
+            ("A".into(), NodeData::default()),
+            ("B".into(), NodeData::default()),
         ];
         let edges: Vec<(String, String, String, EdgeData)> = vec![(
             "A".into(),

--- a/crates/engine/src/graph/ontology.rs
+++ b/crates/engine/src/graph/ontology.rs
@@ -33,8 +33,8 @@ impl GraphStore {
         self.ensure_not_frozen(branch_id, graph, "Cannot modify ontology: graph is frozen")?;
         self.ensure_draft_status(branch_id, graph)?;
 
-        let type_json = serde_json::to_string(&def)
-            .map_err(|e| StrataError::serialization(e.to_string()))?;
+        let type_json =
+            serde_json::to_string(&def).map_err(|e| StrataError::serialization(e.to_string()))?;
         let user_key = keys::object_type_key(graph, &def.name);
         let storage_key = keys::storage_key(branch_id, &user_key);
 
@@ -70,11 +70,7 @@ impl GraphStore {
     }
 
     /// List all object type names in the graph's ontology.
-    pub fn list_object_types(
-        &self,
-        branch_id: BranchId,
-        graph: &str,
-    ) -> StrataResult<Vec<String>> {
+    pub fn list_object_types(&self, branch_id: BranchId, graph: &str) -> StrataResult<Vec<String>> {
         let prefix = keys::all_object_types_prefix(graph);
         let prefix_key = keys::storage_key(branch_id, &prefix);
 
@@ -127,8 +123,8 @@ impl GraphStore {
         self.ensure_not_frozen(branch_id, graph, "Cannot modify ontology: graph is frozen")?;
         self.ensure_draft_status(branch_id, graph)?;
 
-        let type_json = serde_json::to_string(&def)
-            .map_err(|e| StrataError::serialization(e.to_string()))?;
+        let type_json =
+            serde_json::to_string(&def).map_err(|e| StrataError::serialization(e.to_string()))?;
         let user_key = keys::link_type_key(graph, &def.name);
         let storage_key = keys::storage_key(branch_id, &user_key);
 
@@ -164,11 +160,7 @@ impl GraphStore {
     }
 
     /// List all link type names in the graph's ontology.
-    pub fn list_link_types(
-        &self,
-        branch_id: BranchId,
-        graph: &str,
-    ) -> StrataResult<Vec<String>> {
+    pub fn list_link_types(&self, branch_id: BranchId, graph: &str) -> StrataResult<Vec<String>> {
         let prefix = keys::all_link_types_prefix(graph);
         let prefix_key = keys::storage_key(branch_id, &prefix);
 
@@ -431,14 +423,12 @@ impl GraphStore {
         let mut link_types = HashMap::new();
         let link_names = self.list_link_types(branch_id, graph)?;
         for name in &link_names {
-            let def = self
-                .get_link_type(branch_id, graph, name)?
-                .ok_or_else(|| {
-                    StrataError::serialization(format!(
-                        "Link type '{}' listed but definition not found",
-                        name
-                    ))
-                })?;
+            let def = self.get_link_type(branch_id, graph, name)?.ok_or_else(|| {
+                StrataError::serialization(format!(
+                    "Link type '{}' listed but definition not found",
+                    name
+                ))
+            })?;
 
             // Count edges by scanning forward edges filtered by edge_type
             let edge_count = self.count_edges_by_type(branch_id, graph, name)?;
@@ -467,12 +457,7 @@ impl GraphStore {
     // =========================================================================
 
     /// Ensure the ontology is not frozen. Returns an error with the given message if frozen.
-    fn ensure_not_frozen(
-        &self,
-        branch_id: BranchId,
-        graph: &str,
-        msg: &str,
-    ) -> StrataResult<()> {
+    fn ensure_not_frozen(&self, branch_id: BranchId, graph: &str, msg: &str) -> StrataResult<()> {
         if let Some(meta) = self.get_graph_meta(branch_id, graph)? {
             if meta.ontology_status == Some(OntologyStatus::Frozen) {
                 return Err(StrataError::invalid_input(msg));
@@ -656,7 +641,10 @@ mod tests {
         let b = default_branch();
         gs.create_graph(b, "g", None).unwrap();
 
-        assert!(gs.get_object_type(b, "g", "DoesNotExist").unwrap().is_none());
+        assert!(gs
+            .get_object_type(b, "g", "DoesNotExist")
+            .unwrap()
+            .is_none());
     }
 
     // =========================================================================
@@ -766,7 +754,11 @@ mod tests {
         let result = gs.define_object_type(b, "g", lab_result_type());
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("frozen"), "Error should mention frozen: {}", err);
+        assert!(
+            err.contains("frozen"),
+            "Error should mention frozen: {}",
+            err
+        );
     }
 
     #[test]
@@ -781,7 +773,11 @@ mod tests {
         let result = gs.delete_object_type(b, "g", "Patient");
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("frozen"), "Error should mention frozen: {}", err);
+        assert!(
+            err.contains("frozen"),
+            "Error should mention frozen: {}",
+            err
+        );
     }
 
     #[test]
@@ -868,7 +864,11 @@ mod tests {
         let result = gs.add_node(b, "g", "p1", data);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("name"), "Error should mention missing prop: {}", err);
+        assert!(
+            err.contains("name"),
+            "Error should mention missing prop: {}",
+            err
+        );
     }
 
     #[test]
@@ -1558,7 +1558,11 @@ mod tests {
         let result = gs.delete_link_type(b, "g", "HAS_RESULT");
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("frozen"), "Error should mention frozen: {}", err);
+        assert!(
+            err.contains("frozen"),
+            "Error should mention frozen: {}",
+            err
+        );
     }
 
     #[test]
@@ -1573,7 +1577,11 @@ mod tests {
         let result = gs.define_link_type(b, "g", has_result_link());
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("frozen"), "Error should mention frozen: {}", err);
+        assert!(
+            err.contains("frozen"),
+            "Error should mention frozen: {}",
+            err
+        );
     }
 
     #[test]

--- a/crates/engine/tests/multi_process_tests.rs
+++ b/crates/engine/tests/multi_process_tests.rs
@@ -22,7 +22,6 @@ fn ensure_recovery_registered() {
     });
 }
 
-
 fn create_test_namespace(branch_id: BranchId) -> Namespace {
     Namespace::new(
         "tenant".to_string(),
@@ -35,8 +34,7 @@ fn create_test_namespace(branch_id: BranchId) -> Namespace {
 
 /// Read a key value through a read-only transaction.
 fn read_key(db: &Database, branch_id: BranchId, key: &Key) -> Option<Value> {
-    db.transaction(branch_id, |txn| Ok(txn.get(key)?))
-        .unwrap()
+    db.transaction(branch_id, |txn| Ok(txn.get(key)?)).unwrap()
 }
 
 // ============================================================================
@@ -590,8 +588,16 @@ fn test_stale_counter_file_recovery() {
 
     // The counter file should have been reseeded from recovery
     let (cf_ver, cf_txn) = counter_file.read().unwrap();
-    assert!(cf_ver >= 5, "Counter file version should be >= 5, got {}", cf_ver);
-    assert!(cf_txn >= 5, "Counter file txn_id should be >= 5, got {}", cf_txn);
+    assert!(
+        cf_ver >= 5,
+        "Counter file version should be >= 5, got {}",
+        cf_ver
+    );
+    assert!(
+        cf_txn >= 5,
+        "Counter file txn_id should be >= 5, got {}",
+        cf_txn
+    );
 
     // A new commit should get a version higher than anything before
     let key_new = Key::new_kv(ns.clone(), "after_recovery");
@@ -798,7 +804,10 @@ fn test_crash_recovery_counter_file_consistency() {
     .unwrap();
 
     let new_version = db.current_version();
-    assert!(new_version > ver_before, "New version must exceed pre-crash version");
+    assert!(
+        new_version > ver_before,
+        "New version must exceed pre-crash version"
+    );
 
     // All data readable
     assert_eq!(

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -188,9 +188,10 @@ impl Strata {
             })?;
             // Write config to strata.toml so restarts pick it up
             let config_path = data_dir.join(strata_engine::database::config::CONFIG_FILE_NAME);
-            cfg.write_to_file(&config_path).map_err(|e| Error::Internal {
-                reason: format!("Failed to write config: {}", e),
-            })?;
+            cfg.write_to_file(&config_path)
+                .map_err(|e| Error::Internal {
+                    reason: format!("Failed to write config: {}", e),
+                })?;
             Database::open_multi_process(&data_dir, mode, cfg).map_err(|e| Error::Internal {
                 reason: format!("Failed to open database (multi-process): {}", e),
             })?

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -1156,7 +1156,6 @@ pub enum Command {
     },
 
     // ==================== Graph Ontology ====================
-
     /// Define an object type in the graph's ontology.
     /// Returns: `Output::Unit`
     GraphDefineObjectType {

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -1208,12 +1208,7 @@ impl Executor {
                 let branch = branch.ok_or(Error::InvalidInput {
                     reason: "Branch must be specified or resolved to default".into(),
                 })?;
-                crate::handlers::graph::graph_get_object_type(
-                    &self.primitives,
-                    branch,
-                    graph,
-                    name,
-                )
+                crate::handlers::graph::graph_get_object_type(&self.primitives, branch, graph, name)
             }
             Command::GraphListObjectTypes { branch, graph } => {
                 let branch = branch.ok_or(Error::InvalidInput {
@@ -1259,12 +1254,7 @@ impl Executor {
                 let branch = branch.ok_or(Error::InvalidInput {
                     reason: "Branch must be specified or resolved to default".into(),
                 })?;
-                crate::handlers::graph::graph_get_link_type(
-                    &self.primitives,
-                    branch,
-                    graph,
-                    name,
-                )
+                crate::handlers::graph::graph_get_link_type(&self.primitives, branch, graph, name)
             }
             Command::GraphListLinkTypes { branch, graph } => {
                 let branch = branch.ok_or(Error::InvalidInput {

--- a/crates/executor/src/handlers/graph.rs
+++ b/crates/executor/src/handlers/graph.rs
@@ -4,8 +4,7 @@ use std::sync::Arc;
 
 use strata_core::Value;
 use strata_engine::graph::types::{
-    BfsOptions, CascadePolicy, Direction, EdgeData, GraphMeta, LinkTypeDef, NodeData,
-    ObjectTypeDef,
+    BfsOptions, CascadePolicy, Direction, EdgeData, GraphMeta, LinkTypeDef, NodeData, ObjectTypeDef,
 };
 
 use crate::bridge::{to_core_branch_id, Primitives};
@@ -342,10 +341,9 @@ pub fn graph_define_object_type(
 ) -> Result<Output> {
     let core_branch = to_core_branch_id(&branch)?;
     let json = crate::bridge::value_to_serde_json_public(definition)?;
-    let def: ObjectTypeDef =
-        serde_json::from_value(json).map_err(|e| Error::InvalidInput {
-            reason: format!("Invalid object type definition: {}", e),
-        })?;
+    let def: ObjectTypeDef = serde_json::from_value(json).map_err(|e| Error::InvalidInput {
+        reason: format!("Invalid object type definition: {}", e),
+    })?;
     convert_result(p.graph.define_object_type(core_branch, &graph, def))?;
     Ok(Output::Unit)
 }
@@ -402,10 +400,9 @@ pub fn graph_define_link_type(
 ) -> Result<Output> {
     let core_branch = to_core_branch_id(&branch)?;
     let json = crate::bridge::value_to_serde_json_public(definition)?;
-    let def: LinkTypeDef =
-        serde_json::from_value(json).map_err(|e| Error::InvalidInput {
-            reason: format!("Invalid link type definition: {}", e),
-        })?;
+    let def: LinkTypeDef = serde_json::from_value(json).map_err(|e| Error::InvalidInput {
+        reason: format!("Invalid link type definition: {}", e),
+    })?;
     convert_result(p.graph.define_link_type(core_branch, &graph, def))?;
     Ok(Output::Unit)
 }
@@ -513,7 +510,6 @@ pub fn graph_nodes_by_type(
     let node_ids = convert_result(p.graph.nodes_by_type(core_branch, &graph, &object_type))?;
     Ok(Output::Keys(node_ids))
 }
-
 
 /// Convert serde_json::Value to strata_core::Value.
 fn serde_json_to_value(json: serde_json::Value) -> Result<Value> {


### PR DESCRIPTION
## Summary

- Run `cargo fmt --all` to fix CI formatting check failures across 11 files

## Details

The formatting check in CI has been failing due to inconsistent formatting in several crates (durability, engine, executor). This is a pure `cargo fmt` pass with no logic changes.

Files touched: `wal/reader.rs`, `wal/writer.rs`, `database/mod.rs`, `graph/keys.rs`, `graph/mod.rs`, `graph/ontology.rs`, `multi_process_tests.rs`, `api/mod.rs`, `command.rs`, `executor.rs`, `handlers/graph.rs`

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --workspace` — all tests pass, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)