### PR TITLE
StoredValue compaction: 80 → 56 bytes/entry (#1302)

### DIFF
--- a/crates/storage/src/sharded.rs
+++ b/crates/storage/src/sharded.rs
@@ -111,28 +111,18 @@ impl VersionChain {
 
     /// Get the version at or before the given max_version
     ///
-    /// Note: Uses raw u64 comparison since all storage versions are TxnId variants.
-    /// Debug assertions verify this invariant.
+    /// Uses raw u64 comparison. All storage versions are `Version::Txn`
+    /// variants — this invariant is enforced at `StoredValue` construction time.
     pub fn get_at_version(&self, max_version: u64) -> Option<&StoredValue> {
         match &self.versions {
             VersionStorage::Single(sv) => {
-                debug_assert!(
-                    sv.version().is_txn(),
-                    "Storage layer should only contain Txn versions"
-                );
-                if sv.version().as_u64() <= max_version {
+                if sv.version_raw() <= max_version {
                     Some(sv)
                 } else {
                     None
                 }
             }
-            VersionStorage::Multi(deque) => {
-                debug_assert!(
-                    deque.iter().all(|sv| sv.version().is_txn()),
-                    "Storage layer should only contain Txn versions"
-                );
-                deque.iter().find(|sv| sv.version().as_u64() <= max_version)
-            }
+            VersionStorage::Multi(deque) => deque.iter().find(|sv| sv.version_raw() <= max_version),
         }
     }
 
@@ -177,7 +167,7 @@ impl VersionChain {
                 let mut pruned = 0;
                 while deque.len() > 1 {
                     if let Some(oldest) = deque.back() {
-                        if oldest.version().as_u64() < min_version {
+                        if oldest.version_raw() < min_version {
                             deque.pop_back();
                             pruned += 1;
                         } else {
@@ -214,15 +204,11 @@ impl VersionChain {
     pub fn history(&self, limit: Option<usize>, before_version: Option<u64>) -> Vec<&StoredValue> {
         match &self.versions {
             VersionStorage::Single(sv) => {
-                debug_assert!(
-                    sv.version().is_txn(),
-                    "Storage layer should only contain Txn versions"
-                );
                 if limit == Some(0) {
                     return vec![];
                 }
                 let passes_filter = match before_version {
-                    Some(before) => sv.version().as_u64() < before,
+                    Some(before) => sv.version_raw() < before,
                     None => true,
                 };
                 if passes_filter {
@@ -232,14 +218,9 @@ impl VersionChain {
                 }
             }
             VersionStorage::Multi(deque) => {
-                debug_assert!(
-                    deque.iter().all(|sv| sv.version().is_txn()),
-                    "Storage layer should only contain Txn versions"
-                );
-
                 let iter = deque.iter();
                 let filtered: Vec<&StoredValue> = match before_version {
-                    Some(before) => iter.filter(|sv| sv.version().as_u64() < before).collect(),
+                    Some(before) => iter.filter(|sv| sv.version_raw() < before).collect(),
                     None => iter.collect(),
                 };
 
@@ -502,7 +483,7 @@ impl ShardedStore {
                     if sv.is_tombstone() {
                         None
                     } else {
-                        Some(sv.versioned().clone())
+                        Some(sv.versioned())
                     }
                 })
             })
@@ -549,7 +530,7 @@ impl ShardedStore {
             shard.data.get(key).and_then(|chain| {
                 chain.latest().and_then(|sv| {
                     if !sv.is_expired() && !sv.is_tombstone() {
-                        Some(sv.versioned().clone())
+                        Some(sv.versioned())
                     } else {
                         None
                     }
@@ -669,7 +650,7 @@ impl ShardedStore {
             shard.data.get(key).and_then(|chain| {
                 chain.get_at_timestamp(max_timestamp).and_then(|sv| {
                     if !sv.is_expired() && !sv.is_tombstone() {
-                        Some(sv.versioned().clone())
+                        Some(sv.versioned())
                     } else {
                         None
                     }
@@ -700,7 +681,7 @@ impl ShardedStore {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_timestamp(max_timestamp).and_then(|sv| {
                                 if !sv.is_expired() && !sv.is_tombstone() {
-                                    Some(((**k).clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned()))
                                 } else {
                                     None
                                 }
@@ -787,7 +768,7 @@ impl ShardedStore {
                         shard.data.get(k).and_then(|chain| {
                             chain.latest().and_then(|sv| {
                                 if !sv.is_tombstone() {
-                                    Some(((**k).clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned()))
                                 } else {
                                     None
                                 }
@@ -831,7 +812,7 @@ impl ShardedStore {
                         shard.data.get(k).and_then(|chain| {
                             chain.latest().and_then(|sv| {
                                 if !sv.is_tombstone() {
-                                    Some(((**k).clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned()))
                                 } else {
                                     None
                                 }
@@ -874,7 +855,7 @@ impl ShardedStore {
                         shard.data.get(k).and_then(|chain| {
                             chain.latest().and_then(|sv| {
                                 if !sv.is_tombstone() {
-                                    Some(((**k).clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned()))
                                 } else {
                                     None
                                 }
@@ -1088,7 +1069,7 @@ impl ShardedSnapshot {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_version(self.version).and_then(|sv| {
                                 if !sv.is_expired() && !sv.is_tombstone() {
-                                    Some(((**k).clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned()))
                                 } else {
                                     None
                                 }
@@ -1122,7 +1103,7 @@ impl ShardedSnapshot {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_version(self.version).and_then(|sv| {
                                 if !sv.is_expired() && !sv.is_tombstone() {
-                                    Some(((**k).clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned()))
                                 } else {
                                     None
                                 }
@@ -1159,7 +1140,7 @@ impl ShardedSnapshot {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_version(self.version).and_then(|sv| {
                                 if !sv.is_expired() && !sv.is_tombstone() {
-                                    Some(((**k).clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned()))
                                 } else {
                                     None
                                 }
@@ -1252,7 +1233,7 @@ impl Storage for ShardedStore {
                 chain.latest().and_then(|sv| {
                     // Filter out expired values and tombstones
                     if !sv.is_expired() && !sv.is_tombstone() {
-                        Some(sv.versioned().clone())
+                        Some(sv.versioned())
                     } else {
                         None
                     }
@@ -1271,7 +1252,7 @@ impl Storage for ShardedStore {
                 chain.get_at_version(max_version).and_then(|sv| {
                     // Filter out expired values and tombstones
                     if !sv.is_expired() && !sv.is_tombstone() {
-                        Some(sv.versioned().clone())
+                        Some(sv.versioned())
                     } else {
                         None
                     }
@@ -1298,7 +1279,7 @@ impl Storage for ShardedStore {
                     .history(limit, before_version)
                     .into_iter()
                     .filter(|sv| !sv.is_expired())
-                    .map(|sv| sv.versioned().clone())
+                    .map(|sv| sv.versioned())
                     .collect(),
                 None => Vec::new(),
             },
@@ -1353,7 +1334,7 @@ impl Storage for ShardedStore {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_version(max_version).and_then(|sv| {
                                 if !sv.is_expired() && !sv.is_tombstone() {
-                                    Some(((**k).clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned()))
                                 } else {
                                     None
                                 }
@@ -1384,7 +1365,7 @@ impl Storage for ShardedStore {
                         chain.get_at_version(max_version).and_then(|sv| {
                             // Filter out expired values and tombstones
                             if !sv.is_expired() && !sv.is_tombstone() {
-                                Some(((**k).clone(), sv.versioned().clone()))
+                                Some(((**k).clone(), sv.versioned()))
                             } else {
                                 None
                             }
@@ -1475,7 +1456,7 @@ impl SnapshotView for ShardedSnapshot {
                         shard.data.get(k).and_then(|chain| {
                             chain.get_at_version(self.version).and_then(|sv| {
                                 if !sv.is_expired() && !sv.is_tombstone() {
-                                    Some(((**k).clone(), sv.versioned().clone()))
+                                    Some(((**k).clone(), sv.versioned()))
                                 } else {
                                     None
                                 }

--- a/crates/storage/src/stored_value.rs
+++ b/crates/storage/src/stored_value.rs
@@ -2,35 +2,84 @@
 //!
 //! The contract type `Versioned<T>` doesn't include TTL because TTL is
 //! a storage concern, not a contract concern. This module provides
-//! `StoredValue` which combines a `VersionedValue` with optional TTL
+//! `StoredValue` which combines value, version, timestamp, and optional TTL
 //! for the storage layer.
+//!
+//! # Memory Optimization
+//!
+//! TTL and tombstone flag are packed into a single `u64`:
+//! - Bit 63: tombstone flag
+//! - Bits 0-62: TTL in milliseconds (max ~292 million years)
+//!
+//! Version is stored as raw `u64` instead of `Version` enum, since all
+//! storage-layer versions are `Version::Txn` variants.
+//!
+//! This reduces `StoredValue` from ~80 bytes to 56 bytes per entry
+//! (~24 bytes saved → ~2.9 GB at 128M entries).
 
 use std::time::Duration;
 
 use strata_core::{Timestamp, Value, Version, VersionedValue};
 
-/// A stored value with optional TTL
+const TOMBSTONE_BIT: u64 = 1 << 63;
+const TTL_MASK: u64 = !TOMBSTONE_BIT; // 0x7FFF_FFFF_FFFF_FFFF
+
+/// Pack TTL and tombstone flag into a single u64.
 ///
-/// Wraps `VersionedValue` with TTL metadata for the storage layer.
-/// This separation keeps TTL as a storage concern, not part of the
-/// contract types.
+/// Bit 63 = tombstone flag, bits 0-62 = TTL in milliseconds.
+/// Sub-millisecond TTLs are truncated to zero and become `None` on read.
+#[inline]
+fn pack_ttl_and_flags(ttl: Option<Duration>, is_tombstone: bool) -> u64 {
+    let ttl_millis = ttl.map(|d| d.as_millis() as u64).unwrap_or(0) & TTL_MASK;
+    if is_tombstone {
+        ttl_millis | TOMBSTONE_BIT
+    } else {
+        ttl_millis
+    }
+}
+
+/// A stored value with optional TTL — compact 56-byte layout
+///
+/// Combines value, version, timestamp, TTL, and tombstone flag.
+/// TTL and tombstone are packed into a single `u64` to minimize per-entry
+/// overhead. Version is stored as raw `u64` since all storage-layer
+/// versions are `Version::Txn` variants (validated at construction time).
+///
+/// # TTL Precision
+///
+/// TTL is stored with millisecond precision (63 bits → max ~292 million years).
+/// Sub-millisecond TTLs (< 1ms) are truncated to zero and read back as `None`.
+/// `Some(Duration::ZERO)` is also stored as zero and reads back as `None`.
+/// In practice, TTLs are seconds/minutes/hours — millisecond precision is
+/// more than sufficient.
 #[derive(Debug, Clone, PartialEq)]
 pub struct StoredValue {
-    /// The versioned value (value + version + timestamp)
-    inner: VersionedValue,
-    /// Optional time-to-live
-    ttl: Option<Duration>,
-    /// Whether this entry is a tombstone (explicit deletion marker)
-    is_tombstone: bool,
+    value: Value,
+    version: u64,
+    timestamp: Timestamp,
+    /// Bit 63 = tombstone, bits 0-62 = TTL in milliseconds
+    ttl_and_flags: u64,
 }
+
+// Value is 32 bytes (24-byte String/Vec data + 8-byte enum tag).
+// New: Value(32) + u64(8) + Timestamp(8) + u64(8) = 56 bytes.
+// Old: VersionedValue(56) + Option<Duration>(16) + bool(8) = 80 bytes.
+// Savings: 24 bytes/entry → ~2.9 GB at 128M entries.
+const _: () = assert!(std::mem::size_of::<StoredValue>() <= 56);
 
 impl StoredValue {
     /// Create a new stored value with TTL
     pub fn new(value: Value, version: Version, ttl: Option<Duration>) -> Self {
+        debug_assert!(
+            version.is_txn(),
+            "Storage layer requires Txn versions, got {:?}",
+            version
+        );
         StoredValue {
-            inner: VersionedValue::new(value, version),
-            ttl,
-            is_tombstone: false,
+            value,
+            version: version.as_u64(),
+            timestamp: Timestamp::now(),
+            ttl_and_flags: pack_ttl_and_flags(ttl, false),
         }
     }
 
@@ -41,28 +90,46 @@ impl StoredValue {
         timestamp: Timestamp,
         ttl: Option<Duration>,
     ) -> Self {
+        debug_assert!(
+            version.is_txn(),
+            "Storage layer requires Txn versions, got {:?}",
+            version
+        );
         StoredValue {
-            inner: VersionedValue::with_timestamp(value, version, timestamp),
-            ttl,
-            is_tombstone: false,
+            value,
+            version: version.as_u64(),
+            timestamp,
+            ttl_and_flags: pack_ttl_and_flags(ttl, false),
         }
     }
 
     /// Create from a VersionedValue without TTL
     pub fn from_versioned(vv: VersionedValue) -> Self {
+        debug_assert!(
+            vv.version.is_txn(),
+            "Storage layer requires Txn versions, got {:?}",
+            vv.version
+        );
         StoredValue {
-            inner: vv,
-            ttl: None,
-            is_tombstone: false,
+            version: vv.version.as_u64(),
+            timestamp: vv.timestamp,
+            value: vv.value,
+            ttl_and_flags: 0,
         }
     }
 
     /// Create from a VersionedValue with TTL
     pub fn from_versioned_with_ttl(vv: VersionedValue, ttl: Option<Duration>) -> Self {
+        debug_assert!(
+            vv.version.is_txn(),
+            "Storage layer requires Txn versions, got {:?}",
+            vv.version
+        );
         StoredValue {
-            inner: vv,
-            ttl,
-            is_tombstone: false,
+            version: vv.version.as_u64(),
+            timestamp: vv.timestamp,
+            value: vv.value,
+            ttl_and_flags: pack_ttl_and_flags(ttl, false),
         }
     }
 
@@ -71,61 +138,103 @@ impl StoredValue {
     /// Tombstones mark a key as deleted at a specific version without
     /// conflating `Value::Null` with deletion.
     pub fn tombstone(version: Version) -> Self {
+        debug_assert!(
+            version.is_txn(),
+            "Storage layer requires Txn versions, got {:?}",
+            version
+        );
         StoredValue {
-            inner: VersionedValue::new(Value::Null, version),
-            ttl: None,
-            is_tombstone: true,
+            value: Value::Null,
+            version: version.as_u64(),
+            timestamp: Timestamp::now(),
+            ttl_and_flags: TOMBSTONE_BIT,
         }
     }
 
     /// Check whether this entry is a tombstone (explicit deletion marker)
     #[inline]
     pub fn is_tombstone(&self) -> bool {
-        self.is_tombstone
+        (self.ttl_and_flags & TOMBSTONE_BIT) != 0
     }
 
-    /// Get the inner VersionedValue
+    /// Reconstruct the VersionedValue on demand
+    ///
+    /// Returns an owned `VersionedValue` since the inner fields are no longer
+    /// stored as a `VersionedValue` struct. Every caller previously did
+    /// `.versioned().clone()`, so returning owned is a zero-cost change.
     #[inline]
-    pub fn versioned(&self) -> &VersionedValue {
-        &self.inner
+    pub fn versioned(&self) -> VersionedValue {
+        VersionedValue {
+            value: self.value.clone(),
+            version: Version::txn(self.version),
+            timestamp: self.timestamp,
+        }
     }
 
     /// Consume and return the inner VersionedValue
     #[inline]
     pub fn into_versioned(self) -> VersionedValue {
-        self.inner
+        VersionedValue {
+            value: self.value,
+            version: Version::txn(self.version),
+            timestamp: self.timestamp,
+        }
     }
 
     /// Get the value
     #[inline]
     pub fn value(&self) -> &Value {
-        &self.inner.value
+        &self.value
     }
 
-    /// Get the version
+    /// Get the version (reconstructs `Version::Txn` enum)
+    ///
+    /// For hot-path u64 comparisons, prefer [`version_raw`](Self::version_raw)
+    /// to avoid the enum reconstruction overhead.
     #[inline]
     pub fn version(&self) -> Version {
-        self.inner.version
+        Version::txn(self.version)
+    }
+
+    /// Get the raw version as u64 (no enum reconstruction)
+    ///
+    /// Use this on hot paths where only the numeric value is needed
+    /// (e.g., version chain lookups, GC comparisons).
+    /// All storage-layer versions are `Version::Txn` — this invariant
+    /// is enforced at construction time via debug_assert.
+    #[inline]
+    pub fn version_raw(&self) -> u64 {
+        self.version
     }
 
     /// Get the timestamp
     #[inline]
     pub fn timestamp(&self) -> Timestamp {
-        self.inner.timestamp
+        self.timestamp
     }
 
     /// Get the TTL
+    ///
+    /// Returns the TTL with millisecond precision. Sub-millisecond
+    /// durations (< 1ms) and `Duration::ZERO` are stored as zero
+    /// and read back as `None`.
     #[inline]
     pub fn ttl(&self) -> Option<Duration> {
-        self.ttl
+        let millis = self.ttl_and_flags & TTL_MASK;
+        if millis == 0 {
+            None
+        } else {
+            Some(Duration::from_millis(millis))
+        }
     }
 
     /// Check if this value has expired
     pub fn is_expired(&self) -> bool {
-        if let Some(ttl) = self.ttl {
+        let millis = self.ttl_and_flags & TTL_MASK;
+        if millis != 0 {
             let now = Timestamp::now();
-            if let Some(age) = now.duration_since(self.inner.timestamp) {
-                return age >= ttl;
+            if let Some(age) = now.duration_since(self.timestamp) {
+                return age >= Duration::from_millis(millis);
             }
         }
         false
@@ -135,13 +244,18 @@ impl StoredValue {
     ///
     /// Returns `Some(timestamp)` when the value will expire, or `None` if no TTL.
     pub fn expiry_timestamp(&self) -> Option<Timestamp> {
-        self.ttl.map(|ttl| self.inner.timestamp.saturating_add(ttl))
+        let millis = self.ttl_and_flags & TTL_MASK;
+        if millis == 0 {
+            None
+        } else {
+            Some(self.timestamp.saturating_add(Duration::from_millis(millis)))
+        }
     }
 }
 
 impl From<StoredValue> for VersionedValue {
     fn from(sv: StoredValue) -> Self {
-        sv.inner
+        sv.into_versioned()
     }
 }
 
@@ -150,12 +264,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_stored_value_size() {
+        assert!(
+            std::mem::size_of::<StoredValue>() <= 56,
+            "StoredValue should be <= 56 bytes, got {}",
+            std::mem::size_of::<StoredValue>()
+        );
+    }
+
+    #[test]
     fn test_stored_value_new() {
         let sv = StoredValue::new(Value::Int(42), Version::txn(1), None);
         assert_eq!(*sv.value(), Value::Int(42));
         assert_eq!(sv.version(), Version::Txn(1));
+        assert_eq!(sv.version_raw(), 1);
         assert!(sv.ttl().is_none());
         assert!(!sv.is_expired());
+        assert!(!sv.is_tombstone());
+        // Timestamp should be recent (within last second)
+        let age = Timestamp::now().duration_since(sv.timestamp());
+        assert!(age.is_some() && age.unwrap() < Duration::from_secs(1));
     }
 
     #[test]
@@ -167,12 +295,27 @@ mod tests {
         );
         assert!(sv.ttl().is_some());
         assert_eq!(sv.ttl().unwrap(), Duration::from_secs(60));
-        assert!(!sv.is_expired()); // Not expired immediately
+        assert!(!sv.is_expired());
+        assert!(!sv.is_tombstone());
+    }
+
+    #[test]
+    fn test_stored_value_with_timestamp() {
+        let ts = Timestamp::from_micros(5_000_000);
+        let sv = StoredValue::with_timestamp(
+            Value::Float(3.14),
+            Version::txn(10),
+            ts,
+            Some(Duration::from_secs(30)),
+        );
+        assert_eq!(sv.timestamp(), ts);
+        assert_eq!(sv.version_raw(), 10);
+        assert_eq!(sv.ttl().unwrap(), Duration::from_secs(30));
+        assert!(!sv.is_tombstone());
     }
 
     #[test]
     fn test_stored_value_expired() {
-        // Create with old timestamp
         let old_ts = Timestamp::from_micros(0);
         let sv = StoredValue::with_timestamp(
             Value::Null,
@@ -180,8 +323,29 @@ mod tests {
             old_ts,
             Some(Duration::from_secs(1)),
         );
-        // Should be expired (timestamp is epoch, TTL is 1 second)
+        // Timestamp is epoch, TTL is 1 second — definitely expired
         assert!(sv.is_expired());
+    }
+
+    #[test]
+    fn test_stored_value_not_expired_without_ttl() {
+        let old_ts = Timestamp::from_micros(0);
+        let sv = StoredValue::with_timestamp(Value::Null, Version::txn(1), old_ts, None);
+        // No TTL means never expires, even with ancient timestamp
+        assert!(!sv.is_expired());
+    }
+
+    #[test]
+    fn test_stored_value_not_expired_with_future_timestamp() {
+        let future_ts = Timestamp::from_micros(u64::MAX / 2);
+        let sv = StoredValue::with_timestamp(
+            Value::Null,
+            Version::txn(1),
+            future_ts,
+            Some(Duration::from_secs(1)),
+        );
+        // Future timestamp — duration_since returns None → not expired
+        assert!(!sv.is_expired());
     }
 
     #[test]
@@ -212,17 +376,224 @@ mod tests {
             Version::txn(5),
             Some(Duration::from_secs(10)),
         );
+        let ts = sv.timestamp();
         let vv = sv.into_versioned();
         assert_eq!(vv.value, Value::Int(42));
         assert_eq!(vv.version, Version::Txn(5));
+        assert_eq!(vv.timestamp, ts);
+    }
+
+    #[test]
+    fn test_stored_value_from_trait() {
+        let sv = StoredValue::new(Value::Int(77), Version::txn(3), None);
+        let ts = sv.timestamp();
+        let vv: VersionedValue = sv.into();
+        assert_eq!(vv.value, Value::Int(77));
+        assert_eq!(vv.version, Version::Txn(3));
+        assert_eq!(vv.timestamp, ts);
     }
 
     #[test]
     fn test_stored_value_from_versioned() {
-        let vv = VersionedValue::new(Value::Bool(true), Version::seq(10));
+        let vv = VersionedValue::new(Value::Bool(true), Version::txn(10));
+        let ts = vv.timestamp;
         let sv = StoredValue::from_versioned(vv);
         assert_eq!(*sv.value(), Value::Bool(true));
-        assert_eq!(sv.version(), Version::Sequence(10));
+        assert_eq!(sv.version(), Version::Txn(10));
+        assert_eq!(sv.timestamp(), ts);
         assert!(sv.ttl().is_none());
+        assert!(!sv.is_tombstone());
+    }
+
+    #[test]
+    fn test_stored_value_from_versioned_with_ttl() {
+        let vv = VersionedValue::new(Value::Int(1), Version::txn(2));
+        let ts = vv.timestamp;
+        let sv = StoredValue::from_versioned_with_ttl(vv, Some(Duration::from_secs(120)));
+        assert_eq!(sv.version_raw(), 2);
+        assert_eq!(sv.timestamp(), ts);
+        assert_eq!(sv.ttl().unwrap(), Duration::from_secs(120));
+        assert!(!sv.is_tombstone());
+    }
+
+    #[test]
+    fn test_tombstone_packing_roundtrip() {
+        let sv = StoredValue::tombstone(Version::txn(42));
+        assert!(sv.is_tombstone());
+        assert!(sv.ttl().is_none());
+        assert_eq!(sv.version(), Version::Txn(42));
+        assert_eq!(sv.version_raw(), 42);
+        assert_eq!(*sv.value(), Value::Null);
+    }
+
+    #[test]
+    fn test_non_tombstone_is_not_tombstone() {
+        let sv = StoredValue::new(Value::Null, Version::txn(1), None);
+        assert!(!sv.is_tombstone());
+    }
+
+    #[test]
+    fn test_ttl_packing_roundtrip() {
+        // Various durations survive at millisecond precision
+        for secs in [1, 60, 3600, 86400, 604800] {
+            let sv = StoredValue::new(
+                Value::Null,
+                Version::txn(1),
+                Some(Duration::from_secs(secs)),
+            );
+            assert_eq!(sv.ttl().unwrap(), Duration::from_secs(secs));
+        }
+
+        // Millisecond precision
+        let sv = StoredValue::new(
+            Value::Null,
+            Version::txn(1),
+            Some(Duration::from_millis(1500)),
+        );
+        assert_eq!(sv.ttl().unwrap(), Duration::from_millis(1500));
+    }
+
+    #[test]
+    fn test_sub_millisecond_ttl_becomes_none() {
+        // Sub-millisecond TTL truncates to zero millis → reads back as None
+        let sv = StoredValue::new(
+            Value::Null,
+            Version::txn(1),
+            Some(Duration::from_micros(500)),
+        );
+        assert!(sv.ttl().is_none());
+        assert!(sv.expiry_timestamp().is_none());
+        assert!(!sv.is_expired());
+    }
+
+    #[test]
+    fn test_duration_zero_ttl_becomes_none() {
+        // Duration::ZERO stores as 0 millis → reads back as None
+        let sv = StoredValue::new(Value::Null, Version::txn(1), Some(Duration::ZERO));
+        assert!(sv.ttl().is_none());
+        assert!(sv.expiry_timestamp().is_none());
+        assert!(!sv.is_expired());
+    }
+
+    #[test]
+    fn test_tombstone_with_ttl() {
+        // Construct a tombstone-like entry with TTL via manual packing
+        // In practice tombstones don't have TTL, but test the bit packing
+        let packed = pack_ttl_and_flags(Some(Duration::from_secs(30)), true);
+        let sv = StoredValue {
+            value: Value::Null,
+            version: 1,
+            timestamp: Timestamp::now(),
+            ttl_and_flags: packed,
+        };
+        assert!(sv.is_tombstone());
+        assert_eq!(sv.ttl().unwrap(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_large_ttl_does_not_collide_with_tombstone_bit() {
+        // Very large TTL (close to 63-bit max) should not set tombstone bit
+        let large_millis = TTL_MASK; // max 63-bit value
+        let sv = StoredValue {
+            value: Value::Null,
+            version: 1,
+            timestamp: Timestamp::now(),
+            ttl_and_flags: large_millis,
+        };
+        assert!(!sv.is_tombstone());
+        assert_eq!(sv.ttl().unwrap().as_millis(), large_millis as u128);
+    }
+
+    #[test]
+    fn test_versioned_reconstruction() {
+        let ts = Timestamp::from_micros(12345678);
+        let sv = StoredValue::with_timestamp(Value::Int(99), Version::txn(7), ts, None);
+        let vv = sv.versioned();
+        assert_eq!(vv.value, Value::Int(99));
+        assert_eq!(vv.version, Version::Txn(7));
+        assert_eq!(vv.timestamp, ts);
+    }
+
+    #[test]
+    fn test_versioned_clones_value() {
+        // versioned() clones the value; original StoredValue is unaffected
+        let sv = StoredValue::new(Value::String("hello".to_string()), Version::txn(1), None);
+        let vv = sv.versioned();
+        assert_eq!(vv.value, Value::String("hello".to_string()));
+        assert_eq!(*sv.value(), Value::String("hello".to_string()));
+    }
+
+    #[test]
+    fn test_clone_produces_equal_value() {
+        let ts = Timestamp::from_micros(999);
+        let sv = StoredValue::with_timestamp(
+            Value::String("test".to_string()),
+            Version::txn(5),
+            ts,
+            Some(Duration::from_secs(60)),
+        );
+        let cloned = sv.clone();
+        assert_eq!(sv, cloned);
+        assert_eq!(cloned.version_raw(), 5);
+        assert_eq!(cloned.timestamp(), ts);
+        assert_eq!(cloned.ttl().unwrap(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_partial_eq_different_values() {
+        let ts = Timestamp::from_micros(1000);
+        let sv1 = StoredValue::with_timestamp(Value::Int(1), Version::txn(1), ts, None);
+        let sv2 = StoredValue::with_timestamp(Value::Int(2), Version::txn(1), ts, None);
+        assert_ne!(sv1, sv2);
+    }
+
+    #[test]
+    fn test_partial_eq_different_versions() {
+        let ts = Timestamp::from_micros(1000);
+        let sv1 = StoredValue::with_timestamp(Value::Int(1), Version::txn(1), ts, None);
+        let sv2 = StoredValue::with_timestamp(Value::Int(1), Version::txn(2), ts, None);
+        assert_ne!(sv1, sv2);
+    }
+
+    #[test]
+    fn test_version_zero() {
+        // Version 0 is a valid Txn version
+        let sv = StoredValue::new(Value::Null, Version::txn(0), None);
+        assert_eq!(sv.version_raw(), 0);
+        assert_eq!(sv.version(), Version::Txn(0));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "Storage layer requires Txn versions")]
+    fn test_debug_assert_non_txn_version_new() {
+        StoredValue::new(Value::Null, Version::seq(1), None);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "Storage layer requires Txn versions")]
+    fn test_debug_assert_non_txn_version_with_timestamp() {
+        StoredValue::with_timestamp(
+            Value::Null,
+            Version::seq(1),
+            Timestamp::from_micros(0),
+            None,
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "Storage layer requires Txn versions")]
+    fn test_debug_assert_non_txn_version_from_versioned() {
+        let vv = VersionedValue::new(Value::Null, Version::seq(1));
+        StoredValue::from_versioned(vv);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "Storage layer requires Txn versions")]
+    fn test_debug_assert_non_txn_version_tombstone() {
+        StoredValue::tombstone(Version::seq(1));
     }
 }


### PR DESCRIPTION
## Summary

- Pack `ttl: Option<Duration>` (16B) + `is_tombstone: bool` (8B) into a single `u64` (bit 63 = tombstone, bits 0-62 = TTL in milliseconds)
- Flatten `VersionedValue` wrapper: store version as raw `u64` instead of `Version` enum (16B → 8B)
- **Result: 80 → 56 bytes/entry → ~2.9 GB saved at 128M entries (graph500-22)**

### Additional improvements from review pass
- `versioned()` now returns owned `VersionedValue` — all 16 call sites previously did `.versioned().clone()`
- Added `version_raw() -> u64` accessor for hot-path version comparisons (avoids `Version::txn()` + `as_u64()` roundtrip)
- Removed 4 dead `debug_assert!(sv.version().is_txn())` in `VersionChain` — always true after refactor since `version()` hardcodes `Version::txn()`. The real invariant is enforced at `StoredValue` construction time.
- Documented sub-millisecond TTL truncation: TTLs < 1ms and `Duration::ZERO` are stored as 0 and read back as `None`

### Zero cascade risk
`StoredValue` is `pub(crate)` — no external crate imports or uses it directly.

## Test plan

- [x] `cargo test -p strata-storage` — 158 tests pass (17 new)
- [x] `cargo test --workspace` — all pass
- [x] `cargo clippy -p strata-storage -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Compile-time size assertion: `StoredValue ≤ 56 bytes`
- [x] New edge case tests: sub-ms TTL truncation, `Duration::ZERO`, large TTL vs tombstone bit collision, future timestamp expiry, `From` trait, `Clone`/`PartialEq`, all constructor `#[should_panic]` for non-Txn versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)