### PR TITLE
Add graph analytics documentation and cookbook

### DIFF
--- a/docs/cookbook/graph-analytics.md
+++ b/docs/cookbook/graph-analytics.md
@@ -1,0 +1,276 @@
+# Graph Analytics Cookbook
+
+Analyze a social network using Strata's built-in graph algorithms. This recipe builds a small graph, then runs all six analytics algorithms to extract insights.
+
+## Setup: Build a Social Network
+
+```rust
+let db = Strata::cache()?;
+db.graph_create("social")?;
+
+// Add people
+for name in &["alice", "bob", "carol", "dave", "eve", "frank"] {
+    db.graph_add_node("social", name, None, None)?;
+}
+
+// Add relationships (directed: "follows")
+db.graph_add_edge("social", "alice", "bob",   "FOLLOWS", None, None)?;
+db.graph_add_edge("social", "bob",   "alice", "FOLLOWS", None, None)?;
+db.graph_add_edge("social", "alice", "carol", "FOLLOWS", None, None)?;
+db.graph_add_edge("social", "carol", "alice", "FOLLOWS", None, None)?;
+db.graph_add_edge("social", "bob",   "carol", "FOLLOWS", None, None)?;
+db.graph_add_edge("social", "carol", "bob",   "FOLLOWS", None, None)?;
+db.graph_add_edge("social", "carol", "dave",  "FOLLOWS", None, None)?;
+db.graph_add_edge("social", "dave",  "eve",   "FOLLOWS", None, None)?;
+db.graph_add_edge("social", "eve",   "dave",  "FOLLOWS", None, None)?;
+db.graph_add_edge("social", "dave",  "frank", "FOLLOWS", None, None)?;
+db.graph_add_edge("social", "frank", "dave",  "FOLLOWS", None, None)?;
+db.graph_add_edge("social", "eve",   "frank", "FOLLOWS", None, None)?;
+db.graph_add_edge("social", "frank", "eve",   "FOLLOWS", None, None)?;
+```
+
+This creates two clusters connected by a bridge:
+
+```
+  alice --- bob          dave --- eve
+     \   /        bridge    \   /
+      carol  ------------->  frank
+```
+
+The equivalent CLI setup:
+
+```
+graph create social
+graph add-node social alice
+graph add-node social bob
+graph add-node social carol
+graph add-node social dave
+graph add-node social eve
+graph add-node social frank
+graph add-edge social alice bob   FOLLOWS
+graph add-edge social bob   alice FOLLOWS
+graph add-edge social alice carol FOLLOWS
+graph add-edge social carol alice FOLLOWS
+graph add-edge social bob   carol FOLLOWS
+graph add-edge social carol bob   FOLLOWS
+graph add-edge social carol dave  FOLLOWS
+graph add-edge social dave  eve   FOLLOWS
+graph add-edge social eve   dave  FOLLOWS
+graph add-edge social dave  frank FOLLOWS
+graph add-edge social frank dave  FOLLOWS
+graph add-edge social eve   frank FOLLOWS
+graph add-edge social frank eve   FOLLOWS
+```
+
+## 1. BFS — Explore the Graph
+
+Starting from alice, explore the network up to depth 3:
+
+```rust
+let result = db.graph_bfs("social", "alice", 3, None, None, None)?;
+
+// Visited in order: ["alice", "bob", "carol", "dave", "eve", "frank"]
+// Depths: alice=0, bob=1, carol=1, dave=2, eve=3, frank=3
+```
+
+```
+graph bfs social alice 3
+```
+
+**Use case:** Friend-of-friend discovery, reachability queries, shortest hop count.
+
+## 2. WCC — Find Connected Components
+
+Identify disconnected groups:
+
+```rust
+let components = db.graph_wcc("social")?;
+
+// All six nodes are in the same component (connected via carol→dave bridge)
+// {"alice": 0, "bob": 0, "carol": 0, "dave": 0, "eve": 0, "frank": 0}
+```
+
+```
+graph wcc social
+```
+
+Now remove the bridge and check again:
+
+```rust
+db.graph_remove_edge("social", "carol", "dave", "FOLLOWS")?;
+let components = db.graph_wcc("social")?;
+
+// Two components:
+// {"alice": 0, "bob": 0, "carol": 0, "dave": 1, "eve": 1, "frank": 1}
+```
+
+**Use case:** Finding isolated subgraphs, detecting network partitions, data quality checks.
+
+## 3. CDLP — Detect Communities
+
+Discover natural groupings through label propagation:
+
+```rust
+let communities = db.graph_cdlp("social", 10, None)?;
+
+// Nodes in the same tight cluster converge to the same label:
+// alice, bob, carol → community A
+// dave, eve, frank  → community B
+```
+
+```
+graph cdlp social 10
+```
+
+Try directed community detection:
+
+```rust
+// Only consider outgoing edges
+let communities = db.graph_cdlp("social", 10, Some("outgoing"))?;
+```
+
+```
+graph cdlp social 10 --direction outgoing
+```
+
+**Use case:** Interest-based user grouping, topic clustering, organizational structure detection.
+
+## 4. PageRank — Rank by Importance
+
+Find the most influential nodes:
+
+```rust
+let ranks = db.graph_pagerank("social", None, None, None)?;
+
+// carol likely ranks highest — she bridges two clusters and receives
+// links from both sides. The sum of all ranks equals 1.0.
+```
+
+```
+graph pagerank social
+```
+
+Tune the algorithm:
+
+```rust
+// Higher damping (0.95) emphasizes link structure more
+let ranks = db.graph_pagerank("social", Some(0.95), Some(100), Some(1e-8))?;
+```
+
+```
+graph pagerank social --damping 0.95 --max-iterations 100 --tolerance 0.00000001
+```
+
+**Use case:** Identifying key influencers, ranking documents, finding critical infrastructure nodes.
+
+## 5. LCC — Measure Local Clustering
+
+How tightly connected are each node's neighbors?
+
+```rust
+let coefficients = db.graph_lcc("social")?;
+
+// alice: 1.0 — both of her neighbors (bob, carol) are connected to each other
+// carol: lower — she has neighbors in both clusters, and cross-cluster
+//   neighbors don't know each other
+// dave: high — his neighbors (eve, frank) are connected
+```
+
+```
+graph lcc social
+```
+
+**Use case:** Identifying cliques, measuring social cohesion, spam detection (spammers tend to have low LCC).
+
+## 6. SSSP — Shortest Paths
+
+Find the shortest path from a source to all other nodes:
+
+```rust
+let distances = db.graph_sssp("social", "alice", None)?;
+
+// {"alice": 0.0, "bob": 1.0, "carol": 1.0, "dave": 2.0, "eve": 3.0, "frank": 3.0}
+```
+
+```
+graph sssp social alice
+```
+
+With weighted edges:
+
+```rust
+// Add weighted edges (e.g., latency in milliseconds)
+db.graph_add_edge("net", "server_a", "server_b", "LINK", Some(5.0), None)?;
+db.graph_add_edge("net", "server_b", "server_c", "LINK", Some(10.0), None)?;
+db.graph_add_edge("net", "server_a", "server_c", "LINK", Some(20.0), None)?;
+
+let distances = db.graph_sssp("net", "server_a", None)?;
+// {"server_a": 0.0, "server_b": 5.0, "server_c": 15.0}
+// server_c via server_b (5+10=15) is shorter than the direct link (20)
+```
+
+Traverse in reverse (who can reach me?):
+
+```rust
+let distances = db.graph_sssp("social", "dave", Some("incoming"))?;
+// Finds shortest paths from all nodes TO dave (by following edges in reverse)
+```
+
+```
+graph sssp social dave --direction incoming
+```
+
+**Use case:** Network routing, supply chain optimization, social distance measurement.
+
+## Putting It All Together
+
+A typical analytics workflow combines multiple algorithms:
+
+```rust
+let db = Strata::cache()?;
+
+// 1. Check connectivity
+let components = db.graph_wcc("social")?;
+let num_components: std::collections::HashSet<_> = components.values().collect();
+println!("{} connected component(s)", num_components.len());
+
+// 2. Detect communities within the largest component
+let communities = db.graph_cdlp("social", 20, None)?;
+
+// 3. Rank nodes by importance
+let ranks = db.graph_pagerank("social", None, None, None)?;
+
+// 4. Find the top influencer
+let top_node = ranks.iter()
+    .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+    .map(|(node, rank)| (node.clone(), *rank));
+println!("Top influencer: {:?}", top_node);
+
+// 5. Measure how tightly-knit each community is
+let lcc = db.graph_lcc("social")?;
+let avg_clustering: f64 = lcc.values().sum::<f64>() / lcc.len() as f64;
+println!("Average clustering coefficient: {:.3}", avg_clustering);
+
+// 6. Shortest paths from the top influencer
+if let Some((top, _)) = &top_node {
+    let distances = db.graph_sssp("social", top, None)?;
+    let max_dist = distances.values().cloned().fold(0.0f64, f64::max);
+    println!("Max distance from {}: {}", top, max_dist);
+}
+```
+
+## Algorithm Reference
+
+| Algorithm | What it computes | Output type | Key parameters |
+|-----------|-----------------|-------------|----------------|
+| **BFS** | Level-by-level traversal | Visited nodes, depths, edges | `max_depth`, `direction` |
+| **WCC** | Connected components | Node → component ID (u64) | None |
+| **CDLP** | Community labels | Node → label (u64) | `max_iterations`, `direction` |
+| **PageRank** | Node importance | Node → rank (f64, sum = 1.0) | `damping`, `max_iterations`, `tolerance` |
+| **LCC** | Neighbor connectivity | Node → coefficient (f64, 0.0–1.0) | None |
+| **SSSP** | Shortest weighted paths | Node → distance (f64) | `source`, `direction` |
+
+## Next
+
+- [Graph Guide](../guides/graph.md) — full graph API reference
+- [Knowledge Graph Cookbook](knowledge-graph.md) — typed graphs with ontology

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -9,3 +9,4 @@ Real-world patterns and recipes for building with StrataDB.
 - **[Intelligent Search](intelligent-search.md)** — time-scoped cross-primitive search with expansion and reranking
 - **[A/B Testing with Branches](ab-testing-with-branches.md)** — run two strategies, compare results
 - **[Knowledge Graph](knowledge-graph.md)** — typed knowledge graph with ontology validation and bulk loading
