### PR TITLE
Fix formatting and clippy warnings

### DIFF
--- a/crates/engine/src/primitives/vector/store.rs
+++ b/crates/engine/src/primitives/vector/store.rs
@@ -500,7 +500,9 @@ impl VectorStore {
             // New vector: allocate VectorId from backend's per-collection counter
             let vector_id = backend.allocate_id();
             let record = match source_ref {
-                Some(sr) => VectorRecord::new_with_source(vector_id, embedding.to_vec(), metadata, sr),
+                Some(sr) => {
+                    VectorRecord::new_with_source(vector_id, embedding.to_vec(), metadata, sr)
+                }
                 None => VectorRecord::new(vector_id, embedding.to_vec(), metadata),
             };
             (vector_id, record)
@@ -2923,22 +2925,11 @@ mod tests {
 
         // Insert a vector
         store
-            .insert(
-                branch_id,
-                "default",
-                "test",
-                "doc1",
-                &[1.0, 0.0, 0.0],
-                None,
-            )
+            .insert(branch_id, "default", "test", "doc1", &[1.0, 0.0, 0.0], None)
             .unwrap();
 
         // Read the raw KV record and verify the embedding is present
-        let kv_key = Key::new_vector(
-            store.namespace_for(branch_id, "default"),
-            "test",
-            "doc1",
-        );
+        let kv_key = Key::new_vector(store.namespace_for(branch_id, "default"), "test", "doc1");
         let record = store.get_vector_record_by_key(&kv_key).unwrap().unwrap();
         assert_eq!(
             record.embedding,
@@ -2948,14 +2939,7 @@ mod tests {
 
         // Upsert with new embedding and verify KV record is updated
         store
-            .insert(
-                branch_id,
-                "default",
-                "test",
-                "doc1",
-                &[0.0, 1.0, 0.0],
-                None,
-            )
+            .insert(branch_id, "default", "test", "doc1", &[0.0, 1.0, 0.0], None)
             .unwrap();
 
         let record = store.get_vector_record_by_key(&kv_key).unwrap().unwrap();

--- a/crates/inference/src/llama/mod.rs
+++ b/crates/inference/src/llama/mod.rs
@@ -8,4 +8,6 @@
 
 pub(crate) mod context;
 pub mod dl;
+// Safe wrappers intentionally accept raw pointers (opaque FFI handles).
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub mod ffi;

--- a/crates/inference/src/registry/download.rs
+++ b/crates/inference/src/registry/download.rs
@@ -128,7 +128,7 @@ pub fn download_hf_file_with_size(
     // Validate content-length against expected size from catalog (if both known)
     if total_bytes > 0 && expected_size > 0 {
         let ratio = total_bytes as f64 / expected_size as f64;
-        if ratio < 0.5 || ratio > 2.0 {
+        if !(0.5..=2.0).contains(&ratio) {
             return Err(InferenceError::Registry(format!(
                 "Unexpected file size: server reports {} bytes, catalog expects {} bytes",
                 total_bytes, expected_size


### PR DESCRIPTION
## Summary

- rustfmt: reflow long lines in store.rs (from vector persistence fix + regression test)
- clippy: allow `not_unsafe_ptr_arg_deref` on FFI module (opaque pointer handles are not Rust-owned)
- clippy: use `RangeInclusive::contains` in download size validation

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)