### PR TITLE
ANN search: hot-path profiling tests — timing breakdown, bandwidth, compact@384d

### DIFF
--- a/crates/engine/src/primitives/vector/hnsw.rs
+++ b/crates/engine/src/primitives/vector/hnsw.rs
@@ -3130,12 +3130,7 @@ mod profiling_tests {
 
             // Warmup: run all warmup queries through search_with_heap_ef
             for i in 0..warmup_queries {
-                std::hint::black_box(compact.search_with_heap_ef(
-                    &all_queries[i],
-                    k,
-                    ef,
-                    &heap,
-                ));
+                std::hint::black_box(compact.search_with_heap_ef(&all_queries[i], k, ef, &heap));
             }
 
             // =============================================================
@@ -3150,8 +3145,7 @@ mod profiling_tests {
                 std::hint::black_box(compact.search_with_heap_ef(q, k, ef, &heap));
             }
             let phase0_full_elapsed = start.elapsed();
-            let phase0_full_us =
-                phase0_full_elapsed.as_micros() as f64 / num_queries as f64;
+            let phase0_full_us = phase0_full_elapsed.as_micros() as f64 / num_queries as f64;
             let phase0_qps = num_queries as f64 / phase0_full_elapsed.as_secs_f64();
 
             // Phase 0b: Greedy descent only
@@ -3183,8 +3177,7 @@ mod profiling_tests {
                 ));
             }
             let phase0_beam_elapsed = start.elapsed();
-            let phase0_beam_us =
-                phase0_beam_elapsed.as_micros() as f64 / num_queries as f64;
+            let phase0_beam_us = phase0_beam_elapsed.as_micros() as f64 / num_queries as f64;
 
             // =============================================================
             // Phase 1: Coarse per-outer-loop timing
@@ -3223,8 +3216,7 @@ mod profiling_tests {
                     id: current_entry,
                 });
 
