### PR TITLE
Eliminate CAS-loop contention: fetch_add counters + pre-serialized WAL append (#1346)

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -116,11 +116,29 @@ impl TransactionManager {
 
     /// Allocate next transaction ID
     ///
-    /// Returns an error if the transaction ID counter reaches `u64::MAX` (overflow).
+    /// Uses a single `fetch_add` (LOCK XADD on x86) instead of a CAS loop.
+    /// Overflow at `u64::MAX` is detected and repaired — practically unreachable
+    /// (584 years at 1 billion txn/sec).
+    ///
+    /// # Overflow race tradeoff
+    ///
+    /// At `u64::MAX`, `fetch_add` wraps to 0 before the `store` repair runs.
+    /// A concurrent caller could observe the wrapped value and return a
+    /// duplicate ID. The old `fetch_update` (CAS loop) was atomic at this
+    /// boundary but suffered thundering-herd contention at 16+ threads.
+    /// Since reaching `u64::MAX` is physically impossible at any realistic
+    /// throughput, we accept this theoretical race in exchange for
+    /// contention-free allocation.
     pub fn next_txn_id(&self) -> std::result::Result<u64, CommitError> {
-        self.next_txn_id
-            .fetch_update(Ordering::AcqRel, Ordering::Relaxed, |v| v.checked_add(1))
-            .map_err(|_| CommitError::CounterOverflow("transaction ID counter at u64::MAX".into()))
+        let prev = self.next_txn_id.fetch_add(1, Ordering::AcqRel);
+        if prev == u64::MAX {
+            // Undo the wrapping increment: restore counter to u64::MAX
+            self.next_txn_id.store(u64::MAX, Ordering::Release);
+            return Err(CommitError::CounterOverflow(
+                "transaction ID counter at u64::MAX".into(),
+            ));
+        }
+        Ok(prev)
     }
 
     /// Allocate next commit version (increment global version)
@@ -138,12 +156,20 @@ impl TransactionManager {
     /// while failure handling during commit does not attempt to "return"
     /// the allocated version.
     ///
-    /// Returns an error if the version counter reaches `u64::MAX` (overflow).
+    /// Uses a single `fetch_add` (LOCK XADD on x86) instead of a CAS loop.
+    /// Overflow at `u64::MAX` is detected and repaired — practically unreachable
+    /// (584 years at 1 billion txn/sec). See `next_txn_id` for the overflow
+    /// race tradeoff rationale.
     pub fn allocate_version(&self) -> std::result::Result<u64, CommitError> {
-        self.version
-            .fetch_update(Ordering::AcqRel, Ordering::Relaxed, |v| v.checked_add(1))
-            .map(|v| v + 1)
-            .map_err(|_| CommitError::CounterOverflow("version counter at u64::MAX".into()))
+        let prev = self.version.fetch_add(1, Ordering::AcqRel);
+        if prev == u64::MAX {
+            // Undo the wrapping increment: restore counter to u64::MAX
+            self.version.store(u64::MAX, Ordering::Release);
+            return Err(CommitError::CounterOverflow(
+                "version counter at u64::MAX".into(),
+            ));
+        }
+        Ok(prev + 1)
     }
 
     /// Commit a transaction atomically

--- a/crates/durability/src/wal/writer.rs
+++ b/crates/durability/src/wal/writer.rs
@@ -235,6 +235,57 @@ impl WalWriter {
         Ok(())
     }
 
+    /// Append a pre-serialized WAL record.
+    ///
+    /// Like `append()`, but accepts already-serialized record bytes (from
+    /// `WalRecord::to_bytes()`). This avoids serialization + CRC under the
+    /// WAL lock, reducing lock hold time on the hot path.
+    pub fn append_pre_serialized(
+        &mut self,
+        record_bytes: &[u8],
+        txn_id: u64,
+        timestamp: u64,
+    ) -> std::io::Result<()> {
+        if !self.durability.requires_wal() {
+            return Ok(());
+        }
+
+        let segment = self
+            .segment
+            .as_mut()
+            .expect("Segment should exist for non-Cache mode");
+
+        // Encode through codec (identity codec: memcpy only)
+        let encoded = self.codec.encode(record_bytes);
+
+        // Check if we need to rotate before writing
+        if segment.size() + encoded.len() as u64 > self.config.segment_size {
+            self.rotate_segment()?;
+        }
+
+        // Write to segment
+        let segment = self.segment.as_mut().unwrap();
+        segment.write(&encoded)?;
+
+        // Track metadata for the current segment
+        if let Some(ref mut meta) = self.current_segment_meta {
+            meta.track_record(txn_id, timestamp);
+        }
+
+        self.total_wal_appends += 1;
+        self.total_bytes_written += encoded.len() as u64;
+
+        debug!(target: "strata::wal", txn_id, record_bytes = encoded.len(), segment = self.current_segment_number, "WAL record appended");
+
+        self.bytes_since_sync += encoded.len() as u64;
+        self.writes_since_sync += 1;
+        self.has_unsynced_data = true;
+
+        self.maybe_sync()?;
+
+        Ok(())
+    }
+
     /// Handle fsync based on durability mode.
     fn maybe_sync(&mut self) -> std::io::Result<()> {
         match self.durability {
@@ -878,5 +929,178 @@ mod tests {
 
         // Segment should have data
         assert!(writer.current_segment_size() > SEGMENT_HEADER_SIZE_V2 as u64);
+    }
+
+    // ========================================================================
+    // append_pre_serialized tests
+    // ========================================================================
+
+    #[test]
+    fn test_pre_serialized_roundtrip_readable() {
+        // Records written via append_pre_serialized must be readable by WalReader
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+
+        let mut writer = make_writer(&wal_dir, DurabilityMode::Always);
+
+        let record = make_record(42);
+        let record_bytes = record.to_bytes();
+        writer
+            .append_pre_serialized(&record_bytes, 42, 12345)
+            .unwrap();
+        writer.flush().unwrap();
+
+        // Read back via WalReader
+        let reader = crate::wal::WalReader::new(Box::new(IdentityCodec));
+        let result = reader.read_all(&wal_dir).unwrap();
+        assert_eq!(result.records.len(), 1);
+        assert_eq!(result.records[0].txn_id, 42);
+        assert_eq!(result.records[0].timestamp, 12345);
+        assert_eq!(result.records[0].writeset, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_pre_serialized_equivalent_to_append() {
+        // append_pre_serialized must produce byte-identical output to append
+        let dir1 = tempdir().unwrap();
+        let dir2 = tempdir().unwrap();
+        let wal_dir1 = dir1.path().join("wal");
+        let wal_dir2 = dir2.path().join("wal");
+
+        // Write via append()
+        let mut writer1 = make_writer(&wal_dir1, DurabilityMode::Always);
+        let record = make_record(7);
+        writer1.append(&record).unwrap();
+        writer1.flush().unwrap();
+
+        // Write via append_pre_serialized()
+        let mut writer2 = make_writer(&wal_dir2, DurabilityMode::Always);
+        let record_bytes = record.to_bytes();
+        writer2
+            .append_pre_serialized(&record_bytes, record.txn_id, record.timestamp)
+            .unwrap();
+        writer2.flush().unwrap();
+
+        // Read back both and compare
+        let reader = crate::wal::WalReader::new(Box::new(IdentityCodec));
+        let result1 = reader.read_all(&wal_dir1).unwrap();
+        let result2 = reader.read_all(&wal_dir2).unwrap();
+
+        assert_eq!(result1.records.len(), 1);
+        assert_eq!(result2.records.len(), 1);
+        assert_eq!(result1.records[0], result2.records[0]);
+    }
+
+    #[test]
+    fn test_pre_serialized_segment_rotation() {
+        // append_pre_serialized must handle segment rotation correctly
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+
+        let config = WalConfig::new()
+            .with_segment_size(100) // Very small to force rotation
+            .with_buffered_sync_bytes(50);
+
+        let mut writer = WalWriter::new(
+            wal_dir.clone(),
+            [1u8; 16],
+            DurabilityMode::Always,
+            config,
+            Box::new(IdentityCodec),
+        )
+        .unwrap();
+
+        // Write enough records via pre_serialized to trigger rotation
+        for i in 0..10u64 {
+            let record = WalRecord::new(i, [1u8; 16], i * 1000, vec![0; 50]);
+            let record_bytes = record.to_bytes();
+            writer
+                .append_pre_serialized(&record_bytes, i, i * 1000)
+                .unwrap();
+        }
+
+        // Should have rotated to multiple segments
+        let segments = writer.list_segments().unwrap();
+        assert!(
+            segments.len() > 1,
+            "Should have rotated, got {} segments",
+            segments.len()
+        );
+
+        // All records should be readable
+        writer.flush().unwrap();
+        let reader = crate::wal::WalReader::new(Box::new(IdentityCodec));
+        let result = reader.read_all(&wal_dir).unwrap();
+        assert_eq!(result.records.len(), 10);
+        for (i, rec) in result.records.iter().enumerate() {
+            assert_eq!(rec.txn_id, i as u64);
+        }
+    }
+
+    #[test]
+    fn test_pre_serialized_cache_mode_noop() {
+        let dir = tempdir().unwrap();
+
+        let mut writer = make_writer(dir.path(), DurabilityMode::Cache);
+        let record = make_record(1);
+        let record_bytes = record.to_bytes();
+        writer
+            .append_pre_serialized(&record_bytes, 1, 12345)
+            .unwrap();
+
+        // No files should be created
+        assert!(std::fs::read_dir(dir.path()).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn test_pre_serialized_counters_updated() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+
+        let mut writer = make_writer(&wal_dir, DurabilityMode::Always);
+
+        let counters_before = writer.counters();
+        assert_eq!(counters_before.wal_appends, 0);
+
+        let record = make_record(1);
+        let record_bytes = record.to_bytes();
+        writer
+            .append_pre_serialized(&record_bytes, 1, 12345)
+            .unwrap();
+
+        let counters_after = writer.counters();
+        assert_eq!(counters_after.wal_appends, 1);
+        assert!(counters_after.bytes_written > 0);
+        // Always mode fsyncs on every append
+        assert!(counters_after.sync_calls >= 1);
+    }
+
+    #[test]
+    fn test_pre_serialized_interleaved_with_append() {
+        // Mixing append() and append_pre_serialized() should produce
+        // all records in order
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+
+        let mut writer = make_writer(&wal_dir, DurabilityMode::Always);
+
+        // append()
+        writer.append(&make_record(1)).unwrap();
+
+        // append_pre_serialized()
+        let r2 = make_record(2);
+        writer
+            .append_pre_serialized(&r2.to_bytes(), 2, 12345)
+            .unwrap();
+
+        // append()
+        writer.append(&make_record(3)).unwrap();
+
+        writer.flush().unwrap();
+
+        let reader = crate::wal::WalReader::new(Box::new(IdentityCodec));
+        let result = reader.read_all(&wal_dir).unwrap();
+        let ids: Vec<u64> = result.records.iter().map(|r| r.txn_id).collect();
+        assert_eq!(ids, vec![1, 2, 3]);
     }
 }

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -732,6 +732,7 @@ impl Database {
                     use strata_durability::format::WalRecord;
                     use strata_durability::now_micros;
 
+                    let timestamp = now_micros();
                     let payload = TransactionPayload {
                         version: commit_version,
                         puts: vec![(key.clone(), value.clone())],
@@ -740,12 +741,16 @@ impl Database {
                     let record = WalRecord::new(
                         txn_id,
                         *key.namespace.branch_id.as_bytes(),
-                        now_micros(),
+                        timestamp,
                         payload.to_bytes(),
                     );
 
+                    // Pre-serialize outside the lock: moves CRC computation
+                    // and two Vec allocations out of the critical section.
+                    let record_bytes = record.to_bytes();
+
                     let mut wal = wal_arc.lock();
-                    if let Err(e) = wal.append(&record) {
+                    if let Err(e) = wal.append_pre_serialized(&record_bytes, txn_id, timestamp) {
                         self.coordinator.record_abort(txn_id);
                         return Err(StrataError::storage(format!(
                             "WAL write failed in put_direct: {}",


### PR DESCRIPTION
## Summary

- Replace `fetch_update` CAS loops with single-instruction `fetch_add` (LOCK XADD on x86) for both `allocate_version()` and `next_txn_id()`, eliminating thundering-herd contention at 16+ threads
- Add `append_pre_serialized()` to WalWriter that accepts already-serialized record bytes, moving CRC computation and Vec allocations outside the WAL mutex critical section in `put_direct`
- Add 6 dedicated tests for `append_pre_serialized` (roundtrip, equivalence, rotation, cache no-op, counters, interleaved)
- Document overflow race tradeoff at `u64::MAX` (theoretical only — 584 years at 1B txn/sec)

## Test plan

- [x] 89 concurrency tests pass
- [x] 435 durability tests pass (6 new)
- [x] 1173 engine tests pass
- [x] Clippy clean, fmt clean
- [ ] Benchmark `kv_put_independent/standard/16t` to confirm contention resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)