+- **[Graph Analytics](graph-analytics.md)** — BFS, WCC, CDLP, PageRank, LCC, SSSP on a social network

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -44,6 +44,16 @@ Model relationships between entities using a property graph with typed nodes and
 | `graph_neighbors` | `(graph, node_id, direction, edge_type?) -> Result<Vec<GraphNeighborHit>>` | Neighbor list |
 | `graph_bfs` | `(graph, start, max_depth, max_nodes?, edge_types?, direction?) -> Result<GraphBfsResult>` | BFS result |
 
+### Analytics
+
+| Method | Signature | Returns |
+|--------|-----------|---------|
+| `graph_wcc` | `(graph) -> Result<HashMap<String, u64>>` | Node → component ID |
+| `graph_cdlp` | `(graph, max_iterations, direction?) -> Result<HashMap<String, u64>>` | Node → community label |
+| `graph_pagerank` | `(graph, damping?, max_iterations?, tolerance?) -> Result<HashMap<String, f64>>` | Node → rank |
+| `graph_lcc` | `(graph) -> Result<HashMap<String, f64>>` | Node → clustering coefficient |
+| `graph_sssp` | `(graph, source, direction?) -> Result<HashMap<String, f64>>` | Node → distance from source |
+
 ## Creating a Graph
 
 Use `graph_create` to create a new empty graph on the current branch:
