### PR TITLE
ANN search: dense array, unified get(), norms cache

### DIFF
--- a/crates/engine/src/primitives/vector/distance.rs
+++ b/crates/engine/src/primitives/vector/distance.rs
@@ -14,6 +14,26 @@
 
 use crate::primitives::vector::DistanceMetric;
 
+/// Compute similarity using pre-cached norms when available.
+///
+/// For Cosine metric with both norms present, avoids recomputing them
+/// (saves ~13% per call). Falls back to `compute_similarity` otherwise.
+#[inline]
+pub fn compute_similarity_cached(
+    a: &[f32],
+    b: &[f32],
+    metric: DistanceMetric,
+    norm_a: Option<f32>,
+    norm_b: Option<f32>,
+) -> f32 {
+    if metric == DistanceMetric::Cosine {
+        if let (Some(na), Some(nb)) = (norm_a, norm_b) {
+            return cosine_similarity_with_norms(a, b, na, nb);
+        }
+    }
+    compute_similarity(a, b, metric)
+}
+
 /// Compute similarity score between two vectors
 ///
 /// All scores are normalized to "higher = more similar" (Invariant R2).
@@ -539,5 +559,160 @@ mod tests {
         let sim1 = cosine_similarity(&a, &b);
         let sim2 = cosine_similarity_with_norms(&a, &b, norm_a, norm_b);
         assert!((sim1 - sim2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_similarity_cached_cosine_matches() {
+        let a = vec![1.0, 2.0, 3.0];
+        let b = vec![4.0, 5.0, 6.0];
+        let norm_a = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let norm_b = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+
+        // With both norms: should use cached path
+        let cached =
+            compute_similarity_cached(&a, &b, DistanceMetric::Cosine, Some(norm_a), Some(norm_b));
+        let direct = compute_similarity(&a, &b, DistanceMetric::Cosine);
+        assert!((cached - direct).abs() < 1e-6);
+
+        // With one norm missing: should fall back to compute_similarity
+        let partial = compute_similarity_cached(&a, &b, DistanceMetric::Cosine, Some(norm_a), None);
+        assert!((partial - direct).abs() < 1e-6);
+        let partial2 =
+            compute_similarity_cached(&a, &b, DistanceMetric::Cosine, None, Some(norm_b));
+        assert!((partial2 - direct).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_similarity_cached_non_cosine_ignores_norms() {
+        let a = vec![1.0, 2.0, 3.0];
+        let b = vec![4.0, 5.0, 6.0];
+
+        // Euclidean: norms should be ignored
+        let euclidean_cached =
+            compute_similarity_cached(&a, &b, DistanceMetric::Euclidean, Some(999.0), Some(999.0));
+        let euclidean_direct = compute_similarity(&a, &b, DistanceMetric::Euclidean);
+        assert!((euclidean_cached - euclidean_direct).abs() < 1e-6);
+
+        // DotProduct: norms should be ignored
+        let dot_cached =
+            compute_similarity_cached(&a, &b, DistanceMetric::DotProduct, Some(999.0), Some(999.0));
+        let dot_direct = compute_similarity(&a, &b, DistanceMetric::DotProduct);
+        assert!((dot_cached - dot_direct).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_similarity_cached_zero_norms() {
+        let zero = vec![0.0, 0.0, 0.0];
+        let nonzero = vec![1.0, 2.0, 3.0];
+
+        // Zero norm with cached path should return 0.0 (same as uncached)
+        let cached = compute_similarity_cached(
+            &zero,
+            &nonzero,
+            DistanceMetric::Cosine,
+            Some(0.0),
+            Some(3.742),
+        );
+        assert_eq!(cached, 0.0);
+
+        let direct = compute_similarity(&zero, &nonzero, DistanceMetric::Cosine);
+        assert_eq!(direct, 0.0);
+    }
+}
+
+#[cfg(test)]
+mod profiling_tests {
+    use super::*;
+    use std::time::Instant;
+
+    fn make_embedding(dim: usize, seed: usize) -> Vec<f32> {
+        (0..dim)
+            .map(|j| ((seed * dim + j) as f32 / 1000.0).sin())
+            .collect()
+    }
+
+    /// Test 4: SIMD Activation Verification
+    ///
+    /// Times 100K distance computations via scalar vs SIMD-dispatched paths
+    /// to confirm SIMD is actually activating and providing speedup.
+    #[test]
+    fn profile_simd_vs_scalar() {
+        let dim = 128;
+        let num_pairs = 100_000;
+
+        // Pre-generate vector pairs
+        let pairs: Vec<(Vec<f32>, Vec<f32>)> = (0..num_pairs)
+            .map(|i| (make_embedding(dim, i), make_embedding(dim, i + num_pairs)))
+            .collect();
+
+        // --- dot_norms: scalar ---
+        let start = Instant::now();
+        let mut checksum_scalar = 0.0f64;
+        for (a, b) in &pairs {
+            let (dot, na, nb) = dot_norms_scalar(a, b);
+            checksum_scalar += dot as f64 + na as f64 + nb as f64;
+        }
+        let scalar_dot_ns = start.elapsed().as_nanos() as f64 / num_pairs as f64;
+
+        // --- dot_norms: SIMD-dispatched ---
+        let start = Instant::now();
+        let mut checksum_simd = 0.0f64;
+        for (a, b) in &pairs {
+            let (dot, na, nb) = dot_norms(a, b);
+            checksum_simd += dot as f64 + na as f64 + nb as f64;
+        }
+        let simd_dot_ns = start.elapsed().as_nanos() as f64 / num_pairs as f64;
+
+        // --- euclidean_distance: scalar ---
+        let start = Instant::now();
+        let mut checksum_eu_scalar = 0.0f64;
+        for (a, b) in &pairs {
+            checksum_eu_scalar += euclidean_distance_scalar(a, b) as f64;
+        }
+        let scalar_eu_ns = start.elapsed().as_nanos() as f64 / num_pairs as f64;
+
+        // --- euclidean_distance: SIMD-dispatched ---
+        let start = Instant::now();
+        let mut checksum_eu_simd = 0.0f64;
+        for (a, b) in &pairs {
+            checksum_eu_simd += euclidean_distance(a, b) as f64;
+        }
+        let simd_eu_ns = start.elapsed().as_nanos() as f64 / num_pairs as f64;
+
+        // Detect platform
+        let platform = if cfg!(target_arch = "aarch64") {
+            "aarch64/NEON"
+        } else if cfg!(target_arch = "x86_64") {
+            "x86_64 (AVX2 detection at runtime)"
+        } else {
+            "scalar"
+        };
+
+        let dot_speedup = scalar_dot_ns / simd_dot_ns;
+        let eu_speedup = scalar_eu_ns / simd_eu_ns;
+
+        println!("\n=== SIMD vs Scalar Throughput ({num_pairs} pairs, dim={dim}) ===");
+        println!("  Platform: {platform}");
+        println!("  dot_norms_scalar:            {scalar_dot_ns:.1} ns/pair");
+        println!("  dot_norms (SIMD-dispatched):  {simd_dot_ns:.1} ns/pair");
+        println!("  dot_norms speedup: {dot_speedup:.2}x");
+        println!();
+        println!("  euclidean_distance_scalar:            {scalar_eu_ns:.1} ns/pair");
+        println!("  euclidean_distance (SIMD-dispatched):  {simd_eu_ns:.1} ns/pair");
+        println!("  euclidean_distance speedup: {eu_speedup:.2}x");
+        println!();
+        println!("  checksums (dot): scalar={checksum_scalar:.2}, simd={checksum_simd:.2}");
+        println!("  checksums (eu):  scalar={checksum_eu_scalar:.2}, simd={checksum_eu_simd:.2}");
+
+        if platform != "scalar" && platform != "x86_64/scalar-fallback" && dot_speedup < 1.5 {
+            println!(
+                "  WARNING: SIMD dot_norms speedup < 1.5x — SIMD may not be activating properly"
+            );
+        }
+        if platform != "scalar" && platform != "x86_64/scalar-fallback" && eu_speedup < 1.5 {
+            println!(
+                "  WARNING: SIMD euclidean speedup < 1.5x — SIMD may not be activating properly"
+            );
+        }
     }
 }

--- a/crates/engine/src/primitives/vector/heap.rs
+++ b/crates/engine/src/primitives/vector/heap.rs
@@ -501,27 +501,6 @@ impl VectorHeap {
     // Dense Acceleration (O(1) lookups for hot paths)
     // ========================================================================
 
-    /// O(1) embedding lookup via dense offset array.
-    ///
-    /// Only works for InMemory heaps. Falls back to `get()` for Mmap/Tiered.
-    #[inline]
-    pub fn get_fast(&self, id: VectorId) -> Option<&[f32]> {
-        let idx = id.0 as usize;
-        if idx < self.dense_offsets.len() {
-            let slot = self.dense_offsets[idx];
-            if slot != DENSE_ABSENT {
-                let dim = self.config.dimension;
-                let offset = slot as usize * dim;
-                return match &self.data {
-                    VectorData::InMemory(vec) => Some(&vec[offset..offset + dim]),
-                    _ => self.get(id),
-                };
-            }
-        }
-        // Fallback: try BTreeMap path (handles Mmap/Tiered)
-        self.get(id)
-    }
-
     /// Get the raw f32 offset for a VectorId (for CompactHnswGraph pre-resolution).
     ///
     /// Returns the slot number (offset / dim) if present, None otherwise.
@@ -566,7 +545,7 @@ impl VectorHeap {
                 ..
             } => {
                 // Slot-based access doesn't know which layer, try InMemory-like path
-                // This is a fallback; callers on Tiered heaps should use get_fast()
+                // This is a fallback; callers on Tiered heaps should use get()
                 let _ = (base, overlay, overlay_id_to_offset);
                 None
             }
@@ -637,7 +616,7 @@ impl VectorHeap {
                 ..
             } => {
                 // For Tiered heaps, id_to_offset stores dummy values (0).
-                // dense_offsets are not usable (get_fast falls back to get() anyway).
+                // dense_offsets are not usable (get() falls back to get_btree() anyway).
                 // We only need to compute correct norms by resolving embeddings
                 // through the overlay (precedence) or base mmap.
                 for (idx, _offset) in entries {
@@ -665,8 +644,30 @@ impl VectorHeap {
     /// Get embedding by VectorId
     ///
     /// Returns None if the vector doesn't exist.
-    /// Works for both InMemory and Mmap backing.
+    /// Uses O(1) dense offset lookup for InMemory heaps, falls back to
+    /// BTreeMap for Mmap/Tiered.
+    #[inline]
     pub fn get(&self, id: VectorId) -> Option<&[f32]> {
+        let idx = id.0 as usize;
+        if idx < self.dense_offsets.len() {
+            let slot = self.dense_offsets[idx];
+            if slot != DENSE_ABSENT {
+                let dim = self.config.dimension;
+                let offset = slot as usize * dim;
+                return match &self.data {
+                    VectorData::InMemory(vec) => Some(&vec[offset..offset + dim]),
+                    _ => self.get_btree(id),
+                };
+            }
+        }
+        // Fallback: try BTreeMap path (handles Mmap/Tiered)
+        self.get_btree(id)
+    }
+
+    /// BTreeMap-only embedding lookup (slow path).
+    ///
+    /// Used as fallback when the dense offset array doesn't cover this ID.
+    fn get_btree(&self, id: VectorId) -> Option<&[f32]> {
         match &self.data {
             VectorData::InMemory(vec) => {
                 let offset = *self.id_to_offset.get(&id)?;
@@ -1685,22 +1686,31 @@ mod tests {
     // ====================================================================
 
     #[test]
-    fn test_get_fast_matches_get() {
+    fn test_get_uses_dense_path() {
         let config = VectorConfig::new(3, DistanceMetric::Cosine).unwrap();
         let mut heap = VectorHeap::new(config);
 
+        // Insert non-contiguous IDs to exercise dense_offsets with gaps
         heap.upsert(VectorId::new(1), &[1.0, 0.0, 0.0]).unwrap();
         heap.upsert(VectorId::new(5), &[0.0, 1.0, 0.0]).unwrap();
         heap.upsert(VectorId::new(10), &[0.0, 0.0, 1.0]).unwrap();
 
-        // get_fast should return same results as get
-        for &id in &[1u64, 5, 10] {
-            let vid = VectorId::new(id);
-            assert_eq!(heap.get_fast(vid), heap.get(vid));
-        }
+        // Verify get() returns correct embeddings (not just self-consistent)
+        assert_eq!(heap.get(VectorId::new(1)).unwrap(), &[1.0, 0.0, 0.0]);
+        assert_eq!(heap.get(VectorId::new(5)).unwrap(), &[0.0, 1.0, 0.0]);
+        assert_eq!(heap.get(VectorId::new(10)).unwrap(), &[0.0, 0.0, 1.0]);
 
-        // Non-existent ID
-        assert!(heap.get_fast(VectorId::new(99)).is_none());
+        // Both paths (dense and btree) must agree
+        assert_eq!(heap.get(VectorId::new(1)), heap.get_btree(VectorId::new(1)),);
+        assert_eq!(heap.get(VectorId::new(5)), heap.get_btree(VectorId::new(5)),);
+
+        // Gap IDs should return None
+        assert!(heap.get(VectorId::new(3)).is_none());
+        assert!(heap.get(VectorId::new(7)).is_none());
+        // Non-existent ID beyond range
+        assert!(heap.get(VectorId::new(99)).is_none());
+        // ID 0 (before any inserts)
+        assert!(heap.get(VectorId::new(0)).is_none());
     }
 
     #[test]
@@ -1711,11 +1721,11 @@ mod tests {
         heap.upsert(VectorId::new(1), &[1.0, 0.0, 0.0]).unwrap();
         heap.upsert(VectorId::new(2), &[0.0, 1.0, 0.0]).unwrap();
 
-        assert!(heap.get_fast(VectorId::new(1)).is_some());
+        assert!(heap.get(VectorId::new(1)).is_some());
         heap.delete(VectorId::new(1));
-        assert!(heap.get_fast(VectorId::new(1)).is_none());
+        assert!(heap.get(VectorId::new(1)).is_none());
         // Other entries unaffected
-        assert!(heap.get_fast(VectorId::new(2)).is_some());
+        assert!(heap.get(VectorId::new(2)).is_some());
     }
 
     #[test]
@@ -1825,5 +1835,79 @@ mod tests {
 
         // Out of range should return None
         assert!(heap.get_by_slot(999).is_none());
+    }
+}
+
+#[cfg(test)]
+mod profiling_tests {
+    use super::*;
+    use std::time::Instant;
+
+    fn make_embedding(dim: usize, seed: usize) -> Vec<f32> {
+        (0..dim)
+            .map(|j| ((seed * dim + j) as f32 / 1000.0).sin())
+            .collect()
+    }
+
+    /// Test 7: VectorHeap get() vs get_btree() (100K vectors, 1M lookups)
+    ///
+    /// Benchmarks the O(1) dense-offset path (get) against the
+    /// BTreeMap-only path (get_btree) to quantify the acceleration ratio.
+    #[test]
+    fn profile_heap_get_vs_get_btree() {
+        let dim = 128;
+        let n = 100_000;
+        let num_lookups = 1_000_000;
+
+        let config = VectorConfig::new(dim, DistanceMetric::Cosine).unwrap();
+        let mut heap = VectorHeap::new(config);
+
+        // Insert n vectors (IDs 1..=n)
+        for i in 1..=n {
+            let emb = make_embedding(dim, i);
+            heap.upsert(VectorId::new(i as u64), &emb).unwrap();
+        }
+
+        // Pre-generate random lookup IDs (deterministic via sin-based hash)
+        let lookup_ids: Vec<VectorId> = (0..num_lookups)
+            .map(|i| {
+                let idx = ((i as f64 * 0.618033988749895).fract() * n as f64) as u64 + 1;
+                VectorId::new(idx)
+            })
+            .collect();
+
+        // --- get() (dense fast path) ---
+        let start = Instant::now();
+        let mut checksum_fast = 0.0f64;
+        for &id in &lookup_ids {
+            if let Some(emb) = heap.get(id) {
+                checksum_fast += emb[0] as f64;
+            }
+        }
+        let fast_elapsed = start.elapsed();
+        let fast_ns = fast_elapsed.as_nanos() as f64 / num_lookups as f64;
+
+        // --- get_btree() (BTreeMap-only path) ---
+        let start = Instant::now();
+        let mut checksum_get = 0.0f64;
+        for &id in &lookup_ids {
+            if let Some(emb) = heap.get_btree(id) {
+                checksum_get += emb[0] as f64;
+            }
+        }
+        let get_elapsed = start.elapsed();
+        let get_ns = get_elapsed.as_nanos() as f64 / num_lookups as f64;
+
+        let speedup = get_ns / fast_ns;
+
+        println!("\n=== VectorHeap: get() vs get_btree() ({n} vectors, {num_lookups} lookups, dim={dim}) ===");
+        println!("  get():          {fast_ns:.1} ns/call ({fast_elapsed:?} total)");
+        println!("  get_btree():    {get_ns:.1} ns/call ({get_elapsed:?} total)");
+        println!("  speedup: {speedup:.2}x");
+        println!("  checksums: get={checksum_fast:.4}, get_btree={checksum_get:.4}");
+        assert!(
+            (checksum_fast - checksum_get).abs() < 1e-2,
+            "Checksums diverged: get={checksum_fast}, get_btree={checksum_get}"
+        );
     }
 }

--- a/crates/engine/src/primitives/vector/hnsw.rs
+++ b/crates/engine/src/primitives/vector/hnsw.rs
@@ -19,7 +19,7 @@
 //! ## Determinism
 //!
 //! - Fixed RNG seed + monotonic counter for level assignment
-//! - BTreeMap for node storage (deterministic iteration)
+//! - Dense array for CompactHnswGraph node storage (O(1) lookup)
 //! - BTreeSet for neighbor lists (sorted)
 //! - Tie-breaking: (score desc, VectorId asc)
 
@@ -27,7 +27,7 @@ use std::cmp::{Ordering, Reverse};
 use std::collections::{BTreeMap, BinaryHeap, HashMap};
 
 use crate::primitives::vector::backend::VectorIndexBackend;
-use crate::primitives::vector::distance::compute_similarity;
+use crate::primitives::vector::distance::{compute_similarity, compute_similarity_cached};
 use crate::primitives::vector::heap::VectorHeap;
 use crate::primitives::vector::types::InlineMeta;
 use crate::primitives::vector::{DistanceMetric, VectorConfig, VectorError, VectorId};
@@ -1118,25 +1118,115 @@ impl NeighborData {
 /// Neighbors are stored in a contiguous sorted `Vec<u64>` (or mmap-backed
 /// slice) instead of one `BTreeSet<VectorId>` per layer per node.  This
 /// reduces per-element overhead from ~48 bytes (BTreeSet) to 8 bytes (u64).
+///
+/// Nodes are stored in a dense `Vec<Option<CompactHnswNode>>` indexed by
+/// `id.0 - id_offset` for O(1) lookup instead of BTreeMap's O(log n).
+/// This is the #1 performance optimization for ANN search — the search loop
+/// does ~1000 `neighbors_at()` + `is_deleted()` calls per query.
 pub(crate) struct CompactHnswGraph {
     pub(crate) config: HnswConfig,
     pub(crate) vector_config: VectorConfig,
     /// Flat array of all neighbor IDs (u64 for VectorId)
     pub(crate) neighbor_data: NeighborData,
-    /// Per-node metadata indexed by VectorId
-    pub(crate) nodes: BTreeMap<VectorId, CompactHnswNode>,
+    /// Dense node storage: index = id.0 - id_offset
+    pub(crate) dense_nodes: Vec<Option<CompactHnswNode>>,
+    /// VectorId.0 of the first entry (minimum ID in the graph)
+    pub(crate) id_offset: u64,
+    /// Number of occupied (Some) slots
+    pub(crate) node_count: usize,
     pub(crate) entry_point: Option<VectorId>,
     pub(crate) max_level: usize,
 }
 
 impl CompactHnswGraph {
+    // ====================================================================
+    // Dense node helpers (O(1) lookup)
+    // ====================================================================
+
+    #[inline]
+    pub(crate) fn get_node(&self, id: VectorId) -> Option<&CompactHnswNode> {
+        let raw = id.0;
+        if raw < self.id_offset {
+            return None;
+        }
+        let idx = (raw - self.id_offset) as usize;
+        self.dense_nodes.get(idx).and_then(|opt| opt.as_ref())
+    }
+
+    #[inline]
+    fn get_node_mut(&mut self, id: VectorId) -> Option<&mut CompactHnswNode> {
+        let raw = id.0;
+        if raw < self.id_offset {
+            return None;
+        }
+        let idx = (raw - self.id_offset) as usize;
+        self.dense_nodes.get_mut(idx).and_then(|opt| opt.as_mut())
+    }
+
+    /// Iterate over all present (id, node) pairs in VectorId order.
+    pub(crate) fn iter_nodes(&self) -> impl Iterator<Item = (VectorId, &CompactHnswNode)> {
+        let offset = self.id_offset;
+        self.dense_nodes
+            .iter()
+            .enumerate()
+            .filter_map(move |(i, opt)| {
+                opt.as_ref()
+                    .map(|node| (VectorId::new(offset + i as u64), node))
+            })
+    }
+
+    /// Iterate over all present VectorIds in order.
+    pub(crate) fn node_ids(&self) -> impl Iterator<Item = VectorId> + '_ {
+        let offset = self.id_offset;
+        self.dense_nodes
+            .iter()
+            .enumerate()
+            .filter_map(move |(i, opt)| {
+                if opt.is_some() {
+                    Some(VectorId::new(offset + i as u64))
+                } else {
+                    None
+                }
+            })
+    }
+
+    /// Build dense_nodes from a list of (VectorId, CompactHnswNode) pairs.
+    ///
+    /// `entries` must be sorted by VectorId with no duplicates.
+    pub(crate) fn build_dense(
+        entries: Vec<(VectorId, CompactHnswNode)>,
+    ) -> (Vec<Option<CompactHnswNode>>, u64, usize) {
+        if entries.is_empty() {
+            return (Vec::new(), 0, 0);
+        }
+        debug_assert!(
+            entries.windows(2).all(|w| w[0].0 < w[1].0),
+            "build_dense: entries must be sorted by VectorId with no duplicates"
+        );
+        let id_offset = entries.first().unwrap().0 .0;
+        let id_max = entries.last().unwrap().0 .0;
+        let len = (id_max - id_offset + 1) as usize;
+        let node_count = entries.len();
+        let mut dense = Vec::with_capacity(len);
+        dense.resize_with(len, || None);
+        for (id, node) in entries {
+            let idx = (id.0 - id_offset) as usize;
+            dense[idx] = Some(node);
+        }
+        (dense, id_offset, node_count)
+    }
+
+    // ====================================================================
+    // Construction
+    // ====================================================================
+
     /// Build from an existing `HnswGraph` (consumes graph state).
     ///
     /// Neighbor Vecs are already sorted, so the resulting flat array
     /// preserves deterministic neighbor ordering.
     pub(crate) fn from_graph(graph: &HnswGraph) -> Self {
         let mut neighbor_data: Vec<u64> = Vec::new();
-        let mut compact_nodes: BTreeMap<VectorId, CompactHnswNode> = BTreeMap::new();
+        let mut entries: Vec<(VectorId, CompactHnswNode)> = Vec::new();
 
         // Sort keys for deterministic order (HashMap has no inherent order)
         let mut sorted_ids: Vec<VectorId> = graph.nodes.keys().copied().collect();
@@ -1153,29 +1243,34 @@ impl CompactHnswGraph {
                 }
                 layer_ranges.push((start, count));
             }
-            compact_nodes.insert(
+            entries.push((
                 id,
                 CompactHnswNode {
                     layer_ranges,
                     created_at: node.created_at,
                     deleted_at: node.deleted_at,
                 },
-            );
+            ));
         }
+
+        let (dense_nodes, id_offset, node_count) = Self::build_dense(entries);
 
         CompactHnswGraph {
             config: graph.config.clone(),
             vector_config: graph.vector_config.clone(),
             neighbor_data: NeighborData::Owned(neighbor_data),
-            nodes: compact_nodes,
+            dense_nodes,
+            id_offset,
+            node_count,
             entry_point: graph.entry_point,
             max_level: graph.max_level,
         }
     }
 
     /// Get neighbor IDs for a node at a given layer.
+    #[inline]
     fn neighbors_at(&self, id: VectorId, layer: usize) -> &[u64] {
-        match self.nodes.get(&id) {
+        match self.get_node(id) {
             Some(node) if layer < node.layer_ranges.len() => {
                 let (start, count) = node.layer_ranges[layer];
                 let data = self.neighbor_data.as_slice();
@@ -1186,13 +1281,15 @@ impl CompactHnswGraph {
     }
 
     /// Check if node is deleted
+    #[inline]
     fn is_deleted(&self, id: VectorId) -> bool {
-        self.nodes.get(&id).is_some_and(|n| n.deleted_at.is_some())
+        self.get_node(id).is_some_and(|n| n.deleted_at.is_some())
     }
 
     /// Check if node was alive at `as_of_ts`
+    #[inline]
     fn is_alive_at(&self, id: VectorId, as_of_ts: u64) -> bool {
-        self.nodes.get(&id).is_some_and(|n| {
+        self.get_node(id).is_some_and(|n| {
             (n.created_at == 0 || n.created_at <= as_of_ts)
                 && n.deleted_at.map_or(true, |d| d > as_of_ts)
         })
@@ -1212,12 +1309,24 @@ impl CompactHnswGraph {
         heap: &VectorHeap,
     ) -> Vec<ScoredId> {
         let metric = self.vector_config.metric;
+        // Pre-compute query norm once for cosine similarity caching
+        let q_norm = if metric == DistanceMetric::Cosine {
+            Some(query.iter().map(|x| x * x).sum::<f32>().sqrt())
+        } else {
+            None
+        };
 
-        let entry_embedding = match heap.get_fast(entry_id) {
+        let entry_embedding = match heap.get(entry_id) {
             Some(e) => e,
             None => return Vec::new(),
         };
-        let entry_score = compute_similarity(query, entry_embedding, metric);
+        let entry_score = compute_similarity_cached(
+            query,
+            entry_embedding,
+            metric,
+            q_norm,
+            heap.get_norm(entry_id),
+        );
 
         let mut visited = VisitedSet::new();
         visited.mark(entry_id.0 as usize);
@@ -1252,8 +1361,14 @@ impl CompactHnswGraph {
                 }
                 visited.mark(neighbor_id.0 as usize);
 
-                if let Some(neighbor_embedding) = heap.get_fast(neighbor_id) {
-                    let score = compute_similarity(query, neighbor_embedding, metric);
+                if let Some(neighbor_embedding) = heap.get(neighbor_id) {
+                    let score = compute_similarity_cached(
+                        query,
+                        neighbor_embedding,
+                        metric,
+                        q_norm,
+                        heap.get_norm(neighbor_id),
+                    );
 
                     let worst_result_score = results
                         .peek()
@@ -1298,25 +1413,42 @@ impl CompactHnswGraph {
         heap: &VectorHeap,
     ) -> VectorId {
         let metric = self.vector_config.metric;
+        let q_norm = if metric == DistanceMetric::Cosine {
+            Some(query.iter().map(|x| x * x).sum::<f32>().sqrt())
+        } else {
+            None
+        };
         let mut current = entry_id;
 
         for layer in (to_layer..=from_layer).rev() {
             let mut improved = true;
             while improved {
                 improved = false;
-                let current_embedding = match heap.get_fast(current) {
+                let current_embedding = match heap.get(current) {
                     Some(e) => e,
                     None => break,
                 };
-                let current_score = compute_similarity(query, current_embedding, metric);
+                let current_score = compute_similarity_cached(
+                    query,
+                    current_embedding,
+                    metric,
+                    q_norm,
+                    heap.get_norm(current),
+                );
 
                 let mut best_score = current_score;
                 let mut best_id = current;
 
                 for &neighbor_u64 in self.neighbors_at(current, layer) {
                     let neighbor_id = VectorId::new(neighbor_u64);
-                    if let Some(neighbor_embedding) = heap.get_fast(neighbor_id) {
-                        let score = compute_similarity(query, neighbor_embedding, metric);
+                    if let Some(neighbor_embedding) = heap.get(neighbor_id) {
+                        let score = compute_similarity_cached(
+                            query,
+                            neighbor_embedding,
+                            metric,
+                            q_norm,
+                            heap.get_norm(neighbor_id),
+                        );
                         if score > best_score || (score == best_score && neighbor_id < best_id) {
                             best_score = score;
                             best_id = neighbor_id;
@@ -1352,7 +1484,7 @@ impl CompactHnswGraph {
         ef_search: usize,
         heap: &VectorHeap,
     ) -> Vec<(VectorId, f32)> {
-        if k == 0 || self.nodes.is_empty() {
+        if k == 0 || self.node_count == 0 {
             return Vec::new();
         }
 
@@ -1365,7 +1497,12 @@ impl CompactHnswGraph {
             None => return Vec::new(),
         };
 
-        if self.nodes.values().all(|n| n.deleted_at.is_some()) {
+        if self
+            .dense_nodes
+            .iter()
+            .flatten()
+            .all(|n| n.deleted_at.is_some())
+        {
             return Vec::new();
         }
 
@@ -1393,14 +1530,17 @@ impl CompactHnswGraph {
         as_of_ts: u64,
         heap: &VectorHeap,
     ) -> Vec<(VectorId, f32)> {
-        if self.nodes.is_empty() || k == 0 {
+        if self.node_count == 0 || k == 0 {
             return Vec::new();
         }
         if query.len() != heap.dimension() {
             return Vec::new();
         }
 
-        let has_alive = self.nodes.keys().any(|&id| self.is_alive_at(id, as_of_ts));
+        let has_alive = self.dense_nodes.iter().flatten().any(|n| {
+            (n.created_at == 0 || n.created_at <= as_of_ts)
+                && n.deleted_at.map_or(true, |d| d > as_of_ts)
+        });
         if !has_alive {
             return Vec::new();
         }
@@ -1420,7 +1560,7 @@ impl CompactHnswGraph {
         end_ts: u64,
         heap: &VectorHeap,
     ) -> Vec<(VectorId, f32)> {
-        if self.nodes.is_empty() || k == 0 {
+        if self.node_count == 0 || k == 0 {
             return Vec::new();
         }
         if query.len() != heap.dimension() {
@@ -1429,7 +1569,7 @@ impl CompactHnswGraph {
 
         let mut results = self.search_with_heap(query, k * 2, heap);
         results.retain(|(id, _)| {
-            self.nodes.get(id).is_some_and(|n| {
+            self.get_node(*id).is_some_and(|n| {
                 n.created_at >= start_ts && n.created_at <= end_ts && n.deleted_at.is_none()
             })
         });
@@ -1443,23 +1583,32 @@ impl CompactHnswGraph {
 
     /// Check if a vector exists and is alive
     pub(crate) fn contains(&self, id: VectorId) -> bool {
-        self.nodes.get(&id).is_some_and(|n| n.deleted_at.is_none())
+        self.get_node(id).is_some_and(|n| n.deleted_at.is_none())
     }
 
     /// Soft-delete a vector. Returns true if it was alive.
     pub(crate) fn delete_with_timestamp(&mut self, id: VectorId, deleted_at: u64) -> bool {
-        let was_alive = self.nodes.get(&id).is_some_and(|n| n.deleted_at.is_none());
-        if let Some(node) = self.nodes.get_mut(&id) {
+        let was_alive = self.get_node(id).is_some_and(|n| n.deleted_at.is_none());
+        if let Some(node) = self.get_node_mut(id) {
             node.deleted_at = Some(deleted_at);
         }
         if was_alive && self.entry_point == Some(id) {
-            self.entry_point = self
-                .nodes
+            let new_ep = self
+                .dense_nodes
                 .iter()
-                .find(|(_, n)| n.deleted_at.is_none())
-                .map(|(id, _)| *id);
-            if let Some(ep) = self.entry_point {
-                self.max_level = self.nodes[&ep].layer_ranges.len().saturating_sub(1);
+                .enumerate()
+                .filter_map(|(i, opt)| {
+                    opt.as_ref()
+                        .filter(|n| n.deleted_at.is_none())
+                        .map(|_| VectorId::new(self.id_offset + i as u64))
+                })
+                .next();
+            self.entry_point = new_ep;
+            if let Some(ep) = new_ep {
+                self.max_level = self
+                    .get_node(ep)
+                    .map(|n| n.layer_ranges.len().saturating_sub(1))
+                    .unwrap_or(0);
             } else {
                 self.max_level = 0;
             }
@@ -1470,7 +1619,7 @@ impl CompactHnswGraph {
     /// Number of nodes in the graph (including soft-deleted)
     #[allow(dead_code)]
     pub(crate) fn len(&self) -> usize {
-        self.nodes.len()
+        self.node_count
     }
 
     /// Whether the neighbor data is backed by a memory-mapped file.
@@ -1487,15 +1636,17 @@ impl CompactHnswGraph {
         } else {
             self.neighbor_data.len() * std::mem::size_of::<u64>()
         };
-        let node_bytes: usize = self
-            .nodes
-            .values()
-            .map(|n| {
-                std::mem::size_of::<CompactHnswNode>()
-                    + n.layer_ranges.capacity() * std::mem::size_of::<(u32, u16)>()
-                    + 64 // BTreeMap node overhead
-            })
+        // dense_nodes Vec backing array (all slots including None)
+        let dense_vec_bytes =
+            self.dense_nodes.len() * std::mem::size_of::<Option<CompactHnswNode>>();
+        // Per-node heap allocations (layer_ranges Vec data on the heap)
+        let layer_heap_bytes: usize = self
+            .dense_nodes
+            .iter()
+            .flatten()
+            .map(|n| n.layer_ranges.capacity() * std::mem::size_of::<(u32, u16)>())
             .sum();
+        let node_bytes = dense_vec_bytes + layer_heap_bytes;
         neighbor_bytes + node_bytes
     }
 }
@@ -2118,5 +2269,623 @@ mod tests {
             avg_recall,
             num_queries
         );
+    }
+
+    // ====================================================================
+    // Dense array edge case tests
+    // ====================================================================
+
+    #[test]
+    fn test_build_dense_non_contiguous_ids() {
+        // IDs with large gaps: 1, 50, 100
+        let entries = vec![
+            (
+                VectorId::new(1),
+                CompactHnswNode {
+                    layer_ranges: vec![(0, 0)],
+                    created_at: 10,
+                    deleted_at: None,
+                },
+            ),
+            (
+                VectorId::new(50),
+                CompactHnswNode {
+                    layer_ranges: vec![(0, 0)],
+                    created_at: 20,
+                    deleted_at: None,
+                },
+            ),
+            (
+                VectorId::new(100),
+                CompactHnswNode {
+                    layer_ranges: vec![(0, 0)],
+                    created_at: 30,
+                    deleted_at: None,
+                },
+            ),
+        ];
+
+        let (dense, id_offset, node_count) = CompactHnswGraph::build_dense(entries);
+
+        assert_eq!(id_offset, 1);
+        assert_eq!(node_count, 3);
+        assert_eq!(dense.len(), 100); // 100 - 1 + 1
+
+        // Verify occupied slots
+        assert!(dense[0].is_some()); // id=1, idx=0
+        assert!(dense[49].is_some()); // id=50, idx=49
+        assert!(dense[99].is_some()); // id=100, idx=99
+
+        // Verify gaps are None
+        assert!(dense[1].is_none()); // id=2
+        assert!(dense[48].is_none()); // id=49
+        assert!(dense[50].is_none()); // id=51
+
+        // Verify created_at preserved
+        assert_eq!(dense[0].as_ref().unwrap().created_at, 10);
+        assert_eq!(dense[49].as_ref().unwrap().created_at, 20);
+        assert_eq!(dense[99].as_ref().unwrap().created_at, 30);
+    }
+
+    #[test]
+    fn test_build_dense_high_offset_ids() {
+        // IDs starting at a high number: 1000, 1001, 1002
+        let entries = vec![
+            (
+                VectorId::new(1000),
+                CompactHnswNode {
+                    layer_ranges: vec![(0, 1)],
+                    created_at: 1,
+                    deleted_at: None,
+                },
+            ),
+            (
+                VectorId::new(1001),
+                CompactHnswNode {
+                    layer_ranges: vec![(1, 1)],
+                    created_at: 2,
+                    deleted_at: None,
+                },
+            ),
+            (
+                VectorId::new(1002),
+                CompactHnswNode {
+                    layer_ranges: vec![(2, 1)],
+                    created_at: 3,
+                    deleted_at: None,
+                },
+            ),
+        ];
+
+        let (dense, id_offset, node_count) = CompactHnswGraph::build_dense(entries);
+
+        assert_eq!(id_offset, 1000);
+        assert_eq!(node_count, 3);
+        assert_eq!(dense.len(), 3); // tightly packed: 1002 - 1000 + 1
+
+        // All slots should be occupied
+        for slot in &dense {
+            assert!(slot.is_some());
+        }
+    }
+
+    #[test]
+    fn test_compact_graph_get_node_with_offset() {
+        // Build a CompactHnswGraph with IDs starting at 100
+        let config = VectorConfig::new(3, DistanceMetric::Cosine).unwrap();
+        let entries = vec![
+            (
+                VectorId::new(100),
+                CompactHnswNode {
+                    layer_ranges: vec![(0, 0)],
+                    created_at: 10,
+                    deleted_at: None,
+                },
+            ),
+            (
+                VectorId::new(103),
+                CompactHnswNode {
+                    layer_ranges: vec![(0, 0)],
+                    created_at: 20,
+                    deleted_at: Some(50),
+                },
+            ),
+        ];
+        let (dense_nodes, id_offset, node_count) = CompactHnswGraph::build_dense(entries);
+        let graph = CompactHnswGraph {
+            config: HnswConfig::default(),
+            vector_config: config,
+            neighbor_data: NeighborData::Owned(Vec::new()),
+            dense_nodes,
+            id_offset,
+            node_count,
+            entry_point: Some(VectorId::new(100)),
+            max_level: 0,
+        };
+
+        // get_node should work with offset
+        assert!(graph.get_node(VectorId::new(100)).is_some());
+        assert!(graph.get_node(VectorId::new(103)).is_some());
+
+        // Gap ID returns None
+        assert!(graph.get_node(VectorId::new(101)).is_none());
+        assert!(graph.get_node(VectorId::new(102)).is_none());
+
+        // ID below offset returns None
+        assert!(graph.get_node(VectorId::new(99)).is_none());
+
+        // ID above range returns None
+        assert!(graph.get_node(VectorId::new(200)).is_none());
+
+        // is_deleted respects offset
+        assert!(!graph.is_deleted(VectorId::new(100)));
+        assert!(graph.is_deleted(VectorId::new(103)));
+
+        // contains respects deletion
+        assert!(graph.contains(VectorId::new(100)));
+        assert!(!graph.contains(VectorId::new(103))); // deleted
+
+        // iter_nodes returns both
+        let ids: Vec<u64> = graph.iter_nodes().map(|(id, _)| id.as_u64()).collect();
+        assert_eq!(ids, vec![100, 103]);
+
+        // node_ids returns both
+        let ids2: Vec<u64> = graph.node_ids().map(|id| id.as_u64()).collect();
+        assert_eq!(ids2, vec![100, 103]);
+    }
+
+    #[test]
+    fn test_compact_graph_search_with_offset_ids() {
+        // End-to-end search test with IDs that don't start at 1
+        let config = VectorConfig::new(3, DistanceMetric::Cosine).unwrap();
+        let mut graph = HnswGraph::new(&config, HnswConfig::default());
+
+        let mut heap = VectorHeap::new(config.clone());
+        // Start IDs at 50
+        heap.insert_with_id(VectorId::new(50), &[1.0, 0.0, 0.0])
+            .unwrap();
+        heap.insert_with_id(VectorId::new(51), &[0.0, 1.0, 0.0])
+            .unwrap();
+        heap.insert_with_id(VectorId::new(52), &[0.0, 0.0, 1.0])
+            .unwrap();
+
+        graph.insert_into_graph(VectorId::new(50), &[1.0, 0.0, 0.0], 10, &heap);
+        graph.insert_into_graph(VectorId::new(51), &[0.0, 1.0, 0.0], 20, &heap);
+        graph.insert_into_graph(VectorId::new(52), &[0.0, 0.0, 1.0], 30, &heap);
+
+        let compact = CompactHnswGraph::from_graph(&graph);
+
+        assert_eq!(compact.id_offset, 50);
+        assert_eq!(compact.node_count, 3);
+
+        // Search should find the nearest vector
+        let results = compact.search_with_heap(&[1.0, 0.0, 0.0], 3, &heap);
+        assert!(!results.is_empty());
+        assert_eq!(results[0].0, VectorId::new(50));
+
+        // Temporal search
+        let results_at = compact.search_at_with_heap(&[1.0, 0.0, 0.0], 3, 15, &heap);
+        // Only VectorId(50) was created at ts=10, which is <= 15
+        assert!(!results_at.is_empty());
+        assert!(results_at.iter().all(|(id, _)| id.as_u64() == 50));
+    }
+
+    #[test]
+    fn test_build_dense_single_entry() {
+        let entries = vec![(
+            VectorId::new(42),
+            CompactHnswNode {
+                layer_ranges: vec![(0, 0)],
+                created_at: 100,
+                deleted_at: None,
+            },
+        )];
+
+        let (dense, id_offset, node_count) = CompactHnswGraph::build_dense(entries);
+
+        assert_eq!(id_offset, 42);
+        assert_eq!(node_count, 1);
+        assert_eq!(dense.len(), 1);
+        assert!(dense[0].is_some());
+        assert_eq!(dense[0].as_ref().unwrap().created_at, 100);
+    }
+}
+
+#[cfg(test)]
+mod profiling_tests {
+    use super::*;
+    use std::collections::HashMap as StdHashMap;
+    use std::time::Instant;
+
+    fn make_embedding(dim: usize, seed: usize) -> Vec<f32> {
+        (0..dim)
+            .map(|j| ((seed * dim + j) as f32 / 1000.0).sin())
+            .collect()
+    }
+
+    /// Build a CompactHnswGraph + VectorHeap with `n` vectors of dimension `dim`.
+    fn build_compact_graph(n: usize, dim: usize) -> (CompactHnswGraph, VectorHeap) {
+        let config = VectorConfig::new(dim, DistanceMetric::Cosine).unwrap();
+        let hnsw_config = HnswConfig::default();
+        let mut graph = HnswGraph::new(&config, hnsw_config);
+        let mut heap = VectorHeap::new(config.clone());
+
+        for i in 1..=n {
+            let emb = make_embedding(dim, i);
+            heap.upsert(VectorId::new(i as u64), &emb).unwrap();
+        }
+        // Build graph: insert in ID order for determinism
+        for i in 1..=n {
+            let emb = make_embedding(dim, i);
+            graph.insert_into_graph(VectorId::new(i as u64), &emb, 0, &heap);
+        }
+
+        let compact = CompactHnswGraph::from_graph(&graph);
+        (compact, heap)
+    }
+
+    // ====================================================================
+    // Test 1: Full Search Path Breakdown
+    // ====================================================================
+
+    /// Test 1: HNSW Search Path Breakdown
+    ///
+    /// Builds CompactHnswGraph with 10K vectors (128d, cosine).
+    /// For 100 queries, separately times:
+    /// - greedy_search_to_layer (upper layers)
+    /// - search_layer (layer 0 beam search)
+    /// - Full search_with_heap_ef (end-to-end)
+    /// - Post-processing overhead (difference)
+    #[test]
+    fn profile_search_path_breakdown() {
+        let n = 10_000;
+        let dim = 128;
+        let num_queries = 100;
+        let k = 10;
+
+        let (compact, heap) = build_compact_graph(n, dim);
+        let ef = compact.config.ef_search.max(k);
+
+        // Pre-generate queries
+        let queries: Vec<Vec<f32>> = (0..num_queries)
+            .map(|i| make_embedding(dim, n + 1 + i))
+            .collect();
+
+        let entry_id = compact.entry_point.unwrap();
+        let max_level = compact.max_level;
+
+        // --- Time greedy_search_to_layer ---
+        let start = Instant::now();
+        let mut layer0_entries = Vec::with_capacity(num_queries);
+        for q in &queries {
+            let entry = if max_level > 0 {
+                compact.greedy_search_to_layer(q, entry_id, max_level, 1, &heap)
+            } else {
+                entry_id
+            };
+            layer0_entries.push(entry);
+        }
+        let greedy_us = start.elapsed().as_micros() as f64 / num_queries as f64;
+
+        // --- Time search_layer (layer 0) ---
+        let start = Instant::now();
+        let mut search_results = Vec::with_capacity(num_queries);
+        for (i, q) in queries.iter().enumerate() {
+            let results = compact.search_layer(q, layer0_entries[i], ef, 0, &heap);
+            search_results.push(results);
+        }
+        let search_layer_us = start.elapsed().as_micros() as f64 / num_queries as f64;
+
+        // --- Time full search_with_heap_ef ---
+        let start = Instant::now();
+        for q in &queries {
+            let _ = compact.search_with_heap_ef(q, k, ef, &heap);
+        }
+        let total_us = start.elapsed().as_micros() as f64 / num_queries as f64;
+
+        let postprocess_us = total_us - greedy_us - search_layer_us;
+        let postprocess_us = postprocess_us.max(0.0);
+
+        println!("\n=== HNSW Search Path Breakdown ({n} vectors, dim={dim}, cosine) ===");
+        println!(
+            "  greedy_search_to_layer:  {:7.1} us/query ({:5.1}%)",
+            greedy_us,
+            greedy_us / total_us * 100.0
+        );
+        println!(
+            "  search_layer (layer 0):  {:7.1} us/query ({:5.1}%)",
+            search_layer_us,
+            search_layer_us / total_us * 100.0
+        );
+        println!(
+            "  result_postprocess:      {:7.1} us/query ({:5.1}%)",
+            postprocess_us,
+            postprocess_us / total_us * 100.0
+        );
+        println!("  total:                   {:7.1} us/query", total_us);
+        println!("  implied QPS:             {:.0}", 1_000_000.0 / total_us);
+    }
+
+    // ====================================================================
+    // Test 2: BTreeMap vs Dense Lookup Cost
+    // ====================================================================
+
+    /// Test 2: CompactHnswGraph Node Lookup — Dense get_node() vs HashMap
+    ///
+    /// Builds CompactHnswGraph with 50K vectors.
+    /// Benchmarks 1M random lookups via:
+    /// (a) Dense get_node() (current path — O(1) array index)
+    /// (b) HashMap (rebuilt from iter_nodes for comparison)
+    #[test]
+    fn profile_dense_vs_hashmap_lookup() {
+        let n = 50_000;
+        let dim = 128;
+        let num_lookups = 1_000_000;
+
+        let (compact, _heap) = build_compact_graph(n, dim);
+
+        // Build a HashMap mirror for comparison
+        let hashmap_nodes: StdHashMap<VectorId, &CompactHnswNode> =
+            compact.iter_nodes().map(|(k, v)| (k, v)).collect();
+
+        // Pre-generate random lookup IDs
+        let lookup_ids: Vec<VectorId> = (0..num_lookups)
+            .map(|i| {
+                let idx = ((i as f64 * 0.618033988749895).fract() * n as f64) as u64 + 1;
+                VectorId::new(idx)
+            })
+            .collect();
+
+        // --- Dense get_node() ---
+        let start = Instant::now();
+        let mut checksum_dense: u64 = 0;
+        for &id in &lookup_ids {
+            if let Some(node) = compact.get_node(id) {
+                checksum_dense += node.layer_ranges.len() as u64;
+            }
+        }
+        let dense_ns = start.elapsed().as_nanos() as f64 / num_lookups as f64;
+
+        // --- HashMap.get() ---
+        let start = Instant::now();
+        let mut checksum_hm: u64 = 0;
+        for &id in &lookup_ids {
+            if let Some(node) = hashmap_nodes.get(&id) {
+                checksum_hm += node.layer_ranges.len() as u64;
+            }
+        }
+        let hashmap_ns = start.elapsed().as_nanos() as f64 / num_lookups as f64;
+
+        let speedup = hashmap_ns / dense_ns;
+
+        println!("\n=== CompactHnswGraph Node Lookup: Dense vs HashMap ({n} nodes) ===");
+        println!("  Dense get_node(): {dense_ns:.1} ns/lookup");
+        println!("  HashMap.get():    {hashmap_ns:.1} ns/lookup");
+        println!("  Dense speedup vs HashMap: {speedup:.1}x");
+        println!("  checksums: dense={checksum_dense}, hm={checksum_hm}");
+        assert_eq!(
+            checksum_dense, checksum_hm,
+            "Dense and HashMap checksums must match"
+        );
+    }
+
+    // ====================================================================
+    // Test 3: Norm Cache vs Recompute
+    // ====================================================================
+
+    /// Test 3: Cosine Norm Cache vs Recompute
+    ///
+    /// Generates 10K stored vectors (128d) + 100 queries.
+    /// Computes cosine similarity for all 10K × 100 pairs:
+    /// - Method A: compute_similarity(q, v, Cosine) — recomputes norms
+    /// - Method B: cosine_similarity_with_norms(q, v, q_norm, v_norm) — cached
+    #[test]
+    fn profile_norm_cache_vs_recompute() {
+        use crate::primitives::vector::distance::cosine_similarity_with_norms;
+
+        let n = 10_000;
+        let dim = 128;
+        let num_queries = 100;
+
+        // Generate stored vectors and queries
+        let vectors: Vec<Vec<f32>> = (0..n).map(|i| make_embedding(dim, i)).collect();
+        let queries: Vec<Vec<f32>> = (0..num_queries)
+            .map(|i| make_embedding(dim, n + i))
+            .collect();
+
+        // Pre-compute norms
+        let vector_norms: Vec<f32> = vectors
+            .iter()
+            .map(|v| v.iter().map(|x| x * x).sum::<f32>().sqrt())
+            .collect();
+        let query_norms: Vec<f32> = queries
+            .iter()
+            .map(|q| q.iter().map(|x| x * x).sum::<f32>().sqrt())
+            .collect();
+
+        let total_pairs = n * num_queries;
+
+        // --- Method A: compute_similarity (recomputes norms each time) ---
+        let start = Instant::now();
+        let mut checksum_a = 0.0f64;
+        for q in &queries {
+            for v in &vectors {
+                checksum_a += compute_similarity(q, v, DistanceMetric::Cosine) as f64;
+            }
+        }
+        let recompute_ms = start.elapsed().as_millis() as f64;
+
+        // --- Method B: cosine_similarity_with_norms (pre-cached norms) ---
+        let start = Instant::now();
+        let mut checksum_b = 0.0f64;
+        for (qi, q) in queries.iter().enumerate() {
+            let q_norm = query_norms[qi];
+            for (vi, v) in vectors.iter().enumerate() {
+                let v_norm = vector_norms[vi];
+                checksum_b += cosine_similarity_with_norms(q, v, q_norm, v_norm) as f64;
+            }
+        }
+        let cached_ms = start.elapsed().as_millis() as f64;
+
+        let speedup = recompute_ms / cached_ms;
+
+        println!(
+            "\n=== Cosine: Norm Cache vs Recompute ({total_pairs} distance calls, dim={dim}) ==="
+        );
+        println!("  compute_similarity():               {recompute_ms:.1} ms");
+        println!("  cosine_similarity_with_norms():      {cached_ms:.1} ms");
+        println!("  speedup: {speedup:.2}x");
+        println!(
+            "  checksums: recompute={checksum_a:.4}, cached={checksum_b:.4}, diff={:.6}",
+            (checksum_a - checksum_b).abs()
+        );
+
+        // Checksums should be very close (floating point differences only)
+        assert!(
+            (checksum_a - checksum_b).abs() < total_pairs as f64 * 1e-5,
+            "Checksums diverged too much: {} vs {}",
+            checksum_a,
+            checksum_b
+        );
+    }
+
+    // ====================================================================
+    // Test 6: Per-Query Operation Counting
+    // ====================================================================
+
+    /// Test 6: Per-Query Operation Counting
+    ///
+    /// Builds CompactHnswGraph with 10K vectors.
+    /// Reimplements search_layer with counters to measure:
+    /// - distance_computations
+    /// - node_lookups (neighbors_at calls)
+    /// - visited_checks / visited_marks
+    /// - candidate_pushes / result_pushes
+    #[test]
+    fn profile_operation_counts() {
+        let n = 10_000;
+        let dim = 128;
+        let num_queries = 100;
+        let k = 10;
+
+        let (compact, heap) = build_compact_graph(n, dim);
+        let ef = compact.config.ef_search.max(k);
+        let metric = compact.vector_config.metric;
+        let entry_id = compact.entry_point.unwrap();
+        let max_level = compact.max_level;
+
+        let queries: Vec<Vec<f32>> = (0..num_queries)
+            .map(|i| make_embedding(dim, n + 1 + i))
+            .collect();
+
+        // Counters
+        let mut total_distance_computations: u64 = 0;
+        let mut total_node_lookups: u64 = 0;
+        let mut total_visited_checks: u64 = 0;
+        let mut total_visited_marks: u64 = 0;
+        let mut total_candidate_pushes: u64 = 0;
+        let mut total_result_pushes: u64 = 0;
+
+        for query in &queries {
+            // Greedy descent to layer 0
+            let current_entry = if max_level > 0 {
+                compact.greedy_search_to_layer(query, entry_id, max_level, 1, &heap)
+            } else {
+                entry_id
+            };
+
+            // Instrumented search_layer at layer 0
+            let entry_embedding = heap.get(current_entry).unwrap();
+            let entry_score = compute_similarity(query, entry_embedding, metric);
+            total_distance_computations += 1;
+
+            let mut visited = VisitedSet::new();
+            visited.mark(current_entry.0 as usize);
+            total_visited_marks += 1;
+
+            let mut candidates = BinaryHeap::new();
+            candidates.push(ScoredId {
+                score: entry_score,
+                id: current_entry,
+            });
+            total_candidate_pushes += 1;
+
+            let mut results: BinaryHeap<Reverse<ScoredId>> = BinaryHeap::new();
+            if !compact.is_deleted(current_entry) {
+                results.push(Reverse(ScoredId {
+                    score: entry_score,
+                    id: current_entry,
+                }));
+                total_result_pushes += 1;
+            }
+
+            while let Some(nearest) = candidates.pop() {
+                let worst_result_score = results
+                    .peek()
+                    .map(|r| r.0.score)
+                    .unwrap_or(f32::NEG_INFINITY);
+                if nearest.score < worst_result_score && results.len() >= ef {
+                    break;
+                }
+
+                total_node_lookups += 1;
+                for &neighbor_u64 in compact.neighbors_at(nearest.id, 0) {
+                    let neighbor_id = VectorId::new(neighbor_u64);
+
+                    total_visited_checks += 1;
+                    if visited.is_visited(neighbor_id.0 as usize) {
+                        continue;
+                    }
+                    visited.mark(neighbor_id.0 as usize);
+                    total_visited_marks += 1;
+
+                    if let Some(neighbor_embedding) = heap.get(neighbor_id) {
+                        let score = compute_similarity(query, neighbor_embedding, metric);
+                        total_distance_computations += 1;
+
+                        let worst_result_score = results
+                            .peek()
+                            .map(|r| r.0.score)
+                            .unwrap_or(f32::NEG_INFINITY);
+                        if score > worst_result_score || results.len() < ef {
+                            candidates.push(ScoredId {
+                                score,
+                                id: neighbor_id,
+                            });
+                            total_candidate_pushes += 1;
+
+                            if !compact.is_deleted(neighbor_id) {
+                                results.push(Reverse(ScoredId {
+                                    score,
+                                    id: neighbor_id,
+                                }));
+                                total_result_pushes += 1;
+                                if results.len() > ef {
+                                    results.pop();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let nq = num_queries as f64;
+        let avg_dist = total_distance_computations as f64 / nq;
+        let avg_lookups = total_node_lookups as f64 / nq;
+        let avg_visited_checks = total_visited_checks as f64 / nq;
+        let avg_visited_marks = total_visited_marks as f64 / nq;
+        let avg_cand_push = total_candidate_pushes as f64 / nq;
+        let avg_result_push = total_result_pushes as f64 / nq;
+        let selectivity = avg_dist / n as f64 * 100.0;
+
+        println!("\n=== Operation Counts Per Query ({n} vectors, k={k}, ef={ef}) ===");
+        println!("  distance_computations: {avg_dist:.1} avg");
+        println!("  node_lookups:          {avg_lookups:.1} avg");
+        println!("  visited_checks:        {avg_visited_checks:.1} avg");
+        println!("  visited_marks:         {avg_visited_marks:.1} avg");
+        println!("  candidate_pushes:      {avg_cand_push:.1} avg");
+        println!("  result_pushes:         {avg_result_push:.1} avg");
+        println!("  selectivity:           {selectivity:.1}% of total vectors");
     }
 }

--- a/crates/engine/src/primitives/vector/mmap_graph.rs
+++ b/crates/engine/src/primitives/vector/mmap_graph.rs
@@ -41,7 +41,6 @@
 compile_error!("mmap graph requires little-endian architecture");
 
 use memmap2::Mmap;
-use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
@@ -77,7 +76,7 @@ pub(crate) fn write_graph_file(path: &Path, graph: &CompactHnswGraph) -> Result<
 
     // Compute node section size
     let mut node_section_size: usize = 0;
-    for node in graph.nodes.values() {
+    for (_, node) in graph.iter_nodes() {
         // VectorId(8) + created_at(8) + deleted_at(8) + num_layers(4) + pad(4)
         // + num_layers * (start(4) + count(4))
         node_section_size += 32 + node.layer_ranges.len() * 8;
@@ -104,7 +103,7 @@ pub(crate) fn write_graph_file(path: &Path, graph: &CompactHnswGraph) -> Result<
     .map_err(|e| VectorError::Io(e.to_string()))?;
     file.write_all(&(graph.max_level as u32).to_le_bytes())
         .map_err(|e| VectorError::Io(e.to_string()))?;
-    file.write_all(&(graph.nodes.len() as u32).to_le_bytes())
+    file.write_all(&(graph.len() as u32).to_le_bytes())
         .map_err(|e| VectorError::Io(e.to_string()))?;
     file.write_all(&(neighbor_data_len as u64).to_le_bytes())
         .map_err(|e| VectorError::Io(e.to_string()))?;
@@ -113,8 +112,8 @@ pub(crate) fn write_graph_file(path: &Path, graph: &CompactHnswGraph) -> Result<
     file.write_all(&0u64.to_le_bytes()) // reserved
         .map_err(|e| VectorError::Io(e.to_string()))?;
 
-    // Node entries (sorted by VectorId — BTreeMap guarantees this)
-    for (&id, node) in &graph.nodes {
+    // Node entries (sorted by VectorId — iter_nodes guarantees this)
+    for (id, node) in graph.iter_nodes() {
         file.write_all(&id.as_u64().to_le_bytes())
             .map_err(|e| VectorError::Io(e.to_string()))?;
         file.write_all(&node.created_at.to_le_bytes())
@@ -160,7 +159,7 @@ pub(crate) fn write_graph_file(path: &Path, graph: &CompactHnswGraph) -> Result<
 
 /// Open a `CompactHnswGraph` from an mmap file.
 ///
-/// Node metadata is loaded into memory (BTreeMap — small).
+/// Node metadata is loaded into memory (dense array — small).
 /// Neighbor data remains mmap-backed and is only paged in on access.
 ///
 /// The caller provides `hnsw_config` and `vector_config` since the file
@@ -236,8 +235,8 @@ pub(crate) fn open_graph_file(
         )));
     }
 
-    // Read node entries
-    let mut nodes = BTreeMap::new();
+    // Read node entries into a sorted Vec for dense array construction
+    let mut entries: Vec<(VectorId, CompactHnswNode)> = Vec::with_capacity(node_count);
     let mut pos = HEADER_SIZE;
     for _ in 0..node_count {
         if pos + 32 > HEADER_SIZE + node_section_size {
@@ -278,15 +277,18 @@ pub(crate) fn open_graph_file(
             pos += 8;
         }
 
-        nodes.insert(
+        entries.push((
             VectorId::new(vid),
             CompactHnswNode {
                 layer_ranges,
                 created_at,
                 deleted_at,
             },
-        );
+        ));
     }
+
+    // Build dense array (entries are already sorted by VectorId from the file format)
+    let (dense_nodes, id_offset, actual_node_count) = CompactHnswGraph::build_dense(entries);
 
     // Neighbor data stays mmap-backed
     let neighbor_data = NeighborData::Mmap {
@@ -299,7 +301,9 @@ pub(crate) fn open_graph_file(
         config: hnsw_config,
         vector_config,
         neighbor_data,
-        nodes,
+        dense_nodes,
+        id_offset,
+        node_count: actual_node_count,
         entry_point,
         max_level,
     })
@@ -347,7 +351,7 @@ mod tests {
         let loaded = open_graph_file(&path, HnswConfig::default(), config.clone()).unwrap();
 
         // Verify structure matches
-        assert_eq!(original.nodes.len(), loaded.nodes.len());
+        assert_eq!(original.len(), loaded.len());
         assert_eq!(original.entry_point, loaded.entry_point);
         assert_eq!(original.max_level, loaded.max_level);
         assert_eq!(original.neighbor_data.len(), loaded.neighbor_data.len());
@@ -358,8 +362,8 @@ mod tests {
         assert_eq!(orig_data, loaded_data);
 
         // Verify node metadata matches
-        for (&id, orig_node) in &original.nodes {
-            let loaded_node = loaded.nodes.get(&id).expect("node missing");
+        for (id, orig_node) in original.iter_nodes() {
+            let loaded_node = loaded.get_node(id).expect("node missing");
             assert_eq!(orig_node.created_at, loaded_node.created_at);
             assert_eq!(orig_node.deleted_at, loaded_node.deleted_at);
             assert_eq!(orig_node.layer_ranges, loaded_node.layer_ranges);
@@ -417,7 +421,9 @@ mod tests {
             config: HnswConfig::default(),
             vector_config: config.clone(),
             neighbor_data: NeighborData::Owned(Vec::new()),
-            nodes: BTreeMap::new(),
+            dense_nodes: Vec::new(),
+            id_offset: 0,
+            node_count: 0,
             entry_point: None,
             max_level: 0,
         };
@@ -425,7 +431,7 @@ mod tests {
         write_graph_file(&path, &graph).unwrap();
         let loaded = open_graph_file(&path, HnswConfig::default(), config).unwrap();
 
-        assert_eq!(loaded.nodes.len(), 0);
+        assert_eq!(loaded.len(), 0);
         assert!(loaded.entry_point.is_none());
         assert_eq!(loaded.neighbor_data.len(), 0);
     }
@@ -551,21 +557,23 @@ mod tests {
 
         let config = VectorConfig::new(3, DistanceMetric::Cosine).unwrap();
 
-        let mut nodes = BTreeMap::new();
-        nodes.insert(
+        let entries = vec![(
             VectorId::new(42),
             CompactHnswNode {
                 layer_ranges: vec![(0, 0)], // layer 0, zero neighbors
                 created_at: 100,
                 deleted_at: None,
             },
-        );
+        )];
+        let (dense_nodes, id_offset, node_count) = CompactHnswGraph::build_dense(entries);
 
         let graph = CompactHnswGraph {
             config: HnswConfig::default(),
             vector_config: config.clone(),
             neighbor_data: NeighborData::Owned(Vec::new()),
-            nodes,
+            dense_nodes,
+            id_offset,
+            node_count,
             entry_point: Some(VectorId::new(42)),
             max_level: 0,
         };
@@ -573,7 +581,7 @@ mod tests {
         write_graph_file(&path, &graph).unwrap();
         let loaded = open_graph_file(&path, HnswConfig::default(), config.clone()).unwrap();
 
-        assert_eq!(loaded.nodes.len(), 1);
+        assert_eq!(loaded.len(), 1);
         assert_eq!(loaded.entry_point, Some(VectorId::new(42)));
         assert!(loaded.is_neighbor_data_mmap());
 

--- a/crates/engine/src/primitives/vector/segmented.rs
+++ b/crates/engine/src/primitives/vector/segmented.rs
@@ -937,7 +937,7 @@ impl VectorIndexBackend for SegmentedHnswBackend {
         // so temporal queries still work after compaction.
         let mut timestamps: BTreeMap<VectorId, u64> = BTreeMap::new();
         for seg in &self.sealed {
-            for (&id, node) in &seg.graph.nodes {
+            for (id, node) in seg.graph.iter_nodes() {
                 if node.deleted_at.is_none() && node.created_at != 0 {
                     timestamps.insert(id, node.created_at);
                 }
@@ -1214,7 +1214,7 @@ impl VectorIndexBackend for SegmentedHnswBackend {
         let sealed_ids: std::collections::BTreeSet<VectorId> = self
             .sealed
             .iter()
-            .flat_map(|seg| seg.graph.nodes.keys().copied())
+            .flat_map(|seg| seg.graph.node_ids())
             .collect();
         self.active.ids.retain(|id| !sealed_ids.contains(id));
         self.active
@@ -2400,5 +2400,116 @@ mod tests {
             results_high[0].1 >= results_low[0].1 - 1e-6,
             "Higher ef should find at least as good results"
         );
+    }
+}
+
+#[cfg(test)]
+mod profiling_tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use std::time::Instant;
+
+    fn make_embedding(dim: usize, seed: usize) -> Vec<f32> {
+        (0..dim)
+            .map(|j| ((seed * dim + j) as f32 / 1000.0).sin())
+            .collect()
+    }
+
+    /// Test 5: Segment Fan-Out vs Compact
+    ///
+    /// Builds a SegmentedHnswBackend with 100K vectors (seal_threshold=50K → 2 segments).
+    /// Times 100 queries. Then compact() into 1 segment, times same queries.
+    /// Reports QPS and recall@10 for both configurations.
+    #[test]
+    fn profile_segment_fanout_vs_compact() {
+        use crate::primitives::vector::brute_force::BruteForceBackend;
+
+        let n = 100_000;
+        let dim = 128;
+        let num_queries = 100;
+        let k = 10;
+        let seal_threshold = 50_000;
+
+        let config = VectorConfig::new(dim, DistanceMetric::Cosine).unwrap();
+        let seg_config = SegmentedHnswConfig {
+            hnsw: HnswConfig::default(),
+            seal_threshold,
+            heap_flush_threshold: 0, // Disable mmap flushing in tests
+        };
+        let mut backend = SegmentedHnswBackend::new(&config, seg_config);
+
+        // Also build brute-force for recall measurement
+        let mut brute = BruteForceBackend::new(&config);
+
+        // Insert all vectors
+        for i in 1..=n {
+            let emb = make_embedding(dim, i);
+            let id = VectorId::new(i as u64);
+            backend.insert(id, &emb).unwrap();
+            brute.insert(id, &emb).unwrap();
+        }
+
+        let num_segments_before = backend.sealed.len();
+
+        // Pre-generate queries
+        let queries: Vec<Vec<f32>> = (0..num_queries)
+            .map(|i| make_embedding(dim, n + 1 + i))
+            .collect();
+
+        // --- Time multi-segment search ---
+        let start = Instant::now();
+        let mut multi_results: Vec<Vec<(VectorId, f32)>> = Vec::with_capacity(num_queries);
+        for q in &queries {
+            multi_results.push(backend.search(q, k));
+        }
+        let multi_elapsed = start.elapsed();
+        let multi_qps = num_queries as f64 / multi_elapsed.as_secs_f64();
+
+        // Compute recall@k for multi-segment
+        let mut multi_recall_sum = 0.0;
+        for (i, q) in queries.iter().enumerate() {
+            let brute_results = brute.search(q, k);
+            let brute_ids: BTreeSet<VectorId> = brute_results.iter().map(|(id, _)| *id).collect();
+            let hnsw_ids: BTreeSet<VectorId> = multi_results[i].iter().map(|(id, _)| *id).collect();
+            let overlap = brute_ids.intersection(&hnsw_ids).count();
+            multi_recall_sum += overlap as f64 / k as f64;
+        }
+        let multi_recall = multi_recall_sum / num_queries as f64;
+
+        // --- Compact ---
+        backend.compact();
+        let num_segments_after = backend.sealed.len();
+
+        // --- Time single-segment search ---
+        let start = Instant::now();
+        let mut compact_results: Vec<Vec<(VectorId, f32)>> = Vec::with_capacity(num_queries);
+        for q in &queries {
+            compact_results.push(backend.search(q, k));
+        }
+        let compact_elapsed = start.elapsed();
+        let compact_qps = num_queries as f64 / compact_elapsed.as_secs_f64();
+
+        // Compute recall@k for compacted
+        let mut compact_recall_sum = 0.0;
+        for (i, q) in queries.iter().enumerate() {
+            let brute_results = brute.search(q, k);
+            let brute_ids: BTreeSet<VectorId> = brute_results.iter().map(|(id, _)| *id).collect();
+            let hnsw_ids: BTreeSet<VectorId> =
+                compact_results[i].iter().map(|(id, _)| *id).collect();
+            let overlap = brute_ids.intersection(&hnsw_ids).count();
+            compact_recall_sum += overlap as f64 / k as f64;
+        }
+        let compact_recall = compact_recall_sum / num_queries as f64;
+
+        let speedup = compact_qps / multi_qps;
+
+        println!("\n=== Segment Fan-Out: {num_segments_before} Segments vs {num_segments_after} Compact ({n} vectors, dim={dim}) ===");
+        println!(
+            "  {num_segments_before} segments: {multi_qps:.0} QPS, recall@{k} = {multi_recall:.3} ({multi_elapsed:?})"
+        );
+        println!(
+            "  {num_segments_after} segment:  {compact_qps:.0} QPS, recall@{k} = {compact_recall:.3} ({compact_elapsed:?})"
+        );
+        println!("  compact speedup: {speedup:.2}x");
     }
 }


### PR DESCRIPTION
## Summary

- **Merge `get()`/`get_fast()` in VectorHeap** — `get()` now always tries O(1) dense lookup first, eliminating the dual-API footgun where callers accidentally used the 5.67x slower BTreeMap path
- **Replace `BTreeMap` with dense `Vec<Option<CompactHnswNode>>` in CompactHnswGraph** — the #1 bottleneck (19.9x per-lookup overhead). Adds `iter_nodes()`, `node_ids()`, `build_dense()` helpers. Index = `id.0 - id_offset` for O(1) access
- **Wire pre-computed L2 norms into cosine search** — `compute_similarity_cached()` uses VectorHeap's norms cache and pre-computes query norm once per search (~13% savings on cosine distance calls)
- **Fixes**: `memory_usage` double-counting inline node size, `debug_assert` for `build_dense` sorted-input invariant, tautological test
- **8 new tests**: non-contiguous IDs, high-offset IDs, single-entry graphs, cached similarity with non-cosine metrics, zero-norm edge cases

## Test plan

- [x] All 1078 unit tests pass (`cargo test -p strata-engine`)
- [x] Integration tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean (zero warnings)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)