### PR TITLE
Add graph analytics algorithms: WCC, CDLP, PageRank, LCC, SSSP

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1131,6 +1131,63 @@ fn build_graph() -> Command {
                         .help("Object type name"),
                 ),
         )
+        // Analytics
+        .subcommand(
+            Command::new("wcc")
+                .about("Weakly Connected Components")
+                .arg(Arg::new("graph").required(true).help("Graph name")),
+        )
+        .subcommand(
+            Command::new("cdlp")
+                .about("Community Detection via Label Propagation")
+                .arg(Arg::new("graph").required(true).help("Graph name"))
+                .arg(
+                    Arg::new("max-iterations")
+                        .required(true)
+                        .help("Maximum iterations"),
+                )
+                .arg(
+                    Arg::new("direction")
+                        .long("direction")
+                        .help("Direction: outgoing, incoming, both"),
+                ),
+        )
+        .subcommand(
+            Command::new("pagerank")
+                .about("PageRank importance scoring")
+                .arg(Arg::new("graph").required(true).help("Graph name"))
+                .arg(
+                    Arg::new("damping")
+                        .long("damping")
+                        .help("Damping factor (default 0.85)"),
+                )
+                .arg(
+                    Arg::new("max-iterations")
+                        .long("max-iterations")
+                        .help("Maximum iterations (default 20)"),
+                )
+                .arg(
+                    Arg::new("tolerance")
+                        .long("tolerance")
+                        .help("Convergence tolerance (default 1e-6)"),
+                ),
+        )
+        .subcommand(
+            Command::new("lcc")
+                .about("Local Clustering Coefficient")
+                .arg(Arg::new("graph").required(true).help("Graph name")),
+        )
+        .subcommand(
+            Command::new("sssp")
+                .about("Single-Source Shortest Path (Dijkstra)")
+                .arg(Arg::new("graph").required(true).help("Graph name"))
+                .arg(Arg::new("source").required(true).help("Source node ID"))
+                .arg(
+                    Arg::new("direction")
+                        .long("direction")
+                        .help("Direction: outgoing, incoming, both"),
+                ),
+        )
 }
 
 // =========================================================================

--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -383,6 +383,8 @@ fn format_raw(output: &Output) -> String {
         }
         Output::ConfigValue(None) => String::new(),
         Output::ConfigValue(Some(v)) => v.clone(),
+        Output::GraphAnalyticsU64(result) => serde_json::to_string(&result).unwrap_or_default(),
+        Output::GraphAnalyticsF64(result) => serde_json::to_string(&result).unwrap_or_default(),
     }
 }
 
@@ -824,6 +826,22 @@ fn format_human(output: &Output) -> String {
         }
         Output::ConfigValue(None) => "(nil)".to_string(),
         Output::ConfigValue(Some(v)) => format!("\"{}\"", v),
+        Output::GraphAnalyticsU64(result) => {
+            format!(
+                "({}) {} node(s)\n{}",
+                result.algorithm,
+                result.result.len(),
+                serde_json::to_string_pretty(&result).unwrap_or_default()
+            )
+        }
+        Output::GraphAnalyticsF64(result) => {
+            format!(
+                "({}) {} node(s)\n{}",
+                result.algorithm,
+                result.result.len(),
+                serde_json::to_string_pretty(&result).unwrap_or_default()
+            )
+        }
     }
 }
 

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -1109,6 +1109,72 @@ fn parse_graph(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, 
                 object_type,
             }))
         }
+        // Analytics
+        "wcc" => {
+            let graph = m.get_one::<String>("graph").unwrap().clone();
+            Ok(CliAction::Execute(Command::GraphWcc {
+                branch: branch(state),
+                graph,
+            }))
+        }
+        "cdlp" => {
+            let graph = m.get_one::<String>("graph").unwrap().clone();
+            let max_iterations = m
+                .get_one::<String>("max-iterations")
+                .unwrap()
+                .parse::<usize>()
+                .map_err(|e| format!("Invalid max-iterations: {}", e))?;
+            let direction = m.get_one::<String>("direction").cloned();
+            Ok(CliAction::Execute(Command::GraphCdlp {
+                branch: branch(state),
+                graph,
+                max_iterations,
+                direction,
+            }))
+        }
+        "pagerank" => {
+            let graph = m.get_one::<String>("graph").unwrap().clone();
+            let damping = m
+                .get_one::<String>("damping")
+                .map(|s| s.parse::<f64>())
+                .transpose()
+                .map_err(|e| format!("Invalid damping: {}", e))?;
+            let max_iterations = m
+                .get_one::<String>("max-iterations")
+                .map(|s| s.parse::<usize>())
+                .transpose()
+                .map_err(|e| format!("Invalid max-iterations: {}", e))?;
+            let tolerance = m
+                .get_one::<String>("tolerance")
+                .map(|s| s.parse::<f64>())
+                .transpose()
+                .map_err(|e| format!("Invalid tolerance: {}", e))?;
+            Ok(CliAction::Execute(Command::GraphPagerank {
+                branch: branch(state),
+                graph,
+                damping,
+                max_iterations,
+                tolerance,
+            }))
+        }
+        "lcc" => {
+            let graph = m.get_one::<String>("graph").unwrap().clone();
+            Ok(CliAction::Execute(Command::GraphLcc {
+                branch: branch(state),
+                graph,
+            }))
+        }
+        "sssp" => {
+            let graph = m.get_one::<String>("graph").unwrap().clone();
+            let source = m.get_one::<String>("source").unwrap().clone();
+            let direction = m.get_one::<String>("direction").cloned();
+            Ok(CliAction::Execute(Command::GraphSssp {
+                branch: branch(state),
+                graph,
+                source,
+                direction,
+            }))
+        }
         other => Err(format!("Unknown graph subcommand: {}", other)),
     }
 }

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -504,6 +504,11 @@ fn subcommands_for(cmd: &str) -> &'static [&'static str] {
             "ontology-status",
             "ontology-summary",
             "nodes-by-type",
+            "wcc",
+            "cdlp",
+            "pagerank",
+            "lcc",
+            "sssp",
         ],
         "branch" => &[
             "create", "info", "get", "list", "exists", "del", "fork", "diff", "merge", "export",

--- a/crates/engine/src/graph/adjacency.rs
+++ b/crates/engine/src/graph/adjacency.rs
@@ -141,6 +141,18 @@ impl AdjacencyIndex {
             })
     }
 
+    /// Iterate outgoing neighbors with weights, without allocating Neighbor structs.
+    ///
+    /// Returns `(dst, weight)` pairs as string references + f64, avoiding
+    /// the Vec<Neighbor> + EdgeData cloning overhead.
+    pub fn outgoing_weighted<'a>(&'a self, node_id: &str) -> impl Iterator<Item = (&'a str, f64)> {
+        self.outgoing.get(node_id).into_iter().flat_map(|edges| {
+            edges
+                .iter()
+                .map(|(dst, _, data)| (dst.as_str(), data.weight))
+        })
+    }
+
     /// Iterate incoming neighbors without allocating Neighbor structs.
     ///
     /// Returns `(src, edge_type)` pairs as string references, avoiding

