### PR TITLE
Add graph CLI commands

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -959,11 +959,7 @@ fn build_graph() -> Command {
                 .arg(Arg::new("src").required(true).help("Source node ID"))
                 .arg(Arg::new("dst").required(true).help("Destination node ID"))
                 .arg(Arg::new("edge-type").required(true).help("Edge type"))
-                .arg(
-                    Arg::new("weight")
-                        .long("weight")
-                        .help("Edge weight (f64)"),
-                )
+                .arg(Arg::new("weight").long("weight").help("Edge weight (f64)"))
                 .arg(
                     Arg::new("properties")
                         .long("properties")

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -940,8 +940,8 @@ fn parse_graph(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, 
                 m.get_one::<String>("json").unwrap().clone()
             };
 
-            let parsed: serde_json::Value = serde_json::from_str(&raw_json)
-                .map_err(|e| format!("Invalid JSON: {}", e))?;
+            let parsed: serde_json::Value =
+                serde_json::from_str(&raw_json).map_err(|e| format!("Invalid JSON: {}", e))?;
 
             let nodes: Vec<BulkGraphNode> = parsed
                 .get("nodes")
@@ -1448,9 +1448,7 @@ mod tests {
     fn parse(args: &[&str]) -> Result<CliAction, String> {
         let state = test_state();
         let cmd = build_repl_cmd();
-        let matches = cmd
-            .try_get_matches_from(args)
-            .map_err(|e| e.to_string())?;
+        let matches = cmd.try_get_matches_from(args).map_err(|e| e.to_string())?;
         matches_to_action(&matches, &state)
     }
 
@@ -1575,9 +1573,7 @@ mod tests {
                 graph: "social".into(),
                 node_id: "alice".into(),
                 entity_ref: Some("kv://main/alice".into()),
-                properties: Some(Value::from(
-                    serde_json::json!({"age": 30})
-                )),
+                properties: Some(Value::from(serde_json::json!({"age": 30}))),
                 object_type: Some("Person".into()),
             }
         );
@@ -2046,49 +2042,34 @@ mod tests {
     #[test]
     fn graph_add_edge_invalid_weight() {
         let err = parse_err(&[
-            "graph", "add-edge", "g", "a", "b", "E", "--weight", "not_a_float",
+            "graph",
+            "add-edge",
+            "g",
+            "a",
+            "b",
+            "E",
+            "--weight",
+            "not_a_float",
         ]);
         assert!(err.contains("Invalid weight"), "got: {}", err);
     }
 
     #[test]
     fn graph_add_node_invalid_properties_json() {
-        let err = parse_err(&[
-            "graph",
-            "add-node",
-            "g",
-            "n",
-            "--properties",
-            "not json",
-        ]);
+        let err = parse_err(&["graph", "add-node", "g", "n", "--properties", "not json"]);
         assert!(!err.is_empty());
     }
 
     #[test]
     fn graph_bfs_invalid_max_nodes() {
-        let err = parse_err(&[
-            "graph",
-            "bfs",
-            "g",
-            "start",
-            "3",
-            "--max-nodes",
-            "xyz",
-        ]);
+        let err = parse_err(&["graph", "bfs", "g", "start", "3", "--max-nodes", "xyz"]);
         assert!(err.contains("Invalid max-nodes"), "got: {}", err);
     }
 
     #[test]
     fn graph_bulk_insert_invalid_chunk_size() {
         let json = r#"{"nodes":[]}"#;
-        let err = parse_err(&[
-            "graph",
-            "bulk-insert",
-            "g",
-            json,
-            "--chunk-size",
-            "abc",
-        ]);
+        let err = parse_err(&["graph", "bulk-insert", "g", json, "--chunk-size", "abc"]);
         assert!(err.contains("Invalid chunk-size"), "got: {}", err);
     }
 

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -424,7 +424,9 @@ fn print_help(command: Option<&str>) {
         println!("  event       Event log operations (append, get, list, len)");
         println!("  state       State cell operations (set, get, del, init, cas, list, history)");
         println!("  vector      Vector store operations (upsert, get, del, search, create, ...)");
-        println!("  graph       Graph operations (add-node, add-edge, neighbors, bfs, ontology, ...)");
+        println!(
+            "  graph       Graph operations (add-node, add-edge, neighbors, bfs, ontology, ...)"
+        );
         println!("  branch      Branch operations (create, info, list, fork, diff, merge, ...)");
         println!("  space       Space operations (list, create, del, exists)");
         println!("  begin       Begin a transaction");


### PR DESCRIPTION
## Summary
- Wires all 25 graph engine operations to the CLI/REPL, following existing patterns used by kv, json, vector primitives
- Adds `graph` namespace with subcommands for lifecycle (create/delete/list/info), nodes, edges, bulk insert, BFS traversal, and full ontology management
- Includes 43 parse tests covering all subcommands, optional args, JSON parsing edge cases, and error handling

## Test plan
- [x] `cargo build -p strata-cli` compiles cleanly
- [x] `cargo test -p strata-cli` — all 59 tests pass (16 existing + 43 new)
- [ ] CI passes
- [ ] Manual REPL test: `graph create social` → `graph add-node social alice` → `graph neighbors social alice` → `graph delete social`

🤖 Generated with [Claude Code](https://claude.com/claude-code)