### PR TITLE
Core crate production readiness: memory, type safety, validation

### DIFF
--- a/crates/core/src/branch_types.rs
+++ b/crates/core/src/branch_types.rs
@@ -157,6 +157,12 @@ impl BranchEventOffsets {
 
     /// Add an offset
     pub fn push(&mut self, offset: u64) {
+        debug_assert!(
+            self.offsets.last().map_or(true, |&last| offset >= last),
+            "BranchEventOffsets: new offset {} is less than last offset {:?}",
+            offset,
+            self.offsets.last()
+        );
         self.offsets.push(offset);
     }
 
@@ -363,12 +369,21 @@ mod tests {
     }
 
     #[test]
-    fn test_branch_event_offsets_ordering_not_enforced() {
-        // Offsets are just a Vec - no ordering enforcement
+    fn test_branch_event_offsets_monotonic_order() {
+        // Offsets should be pushed in monotonic order
         let mut offsets = BranchEventOffsets::new();
-        offsets.push(300);
         offsets.push(100);
         offsets.push(200);
-        assert_eq!(offsets.as_slice(), &[300, 100, 200]);
+        offsets.push(300);
+        assert_eq!(offsets.as_slice(), &[100, 200, 300]);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "new offset")]
+    fn test_branch_event_offsets_debug_rejects_non_monotonic() {
+        let mut offsets = BranchEventOffsets::new();
+        offsets.push(300);
+        offsets.push(100); // Should panic in debug
     }
 }

