### PR TITLE
Fix graph memory bloat: 3-phase storage optimization (#1287)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ repository = "https://github.com/anibjoshi/strata"
 [workspace.dependencies]
 # Core dependencies shared across crates
 uuid = { version = "1.6", features = ["v4", "v5", "serde"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 bincode = "1.3"
 thiserror = "1.0"
 # Concurrency

--- a/crates/concurrency/src/conflict.rs
+++ b/crates/concurrency/src/conflict.rs
@@ -152,11 +152,12 @@ pub fn check_write_write_conflicts(writes: &[JsonPatchEntry]) -> Vec<ConflictRes
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use strata_core::primitives::json::JsonPatch;
     use strata_core::types::{BranchId, Namespace};
 
     fn test_key() -> Key {
-        Key::new_json(Namespace::for_branch(BranchId::new()), "test-doc")
+        Key::new_json(Arc::new(Namespace::for_branch(BranchId::new())), "test-doc")
     }
 
     #[test]

--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -454,17 +454,17 @@ mod tests {
     use strata_storage::ShardedStore;
     use tempfile::TempDir;
 
-    fn create_test_namespace(branch_id: BranchId) -> Namespace {
-        Namespace::new(
+    fn create_test_namespace(branch_id: BranchId) -> Arc<Namespace> {
+        Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        )
+        ))
     }
 
-    fn create_test_key(ns: &Namespace, name: &str) -> Key {
+    fn create_test_key(ns: &Arc<Namespace>, name: &str) -> Key {
         Key::new_kv(ns.clone(), name)
     }
 

--- a/crates/concurrency/src/payload.rs
+++ b/crates/concurrency/src/payload.rs
@@ -79,18 +79,19 @@ pub enum PayloadError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use strata_core::types::{BranchId, Key, Namespace};
     use strata_core::value::Value;
 
-    fn test_ns() -> Namespace {
+    fn test_ns() -> Arc<Namespace> {
         let branch_id = BranchId::new();
-        Namespace::new(
+        Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        )
+        ))
     }
 
     #[test]

--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -228,6 +228,7 @@ impl RecoveryStats {
 mod tests {
     use super::*;
     use crate::payload::TransactionPayload;
+    use std::sync::Arc;
     use strata_core::types::{BranchId, Key, Namespace};
     use strata_core::value::Value;
     use strata_durability::codec::IdentityCodec;
@@ -236,14 +237,14 @@ mod tests {
     use strata_durability::wal::{DurabilityMode, WalConfig, WalWriter};
     use tempfile::TempDir;
 
-    fn create_test_namespace(branch_id: BranchId) -> Namespace {
-        Namespace::new(
+    fn create_test_namespace(branch_id: BranchId) -> Arc<Namespace> {
+        Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        )
+        ))
     }
 
     fn create_test_wal(dir: &std::path::Path) -> WalWriter {

--- a/crates/concurrency/src/snapshot.rs
+++ b/crates/concurrency/src/snapshot.rs
@@ -152,17 +152,17 @@ mod tests {
 
     // === Test Helpers ===
 
-    fn create_test_namespace() -> Namespace {
-        Namespace::new(
+    fn create_test_namespace() -> Arc<Namespace> {
+        Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             BranchId::new(),
             "default".to_string(),
-        )
+        ))
     }
 
-    fn create_test_key(ns: &Namespace, user_key: &[u8]) -> Key {
+    fn create_test_key(ns: &Arc<Namespace>, user_key: &[u8]) -> Key {
         Key::new(ns.clone(), TypeTag::KV, user_key.to_vec())
     }
 
@@ -170,7 +170,7 @@ mod tests {
         VersionedValue::new(Value::Bytes(data.to_vec()), Version::txn(version))
     }
 
-    fn create_populated_snapshot() -> (ClonedSnapshotView, Namespace) {
+    fn create_populated_snapshot() -> (ClonedSnapshotView, Arc<Namespace>) {
         let ns = create_test_namespace();
         let mut data = BTreeMap::new();
 
@@ -275,13 +275,13 @@ mod tests {
         let (snapshot, _) = create_populated_snapshot();
 
         // Create key with different namespace
-        let other_ns = Namespace::new(
+        let other_ns = Arc::new(Namespace::new(
             "other_tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             BranchId::new(),
             "default".to_string(),
-        );
+        ));
         let key = create_test_key(&other_ns, b"key1");
 
         let result = snapshot.get(&key).unwrap();
@@ -338,13 +338,13 @@ mod tests {
     fn test_scan_prefix_different_namespace() {
         let (snapshot, _) = create_populated_snapshot();
 
-        let other_ns = Namespace::new(
+        let other_ns = Arc::new(Namespace::new(
             "other_tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             BranchId::new(),
             "default".to_string(),
-        );
+        ));
         let prefix = create_test_key(&other_ns, b"key");
 
         let results = snapshot.scan_prefix(&prefix).unwrap();

--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -248,8 +248,9 @@ impl JsonPatchEntry {
 /// # use strata_core::types::{BranchId, Key, Namespace, TypeTag};
 /// # use strata_core::value::Value;
 /// # use strata_core::primitives::json::JsonPath;
+/// # use std::sync::Arc;
 /// # fn example(txn: &mut TransactionContext) -> strata_core::StrataResult<()> {
-/// # let ns = Namespace::for_branch(BranchId::default());
+/// # let ns = Arc::new(Namespace::for_branch(BranchId::default()));
 /// # let key = Key::new(ns.clone(), TypeTag::Json, b"doc".to_vec());
 /// # let path = JsonPath::root();
 /// # let other_key = Key::new_kv(ns, "other");
@@ -545,8 +546,9 @@ impl TransactionContext {
     /// ```no_run
     /// # use strata_concurrency::TransactionContext;
     /// # use strata_core::types::{BranchId, Key, Namespace};
+    /// # use std::sync::Arc;
     /// # fn example(txn: &mut TransactionContext) -> strata_core::StrataResult<()> {
-    /// # let key = Key::new_kv(Namespace::for_branch(BranchId::default()), "key");
+    /// # let key = Key::new_kv(Arc::new(Namespace::for_branch(BranchId::default())), "key");
     /// let value = txn.get(&key)?;
     /// if let Some(v) = value {
     ///     // Process value
@@ -674,8 +676,9 @@ impl TransactionContext {
     /// ```no_run
     /// # use strata_concurrency::TransactionContext;
     /// # use strata_core::types::{BranchId, Key, Namespace};
+    /// # use std::sync::Arc;
     /// # fn example(txn: &mut TransactionContext) -> strata_core::StrataResult<()> {
-    /// let namespace = Namespace::for_branch(BranchId::default());
+    /// let namespace = Arc::new(Namespace::for_branch(BranchId::default()));
     /// let prefix = Key::new_kv(namespace, "user:");
     /// let users = txn.scan_prefix(&prefix)?;
     /// for (key, value) in users {
@@ -752,8 +755,9 @@ impl TransactionContext {
     /// # use strata_concurrency::TransactionContext;
     /// # use strata_core::types::{BranchId, Key, Namespace};
     /// # use strata_core::value::Value;
+    /// # use std::sync::Arc;
     /// # fn example(txn: &mut TransactionContext) -> strata_core::StrataResult<()> {
-    /// # let key = Key::new_kv(Namespace::for_branch(BranchId::default()), "key");
+    /// # let key = Key::new_kv(Arc::new(Namespace::for_branch(BranchId::default())), "key");
     /// txn.put(key, Value::Bytes(b"value".to_vec()))?;
     /// // Value is NOT visible to other transactions yet
     /// // Will be visible after successful commit
@@ -789,8 +793,9 @@ impl TransactionContext {
     /// ```no_run
     /// # use strata_concurrency::TransactionContext;
     /// # use strata_core::types::{BranchId, Key, Namespace};
+    /// # use std::sync::Arc;
     /// # fn example(txn: &mut TransactionContext) -> strata_core::StrataResult<()> {
-    /// # let key = Key::new_kv(Namespace::for_branch(BranchId::default()), "key");
+    /// # let key = Key::new_kv(Arc::new(Namespace::for_branch(BranchId::default())), "key");
     /// txn.delete(key)?;
     /// // Key is NOT deleted from storage yet
     /// // Will be deleted after successful commit
@@ -830,8 +835,9 @@ impl TransactionContext {
     /// # use strata_concurrency::TransactionContext;
     /// # use strata_core::types::{BranchId, Key, Namespace};
     /// # use strata_core::value::Value;
+    /// # use std::sync::Arc;
     /// # fn example(txn: &mut TransactionContext) -> strata_core::StrataResult<()> {
-    /// # let ns = Namespace::for_branch(BranchId::default());
+    /// # let ns = Arc::new(Namespace::for_branch(BranchId::default()));
     /// # let key = Key::new_kv(ns.clone(), "key");
     /// # let other_key = Key::new_kv(ns, "other");
     /// // Create key only if it doesn't exist (expected_version = 0)
@@ -1604,20 +1610,21 @@ mod tests {
     use super::*;
     use crate::ClonedSnapshotView;
     use std::collections::BTreeMap;
+    use std::sync::Arc;
     use strata_core::types::{BranchId, Namespace, TypeTag};
     use strata_core::value::Value;
 
-    fn test_namespace() -> Namespace {
-        Namespace::new(
+    fn test_namespace() -> Arc<Namespace> {
+        Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             BranchId::new(),
             "default".to_string(),
-        )
+        ))
     }
 
-    fn test_key(ns: &Namespace, name: &str) -> Key {
+    fn test_key(ns: &Arc<Namespace>, name: &str) -> Key {
         Key::new(ns.clone(), TypeTag::KV, name.as_bytes().to_vec())
     }
 

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -212,6 +212,7 @@ mod tests {
     use crate::error::StrataError;
     use crate::types::Namespace;
     use std::collections::BTreeMap;
+    use std::sync::Arc;
     use std::sync::{
         atomic::{AtomicU64, Ordering},
         RwLock,
@@ -406,17 +407,17 @@ mod tests {
         }
     }
 
-    fn test_ns() -> Namespace {
-        Namespace::new(
+    fn test_ns() -> Arc<Namespace> {
+        Arc::new(Namespace::new(
             "test".into(),
             "app".into(),
             "agent".into(),
             BranchId::new(),
             "default".into(),
-        )
+        ))
     }
 
-    fn test_key(ns: &Namespace, name: &str) -> Key {
+    fn test_key(ns: &Arc<Namespace>, name: &str) -> Key {
         Key::new_kv(ns.clone(), name)
     }
 
@@ -639,20 +640,20 @@ mod tests {
         let store = MockStorage::new();
         let branch1 = BranchId::new();
         let branch2 = BranchId::new();
-        let ns1 = Namespace::new(
+        let ns1 = Arc::new(Namespace::new(
             "t".into(),
             "a".into(),
             "g".into(),
             branch1,
             "default".into(),
-        );
-        let ns2 = Namespace::new(
+        ));
+        let ns2 = Arc::new(Namespace::new(
             "t".into(),
             "a".into(),
             "g".into(),
             branch2,
             "default".into(),
-        );
+        ));
 
         store
             .put(Key::new_kv(ns1.clone(), "k1"), Value::Int(1), None)

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -8,6 +8,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::sync::Arc;
 use uuid::Uuid;
 
 /// Unique identifier for an agent branch
@@ -242,10 +243,11 @@ impl TypeTag {
 ///
 /// ```
 /// use strata_core::{Key, Namespace, TypeTag, BranchId};
+/// use std::sync::Arc;
 ///
 /// let branch_id = BranchId::new();
-/// let ns = Namespace::new("tenant".to_string(), "app".to_string(),
-///                         "agent".to_string(), branch_id, "default".to_string());
+/// let ns = Arc::new(Namespace::new("tenant".to_string(), "app".to_string(),
+///                         "agent".to_string(), branch_id, "default".to_string()));
 ///
 /// // Create a KV key
 /// let key = Key::new_kv(ns.clone(), "session_state");
@@ -261,7 +263,9 @@ impl TypeTag {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Key {
     /// Namespace (tenant/app/agent/branch hierarchy)
-    pub namespace: Namespace,
+    /// Wrapped in Arc for memory-efficient sharing — all keys in the same
+    /// namespace (e.g., all graph edges on a branch) share a single allocation.
+    pub namespace: Arc<Namespace>,
     /// Type discriminator (KV, Event, State, Trace, Branch, etc.)
     pub type_tag: TypeTag,
     /// User-defined key bytes (supports arbitrary binary keys)
@@ -270,7 +274,7 @@ pub struct Key {
 
 impl Key {
     /// Create a new key with the given namespace, type tag, and user key
-    pub fn new(namespace: Namespace, type_tag: TypeTag, user_key: Vec<u8>) -> Self {
+    pub fn new(namespace: Arc<Namespace>, type_tag: TypeTag, user_key: Vec<u8>) -> Self {
         Self {
             namespace,
             type_tag,
@@ -281,7 +285,7 @@ impl Key {
     /// Create a KV key
     ///
     /// Helper that automatically sets type_tag to TypeTag::KV
-    pub fn new_kv(namespace: Namespace, key: impl AsRef<[u8]>) -> Self {
+    pub fn new_kv(namespace: Arc<Namespace>, key: impl AsRef<[u8]>) -> Self {
         Self::new(namespace, TypeTag::KV, key.as_ref().to_vec())
     }
 
@@ -289,14 +293,14 @@ impl Key {
     ///
     /// Helper that automatically sets type_tag to TypeTag::Event and
     /// encodes the sequence number as big-endian bytes
-    pub fn new_event(namespace: Namespace, seq: u64) -> Self {
+    pub fn new_event(namespace: Arc<Namespace>, seq: u64) -> Self {
         Self::new(namespace, TypeTag::Event, seq.to_be_bytes().to_vec())
     }
 
     /// Create an event log metadata key
     ///
     /// The metadata key stores: { next_sequence: u64, head_hash: [u8; 32] }
-    pub fn new_event_meta(namespace: Namespace) -> Self {
+    pub fn new_event_meta(namespace: Arc<Namespace>) -> Self {
         Self::new(namespace, TypeTag::Event, b"__meta__".to_vec())
     }
 
@@ -308,7 +312,7 @@ impl Key {
     /// The null byte separator ensures correct prefix scanning: scanning
     /// `__tidx__{event_type}\0` matches only that exact type. Big-endian
     /// sequence bytes ensure results are returned in sequence order.
-    pub fn new_event_type_idx(namespace: Namespace, event_type: &str, sequence: u64) -> Self {
+    pub fn new_event_type_idx(namespace: Arc<Namespace>, event_type: &str, sequence: u64) -> Self {
         let mut user_key = Vec::with_capacity(8 + event_type.len() + 1 + 8);
         user_key.extend_from_slice(b"__tidx__");
         user_key.extend_from_slice(event_type.as_bytes());
@@ -320,7 +324,7 @@ impl Key {
     /// Create a prefix key for scanning all type index entries of a given event type
     ///
     /// Used by `get_by_type` to find all sequence numbers for a specific event type.
-    pub fn new_event_type_idx_prefix(namespace: Namespace, event_type: &str) -> Self {
+    pub fn new_event_type_idx_prefix(namespace: Arc<Namespace>, event_type: &str) -> Self {
         let mut user_key = Vec::with_capacity(8 + event_type.len() + 1);
         user_key.extend_from_slice(b"__tidx__");
         user_key.extend_from_slice(event_type.as_bytes());
@@ -331,7 +335,7 @@ impl Key {
     /// Create a state cell key
     ///
     /// Helper that automatically sets type_tag to TypeTag::State
-    pub fn new_state(namespace: Namespace, key: impl AsRef<[u8]>) -> Self {
+    pub fn new_state(namespace: Arc<Namespace>, key: impl AsRef<[u8]>) -> Self {
         Self::new(namespace, TypeTag::State, key.as_ref().to_vec())
     }
 
@@ -339,14 +343,14 @@ impl Key {
     ///
     /// Helper that automatically sets type_tag to TypeTag::Branch and
     /// uses the branch_id as the key
-    pub fn new_branch(namespace: Namespace, branch_id: BranchId) -> Self {
+    pub fn new_branch(namespace: Arc<Namespace>, branch_id: BranchId) -> Self {
         Self::new(namespace, TypeTag::Branch, branch_id.as_bytes().to_vec())
     }
 
     /// Create a branch index key from string branch_id
     ///
     /// Alternative helper that accepts string branch_id for index keys
-    pub fn new_branch_with_id(namespace: Namespace, branch_id: &str) -> Self {
+    pub fn new_branch_with_id(namespace: Arc<Namespace>, branch_id: &str) -> Self {
         Self::new(namespace, TypeTag::Branch, branch_id.as_bytes().to_vec())
     }
 
@@ -360,7 +364,7 @@ impl Key {
     /// - by-tag: `__idx_tag__experiment__branch123`
     /// - by-parent: `__idx_parent__parent123__branch123`
     pub fn new_branch_index(
-        namespace: Namespace,
+        namespace: Arc<Namespace>,
         index_type: &str,
         index_value: &str,
         branch_id: &str,
@@ -378,13 +382,14 @@ impl Key {
     ///
     /// ```
     /// use strata_core::{Key, Namespace, TypeTag, BranchId};
+    /// use std::sync::Arc;
     ///
     /// let branch_id = BranchId::new();
-    /// let namespace = Namespace::for_branch(branch_id);
+    /// let namespace = Arc::new(Namespace::for_branch(branch_id));
     /// let key = Key::new_json(namespace, "my-document");
     /// assert_eq!(key.type_tag, TypeTag::Json);
     /// ```
-    pub fn new_json(namespace: Namespace, doc_id: &str) -> Self {
+    pub fn new_json(namespace: Arc<Namespace>, doc_id: &str) -> Self {
         Self::new(namespace, TypeTag::Json, doc_id.as_bytes().to_vec())
     }
 
@@ -392,14 +397,14 @@ impl Key {
     ///
     /// This key can be used with starts_with() to match all JSON
     /// documents in a namespace.
-    pub fn new_json_prefix(namespace: Namespace) -> Self {
+    pub fn new_json_prefix(namespace: Arc<Namespace>) -> Self {
         Self::new(namespace, TypeTag::Json, vec![])
     }
 
     /// Create key for vector metadata
     ///
     /// Format: namespace + TypeTag::Vector + collection_name + "/" + vector_key
-    pub fn new_vector(namespace: Namespace, collection: &str, key: &str) -> Self {
+    pub fn new_vector(namespace: Arc<Namespace>, collection: &str, key: &str) -> Self {
         let user_key = format!("{}/{}", collection, key);
         Self::new(namespace, TypeTag::Vector, user_key.into_bytes())
     }
@@ -407,7 +412,7 @@ impl Key {
     /// Create key for collection configuration
     ///
     /// Format: namespace + TypeTag::VectorConfig + collection_name
-    pub fn new_vector_config(namespace: Namespace, collection: &str) -> Self {
+    pub fn new_vector_config(namespace: Arc<Namespace>, collection: &str) -> Self {
         Self::new(
             namespace,
             TypeTag::VectorConfig,
@@ -416,13 +421,13 @@ impl Key {
     }
 
     /// Create prefix for scanning all vectors in a collection
-    pub fn vector_collection_prefix(namespace: Namespace, collection: &str) -> Self {
+    pub fn vector_collection_prefix(namespace: Arc<Namespace>, collection: &str) -> Self {
         let user_key = format!("{}/", collection);
         Self::new(namespace, TypeTag::Vector, user_key.into_bytes())
     }
 
     /// Create prefix for scanning all vector collections
-    pub fn new_vector_config_prefix(namespace: Namespace) -> Self {
+    pub fn new_vector_config_prefix(namespace: Arc<Namespace>) -> Self {
         Self::new(namespace, TypeTag::VectorConfig, vec![])
     }
 
@@ -432,13 +437,13 @@ impl Key {
     /// space metadata. This avoids circular dependency where space
     /// metadata would be stored in the space itself.
     pub fn new_space(branch_id: BranchId, space_name: &str) -> Self {
-        let namespace = Namespace::for_branch(branch_id);
+        let namespace = Arc::new(Namespace::for_branch(branch_id));
         Self::new(namespace, TypeTag::Space, space_name.as_bytes().to_vec())
     }
 
     /// Prefix for scanning all space metadata in a branch.
     pub fn new_space_prefix(branch_id: BranchId) -> Self {
-        let namespace = Namespace::for_branch(branch_id);
+        let namespace = Arc::new(Namespace::for_branch(branch_id));
         Self::new(namespace, TypeTag::Space, vec![])
     }
 
@@ -459,8 +464,9 @@ impl Key {
     /// This enables efficient prefix scans in BTreeMap:
     /// ```
     /// # use strata_core::{Key, Namespace, BranchId};
+    /// # use std::sync::Arc;
     /// # let branch_id = BranchId::new();
-    /// # let ns = Namespace::new("t".to_string(), "a".to_string(), "ag".to_string(), branch_id, "default".to_string());
+    /// # let ns = Arc::new(Namespace::new("t".to_string(), "a".to_string(), "ag".to_string(), branch_id, "default".to_string()));
     /// let prefix = Key::new_kv(ns.clone(), "user:");
     /// let key = Key::new_kv(ns.clone(), "user:alice");
     /// assert!(key.starts_with(&prefix));
@@ -1173,13 +1179,13 @@ mod tests {
     #[test]
     fn test_key_construction() {
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         // Test generic constructor
         let key = Key::new(ns.clone(), TypeTag::KV, b"mykey".to_vec());
@@ -1191,13 +1197,13 @@ mod tests {
     #[test]
     fn test_key_helpers() {
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         // Test KV helper
         let kv_key = Key::new_kv(ns.clone(), "mykey");
@@ -1226,13 +1232,13 @@ mod tests {
     #[test]
     fn test_new_event_meta() {
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         let key = Key::new_event_meta(ns);
         assert_eq!(key.type_tag, TypeTag::Event);
@@ -1242,13 +1248,13 @@ mod tests {
     #[test]
     fn test_new_branch_index() {
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         // Test by-status index
         let key = Key::new_branch_index(ns.clone(), "status", "Active", "branch-123");
@@ -1269,13 +1275,13 @@ mod tests {
     #[test]
     fn test_user_key_string() {
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         // Valid UTF-8
         let key = Key::new_kv(ns.clone(), "hello-world");
@@ -1289,13 +1295,13 @@ mod tests {
     #[test]
     fn test_event_keys_sort_by_sequence() {
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         let key1 = Key::new_event(ns.clone(), 1);
         let key2 = Key::new_event(ns.clone(), 10);
@@ -1309,20 +1315,20 @@ mod tests {
     #[test]
     fn test_keys_with_same_inputs_are_equal() {
         let branch_id = BranchId::new();
-        let ns1 = Namespace::new(
+        let ns1 = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
-        let ns2 = Namespace::new(
+        ));
+        let ns2 = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         let key1 = Key::new_kv(ns1, "same-key");
         let key2 = Key::new_kv(ns2, "same-key");
@@ -1335,20 +1341,20 @@ mod tests {
 
         let branch1 = BranchId::new();
 
-        let ns1 = Namespace::new(
+        let ns1 = Arc::new(Namespace::new(
             "tenant1".to_string(),
             "app1".to_string(),
             "agent1".to_string(),
             branch1,
             "default".to_string(),
-        );
-        let ns2 = Namespace::new(
+        ));
+        let ns2 = Arc::new(Namespace::new(
             "tenant2".to_string(),
             "app1".to_string(),
             "agent1".to_string(),
             branch1,
             "default".to_string(),
-        );
+        ));
 
         // Test ordering: namespace → type_tag → user_key
         let key1 = Key::new_kv(ns1.clone(), b"aaa");
@@ -1384,20 +1390,20 @@ mod tests {
     #[test]
     fn test_key_ordering_components() {
         let branch_id = BranchId::new();
-        let ns1 = Namespace::new(
+        let ns1 = Arc::new(Namespace::new(
             "a".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
-        let ns2 = Namespace::new(
+        ));
+        let ns2 = Arc::new(Namespace::new(
             "b".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         let key1 = Key::new(ns1.clone(), TypeTag::KV, b"key1".to_vec());
         let key2 = Key::new(ns1.clone(), TypeTag::Event, b"key1".to_vec());
@@ -1423,13 +1429,13 @@ mod tests {
     #[test]
     fn test_key_prefix_matching() {
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         let prefix = Key::new_kv(ns.clone(), b"user:");
         let key1 = Key::new_kv(ns.clone(), b"user:alice");
@@ -1463,13 +1469,13 @@ mod tests {
     #[test]
     fn test_key_prefix_matching_empty() {
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         // Empty prefix should match all keys of same namespace and type
         let prefix = Key::new_kv(ns.clone(), b"");
@@ -1489,13 +1495,13 @@ mod tests {
     #[test]
     fn test_key_serialization() {
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
         let key = Key::new_kv(ns, "testkey");
 
         // Test JSON roundtrip
@@ -1507,13 +1513,13 @@ mod tests {
     #[test]
     fn test_key_equality() {
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         let key1 = Key::new_kv(ns.clone(), "mykey");
         let key2 = Key::new_kv(ns.clone(), "mykey");
@@ -1525,14 +1531,14 @@ mod tests {
 
     #[test]
     fn test_key_user_key_string_empty() {
-        let ns = Namespace::for_branch(BranchId::new());
+        let ns = Arc::new(Namespace::for_branch(BranchId::new()));
         let key = Key::new_kv(ns, b"");
         assert_eq!(key.user_key_string(), Some(String::new()));
     }
 
     #[test]
     fn test_key_new_vector() {
-        let ns = Namespace::for_branch(BranchId::new());
+        let ns = Arc::new(Namespace::for_branch(BranchId::new()));
         let key = Key::new_vector(ns.clone(), "my_collection", "vec_001");
         assert_eq!(key.type_tag, TypeTag::Vector);
         assert_eq!(key.user_key_string().unwrap(), "my_collection/vec_001");
@@ -1540,7 +1546,7 @@ mod tests {
 
     #[test]
     fn test_key_new_vector_config() {
-        let ns = Namespace::for_branch(BranchId::new());
+        let ns = Arc::new(Namespace::for_branch(BranchId::new()));
         let key = Key::new_vector_config(ns.clone(), "my_collection");
         assert_eq!(key.type_tag, TypeTag::VectorConfig);
         assert_eq!(key.user_key_string().unwrap(), "my_collection");
@@ -1548,7 +1554,7 @@ mod tests {
 
     #[test]
     fn test_key_vector_collection_prefix_matches_vectors() {
-        let ns = Namespace::for_branch(BranchId::new());
+        let ns = Arc::new(Namespace::for_branch(BranchId::new()));
         let prefix = Key::vector_collection_prefix(ns.clone(), "coll");
         let vec_key = Key::new_vector(ns.clone(), "coll", "vec_1");
         let other_coll = Key::new_vector(ns.clone(), "other", "vec_1");
@@ -1565,7 +1571,7 @@ mod tests {
 
     #[test]
     fn test_key_vector_config_prefix_matches_configs() {
-        let ns = Namespace::for_branch(BranchId::new());
+        let ns = Arc::new(Namespace::for_branch(BranchId::new()));
         let prefix = Key::new_vector_config_prefix(ns.clone());
         let config_key = Key::new_vector_config(ns.clone(), "any_collection");
         let vector_key = Key::new_vector(ns.clone(), "any_collection", "v1");
@@ -1582,8 +1588,8 @@ mod tests {
 
     #[test]
     fn test_key_starts_with_different_namespace_never_matches() {
-        let ns1 = Namespace::for_branch(BranchId::new());
-        let ns2 = Namespace::for_branch(BranchId::new());
+        let ns1 = Arc::new(Namespace::for_branch(BranchId::new()));
+        let ns2 = Arc::new(Namespace::for_branch(BranchId::new()));
         let prefix = Key::new_kv(ns1, b"");
         let key = Key::new_kv(ns2, b"anything");
         assert!(
@@ -1594,7 +1600,7 @@ mod tests {
 
     #[test]
     fn test_key_event_sequence_zero_and_max() {
-        let ns = Namespace::for_branch(BranchId::new());
+        let ns = Arc::new(Namespace::for_branch(BranchId::new()));
         let key_zero = Key::new_event(ns.clone(), 0);
         let key_max = Key::new_event(ns.clone(), u64::MAX);
 
@@ -1610,7 +1616,7 @@ mod tests {
 
     #[test]
     fn test_key_new_branch_with_id_string_vs_branch_id() {
-        let ns = Namespace::for_branch(BranchId::new());
+        let ns = Arc::new(Namespace::for_branch(BranchId::new()));
         let branch_id = BranchId::new();
         let branch_str = format!("{}", branch_id);
 
@@ -1629,13 +1635,13 @@ mod tests {
         use std::collections::HashSet;
 
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         let key1 = Key::new_kv(ns.clone(), "key1");
         let key2 = Key::new_kv(ns.clone(), "key2");
@@ -1652,13 +1658,13 @@ mod tests {
     #[test]
     fn test_key_binary_user_key() {
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         // Test with binary data (not UTF-8)
         let binary_data = vec![0u8, 1, 2, 255, 254, 253];
@@ -1678,7 +1684,7 @@ mod tests {
     fn test_key_new_json() {
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
-        let namespace = Namespace::for_branch(branch_id);
+        let namespace = Arc::new(Namespace::for_branch(branch_id));
         let key = Key::new_json(namespace.clone(), doc_id);
 
         assert_eq!(key.type_tag, TypeTag::Json);
@@ -1689,7 +1695,7 @@ mod tests {
     #[test]
     fn test_key_new_json_prefix() {
         let branch_id = BranchId::new();
-        let namespace = Namespace::for_branch(branch_id);
+        let namespace = Arc::new(Namespace::for_branch(branch_id));
         let prefix = Key::new_json_prefix(namespace.clone());
 
         assert_eq!(prefix.type_tag, TypeTag::Json);
@@ -1708,7 +1714,7 @@ mod tests {
     #[test]
     fn test_key_json_different_docs_different_keys() {
         let branch_id = BranchId::new();
-        let namespace = Namespace::for_branch(branch_id);
+        let namespace = Arc::new(Namespace::for_branch(branch_id));
         let doc_id1 = "doc-1";
         let doc_id2 = "doc-2";
 
@@ -1721,7 +1727,7 @@ mod tests {
     #[test]
     fn test_key_json_same_doc_same_key() {
         let branch_id = BranchId::new();
-        let namespace = Namespace::for_branch(branch_id);
+        let namespace = Arc::new(Namespace::for_branch(branch_id));
         let doc_id = "test-doc";
 
         let key1 = Key::new_json(namespace.clone(), doc_id);
@@ -1733,7 +1739,7 @@ mod tests {
     #[test]
     fn test_key_json_ordering_with_other_types() {
         let branch_id = BranchId::new();
-        let namespace = Namespace::for_branch(branch_id);
+        let namespace = Arc::new(Namespace::for_branch(branch_id));
         let doc_id = "test-doc";
 
         let kv_key = Key::new_kv(namespace.clone(), "test");
@@ -1748,7 +1754,7 @@ mod tests {
     #[test]
     fn test_key_json_does_not_match_other_type_prefix() {
         let branch_id = BranchId::new();
-        let namespace = Namespace::for_branch(branch_id);
+        let namespace = Arc::new(Namespace::for_branch(branch_id));
         let doc_id = "test-doc";
 
         let json_key = Key::new_json(namespace.clone(), doc_id);

--- a/crates/durability/src/branch_bundle/reader.rs
+++ b/crates/durability/src/branch_bundle/reader.rs
@@ -339,6 +339,7 @@ mod tests {
     use crate::branch_bundle::types::ExportOptions;
     use crate::branch_bundle::wal_log::BranchlogPayload;
     use crate::branch_bundle::writer::BranchBundleWriter;
+    use std::sync::Arc;
     use strata_core::types::{BranchId, Key, Namespace, TypeTag};
     use strata_core::value::Value;
     use tempfile::tempdir;
@@ -357,7 +358,7 @@ mod tests {
 
     fn make_test_payloads() -> Vec<BranchlogPayload> {
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
         vec![
             BranchlogPayload {
                 branch_id: branch_id.to_string(),

--- a/crates/durability/src/branch_bundle/wal_log.rs
+++ b/crates/durability/src/branch_bundle/wal_log.rs
@@ -428,6 +428,7 @@ fn validate_single_entry<R: Read>(reader: &mut R, index: usize) -> BranchBundleR
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use strata_core::types::{BranchId, Key, Namespace, TypeTag};
     use strata_core::value::Value;
 
@@ -439,7 +440,7 @@ mod tests {
 
     fn make_test_payloads(branch_id_str: &str) -> Vec<BranchlogPayload> {
         let branch_id = BranchId::from_string(branch_id_str).unwrap_or_else(|| BranchId::new());
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
         vec![
             BranchlogPayload {
                 branch_id: branch_id_str.to_string(),
@@ -582,7 +583,7 @@ mod tests {
     fn test_large_entry() {
         let branch_id = BranchId::new();
         let branch_id_str = branch_id.to_string();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
 
         // Create payload with large value
         let large_value = "x".repeat(1024 * 1024); // 1MB string
@@ -685,7 +686,7 @@ mod tests {
     fn test_checksum_changes_with_different_data() {
         let branch_id = BranchId::new();
         let branch_id_str = branch_id.to_string();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
 
         let payloads1 = vec![BranchlogPayload {
             branch_id: branch_id_str.clone(),
@@ -720,7 +721,7 @@ mod tests {
     fn test_payload_with_deletes() {
         let branch_id = BranchId::new();
         let branch_id_str = branch_id.to_string();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
 
         let payloads = vec![BranchlogPayload {
             branch_id: branch_id_str,

--- a/crates/durability/src/branch_bundle/writer.rs
+++ b/crates/durability/src/branch_bundle/writer.rs
@@ -229,6 +229,7 @@ mod tests {
     use crate::branch_bundle::types::BRANCHBUNDLE_FORMAT_VERSION;
     use crate::branch_bundle::wal_log::BranchlogPayload;
     use std::io::Read;
+    use std::sync::Arc;
     use strata_core::types::{BranchId, Key, Namespace, TypeTag};
     use strata_core::value::Value;
     use tempfile::tempdir;
@@ -247,7 +248,7 @@ mod tests {
 
     fn make_test_payloads() -> Vec<BranchlogPayload> {
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
         vec![
             BranchlogPayload {
                 branch_id: branch_id.to_string(),
@@ -452,7 +453,7 @@ mod tests {
 
         // Create payloads with repetitive data (compresses well)
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
         let mut payloads = Vec::new();
         for i in 0..100 {
             payloads.push(BranchlogPayload {

--- a/crates/engine/src/branch_ops.rs
+++ b/crates/engine/src/branch_ops.rs
@@ -263,7 +263,7 @@ pub fn fork_branch(db: &Arc<Database>, source: &str, destination: &str) -> Strat
             .into_iter()
             .map(|(key, vv)| {
                 // Rewrite key with destination namespace (preserving space and user_key)
-                let new_ns = Namespace::for_branch_space(dest_id, &key.namespace.space);
+                let new_ns = Arc::new(Namespace::for_branch_space(dest_id, &key.namespace.space));
                 let new_key = Key::new(new_ns, key.type_tag, key.user_key.clone());
                 (new_key, vv.value)
             })
@@ -578,7 +578,7 @@ pub fn merge_branches(
                 if type_tag_to_primitive(type_tag) == diff_entry.primitive {
                     let user_key_bytes = diff_entry.raw_key.clone();
                     if let Some(value) = source_values.get(&(user_key_bytes.clone(), type_tag)) {
-                        let target_ns = Namespace::for_branch_space(target_id, space);
+                        let target_ns = Arc::new(Namespace::for_branch_space(target_id, space));
                         let target_key = Key::new(target_ns, type_tag, user_key_bytes);
                         batch.push((target_key, value.clone()));
                         break;
@@ -657,7 +657,7 @@ mod tests {
 
     fn write_kv(db: &Arc<Database>, branch: &str, space: &str, key: &str, value: Value) {
         let branch_id = resolve_branch_name(branch);
-        let ns = Namespace::for_branch_space(branch_id, space);
+        let ns = Arc::new(Namespace::for_branch_space(branch_id, space));
         db.transaction(branch_id, |txn| {
             txn.put(
                 Key::new(ns.clone(), TypeTag::KV, key.as_bytes().to_vec()),
@@ -670,7 +670,7 @@ mod tests {
 
     fn write_state(db: &Arc<Database>, branch: &str, space: &str, key: &str, value: Value) {
         let branch_id = resolve_branch_name(branch);
-        let ns = Namespace::for_branch_space(branch_id, space);
+        let ns = Arc::new(Namespace::for_branch_space(branch_id, space));
         db.transaction(branch_id, |txn| {
             txn.put(
                 Key::new(ns.clone(), TypeTag::State, key.as_bytes().to_vec()),
@@ -683,7 +683,7 @@ mod tests {
 
     fn write_json(db: &Arc<Database>, branch: &str, space: &str, key: &str, value: Value) {
         let branch_id = resolve_branch_name(branch);
-        let ns = Namespace::for_branch_space(branch_id, space);
+        let ns = Arc::new(Namespace::for_branch_space(branch_id, space));
         db.transaction(branch_id, |txn| {
             txn.put(
                 Key::new(ns.clone(), TypeTag::Json, key.as_bytes().to_vec()),
@@ -1075,7 +1075,7 @@ mod tests {
 
         // Check version history before merge
         let target_id = resolve_branch_name("target");
-        let ns = Namespace::for_branch_space(target_id, "default");
+        let ns = Arc::new(Namespace::for_branch_space(target_id, "default"));
         let history_key = Key::new(ns, TypeTag::KV, b"key".to_vec());
         let history_before = db.get_history(&history_key, None, None).unwrap();
         let versions_before = history_before.len();
@@ -1084,7 +1084,7 @@ mod tests {
         merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
 
         // Check version history after merge — should have one more version
-        let ns2 = Namespace::for_branch_space(target_id, "default");
+        let ns2 = Arc::new(Namespace::for_branch_space(target_id, "default"));
         let history_key2 = Key::new(ns2, TypeTag::KV, b"key".to_vec());
         let history_after = db.get_history(&history_key2, None, None).unwrap();
         assert!(
@@ -1112,7 +1112,7 @@ mod tests {
 
         // Write data with binary keys (simulating event sequence numbers)
         let binary_key: Vec<u8> = 1u64.to_be_bytes().to_vec();
-        let ns_source = Namespace::for_branch_space(source_id, "default");
+        let ns_source = Arc::new(Namespace::for_branch_space(source_id, "default"));
         db.transaction(source_id, |txn| {
             txn.put(
                 Key::new(ns_source.clone(), TypeTag::Event, binary_key.clone()),

--- a/crates/engine/src/bundle.rs
+++ b/crates/engine/src/bundle.rs
@@ -317,6 +317,7 @@ fn format_micros(micros: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use strata_core::types::Namespace;
     use tempfile::TempDir;
 
@@ -367,7 +368,7 @@ mod tests {
             .unwrap()
             .value;
         let core_branch_id = crate::primitives::branch::resolve_branch_name(&meta.name);
-        let ns = Namespace::for_branch(core_branch_id);
+        let ns = Arc::new(Namespace::for_branch(core_branch_id));
 
         db.transaction(core_branch_id, |txn| {
             txn.put(
@@ -423,7 +424,7 @@ mod tests {
             .unwrap()
             .value;
         let core_branch_id = crate::primitives::branch::resolve_branch_name(&meta.name);
-        let ns = Namespace::for_branch(core_branch_id);
+        let ns = Arc::new(Namespace::for_branch(core_branch_id));
 
         db.transaction(core_branch_id, |txn| {
             txn.put(

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -2122,6 +2122,7 @@ impl Drop for Database {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use strata_concurrency::TransactionPayload;
     use strata_core::types::{Key, Namespace};
     use strata_core::value::Value;
@@ -2187,13 +2188,13 @@ mod tests {
         let db_path = temp_dir.path().join("db");
 
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         // Write directly to segmented WAL (simulating a crash recovery scenario)
         {
@@ -2232,13 +2233,13 @@ mod tests {
         let db_path = temp_dir.path().join("db");
 
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         // Open database, write via transaction, close
         {
@@ -2281,13 +2282,13 @@ mod tests {
         let db_path = temp_dir.path().join("db");
 
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         // Write one valid record, then append garbage to simulate crash
         {
@@ -2389,14 +2390,14 @@ mod tests {
     // Transaction API Tests
     // ========================================================================
 
-    fn create_test_namespace(branch_id: BranchId) -> Namespace {
-        Namespace::new(
+    fn create_test_namespace(branch_id: BranchId) -> Arc<Namespace> {
+        Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        )
+        ))
     }
 
     #[test]

--- a/crates/engine/src/graph/keys.rs
+++ b/crates/engine/src/graph/keys.rs
@@ -3,6 +3,7 @@
 //! All graph data is stored under the `_graph_` space using KV-type keys.
 //! Key format uses `/` as a separator between path segments.
 
+use std::sync::Arc;
 #[cfg(test)]
 use strata_core::types::TypeTag;
 use strata_core::types::{BranchId, Key, Namespace};
@@ -63,8 +64,8 @@ pub fn validate_edge_type(t: &str) -> StrataResult<()> {
 pub const GRAPH_SPACE: &str = "_graph_";
 
 /// Build a namespace for graph operations on a given branch.
-pub fn graph_namespace(branch_id: BranchId) -> Namespace {
-    Namespace::for_branch_space(branch_id, GRAPH_SPACE)
+pub fn graph_namespace(branch_id: BranchId) -> Arc<Namespace> {
+    Arc::new(Namespace::for_branch_space(branch_id, GRAPH_SPACE))
 }
 
 /// Build a full storage Key from a user_key string in the graph namespace.

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -61,8 +61,8 @@ fn global_branch_id() -> BranchId {
 }
 
 /// Get the global namespace for BranchIndex operations
-fn global_namespace() -> Namespace {
-    Namespace::for_branch(global_branch_id())
+fn global_namespace() -> Arc<Namespace> {
+    Arc::new(Namespace::for_branch(global_branch_id()))
 }
 
 // ========== BranchStatus Enum ==========
@@ -347,7 +347,7 @@ impl BranchIndex {
         txn: &mut strata_concurrency::TransactionContext,
         branch_id: BranchId,
     ) -> StrataResult<()> {
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
 
         #[allow(deprecated)]
         for type_tag in [

--- a/crates/engine/src/primitives/event.rs
+++ b/crates/engine/src/primitives/event.rs
@@ -277,8 +277,8 @@ impl EventLog {
     }
 
     /// Build namespace for branch+space-scoped operations
-    fn namespace_for(&self, branch_id: &BranchId, space: &str) -> Namespace {
-        Namespace::for_branch_space(*branch_id, space)
+    fn namespace_for(&self, branch_id: &BranchId, space: &str) -> Arc<Namespace> {
+        Arc::new(Namespace::for_branch_space(*branch_id, space))
     }
 
     // ========== Append Operation ==========
@@ -762,7 +762,7 @@ impl EventLogExt for TransactionContext {
         validate_event_type(event_type).map_err(|e| StrataError::invalid_input(e.to_string()))?;
         validate_payload(&payload).map_err(|e| StrataError::invalid_input(e.to_string()))?;
 
-        let ns = Namespace::for_branch(self.branch_id);
+        let ns = Arc::new(Namespace::for_branch(self.branch_id));
 
         // Read current metadata (or default)
         let meta_key = Key::new_event_meta(ns.clone());
@@ -817,7 +817,7 @@ impl EventLogExt for TransactionContext {
     }
 
     fn event_get(&mut self, sequence: u64) -> StrataResult<Option<Value>> {
-        let ns = Namespace::for_branch(self.branch_id);
+        let ns = Arc::new(Namespace::for_branch(self.branch_id));
         let event_key = Key::new_event(ns, sequence);
         self.get(&event_key)
     }

--- a/crates/engine/src/primitives/json.rs
+++ b/crates/engine/src/primitives/json.rs
@@ -187,7 +187,7 @@ impl JsonStore {
 
     /// Build key for JSON document
     fn key_for(&self, branch_id: &BranchId, space: &str, doc_id: &str) -> Key {
-        Key::new_json(self.namespace_for(branch_id, space), doc_id)
+        Key::new_json(Arc::new(self.namespace_for(branch_id, space)), doc_id)
     }
 
     // ========================================================================
@@ -678,7 +678,7 @@ impl JsonStore {
     ) -> StrataResult<JsonListResult> {
         let ns = self.namespace_for(branch_id, space);
         // Narrow scan at storage level: if prefix is given, only scan matching keys
-        let scan_prefix = Key::new_json(ns, prefix.unwrap_or(""));
+        let scan_prefix = Key::new_json(Arc::new(ns), prefix.unwrap_or(""));
 
         self.db.transaction(*branch_id, |txn| {
             let mut doc_ids = Vec::with_capacity(limit + 1);
@@ -757,7 +757,7 @@ impl JsonStore {
         as_of_ts: u64,
     ) -> StrataResult<Vec<String>> {
         let ns = self.namespace_for(branch_id, space);
-        let scan_prefix = Key::new_json_prefix(ns);
+        let scan_prefix = Key::new_json_prefix(Arc::new(ns));
         let results = self.db.scan_prefix_at_timestamp(&scan_prefix, as_of_ts)?;
         let mut doc_ids = Vec::new();
         for (_, vv) in results {
@@ -803,7 +803,7 @@ impl JsonStoreExt for TransactionContext {
         // Validate path limits (Issue #440)
         path.validate().map_err(limit_error_to_error)?;
 
-        let key = Key::new_json(Namespace::for_branch(self.branch_id), doc_id);
+        let key = Key::new_json(Arc::new(Namespace::for_branch(self.branch_id)), doc_id);
 
         // Read from transaction context (respects read-your-writes)
         match self.get(&key)? {
@@ -825,7 +825,7 @@ impl JsonStoreExt for TransactionContext {
         path.validate().map_err(limit_error_to_error)?;
         value.validate().map_err(limit_error_to_error)?;
 
-        let key = Key::new_json(Namespace::for_branch(self.branch_id), doc_id);
+        let key = Key::new_json(Arc::new(Namespace::for_branch(self.branch_id)), doc_id);
 
         // Load existing document from transaction context
         let stored = self.get(&key)?.ok_or_else(|| {
@@ -849,7 +849,7 @@ impl JsonStoreExt for TransactionContext {
         // Validate document limits (Issue #440)
         value.validate().map_err(limit_error_to_error)?;
 
-        let key = Key::new_json(Namespace::for_branch(self.branch_id), doc_id);
+        let key = Key::new_json(Arc::new(Namespace::for_branch(self.branch_id)), doc_id);
         let doc = JsonDoc::new(doc_id, value);
 
         // Check if document already exists

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -59,8 +59,8 @@ impl KVStore {
     }
 
     /// Build namespace for branch+space-scoped operations
-    fn namespace_for(&self, branch_id: &BranchId, space: &str) -> Namespace {
-        Namespace::for_branch_space(*branch_id, space)
+    fn namespace_for(&self, branch_id: &BranchId, space: &str) -> Arc<Namespace> {
+        Arc::new(Namespace::for_branch_space(*branch_id, space))
     }
 
     /// Build key for KV operation
@@ -407,17 +407,20 @@ impl crate::search::Searchable for KVStore {
 
 impl KVStoreExt for TransactionContext {
     fn kv_get(&mut self, key: &str) -> StrataResult<Option<Value>> {
-        let storage_key = Key::new_kv(Namespace::for_branch(self.branch_id), key);
+        let ns = Arc::new(Namespace::for_branch(self.branch_id));
+        let storage_key = Key::new_kv(ns, key);
         self.get(&storage_key)
     }
 
     fn kv_put(&mut self, key: &str, value: Value) -> StrataResult<()> {
-        let storage_key = Key::new_kv(Namespace::for_branch(self.branch_id), key);
+        let ns = Arc::new(Namespace::for_branch(self.branch_id));
+        let storage_key = Key::new_kv(ns, key);
         self.put(storage_key, value)
     }
 
     fn kv_delete(&mut self, key: &str) -> StrataResult<()> {
-        let storage_key = Key::new_kv(Namespace::for_branch(self.branch_id), key);
+        let ns = Arc::new(Namespace::for_branch(self.branch_id));
+        let storage_key = Key::new_kv(ns, key);
         self.delete(storage_key)?;
         Ok(())
     }
@@ -782,8 +785,8 @@ mod tests {
         // Start a manual transaction, read, then check the versioned read
         // is consistent even if a concurrent write happens
         let mut txn = db.begin_transaction(branch_id);
-        let storage_key =
-            strata_core::types::Key::new_kv(Namespace::for_branch(branch_id), "iso_key");
+        let ns = Arc::new(Namespace::for_branch(branch_id));
+        let storage_key = strata_core::types::Key::new_kv(ns.clone(), "iso_key");
         let vv = txn.get_versioned(&storage_key).unwrap().unwrap();
         assert_eq!(vv.value, Value::Int(1));
 

--- a/crates/engine/src/primitives/space.rs
+++ b/crates/engine/src/primitives/space.rs
@@ -109,7 +109,7 @@ impl SpaceIndex {
     /// space's namespace to determine if any keys exist.
     pub fn is_empty(&self, branch_id: BranchId, space: &str) -> StrataResult<bool> {
         self.db.transaction(branch_id, |txn| {
-            let ns = Namespace::for_branch_space(branch_id, space);
+            let ns = Arc::new(Namespace::for_branch_space(branch_id, space));
 
             for type_tag in [
                 TypeTag::KV,

--- a/crates/engine/src/primitives/state.rs
+++ b/crates/engine/src/primitives/state.rs
@@ -92,7 +92,7 @@ impl StateCell {
 
     /// Build key for state cell
     fn key_for(&self, branch_id: &BranchId, space: &str, name: &str) -> Key {
-        Key::new_state(self.namespace_for(branch_id, space), name)
+        Key::new_state(Arc::new(self.namespace_for(branch_id, space)), name)
     }
 
     // ========== Read/Init Operations ==========
@@ -431,7 +431,7 @@ impl StateCell {
         prefix: Option<&str>,
     ) -> StrataResult<Vec<String>> {
         self.db.transaction(*branch_id, |txn| {
-            let ns = self.namespace_for(branch_id, space);
+            let ns = Arc::new(self.namespace_for(branch_id, space));
             let scan_prefix = Key::new_state(ns, prefix.unwrap_or(""));
 
             let results = txn.scan_prefix(&scan_prefix)?;
@@ -475,7 +475,7 @@ impl StateCell {
         prefix: Option<&str>,
         as_of_ts: u64,
     ) -> StrataResult<Vec<String>> {
-        let ns = self.namespace_for(branch_id, space);
+        let ns = Arc::new(self.namespace_for(branch_id, space));
         let scan_prefix = Key::new_state(ns, prefix.unwrap_or(""));
         let results = self.db.scan_prefix_at_timestamp(&scan_prefix, as_of_ts)?;
         Ok(results
@@ -505,7 +505,7 @@ impl crate::search::Searchable for StateCell {
 
 impl StateCellExt for TransactionContext {
     fn state_get(&mut self, name: &str) -> StrataResult<Option<Value>> {
-        let ns = Namespace::for_branch(self.branch_id);
+        let ns = Arc::new(Namespace::for_branch(self.branch_id));
         let key = Key::new_state(ns, name);
 
         match self.get(&key)? {
@@ -524,7 +524,7 @@ impl StateCellExt for TransactionContext {
         expected_version: Version,
         new_value: Value,
     ) -> StrataResult<Version> {
-        let ns = Namespace::for_branch(self.branch_id);
+        let ns = Arc::new(Namespace::for_branch(self.branch_id));
         let key = Key::new_state(ns, name);
 
         let current: State = match self.get(&key)? {
@@ -557,7 +557,7 @@ impl StateCellExt for TransactionContext {
     }
 
     fn state_set(&mut self, name: &str, value: Value) -> StrataResult<Version> {
-        let ns = Namespace::for_branch(self.branch_id);
+        let ns = Arc::new(Namespace::for_branch(self.branch_id));
         let key = Key::new_state(ns, name);
 
         let new_version = match self.get(&key)? {

--- a/crates/engine/src/primitives/vector/recovery.rs
+++ b/crates/engine/src/primitives/vector/recovery.rs
@@ -60,6 +60,7 @@ pub(crate) fn mmap_path(
 fn recover_from_db(db: &Database) -> StrataResult<()> {
     use super::{CollectionId, IndexBackendFactory, VectorBackendState, VectorConfig, VectorId};
     use crate::primitives::vector::heap::VectorHeap;
+    use std::sync::Arc;
     use strata_core::traits::SnapshotView;
     use strata_core::types::{Key, Namespace};
     use strata_core::value::Value;
@@ -80,7 +81,7 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
 
     // Iterate all branch_ids in storage
     for branch_id in db.storage().branch_ids() {
-        let ns = Namespace::for_branch_space(branch_id, "default");
+        let ns = Arc::new(Namespace::for_branch_space(branch_id, "default"));
 
         // Scan for vector config entries in this run
         let config_prefix = Key::new_vector_config_prefix(ns.clone());

--- a/crates/engine/src/primitives/vector/snapshot.rs
+++ b/crates/engine/src/primitives/vector/snapshot.rs
@@ -281,7 +281,10 @@ impl VectorStore {
             // Use "default" space for snapshot deserialization (backwards compat)
             let collection_record = crate::primitives::vector::CollectionRecord::new(&config);
             let config_key = strata_core::types::Key::new_vector_config(
-                strata_core::types::Namespace::for_branch_space(header.branch_id, "default"),
+                std::sync::Arc::new(strata_core::types::Namespace::for_branch_space(
+                    header.branch_id,
+                    "default",
+                )),
                 &header.name,
             );
             let config_bytes = collection_record.to_bytes()?;

--- a/crates/engine/src/primitives/vector/store.rs
+++ b/crates/engine/src/primitives/vector/store.rs
@@ -144,8 +144,8 @@ impl VectorStore {
     }
 
     /// Build namespace for branch+space-scoped operations
-    fn namespace_for(&self, branch_id: BranchId, space: &str) -> Namespace {
-        Namespace::for_branch_space(branch_id, space)
+    fn namespace_for(&self, branch_id: BranchId, space: &str) -> Arc<Namespace> {
+        Arc::new(Namespace::for_branch_space(branch_id, space))
     }
 
     /// Get the backend factory (hardcoded currently, configurable in future versions)
@@ -1592,7 +1592,7 @@ impl VectorStore {
 
         let now = now_micros();
         let record = CollectionRecord::new(&config);
-        let config_key = Key::new_vector_config(Namespace::for_branch(branch_id), name);
+        let config_key = Key::new_vector_config(Arc::new(Namespace::for_branch(branch_id)), name);
         let config_bytes = record.to_bytes()?;
 
         self.db
@@ -2057,7 +2057,7 @@ impl VectorStore {
                 // to read from when VectorIds collide between source and target.
                 let source_key_to_vid: BTreeMap<Vec<u8>, u64> =
                     if let Some(src_bid) = source_branch_id {
-                        let src_ns = Namespace::for_branch_space(src_bid, space);
+                        let src_ns = Arc::new(Namespace::for_branch_space(src_bid, space));
                         let src_prefix = Key::new_vector(src_ns, &collection_name, "");
                         if let Ok(src_entries) = snapshot.scan_prefix(&src_prefix) {
                             src_entries

--- a/crates/engine/src/recovery/replay.rs
+++ b/crates/engine/src/recovery/replay.rs
@@ -509,10 +509,11 @@ pub enum ReplayError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use strata_core::types::Namespace;
 
-    fn test_namespace() -> Namespace {
-        Namespace::for_branch(BranchId::new())
+    fn test_namespace() -> Arc<Namespace> {
+        Arc::new(Namespace::for_branch(BranchId::new()))
     }
 
     // ========== BranchIndex Tests ==========
@@ -890,7 +891,7 @@ mod tests {
         let ns = test_namespace();
 
         // Function to build a view from operations
-        fn build_view(branch_id: BranchId, ns: &Namespace) -> ReadOnlyView {
+        fn build_view(branch_id: BranchId, ns: &Arc<Namespace>) -> ReadOnlyView {
             let mut view = ReadOnlyView::new(branch_id);
             view.apply_kv_put(Key::new_kv(ns.clone(), "a"), Value::Int(1));
             view.apply_kv_put(Key::new_kv(ns.clone(), "b"), Value::Int(2));

--- a/crates/engine/src/transaction/context.rs
+++ b/crates/engine/src/transaction/context.rs
@@ -19,6 +19,7 @@
 
 use crate::primitives::event::{EventLogMeta, HASH_VERSION_SHA256};
 use crate::transaction_ops::TransactionOps;
+use std::sync::Arc;
 use strata_concurrency::{JsonStoreExt, TransactionContext};
 use strata_core::types::{BranchId, Key, Namespace, TypeTag};
 use strata_core::{
@@ -53,7 +54,7 @@ pub struct Transaction<'a> {
     /// The underlying transaction context
     ctx: &'a mut TransactionContext,
     /// Namespace for this transaction's run
-    namespace: Namespace,
+    namespace: Arc<Namespace>,
     /// Pending events buffered in this transaction
     pending_events: Vec<Event>,
     /// Base sequence number from snapshot (events start at base_sequence)
@@ -68,7 +69,7 @@ impl<'a> Transaction<'a> {
     /// Reads event state (sequence count, last hash) from TransactionContext
     /// to maintain continuity across multiple Transaction instances within
     /// the same session transaction.
-    pub fn new(ctx: &'a mut TransactionContext, namespace: Namespace) -> Self {
+    pub fn new(ctx: &'a mut TransactionContext, namespace: Arc<Namespace>) -> Self {
         let base_sequence = ctx.event_sequence_count();
         let last_hash = ctx.event_last_hash();
         Self {
@@ -85,7 +86,7 @@ impl<'a> Transaction<'a> {
     /// Use this when you know the current event count from snapshot.
     pub fn with_base_sequence(
         ctx: &'a mut TransactionContext,
-        namespace: Namespace,
+        namespace: Arc<Namespace>,
         base_sequence: u64,
         last_hash: [u8; 32],
     ) -> Self {
@@ -684,15 +685,15 @@ mod tests {
     use super::*;
     use strata_concurrency::snapshot::ClonedSnapshotView;
 
-    fn create_test_namespace() -> Namespace {
+    fn create_test_namespace() -> Arc<Namespace> {
         let branch_id = BranchId::new();
-        Namespace::new(
+        Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        )
+        ))
     }
 
     fn create_test_context(ns: &Namespace) -> TransactionContext {

--- a/crates/engine/src/transaction/pool.rs
+++ b/crates/engine/src/transaction/pool.rs
@@ -162,21 +162,22 @@ impl TransactionPool {
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
+    use std::sync::Arc;
     use strata_concurrency::snapshot::ClonedSnapshotView;
     use strata_core::types::{Namespace, TypeTag};
     use strata_core::value::Value;
 
-    fn create_test_namespace() -> Namespace {
-        Namespace::new(
+    fn create_test_namespace() -> Arc<Namespace> {
+        Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             BranchId::new(),
             "default".to_string(),
-        )
+        ))
     }
 
-    fn create_test_key(ns: &Namespace, user_key: &[u8]) -> strata_core::types::Key {
+    fn create_test_key(ns: &Arc<Namespace>, user_key: &[u8]) -> strata_core::types::Key {
         strata_core::types::Key::new(ns.clone(), TypeTag::KV, user_key.to_vec())
     }
 

--- a/crates/engine/tests/branch_lifecycle_tests.rs
+++ b/crates/engine/tests/branch_lifecycle_tests.rs
@@ -7,6 +7,7 @@
 //! - diff_branches() key-level comparison
 //! - Orphaned branch detection
 
+use std::sync::Arc;
 use strata_core::branch_types::{BranchMetadata, BranchStatus};
 use strata_core::types::{BranchId, Key, Namespace};
 use strata_core::value::Value;
@@ -176,8 +177,8 @@ fn test_branch_index_multiple_branches() {
 // ReadOnlyView Tests
 // ============================================================================
 
-fn test_namespace() -> Namespace {
-    Namespace::for_branch(BranchId::new())
+fn test_namespace() -> Arc<Namespace> {
+    Arc::new(Namespace::for_branch(BranchId::new()))
 }
 
 #[test]
@@ -537,7 +538,7 @@ fn test_replay_invariant_p6_idempotent() {
     let ns = test_namespace();
 
     // Simulate replay by building the same view multiple times
-    fn build_view(branch_id: BranchId, ns: Namespace) -> ReadOnlyView {
+    fn build_view(branch_id: BranchId, ns: Arc<Namespace>) -> ReadOnlyView {
         let mut view = ReadOnlyView::new(branch_id);
         view.apply_kv_put(Key::new_kv(ns.clone(), "counter"), Value::Int(1));
         view.apply_kv_put(Key::new_kv(ns.clone(), "counter"), Value::Int(2));

--- a/crates/engine/tests/concurrency_tests.rs
+++ b/crates/engine/tests/concurrency_tests.rs
@@ -11,14 +11,14 @@ use strata_core::value::Value;
 use strata_engine::Database;
 use tempfile::TempDir;
 
-fn create_ns(branch_id: BranchId) -> Namespace {
-    Namespace::new(
+fn create_ns(branch_id: BranchId) -> Arc<Namespace> {
+    Arc::new(Namespace::new(
         "tenant".to_string(),
         "app".to_string(),
         "agent".to_string(),
         branch_id,
         "default".to_string(),
-    )
+    ))
 }
 
 // ============================================================================

--- a/crates/engine/tests/m4_pooling_tests.rs
+++ b/crates/engine/tests/m4_pooling_tests.rs
@@ -8,22 +8,23 @@
 //!
 //! Per specification: Hot path must have zero allocations after warmup.
 
+use std::sync::Arc;
 use strata_core::types::{BranchId, Key, Namespace, TypeTag};
 use strata_core::value::Value;
 use strata_engine::{Database, TransactionPool, MAX_POOL_SIZE};
 use tempfile::TempDir;
 
-fn create_ns(branch_id: BranchId) -> Namespace {
-    Namespace::new(
+fn create_ns(branch_id: BranchId) -> Arc<Namespace> {
+    Arc::new(Namespace::new(
         "tenant".to_string(),
         "app".to_string(),
         "agent".to_string(),
         branch_id,
         "default".to_string(),
-    )
+    ))
 }
 
-fn create_key(ns: &Namespace, user_key: &str) -> Key {
+fn create_key(ns: &Arc<Namespace>, user_key: &str) -> Key {
     Key::new(ns.clone(), TypeTag::KV, user_key.as_bytes().to_vec())
 }
 

--- a/crates/engine/tests/memory_profiling.rs
+++ b/crates/engine/tests/memory_profiling.rs
@@ -3,19 +3,20 @@
 //! Documents ClonedSnapshotView memory overhead
 //! and TransactionContext footprint.
 
+use std::sync::Arc;
 use strata_core::types::{BranchId, Key, Namespace};
 use strata_core::value::Value;
 use strata_engine::Database;
 use tempfile::TempDir;
 
-fn create_ns(branch_id: BranchId) -> Namespace {
-    Namespace::new(
+fn create_ns(branch_id: BranchId) -> Arc<Namespace> {
+    Arc::new(Namespace::new(
         "tenant".to_string(),
         "app".to_string(),
         "agent".to_string(),
         branch_id,
         "default".to_string(),
-    )
+    ))
 }
 
 /// Test: Memory grows with read-set size

--- a/crates/engine/tests/multi_process_tests.rs
+++ b/crates/engine/tests/multi_process_tests.rs
@@ -22,14 +22,14 @@ fn ensure_recovery_registered() {
     });
 }
 
-fn create_test_namespace(branch_id: BranchId) -> Namespace {
-    Namespace::new(
+fn create_test_namespace(branch_id: BranchId) -> Arc<Namespace> {
+    Arc::new(Namespace::new(
         "tenant".to_string(),
         "app".to_string(),
         "agent".to_string(),
         branch_id,
         "default".to_string(),
-    )
+    ))
 }
 
 /// Read a key value through a read-only transaction.

--- a/crates/engine/tests/replay_invariants.rs
+++ b/crates/engine/tests/replay_invariants.rs
@@ -13,20 +13,21 @@
 //! ReadOnlyView is derived, not authoritative.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use strata_core::types::{BranchId, Key, Namespace};
 use strata_core::value::Value;
 use strata_core::PrimitiveType;
 use strata_engine::{diff_views, ReadOnlyView};
 
 /// Helper to create a test namespace
-fn test_namespace(branch_id: BranchId) -> Namespace {
-    Namespace::new(
+fn test_namespace(branch_id: BranchId) -> Arc<Namespace> {
+    Arc::new(Namespace::new(
         "tenant".to_string(),
         "app".to_string(),
         "agent".to_string(),
         branch_id,
         "default".to_string(),
-    )
+    ))
 }
 
 /// Helper to build a ReadOnlyView with specified KV entries

--- a/crates/executor/src/handlers/space.rs
+++ b/crates/executor/src/handlers/space.rs
@@ -55,7 +55,7 @@ pub fn space_delete(
     }
 
     // Delete all data in the space by scanning+deleting all TypeTag prefixes
-    let ns = Namespace::for_branch_space(core_branch_id, &space);
+    let ns = std::sync::Arc::new(Namespace::for_branch_space(core_branch_id, &space));
     convert_result(p.db.transaction(core_branch_id, |txn| {
         #[allow(deprecated)]
         for type_tag in [

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -305,7 +305,7 @@ impl Session {
             }
             _ => "default".to_string(),
         };
-        let ns = Namespace::for_branch_space(branch_id, &space);
+        let ns = Arc::new(Namespace::for_branch_space(branch_id, &space));
 
         // Temporarily take the context to create a Transaction
         let mut ctx = self.txn_ctx.take().unwrap();
@@ -318,7 +318,7 @@ impl Session {
     fn dispatch_in_txn(
         executor: &Executor,
         ctx: &mut TransactionContext,
-        ns: Namespace,
+        ns: Arc<Namespace>,
         cmd: Command,
     ) -> Result<Output> {
         // Read commands use ctx.get() / ctx.scan_prefix() directly so they

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -136,17 +136,18 @@ impl TypeIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use strata_core::Namespace;
 
     /// Helper to create a test namespace
-    fn test_namespace(branch_id: BranchId) -> Namespace {
-        Namespace::new(
+    fn test_namespace(branch_id: BranchId) -> Arc<Namespace> {
+        Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        )
+        ))
     }
 
     // ========================================

--- a/crates/storage/src/sharded.rs
+++ b/crates/storage/src/sharded.rs
@@ -41,6 +41,19 @@ use strata_core::{Timestamp, Version, VersionedValue};
 
 use crate::stored_value::StoredValue;
 
+/// Internal storage for version chains — optimized for the common single-version case.
+///
+/// Most keys (especially graph edges) only ever have one version. `Single` stores
+/// the value inline without any heap allocation for the container, saving ~270 bytes
+/// per entry compared to `VecDeque::with_capacity(4)`.
+#[derive(Debug, Clone)]
+enum VersionStorage {
+    /// Single version stored inline — no heap allocation for the container
+    Single(StoredValue),
+    /// Multiple versions stored newest-first in a VecDeque
+    Multi(VecDeque<StoredValue>),
+}
+
 /// Per-branch shard containing branch's data
 ///
 /// Version chain for MVCC - stores multiple versions of a value
@@ -48,33 +61,52 @@ use crate::stored_value::StoredValue;
 /// Versions are stored in descending order (newest first) for efficient
 /// snapshot reads - we typically want the most recent version <= snapshot_version.
 ///
-/// # Performance
+/// # Memory Optimization
 ///
-/// Uses VecDeque for O(1) push_front instead of SmallVec's O(n) insert(0, ...).
-/// This is critical for workloads that repeatedly update the same key (like CAS).
+/// Uses `VersionStorage` enum to avoid VecDeque allocation for the common
+/// single-version case. For keys with multiple versions, promotes to
+/// VecDeque with O(1) push_front.
 #[derive(Debug, Clone)]
 pub struct VersionChain {
     /// Versions stored newest-first for efficient MVCC reads
-    /// VecDeque provides O(1) push_front for new versions
-    /// Uses StoredValue to include TTL information
-    versions: VecDeque<StoredValue>,
+    /// Uses VersionStorage enum to inline single-version entries
+    versions: VersionStorage,
 }
 
 impl VersionChain {
     /// Create a new version chain with a single version
     pub fn new(value: StoredValue) -> Self {
-        let mut versions = VecDeque::with_capacity(4);
-        versions.push_front(value);
-        Self { versions }
+        Self {
+            versions: VersionStorage::Single(value),
+        }
     }
 
     /// Add a new version (must be newer than existing versions)
     ///
-    /// O(1) operation using VecDeque::push_front
+    /// Promotes Single → Multi on second version, then O(1) push_front.
     #[inline]
     pub fn push(&mut self, value: StoredValue) {
-        // O(1) insert at front (newest first)
-        self.versions.push_front(value);
+        match &mut self.versions {
+            VersionStorage::Single(_) => {
+                // Promote to Multi: take the existing single value, create VecDeque
+                let old =
+                    std::mem::replace(&mut self.versions, VersionStorage::Multi(VecDeque::new()));
+                match old {
+                    VersionStorage::Single(old_value) => {
+                        let mut deque = VecDeque::with_capacity(2);
+                        deque.push_back(old_value);
+                        deque.push_front(value);
+                        self.versions = VersionStorage::Multi(deque);
+                    }
+                    VersionStorage::Multi(_) => {
+                        unreachable!("matched Single but mem::replace returned Multi")
+                    }
+                }
+            }
+            VersionStorage::Multi(deque) => {
+                deque.push_front(value);
+            }
+        }
     }
 
     /// Get the version at or before the given max_version
@@ -82,15 +114,26 @@ impl VersionChain {
     /// Note: Uses raw u64 comparison since all storage versions are TxnId variants.
     /// Debug assertions verify this invariant.
     pub fn get_at_version(&self, max_version: u64) -> Option<&StoredValue> {
-        // Debug assertion: all versions should be Txn variants
-        debug_assert!(
-            self.versions.iter().all(|sv| sv.version().is_txn()),
-            "Storage layer should only contain Txn versions"
-        );
-        // Versions are newest-first, so we scan until we find one <= max_version
-        self.versions
-            .iter()
-            .find(|sv| sv.version().as_u64() <= max_version)
+        match &self.versions {
+            VersionStorage::Single(sv) => {
+                debug_assert!(
+                    sv.version().is_txn(),
+                    "Storage layer should only contain Txn versions"
+                );
+                if sv.version().as_u64() <= max_version {
+                    Some(sv)
+                } else {
+                    None
+                }
+            }
+            VersionStorage::Multi(deque) => {
+                debug_assert!(
+                    deque.iter().all(|sv| sv.version().is_txn()),
+                    "Storage layer should only contain Txn versions"
+                );
+                deque.iter().find(|sv| sv.version().as_u64() <= max_version)
+            }
+        }
     }
 
     /// Get the version at or before the given timestamp (microseconds since epoch).
@@ -98,45 +141,63 @@ impl VersionChain {
     /// Versions are stored newest-first, so we scan until we find one with timestamp <= max_timestamp.
     /// Returns None if no version exists at or before the given timestamp.
     pub fn get_at_timestamp(&self, max_timestamp: u64) -> Option<&StoredValue> {
-        self.versions
-            .iter()
-            .find(|sv| u64::from(sv.timestamp()) <= max_timestamp)
+        match &self.versions {
+            VersionStorage::Single(sv) => {
+                if u64::from(sv.timestamp()) <= max_timestamp {
+                    Some(sv)
+                } else {
+                    None
+                }
+            }
+            VersionStorage::Multi(deque) => deque
+                .iter()
+                .find(|sv| u64::from(sv.timestamp()) <= max_timestamp),
+        }
     }
 
     /// Get the latest version
     #[inline]
     pub fn latest(&self) -> Option<&StoredValue> {
-        self.versions.front()
+        match &self.versions {
+            VersionStorage::Single(sv) => Some(sv),
+            VersionStorage::Multi(deque) => deque.front(),
+        }
     }
 
     /// Remove versions older than min_version (garbage collection)
     /// Keeps at least one version.
     /// Returns the number of pruned versions.
     pub fn gc(&mut self, min_version: u64) -> usize {
-        if self.versions.len() <= 1 {
-            return 0;
-        }
-        let mut pruned = 0;
-        // Keep versions >= min_version, but always keep at least the latest
-        // Versions are newest-first, so pop from back (oldest)
-        while self.versions.len() > 1 {
-            if let Some(oldest) = self.versions.back() {
-                if oldest.version().as_u64() < min_version {
-                    self.versions.pop_back();
-                    pruned += 1;
-                } else {
-                    break;
+        match &mut self.versions {
+            VersionStorage::Single(_) => 0, // Only one version, always keep it
+            VersionStorage::Multi(deque) => {
+                if deque.len() <= 1 {
+                    return 0;
                 }
-            } else {
-                break;
+                let mut pruned = 0;
+                while deque.len() > 1 {
+                    if let Some(oldest) = deque.back() {
+                        if oldest.version().as_u64() < min_version {
+                            deque.pop_back();
+                            pruned += 1;
+                        } else {
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                pruned
             }
         }
-        pruned
     }
 
     /// Number of versions stored
     pub fn version_count(&self) -> usize {
-        self.versions.len()
+        match &self.versions {
+            VersionStorage::Single(_) => 1,
+            VersionStorage::Multi(deque) => deque.len(),
+        }
     }
 
     /// Get version history (newest first)
@@ -151,30 +212,51 @@ impl VersionChain {
     /// # Returns
     /// Vector of StoredValue references, newest first
     pub fn history(&self, limit: Option<usize>, before_version: Option<u64>) -> Vec<&StoredValue> {
-        // Debug assertion: all versions should be Txn variants
-        debug_assert!(
-            self.versions.iter().all(|sv| sv.version().is_txn()),
-            "Storage layer should only contain Txn versions"
-        );
+        match &self.versions {
+            VersionStorage::Single(sv) => {
+                debug_assert!(
+                    sv.version().is_txn(),
+                    "Storage layer should only contain Txn versions"
+                );
+                if limit == Some(0) {
+                    return vec![];
+                }
+                let passes_filter = match before_version {
+                    Some(before) => sv.version().as_u64() < before,
+                    None => true,
+                };
+                if passes_filter {
+                    vec![sv]
+                } else {
+                    vec![]
+                }
+            }
+            VersionStorage::Multi(deque) => {
+                debug_assert!(
+                    deque.iter().all(|sv| sv.version().is_txn()),
+                    "Storage layer should only contain Txn versions"
+                );
 
-        let iter = self.versions.iter();
+                let iter = deque.iter();
+                let filtered: Vec<&StoredValue> = match before_version {
+                    Some(before) => iter.filter(|sv| sv.version().as_u64() < before).collect(),
+                    None => iter.collect(),
+                };
 
-        // Filter by before_version if specified (only versions < before)
-        let filtered: Vec<&StoredValue> = match before_version {
-            Some(before) => iter.filter(|sv| sv.version().as_u64() < before).collect(),
-            None => iter.collect(),
-        };
-
-        // Apply limit if specified
-        match limit {
-            Some(n) => filtered.into_iter().take(n).collect(),
-            None => filtered,
+                match limit {
+                    Some(n) => filtered.into_iter().take(n).collect(),
+                    None => filtered,
+                }
+            }
         }
     }
 
     /// Check if the version chain is empty
     pub fn is_empty(&self) -> bool {
-        self.versions.is_empty()
+        match &self.versions {
+            VersionStorage::Single(_) => false, // Single always has one value
+            VersionStorage::Multi(deque) => deque.is_empty(),
+        }
     }
 }
 
@@ -182,13 +264,18 @@ impl VersionChain {
 /// This ensures different branches never contend with each other.
 ///
 /// Uses VersionChain for MVCC - multiple versions per key for snapshot isolation.
+///
+/// # Memory Optimization
+///
+/// Both `data` and `ordered_keys` store `Arc<Key>` so the BTreeSet shares
+/// Key allocations with the HashMap instead of deep-cloning every Key.
 #[derive(Debug)]
 pub struct Shard {
     /// HashMap with FxHash for O(1) lookups, storing version chains
-    pub(crate) data: FxHashMap<Key, VersionChain>,
+    pub(crate) data: FxHashMap<Arc<Key>, VersionChain>,
     /// Sorted index of all keys for O(log n + k) prefix scans.
     /// Built lazily on first scan request, then maintained incrementally.
-    pub(crate) ordered_keys: Option<BTreeSet<Key>>,
+    pub(crate) ordered_keys: Option<BTreeSet<Arc<Key>>>,
 }
 
 impl Shard {
@@ -355,11 +442,12 @@ impl ShardedStore {
             // Add new version to existing chain
             chain.push(value);
         } else {
-            // Create new chain — incrementally update ordered index
+            // Create new chain — share Arc<Key> between HashMap and BTreeSet
+            let arc_key = Arc::new(key);
             if let Some(ref mut btree) = shard.ordered_keys {
-                btree.insert(key.clone());
+                btree.insert(Arc::clone(&arc_key));
             }
-            shard.data.insert(key, VersionChain::new(value));
+            shard.data.insert(arc_key, VersionChain::new(value));
         }
     }
 
@@ -522,10 +610,11 @@ impl ShardedStore {
                 if let Some(chain) = shard.data.get_mut(&key) {
                     chain.push(stored);
                 } else {
+                    let arc_key = Arc::new(key);
                     if let Some(ref mut btree) = shard.ordered_keys {
-                        btree.insert(key.clone());
+                        btree.insert(Arc::clone(&arc_key));
                     }
-                    shard.data.insert(key, VersionChain::new(stored));
+                    shard.data.insert(arc_key, VersionChain::new(stored));
                 }
             }
 
@@ -534,10 +623,11 @@ impl ShardedStore {
                 if let Some(chain) = shard.data.get_mut(&key) {
                     chain.push(tombstone);
                 } else {
+                    let arc_key = Arc::new(key);
                     if let Some(ref mut btree) = shard.ordered_keys {
-                        btree.insert(key.clone());
+                        btree.insert(Arc::clone(&arc_key));
                     }
-                    shard.data.insert(key, VersionChain::new(tombstone));
+                    shard.data.insert(arc_key, VersionChain::new(tombstone));
                 }
             }
         }
@@ -600,7 +690,7 @@ impl ShardedStore {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_timestamp(max_timestamp).and_then(|sv| {
                                 if !sv.is_expired() && !sv.is_tombstone() {
-                                    Some((k.clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned().clone()))
                                 } else {
                                     None
                                 }
@@ -687,7 +777,7 @@ impl ShardedStore {
                         shard.data.get(k).and_then(|chain| {
                             chain.latest().and_then(|sv| {
                                 if !sv.is_tombstone() {
-                                    Some((k.clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned().clone()))
                                 } else {
                                     None
                                 }
@@ -731,7 +821,7 @@ impl ShardedStore {
                         shard.data.get(k).and_then(|chain| {
                             chain.latest().and_then(|sv| {
                                 if !sv.is_tombstone() {
-                                    Some((k.clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned().clone()))
                                 } else {
                                     None
                                 }
@@ -774,7 +864,7 @@ impl ShardedStore {
                         shard.data.get(k).and_then(|chain| {
                             chain.latest().and_then(|sv| {
                                 if !sv.is_tombstone() {
-                                    Some((k.clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned().clone()))
                                 } else {
                                     None
                                 }
@@ -988,7 +1078,7 @@ impl ShardedSnapshot {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_version(self.version).and_then(|sv| {
                                 if !sv.is_expired() && !sv.is_tombstone() {
-                                    Some((k.clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned().clone()))
                                 } else {
                                     None
                                 }
@@ -1022,7 +1112,7 @@ impl ShardedSnapshot {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_version(self.version).and_then(|sv| {
                                 if !sv.is_expired() && !sv.is_tombstone() {
-                                    Some((k.clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned().clone()))
                                 } else {
                                     None
                                 }
@@ -1059,7 +1149,7 @@ impl ShardedSnapshot {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_version(self.version).and_then(|sv| {
                                 if !sv.is_expired() && !sv.is_tombstone() {
-                                    Some((k.clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned().clone()))
                                 } else {
                                     None
                                 }
@@ -1253,7 +1343,7 @@ impl Storage for ShardedStore {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_version(max_version).and_then(|sv| {
                                 if !sv.is_expired() && !sv.is_tombstone() {
-                                    Some((k.clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned().clone()))
                                 } else {
                                     None
                                 }
@@ -1284,7 +1374,7 @@ impl Storage for ShardedStore {
                         chain.get_at_version(max_version).and_then(|sv| {
                             // Filter out expired values and tombstones
                             if !sv.is_expired() && !sv.is_tombstone() {
-                                Some((k.clone(), sv.versioned().clone()))
+                                Some(((**k).clone(), sv.versioned().clone()))
                             } else {
                                 None
                             }
@@ -1375,7 +1465,7 @@ impl SnapshotView for ShardedSnapshot {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_version(self.version).and_then(|sv| {
                                 if !sv.is_expired() && !sv.is_tombstone() {
-                                    Some((k.clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned().clone()))
                                 } else {
                                     None
                                 }
@@ -1397,6 +1487,293 @@ impl SnapshotView for ShardedSnapshot {
 mod tests {
     use super::*;
     use std::sync::Arc;
+
+    // ========================================================================
+    // VersionChain / VersionStorage Tests
+    // ========================================================================
+
+    fn make_sv(version: u64) -> StoredValue {
+        StoredValue::new(
+            strata_core::value::Value::Int(version as i64),
+            Version::txn(version),
+            None,
+        )
+    }
+
+    fn make_sv_with_ts(version: u64, timestamp_micros: u64) -> StoredValue {
+        StoredValue::with_timestamp(
+            strata_core::value::Value::Int(version as i64),
+            Version::txn(version),
+            Timestamp::from_micros(timestamp_micros),
+            None,
+        )
+    }
+
+    #[test]
+    fn test_version_chain_single_latest() {
+        let chain = VersionChain::new(make_sv(1));
+        assert_eq!(chain.version_count(), 1);
+        assert!(!chain.is_empty());
+        let latest = chain.latest().unwrap();
+        assert_eq!(latest.version(), Version::txn(1));
+    }
+
+    #[test]
+    fn test_version_chain_single_to_multi_promotion() {
+        let mut chain = VersionChain::new(make_sv(1));
+        assert_eq!(chain.version_count(), 1);
+
+        // Push promotes Single → Multi
+        chain.push(make_sv(2));
+        assert_eq!(chain.version_count(), 2);
+
+        // Latest is the newest
+        assert_eq!(chain.latest().unwrap().version(), Version::txn(2));
+
+        // Push a third — stays Multi
+        chain.push(make_sv(3));
+        assert_eq!(chain.version_count(), 3);
+        assert_eq!(chain.latest().unwrap().version(), Version::txn(3));
+    }
+
+    #[test]
+    fn test_version_chain_get_at_version_single_boundary() {
+        let chain = VersionChain::new(make_sv(5));
+
+        // Version <= 5 finds it
+        assert!(chain.get_at_version(5).is_some());
+        assert!(chain.get_at_version(10).is_some());
+
+        // Version < 5 misses
+        assert!(chain.get_at_version(4).is_none());
+        assert!(chain.get_at_version(0).is_none());
+    }
+
+    #[test]
+    fn test_version_chain_get_at_version_multi_scan() {
+        let mut chain = VersionChain::new(make_sv(1));
+        chain.push(make_sv(5));
+        chain.push(make_sv(10));
+        // Stored newest-first: [10, 5, 1]
+
+        // At version 10 → gets version 10
+        assert_eq!(
+            chain.get_at_version(10).unwrap().version(),
+            Version::txn(10)
+        );
+        // At version 7 → gets version 5 (first <= 7)
+        assert_eq!(chain.get_at_version(7).unwrap().version(), Version::txn(5));
+        // At version 3 → gets version 1
+        assert_eq!(chain.get_at_version(3).unwrap().version(), Version::txn(1));
+        // At version 0 → nothing
+        assert!(chain.get_at_version(0).is_none());
+    }
+
+    #[test]
+    fn test_version_chain_get_at_timestamp_single() {
+        let chain = VersionChain::new(make_sv_with_ts(1, 1000));
+
+        // Timestamp >= 1000 finds it
+        assert!(chain.get_at_timestamp(1000).is_some());
+        assert!(chain.get_at_timestamp(2000).is_some());
+
+        // Timestamp < 1000 misses
+        assert!(chain.get_at_timestamp(999).is_none());
+    }
+
+    #[test]
+    fn test_version_chain_get_at_timestamp_multi() {
+        let mut chain = VersionChain::new(make_sv_with_ts(1, 100));
+        chain.push(make_sv_with_ts(2, 500));
+        chain.push(make_sv_with_ts(3, 1000));
+        // Stored newest-first: [ts=1000, ts=500, ts=100]
+
+        // At ts=1000 → newest
+        assert_eq!(
+            chain.get_at_timestamp(1000).unwrap().version(),
+            Version::txn(3)
+        );
+        // At ts=700 → middle
+        assert_eq!(
+            chain.get_at_timestamp(700).unwrap().version(),
+            Version::txn(2)
+        );
+        // At ts=200 → oldest
+        assert_eq!(
+            chain.get_at_timestamp(200).unwrap().version(),
+            Version::txn(1)
+        );
+        // At ts=50 → nothing
+        assert!(chain.get_at_timestamp(50).is_none());
+    }
+
+    #[test]
+    fn test_version_chain_gc_single_is_noop() {
+        let mut chain = VersionChain::new(make_sv(1));
+
+        // GC on Single should always return 0 — we never prune the last version
+        let pruned = chain.gc(100);
+        assert_eq!(pruned, 0);
+        assert_eq!(chain.version_count(), 1);
+        assert_eq!(chain.latest().unwrap().version(), Version::txn(1));
+    }
+
+    #[test]
+    fn test_version_chain_gc_multi_prunes_old() {
+        let mut chain = VersionChain::new(make_sv(1));
+        chain.push(make_sv(5));
+        chain.push(make_sv(10));
+        chain.push(make_sv(15));
+        // Stored newest-first: [15, 10, 5, 1]
+
+        // GC with min_version=6 → prunes versions < 6 (i.e., versions 1 and 5)
+        let pruned = chain.gc(6);
+        assert_eq!(pruned, 2);
+        assert_eq!(chain.version_count(), 2);
+
+        // Remaining: [15, 10]
+        assert_eq!(chain.latest().unwrap().version(), Version::txn(15));
+        assert!(chain.get_at_version(10).is_some());
+        assert!(chain.get_at_version(5).is_none()); // pruned
+    }
+
+    #[test]
+    fn test_version_chain_gc_multi_keeps_at_least_one() {
+        let mut chain = VersionChain::new(make_sv(1));
+        chain.push(make_sv(5));
+        // Stored: [5, 1]
+
+        // GC with min_version=100 → would prune both, but keeps at least one
+        let pruned = chain.gc(100);
+        assert_eq!(pruned, 1); // Only pruned version 1, kept version 5
+        assert_eq!(chain.version_count(), 1);
+        assert_eq!(chain.latest().unwrap().version(), Version::txn(5));
+    }
+
+    #[test]
+    fn test_version_chain_gc_multi_prunes_nothing_if_all_recent() {
+        let mut chain = VersionChain::new(make_sv(10));
+        chain.push(make_sv(20));
+        // Stored: [20, 10]
+
+        // GC with min_version=5 → nothing to prune (both >= 5)
+        let pruned = chain.gc(5);
+        assert_eq!(pruned, 0);
+        assert_eq!(chain.version_count(), 2);
+    }
+
+    #[test]
+    fn test_version_chain_history_limit_zero() {
+        let chain = VersionChain::new(make_sv(1));
+        // limit=0 should return empty even for Single
+        assert!(chain.history(Some(0), None).is_empty());
+
+        let mut multi_chain = VersionChain::new(make_sv(1));
+        multi_chain.push(make_sv(2));
+        // limit=0 on Multi too
+        assert!(multi_chain.history(Some(0), None).is_empty());
+    }
+
+    #[test]
+    fn test_version_chain_history_with_before_version() {
+        let mut chain = VersionChain::new(make_sv(1));
+        chain.push(make_sv(5));
+        chain.push(make_sv(10));
+        // Stored newest-first: [10, 5, 1]
+
+        // before_version=10 → only versions < 10 → [5, 1]
+        let h = chain.history(None, Some(10));
+        assert_eq!(h.len(), 2);
+        assert_eq!(h[0].version(), Version::txn(5));
+        assert_eq!(h[1].version(), Version::txn(1));
+
+        // before_version=6, limit=1 → [5]
+        let h = chain.history(Some(1), Some(6));
+        assert_eq!(h.len(), 1);
+        assert_eq!(h[0].version(), Version::txn(5));
+    }
+
+    #[test]
+    fn test_version_chain_history_single_before_version_filters() {
+        let chain = VersionChain::new(make_sv(5));
+
+        // before_version=10 → 5 < 10 → returns it
+        assert_eq!(chain.history(None, Some(10)).len(), 1);
+
+        // before_version=5 → 5 < 5 is false → empty
+        assert!(chain.history(None, Some(5)).is_empty());
+
+        // before_version=3 → 5 < 3 is false → empty
+        assert!(chain.history(None, Some(3)).is_empty());
+    }
+
+    // ========================================================================
+    // Arc<Key> Sharing Tests (Phase 3)
+    // ========================================================================
+
+    #[test]
+    fn test_arc_key_hash_consistency() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let branch_id = BranchId::new();
+        let key1 = create_test_key(branch_id, "same_key");
+        let key2 = create_test_key(branch_id, "same_key");
+
+        // Two Arc<Key>s wrapping equal Keys must produce identical hashes
+        let arc1 = Arc::new(key1);
+        let arc2 = Arc::new(key2);
+
+        let mut h1 = DefaultHasher::new();
+        let mut h2 = DefaultHasher::new();
+        arc1.hash(&mut h1);
+        arc2.hash(&mut h2);
+
+        assert_eq!(h1.finish(), h2.finish());
+        assert_eq!(arc1, arc2); // PartialEq through Deref
+    }
+
+    #[test]
+    fn test_arc_key_shared_between_hashmap_and_btreeset() {
+        use strata_core::value::Value;
+
+        let store = ShardedStore::new();
+        let branch_id = BranchId::new();
+
+        // Insert several keys
+        for i in 0..5 {
+            let key = create_test_key(branch_id, &format!("shared_{}", i));
+            store.put(key, create_stored_value(Value::Int(i), 1));
+        }
+
+        // Force BTreeSet creation by doing a list operation
+        let results = store.list_branch(&branch_id);
+        assert_eq!(results.len(), 5);
+
+        // Access the shard and verify Arc sharing
+        let shard_ref = store.shards.get(&branch_id).unwrap();
+        let shard = shard_ref.value();
+        let btree = shard
+            .ordered_keys
+            .as_ref()
+            .expect("BTreeSet should exist after list_branch");
+        // Every key in the BTreeSet should be the same Arc as in the HashMap
+        for arc_key in btree.iter() {
+            // Verify it exists in the HashMap
+            assert!(shard.data.contains_key(arc_key.as_ref()));
+            // The Arc in the BTreeSet should point to the same allocation
+            // as the one used as HashMap key (Arc::ptr_eq)
+            let hashmap_arc = shard.data.keys().find(|k| *k == arc_key).unwrap();
+            assert!(
+                Arc::ptr_eq(arc_key, hashmap_arc),
+                "BTreeSet and HashMap should share the same Arc<Key> allocation"
+            );
+        }
+    }
+
+    // ========================================================================
+    // ShardedStore Tests
+    // ========================================================================
 
     #[test]
     fn test_sharded_store_creation() {
@@ -1476,13 +1853,13 @@ mod tests {
 
     fn create_test_key(branch_id: BranchId, name: &str) -> Key {
         use strata_core::types::Namespace;
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
         Key::new_kv(ns, name)
     }
 
@@ -1713,13 +2090,13 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         // Insert keys with different prefixes
         store.put(
@@ -1752,13 +2129,13 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         store.put(
             Key::new_kv(ns.clone(), "data:foo"),
@@ -1779,13 +2156,13 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         // Insert KV entries
         store.put(
@@ -1827,13 +2204,13 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         // Insert mixed types
         for i in 0..5 {
@@ -1923,13 +2300,13 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
 
         // Insert in random order
         let keys = vec!["zebra", "apple", "mango", "banana"];
@@ -2179,7 +2556,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
         let key = Key::new_kv(ns, "test_key");
 
         // Put via Storage trait
@@ -2200,7 +2577,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
         let key = Key::new_kv(ns, "test_key");
 
         // Put with version 1
@@ -2223,7 +2600,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
         let key = Key::new_kv(ns, "test_key");
 
         Storage::put(&store, key.clone(), Value::Int(42), None).unwrap();
@@ -2243,7 +2620,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
 
         // Insert keys with different prefixes
         Storage::put(
@@ -2286,8 +2663,8 @@ mod tests {
         let branch2 = BranchId::new();
 
         // Insert data for two branches
-        let ns1 = Namespace::for_branch(branch1);
-        let ns2 = Namespace::for_branch(branch2);
+        let ns1 = Arc::new(Namespace::for_branch(branch1));
+        let ns2 = Arc::new(Namespace::for_branch(branch2));
 
         Storage::put(
             &store,
@@ -2328,7 +2705,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
         let key = Key::new_kv(ns, "test_key");
 
         // Put with specific version 42
@@ -2350,7 +2727,7 @@ mod tests {
 
         let store = Arc::new(ShardedStore::new());
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
 
         // Put at version 1
         let key1 = Key::new_kv(ns.clone(), "key1");
@@ -2387,7 +2764,7 @@ mod tests {
 
         let store = Arc::new(ShardedStore::new());
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
 
         // Put two keys at version 1
         Storage::put(
@@ -2653,7 +3030,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
         let key = Key::new_kv(ns.clone(), "test-key");
 
         // Put multiple versions of the same key
@@ -2677,7 +3054,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
         let key = Key::new_kv(ns.clone(), "paginated-key");
 
         // Put 5 versions
@@ -2710,7 +3087,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
         let key = Key::new_kv(ns.clone(), "nonexistent");
 
         let history = Storage::get_history(&store, &key, None, None).unwrap();
@@ -3212,7 +3589,7 @@ mod tests {
         let branch_id = BranchId::new();
 
         // Create a mix of expired and non-expired values
-        let ns = strata_core::types::Namespace::for_branch(branch_id);
+        let ns = Arc::new(strata_core::types::Namespace::for_branch(branch_id));
 
         // Non-expired key
         let key1 = Key::new_kv(ns.clone(), "fresh");
@@ -3304,7 +3681,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
 
         // Insert keys in reverse order
         let names = vec![
@@ -3341,7 +3718,7 @@ mod tests {
 
         let store = Arc::new(ShardedStore::new());
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
 
         // Insert 3 keys at version 1, 2, 3
         Storage::put(
@@ -3404,7 +3781,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = Namespace::for_branch(branch_id);
+        let ns = Arc::new(Namespace::for_branch(branch_id));
 
         // Insert 5000 keys with prefix "alpha:" and 5000 with prefix "beta:"
         for i in 0..5000 {
@@ -3541,7 +3918,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = strata_core::types::Namespace::for_branch(branch_id);
+        let ns = Arc::new(strata_core::types::Namespace::for_branch(branch_id));
 
         // Insert keys — ordered_keys starts as None (never built yet)
         Storage::put(&store, Key::new_kv(ns.clone(), "c"), Value::Int(3), None).unwrap();
@@ -3608,7 +3985,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = strata_core::types::Namespace::for_branch(branch_id);
+        let ns = Arc::new(strata_core::types::Namespace::for_branch(branch_id));
 
         // Insert initial key
         Storage::put(&store, Key::new_kv(ns.clone(), "k"), Value::Int(1), None).unwrap();
@@ -3644,7 +4021,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = strata_core::types::Namespace::for_branch(branch_id);
+        let ns = Arc::new(strata_core::types::Namespace::for_branch(branch_id));
 
         // Seed with initial keys
         for i in 0..10 {
@@ -3715,7 +4092,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = strata_core::types::Namespace::for_branch(branch_id);
+        let ns = Arc::new(strata_core::types::Namespace::for_branch(branch_id));
 
         // Insert initial keys and build ordered_keys via scan
         Storage::put(&store, Key::new_kv(ns.clone(), "b"), Value::Int(1), None).unwrap();
@@ -3764,7 +4141,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = strata_core::types::Namespace::for_branch(branch_id);
+        let ns = Arc::new(strata_core::types::Namespace::for_branch(branch_id));
 
         // Insert initial keys and build ordered_keys via scan
         Storage::put(&store, Key::new_kv(ns.clone(), "a"), Value::Int(1), None).unwrap();
@@ -3815,7 +4192,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = strata_core::types::Namespace::for_branch(branch_id);
+        let ns = Arc::new(strata_core::types::Namespace::for_branch(branch_id));
 
         // Insert initial key and build ordered_keys via scan
         Storage::put(&store, Key::new_kv(ns.clone(), "a"), Value::Int(1), None).unwrap();
@@ -3855,7 +4232,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = strata_core::types::Namespace::for_branch(branch_id);
+        let ns = Arc::new(strata_core::types::Namespace::for_branch(branch_id));
 
         // Insert initial key and build ordered_keys via scan
         Storage::put(&store, Key::new_kv(ns.clone(), "a"), Value::Int(1), None).unwrap();
@@ -3895,7 +4272,7 @@ mod tests {
 
         let store = ShardedStore::new();
         let branch_id = BranchId::new();
-        let ns = strata_core::types::Namespace::for_branch(branch_id);
+        let ns = Arc::new(strata_core::types::Namespace::for_branch(branch_id));
 
         // Insert initial keys and build ordered_keys
         Storage::put(&store, Key::new_kv(ns.clone(), "a"), Value::Int(1), None).unwrap();

--- a/crates/storage/src/ttl.rs
+++ b/crates/storage/src/ttl.rs
@@ -99,18 +99,19 @@ impl TTLIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use strata_core::{BranchId, Namespace};
 
     /// Helper to create a test key
     fn test_key(suffix: &str) -> Key {
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let ns = Arc::new(Namespace::new(
             "tenant".to_string(),
             "app".to_string(),
             "agent".to_string(),
             branch_id,
             "default".to_string(),
-        );
+        ));
         Key::new_kv(ns, suffix)
     }
 

--- a/tests/concurrency/cas_operations.rs
+++ b/tests/concurrency/cas_operations.rs
@@ -16,7 +16,7 @@ use strata_core::BranchId;
 use strata_storage::sharded::ShardedStore;
 
 fn create_test_key(branch_id: BranchId, name: &str) -> Key {
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
     Key::new_kv(ns, name)
 }
 

--- a/tests/concurrency/concurrent_transactions.rs
+++ b/tests/concurrency/concurrent_transactions.rs
@@ -18,7 +18,7 @@ use strata_core::BranchId;
 use strata_storage::sharded::ShardedStore;
 
 fn create_test_key(branch_id: BranchId, name: &str) -> Key {
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
     Key::new_kv(ns, name)
 }
 

--- a/tests/concurrency/conflict_detection.rs
+++ b/tests/concurrency/conflict_detection.rs
@@ -19,7 +19,7 @@ use strata_core::BranchId;
 use strata_storage::sharded::ShardedStore;
 
 fn create_test_key(branch_id: BranchId, name: &str) -> Key {
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
     Key::new_kv(ns, name)
 }
 

--- a/tests/concurrency/occ_invariants.rs
+++ b/tests/concurrency/occ_invariants.rs
@@ -16,7 +16,7 @@ use strata_core::BranchId;
 use strata_storage::sharded::ShardedStore;
 
 fn create_test_key(branch_id: BranchId, name: &str) -> Key {
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
     Key::new_kv(ns, name)
 }
 

--- a/tests/concurrency/snapshot_isolation.rs
+++ b/tests/concurrency/snapshot_isolation.rs
@@ -15,7 +15,7 @@ use strata_core::value::Value;
 use strata_core::{BranchId, Versioned};
 
 fn create_test_key(branch_id: BranchId, name: &str) -> Key {
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
     Key::new_kv(ns, name)
 }
 
@@ -172,7 +172,7 @@ fn write_then_delete_sees_delete() {
 #[test]
 fn snapshot_scan_prefix_returns_matching_keys() {
     let branch_id = BranchId::new();
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
 
     let mut data = BTreeMap::new();
     for i in 0..10 {
@@ -201,7 +201,7 @@ fn snapshot_scan_prefix_returns_matching_keys() {
 #[test]
 fn snapshot_scan_empty_prefix() {
     let branch_id = BranchId::new();
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
 
     let snapshot = ClonedSnapshotView::new(1, BTreeMap::new());
 
@@ -333,7 +333,7 @@ fn empty_snapshot_get_returns_none() {
 #[test]
 fn empty_snapshot_scan_returns_empty() {
     let branch_id = BranchId::new();
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
     let prefix = Key::new_kv(ns, "any");
 
     let snapshot = ClonedSnapshotView::empty(0);

--- a/tests/concurrency/stress.rs
+++ b/tests/concurrency/stress.rs
@@ -17,7 +17,7 @@ use strata_core::BranchId;
 use strata_storage::sharded::ShardedStore;
 
 fn create_test_key(branch_id: BranchId, name: &str) -> Key {
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
     Key::new_kv(ns, name)
 }
 

--- a/tests/concurrency/transaction_lifecycle.rs
+++ b/tests/concurrency/transaction_lifecycle.rs
@@ -15,7 +15,7 @@ use strata_core::BranchId;
 use strata_storage::sharded::ShardedStore;
 
 fn create_test_key(branch_id: BranchId, name: &str) -> Key {
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
     Key::new_kv(ns, name)
 }
 

--- a/tests/concurrency/transaction_states.rs
+++ b/tests/concurrency/transaction_states.rs
@@ -232,13 +232,14 @@ fn empty_transaction_is_read_only() {
 
 #[test]
 fn transaction_with_write_is_not_read_only() {
+    use std::sync::Arc;
     use strata_core::types::{Key, Namespace};
     use strata_core::value::Value;
 
     let branch_id = BranchId::new();
     let mut txn = TransactionContext::new(1, branch_id, 100);
 
-    let key = Key::new_kv(Namespace::for_branch(branch_id), "test");
+    let key = Key::new_kv(Arc::new(Namespace::for_branch(branch_id)), "test");
     txn.write_set.insert(key, Value::Int(42));
 
     assert!(!txn.is_read_only());
@@ -246,12 +247,13 @@ fn transaction_with_write_is_not_read_only() {
 
 #[test]
 fn transaction_with_delete_is_not_read_only() {
+    use std::sync::Arc;
     use strata_core::types::{Key, Namespace};
 
     let branch_id = BranchId::new();
     let mut txn = TransactionContext::new(1, branch_id, 100);
 
-    let key = Key::new_kv(Namespace::for_branch(branch_id), "test");
+    let key = Key::new_kv(Arc::new(Namespace::for_branch(branch_id)), "test");
     txn.delete_set.insert(key);
 
     assert!(!txn.is_read_only());
@@ -259,6 +261,7 @@ fn transaction_with_delete_is_not_read_only() {
 
 #[test]
 fn transaction_with_cas_is_not_read_only() {
+    use std::sync::Arc;
     use strata_concurrency::transaction::CASOperation;
     use strata_core::types::{Key, Namespace};
     use strata_core::value::Value;
@@ -266,7 +269,7 @@ fn transaction_with_cas_is_not_read_only() {
     let branch_id = BranchId::new();
     let mut txn = TransactionContext::new(1, branch_id, 100);
 
-    let key = Key::new_kv(Namespace::for_branch(branch_id), "test");
+    let key = Key::new_kv(Arc::new(Namespace::for_branch(branch_id)), "test");
     txn.cas_set.push(CASOperation {
         key,
         expected_version: 1,
@@ -278,12 +281,13 @@ fn transaction_with_cas_is_not_read_only() {
 
 #[test]
 fn transaction_with_only_reads_is_read_only() {
+    use std::sync::Arc;
     use strata_core::types::{Key, Namespace};
 
     let branch_id = BranchId::new();
     let mut txn = TransactionContext::new(1, branch_id, 100);
 
-    let key = Key::new_kv(Namespace::for_branch(branch_id), "test");
+    let key = Key::new_kv(Arc::new(Namespace::for_branch(branch_id)), "test");
     txn.read_set.insert(key, 1);
 
     assert!(txn.is_read_only());
@@ -295,13 +299,14 @@ fn transaction_with_only_reads_is_read_only() {
 
 #[test]
 fn pending_operations_count() {
+    use std::sync::Arc;
     use strata_core::types::{Key, Namespace};
     use strata_core::value::Value;
 
     let branch_id = BranchId::new();
     let mut txn = TransactionContext::new(1, branch_id, 100);
 
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
 
     // Add some operations
     txn.write_set
@@ -318,12 +323,13 @@ fn pending_operations_count() {
 
 #[test]
 fn read_count_tracks_reads() {
+    use std::sync::Arc;
     use strata_core::types::{Key, Namespace};
 
     let branch_id = BranchId::new();
     let mut txn = TransactionContext::new(1, branch_id, 100);
 
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
 
     txn.read_set.insert(Key::new_kv(ns.clone(), "r1"), 1);
     txn.read_set.insert(Key::new_kv(ns.clone(), "r2"), 2);
@@ -334,13 +340,14 @@ fn read_count_tracks_reads() {
 
 #[test]
 fn write_count_tracks_only_writes() {
+    use std::sync::Arc;
     use strata_core::types::{Key, Namespace};
     use strata_core::value::Value;
 
     let branch_id = BranchId::new();
     let mut txn = TransactionContext::new(1, branch_id, 100);
 
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
 
     txn.write_set
         .insert(Key::new_kv(ns.clone(), "w1"), Value::Int(1));

--- a/tests/engine/database/transactions.rs
+++ b/tests/engine/database/transactions.rs
@@ -216,8 +216,9 @@ fn commit_transaction_returns_version() {
     let mut ctx = test_db.db.begin_transaction(branch_id);
 
     // Add a write to the transaction
+    use std::sync::Arc;
     use strata_core::types::{Key, Namespace};
-    let key = Key::new_kv(Namespace::for_branch(branch_id), "manual_tx_key");
+    let key = Key::new_kv(Arc::new(Namespace::for_branch(branch_id)), "manual_tx_key");
     ctx.write_set.insert(key, Value::Int(42));
 
     // Commit

--- a/tests/storage/branch_isolation.rs
+++ b/tests/storage/branch_isolation.rs
@@ -11,7 +11,7 @@ use strata_core::BranchId;
 use strata_storage::sharded::ShardedStore;
 
 fn create_test_key(branch_id: BranchId, name: &str) -> Key {
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
     Key::new_kv(ns, name)
 }
 
@@ -225,7 +225,7 @@ fn branch_entry_count() {
 fn list_branch_keys() {
     let store = ShardedStore::new();
     let branch_id = BranchId::new();
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
 
     // Put 5 keys
     for i in 0..5 {

--- a/tests/storage/mvcc_invariants.rs
+++ b/tests/storage/mvcc_invariants.rs
@@ -16,7 +16,7 @@ use strata_core::BranchId;
 use strata_storage::sharded::ShardedStore;
 
 fn create_test_key(branch_id: BranchId, name: &str) -> Key {
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
     Key::new_kv(ns, name)
 }
 

--- a/tests/storage/snapshot_isolation.rs
+++ b/tests/storage/snapshot_isolation.rs
@@ -16,7 +16,7 @@ use strata_core::BranchId;
 use strata_storage::sharded::ShardedStore;
 
 fn create_test_key(branch_id: BranchId, name: &str) -> Key {
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
     Key::new_kv(ns, name)
 }
 
@@ -326,7 +326,7 @@ fn snapshot_cache_provides_isolation() {
 fn snapshot_scan_sees_consistent_state() {
     let store = Arc::new(ShardedStore::new());
     let branch_id = BranchId::new();
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
 
     // Put values with common prefix
     for i in 0..10 {
@@ -358,7 +358,7 @@ fn snapshot_scan_sees_consistent_state() {
 fn snapshot_list_sees_all_keys() {
     let store = Arc::new(ShardedStore::new());
     let branch_id = BranchId::new();
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
 
     // Put 5 values
     for i in 0..5 {

--- a/tests/storage/stress.rs
+++ b/tests/storage/stress.rs
@@ -14,7 +14,7 @@ use strata_core::BranchId;
 use strata_storage::sharded::ShardedStore;
 
 fn create_test_key(branch_id: BranchId, name: &str) -> Key {
-    let ns = Namespace::for_branch(branch_id);
+    let ns = Arc::new(Namespace::for_branch(branch_id));
     Key::new_kv(ns, name)
 }
 


### PR DESCRIPTION
## Summary

- **Phase 1 — VersionChain compaction** (`sharded.rs`): Replace `VecDeque<StoredValue>` with `VersionStorage` enum that inlines the common single-version case, eliminating ~270 bytes of heap allocation per entry (~8-12GB savings)
- **Phase 2 — Namespace interning** (`types.rs` + 52 call sites): Change `Key.namespace` from `Namespace` to `Arc<Namespace>` so all keys sharing the same namespace share one heap allocation instead of 128M duplicates (~20-25GB savings)
- **Phase 3 — Shared `Arc<Key>`** (`sharded.rs`): `FxHashMap<Arc<Key>, VersionChain>` and `BTreeSet<Arc<Key>>` share Key allocations via `Arc::clone` instead of deep-cloning (~7-10GB savings)

**Combined savings: ~35-47GB**, bringing graph500-22 from ~53GB to ~8-18GB — well within 61GB RAM and comparable to Neo4j (~10GB).

Closes #1287

## Verification

| Capability | Tests | Passed | Failed |
|---|---|---|---|
| ACID Transactions | 221 | 221 | 0 |
| Branching | 226 | 226 | 0 |
| Versioning (MVCC) | 244 | 244 | 0 |
| Snapshot Isolation | 210 | 210 | 0 |
| Durability / WAL | 430 | 430 | 0 |
| Hybrid Search | 77 | 77 | 0 |
| Graph | 331 | 331 | 0 |
| Vectors / ANN | 389 | 389 | 0 |
| **Full Workspace** | **2993** | **2993** | **0** |

## Test plan

- [x] `cargo test --workspace` — 2993 tests pass, 0 regressions
- [x] `cargo clippy --workspace` — 0 warnings
- [x] `cargo fmt --all` — clean
- [ ] CI passes on this PR
- [ ] Benchmark graph500-22 load to confirm memory reduction (in strata-benchmarks repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)