### PR TITLE
Engine: shutdown coordination (E-2, E-5, E-8) (#1314)

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -445,16 +445,41 @@ impl TransactionManager {
     /// Remove the per-branch commit lock for a deleted branch.
     ///
     /// Called during branch deletion to prevent unbounded growth of the
-    /// `commit_locks` map. Safe to call even if no lock exists for the branch.
+    /// `commit_locks` map. Returns `true` if the lock was removed (or didn't
+    /// exist), `false` if a concurrent commit is in-flight and removal was
+    /// skipped.
     ///
-    /// # Safety
-    ///
-    /// This should only be called after the branch has been fully deleted
-    /// and no further transactions will target it. If a concurrent transaction
-    /// is in-flight for this branch, the lock will be lazily re-created on
-    /// next commit (via `or_insert_with` in `commit()`).
-    pub fn remove_branch_lock(&self, branch_id: &BranchId) {
-        self.commit_locks.remove(branch_id);
+    /// If a concurrent commit holds the lock, removal is skipped to avoid
+    /// defeating the TOCTOU protection the lock provides. The stale entry
+    /// will be cleaned up on the next branch delete attempt or lazily collected.
+    pub fn remove_branch_lock(&self, branch_id: &BranchId) -> bool {
+        let can_remove = match self.commit_locks.get(branch_id) {
+            Some(entry) => {
+                // Try to acquire the lock to verify no commit is in-flight
+                let held = entry.value().try_lock().is_some();
+                // Drop entry ref (and any guard) before we attempt removal
+                drop(entry);
+                held
+            }
+            None => {
+                // No lock entry exists — nothing to remove
+                return true;
+            }
+        };
+
+        if can_remove {
+            // Lock was not held — safe to remove
+            self.commit_locks.remove(branch_id);
+            true
+        } else {
+            // Lock is held — concurrent commit in-flight, skip removal
+            tracing::warn!(
+                target: "strata::txn",
+                branch = %branch_id,
+                "Skipping branch lock removal: concurrent commit in-flight"
+            );
+            false
+        }
     }
 
     /// Advance the version counter to at least `v`.
@@ -1513,5 +1538,123 @@ mod tests {
         let v2 = store.get(&key2).unwrap().unwrap();
         assert_eq!(v2.value, Value::Int(200));
         assert_eq!(v2.version.as_u64(), 2);
+    }
+
+    // ========================================================================
+    // E-8: remove_branch_lock coordination tests
+    // ========================================================================
+
+    #[test]
+    fn test_remove_branch_lock_succeeds_when_not_held() {
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+
+        // Insert a lock entry by accessing it (simulates a prior commit)
+        manager
+            .commit_locks
+            .entry(branch_id)
+            .or_insert_with(|| Mutex::new(()));
+        assert!(manager.commit_locks.contains_key(&branch_id));
+
+        // Removal should succeed since no one holds the lock
+        assert!(manager.remove_branch_lock(&branch_id));
+        assert!(!manager.commit_locks.contains_key(&branch_id));
+    }
+
+    #[test]
+    fn test_remove_branch_lock_skips_when_held() {
+        let manager = Arc::new(TransactionManager::new(0));
+        let branch_id = BranchId::new();
+
+        // Insert a lock entry
+        manager
+            .commit_locks
+            .entry(branch_id)
+            .or_insert_with(|| Mutex::new(()));
+
+        // Hold the lock on a background thread
+        let manager2 = Arc::clone(&manager);
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+
+        let handle = std::thread::spawn(move || {
+            let entry = manager2.commit_locks.get(&branch_id).unwrap();
+            let _guard = entry.value().lock();
+            // Signal that lock is held
+            tx.send(()).unwrap();
+            // Wait for main thread to finish its check
+            done_rx.recv().unwrap();
+        });
+
+        // Wait for background thread to hold the lock
+        rx.recv().unwrap();
+
+        // Removal should fail since the lock is held
+        assert!(!manager.remove_branch_lock(&branch_id));
+        assert!(manager.commit_locks.contains_key(&branch_id));
+
+        // Release the background thread
+        done_tx.send(()).unwrap();
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn test_remove_branch_lock_nonexistent_succeeds() {
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+
+        // No lock entry exists — removal should return true
+        assert!(manager.remove_branch_lock(&branch_id));
+    }
+
+    #[test]
+    fn test_remove_branch_lock_still_functional_after_failed_removal() {
+        // After remove_branch_lock returns false (skipped because lock was
+        // held), verify the lock is still present and functional — a
+        // subsequent commit can still acquire and use it.
+        let manager = Arc::new(TransactionManager::new(0));
+        let branch_id = BranchId::new();
+
+        // Insert a lock entry
+        manager
+            .commit_locks
+            .entry(branch_id)
+            .or_insert_with(|| Mutex::new(()));
+
+        // Hold the lock on a background thread
+        let manager2 = Arc::clone(&manager);
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+
+        let handle = std::thread::spawn(move || {
+            let entry = manager2.commit_locks.get(&branch_id).unwrap();
+            let _guard = entry.value().lock();
+            tx.send(()).unwrap();
+            done_rx.recv().unwrap();
+        });
+
+        rx.recv().unwrap();
+
+        // Removal should fail
+        assert!(!manager.remove_branch_lock(&branch_id));
+
+        // Release background thread's lock
+        done_tx.send(()).unwrap();
+        handle.join().unwrap();
+
+        // Lock should still exist and be acquirable
+        assert!(manager.commit_locks.contains_key(&branch_id));
+        let entry = manager.commit_locks.get(&branch_id).unwrap();
+        let guard = entry.value().try_lock();
+        assert!(
+            guard.is_some(),
+            "Lock should be acquirable after failed removal and holder release"
+        );
+        drop(guard);
+        drop(entry);
+
+        // Now removal should succeed since no one holds it
+        assert!(manager.remove_branch_lock(&branch_id));
+        assert!(!manager.commit_locks.contains_key(&branch_id));
     }
 }

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -332,8 +332,10 @@ impl TransactionCoordinator {
     ///
     /// Delegates to `TransactionManager::remove_branch_lock` to prevent
     /// unbounded growth of the commit_locks map when branches are deleted.
-    pub fn remove_branch_lock(&self, branch_id: &BranchId) {
-        self.manager.remove_branch_lock(branch_id);
+    /// Returns `true` if removed (or didn't exist), `false` if skipped
+    /// because a concurrent commit is in-flight.
+    pub fn remove_branch_lock(&self, branch_id: &BranchId) -> bool {
+        self.manager.remove_branch_lock(branch_id)
     }
 
     /// Advance the version counter to at least `v`.

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -585,6 +585,11 @@ impl Database {
                         }
                         wal.flush_active_meta();
                     }
+                    // Final sync: flush any data written since the last periodic sync
+                    let mut wal = wal.lock();
+                    if let Err(e) = wal.flush() {
+                        tracing::error!(target: "strata::wal", error = %e, "Final WAL flush failed during shutdown");
+                    }
                 })
                 .map_err(|e| {
                     StrataError::internal(format!("failed to spawn WAL flush thread: {}", e))
@@ -1135,10 +1140,12 @@ impl Database {
     ///
     /// This prevents unbounded growth of the commit_locks map in the
     /// TransactionManager when branches are repeatedly created and deleted.
+    /// Returns `true` if removed (or didn't exist), `false` if skipped
+    /// because a concurrent commit is in-flight.
     ///
     /// Should be called after `BranchIndex::delete_branch()` succeeds.
-    pub fn remove_branch_lock(&self, branch_id: &BranchId) {
-        self.coordinator.remove_branch_lock(branch_id);
+    pub fn remove_branch_lock(&self, branch_id: &BranchId) -> bool {
+        self.coordinator.remove_branch_lock(branch_id)
     }
 
     // ========================================================================
@@ -2201,23 +2208,15 @@ impl Database {
     /// assert!(!db.is_open());
     /// ```
     pub fn shutdown(&self) -> StrataResult<()> {
-        // Stop accepting new transactions
+        // 1. Stop accepting new transactions
         self.accepting_transactions.store(false, Ordering::SeqCst);
 
-        // Drain background tasks (embeddings etc.) before final WAL flush
+        // 2. Drain background tasks (embeddings etc.) before final WAL flush
         self.scheduler.drain();
 
-        // Signal the background flush thread to stop
-        self.flush_shutdown.store(true, Ordering::SeqCst);
-
-        // Join the flush thread so it releases the WAL lock
-        if let Some(handle) = self.flush_handle.lock().take() {
-            let _ = handle.join();
-        }
-
-        // Wait for in-flight transactions to complete
-        // This ensures all transactions that started before shutdown
-        // have a chance to commit before we flush the WAL.
+        // 3. Wait for in-flight transactions to complete FIRST.
+        //    The flush thread keeps running during this window, providing
+        //    periodic syncs for any transactions that commit during drain.
         let timeout = std::time::Duration::from_secs(30);
         let start = std::time::Instant::now();
 
@@ -2225,10 +2224,30 @@ impl Database {
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
 
-        // Final flush to ensure all data is persisted
+        let remaining = self.coordinator.active_count();
+        if remaining > 0 {
+            warn!(
+                target: "strata::db",
+                remaining,
+                "Shutdown timed out waiting for {} active transaction(s) after {:?}",
+                remaining,
+                timeout,
+            );
+        }
+
+        // 4. Signal the background flush thread to stop (after transactions are drained)
+        self.flush_shutdown.store(true, Ordering::SeqCst);
+
+        // Join the flush thread so it releases the WAL lock
+        // (E-5: the thread performs a final sync before exiting)
+        if let Some(handle) = self.flush_handle.lock().take() {
+            let _ = handle.join();
+        }
+
+        // 5. Final flush to ensure all data is persisted
         self.flush()?;
 
-        // Freeze both vector heaps and search index. Attempt both even if
+        // 6. Freeze both vector heaps and search index. Attempt both even if
         // the first fails, so a vector freeze error doesn't also lose search data.
         let vec_result = self.freeze_vector_heaps();
         let search_result = self.freeze_search_index();
@@ -3263,5 +3282,246 @@ mod tests {
             "Expected at least 2 recovery participants (vector + search), got {}",
             count
         );
+    }
+
+    // ========================================================================
+    // E-5 + E-2: Shutdown coordination tests
+    // ========================================================================
+
+    #[test]
+    fn test_flush_thread_performs_final_sync() {
+        // Use a 2-second flush interval so the periodic sync will NOT have
+        // run by the time we call shutdown() (the write + shutdown completes
+        // well within the first sleep cycle). In Standard mode, commit only
+        // writes to BufWriter without fsync. The data can only reach disk via:
+        //   (a) the flush thread's final sync (E-5), or
+        //   (b) shutdown's explicit self.flush()
+        //
+        // This test verifies the full shutdown path (a + b) persists data.
+        // The E-5 final sync provides defense-in-depth for crash scenarios
+        // where the process dies between thread join and the explicit flush.
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("final_sync_db");
+
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key = Key::new_kv(ns.clone(), "final_sync_key");
+
+        {
+            // 2s interval: long enough that no periodic sync runs before we
+            // call shutdown, short enough that the test doesn't take forever
+            // (the flush thread sleeps for one interval before checking the flag).
+            let mode = DurabilityMode::Standard {
+                interval_ms: 2_000,
+                batch_size: 1_000_000,
+            };
+            let db = Database::open_with_mode(&db_path, mode).unwrap();
+
+            db.transaction(branch_id, |txn| {
+                txn.put(key.clone(), Value::Bytes(b"final_sync_value".to_vec()))?;
+                Ok(())
+            })
+            .unwrap();
+
+            // At this point data is in the WAL BufWriter but NOT fsynced.
+            // Neither the periodic sync (2s away) nor the inline safety-net
+            // (3×2s = 6s away) could have run.
+            db.shutdown().unwrap();
+        }
+
+        // Re-open and verify data was persisted
+        let db = Database::open(&db_path).unwrap();
+        let val = db.storage().get(&key).unwrap();
+        assert!(
+            val.is_some(),
+            "Data should be recoverable after shutdown (flush thread final sync + explicit flush)"
+        );
+        assert_eq!(
+            val.unwrap().value,
+            Value::Bytes(b"final_sync_value".to_vec())
+        );
+    }
+
+    #[test]
+    fn test_shutdown_blocks_until_in_flight_transactions_drain() {
+        // Verify that shutdown() actually BLOCKS while a transaction is
+        // in-flight, rather than returning immediately.
+        //
+        // Sequence:
+        //   1. Background thread: begin_transaction (active_count=1)
+        //   2. Background thread: signal "txn started"
+        //   3. Main thread: call shutdown() → enters drain loop (blocked)
+        //   4. Background thread: sleep 200ms → commit → active_count=0
+        //   5. Main thread: drain loop exits → shutdown continues
+        //
+        // We verify shutdown took at least 150ms (i.e., it actually waited
+        // for the transaction, not just returned immediately).
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("drain_db");
+        let db = Database::open(&db_path).unwrap();
+
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key = Key::new_kv(ns.clone(), "drain_key");
+
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+
+        let db2 = Arc::clone(&db);
+        let key2 = key.clone();
+        let handle = std::thread::spawn(move || {
+            let mut txn = db2.begin_transaction(branch_id).unwrap();
+            // Signal that the transaction is in-flight
+            started_tx.send(()).unwrap();
+            // Hold the transaction open for 200ms before committing
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            txn.put(key2, Value::Bytes(b"drain_value".to_vec()))
+                .unwrap();
+            db2.commit_transaction(&mut txn).unwrap();
+            db2.end_transaction(txn);
+        });
+
+        // Wait until the background thread has started the transaction
+        started_rx.recv().unwrap();
+        assert_eq!(
+            db.coordinator.active_count(),
+            1,
+            "Should have 1 active transaction before shutdown"
+        );
+
+        // shutdown() should block until the transaction commits (~200ms)
+        let start = std::time::Instant::now();
+        db.shutdown().unwrap();
+        let elapsed = start.elapsed();
+
+        handle.join().unwrap();
+
+        // Verify shutdown actually waited for the transaction
+        assert!(
+            elapsed >= std::time::Duration::from_millis(150),
+            "Shutdown returned in {:?}, should have blocked waiting for in-flight transaction",
+            elapsed
+        );
+
+        // Re-open and verify committed data was persisted
+        drop(db);
+        let db = Database::open(&db_path).unwrap();
+        let val = db.storage().get(&key).unwrap();
+        assert!(
+            val.is_some(),
+            "Transaction committed during shutdown drain should be persisted"
+        );
+        assert_eq!(val.unwrap().value, Value::Bytes(b"drain_value".to_vec()));
+    }
+
+    #[test]
+    fn test_shutdown_proceeds_after_draining_with_no_transactions() {
+        // Verify that shutdown completes quickly when no transactions are
+        // active, and that data committed before shutdown is persisted.
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("fast_shutdown_db");
+        let db = Database::open(&db_path).unwrap();
+
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key = Key::new_kv(ns.clone(), "pre_shutdown_key");
+
+        // Commit data, then verify shutdown is fast and data persists
+        db.transaction(branch_id, |txn| {
+            txn.put(key.clone(), Value::Bytes(b"pre_shutdown".to_vec()))?;
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(
+            db.coordinator.active_count(),
+            0,
+            "No active transactions after commit"
+        );
+
+        let start = std::time::Instant::now();
+        db.shutdown().unwrap();
+        let elapsed = start.elapsed();
+
+        // Drain loop should skip immediately when active_count == 0
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "Shutdown took {:?}, expected fast completion with no active transactions",
+            elapsed
+        );
+        assert!(!db.is_open());
+
+        // Re-open and verify persistence
+        drop(db);
+        let db = Database::open(&db_path).unwrap();
+        let val = db.storage().get(&key).unwrap();
+        assert!(val.is_some(), "Data committed before shutdown must persist");
+    }
+
+    #[test]
+    fn test_shutdown_multiple_in_flight_transactions() {
+        // Verify shutdown waits for ALL in-flight transactions, not just one.
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("multi_txn_db");
+        let db = Database::open(&db_path).unwrap();
+
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key1 = Key::new_kv(ns.clone(), "txn1_key");
+        let key2 = Key::new_kv(ns.clone(), "txn2_key");
+
+        let (started_tx, started_rx) = std::sync::mpsc::channel::<()>();
+
+        // Spawn two transactions that hold open for different durations
+        let db2 = Arc::clone(&db);
+        let k1 = key1.clone();
+        let started_tx1 = started_tx.clone();
+        let h1 = std::thread::spawn(move || {
+            let mut txn = db2.begin_transaction(branch_id).unwrap();
+            started_tx1.send(()).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            txn.put(k1, Value::Bytes(b"value1".to_vec())).unwrap();
+            db2.commit_transaction(&mut txn).unwrap();
+            db2.end_transaction(txn);
+        });
+
+        let db3 = Arc::clone(&db);
+        let k2 = key2.clone();
+        let h2 = std::thread::spawn(move || {
+            let mut txn = db3.begin_transaction(branch_id).unwrap();
+            started_tx.send(()).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(250));
+            txn.put(k2, Value::Bytes(b"value2".to_vec())).unwrap();
+            db3.commit_transaction(&mut txn).unwrap();
+            db3.end_transaction(txn);
+        });
+
+        // Wait for both transactions to start
+        started_rx.recv().unwrap();
+        started_rx.recv().unwrap();
+        assert!(
+            db.coordinator.active_count() >= 2,
+            "Should have 2 active transactions"
+        );
+
+        // Shutdown must wait for BOTH transactions
+        let start = std::time::Instant::now();
+        db.shutdown().unwrap();
+        let elapsed = start.elapsed();
+
+        h1.join().unwrap();
+        h2.join().unwrap();
+
+        // Should have waited for the slower transaction (~250ms)
+        assert!(
+            elapsed >= std::time::Duration::from_millis(200),
+            "Shutdown returned in {:?}, should have waited for both transactions",
+            elapsed
+        );
+
+        // Both transactions' data should be persisted
+        drop(db);
+        let db = Database::open(&db_path).unwrap();
+        assert!(db.storage().get(&key1).unwrap().is_some(), "txn1 data lost");
+        assert!(db.storage().get(&key2).unwrap().is_some(), "txn2 data lost");
     }
 }

--- a/crates/executor/src/handlers/branch.rs
+++ b/crates/executor/src/handlers/branch.rs
@@ -162,7 +162,9 @@ pub fn branch_delete(p: &Arc<Primitives>, branch: BranchId) -> Result<Output> {
     // Cleanup: remove per-branch commit lock (#944)
     // Convert the executor BranchId to core BranchId for the lock cleanup
     if let Ok(core_branch_id) = crate::bridge::to_core_branch_id(&branch) {
-        p.db.remove_branch_lock(&core_branch_id);
+        // Best-effort: if a concurrent commit holds the lock, skip removal.
+        // The stale entry is harmless and will be cleaned up on next attempt.
+        let _ = p.db.remove_branch_lock(&core_branch_id);
 
         // Cleanup: delete all vector collections for this branch (#946)
         // Best-effort: silently continue if vector cleanup fails, since the


### PR DESCRIPTION
## Summary
- **E-5**: Final WAL flush in background flush thread before exit — closes the window where up to `interval_ms` of commits sit unsynced
- **E-2**: Reorder `shutdown()` to drain in-flight transactions *before* stopping the flush thread, so periodic syncs continue during drain. Adds timeout warning for stuck transactions
- **E-8**: Guard `remove_branch_lock()` with `try_lock` check — skip removal when a concurrent commit holds the lock to preserve TOCTOU protection. Return type changes from `()` to `bool`

## Test plan
- [x] 4 new E-8 tests: succeeds when not held, skips when held, nonexistent succeeds, lock still functional after failed removal
- [x] 4 new shutdown tests: flush thread final sync, shutdown blocks until drain, fast path with no transactions, multiple in-flight transactions
- [x] Full engine lib suite (1184 tests), concurrency suite, executor suite — all pass
- [x] Clippy clean (`-D warnings`), `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)