### PR TITLE
Concurrency hardening: fallible counters, read-only txns, metrics (#1307, #1308, #1309)

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -116,13 +116,11 @@ impl TransactionManager {
 
     /// Allocate next transaction ID
     ///
-    /// # Panics
-    ///
-    /// Panics if the transaction ID counter reaches `u64::MAX` (overflow).
-    pub fn next_txn_id(&self) -> u64 {
+    /// Returns an error if the transaction ID counter reaches `u64::MAX` (overflow).
+    pub fn next_txn_id(&self) -> std::result::Result<u64, CommitError> {
         self.next_txn_id
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| v.checked_add(1))
-            .expect("transaction ID overflow: u64::MAX reached")
+            .map_err(|_| CommitError::CounterOverflow("transaction ID counter at u64::MAX".into()))
     }
 
     /// Allocate next commit version (increment global version)
@@ -140,14 +138,12 @@ impl TransactionManager {
     /// while failure handling during commit does not attempt to "return"
     /// the allocated version.
     ///
-    /// # Panics
-    ///
-    /// Panics if the version counter reaches `u64::MAX` (overflow).
-    pub fn allocate_version(&self) -> u64 {
+    /// Returns an error if the version counter reaches `u64::MAX` (overflow).
+    pub fn allocate_version(&self) -> std::result::Result<u64, CommitError> {
         self.version
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| v.checked_add(1))
-            .expect("version counter overflow: u64::MAX reached")
-            + 1
+            .map(|v| v + 1)
+            .map_err(|_| CommitError::CounterOverflow("version counter at u64::MAX".into()))
     }
 
     /// Commit a transaction atomically
@@ -242,7 +238,7 @@ impl TransactionManager {
         // but NOT yet durable (not in WAL)
 
         // Step 2: Allocate commit version
-        let commit_version = self.allocate_version();
+        let commit_version = self.allocate_version()?;
 
         // Step 3: Write to WAL (durability) - only for transactions with mutations
         // Skip WAL for read-only transactions (no writes, deletes, CAS ops, or JSON patches)
@@ -488,9 +484,9 @@ mod tests {
     #[test]
     fn test_allocate_version_increments() {
         let manager = TransactionManager::new(0);
-        assert_eq!(manager.allocate_version(), 1);
-        assert_eq!(manager.allocate_version(), 2);
-        assert_eq!(manager.allocate_version(), 3);
+        assert_eq!(manager.allocate_version().unwrap(), 1);
+        assert_eq!(manager.allocate_version().unwrap(), 2);
+        assert_eq!(manager.allocate_version().unwrap(), 3);
         assert_eq!(manager.current_version(), 3);
     }
 
@@ -498,16 +494,37 @@ mod tests {
     fn test_next_txn_id_increments() {
         // TransactionManager::new(0) calls with_txn_id(0, 0), which sets next_txn_id = 0 + 1 = 1
         let manager = TransactionManager::new(0);
-        assert_eq!(manager.next_txn_id(), 1);
-        assert_eq!(manager.next_txn_id(), 2);
-        assert_eq!(manager.next_txn_id(), 3);
+        assert_eq!(manager.next_txn_id().unwrap(), 1);
+        assert_eq!(manager.next_txn_id().unwrap(), 2);
+        assert_eq!(manager.next_txn_id().unwrap(), 3);
     }
 
     #[test]
     fn test_with_txn_id_starts_from_max_plus_one() {
         let manager = TransactionManager::with_txn_id(50, 100);
         assert_eq!(manager.current_version(), 50);
-        assert_eq!(manager.next_txn_id(), 101); // max_txn_id + 1
+        assert_eq!(manager.next_txn_id().unwrap(), 101); // max_txn_id + 1
+    }
+
+    #[test]
+    fn test_next_txn_id_overflow_returns_error() {
+        // with_txn_id(0, max_txn_id) sets next_txn_id = max_txn_id + 1
+        // So with_txn_id(0, u64::MAX - 2) → next_txn_id starts at u64::MAX - 1
+        let manager = TransactionManager::with_txn_id(0, u64::MAX - 2);
+        // First call: returns u64::MAX - 1, counter advances to u64::MAX
+        assert!(manager.next_txn_id().is_ok());
+        // Second call fails: counter is at u64::MAX, cannot increment
+        assert!(manager.next_txn_id().is_err());
+    }
+
+    #[test]
+    fn test_allocate_version_overflow_returns_error() {
+        // Version starts at u64::MAX - 1
+        let manager = TransactionManager::with_txn_id(u64::MAX - 1, 0);
+        // First call: version advances from MAX-1 to MAX, returns MAX
+        assert!(manager.allocate_version().is_ok());
+        // Second call fails: version is at u64::MAX, cannot increment
+        assert!(manager.allocate_version().is_err());
     }
 
     #[test]

--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -887,7 +887,7 @@ mod tests {
         let result = coordinator.recover().unwrap();
 
         assert_eq!(result.txn_manager.current_version(), 100);
-        let new_txn_id = result.txn_manager.next_txn_id();
+        let new_txn_id = result.txn_manager.next_txn_id().unwrap();
         assert!(new_txn_id > 0);
     }
 

--- a/crates/concurrency/src/snapshot.rs
+++ b/crates/concurrency/src/snapshot.rs
@@ -30,17 +30,22 @@ use strata_core::types::Key;
 use strata_core::StrataResult;
 use strata_core::VersionedValue;
 
-/// M2 Implementation: Clone-based snapshot
+/// Clone-based snapshot (O(n) deep copy).
 ///
 /// Creates an immutable, isolated view of storage by cloning the data
-/// at snapshot creation time.
+/// at snapshot creation time. This is primarily used in **tests** and
+/// **recovery** where simplicity matters more than performance.
 ///
-/// # Known Limitations (Acceptable for M2)
+/// For production transaction workloads, prefer `ShardedSnapshot` from
+/// `strata_storage`, which provides O(1) snapshot creation via
+/// lock-free DashMap iteration.
+///
+/// # Known Limitations
 ///
 /// - **Memory**: O(data_size) per active transaction
 /// - **Time**: O(data_size) per snapshot creation
 ///
-/// # Why This is Acceptable for M2
+/// # Why This Exists
 ///
 /// - Agent workloads have small working sets (<100MB typical)
 /// - Transactions are short-lived (<1 second)

--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -45,6 +45,9 @@ pub enum CommitError {
     /// A storage I/O error occurred while reading current versions for
     /// conflict detection. The transaction is aborted to prevent incorrect commits.
     StorageError(String),
+
+    /// Counter overflow (transaction ID or version counter reached u64::MAX)
+    CounterOverflow(String),
 }
 
 impl std::fmt::Display for CommitError {
@@ -56,6 +59,7 @@ impl std::fmt::Display for CommitError {
             CommitError::InvalidState(msg) => write!(f, "Invalid state: {}", msg),
             CommitError::WALError(msg) => write!(f, "WAL error: {}", msg),
             CommitError::StorageError(msg) => write!(f, "Storage error during validation: {}", msg),
+            CommitError::CounterOverflow(msg) => write!(f, "Counter overflow: {}", msg),
         }
     }
 }
@@ -78,6 +82,9 @@ impl From<CommitError> for StrataError {
                 message: format!("Storage error during validation: {}", msg),
                 source: None,
             },
+            CommitError::CounterOverflow(msg) => {
+                StrataError::capacity_exceeded(msg, usize::MAX, usize::MAX)
+            }
         }
     }
 }
@@ -352,6 +359,14 @@ pub trait JsonStoreExt {
 /// 2. **READ/WRITE**: Use `get()`, `put()`, `delete()`, `cas()`
 /// 3. **VALIDATE**: Call `mark_validating()`, check for conflicts
 /// 4. **COMMIT/ABORT**: Call `mark_committed()` or `mark_aborted()`
+///
+/// # Future: Savepoints
+///
+/// A future enhancement could add savepoint support (partial rollback
+/// within a transaction). This would allow `SAVEPOINT name` /
+/// `ROLLBACK TO name` semantics by snapshotting the write/delete/cas
+/// sets at savepoint time and restoring them on rollback. Deferred
+/// to a later milestone.
 pub struct TransactionContext {
     // Identity
     /// Unique transaction ID
@@ -434,6 +449,12 @@ pub struct TransactionContext {
     /// Maximum entries allowed in the write buffer (0 = unlimited).
     /// Counts puts + deletes + CAS operations.
     max_write_entries: usize,
+
+    /// Per-transaction read-only mode.
+    ///
+    /// When true, writes are rejected and read-set tracking is skipped,
+    /// saving memory on large scan workloads.
+    read_only: bool,
 }
 
 impl TransactionContext {
@@ -477,6 +498,7 @@ impl TransactionContext {
             status: TransactionStatus::Active,
             start_time: Instant::now(),
             max_write_entries: 0,
+            read_only: false,
         }
     }
 
@@ -526,6 +548,7 @@ impl TransactionContext {
             status: TransactionStatus::Active,
             start_time: Instant::now(),
             max_write_entries: 0,
+            read_only: false,
         }
     }
 
@@ -594,14 +617,18 @@ impl TransactionContext {
         match snapshot.get_value_and_version(key)? {
             Some((value, version)) => {
                 // Key exists - track its version for conflict detection
-                self.read_set.insert(key.clone(), version);
+                if !self.read_only {
+                    self.read_set.insert(key.clone(), version);
+                }
                 Ok(Some(value)) // already owned, no clone needed
             }
             None => {
                 // Key doesn't exist - track with version 0
                 // This is important: if someone creates this key before we commit,
                 // we have a conflict (we assumed it didn't exist)
-                self.read_set.insert(key.clone(), 0);
+                if !self.read_only {
+                    self.read_set.insert(key.clone(), 0);
+                }
                 Ok(None)
             }
         }
@@ -646,11 +673,13 @@ impl TransactionContext {
 
         let versioned = snapshot.get(key)?;
 
-        // Track in read_set for conflict detection
-        if let Some(ref vv) = versioned {
-            self.read_set.insert(key.clone(), vv.version.as_u64());
-        } else {
-            self.read_set.insert(key.clone(), 0);
+        // Track in read_set for conflict detection (skip in read-only mode)
+        if !self.read_only {
+            if let Some(ref vv) = versioned {
+                self.read_set.insert(key.clone(), vv.version.as_u64());
+            } else {
+                self.read_set.insert(key.clone(), 0);
+            }
         }
 
         Ok(versioned)
@@ -714,7 +743,9 @@ impl TransactionContext {
             // This is important for conflict detection: if another transaction modifies
             // a key we observed during scan (even if we're deleting it), we should detect
             // the conflict. Otherwise, our delete could overwrite concurrent updates.
-            self.read_set.insert(key.clone(), vv.version.as_u64());
+            if !self.read_only {
+                self.read_set.insert(key.clone(), vv.version.as_u64());
+            }
 
             if !self.delete_set.contains(&key) {
                 // Only include non-deleted keys in the result set
@@ -747,6 +778,19 @@ impl TransactionContext {
     /// Set the maximum number of write buffer entries (0 = unlimited).
     pub fn set_max_write_entries(&mut self, max: usize) {
         self.max_write_entries = max;
+    }
+
+    /// Enable or disable per-transaction read-only mode.
+    ///
+    /// When enabled, write operations (`put`, `delete`, `cas`) are rejected
+    /// and read-set tracking is skipped, saving memory on large scans.
+    pub fn set_read_only(&mut self, read_only: bool) {
+        self.read_only = read_only;
+    }
+
+    /// Check if this transaction is in per-transaction read-only mode.
+    pub fn is_read_only_mode(&self) -> bool {
+        self.read_only
     }
 
     /// Check if the write buffer has exceeded the configured limit.
@@ -807,6 +851,11 @@ impl TransactionContext {
     /// ```
     pub fn put(&mut self, key: Key, value: Value) -> StrataResult<()> {
         self.ensure_active()?;
+        if self.read_only {
+            return Err(StrataError::invalid_input(
+                "Cannot write in a read-only transaction",
+            ));
+        }
         self.check_write_limit(Some(&key))?;
 
         // Remove from delete_set if previously deleted in this txn
@@ -847,6 +896,11 @@ impl TransactionContext {
     /// ```
     pub fn delete(&mut self, key: Key) -> StrataResult<()> {
         self.ensure_active()?;
+        if self.read_only {
+            return Err(StrataError::invalid_input(
+                "Cannot write in a read-only transaction",
+            ));
+        }
         self.check_write_limit(Some(&key))?;
 
         // Remove from write_set if previously written in this txn
@@ -893,8 +947,40 @@ impl TransactionContext {
     /// ```
     pub fn cas(&mut self, key: Key, expected_version: u64, new_value: Value) -> StrataResult<()> {
         self.ensure_active()?;
+        if self.read_only {
+            return Err(StrataError::invalid_input(
+                "Cannot write in a read-only transaction",
+            ));
+        }
         self.check_write_limit(None)?;
 
+        self.cas_set.push(CASOperation {
+            key,
+            expected_version,
+            new_value,
+        });
+        Ok(())
+    }
+
+    /// Compare-and-swap with automatic read-set tracking.
+    ///
+    /// Like `cas()`, but also reads the key from the snapshot to populate
+    /// the read-set. This gives BOTH CAS validation AND read-set protection.
+    /// Equivalent to `txn.get(&key)?; txn.cas(key, expected_version, value)?;`
+    pub fn cas_with_read(
+        &mut self,
+        key: Key,
+        expected_version: u64,
+        new_value: Value,
+    ) -> StrataResult<()> {
+        self.ensure_active()?;
+        if self.read_only {
+            return Err(StrataError::invalid_input(
+                "Cannot write in a read-only transaction",
+            ));
+        }
+        self.check_write_limit(None)?;
+        self.read_from_snapshot(&key)?;
         self.cas_set.push(CASOperation {
             key,
             expected_version,
@@ -1470,6 +1556,7 @@ impl TransactionContext {
         // Reset state
         self.status = TransactionStatus::Active;
         self.start_time = Instant::now();
+        self.read_only = false;
     }
 
     /// Get current capacity of internal collections (for debugging/testing)
@@ -1925,5 +2012,231 @@ mod tests {
 
         // Capacity should be preserved (not shrunk)
         assert_eq!(txn.write_set.capacity(), cap_before);
+    }
+
+    // ========================================================================
+    // Read-Only Mode Tests
+    // ========================================================================
+
+    #[test]
+    fn test_read_only_skips_read_set() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let mut data = BTreeMap::new();
+        let key = test_key(&ns, "k1");
+        data.insert(
+            key.clone(),
+            VersionedValue {
+                value: Value::Int(42),
+                version: Version::Txn(1),
+                timestamp: strata_core::Timestamp::from_micros(0),
+            },
+        );
+        let snapshot = Box::new(ClonedSnapshotView::new(1, data));
+        let mut txn = TransactionContext::with_snapshot(1, branch_id, snapshot);
+        txn.set_read_only(true);
+
+        // Read should succeed
+        let val = txn.get(&key).unwrap();
+        assert_eq!(val, Some(Value::Int(42)));
+
+        // But read_set should be empty
+        assert!(
+            txn.read_set.is_empty(),
+            "read_set should be empty in read-only mode"
+        );
+    }
+
+    #[test]
+    fn test_read_only_rejects_put() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let mut txn = TransactionContext::new(1, branch_id, 0);
+        txn.set_read_only(true);
+
+        let key = test_key(&ns, "k1");
+        let result = txn.put(key, Value::Int(1));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_only_rejects_delete() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let mut txn = TransactionContext::new(1, branch_id, 0);
+        txn.set_read_only(true);
+
+        let key = test_key(&ns, "k1");
+        let result = txn.delete(key);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_only_rejects_cas() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let mut txn = TransactionContext::new(1, branch_id, 0);
+        txn.set_read_only(true);
+
+        let key = test_key(&ns, "k1");
+        let result = txn.cas(key, 0, Value::Int(1));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_only_reset_clears_flag() {
+        let branch_id = BranchId::new();
+        let mut txn = TransactionContext::new(1, branch_id, 0);
+        txn.set_read_only(true);
+        assert!(txn.is_read_only_mode());
+
+        let snap = Box::new(ClonedSnapshotView::empty(100));
+        txn.reset(2, branch_id, Some(snap));
+        assert!(
+            !txn.is_read_only_mode(),
+            "read_only should be cleared after reset"
+        );
+    }
+
+    // ========================================================================
+    // CAS with Read Tests
+    // ========================================================================
+
+    #[test]
+    fn test_cas_with_read_populates_read_set() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let key = test_key(&ns, "k1");
+        let mut data = BTreeMap::new();
+        data.insert(
+            key.clone(),
+            VersionedValue {
+                value: Value::Int(10),
+                version: Version::Txn(5),
+                timestamp: strata_core::Timestamp::from_micros(0),
+            },
+        );
+        let snapshot = Box::new(ClonedSnapshotView::new(5, data));
+        let mut txn = TransactionContext::with_snapshot(1, branch_id, snapshot);
+
+        txn.cas_with_read(key.clone(), 5, Value::Int(20)).unwrap();
+
+        // read_set should contain the key (from the read)
+        assert_eq!(txn.read_set.get(&key), Some(&5));
+        // cas_set should have the CAS operation
+        assert_eq!(txn.cas_set.len(), 1);
+        assert_eq!(txn.cas_set[0].expected_version, 5);
+    }
+
+    #[test]
+    fn test_cas_with_read_nonexistent_key_tracks_version_zero() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let key = test_key(&ns, "missing");
+        // Empty snapshot — key doesn't exist
+        let snapshot = Box::new(ClonedSnapshotView::new(1, BTreeMap::new()));
+        let mut txn = TransactionContext::with_snapshot(1, branch_id, snapshot);
+
+        txn.cas_with_read(key.clone(), 0, Value::Int(1)).unwrap();
+
+        // Non-existent key should be tracked with version 0
+        assert_eq!(txn.read_set.get(&key), Some(&0));
+        assert_eq!(txn.cas_set.len(), 1);
+    }
+
+    #[test]
+    fn test_cas_with_read_rejects_read_only() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let snapshot = Box::new(ClonedSnapshotView::new(1, BTreeMap::new()));
+        let mut txn = TransactionContext::with_snapshot(1, branch_id, snapshot);
+        txn.set_read_only(true);
+
+        let key = test_key(&ns, "k1");
+        let result = txn.cas_with_read(key, 0, Value::Int(1));
+        assert!(result.is_err());
+        assert!(
+            format!("{}", result.unwrap_err()).contains("read-only"),
+            "Error should mention read-only"
+        );
+    }
+
+    #[test]
+    fn test_read_only_get_versioned_skips_read_set() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let key = test_key(&ns, "k1");
+        let mut data = BTreeMap::new();
+        data.insert(
+            key.clone(),
+            VersionedValue {
+                value: Value::Int(42),
+                version: Version::Txn(7),
+                timestamp: strata_core::Timestamp::from_micros(0),
+            },
+        );
+        let snapshot = Box::new(ClonedSnapshotView::new(7, data));
+        let mut txn = TransactionContext::with_snapshot(1, branch_id, snapshot);
+        txn.set_read_only(true);
+
+        // get_versioned should return the value
+        let result = txn.get_versioned(&key).unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().version.as_u64(), 7);
+
+        // But read_set should remain empty
+        assert!(
+            txn.read_set.is_empty(),
+            "read_set should be empty after get_versioned in read-only mode"
+        );
+    }
+
+    #[test]
+    fn test_read_only_get_versioned_nonexistent_skips_read_set() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let snapshot = Box::new(ClonedSnapshotView::new(1, BTreeMap::new()));
+        let mut txn = TransactionContext::with_snapshot(1, branch_id, snapshot);
+        txn.set_read_only(true);
+
+        let key = test_key(&ns, "missing");
+        let result = txn.get_versioned(&key).unwrap();
+        assert!(result.is_none());
+
+        // Non-existent key lookup should also skip read_set
+        assert!(
+            txn.read_set.is_empty(),
+            "read_set should be empty for non-existent key in read-only mode"
+        );
+    }
+
+    #[test]
+    fn test_read_only_scan_prefix_skips_read_set() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let mut data = BTreeMap::new();
+        for i in 0..3 {
+            data.insert(
+                test_key(&ns, &format!("pfx:{}", i)),
+                VersionedValue {
+                    value: Value::Int(i as i64),
+                    version: Version::Txn(1),
+                    timestamp: strata_core::Timestamp::from_micros(0),
+                },
+            );
+        }
+        let snapshot = Box::new(ClonedSnapshotView::new(1, data));
+        let mut txn = TransactionContext::with_snapshot(1, branch_id, snapshot);
+        txn.set_read_only(true);
+
+        let prefix = test_key(&ns, "pfx:");
+        let results = txn.scan_prefix(&prefix).unwrap();
+        assert_eq!(results.len(), 3);
+
+        // All 3 keys scanned, but read_set should be empty
+        assert!(
+            txn.read_set.is_empty(),
+            "read_set should be empty after scan_prefix in read-only mode"
+        );
     }
 }

--- a/crates/concurrency/src/validation.rs
+++ b/crates/concurrency/src/validation.rs
@@ -1,9 +1,37 @@
-//! Transaction validation for OCC
+//! Transaction validation for OCC (Optimistic Concurrency Control)
 //!
 //! This module implements conflict detection per Section 3 of
 //! `docs/architecture/M2_TRANSACTION_SEMANTICS.md`.
 //!
-//! Key rules from the spec:
+//! # Snapshot Isolation Semantics
+//!
+//! Strata uses **Snapshot Isolation (SI)** with first-committer-wins:
+//!
+//! - Each transaction reads from a consistent point-in-time snapshot.
+//! - At commit, only the **read-set** is validated: if any key read by
+//!   the transaction was modified (version changed) since the snapshot,
+//!   the transaction aborts.
+//! - **Blind writes** (writes without a preceding read) never conflict.
+//!
+//! # Write Skew
+//!
+//! SI intentionally **allows** write skew. Write skew occurs when two
+//! transactions each read disjoint keys but write to the other's read
+//! key, and both commit:
+//!
+//! ```text
+//! T1: read(A), write(B)
+//! T2: read(B), write(A)
+//! // Both pass validation → both commit → write skew
+//! ```
+//!
+//! Mitigation strategies:
+//! - Use `cas()` or `cas_with_read()` for atomic check-and-set
+//! - Combine reads and writes on the same key
+//! - Use application-level locking for invariants that span keys
+//!
+//! # Key rules from the spec
+//!
 //! - First-committer-wins based on READ-SET, not write-set
 //! - Blind writes (write without read) do NOT conflict
 //! - CAS is validated separately from read-set
@@ -231,6 +259,19 @@ pub fn validate_cas_set<S: Storage>(
 /// Per M5 spec: JSON conflict detection is document-level (conservative).
 /// If any JSON document read during the transaction has been modified,
 /// the transaction must abort.
+///
+/// # Document-Level vs Path-Level Detection
+///
+/// This uses **document-level** (conservative) detection: if a JSON
+/// document's version changed at all, the transaction aborts — even if
+/// the modified paths don't overlap with the paths read by the
+/// transaction. This is simpler and cheaper than path-level tracking,
+/// but may cause false positives when concurrent transactions modify
+/// disjoint paths within the same document.
+///
+/// Path-level detection would reduce false positives but requires
+/// tracking every path read and comparing against every path written,
+/// adding O(paths_read × paths_written) overhead per document.
 ///
 /// # Arguments
 /// * `json_snapshot_versions` - Document keys and their versions at read time

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -46,6 +46,8 @@ pub struct TransactionCoordinator {
     total_committed: AtomicU64,
     /// Total transactions aborted - uses Relaxed ordering
     total_aborted: AtomicU64,
+    /// Cumulative commit duration in microseconds (includes lock wait)
+    commit_time_us: AtomicU64,
     /// Active transaction tracking: (txn_id, start_version) pairs.
     ///
     /// Vec behind a Mutex is optimal here: concurrent txn count is small
@@ -79,6 +81,7 @@ impl TransactionCoordinator {
             total_started: AtomicU64::new(0),
             total_committed: AtomicU64::new(0),
             total_aborted: AtomicU64::new(0),
+            commit_time_us: AtomicU64::new(0),
             active_versions: Mutex::new(Vec::new()),
             max_write_buffer_entries: 0,
         }
@@ -105,6 +108,7 @@ impl TransactionCoordinator {
             total_started: AtomicU64::new(0),
             total_committed: AtomicU64::new(0),
             total_aborted: AtomicU64::new(0),
+            commit_time_us: AtomicU64::new(0),
             active_versions: Mutex::new(Vec::new()),
             max_write_buffer_entries: 0,
         }
@@ -124,6 +128,7 @@ impl TransactionCoordinator {
             total_started: AtomicU64::new(0),
             total_committed: AtomicU64::new(0),
             total_aborted: AtomicU64::new(0),
+            commit_time_us: AtomicU64::new(0),
             active_versions: Mutex::new(Vec::new()),
             max_write_buffer_entries,
         }
@@ -144,8 +149,8 @@ impl TransactionCoordinator {
         &self,
         branch_id: BranchId,
         storage: &Arc<ShardedStore>,
-    ) -> TransactionContext {
-        let txn_id = self.manager.next_txn_id();
+    ) -> StrataResult<TransactionContext> {
+        let txn_id = self.manager.next_txn_id().map_err(StrataError::from)?;
         let snapshot = storage.create_snapshot();
         let snapshot_version = snapshot.version();
 
@@ -157,15 +162,15 @@ impl TransactionCoordinator {
 
         let mut txn = TransactionContext::with_snapshot(txn_id, branch_id, Box::new(snapshot));
         txn.set_max_write_entries(self.max_write_buffer_entries);
-        txn
+        Ok(txn)
     }
 
     /// Allocate commit version
     ///
     /// Per spec Section 6.1: Version incremented ONCE for the whole transaction.
     /// All keys in a transaction get the same commit version.
-    pub fn allocate_commit_version(&self) -> u64 {
-        self.manager.allocate_version()
+    pub fn allocate_commit_version(&self) -> StrataResult<u64> {
+        self.manager.allocate_version().map_err(StrataError::from)
     }
 
     /// Commit a transaction through the concurrency layer
@@ -198,7 +203,12 @@ impl TransactionCoordinator {
     ) -> StrataResult<u64> {
         let txn_id = txn.txn_id;
 
-        match self.manager.commit(txn, store, wal) {
+        let start = std::time::Instant::now();
+        let result = self.manager.commit(txn, store, wal);
+        self.commit_time_us
+            .fetch_add(start.elapsed().as_micros() as u64, Ordering::Relaxed);
+
+        match result {
             Ok(version) => {
                 self.record_commit(txn_id);
                 info!(target: "strata::txn", "Transaction committed");
@@ -276,8 +286,8 @@ impl TransactionCoordinator {
     }
 
     /// Get next transaction ID (for internal use)
-    pub fn next_txn_id(&self) -> u64 {
-        self.manager.next_txn_id()
+    pub fn next_txn_id(&self) -> StrataResult<u64> {
+        self.manager.next_txn_id().map_err(StrataError::from)
     }
 
     /// Get the configured max write buffer entries limit.
@@ -351,6 +361,7 @@ impl TransactionCoordinator {
             total_started: started,
             total_committed: committed,
             total_aborted: self.total_aborted.load(Ordering::Relaxed),
+            commit_time_us: self.commit_time_us.load(Ordering::Relaxed),
             commit_rate: if started > 0 {
                 committed as f64 / started as f64
             } else {
@@ -413,6 +424,8 @@ pub struct TransactionMetrics {
     pub total_committed: u64,
     /// Total number of transactions aborted
     pub total_aborted: u64,
+    /// Cumulative commit duration in microseconds (includes lock wait)
+    pub commit_time_us: u64,
     /// Commit success rate (committed / started)
     pub commit_rate: f64,
 }
@@ -484,8 +497,8 @@ mod tests {
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
-        let _txn1 = coordinator.start_transaction(branch_id, &storage);
-        let _txn2 = coordinator.start_transaction(branch_id, &storage);
+        let _txn1 = coordinator.start_transaction(branch_id, &storage).unwrap();
+        let _txn2 = coordinator.start_transaction(branch_id, &storage).unwrap();
 
         let metrics = coordinator.metrics();
         assert_eq!(metrics.total_started, 2);
@@ -498,7 +511,7 @@ mod tests {
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
-        let txn = coordinator.start_transaction(branch_id, &storage);
+        let txn = coordinator.start_transaction(branch_id, &storage).unwrap();
         coordinator.record_commit(txn.txn_id);
 
         let metrics = coordinator.metrics();
@@ -514,7 +527,7 @@ mod tests {
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
-        let txn = coordinator.start_transaction(branch_id, &storage);
+        let txn = coordinator.start_transaction(branch_id, &storage).unwrap();
         coordinator.record_abort(txn.txn_id);
 
         let metrics = coordinator.metrics();
@@ -528,9 +541,9 @@ mod tests {
     fn test_version_monotonic() {
         let coordinator = TransactionCoordinator::new(100);
 
-        let v1 = coordinator.allocate_commit_version();
-        let v2 = coordinator.allocate_commit_version();
-        let v3 = coordinator.allocate_commit_version();
+        let v1 = coordinator.allocate_commit_version().unwrap();
+        let v2 = coordinator.allocate_commit_version().unwrap();
+        let v3 = coordinator.allocate_commit_version().unwrap();
 
         assert!(v1 < v2);
         assert!(v2 < v3);
@@ -548,7 +561,7 @@ mod tests {
         // Start 4 transactions, collect txn_ids
         let mut txn_ids = Vec::new();
         for _ in 0..4 {
-            let txn = coordinator.start_transaction(branch_id, &storage);
+            let txn = coordinator.start_transaction(branch_id, &storage).unwrap();
             txn_ids.push(txn.txn_id);
         }
 
@@ -571,8 +584,8 @@ mod tests {
         let branch_id = BranchId::new();
 
         // Simulate realistic usage
-        let txn1 = coordinator.start_transaction(branch_id, &storage);
-        let txn2 = coordinator.start_transaction(branch_id, &storage);
+        let txn1 = coordinator.start_transaction(branch_id, &storage).unwrap();
+        let txn2 = coordinator.start_transaction(branch_id, &storage).unwrap();
 
         assert_eq!(coordinator.metrics().active_count, 2);
 
@@ -581,7 +594,7 @@ mod tests {
         assert_eq!(coordinator.metrics().active_count, 1);
         assert_eq!(coordinator.metrics().total_committed, 1);
 
-        let txn3 = coordinator.start_transaction(branch_id, &storage);
+        let txn3 = coordinator.start_transaction(branch_id, &storage).unwrap();
 
         assert_eq!(coordinator.metrics().active_count, 2);
         assert_eq!(coordinator.metrics().total_started, 3);
@@ -617,7 +630,7 @@ mod tests {
         let branch_id = BranchId::new();
 
         // Start a transaction but don't complete it
-        let _txn = coordinator.start_transaction(branch_id, &storage);
+        let _txn = coordinator.start_transaction(branch_id, &storage).unwrap();
         assert_eq!(coordinator.active_count(), 1);
 
         // Wait with a short timeout - should return false
@@ -647,7 +660,7 @@ mod tests {
         let branch_id = BranchId::new();
 
         // Start a transaction
-        let txn = coordinator.start_transaction(branch_id, &storage);
+        let txn = coordinator.start_transaction(branch_id, &storage).unwrap();
         let txn_id = txn.txn_id;
 
         // Spawn a thread to complete the transaction after a short delay
@@ -687,7 +700,7 @@ mod tests {
         // Start 5 transactions, collect txn_ids
         let mut txn_ids = Vec::new();
         for _ in 0..5 {
-            let txn = coordinator.start_transaction(branch_id, &storage);
+            let txn = coordinator.start_transaction(branch_id, &storage).unwrap();
             txn_ids.push(txn.txn_id);
         }
         assert_eq!(coordinator.active_count(), 5);
@@ -731,7 +744,7 @@ mod tests {
         let branch_id = BranchId::new();
 
         // Start a transaction
-        let _txn = coordinator.start_transaction(branch_id, &storage);
+        let _txn = coordinator.start_transaction(branch_id, &storage).unwrap();
 
         // Zero timeout should return false immediately
         let start = std::time::Instant::now();
@@ -767,7 +780,9 @@ mod tests {
         let worker = thread::spawn(move || {
             let mut completed = 0;
             while !stop_clone.load(Ordering::SeqCst) {
-                let txn = coord_clone.start_transaction(branch_id, &storage_clone);
+                let txn = coord_clone
+                    .start_transaction(branch_id, &storage_clone)
+                    .unwrap();
                 thread::yield_now();
                 coord_clone.record_commit(txn.txn_id);
                 completed += 1;
@@ -817,7 +832,7 @@ mod tests {
             let ids = Arc::clone(&txn_ids);
             handles.push(thread::spawn(move || {
                 barr.wait();
-                let txn = coord.start_transaction(branch_id, &stor);
+                let txn = coord.start_transaction(branch_id, &stor).unwrap();
                 ids.lock().push(txn.txn_id);
                 // Don't record_commit - leave active
             }));
@@ -882,7 +897,7 @@ mod tests {
         assert_eq!(coordinator.current_version(), 500);
 
         // Next txn_id should be > max_txn_id from recovery
-        let next_id = coordinator.next_txn_id();
+        let next_id = coordinator.next_txn_id().unwrap();
         assert!(
             next_id > 15,
             "Next txn_id ({}) should be > max_txn_id from recovery (15)",
@@ -958,7 +973,7 @@ mod tests {
 
                 thread::spawn(move || {
                     for _ in 0..iterations {
-                        let txn = coord.start_transaction(branch_id, &stor);
+                        let txn = coord.start_transaction(branch_id, &stor).unwrap();
                         started.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
                         // Small delay to increase contention
@@ -1014,7 +1029,7 @@ mod tests {
                 thread::spawn(move || {
                     let mut local_versions = Vec::new();
                     for _ in 0..100 {
-                        let v = coord.allocate_commit_version();
+                        let v = coord.allocate_commit_version().unwrap();
                         local_versions.push(v);
                     }
                     vers.lock().extend(local_versions);
@@ -1063,7 +1078,7 @@ mod tests {
                 thread::spawn(move || {
                     let mut local_ids = Vec::new();
                     for _ in 0..100 {
-                        let id = coord.next_txn_id();
+                        let id = coord.next_txn_id().unwrap();
                         local_ids.push(id);
                     }
                     ids.lock().extend(local_ids);
@@ -1124,7 +1139,9 @@ mod tests {
         let worker = thread::spawn(move || {
             let mut count = 0;
             while !stop_clone.load(Ordering::SeqCst) && count < 50 {
-                let txn = coord_clone.start_transaction(branch_id, &stor_clone);
+                let txn = coord_clone
+                    .start_transaction(branch_id, &stor_clone)
+                    .unwrap();
                 // Very short delay
                 coord_clone.record_commit(txn.txn_id);
                 count += 1;
@@ -1174,7 +1191,7 @@ mod tests {
                 thread::spawn(move || {
                     let mut local = Vec::new();
                     for _ in 0..10 {
-                        let v = coord.allocate_commit_version();
+                        let v = coord.allocate_commit_version().unwrap();
                         local.push(v);
                     }
 
@@ -1270,10 +1287,38 @@ mod tests {
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
-        let txn = coordinator.start_transaction(branch_id, &storage);
+        let txn = coordinator.start_transaction(branch_id, &storage).unwrap();
         assert!(coordinator.min_active_version().is_some());
 
         coordinator.record_abort(txn.txn_id);
         assert_eq!(coordinator.min_active_version(), None);
+    }
+
+    #[test]
+    fn test_metrics_includes_commit_time() {
+        let coordinator = TransactionCoordinator::new(0);
+        let storage = create_test_storage();
+        let branch_id = BranchId::new();
+
+        // Commit a transaction through the coordinator
+        let snapshot = storage.snapshot();
+        let mut txn = TransactionContext::with_snapshot(1, branch_id, Box::new(snapshot));
+        txn.put(
+            strata_core::types::Key::new_kv(
+                std::sync::Arc::new(strata_core::types::Namespace::for_branch(branch_id)),
+                "key",
+            ),
+            strata_core::value::Value::Int(1),
+        )
+        .unwrap();
+        coordinator.record_start(1, 0);
+
+        let _ = coordinator.commit(&mut txn, storage.as_ref(), None);
+
+        let metrics = coordinator.metrics();
+        assert!(
+            metrics.commit_time_us > 0,
+            "commit_time_us should be > 0 after a commit"
+        );
     }
 }

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -713,11 +713,11 @@ impl Database {
             return Ok(version);
         }
 
-        let txn_id = self.coordinator.next_txn_id();
+        let txn_id = self.coordinator.next_txn_id()?;
         let start_version = self.coordinator.current_version();
         self.coordinator.record_start(txn_id, start_version);
 
-        let commit_version = self.coordinator.allocate_commit_version();
+        let commit_version = self.coordinator.allocate_commit_version()?;
 
         // WAL write (if needed for durability)
         if self.durability_mode.requires_wal() {
@@ -1719,7 +1719,7 @@ impl Database {
         F: FnOnce(&mut TransactionContext) -> StrataResult<T>,
     {
         self.check_accepting()?;
-        let mut txn = self.begin_transaction(branch_id);
+        let mut txn = self.begin_transaction(branch_id)?;
         let result = f(&mut txn);
         let outcome = self.run_single_attempt(&mut txn, result, self.durability_mode);
         self.end_transaction(txn);
@@ -1752,7 +1752,7 @@ impl Database {
         F: FnOnce(&mut TransactionContext) -> StrataResult<T>,
     {
         self.check_accepting()?;
-        let mut txn = self.begin_transaction(branch_id);
+        let mut txn = self.begin_transaction(branch_id)?;
         let result = f(&mut txn);
         let outcome = self.run_single_attempt(&mut txn, result, self.durability_mode);
         self.end_transaction(txn);
@@ -1801,7 +1801,7 @@ impl Database {
         let mut last_error = None;
 
         for attempt in 0..=config.max_retries {
-            let mut txn = self.begin_transaction(branch_id);
+            let mut txn = self.begin_transaction(branch_id)?;
             let result = f(&mut txn);
             let outcome = self.run_single_attempt(&mut txn, result, self.durability_mode);
             self.end_transaction(txn);
@@ -1840,20 +1840,33 @@ impl Database {
     ///
     /// # Example
     /// ```text
-    /// let mut txn = db.begin_transaction(branch_id);
+    /// let mut txn = db.begin_transaction(branch_id)?;
     /// txn.put(key, value)?;
     /// db.commit_transaction(&mut txn)?;
     /// db.end_transaction(txn); // Return to pool
     /// ```
-    pub fn begin_transaction(&self, branch_id: BranchId) -> TransactionContext {
-        let txn_id = self.coordinator.next_txn_id();
+    pub fn begin_transaction(&self, branch_id: BranchId) -> StrataResult<TransactionContext> {
+        let txn_id = self.coordinator.next_txn_id()?;
         let snapshot = self.storage.create_snapshot();
         let snapshot_version = snapshot.version();
         self.coordinator.record_start(txn_id, snapshot_version);
 
         let mut txn = TransactionPool::acquire(txn_id, branch_id, Some(Box::new(snapshot)));
         txn.set_max_write_entries(self.coordinator.max_write_buffer_entries());
-        txn
+        Ok(txn)
+    }
+
+    /// Begin a read-only transaction
+    ///
+    /// Returns a transaction that rejects writes and skips read-set tracking,
+    /// saving memory on large scan workloads.
+    pub fn begin_read_only_transaction(
+        &self,
+        branch_id: BranchId,
+    ) -> StrataResult<TransactionContext> {
+        let mut txn = self.begin_transaction(branch_id)?;
+        txn.set_read_only(true);
+        Ok(txn)
     }
 
     /// End a transaction (return to pool)
@@ -1869,7 +1882,7 @@ impl Database {
     ///
     /// # Example
     /// ```text
-    /// let mut txn = db.begin_transaction(branch_id);
+    /// let mut txn = db.begin_transaction(branch_id)?;
     /// txn.put(key, value)?;
     /// db.commit_transaction(&mut txn)?;
     /// db.end_transaction(txn); // Return to pool for reuse
@@ -2582,7 +2595,7 @@ mod tests {
         let key = Key::new_kv(ns, "manual_key");
 
         // Manual transaction control
-        let mut txn = db.begin_transaction(branch_id);
+        let mut txn = db.begin_transaction(branch_id).unwrap();
         txn.put(key.clone(), Value::Int(123)).unwrap();
 
         // Commit manually
@@ -2922,7 +2935,7 @@ mod tests {
         }
 
         // Start a transaction but don't commit it yet — pins version
-        let txn = db.begin_transaction(branch_id);
+        let txn = db.begin_transaction(branch_id).unwrap();
         let txn_start_version = txn.start_version;
 
         // Commit two more transactions to advance version further

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -784,7 +784,7 @@ mod tests {
 
         // Start a manual transaction, read, then check the versioned read
         // is consistent even if a concurrent write happens
-        let mut txn = db.begin_transaction(branch_id);
+        let mut txn = db.begin_transaction(branch_id).unwrap();
         let ns = Arc::new(Namespace::for_branch(branch_id));
         let storage_key = strata_core::types::Key::new_kv(ns.clone(), "iso_key");
         let vv = txn.get_versioned(&storage_key).unwrap().unwrap();

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -207,7 +207,7 @@ impl Session {
         };
 
         let core_branch_id = to_core_branch_id(&branch)?;
-        let ctx = self.db.begin_transaction(core_branch_id);
+        let ctx = self.db.begin_transaction(core_branch_id)?;
         self.txn_ctx = Some(ctx);
         self.txn_branch_id = Some(core_branch_id);
 

--- a/crates/storage/src/sharded.rs
+++ b/crates/storage/src/sharded.rs
@@ -425,9 +425,12 @@ impl ShardedStore {
         self.version.load(Ordering::Acquire)
     }
 
-    /// Increment version and return new value
+    /// Increment version and return new value.
     ///
-    /// Uses wrapping arithmetic to prevent panic at u64::MAX.
+    /// Uses wrapping arithmetic intentionally — this is a storage-local
+    /// counter (not the global MVCC version in `TransactionManager`).
+    /// Wrapping at u64::MAX is safe here because the counter is only
+    /// used for snapshot ordering within a single `ShardedStore` instance.
     /// In practice, overflow is extremely unlikely (~584 years at 1B versions/sec).
     #[inline]
     pub fn next_version(&self) -> u64 {

--- a/tests/concurrency/concurrent_transactions.rs
+++ b/tests/concurrency/concurrent_transactions.rs
@@ -51,9 +51,12 @@ fn parallel_commits_different_runs_no_contention() {
 
                 // Each thread commits 10 transactions
                 for i in 0..10 {
-                    let txn_id = manager.next_txn_id();
-                    let mut txn =
-                        TransactionContext::new(txn_id, branch_id, manager.allocate_version());
+                    let txn_id = manager.next_txn_id().unwrap();
+                    let mut txn = TransactionContext::new(
+                        txn_id,
+                        branch_id,
+                        manager.allocate_version().unwrap(),
+                    );
 
                     // Read and write
                     let v = Storage::get(&*store, &key)
@@ -141,7 +144,7 @@ fn high_contention_single_key() {
                         let read_version = current.version.as_u64();
 
                         // Create transaction
-                        let txn_id = manager.next_txn_id();
+                        let txn_id = manager.next_txn_id().unwrap();
                         let mut txn = TransactionContext::new(txn_id, branch_id, read_version);
                         txn.read_set.insert(key.clone(), read_version);
                         txn.write_set
@@ -250,7 +253,7 @@ fn version_allocation_is_unique() {
                 barrier.wait();
                 let mut versions = Vec::with_capacity(1000);
                 for _ in 0..1000 {
-                    versions.push(manager.allocate_version());
+                    versions.push(manager.allocate_version().unwrap());
                 }
                 versions
             })
@@ -289,7 +292,7 @@ fn txn_id_allocation_is_unique() {
                 barrier.wait();
                 let mut ids = Vec::with_capacity(100);
                 for _ in 0..100 {
-                    ids.push(manager.next_txn_id());
+                    ids.push(manager.next_txn_id().unwrap());
                 }
                 ids
             })
@@ -322,9 +325,9 @@ fn txn_id_allocation_is_unique() {
 fn manager_version_monotonically_increases() {
     let manager = TransactionManager::new(100);
 
-    let v1 = manager.allocate_version();
-    let v2 = manager.allocate_version();
-    let v3 = manager.allocate_version();
+    let v1 = manager.allocate_version().unwrap();
+    let v2 = manager.allocate_version().unwrap();
+    let v3 = manager.allocate_version().unwrap();
 
     assert!(v2 > v1);
     assert!(v3 > v2);
@@ -334,7 +337,7 @@ fn manager_version_monotonically_increases() {
 fn manager_with_initial_version() {
     let manager = TransactionManager::new(1000);
 
-    let v1 = manager.allocate_version();
+    let v1 = manager.allocate_version().unwrap();
     assert!(v1 >= 1000, "First version should be >= initial");
 }
 
@@ -343,7 +346,7 @@ fn manager_with_txn_id_recovery() {
     // Simulating recovery where we need to continue from a known max txn_id
     let manager = TransactionManager::with_txn_id(100, 500);
 
-    let txn_id = manager.next_txn_id();
+    let txn_id = manager.next_txn_id().unwrap();
     assert!(txn_id > 500, "Txn ID should continue from max");
 }
 
@@ -389,8 +392,8 @@ fn rapid_transaction_creation() {
     // Create many transactions rapidly
     let txns: Vec<_> = (0..1000)
         .map(|_| {
-            let txn_id = manager.next_txn_id();
-            let start_version = manager.allocate_version();
+            let txn_id = manager.next_txn_id().unwrap();
+            let start_version = manager.allocate_version().unwrap();
             TransactionContext::new(txn_id, branch_id, start_version)
         })
         .collect();

--- a/tests/concurrency/stress.rs
+++ b/tests/concurrency/stress.rs
@@ -59,7 +59,7 @@ fn stress_concurrent_read_write() {
                         let current = Storage::get(&*store, &key).unwrap().unwrap();
                         let version = current.version.as_u64();
 
-                        let txn_id = manager.next_txn_id();
+                        let txn_id = manager.next_txn_id().unwrap();
                         let mut txn = TransactionContext::new(txn_id, branch_id, version);
                         txn.read_set.insert(key.clone(), version);
                         txn.write_set
@@ -122,7 +122,7 @@ fn stress_transaction_throughput() {
         let current = Storage::get(&*store, &key).unwrap().unwrap();
         let version = current.version.as_u64();
 
-        let txn_id = manager.next_txn_id();
+        let txn_id = manager.next_txn_id().unwrap();
         let mut txn = TransactionContext::new(txn_id, branch_id, version);
         txn.read_set.insert(key.clone(), version);
 
@@ -215,7 +215,7 @@ fn stress_many_branches() {
                 barrier.wait();
 
                 for i in 0..100 {
-                    let txn_id = manager.next_txn_id();
+                    let txn_id = manager.next_txn_id().unwrap();
                     let mut txn = TransactionContext::new(txn_id, branch_id, 1);
                     txn.write_set.insert(key.clone(), Value::Int(i));
 
@@ -326,7 +326,7 @@ fn stress_sustained_workload() {
                         let current = Storage::get(&*store, &key).unwrap().unwrap();
                         let version = current.version.as_u64();
 
-                        let txn_id = manager.next_txn_id();
+                        let txn_id = manager.next_txn_id().unwrap();
                         let mut txn = TransactionContext::new(txn_id, branch_id, version);
                         txn.read_set.insert(key.clone(), version);
                         txn.write_set

--- a/tests/concurrency/version_counter.rs
+++ b/tests/concurrency/version_counter.rs
@@ -21,7 +21,7 @@ fn versions_monotonically_increase() {
 
     let mut prev = 0u64;
     for _ in 0..100 {
-        let v = manager.allocate_version();
+        let v = manager.allocate_version().unwrap();
         assert!(v > prev, "Version should increase: {} -> {}", prev, v);
         prev = v;
     }
@@ -33,7 +33,7 @@ fn txn_ids_monotonically_increase() {
 
     let mut prev = 0u64;
     for _ in 0..100 {
-        let id = manager.next_txn_id();
+        let id = manager.next_txn_id().unwrap();
         assert!(id > prev, "Txn ID should increase: {} -> {}", prev, id);
         prev = id;
     }
@@ -43,7 +43,7 @@ fn txn_ids_monotonically_increase() {
 fn version_starts_from_initial() {
     let manager = TransactionManager::new(1000);
 
-    let v = manager.allocate_version();
+    let v = manager.allocate_version().unwrap();
     assert!(
         v >= 1000,
         "First version should be >= initial (1000), got {}",
@@ -70,7 +70,7 @@ fn concurrent_version_allocation_unique() {
                 barrier.wait();
                 let mut versions = Vec::with_capacity(count_per_thread);
                 for _ in 0..count_per_thread {
-                    versions.push(manager.allocate_version());
+                    versions.push(manager.allocate_version().unwrap());
                 }
                 versions
             })
@@ -109,7 +109,7 @@ fn concurrent_txn_id_allocation_unique() {
                 barrier.wait();
                 let mut ids = Vec::with_capacity(500);
                 for _ in 0..500 {
-                    ids.push(manager.next_txn_id());
+                    ids.push(manager.next_txn_id().unwrap());
                 }
                 ids
             })
@@ -143,7 +143,7 @@ fn high_contention_version_allocation() {
             thread::spawn(move || {
                 barrier.wait();
                 for _ in 0..100 {
-                    let _ = manager.allocate_version();
+                    let _ = manager.allocate_version().unwrap();
                     total.fetch_add(1, Ordering::Relaxed);
                 }
             })
@@ -168,7 +168,7 @@ fn sequential_allocation_no_gaps() {
 
     let mut versions = Vec::new();
     for _ in 0..100 {
-        versions.push(manager.allocate_version());
+        versions.push(manager.allocate_version().unwrap());
     }
 
     // Should form a contiguous sequence
@@ -192,7 +192,7 @@ fn manager_with_txn_id_continues_from_max() {
     // Simulating recovery where max txn_id was 1000
     let manager = TransactionManager::with_txn_id(100, 1000);
 
-    let id = manager.next_txn_id();
+    let id = manager.next_txn_id().unwrap();
     assert!(
         id > 1000,
         "After recovery, txn_id should be > max (1000), got {}",
@@ -204,7 +204,7 @@ fn manager_with_txn_id_continues_from_max() {
 fn manager_initial_version_respected() {
     let manager = TransactionManager::new(5000);
 
-    let v = manager.allocate_version();
+    let v = manager.allocate_version().unwrap();
     assert!(v >= 5000, "Initial version should be respected");
 }
 
@@ -214,15 +214,15 @@ fn manager_recovery_scenario() {
     let manager = TransactionManager::with_txn_id(10000, 500);
 
     // New allocations should continue from those points
-    let v1 = manager.allocate_version();
-    let id1 = manager.next_txn_id();
+    let v1 = manager.allocate_version().unwrap();
+    let id1 = manager.next_txn_id().unwrap();
 
     assert!(v1 >= 10000, "Version should continue from 10000");
     assert!(id1 > 500, "Txn ID should continue from 500");
 
     // Subsequent allocations should still be monotonic
-    let v2 = manager.allocate_version();
-    let id2 = manager.next_txn_id();
+    let v2 = manager.allocate_version().unwrap();
+    let id2 = manager.next_txn_id().unwrap();
 
     assert!(v2 > v1);
     assert!(id2 > id1);
@@ -242,7 +242,7 @@ fn version_allocation_thread_safe() {
             let manager = Arc::clone(&manager);
             thread::spawn(move || {
                 for _ in 0..1000 {
-                    let v = manager.allocate_version();
+                    let v = manager.allocate_version().unwrap();
                     // Each version should be valid (non-zero after first allocation)
                     assert!(v > 0 || v == 1);
                 }
@@ -264,10 +264,10 @@ fn interleaved_version_and_txn_id_allocation() {
 
     // Interleave allocations
     for _ in 0..50 {
-        versions.push(manager.allocate_version());
-        txn_ids.push(manager.next_txn_id());
-        versions.push(manager.allocate_version());
-        txn_ids.push(manager.next_txn_id());
+        versions.push(manager.allocate_version().unwrap());
+        txn_ids.push(manager.next_txn_id().unwrap());
+        versions.push(manager.allocate_version().unwrap());
+        txn_ids.push(manager.next_txn_id().unwrap());
     }
 
     // Both should be monotonic independently
@@ -288,7 +288,7 @@ fn rapid_allocation_performance() {
 
     let start = std::time::Instant::now();
     for _ in 0..100_000 {
-        let _ = manager.allocate_version();
+        let _ = manager.allocate_version().unwrap();
     }
     let elapsed = start.elapsed();
 

--- a/tests/engine/acid_properties.rs
+++ b/tests/engine/acid_properties.rs
@@ -317,7 +317,7 @@ fn durability_uncommitted_lost() {
     let branch_id = test_db.branch_id;
 
     // Start transaction but don't commit
-    let _ctx = test_db.db.begin_transaction(branch_id);
+    let _ctx = test_db.db.begin_transaction(branch_id).unwrap();
 
     // End without commit (let it drop)
     test_db.db.end_transaction(_ctx);

--- a/tests/engine/database/transactions.rs
+++ b/tests/engine/database/transactions.rs
@@ -198,7 +198,7 @@ fn begin_transaction_returns_context() {
     let test_db = TestDb::new();
     let branch_id = test_db.branch_id;
 
-    let ctx = test_db.db.begin_transaction(branch_id);
+    let ctx = test_db.db.begin_transaction(branch_id).unwrap();
 
     // Context is active
     assert!(ctx.is_active());
@@ -213,7 +213,7 @@ fn commit_transaction_returns_version() {
     let test_db = TestDb::new();
     let branch_id = test_db.branch_id;
 
-    let mut ctx = test_db.db.begin_transaction(branch_id);
+    let mut ctx = test_db.db.begin_transaction(branch_id).unwrap();
 
     // Add a write to the transaction
     use std::sync::Arc;
@@ -233,7 +233,7 @@ fn end_transaction_cleans_up() {
     let test_db = TestDb::new();
     let branch_id = test_db.branch_id;
 
-    let ctx = test_db.db.begin_transaction(branch_id);
+    let ctx = test_db.db.begin_transaction(branch_id).unwrap();
 
     // End without commit
     test_db.db.end_transaction(ctx);


### PR DESCRIPTION
## Summary

- **Fallible counter allocation (#1307):** Replace `panic`-on-overflow in `next_txn_id()` and `allocate_version()` with `CommitError::CounterOverflow`, propagated through coordinator and database layers
- **Read-only transaction mode (#1308):** Per-transaction `set_read_only(true)` skips read_set tracking (saves memory on large scans) and rejects writes with clear errors. Guards on all write paths: `put()`, `delete()`, `cas()`, `cas_with_read()`, plus both snapshot read paths (`read_from_snapshot`, `get_versioned_from_snapshot`, `scan_prefix`)
- **Commit timing metric (#1308):** `commit_time_us` on `TransactionCoordinator` tracks cumulative commit duration including lock wait
- **`cas_with_read()` (#1309):** Combines CAS + read-set tracking in a single call — equivalent to `get(); cas()` but avoids the intermediate value construction
- **Documentation (#1309):** SI semantics and write-skew trade-offs on `validation.rs`, document-level vs path-level detection on `validate_json_set()`, `ClonedSnapshotView` usage guidance, `next_version()` wrapping arithmetic rationale, future savepoint design on `TransactionContext`

## Test plan

- [x] `cargo test -p strata-concurrency` — 84 passed
- [x] `cargo test -p strata-engine` — 55 passed
- [x] `cargo test --test concurrency` — 119 passed
- [x] `cargo clippy --workspace` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New tests: counter overflow (2), read-only mode (8), cas_with_read (3), commit metrics (1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)