--- a/crates/engine/src/graph/analytics.rs
+++ b/crates/engine/src/graph/analytics.rs
@@ -1,0 +1,1081 @@
+//! Graph analytics algorithms: WCC, CDLP, PageRank, LCC, SSSP.
+//!
+//! All algorithms follow the same pattern as BFS: build an in-memory
+//! `AdjacencyIndex` from KV storage, then run the algorithm in-memory.
+
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap, HashSet};
+
+use strata_core::types::BranchId;
+use strata_core::StrataResult;
+
+use super::adjacency::AdjacencyIndex;
+use super::types::*;
+use super::GraphStore;
+
+impl GraphStore {
+    /// Weakly Connected Components using union-find.
+    pub fn wcc(&self, branch_id: BranchId, graph: &str) -> StrataResult<WccResult> {
+        let index = self.build_adjacency_index(branch_id, graph)?;
+        // Also load isolated nodes (nodes with no edges).
+        let all_nodes = self.list_nodes(branch_id, graph)?;
+        let mut full_index = index;
+        for node_id in &all_nodes {
+            full_index.nodes.insert(node_id.clone());
+        }
+        Ok(wcc_with_index(&full_index))
+    }
+
+    /// Community Detection via Label Propagation.
+    pub fn cdlp(
+        &self,
+        branch_id: BranchId,
+        graph: &str,
+        opts: CdlpOptions,
+    ) -> StrataResult<CdlpResult> {
+        let index = self.build_adjacency_index(branch_id, graph)?;
+        let all_nodes = self.list_nodes(branch_id, graph)?;
+        let mut full_index = index;
+        for node_id in &all_nodes {
+            full_index.nodes.insert(node_id.clone());
+        }
+        Ok(cdlp_with_index(&full_index, &opts))
+    }
+
+    /// PageRank iterative importance scoring.
+    pub fn pagerank(
+        &self,
+        branch_id: BranchId,
+        graph: &str,
+        opts: PageRankOptions,
+    ) -> StrataResult<PageRankResult> {
+        let index = self.build_adjacency_index(branch_id, graph)?;
+        let all_nodes = self.list_nodes(branch_id, graph)?;
+        let mut full_index = index;
+        for node_id in &all_nodes {
+            full_index.nodes.insert(node_id.clone());
+        }
+        Ok(pagerank_with_index(&full_index, &opts))
+    }
+
+    /// Local Clustering Coefficient.
+    pub fn lcc(&self, branch_id: BranchId, graph: &str) -> StrataResult<LccResult> {
+        let index = self.build_adjacency_index(branch_id, graph)?;
+        let all_nodes = self.list_nodes(branch_id, graph)?;
+        let mut full_index = index;
+        for node_id in &all_nodes {
+            full_index.nodes.insert(node_id.clone());
+        }
+        Ok(lcc_with_index(&full_index))
+    }
+
+    /// Single-Source Shortest Path (Dijkstra).
+    pub fn sssp(
+        &self,
+        branch_id: BranchId,
+        graph: &str,
+        source: &str,
+        opts: SsspOptions,
+    ) -> StrataResult<SsspResult> {
+        let index = self.build_adjacency_index(branch_id, graph)?;
+        Ok(sssp_with_index(&index, source, &opts))
+    }
+}
+
+// =============================================================================
+// Pure algorithm implementations (testable with hand-built AdjacencyIndex)
+// =============================================================================
+
+/// Weakly Connected Components using union-find with path compression.
+pub fn wcc_with_index(index: &AdjacencyIndex) -> WccResult {
+    // Collect all node IDs (from edges + explicit nodes set).
+    let mut all_nodes: Vec<&str> = Vec::new();
+    let mut node_set: HashSet<&str> = HashSet::new();
+
+    for node_id in &index.nodes {
+        if node_set.insert(node_id.as_str()) {
+            all_nodes.push(node_id.as_str());
+        }
+    }
+    for (src, edges) in &index.outgoing {
+        if node_set.insert(src.as_str()) {
+            all_nodes.push(src.as_str());
+        }
+        for (dst, _, _) in edges {
+            if node_set.insert(dst.as_str()) {
+                all_nodes.push(dst.as_str());
+            }
+        }
+    }
+    for (dst, edges) in &index.incoming {
+        if node_set.insert(dst.as_str()) {
+            all_nodes.push(dst.as_str());
+        }
+        for (src, _, _) in edges {
+            if node_set.insert(src.as_str()) {
+                all_nodes.push(src.as_str());
+            }
+        }
+    }
+
+    all_nodes.sort();
+
+    // Map node_id → index
+    let id_map: HashMap<&str, usize> = all_nodes
+        .iter()
+        .enumerate()
+        .map(|(i, &id)| (id, i))
+        .collect();
+
+    let n = all_nodes.len();
+    let mut parent: Vec<usize> = (0..n).collect();
+    let mut rank: Vec<usize> = vec![0; n];
+
+    fn find(parent: &mut [usize], x: usize) -> usize {
+        if parent[x] != x {
+            parent[x] = find(parent, parent[x]);
+        }
+        parent[x]
+    }
+
+    fn union(parent: &mut [usize], rank: &mut [usize], x: usize, y: usize) {
+        let rx = find(parent, x);
+        let ry = find(parent, y);
+        if rx == ry {
+            return;
+        }
+        match rank[rx].cmp(&rank[ry]) {
+            std::cmp::Ordering::Less => parent[rx] = ry,
+            std::cmp::Ordering::Greater => parent[ry] = rx,
+            std::cmp::Ordering::Equal => {
+                parent[ry] = rx;
+                rank[rx] += 1;
+            }
+        }
+    }
+
+    // Process all edges (undirected — only need outgoing since each edge appears once).
+    for (src, edges) in &index.outgoing {
+        if let Some(&src_idx) = id_map.get(src.as_str()) {
+            for (dst, _, _) in edges {
+                if let Some(&dst_idx) = id_map.get(dst.as_str()) {
+                    union(&mut parent, &mut rank, src_idx, dst_idx);
+                }
+            }
+        }
+    }
+
+    // Assign component IDs (use stable hash of smallest node_id in component).
+    // First, find the minimum-index node in each component.
+    let mut component_min: HashMap<usize, usize> = HashMap::new();
+    for i in 0..n {
+        let root = find(&mut parent, i);
+        let entry = component_min.entry(root).or_insert(i);
+        if i < *entry {
+            *entry = i;
+        }
+    }
+
+    // Build result: each node maps to its component ID (the index of the smallest node).
+    let mut components = HashMap::new();
+    for (i, &node_id) in all_nodes.iter().enumerate() {
+        let root = find(&mut parent, i);
+        let min_idx = component_min[&root];
+        components.insert(node_id.to_string(), min_idx as u64);
+    }
+
+    WccResult { components }
+}
+
+/// Community Detection via Label Propagation.
+pub fn cdlp_with_index(index: &AdjacencyIndex, opts: &CdlpOptions) -> CdlpResult {
+    // Collect all nodes.
+    let mut all_nodes: Vec<String> = Vec::new();
+    let mut node_set: HashSet<&str> = HashSet::new();
+
+    // Helper: collect from nodes set and edges
+    for node_id in &index.nodes {
+        if node_set.insert(node_id.as_str()) {
+            all_nodes.push(node_id.clone());
+        }
+    }
+    for (src, edges) in &index.outgoing {
+        if node_set.insert(src.as_str()) {
+            all_nodes.push(src.clone());
+        }
+        for (dst, _, _) in edges {
+            if node_set.insert(dst.as_str()) {
+                all_nodes.push(dst.clone());
+            }
+        }
+    }
+    for (dst, edges) in &index.incoming {
+        if node_set.insert(dst.as_str()) {
+            all_nodes.push(dst.clone());
+        }
+        for (src, _, _) in edges {
+            if node_set.insert(src.as_str()) {
+                all_nodes.push(src.clone());
+            }
+        }
+    }
+
+    all_nodes.sort();
+
+    // Initialize each node with a unique label (its sorted index).
+    let mut labels: HashMap<String, u64> = all_nodes
+        .iter()
+        .enumerate()
+        .map(|(i, id)| (id.clone(), i as u64))
+        .collect();
+
+    for _ in 0..opts.max_iterations {
+        let mut changed = false;
+        let mut new_labels = labels.clone();
+
+        for node_id in &all_nodes {
+            // Collect neighbor labels based on direction.
+            let mut neighbor_labels: Vec<u64> = Vec::new();
+
+            match opts.direction {
+                Direction::Outgoing => {
+                    for (dst, _) in index.outgoing_neighbor_ids(node_id, None) {
+                        if let Some(&lbl) = labels.get(dst) {
+                            neighbor_labels.push(lbl);
+                        }
+                    }
+                }
+                Direction::Incoming => {
+                    for (src, _) in index.incoming_neighbor_ids(node_id, None) {
+                        if let Some(&lbl) = labels.get(src) {
+                            neighbor_labels.push(lbl);
+                        }
+                    }
+                }
+                Direction::Both => {
+                    for (dst, _) in index.outgoing_neighbor_ids(node_id, None) {
+                        if let Some(&lbl) = labels.get(dst) {
+                            neighbor_labels.push(lbl);
+                        }
+                    }
+                    for (src, _) in index.incoming_neighbor_ids(node_id, None) {
+                        if let Some(&lbl) = labels.get(src) {
+                            neighbor_labels.push(lbl);
+                        }
+                    }
+                }
+            }
+
+            if neighbor_labels.is_empty() {
+                continue;
+            }
+
+            // Find most frequent label, ties broken by smallest label.
+            let mut freq: HashMap<u64, usize> = HashMap::new();
+            for &lbl in &neighbor_labels {
+                *freq.entry(lbl).or_insert(0) += 1;
+            }
+
+            let max_count = *freq.values().max().unwrap();
+            let best_label = *freq
+                .iter()
+                .filter(|(_, &count)| count == max_count)
+                .map(|(&lbl, _)| lbl)
+                .collect::<Vec<_>>()
+                .iter()
+                .min()
+                .unwrap();
+
+            if best_label != labels[node_id.as_str()] {
+                new_labels.insert(node_id.clone(), best_label);
+                changed = true;
+            }
+        }
+
+        labels = new_labels;
+        if !changed {
+            break;
+        }
+    }
+
+    CdlpResult { labels }
+}
+
+/// PageRank power iteration.
+pub fn pagerank_with_index(index: &AdjacencyIndex, opts: &PageRankOptions) -> PageRankResult {
+    // Collect all nodes.
+    let mut all_nodes: Vec<String> = Vec::new();
+    let mut node_set: HashSet<&str> = HashSet::new();
+
+    for node_id in &index.nodes {
+        if node_set.insert(node_id.as_str()) {
+            all_nodes.push(node_id.clone());
+        }
+    }
+    for (src, edges) in &index.outgoing {
+        if node_set.insert(src.as_str()) {
+            all_nodes.push(src.clone());
+        }
+        for (dst, _, _) in edges {
+            if node_set.insert(dst.as_str()) {
+                all_nodes.push(dst.clone());
+            }
+        }
+    }
+    for (dst, edges) in &index.incoming {
+        if node_set.insert(dst.as_str()) {
+            all_nodes.push(dst.clone());
+        }
+        for (src, _, _) in edges {
+            if node_set.insert(src.as_str()) {
+                all_nodes.push(src.clone());
+            }
+        }
+    }
+
+    let n = all_nodes.len();
+    if n == 0 {
+        return PageRankResult {
+            ranks: HashMap::new(),
+            iterations: 0,
+        };
+    }
+
+    let init_rank = 1.0 / n as f64;
+    let mut ranks: HashMap<String, f64> =
+        all_nodes.iter().map(|id| (id.clone(), init_rank)).collect();
+
+    // Precompute out-degrees.
+    let mut out_degree: HashMap<&str, usize> = HashMap::new();
+    for node_id in &all_nodes {
+        let deg = index
+            .outgoing
+            .get(node_id.as_str())
+            .map(|e| e.len())
+            .unwrap_or(0);
+        out_degree.insert(node_id.as_str(), deg);
+    }
+
+    let d = opts.damping;
+    let base = (1.0 - d) / n as f64;
+    let mut iterations = 0;
+
+    for _ in 0..opts.max_iterations {
+        iterations += 1;
+
+        // Compute dangling node mass: sum of ranks for nodes with no outgoing edges.
+        let dangling_sum: f64 = all_nodes
+            .iter()
+            .filter(|id| *out_degree.get(id.as_str()).unwrap_or(&0) == 0)
+            .map(|id| ranks[id])
+            .sum();
+        let dangling_contrib = d * dangling_sum / n as f64;
+
+        let mut new_ranks: HashMap<String, f64> = HashMap::with_capacity(n);
+
+        for node_id in &all_nodes {
+            let mut sum = 0.0;
+            // Sum contributions from incoming neighbors.
+            if let Some(incoming) = index.incoming.get(node_id.as_str()) {
+                for (src, _, _) in incoming {
+                    let src_rank = ranks.get(src.as_str()).copied().unwrap_or(0.0);
+                    let src_deg = *out_degree.get(src.as_str()).unwrap_or(&1);
+                    if src_deg > 0 {
+                        sum += src_rank / src_deg as f64;
+                    }
+                }
+            }
+            new_ranks.insert(node_id.clone(), base + dangling_contrib + d * sum);
+        }
+
+        // Check convergence (L1 norm).
+        let delta: f64 = all_nodes
+            .iter()
+            .map(|id| (new_ranks[id] - ranks[id]).abs())
+            .sum();
+
+        ranks = new_ranks;
+        if delta < opts.tolerance {
+            break;
+        }
+    }
+
+    PageRankResult { ranks, iterations }
+}
+
+/// Local Clustering Coefficient.
+pub fn lcc_with_index(index: &AdjacencyIndex) -> LccResult {
+    // Collect all nodes.
+    let mut all_nodes: Vec<String> = Vec::new();
+    let mut node_set: HashSet<&str> = HashSet::new();
+
+    for node_id in &index.nodes {
+        if node_set.insert(node_id.as_str()) {
+            all_nodes.push(node_id.clone());
+        }
+    }
+    for (src, edges) in &index.outgoing {
+        if node_set.insert(src.as_str()) {
+            all_nodes.push(src.clone());
+        }
+        for (dst, _, _) in edges {
+            if node_set.insert(dst.as_str()) {
+                all_nodes.push(dst.clone());
+            }
+        }
+    }
+    for (dst, edges) in &index.incoming {
+        if node_set.insert(dst.as_str()) {
+            all_nodes.push(dst.clone());
+        }
+        for (src, _, _) in edges {
+            if node_set.insert(src.as_str()) {
+                all_nodes.push(src.clone());
+            }
+        }
+    }
+
+    // Build an edge set for O(1) connectivity checks (undirected).
+    let mut edge_set: HashSet<(&str, &str)> = HashSet::new();
+    for (src, edges) in &index.outgoing {
+        for (dst, _, _) in edges {
+            edge_set.insert((src.as_str(), dst.as_str()));
+        }
+    }
+
+    let mut coefficients = HashMap::new();
+
+    for node_id in &all_nodes {
+        // Get undirected neighbors (union of outgoing and incoming).
+        // Exclude self-loops: a node is not its own neighbor for LCC purposes.
+        let mut neighbors: HashSet<&str> = HashSet::new();
+        for (dst, _) in index.outgoing_neighbor_ids(node_id, None) {
+            if dst != node_id.as_str() {
+                neighbors.insert(dst);
+            }
+        }
+        for (src, _) in index.incoming_neighbor_ids(node_id, None) {
+            if src != node_id.as_str() {
+                neighbors.insert(src);
+            }
+        }
+
+        let deg = neighbors.len();
+        if deg < 2 {
+            coefficients.insert(node_id.clone(), 0.0);
+            continue;
+        }
+
+        // Count edges between neighbors (triangles).
+        let neighbor_vec: Vec<&str> = neighbors.iter().copied().collect();
+        let mut triangles = 0u64;
+
+        for i in 0..neighbor_vec.len() {
+            for j in (i + 1)..neighbor_vec.len() {
+                let u = neighbor_vec[i];
+                let w = neighbor_vec[j];
+                // Check if u and w are connected (either direction).
+                if edge_set.contains(&(u, w)) || edge_set.contains(&(w, u)) {
+                    triangles += 1;
+                }
+            }
+        }
+
+        let max_edges = (deg * (deg - 1)) / 2;
+        let coeff = triangles as f64 / max_edges as f64;
+        coefficients.insert(node_id.clone(), coeff);
+    }
+
+    LccResult { coefficients }
+}
+
+/// Single-Source Shortest Path using Dijkstra.
+pub fn sssp_with_index(index: &AdjacencyIndex, source: &str, opts: &SsspOptions) -> SsspResult {
+    let mut distances: HashMap<String, f64> = HashMap::new();
+    // Min-heap: (distance, node_id)
+    let mut heap: BinaryHeap<Reverse<(OrdF64, String)>> = BinaryHeap::new();
+
+    distances.insert(source.to_string(), 0.0);
+    heap.push(Reverse((OrdF64(0.0), source.to_string())));
+
+    while let Some(Reverse((OrdF64(dist), node))) = heap.pop() {
+        // Skip if we already found a shorter path.
+        if let Some(&known) = distances.get(&node) {
+            if dist > known {
+                continue;
+            }
+        }
+
+        // Iterate weighted neighbors based on direction.
+        match opts.direction {
+            Direction::Outgoing => {
+                for (dst, weight) in index.outgoing_weighted(&node) {
+                    let new_dist = dist + weight;
+                    let current = distances.get(dst).copied().unwrap_or(f64::INFINITY);
+                    if new_dist < current {
+                        distances.insert(dst.to_string(), new_dist);
+                        heap.push(Reverse((OrdF64(new_dist), dst.to_string())));
+                    }
+                }
+            }
+            Direction::Incoming => {
+                if let Some(incoming) = index.incoming.get(node.as_str()) {
+                    for (src, _, data) in incoming {
+                        let new_dist = dist + data.weight;
+                        let current = distances
+                            .get(src.as_str())
+                            .copied()
+                            .unwrap_or(f64::INFINITY);
+                        if new_dist < current {
+                            distances.insert(src.clone(), new_dist);
+                            heap.push(Reverse((OrdF64(new_dist), src.clone())));
+                        }
+                    }
+                }
+            }
+            Direction::Both => {
+                for (dst, weight) in index.outgoing_weighted(&node) {
+                    let new_dist = dist + weight;
+                    let current = distances.get(dst).copied().unwrap_or(f64::INFINITY);
+                    if new_dist < current {
+                        distances.insert(dst.to_string(), new_dist);
+                        heap.push(Reverse((OrdF64(new_dist), dst.to_string())));
+                    }
+                }
+                if let Some(incoming) = index.incoming.get(node.as_str()) {
+                    for (src, _, data) in incoming {
+                        let new_dist = dist + data.weight;
+                        let current = distances
+                            .get(src.as_str())
+                            .copied()
+                            .unwrap_or(f64::INFINITY);
+                        if new_dist < current {
+                            distances.insert(src.clone(), new_dist);
+                            heap.push(Reverse((OrdF64(new_dist), src.clone())));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    SsspResult { distances }
+}
+
+/// Wrapper for f64 that implements Ord (required for BinaryHeap).
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct OrdF64(f64);
+
+impl Eq for OrdF64 {}
+
+impl PartialOrd for OrdF64 {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OrdF64 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0
+            .partial_cmp(&other.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::types::EdgeData;
+
+    fn make_index(edges: &[(&str, &str, f64)]) -> AdjacencyIndex {
+        let mut idx = AdjacencyIndex::new();
+        for &(src, dst, weight) in edges {
+            idx.add_node(src);
+            idx.add_node(dst);
+            idx.add_edge(
+                src,
+                dst,
+                "E",
+                EdgeData {
+                    weight,
+                    properties: None,
+                },
+            );
+        }
+        idx
+    }
+
+    fn make_unweighted_index(edges: &[(&str, &str)]) -> AdjacencyIndex {
+        let mut idx = AdjacencyIndex::new();
+        for &(src, dst) in edges {
+            idx.add_node(src);
+            idx.add_node(dst);
+            idx.add_edge(src, dst, "E", EdgeData::default());
+        }
+        idx
+    }
+
+    // =========================================================================
+    // WCC
+    // =========================================================================
+
+    #[test]
+    fn wcc_disconnected_components() {
+        let idx = make_unweighted_index(&[("A", "B"), ("C", "D")]);
+        let result = wcc_with_index(&idx);
+        // A and B should be in the same component
+        assert_eq!(result.components["A"], result.components["B"]);
+        // C and D should be in the same component
+        assert_eq!(result.components["C"], result.components["D"]);
+        // A and C should be in different components
+        assert_ne!(result.components["A"], result.components["C"]);
+    }
+
+    #[test]
+    fn wcc_single_component() {
+        let idx = make_unweighted_index(&[("A", "B"), ("B", "C"), ("C", "D")]);
+        let result = wcc_with_index(&idx);
+        let comp = result.components["A"];
+        assert_eq!(result.components["B"], comp);
+        assert_eq!(result.components["C"], comp);
+        assert_eq!(result.components["D"], comp);
+    }
+
+    #[test]
+    fn wcc_isolated_nodes() {
+        let mut idx = AdjacencyIndex::new();
+        idx.add_node("A");
+        idx.add_node("B");
+        idx.add_node("C");
+        let result = wcc_with_index(&idx);
+        // Each isolated node is its own component.
+        assert_eq!(result.components.len(), 3);
+        let values: HashSet<u64> = result.components.values().copied().collect();
+        assert_eq!(values.len(), 3);
+    }
+
+    #[test]
+    fn wcc_self_loop() {
+        let idx = make_unweighted_index(&[("A", "A"), ("B", "C")]);
+        let result = wcc_with_index(&idx);
+        assert_ne!(result.components["A"], result.components["B"]);
+        assert_eq!(result.components["B"], result.components["C"]);
+    }
+
+    #[test]
+    fn wcc_empty_graph() {
+        let idx = AdjacencyIndex::new();
+        let result = wcc_with_index(&idx);
+        assert!(result.components.is_empty());
+    }
+
+    // =========================================================================
+    // CDLP
+    // =========================================================================
+
+    #[test]
+    fn cdlp_two_communities() {
+        // Two cliques connected by a single edge
+        let idx = make_unweighted_index(&[
+            ("A", "B"),
+            ("B", "A"),
+            ("A", "C"),
+            ("C", "A"),
+            ("B", "C"),
+            ("C", "B"),
+            ("D", "E"),
+            ("E", "D"),
+            ("D", "F"),
+            ("F", "D"),
+            ("E", "F"),
+            ("F", "E"),
+            ("C", "D"), // bridge
+        ]);
+        let result = cdlp_with_index(&idx, &CdlpOptions::default());
+        // Nodes in same clique should have the same label
+        assert_eq!(result.labels["A"], result.labels["B"]);
+        assert_eq!(result.labels["A"], result.labels["C"]);
+        assert_eq!(result.labels["D"], result.labels["E"]);
+        assert_eq!(result.labels["D"], result.labels["F"]);
+    }
+
+    #[test]
+    fn cdlp_single_node() {
+        let mut idx = AdjacencyIndex::new();
+        idx.add_node("A");
+        let result = cdlp_with_index(&idx, &CdlpOptions::default());
+        assert_eq!(result.labels.len(), 1);
+        assert!(result.labels.contains_key("A"));
+    }
+
+    #[test]
+    fn cdlp_convergence_stops_early() {
+        // A fully connected triangle should converge quickly — all labels become the same.
+        let idx = make_unweighted_index(&[
+            ("A", "B"),
+            ("B", "A"),
+            ("A", "C"),
+            ("C", "A"),
+            ("B", "C"),
+            ("C", "B"),
+        ]);
+        // Run with high max_iterations but convergence should happen in ~2.
+        let result = cdlp_with_index(
+            &idx,
+            &CdlpOptions {
+                max_iterations: 100,
+                ..Default::default()
+            },
+        );
+        // All nodes should have the same label after convergence.
+        assert_eq!(result.labels["A"], result.labels["B"]);
+        assert_eq!(result.labels["B"], result.labels["C"]);
+    }
+
+    #[test]
+    fn cdlp_directed_outgoing_only() {
+        // A → B, A → C: with Direction::Outgoing, B and C have no outgoing neighbors,
+        // so their labels stay fixed. A sees B and C's labels.
+        let idx = make_unweighted_index(&[("A", "B"), ("A", "C")]);
+        let result = cdlp_with_index(
+            &idx,
+            &CdlpOptions {
+                max_iterations: 10,
+                direction: Direction::Outgoing,
+            },
+        );
+        // B and C should keep their original labels (no outgoing neighbors).
+        assert_ne!(result.labels["B"], result.labels["C"]);
+        // A should adopt the smaller of B's or C's label.
+        let min_label = result.labels["B"].min(result.labels["C"]);
+        assert_eq!(result.labels["A"], min_label);
+    }
+
+    // =========================================================================
+    // PageRank
+    // =========================================================================
+
+    #[test]
+    fn pagerank_simple_chain() {
+        // A → B → C
+        let idx = make_unweighted_index(&[("A", "B"), ("B", "C")]);
+        let result = pagerank_with_index(&idx, &PageRankOptions::default());
+        // C should have highest rank (receives from B, which receives from A)
+        assert!(result.ranks["C"] > result.ranks["B"]);
+        assert!(result.ranks["B"] > result.ranks["A"]);
+    }
+
+    #[test]
+    fn pagerank_star_graph() {
+        // A → B, A → C, A → D (hub pattern)
+        let idx = make_unweighted_index(&[("A", "B"), ("A", "C"), ("A", "D")]);
+        let result = pagerank_with_index(&idx, &PageRankOptions::default());
+        // B, C, D should have roughly equal rank
+        assert!((result.ranks["B"] - result.ranks["C"]).abs() < 1e-10);
+        assert!((result.ranks["B"] - result.ranks["D"]).abs() < 1e-10);
+    }
+
+    #[test]
+    fn pagerank_sum_approximately_one() {
+        let idx = make_unweighted_index(&[("A", "B"), ("B", "C"), ("C", "A")]);
+        let result = pagerank_with_index(&idx, &PageRankOptions::default());
+        let sum: f64 = result.ranks.values().sum();
+        assert!((sum - 1.0).abs() < 1e-6, "sum was {}", sum);
+    }
+
+    #[test]
+    fn pagerank_damping_effect() {
+        let idx = make_unweighted_index(&[("A", "B"), ("B", "C"), ("C", "A")]);
+        let result_high = pagerank_with_index(
+            &idx,
+            &PageRankOptions {
+                damping: 0.99,
+                ..Default::default()
+            },
+        );
+        let result_low = pagerank_with_index(
+            &idx,
+            &PageRankOptions {
+                damping: 0.5,
+                ..Default::default()
+            },
+        );
+        // With low damping, ranks should be more uniform
+        let high_range = result_high.ranks.values().cloned().fold(0.0f64, f64::max)
+            - result_high
+                .ranks
+                .values()
+                .cloned()
+                .fold(f64::INFINITY, f64::min);
+        let low_range = result_low.ranks.values().cloned().fold(0.0f64, f64::max)
+            - result_low
+                .ranks
+                .values()
+                .cloned()
+                .fold(f64::INFINITY, f64::min);
+        assert!(low_range <= high_range + 1e-10);
+    }
+
+    #[test]
+    fn pagerank_empty_graph() {
+        let idx = AdjacencyIndex::new();
+        let result = pagerank_with_index(&idx, &PageRankOptions::default());
+        assert!(result.ranks.is_empty());
+        assert_eq!(result.iterations, 0);
+    }
+
+    #[test]
+    fn pagerank_dangling_nodes_preserve_mass() {
+        // A → B, B → C: C is a dangling node (no outgoing edges).
+        // Without dangling node handling, rank mass leaks and sum != 1.0.
+        let idx = make_unweighted_index(&[("A", "B"), ("B", "C")]);
+        let result = pagerank_with_index(&idx, &PageRankOptions::default());
+        let sum: f64 = result.ranks.values().sum();
+        assert!(
+            (sum - 1.0).abs() < 1e-6,
+            "sum was {} (dangling node mass leaked)",
+            sum
+        );
+    }
+
+    #[test]
+    fn pagerank_all_dangling() {
+        // Three isolated nodes — all are dangling. Ranks should remain uniform.
+        let mut idx = AdjacencyIndex::new();
+        idx.add_node("A");
+        idx.add_node("B");
+        idx.add_node("C");
+        let result = pagerank_with_index(&idx, &PageRankOptions::default());
+        let sum: f64 = result.ranks.values().sum();
+        assert!((sum - 1.0).abs() < 1e-6, "sum was {}", sum);
+        // All ranks should be equal (1/3 each).
+        for &rank in result.ranks.values() {
+            assert!((rank - 1.0 / 3.0).abs() < 1e-6, "rank {} != 1/3", rank);
+        }
+    }
+
+    // =========================================================================
+    // LCC
+    // =========================================================================
+
+    #[test]
+    fn lcc_triangle() {
+        // A → B, B → C, C → A (triangle)
+        let idx = make_unweighted_index(&[("A", "B"), ("B", "C"), ("C", "A")]);
+        let result = lcc_with_index(&idx);
+        // All nodes have degree 2 (undirected) and 1 triangle → coefficient = 1.0
+        assert!((result.coefficients["A"] - 1.0).abs() < 1e-10);
+        assert!((result.coefficients["B"] - 1.0).abs() < 1e-10);
+        assert!((result.coefficients["C"] - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn lcc_star() {
+        // A → B, A → C, A → D (star from A)
+        let idx = make_unweighted_index(&[("A", "B"), ("A", "C"), ("A", "D")]);
+        let result = lcc_with_index(&idx);
+        // A has degree 3, no edges between B, C, D → coefficient = 0.0
+        assert!((result.coefficients["A"] - 0.0).abs() < 1e-10);
+        // B, C, D have degree 1 → coefficient = 0.0
+        assert!((result.coefficients["B"] - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn lcc_square() {
+        // A → B, B → C, C → D, D → A (square)
+        let idx = make_unweighted_index(&[("A", "B"), ("B", "C"), ("C", "D"), ("D", "A")]);
+        let result = lcc_with_index(&idx);
+        // Each node has degree 2 (undirected), no triangles → coefficient = 0.0
+        assert!((result.coefficients["A"] - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn lcc_self_loop_ignored() {
+        // A → A (self-loop), A → B, A → C, B → C
+        // Self-loop should NOT inflate A's degree or create false triangles.
+        let idx = make_unweighted_index(&[("A", "A"), ("A", "B"), ("A", "C"), ("B", "C")]);
+        let result = lcc_with_index(&idx);
+        // A's neighbors (excluding self): {B, C}. B-C edge exists → 1 triangle / 1 possible = 1.0
+        assert!(
+            (result.coefficients["A"] - 1.0).abs() < 1e-10,
+            "A's LCC = {} (expected 1.0, self-loop should be excluded)",
+            result.coefficients["A"]
+        );
+    }
+
+    #[test]
+    fn lcc_isolated_nodes() {
+        let mut idx = AdjacencyIndex::new();
+        idx.add_node("A");
+        idx.add_node("B");
+        let result = lcc_with_index(&idx);
+        // Isolated nodes have degree 0 → coefficient = 0.0
+        assert!((result.coefficients["A"] - 0.0).abs() < 1e-10);
+        assert!((result.coefficients["B"] - 0.0).abs() < 1e-10);
+    }
+
+    // =========================================================================
+    // SSSP
+    // =========================================================================
+
+    #[test]
+    fn sssp_weighted_path() {
+        // A --1--> B --2--> C, A --10--> C
+        let idx = make_index(&[("A", "B", 1.0), ("B", "C", 2.0), ("A", "C", 10.0)]);
+        let result = sssp_with_index(&idx, "A", &SsspOptions::default());
+        assert!((result.distances["A"] - 0.0).abs() < 1e-10);
+        assert!((result.distances["B"] - 1.0).abs() < 1e-10);
+        assert!((result.distances["C"] - 3.0).abs() < 1e-10); // via A→B→C
+    }
+
+    #[test]
+    fn sssp_unreachable_node() {
+        let mut idx = make_unweighted_index(&[("A", "B")]);
+        idx.add_node("C"); // C is isolated
+        let result = sssp_with_index(&idx, "A", &SsspOptions::default());
+        assert!(result.distances.contains_key("A"));
+        assert!(result.distances.contains_key("B"));
+        assert!(!result.distances.contains_key("C"));
+    }
+
+    #[test]
+    fn sssp_source_to_itself() {
+        let idx = make_unweighted_index(&[("A", "B")]);
+        let result = sssp_with_index(&idx, "A", &SsspOptions::default());
+        assert!((result.distances["A"] - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn sssp_zero_weight_edges() {
+        let idx = make_index(&[("A", "B", 0.0), ("B", "C", 0.0)]);
+        let result = sssp_with_index(&idx, "A", &SsspOptions::default());
+        assert!((result.distances["A"] - 0.0).abs() < 1e-10);
+        assert!((result.distances["B"] - 0.0).abs() < 1e-10);
+        assert!((result.distances["C"] - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn sssp_nonexistent_source() {
+        let idx = make_unweighted_index(&[("A", "B")]);
+        let result = sssp_with_index(&idx, "Z", &SsspOptions::default());
+        // Only the source should be in the result with distance 0.
+        assert_eq!(result.distances.len(), 1);
+        assert!((result.distances["Z"] - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn sssp_direction_both() {
+        // A → B → C: with Direction::Both, C can also reach A via B.
+        let idx = make_index(&[("A", "B", 1.0), ("B", "C", 2.0)]);
+        let result = sssp_with_index(
+            &idx,
+            "C",
+            &SsspOptions {
+                direction: Direction::Both,
+            },
+        );
+        // C→B (reverse edge, weight 2.0), C→B→A (reverse edges, weight 2.0 + 1.0)
+        assert!((result.distances["C"] - 0.0).abs() < 1e-10);
+        assert!((result.distances["B"] - 2.0).abs() < 1e-10);
+        assert!((result.distances["A"] - 3.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn sssp_direction_incoming() {
+        // A → B → C: with Direction::Incoming from C, traverse reverse edges.
+        let idx = make_index(&[("A", "B", 1.0), ("B", "C", 2.0)]);
+        let result = sssp_with_index(
+            &idx,
+            "C",
+            &SsspOptions {
+                direction: Direction::Incoming,
+            },
+        );
+        assert!((result.distances["C"] - 0.0).abs() < 1e-10);
+        assert!((result.distances["B"] - 2.0).abs() < 1e-10);
+        assert!((result.distances["A"] - 3.0).abs() < 1e-10);
+    }
+
+    // =========================================================================
+    // Integration: GraphStore-level tests
+    // =========================================================================
+
+    use crate::database::Database;
+    use std::sync::Arc;
+
+    fn setup() -> (Arc<Database>, GraphStore) {
+        let db = Database::cache().unwrap();
+        let gs = GraphStore::new(db.clone());
+        (db, gs)
+    }
+
+    fn default_branch() -> BranchId {
+        BranchId::from_bytes([0u8; 16])
+    }
+
+    #[test]
+    fn graph_store_wcc() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+        gs.create_graph(b, "g", None).unwrap();
+        gs.add_node(b, "g", "A", NodeData::default()).unwrap();
+        gs.add_node(b, "g", "B", NodeData::default()).unwrap();
+        gs.add_node(b, "g", "C", NodeData::default()).unwrap();
+        gs.add_edge(b, "g", "A", "B", "E", EdgeData::default())
+            .unwrap();
+        let result = gs.wcc(b, "g").unwrap();
+        assert_eq!(result.components["A"], result.components["B"]);
+        assert_ne!(result.components["A"], result.components["C"]);
+    }
+
+    #[test]
+    fn graph_store_pagerank() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+        gs.create_graph(b, "g", None).unwrap();
+        gs.add_node(b, "g", "A", NodeData::default()).unwrap();
+        gs.add_node(b, "g", "B", NodeData::default()).unwrap();
+        gs.add_edge(b, "g", "A", "B", "E", EdgeData::default())
+            .unwrap();
+        let result = gs.pagerank(b, "g", PageRankOptions::default()).unwrap();
+        assert!(result.ranks["B"] > result.ranks["A"]);
+    }
+
+    #[test]
+    fn graph_store_sssp() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+        gs.create_graph(b, "g", None).unwrap();
+        gs.add_node(b, "g", "A", NodeData::default()).unwrap();
+        gs.add_node(b, "g", "B", NodeData::default()).unwrap();
+        gs.add_node(b, "g", "C", NodeData::default()).unwrap();
+        gs.add_edge(
+            b,
+            "g",
+            "A",
+            "B",
+            "E",
+            EdgeData {
+                weight: 2.0,
+                properties: None,
+            },
+        )
+        .unwrap();
+        gs.add_edge(
+            b,
+            "g",
+            "B",
+            "C",
+            "E",
+            EdgeData {
+                weight: 3.0,
+                properties: None,
+            },
+        )
+        .unwrap();
+        let result = gs.sssp(b, "g", "A", SsspOptions::default()).unwrap();
+        assert!((result.distances["A"] - 0.0).abs() < 1e-10);
+        assert!((result.distances["B"] - 2.0).abs() < 1e-10);
+        assert!((result.distances["C"] - 5.0).abs() < 1e-10);
+    }
+}

--- a/crates/engine/src/graph/mod.rs
+++ b/crates/engine/src/graph/mod.rs
@@ -5,6 +5,7 @@
 //! providing branch isolation, time-travel, and transactional guarantees.
 
 pub mod adjacency;
+pub mod analytics;
 pub mod boost;
 pub mod integrity;
 pub mod keys;

--- a/crates/engine/src/graph/types.rs
+++ b/crates/engine/src/graph/types.rs
@@ -297,6 +297,101 @@ fn csv_escape(s: &str) -> String {
     }
 }
 
+// =============================================================================
+// Analytics Result & Options Types
+// =============================================================================
+
+/// Result of Weakly Connected Components (WCC).
+#[derive(Debug, Clone, PartialEq)]
+pub struct WccResult {
+    /// Node → component ID (smallest node hash in each component).
+    pub components: HashMap<String, u64>,
+}
+
+/// Result of Community Detection via Label Propagation (CDLP).
+#[derive(Debug, Clone, PartialEq)]
+pub struct CdlpResult {
+    /// Node → community label.
+    pub labels: HashMap<String, u64>,
+}
+
+/// Options for CDLP.
+#[derive(Debug, Clone)]
+pub struct CdlpOptions {
+    /// Maximum iterations before stopping.
+    pub max_iterations: usize,
+    /// Traversal direction for neighbor lookups.
+    pub direction: Direction,
+}
+
+impl Default for CdlpOptions {
+    fn default() -> Self {
+        Self {
+            max_iterations: 10,
+            direction: Direction::Both,
+        }
+    }
+}
+
+/// Result of PageRank.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PageRankResult {
+    /// Node → rank score.
+    pub ranks: HashMap<String, f64>,
+    /// Number of iterations performed.
+    pub iterations: usize,
+}
+
+/// Options for PageRank.
+#[derive(Debug, Clone)]
+pub struct PageRankOptions {
+    /// Damping factor (default 0.85).
+    pub damping: f64,
+    /// Maximum iterations (default 20).
+    pub max_iterations: usize,
+    /// Convergence tolerance (default 1e-6).
+    pub tolerance: f64,
+}
+
+impl Default for PageRankOptions {
+    fn default() -> Self {
+        Self {
+            damping: 0.85,
+            max_iterations: 20,
+            tolerance: 1e-6,
+        }
+    }
+}
+
+/// Result of Local Clustering Coefficient (LCC).
+#[derive(Debug, Clone, PartialEq)]
+pub struct LccResult {
+    /// Node → clustering coefficient (0.0 for degree < 2).
+    pub coefficients: HashMap<String, f64>,
+}
+
+/// Result of Single-Source Shortest Path (SSSP).
+#[derive(Debug, Clone, PartialEq)]
+pub struct SsspResult {
+    /// Node → shortest distance from source (unreachable nodes omitted).
+    pub distances: HashMap<String, f64>,
+}
+
+/// Options for SSSP.
+#[derive(Debug, Clone)]
+pub struct SsspOptions {
+    /// Direction for edge traversal.
+    pub direction: Direction,
+}
+
+impl Default for SsspOptions {
+    fn default() -> Self {
+        Self {
+            direction: Direction::Outgoing,
+        }
+    }
+}
+
 /// Trait for graph algorithms that operate on a snapshot.
 pub trait GraphAlgorithm {
     /// The result type of this algorithm.

--- a/crates/executor/src/api/graph.rs
+++ b/crates/executor/src/api/graph.rs
@@ -1,7 +1,9 @@
 //! Graph operations on the Strata API surface.
 
 use super::Strata;
-use crate::types::{GraphBfsResult, GraphNeighborHit};
+use crate::types::{
+    GraphAnalyticsF64Result, GraphAnalyticsU64Result, GraphBfsResult, GraphNeighborHit,
+};
 use crate::{Command, Error, Output, Result, Value};
 
 impl Strata {
@@ -487,6 +489,98 @@ impl Strata {
             Output::Keys(ids) => Ok(ids),
             _ => Err(Error::Internal {
                 reason: "Unexpected output for GraphNodesByType".into(),
+            }),
+        }
+    }
+
+    // =========================================================================
+    // Analytics
+    // =========================================================================
+
+    /// Compute Weakly Connected Components.
+    pub fn graph_wcc(&self, graph: &str) -> Result<GraphAnalyticsU64Result> {
+        match self.executor.execute(Command::GraphWcc {
+            branch: self.branch_id(),
+            graph: graph.to_string(),
+        })? {
+            Output::GraphAnalyticsU64(r) => Ok(r),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for GraphWcc".into(),
+            }),
+        }
+    }
+
+    /// Compute Community Detection via Label Propagation.
+    pub fn graph_cdlp(
+        &self,
+        graph: &str,
+        max_iterations: usize,
+        direction: Option<&str>,
+    ) -> Result<GraphAnalyticsU64Result> {
+        match self.executor.execute(Command::GraphCdlp {
+            branch: self.branch_id(),
+            graph: graph.to_string(),
+            max_iterations,
+            direction: direction.map(|s| s.to_string()),
+        })? {
+            Output::GraphAnalyticsU64(r) => Ok(r),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for GraphCdlp".into(),
+            }),
+        }
+    }
+
+    /// Compute PageRank importance scores.
+    pub fn graph_pagerank(
+        &self,
+        graph: &str,
+        damping: Option<f64>,
+        max_iterations: Option<usize>,
+        tolerance: Option<f64>,
+    ) -> Result<GraphAnalyticsF64Result> {
+        match self.executor.execute(Command::GraphPagerank {
+            branch: self.branch_id(),
+            graph: graph.to_string(),
+            damping,
+            max_iterations,
+            tolerance,
+        })? {
+            Output::GraphAnalyticsF64(r) => Ok(r),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for GraphPagerank".into(),
+            }),
+        }
+    }
+
+    /// Compute Local Clustering Coefficients.
+    pub fn graph_lcc(&self, graph: &str) -> Result<GraphAnalyticsF64Result> {
+        match self.executor.execute(Command::GraphLcc {
+            branch: self.branch_id(),
+            graph: graph.to_string(),
+        })? {
+            Output::GraphAnalyticsF64(r) => Ok(r),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for GraphLcc".into(),
+            }),
+        }
+    }
+
+    /// Compute Single-Source Shortest Path (Dijkstra).
+    pub fn graph_sssp(
+        &self,
+        graph: &str,
+        source: &str,
+        direction: Option<&str>,
+    ) -> Result<GraphAnalyticsF64Result> {
+        match self.executor.execute(Command::GraphSssp {
+            branch: self.branch_id(),
+            graph: graph.to_string(),
+            source: source.to_string(),
+            direction: direction.map(|s| s.to_string()),
+        })? {
+            Output::GraphAnalyticsF64(r) => Ok(r),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for GraphSssp".into(),
             }),
         }
     }

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -1311,6 +1311,76 @@ pub enum Command {
         /// Object type name.
         object_type: String,
     },
+
+    // ==================== Graph Analytics ====================
+    /// Weakly Connected Components (union-find).
+    /// Returns: `Output::GraphAnalyticsU64`
+    GraphWcc {
+        /// Target branch.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Graph name.
+        graph: String,
+    },
+
+    /// Community Detection via Label Propagation.
+    /// Returns: `Output::GraphAnalyticsU64`
+    GraphCdlp {
+        /// Target branch.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Graph name.
+        graph: String,
+        /// Maximum number of iterations.
+        max_iterations: usize,
+        /// Direction: `"outgoing"`, `"incoming"`, or `"both"`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        direction: Option<String>,
+    },
+
+    /// PageRank importance scoring.
+    /// Returns: `Output::GraphAnalyticsF64`
+    GraphPagerank {
+        /// Target branch.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Graph name.
+        graph: String,
+        /// Damping factor (default 0.85).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        damping: Option<f64>,
+        /// Maximum number of iterations (default 20).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_iterations: Option<usize>,
+        /// Convergence tolerance (default 1e-6).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tolerance: Option<f64>,
+    },
+
+    /// Local Clustering Coefficient.
+    /// Returns: `Output::GraphAnalyticsF64`
+    GraphLcc {
+        /// Target branch.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Graph name.
+        graph: String,
+    },
+
+    /// Single-Source Shortest Path (Dijkstra).
+    /// Returns: `Output::GraphAnalyticsF64`
+    GraphSssp {
+        /// Target branch.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Graph name.
+        graph: String,
+        /// Source node ID.
+        source: String,
+        /// Direction: `"outgoing"`, `"incoming"`, or `"both"`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        direction: Option<String>,
+    },
 }
 
 impl Command {
@@ -1483,6 +1553,11 @@ impl Command {
             Command::GraphOntologyStatus { .. } => "GraphOntologyStatus",
             Command::GraphOntologySummary { .. } => "GraphOntologySummary",
             Command::GraphNodesByType { .. } => "GraphNodesByType",
+            Command::GraphWcc { .. } => "GraphWcc",
+            Command::GraphCdlp { .. } => "GraphCdlp",
+            Command::GraphPagerank { .. } => "GraphPagerank",
+            Command::GraphLcc { .. } => "GraphLcc",
+            Command::GraphSssp { .. } => "GraphSssp",
         }
     }
 
@@ -1594,7 +1669,12 @@ impl Command {
             | Command::GraphFreezeOntology { branch, .. }
             | Command::GraphOntologyStatus { branch, .. }
             | Command::GraphOntologySummary { branch, .. }
-            | Command::GraphNodesByType { branch, .. } => {
+            | Command::GraphNodesByType { branch, .. }
+            | Command::GraphWcc { branch, .. }
+            | Command::GraphCdlp { branch, .. }
+            | Command::GraphPagerank { branch, .. }
+            | Command::GraphLcc { branch, .. }
+            | Command::GraphSssp { branch, .. } => {
                 resolve_branch!(branch);
             }
 

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -1318,6 +1318,73 @@ impl Executor {
                     object_type,
                 )
             }
+
+            // Graph Analytics
+            Command::GraphWcc { branch, graph } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                })?;
+                crate::handlers::graph::graph_wcc(&self.primitives, branch, graph)
+            }
+            Command::GraphCdlp {
+                branch,
+                graph,
+                max_iterations,
+                direction,
+            } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                })?;
+                crate::handlers::graph::graph_cdlp(
+                    &self.primitives,
+                    branch,
+                    graph,
+                    max_iterations,
+                    direction,
+                )
+            }
+            Command::GraphPagerank {
+                branch,
+                graph,
+                damping,
+                max_iterations,
+                tolerance,
+            } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                })?;
+                crate::handlers::graph::graph_pagerank(
+                    &self.primitives,
+                    branch,
+                    graph,
+                    damping,
+                    max_iterations,
+                    tolerance,
+                )
+            }
+            Command::GraphLcc { branch, graph } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                })?;
+                crate::handlers::graph::graph_lcc(&self.primitives, branch, graph)
+            }
+            Command::GraphSssp {
+                branch,
+                graph,
+                source,
+                direction,
+            } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                })?;
+                crate::handlers::graph::graph_sssp(
+                    &self.primitives,
+                    branch,
+                    graph,
+                    source,
+                    direction,
+                )
+            }
         };
 
         match &result {

--- a/crates/executor/src/handlers/graph.rs
+++ b/crates/executor/src/handlers/graph.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 
 use strata_core::Value;
 use strata_engine::graph::types::{
-    BfsOptions, CascadePolicy, Direction, EdgeData, GraphMeta, LinkTypeDef, NodeData, ObjectTypeDef,
+    BfsOptions, CascadePolicy, CdlpOptions, Direction, EdgeData, GraphMeta, LinkTypeDef, NodeData,
+    ObjectTypeDef, PageRankOptions, SsspOptions,
 };
 
 use crate::bridge::{to_core_branch_id, Primitives};
@@ -509,6 +510,105 @@ pub fn graph_nodes_by_type(
     let core_branch = to_core_branch_id(&branch)?;
     let node_ids = convert_result(p.graph.nodes_by_type(core_branch, &graph, &object_type))?;
     Ok(Output::Keys(node_ids))
+}
+
+// =============================================================================
+// Analytics handlers
+// =============================================================================
+
+/// Handle GraphWcc command.
+pub fn graph_wcc(p: &Arc<Primitives>, branch: BranchId, graph: String) -> Result<Output> {
+    let core_branch = to_core_branch_id(&branch)?;
+    let result = convert_result(p.graph.wcc(core_branch, &graph))?;
+    Ok(Output::GraphAnalyticsU64(
+        crate::types::GraphAnalyticsU64Result {
+            algorithm: "wcc".to_string(),
+            result: result.components,
+        },
+    ))
+}
+
+/// Handle GraphCdlp command.
+pub fn graph_cdlp(
+    p: &Arc<Primitives>,
+    branch: BranchId,
+    graph: String,
+    max_iterations: usize,
+    direction: Option<String>,
+) -> Result<Output> {
+    let core_branch = to_core_branch_id(&branch)?;
+    let dir = parse_direction(direction.as_deref())?;
+    let opts = CdlpOptions {
+        max_iterations,
+        direction: dir,
+    };
+    let result = convert_result(p.graph.cdlp(core_branch, &graph, opts))?;
+    Ok(Output::GraphAnalyticsU64(
+        crate::types::GraphAnalyticsU64Result {
+            algorithm: "cdlp".to_string(),
+            result: result.labels,
+        },
+    ))
+}
+
+/// Handle GraphPagerank command.
+pub fn graph_pagerank(
+    p: &Arc<Primitives>,
+    branch: BranchId,
+    graph: String,
+    damping: Option<f64>,
+    max_iterations: Option<usize>,
+    tolerance: Option<f64>,
+) -> Result<Output> {
+    let core_branch = to_core_branch_id(&branch)?;
+    let defaults = PageRankOptions::default();
+    let opts = PageRankOptions {
+        damping: damping.unwrap_or(defaults.damping),
+        max_iterations: max_iterations.unwrap_or(defaults.max_iterations),
+        tolerance: tolerance.unwrap_or(defaults.tolerance),
+    };
+    let result = convert_result(p.graph.pagerank(core_branch, &graph, opts))?;
+    Ok(Output::GraphAnalyticsF64(
+        crate::types::GraphAnalyticsF64Result {
+            algorithm: "pagerank".to_string(),
+            result: result.ranks,
+            iterations: Some(result.iterations),
+        },
+    ))
+}
+
+/// Handle GraphLcc command.
+pub fn graph_lcc(p: &Arc<Primitives>, branch: BranchId, graph: String) -> Result<Output> {
+    let core_branch = to_core_branch_id(&branch)?;
+    let result = convert_result(p.graph.lcc(core_branch, &graph))?;
+    Ok(Output::GraphAnalyticsF64(
+        crate::types::GraphAnalyticsF64Result {
+            algorithm: "lcc".to_string(),
+            result: result.coefficients,
+            iterations: None,
+        },
+    ))
+}
+
+/// Handle GraphSssp command.
+pub fn graph_sssp(
+    p: &Arc<Primitives>,
+    branch: BranchId,
+    graph: String,
+    source: String,
+    direction: Option<String>,
+) -> Result<Output> {
+    let core_branch = to_core_branch_id(&branch)?;
+    let dir = parse_direction(direction.as_deref())?;
+    let opts = SsspOptions { direction: dir };
+    let result = convert_result(p.graph.sssp(core_branch, &graph, &source, opts))?;
+    Ok(Output::GraphAnalyticsF64(
+        crate::types::GraphAnalyticsF64Result {
+            algorithm: "sssp".to_string(),
+            result: result.distances,
+            iterations: None,
+        },
+    ))
 }
 
 /// Convert serde_json::Value to strata_core::Value.

--- a/crates/executor/src/output.rs
+++ b/crates/executor/src/output.rs
@@ -218,6 +218,12 @@ pub enum Output {
         /// Local file path where the model was saved.
         path: String,
     },
+
+    /// Graph analytics result with u64 values (WCC, CDLP).
+    GraphAnalyticsU64(GraphAnalyticsU64Result),
+
+    /// Graph analytics result with f64 values (PageRank, LCC, SSSP).
+    GraphAnalyticsF64(GraphAnalyticsF64Result),
 }
 
 /// Snapshot of the embedding pipeline status.

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -494,6 +494,27 @@ pub struct SearchResultHit {
 // Graph Types
 // =============================================================================
 
+/// Graph analytics result with u64 per-node values (WCC components, CDLP labels).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GraphAnalyticsU64Result {
+    /// Algorithm name (e.g. "wcc", "cdlp").
+    pub algorithm: String,
+    /// Per-node result values.
+    pub result: std::collections::HashMap<String, u64>,
+}
+
+/// Graph analytics result with f64 per-node values (PageRank, LCC, SSSP).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GraphAnalyticsF64Result {
+    /// Algorithm name (e.g. "pagerank", "lcc", "sssp").
+    pub algorithm: String,
+    /// Per-node result values.
+    pub result: std::collections::HashMap<String, f64>,
+    /// Number of iterations (for iterative algorithms like PageRank).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iterations: Option<usize>,
+}
+
 /// A neighbor entry returned by graph neighbor queries.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GraphNeighborHit {


### PR DESCRIPTION
## Summary
- Implements 5 LDBC Graphalytics benchmark algorithms (WCC, CDLP, PageRank, LCC, SSSP) using the adjacency-cached traversal pattern from BFS
- Full stack across engine (algorithms + types), executor (commands/handlers/API), and CLI (subcommands + tab completion)
- Includes dangling node redistribution for PageRank and self-loop exclusion for LCC
- 31 unit tests covering edge cases: empty graphs, self-loops, dangling nodes, convergence, direction modes, non-existent sources

## Test plan
- [x] `cargo build -p strata-cli` — full stack compiles
- [x] `cargo test -p strata-engine -- graph::analytics` — 31 analytics tests pass
- [x] `cargo fmt` and `cargo clippy` — clean
- [ ] CI passes

Closes #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)