### PR TITLE
Use Value::array()/object() instead of Box::new

### DIFF
--- a/crates/core/src/contract/versioned.rs
+++ b/crates/core/src/contract/versioned.rs
@@ -474,13 +474,13 @@ mod tests {
         assert!(v_bytes.is_bytes());
         assert_eq!(v_bytes.as_bytes(), Some(&[1u8, 2, 3][..]));
 
-        let v_arr = Versioned::new(Value::Array(Box::new(vec![Value::Int(1)])), Version::txn(1));
+        let v_arr = Versioned::new(Value::array(vec![Value::Int(1)]), Version::txn(1));
         assert!(v_arr.is_array());
         assert_eq!(v_arr.as_array().unwrap().len(), 1);
 
         let mut map = HashMap::new();
         map.insert("k".to_string(), Value::Int(1));
-        let v_obj = Versioned::new(Value::Object(Box::new(map)), Version::txn(1));
+        let v_obj = Versioned::new(Value::object(map), Version::txn(1));
         assert!(v_obj.is_object());
         assert_eq!(v_obj.as_object().unwrap().len(), 1);
     }

--- a/crates/core/src/limits.rs
+++ b/crates/core/src/limits.rs
@@ -431,7 +431,7 @@ mod tests {
     fn test_array_at_max_length() {
         let limits = Limits::with_small_limits();
         let arr = vec![Value::Null; limits.max_array_len];
-        let value = Value::Array(Box::new(arr));
+        let value = Value::array(arr);
         assert!(limits.validate_value(&value).is_ok());
     }
 
@@ -439,7 +439,7 @@ mod tests {
     fn test_array_exceeds_max_length() {
         let limits = Limits::with_small_limits();
         let arr = vec![Value::Null; limits.max_array_len + 1];
-        let value = Value::Array(Box::new(arr));
+        let value = Value::array(arr);
         let result = limits.validate_value(&value);
         assert!(matches!(result, Err(LimitError::ValueTooLarge { .. })));
     }
@@ -453,7 +453,7 @@ mod tests {
         for i in 0..limits.max_object_entries {
             map.insert(format!("key{}", i), Value::Null);
         }
-        let value = Value::Object(Box::new(map));
+        let value = Value::object(map);
         assert!(limits.validate_value(&value).is_ok());
     }
 
@@ -464,7 +464,7 @@ mod tests {
         for i in 0..=limits.max_object_entries {
             map.insert(format!("key{}", i), Value::Null);
         }
-        let value = Value::Object(Box::new(map));
+        let value = Value::object(map);
         let result = limits.validate_value(&value);
         assert!(matches!(result, Err(LimitError::ValueTooLarge { .. })));
     }
@@ -474,7 +474,7 @@ mod tests {
     fn create_nested_array(depth: usize) -> Value {
         let mut value = Value::Null;
         for _ in 0..depth {
-            value = Value::Array(Box::new(vec![value]));
+            value = Value::array(vec![value]);
         }
         value
     }
@@ -684,14 +684,14 @@ mod tests {
     #[test]
     fn test_validate_value_full_empty_array() {
         let limits = Limits::default();
-        let value = Value::Array(Box::new(vec![]));
+        let value = Value::array(vec![]);
         assert!(limits.validate_value_full(&value).is_ok());
     }
 
     #[test]
     fn test_validate_value_full_empty_object() {
         let limits = Limits::default();
-        let value = Value::Object(Box::new(HashMap::new()));
+        let value = Value::object(HashMap::new());
         assert!(limits.validate_value_full(&value).is_ok());
     }
 

--- a/crates/core/src/primitives/state.rs
+++ b/crates/core/src/primitives/state.rs
@@ -169,14 +169,14 @@ mod tests {
 
     #[test]
     fn test_state_with_complex_value() {
-        let complex = Value::Object(Box::new({
+        let complex = Value::object({
             let mut m = std::collections::HashMap::new();
             m.insert(
                 "nested".to_string(),
-                Value::Array(Box::new(vec![Value::Int(1), Value::Null])),
+                Value::array(vec![Value::Int(1), Value::Null]),
             );
             m
-        }));
+        });
         let state = State::new(complex.clone());
         assert_eq!(state.value, complex);
 

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -275,13 +275,13 @@ impl From<&[u8]> for Value {
 
 impl From<Vec<Value>> for Value {
     fn from(a: Vec<Value>) -> Self {
-        Value::Array(Box::new(a))
+        Value::array(a)
     }
 }
 
 impl From<HashMap<String, Value>> for Value {
     fn from(o: HashMap<String, Value>) -> Self {
-        Value::Object(Box::new(o))
+        Value::object(o)
     }
 }
 
@@ -312,11 +312,11 @@ impl From<serde_json::Value> for Value {
             }
             serde_json::Value::String(s) => Value::String(s),
             serde_json::Value::Array(arr) => {
-                Value::Array(Box::new(arr.into_iter().map(Value::from).collect()))
+                Value::array(arr.into_iter().map(Value::from).collect())
             }
-            serde_json::Value::Object(obj) => Value::Object(Box::new(
-                obj.into_iter().map(|(k, v)| (k, Value::from(v))).collect(),
-            )),
+            serde_json::Value::Object(obj) => {
+                Value::object(obj.into_iter().map(|(k, v)| (k, Value::from(v))).collect())
+            }
         }
     }
 }
@@ -458,7 +458,7 @@ mod tests {
             Value::String("test".to_string()),
             Value::Bool(true),
         ];
-        let value = Value::Array(Box::new(array.clone()));
+        let value = Value::array(array.clone());
 
         assert!(matches!(value, Value::Array(_)));
         assert!(value.is_array());
@@ -476,7 +476,7 @@ mod tests {
         map.insert("key1".to_string(), Value::Int(42));
         map.insert("key2".to_string(), Value::String("value".to_string()));
 
-        let value = Value::Object(Box::new(map.clone()));
+        let value = Value::object(map.clone());
         assert!(matches!(value, Value::Object(_)));
         assert!(value.is_object());
 
@@ -496,10 +496,7 @@ mod tests {
             Value::Float(3.14),
             Value::String("test".to_string()),
             Value::Bytes(vec![1, 2, 3]),
-            Value::Array(Box::new(vec![
-                Value::Int(1),
-                Value::String("a".to_string()),
-            ])),
+            Value::array(vec![Value::Int(1), Value::String("a".to_string())]),
         ];
 
         for value in test_values {
@@ -513,7 +510,7 @@ mod tests {
     fn test_value_object_serialization() {
         let mut map = HashMap::new();
         map.insert("test".to_string(), Value::Int(123));
-        let value = Value::Object(Box::new(map));
+        let value = Value::object(map);
 
         let serialized = serde_json::to_string(&value).unwrap();
         let deserialized: Value = serde_json::from_str(&serialized).unwrap();
@@ -554,11 +551,8 @@ mod tests {
         assert_eq!(Value::Float(1.0).type_name(), "Float");
         assert_eq!(Value::String("".to_string()).type_name(), "String");
         assert_eq!(Value::Bytes(vec![]).type_name(), "Bytes");
-        assert_eq!(Value::Array(Box::new(vec![])).type_name(), "Array");
-        assert_eq!(
-            Value::Object(Box::new(HashMap::new())).type_name(),
-            "Object"
-        );
+        assert_eq!(Value::array(vec![]).type_name(), "Array");
+        assert_eq!(Value::object(HashMap::new()).type_name(), "Object");
     }
 
     // ====================================================================
@@ -716,14 +710,14 @@ mod tests {
 
     #[test]
     fn test_empty_array() {
-        let v = Value::Array(Box::new(vec![]));
+        let v = Value::array(vec![]);
         assert!(v.is_array());
         assert_eq!(v.as_array().unwrap().len(), 0);
     }
 
     #[test]
     fn test_empty_object() {
-        let v = Value::Object(Box::new(HashMap::new()));
+        let v = Value::object(HashMap::new());
         assert!(v.is_object());
         assert_eq!(v.as_object().unwrap().len(), 0);
     }
@@ -734,8 +728,8 @@ mod tests {
 
     #[test]
     fn test_nested_array() {
-        let inner = Value::Array(Box::new(vec![Value::Int(1), Value::Int(2)]));
-        let outer = Value::Array(Box::new(vec![inner.clone(), Value::Int(3)]));
+        let inner = Value::array(vec![Value::Int(1), Value::Int(2)]);
+        let outer = Value::array(vec![inner.clone(), Value::Int(3)]);
         assert!(outer.is_array());
         let arr = outer.as_array().unwrap();
         assert_eq!(arr.len(), 2);
@@ -747,8 +741,8 @@ mod tests {
         let mut inner = HashMap::new();
         inner.insert("x".to_string(), Value::Int(1));
         let mut outer = HashMap::new();
-        outer.insert("nested".to_string(), Value::Object(Box::new(inner)));
-        let v = Value::Object(Box::new(outer));
+        outer.insert("nested".to_string(), Value::object(inner));
+        let v = Value::object(outer);
         assert!(v.is_object());
         let obj = v.as_object().unwrap();
         assert!(obj.get("nested").unwrap().is_object());
@@ -804,7 +798,7 @@ mod tests {
         let mut m2 = HashMap::new();
         m2.insert("b".to_string(), Value::Int(2));
         m2.insert("a".to_string(), Value::Int(1));
-        assert_eq!(Value::Object(Box::new(m1)), Value::Object(Box::new(m2)));
+        assert_eq!(Value::object(m1), Value::object(m2));
     }
 
     #[test]
@@ -814,18 +808,18 @@ mod tests {
         let mut m2 = HashMap::new();
         m2.insert("a".to_string(), Value::Int(1));
         m2.insert("b".to_string(), Value::Int(2));
-        assert_ne!(Value::Object(Box::new(m1)), Value::Object(Box::new(m2)));
+        assert_ne!(Value::object(m1), Value::object(m2));
     }
 
     #[test]
     fn test_deeply_nested_equality() {
-        let inner = Value::Array(Box::new(vec![Value::Object(Box::new({
+        let inner = Value::array(vec![Value::object({
             let mut m = HashMap::new();
             m.insert("x".to_string(), Value::Int(1));
             m
-        }))]));
-        let v1 = Value::Array(Box::new(vec![inner.clone()]));
-        let v2 = Value::Array(Box::new(vec![inner]));
+        })]);
+        let v1 = Value::array(vec![inner.clone()]);
+        let v2 = Value::array(vec![inner]);
         assert_eq!(v1, v2);
     }
 

--- a/crates/engine/src/primitives/event.rs
+++ b/crates/engine/src/primitives/event.rs
@@ -837,12 +837,12 @@ mod tests {
 
     /// Helper to create an empty object payload
     fn empty_payload() -> Value {
-        Value::Object(Box::new(HashMap::new()))
+        Value::object(HashMap::new())
     }
 
     /// Helper to create an object payload with a single value
     fn payload_with(key: &str, value: Value) -> Value {
-        Value::Object(Box::new(HashMap::from([(key.to_string(), value)])))
+        Value::object(HashMap::from([(key.to_string(), value)]))
     }
 
     /// Helper to create an object payload with an integer
@@ -938,7 +938,7 @@ mod tests {
             &branch_id,
             "default",
             "test",
-            Value::Array(Box::new(vec![Value::Int(1)])),
+            Value::array(vec![Value::Int(1)]),
         );
         assert!(result.is_err());
     }
@@ -990,10 +990,10 @@ mod tests {
         let (_temp, _db, log) = setup();
         let branch_id = BranchId::new();
 
-        let payload = Value::Object(Box::new(HashMap::from([
+        let payload = Value::object(HashMap::from([
             ("tool".to_string(), Value::String("search".into())),
             ("count".to_string(), Value::Int(42)),
-        ])));
+        ]));
 
         let result = log.append(&branch_id, "default", "test", payload);
         assert!(result.is_ok());
@@ -1053,10 +1053,10 @@ mod tests {
         let (_temp, _db, log) = setup();
         let branch_id = BranchId::new();
 
-        let payload = Value::Object(Box::new(HashMap::from([
+        let payload = Value::object(HashMap::from([
             ("tool".to_string(), Value::String("search".into())),
             ("query".to_string(), Value::String("rust async".into())),
-        ])));
+        ]));
 
         let version = log
             .append(&branch_id, "default", "tool_call", payload.clone())

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -712,12 +712,12 @@ mod tests {
             &branch_id,
             "default",
             "array",
-            Value::Array(Box::new(vec![Value::Int(1), Value::Int(2)])),
+            Value::array(vec![Value::Int(1), Value::Int(2)]),
         )
         .unwrap();
         assert_eq!(
             kv.get(&branch_id, "default", "array").unwrap(),
-            Some(Value::Array(Box::new(vec![Value::Int(1), Value::Int(2)])))
+            Some(Value::array(vec![Value::Int(1), Value::Int(2)]))
         );
     }
 

--- a/crates/engine/tests/adversarial_tests.rs
+++ b/crates/engine/tests/adversarial_tests.rs
@@ -47,11 +47,11 @@ fn setup() -> (Arc<Database>, TempDir, BranchId) {
 }
 
 fn empty_payload() -> Value {
-    Value::Object(Box::new(HashMap::new()))
+    Value::object(HashMap::new())
 }
 
 fn int_payload(v: i64) -> Value {
-    Value::Object(Box::new(HashMap::from([("value".to_string(), Value::Int(v))])))
+    Value::object(HashMap::from([("value".to_string(), Value::Int(v))]))
 }
 
 // ============================================================================
@@ -450,7 +450,7 @@ fn test_eventlog_payload_validation() {
     }
 
     // Array payload should fail
-    let array_payload = Value::Array(Box::new(vec![Value::Int(1), Value::Int(2)]));
+    let array_payload = Value::array(vec![Value::Int(1), Value::Int(2)]);
     let result = event_log.append(&branch_id, "test", array_payload);
     assert!(result.is_err(), "Array payload should be rejected");
 }

--- a/crates/engine/tests/branch_isolation_tests.rs
+++ b/crates/engine/tests/branch_isolation_tests.rs
@@ -14,23 +14,20 @@ use tempfile::TempDir;
 
 /// Helper to create an empty object payload for EventLog
 fn empty_payload() -> Value {
-    Value::Object(Box::new(HashMap::new()))
+    Value::object(HashMap::new())
 }
 
 /// Helper to create an object payload with an integer value
 fn int_payload(v: i64) -> Value {
-    Value::Object(Box::new(HashMap::from([(
-        "value".to_string(),
-        Value::Int(v),
-    )])))
+    Value::object(HashMap::from([("value".to_string(), Value::Int(v))]))
 }
 
 /// Helper to create an object payload with a string value
 fn string_payload(s: &str) -> Value {
-    Value::Object(Box::new(HashMap::from([(
+    Value::object(HashMap::from([(
         "data".to_string(),
         Value::String(s.into()),
-    )])))
+    )]))
 }
 
 fn setup() -> (Arc<Database>, TempDir) {

--- a/crates/engine/tests/primitives_cross_tests.rs
+++ b/crates/engine/tests/primitives_cross_tests.rs
@@ -13,23 +13,20 @@ use tempfile::TempDir;
 
 /// Helper to create an empty object payload for EventLog
 fn empty_payload() -> Value {
-    Value::Object(Box::new(HashMap::new()))
+    Value::object(HashMap::new())
 }
 
 /// Helper to create an object payload with a string value
 fn string_payload(s: &str) -> Value {
-    Value::Object(Box::new(HashMap::from([(
+    Value::object(HashMap::from([(
         "data".to_string(),
         Value::String(s.into()),
-    )])))
+    )]))
 }
 
 /// Helper to create an object payload with an integer value
 fn int_payload(v: i64) -> Value {
-    Value::Object(Box::new(HashMap::from([(
-        "value".to_string(),
-        Value::Int(v),
-    )])))
+    Value::object(HashMap::from([("value".to_string(), Value::Int(v))]))
 }
 
 fn setup() -> (Arc<Database>, TempDir, BranchId) {
@@ -245,10 +242,7 @@ fn test_nested_primitive_operations() {
         let kv_value = txn.kv_get("initial_value")?;
         let inner_value = kv_value.unwrap_or(Value::Null);
         // EventLog requires object payloads, so wrap the KV value
-        let payload = Value::Object(Box::new(HashMap::from([(
-            "from_kv".to_string(),
-            inner_value,
-        )])));
+        let payload = Value::object(HashMap::from([("from_kv".to_string(), inner_value)]));
 
         // Append Event with payload from KV (sequence starts at 0)
         let seq = txn.event_append("chained_event", payload)?;
@@ -267,10 +261,7 @@ fn test_nested_primitive_operations() {
     let event_log = EventLog::new(db.clone());
     let event = event_log.get(&branch_id, "default", 0).unwrap().unwrap();
     // Payload is now wrapped: {"from_kv": 42}
-    let expected_payload = Value::Object(Box::new(HashMap::from([(
-        "from_kv".to_string(),
-        Value::Int(42),
-    )])));
+    let expected_payload = Value::object(HashMap::from([("from_kv".to_string(), Value::Int(42))]));
     assert_eq!(event.value.payload, expected_payload);
 
     let state = state_cell

--- a/crates/engine/tests/recovery_tests.rs
+++ b/crates/engine/tests/recovery_tests.rs
@@ -18,18 +18,15 @@ use tempfile::TempDir;
 
 /// Helper to create an object payload with a string value
 fn string_payload(s: &str) -> Value {
-    Value::Object(Box::new(HashMap::from([(
+    Value::object(HashMap::from([(
         "data".to_string(),
         Value::String(s.into()),
-    )])))
+    )]))
 }
 
 /// Helper to create an object payload with an integer value
 fn int_payload(v: i64) -> Value {
-    Value::Object(Box::new(HashMap::from([(
-        "value".to_string(),
-        Value::Int(v),
-    )])))
+    Value::object(HashMap::from([("value".to_string(), Value::Int(v))]))
 }
 
 fn setup() -> (Arc<Database>, TempDir, BranchId) {

--- a/crates/engine/tests/versioned_conformance_tests.rs
+++ b/crates/engine/tests/versioned_conformance_tests.rs
@@ -25,23 +25,20 @@ use strata_engine::*;
 
 /// Helper to create an empty object payload for EventLog
 fn empty_payload() -> Value {
-    Value::Object(Box::new(HashMap::new()))
+    Value::object(HashMap::new())
 }
 
 /// Helper to create an object payload with a string value
 fn string_payload(s: &str) -> Value {
-    Value::Object(Box::new(HashMap::from([(
+    Value::object(HashMap::from([(
         "data".to_string(),
         Value::String(s.into()),
-    )])))
+    )]))
 }
 
 /// Helper to create an object payload with an integer value
 fn int_payload(v: i64) -> Value {
-    Value::Object(Box::new(HashMap::from([(
-        "value".to_string(),
-        Value::Int(v),
-    )])))
+    Value::object(HashMap::from([("value".to_string(), Value::Int(v))]))
 }
 
 fn setup() -> (Arc<Database>, BranchId) {

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -652,16 +652,12 @@ mod tests {
         // Event payloads must be Objects
         db.event_append(
             "stream",
-            Value::Object(Box::new(
-                [("value".to_string(), Value::Int(1))].into_iter().collect(),
-            )),
+            Value::object([("value".to_string(), Value::Int(1))].into_iter().collect()),
         )
         .unwrap();
         db.event_append(
             "stream",
-            Value::Object(Box::new(
-                [("value".to_string(), Value::Int(2))].into_iter().collect(),
-            )),
+            Value::object([("value".to_string(), Value::Int(2))].into_iter().collect()),
         )
         .unwrap();
 
@@ -832,9 +828,7 @@ mod tests {
         db.state_set("state-cell", 10i64).unwrap();
         db.event_append(
             "stream",
-            Value::Object(Box::new(
-                [("x".to_string(), Value::Int(100))].into_iter().collect(),
-            )),
+            Value::object([("x".to_string(), Value::Int(100))].into_iter().collect()),
         )
         .unwrap();
 
@@ -1140,11 +1134,11 @@ mod tests {
             "ng",
             "n1",
             None,
-            Some(Value::Object(Box::new(
+            Some(Value::object(
                 [("name".to_string(), Value::String("Alice".into()))]
                     .into_iter()
                     .collect(),
-            ))),
+            )),
         )
         .unwrap();
 
@@ -1226,28 +1220,28 @@ mod tests {
             "patient_care",
             "patient-4821",
             Some("json://main/patient-4821"),
-            Some(Value::Object(Box::new(
+            Some(Value::object(
                 [(
                     "department".to_string(),
                     Value::String("endocrinology".into()),
                 )]
                 .into_iter()
                 .collect(),
-            ))),
+            )),
         )
         .unwrap();
         db.graph_add_node(
             "patient_care",
             "ICD:E11.9",
             None,
-            Some(Value::Object(Box::new(
+            Some(Value::object(
                 [(
                     "description".to_string(),
                     Value::String("Type 2 Diabetes".into()),
                 )]
                 .into_iter()
                 .collect(),
-            ))),
+            )),
         )
         .unwrap();
         db.graph_add_node(
@@ -1263,14 +1257,14 @@ mod tests {
             "patient_care",
             "ICD:N18.3",
             None,
-            Some(Value::Object(Box::new(
+            Some(Value::object(
                 [(
                     "description".to_string(),
                     Value::String("CKD Stage 3".into()),
                 )]
                 .into_iter()
                 .collect(),
-            ))),
+            )),
         )
         .unwrap();
 
@@ -1363,14 +1357,14 @@ mod tests {
             "ng",
             "patient-1",
             Some("kv://main/p1"),
-            Some(Value::Object(Box::new(
+            Some(Value::object(
                 [
                     ("department".to_string(), Value::String("cardiology".into())),
                     ("age".to_string(), Value::Int(45)),
                 ]
                 .into_iter()
                 .collect(),
-            ))),
+            )),
         )
         .unwrap();
 
@@ -1442,11 +1436,11 @@ mod tests {
             "B",
             "SCORED",
             Some(0.95),
-            Some(Value::Object(Box::new(
+            Some(Value::object(
                 [("confidence".to_string(), Value::String("high".into()))]
                     .into_iter()
                     .collect(),
-            ))),
+            )),
         )
         .unwrap();
 

--- a/crates/executor/src/bridge.rs
+++ b/crates/executor/src/bridge.rs
@@ -262,14 +262,14 @@ fn serde_json_to_value(json: serde_json::Value) -> StrataResult<Value> {
         }
         JV::Array(arr) => {
             let converted: Result<Vec<_>, _> = arr.into_iter().map(serde_json_to_value).collect();
-            Ok(Value::Array(Box::new(converted?)))
+            Ok(Value::array(converted?))
         }
         JV::Object(obj) => {
             let mut map = std::collections::HashMap::new();
             for (k, v) in obj {
                 map.insert(k, serde_json_to_value(v)?);
             }
-            Ok(Value::Object(Box::new(map)))
+            Ok(Value::object(map))
         }
     }
 }

--- a/crates/executor/src/json.rs
+++ b/crates/executor/src/json.rs
@@ -88,7 +88,7 @@ pub fn json_to_value(json: &JsonValue) -> Result<Value, String> {
         JsonValue::String(s) => Ok(Value::String(s.clone())),
         JsonValue::Array(arr) => {
             let items: Result<Vec<Value>, String> = arr.iter().map(json_to_value).collect();
-            Ok(Value::Array(Box::new(items?)))
+            Ok(Value::array(items?))
         }
         JsonValue::Object(obj) => {
             // Check for special encodings
@@ -116,7 +116,7 @@ pub fn json_to_value(json: &JsonValue) -> Result<Value, String> {
                 .iter()
                 .map(|(k, v)| json_to_value(v).map(|val| (k.clone(), val)))
                 .collect();
-            Ok(Value::Object(Box::new(map?)))
+            Ok(Value::object(map?))
         }
     }
 }
@@ -264,7 +264,7 @@ mod tests {
 
     #[test]
     fn test_complex_value_round_trip() {
-        let original = Value::Object(Box::new(
+        let original = Value::object(
             [
                 ("name".to_string(), Value::String("test".to_string())),
                 ("count".to_string(), Value::Int(42)),
@@ -272,15 +272,12 @@ mod tests {
                 ("nan".to_string(), Value::Float(f64::NAN)),
                 (
                     "nested".to_string(),
-                    Value::Array(Box::new(vec![
-                        Value::Float(f64::INFINITY),
-                        Value::Float(-0.0),
-                    ])),
+                    Value::array(vec![Value::Float(f64::INFINITY), Value::Float(-0.0)]),
                 ),
             ]
             .into_iter()
             .collect(),
-        ));
+        );
 
         let json = value_to_json(&original);
         let restored = json_to_value(&json).unwrap();

--- a/crates/executor/src/tests/access_mode.rs
+++ b/crates/executor/src/tests/access_mode.rs
@@ -95,7 +95,7 @@ fn test_read_only_blocks_all_writes() {
             branch: None,
             space: None,
             event_type: "t".into(),
-            payload: Value::Object(Box::new(Default::default())),
+            payload: Value::object(Default::default()),
         },
         Command::StateSet {
             branch: None,

--- a/crates/executor/src/tests/determinism.rs
+++ b/crates/executor/src/tests/determinism.rs
@@ -364,9 +364,7 @@ fn test_event_get_by_type_determinism() {
                 branch: Some(BranchId::from("default")),
                 space: None,
                 event_type: "events".to_string(),
-                payload: Value::Object(Box::new(
-                    [("seq".to_string(), Value::Int(i))].into_iter().collect(),
-                )),
+                payload: Value::object([("seq".to_string(), Value::Int(i))].into_iter().collect()),
             })
             .unwrap();
     }
@@ -411,14 +409,14 @@ fn test_json_get_determinism() {
             space: None,
             key: "doc".to_string(),
             path: "".to_string(),
-            value: Value::Object(Box::new(
+            value: Value::object(
                 [
                     ("name".to_string(), Value::String("Alice".into())),
                     ("age".to_string(), Value::Int(30)),
                 ]
                 .into_iter()
                 .collect(),
-            )),
+            ),
         })
         .unwrap();
 

--- a/crates/executor/src/tests/parity.rs
+++ b/crates/executor/src/tests/parity.rs
@@ -181,11 +181,11 @@ fn test_json_set_get_parity() {
         space: None,
         key: "doc1".to_string(),
         path: "".to_string(), // Root path
-        value: Value::Object(Box::new(
+        value: Value::object(
             [("name".to_string(), Value::String("Alice".into()))]
                 .into_iter()
                 .collect(),
-        )),
+        ),
     });
 
     // JsonSet returns Version
@@ -226,11 +226,11 @@ fn test_event_append_get_by_type_parity() {
         branch: None,
         space: None,
         event_type: "events".to_string(),
-        payload: Value::Object(Box::new(
+        payload: Value::object(
             [("type".to_string(), Value::String("click".into()))]
                 .into_iter()
                 .collect(),
-        )),
+        ),
     });
 
     // Just verify it returns a Version
@@ -246,11 +246,11 @@ fn test_event_append_get_by_type_parity() {
             &branch_id,
             "default",
             "events",
-            Value::Object(Box::new(
+            Value::object(
                 [("type".to_string(), Value::String("scroll".into()))]
                     .into_iter()
                     .collect(),
-            )),
+            ),
         )
         .unwrap();
 
@@ -426,11 +426,11 @@ fn test_branch_create_get_parity() {
     // Create branch via executor with a UUID
     let result = executor.execute(Command::BranchCreate {
         branch_id: Some("550e8400-e29b-41d4-a716-446655440001".to_string()),
-        metadata: Some(Value::Object(Box::new(
+        metadata: Some(Value::object(
             [("name".to_string(), Value::String("Test".into()))]
                 .into_iter()
                 .collect(),
-        ))),
+        )),
     });
 
     match result {

--- a/crates/executor/src/tests/serialization.rs
+++ b/crates/executor/src/tests/serialization.rs
@@ -143,11 +143,11 @@ fn test_command_event_append() {
         branch: Some(BranchId::from("default")),
         space: None,
         event_type: "events".to_string(),
-        payload: Value::Object(Box::new(
+        payload: Value::object(
             [("type".to_string(), Value::String("click".to_string()))]
                 .into_iter()
                 .collect(),
-        )),
+        ),
     });
 }
 
@@ -218,11 +218,11 @@ fn test_command_vector_upsert() {
         collection: "embeddings".to_string(),
         key: "vec1".to_string(),
         vector: vec![0.1, 0.2, 0.3, 0.4],
-        metadata: Some(Value::Object(Box::new(
+        metadata: Some(Value::object(
             [("label".to_string(), Value::String("test".to_string()))]
                 .into_iter()
                 .collect(),
-        ))),
+        )),
     });
 }
 
@@ -259,11 +259,11 @@ fn test_command_vector_create_collection() {
 fn test_command_branch_create() {
     test_command_round_trip(Command::BranchCreate {
         branch_id: Some("my-branch".to_string()),
-        metadata: Some(Value::Object(Box::new(
+        metadata: Some(Value::object(
             [("name".to_string(), Value::String("Test Branch".to_string()))]
                 .into_iter()
                 .collect(),
-        ))),
+        )),
     });
 }
 
@@ -447,7 +447,7 @@ fn test_command_search_full() {
 
 #[test]
 fn test_command_with_complex_value() {
-    let complex_value = Value::Object(Box::new(
+    let complex_value = Value::object(
         [
             ("string".to_string(), Value::String("hello".to_string())),
             ("int".to_string(), Value::Int(42)),
@@ -456,20 +456,20 @@ fn test_command_with_complex_value() {
             ("null".to_string(), Value::Null),
             (
                 "array".to_string(),
-                Value::Array(Box::new(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),
+                Value::array(vec![Value::Int(1), Value::Int(2), Value::Int(3)]),
             ),
             (
                 "nested".to_string(),
-                Value::Object(Box::new(
+                Value::object(
                     [("deep".to_string(), Value::String("value".to_string()))]
                         .into_iter()
                         .collect(),
-                )),
+                ),
             ),
         ]
         .into_iter()
         .collect(),
-    ));
+    );
 
     test_command_round_trip(Command::KvPut {
         branch: Some(BranchId::from("default")),

--- a/crates/executor/src/tests/session.rs
+++ b/crates/executor/src/tests/session.rs
@@ -408,10 +408,10 @@ fn test_event_append_in_txn() {
         branch: None,
         space: None,
         event_type: "test_stream".to_string(),
-        payload: Value::Object(Box::new(std::collections::HashMap::from([(
+        payload: Value::object(std::collections::HashMap::from([(
             "data".to_string(),
             Value::String("event_data".into()),
-        )]))),
+        )])),
     });
     assert!(result.is_ok(), "EventAppend should succeed in txn");
 

--- a/crates/executor/src/tests/spaces.rs
+++ b/crates/executor/src/tests/spaces.rs
@@ -195,14 +195,14 @@ fn test_event_isolation_across_spaces() {
     let mut db = strata();
 
     // Append events in default space (payload must be a JSON object)
-    let payload1 = Value::Object(Box::new(HashMap::from([(
+    let payload1 = Value::object(HashMap::from([(
         "page".into(),
         Value::String("page1".into()),
-    )])));
-    let payload2 = Value::Object(Box::new(HashMap::from([(
+    )]));
+    let payload2 = Value::object(HashMap::from([(
         "page".into(),
         Value::String("page2".into()),
-    )])));
+    )]));
     db.event_append("click", payload1).unwrap();
     db.event_append("click", payload2).unwrap();
 
@@ -215,10 +215,10 @@ fn test_event_isolation_across_spaces() {
     assert_eq!(epsilon_len, 0);
 
     // Append in epsilon
-    let payload3 = Value::Object(Box::new(HashMap::from([(
+    let payload3 = Value::object(HashMap::from([(
         "page".into(),
         Value::String("page3".into()),
-    )])));
+    )]));
     db.event_append("click", payload3).unwrap();
     assert_eq!(db.event_len().unwrap(), 1);
 

--- a/crates/intelligence/src/embed/extract.rs
+++ b/crates/intelligence/src/embed/extract.rs
@@ -121,11 +121,11 @@ mod tests {
 
     #[test]
     fn test_array() {
-        let arr = Value::Array(Box::new(vec![
+        let arr = Value::array(vec![
             Value::String("hello".into()),
             Value::Int(42),
             Value::Null,
-        ]));
+        ]);
         assert_eq!(extract_text(&arr), Some("hello 42".into()));
     }
 
@@ -134,7 +134,7 @@ mod tests {
         let mut map = HashMap::new();
         map.insert("name".to_string(), Value::String("Alice".into()));
         map.insert("age".to_string(), Value::Int(30));
-        let obj = Value::Object(Box::new(map));
+        let obj = Value::object(map);
         let text = extract_text(&obj).unwrap();
         assert!(text.contains("age: 30"));
         assert!(text.contains("name: Alice"));
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn test_empty_array() {
-        assert_eq!(extract_text(&Value::Array(Box::new(vec![]))), None);
+        assert_eq!(extract_text(&Value::array(vec![])), None);
     }
 
     #[test]
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn test_array_all_null() {
         assert_eq!(
-            extract_text(&Value::Array(Box::new(vec![Value::Null, Value::Null]))),
+            extract_text(&Value::array(vec![Value::Null, Value::Null])),
             None
         );
     }
@@ -176,7 +176,7 @@ mod tests {
         // Build a deeply nested structure exceeding MAX_DEPTH
         let mut value = Value::String("deep".into());
         for _ in 0..20 {
-            value = Value::Array(Box::new(vec![value]));
+            value = Value::array(vec![value]);
         }
         // The leaf "deep" is at depth 20, which exceeds MAX_DEPTH (16).
         // extract_text should return None because the recursion stops before reaching it.
@@ -188,7 +188,7 @@ mod tests {
         // Build a nested structure exactly at MAX_DEPTH (16 levels of nesting)
         let mut value = Value::String("found".into());
         for _ in 0..15 {
-            value = Value::Array(Box::new(vec![value]));
+            value = Value::array(vec![value]);
         }
         // 15 levels of Array wrapping: depths 0..14 are Array, depth 15 is String.
         // All within MAX_DEPTH (16), so the text should be extractable.
@@ -201,10 +201,7 @@ mod tests {
         m1.insert("name".to_string(), Value::String("Alice".into()));
         let mut m2 = HashMap::new();
         m2.insert("name".to_string(), Value::String("Bob".into()));
-        let arr = Value::Array(Box::new(vec![
-            Value::Object(Box::new(m1)),
-            Value::Object(Box::new(m2)),
-        ]));
+        let arr = Value::array(vec![Value::object(m1), Value::object(m2)]);
         let text = extract_text(&arr).unwrap();
         assert!(text.contains("name: Alice"));
         assert!(text.contains("name: Bob"));
@@ -215,13 +212,13 @@ mod tests {
         let mut map = HashMap::new();
         map.insert("a".to_string(), Value::Null);
         map.insert("b".to_string(), Value::Null);
-        assert_eq!(extract_text(&Value::Object(Box::new(map))), None);
+        assert_eq!(extract_text(&Value::object(map)), None);
     }
 
     #[test]
     fn test_empty_object() {
         let map = HashMap::new();
-        assert_eq!(extract_text(&Value::Object(Box::new(map))), None);
+        assert_eq!(extract_text(&Value::object(map)), None);
     }
 
     #[test]
@@ -230,7 +227,7 @@ mod tests {
         map.insert("z".to_string(), Value::String("last".into()));
         map.insert("a".to_string(), Value::String("first".into()));
         map.insert("m".to_string(), Value::String("middle".into()));
-        let text = extract_text(&Value::Object(Box::new(map))).unwrap();
+        let text = extract_text(&Value::object(map)).unwrap();
         let a_pos = text.find("a:").unwrap();
         let m_pos = text.find("m:").unwrap();
         let z_pos = text.find("z:").unwrap();
@@ -242,14 +239,14 @@ mod tests {
     fn test_mixed_depth_objects_and_arrays() {
         let mut inner = HashMap::new();
         inner.insert("nested".to_string(), Value::Bool(true));
-        let arr = Value::Array(Box::new(vec![
+        let arr = Value::array(vec![
             Value::Int(1),
             Value::String("two".into()),
-            Value::Object(Box::new(inner)),
-        ]));
+            Value::object(inner),
+        ]);
         let mut outer = HashMap::new();
         outer.insert("items".to_string(), arr);
-        let text = extract_text(&Value::Object(Box::new(outer))).unwrap();
+        let text = extract_text(&Value::object(outer)).unwrap();
         assert!(text.contains("items:"));
         assert!(text.contains("1"));
         assert!(text.contains("two"));

--- a/crates/intelligence/tests/embed_pipeline_tests.rs
+++ b/crates/intelligence/tests/embed_pipeline_tests.rs
@@ -23,7 +23,7 @@ fn test_extract_returns_none_for_non_embeddable() {
     assert!(extract_text(&Value::Null).is_none());
     assert!(extract_text(&Value::Bytes(vec![1, 2, 3])).is_none());
     assert!(extract_text(&Value::String("".into())).is_none());
-    assert!(extract_text(&Value::Array(Box::new(vec![Value::Null, Value::Null]))).is_none());
+    assert!(extract_text(&Value::array(vec![Value::Null, Value::Null])).is_none());
 }
 
 #[test]
@@ -52,9 +52,9 @@ fn test_extract_complex_value() {
     map.insert("name".to_string(), Value::String("Alice".into()));
     map.insert(
         "scores".to_string(),
-        Value::Array(Box::new(vec![Value::Int(10), Value::Int(20)])),
+        Value::array(vec![Value::Int(10), Value::Int(20)]),
     );
-    let nested = Value::Object(Box::new(map));
+    let nested = Value::object(map);
 
     let text = extract_text(&nested).unwrap();
     assert!(text.contains("name: Alice"));
@@ -65,13 +65,13 @@ fn test_extract_complex_value() {
 
 #[test]
 fn test_extract_mixed_array_filters_nulls() {
-    let arr = Value::Array(Box::new(vec![
+    let arr = Value::array(vec![
         Value::String("keep".into()),
         Value::Null,
         Value::Int(7),
         Value::Bytes(vec![0xFF]),
         Value::String("also keep".into()),
-    ]));
+    ]);
     let text = extract_text(&arr).unwrap();
     assert!(text.contains("keep"));
     assert!(text.contains("7"));
@@ -87,9 +87,9 @@ fn test_extract_preserves_key_order_in_nested_objects() {
     inner.insert("a_field".to_string(), Value::String("first".into()));
 
     let mut outer = HashMap::new();
-    outer.insert("data".to_string(), Value::Object(Box::new(inner)));
+    outer.insert("data".to_string(), Value::object(inner));
 
-    let text = extract_text(&Value::Object(Box::new(outer))).unwrap();
+    let text = extract_text(&Value::object(outer)).unwrap();
     let a_pos = text.find("a_field").expect("a_field missing");
     let z_pos = text.find("z_field").expect("z_field missing");
     assert!(
@@ -207,7 +207,7 @@ fn test_extract_object_then_embed_produces_valid_vector() {
         Value::String("Rust programming".into()),
     );
     map.insert("year".to_string(), Value::Int(2024));
-    let obj = Value::Object(Box::new(map));
+    let obj = Value::object(map);
 
     let text = extract_text(&obj).expect("extraction should succeed");
     let engine = strata_intelligence::EmbeddingEngine::from_registry("miniLM")

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -339,23 +339,20 @@ pub fn unit_vector(dimension: usize) -> Vec<f32> {
 
 /// Create an empty object payload for EventLog.
 pub fn empty_payload() -> Value {
-    Value::Object(Box::new(std::collections::HashMap::new()))
+    Value::object(std::collections::HashMap::new())
 }
 
 /// Create an object payload wrapping an integer.
 pub fn int_payload(v: i64) -> Value {
-    Value::Object(Box::new(HashMap::from([(
-        "value".to_string(),
-        Value::Int(v),
-    )])))
+    Value::object(HashMap::from([("value".to_string(), Value::Int(v))]))
 }
 
 /// Create an object payload wrapping a string.
 pub fn string_payload(s: &str) -> Value {
-    Value::Object(Box::new(HashMap::from([(
+    Value::object(HashMap::from([(
         "data".to_string(),
         Value::String(s.into()),
-    )])))
+    )]))
 }
 
 // ============================================================================
@@ -384,26 +381,26 @@ pub mod values {
         Value::Null
     }
     pub fn array(items: Vec<Value>) -> Value {
-        Value::Array(Box::new(items))
+        Value::array(items)
     }
     pub fn map(pairs: Vec<(&str, Value)>) -> Value {
         let mut m = std::collections::HashMap::new();
         for (k, v) in pairs {
             m.insert(k.to_string(), v);
         }
-        Value::Object(Box::new(m))
+        Value::object(m)
     }
 
     /// Event payload wrapping a value as `{"data": value}`.
     pub fn event_payload(value: Value) -> Value {
         let mut m = std::collections::HashMap::new();
         m.insert("data".to_string(), value);
-        Value::Object(Box::new(m))
+        Value::object(m)
     }
 
     /// Empty event payload.
     pub fn empty_event_payload() -> Value {
-        Value::Object(Box::new(std::collections::HashMap::new()))
+        Value::object(std::collections::HashMap::new())
     }
 
     /// Large bytes value for stress tests.

--- a/tests/engine/acid_concurrent.rs
+++ b/tests/engine/acid_concurrent.rs
@@ -14,7 +14,7 @@ use std::thread;
 use strata_engine::{EventLogExt, KVStoreExt, StateCellExt};
 
 fn event_payload(data: Value) -> Value {
-    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
+    Value::object(HashMap::from([("data".to_string(), data)]))
 }
 
 // ============================================================================

--- a/tests/engine/acid_properties.rs
+++ b/tests/engine/acid_properties.rs
@@ -15,7 +15,7 @@ use strata_engine::{EventLogExt, KVStoreExt};
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
+    Value::object(HashMap::from([("data".to_string(), data)]))
 }
 
 // ============================================================================

--- a/tests/engine/adversarial.rs
+++ b/tests/engine/adversarial.rs
@@ -13,7 +13,7 @@ use strata_engine::{EventLogExt, KVStoreExt};
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
+    Value::object(HashMap::from([("data".to_string(), data)]))
 }
 
 // ============================================================================

--- a/tests/engine/adversarial_deep.rs
+++ b/tests/engine/adversarial_deep.rs
@@ -13,7 +13,7 @@ use strata_engine::{EventLogExt, KVStoreExt};
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
+    Value::object(HashMap::from([("data".to_string(), data)]))
 }
 
 // ============================================================================

--- a/tests/engine/branch_isolation.rs
+++ b/tests/engine/branch_isolation.rs
@@ -8,7 +8,7 @@ use strata_core::primitives::json::JsonPath;
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
+    Value::object(HashMap::from([("data".to_string(), data)]))
 }
 
 // ============================================================================

--- a/tests/engine/cross_primitive.rs
+++ b/tests/engine/cross_primitive.rs
@@ -8,7 +8,7 @@ use strata_engine::{EventLogExt, KVStoreExt, StateCellExt};
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
+    Value::object(HashMap::from([("data".to_string(), data)]))
 }
 
 // ============================================================================

--- a/tests/engine/database/durability_modes.rs
+++ b/tests/engine/database/durability_modes.rs
@@ -11,7 +11,7 @@ use strata_engine::KVStoreExt;
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
+    Value::object(HashMap::from([("data".to_string(), data)]))
 }
 
 // ============================================================================

--- a/tests/engine/primitives/eventlog.rs
+++ b/tests/engine/primitives/eventlog.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
+    Value::object(HashMap::from([("data".to_string(), data)]))
 }
 
 /// Helper to create a simple event payload with an integer
@@ -437,12 +437,7 @@ fn payload_must_be_object() {
     );
     assert!(result.is_err());
 
-    let result = event.append(
-        &test_db.branch_id,
-        "default",
-        "type",
-        Value::Array(Box::new(vec![])),
-    );
+    let result = event.append(&test_db.branch_id, "default", "type", Value::array(vec![]));
     assert!(result.is_err());
 
     // Object payload should work

--- a/tests/engine/stress.rs
+++ b/tests/engine/stress.rs
@@ -13,7 +13,7 @@ use strata_engine::{EventLogExt, KVStoreExt};
 
 /// Helper to create an event payload object
 fn event_payload(data: Value) -> Value {
-    Value::Object(Box::new(HashMap::from([("data".to_string(), data)])))
+    Value::object(HashMap::from([("data".to_string(), data)]))
 }
 
 /// High concurrency KV workload

--- a/tests/executor/adversarial.rs
+++ b/tests/executor/adversarial.rs
@@ -724,10 +724,10 @@ fn large_nested_object() {
     }
 
     let mut outer = std::collections::HashMap::new();
-    outer.insert("nested".to_string(), Value::Object(Box::new(inner)));
+    outer.insert("nested".to_string(), Value::object(inner));
     outer.insert(
         "array".to_string(),
-        Value::Array(Box::new((0..100).map(|i| Value::Int(i)).collect())),
+        Value::array((0..100).map(|i| Value::Int(i)).collect()),
     );
 
     executor
@@ -735,7 +735,7 @@ fn large_nested_object() {
             branch: None,
             space: None,
             key: "large_object".into(),
-            value: Value::Object(Box::new(outer.clone())),
+            value: Value::object(outer.clone()),
         })
         .unwrap();
 
@@ -751,7 +751,7 @@ fn large_nested_object() {
     match output {
         Output::MaybeVersioned(Some(vv)) => {
             let val = vv.value;
-            assert_eq!(val, Value::Object(Box::new(outer)));
+            assert_eq!(val, Value::object(outer));
         }
         _ => panic!("Large object should be retrievable"),
     }

--- a/tests/executor/common.rs
+++ b/tests/executor/common.rs
@@ -28,7 +28,7 @@ pub fn create_db() -> Arc<Database> {
 
 /// Helper to create an event payload (must be an Object)
 pub fn event_payload(key: &str, value: strata_core::Value) -> strata_core::Value {
-    strata_core::Value::Object(Box::new([(key.to_string(), value)].into_iter().collect()))
+    strata_core::Value::object([(key.to_string(), value)].into_iter().collect())
 }
 
 /// Extract version from Output::Version

--- a/tests/executor/serialization.rs
+++ b/tests/executor/serialization.rs
@@ -61,11 +61,11 @@ fn event_append_roundtrip() {
         branch: None,
         space: None,
         event_type: "events".into(),
-        payload: Value::Object(Box::new(
+        payload: Value::object(
             [("data".to_string(), Value::Int(123))]
                 .into_iter()
                 .collect(),
-        )),
+        ),
     };
 
     let json = serde_json::to_string(&cmd).unwrap();
@@ -97,11 +97,11 @@ fn vector_search_roundtrip() {
 fn branch_create_roundtrip() {
     let cmd = Command::BranchCreate {
         branch_id: Some("550e8400-e29b-41d4-a716-446655440401-id".into()),
-        metadata: Some(Value::Object(Box::new(
+        metadata: Some(Value::object(
             [("key".to_string(), Value::String("value".into()))]
                 .into_iter()
                 .collect(),
-        ))),
+        )),
     };
 
     let json = serde_json::to_string(&cmd).unwrap();
@@ -414,7 +414,7 @@ fn value_types_roundtrip() {
         branch: None,
         space: None,
         key: "k".into(),
-        value: Value::Array(Box::new(vec![Value::Int(1), Value::Int(2)])),
+        value: Value::array(vec![Value::Int(1), Value::Int(2)]),
     };
     let json = serde_json::to_string(&cmd).unwrap();
     let parsed: Command = serde_json::from_str(&json).unwrap();
@@ -425,11 +425,11 @@ fn value_types_roundtrip() {
         branch: None,
         space: None,
         key: "k".into(),
-        value: Value::Object(Box::new(
+        value: Value::object(
             [("nested".to_string(), Value::Int(1))]
                 .into_iter()
                 .collect(),
-        )),
+        ),
     };
     let json = serde_json::to_string(&cmd).unwrap();
     let parsed: Command = serde_json::from_str(&json).unwrap();

--- a/tests/executor/strata_api.rs
+++ b/tests/executor/strata_api.rs
@@ -241,14 +241,14 @@ fn branch_list() {
 fn json_set_and_get() {
     let db = create_strata();
 
-    let doc = Value::Object(Box::new(
+    let doc = Value::object(
         [
             ("name".to_string(), Value::String("Alice".into())),
             ("age".to_string(), Value::Int(30)),
         ]
         .into_iter()
         .collect(),
-    ));
+    );
 
     db.json_set("user:1", "$", doc).unwrap();
 
@@ -268,9 +268,7 @@ fn json_set_and_get() {
 fn json_delete() {
     let db = create_strata();
 
-    let doc = Value::Object(Box::new(
-        [("key".to_string(), Value::Int(1))].into_iter().collect(),
-    ));
+    let doc = Value::object([("key".to_string(), Value::Int(1))].into_iter().collect());
 
     db.json_set("doc1", "$", doc).unwrap();
 
@@ -315,11 +313,11 @@ fn use_all_primitives() {
         .unwrap();
 
     // JSON
-    let doc = Value::Object(Box::new(
+    let doc = Value::object(
         [("type".to_string(), Value::String("test".into()))]
             .into_iter()
             .collect(),
-    ));
+    );
     db.json_set("doc1", "$", doc).unwrap();
 
     // Branch


### PR DESCRIPTION
## Summary

- Replace all 130+ occurrences of `Value::Array(Box::new(...))` and `Value::Object(Box::new(...))` with the existing convenience constructors `Value::array()` and `Value::object()`
- `Box::new` is now only used in the two constructor definitions themselves (in `value.rs`)
- No behavioral change — purely mechanical cleanup across 36 files

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test --workspace` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)