@@ -296,8 +306,159 @@ let nodes = db.graph_list_nodes("social")?;
 assert!(!nodes.contains(&"dave".to_string()));
 ```
 
+## Graph Analytics
+
+Strata includes six built-in graph algorithms covering the [LDBC Graphalytics](https://graphalytics.org/) benchmark suite. All algorithms build an in-memory adjacency index from KV storage, then run in-memory for fast execution.
+
+### BFS — Breadth-First Search
+
+Explores the graph level by level from a start node. Returns visited nodes in BFS order, their depths, and the edges traversed.
+
+```rust
+let result = db.graph_bfs("social", "alice", 3, None, None, None)?;
+
+// result.visited — ["alice", "bob", "carol"]
+// result.depths  — {"alice": 0, "bob": 1, "carol": 1}
+// result.edges   — [("alice", "bob", "FOLLOWS"), ("alice", "carol", "FOLLOWS")]
+```
+
+Filter by edge type, limit nodes, or restrict direction:
+
+```rust
+let result = db.graph_bfs(
+    "social", "alice",
+    5,                                        // max_depth
+    Some(10),                                 // max_nodes
+    Some(vec!["FOLLOWS".to_string()]),        // edge_types
+    Some("outgoing"),                         // direction
+)?;
+```
+
+**CLI:**
+```
+graph bfs social alice 3
+graph bfs social alice 5 --max-nodes 10 --edge-types FOLLOWS --direction outgoing
+```
+
+### WCC — Weakly Connected Components
+
+Finds groups of nodes that are connected to each other (ignoring edge direction). Uses union-find with path compression. Each node maps to a component ID — nodes with the same ID are in the same component.
+
+```rust
+let result = db.graph_wcc("social")?;
+// {"alice": 0, "bob": 0, "carol": 0, "dave": 1, "eve": 1}
+// alice/bob/carol are connected; dave/eve form a separate component
+```
+
+**CLI:**
+```
+graph wcc social
+```
+
+### CDLP — Community Detection via Label Propagation
+
+Discovers communities by iteratively assigning each node the most frequent label among its neighbors. Nodes in tight clusters converge to the same label.
+
+- `max_iterations` — maximum rounds of propagation
+- `direction` — which edges count as neighbor links (`outgoing`, `incoming`, `both`)
+
+```rust
+let result = db.graph_cdlp("social", 10, None)?;
+// {"alice": 0, "bob": 0, "carol": 0, "dave": 3, "eve": 3}
+// Nodes in the same community share a label
+
+// Directed: only consider outgoing edges
+let result = db.graph_cdlp("social", 10, Some("outgoing"))?;
+```
+
+**CLI:**
+```
+graph cdlp social 10
+graph cdlp social 10 --direction outgoing
+```
+
+### PageRank — Iterative Importance Scoring
+
+Computes the relative importance of each node based on the link structure. Nodes that receive links from many important nodes get higher ranks. The sum of all ranks equals 1.0.
+
+- `damping` — probability of following a link vs. jumping randomly (default: 0.85)
+- `max_iterations` — maximum iterations (default: 20)
+- `tolerance` — convergence threshold (default: 1e-6)
+
+```rust
+let result = db.graph_pagerank("social", None, None, None)?;
+// {"alice": 0.15, "bob": 0.38, "carol": 0.47}
+// carol has the highest rank (most incoming links)
+
+// Custom parameters
+let result = db.graph_pagerank("social", Some(0.90), Some(50), Some(1e-8))?;
+```
+
+**CLI:**
+```
+graph pagerank social
+graph pagerank social --damping 0.90 --max-iterations 50 --tolerance 0.00000001
+```
+
+### LCC — Local Clustering Coefficient
+
+Measures how tightly connected each node's neighbors are to each other. A coefficient of 1.0 means all neighbors are connected; 0.0 means none are. Self-loops are excluded from the calculation.
+
+```rust
+let result = db.graph_lcc("social")?;
+// {"alice": 1.0, "bob": 0.5, "carol": 0.0}
+// All of alice's neighbors know each other (coefficient 1.0)
+// None of carol's neighbors know each other (coefficient 0.0)
+```
+
+**CLI:**
+```
+graph lcc social
+```
+
+### SSSP — Single-Source Shortest Path
+
+Finds the shortest weighted path from a source node to all reachable nodes using Dijkstra's algorithm. Edge weights come from the `weight` field (default 1.0). Unreachable nodes are omitted from the result.
+
+- `source` — the starting node
+- `direction` — which edges to follow (`outgoing`, `incoming`, `both`)
+
+```rust
+let result = db.graph_sssp("social", "alice", None)?;
+// {"alice": 0.0, "bob": 1.0, "carol": 1.0}
+// Distance from alice to herself is 0, to bob and carol is 1
+
+// Follow edges in reverse (who can reach alice?)
+let result = db.graph_sssp("social", "alice", Some("incoming"))?;
+
+// Treat edges as undirected
+let result = db.graph_sssp("social", "alice", Some("both"))?;
+```
+
+**CLI:**
+```
+graph sssp social alice
+graph sssp social alice --direction both
+```
+
+### Direction Parameter
+
+Several algorithms accept a `direction` parameter that controls which edges are followed:
+
+| Value | Meaning |
+|-------|---------|
+| `outgoing` | Follow edges in their natural direction (A→B) |
+| `incoming` | Follow edges in reverse (traverse B→A as if it were A→B) |
+| `both` | Follow edges in both directions (treat the graph as undirected) |
+
+The default depends on the algorithm:
+- **BFS, SSSP**: `outgoing` (directed traversal)
+- **CDLP**: `both` (undirected community detection)
+- **WCC, LCC**: always undirected (direction parameter not applicable)
+
 ## Next
 
 - [Ontology Guide](ontology.md) — define typed schemas with validation
 - [Knowledge Graph Cookbook](../cookbook/knowledge-graph.md) — end-to-end recipe combining graph + ontology
+- [Graph Analytics Cookbook](../cookbook/graph-analytics.md) — end-to-end example analyzing a social network
 - [API Quick Reference](../reference/api-quick-reference.md) — all method signatures


### PR DESCRIPTION
## Summary
- Extends the [Graph Guide](docs/guides/graph.md) with an Analytics API table and detailed documentation for all 6 algorithms (BFS, WCC, CDLP, PageRank, LCC, SSSP) — Rust API examples, CLI examples, direction parameter reference
- Adds a new [Graph Analytics Cookbook](docs/cookbook/graph-analytics.md) with an end-to-end social network example running all 6 algorithms
- Updates the cookbook index

## Test plan
- [x] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)