### PR TITLE
Wire stop_sequences through Generate command

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -843,6 +843,12 @@ fn build_generate() -> Command {
                 .long("seed")
                 .help("Random seed for reproducibility"),
         )
+        .arg(
+            Arg::new("stop")
+                .long("stop")
+                .num_args(1..)
+                .help("Stop sequences (text strings that stop generation)"),
+        )
 }
 
 // =========================================================================

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -1028,6 +1028,9 @@ fn parse_generate(matches: &ArgMatches) -> Result<CliAction, String> {
         .map(|s| s.parse::<u64>())
         .transpose()
         .map_err(|e| format!("Invalid seed: {}", e))?;
+    let stop_sequences: Option<Vec<String>> = matches
+        .get_many::<String>("stop")
+        .map(|vals| vals.cloned().collect());
     Ok(CliAction::Execute(Command::Generate {
         model,
         prompt,
@@ -1037,6 +1040,7 @@ fn parse_generate(matches: &ArgMatches) -> Result<CliAction, String> {
         top_p,
         seed,
         stop_tokens: None,
+        stop_sequences,
     }))
 }
 

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -863,6 +863,9 @@ pub enum Command {
         /// Stop generation when any of these token IDs are produced.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         stop_tokens: Option<Vec<u32>>,
+        /// Stop generation when any of these text sequences are produced.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        stop_sequences: Option<Vec<String>>,
     },
 
     /// Tokenize text into token IDs using a model's tokenizer.

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -922,6 +922,7 @@ impl Executor {
                 top_p,
                 seed,
                 stop_tokens,
+                stop_sequences,
             } => crate::handlers::generate::generate(
                 &self.primitives,
                 model,
@@ -932,6 +933,7 @@ impl Executor {
                 top_p,
                 seed,
                 stop_tokens,
+                stop_sequences,
             ),
             Command::Tokenize {
                 model,

--- a/crates/executor/src/handlers/generate.rs
+++ b/crates/executor/src/handlers/generate.rs
@@ -18,6 +18,7 @@ pub fn generate(
     top_p: Option<f32>,
     seed: Option<u64>,
     stop_tokens: Option<Vec<u32>>,
+    stop_sequences: Option<Vec<String>>,
 ) -> Result<Output> {
     use crate::types::GenerationResult;
     use strata_intelligence::generate::GenerateModelState;
@@ -98,7 +99,7 @@ pub fn generate(
         top_k: top_k.unwrap_or(0),
         top_p: top_p.unwrap_or(1.0),
         seed,
-        stop_sequences: vec![], // TODO(#1244): Wire from Command::Generate when added
+        stop_sequences: stop_sequences.unwrap_or_default(),
         stop_tokens: stop_tokens.unwrap_or_default(),
     };
 
@@ -223,6 +224,7 @@ pub fn generate(
     _top_p: Option<f32>,
     _seed: Option<u64>,
     _stop_tokens: Option<Vec<u32>>,
+    _stop_sequences: Option<Vec<String>>,
 ) -> Result<Output> {
     Err(Error::Internal {
         reason: "Generation not available: compile with --features embed".to_string(),


### PR DESCRIPTION
## Summary
- Adds `stop_sequences: Option<Vec<String>>` field to `Command::Generate`
- Threads it through executor dispatch → handler → `GenerateRequest`
- Adds `--stop` CLI flag accepting one or more stop strings
- Updates Python SDK (`strata-python`) with `stop_sequences` param on `generate()`

Cloud providers (Anthropic, OpenAI, Google) already support stop sequences in the inference layer — this was the last missing link from command surface to inference engine.

Closes #1244

## Test plan
- [x] `cargo build --workspace` — compiles clean
- [x] `cargo test -p strata-executor` — 296 passed
- [x] `cargo fmt --all` / `cargo clippy` — clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)