### PR TITLE
Expose generic config_set/config_get in Rust SDK

### DIFF
--- a/crates/executor/src/api/db.rs
+++ b/crates/executor/src/api/db.rs
@@ -93,8 +93,44 @@ impl Strata {
     }
 
     // =========================================================================
-    // Configuration (4)
+    // Configuration (6)
     // =========================================================================
+
+    /// Set a configuration key.
+    ///
+    /// All 15 keys are supported: `provider`, `default_model`,
+    /// `anthropic_api_key`, `openai_api_key`, `google_api_key`, `embed_model`,
+    /// `durability`, `auto_embed`, `bm25_k1`, `bm25_b`, `embed_batch_size`,
+    /// `model_endpoint`, `model_name`, `model_api_key`, `model_timeout_ms`.
+    ///
+    /// Values are validated at the handler level.  Changes are persisted to
+    /// `strata.toml` for disk-backed databases.
+    pub fn config_set(&self, key: &str, value: &str) -> Result<()> {
+        match self.executor.execute(Command::ConfigureSet {
+            key: key.to_string(),
+            value: value.to_string(),
+        })? {
+            Output::Unit => Ok(()),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for ConfigureSet".into(),
+            }),
+        }
+    }
+
+    /// Get a configuration value by key.
+    ///
+    /// Returns `Some(value)` for keys that are set, or `None` for optional
+    /// keys that have no value (e.g. `default_model` when unset).
+    pub fn config_get(&self, key: &str) -> Result<Option<String>> {
+        match self.executor.execute(Command::ConfigureGetKey {
+            key: key.to_string(),
+        })? {
+            Output::ConfigValue(v) => Ok(v),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for ConfigureGetKey".into(),
+            }),
+        }
+    }
 
     /// Get the current database configuration.
     ///

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -1054,6 +1054,56 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_config_set_and_get() {
+        let db = create_strata();
+        db.config_set("auto_embed", "true").unwrap();
+        assert_eq!(db.config_get("auto_embed").unwrap(), Some("true".into()));
+        assert!(db.auto_embed_enabled().unwrap());
+    }
+
+    #[test]
+    fn test_config_set_bm25() {
+        let db = create_strata();
+        db.config_set("bm25_k1", "1.5").unwrap();
+        db.config_set("bm25_b", "0.8").unwrap();
+        assert_eq!(db.config_get("bm25_k1").unwrap(), Some("1.5".into()));
+        assert_eq!(db.config_get("bm25_b").unwrap(), Some("0.8".into()));
+    }
+
+    #[test]
+    fn test_config_set_invalid_key() {
+        let db = create_strata();
+        let err = db.config_set("nonexistent_key", "value").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Unknown configuration key"), "Error: {msg}");
+    }
+
+    #[test]
+    fn test_config_get_optional_key_returns_none() {
+        let db = create_strata();
+        // default_model is optional and unset by default
+        assert_eq!(db.config_get("default_model").unwrap(), None);
+    }
+
+    #[test]
+    fn test_config_set_persists_across_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let db = Strata::open(dir.path()).unwrap();
+            db.config_set("bm25_k1", "2.0").unwrap();
+            db.config_set("embed_batch_size", "256").unwrap();
+        }
+        {
+            let db = Strata::open(dir.path()).unwrap();
+            assert_eq!(db.config_get("bm25_k1").unwrap(), Some("2".into()));
+            assert_eq!(
+                db.config_get("embed_batch_size").unwrap(),
+                Some("256".into())
+            );
+        }
+    }
+
     // =========================================================================
     // Graph API Tests
     // =========================================================================


### PR DESCRIPTION
## Summary
- Adds `config_set(key, value)` and `config_get(key)` methods to the `Strata` struct for generic key-value configuration access
- All 15 configuration keys are supported with validation at the handler level
- Includes 5 tests: basic round-trip, BM25 keys, invalid key error, optional None return, and persistence across reopen

Closes #1265

## Test plan
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)