--- a/crates/core/src/contract/entity_ref.rs
+++ b/crates/core/src/contract/entity_ref.rs
@@ -108,10 +108,9 @@ impl EntityRef {
 
     /// Create a KV entity reference
     pub fn kv(branch_id: BranchId, key: impl Into<String>) -> Self {
-        EntityRef::Kv {
-            branch_id,
-            key: key.into(),
-        }
+        let key = key.into();
+        debug_assert!(!key.is_empty(), "EntityRef::kv key must not be empty");
+        EntityRef::Kv { branch_id, key }
     }
 
     /// Create an event entity reference
@@ -124,10 +123,9 @@ impl EntityRef {
 
     /// Create a state cell entity reference
     pub fn state(branch_id: BranchId, name: impl Into<String>) -> Self {
-        EntityRef::State {
-            branch_id,
-            name: name.into(),
-        }
+        let name = name.into();
+        debug_assert!(!name.is_empty(), "EntityRef::state name must not be empty");
+        EntityRef::State { branch_id, name }
     }
 
     /// Create a branch entity reference
@@ -137,10 +135,12 @@ impl EntityRef {
 
     /// Create a JSON document entity reference
     pub fn json(branch_id: BranchId, doc_id: impl Into<String>) -> Self {
-        EntityRef::Json {
-            branch_id,
-            doc_id: doc_id.into(),
-        }
+        let doc_id = doc_id.into();
+        debug_assert!(
+            !doc_id.is_empty(),
+            "EntityRef::json doc_id must not be empty"
+        );
+        EntityRef::Json { branch_id, doc_id }
     }
 
     /// Create a vector entity reference
@@ -149,10 +149,17 @@ impl EntityRef {
         collection: impl Into<String>,
         key: impl Into<String>,
     ) -> Self {
+        let collection = collection.into();
+        let key = key.into();
+        debug_assert!(
+            !collection.is_empty(),
+            "EntityRef::vector collection must not be empty"
+        );
+        // Note: key may be empty for collection-level references (e.g., error reporting)
         EntityRef::Vector {
             branch_id,
-            collection: collection.into(),
-            key: key.into(),
+            collection,
+            key,
         }
     }
 
@@ -520,8 +527,10 @@ mod tests {
         assert_ne!(ref1, ref2);
     }
 
+    #[cfg(not(debug_assertions))]
     #[test]
-    fn test_entity_ref_empty_string_keys() {
+    fn test_entity_ref_empty_string_keys_release() {
+        // In release builds, empty keys are allowed (no debug_assert)
         let branch_id = BranchId::new();
         let kv = EntityRef::kv(branch_id, "");
         assert_eq!(kv.kv_key(), Some(""));
@@ -531,6 +540,38 @@ mod tests {
 
         let json = EntityRef::json(branch_id, "");
         assert_eq!(json.json_doc_id(), Some(""));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "must not be empty")]
+    fn test_entity_ref_empty_kv_key_debug_panics() {
+        let branch_id = BranchId::new();
+        let _kv = EntityRef::kv(branch_id, "");
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "EntityRef::state name must not be empty")]
+    fn test_entity_ref_empty_state_name_debug_panics() {
+        let branch_id = BranchId::new();
+        let _state = EntityRef::state(branch_id, "");
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "EntityRef::json doc_id must not be empty")]
+    fn test_entity_ref_empty_json_docid_debug_panics() {
+        let branch_id = BranchId::new();
+        let _json = EntityRef::json(branch_id, "");
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "EntityRef::vector collection must not be empty")]
+    fn test_entity_ref_empty_vector_collection_debug_panics() {
+        let branch_id = BranchId::new();
+        let _vector = EntityRef::vector(branch_id, "", "key");
     }
 
     #[test]

--- a/crates/core/src/contract/version.rs
+++ b/crates/core/src/contract/version.rs
@@ -174,36 +174,17 @@ impl Version {
 }
 
 impl PartialOrd for Version {
-    /// Compare versions
+    /// Compare versions within the same variant type.
     ///
-    /// Delegates to `Ord::cmp` for consistency.
-    /// For semantic same-variant comparison, use dedicated methods.
+    /// Returns `None` for cross-variant comparison (e.g., `Txn` vs `Sequence`),
+    /// since comparing across versioning schemes is not meaningful.
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Version {
-    /// Total ordering for sorting purposes
-    ///
-    /// WARNING: This provides a total ordering by comparing numeric values
-    /// regardless of variant. Use `partial_cmp` for semantic comparison.
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // First compare by variant discriminant, then by value
-        let self_discriminant = match self {
-            Version::Txn(_) => 0,
-            Version::Sequence(_) => 1,
-            Version::Counter(_) => 2,
-        };
-        let other_discriminant = match other {
-            Version::Txn(_) => 0,
-            Version::Sequence(_) => 1,
-            Version::Counter(_) => 2,
-        };
-
-        self_discriminant
-            .cmp(&other_discriminant)
-            .then_with(|| self.as_u64().cmp(&other.as_u64()))
+        match (self, other) {
+            (Version::Txn(a), Version::Txn(b)) => Some(a.cmp(b)),
+            (Version::Sequence(a), Version::Sequence(b)) => Some(a.cmp(b)),
+            (Version::Counter(a), Version::Counter(b)) => Some(a.cmp(b)),
+            _ => None,
+        }
     }
 }
 
@@ -314,43 +295,29 @@ mod tests {
 
     #[test]
     fn test_version_partial_ord_different_types() {
-        use std::cmp::Ordering;
-
-        // Cross-variant comparison delegates to Ord for consistency
-        // TxnId < Sequence < Counter
-        assert_eq!(
-            Version::Txn(1).partial_cmp(&Version::Sequence(1)),
-            Some(Ordering::Less)
-        );
-        assert_eq!(
-            Version::Sequence(1).partial_cmp(&Version::Counter(1)),
-            Some(Ordering::Less)
-        );
-        assert_eq!(
-            Version::Txn(1).partial_cmp(&Version::Counter(1)),
-            Some(Ordering::Less)
-        );
+        // Cross-variant comparison returns None (not meaningful)
+        assert_eq!(Version::Txn(1).partial_cmp(&Version::Sequence(1)), None);
+        assert_eq!(Version::Sequence(1).partial_cmp(&Version::Counter(1)), None);
+        assert_eq!(Version::Txn(1).partial_cmp(&Version::Counter(1)), None);
     }
 
     #[test]
     fn test_version_partial_ord_reverse_direction() {
-        use std::cmp::Ordering;
-
-        // Test the reverse direction (Greater)
+        // Cross-variant comparison returns None in both directions
         assert_eq!(
             Version::Sequence(1).partial_cmp(&Version::Txn(1)),
-            Some(Ordering::Greater),
-            "Sequence should be greater than Txn"
+            None,
+            "Cross-variant should return None"
         );
         assert_eq!(
             Version::Counter(1).partial_cmp(&Version::Sequence(1)),
-            Some(Ordering::Greater),
-            "Counter should be greater than Sequence"
+            None,
+            "Cross-variant should return None"
         );
         assert_eq!(
             Version::Counter(1).partial_cmp(&Version::Txn(1)),
-            Some(Ordering::Greater),
-            "Counter should be greater than Txn"
+            None,
+            "Cross-variant should return None"
         );
     }
 
@@ -379,26 +346,21 @@ mod tests {
 
     #[test]
     fn test_version_boundary_values_different_types() {
-        use std::cmp::Ordering;
-
-        // Even with extreme values, ordering by discriminant takes precedence
-        // Txn(MAX) < Sequence(0) because Txn discriminant < Sequence discriminant
+        // Cross-variant comparison returns None regardless of values
         assert_eq!(
             Version::Txn(u64::MAX).partial_cmp(&Version::Sequence(0)),
-            Some(Ordering::Less),
-            "Txn(MAX) should still be less than Sequence(0)"
+            None,
+            "Cross-variant should return None"
         );
         assert_eq!(
             Version::Sequence(u64::MAX).partial_cmp(&Version::Counter(0)),
-            Some(Ordering::Less),
-            "Sequence(MAX) should still be less than Counter(0)"
+            None,
+            "Cross-variant should return None"
         );
-
-        // And the reverse
         assert_eq!(
             Version::Counter(0).partial_cmp(&Version::Txn(u64::MAX)),
-            Some(Ordering::Greater),
-            "Counter(0) should be greater than Txn(MAX)"
+            None,
+            "Cross-variant should return None"
         );
     }
 
@@ -406,17 +368,14 @@ mod tests {
     fn test_version_ordering_symmetry() {
         use std::cmp::Ordering;
 
-        // For any a, b: if a < b then b > a (ordering symmetry)
-        let pairs = [
+        // Same-variant pairs have total ordering
+        let same_variant_pairs = [
             (Version::Txn(5), Version::Txn(10)),
             (Version::Sequence(5), Version::Sequence(10)),
             (Version::Counter(5), Version::Counter(10)),
-            (Version::Txn(5), Version::Sequence(5)),
-            (Version::Sequence(5), Version::Counter(5)),
-            (Version::Txn(5), Version::Counter(5)),
         ];
 
-        for (a, b) in pairs {
+        for (a, b) in same_variant_pairs {
             let a_cmp_b = a.partial_cmp(&b);
             let b_cmp_a = b.partial_cmp(&a);
 
@@ -430,66 +389,53 @@ mod tests {
                 ),
             }
         }
+
+        // Cross-variant pairs return None
+        let cross_variant_pairs = [
+            (Version::Txn(5), Version::Sequence(5)),
+            (Version::Sequence(5), Version::Counter(5)),
+            (Version::Txn(5), Version::Counter(5)),
+        ];
+
+        for (a, b) in cross_variant_pairs {
+            assert_eq!(
+                a.partial_cmp(&b),
+                None,
+                "Cross-variant {:?} vs {:?} should be None",
+                a,
+                b
+            );
+            assert_eq!(
+                b.partial_cmp(&a),
+                None,
+                "Cross-variant {:?} vs {:?} should be None",
+                b,
+                a
+            );
+        }
     }
 
     #[test]
-    fn test_version_cmp_directly() {
+    fn test_version_partial_cmp_same_variant() {
         use std::cmp::Ordering;
 
-        // TxnId < Sequence < Counter (by discriminant)
-        assert_eq!(Version::Txn(5).cmp(&Version::Sequence(5)), Ordering::Less);
+        // Same variant: compare by value
         assert_eq!(
-            Version::Txn(5).cmp(&Version::Counter(5)),
-            Ordering::Less,
-            "TxnId should be less than Counter"
+            Version::Txn(5).partial_cmp(&Version::Txn(10)),
+            Some(Ordering::Less)
         );
         assert_eq!(
-            Version::Sequence(5).cmp(&Version::Counter(5)),
-            Ordering::Less
+            Version::Txn(10).partial_cmp(&Version::Txn(5)),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            Version::Txn(5).partial_cmp(&Version::Txn(5)),
+            Some(Ordering::Equal)
         );
 
-        // Same variant, compare by value
-        assert_eq!(Version::Txn(5).cmp(&Version::Txn(10)), Ordering::Less);
-        assert_eq!(Version::Txn(10).cmp(&Version::Txn(5)), Ordering::Greater);
-        assert_eq!(Version::Txn(5).cmp(&Version::Txn(5)), Ordering::Equal);
-    }
-
-    #[test]
-    fn test_version_ord_total_ordering() {
-        // Total ordering groups by variant first, then by value
-        let mut versions = vec![
-            Version::Counter(5),
-            Version::Txn(10),
-            Version::Sequence(1),
-            Version::Txn(5),
-            Version::Sequence(10),
-            Version::Counter(1),
-        ];
-        versions.sort();
-
-        // Expected order: TxnId(5), TxnId(10), Sequence(1), Sequence(10), Counter(1), Counter(5)
-        assert_eq!(versions[0], Version::Txn(5), "First should be TxnId(5)");
-        assert_eq!(versions[1], Version::Txn(10), "Second should be TxnId(10)");
-        assert_eq!(
-            versions[2],
-            Version::Sequence(1),
-            "Third should be Sequence(1)"
-        );
-        assert_eq!(
-            versions[3],
-            Version::Sequence(10),
-            "Fourth should be Sequence(10)"
-        );
-        assert_eq!(
-            versions[4],
-            Version::Counter(1),
-            "Fifth should be Counter(1)"
-        );
-        assert_eq!(
-            versions[5],
-            Version::Counter(5),
-            "Sixth should be Counter(5)"
-        );
+        // Cross-variant: None
+        assert_eq!(Version::Txn(5).partial_cmp(&Version::Sequence(5)), None);
+        assert_eq!(Version::Sequence(5).partial_cmp(&Version::Counter(5)), None);
     }
 
     #[test]

--- a/crates/core/src/contract/versioned.rs
+++ b/crates/core/src/contract/versioned.rs
@@ -474,13 +474,13 @@ mod tests {
         assert!(v_bytes.is_bytes());
         assert_eq!(v_bytes.as_bytes(), Some(&[1u8, 2, 3][..]));
 
-        let v_arr = Versioned::new(Value::Array(vec![Value::Int(1)]), Version::txn(1));
+        let v_arr = Versioned::new(Value::Array(Box::new(vec![Value::Int(1)])), Version::txn(1));
         assert!(v_arr.is_array());
         assert_eq!(v_arr.as_array().unwrap().len(), 1);
 
         let mut map = HashMap::new();
         map.insert("k".to_string(), Value::Int(1));
-        let v_obj = Versioned::new(Value::Object(map), Version::txn(1));
+        let v_obj = Versioned::new(Value::Object(Box::new(map)), Version::txn(1));
         assert!(v_obj.is_object());
         assert_eq!(v_obj.as_object().unwrap().len(), 1);
     }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -509,6 +509,8 @@ pub enum StrataError {
         reason: String,
         /// Optional entity reference
         entity_ref: Option<EntityRef>,
+        /// Optional transaction ID that caused the conflict
+        transaction_id: Option<u64>,
     },
 
     /// Version conflict
@@ -1155,6 +1157,7 @@ impl StrataError {
         StrataError::Conflict {
             reason: reason.into(),
             entity_ref: None,
+            transaction_id: None,
         }
     }
 
@@ -1170,6 +1173,19 @@ impl StrataError {
         StrataError::Conflict {
             reason: reason.into(),
             entity_ref: Some(entity_ref),
+            transaction_id: None,
+        }
+    }
+
+    /// Create a Conflict error with transaction ID
+    ///
+    /// Use this when a conflict can be attributed to a specific transaction,
+    /// enabling clients to correlate conflicts with their transaction IDs.
+    pub fn conflict_with_txn(reason: impl Into<String>, transaction_id: u64) -> Self {
+        StrataError::Conflict {
+            reason: reason.into(),
+            entity_ref: None,
+            transaction_id: Some(transaction_id),
         }
     }
 
@@ -1242,10 +1258,17 @@ impl StrataError {
             StrataError::WrongType { expected, actual } => ErrorDetails::new()
                 .with_string("expected", expected)
                 .with_string("actual", actual),
-            StrataError::Conflict { reason, entity_ref } => {
+            StrataError::Conflict {
+                reason,
+                entity_ref,
+                transaction_id,
+            } => {
                 let mut details = ErrorDetails::new().with_string("reason", reason);
                 if let Some(ref e) = entity_ref {
                     details = details.with_string("entity", e.to_string());
+                }
+                if let Some(txn_id) = transaction_id {
+                    details = details.with_int("transaction_id", *txn_id as i64);
                 }
                 details
             }
@@ -1530,6 +1553,10 @@ impl StrataError {
     pub fn entity_ref(&self) -> Option<&EntityRef> {
         match self {
             StrataError::NotFound { entity_ref } => Some(entity_ref),
+            StrataError::Conflict {
+                entity_ref: Some(ref e),
+                ..
+            } => Some(e),
             StrataError::VersionConflict { entity_ref, .. } => Some(entity_ref),
             StrataError::WriteConflict { entity_ref } => Some(entity_ref),
             StrataError::InvalidOperation { entity_ref, .. } => Some(entity_ref),
@@ -2399,9 +2426,30 @@ mod adversarial_error_tests {
 
         assert_eq!(e.code(), ErrorCode::Conflict);
         assert!(e.is_retryable());
-        // conflict_on does NOT expose entity via entity_ref() accessor
-        // (it's stored inside the Conflict variant, not the entity_ref accessor match)
+        // conflict_on exposes entity via entity_ref() accessor
+        assert_eq!(e.entity_ref(), Some(&entity));
         assert!(e.to_string().contains("concurrent modification"));
+        // details() contains the "entity" key
+        let details = e.details();
+        assert!(
+            details.fields().contains_key("entity"),
+            "conflict_on details should contain 'entity' key"
+        );
+    }
+
+    #[test]
+    fn test_conflict_with_txn_constructor() {
+        let e = StrataError::conflict_with_txn("txn conflict", 42);
+
+        assert_eq!(e.code(), ErrorCode::Conflict);
+        assert!(e.is_retryable());
+        assert!(e.to_string().contains("txn conflict"));
+
+        let details = e.details();
+        assert!(
+            details.fields().contains_key("transaction_id"),
+            "conflict_with_txn details should contain 'transaction_id' key"
+        );
     }
 
     #[test]
@@ -2494,6 +2542,7 @@ mod adversarial_error_tests {
             StrataError::wrong_type("A", "B"),
             StrataError::conflict("reason"),
             StrataError::conflict_on(entity.clone(), "reason"),
+            StrataError::conflict_with_txn("txn conflict", 99),
             StrataError::version_conflict(entity.clone(), Version::Txn(1), Version::Txn(2)),
             StrataError::write_conflict(entity.clone()),
             StrataError::transaction_aborted("reason"),
@@ -2516,7 +2565,7 @@ mod adversarial_error_tests {
             let _ = e.message(); // Should not panic
             let _ = e.details(); // Should not panic
         }
-        assert_eq!(errors.len(), 21, "Should test all 21 error constructors");
+        assert_eq!(errors.len(), 22, "Should test all 22 error constructors");
     }
 
     #[test]

--- a/crates/core/src/limits.rs
+++ b/crates/core/src/limits.rs
@@ -148,7 +148,7 @@ impl Limits {
                         max: self.max_array_len,
                     });
                 }
-                for v in arr {
+                for v in arr.iter() {
                     self.validate_value_impl(v, depth + 1)?;
                 }
                 Ok(())
@@ -168,6 +168,72 @@ impl Limits {
                 Ok(())
             }
         }
+    }
+
+    /// Recursively reject non-finite floats (NaN, Infinity, -Infinity) anywhere
+    /// in the value tree. These cannot be faithfully represented in JSON;
+    /// `serde_json` silently converts them to `null` rather than returning an error.
+    fn reject_non_finite_floats(value: &Value) -> Result<(), LimitError> {
+        match value {
+            Value::Float(f) if !f.is_finite() => Err(LimitError::ValueTooLarge {
+                reason: "value_not_serializable".to_string(),
+                actual: 0,
+                max: 0,
+            }),
+            Value::Array(arr) => {
+                for v in arr.iter() {
+                    Self::reject_non_finite_floats(v)?;
+                }
+                Ok(())
+            }
+            Value::Object(obj) => {
+                for v in obj.values() {
+                    Self::reject_non_finite_floats(v)?;
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Validate a value against all limits in a single pass
+    ///
+    /// This combines structural validation (string/bytes/array/object/nesting limits)
+    /// with an encoded size check. Use this at API boundaries where both checks
+    /// are needed. Existing `validate_value()` remains for callers that don't
+    /// need the encoded size check.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first limit violation encountered (structural checks first,
+    /// then encoded size).
+    pub fn validate_value_full(&self, value: &Value) -> Result<(), LimitError> {
+        // First, validate structural limits
+        self.validate_value(value)?;
+
+        // Reject non-finite floats (NaN, Infinity, -Infinity) which cannot be
+        // faithfully represented in JSON. serde_json silently converts them to null
+        // rather than returning an error, so we must check explicitly.
+        Self::reject_non_finite_floats(value)?;
+
+        // Then check encoded size
+        let encoded_size =
+            serde_json::to_vec(value)
+                .map(|v| v.len())
+                .map_err(|_| LimitError::ValueTooLarge {
+                    reason: "value_not_serializable".to_string(),
+                    actual: 0,
+                    max: self.max_value_bytes_encoded,
+                })?;
+        if encoded_size > self.max_value_bytes_encoded {
+            return Err(LimitError::ValueTooLarge {
+                reason: "encoded_value_too_large".to_string(),
+                actual: encoded_size,
+                max: self.max_value_bytes_encoded,
+            });
+        }
+
+        Ok(())
     }
 
     /// Validate a vector against dimension limits
@@ -365,7 +431,7 @@ mod tests {
     fn test_array_at_max_length() {
         let limits = Limits::with_small_limits();
         let arr = vec![Value::Null; limits.max_array_len];
-        let value = Value::Array(arr);
+        let value = Value::Array(Box::new(arr));
         assert!(limits.validate_value(&value).is_ok());
     }
 
@@ -373,7 +439,7 @@ mod tests {
     fn test_array_exceeds_max_length() {
         let limits = Limits::with_small_limits();
         let arr = vec![Value::Null; limits.max_array_len + 1];
-        let value = Value::Array(arr);
+        let value = Value::Array(Box::new(arr));
         let result = limits.validate_value(&value);
         assert!(matches!(result, Err(LimitError::ValueTooLarge { .. })));
     }
@@ -387,7 +453,7 @@ mod tests {
         for i in 0..limits.max_object_entries {
             map.insert(format!("key{}", i), Value::Null);
         }
-        let value = Value::Object(map);
+        let value = Value::Object(Box::new(map));
         assert!(limits.validate_value(&value).is_ok());
     }
 
@@ -398,7 +464,7 @@ mod tests {
         for i in 0..=limits.max_object_entries {
             map.insert(format!("key{}", i), Value::Null);
         }
-        let value = Value::Object(map);
+        let value = Value::Object(Box::new(map));
         let result = limits.validate_value(&value);
         assert!(matches!(result, Err(LimitError::ValueTooLarge { .. })));
     }
@@ -408,7 +474,7 @@ mod tests {
     fn create_nested_array(depth: usize) -> Value {
         let mut value = Value::Null;
         for _ in 0..depth {
-            value = Value::Array(vec![value]);
+            value = Value::Array(Box::new(vec![value]));
         }
         value
     }
@@ -561,5 +627,108 @@ mod tests {
         assert!(limits.validate_value(&Value::Float(f64::MAX)).is_ok());
         assert!(limits.validate_value(&Value::Float(f64::NAN)).is_ok());
         assert!(limits.validate_value(&Value::Float(f64::INFINITY)).is_ok());
+    }
+
+    // === Full Validation Tests ===
+
+    #[test]
+    fn test_validate_value_full_passes_valid() {
+        let limits = Limits::with_small_limits();
+        let value = Value::String("hello".to_string());
+        assert!(limits.validate_value_full(&value).is_ok());
+    }
+
+    #[test]
+    fn test_validate_value_full_rejects_structural_violation() {
+        let limits = Limits::with_small_limits();
+        let s = "x".repeat(limits.max_string_bytes + 1);
+        let value = Value::String(s);
+        let result = limits.validate_value_full(&value);
+        assert!(matches!(result, Err(LimitError::ValueTooLarge { .. })));
+    }
+
+    #[test]
+    fn test_validate_value_full_rejects_encoded_size() {
+        let limits = Limits {
+            max_value_bytes_encoded: 10, // very small
+            ..Limits::default()
+        };
+        // A valid value that's larger than 10 bytes when encoded
+        let value = Value::String("this is a long string".to_string());
+        let result = limits.validate_value_full(&value);
+        assert!(
+            matches!(result, Err(LimitError::ValueTooLarge { reason, .. }) if reason == "encoded_value_too_large")
+        );
+    }
+
+    #[test]
+    fn test_validate_value_full_nan_float() {
+        let limits = Limits::default();
+        let value = Value::Float(f64::NAN);
+        let result = limits.validate_value_full(&value);
+        assert!(
+            matches!(result, Err(LimitError::ValueTooLarge { reason, .. }) if reason == "value_not_serializable")
+        );
+    }
+
+    #[test]
+    fn test_validate_value_full_infinity_float() {
+        let limits = Limits::default();
+        let value = Value::Float(f64::INFINITY);
+        let result = limits.validate_value_full(&value);
+        assert!(
+            matches!(result, Err(LimitError::ValueTooLarge { reason, .. }) if reason == "value_not_serializable")
+        );
+    }
+
+    #[test]
+    fn test_validate_value_full_empty_array() {
+        let limits = Limits::default();
+        let value = Value::Array(Box::new(vec![]));
+        assert!(limits.validate_value_full(&value).is_ok());
+    }
+
+    #[test]
+    fn test_validate_value_full_empty_object() {
+        let limits = Limits::default();
+        let value = Value::Object(Box::new(HashMap::new()));
+        assert!(limits.validate_value_full(&value).is_ok());
+    }
+
+    #[test]
+    fn test_validate_value_full_primitives_pass() {
+        let limits = Limits::default();
+        assert!(limits.validate_value_full(&Value::Null).is_ok());
+        assert!(limits.validate_value_full(&Value::Bool(true)).is_ok());
+        assert!(limits.validate_value_full(&Value::Bool(false)).is_ok());
+        assert!(limits.validate_value_full(&Value::Int(42)).is_ok());
+        assert!(limits.validate_value_full(&Value::Int(i64::MIN)).is_ok());
+        assert!(limits.validate_value_full(&Value::Int(i64::MAX)).is_ok());
+        assert!(limits.validate_value_full(&Value::Float(3.14)).is_ok());
+        assert!(limits.validate_value_full(&Value::Float(0.0)).is_ok());
+        assert!(limits.validate_value_full(&Value::Float(-0.0)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_value_full_at_exact_boundary() {
+        // Use a custom limit where max_value_bytes_encoded equals the exact encoded size
+        let value = Value::Int(42);
+        let encoded_len = serde_json::to_vec(&value).unwrap().len();
+        let limits = Limits {
+            max_value_bytes_encoded: encoded_len,
+            ..Limits::default()
+        };
+        // Exactly at the boundary should pass
+        assert!(limits.validate_value_full(&value).is_ok());
+
+        // One byte smaller should fail
+        let limits_smaller = Limits {
+            max_value_bytes_encoded: encoded_len - 1,
+            ..Limits::default()
+        };
+        let result = limits_smaller.validate_value_full(&value);
+        assert!(
+            matches!(result, Err(LimitError::ValueTooLarge { reason, .. }) if reason == "encoded_value_too_large")
+        );
     }
 }

--- a/crates/core/src/primitives/json.rs
+++ b/crates/core/src/primitives/json.rs
@@ -125,6 +125,13 @@ pub enum JsonLimitError {
 #[repr(transparent)]
 pub struct JsonValue(serde_json::Value);
 
+// Compile-time layout assertion: JsonValue must have identical layout to serde_json::Value.
+// This guards the two `unsafe` pointer casts in get_at_path() and get_at_path_mut().
+const _: () = {
+    assert!(std::mem::size_of::<JsonValue>() == std::mem::size_of::<serde_json::Value>());
+    assert!(std::mem::align_of::<JsonValue>() == std::mem::align_of::<serde_json::Value>());
+};
+
 impl JsonValue {
     /// Create a null JSON value
     pub fn null() -> Self {

--- a/crates/core/src/primitives/state.rs
+++ b/crates/core/src/primitives/state.rs
@@ -169,14 +169,14 @@ mod tests {
 
     #[test]
     fn test_state_with_complex_value() {
-        let complex = Value::Object({
+        let complex = Value::Object(Box::new({
             let mut m = std::collections::HashMap::new();
             m.insert(
                 "nested".to_string(),
-                Value::Array(vec![Value::Int(1), Value::Null]),
+                Value::Array(Box::new(vec![Value::Int(1), Value::Null])),
             );
             m
-        });
+        }));
         let state = State::new(complex.clone());
         assert_eq!(state.value, complex);
 

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -16,15 +16,41 @@ use crate::value::Value;
 /// with sharded, lock-free, or distributed storage without breaking
 /// upper layers (concurrency, primitives, engine).
 ///
-/// Thread safety: All methods must be safe to call concurrently from
-/// multiple threads (requires Send + Sync).
+/// ## Thread Safety
 ///
-/// # Examples
+/// All implementations **must** be `Send + Sync`. Methods may be called
+/// concurrently from multiple threads without external synchronization.
 ///
-/// ```
-/// use strata_core::traits::Storage;
-/// // Storage implementations will be added in Epic 2
-/// ```
+/// ## Visibility Semantics
+///
+/// A successful `put()` **happens-before** any subsequent `get()` on the same
+/// key within the same thread. Cross-thread visibility is guaranteed by the
+/// `Send + Sync` bounds — implementations must use internal synchronization
+/// (e.g., `RwLock`, atomics, or lock-free structures) to ensure that a `put()`
+/// on thread A is visible to a `get()` on thread B that starts after the `put()`
+/// returns.
+///
+/// ## Snapshot Consistency
+///
+/// `get_versioned()` and `scan_prefix()` accept a `max_version` parameter.
+/// They must return a view consistent with that version — i.e., only values
+/// written at or before `max_version` are visible. This is the foundation
+/// for snapshot isolation in the concurrency layer.
+///
+/// ## Error Conditions
+///
+/// All fallible methods return `StrataResult`. Implementations should return:
+/// - `StrataError::storage(...)` for I/O failures (disk, network)
+/// - `StrataError::internal(...)` for invariant violations (bugs)
+///
+/// Callers should **not** assume that errors are transient — a `StorageError`
+/// may indicate permanent media failure.
+///
+/// ## Implementors
+///
+/// Implementors **should** validate size limits in `put()` and `put_with_version()`
+/// using [`crate::limits::Limits`]. This enforcement is planned for the storage
+/// epic (#1306) but is not yet required by this trait.
 pub trait Storage: Send + Sync {
     /// Get current value for key (latest version)
     ///
@@ -72,11 +98,15 @@ pub trait Storage: Send + Sync {
     /// Put key-value pair with optional TTL
     ///
     /// Returns the version assigned to this write.
-    /// Version is monotonically increasing and assigned by storage layer.
+    /// Version is monotonically increasing and assigned by the storage layer.
+    ///
+    /// After a successful return, the written value is immediately visible
+    /// to `get()` calls on the same or any other thread.
     ///
     /// # Errors
     ///
-    /// Returns an error if the storage operation fails.
+    /// - `StorageError` — I/O or backend failure
+    /// - Future: `ConstraintViolation` when limit enforcement is added (#1306)
     fn put(&self, key: Key, value: Value, ttl: Option<Duration>) -> StrataResult<u64>;
 
     /// Delete key
@@ -167,18 +197,29 @@ pub trait Storage: Send + Sync {
 
 /// Snapshot view abstraction for snapshot isolation
 ///
-/// Provides version-bounded read view of storage.
-/// MVP: ClonedSnapshotView (deep clone at version)
-/// Future: LazySnapshotView (version-bounded reads from live storage)
+/// Provides a **frozen, read-only** view of storage at a specific version.
+/// All reads through a snapshot return data as it existed at `version()`,
+/// regardless of concurrent writes to the underlying storage.
 ///
-/// Thread safety: Must be safe to pass between threads (Send + Sync).
+/// ## Thread Safety
 ///
-/// # Examples
+/// All implementations **must** be `Send + Sync`. A snapshot may be created
+/// on one thread and read from another.
 ///
-/// ```
-/// use strata_core::traits::SnapshotView;
-/// // SnapshotView implementations will be added in Epic 2
-/// ```
+/// ## Consistency Guarantees
+///
+/// - `get()` returns the latest value written at or before `version()`.
+/// - `scan_prefix()` returns a consistent set of key-value pairs — all
+///   visible at `version()`, none written after.
+/// - The snapshot is **immutable**: repeated reads of the same key always
+///   return the same result (or `None` if the key didn't exist at that version).
+///
+/// ## Lifetime
+///
+/// Snapshots may hold references to shared state (e.g., an `Arc` to the
+/// underlying storage). Dropping a snapshot releases these references.
+/// Long-lived snapshots may prevent garbage collection of old versions
+/// in compacting storage implementations.
 pub trait SnapshotView: Send + Sync {
     /// Get value from snapshot
     ///

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -92,6 +92,10 @@ impl Namespace {
         branch_id: BranchId,
         space: String,
     ) -> Self {
+        debug_assert!(!tenant.is_empty(), "Namespace tenant must not be empty");
+        debug_assert!(!app.is_empty(), "Namespace app must not be empty");
+        debug_assert!(!agent.is_empty(), "Namespace agent must not be empty");
+        debug_assert!(!space.is_empty(), "Namespace space must not be empty");
         Self {
             tenant,
             app,
@@ -101,29 +105,70 @@ impl Namespace {
         }
     }
 
+    /// Create a new namespace with validation
+    ///
+    /// Returns an error if any string field is empty. Use this at API boundaries
+    /// where input validation is required. For internal use where inputs are
+    /// known-valid, prefer `new()` which uses `debug_assert!`.
+    pub fn try_new(
+        tenant: String,
+        app: String,
+        agent: String,
+        branch_id: BranchId,
+        space: String,
+    ) -> Result<Self, crate::error::StrataError> {
+        if tenant.is_empty() {
+            return Err(crate::error::StrataError::invalid_input(
+                "Namespace tenant must not be empty",
+            ));
+        }
+        if app.is_empty() {
+            return Err(crate::error::StrataError::invalid_input(
+                "Namespace app must not be empty",
+            ));
+        }
+        if agent.is_empty() {
+            return Err(crate::error::StrataError::invalid_input(
+                "Namespace agent must not be empty",
+            ));
+        }
+        if space.is_empty() {
+            return Err(crate::error::StrataError::invalid_input(
+                "Namespace space must not be empty",
+            ));
+        }
+        Ok(Self {
+            tenant,
+            app,
+            agent,
+            branch_id,
+            space,
+        })
+    }
+
     /// Create a namespace for a branch with default tenant/app/agent/space
     ///
     /// This is a convenience method for primitives that only need
     /// branch-level isolation. Uses "default" for tenant, app, agent, and space.
     pub fn for_branch(branch_id: BranchId) -> Self {
-        Self {
-            tenant: "default".to_string(),
-            app: "default".to_string(),
-            agent: "default".to_string(),
+        Self::new(
+            "default".to_string(),
+            "default".to_string(),
+            "default".to_string(),
             branch_id,
-            space: "default".to_string(),
-        }
+            "default".to_string(),
+        )
     }
 
     /// Create a namespace for a branch and space with default tenant/app/agent
     pub fn for_branch_space(branch_id: BranchId, space: &str) -> Self {
-        Self {
-            tenant: "default".to_string(),
-            app: "default".to_string(),
-            agent: "default".to_string(),
+        Self::new(
+            "default".to_string(),
+            "default".to_string(),
+            "default".to_string(),
             branch_id,
-            space: space.to_string(),
-        }
+            space.to_string(),
+        )
     }
 }
 
@@ -169,13 +214,14 @@ impl PartialOrd for Namespace {
 /// - Event = 0x02
 /// - State = 0x03
 /// - Branch = 0x05
+/// - Space = 0x06
 /// - Vector = 0x10 (vector metadata)
 /// - Json = 0x11 (JSON primitive)
 /// - VectorConfig = 0x12 (vector collection config)
 ///
 /// Note: 0x04 was formerly Trace (TraceStore was removed in 0.12.0)
 ///
-/// Ordering: KV < Event < State < Branch < Vector < Json < VectorConfig
+/// Ordering: KV < Event < State < Trace < Branch < Space < Vector < Json < VectorConfig
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum TypeTag {
@@ -185,7 +231,12 @@ pub enum TypeTag {
     Event = 0x02,
     /// State cell records (renamed from StateMachine )
     State = 0x03,
-    /// Reserved for backwards compatibility (TraceStore was removed)
+    /// Reserved for backwards compatibility (TraceStore was removed in 0.12.0).
+    ///
+    /// This variant is preserved **only** for legacy deserialization of on-disk data
+    /// that may contain `0x04` type tags. It must never be used for new writes.
+    /// The `from_byte(0x04)` arm returns `Some(TypeTag::Trace)` to avoid data loss
+    /// during recovery of databases created before 0.12.0.
     #[deprecated(since = "0.12.0", note = "TraceStore primitive was removed")]
     Trace = 0x04,
     /// Branch index entries
@@ -213,7 +264,7 @@ impl TypeTag {
             0x01 => Some(TypeTag::KV),
             0x02 => Some(TypeTag::Event),
             0x03 => Some(TypeTag::State),
-            0x04 => Some(TypeTag::Trace), // Deprecated but needed for backwards compatibility
+            0x04 => Some(TypeTag::Trace), // Legacy only: preserved for deserialization, never for new writes
             0x05 => Some(TypeTag::Branch),
             0x06 => Some(TypeTag::Space),
             0x10 => Some(TypeTag::Vector),
@@ -269,16 +320,22 @@ pub struct Key {
     /// Type discriminator (KV, Event, State, Trace, Branch, etc.)
     pub type_tag: TypeTag,
     /// User-defined key bytes (supports arbitrary binary keys)
-    pub user_key: Vec<u8>,
+    ///
+    /// Uses `Box<[u8]>` instead of `Vec<u8>` to save 8 bytes per key
+    /// (no capacity field). At 128M entries this saves ~1 GB of RAM.
+    pub user_key: Box<[u8]>,
 }
 
 impl Key {
     /// Create a new key with the given namespace, type tag, and user key
+    ///
+    /// Accepts `Vec<u8>` for ergonomic construction and converts internally
+    /// to `Box<[u8]>` for memory efficiency.
     pub fn new(namespace: Arc<Namespace>, type_tag: TypeTag, user_key: Vec<u8>) -> Self {
         Self {
             namespace,
             type_tag,
-            user_key,
+            user_key: user_key.into_boxed_slice(),
         }
     }
 
@@ -451,7 +508,9 @@ impl Key {
     ///
     /// Returns None if the user_key is not valid UTF-8
     pub fn user_key_string(&self) -> Option<String> {
-        String::from_utf8(self.user_key.clone()).ok()
+        std::str::from_utf8(&self.user_key)
+            .ok()
+            .map(|s| s.to_string())
     }
 
     /// Check if this key starts with the given prefix
@@ -805,23 +864,126 @@ mod tests {
         );
     }
 
+    // ========================================
+    // Namespace::try_new Tests
+    // ========================================
+
     #[test]
-    fn test_namespace_display_empty_components() {
+    fn test_namespace_try_new_valid() {
         let branch_id = BranchId::new();
-        let ns = Namespace::new(
+        let result = Namespace::try_new(
+            "acme".to_string(),
+            "myapp".to_string(),
+            "agent-1".to_string(),
+            branch_id,
+            "production".to_string(),
+        );
+        assert!(result.is_ok(), "All non-empty strings should succeed");
+        let ns = result.unwrap();
+        assert_eq!(ns.tenant, "acme");
+        assert_eq!(ns.app, "myapp");
+        assert_eq!(ns.agent, "agent-1");
+        assert_eq!(ns.branch_id, branch_id);
+        assert_eq!(ns.space, "production");
+    }
+
+    #[test]
+    fn test_namespace_try_new_empty_tenant() {
+        let branch_id = BranchId::new();
+        let result = Namespace::try_new(
             "".to_string(),
+            "myapp".to_string(),
+            "agent-1".to_string(),
+            branch_id,
+            "default".to_string(),
+        );
+        assert!(result.is_err(), "Empty tenant should fail");
+        let err = format!("{}", result.unwrap_err());
+        assert!(
+            err.contains("tenant"),
+            "Error should mention 'tenant', got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_namespace_try_new_empty_app() {
+        let branch_id = BranchId::new();
+        let result = Namespace::try_new(
+            "acme".to_string(),
             "".to_string(),
+            "agent-1".to_string(),
+            branch_id,
+            "default".to_string(),
+        );
+        assert!(result.is_err(), "Empty app should fail");
+        let err = format!("{}", result.unwrap_err());
+        assert!(
+            err.contains("app"),
+            "Error should mention 'app', got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_namespace_try_new_empty_agent() {
+        let branch_id = BranchId::new();
+        let result = Namespace::try_new(
+            "acme".to_string(),
+            "myapp".to_string(),
             "".to_string(),
             branch_id,
             "default".to_string(),
         );
-        let display = format!("{}", ns);
-        // Should produce "///branch_id/default" with empty components
+        assert!(result.is_err(), "Empty agent should fail");
+        let err = format!("{}", result.unwrap_err());
         assert!(
-            display.starts_with("///"),
-            "Empty components should produce leading slashes"
+            err.contains("agent"),
+            "Error should mention 'agent', got: {}",
+            err
         );
-        assert!(display.ends_with("/default"));
+    }
+
+    #[test]
+    fn test_namespace_try_new_empty_space() {
+        let branch_id = BranchId::new();
+        let result = Namespace::try_new(
+            "acme".to_string(),
+            "myapp".to_string(),
+            "agent-1".to_string(),
+            branch_id,
+            "".to_string(),
+        );
+        assert!(result.is_err(), "Empty space should fail");
+        let err = format!("{}", result.unwrap_err());
+        assert!(
+            err.contains("space"),
+            "Error should mention 'space', got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_namespace_try_new_multiple_empty() {
+        let branch_id = BranchId::new();
+        let result = Namespace::try_new(
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
+            branch_id,
+            "".to_string(),
+        );
+        assert!(result.is_err(), "Multiple empty fields should fail");
+        let err = format!("{}", result.unwrap_err());
+        // At least one empty field should be reported
+        assert!(
+            err.contains("tenant")
+                || err.contains("app")
+                || err.contains("agent")
+                || err.contains("space"),
+            "Error should mention at least one empty field, got: {}",
+            err
+        );
     }
 
     #[test]
@@ -852,6 +1014,27 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
+    fn test_namespace_with_empty_strings() {
+        let branch_id = BranchId::new();
+        // In debug mode, empty tenant triggers debug_assert panic
+        let result = std::panic::catch_unwind(|| {
+            Namespace::new(
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+                branch_id,
+                "default".to_string(),
+            )
+        });
+        assert!(
+            result.is_err(),
+            "Empty namespace components should panic in debug mode"
+        );
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
     fn test_namespace_with_empty_strings() {
         let branch_id = BranchId::new();
         let ns = Namespace::new(
@@ -1191,7 +1374,7 @@ mod tests {
         let key = Key::new(ns.clone(), TypeTag::KV, b"mykey".to_vec());
         assert_eq!(key.namespace, ns);
         assert_eq!(key.type_tag, TypeTag::KV);
-        assert_eq!(key.user_key, b"mykey");
+        assert_eq!(&*key.user_key, b"mykey");
     }
 
     #[test]
@@ -1208,25 +1391,25 @@ mod tests {
         // Test KV helper
         let kv_key = Key::new_kv(ns.clone(), "mykey");
         assert_eq!(kv_key.type_tag, TypeTag::KV);
-        assert_eq!(kv_key.user_key, b"mykey");
+        assert_eq!(&*kv_key.user_key, b"mykey");
 
         // Test event helper
         let event_key = Key::new_event(ns.clone(), 42);
         assert_eq!(event_key.type_tag, TypeTag::Event);
         assert_eq!(
-            u64::from_be_bytes(event_key.user_key.as_slice().try_into().unwrap()),
+            u64::from_be_bytes((*event_key.user_key).try_into().unwrap()),
             42
         );
 
         // Test state cell helper
         let state_key = Key::new_state(ns.clone(), "state1");
         assert_eq!(state_key.type_tag, TypeTag::State);
-        assert_eq!(state_key.user_key, b"state1");
+        assert_eq!(&*state_key.user_key, b"state1");
 
         // Test branch index helper
         let branch_key = Key::new_branch(ns.clone(), branch_id);
         assert_eq!(branch_key.type_tag, TypeTag::Branch);
-        assert_eq!(branch_key.user_key, branch_id.as_bytes().to_vec());
+        assert_eq!(&*branch_key.user_key, branch_id.as_bytes());
     }
 
     #[test]
@@ -1242,7 +1425,7 @@ mod tests {
 
         let key = Key::new_event_meta(ns);
         assert_eq!(key.type_tag, TypeTag::Event);
-        assert_eq!(key.user_key, b"__meta__");
+        assert_eq!(&*key.user_key, b"__meta__");
     }
 
     #[test]
@@ -1608,8 +1791,8 @@ mod tests {
         assert!(key_zero < key_max);
 
         // Verify roundtrip of sequence numbers
-        let seq_zero = u64::from_be_bytes(key_zero.user_key.as_slice().try_into().unwrap());
-        let seq_max = u64::from_be_bytes(key_max.user_key.as_slice().try_into().unwrap());
+        let seq_zero = u64::from_be_bytes((*key_zero.user_key).try_into().unwrap());
+        let seq_max = u64::from_be_bytes((*key_max.user_key).try_into().unwrap());
         assert_eq!(seq_zero, 0);
         assert_eq!(seq_max, u64::MAX);
     }
@@ -1671,7 +1854,8 @@ mod tests {
         let key = Key::new(ns.clone(), TypeTag::KV, binary_data.clone());
 
         assert_eq!(
-            key.user_key, binary_data,
+            &*key.user_key,
+            binary_data.as_slice(),
             "Binary user_key should be preserved"
         );
     }
@@ -1689,7 +1873,7 @@ mod tests {
 
         assert_eq!(key.type_tag, TypeTag::Json);
         assert_eq!(key.namespace, namespace);
-        assert_eq!(key.user_key, doc_id.as_bytes().to_vec());
+        assert_eq!(&*key.user_key, doc_id.as_bytes());
     }
 
     #[test]

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -62,9 +62,14 @@ pub enum Value {
     /// MessagePack) for lossless `Bytes` roundtrips.
     Bytes(Vec<u8>),
     /// Array of values
-    Array(Vec<Value>),
+    ///
+    /// Boxed to shrink `Value` from ~56 to ~24 bytes. At 128M entries
+    /// this saves ~3.8 GB of RAM. The `Box` is transparent to serde.
+    Array(Box<Vec<Value>>),
     /// Object with string keys (JSON object)
-    Object(HashMap<String, Value>),
+    ///
+    /// Boxed to shrink `Value` from ~56 to ~24 bytes. See `Array` above.
+    Object(Box<HashMap<String, Value>>),
 }
 
 // Custom PartialEq implementation for IEEE-754 float semantics
@@ -89,6 +94,16 @@ impl PartialEq for Value {
 }
 
 impl Value {
+    /// Create an Array value (convenience constructor that handles boxing)
+    pub fn array(v: Vec<Value>) -> Self {
+        Value::Array(Box::new(v))
+    }
+
+    /// Create an Object value (convenience constructor that handles boxing)
+    pub fn object(m: HashMap<String, Value>) -> Self {
+        Value::Object(Box::new(m))
+    }
+
     /// Get the type name as a string
     pub fn type_name(&self) -> &'static str {
         match self {
@@ -260,13 +275,13 @@ impl From<&[u8]> for Value {
 
 impl From<Vec<Value>> for Value {
     fn from(a: Vec<Value>) -> Self {
-        Value::Array(a)
+        Value::Array(Box::new(a))
     }
 }
 
 impl From<HashMap<String, Value>> for Value {
     fn from(o: HashMap<String, Value>) -> Self {
-        Value::Object(o)
+        Value::Object(Box::new(o))
     }
 }
 
@@ -297,11 +312,11 @@ impl From<serde_json::Value> for Value {
             }
             serde_json::Value::String(s) => Value::String(s),
             serde_json::Value::Array(arr) => {
-                Value::Array(arr.into_iter().map(Value::from).collect())
+                Value::Array(Box::new(arr.into_iter().map(Value::from).collect()))
             }
-            serde_json::Value::Object(obj) => {
-                Value::Object(obj.into_iter().map(|(k, v)| (k, Value::from(v))).collect())
-            }
+            serde_json::Value::Object(obj) => Value::Object(Box::new(
+                obj.into_iter().map(|(k, v)| (k, Value::from(v))).collect(),
+            )),
         }
     }
 }
@@ -321,10 +336,11 @@ impl From<Value> for serde_json::Value {
                 serde_json::Value::String(base64_encode(&b))
             }
             Value::Array(arr) => {
-                serde_json::Value::Array(arr.into_iter().map(serde_json::Value::from).collect())
+                serde_json::Value::Array((*arr).into_iter().map(serde_json::Value::from).collect())
             }
             Value::Object(obj) => serde_json::Value::Object(
-                obj.into_iter()
+                (*obj)
+                    .into_iter()
                     .map(|(k, v)| (k, serde_json::Value::from(v)))
                     .collect(),
             ),
@@ -442,7 +458,7 @@ mod tests {
             Value::String("test".to_string()),
             Value::Bool(true),
         ];
-        let value = Value::Array(array.clone());
+        let value = Value::Array(Box::new(array.clone()));
 
         assert!(matches!(value, Value::Array(_)));
         assert!(value.is_array());
@@ -460,7 +476,7 @@ mod tests {
         map.insert("key1".to_string(), Value::Int(42));
         map.insert("key2".to_string(), Value::String("value".to_string()));
 
-        let value = Value::Object(map.clone());
+        let value = Value::Object(Box::new(map.clone()));
         assert!(matches!(value, Value::Object(_)));
         assert!(value.is_object());
 
@@ -480,7 +496,10 @@ mod tests {
             Value::Float(3.14),
             Value::String("test".to_string()),
             Value::Bytes(vec![1, 2, 3]),
-            Value::Array(vec![Value::Int(1), Value::String("a".to_string())]),
+            Value::Array(Box::new(vec![
+                Value::Int(1),
+                Value::String("a".to_string()),
+            ])),
         ];
 
         for value in test_values {
@@ -494,7 +513,7 @@ mod tests {
     fn test_value_object_serialization() {
         let mut map = HashMap::new();
         map.insert("test".to_string(), Value::Int(123));
-        let value = Value::Object(map);
+        let value = Value::Object(Box::new(map));
 
         let serialized = serde_json::to_string(&value).unwrap();
         let deserialized: Value = serde_json::from_str(&serialized).unwrap();
@@ -535,8 +554,11 @@ mod tests {
         assert_eq!(Value::Float(1.0).type_name(), "Float");
         assert_eq!(Value::String("".to_string()).type_name(), "String");
         assert_eq!(Value::Bytes(vec![]).type_name(), "Bytes");
-        assert_eq!(Value::Array(vec![]).type_name(), "Array");
-        assert_eq!(Value::Object(HashMap::new()).type_name(), "Object");
+        assert_eq!(Value::Array(Box::new(vec![])).type_name(), "Array");
+        assert_eq!(
+            Value::Object(Box::new(HashMap::new())).type_name(),
+            "Object"
+        );
     }
 
     // ====================================================================
@@ -694,14 +716,14 @@ mod tests {
 
     #[test]
     fn test_empty_array() {
-        let v = Value::Array(vec![]);
+        let v = Value::Array(Box::new(vec![]));
         assert!(v.is_array());
         assert_eq!(v.as_array().unwrap().len(), 0);
     }
 
     #[test]
     fn test_empty_object() {
-        let v = Value::Object(HashMap::new());
+        let v = Value::Object(Box::new(HashMap::new()));
         assert!(v.is_object());
         assert_eq!(v.as_object().unwrap().len(), 0);
     }
@@ -712,8 +734,8 @@ mod tests {
 
     #[test]
     fn test_nested_array() {
-        let inner = Value::Array(vec![Value::Int(1), Value::Int(2)]);
-        let outer = Value::Array(vec![inner.clone(), Value::Int(3)]);
+        let inner = Value::Array(Box::new(vec![Value::Int(1), Value::Int(2)]));
+        let outer = Value::Array(Box::new(vec![inner.clone(), Value::Int(3)]));
         assert!(outer.is_array());
         let arr = outer.as_array().unwrap();
         assert_eq!(arr.len(), 2);
@@ -725,8 +747,8 @@ mod tests {
         let mut inner = HashMap::new();
         inner.insert("x".to_string(), Value::Int(1));
         let mut outer = HashMap::new();
-        outer.insert("nested".to_string(), Value::Object(inner));
-        let v = Value::Object(outer);
+        outer.insert("nested".to_string(), Value::Object(Box::new(inner)));
+        let v = Value::Object(Box::new(outer));
         assert!(v.is_object());
         let obj = v.as_object().unwrap();
         assert!(obj.get("nested").unwrap().is_object());
@@ -782,7 +804,7 @@ mod tests {
         let mut m2 = HashMap::new();
         m2.insert("b".to_string(), Value::Int(2));
         m2.insert("a".to_string(), Value::Int(1));
-        assert_eq!(Value::Object(m1), Value::Object(m2));
+        assert_eq!(Value::Object(Box::new(m1)), Value::Object(Box::new(m2)));
     }
 
     #[test]
@@ -792,18 +814,18 @@ mod tests {
         let mut m2 = HashMap::new();
         m2.insert("a".to_string(), Value::Int(1));
         m2.insert("b".to_string(), Value::Int(2));
-        assert_ne!(Value::Object(m1), Value::Object(m2));
+        assert_ne!(Value::Object(Box::new(m1)), Value::Object(Box::new(m2)));
     }
 
     #[test]
     fn test_deeply_nested_equality() {
-        let inner = Value::Array(vec![Value::Object({
+        let inner = Value::Array(Box::new(vec![Value::Object(Box::new({
             let mut m = HashMap::new();
             m.insert("x".to_string(), Value::Int(1));
             m
-        })]);
-        let v1 = Value::Array(vec![inner.clone()]);
-        let v2 = Value::Array(vec![inner]);
+        }))]));
+        let v1 = Value::Array(Box::new(vec![inner.clone()]));
+        let v2 = Value::Array(Box::new(vec![inner]));
         assert_eq!(v1, v2);
     }
 

--- a/crates/durability/src/format/writeset.rs
+++ b/crates/durability/src/format/writeset.rs
@@ -635,6 +635,16 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
+    fn test_writeset_empty_strings() {
+        let branch_id = test_branch_id();
+        // In debug mode, empty keys trigger debug_assert panic in EntityRef constructors
+        let result = std::panic::catch_unwind(move || EntityRef::kv(branch_id, ""));
+        assert!(result.is_err(), "Empty key should panic in debug mode");
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
     fn test_writeset_empty_strings() {
         let branch_id = test_branch_id();
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -41,6 +41,7 @@ tempfile = { workspace = true }
 chrono = { workspace = true }
 criterion = "0.5"
 serde_json = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [[bench]]
 name = "transaction_benchmarks"

--- a/crates/engine/src/branch_ops.rs
+++ b/crates/engine/src/branch_ops.rs
@@ -264,7 +264,7 @@ pub fn fork_branch(db: &Arc<Database>, source: &str, destination: &str) -> Strat
             .map(|(key, vv)| {
                 // Rewrite key with destination namespace (preserving space and user_key)
                 let new_ns = Arc::new(Namespace::for_branch_space(dest_id, &key.namespace.space));
-                let new_key = Key::new(new_ns, key.type_tag, key.user_key.clone());
+                let new_key = Key::new(new_ns, key.type_tag, key.user_key.to_vec());
                 (new_key, vv.value)
             })
             .collect();
@@ -358,13 +358,13 @@ pub fn diff_branches(
             maps_a
                 .entry(key.namespace.space.clone())
                 .or_default()
-                .insert((key.user_key.clone(), type_tag), vv.value);
+                .insert((key.user_key.to_vec(), type_tag), vv.value);
         }
         for (key, vv) in storage.list_by_type(&id_b, type_tag) {
             maps_b
                 .entry(key.namespace.space.clone())
                 .or_default()
-                .insert((key.user_key.clone(), type_tag), vv.value);
+                .insert((key.user_key.to_vec(), type_tag), vv.value);
         }
     }
 
@@ -565,7 +565,7 @@ pub fn merge_branches(
             let entries = storage.list_by_type(&source_id, type_tag);
             for (key, vv) in entries {
                 if key.namespace.space == *space {
-                    source_values.insert((key.user_key.clone(), type_tag), vv.value);
+                    source_values.insert((key.user_key.to_vec(), type_tag), vv.value);
                 }
             }
         }
@@ -700,7 +700,7 @@ mod tests {
         let storage = db.storage();
         let entries = storage.list_by_type(&branch_id, TypeTag::KV);
         for (k, vv) in entries {
-            if k.namespace.space == space && k.user_key == key.as_bytes() {
+            if k.namespace.space == space && *k.user_key == *key.as_bytes() {
                 return Some(vv.value);
             }
         }
@@ -746,7 +746,7 @@ mod tests {
         assert!(
             state_entries
                 .iter()
-                .any(|(k, _)| k.user_key == b"s1" && k.namespace.space == "default"),
+                .any(|(k, _)| *k.user_key == *b"s1" && k.namespace.space == "default"),
             "State data should be forked"
         );
 
@@ -755,7 +755,7 @@ mod tests {
         assert!(
             json_entries
                 .iter()
-                .any(|(k, _)| k.user_key == b"doc1" && k.namespace.space == "default"),
+                .any(|(k, _)| *k.user_key == *b"doc1" && k.namespace.space == "default"),
             "JSON data should be forked"
         );
     }
@@ -1130,8 +1130,10 @@ mod tests {
         let storage = db.storage();
         let target_events = storage.list_by_type(&target_id, TypeTag::Event);
         assert!(
-            target_events.iter().any(|(k, vv)| k.user_key == binary_key
-                && vv.value == Value::String("event-data".into())),
+            target_events
+                .iter()
+                .any(|(k, vv)| *k.user_key == *binary_key
+                    && vv.value == Value::String("event-data".into())),
             "Binary key event should be present in target after merge"
         );
     }

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1144,14 +1144,15 @@ impl Database {
                             }
                         }
                         TypeTag::Event => {
-                            if key.user_key == b"__meta__" || key.user_key.starts_with(b"__tidx__")
+                            if *key.user_key == *b"__meta__"
+                                || key.user_key.starts_with(b"__tidx__")
                             {
                                 continue;
                             }
                             if let Some(text) = crate::search::extract_indexable_text(value) {
                                 if key.user_key.len() == 8 {
                                     let sequence = u64::from_be_bytes(
-                                        key.user_key.as_slice().try_into().unwrap_or([0; 8]),
+                                        (*key.user_key).try_into().unwrap_or([0; 8]),
                                     );
                                     let entity_ref = strata_core::EntityRef::Event {
                                         branch_id,
@@ -1184,13 +1185,14 @@ impl Database {
                             }
                         }
                         TypeTag::Event => {
-                            if key.user_key == b"__meta__" || key.user_key.starts_with(b"__tidx__")
+                            if *key.user_key == *b"__meta__"
+                                || key.user_key.starts_with(b"__tidx__")
                             {
                                 continue;
                             }
                             if key.user_key.len() == 8 {
                                 let sequence = u64::from_be_bytes(
-                                    key.user_key.as_slice().try_into().unwrap_or([0; 8]),
+                                    (*key.user_key).try_into().unwrap_or([0; 8]),
                                 );
                                 let branch_id = key.namespace.branch_id;
                                 let entity_ref = strata_core::EntityRef::Event {
@@ -1465,11 +1467,11 @@ impl Database {
             // Event entries
             for (key, vv) in self.storage.list_by_type(&branch_id, TypeTag::Event) {
                 // Skip metadata keys
-                if key.user_key == b"__meta__" || key.user_key.starts_with(b"__tidx__") {
+                if *key.user_key == *b"__meta__" || key.user_key.starts_with(b"__tidx__") {
                     continue;
                 }
                 let sequence = if key.user_key.len() == 8 {
-                    u64::from_be_bytes(key.user_key.as_slice().try_into().unwrap_or([0; 8]))
+                    u64::from_be_bytes((*key.user_key).try_into().unwrap_or([0; 8]))
                 } else {
                     0
                 };
@@ -1499,7 +1501,7 @@ impl Database {
                     continue;
                 }
                 let branch_id_bytes: [u8; 16] = if key.user_key.len() == 16 {
-                    key.user_key.as_slice().try_into().unwrap_or([0; 16])
+                    (*key.user_key).try_into().unwrap_or([0; 16])
                 } else {
                     [0; 16]
                 };

--- a/crates/engine/src/graph/keys.rs
+++ b/crates/engine/src/graph/keys.rs
@@ -3,11 +3,25 @@
 //! All graph data is stored under the `_graph_` space using KV-type keys.
 //! Key format uses `/` as a separator between path segments.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+
+use dashmap::DashMap;
+use once_cell::sync::Lazy;
 #[cfg(test)]
 use strata_core::types::TypeTag;
 use strata_core::types::{BranchId, Key, Namespace};
 use strata_core::{StrataError, StrataResult};
+
+/// Global cache of `Arc<Namespace>` per branch.  One heap allocation per branch,
+/// ever — all subsequent calls return `Arc::clone()` (atomic refcount bump, zero
+/// heap allocation).  Fixes graph OOM (#1297).
+static NS_CACHE: Lazy<DashMap<BranchId, Arc<Namespace>>> = Lazy::new(DashMap::new);
+
+/// Counter tracking the number of `graph_namespace` *calls* (cache lookups).
+/// Not actual heap allocations — after the first call per branch, the cache
+/// serves `Arc::clone()`.  Used for profiling graph OOM (#1297).
+static NAMESPACE_ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
 
 /// Separator used between path segments in graph keys.
 const SEP: char = '/';
@@ -64,8 +78,30 @@ pub fn validate_edge_type(t: &str) -> StrataResult<()> {
 pub const GRAPH_SPACE: &str = "_graph_";
 
 /// Build a namespace for graph operations on a given branch.
+///
+/// Returns a cached `Arc<Namespace>` — one heap allocation per branch, ever.
+/// Subsequent calls return `Arc::clone()` (atomic refcount bump only).
 pub fn graph_namespace(branch_id: BranchId) -> Arc<Namespace> {
-    Arc::new(Namespace::for_branch_space(branch_id, GRAPH_SPACE))
+    NAMESPACE_ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+    NS_CACHE
+        .entry(branch_id)
+        .or_insert_with(|| Arc::new(Namespace::for_branch_space(branch_id, GRAPH_SPACE)))
+        .clone()
+}
+
+/// Remove a cached namespace entry (call on branch deletion).
+pub fn invalidate_namespace_cache(branch_id: &BranchId) {
+    NS_CACHE.remove(branch_id);
+}
+
+/// Return the cumulative number of `graph_namespace` allocations since last reset.
+pub fn namespace_alloc_count() -> u64 {
+    NAMESPACE_ALLOC_COUNT.load(Ordering::Relaxed)
+}
+
+/// Reset the namespace allocation counter to zero.
+pub fn reset_namespace_alloc_count() {
+    NAMESPACE_ALLOC_COUNT.store(0, Ordering::Relaxed);
 }
 
 /// Build a full storage Key from a user_key string in the graph namespace.
@@ -675,5 +711,108 @@ mod tests {
     fn parse_type_index_key_wrong_graph_returns_none() {
         let key = type_index_key("g", "Patient", "p1");
         assert!(parse_type_index_key("other", &key).is_none());
+    }
+
+    // --- Namespace cache tests (#1297) ---
+
+    #[test]
+    fn namespace_cache_returns_same_arc_pointer() {
+        // Use a unique branch ID to avoid interference from other tests
+        let branch =
+            BranchId::from_bytes([0xCA, 0xCE, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        let ns1 = graph_namespace(branch);
+        let ns2 = graph_namespace(branch);
+        // Must be the *same* heap allocation (Arc pointer equality), not just
+        // value-equal — this is the whole point of the cache.
+        assert!(Arc::ptr_eq(&ns1, &ns2));
+    }
+
+    #[test]
+    fn namespace_cache_different_branches_return_different_namespaces() {
+        let branch_a =
+            BranchId::from_bytes([0xCA, 0xCE, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        let branch_b =
+            BranchId::from_bytes([0xCA, 0xCE, 0x03, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        let ns_a = graph_namespace(branch_a);
+        let ns_b = graph_namespace(branch_b);
+        // Different branches → different namespace content
+        assert_ne!(*ns_a, *ns_b);
+        assert_eq!(ns_a.branch_id, branch_a);
+        assert_eq!(ns_b.branch_id, branch_b);
+        // Both must use the graph space
+        assert_eq!(ns_a.space, GRAPH_SPACE);
+        assert_eq!(ns_b.space, GRAPH_SPACE);
+    }
+
+    #[test]
+    fn invalidate_namespace_cache_forces_new_allocation() {
+        let branch =
+            BranchId::from_bytes([0xCA, 0xCE, 0x04, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        let ns_before = graph_namespace(branch);
+
+        invalidate_namespace_cache(&branch);
+
+        let ns_after = graph_namespace(branch);
+        // Value must be identical (same branch, same space)
+        assert_eq!(*ns_before, *ns_after);
+        // But must be a *new* heap allocation (different Arc pointer)
+        assert!(!Arc::ptr_eq(&ns_before, &ns_after));
+    }
+
+    #[test]
+    fn invalidate_nonexistent_branch_is_noop() {
+        let branch =
+            BranchId::from_bytes([0xCA, 0xCE, 0x05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        // Should not panic or error
+        invalidate_namespace_cache(&branch);
+    }
+
+    #[test]
+    fn hoisted_namespace_key_equals_storage_key() {
+        // Verify that the bulk_insert optimization path
+        // (Key::new_kv(ns.clone(), ...)) produces keys identical to
+        // the standard path (storage_key(branch_id, ...)).
+        let branch =
+            BranchId::from_bytes([0xCA, 0xCE, 0x06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        let ns = graph_namespace(branch);
+
+        // Test with various user_key patterns used in graph operations
+        let user_keys = [
+            node_key("mygraph", "patient-1"),
+            forward_edge_key("mygraph", "A", "KNOWS", "B"),
+            reverse_edge_key("mygraph", "B", "KNOWS", "A"),
+            ref_index_key("kv://main/key1", "mygraph", "n1"),
+            type_index_key("mygraph", "Patient", "p1"),
+            meta_key("mygraph"),
+        ];
+
+        for user_key in &user_keys {
+            let via_storage = storage_key(branch, user_key);
+            let via_hoisted = Key::new_kv(ns.clone(), user_key);
+            assert_eq!(
+                via_storage, via_hoisted,
+                "Key mismatch for user_key={user_key:?}"
+            );
+            // Also verify ordering is consistent (used in BTreeMap scans)
+            assert_eq!(
+                via_storage.cmp(&via_hoisted),
+                std::cmp::Ordering::Equal,
+                "Ord mismatch for user_key={user_key:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn namespace_cache_lookup_counter_increments() {
+        let branch =
+            BranchId::from_bytes([0xCA, 0xCE, 0x07, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        let before = namespace_alloc_count();
+        graph_namespace(branch);
+        graph_namespace(branch);
+        graph_namespace(branch);
+        let after = namespace_alloc_count();
+        // Counter must have incremented by at least 3 (may be higher due to
+        // parallel tests, so we only assert the delta is >= 3).
+        assert!(after - before >= 3);
     }
 }

--- a/crates/engine/src/graph/mod.rs
+++ b/crates/engine/src/graph/mod.rs
@@ -16,12 +16,34 @@ pub mod types;
 
 use std::sync::Arc;
 
-use strata_core::types::BranchId;
+use strata_core::types::{BranchId, Key};
 use strata_core::{StrataError, StrataResult, Value};
 
 use crate::database::Database;
 use adjacency::AdjacencyIndex;
 use types::*;
+
+// ---------------------------------------------------------------------------
+// RSS reader for profiling graph OOM (#1297)
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "linux")]
+fn current_rss_mb() -> Option<u64> {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|s| {
+            s.lines()
+                .find(|l| l.starts_with("VmRSS:"))
+                .and_then(|l| l.split_whitespace().nth(1))
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(|kb| kb / 1024)
+        })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn current_rss_mb() -> Option<u64> {
+    None
+}
 
 /// Graph store providing CRUD operations on nodes and edges.
 ///
@@ -637,14 +659,34 @@ impl GraphStore {
         let empty_json = "{}";
         let default_edge_json = "{\"weight\":1.0}";
 
+        // --- Profiling: OOM diagnosis (#1297) ---
+        let t_start = std::time::Instant::now();
+        keys::reset_namespace_alloc_count();
+        tracing::info!(
+            "[graph::bulk_insert] START nodes={} edges={} chunk_size={} RSS={}MB",
+            nodes.len(),
+            edges.len(),
+            chunk_size,
+            current_rss_mb().unwrap_or(0),
+        );
+        // Log sizes of key storage types
+        tracing::info!(
+            "[graph::bulk_insert] SIZES: Key={} Namespace={} Arc<Namespace>={}",
+            std::mem::size_of::<strata_core::types::Key>(),
+            std::mem::size_of::<strata_core::types::Namespace>(),
+            std::mem::size_of::<Arc<strata_core::types::Namespace>>(),
+        );
+
+        // Hoist namespace once — avoids DashMap lookup per key in inner loops.
+        let ns = keys::graph_namespace(branch_id);
+
         // Insert nodes in chunks
         let mut nodes_inserted = 0usize;
         for chunk in nodes.chunks(chunk_size) {
             // Pre-compute keys and serialized values outside the transaction
-            let mut entries: Vec<(strata_core::types::Key, String)> =
-                Vec::with_capacity(chunk.len());
-            let mut ref_entries: Vec<strata_core::types::Key> = Vec::new();
-            let mut type_entries: Vec<strata_core::types::Key> = Vec::new();
+            let mut entries: Vec<(Key, String)> = Vec::with_capacity(chunk.len());
+            let mut ref_entries: Vec<Key> = Vec::new();
+            let mut type_entries: Vec<Key> = Vec::new();
 
             for (node_id, data) in chunk {
                 keys::validate_node_id(node_id)?;
@@ -655,7 +697,7 @@ impl GraphStore {
                 }
 
                 let user_key = keys::node_key(graph, node_id);
-                let sk = keys::storage_key(branch_id, &user_key);
+                let sk = Key::new_kv(ns.clone(), &user_key);
 
                 let json = if data.entity_ref.is_none()
                     && data.properties.is_none()
@@ -671,12 +713,12 @@ impl GraphStore {
 
                 if let Some(uri) = &data.entity_ref {
                     let rk = keys::ref_index_key(uri, graph, node_id);
-                    ref_entries.push(keys::storage_key(branch_id, &rk));
+                    ref_entries.push(Key::new_kv(ns.clone(), &rk));
                 }
 
                 if let Some(ot) = &data.object_type {
                     let tk = keys::type_index_key(graph, ot, node_id);
-                    type_entries.push(keys::storage_key(branch_id, &tk));
+                    type_entries.push(Key::new_kv(ns.clone(), &tk));
                 }
             }
 
@@ -684,16 +726,16 @@ impl GraphStore {
                 // Clean up old index entries for nodes being re-inserted (upsert)
                 for (node_id, _data) in chunk {
                     let user_key = keys::node_key(graph, node_id);
-                    let sk = keys::storage_key(branch_id, &user_key);
+                    let sk = Key::new_kv(ns.clone(), &user_key);
                     if let Some(Value::String(old_json)) = txn.get(&sk)? {
                         if let Ok(old_data) = serde_json::from_str::<NodeData>(&old_json) {
                             if let Some(old_uri) = old_data.entity_ref {
                                 let old_rk = keys::ref_index_key(&old_uri, graph, node_id);
-                                txn.delete(keys::storage_key(branch_id, &old_rk))?;
+                                txn.delete(Key::new_kv(ns.clone(), &old_rk))?;
                             }
                             if let Some(old_ot) = old_data.object_type {
                                 let old_tk = keys::type_index_key(graph, &old_ot, node_id);
-                                txn.delete(keys::storage_key(branch_id, &old_tk))?;
+                                txn.delete(Key::new_kv(ns.clone(), &old_tk))?;
                             }
                         }
                     }
@@ -714,12 +756,19 @@ impl GraphStore {
             nodes_inserted += chunk.len();
         }
 
+        tracing::info!(
+            "[graph::bulk_insert] NODES COMPLETE: {} nodes in {}ms, RSS={}MB, ns_allocs={}",
+            nodes_inserted,
+            t_start.elapsed().as_millis(),
+            current_rss_mb().unwrap_or(0),
+            keys::namespace_alloc_count(),
+        );
+
         // Insert edges in chunks (each edge = 2 puts, so use chunk_size/2)
         let edge_chunk_size = std::cmp::max(1, chunk_size / 2);
         let mut edges_inserted = 0usize;
         for chunk in edges.chunks(edge_chunk_size) {
-            let mut entries: Vec<(strata_core::types::Key, strata_core::types::Key, String)> =
-                Vec::with_capacity(chunk.len());
+            let mut entries: Vec<(Key, Key, String)> = Vec::with_capacity(chunk.len());
 
             for (src, dst, edge_type, data) in chunk {
                 keys::validate_node_id(src)?;
@@ -733,8 +782,8 @@ impl GraphStore {
 
                 let fwd = keys::forward_edge_key(graph, src, edge_type, dst);
                 let rev = keys::reverse_edge_key(graph, dst, edge_type, src);
-                let fwd_sk = keys::storage_key(branch_id, &fwd);
-                let rev_sk = keys::storage_key(branch_id, &rev);
+                let fwd_sk = Key::new_kv(ns.clone(), &fwd);
+                let rev_sk = Key::new_kv(ns.clone(), &rev);
 
                 let json = if data.properties.is_none() && (data.weight - 1.0).abs() < f64::EPSILON
                 {
@@ -756,7 +805,37 @@ impl GraphStore {
             })?;
 
             edges_inserted += chunk.len();
+
+            // Progress log every 1M edges
+            if edges_inserted % 1_000_000 < edge_chunk_size {
+                tracing::info!(
+                    "[graph::bulk_insert] EDGES: {}/{} ({:.1}%) RSS={}MB ns_allocs={}",
+                    edges_inserted,
+                    edges.len(),
+                    edges_inserted as f64 / edges.len().max(1) as f64 * 100.0,
+                    current_rss_mb().unwrap_or(0),
+                    keys::namespace_alloc_count(),
+                );
+            }
         }
+
+        // Shard diagnostics
+        if let Some((entry_count, has_btree)) = self.db.storage().shard_stats(&branch_id) {
+            tracing::info!(
+                "[graph::bulk_insert] SHARD: entries={} btree_built={}",
+                entry_count,
+                has_btree,
+            );
+        }
+
+        tracing::info!(
+            "[graph::bulk_insert] DONE: {} nodes + {} edges in {}ms, RSS={}MB, ns_allocs={}",
+            nodes_inserted,
+            edges_inserted,
+            t_start.elapsed().as_millis(),
+            current_rss_mb().unwrap_or(0),
+            keys::namespace_alloc_count(),
+        );
 
         Ok((nodes_inserted, edges_inserted))
     }

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -287,7 +287,7 @@ impl BranchIndex {
             Ok(results
                 .into_iter()
                 .filter_map(|(k, _)| {
-                    let key_str = String::from_utf8(k.user_key.clone()).ok()?;
+                    let key_str = String::from_utf8(k.user_key.to_vec()).ok()?;
                     // Filter out any index keys (legacy data)
                     if key_str.contains("__idx_") {
                         None

--- a/crates/engine/src/primitives/event.rs
+++ b/crates/engine/src/primitives/event.rs
@@ -837,12 +837,12 @@ mod tests {
 
     /// Helper to create an empty object payload
     fn empty_payload() -> Value {
-        Value::Object(HashMap::new())
+        Value::Object(Box::new(HashMap::new()))
     }
 
     /// Helper to create an object payload with a single value
     fn payload_with(key: &str, value: Value) -> Value {
-        Value::Object(HashMap::from([(key.to_string(), value)]))
+        Value::Object(Box::new(HashMap::from([(key.to_string(), value)])))
     }
 
     /// Helper to create an object payload with an integer
@@ -938,7 +938,7 @@ mod tests {
             &branch_id,
             "default",
             "test",
-            Value::Array(vec![Value::Int(1)]),
+            Value::Array(Box::new(vec![Value::Int(1)])),
         );
         assert!(result.is_err());
     }
@@ -990,10 +990,10 @@ mod tests {
         let (_temp, _db, log) = setup();
         let branch_id = BranchId::new();
 
-        let payload = Value::Object(HashMap::from([
+        let payload = Value::Object(Box::new(HashMap::from([
             ("tool".to_string(), Value::String("search".into())),
             ("count".to_string(), Value::Int(42)),
-        ]));
+        ])));
 
         let result = log.append(&branch_id, "default", "test", payload);
         assert!(result.is_ok());
@@ -1053,10 +1053,10 @@ mod tests {
         let (_temp, _db, log) = setup();
         let branch_id = BranchId::new();
 
-        let payload = Value::Object(HashMap::from([
+        let payload = Value::Object(Box::new(HashMap::from([
             ("tool".to_string(), Value::String("search".into())),
             ("query".to_string(), Value::String("rust async".into())),
-        ]));
+        ])));
 
         let version = log
             .append(&branch_id, "default", "tool_call", payload.clone())

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -712,12 +712,12 @@ mod tests {
             &branch_id,
             "default",
             "array",
-            Value::Array(vec![Value::Int(1), Value::Int(2)]),
+            Value::Array(Box::new(vec![Value::Int(1), Value::Int(2)])),
         )
         .unwrap();
         assert_eq!(
             kv.get(&branch_id, "default", "array").unwrap(),
-            Some(Value::Array(vec![Value::Int(1), Value::Int(2)]))
+            Some(Value::Array(Box::new(vec![Value::Int(1), Value::Int(2)])))
         );
     }
 

--- a/crates/engine/src/primitives/space.rs
+++ b/crates/engine/src/primitives/space.rs
@@ -78,7 +78,7 @@ impl SpaceIndex {
 
             let mut spaces: Vec<String> = results
                 .into_iter()
-                .filter_map(|(k, _)| String::from_utf8(k.user_key.clone()).ok())
+                .filter_map(|(k, _)| String::from_utf8(k.user_key.to_vec()).ok())
                 .collect();
 
             // Always include "default"

--- a/crates/engine/src/primitives/vector/recovery.rs
+++ b/crates/engine/src/primitives/vector/recovery.rs
@@ -260,7 +260,7 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
                 }
 
                 // Populate inline metadata for O(1) search resolution
-                let vector_key = String::from_utf8(vec_key.user_key.clone())
+                let vector_key = String::from_utf8(vec_key.user_key.to_vec())
                     .ok()
                     .and_then(|uk| uk.strip_prefix(&collection_prefix).map(|s| s.to_string()))
                     .unwrap_or_default();

--- a/crates/engine/src/primitives/vector/store.rs
+++ b/crates/engine/src/primitives/vector/store.rs
@@ -301,7 +301,7 @@ impl VectorStore {
 
         for (key, versioned_value) in entries {
             // Extract collection name from key
-            let name = String::from_utf8(key.user_key.clone())
+            let name = String::from_utf8(key.user_key.to_vec())
                 .map_err(|e| VectorError::Serialization(e.to_string()))?;
 
             // Deserialize the record from the stored bytes
@@ -1091,7 +1091,7 @@ impl VectorStore {
                 Err(_) => continue,
             };
             if VectorId(record.vector_id) == target_id {
-                let user_key = String::from_utf8(key.user_key.clone()).unwrap_or_default();
+                let user_key = String::from_utf8(key.user_key.to_vec()).unwrap_or_default();
                 // Strip the collection prefix to get just the vector key
                 let vector_key = user_key
                     .strip_prefix(&format!("{}/", collection))
@@ -1198,7 +1198,7 @@ impl VectorStore {
             if record.vector_id == target_id.0 {
                 // Extract vector key from the full key
                 // Key format: collection/key
-                let user_key = String::from_utf8(key.user_key.clone())
+                let user_key = String::from_utf8(key.user_key.to_vec())
                     .map_err(|e| VectorError::Serialization(e.to_string()))?;
 
                 // Remove collection prefix
@@ -1256,7 +1256,7 @@ impl VectorStore {
             };
 
             if record.vector_id == target_id.0 {
-                let user_key = String::from_utf8(key.user_key.clone())
+                let user_key = String::from_utf8(key.user_key.to_vec())
                     .map_err(|e| VectorError::Serialization(e.to_string()))?;
 
                 let vector_key = user_key
@@ -2066,7 +2066,7 @@ impl VectorStore {
                                     if let Value::Bytes(b) = &vv.value {
                                         VectorRecord::from_bytes(b)
                                             .ok()
-                                            .map(|r| (k.user_key.clone(), r.vector_id))
+                                            .map(|r| (k.user_key.to_vec(), r.vector_id))
                                     } else {
                                         None
                                     }
@@ -2130,7 +2130,7 @@ impl VectorStore {
                         // Determine provenance: did this key come from the source branch?
                         // Check by matching user_key + VectorId against source KV scan.
                         let is_from_source = source_key_to_vid
-                            .get(&vec_key.user_key)
+                            .get(&*vec_key.user_key)
                             .is_some_and(|&src_vid| src_vid == vec_record.vector_id);
 
                         if is_from_source {

--- a/crates/engine/src/search/recovery.rs
+++ b/crates/engine/src/search/recovery.rs
@@ -142,7 +142,7 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
         // --- Event entries ---
         for (key, vv) in db.storage().list_by_type(&branch_id, TypeTag::Event) {
             // Skip metadata keys (same as checkpoint logic)
-            if key.user_key == b"__meta__" || key.user_key.starts_with(b"__tidx__") {
+            if *key.user_key == *b"__meta__" || key.user_key.starts_with(b"__tidx__") {
                 continue;
             }
 
@@ -153,7 +153,7 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
 
             // Parse sequence from the key (8-byte big-endian u64)
             let sequence = if key.user_key.len() == 8 {
-                u64::from_be_bytes(key.user_key.as_slice().try_into().unwrap_or([0; 8]))
+                u64::from_be_bytes((*key.user_key).try_into().unwrap_or([0; 8]))
             } else {
                 continue; // Skip non-sequence keys
             };

--- a/crates/engine/tests/adversarial_tests.rs
+++ b/crates/engine/tests/adversarial_tests.rs
@@ -47,11 +47,11 @@ fn setup() -> (Arc<Database>, TempDir, BranchId) {
 }
 
 fn empty_payload() -> Value {
-    Value::Object(HashMap::new())
+    Value::Object(Box::new(HashMap::new()))
 }
 
 fn int_payload(v: i64) -> Value {
-    Value::Object(HashMap::from([("value".to_string(), Value::Int(v))]))
+    Value::Object(Box::new(HashMap::from([("value".to_string(), Value::Int(v))])))
 }
 
 // ============================================================================
@@ -450,7 +450,7 @@ fn test_eventlog_payload_validation() {
     }
 
     // Array payload should fail
-    let array_payload = Value::Array(vec![Value::Int(1), Value::Int(2)]);
+    let array_payload = Value::Array(Box::new(vec![Value::Int(1), Value::Int(2)]));
     let result = event_log.append(&branch_id, "test", array_payload);
     assert!(result.is_err(), "Array payload should be rejected");
 }

--- a/crates/engine/tests/branch_isolation_tests.rs
+++ b/crates/engine/tests/branch_isolation_tests.rs
@@ -14,20 +14,23 @@ use tempfile::TempDir;
 
 /// Helper to create an empty object payload for EventLog
 fn empty_payload() -> Value {
-    Value::Object(HashMap::new())
+    Value::Object(Box::new(HashMap::new()))
 }
 
 /// Helper to create an object payload with an integer value
 fn int_payload(v: i64) -> Value {
-    Value::Object(HashMap::from([("value".to_string(), Value::Int(v))]))
+    Value::Object(Box::new(HashMap::from([(
+        "value".to_string(),
+        Value::Int(v),
+    )])))
 }
 
 /// Helper to create an object payload with a string value
 fn string_payload(s: &str) -> Value {
-    Value::Object(HashMap::from([(
+    Value::Object(Box::new(HashMap::from([(
         "data".to_string(),
         Value::String(s.into()),
-    )]))
+    )])))
 }
 
 fn setup() -> (Arc<Database>, TempDir) {

--- a/crates/engine/tests/primitives_cross_tests.rs
+++ b/crates/engine/tests/primitives_cross_tests.rs
@@ -13,20 +13,23 @@ use tempfile::TempDir;
 
 /// Helper to create an empty object payload for EventLog
 fn empty_payload() -> Value {
-    Value::Object(HashMap::new())
+    Value::Object(Box::new(HashMap::new()))
 }
 
 /// Helper to create an object payload with a string value
 fn string_payload(s: &str) -> Value {
-    Value::Object(HashMap::from([(
+    Value::Object(Box::new(HashMap::from([(
         "data".to_string(),
         Value::String(s.into()),
-    )]))
+    )])))
 }
 
 /// Helper to create an object payload with an integer value
 fn int_payload(v: i64) -> Value {
-    Value::Object(HashMap::from([("value".to_string(), Value::Int(v))]))
+    Value::Object(Box::new(HashMap::from([(
+        "value".to_string(),
+        Value::Int(v),
+    )])))
 }
 
 fn setup() -> (Arc<Database>, TempDir, BranchId) {
@@ -242,7 +245,10 @@ fn test_nested_primitive_operations() {
         let kv_value = txn.kv_get("initial_value")?;
         let inner_value = kv_value.unwrap_or(Value::Null);
         // EventLog requires object payloads, so wrap the KV value
-        let payload = Value::Object(HashMap::from([("from_kv".to_string(), inner_value)]));
+        let payload = Value::Object(Box::new(HashMap::from([(
+            "from_kv".to_string(),
+            inner_value,
+        )])));
 
         // Append Event with payload from KV (sequence starts at 0)
         let seq = txn.event_append("chained_event", payload)?;
@@ -261,7 +267,10 @@ fn test_nested_primitive_operations() {
     let event_log = EventLog::new(db.clone());
     let event = event_log.get(&branch_id, "default", 0).unwrap().unwrap();
     // Payload is now wrapped: {"from_kv": 42}
-    let expected_payload = Value::Object(HashMap::from([("from_kv".to_string(), Value::Int(42))]));
+    let expected_payload = Value::Object(Box::new(HashMap::from([(
+        "from_kv".to_string(),
+        Value::Int(42),
+    )])));
     assert_eq!(event.value.payload, expected_payload);
 
     let state = state_cell

--- a/crates/engine/tests/recovery_tests.rs
+++ b/crates/engine/tests/recovery_tests.rs
@@ -18,15 +18,18 @@ use tempfile::TempDir;
 
 /// Helper to create an object payload with a string value
 fn string_payload(s: &str) -> Value {
-    Value::Object(HashMap::from([(
+    Value::Object(Box::new(HashMap::from([(
         "data".to_string(),
         Value::String(s.into()),
-    )]))
+    )])))
 }
 
 /// Helper to create an object payload with an integer value
 fn int_payload(v: i64) -> Value {
-    Value::Object(HashMap::from([("value".to_string(), Value::Int(v))]))
+    Value::Object(Box::new(HashMap::from([(
+        "value".to_string(),
+        Value::Int(v),
+    )])))
 }
 
 fn setup() -> (Arc<Database>, TempDir, BranchId) {

--- a/crates/engine/tests/versioned_conformance_tests.rs
+++ b/crates/engine/tests/versioned_conformance_tests.rs
@@ -25,20 +25,23 @@ use strata_engine::*;
 
 /// Helper to create an empty object payload for EventLog
 fn empty_payload() -> Value {
-    Value::Object(HashMap::new())
+    Value::Object(Box::new(HashMap::new()))
 }
 
 /// Helper to create an object payload with a string value
 fn string_payload(s: &str) -> Value {
-    Value::Object(HashMap::from([(
+    Value::Object(Box::new(HashMap::from([(
         "data".to_string(),
         Value::String(s.into()),
-    )]))
+    )])))
 }
 
 /// Helper to create an object payload with an integer value
 fn int_payload(v: i64) -> Value {
-    Value::Object(HashMap::from([("value".to_string(), Value::Int(v))]))
+    Value::Object(Box::new(HashMap::from([(
+        "value".to_string(),
+        Value::Int(v),
+    )])))
 }
 
 fn setup() -> (Arc<Database>, BranchId) {

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -652,12 +652,16 @@ mod tests {
         // Event payloads must be Objects
         db.event_append(
             "stream",
-            Value::Object([("value".to_string(), Value::Int(1))].into_iter().collect()),
+            Value::Object(Box::new(
+                [("value".to_string(), Value::Int(1))].into_iter().collect(),
+            )),
         )
         .unwrap();
         db.event_append(
             "stream",
-            Value::Object([("value".to_string(), Value::Int(2))].into_iter().collect()),
+            Value::Object(Box::new(
+                [("value".to_string(), Value::Int(2))].into_iter().collect(),
+            )),
         )
         .unwrap();
 
@@ -828,7 +832,9 @@ mod tests {
         db.state_set("state-cell", 10i64).unwrap();
         db.event_append(
             "stream",
-            Value::Object([("x".to_string(), Value::Int(100))].into_iter().collect()),
+            Value::Object(Box::new(
+                [("x".to_string(), Value::Int(100))].into_iter().collect(),
+            )),
         )
         .unwrap();
 
@@ -1134,11 +1140,11 @@ mod tests {
             "ng",
             "n1",
             None,
-            Some(Value::Object(
+            Some(Value::Object(Box::new(
                 [("name".to_string(), Value::String("Alice".into()))]
                     .into_iter()
                     .collect(),
-            )),
+            ))),
         )
         .unwrap();
 
@@ -1220,28 +1226,28 @@ mod tests {
             "patient_care",
             "patient-4821",
             Some("json://main/patient-4821"),
-            Some(Value::Object(
+            Some(Value::Object(Box::new(
                 [(
                     "department".to_string(),
                     Value::String("endocrinology".into()),
                 )]
                 .into_iter()
                 .collect(),
-            )),
+            ))),
         )
         .unwrap();
         db.graph_add_node(
             "patient_care",
             "ICD:E11.9",
             None,
-            Some(Value::Object(
+            Some(Value::Object(Box::new(
                 [(
                     "description".to_string(),
                     Value::String("Type 2 Diabetes".into()),
                 )]
                 .into_iter()
                 .collect(),
-            )),
+            ))),
         )
         .unwrap();
         db.graph_add_node(
@@ -1257,14 +1263,14 @@ mod tests {
             "patient_care",
             "ICD:N18.3",
             None,
-            Some(Value::Object(
+            Some(Value::Object(Box::new(
                 [(
                     "description".to_string(),
                     Value::String("CKD Stage 3".into()),
                 )]
                 .into_iter()
                 .collect(),
-            )),
+            ))),
         )
         .unwrap();
 
@@ -1357,14 +1363,14 @@ mod tests {
             "ng",
             "patient-1",
             Some("kv://main/p1"),
-            Some(Value::Object(
+            Some(Value::Object(Box::new(
                 [
                     ("department".to_string(), Value::String("cardiology".into())),
                     ("age".to_string(), Value::Int(45)),
                 ]
                 .into_iter()
                 .collect(),
-            )),
+            ))),
         )
         .unwrap();
 
@@ -1436,11 +1442,11 @@ mod tests {
             "B",
             "SCORED",
             Some(0.95),
-            Some(Value::Object(
+            Some(Value::Object(Box::new(
                 [("confidence".to_string(), Value::String("high".into()))]
                     .into_iter()
                     .collect(),
-            )),
+            ))),
         )
         .unwrap();
 

--- a/crates/executor/src/bridge.rs
+++ b/crates/executor/src/bridge.rs
@@ -214,12 +214,13 @@ fn value_to_serde_json(value: Value) -> StrataResult<serde_json::Value> {
             Ok(JV::String(format!("__bytes__:{}", encoded)))
         }
         Value::Array(arr) => {
-            let converted: Result<Vec<_>, _> = arr.into_iter().map(value_to_serde_json).collect();
+            let converted: Result<Vec<_>, _> =
+                (*arr).into_iter().map(value_to_serde_json).collect();
             Ok(JV::Array(converted?))
         }
         Value::Object(obj) => {
             let mut map = Map::new();
-            for (k, v) in obj {
+            for (k, v) in *obj {
                 map.insert(k, value_to_serde_json(v)?);
             }
             Ok(JV::Object(map))
@@ -261,14 +262,14 @@ fn serde_json_to_value(json: serde_json::Value) -> StrataResult<Value> {
         }
         JV::Array(arr) => {
             let converted: Result<Vec<_>, _> = arr.into_iter().map(serde_json_to_value).collect();
-            Ok(Value::Array(converted?))
+            Ok(Value::Array(Box::new(converted?)))
         }
         JV::Object(obj) => {
             let mut map = std::collections::HashMap::new();
             for (k, v) in obj {
                 map.insert(k, serde_json_to_value(v)?);
             }
-            Ok(Value::Object(map))
+            Ok(Value::Object(Box::new(map)))
         }
     }
 }

--- a/crates/executor/src/json.rs
+++ b/crates/executor/src/json.rs
@@ -88,7 +88,7 @@ pub fn json_to_value(json: &JsonValue) -> Result<Value, String> {
         JsonValue::String(s) => Ok(Value::String(s.clone())),
         JsonValue::Array(arr) => {
             let items: Result<Vec<Value>, String> = arr.iter().map(json_to_value).collect();
-            Ok(Value::Array(items?))
+            Ok(Value::Array(Box::new(items?)))
         }
         JsonValue::Object(obj) => {
             // Check for special encodings
@@ -116,7 +116,7 @@ pub fn json_to_value(json: &JsonValue) -> Result<Value, String> {
                 .iter()
                 .map(|(k, v)| json_to_value(v).map(|val| (k.clone(), val)))
                 .collect();
-            Ok(Value::Object(map?))
+            Ok(Value::Object(Box::new(map?)))
         }
     }
 }
@@ -264,7 +264,7 @@ mod tests {
 
     #[test]
     fn test_complex_value_round_trip() {
-        let original = Value::Object(
+        let original = Value::Object(Box::new(
             [
                 ("name".to_string(), Value::String("test".to_string())),
                 ("count".to_string(), Value::Int(42)),
@@ -272,12 +272,15 @@ mod tests {
                 ("nan".to_string(), Value::Float(f64::NAN)),
                 (
                     "nested".to_string(),
-                    Value::Array(vec![Value::Float(f64::INFINITY), Value::Float(-0.0)]),
+                    Value::Array(Box::new(vec![
+                        Value::Float(f64::INFINITY),
+                        Value::Float(-0.0),
+                    ])),
                 ),
             ]
             .into_iter()
             .collect(),
-        );
+        ));
 
         let json = value_to_json(&original);
         let restored = json_to_value(&json).unwrap();

--- a/crates/executor/src/tests/access_mode.rs
+++ b/crates/executor/src/tests/access_mode.rs
@@ -95,7 +95,7 @@ fn test_read_only_blocks_all_writes() {
             branch: None,
             space: None,
             event_type: "t".into(),
-            payload: Value::Object(Default::default()),
+            payload: Value::Object(Box::new(Default::default())),
         },
         Command::StateSet {
             branch: None,

--- a/crates/executor/src/tests/determinism.rs
+++ b/crates/executor/src/tests/determinism.rs
@@ -364,7 +364,9 @@ fn test_event_get_by_type_determinism() {
                 branch: Some(BranchId::from("default")),
                 space: None,
                 event_type: "events".to_string(),
-                payload: Value::Object([("seq".to_string(), Value::Int(i))].into_iter().collect()),
+                payload: Value::Object(Box::new(
+                    [("seq".to_string(), Value::Int(i))].into_iter().collect(),
+                )),
             })
             .unwrap();
     }
@@ -409,14 +411,14 @@ fn test_json_get_determinism() {
             space: None,
             key: "doc".to_string(),
             path: "".to_string(),
-            value: Value::Object(
+            value: Value::Object(Box::new(
                 [
                     ("name".to_string(), Value::String("Alice".into())),
                     ("age".to_string(), Value::Int(30)),
                 ]
                 .into_iter()
                 .collect(),
-            ),
+            )),
         })
         .unwrap();
 

--- a/crates/executor/src/tests/parity.rs
+++ b/crates/executor/src/tests/parity.rs
@@ -181,11 +181,11 @@ fn test_json_set_get_parity() {
         space: None,
         key: "doc1".to_string(),
         path: "".to_string(), // Root path
-        value: Value::Object(
+        value: Value::Object(Box::new(
             [("name".to_string(), Value::String("Alice".into()))]
                 .into_iter()
                 .collect(),
-        ),
+        )),
     });
 
     // JsonSet returns Version
@@ -226,11 +226,11 @@ fn test_event_append_get_by_type_parity() {
         branch: None,
         space: None,
         event_type: "events".to_string(),
-        payload: Value::Object(
+        payload: Value::Object(Box::new(
             [("type".to_string(), Value::String("click".into()))]
                 .into_iter()
                 .collect(),
-        ),
+        )),
     });
 
     // Just verify it returns a Version
@@ -246,11 +246,11 @@ fn test_event_append_get_by_type_parity() {
             &branch_id,
             "default",
             "events",
-            Value::Object(
+            Value::Object(Box::new(
                 [("type".to_string(), Value::String("scroll".into()))]
                     .into_iter()
                     .collect(),
-            ),
+            )),
         )
         .unwrap();
 
@@ -426,11 +426,11 @@ fn test_branch_create_get_parity() {
     // Create branch via executor with a UUID
     let result = executor.execute(Command::BranchCreate {
         branch_id: Some("550e8400-e29b-41d4-a716-446655440001".to_string()),
-        metadata: Some(Value::Object(
+        metadata: Some(Value::Object(Box::new(
             [("name".to_string(), Value::String("Test".into()))]
                 .into_iter()
                 .collect(),
-        )),
+        ))),
     });
 
     match result {

--- a/crates/executor/src/tests/serialization.rs
+++ b/crates/executor/src/tests/serialization.rs
@@ -143,11 +143,11 @@ fn test_command_event_append() {
         branch: Some(BranchId::from("default")),
         space: None,
         event_type: "events".to_string(),
-        payload: Value::Object(
+        payload: Value::Object(Box::new(
             [("type".to_string(), Value::String("click".to_string()))]
                 .into_iter()
                 .collect(),
-        ),
+        )),
     });
 }
 
@@ -218,11 +218,11 @@ fn test_command_vector_upsert() {
         collection: "embeddings".to_string(),
         key: "vec1".to_string(),
         vector: vec![0.1, 0.2, 0.3, 0.4],
-        metadata: Some(Value::Object(
+        metadata: Some(Value::Object(Box::new(
             [("label".to_string(), Value::String("test".to_string()))]
                 .into_iter()
                 .collect(),
-        )),
+        ))),
     });
 }
 
@@ -259,11 +259,11 @@ fn test_command_vector_create_collection() {
 fn test_command_branch_create() {
     test_command_round_trip(Command::BranchCreate {
         branch_id: Some("my-branch".to_string()),
-        metadata: Some(Value::Object(
+        metadata: Some(Value::Object(Box::new(
             [("name".to_string(), Value::String("Test Branch".to_string()))]
                 .into_iter()
                 .collect(),
-        )),
+        ))),
     });
 }
 
@@ -447,7 +447,7 @@ fn test_command_search_full() {
 
 #[test]
 fn test_command_with_complex_value() {
-    let complex_value = Value::Object(
+    let complex_value = Value::Object(Box::new(
         [
             ("string".to_string(), Value::String("hello".to_string())),
             ("int".to_string(), Value::Int(42)),
@@ -456,20 +456,20 @@ fn test_command_with_complex_value() {
             ("null".to_string(), Value::Null),
             (
                 "array".to_string(),
-                Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)]),
+                Value::Array(Box::new(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),
             ),
             (
                 "nested".to_string(),
-                Value::Object(
+                Value::Object(Box::new(
                     [("deep".to_string(), Value::String("value".to_string()))]
                         .into_iter()
                         .collect(),
-                ),
+                )),
             ),
         ]
         .into_iter()
         .collect(),
-    );
+    ));
 
     test_command_round_trip(Command::KvPut {
         branch: Some(BranchId::from("default")),

--- a/crates/executor/src/tests/session.rs
+++ b/crates/executor/src/tests/session.rs
@@ -408,10 +408,10 @@ fn test_event_append_in_txn() {
         branch: None,
         space: None,
         event_type: "test_stream".to_string(),
-        payload: Value::Object(std::collections::HashMap::from([(
+        payload: Value::Object(Box::new(std::collections::HashMap::from([(
             "data".to_string(),
             Value::String("event_data".into()),
-        )])),
+        )]))),
     });
     assert!(result.is_ok(), "EventAppend should succeed in txn");
 

--- a/crates/executor/src/tests/spaces.rs
+++ b/crates/executor/src/tests/spaces.rs
@@ -195,14 +195,14 @@ fn test_event_isolation_across_spaces() {
     let mut db = strata();
 
     // Append events in default space (payload must be a JSON object)
-    let payload1 = Value::Object(HashMap::from([(
+    let payload1 = Value::Object(Box::new(HashMap::from([(
         "page".into(),
         Value::String("page1".into()),
-    )]));
-    let payload2 = Value::Object(HashMap::from([(
+    )])));
+    let payload2 = Value::Object(Box::new(HashMap::from([(
         "page".into(),
         Value::String("page2".into()),
-    )]));
+    )])));
     db.event_append("click", payload1).unwrap();
     db.event_append("click", payload2).unwrap();
 
@@ -215,10 +215,10 @@ fn test_event_isolation_across_spaces() {
     assert_eq!(epsilon_len, 0);
 
     // Append in epsilon
-    let payload3 = Value::Object(HashMap::from([(
+    let payload3 = Value::Object(Box::new(HashMap::from([(
         "page".into(),
         Value::String("page3".into()),
-    )]));
+    )])));
     db.event_append("click", payload3).unwrap();
     assert_eq!(db.event_len().unwrap(), 1);
 

--- a/crates/intelligence/src/embed/extract.rs
+++ b/crates/intelligence/src/embed/extract.rs
@@ -121,11 +121,11 @@ mod tests {
 
     #[test]
     fn test_array() {
-        let arr = Value::Array(vec![
+        let arr = Value::Array(Box::new(vec![
             Value::String("hello".into()),
             Value::Int(42),
             Value::Null,
-        ]);
+        ]));
         assert_eq!(extract_text(&arr), Some("hello 42".into()));
     }
 
@@ -134,7 +134,7 @@ mod tests {
         let mut map = HashMap::new();
         map.insert("name".to_string(), Value::String("Alice".into()));
         map.insert("age".to_string(), Value::Int(30));
-        let obj = Value::Object(map);
+        let obj = Value::Object(Box::new(map));
         let text = extract_text(&obj).unwrap();
         assert!(text.contains("age: 30"));
         assert!(text.contains("name: Alice"));
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn test_empty_array() {
-        assert_eq!(extract_text(&Value::Array(vec![])), None);
+        assert_eq!(extract_text(&Value::Array(Box::new(vec![]))), None);
     }
 
     #[test]
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn test_array_all_null() {
         assert_eq!(
-            extract_text(&Value::Array(vec![Value::Null, Value::Null])),
+            extract_text(&Value::Array(Box::new(vec![Value::Null, Value::Null]))),
             None
         );
     }
@@ -176,7 +176,7 @@ mod tests {
         // Build a deeply nested structure exceeding MAX_DEPTH
         let mut value = Value::String("deep".into());
         for _ in 0..20 {
-            value = Value::Array(vec![value]);
+            value = Value::Array(Box::new(vec![value]));
         }
         // The leaf "deep" is at depth 20, which exceeds MAX_DEPTH (16).
         // extract_text should return None because the recursion stops before reaching it.
@@ -188,7 +188,7 @@ mod tests {
         // Build a nested structure exactly at MAX_DEPTH (16 levels of nesting)
         let mut value = Value::String("found".into());
         for _ in 0..15 {
-            value = Value::Array(vec![value]);
+            value = Value::Array(Box::new(vec![value]));
         }
         // 15 levels of Array wrapping: depths 0..14 are Array, depth 15 is String.
         // All within MAX_DEPTH (16), so the text should be extractable.
@@ -201,7 +201,10 @@ mod tests {
         m1.insert("name".to_string(), Value::String("Alice".into()));
         let mut m2 = HashMap::new();
         m2.insert("name".to_string(), Value::String("Bob".into()));
-        let arr = Value::Array(vec![Value::Object(m1), Value::Object(m2)]);
+        let arr = Value::Array(Box::new(vec![
+            Value::Object(Box::new(m1)),
+            Value::Object(Box::new(m2)),
+        ]));
         let text = extract_text(&arr).unwrap();
         assert!(text.contains("name: Alice"));
         assert!(text.contains("name: Bob"));
@@ -212,13 +215,13 @@ mod tests {
         let mut map = HashMap::new();
         map.insert("a".to_string(), Value::Null);
         map.insert("b".to_string(), Value::Null);
-        assert_eq!(extract_text(&Value::Object(map)), None);
+        assert_eq!(extract_text(&Value::Object(Box::new(map))), None);
     }
 
     #[test]
     fn test_empty_object() {
         let map = HashMap::new();
-        assert_eq!(extract_text(&Value::Object(map)), None);
+        assert_eq!(extract_text(&Value::Object(Box::new(map))), None);
     }
 
     #[test]
@@ -227,7 +230,7 @@ mod tests {
         map.insert("z".to_string(), Value::String("last".into()));
         map.insert("a".to_string(), Value::String("first".into()));
         map.insert("m".to_string(), Value::String("middle".into()));
-        let text = extract_text(&Value::Object(map)).unwrap();
+        let text = extract_text(&Value::Object(Box::new(map))).unwrap();
         let a_pos = text.find("a:").unwrap();
         let m_pos = text.find("m:").unwrap();
         let z_pos = text.find("z:").unwrap();
@@ -239,14 +242,14 @@ mod tests {
     fn test_mixed_depth_objects_and_arrays() {
         let mut inner = HashMap::new();
         inner.insert("nested".to_string(), Value::Bool(true));
-        let arr = Value::Array(vec![
+        let arr = Value::Array(Box::new(vec![
             Value::Int(1),
             Value::String("two".into()),
-            Value::Object(inner),
-        ]);
+            Value::Object(Box::new(inner)),
+        ]));
         let mut outer = HashMap::new();
         outer.insert("items".to_string(), arr);
-        let text = extract_text(&Value::Object(outer)).unwrap();
+        let text = extract_text(&Value::Object(Box::new(outer))).unwrap();
         assert!(text.contains("items:"));
         assert!(text.contains("1"));
         assert!(text.contains("two"));

--- a/crates/intelligence/tests/embed_pipeline_tests.rs
+++ b/crates/intelligence/tests/embed_pipeline_tests.rs
@@ -23,7 +23,7 @@ fn test_extract_returns_none_for_non_embeddable() {
     assert!(extract_text(&Value::Null).is_none());
     assert!(extract_text(&Value::Bytes(vec![1, 2, 3])).is_none());
     assert!(extract_text(&Value::String("".into())).is_none());
-    assert!(extract_text(&Value::Array(vec![Value::Null, Value::Null])).is_none());
+    assert!(extract_text(&Value::Array(Box::new(vec![Value::Null, Value::Null]))).is_none());
 }
 
 #[test]
@@ -52,9 +52,9 @@ fn test_extract_complex_value() {
     map.insert("name".to_string(), Value::String("Alice".into()));
     map.insert(
         "scores".to_string(),
-        Value::Array(vec![Value::Int(10), Value::Int(20)]),
+        Value::Array(Box::new(vec![Value::Int(10), Value::Int(20)])),
     );
-    let nested = Value::Object(map);
+    let nested = Value::Object(Box::new(map));
 
     let text = extract_text(&nested).unwrap();
     assert!(text.contains("name: Alice"));
@@ -65,13 +65,13 @@ fn test_extract_complex_value() {
 
 #[test]
 fn test_extract_mixed_array_filters_nulls() {
-    let arr = Value::Array(vec![
+    let arr = Value::Array(Box::new(vec![
         Value::String("keep".into()),
         Value::Null,
         Value::Int(7),
         Value::Bytes(vec![0xFF]),
         Value::String("also keep".into()),
-    ]);
+    ]));
     let text = extract_text(&arr).unwrap();
     assert!(text.contains("keep"));
     assert!(text.contains("7"));
@@ -87,9 +87,9 @@ fn test_extract_preserves_key_order_in_nested_objects() {
     inner.insert("a_field".to_string(), Value::String("first".into()));
 
     let mut outer = HashMap::new();
-    outer.insert("data".to_string(), Value::Object(inner));
+    outer.insert("data".to_string(), Value::Object(Box::new(inner)));
 
-    let text = extract_text(&Value::Object(outer)).unwrap();
+    let text = extract_text(&Value::Object(Box::new(outer))).unwrap();
     let a_pos = text.find("a_field").expect("a_field missing");
     let z_pos = text.find("z_field").expect("z_field missing");
     assert!(
@@ -207,7 +207,7 @@ fn test_extract_object_then_embed_produces_valid_vector() {
         Value::String("Rust programming".into()),
     );
     map.insert("year".to_string(), Value::Int(2024));
-    let obj = Value::Object(map);
+    let obj = Value::Object(Box::new(map));
 
     let text = extract_text(&obj).expect("extraction should succeed");
     let engine = strata_intelligence::EmbeddingEngine::from_registry("miniLM")

--- a/crates/storage/src/sharded.rs
+++ b/crates/storage/src/sharded.rs
@@ -26,8 +26,8 @@
 //! The storage layer uses raw `u64` for version comparisons because:
 //! 1. All versions in storage are `Version::Txn` variants (transaction versions)
 //! 2. Raw u64 comparison is correct for same-variant versions
-//! 3. The `Version::Ord` implementation compares discriminant first, ensuring
-//!    cross-variant comparisons are safe (though they shouldn't occur here)
+//! 3. `Version` only supports same-variant comparison via `PartialOrd`
+//!    (cross-variant returns `None`), but storage only uses same-variant versions
 //! 4. Performance: Avoiding enum matching on every comparison
 
 use dashmap::DashMap;
@@ -398,6 +398,16 @@ impl ShardedStore {
     /// Get number of shards (branches)
     pub fn shard_count(&self) -> usize {
         self.shards.len()
+    }
+
+    /// Return `(entry_count, has_ordered_keys)` for a branch shard.
+    ///
+    /// Used for profiling graph OOM (#1297) — confirms the FxHashMap has the
+    /// expected entry count and whether the BTreeSet index has been built.
+    pub fn shard_stats(&self, branch_id: &BranchId) -> Option<(usize, bool)> {
+        self.shards
+            .get(branch_id)
+            .map(|s| (s.data.len(), s.ordered_keys.is_some()))
     }
 
     /// Check if a branch exists

--- a/docs/design/production-readiness.md
+++ b/docs/design/production-readiness.md
@@ -30,18 +30,18 @@ The most important gaps fall into five cross-cutting themes:
 
 **Verdict:** Solid foundation with a few safety gaps in unsafe code, validation boundaries, and version semantics.
 
-| # | Finding | Severity | Code Reference | Comparison |
-|---|---------|----------|----------------|------------|
-| C-1 | Unsafe JSON transmute without compile-time layout assertion | **CRITICAL** | `primitives/json.rs:1028, 1088` | SQLite never uses unsafe for JSON |
-| C-2 | Constraint validation not enforced at all write boundaries | **CRITICAL** | `limits.rs`, `error.rs` | SQLite enforces `SQLITE_MAX_LENGTH` at every entry point |
-| C-3 | Cross-variant Version comparison (`Txn(5)` == `Counter(5)`) | **HIGH** | `contract/version.rs:186-208` | PostgreSQL uses single monotonic XID type |
-| C-4 | Namespace components accept empty strings | **HIGH** | `types.rs` | Redis requires non-empty key names; DuckDB validates schema names |
-| C-5 | Conflict errors lack forensic context (no structured data) | **HIGH** | `error.rs` | PostgreSQL conflict errors include table, constraint, column |
-| C-6 | Deprecated TypeTag variant (`Trace = 0x04`) deserializes silently | **HIGH** | `types.rs` | SQLite schema versioning rejects unknown types |
-| C-7 | `Storage`/`SnapshotView` trait concurrency contracts underspecified | **HIGH** | `traits.rs` | LMDB documents exact thread-safety guarantees per operation |
-| C-8 | Value validation and `max_value_bytes_encoded` are separate checks | **MEDIUM** | `limits.rs` | — |
-| C-9 | `BranchEventOffsets::push()` accepts out-of-order offsets | **MEDIUM** | `branch_types.rs` | — |
-| C-10 | `EntityRef` fields are plain Strings with no validation | **MEDIUM** | `contract/entity_ref.rs` | — |
+| # | Finding | Severity | Code Reference | Comparison | Tracked |
+|---|---------|----------|----------------|------------|---------|
+| C-1 | Unsafe JSON transmute without compile-time layout assertion | **CRITICAL** | `primitives/json.rs:1028, 1088` | SQLite never uses unsafe for JSON | #1300 |
+| C-2 | Constraint validation not enforced at all write boundaries | **CRITICAL** | `limits.rs`, `error.rs` | SQLite enforces `SQLITE_MAX_LENGTH` at every entry point | #1299 |
+| C-3 | Cross-variant Version comparison (`Txn(5)` == `Counter(5)`) | **HIGH** | `contract/version.rs:186-208` | PostgreSQL uses single monotonic XID type | #1300 |
+| C-4 | Namespace components accept empty strings | **HIGH** | `types.rs` | Redis requires non-empty key names; DuckDB validates schema names | #1299 |
+| C-5 | Conflict errors lack forensic context (no structured data) | **HIGH** | `error.rs` | PostgreSQL conflict errors include table, constraint, column | #1301 |
+| C-6 | Deprecated TypeTag variant (`Trace = 0x04`) deserializes silently | **HIGH** | `types.rs` | SQLite schema versioning rejects unknown types | #1300 |
+| C-7 | `Storage`/`SnapshotView` trait concurrency contracts underspecified | **HIGH** | `traits.rs` | LMDB documents exact thread-safety guarantees per operation | #1301 |
+| C-8 | Value validation and `max_value_bytes_encoded` are separate checks | **MEDIUM** | `limits.rs` | — | #1299 |
+| C-9 | `BranchEventOffsets::push()` accepts out-of-order offsets | **MEDIUM** | `branch_types.rs` | — | #1299 |
+| C-10 | `EntityRef` fields are plain Strings with no validation | **MEDIUM** | `contract/entity_ref.rs` | — | #1299 |
 
 **Strengths:** Excellent newtype pattern (`BranchId`, `TypeTag`). Comprehensive `Limits` framework. Strong `Serialize`/`Deserialize` coverage. Excellent error code design (10 canonical codes). Extensive test coverage (300+ tests across `types.rs` alone).
 
@@ -53,17 +53,17 @@ The most important gaps fall into five cross-cutting themes:
 
 **Verdict:** Correct MVCC semantics, but unbounded by design — no memory limits, no automatic GC, TTL exists but is not integrated.
 
-| # | Finding | Severity | Code Reference | Comparison |
-|---|---------|----------|----------------|------------|
-| S-1 | Unbounded version chain growth; GC never called automatically | **CRITICAL** | `sharded.rs:56, 115` | Redis has `maxmemory` + eviction policies |
-| S-2 | No shard/branch count limit; DashMap grows without bound | **CRITICAL** | `sharded.rs:260-265` | LMDB has `max_dbs` limit |
-| S-3 | O(v) linear scan in `get_at_version()` | **HIGH** | `sharded.rs:84-93` | RocksDB uses binary search within SST blocks |
-| S-4 | TTL index implemented but never integrated with ShardedStore | **HIGH** | `ttl.rs:12-22`, `stored_value.rs:125` | Redis combines lazy + active expiration |
-| S-5 | `apply_batch` allows partial failure across branches (no rollback) | **HIGH** | `sharded.rs:489-517` | Redis `MSET` is atomic |
-| S-6 | GC always keeps >= 1 version, even if it's a tombstone | **MEDIUM** | `sharded.rs:115-135` | PostgreSQL vacuum removes dead tuples entirely |
-| S-7 | `ordered_keys` BTreeSet never pruned on delete | **MEDIUM** | `sharded.rs:212-216` | — |
-| S-8 | TTL `saturating_add()` can produce u64::MAX (key never expires) | **MEDIUM** | `stored_value.rs:137` | — |
-| S-9 | Every returned value is cloned; no zero-copy path | **MEDIUM** | `sharded.rs:1136-1140` | LMDB returns zero-copy memory-mapped slices |
+| # | Finding | Severity | Code Reference | Comparison | Tracked |
+|---|---------|----------|----------------|------------|---------|
+| S-1 | Unbounded version chain growth; GC never called automatically | **CRITICAL** | `sharded.rs:56, 115` | Redis has `maxmemory` + eviction policies | #1303 |
+| S-2 | No shard/branch count limit; DashMap grows without bound | **CRITICAL** | `sharded.rs:260-265` | LMDB has `max_dbs` limit | #1306 |
+| S-3 | O(v) linear scan in `get_at_version()` | **HIGH** | `sharded.rs:84-93` | RocksDB uses binary search within SST blocks | #1306 |
+| S-4 | TTL index implemented but never integrated with ShardedStore | **HIGH** | `ttl.rs:12-22`, `stored_value.rs:125` | Redis combines lazy + active expiration | #1303 |
+| S-5 | `apply_batch` allows partial failure across branches (no rollback) | **HIGH** | `sharded.rs:489-517` | Redis `MSET` is atomic | #1306 |
+| S-6 | GC always keeps >= 1 version, even if it's a tombstone | **MEDIUM** | `sharded.rs:115-135` | PostgreSQL vacuum removes dead tuples entirely | #1303 |
+| S-7 | `ordered_keys` BTreeSet never pruned on delete | **MEDIUM** | `sharded.rs:212-216` | — | #1304 |
+| S-8 | TTL `saturating_add()` can produce u64::MAX (key never expires) | **MEDIUM** | `stored_value.rs:137` | — | #1303 |
+| S-9 | Every returned value is cloned; no zero-copy path | **MEDIUM** | `sharded.rs:1136-1140` | LMDB returns zero-copy memory-mapped slices | #1305 |
 
 **Strengths:** Lock-free reads via DashMap. O(1) lookups via FxHashMap. Correct MVCC snapshot semantics via Arc-based snapshots. No unsafe code. Atomic version counter prevents lost updates.
 
@@ -75,18 +75,18 @@ The most important gaps fall into five cross-cutting themes:
 
 **Verdict:** Correct Snapshot Isolation via OCC, but version overflow panics the process, no transaction timeout, and clone-based snapshots are O(n).
 
-| # | Finding | Severity | Code Reference | Comparison |
-|---|---------|----------|----------------|------------|
-| T-1 | Version counter overflow panics (`expect()` on `checked_add`) | **CRITICAL** | `manager.rs:146-151` | PostgreSQL has `txid_wraparound` prevention with automated vacuum |
-| T-2 | Transaction ID overflow — same panic risk | **CRITICAL** | `manager.rs:122-126` | — |
-| T-3 | Implements Snapshot Isolation but write-skew is silently allowed | **CRITICAL** | — | SQLite documents `DEFERRED`/`IMMEDIATE`/`EXCLUSIVE` isolation |
-| T-4 | No abandoned transaction detection or timeout | **CRITICAL** | `transaction.rs:1038` (helper exists, not enforced) | PostgreSQL has `idle_in_transaction_session_timeout` |
-| T-5 | `ClonedSnapshotView` deep-copies entire branch — O(data_size) | **HIGH** | `snapshot.rs:69-74` | SQLite/LMDB snapshots are O(1); RocksDB uses reference counting |
-| T-6 | Per-branch commit lock serializes all commits on same branch | **HIGH** | `manager.rs:216` | RocksDB supports concurrent memtable writes |
-| T-7 | CAS operations don't track reads (not added to read_set) | **HIGH** | `transaction.rs:845-854` | — |
-| T-8 | JSON document-level conflict detection is overly conservative | **HIGH** | `validation.rs:241-275` | — |
-| T-9 | No deadlock/livelock detection or metrics | **HIGH** | — | PostgreSQL tracks lock waits and reports deadlocks |
-| T-10 | No savepoints or nested transactions | **MEDIUM** | `transaction.rs` (state machine) | SQLite supports `SAVEPOINT` |
+| # | Finding | Severity | Code Reference | Comparison | Tracked |
+|---|---------|----------|----------------|------------|---------|
+| T-1 | Version counter overflow panics (`expect()` on `checked_add`) | **CRITICAL** | `manager.rs:146-151` | PostgreSQL has `txid_wraparound` prevention with automated vacuum | #1307 |
+| T-2 | Transaction ID overflow — same panic risk | **CRITICAL** | `manager.rs:122-126` | — | #1307 |
+| T-3 | Implements Snapshot Isolation but write-skew is silently allowed | **CRITICAL** | — | SQLite documents `DEFERRED`/`IMMEDIATE`/`EXCLUSIVE` isolation | #1309 |
+| T-4 | No abandoned transaction detection or timeout | **CRITICAL** | `transaction.rs:1038` (helper exists, not enforced) | PostgreSQL has `idle_in_transaction_session_timeout` | #1308 |
+| T-5 | `ClonedSnapshotView` deep-copies entire branch — O(data_size) | **HIGH** | `snapshot.rs:69-74` | SQLite/LMDB snapshots are O(1); RocksDB uses reference counting | #1309 |
+| T-6 | Per-branch commit lock serializes all commits on same branch | **HIGH** | `manager.rs:216` | RocksDB supports concurrent memtable writes | #1308 |
+| T-7 | CAS operations don't track reads (not added to read_set) | **HIGH** | `transaction.rs:845-854` | — | #1309 |
+| T-8 | JSON document-level conflict detection is overly conservative | **HIGH** | `validation.rs:241-275` | — | #1309 |
+| T-9 | No deadlock/livelock detection or metrics | **HIGH** | — | PostgreSQL tracks lock waits and reports deadlocks | #1308 |
+| T-10 | No savepoints or nested transactions | **MEDIUM** | `transaction.rs` (state machine) | SQLite supports `SAVEPOINT` | #1309 |
 
 **Strengths:** Correct OCC protocol. Deadlock impossible by design (single lock per branch, no nested acquisition). Clean state machine transitions with guards. Idempotent recovery.
 
@@ -98,18 +98,18 @@ The most important gaps fall into five cross-cutting themes:
 
 **Verdict:** Good crash recovery fundamentals with per-record CRC and atomic manifest updates, but Standard mode defers fsync to a background thread with no health monitoring.
 
-| # | Finding | Severity | Code Reference | Comparison |
-|---|---------|----------|----------------|------------|
-| D-1 | Standard mode fsync deferred to background thread; no health check | **CRITICAL** | `wal/writer.rs:252-256` | SQLite documents `PRAGMA synchronous` levels with exact data-loss windows |
-| D-2 | Segment header CRC missing from record integrity chain | **HIGH** | `format/wal_record.rs:32-51` | RocksDB uses per-record CRC + block checksums |
-| D-3 | Stale WAL lock: no PID validation, crashed process blocks others | **HIGH** | `coordination.rs:14-67` | PostgreSQL validates PID in postmaster.pid |
-| D-4 | Snapshot parent directory fsync may fail silently | **HIGH** | `disk_snapshot/writer.rs:127-132` | ext4/XFS require parent dir fsync for rename durability |
-| D-5 | Recovery doesn't validate watermark-snapshot consistency | **HIGH** | `recovery/coordinator.rs:103-109` | SQLite cross-validates WAL checkpoints |
-| D-6 | Compaction not atomic with concurrent writes (race on segment list) | **HIGH** | `compaction/wal_only.rs:81-147` | RocksDB uses version edits with manifest lock |
-| D-7 | Active segment never gets `.meta` sidecar until rotation | **HIGH** | `wal/reader.rs:205-260` | — |
-| D-8 | 1 MB corruption scan window; data beyond may be lost | **MEDIUM** | `wal/reader.rs:14, 94-122` | — |
-| D-9 | No disk space monitoring or emergency compaction trigger | **MEDIUM** | — | PostgreSQL monitors `pg_tablespace` usage |
-| D-10 | Format version checking incomplete (v1 without CRC still supported) | **MEDIUM** | `format/wal_record.rs:130-143` | — |
+| # | Finding | Severity | Code Reference | Comparison | Tracked |
+|---|---------|----------|----------------|------------|---------|
+| D-1 | Standard mode fsync deferred to background thread; no health check | **CRITICAL** | `wal/writer.rs:252-256` | SQLite documents `PRAGMA synchronous` levels with exact data-loss windows | #1310 |
+| D-2 | Segment header CRC missing from record integrity chain | **HIGH** | `format/wal_record.rs:32-51` | RocksDB uses per-record CRC + block checksums | #1310 |
+| D-3 | Stale WAL lock: no PID validation, crashed process blocks others | **HIGH** | `coordination.rs:14-67` | PostgreSQL validates PID in postmaster.pid | #1310 |
+| D-4 | Snapshot parent directory fsync may fail silently | **HIGH** | `disk_snapshot/writer.rs:127-132` | ext4/XFS require parent dir fsync for rename durability | #1311 |
+| D-5 | Recovery doesn't validate watermark-snapshot consistency | **HIGH** | `recovery/coordinator.rs:103-109` | SQLite cross-validates WAL checkpoints | #1311 |
+| D-6 | Compaction not atomic with concurrent writes (race on segment list) | **HIGH** | `compaction/wal_only.rs:81-147` | RocksDB uses version edits with manifest lock | #1312 |
+| D-7 | Active segment never gets `.meta` sidecar until rotation | **HIGH** | `wal/reader.rs:205-260` | — | #1311 |
+| D-8 | 1 MB corruption scan window; data beyond may be lost | **MEDIUM** | `wal/reader.rs:14, 94-122` | — | #1312 |
+| D-9 | No disk space monitoring or emergency compaction trigger | **MEDIUM** | — | PostgreSQL monitors `pg_tablespace` usage | #1312 |
+| D-10 | Format version checking incomplete (v1 without CRC still supported) | **MEDIUM** | `format/wal_record.rs:130-143` | — | #1312 |
 
 **Crash Safety Assessment:**
 
@@ -131,20 +131,20 @@ The most important gaps fall into five cross-cutting themes:
 
 **Verdict:** Core orchestration works, but recovery failure silently returns empty state (data loss), and shutdown has a 30-second timeout that ignores in-flight transactions.
 
-| # | Finding | Severity | Code Reference | Comparison |
-|---|---------|----------|----------------|------------|
-| E-1 | Recovery failure returns `RecoveryResult::empty()` — silent data loss | **CRITICAL** | `database/mod.rs:466-476` | SQLite refuses to open a corrupt database |
-| E-2 | Shutdown timeout ignores in-flight transactions after 30s | **CRITICAL** | `database/mod.rs:1954-1959` | PostgreSQL's `smart` shutdown waits for all sessions |
-| E-3 | Search index updated non-atomically during refresh | **HIGH** | `database/mod.rs:1004-1091` | — |
-| E-4 | Vector recovery requires manual `register_vector_recovery()` | **HIGH** | `primitives/vector/recovery.rs:42-44` | — |
-| E-5 | WAL flush thread shutdown race (flag check without lock) | **HIGH** | `database/mod.rs:538-546` | — |
-| E-6 | Vector heap freeze errors silently ignored in Drop | **HIGH** | `database/mod.rs:1985-1986` | — |
-| E-7 | Multi-process counter file seeding failure allows wrong starting versions | **HIGH** | `database/mod.rs:505-521` | — |
-| E-8 | Branch lock removal not coordinated with in-flight transactions | **HIGH** | `database/mod.rs:893-901` | — |
-| E-9 | No health check or liveness probe API | **HIGH** | — | Redis has `PING`; RocksDB has `GetProperty()` |
-| E-10 | No metrics export for observability | **HIGH** | — | Redis has 200+ `INFO` metrics; RocksDB has 100+ properties |
-| E-11 | Transaction coordinator metrics use `Relaxed` ordering | **MEDIUM** | `coordinator.rs:30-34` | — |
-| E-12 | Search index fast path doesn't validate manifest version | **MEDIUM** | `search/recovery.rs:72-81` | — |
+| # | Finding | Severity | Code Reference | Comparison | Tracked |
+|---|---------|----------|----------------|------------|---------|
+| E-1 | Recovery failure returns `RecoveryResult::empty()` — silent data loss | **CRITICAL** | `database/mod.rs:466-476` | SQLite refuses to open a corrupt database | #1313 |
+| E-2 | Shutdown timeout ignores in-flight transactions after 30s | **CRITICAL** | `database/mod.rs:1954-1959` | PostgreSQL's `smart` shutdown waits for all sessions | #1314 |
+| E-3 | Search index updated non-atomically during refresh | **HIGH** | `database/mod.rs:1004-1091` | — | #1322 |
+| E-4 | Vector recovery requires manual `register_vector_recovery()` | **HIGH** | `primitives/vector/recovery.rs:42-44` | — | #1313 |
+| E-5 | WAL flush thread shutdown race (flag check without lock) | **HIGH** | `database/mod.rs:538-546` | — | #1314 |
+| E-6 | Vector heap freeze errors silently ignored in Drop | **HIGH** | `database/mod.rs:1985-1986` | — | #1313 |
+| E-7 | Multi-process counter file seeding failure allows wrong starting versions | **HIGH** | `database/mod.rs:505-521` | — | #1313 |
+| E-8 | Branch lock removal not coordinated with in-flight transactions | **HIGH** | `database/mod.rs:893-901` | — | #1314 |
+| E-9 | No health check or liveness probe API | **HIGH** | — | Redis has `PING`; RocksDB has `GetProperty()` | #1320 |
+| E-10 | No metrics export for observability | **HIGH** | — | Redis has 200+ `INFO` metrics; RocksDB has 100+ properties | #1320 |
+| E-11 | Transaction coordinator metrics use `Relaxed` ordering | **MEDIUM** | `coordinator.rs:30-34` | — | #1320 |
+| E-12 | Search index fast path doesn't validate manifest version | **MEDIUM** | `search/recovery.rs:72-81` | — | #1322 |
 
 **Strengths:** Clean primitive handler architecture. Background scheduler with priority-based task execution. Auto-embed hook pattern. Comprehensive command dispatch.
 
@@ -156,15 +156,15 @@ The most important gaps fall into five cross-cutting themes:
 
 **Verdict:** Well-designed API layer with comprehensive typed command enum, but batch operation semantics are undocumented and the Output type has no compile-time enforcement.
 
-| # | Finding | Severity | Code Reference | Comparison |
-|---|---------|----------|----------------|------------|
-| X-1 | Batch operations can partially succeed (not atomic, not documented) | **CRITICAL** | `handlers/kv.rs:180-265` | Redis `MSET` is atomic; DynamoDB `BatchWriteItem` documents partial success |
-| X-2 | Handler can return wrong Output variant — compiles without error | **CRITICAL** | `executor.rs:170-1313`, `output.rs:32-217` | — |
-| X-3 | Embedding write-behind consistency model undocumented | **HIGH** | `embed_hook.rs:110-173` | Elasticsearch documents NRT (near-real-time) behavior explicitly |
-| X-4 | Vector writes blocked inside transactions | **HIGH** | `session.rs:100-110` | — |
-| X-5 | Transaction commands split between Executor and Session (confusing) | **HIGH** | `executor.rs:858-864` | — |
-| X-6 | Embed buffer backpressure falls back to synchronous flush | **MEDIUM** | `embed_hook.rs:162-170` | — |
-| X-7 | Branch name resolution (UUID v5 hashing) undocumented | **MEDIUM** | `bridge.rs:93-105` | — |
+| # | Finding | Severity | Code Reference | Comparison | Tracked |
+|---|---------|----------|----------------|------------|---------|
+| X-1 | Batch operations can partially succeed (not atomic, not documented) | **CRITICAL** | `handlers/kv.rs:180-265` | Redis `MSET` is atomic; DynamoDB `BatchWriteItem` documents partial success | #1319 |
+| X-2 | Handler can return wrong Output variant — compiles without error | **CRITICAL** | `executor.rs:170-1313`, `output.rs:32-217` | — | #1319 |
+| X-3 | Embedding write-behind consistency model undocumented | **HIGH** | `embed_hook.rs:110-173` | Elasticsearch documents NRT (near-real-time) behavior explicitly | #1319 |
+| X-4 | Vector writes blocked inside transactions | **HIGH** | `session.rs:100-110` | — | #1326 |
+| X-5 | Transaction commands split between Executor and Session (confusing) | **HIGH** | `executor.rs:858-864` | — | #1326 |
+| X-6 | Embed buffer backpressure falls back to synchronous flush | **MEDIUM** | `embed_hook.rs:162-170` | — | #1326 |
+| X-7 | Branch name resolution (UUID v5 hashing) undocumented | **MEDIUM** | `bridge.rs:93-105` | — | #1326 |
 
 **Strengths:** Exhaustive typed command enum (70+ variants). Comprehensive input validation at API boundary. Stateless executor design (thread-safe by construction). `#[serde(deny_unknown_fields)]` rejects malformed JSON. Extensive test suite (3928 lines across 9 test files).
 
@@ -176,12 +176,12 @@ The most important gaps fall into five cross-cutting themes:
 
 **Verdict:** Minimal — binary read/write access mode only, no cryptography, no RBAC, no audit logging.
 
-| # | Finding | Severity | Code Reference | Comparison |
-|---|---------|----------|----------------|------------|
-| SEC-1 | No encryption at rest — zero cryptographic implementation | **CRITICAL** | `lib.rs` (entire crate, 137 lines); `durability/src/codec/identity.rs` | SQLite has SEE/sqlcipher AES-256; RocksDB has env-level encryption |
-| SEC-2 | API keys stored as plain `String` — no zeroize, appears in debug | **HIGH** | `lib.rs:46-48` (`OpenOptions.model_api_key`) | Redis redacts `requirepass` in `CONFIG GET` |
-| SEC-3 | Binary ReadOnly/ReadWrite only — no per-collection or per-user RBAC | **MEDIUM** | `lib.rs:10-18` | Redis has per-command, per-key ACLs |
-| SEC-4 | Durability mode string validation missing | **MEDIUM** | `lib.rs` (durability method) | — |
+| # | Finding | Severity | Code Reference | Comparison | Tracked |
+|---|---------|----------|----------------|------------|---------|
+| SEC-1 | No encryption at rest — zero cryptographic implementation | **CRITICAL** | `lib.rs` (entire crate, 137 lines); `durability/src/codec/identity.rs` | SQLite has SEE/sqlcipher AES-256; RocksDB has env-level encryption | #1321 |
+| SEC-2 | API keys stored as plain `String` — no zeroize, appears in debug | **HIGH** | `lib.rs:46-48` (`OpenOptions.model_api_key`) | Redis redacts `requirepass` in `CONFIG GET` | #1321 |
+| SEC-3 | Binary ReadOnly/ReadWrite only — no per-collection or per-user RBAC | **MEDIUM** | `lib.rs:10-18` | Redis has per-command, per-key ACLs | #1321 |
+| SEC-4 | Durability mode string validation missing | **MEDIUM** | `lib.rs` (durability method) | — | #1321 |
 
 **Strengths:** None beyond basic type safety. **0 tests** in the crate.
 
@@ -193,14 +193,14 @@ The most important gaps fall into five cross-cutting themes:
 
 **Verdict:** Functional but fragile under failure conditions — `OnceCell` caches errors permanently, and text extraction silently returns `None` on depth limit.
 
-| # | Finding | Severity | Code Reference | Comparison |
-|---|---------|----------|----------------|------------|
-| I-1 | Model load failure cached permanently via `OnceCell` | **CRITICAL** | `embed/mod.rs:39-51` (test at lines 150-163 confirms) | Any production ML pipeline retries with backoff |
-| I-2 | Text extraction returns `None` on depth limit (indistinguishable from "no text") | **CRITICAL** | `embed/extract.rs:6-9` (`MAX_DEPTH=16`, `MAX_TEXT_LEN=1024`) | Elasticsearch rejects docs exceeding nesting limits with explicit error |
-| I-3 | No model hash/signature validation after download | **HIGH** | `embed/download.rs` | Production ML pipelines validate model checksums |
-| I-4 | Poisoned Mutex recovery uses potentially corrupted state | **HIGH** | `generate.rs:52, 66` | — |
-| I-5 | Unbounded model cache (`HashMap` with no eviction) | **MEDIUM** | `generate.rs` (`GenerateModelState`) | — |
-| I-6 | Batch embedding doesn't validate uniform output dimensions | **MEDIUM** | `embed/mod.rs:99-119` | — |
+| # | Finding | Severity | Code Reference | Comparison | Tracked |
+|---|---------|----------|----------------|------------|---------|
+| I-1 | Model load failure cached permanently via `OnceCell` | **CRITICAL** | `embed/mod.rs:39-51` (test at lines 150-163 confirms) | Any production ML pipeline retries with backoff | #1318 |
+| I-2 | Text extraction returns `None` on depth limit (indistinguishable from "no text") | **CRITICAL** | `embed/extract.rs:6-9` (`MAX_DEPTH=16`, `MAX_TEXT_LEN=1024`) | Elasticsearch rejects docs exceeding nesting limits with explicit error | #1318 |
+| I-3 | No model hash/signature validation after download | **HIGH** | `embed/download.rs` | Production ML pipelines validate model checksums | #1327 |
+| I-4 | Poisoned Mutex recovery uses potentially corrupted state | **HIGH** | `generate.rs:52, 66` | — | #1318 |
+| I-5 | Unbounded model cache (`HashMap` with no eviction) | **MEDIUM** | `generate.rs` (`GenerateModelState`) | — | #1327 |
+| I-6 | Batch embedding doesn't validate uniform output dimensions | **MEDIUM** | `embed/mod.rs:99-119` | — | #1327 |
 
 **Strengths:** Comprehensive unit tests (14+ test functions). Lazy model loading (zero overhead for non-embedding workloads). Proper depth and text length limits in extraction (the issue is the error reporting, not the limit itself).
 
@@ -212,15 +212,15 @@ The most important gaps fall into five cross-cutting themes:
 
 **Verdict:** Sophisticated design with weighted RRF fusion, but prompt injection risk in LLM-based query expansion and NaN scores can propagate silently.
 
-| # | Finding | Severity | Code Reference | Comparison |
-|---|---------|----------|----------------|------------|
-| SR-1 | RRF fusion creates placeholder rank-0 hits before reassignment | **HIGH** | `fuser.rs:188`, `hybrid.rs:268, 285` | Standard RRF implementations validate rank > 0 |
-| SR-2 | User query injected directly into LLM prompt (prompt injection) | **HIGH** | `expand/prompt.rs:26-31` | Production RAG systems sanitize/escape user queries |
-| SR-3 | NaN scores not rejected; `partial_cmp()` falls back silently | **HIGH** | `fuser.rs:74-96`, `rerank/api.rs:96-104` | Lucene rejects NaN scores explicitly |
-| SR-4 | LLM response parser silently drops invalid lines | **HIGH** | `expand/parser.rs:36-37` | — |
-| SR-5 | Reranker partial failures silently keep original scores | **MEDIUM** | `rerank/api.rs:98-106`, `blend.rs:40` | Production rerankers validate output count |
-| SR-6 | Budget allocation doesn't account for vector search timing | **MEDIUM** | `hybrid.rs:335-351` | — |
-| SR-7 | RRF k=60 hardcoded, not configurable | **LOW** | `hybrid.rs:479` | — |
+| # | Finding | Severity | Code Reference | Comparison | Tracked |
+|---|---------|----------|----------------|------------|---------|
+| SR-1 | RRF fusion creates placeholder rank-0 hits before reassignment | **HIGH** | `fuser.rs:188`, `hybrid.rs:268, 285` | Standard RRF implementations validate rank > 0 | #1322 |
+| SR-2 | User query injected directly into LLM prompt (prompt injection) | **HIGH** | `expand/prompt.rs:26-31` | Production RAG systems sanitize/escape user queries | #1322 |
+| SR-3 | NaN scores not rejected; `partial_cmp()` falls back silently | **HIGH** | `fuser.rs:74-96`, `rerank/api.rs:96-104` | Lucene rejects NaN scores explicitly | #1322 |
+| SR-4 | LLM response parser silently drops invalid lines | **HIGH** | `expand/parser.rs:36-37` | — | #1322 |
+| SR-5 | Reranker partial failures silently keep original scores | **MEDIUM** | `rerank/api.rs:98-106`, `blend.rs:40` | Production rerankers validate output count | #1322 |
+| SR-6 | Budget allocation doesn't account for vector search timing | **MEDIUM** | `hybrid.rs:335-351` | — | #1322 |
+| SR-7 | RRF k=60 hardcoded, not configurable | **LOW** | `hybrid.rs:479` | — | #1322 |
 
 **Strengths:** Excellent architecture documentation with ASCII diagrams. Comprehensive unit tests (60+ test functions). Feature-flagged HTTP dependencies (`expand` and `rerank` features). Weighted RRF fusion is well-designed. Sort determinism with EntityRef hash tie-breaking.
 
@@ -238,26 +238,26 @@ The most important gaps fall into five cross-cutting themes:
 
 **Verdict:** Zero unsafe code and zero production panics (excellent), but pervasive O(E) full-scans, unbounded result sets, and silent corruption swallowing.
 
-| # | Finding | Severity | Code Reference | Comparison |
-|---|---------|----------|----------------|------------|
-| G-1 | `unwrap_or_default()` silently replaces corrupted edge/node data | **HIGH** | `graph/mod.rs:460, 501, 531, 564` | Neo4j/JanusGraph surface deserialization errors |
-| G-2 | `subgraph()` full-scans all edges O(E) then filters client-side | **HIGH** | `graph/traversal.rs:127-153` | Neo4j uses per-node index lookups for subgraph projection |
-| G-4 | BFS default `max_depth: usize::MAX` — unbounded traversal on connected graphs | **HIGH** | `graph/types.rs:193-202` | Neo4j/DGraph require explicit depth/result limits |
-| G-3 | `count_edges_by_type()` full-scans all edges per type — O(L * E) for summary | **MEDIUM** | `graph/ontology.rs:506-529` | Production graph DBs maintain per-type count metadata |
-| G-5 | `list_graphs()` scans entire `_graph_` namespace including all data | **MEDIUM** | `graph/mod.rs:88-108` | Production DBs maintain a graph catalog/registry |
-| G-6 | No max-length on node IDs, graph names, edge types, or entity_ref URIs | **MEDIUM** | `graph/keys.rs:19-56` | Neo4j limits label names to 65534 bytes |
-| G-7 | Edges allowed between non-existent nodes (dangling edges) | **MEDIUM** | `graph/mod.rs:348-382` | Neo4j requires nodes to exist before creating relationships |
-| G-8 | `on_entity_deleted()` cascade errors logged but not returned | **MEDIUM** | `graph/integrity.rs:47-55` | — |
-| G-11 | `delete_graph()` loads all graph data into memory in a single scan | **MEDIUM** | `graph/mod.rs:111-149` | Neo4j uses batched deletion |
-| G-12 | `snapshot()` loads entire graph into memory (all nodes + all edges) | **MEDIUM** | `graph/mod.rs:518-581` | Neo4j/DGraph stream results; never load full graph |
-| G-14 | Frozen ontology uses open-world semantics — undeclared types bypass all checks | **MEDIUM** | `graph/ontology.rs:307-309, 344-347` | — |
-| G-18 | `list_nodes()` and `list_graphs()` return unbounded `Vec<String>` | **MEDIUM** | `graph/mod.rs:88-108, 252-268` | All production graph DBs support pagination |
-| G-9 | `degree()` materializes all neighbors just to count them | **LOW** | `graph/traversal.rs:43-52` | Neo4j returns degree count without materialization |
-| G-10 | `AdjacencyIndex` allows duplicate edges and has no size bound | **LOW** | `graph/adjacency.rs:57-68` | — |
-| G-13 | Bulk insert does per-node KV read for ontology validation | **LOW** | `graph/mod.rs:633-635` | — |
-| G-15 | `freeze_ontology()` read-then-write is not atomic | **LOW** | `graph/ontology.rs:220-285` | Neo4j holds schema write lock for the entire operation |
-| G-16 | Property types recorded but not enforced, even when ontology is frozen | **LOW** | `graph/types.rs:22-30` | Neo4j property type constraints enforce at write time |
-| G-17 | Hand-rolled URI encoding/decoding is fragile | **LOW** | `graph/keys.rs:164-171` | — |
+| # | Finding | Severity | Code Reference | Comparison | Tracked |
+|---|---------|----------|----------------|------------|---------|
+| G-1 | `unwrap_or_default()` silently replaces corrupted edge/node data | **HIGH** | `graph/mod.rs:460, 501, 531, 564` | Neo4j/JanusGraph surface deserialization errors | #1315 |
+| G-2 | `subgraph()` full-scans all edges O(E) then filters client-side | **HIGH** | `graph/traversal.rs:127-153` | Neo4j uses per-node index lookups for subgraph projection | #1316 |
+| G-4 | BFS default `max_depth: usize::MAX` — unbounded traversal on connected graphs | **HIGH** | `graph/types.rs:193-202` | Neo4j/DGraph require explicit depth/result limits | #1316 |
+| G-3 | `count_edges_by_type()` full-scans all edges per type — O(L * E) for summary | **MEDIUM** | `graph/ontology.rs:506-529` | Production graph DBs maintain per-type count metadata | #1316 |
+| G-5 | `list_graphs()` scans entire `_graph_` namespace including all data | **MEDIUM** | `graph/mod.rs:88-108` | Production DBs maintain a graph catalog/registry | #1316 |
+| G-6 | No max-length on node IDs, graph names, edge types, or entity_ref URIs | **MEDIUM** | `graph/keys.rs:19-56` | Neo4j limits label names to 65534 bytes | #1315 |
+| G-7 | Edges allowed between non-existent nodes (dangling edges) | **MEDIUM** | `graph/mod.rs:348-382` | Neo4j requires nodes to exist before creating relationships | #1315 |
+| G-8 | `on_entity_deleted()` cascade errors logged but not returned | **MEDIUM** | `graph/integrity.rs:47-55` | — | #1323 |
+| G-11 | `delete_graph()` loads all graph data into memory in a single scan | **MEDIUM** | `graph/mod.rs:111-149` | Neo4j uses batched deletion | #1316 |
+| G-12 | `snapshot()` loads entire graph into memory (all nodes + all edges) | **MEDIUM** | `graph/mod.rs:518-581` | Neo4j/DGraph stream results; never load full graph | #1323 |
+| G-14 | Frozen ontology uses open-world semantics — undeclared types bypass all checks | **MEDIUM** | `graph/ontology.rs:307-309, 344-347` | — | #1315 |
+| G-18 | `list_nodes()` and `list_graphs()` return unbounded `Vec<String>` | **MEDIUM** | `graph/mod.rs:88-108, 252-268` | All production graph DBs support pagination | #1316 |
+| G-9 | `degree()` materializes all neighbors just to count them | **LOW** | `graph/traversal.rs:43-52` | Neo4j returns degree count without materialization | #1323 |
+| G-10 | `AdjacencyIndex` allows duplicate edges and has no size bound | **LOW** | `graph/adjacency.rs:57-68` | — | #1323 |
+| G-13 | Bulk insert does per-node KV read for ontology validation | **LOW** | `graph/mod.rs:633-635` | — | #1323 |
+| G-15 | `freeze_ontology()` read-then-write is not atomic | **LOW** | `graph/ontology.rs:220-285` | Neo4j holds schema write lock for the entire operation | #1323 |
+| G-16 | Property types recorded but not enforced, even when ontology is frozen | **LOW** | `graph/types.rs:22-30` | Neo4j property type constraints enforce at write time | #1323 |
+| G-17 | Hand-rolled URI encoding/decoding is fragile | **LOW** | `graph/keys.rs:164-171` | — | #1323 |
 
 **Strengths:** Zero `unsafe` code in 6,917 lines. Zero panics in production paths — all error handling uses `?` propagation. Comprehensive input validation on write paths. Atomic forward+reverse edge updates within a single transaction. Well-designed ontology lifecycle (Draft -> Frozen with cross-reference validation). Referential integrity hooks with configurable cascade policies (Cascade/Detach/Ignore). Extensive test coverage across all 9 files.
 
@@ -269,38 +269,38 @@ The most important gaps fall into five cross-cutting themes:
 
 **Verdict:** Sophisticated segmented HNSW architecture with strong determinism guarantees, but `unsafe` alignment checks disappear in release builds, production `panic!()` calls in the heap, and no SIMD or quantization for competitive performance.
 
-| # | Finding | Severity | Code Reference | Comparison |
-|---|---------|----------|----------------|------------|
-| V-1 | `debug_assert!` guards alignment before `unsafe` pointer cast — disappears in release | **CRITICAL** | `vector/hnsw.rs:958-967` | Qdrant uses `safe_transmute` with runtime validation |
-| V-2 | f32 alignment not validated on mmap open; corrupt file causes UB | **HIGH** | `vector/mmap.rs:228` | pgvector uses typed storage guaranteeing alignment |
-| V-5 | `panic!("cannot mutate mmap-backed VectorHeap")` in production path | **HIGH** | `vector/heap.rs:268` | Production DBs never panic on data-plane operations |
-| V-6 | `panic!("raw_data() not available")` for Mmap and Tiered variants | **HIGH** | `vector/heap.rs:520-521` | — |
-| V-7 | `.expect()` in hot iteration path — panics on stale `id_to_offset` | **HIGH** | `vector/heap.rs:490, 501` | — |
-| V-13 | `delete()` removes from backend first, then KV — reversed from insert ordering | **HIGH** | `vector/store.rs:697-711` | Pinecone uses single transactional delete |
-| V-15 | `delete()` has no lock around check-then-mutate (TOCTOU race) | **HIGH** | `vector/store.rs:677-714` | Insert path correctly holds lock (citing issue #936) |
-| V-17 | No `fsync` before atomic rename of mmap files — crash can lose cache | **HIGH** | `vector/mmap.rs:334-338`, `mmap_graph.rs:152-156` | SQLite/RocksDB/Qdrant all fsync before rename |
-| V-19 | `debug_assert_eq!` for dimension mismatch in distance computation | **HIGH** | `vector/distance.rs:19-23` | FAISS uses runtime assertions; Qdrant validates at all layers |
-| V-23 | No SIMD distance computation — scalar f32 loops only | **HIGH** | `vector/distance.rs` | Qdrant/FAISS/Milvus all use AVX2/NEON SIMD |
-| V-25 | No quantization support — all vectors stored as full-precision f32 | **HIGH** | entire subsystem | Qdrant supports SQ/PQ/binary; Milvus supports IVF_SQ8/PQ |
-| V-27 | No pre-filtering for metadata — post-filter only with adaptive over-fetch | **HIGH** | `vector/store.rs:872-970`, `vector/filter.rs` | Pinecone/Qdrant/Weaviate support pre-filtering |
-| V-3 | `&[f32]` to `&[u8]` cast lacks endianness guard (mmap.rs only; mmap_graph.rs has it) | **MEDIUM** | `vector/mmap.rs:330` | — |
-| V-4 | Mmap lifetime relies on external file not being modified/deleted | **MEDIUM** | `vector/mmap.rs:124`, `mmap_graph.rs:176` | Qdrant uses advisory file locks |
-| V-8 | `.unwrap()` on `entry_point` after None check — fragile to refactoring | **MEDIUM** | `vector/hnsw.rs:508` | — |
-| V-9 | Thread pool `expect()` at first search — delayed crash under resource constraints | **MEDIUM** | `vector/segmented.rs:51` | — |
-| V-10 | Unbounded `inline_meta: BTreeMap` — always in anonymous memory | **MEDIUM** | `vector/heap.rs:101-103` | Qdrant stores metadata with disk backing |
-| V-11 | WAL embeds full vectors (~6KB per 1536-dim entry) | **MEDIUM** | `vector/wal.rs` | Milvus uses separate binlog for vector data |
-| V-12 | O(n) KV scan fallback for VectorId-to-key resolution | **MEDIUM** | `vector/store.rs:1167-1216` | — |
-| V-16 | `ensure_collection_loaded()` has TOCTOU window — two threads can double-init | **MEDIUM** | `vector/store.rs:1377-1406` | — |
-| V-18 | No parent directory fsync after rename | **MEDIUM** | same as V-17 | LevelDB/RocksDB fsync directory after rename |
-| V-20 | No NaN/Infinity validation in distance functions | **MEDIUM** | `vector/distance.rs` | Qdrant rejects NaN/Infinity at ingestion |
-| V-21 | Temporal search uses fixed 4x over-fetch (no adaptive retry like `search()`) | **MEDIUM** | `vector/store.rs:1026` | Pinecone/Weaviate apply filters during traversal (pre-filter) |
-| V-22 | `search()` doesn't validate query vector for NaN (but `search_at()` does) | **MEDIUM** | `vector/store.rs:842-987` | — |
-| V-24 | BTreeSet visited set in HNSW search — O(log n) vs HashSet O(1) | **MEDIUM** | `vector/hnsw.rs` | FAISS/Qdrant use flat bitsets or hash sets |
-| V-26 | Active buffer uses O(n) brute-force scan (seal threshold 50K) | **MEDIUM** | `vector/segmented.rs` | Qdrant builds small HNSW even for mutable segment |
-| V-28 | No sparse, multi-vector, or binary vector support | **MEDIUM** | entire subsystem | Qdrant/Weaviate/Milvus support sparse + multi-vector |
-| V-14 | Silent failure on `create_dir_all` and `flush_heap_to_disk_if_needed` | **LOW** | `vector/store.rs:1119-1121` | — |
-| V-29 | No per-collection namespace or tenant isolation | **LOW** | entire subsystem | Pinecone supports namespaces within an index |
-| V-30 | No index build progress reporting | **LOW** | `vector/segmented.rs` | Milvus reports index build progress |
+| # | Finding | Severity | Code Reference | Comparison | Tracked |
+|---|---------|----------|----------------|------------|---------|
+| V-1 | `debug_assert!` guards alignment before `unsafe` pointer cast — disappears in release | **CRITICAL** | `vector/hnsw.rs:958-967` | Qdrant uses `safe_transmute` with runtime validation | #1317 |
+| V-2 | f32 alignment not validated on mmap open; corrupt file causes UB | **HIGH** | `vector/mmap.rs:228` | pgvector uses typed storage guaranteeing alignment | #1324 |
+| V-5 | `panic!("cannot mutate mmap-backed VectorHeap")` in production path | **HIGH** | `vector/heap.rs:268` | Production DBs never panic on data-plane operations | #1317 |
+| V-6 | `panic!("raw_data() not available")` for Mmap and Tiered variants | **HIGH** | `vector/heap.rs:520-521` | — | #1317 |
+| V-7 | `.expect()` in hot iteration path — panics on stale `id_to_offset` | **HIGH** | `vector/heap.rs:490, 501` | — | #1317 |
+| V-13 | `delete()` removes from backend first, then KV — reversed from insert ordering | **HIGH** | `vector/store.rs:697-711` | Pinecone uses single transactional delete | #1317 |
+| V-15 | `delete()` has no lock around check-then-mutate (TOCTOU race) | **HIGH** | `vector/store.rs:677-714` | Insert path correctly holds lock (citing issue #936) | #1317 |
+| V-17 | No `fsync` before atomic rename of mmap files — crash can lose cache | **HIGH** | `vector/mmap.rs:334-338`, `mmap_graph.rs:152-156` | SQLite/RocksDB/Qdrant all fsync before rename | #1317 |
+| V-19 | `debug_assert_eq!` for dimension mismatch in distance computation | **HIGH** | `vector/distance.rs:19-23` | FAISS uses runtime assertions; Qdrant validates at all layers | #1324 |
+| V-23 | No SIMD distance computation — scalar f32 loops only | **HIGH** | `vector/distance.rs` | Qdrant/FAISS/Milvus all use AVX2/NEON SIMD | #1325 |
+| V-25 | No quantization support — all vectors stored as full-precision f32 | **HIGH** | entire subsystem | Qdrant supports SQ/PQ/binary; Milvus supports IVF_SQ8/PQ | #1325 |
+| V-27 | No pre-filtering for metadata — post-filter only with adaptive over-fetch | **HIGH** | `vector/store.rs:872-970`, `vector/filter.rs` | Pinecone/Qdrant/Weaviate support pre-filtering | #1325 |
+| V-3 | `&[f32]` to `&[u8]` cast lacks endianness guard (mmap.rs only; mmap_graph.rs has it) | **MEDIUM** | `vector/mmap.rs:330` | — | #1324 |
+| V-4 | Mmap lifetime relies on external file not being modified/deleted | **MEDIUM** | `vector/mmap.rs:124`, `mmap_graph.rs:176` | Qdrant uses advisory file locks | #1324 |
+| V-8 | `.unwrap()` on `entry_point` after None check — fragile to refactoring | **MEDIUM** | `vector/hnsw.rs:508` | — | #1324 |
+| V-9 | Thread pool `expect()` at first search — delayed crash under resource constraints | **MEDIUM** | `vector/segmented.rs:51` | — | #1324 |
+| V-10 | Unbounded `inline_meta: BTreeMap` — always in anonymous memory | **MEDIUM** | `vector/heap.rs:101-103` | Qdrant stores metadata with disk backing | #1324 |
+| V-11 | WAL embeds full vectors (~6KB per 1536-dim entry) | **MEDIUM** | `vector/wal.rs` | Milvus uses separate binlog for vector data | #1325 |
+| V-12 | O(n) KV scan fallback for VectorId-to-key resolution | **MEDIUM** | `vector/store.rs:1167-1216` | — | #1325 |
+| V-16 | `ensure_collection_loaded()` has TOCTOU window — two threads can double-init | **MEDIUM** | `vector/store.rs:1377-1406` | — | #1324 |
+| V-18 | No parent directory fsync after rename | **MEDIUM** | same as V-17 | LevelDB/RocksDB fsync directory after rename | #1317 |
+| V-20 | No NaN/Infinity validation in distance functions | **MEDIUM** | `vector/distance.rs` | Qdrant rejects NaN/Infinity at ingestion | #1324 |
+| V-21 | Temporal search uses fixed 4x over-fetch (no adaptive retry like `search()`) | **MEDIUM** | `vector/store.rs:1026` | Pinecone/Weaviate apply filters during traversal (pre-filter) | #1325 |
+| V-22 | `search()` doesn't validate query vector for NaN (but `search_at()` does) | **MEDIUM** | `vector/store.rs:842-987` | — | #1324 |
+| V-24 | BTreeSet visited set in HNSW search — O(log n) vs HashSet O(1) | **MEDIUM** | `vector/hnsw.rs` | FAISS/Qdrant use flat bitsets or hash sets | #1325 |
+| V-26 | Active buffer uses O(n) brute-force scan (seal threshold 50K) | **MEDIUM** | `vector/segmented.rs` | Qdrant builds small HNSW even for mutable segment | #1325 |
+| V-28 | No sparse, multi-vector, or binary vector support | **MEDIUM** | entire subsystem | Qdrant/Weaviate/Milvus support sparse + multi-vector | #1325 |
+| V-14 | Silent failure on `create_dir_all` and `flush_heap_to_disk_if_needed` | **LOW** | `vector/store.rs:1119-1121` | — | #1324 |
+| V-29 | No per-collection namespace or tenant isolation | **LOW** | entire subsystem | Pinecone supports namespaces within an index | #1325 |
+| V-30 | No index build progress reporting | **LOW** | `vector/segmented.rs` | Milvus reports index build progress | #1325 |
 
 **Strengths:** Deterministic results by design — BTreeMap iteration, fixed RNG seeds, and facade-level tie-breaking produce byte-identical output across runs (rare among vector DBs). Temporal search (time-travel queries) is a unique feature not offered by Pinecone/Qdrant/Milvus. Graceful mmap degradation — corrupt or missing `.vec`/`.hgr` files fall back to full KV rebuild with zero data loss. KV-first insert pattern ensures durability before visibility. Slot reuse without ID reuse avoids phantom result bugs. Compile-time endianness guard in `mmap_graph.rs`. Data zeroing on delete prevents information leakage. Comprehensive `VectorError` enum with 15+ contextual variants.
 
@@ -342,43 +342,43 @@ The most important gaps fall into five cross-cutting themes:
 
 ### Phase 1: Must-Fix Before Any Production Use (Weeks 1-4)
 
-| # | Item | Crate | Rationale |
-|---|------|-------|-----------|
-| 1 | **Refuse to open on recovery failure** — return error instead of `RecoveryResult::empty()` | engine | Data loss is the worst possible outcome for a database. Silent data loss is worse — the caller doesn't even know it happened. |
-| 2 | **Add memory limits** — configurable max memory for version chains, branches, and vectors | storage | An embedded database sharing a host process cannot OOM the host. At minimum, document the growth model so users can plan. |
-| 3 | **Fix Standard mode fsync** — health-check the background flush thread, or sync inline | durability | Users who receive `Ok(())` from `commit()` expect durability. An unhealthy flush thread silently violates this contract. |
-| 4 | **Replace version counter `expect()` with error return** | concurrency | `expect()` on `checked_add` at `manager.rs:146` panics the entire host application. Return `Err(VersionOverflow)` instead. |
-| 5 | **Add compile-time layout assertion for JSON transmute** | core | The `unsafe` block at `json.rs:1028` relies on `#[repr(transparent)]` but has no `static_assert` verifying layout. UB is unacceptable in a database. |
-| 6 | **Promote HNSW mmap alignment check to runtime assertion** | engine/vector | `debug_assert!` at `hnsw.rs:958` guards an `unsafe` pointer cast but disappears in release builds. Same class as #5 — UB on misaligned data. |
-| 7 | **Replace `panic!()` calls in VectorHeap with error returns** | engine/vector | `heap.rs:268, 520-521` panic on mmap/tiered variant mismatch. Process crash on a data-plane operation is unacceptable. |
-| 8 | **Document isolation level** — "Snapshot Isolation; write-skew is possible" | concurrency | Users must know what guarantees they get. Every production database documents its isolation levels. |
-| 9 | **Fix model load permanent failure** — replace `OnceCell` with retry + backoff | intelligence | A transient network error during model download permanently breaks inference for the process lifetime. |
+| # | Item | Crate | Rationale | Tracked |
+|---|------|-------|-----------|---------|
+| 1 | **Refuse to open on recovery failure** — return error instead of `RecoveryResult::empty()` | engine | Data loss is the worst possible outcome for a database. Silent data loss is worse — the caller doesn't even know it happened. | #1313 |
+| 2 | **Add memory limits** — configurable max memory for version chains, branches, and vectors | storage | An embedded database sharing a host process cannot OOM the host. At minimum, document the growth model so users can plan. | #1306 |
+| 3 | **Fix Standard mode fsync** — health-check the background flush thread, or sync inline | durability | Users who receive `Ok(())` from `commit()` expect durability. An unhealthy flush thread silently violates this contract. | #1310 |
+| 4 | **Replace version counter `expect()` with error return** | concurrency | `expect()` on `checked_add` at `manager.rs:146` panics the entire host application. Return `Err(VersionOverflow)` instead. | #1307 |
+| 5 | **Add compile-time layout assertion for JSON transmute** | core | The `unsafe` block at `json.rs:1028` relies on `#[repr(transparent)]` but has no `static_assert` verifying layout. UB is unacceptable in a database. | #1300 |
+| 6 | **Promote HNSW mmap alignment check to runtime assertion** | engine/vector | `debug_assert!` at `hnsw.rs:958` guards an `unsafe` pointer cast but disappears in release builds. Same class as #5 — UB on misaligned data. | #1317 |
+| 7 | **Replace `panic!()` calls in VectorHeap with error returns** | engine/vector | `heap.rs:268, 520-521` panic on mmap/tiered variant mismatch. Process crash on a data-plane operation is unacceptable. | #1317 |
+| 8 | **Document isolation level** — "Snapshot Isolation; write-skew is possible" | concurrency | Users must know what guarantees they get. Every production database documents its isolation levels. | #1309 |
+| 9 | **Fix model load permanent failure** — replace `OnceCell` with retry + backoff | intelligence | A transient network error during model download permanently breaks inference for the process lifetime. | #1318 |
 
 ### Phase 2: Should-Fix Before GA (Weeks 5-8)
 
-| # | Item | Crate | Rationale |
-|---|------|-------|-----------|
-| 10 | **Implement automatic maintenance** (GC, compaction, TTL enforcement) | engine | Version chains, WAL segments, tombstones, and expired keys grow without bound. Design doc exists (`maintenance.md`). |
-| 11 | **Add transaction timeout and abandoned transaction detection** | concurrency | Leaked transactions pin the GC safe point forever. `is_expired()` helper exists at `transaction.rs:1038` but is never enforced. |
-| 12 | **Fix stale WAL lock detection** — validate PID, add timeout | durability | A crashed process leaves an orphaned lock file that blocks all other processes from opening the database. |
-| 13 | **Add encryption at rest** (AES-256 via the existing codec seam) | security | The `IdentityCodec` seam at `durability/src/codec/mod.rs` reserves a slot for `AesGcmCodec`. Required for mobile/edge use cases. |
-| 14 | **Add health check API** (`db.health()` returning subsystem status) | engine | Host applications need a liveness probe. No mechanism exists to detect a stuck WAL flush thread or hung recovery. |
-| 15 | **Document batch operation semantics** (non-atomic, partial success) | executor | `KvBatchPut` at `handlers/kv.rs:235` is non-atomic across branches. Users from SQL backgrounds assume atomicity unless told otherwise. |
-| 16 | **Fix shutdown coordination** — drain in-flight transactions before final flush | engine | The 30-second timeout at `database/mod.rs:1954` ignores in-flight transactions. Uncommitted work may be flushed in undefined state. |
-| 17 | **Fix vector delete ordering and add lock** — delete KV first (like insert), hold lock | engine/vector | `store.rs:697` deletes backend before KV (opposite of insert). `delete()` also lacks the TOCTOU lock that insert has. |
-| 18 | **Add fsync before mmap file rename** | engine/vector | `mmap.rs:334` and `mmap_graph.rs:152` call `flush()` but not `sync_all()` before rename. Crash can leave zero-length files. |
-| 19 | **Add per-subsystem memory metrics** (`Command::MemoryStatus`) | engine | Can't manage what you can't measure. Version chain sizes, shard counts, and vector heap usage should be queryable. |
+| # | Item | Crate | Rationale | Tracked |
+|---|------|-------|-----------|---------|
+| 10 | **Implement automatic maintenance** (GC, compaction, TTL enforcement) | engine | Version chains, WAL segments, tombstones, and expired keys grow without bound. Design doc exists (`maintenance.md`). | #1303 |
+| 11 | **Add transaction timeout and abandoned transaction detection** | concurrency | Leaked transactions pin the GC safe point forever. `is_expired()` helper exists at `transaction.rs:1038` but is never enforced. | #1308 |
+| 12 | **Fix stale WAL lock detection** — validate PID, add timeout | durability | A crashed process leaves an orphaned lock file that blocks all other processes from opening the database. | #1310 |
+| 13 | **Add encryption at rest** (AES-256 via the existing codec seam) | security | The `IdentityCodec` seam at `durability/src/codec/mod.rs` reserves a slot for `AesGcmCodec`. Required for mobile/edge use cases. | #1321 |
+| 14 | **Add health check API** (`db.health()` returning subsystem status) | engine | Host applications need a liveness probe. No mechanism exists to detect a stuck WAL flush thread or hung recovery. | #1320 |
+| 15 | **Document batch operation semantics** (non-atomic, partial success) | executor | `KvBatchPut` at `handlers/kv.rs:235` is non-atomic across branches. Users from SQL backgrounds assume atomicity unless told otherwise. | #1319 |
+| 16 | **Fix shutdown coordination** — drain in-flight transactions before final flush | engine | The 30-second timeout at `database/mod.rs:1954` ignores in-flight transactions. Uncommitted work may be flushed in undefined state. | #1314 |
+| 17 | **Fix vector delete ordering and add lock** — delete KV first (like insert), hold lock | engine/vector | `store.rs:697` deletes backend before KV (opposite of insert). `delete()` also lacks the TOCTOU lock that insert has. | #1317 |
+| 18 | **Add fsync before mmap file rename** | engine/vector | `mmap.rs:334` and `mmap_graph.rs:152` call `flush()` but not `sync_all()` before rename. Crash can leave zero-length files. | #1317 |
+| 19 | **Add per-subsystem memory metrics** (`Command::MemoryStatus`) | engine | Can't manage what you can't measure. Version chain sizes, shard counts, and vector heap usage should be queryable. | #1320 |
 
 ### Phase 3: Scale Readiness (Weeks 9-12)
 
-| # | Item | Crate | Rationale |
-|---|------|-------|-----------|
-| 20 | **Replace `ClonedSnapshotView` with lazy/COW snapshots** | concurrency | O(n) snapshot cost at `snapshot.rs:69` limits concurrency. 100 MB branch with 100 concurrent transactions = 10 GB. `ShardedSnapshot` at `sharded.rs:892` is already O(1) — make it the default. |
-| 21 | **Implement KV page cache** (tiered storage Phase 2) | storage | Unbounded memory is the #1 scaling blocker. Design doc exists (`tiered-storage.md`). |
-| 22 | **Add constraint validation at all write boundaries** | core | `validate_value()` and `validate_key_length()` at `limits.rs` are separate checks not enforced at the storage layer. Defense in depth against data corruption. |
-| 23 | **Make vector Tiered mode the default** (spill embeddings to mmap) | engine | Easy win for memory reduction. Tiered mode already exists but InMemory is the default. |
-| 24 | **Auto-persist sealed HNSW graphs to `.shgr` files** | engine | Sealed HNSW segments are in-memory only. A crash after sealing loses the graph, requiring expensive rebuild from vectors. |
-| 25 | **Add SIMD distance computation** | engine/vector | Scalar f32 loops are 4-8x slower than AVX2/NEON. At >100K vectors this dominates search latency. Every production vector DB uses SIMD. |
-| 26 | **Add scalar/product quantization** | engine/vector | Full f32 storage uses 4-32x more memory than quantized representations. Required for >500K vectors in embedded contexts. |
-| 27 | **Replace graph full-scans with per-node adjacency lookups** | engine/graph | `subgraph()`, `count_edges_by_type()`, `delete_graph()`, and `snapshot()` all scan O(E_total). At >100K edges, graph queries become a bottleneck. |
-| 28 | **Add default BFS depth/node limits and graph pagination** | engine/graph | Default `max_depth: usize::MAX` and unbounded `list_nodes()` can OOM on large connected graphs. |
+| # | Item | Crate | Rationale | Tracked |
+|---|------|-------|-----------|---------|
+| 20 | **Replace `ClonedSnapshotView` with lazy/COW snapshots** | concurrency | O(n) snapshot cost at `snapshot.rs:69` limits concurrency. 100 MB branch with 100 concurrent transactions = 10 GB. `ShardedSnapshot` at `sharded.rs:892` is already O(1) — make it the default. | #1309 |
+| 21 | **Implement KV page cache** (tiered storage Phase 2) | storage | Unbounded memory is the #1 scaling blocker. Design doc exists (`tiered-storage.md`). | #1291 |
+| 22 | **Add constraint validation at all write boundaries** | core | `validate_value()` and `validate_key_length()` at `limits.rs` are separate checks not enforced at the storage layer. Defense in depth against data corruption. | #1299 |
+| 23 | **Make vector Tiered mode the default** (spill embeddings to mmap) | engine | Easy win for memory reduction. Tiered mode already exists but InMemory is the default. | #1325 |
+| 24 | **Auto-persist sealed HNSW graphs to `.shgr` files** | engine | Sealed HNSW segments are in-memory only. A crash after sealing loses the graph, requiring expensive rebuild from vectors. | #1317 |
+| 25 | **Add SIMD distance computation** | engine/vector | Scalar f32 loops are 4-8x slower than AVX2/NEON. At >100K vectors this dominates search latency. Every production vector DB uses SIMD. | #1325 |
+| 26 | **Add scalar/product quantization** | engine/vector | Full f32 storage uses 4-32x more memory than quantized representations. Required for >500K vectors in embedded contexts. | #1325 |
+| 27 | **Replace graph full-scans with per-node adjacency lookups** | engine/graph | `subgraph()`, `count_edges_by_type()`, `delete_graph()`, and `snapshot()` all scan O(E_total). At >100K edges, graph queries become a bottleneck. | #1316 |
+| 28 | **Add default BFS depth/node limits and graph pagination** | engine/graph | Default `max_depth: usize::MAX` and unbounded `list_nodes()` can OOM on large connected graphs. | #1316 |

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -339,20 +339,23 @@ pub fn unit_vector(dimension: usize) -> Vec<f32> {
 
 /// Create an empty object payload for EventLog.
 pub fn empty_payload() -> Value {
-    Value::Object(std::collections::HashMap::new())
+    Value::Object(Box::new(std::collections::HashMap::new()))
 }
 
 /// Create an object payload wrapping an integer.
 pub fn int_payload(v: i64) -> Value {
-    Value::Object(HashMap::from([("value".to_string(), Value::Int(v))]))
+    Value::Object(Box::new(HashMap::from([(
+        "value".to_string(),
+        Value::Int(v),
+    )])))
 }
 
 /// Create an object payload wrapping a string.
 pub fn string_payload(s: &str) -> Value {
-    Value::Object(HashMap::from([(
+    Value::Object(Box::new(HashMap::from([(
         "data".to_string(),
         Value::String(s.into()),
-    )]))
+    )])))
 }
 
 // ============================================================================
@@ -381,26 +384,26 @@ pub mod values {
         Value::Null
     }
     pub fn array(items: Vec<Value>) -> Value {
-        Value::Array(items)
+        Value::Array(Box::new(items))
     }
     pub fn map(pairs: Vec<(&str, Value)>) -> Value {
         let mut m = std::collections::HashMap::new();
         for (k, v) in pairs {
             m.insert(k.to_string(), v);
         }
-        Value::Object(m)
+        Value::Object(Box::new(m))
     }
 
     /// Event payload wrapping a value as `{"data": value}`.
     pub fn event_payload(value: Value) -> Value {
         let mut m = std::collections::HashMap::new();
         m.insert("data".to_string(), value);
-        Value::Object(m)
+        Value::Object(Box::new(m))
     }
 
     /// Empty event payload.
     pub fn empty_event_payload() -> Value {
-        Value::Object(std::collections::HashMap::new())
+        Value::Object(Box::new(std::collections::HashMap::new()))
     }
 
     /// Large bytes value for stress tests.

--- a/tests/engine/acid_concurrent.rs
+++ b/tests/engine/acid_concurrent.rs
@@ -14,7 +14,7 @@ use std::thread;
 use strata_engine::{EventLogExt, KVStoreExt, StateCellExt};
 
 fn event_payload(data: Value) -> Value {
-    Value::Object(HashMap::from([("data".to_string(), data)]))
+    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
 }
 
 // ============================================================================

--- a/tests/engine/acid_properties.rs
+++ b/tests/engine/acid_properties.rs
@@ -15,7 +15,7 @@ use strata_engine::{EventLogExt, KVStoreExt};
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(HashMap::from([("data".to_string(), data)]))
+    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
 }
 
 // ============================================================================

--- a/tests/engine/adversarial.rs
+++ b/tests/engine/adversarial.rs
@@ -13,7 +13,7 @@ use strata_engine::{EventLogExt, KVStoreExt};
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(HashMap::from([("data".to_string(), data)]))
+    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
 }
 
 // ============================================================================

--- a/tests/engine/adversarial_deep.rs
+++ b/tests/engine/adversarial_deep.rs
@@ -13,7 +13,7 @@ use strata_engine::{EventLogExt, KVStoreExt};
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(HashMap::from([("data".to_string(), data)]))
+    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
 }
 
 // ============================================================================

--- a/tests/engine/branch_isolation.rs
+++ b/tests/engine/branch_isolation.rs
@@ -8,7 +8,7 @@ use strata_core::primitives::json::JsonPath;
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(HashMap::from([("data".to_string(), data)]))
+    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
 }
 
 // ============================================================================

--- a/tests/engine/cross_primitive.rs
+++ b/tests/engine/cross_primitive.rs
@@ -8,7 +8,7 @@ use strata_engine::{EventLogExt, KVStoreExt, StateCellExt};
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(HashMap::from([("data".to_string(), data)]))
+    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
 }
 
 // ============================================================================

--- a/tests/engine/database/durability_modes.rs
+++ b/tests/engine/database/durability_modes.rs
@@ -11,7 +11,7 @@ use strata_engine::KVStoreExt;
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(HashMap::from([("data".to_string(), data)]))
+    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
 }
 
 // ============================================================================

--- a/tests/engine/primitives/eventlog.rs
+++ b/tests/engine/primitives/eventlog.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(HashMap::from([("data".to_string(), data)]))
+    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
 }
 
 /// Helper to create a simple event payload with an integer
@@ -437,7 +437,12 @@ fn payload_must_be_object() {
     );
     assert!(result.is_err());
 
-    let result = event.append(&test_db.branch_id, "default", "type", Value::Array(vec![]));
+    let result = event.append(
+        &test_db.branch_id,
+        "default",
+        "type",
+        Value::Array(Box::new(vec![])),
+    );
     assert!(result.is_err());
 
     // Object payload should work

--- a/tests/engine/stress.rs
+++ b/tests/engine/stress.rs
@@ -13,7 +13,7 @@ use strata_engine::{EventLogExt, KVStoreExt};
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(HashMap::from([("data".to_string(), data)]))
+    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
 }
 
 /// High concurrency KV workload

--- a/tests/executor/adversarial.rs
+++ b/tests/executor/adversarial.rs
@@ -724,10 +724,10 @@ fn large_nested_object() {
     }
 
     let mut outer = std::collections::HashMap::new();
-    outer.insert("nested".to_string(), Value::Object(inner));
+    outer.insert("nested".to_string(), Value::Object(Box::new(inner)));
     outer.insert(
         "array".to_string(),
-        Value::Array((0..100).map(|i| Value::Int(i)).collect()),
+        Value::Array(Box::new((0..100).map(|i| Value::Int(i)).collect())),
     );
 
     executor
@@ -735,7 +735,7 @@ fn large_nested_object() {
             branch: None,
             space: None,
             key: "large_object".into(),
-            value: Value::Object(outer.clone()),
+            value: Value::Object(Box::new(outer.clone())),
         })
         .unwrap();
 
@@ -751,7 +751,7 @@ fn large_nested_object() {
     match output {
         Output::MaybeVersioned(Some(vv)) => {
             let val = vv.value;
-            assert_eq!(val, Value::Object(outer));
+            assert_eq!(val, Value::Object(Box::new(outer)));
         }
         _ => panic!("Large object should be retrievable"),
     }

--- a/tests/executor/common.rs
+++ b/tests/executor/common.rs
@@ -28,7 +28,7 @@ pub fn create_db() -> Arc<Database> {
 
 /// Helper to create an event payload (must be an Object)
 pub fn event_payload(key: &str, value: strata_core::Value) -> strata_core::Value {
-    strata_core::Value::Object([(key.to_string(), value)].into_iter().collect())
+    strata_core::Value::Object(Box::new([(key.to_string(), value)].into_iter().collect()))
 }
 
 /// Extract version from Output::Version

--- a/tests/executor/serialization.rs
+++ b/tests/executor/serialization.rs
@@ -61,11 +61,11 @@ fn event_append_roundtrip() {
         branch: None,
         space: None,
         event_type: "events".into(),
-        payload: Value::Object(
+        payload: Value::Object(Box::new(
             [("data".to_string(), Value::Int(123))]
                 .into_iter()
                 .collect(),
-        ),
+        )),
     };
 
     let json = serde_json::to_string(&cmd).unwrap();
@@ -97,11 +97,11 @@ fn vector_search_roundtrip() {
 fn branch_create_roundtrip() {
     let cmd = Command::BranchCreate {
         branch_id: Some("550e8400-e29b-41d4-a716-446655440401-id".into()),
-        metadata: Some(Value::Object(
+        metadata: Some(Value::Object(Box::new(
             [("key".to_string(), Value::String("value".into()))]
                 .into_iter()
                 .collect(),
-        )),
+        ))),
     };
 
     let json = serde_json::to_string(&cmd).unwrap();
@@ -414,7 +414,7 @@ fn value_types_roundtrip() {
         branch: None,
         space: None,
         key: "k".into(),
-        value: Value::Array(vec![Value::Int(1), Value::Int(2)]),
+        value: Value::Array(Box::new(vec![Value::Int(1), Value::Int(2)])),
     };
     let json = serde_json::to_string(&cmd).unwrap();
     let parsed: Command = serde_json::from_str(&json).unwrap();
@@ -425,11 +425,11 @@ fn value_types_roundtrip() {
         branch: None,
         space: None,
         key: "k".into(),
-        value: Value::Object(
+        value: Value::Object(Box::new(
             [("nested".to_string(), Value::Int(1))]
                 .into_iter()
                 .collect(),
-        ),
+        )),
     };
     let json = serde_json::to_string(&cmd).unwrap();
     let parsed: Command = serde_json::from_str(&json).unwrap();

--- a/tests/executor/strata_api.rs
+++ b/tests/executor/strata_api.rs
@@ -241,14 +241,14 @@ fn branch_list() {
 fn json_set_and_get() {
     let db = create_strata();
 
-    let doc = Value::Object(
+    let doc = Value::Object(Box::new(
         [
             ("name".to_string(), Value::String("Alice".into())),
             ("age".to_string(), Value::Int(30)),
         ]
         .into_iter()
         .collect(),
-    );
+    ));
 
     db.json_set("user:1", "$", doc).unwrap();
 
@@ -268,7 +268,9 @@ fn json_set_and_get() {
 fn json_delete() {
     let db = create_strata();
 
-    let doc = Value::Object([("key".to_string(), Value::Int(1))].into_iter().collect());
+    let doc = Value::Object(Box::new(
+        [("key".to_string(), Value::Int(1))].into_iter().collect(),
+    ));
 
     db.json_set("doc1", "$", doc).unwrap();
 
@@ -313,11 +315,11 @@ fn use_all_primitives() {
         .unwrap();
 
     // JSON
-    let doc = Value::Object(
+    let doc = Value::Object(Box::new(
         [("type".to_string(), Value::String("test".into()))]
             .into_iter()
             .collect(),
-    );
+    ));
     db.json_set("doc1", "$", doc).unwrap();
 
     // Branch


### PR DESCRIPTION
## Summary

Implements the core crate production readiness plan across epics #1298, #1299, #1300, #1301:

- **Memory compaction**: `Key::user_key` from `Vec<u8>` → `Box<[u8]>` (saves 8 bytes/key); `Value::Array`/`Object` boxed (shrinks enum from ~56 to ~24 bytes)
- **Type safety**: Remove `Ord` from `Version` (cross-variant `PartialOrd` returns `None`); compile-time layout assert for `JsonValue` unsafe cast
- **Validation**: `debug_assert!` in `Namespace::new()`, `EntityRef` constructors, `BranchEventOffsets::push()`; add `Namespace::try_new()`; `validate_value_full()` with NaN/Infinity rejection
- **Error enrichment**: `Conflict` gains `transaction_id` and `entity_ref` fields; `entity_ref()` accessor updated
- **Documentation**: `Storage`/`SnapshotView` trait docs; `TypeTag` on-disk format docs

56 files changed across core, engine, executor, intelligence, durability, storage, and integration tests.

## Test plan

- [x] `cargo test --workspace` — all 3,600+ tests pass, 0 failures
- [x] `cargo clippy --workspace` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Serde roundtrip compatibility verified (Box is transparent to serde)
- [x] NaN/Infinity floats rejected by `validate_value_full()`
- [x] Cross-variant `Version` comparison returns `None`
- [x] `debug_assert!` fires for empty Namespace/EntityRef in debug builds
- [x] All cascade sites (engine, executor, intelligence) updated for `Box<[u8]>` and `Box<Vec<Value>>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)