### PR TITLE
Revert ef_search and seal_threshold to original values

### DIFF
--- a/crates/engine/src/primitives/vector/hnsw.rs
+++ b/crates/engine/src/primitives/vector/hnsw.rs
@@ -52,7 +52,7 @@ impl Default for HnswConfig {
         Self {
             m,
             ef_construction: 200,
-            ef_search: 50,
+            ef_search: 100,
             ml: 1.0 / (m as f64).ln(),
         }
     }

--- a/crates/engine/src/primitives/vector/segmented.rs
+++ b/crates/engine/src/primitives/vector/segmented.rs
@@ -76,7 +76,7 @@ impl Default for SegmentedHnswConfig {
     fn default() -> Self {
         Self {
             hnsw: HnswConfig::default(),
-            seal_threshold: 100_000,
+            seal_threshold: 50_000,
             heap_flush_threshold: 500_000,
         }
     }


### PR DESCRIPTION
## Summary

- Revert `ef_search` from 50 back to 100 — recall dropped from 0.947 to 0.684 at 100K
- Revert `seal_threshold` from 100K back to 50K — caused 50K-scale to brute-force (209 QPS vs 3,639)

The algorithmic improvements from #1278 (O(n) scan removal, VisitedSet pooling, prefetch, heap pre-alloc) provide the real gains. The config tuning was too aggressive.

## Test plan

- [x] All engine tests pass
- [ ] Re-benchmark at 50K/100K to verify recall restored with QPS gains preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)