-                let mut results: BinaryHeap<Reverse<ScoredId>> =
-                    BinaryHeap::with_capacity(ef + 1);
+                let mut results: BinaryHeap<Reverse<ScoredId>> = BinaryHeap::with_capacity(ef + 1);
                 if !compact.is_deleted(current_entry) {
                     results.push(Reverse(ScoredId {
                         score: entry_score,
@@ -3301,8 +3293,7 @@ mod profiling_tests {
             let p1_neighbor_ns = total_neighbor_lookup_ns as f64 / num_queries as f64;
             let p1_inner_ns = total_inner_loop_ns as f64 / num_queries as f64;
             let p1_total_ns = p1_heap_ns + p1_neighbor_ns + p1_inner_ns;
-            let p1_overhead_pct =
-                (p1_total_ns / 1000.0 - phase0_beam_us) / phase0_beam_us * 100.0;
+            let p1_overhead_pct = (p1_total_ns / 1000.0 - phase0_beam_us) / phase0_beam_us * 100.0;
 
             // =============================================================
             // Phase 2: Per-neighbor inner-loop breakdown
@@ -3343,8 +3334,7 @@ mod profiling_tests {
                     id: current_entry,
                 });
 
-                let mut results: BinaryHeap<Reverse<ScoredId>> =
-                    BinaryHeap::with_capacity(ef + 1);
+                let mut results: BinaryHeap<Reverse<ScoredId>> = BinaryHeap::with_capacity(ef + 1);
                 if !compact.is_deleted(current_entry) {
                     results.push(Reverse(ScoredId {
                         score: entry_score,
@@ -3445,7 +3435,8 @@ mod profiling_tests {
             let avg_heap_pushes = count_heap_pushes as f64 / nq;
 
             // Compute percentages relative to Phase 2 measured total
-            let p2_total_for_pct = p2_dist_ns + p2_emb_ns + p2_visited_ns + p2_heap_ns + p2_inner_overhead_ns;
+            let p2_total_for_pct =
+                p2_dist_ns + p2_emb_ns + p2_visited_ns + p2_heap_ns + p2_inner_overhead_ns;
 
             println!("\n=== search_layer_inner Breakdown ({n}, dim={dim}, cosine) ===");
             println!(

--- a/crates/engine/src/primitives/vector/segmented.rs
+++ b/crates/engine/src/primitives/vector/segmented.rs
@@ -2594,8 +2594,7 @@ mod profiling_tests {
                 let hnsw_results = backend.search(q, k);
                 let brute_ids: BTreeSet<VectorId> =
                     brute_results.iter().map(|(id, _)| *id).collect();
-                let hnsw_ids: BTreeSet<VectorId> =
-                    hnsw_results.iter().map(|(id, _)| *id).collect();
+                let hnsw_ids: BTreeSet<VectorId> = hnsw_results.iter().map(|(id, _)| *id).collect();
                 let overlap = brute_ids.intersection(&hnsw_ids).count();
                 multi_recall_sum += overlap as f64 / k as f64;
             }
@@ -2620,25 +2619,24 @@ mod profiling_tests {
                 let hnsw_results = backend.search(q, k);
                 let brute_ids: BTreeSet<VectorId> =
                     brute_results.iter().map(|(id, _)| *id).collect();
-                let hnsw_ids: BTreeSet<VectorId> =
-                    hnsw_results.iter().map(|(id, _)| *id).collect();
+                let hnsw_ids: BTreeSet<VectorId> = hnsw_results.iter().map(|(id, _)| *id).collect();
                 let overlap = brute_ids.intersection(&hnsw_ids).count();
                 compact_recall_sum += overlap as f64 / k as f64;
             }
             let compact_recall = compact_recall_sum / num_recall_queries as f64;
 
             let speedup = compact_qps / multi_qps;
-            let scale_label = if n >= 1000 { format!("{}K", n / 1000) } else { format!("{n}") };
+            let scale_label = if n >= 1000 {
+                format!("{}K", n / 1000)
+            } else {
+                format!("{n}")
+            };
 
             println!(
                 "\n--- {scale_label} vectors ({num_segments_before} segments → {num_segments_after}) ---"
             );
-            println!(
-                "  Before: {multi_qps:.0} QPS, recall@{k} = {multi_recall:.3}"
-            );
-            println!(
-                "  After:  {compact_qps:.0} QPS, recall@{k} = {compact_recall:.3}"
-            );
+            println!("  Before: {multi_qps:.0} QPS, recall@{k} = {multi_recall:.3}");
+            println!("  After:  {compact_qps:.0} QPS, recall@{k} = {compact_recall:.3}");
             println!("  Speedup: {speedup:.2}x");
         }
     }


### PR DESCRIPTION
## Summary
- Add `profile_search_layer_inner_breakdown`: 3-phase fine-grained timing of beam search internals (distance computation, embedding lookup, visited ops, heap ops) at 128d and 384d, 50K scale
- Add `profile_memory_bandwidth_bound`: determines if the hot path is memory-bound vs compute-bound by comparing raw read throughput against distance computation throughput across working set sizes (1K–100K at 384d)
- Add `profile_compact_384d`: measures compact() QPS/recall impact at production dimensions (384d) at 50K and 100K scale

No production code changes. All tests are in `#[cfg(test)] mod profiling_tests` blocks only.

## Context
v4 hot-path optimizations (O(n) scan removal, VisitedSet pooling, prefetch, heap pre-alloc) showed no measurable search QPS improvement. Before doing more work, we need profiling data to identify the actual bottleneck — hypothesis: distance computation (~70-85% of time) and memory bandwidth dominate, making the 5-10ns savings from visited/heap/scan optimizations invisible.

## Test plan
- [ ] `cargo clippy -p strata-engine` passes
- [ ] `cargo test -p strata-engine` passes (existing tests unaffected)
- [ ] `cargo test -p strata-engine --release -- profile_search_layer_inner_breakdown --nocapture`
- [ ] `cargo test -p strata-engine --release -- profile_memory_bandwidth_bound --nocapture`
- [ ] `cargo test -p strata-engine --release -- profile_compact_384d --nocapture`

🤖 Generated with [Claude Code](https://claude.com/claude-code)