### PR TITLE
Add direct-path KV reads/writes bypassing transaction overhead

### DIFF
--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -1249,7 +1249,7 @@ impl TransactionContext {
     /// - StrataError::invalid_input if transaction is not in Committed state
     /// - Error from storage operations if they fail
     pub fn apply_writes<S: Storage>(
-        &self,
+        &mut self,
         store: &S,
         commit_version: u64,
     ) -> StrataResult<ApplyResult> {
@@ -1267,27 +1267,22 @@ impl TransactionContext {
             cas_applied: 0,
         };
 
-        // Apply puts from write_set
-        for (key, value) in &self.write_set {
-            store.put_with_version(key.clone(), value.clone(), commit_version, None)?;
+        // Apply puts from write_set — drain to avoid cloning keys and values
+        for (key, value) in self.write_set.drain() {
+            store.put_with_version(key, value, commit_version, None)?;
             result.puts_applied += 1;
         }
 
-        // Apply deletes from delete_set
-        for key in &self.delete_set {
-            store.delete_with_version(key, commit_version)?;
+        // Apply deletes from delete_set — drain to avoid cloning keys
+        for key in self.delete_set.drain() {
+            store.delete_with_version(&key, commit_version)?;
             result.deletes_applied += 1;
         }
 
-        // Apply CAS operations from cas_set
+        // Apply CAS operations from cas_set — drain to avoid cloning
         // Note: CAS validation already passed in commit(), so we just apply the new values
-        for cas_op in &self.cas_set {
-            store.put_with_version(
-                cas_op.key.clone(),
-                cas_op.new_value.clone(),
-                commit_version,
-                None,
-            )?;
+        for cas_op in self.cas_set.drain(..) {
+            store.put_with_version(cas_op.key, cas_op.new_value, commit_version, None)?;
             result.cas_applied += 1;
         }
 

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -664,6 +664,100 @@ impl Database {
         &self.storage
     }
 
+    /// Direct single-key read bypassing the full transaction machinery.
+    ///
+    /// Returns the latest committed value without snapshot creation,
+    /// pool acquire/release, or coordinator bookkeeping.
+    /// Safe for single-key reads where multi-key consistency isn't needed.
+    pub(crate) fn get_direct(&self, key: &Key) -> Option<VersionedValue> {
+        self.storage.get_direct(key)
+    }
+
+    /// Direct single-key blind write bypassing the full transaction machinery.
+    ///
+    /// Allocates a version, optionally writes to WAL, and applies directly
+    /// to storage. No snapshot, no validation, no pool acquire/release.
+    ///
+    /// Safe for single-key puts where snapshot isolation isn't needed
+    /// (blind writes with no read-before-write).
+    ///
+    /// Falls back to the full transaction path in multi-process mode,
+    /// which requires coordinated version allocation via the WAL file lock.
+    pub(crate) fn put_direct(
+        &self,
+        key: Key,
+        value: strata_core::value::Value,
+    ) -> StrataResult<u64> {
+        self.check_accepting()?;
+
+        // Multi-process mode requires coordinated version allocation;
+        // fall back to the full transaction path.
+        if self.multi_process {
+            use strata_core::value::Value;
+            let branch_id = key.namespace.branch_id;
+            let val: Value = value;
+            let ((), version) =
+                self.transaction_with_version(branch_id, |txn| txn.put(key, val))?;
+            return Ok(version);
+        }
+
+        self.coordinator.record_start();
+
+        let commit_version = self.coordinator.allocate_commit_version();
+
+        // WAL write (if needed for durability)
+        if self.durability_mode.requires_wal() {
+            match self.wal_writer.as_ref() {
+                Some(wal_arc) => {
+                    use strata_concurrency::TransactionPayload;
+                    use strata_durability::format::WalRecord;
+                    use strata_durability::now_micros;
+
+                    let txn_id = self.coordinator.next_txn_id();
+                    let payload = TransactionPayload {
+                        version: commit_version,
+                        puts: vec![(key.clone(), value.clone())],
+                        deletes: vec![],
+                    };
+                    let record = WalRecord::new(
+                        txn_id,
+                        *key.namespace.branch_id.as_bytes(),
+                        now_micros(),
+                        payload.to_bytes(),
+                    );
+
+                    let mut wal = wal_arc.lock();
+                    if let Err(e) = wal.append(&record) {
+                        self.coordinator.record_abort();
+                        return Err(StrataError::storage(format!(
+                            "WAL write failed in put_direct: {}",
+                            e
+                        )));
+                    }
+                }
+                None => {
+                    self.coordinator.record_abort();
+                    return Err(StrataError::storage(
+                        "WAL required by durability mode but writer is unavailable".to_string(),
+                    ));
+                }
+            }
+        }
+
+        // Apply directly to storage
+        use strata_core::traits::Storage;
+        if let Err(e) = self
+            .storage
+            .put_with_version(key, value, commit_version, None)
+        {
+            self.coordinator.record_abort();
+            return Err(e);
+        }
+
+        self.coordinator.record_commit();
+        Ok(commit_version)
+    }
+
     /// Get version history for a key directly from storage.
     ///
     /// History reads bypass the transaction layer because they are

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -83,10 +83,9 @@ impl KVStore {
     /// }
     /// ```
     pub fn get(&self, branch_id: &BranchId, space: &str, key: &str) -> StrataResult<Option<Value>> {
-        self.db.transaction(*branch_id, |txn| {
-            let storage_key = self.key_for(branch_id, space, key);
-            txn.get(&storage_key)
-        })
+        let storage_key = self.key_for(branch_id, space, key);
+        // Direct read from storage — no transaction needed for single-key lookup
+        Ok(self.db.get_direct(&storage_key).map(|vv| vv.value))
     }
 
     /// Get a value with its version metadata.
@@ -138,19 +137,18 @@ impl KVStore {
         key: &str,
         value: Value,
     ) -> StrataResult<Version> {
-        // Extract text for indexing before the value is consumed by the transaction
+        // Extract text for indexing before the value is consumed
         let text_for_index = match &value {
             Value::String(s) => Some(s.clone()),
             Value::Null | Value::Bool(_) | Value::Bytes(_) => None,
             other => serde_json::to_string(other).ok(),
         };
 
-        let ((), commit_version) = self.db.transaction_with_version(*branch_id, |txn| {
-            let storage_key = self.key_for(branch_id, space, key);
-            txn.put(storage_key, value)
-        })?;
+        let storage_key = self.key_for(branch_id, space, key);
+        // Direct blind write — no transaction needed for single-key put
+        let commit_version = self.db.put_direct(storage_key, value)?;
 
-        // Update inverted index for BM25 search (zero overhead when disabled)
+        // Post-commit: update inverted index for BM25 search (zero overhead when disabled)
         if let Some(text) = text_for_index {
             let index = self.db.extension::<crate::search::InvertedIndex>()?;
             if index.is_enabled() {
@@ -1201,5 +1199,182 @@ mod tests {
             response.is_empty(),
             "Deleted doc's unique terms should not match"
         );
+    }
+
+    // ========== Direct-path performance tests ==========
+
+    #[test]
+    fn test_direct_get_returns_none_after_delete() {
+        let (_temp, _db, kv) = setup();
+        let branch_id = BranchId::new();
+
+        kv.put(&branch_id, "default", "k", Value::Int(1)).unwrap();
+        assert_eq!(
+            kv.get(&branch_id, "default", "k").unwrap(),
+            Some(Value::Int(1))
+        );
+
+        kv.delete(&branch_id, "default", "k").unwrap();
+        assert_eq!(
+            kv.get(&branch_id, "default", "k").unwrap(),
+            None,
+            "Direct get must filter tombstones"
+        );
+    }
+
+    #[test]
+    fn test_direct_put_returns_monotonic_versions() {
+        let (_temp, _db, kv) = setup();
+        let branch_id = BranchId::new();
+
+        let v1 = kv.put(&branch_id, "default", "a", Value::Int(1)).unwrap();
+        let v2 = kv.put(&branch_id, "default", "b", Value::Int(2)).unwrap();
+        let v3 = kv.put(&branch_id, "default", "a", Value::Int(3)).unwrap();
+
+        // Versions must be strictly increasing
+        assert!(v2 > v1, "v2 ({v2:?}) must be > v1 ({v1:?})");
+        assert!(v3 > v2, "v3 ({v3:?}) must be > v2 ({v2:?})");
+    }
+
+    #[test]
+    fn test_direct_put_then_list_rebuilds_ordered_index() {
+        let (_temp, _db, kv) = setup();
+        let branch_id = BranchId::new();
+
+        // Insert keys in reverse order (stresses lazy BTreeSet rebuild)
+        for i in (0..20).rev() {
+            kv.put(
+                &branch_id,
+                "default",
+                &format!("key_{:03}", i),
+                Value::Int(i),
+            )
+            .unwrap();
+        }
+
+        // list() triggers a prefix scan which rebuilds the BTreeSet
+        let keys = kv.list(&branch_id, "default", None).unwrap();
+        assert_eq!(keys.len(), 20, "All 20 keys should be listed");
+
+        // Verify sorted order
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(keys, sorted, "Keys must be returned in sorted order");
+    }
+
+    #[test]
+    fn test_direct_put_interleaved_with_scan() {
+        let (_temp, _db, kv) = setup();
+        let branch_id = BranchId::new();
+
+        // Insert some keys, scan, insert more, scan again
+        kv.put(&branch_id, "default", "a:1", Value::Int(1)).unwrap();
+        kv.put(&branch_id, "default", "a:2", Value::Int(2)).unwrap();
+
+        let first_scan = kv.list(&branch_id, "default", Some("a:")).unwrap();
+        assert_eq!(first_scan.len(), 2);
+
+        // Add more keys (invalidates the lazy BTreeSet)
+        kv.put(&branch_id, "default", "a:3", Value::Int(3)).unwrap();
+        kv.put(&branch_id, "default", "b:1", Value::Int(4)).unwrap();
+
+        let second_scan = kv.list(&branch_id, "default", Some("a:")).unwrap();
+        assert_eq!(
+            second_scan.len(),
+            3,
+            "Second scan must see newly inserted 'a:3'"
+        );
+
+        let b_scan = kv.list(&branch_id, "default", Some("b:")).unwrap();
+        assert_eq!(b_scan.len(), 1, "b: prefix scan must find 'b:1'");
+    }
+
+    #[test]
+    fn test_direct_put_concurrent_threads() {
+        use std::thread;
+
+        let (_temp, db, _kv) = setup();
+        let n_threads = 4;
+        let n_ops = 100;
+
+        let mut handles = Vec::new();
+        for t in 0..n_threads {
+            let db = db.clone();
+            handles.push(thread::spawn(move || {
+                let kv = KVStore::new(db);
+                let branch_id = BranchId::new();
+                for i in 0..n_ops {
+                    let key = format!("t{}-k{}", t, i);
+                    kv.put(&branch_id, "default", &key, Value::Int(i as i64))
+                        .unwrap();
+                    let val = kv.get(&branch_id, "default", &key).unwrap();
+                    assert!(val.is_some(), "Key {key} must exist after put");
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().expect("Thread panicked");
+        }
+    }
+
+    #[test]
+    fn test_direct_put_wal_recovery() {
+        let temp_dir = TempDir::new().unwrap();
+        let branch_id = BranchId::new();
+
+        // Phase 1: Write data, then drop the database (simulates crash)
+        {
+            let db = Database::open(temp_dir.path()).unwrap();
+            let kv = KVStore::new(db.clone());
+
+            kv.put(
+                &branch_id,
+                "default",
+                "survive",
+                Value::String("hello".into()),
+            )
+            .unwrap();
+            kv.put(&branch_id, "default", "survive2", Value::Int(42))
+                .unwrap();
+
+            // Explicit shutdown to flush WAL
+            let _ = db.shutdown();
+        }
+
+        // Phase 2: Reopen and verify data survived via WAL recovery
+        {
+            let db = Database::open(temp_dir.path()).unwrap();
+            let kv = KVStore::new(db);
+
+            let v1 = kv.get(&branch_id, "default", "survive").unwrap();
+            assert_eq!(
+                v1,
+                Some(Value::String("hello".into())),
+                "Value must survive WAL recovery"
+            );
+
+            let v2 = kv.get(&branch_id, "default", "survive2").unwrap();
+            assert_eq!(
+                v2,
+                Some(Value::Int(42)),
+                "Second value must survive WAL recovery"
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_versioned_still_uses_transaction() {
+        let (_temp, _db, kv) = setup();
+        let branch_id = BranchId::new();
+
+        kv.put(&branch_id, "default", "vk", Value::Int(99)).unwrap();
+
+        // get_versioned still goes through transactions (snapshot isolation)
+        let vv = kv.get_versioned(&branch_id, "default", "vk").unwrap();
+        assert!(vv.is_some());
+        let vv = vv.unwrap();
+        assert_eq!(vv.value, Value::Int(99));
+        assert!(vv.version.as_u64() > 0, "Version must be non-zero");
     }
 }

--- a/crates/storage/src/sharded.rs
+++ b/crates/storage/src/sharded.rs
@@ -186,8 +186,9 @@ impl VersionChain {
 pub struct Shard {
     /// HashMap with FxHash for O(1) lookups, storing version chains
     pub(crate) data: FxHashMap<Key, VersionChain>,
-    /// Sorted index of all keys for O(log n + k) prefix scans
-    pub(crate) ordered_keys: BTreeSet<Key>,
+    /// Sorted index of all keys for O(log n + k) prefix scans.
+    /// Built lazily on first scan request, invalidated on new-key insertions.
+    pub(crate) ordered_keys: Option<BTreeSet<Key>>,
 }
 
 impl Shard {
@@ -195,7 +196,7 @@ impl Shard {
     pub fn new() -> Self {
         Self {
             data: FxHashMap::default(),
-            ordered_keys: BTreeSet::new(),
+            ordered_keys: None,
         }
     }
 
@@ -203,17 +204,15 @@ impl Shard {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             data: FxHashMap::with_capacity_and_hasher(capacity, Default::default()),
-            ordered_keys: BTreeSet::new(),
+            ordered_keys: None,
         }
     }
 
-    /// Iterate keys matching a prefix using BTreeSet range scan.
-    ///
-    /// O(log n) seek + O(k) iteration where k = number of matching keys.
-    fn keys_with_prefix<'a>(&'a self, prefix: &'a Key) -> impl Iterator<Item = &'a Key> {
-        self.ordered_keys
-            .range::<Key, _>(prefix..)
-            .take_while(move |k| k.starts_with(prefix))
+    /// Rebuild `ordered_keys` from `data.keys()` if invalidated (None).
+    pub(crate) fn ensure_ordered_keys(&mut self) {
+        if self.ordered_keys.is_none() {
+            self.ordered_keys = Some(self.data.keys().cloned().collect());
+        }
     }
 
     /// Get number of keys in this shard
@@ -354,8 +353,8 @@ impl ShardedStore {
             // Add new version to existing chain
             chain.push(value);
         } else {
-            // Create new chain — also add to BTreeSet index
-            shard.ordered_keys.insert(key.clone());
+            // Create new chain — invalidate ordered index (rebuilt lazily on scan)
+            shard.ordered_keys = None;
             shard.data.insert(key, VersionChain::new(value));
         }
     }
@@ -432,6 +431,31 @@ impl ShardedStore {
             .unwrap_or(false)
     }
 
+    /// Direct single-key read without transaction overhead.
+    ///
+    /// Returns the latest committed value, skipping snapshot creation,
+    /// pool acquire/release, and coordinator bookkeeping.
+    ///
+    /// # Safety
+    ///
+    /// Returns the latest committed value (no snapshot isolation).
+    /// Safe for single-key reads where multi-key consistency isn't needed.
+    #[inline]
+    pub fn get_direct(&self, key: &Key) -> Option<VersionedValue> {
+        let branch_id = key.namespace.branch_id;
+        self.shards.get(&branch_id).and_then(|shard| {
+            shard.data.get(key).and_then(|chain| {
+                chain.latest().and_then(|sv| {
+                    if !sv.is_expired() && !sv.is_tombstone() {
+                        Some(sv.versioned().clone())
+                    } else {
+                        None
+                    }
+                })
+            })
+        })
+    }
+
     /// Apply a batch of writes and deletes atomically
     ///
     /// All operations in the batch are applied with the given version.
@@ -489,13 +513,14 @@ impl ShardedStore {
         // Apply atomically per branch (hold shard lock for entire branch batch)
         for (branch_id, (branch_writes, branch_deletes)) in branch_ops {
             let mut shard = self.shards.entry(branch_id).or_default();
+            let mut has_new_keys = false;
 
             for (key, stored) in branch_writes {
                 if let Some(chain) = shard.data.get_mut(&key) {
                     chain.push(stored);
                 } else {
-                    shard.ordered_keys.insert(key.clone());
                     shard.data.insert(key, VersionChain::new(stored));
+                    has_new_keys = true;
                 }
             }
 
@@ -504,9 +529,14 @@ impl ShardedStore {
                 if let Some(chain) = shard.data.get_mut(&key) {
                     chain.push(tombstone);
                 } else {
-                    shard.ordered_keys.insert(key.clone());
                     shard.data.insert(key, VersionChain::new(tombstone));
+                    has_new_keys = true;
                 }
+            }
+
+            // Invalidate ordered index if new keys were added
+            if has_new_keys {
+                shard.ordered_keys = None;
             }
         }
 
@@ -555,10 +585,15 @@ impl ShardedStore {
         let branch_id = prefix.namespace.branch_id;
         Ok(self
             .shards
-            .get(&branch_id)
-            .map(|shard| {
+            .get_mut(&branch_id)
+            .map(|mut shard| {
+                shard.ensure_ordered_keys();
                 shard
-                    .keys_with_prefix(prefix)
+                    .ordered_keys
+                    .as_ref()
+                    .unwrap()
+                    .range::<Key, _>(prefix..)
+                    .take_while(|k| k.starts_with(prefix))
                     .filter_map(|k| {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_timestamp(max_timestamp).and_then(|sv| {
@@ -638,10 +673,13 @@ impl ShardedStore {
     /// Vector of (Key, VersionedValue) pairs, sorted by key
     pub fn list_branch(&self, branch_id: &BranchId) -> Vec<(Key, VersionedValue)> {
         self.shards
-            .get(branch_id)
-            .map(|shard| {
+            .get_mut(branch_id)
+            .map(|mut shard| {
+                shard.ensure_ordered_keys();
                 shard
                     .ordered_keys
+                    .as_ref()
+                    .unwrap()
                     .iter()
                     .filter_map(|k| {
                         shard.data.get(k).and_then(|chain| {
@@ -678,10 +716,15 @@ impl ShardedStore {
         let branch_id = prefix.namespace.branch_id;
 
         self.shards
-            .get(&branch_id)
-            .map(|shard| {
+            .get_mut(&branch_id)
+            .map(|mut shard| {
+                shard.ensure_ordered_keys();
                 shard
-                    .keys_with_prefix(prefix)
+                    .ordered_keys
+                    .as_ref()
+                    .unwrap()
+                    .range::<Key, _>(prefix..)
+                    .take_while(|k| k.starts_with(prefix))
                     .filter_map(|k| {
                         shard.data.get(k).and_then(|chain| {
                             chain.latest().and_then(|sv| {
@@ -716,10 +759,13 @@ impl ShardedStore {
         type_tag: strata_core::types::TypeTag,
     ) -> Vec<(Key, VersionedValue)> {
         self.shards
-            .get(branch_id)
-            .map(|shard| {
+            .get_mut(branch_id)
+            .map(|mut shard| {
+                shard.ensure_ordered_keys();
                 shard
                     .ordered_keys
+                    .as_ref()
+                    .unwrap()
                     .iter()
                     .filter(|k| k.type_tag == type_tag)
                     .filter_map(|k| {
@@ -745,10 +791,13 @@ impl ShardedStore {
         type_tag: strata_core::types::TypeTag,
     ) -> usize {
         self.shards
-            .get(branch_id)
-            .map(|shard| {
+            .get_mut(branch_id)
+            .map(|mut shard| {
+                shard.ensure_ordered_keys();
                 shard
                     .ordered_keys
+                    .as_ref()
+                    .unwrap()
                     .iter()
                     .filter(|k| {
                         k.type_tag == type_tag
@@ -925,10 +974,13 @@ impl ShardedSnapshot {
     pub fn list_branch(&self, branch_id: &BranchId) -> Vec<(Key, VersionedValue)> {
         self.store
             .shards
-            .get(branch_id)
-            .map(|shard| {
+            .get_mut(branch_id)
+            .map(|mut shard| {
+                shard.ensure_ordered_keys();
                 shard
                     .ordered_keys
+                    .as_ref()
+                    .unwrap()
                     .iter()
                     .filter_map(|k| {
                         shard.data.get(k).and_then(|chain| {
@@ -955,10 +1007,15 @@ impl ShardedSnapshot {
         let branch_id = prefix.namespace.branch_id;
         self.store
             .shards
-            .get(&branch_id)
-            .map(|shard| {
+            .get_mut(&branch_id)
+            .map(|mut shard| {
+                shard.ensure_ordered_keys();
                 shard
-                    .keys_with_prefix(prefix)
+                    .ordered_keys
+                    .as_ref()
+                    .unwrap()
+                    .range::<Key, _>(prefix..)
+                    .take_while(|k| k.starts_with(prefix))
                     .filter_map(|k| {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_version(self.version).and_then(|sv| {
@@ -987,10 +1044,13 @@ impl ShardedSnapshot {
     ) -> Vec<(Key, VersionedValue)> {
         self.store
             .shards
-            .get(branch_id)
-            .map(|shard| {
+            .get_mut(branch_id)
+            .map(|mut shard| {
+                shard.ensure_ordered_keys();
                 shard
                     .ordered_keys
+                    .as_ref()
+                    .unwrap()
                     .iter()
                     .filter(|k| k.type_tag == type_tag)
                     .filter_map(|k| {
@@ -1178,10 +1238,15 @@ impl Storage for ShardedStore {
         let branch_id = prefix.namespace.branch_id;
         Ok(self
             .shards
-            .get(&branch_id)
-            .map(|shard| {
+            .get_mut(&branch_id)
+            .map(|mut shard| {
+                shard.ensure_ordered_keys();
                 shard
-                    .keys_with_prefix(prefix)
+                    .ordered_keys
+                    .as_ref()
+                    .unwrap()
+                    .range::<Key, _>(prefix..)
+                    .take_while(|k| k.starts_with(prefix))
                     .filter_map(|k| {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_version(max_version).and_then(|sv| {
@@ -1295,10 +1360,15 @@ impl SnapshotView for ShardedSnapshot {
         Ok(self
             .store
             .shards
-            .get(&branch_id)
-            .map(|shard| {
+            .get_mut(&branch_id)
+            .map(|mut shard| {
+                shard.ensure_ordered_keys();
                 shard
-                    .keys_with_prefix(prefix)
+                    .ordered_keys
+                    .as_ref()
+                    .unwrap()
+                    .range::<Key, _>(prefix..)
+                    .take_while(|k| k.starts_with(prefix))
                     .filter_map(|k| {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_version(self.version).and_then(|sv| {
@@ -3201,15 +3271,18 @@ mod tests {
             Storage::delete(&store, &key).unwrap();
         }
 
-        let shard = store.shards.get(&branch_id).unwrap();
+        // Ensure ordered_keys is rebuilt lazily, then verify consistency
+        let mut shard = store.shards.get_mut(&branch_id).unwrap();
+        shard.ensure_ordered_keys();
+        let ordered = shard.ordered_keys.as_ref().unwrap();
         assert_eq!(
-            shard.ordered_keys.len(),
+            ordered.len(),
             shard.data.len(),
             "ordered_keys and data must have the same number of keys"
         );
 
         // Every key in ordered_keys must exist in data
-        for k in shard.ordered_keys.iter() {
+        for k in ordered.iter() {
             assert!(
                 shard.data.contains_key(k),
                 "ordered_keys has key not in data"
@@ -3217,10 +3290,7 @@ mod tests {
         }
         // Every key in data must exist in ordered_keys
         for k in shard.data.keys() {
-            assert!(
-                shard.ordered_keys.contains(k),
-                "data has key not in ordered_keys"
-            );
+            assert!(ordered.contains(k), "data has key not in ordered_keys");
         }
     }
 
@@ -3370,5 +3440,195 @@ mod tests {
         let prefix_none = Key::new_kv(ns.clone(), "gamma:");
         let results_none = Storage::scan_prefix(&store, &prefix_none, u64::MAX).unwrap();
         assert_eq!(results_none.len(), 0, "gamma: prefix should match 0 keys");
+    }
+
+    // ========================================================================
+    // Direct-path and Lazy BTreeSet Tests
+    // ========================================================================
+
+    #[test]
+    fn test_get_direct_basic() {
+        use strata_core::traits::Storage;
+        use strata_core::value::Value;
+
+        let store = ShardedStore::new();
+        let branch_id = BranchId::new();
+        let key = create_test_key(branch_id, "direct_key");
+
+        // Should return None for missing keys
+        assert!(store.get_direct(&key).is_none());
+
+        // Insert a value
+        Storage::put(&store, key.clone(), Value::Int(42), None).unwrap();
+
+        // Should return the latest value
+        let result = store.get_direct(&key);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().value, Value::Int(42));
+    }
+
+    #[test]
+    fn test_get_direct_filters_tombstones() {
+        use strata_core::traits::Storage;
+        use strata_core::value::Value;
+
+        let store = ShardedStore::new();
+        let branch_id = BranchId::new();
+        let key = create_test_key(branch_id, "tombstone_key");
+
+        Storage::put(&store, key.clone(), Value::Int(1), None).unwrap();
+        assert!(store.get_direct(&key).is_some());
+
+        // Delete creates a tombstone
+        Storage::delete(&store, &key).unwrap();
+        assert!(
+            store.get_direct(&key).is_none(),
+            "get_direct must filter tombstones"
+        );
+    }
+
+    #[test]
+    fn test_get_direct_filters_expired_ttl() {
+        use strata_core::value::Value;
+
+        let store = ShardedStore::new();
+        let branch_id = BranchId::new();
+        let key = create_test_key(branch_id, "ttl_key");
+
+        // Insert with TTL that's already expired
+        let expired_value = StoredValue::with_timestamp(
+            Value::Int(99),
+            Version::txn(1),
+            Timestamp::from_micros(1),               // ancient timestamp
+            Some(std::time::Duration::from_secs(1)), // expired long ago
+        );
+        store.put(key.clone(), expired_value);
+
+        assert!(
+            store.get_direct(&key).is_none(),
+            "get_direct must filter expired values"
+        );
+    }
+
+    #[test]
+    fn test_get_direct_returns_latest_version() {
+        use strata_core::traits::Storage;
+        use strata_core::value::Value;
+
+        let store = ShardedStore::new();
+        let branch_id = BranchId::new();
+        let key = create_test_key(branch_id, "multi_version");
+
+        // Insert multiple versions
+        Storage::put(&store, key.clone(), Value::Int(1), None).unwrap();
+        Storage::put(&store, key.clone(), Value::Int(2), None).unwrap();
+        Storage::put(&store, key.clone(), Value::Int(3), None).unwrap();
+
+        let result = store.get_direct(&key).unwrap();
+        assert_eq!(
+            result.value,
+            Value::Int(3),
+            "get_direct must return the latest version"
+        );
+    }
+
+    #[test]
+    fn test_lazy_ordered_keys_invalidation_and_rebuild() {
+        use strata_core::traits::Storage;
+        use strata_core::value::Value;
+
+        let store = ShardedStore::new();
+        let branch_id = BranchId::new();
+        let ns = strata_core::types::Namespace::for_branch(branch_id);
+
+        // Insert keys — ordered_keys starts as None, gets invalidated on each new key
+        Storage::put(&store, Key::new_kv(ns.clone(), "c"), Value::Int(3), None).unwrap();
+        Storage::put(&store, Key::new_kv(ns.clone(), "a"), Value::Int(1), None).unwrap();
+        Storage::put(&store, Key::new_kv(ns.clone(), "b"), Value::Int(2), None).unwrap();
+
+        // ordered_keys should be None (invalidated by put)
+        {
+            let shard = store.shards.get(&branch_id).unwrap();
+            assert!(
+                shard.ordered_keys.is_none(),
+                "ordered_keys should be None after insertions"
+            );
+        }
+
+        // scan_prefix forces a rebuild via ensure_ordered_keys
+        let prefix = Key::new_kv(ns.clone(), "");
+        let results = Storage::scan_prefix(&store, &prefix, u64::MAX).unwrap();
+        assert_eq!(results.len(), 3);
+
+        // Verify sorted order after lazy rebuild
+        let keys: Vec<String> = results
+            .iter()
+            .filter_map(|(k, _)| k.user_key_string())
+            .collect();
+        assert_eq!(
+            keys,
+            vec!["a", "b", "c"],
+            "Keys must be sorted after lazy rebuild"
+        );
+
+        // ordered_keys should now be Some (rebuilt by the scan)
+        {
+            let shard = store.shards.get(&branch_id).unwrap();
+            assert!(
+                shard.ordered_keys.is_some(),
+                "ordered_keys should be Some after scan triggered rebuild"
+            );
+        }
+
+        // Insert a NEW key — should invalidate again
+        Storage::put(&store, Key::new_kv(ns.clone(), "aa"), Value::Int(4), None).unwrap();
+        {
+            let shard = store.shards.get(&branch_id).unwrap();
+            assert!(
+                shard.ordered_keys.is_none(),
+                "ordered_keys should be None again after new key insertion"
+            );
+        }
+
+        // Scan again — should see all 4 keys in order
+        let results2 = Storage::scan_prefix(&store, &prefix, u64::MAX).unwrap();
+        let keys2: Vec<String> = results2
+            .iter()
+            .filter_map(|(k, _)| k.user_key_string())
+            .collect();
+        assert_eq!(keys2, vec!["a", "aa", "b", "c"]);
+    }
+
+    #[test]
+    fn test_lazy_ordered_keys_update_existing_no_invalidation() {
+        use strata_core::traits::Storage;
+        use strata_core::value::Value;
+
+        let store = ShardedStore::new();
+        let branch_id = BranchId::new();
+        let ns = strata_core::types::Namespace::for_branch(branch_id);
+
+        // Insert initial key
+        Storage::put(&store, Key::new_kv(ns.clone(), "k"), Value::Int(1), None).unwrap();
+
+        // Force a rebuild by scanning
+        let prefix = Key::new_kv(ns.clone(), "");
+        let _ = Storage::scan_prefix(&store, &prefix, u64::MAX).unwrap();
+
+        // ordered_keys should now be Some
+        {
+            let shard = store.shards.get(&branch_id).unwrap();
+            assert!(shard.ordered_keys.is_some());
+        }
+
+        // Update EXISTING key — should NOT invalidate ordered_keys
+        Storage::put(&store, Key::new_kv(ns.clone(), "k"), Value::Int(2), None).unwrap();
+        {
+            let shard = store.shards.get(&branch_id).unwrap();
+            assert!(
+                shard.ordered_keys.is_some(),
+                "Updating an existing key must not invalidate the ordered index"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Direct-path `get()`**: Single-key reads now bypass full MVCC transaction machinery (snapshot creation, pool acquire/release, commit flow), reading directly from the latest committed value in storage
- **Direct-path `put()`**: Single-key blind writes skip snapshot/validation overhead, using only atomic version allocation + WAL append + storage apply. Falls back to full transaction path in multi-process mode
- **Zero-copy `apply_writes()`**: Drains write_set/delete_set/cas_set instead of cloning keys and values during transaction commit
- **Lazy `ordered_keys`**: BTreeSet for prefix scans is now `Option<BTreeSet>` — only built on first scan request, invalidated (not updated) on new key insertion

All other operations (batch_put, delete, list, CAS, get_versioned, time-travel, EventLog, StateStore, JSON) remain on the full ACID transaction path.

## Motivation

YCSB benchmarks show Strata v0.14.2 at 20-28K read ops/s and 5-6.5K write ops/s. Profiling confirmed I/O is not the bottleneck — the overhead comes from full MVCC transaction setup per single-key operation. These changes target 3-10x throughput improvement for KV workloads.

## Files changed

| File | Change |
|------|--------|
| `crates/storage/src/sharded.rs` | `get_direct()`, lazy `Option<BTreeSet>` for ordered_keys, 6 new tests |
| `crates/engine/src/database/mod.rs` | `get_direct()` + `put_direct()` with WAL, metrics, multi-process guard |
| `crates/engine/src/primitives/kv.rs` | `get()`/`put()` use direct paths, 7 new tests |
| `crates/concurrency/src/transaction.rs` | `apply_writes(&mut self)` with `drain()` instead of clone |

## Safety

- Single-key `get()` returns the same value a new snapshot would see — no multi-key consistency needed
- Single-key `put()` uses atomic version counter for ordering; concurrent writes to different keys are naturally safe (DashMap shard locks)
- Multi-process mode detected and falls back to full coordinated transaction path
- WAL-required-but-missing-writer returns explicit error instead of silent success
- Coordinator metrics (`record_start`/`record_commit`/`record_abort`) tracked on all paths

## Test plan

- [x] 40 KV primitive tests pass (including 7 new: delete-then-get, monotonic versions, list rebuild, scan interleave, concurrent threads, WAL recovery, versioned txn path)
- [x] 114 storage tests pass (including 6 new: get_direct basic/tombstone/TTL/latest, lazy ordered_keys invalidation/no-invalidation)
- [x] 68 concurrency tests pass (drain in apply_writes)
- [x] 191 search tests pass (BM25 indexing intact)
- [x] 61 database tests pass (transactions, WAL recovery, durability modes)
- [x] Full workspace: 2,613 tests pass, 0 clippy errors
- [x] Code audit verified: ACID transactions, MVCC versioning, time-travel, branch isolation, all 3 durability modes, hybrid search — all intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)