### PR TITLE
Packed adjacency lists: 27x graph KV entry reduction (#1356)

### DIFF
--- a/crates/engine/src/graph/keys.rs
+++ b/crates/engine/src/graph/keys.rs
@@ -26,6 +26,9 @@ static NAMESPACE_ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
 /// Separator used between path segments in graph keys.
 const SEP: char = '/';
 
+/// Maximum length (in bytes) for graph names, node IDs, and edge types.
+const MAX_IDENTIFIER_BYTES: usize = 255;
+
 // =============================================================================
 // Validation
 // =============================================================================
@@ -45,6 +48,12 @@ pub fn validate_graph_name(name: &str) -> StrataResult<()> {
             "Graph name must not start with '__' (reserved)",
         ));
     }
+    if name.len() > MAX_IDENTIFIER_BYTES {
+        return Err(StrataError::invalid_input(format!(
+            "Graph name exceeds maximum length of {} bytes",
+            MAX_IDENTIFIER_BYTES
+        )));
+    }
     Ok(())
 }
 
@@ -56,6 +65,12 @@ pub fn validate_node_id(id: &str) -> StrataResult<()> {
     if id.contains(SEP) {
         return Err(StrataError::invalid_input("Node ID must not contain '/'"));
     }
+    if id.len() > MAX_IDENTIFIER_BYTES {
+        return Err(StrataError::invalid_input(format!(
+            "Node ID exceeds maximum length of {} bytes",
+            MAX_IDENTIFIER_BYTES
+        )));
+    }
     Ok(())
 }
 
@@ -66,6 +81,12 @@ pub fn validate_edge_type(t: &str) -> StrataResult<()> {
     }
     if t.contains(SEP) {
         return Err(StrataError::invalid_input("Edge type must not contain '/'"));
+    }
+    if t.len() > MAX_IDENTIFIER_BYTES {
+        return Err(StrataError::invalid_input(format!(
+            "Edge type exceeds maximum length of {} bytes",
+            MAX_IDENTIFIER_BYTES
+        )));
     }
     Ok(())
 }
@@ -109,65 +130,32 @@ pub fn graph_key(branch_id: BranchId, user_key: &str) -> Key {
     Key::new_kv(graph_namespace(branch_id), user_key)
 }
 
-// --- Forward edge keys ---
+// --- Packed adjacency list keys ---
 
-/// Key for a forward edge: `{graph}/e/{src}/{edge_type}/{dst}`
-pub fn forward_edge_key(graph: &str, src: &str, edge_type: &str, dst: &str) -> String {
-    format!("{}{SEP}e{SEP}{}{SEP}{}{SEP}{}", graph, src, edge_type, dst)
+/// Key for a forward (outgoing) adjacency list: `{graph}/fwd/{node_id}`
+pub fn forward_adj_key(graph: &str, node_id: &str) -> String {
+    format!("{}{SEP}fwd{SEP}{}", graph, node_id)
 }
 
-/// Prefix for all forward edges from a given source: `{graph}/e/{src}/`
-pub fn forward_edges_prefix(graph: &str, src: &str) -> String {
-    format!("{}{SEP}e{SEP}{}{SEP}", graph, src)
+/// Key for a reverse (incoming) adjacency list: `{graph}/rev/{node_id}`
+pub fn reverse_adj_key(graph: &str, node_id: &str) -> String {
+    format!("{}{SEP}rev{SEP}{}", graph, node_id)
 }
 
-/// Prefix for forward edges of a specific type: `{graph}/e/{src}/{edge_type}/`
-pub fn forward_edges_typed_prefix(graph: &str, src: &str, edge_type: &str) -> String {
-    format!("{}{SEP}e{SEP}{}{SEP}{}{SEP}", graph, src, edge_type)
+/// Prefix for all forward adjacency lists in a graph: `{graph}/fwd/`
+pub fn all_forward_adj_prefix(graph: &str) -> String {
+    format!("{}{SEP}fwd{SEP}", graph)
 }
 
-/// Parse a forward edge key back into (src, edge_type, dst).
-pub fn parse_forward_edge_key(graph: &str, user_key: &str) -> Option<(String, String, String)> {
-    let prefix = format!("{}{SEP}e{SEP}", graph);
-    let rest = user_key.strip_prefix(&prefix)?;
-    let parts: Vec<&str> = rest.splitn(3, SEP).collect();
-    if parts.len() == 3 {
-        Some((
-            parts[0].to_string(),
-            parts[1].to_string(),
-            parts[2].to_string(),
-        ))
-    } else {
-        None
-    }
+/// Prefix for all reverse adjacency lists in a graph: `{graph}/rev/`
+pub fn all_reverse_adj_prefix(graph: &str) -> String {
+    format!("{}{SEP}rev{SEP}", graph)
 }
 
-// --- Reverse edge keys ---
-
-/// Key for a reverse edge: `{graph}/r/{dst}/{edge_type}/{src}`
-pub fn reverse_edge_key(graph: &str, dst: &str, edge_type: &str, src: &str) -> String {
-    format!("{}{SEP}r{SEP}{}{SEP}{}{SEP}{}", graph, dst, edge_type, src)
-}
-
-/// Prefix for all reverse edges to a given destination: `{graph}/r/{dst}/`
-pub fn reverse_edges_prefix(graph: &str, dst: &str) -> String {
-    format!("{}{SEP}r{SEP}{}{SEP}", graph, dst)
-}
-
-/// Parse a reverse edge key back into (dst, edge_type, src).
-pub fn parse_reverse_edge_key(graph: &str, user_key: &str) -> Option<(String, String, String)> {
-    let prefix = format!("{}{SEP}r{SEP}", graph);
-    let rest = user_key.strip_prefix(&prefix)?;
-    let parts: Vec<&str> = rest.splitn(3, SEP).collect();
-    if parts.len() == 3 {
-        Some((
-            parts[0].to_string(),
-            parts[1].to_string(),
-            parts[2].to_string(),
-        ))
-    } else {
-        None
-    }
+/// Parse a forward adjacency key back into node_id.
+pub fn parse_forward_adj_key(graph: &str, user_key: &str) -> Option<String> {
+    let prefix = format!("{}{SEP}fwd{SEP}", graph);
+    user_key.strip_prefix(&prefix).map(|s| s.to_string())
 }
 
 // --- Node keys ---
@@ -317,16 +305,6 @@ pub fn validate_type_name(name: &str) -> StrataResult<()> {
 
 // --- Broad prefixes ---
 
-/// Prefix for all forward edge keys in a graph: `{graph}/e/`
-pub fn all_edges_prefix(graph: &str) -> String {
-    format!("{}{SEP}e{SEP}", graph)
-}
-
-/// Prefix for all reverse edge keys in a graph: `{graph}/r/`
-pub fn all_reverse_edges_prefix(graph: &str) -> String {
-    format!("{}{SEP}r{SEP}", graph)
-}
-
 /// Prefix for all keys in a graph: `{graph}/`
 pub fn graph_prefix(graph: &str) -> String {
     format!("{}{SEP}", graph)
@@ -354,21 +332,17 @@ mod tests {
     // --- Round-trip tests ---
 
     #[test]
-    fn forward_edge_key_roundtrip() {
-        let key = forward_edge_key("g", "A", "KNOWS", "B");
-        let (src, edge_type, dst) = parse_forward_edge_key("g", &key).unwrap();
-        assert_eq!(src, "A");
-        assert_eq!(edge_type, "KNOWS");
-        assert_eq!(dst, "B");
+    fn forward_adj_key_roundtrip() {
+        let key = forward_adj_key("g", "A");
+        assert_eq!(key, "g/fwd/A");
+        let node_id = parse_forward_adj_key("g", &key).unwrap();
+        assert_eq!(node_id, "A");
     }
 
     #[test]
-    fn reverse_edge_key_roundtrip() {
-        let key = reverse_edge_key("g", "B", "KNOWS", "A");
-        let (dst, edge_type, src) = parse_reverse_edge_key("g", &key).unwrap();
-        assert_eq!(dst, "B");
-        assert_eq!(edge_type, "KNOWS");
-        assert_eq!(src, "A");
+    fn reverse_adj_key_format() {
+        let key = reverse_adj_key("g", "B");
+        assert_eq!(key, "g/rev/B");
     }
 
     #[test]
@@ -395,30 +369,15 @@ mod tests {
     // --- Prefix correctness ---
 
     #[test]
-    fn forward_edges_prefix_is_prefix() {
-        let key = forward_edge_key("g", "A", "T", "B");
-        assert!(key.starts_with(&forward_edges_prefix("g", "A")));
+    fn forward_adj_prefix_is_prefix() {
+        let key = forward_adj_key("g", "A");
+        assert!(key.starts_with(&all_forward_adj_prefix("g")));
     }
 
     #[test]
-    fn forward_edges_typed_prefix_matches_type() {
-        let key = forward_edge_key("g", "A", "T", "B");
-        assert!(key.starts_with(&forward_edges_typed_prefix("g", "A", "T")));
-
-        let other_key = forward_edge_key("g", "A", "OTHER", "B");
-        assert!(!other_key.starts_with(&forward_edges_typed_prefix("g", "A", "T")));
-    }
-
-    #[test]
-    fn reverse_edges_prefix_is_prefix() {
-        let key = reverse_edge_key("g", "B", "T", "A");
-        assert!(key.starts_with(&reverse_edges_prefix("g", "B")));
-    }
-
-    #[test]
-    fn all_edges_prefix_matches_forward_keys() {
-        let key = forward_edge_key("g", "A", "T", "B");
-        assert!(key.starts_with(&all_edges_prefix("g")));
+    fn reverse_adj_prefix_is_prefix() {
+        let key = reverse_adj_key("g", "B");
+        assert!(key.starts_with(&all_reverse_adj_prefix("g")));
     }
 
     #[test]
@@ -430,11 +389,13 @@ mod tests {
     #[test]
     fn graph_prefix_matches_all_keys() {
         let nk = node_key("g", "X");
-        let fk = forward_edge_key("g", "A", "T", "B");
+        let fk = forward_adj_key("g", "A");
+        let rk = reverse_adj_key("g", "B");
         let mk = meta_key("g");
         let pfx = graph_prefix("g");
         assert!(nk.starts_with(&pfx));
         assert!(fk.starts_with(&pfx));
+        assert!(rk.starts_with(&pfx));
         assert!(mk.starts_with(&pfx));
     }
 
@@ -561,21 +522,15 @@ mod tests {
     // --- Negative parsing tests ---
 
     #[test]
-    fn parse_forward_edge_key_wrong_graph_returns_none() {
-        let key = forward_edge_key("g", "A", "T", "B");
-        assert!(parse_forward_edge_key("other", &key).is_none());
+    fn parse_forward_adj_key_wrong_graph_returns_none() {
+        let key = forward_adj_key("g", "A");
+        assert!(parse_forward_adj_key("other", &key).is_none());
     }
 
     #[test]
-    fn parse_forward_edge_key_malformed_returns_none() {
-        assert!(parse_forward_edge_key("g", "g/e/A").is_none());
-        assert!(parse_forward_edge_key("g", "garbage").is_none());
-    }
-
-    #[test]
-    fn parse_reverse_edge_key_wrong_graph_returns_none() {
-        let key = reverse_edge_key("g", "B", "T", "A");
-        assert!(parse_reverse_edge_key("other", &key).is_none());
+    fn parse_forward_adj_key_malformed_returns_none() {
+        assert!(parse_forward_adj_key("g", "g/fwd").is_none());
+        assert!(parse_forward_adj_key("g", "garbage").is_none());
     }
 
     #[test]
@@ -593,22 +548,16 @@ mod tests {
     // --- Cross-type parsing tests ---
 
     #[test]
-    fn forward_edge_key_not_parseable_as_node() {
-        let key = forward_edge_key("g", "A", "T", "B");
-        assert!(
-            parse_node_key("g", &key).is_none() || {
-                // It may parse as a node key but the result should not be "A"
-                // since the format is different
-                let parsed = parse_node_key("g", &key).unwrap();
-                parsed != "A"
-            }
-        );
+    fn forward_adj_key_not_parseable_as_node() {
+        let key = forward_adj_key("g", "A");
+        // fwd key should not parse as a node key (prefix is fwd, not n)
+        assert!(parse_node_key("g", &key).is_none());
     }
 
     #[test]
-    fn node_key_not_parseable_as_forward_edge() {
+    fn node_key_not_parseable_as_forward_adj() {
         let key = node_key("g", "mynode");
-        assert!(parse_forward_edge_key("g", &key).is_none());
+        assert!(parse_forward_adj_key("g", &key).is_none());
     }
 
     // --- Ontology key tests ---
@@ -779,8 +728,8 @@ mod tests {
         // Test with various user_key patterns used in graph operations
         let user_keys = [
             node_key("mygraph", "patient-1"),
-            forward_edge_key("mygraph", "A", "KNOWS", "B"),
-            reverse_edge_key("mygraph", "B", "KNOWS", "A"),
+            forward_adj_key("mygraph", "A"),
+            reverse_adj_key("mygraph", "B"),
             ref_index_key("kv://main/key1", "mygraph", "n1"),
             type_index_key("mygraph", "Patient", "p1"),
             meta_key("mygraph"),
@@ -800,6 +749,52 @@ mod tests {
                 "Ord mismatch for user_key={user_key:?}"
             );
         }
+    }
+
+    // --- Identifier length limit tests (G-6) ---
+
+    #[test]
+    fn test_graph_name_length_limit() {
+        // Exactly at limit — should pass
+        let at_limit = "a".repeat(MAX_IDENTIFIER_BYTES);
+        assert!(validate_graph_name(&at_limit).is_ok());
+
+        // One byte over — should fail with descriptive message
+        let over_limit = "a".repeat(MAX_IDENTIFIER_BYTES + 1);
+        let err = validate_graph_name(&over_limit).unwrap_err().to_string();
+        assert!(
+            err.contains("exceeds maximum length"),
+            "Error should mention max length: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_node_id_length_limit() {
+        let at_limit = "n".repeat(MAX_IDENTIFIER_BYTES);
+        assert!(validate_node_id(&at_limit).is_ok());
+
+        let over_limit = "n".repeat(MAX_IDENTIFIER_BYTES + 1);
+        let err = validate_node_id(&over_limit).unwrap_err().to_string();
+        assert!(
+            err.contains("exceeds maximum length"),
+            "Error should mention max length: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_edge_type_length_limit() {
+        let at_limit = "E".repeat(MAX_IDENTIFIER_BYTES);
+        assert!(validate_edge_type(&at_limit).is_ok());
+
+        let over_limit = "E".repeat(MAX_IDENTIFIER_BYTES + 1);
+        let err = validate_edge_type(&over_limit).unwrap_err().to_string();
+        assert!(
+            err.contains("exceeds maximum length"),
+            "Error should mention max length: {}",
+            err
+        );
     }
 
     #[test]

--- a/crates/engine/src/graph/mod.rs
+++ b/crates/engine/src/graph/mod.rs
@@ -10,6 +10,7 @@ pub mod boost;
 pub mod integrity;
 pub mod keys;
 pub mod ontology;
+pub mod packed;
 mod snapshot;
 pub mod traversal;
 pub mod types;
@@ -295,12 +296,10 @@ impl GraphStore {
     pub fn remove_node(&self, branch_id: BranchId, graph: &str, node_id: &str) -> StrataResult<()> {
         let node_user_key = keys::node_key(graph, node_id);
         let node_storage_key = keys::storage_key(branch_id, &node_user_key);
-
-        // Prefixes for scanning incident edges
-        let fwd_prefix = keys::forward_edges_prefix(graph, node_id);
-        let fwd_prefix_key = keys::storage_key(branch_id, &fwd_prefix);
-        let rev_prefix = keys::reverse_edges_prefix(graph, node_id);
-        let rev_prefix_key = keys::storage_key(branch_id, &rev_prefix);
+        let fwd_adj_uk = keys::forward_adj_key(graph, node_id);
+        let fwd_adj_sk = keys::storage_key(branch_id, &fwd_adj_uk);
+        let rev_adj_uk = keys::reverse_adj_key(graph, node_id);
+        let rev_adj_sk = keys::storage_key(branch_id, &rev_adj_uk);
 
         self.db.transaction(branch_id, |txn| {
             // Read node to get entity_ref for ref index cleanup
@@ -325,39 +324,49 @@ impl GraphStore {
                 }
             }
 
-            // Delete outgoing edges (forward + their reverse counterparts)
-            let fwd_edges = txn.scan_prefix(&fwd_prefix_key)?;
-            for (key, _) in fwd_edges {
-                if let Some(user_key) = key.user_key_string() {
-                    if let Some((src, edge_type, dst)) =
-                        keys::parse_forward_edge_key(graph, &user_key)
-                    {
-                        // Delete the reverse counterpart
-                        let rev_key = keys::reverse_edge_key(graph, &dst, &edge_type, &src);
-                        let rev_sk = keys::storage_key(branch_id, &rev_key);
-                        txn.delete(rev_sk)?;
+            // Remove this node from each neighbor's reverse adjacency list
+            if let Some(Value::Bytes(fwd_bytes)) = txn.get(&fwd_adj_sk)? {
+                let outgoing = packed::decode(&fwd_bytes)?;
+                for (dst, edge_type, _) in &outgoing {
+                    let dst_rev_uk = keys::reverse_adj_key(graph, dst);
+                    let dst_rev_sk = keys::storage_key(branch_id, &dst_rev_uk);
+                    if let Some(Value::Bytes(dst_rev_bytes)) = txn.get(&dst_rev_sk)? {
+                        if let Some(new_bytes) =
+                            packed::remove_edge(&dst_rev_bytes, node_id, edge_type)
+                        {
+                            if packed::edge_count(&new_bytes) == 0 {
+                                txn.delete(dst_rev_sk)?;
+                            } else {
+                                txn.put(dst_rev_sk, Value::Bytes(new_bytes))?;
+                            }
+                        }
                     }
                 }
-                txn.delete(key)?;
             }
 
-            // Delete incoming edges (reverse + their forward counterparts)
-            let rev_edges = txn.scan_prefix(&rev_prefix_key)?;
-            for (key, _) in rev_edges {
-                if let Some(user_key) = key.user_key_string() {
-                    if let Some((dst, edge_type, src)) =
-                        keys::parse_reverse_edge_key(graph, &user_key)
-                    {
-                        // Delete the forward counterpart
-                        let fwd_key = keys::forward_edge_key(graph, &src, &edge_type, &dst);
-                        let fwd_sk = keys::storage_key(branch_id, &fwd_key);
-                        txn.delete(fwd_sk)?;
+            // Remove this node from each neighbor's forward adjacency list
+            if let Some(Value::Bytes(rev_bytes)) = txn.get(&rev_adj_sk)? {
+                let incoming = packed::decode(&rev_bytes)?;
+                for (src, edge_type, _) in &incoming {
+                    let src_fwd_uk = keys::forward_adj_key(graph, src);
+                    let src_fwd_sk = keys::storage_key(branch_id, &src_fwd_uk);
+                    if let Some(Value::Bytes(src_fwd_bytes)) = txn.get(&src_fwd_sk)? {
+                        if let Some(new_bytes) =
+                            packed::remove_edge(&src_fwd_bytes, node_id, edge_type)
+                        {
+                            if packed::edge_count(&new_bytes) == 0 {
+                                txn.delete(src_fwd_sk)?;
+                            } else {
+                                txn.put(src_fwd_sk, Value::Bytes(new_bytes))?;
+                            }
+                        }
                     }
                 }
-                txn.delete(key)?;
             }
 
-            // Delete the node itself
+            // Delete the node's own adjacency lists and the node itself
+            txn.delete(fwd_adj_sk)?;
+            txn.delete(rev_adj_sk)?;
             txn.delete(node_storage_key.clone())?;
             Ok(())
         })
@@ -368,7 +377,7 @@ impl GraphStore {
     // =========================================================================
 
     /// Add or update an edge in the graph.
-    /// Creates both forward and reverse entries atomically.
+    /// Appends to packed forward and reverse adjacency lists atomically.
     pub fn add_edge(
         &self,
         branch_id: BranchId,
@@ -390,17 +399,54 @@ impl GraphStore {
             }
         }
 
-        let edge_json =
-            serde_json::to_string(&data).map_err(|e| StrataError::serialization(e.to_string()))?;
+        let src_node_uk = keys::node_key(graph, src);
+        let dst_node_uk = keys::node_key(graph, dst);
+        let src_node_key = keys::storage_key(branch_id, &src_node_uk);
+        let dst_node_key = keys::storage_key(branch_id, &dst_node_uk);
 
-        let fwd = keys::forward_edge_key(graph, src, edge_type, dst);
-        let rev = keys::reverse_edge_key(graph, dst, edge_type, src);
-        let fwd_sk = keys::storage_key(branch_id, &fwd);
-        let rev_sk = keys::storage_key(branch_id, &rev);
+        let fwd_uk = keys::forward_adj_key(graph, src);
+        let fwd_sk = keys::storage_key(branch_id, &fwd_uk);
+        let rev_uk = keys::reverse_adj_key(graph, dst);
+        let rev_sk = keys::storage_key(branch_id, &rev_uk);
 
         self.db.transaction(branch_id, |txn| {
-            txn.put(fwd_sk.clone(), Value::String(edge_json.clone()))?;
-            txn.put(rev_sk.clone(), Value::String(edge_json.clone()))?;
+            // Validate both nodes exist within the transaction (prevents TOCTOU)
+            if txn.get(&src_node_key)?.is_none() {
+                return Err(StrataError::invalid_input(format!(
+                    "Source node '{}' does not exist in graph '{}'",
+                    src, graph
+                )));
+            }
+            if txn.get(&dst_node_key)?.is_none() {
+                return Err(StrataError::invalid_input(format!(
+                    "Target node '{}' does not exist in graph '{}'",
+                    dst, graph
+                )));
+            }
+
+            // Read-modify-write forward adjacency list (src → dst)
+            let mut fwd_buf = match txn.get(&fwd_sk)? {
+                Some(Value::Bytes(b)) => b,
+                _ => packed::empty(),
+            };
+            // Remove existing edge if present (upsert semantics)
+            if let Some(new_buf) = packed::remove_edge(&fwd_buf, dst, edge_type) {
+                fwd_buf = new_buf;
+            }
+            packed::append_edge(&mut fwd_buf, dst, edge_type, &data)?;
+            txn.put(fwd_sk.clone(), Value::Bytes(fwd_buf))?;
+
+            // Read-modify-write reverse adjacency list (dst ← src)
+            let mut rev_buf = match txn.get(&rev_sk)? {
+                Some(Value::Bytes(b)) => b,
+                _ => packed::empty(),
+            };
+            if let Some(new_buf) = packed::remove_edge(&rev_buf, src, edge_type) {
+                rev_buf = new_buf;
+            }
+            packed::append_edge(&mut rev_buf, src, edge_type, &data)?;
+            txn.put(rev_sk.clone(), Value::Bytes(rev_buf))?;
+
             Ok(())
         })
     }
@@ -414,26 +460,17 @@ impl GraphStore {
         dst: &str,
         edge_type: &str,
     ) -> StrataResult<Option<EdgeData>> {
-        let fwd = keys::forward_edge_key(graph, src, edge_type, dst);
-        let fwd_sk = keys::storage_key(branch_id, &fwd);
+        let fwd_uk = keys::forward_adj_key(graph, src);
+        let fwd_sk = keys::storage_key(branch_id, &fwd_uk);
 
-        self.db.transaction(branch_id, |txn| {
-            let val = txn.get(&fwd_sk)?;
-            match val {
-                Some(Value::String(s)) => {
-                    let data: EdgeData = serde_json::from_str(&s)
-                        .map_err(|e| StrataError::serialization(e.to_string()))?;
-                    Ok(Some(data))
-                }
-                Some(_) => Err(StrataError::serialization(
-                    "Edge data is not a string".to_string(),
-                )),
-                None => Ok(None),
-            }
-        })
+        self.db
+            .transaction(branch_id, |txn| match txn.get(&fwd_sk)? {
+                Some(Value::Bytes(bytes)) => Ok(packed::find_edge(&bytes, dst, edge_type)),
+                _ => Ok(None),
+            })
     }
 
-    /// Remove an edge (both forward and reverse entries).
+    /// Remove an edge (from both forward and reverse adjacency lists).
     pub fn remove_edge(
         &self,
         branch_id: BranchId,
@@ -442,14 +479,34 @@ impl GraphStore {
         dst: &str,
         edge_type: &str,
     ) -> StrataResult<()> {
-        let fwd = keys::forward_edge_key(graph, src, edge_type, dst);
-        let rev = keys::reverse_edge_key(graph, dst, edge_type, src);
-        let fwd_sk = keys::storage_key(branch_id, &fwd);
-        let rev_sk = keys::storage_key(branch_id, &rev);
+        let fwd_uk = keys::forward_adj_key(graph, src);
+        let fwd_sk = keys::storage_key(branch_id, &fwd_uk);
+        let rev_uk = keys::reverse_adj_key(graph, dst);
+        let rev_sk = keys::storage_key(branch_id, &rev_uk);
 
         self.db.transaction(branch_id, |txn| {
-            txn.delete(fwd_sk.clone())?;
-            txn.delete(rev_sk.clone())?;
+            // Remove from forward adjacency list
+            if let Some(Value::Bytes(fwd_bytes)) = txn.get(&fwd_sk)? {
+                if let Some(new_bytes) = packed::remove_edge(&fwd_bytes, dst, edge_type) {
+                    if packed::edge_count(&new_bytes) == 0 {
+                        txn.delete(fwd_sk.clone())?;
+                    } else {
+                        txn.put(fwd_sk.clone(), Value::Bytes(new_bytes))?;
+                    }
+                }
+            }
+
+            // Remove from reverse adjacency list
+            if let Some(Value::Bytes(rev_bytes)) = txn.get(&rev_sk)? {
+                if let Some(new_bytes) = packed::remove_edge(&rev_bytes, src, edge_type) {
+                    if packed::edge_count(&new_bytes) == 0 {
+                        txn.delete(rev_sk.clone())?;
+                    } else {
+                        txn.put(rev_sk.clone(), Value::Bytes(new_bytes))?;
+                    }
+                }
+            }
+
             Ok(())
         })
     }
@@ -466,35 +523,30 @@ impl GraphStore {
         node_id: &str,
         edge_type_filter: Option<&str>,
     ) -> StrataResult<Vec<Neighbor>> {
-        let prefix = match edge_type_filter {
-            Some(et) => keys::forward_edges_typed_prefix(graph, node_id, et),
-            None => keys::forward_edges_prefix(graph, node_id),
-        };
-        let prefix_key = keys::storage_key(branch_id, &prefix);
+        let fwd_uk = keys::forward_adj_key(graph, node_id);
+        let fwd_sk = keys::storage_key(branch_id, &fwd_uk);
 
-        self.db.transaction(branch_id, |txn| {
-            let results = txn.scan_prefix(&prefix_key)?;
-            let mut neighbors = Vec::new();
-            for (key, val) in results {
-                if let Some(user_key) = key.user_key_string() {
-                    if let Some((_src, edge_type, dst)) =
-                        keys::parse_forward_edge_key(graph, &user_key)
-                    {
-                        let edge_data = if let Value::String(s) = val {
-                            serde_json::from_str(&s).unwrap_or_default()
-                        } else {
-                            EdgeData::default()
-                        };
+        self.db
+            .transaction(branch_id, |txn| match txn.get(&fwd_sk)? {
+                Some(Value::Bytes(bytes)) => {
+                    let edges = packed::decode(&bytes)?;
+                    let mut neighbors = Vec::new();
+                    for (dst, edge_type, edge_data) in edges {
+                        if let Some(filter) = edge_type_filter {
+                            if edge_type != filter {
+                                continue;
+                            }
+                        }
                         neighbors.push(Neighbor {
                             node_id: dst,
                             edge_type,
                             edge_data,
                         });
                     }
+                    Ok(neighbors)
                 }
-            }
-            Ok(neighbors)
-        })
+                _ => Ok(Vec::new()),
+            })
     }
 
     /// Get incoming neighbors of a node (optionally filtered by edge type).
@@ -505,42 +557,35 @@ impl GraphStore {
         node_id: &str,
         edge_type_filter: Option<&str>,
     ) -> StrataResult<Vec<Neighbor>> {
-        let prefix = keys::reverse_edges_prefix(graph, node_id);
-        let prefix_key = keys::storage_key(branch_id, &prefix);
+        let rev_uk = keys::reverse_adj_key(graph, node_id);
+        let rev_sk = keys::storage_key(branch_id, &rev_uk);
 
-        self.db.transaction(branch_id, |txn| {
-            let results = txn.scan_prefix(&prefix_key)?;
-            let mut neighbors = Vec::new();
-            for (key, val) in results {
-                if let Some(user_key) = key.user_key_string() {
-                    if let Some((_dst, edge_type, src)) =
-                        keys::parse_reverse_edge_key(graph, &user_key)
-                    {
+        self.db
+            .transaction(branch_id, |txn| match txn.get(&rev_sk)? {
+                Some(Value::Bytes(bytes)) => {
+                    let edges = packed::decode(&bytes)?;
+                    let mut neighbors = Vec::new();
+                    for (src, edge_type, edge_data) in edges {
                         if let Some(filter) = edge_type_filter {
                             if edge_type != filter {
                                 continue;
                             }
                         }
-                        let edge_data = if let Value::String(s) = val {
-                            serde_json::from_str(&s).unwrap_or_default()
-                        } else {
-                            EdgeData::default()
-                        };
                         neighbors.push(Neighbor {
                             node_id: src,
                             edge_type,
                             edge_data,
                         });
                     }
+                    Ok(neighbors)
                 }
-            }
-            Ok(neighbors)
-        })
+                _ => Ok(Vec::new()),
+            })
     }
 
     /// Get all edges in a graph (for snapshot).
     pub fn all_edges(&self, branch_id: BranchId, graph: &str) -> StrataResult<Vec<Edge>> {
-        let prefix = keys::all_edges_prefix(graph);
+        let prefix = keys::all_forward_adj_prefix(graph);
         let prefix_key = keys::storage_key(branch_id, &prefix);
 
         self.db.transaction(branch_id, |txn| {
@@ -548,20 +593,18 @@ impl GraphStore {
             let mut edges = Vec::new();
             for (key, val) in results {
                 if let Some(user_key) = key.user_key_string() {
-                    if let Some((src, edge_type, dst)) =
-                        keys::parse_forward_edge_key(graph, &user_key)
-                    {
-                        let data = if let Value::String(s) = val {
-                            serde_json::from_str(&s).unwrap_or_default()
-                        } else {
-                            EdgeData::default()
-                        };
-                        edges.push(Edge {
-                            src,
-                            dst,
-                            edge_type,
-                            data,
-                        });
+                    if let Some(src) = keys::parse_forward_adj_key(graph, &user_key) {
+                        if let Value::Bytes(bytes) = val {
+                            let adj = packed::decode(&bytes)?;
+                            for (dst, edge_type, data) in adj {
+                                edges.push(Edge {
+                                    src: src.clone(),
+                                    dst,
+                                    edge_type,
+                                    data,
+                                });
+                            }
+                        }
                     }
                 }
             }
@@ -585,7 +628,12 @@ impl GraphStore {
                 if let Some(user_key) = key.user_key_string() {
                     if let Some(node_id) = keys::parse_node_key(graph, &user_key) {
                         let data = if let Value::String(s) = val {
-                            serde_json::from_str(&s).unwrap_or_default()
+                            serde_json::from_str(&s).map_err(|e| {
+                                StrataError::serialization(format!(
+                                    "Corrupt node data in graph '{}': {}",
+                                    graph, e
+                                ))
+                            })?
                         } else {
                             NodeData::default()
                         };
@@ -631,12 +679,8 @@ impl GraphStore {
 
     /// Bulk insert nodes and edges into a graph using chunked transactions.
     ///
-    /// This is much faster than individual `add_node`/`add_edge` calls because
-    /// it batches many operations into fewer transactions. Each chunk of nodes
-    /// or edges is committed atomically.
-    ///
-    /// For best performance, use this for fresh insertion. It also handles
-    /// re-insertion (upsert) correctly by cleaning up old index entries.
+    /// Edges are grouped by source/destination and packed into adjacency lists,
+    /// reducing KV entry count by ~27x compared to per-edge storage.
     ///
     /// Returns `(nodes_inserted, edges_inserted)`.
     pub fn bulk_insert(
@@ -657,7 +701,6 @@ impl GraphStore {
 
         let chunk_size = std::cmp::max(1, chunk_size.unwrap_or(Self::DEFAULT_BULK_CHUNK_SIZE));
         let empty_json = "{}";
-        let default_edge_json = "{\"weight\":1.0}";
 
         // --- Profiling: OOM diagnosis (#1297) ---
         let t_start = std::time::Instant::now();
@@ -669,7 +712,6 @@ impl GraphStore {
             chunk_size,
             current_rss_mb().unwrap_or(0),
         );
-        // Log sizes of key storage types
         tracing::info!(
             "[graph::bulk_insert] SIZES: Key={} Namespace={} Arc<Namespace>={}",
             std::mem::size_of::<strata_core::types::Key>(),
@@ -683,7 +725,6 @@ impl GraphStore {
         // Insert nodes in chunks
         let mut nodes_inserted = 0usize;
         for chunk in nodes.chunks(chunk_size) {
-            // Pre-compute keys and serialized values outside the transaction
             let mut entries: Vec<(Key, String)> = Vec::with_capacity(chunk.len());
             let mut ref_entries: Vec<Key> = Vec::new();
             let mut type_entries: Vec<Key> = Vec::new();
@@ -691,7 +732,6 @@ impl GraphStore {
             for (node_id, data) in chunk {
                 keys::validate_node_id(node_id)?;
 
-                // Validate against frozen ontology
                 if is_frozen && data.object_type.is_some() {
                     self.validate_node(branch_id, graph, node_id, data)?;
                 }
@@ -764,60 +804,72 @@ impl GraphStore {
             keys::namespace_alloc_count(),
         );
 
-        // Insert edges in chunks (each edge = 2 puts, so use chunk_size/2)
-        let edge_chunk_size = std::cmp::max(1, chunk_size / 2);
-        let mut edges_inserted = 0usize;
-        for chunk in edges.chunks(edge_chunk_size) {
-            let mut entries: Vec<(Key, Key, String)> = Vec::with_capacity(chunk.len());
+        // Group edges by source (forward) and destination (reverse)
+        let mut fwd_map: std::collections::HashMap<&str, Vec<(&str, &str, &EdgeData)>> =
+            std::collections::HashMap::new();
+        let mut rev_map: std::collections::HashMap<&str, Vec<(&str, &str, &EdgeData)>> =
+            std::collections::HashMap::new();
 
-            for (src, dst, edge_type, data) in chunk {
-                keys::validate_node_id(src)?;
-                keys::validate_node_id(dst)?;
-                keys::validate_edge_type(edge_type)?;
+        for (src, dst, edge_type, data) in edges {
+            keys::validate_node_id(src)?;
+            keys::validate_node_id(dst)?;
+            keys::validate_edge_type(edge_type)?;
 
-                // Validate edge against frozen ontology
-                if is_frozen {
-                    self.validate_edge(branch_id, graph, src, dst, edge_type)?;
-                }
-
-                let fwd = keys::forward_edge_key(graph, src, edge_type, dst);
-                let rev = keys::reverse_edge_key(graph, dst, edge_type, src);
-                let fwd_sk = Key::new_kv(ns.clone(), &fwd);
-                let rev_sk = Key::new_kv(ns.clone(), &rev);
-
-                let json = if data.properties.is_none() && (data.weight - 1.0).abs() < f64::EPSILON
-                {
-                    default_edge_json.to_string()
-                } else {
-                    serde_json::to_string(data)
-                        .map_err(|e| StrataError::serialization(e.to_string()))?
-                };
-
-                entries.push((fwd_sk, rev_sk, json));
+            if is_frozen {
+                self.validate_edge(branch_id, graph, src, dst, edge_type)?;
             }
 
+            fwd_map
+                .entry(src.as_str())
+                .or_default()
+                .push((dst.as_str(), edge_type.as_str(), data));
+            rev_map
+                .entry(dst.as_str())
+                .or_default()
+                .push((src.as_str(), edge_type.as_str(), data));
+        }
+
+        // Write packed forward adjacency lists in chunks, merging with existing lists
+        let fwd_entries: Vec<_> = fwd_map.into_iter().collect();
+        for chunk in fwd_entries.chunks(chunk_size) {
             self.db.transaction(branch_id, |txn| {
-                for (fwd_sk, rev_sk, json) in &entries {
-                    txn.put(fwd_sk.clone(), Value::String(json.clone()))?;
-                    txn.put(rev_sk.clone(), Value::String(json.clone()))?;
+                for (node_id, new_edges) in chunk {
+                    let uk = keys::forward_adj_key(graph, node_id);
+                    let sk = Key::new_kv(ns.clone(), &uk);
+                    let mut buf = match txn.get(&sk)? {
+                        Some(Value::Bytes(existing)) => existing,
+                        _ => packed::empty(),
+                    };
+                    for &(target_id, edge_type, data) in new_edges {
+                        packed::append_edge(&mut buf, target_id, edge_type, data)?;
+                    }
+                    txn.put(sk, Value::Bytes(buf))?;
                 }
                 Ok(())
             })?;
-
-            edges_inserted += chunk.len();
-
-            // Progress log every 1M edges
-            if edges_inserted % 1_000_000 < edge_chunk_size {
-                tracing::info!(
-                    "[graph::bulk_insert] EDGES: {}/{} ({:.1}%) RSS={}MB ns_allocs={}",
-                    edges_inserted,
-                    edges.len(),
-                    edges_inserted as f64 / edges.len().max(1) as f64 * 100.0,
-                    current_rss_mb().unwrap_or(0),
-                    keys::namespace_alloc_count(),
-                );
-            }
         }
+
+        // Write packed reverse adjacency lists in chunks, merging with existing lists
+        let rev_entries: Vec<_> = rev_map.into_iter().collect();
+        for chunk in rev_entries.chunks(chunk_size) {
+            self.db.transaction(branch_id, |txn| {
+                for (node_id, new_edges) in chunk {
+                    let uk = keys::reverse_adj_key(graph, node_id);
+                    let sk = Key::new_kv(ns.clone(), &uk);
+                    let mut buf = match txn.get(&sk)? {
+                        Some(Value::Bytes(existing)) => existing,
+                        _ => packed::empty(),
+                    };
+                    for &(target_id, edge_type, data) in new_edges {
+                        packed::append_edge(&mut buf, target_id, edge_type, data)?;
+                    }
+                    txn.put(sk, Value::Bytes(buf))?;
+                }
+                Ok(())
+            })?;
+        }
+
+        let edges_inserted = edges.len();
 
         // Shard diagnostics
         if let Some((entry_count, has_btree)) = self.db.storage().shard_stats(&branch_id) {
@@ -1101,6 +1153,8 @@ mod tests {
         let branch = default_branch();
 
         gs.create_graph(branch, "eg", None).unwrap();
+        gs.add_node(branch, "eg", "A", NodeData::default()).unwrap();
+        gs.add_node(branch, "eg", "B", NodeData::default()).unwrap();
         gs.add_edge(branch, "eg", "A", "B", "KNOWS", EdgeData::default())
             .unwrap();
 
@@ -1115,6 +1169,8 @@ mod tests {
         let branch = default_branch();
 
         gs.create_graph(branch, "eg", None).unwrap();
+        gs.add_node(branch, "eg", "A", NodeData::default()).unwrap();
+        gs.add_node(branch, "eg", "B", NodeData::default()).unwrap();
         gs.add_edge(
             branch,
             "eg",
@@ -1145,19 +1201,28 @@ mod tests {
         let branch = default_branch();
 
         gs.create_graph(branch, "eg", None).unwrap();
+        gs.add_node(branch, "eg", "A", NodeData::default()).unwrap();
+        gs.add_node(branch, "eg", "B", NodeData::default()).unwrap();
         gs.add_edge(branch, "eg", "A", "B", "KNOWS", EdgeData::default())
             .unwrap();
 
-        // Verify via raw key reads
-        let fwd = keys::forward_edge_key("eg", "A", "KNOWS", "B");
-        let rev = keys::reverse_edge_key("eg", "B", "KNOWS", "A");
-        let fwd_sk = keys::storage_key(branch, &fwd);
-        let rev_sk = keys::storage_key(branch, &rev);
+        // Verify via raw key reads — packed adjacency lists
+        let fwd_uk = keys::forward_adj_key("eg", "A");
+        let rev_uk = keys::reverse_adj_key("eg", "B");
+        let fwd_sk = keys::storage_key(branch, &fwd_uk);
+        let rev_sk = keys::storage_key(branch, &rev_uk);
 
         let fwd_exists = gs.db.transaction(branch, |txn| txn.get(&fwd_sk)).unwrap();
         let rev_exists = gs.db.transaction(branch, |txn| txn.get(&rev_sk)).unwrap();
         assert!(fwd_exists.is_some());
         assert!(rev_exists.is_some());
+
+        // Verify the packed list contains the expected edge
+        if let Some(Value::Bytes(bytes)) = fwd_exists {
+            assert!(packed::find_edge(&bytes, "B", "KNOWS").is_some());
+        } else {
+            panic!("Forward adjacency list should be Value::Bytes");
+        }
     }
 
     #[test]
@@ -1166,6 +1231,8 @@ mod tests {
         let branch = default_branch();
 
         gs.create_graph(branch, "eg", None).unwrap();
+        gs.add_node(branch, "eg", "A", NodeData::default()).unwrap();
+        gs.add_node(branch, "eg", "B", NodeData::default()).unwrap();
         gs.add_edge(branch, "eg", "A", "B", "KNOWS", EdgeData::default())
             .unwrap();
         gs.remove_edge(branch, "eg", "A", "B", "KNOWS").unwrap();
@@ -1175,11 +1242,12 @@ mod tests {
             .unwrap()
             .is_none());
 
-        // Verify reverse is also gone
-        let rev = keys::reverse_edge_key("eg", "B", "KNOWS", "A");
-        let rev_sk = keys::storage_key(branch, &rev);
-        let rev_exists = gs.db.transaction(branch, |txn| txn.get(&rev_sk)).unwrap();
-        assert!(rev_exists.is_none());
+        // Verify reverse adjacency list no longer contains the edge
+        let rev_uk = keys::reverse_adj_key("eg", "B");
+        let rev_sk = keys::storage_key(branch, &rev_uk);
+        let rev_val = gs.db.transaction(branch, |txn| txn.get(&rev_sk)).unwrap();
+        // Should be deleted entirely (last edge was removed)
+        assert!(rev_val.is_none());
     }
 
     #[test]
@@ -1188,6 +1256,8 @@ mod tests {
         let branch = default_branch();
 
         gs.create_graph(branch, "eg", None).unwrap();
+        gs.add_node(branch, "eg", "X", NodeData::default()).unwrap();
+        gs.add_node(branch, "eg", "Y", NodeData::default()).unwrap();
         gs.add_edge(branch, "eg", "X", "Y", "LINKS", EdgeData::default())
             .unwrap();
 
@@ -1235,6 +1305,8 @@ mod tests {
         let branch = default_branch();
 
         gs.create_graph(branch, "eg", None).unwrap();
+        gs.add_node(branch, "eg", "A", NodeData::default()).unwrap();
+        gs.add_node(branch, "eg", "B", NodeData::default()).unwrap();
         gs.add_edge(
             branch,
             "eg",
@@ -1554,6 +1626,8 @@ mod tests {
         let branch = default_branch();
 
         gs.create_graph(branch, "eg", None).unwrap();
+        gs.add_node(branch, "eg", "A", NodeData::default()).unwrap();
+        gs.add_node(branch, "eg", "B", NodeData::default()).unwrap();
         gs.add_edge(
             branch,
             "eg",
@@ -2075,7 +2149,7 @@ mod tests {
 
         gs.create_graph(branch, "bg", None).unwrap();
 
-        // Edges without corresponding node entries (graph allows this)
+        // bulk_insert bypasses add_edge() node existence checks for performance
         let edges: Vec<(String, String, String, EdgeData)> =
             vec![("X".into(), "Y".into(), "E".into(), EdgeData::default())];
 
@@ -2118,5 +2192,413 @@ mod tests {
         assert_eq!(snap.edges[0].dst, "B");
         assert_eq!(snap.edges[0].edge_type, "E1");
         assert_eq!(snap.edges[0].data.weight, 2.5);
+    }
+
+    // =========================================================================
+    // G-1: Deserialization error propagation
+    // =========================================================================
+
+    #[test]
+    fn test_corrupt_edge_data_returns_error() {
+        let (db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+        gs.add_node(branch, "g", "A", NodeData::default()).unwrap();
+        gs.add_node(branch, "g", "B", NodeData::default()).unwrap();
+        gs.add_edge(branch, "g", "A", "B", "KNOWS", EdgeData::default())
+            .unwrap();
+
+        // Corrupt the packed forward adjacency list with truncated bytes
+        let fwd_uk = keys::forward_adj_key("g", "A");
+        let fwd_sk = keys::storage_key(branch, &fwd_uk);
+        db.transaction(branch, |txn| {
+            // Header says 1 edge, but no actual edge data follows
+            txn.put(fwd_sk.clone(), Value::Bytes(vec![1, 0, 0, 0]))
+        })
+        .unwrap();
+
+        let result = gs.outgoing_neighbors(branch, "g", "A", None);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("truncated or corrupt"),
+            "Error should mention corrupt data: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_corrupt_edge_data_incoming_returns_error() {
+        let (db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+        gs.add_node(branch, "g", "A", NodeData::default()).unwrap();
+        gs.add_node(branch, "g", "B", NodeData::default()).unwrap();
+        gs.add_edge(branch, "g", "A", "B", "KNOWS", EdgeData::default())
+            .unwrap();
+
+        // Corrupt the packed reverse adjacency list
+        let rev_uk = keys::reverse_adj_key("g", "B");
+        let rev_sk = keys::storage_key(branch, &rev_uk);
+        db.transaction(branch, |txn| {
+            txn.put(rev_sk.clone(), Value::Bytes(vec![1, 0, 0, 0]))
+        })
+        .unwrap();
+
+        let result = gs.incoming_neighbors(branch, "g", "B", None);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("truncated or corrupt"),
+            "Error should mention corrupt data: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_corrupt_edge_data_all_edges_returns_error() {
+        let (db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+        gs.add_node(branch, "g", "A", NodeData::default()).unwrap();
+        gs.add_node(branch, "g", "B", NodeData::default()).unwrap();
+        gs.add_edge(branch, "g", "A", "B", "KNOWS", EdgeData::default())
+            .unwrap();
+
+        // Corrupt the packed forward adjacency list
+        let fwd_uk = keys::forward_adj_key("g", "A");
+        let fwd_sk = keys::storage_key(branch, &fwd_uk);
+        db.transaction(branch, |txn| {
+            txn.put(fwd_sk.clone(), Value::Bytes(vec![1, 0, 0, 0]))
+        })
+        .unwrap();
+
+        let result = gs.all_edges(branch, "g");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("truncated or corrupt"),
+            "Error should mention corrupt data: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_corrupt_node_data_returns_error() {
+        let (db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+        gs.add_node(branch, "g", "A", NodeData::default()).unwrap();
+
+        // Corrupt the node value directly via the underlying KV store
+        let node_uk = keys::node_key("g", "A");
+        let node_sk = keys::storage_key(branch, &node_uk);
+        db.transaction(branch, |txn| {
+            txn.put(node_sk.clone(), Value::String("NOT VALID JSON{{".into()))
+        })
+        .unwrap();
+
+        let result = gs.all_nodes(branch, "g");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Corrupt node data"),
+            "Error should mention corrupt node data: {}",
+            err
+        );
+    }
+
+    // =========================================================================
+    // G-7: Node existence validation on edge creation
+    // =========================================================================
+
+    #[test]
+    fn test_add_edge_rejects_nonexistent_source() {
+        let (_db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+        gs.add_node(branch, "g", "B", NodeData::default()).unwrap();
+
+        let result = gs.add_edge(branch, "g", "A", "B", "KNOWS", EdgeData::default());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Source node") && err.contains("does not exist"),
+            "Error should mention source node: {}",
+            err
+        );
+
+        // Verify no partial writes — neither forward nor reverse edge should exist
+        assert!(gs
+            .get_edge(branch, "g", "A", "B", "KNOWS")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_add_edge_rejects_nonexistent_target() {
+        let (_db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+        gs.add_node(branch, "g", "A", NodeData::default()).unwrap();
+
+        let result = gs.add_edge(branch, "g", "A", "B", "KNOWS", EdgeData::default());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Target node") && err.contains("does not exist"),
+            "Error should mention target node: {}",
+            err
+        );
+
+        // Verify no partial writes
+        assert!(gs
+            .get_edge(branch, "g", "A", "B", "KNOWS")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_add_edge_rejects_both_nonexistent() {
+        let (_db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+
+        let result = gs.add_edge(branch, "g", "A", "B", "KNOWS", EdgeData::default());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("does not exist"),
+            "Error should mention non-existence: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_add_edge_succeeds_when_both_nodes_exist() {
+        let (_db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+        gs.add_node(branch, "g", "A", NodeData::default()).unwrap();
+        gs.add_node(branch, "g", "B", NodeData::default()).unwrap();
+
+        let result = gs.add_edge(branch, "g", "A", "B", "KNOWS", EdgeData::default());
+        assert!(result.is_ok());
+
+        // Verify edge was actually created
+        let edge = gs.get_edge(branch, "g", "A", "B", "KNOWS").unwrap();
+        assert!(edge.is_some());
+    }
+
+    #[test]
+    fn test_add_edge_self_loop_succeeds() {
+        let (_db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+        gs.add_node(branch, "g", "A", NodeData::default()).unwrap();
+
+        // Self-edge: src == dst, node exists — should succeed
+        let result = gs.add_edge(branch, "g", "A", "A", "SELF", EdgeData::default());
+        assert!(result.is_ok());
+
+        let edge = gs.get_edge(branch, "g", "A", "A", "SELF").unwrap();
+        assert!(edge.is_some());
+    }
+
+    #[test]
+    fn test_add_edge_self_loop_nonexistent_node() {
+        let (_db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+
+        // Self-edge to nonexistent node
+        let result = gs.add_edge(branch, "g", "X", "X", "SELF", EdgeData::default());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("does not exist"),
+            "Error should mention non-existence: {}",
+            err
+        );
+    }
+
+    // =========================================================================
+    // Edge-case tests: remove_node with multiple edges to same neighbor
+    // =========================================================================
+
+    #[test]
+    fn remove_node_with_multiple_edges_to_same_neighbor() {
+        let (_db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+        for id in &["A", "B"] {
+            gs.add_node(branch, "g", id, NodeData::default()).unwrap();
+        }
+        // Two different edge types from A to B
+        gs.add_edge(branch, "g", "A", "B", "KNOWS", EdgeData::default())
+            .unwrap();
+        gs.add_edge(branch, "g", "A", "B", "LIKES", EdgeData::default())
+            .unwrap();
+
+        gs.remove_node(branch, "g", "A").unwrap();
+
+        assert!(gs
+            .get_edge(branch, "g", "A", "B", "KNOWS")
+            .unwrap()
+            .is_none());
+        assert!(gs
+            .get_edge(branch, "g", "A", "B", "LIKES")
+            .unwrap()
+            .is_none());
+        // B's reverse adj list should be empty (both edges removed)
+        let incoming = gs.incoming_neighbors(branch, "g", "B", None).unwrap();
+        assert!(incoming.is_empty());
+    }
+
+    #[test]
+    fn remove_node_with_self_loop() {
+        let (_db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+        gs.add_node(branch, "g", "A", NodeData::default()).unwrap();
+        gs.add_node(branch, "g", "B", NodeData::default()).unwrap();
+        gs.add_edge(branch, "g", "A", "A", "SELF", EdgeData::default())
+            .unwrap();
+        gs.add_edge(branch, "g", "A", "B", "KNOWS", EdgeData::default())
+            .unwrap();
+
+        gs.remove_node(branch, "g", "A").unwrap();
+
+        assert!(gs.get_node(branch, "g", "A").unwrap().is_none());
+        assert!(gs
+            .get_edge(branch, "g", "A", "A", "SELF")
+            .unwrap()
+            .is_none());
+        assert!(gs
+            .get_edge(branch, "g", "A", "B", "KNOWS")
+            .unwrap()
+            .is_none());
+        // B's reverse list should be empty
+        let incoming = gs.incoming_neighbors(branch, "g", "B", None).unwrap();
+        assert!(incoming.is_empty());
+    }
+
+    #[test]
+    fn remove_node_hub_with_many_neighbors() {
+        let (_db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+        // Create a hub node A with edges to 10 neighbors
+        gs.add_node(branch, "g", "A", NodeData::default()).unwrap();
+        for i in 0..10 {
+            let id = format!("N{}", i);
+            gs.add_node(branch, "g", &id, NodeData::default()).unwrap();
+            gs.add_edge(branch, "g", "A", &id, "E", EdgeData::default())
+                .unwrap();
+        }
+
+        gs.remove_node(branch, "g", "A").unwrap();
+
+        // All edges removed
+        for i in 0..10 {
+            let id = format!("N{}", i);
+            assert!(gs.get_edge(branch, "g", "A", &id, "E").unwrap().is_none());
+            let incoming = gs.incoming_neighbors(branch, "g", &id, None).unwrap();
+            assert!(incoming.is_empty(), "N{} should have no incoming edges", i);
+        }
+    }
+
+    // =========================================================================
+    // Edge-case tests: bulk_insert merging with existing edges
+    // =========================================================================
+
+    #[test]
+    fn bulk_insert_merges_with_existing_edges() {
+        let (_db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+
+        // Insert nodes and an initial edge via add_edge
+        gs.add_node(branch, "g", "A", NodeData::default()).unwrap();
+        gs.add_node(branch, "g", "B", NodeData::default()).unwrap();
+        gs.add_node(branch, "g", "C", NodeData::default()).unwrap();
+        gs.add_edge(branch, "g", "A", "B", "KNOWS", EdgeData::default())
+            .unwrap();
+
+        // Now bulk_insert a new edge from the same source A
+        let edges = vec![("A".into(), "C".into(), "LIKES".into(), EdgeData::default())];
+        gs.bulk_insert(branch, "g", &[], &edges, None).unwrap();
+
+        // Both edges should exist
+        assert!(gs
+            .get_edge(branch, "g", "A", "B", "KNOWS")
+            .unwrap()
+            .is_some());
+        assert!(gs
+            .get_edge(branch, "g", "A", "C", "LIKES")
+            .unwrap()
+            .is_some());
+
+        // A should have 2 outgoing neighbors
+        let outgoing = gs.outgoing_neighbors(branch, "g", "A", None).unwrap();
+        assert_eq!(outgoing.len(), 2);
+    }
+
+    #[test]
+    fn bulk_insert_two_batches_merge() {
+        let (_db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+
+        let nodes = vec![
+            ("A".into(), NodeData::default()),
+            ("B".into(), NodeData::default()),
+            ("C".into(), NodeData::default()),
+            ("D".into(), NodeData::default()),
+        ];
+        let edges1 = vec![("A".into(), "B".into(), "E1".into(), EdgeData::default())];
+        gs.bulk_insert(branch, "g", &nodes, &edges1, None).unwrap();
+
+        // Second batch adds another edge from A
+        let edges2 = vec![("A".into(), "C".into(), "E2".into(), EdgeData::default())];
+        gs.bulk_insert(branch, "g", &[], &edges2, None).unwrap();
+
+        // Third batch adds edge from A to D
+        let edges3 = vec![("A".into(), "D".into(), "E3".into(), EdgeData::default())];
+        gs.bulk_insert(branch, "g", &[], &edges3, None).unwrap();
+
+        // All edges should coexist
+        assert!(gs.get_edge(branch, "g", "A", "B", "E1").unwrap().is_some());
+        assert!(gs.get_edge(branch, "g", "A", "C", "E2").unwrap().is_some());
+        assert!(gs.get_edge(branch, "g", "A", "D", "E3").unwrap().is_some());
+        let outgoing = gs.outgoing_neighbors(branch, "g", "A", None).unwrap();
+        assert_eq!(outgoing.len(), 3);
+    }
+
+    #[test]
+    fn bulk_insert_reverse_adj_lists_merge_correctly() {
+        let (_db, gs) = setup();
+        let branch = default_branch();
+        gs.create_graph(branch, "g", None).unwrap();
+
+        let nodes = vec![
+            ("A".into(), NodeData::default()),
+            ("B".into(), NodeData::default()),
+            ("C".into(), NodeData::default()),
+        ];
+        // Batch 1: A→C
+        let edges1 = vec![("A".into(), "C".into(), "E1".into(), EdgeData::default())];
+        gs.bulk_insert(branch, "g", &nodes, &edges1, None).unwrap();
+
+        // Batch 2: B→C (same destination, different source)
+        let edges2 = vec![("B".into(), "C".into(), "E2".into(), EdgeData::default())];
+        gs.bulk_insert(branch, "g", &[], &edges2, None).unwrap();
+
+        // C should have 2 incoming neighbors
+        let incoming = gs.incoming_neighbors(branch, "g", "C", None).unwrap();
+        assert_eq!(incoming.len(), 2);
+        let src_ids: Vec<&str> = incoming.iter().map(|n| n.node_id.as_str()).collect();
+        assert!(src_ids.contains(&"A"));
+        assert!(src_ids.contains(&"B"));
     }
 }

--- a/crates/engine/src/graph/ontology.rs
+++ b/crates/engine/src/graph/ontology.rs
@@ -306,7 +306,12 @@ impl GraphStore {
 
         let type_def = match self.get_object_type(branch_id, graph, object_type)? {
             Some(def) => def,
-            None => return Ok(()), // undeclared type: open-world, pass through
+            None => {
+                return Err(StrataError::invalid_input(format!(
+                    "Object type '{}' is not declared in frozen ontology for graph '{}'",
+                    object_type, graph
+                )))
+            }
         };
 
         // Check required properties
@@ -343,7 +348,12 @@ impl GraphStore {
     ) -> StrataResult<()> {
         let link_def = match self.get_link_type(branch_id, graph, edge_type)? {
             Some(def) => def,
-            None => return Ok(()), // undeclared edge type: no validation
+            None => {
+                return Err(StrataError::invalid_input(format!(
+                    "Edge type '{}' is not declared in frozen ontology for graph '{}'",
+                    edge_type, graph
+                )))
+            }
         };
 
         // Check source node's object_type
@@ -502,22 +512,24 @@ impl GraphStore {
         }
     }
 
-    /// Count edges of a given type by scanning forward edges.
+    /// Count edges of a given type by scanning packed forward adjacency lists.
     fn count_edges_by_type(
         &self,
         branch_id: BranchId,
         graph: &str,
         edge_type: &str,
     ) -> StrataResult<u64> {
-        let prefix = keys::all_edges_prefix(graph);
+        use super::packed;
+        let prefix = keys::all_forward_adj_prefix(graph);
         let prefix_key = keys::storage_key(branch_id, &prefix);
 
         self.db.transaction(branch_id, |txn| {
             let results = txn.scan_prefix(&prefix_key)?;
             let mut count = 0u64;
-            for (key, _) in results {
-                if let Some(user_key) = key.user_key_string() {
-                    if let Some((_, et, _)) = keys::parse_forward_edge_key(graph, &user_key) {
+            for (_key, val) in results {
+                if let Value::Bytes(bytes) = val {
+                    let edges = packed::decode(&bytes)?;
+                    for (_, et, _) in &edges {
                         if et == edge_type {
                             count += 1;
                         }
@@ -985,7 +997,7 @@ mod tests {
     }
 
     #[test]
-    fn frozen_edge_undeclared_type_succeeds() {
+    fn frozen_edge_undeclared_type_rejected() {
         let (_db, gs) = setup();
         let b = default_branch();
         gs.create_graph(b, "g", None).unwrap();
@@ -1006,9 +1018,15 @@ mod tests {
         .unwrap();
         gs.add_node(b, "g", "n1", NodeData::default()).unwrap();
 
-        // FRIEND is not a declared link type → no validation
-        gs.add_edge(b, "g", "p1", "n1", "FRIEND", EdgeData::default())
-            .unwrap();
+        // FRIEND is not a declared link type → rejected (closed-world)
+        let result = gs.add_edge(b, "g", "p1", "n1", "FRIEND", EdgeData::default());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not declared") && err.contains("frozen ontology"),
+            "Error should mention undeclared edge type in frozen ontology: {}",
+            err
+        );
     }
 
     #[test]
@@ -1383,7 +1401,7 @@ mod tests {
     }
 
     #[test]
-    fn frozen_undeclared_object_type_passes_validation() {
+    fn frozen_undeclared_object_type_rejected() {
         let (_db, gs) = setup();
         let b = default_branch();
         gs.create_graph(b, "g", None).unwrap();
@@ -1391,17 +1409,24 @@ mod tests {
         gs.define_object_type(b, "g", patient_type()).unwrap();
         gs.freeze_ontology(b, "g").unwrap();
 
-        // Node with undeclared type should pass (open-world)
+        // Node with undeclared type should be rejected (closed-world)
         let data = NodeData {
             object_type: Some("UnknownType".to_string()),
             properties: None,
             ..Default::default()
         };
-        gs.add_node(b, "g", "n1", data).unwrap();
+        let result = gs.add_node(b, "g", "n1", data);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not declared") && err.contains("frozen ontology"),
+            "Error should mention undeclared type in frozen ontology: {}",
+            err
+        );
     }
 
     #[test]
-    fn frozen_edge_nonexistent_endpoints_passes() {
+    fn frozen_edge_nonexistent_endpoints_rejected() {
         let (_db, gs) = setup();
         let b = default_branch();
         gs.create_graph(b, "g", None).unwrap();
@@ -1411,21 +1436,22 @@ mod tests {
         gs.define_link_type(b, "g", has_result_link()).unwrap();
         gs.freeze_ontology(b, "g").unwrap();
 
-        // Create nodes but don't create the endpoints that the edge references
-        gs.add_node(b, "g", "n1", NodeData::default()).unwrap();
-        gs.add_node(b, "g", "n2", NodeData::default()).unwrap();
-
-        // Edge from non-existent nodes should still succeed (get_node returns None,
-        // so validation skips type checks)
-        gs.add_edge(
+        // Edge from non-existent nodes should be rejected (node existence check)
+        let result = gs.add_edge(
             b,
             "g",
             "phantom_src",
             "phantom_dst",
             "HAS_RESULT",
             EdgeData::default(),
-        )
-        .unwrap();
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("does not exist"),
+            "Error should mention non-existent node: {}",
+            err
+        );
     }
 
     #[test]
@@ -1605,5 +1631,179 @@ mod tests {
 
         let result = gs.bulk_insert(b, "g", &nodes, &[], None);
         assert!(result.is_err());
+    }
+
+    // =========================================================================
+    // G-14: Closed-world semantics for frozen ontology
+    // =========================================================================
+
+    #[test]
+    fn test_frozen_ontology_rejects_undeclared_node_type() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+        gs.create_graph(b, "g", None).unwrap();
+
+        gs.define_object_type(b, "g", patient_type()).unwrap();
+        gs.freeze_ontology(b, "g").unwrap();
+
+        // Try adding a node with an undeclared type
+        let result = gs.add_node(
+            b,
+            "g",
+            "x1",
+            NodeData {
+                object_type: Some("Unknown".to_string()),
+                properties: None,
+                ..Default::default()
+            },
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not declared") && err.contains("frozen ontology"),
+            "Error should mention undeclared type in frozen ontology: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_frozen_ontology_rejects_undeclared_edge_type() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+        gs.create_graph(b, "g", None).unwrap();
+
+        gs.define_object_type(b, "g", patient_type()).unwrap();
+        gs.define_object_type(b, "g", lab_result_type()).unwrap();
+        gs.define_link_type(b, "g", has_result_link()).unwrap();
+        gs.freeze_ontology(b, "g").unwrap();
+
+        // Create nodes so the edge can reference them
+        gs.add_node(
+            b,
+            "g",
+            "p1",
+            NodeData {
+                object_type: Some("Patient".to_string()),
+                properties: Some(serde_json::json!({"name": "Alice"})),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        gs.add_node(
+            b,
+            "g",
+            "p2",
+            NodeData {
+                object_type: Some("Patient".to_string()),
+                properties: Some(serde_json::json!({"name": "Bob"})),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        // Try adding an edge with an undeclared type
+        let result = gs.add_edge(b, "g", "p1", "p2", "LIKES", EdgeData::default());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not declared") && err.contains("frozen ontology"),
+            "Error should mention undeclared edge type in frozen ontology: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_frozen_ontology_allows_declared_types() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+        gs.create_graph(b, "g", None).unwrap();
+
+        gs.define_object_type(b, "g", patient_type()).unwrap();
+        gs.define_object_type(b, "g", lab_result_type()).unwrap();
+        gs.define_link_type(b, "g", has_result_link()).unwrap();
+        gs.freeze_ontology(b, "g").unwrap();
+
+        // Declared node type should succeed
+        let result = gs.add_node(
+            b,
+            "g",
+            "p1",
+            NodeData {
+                object_type: Some("Patient".to_string()),
+                properties: Some(serde_json::json!({"name": "Alice"})),
+                ..Default::default()
+            },
+        );
+        assert!(result.is_ok());
+
+        let result = gs.add_node(
+            b,
+            "g",
+            "l1",
+            NodeData {
+                object_type: Some("LabResult".to_string()),
+                properties: Some(serde_json::json!({"value": 42})),
+                ..Default::default()
+            },
+        );
+        assert!(result.is_ok());
+
+        // Declared edge type should succeed
+        let result = gs.add_edge(b, "g", "p1", "l1", "HAS_RESULT", EdgeData::default());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_unfrozen_ontology_allows_undeclared_types() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+        gs.create_graph(b, "g", None).unwrap();
+
+        // No types defined, no freeze — undeclared types should pass
+        let result = gs.add_node(
+            b,
+            "g",
+            "x1",
+            NodeData {
+                object_type: Some("Anything".to_string()),
+                properties: None,
+                ..Default::default()
+            },
+        );
+        assert!(result.is_ok());
+
+        gs.add_node(b, "g", "x2", NodeData::default()).unwrap();
+        let result = gs.add_edge(b, "g", "x1", "x2", "WHATEVER", EdgeData::default());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_draft_ontology_allows_undeclared_types() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+        gs.create_graph(b, "g", None).unwrap();
+
+        // Define some types but do NOT freeze — ontology is in draft status
+        gs.define_object_type(b, "g", patient_type()).unwrap();
+        gs.define_link_type(b, "g", has_result_link()).unwrap();
+
+        // Undeclared node type should still pass (draft, not frozen)
+        let result = gs.add_node(
+            b,
+            "g",
+            "x1",
+            NodeData {
+                object_type: Some("UnknownType".to_string()),
+                properties: None,
+                ..Default::default()
+            },
+        );
+        assert!(result.is_ok());
+
+        gs.add_node(b, "g", "x2", NodeData::default()).unwrap();
+
+        // Undeclared edge type should still pass (draft, not frozen)
+        let result = gs.add_edge(b, "g", "x1", "x2", "UNDECLARED_LINK", EdgeData::default());
+        assert!(result.is_ok());
     }
 }

--- a/crates/engine/src/graph/packed.rs
+++ b/crates/engine/src/graph/packed.rs
@@ -1,0 +1,564 @@
+//! Packed binary adjacency list encoding for graph edges.
+//!
+//! Stores all edges from/to a single node in a single KV entry as `Value::Bytes`,
+//! reducing entry count by ~27x compared to one-entry-per-edge.
+//!
+//! ## Wire format
+//!
+//! ```text
+//! Header:
+//!   [u32: edge_count]                          (little-endian)
+//!
+//! Per edge (repeated edge_count times):
+//!   [u16: edge_type_len] [u8 × len: edge_type] (UTF-8)
+//!   [u16: target_id_len] [u8 × len: target_id] (UTF-8)
+//!   [f64: weight]                               (little-endian)
+//!   [u32: properties_len]                       (0 = no properties)
+//!   [u8 × len: properties_json]                 (only if len > 0)
+//! ```
+
+use strata_core::{StrataError, StrataResult};
+
+use super::types::EdgeData;
+
+/// Maximum adjacency list size in bytes (16 MB).
+const MAX_ADJ_LIST_BYTES: usize = 16 * 1024 * 1024;
+
+/// Encode a list of edges into a packed binary adjacency list.
+///
+/// Each entry is `(target_id, edge_type, EdgeData)`.
+pub fn encode(edges: &[(&str, &str, &EdgeData)]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    // Header: edge count
+    buf.extend_from_slice(&(edges.len() as u32).to_le_bytes());
+    for &(target_id, edge_type, data) in edges {
+        write_edge(&mut buf, target_id, edge_type, data);
+    }
+    buf
+}
+
+/// Decode a packed binary adjacency list into `(target_id, edge_type, EdgeData)` triples.
+pub fn decode(bytes: &[u8]) -> StrataResult<Vec<(String, String, EdgeData)>> {
+    if bytes.len() < 4 {
+        return Err(StrataError::serialization(
+            "Packed adjacency list too short for header".to_string(),
+        ));
+    }
+    let count = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    let mut result = Vec::with_capacity(count);
+    let mut pos = 4;
+    for _ in 0..count {
+        let (target_id, edge_type, data, new_pos) = read_edge(bytes, pos)?;
+        result.push((target_id, edge_type, data));
+        pos = new_pos;
+    }
+    Ok(result)
+}
+
+/// Append an edge to an existing packed buffer (read-modify-write).
+///
+/// Updates the header count and appends the new entry bytes.
+/// Returns an error if the result would exceed `MAX_ADJ_LIST_BYTES`.
+pub fn append_edge(
+    buf: &mut Vec<u8>,
+    target_id: &str,
+    edge_type: &str,
+    data: &EdgeData,
+) -> StrataResult<()> {
+    if buf.len() < 4 {
+        // Initialize empty list
+        buf.clear();
+        buf.extend_from_slice(&0u32.to_le_bytes());
+    }
+    // Estimate new size before mutating: 2 + edge_type + 2 + target_id + 8 (f64) + 4 (props_len) + props
+    let props_len = match &data.properties {
+        Some(props) => serde_json::to_string(props).unwrap_or_default().len(),
+        None => 0,
+    };
+    let entry_size = 2 + edge_type.len() + 2 + target_id.len() + 8 + 4 + props_len;
+    if buf.len() + entry_size > MAX_ADJ_LIST_BYTES {
+        return Err(StrataError::invalid_input(format!(
+            "Adjacency list would exceed maximum size of {} bytes (~500K+ edges per node)",
+            MAX_ADJ_LIST_BYTES
+        )));
+    }
+    // Increment count
+    let old_count = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+    let new_count = old_count + 1;
+    buf[0..4].copy_from_slice(&new_count.to_le_bytes());
+    // Append entry
+    write_edge(buf, target_id, edge_type, data);
+    Ok(())
+}
+
+/// Remove the first edge matching `(target_id, edge_type)` from a packed list.
+///
+/// Returns `Some(new_bytes)` if found and removed, `None` if not found.
+/// If removing the last edge, returns `Some` with an empty list (count=0).
+pub fn remove_edge(bytes: &[u8], target_id: &str, edge_type: &str) -> Option<Vec<u8>> {
+    if bytes.len() < 4 {
+        return None;
+    }
+    let count = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    let mut pos = 4;
+    let mut found = false;
+    let mut skip_start = 0;
+    let mut skip_end = 0;
+
+    for _ in 0..count {
+        let entry_start = pos;
+        let (tid, et, _data, new_pos) = read_edge(bytes, pos).ok()?;
+        if !found && tid == target_id && et == edge_type {
+            found = true;
+            skip_start = entry_start;
+            skip_end = new_pos;
+        }
+        pos = new_pos;
+    }
+
+    if !found {
+        return None;
+    }
+
+    let new_count = (count - 1) as u32;
+    let mut result = Vec::with_capacity(bytes.len() - (skip_end - skip_start));
+    result.extend_from_slice(&new_count.to_le_bytes());
+    result.extend_from_slice(&bytes[4..skip_start]);
+    result.extend_from_slice(&bytes[skip_end..pos]);
+    Some(result)
+}
+
+/// Find a specific edge in a packed list by `(target_id, edge_type)`.
+pub fn find_edge(bytes: &[u8], target_id: &str, edge_type: &str) -> Option<EdgeData> {
+    if bytes.len() < 4 {
+        return None;
+    }
+    let count = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    let mut pos = 4;
+    for _ in 0..count {
+        let (tid, et, data, new_pos) = read_edge(bytes, pos).ok()?;
+        if tid == target_id && et == edge_type {
+            return Some(data);
+        }
+        pos = new_pos;
+    }
+    None
+}
+
+/// Read the edge count from a packed header (no full decode).
+pub fn edge_count(bytes: &[u8]) -> u32 {
+    if bytes.len() < 4 {
+        return 0;
+    }
+    u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+}
+
+/// Encode an empty adjacency list (count = 0).
+pub fn empty() -> Vec<u8> {
+    0u32.to_le_bytes().to_vec()
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn write_edge(buf: &mut Vec<u8>, target_id: &str, edge_type: &str, data: &EdgeData) {
+    // edge_type
+    buf.extend_from_slice(&(edge_type.len() as u16).to_le_bytes());
+    buf.extend_from_slice(edge_type.as_bytes());
+    // target_id
+    buf.extend_from_slice(&(target_id.len() as u16).to_le_bytes());
+    buf.extend_from_slice(target_id.as_bytes());
+    // weight
+    buf.extend_from_slice(&data.weight.to_le_bytes());
+    // properties
+    match &data.properties {
+        Some(props) => {
+            let json = serde_json::to_string(props).unwrap_or_default();
+            buf.extend_from_slice(&(json.len() as u32).to_le_bytes());
+            buf.extend_from_slice(json.as_bytes());
+        }
+        None => {
+            buf.extend_from_slice(&0u32.to_le_bytes());
+        }
+    }
+}
+
+fn read_edge(bytes: &[u8], mut pos: usize) -> StrataResult<(String, String, EdgeData, usize)> {
+    let err =
+        || StrataError::serialization("Packed adjacency list truncated or corrupt".to_string());
+
+    // edge_type
+    if pos + 2 > bytes.len() {
+        return Err(err());
+    }
+    let et_len = u16::from_le_bytes([bytes[pos], bytes[pos + 1]]) as usize;
+    pos += 2;
+    if pos + et_len > bytes.len() {
+        return Err(err());
+    }
+    let edge_type = std::str::from_utf8(&bytes[pos..pos + et_len])
+        .map_err(|_| err())?
+        .to_string();
+    pos += et_len;
+
+    // target_id
+    if pos + 2 > bytes.len() {
+        return Err(err());
+    }
+    let tid_len = u16::from_le_bytes([bytes[pos], bytes[pos + 1]]) as usize;
+    pos += 2;
+    if pos + tid_len > bytes.len() {
+        return Err(err());
+    }
+    let target_id = std::str::from_utf8(&bytes[pos..pos + tid_len])
+        .map_err(|_| err())?
+        .to_string();
+    pos += tid_len;
+
+    // weight
+    if pos + 8 > bytes.len() {
+        return Err(err());
+    }
+    let weight = f64::from_le_bytes([
+        bytes[pos],
+        bytes[pos + 1],
+        bytes[pos + 2],
+        bytes[pos + 3],
+        bytes[pos + 4],
+        bytes[pos + 5],
+        bytes[pos + 6],
+        bytes[pos + 7],
+    ]);
+    pos += 8;
+
+    // properties
+    if pos + 4 > bytes.len() {
+        return Err(err());
+    }
+    let props_len =
+        u32::from_le_bytes([bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3]]) as usize;
+    pos += 4;
+    let properties = if props_len > 0 {
+        if pos + props_len > bytes.len() {
+            return Err(err());
+        }
+        let json_str = std::str::from_utf8(&bytes[pos..pos + props_len]).map_err(|_| err())?;
+        let val: serde_json::Value = serde_json::from_str(json_str)
+            .map_err(|e| StrataError::serialization(e.to_string()))?;
+        pos += props_len;
+        Some(val)
+    } else {
+        None
+    };
+
+    Ok((target_id, edge_type, EdgeData { weight, properties }, pos))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_data() -> EdgeData {
+        EdgeData::default()
+    }
+
+    fn weighted_data(w: f64) -> EdgeData {
+        EdgeData {
+            weight: w,
+            properties: None,
+        }
+    }
+
+    fn data_with_props() -> EdgeData {
+        EdgeData {
+            weight: 0.75,
+            properties: Some(serde_json::json!({"confidence": "high", "source": "manual"})),
+        }
+    }
+
+    #[test]
+    fn empty_list() {
+        let buf = encode(&[]);
+        assert_eq!(edge_count(&buf), 0);
+        let decoded = decode(&buf).unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn single_edge_roundtrip() {
+        let data = default_data();
+        let buf = encode(&[("B", "KNOWS", &data)]);
+        assert_eq!(edge_count(&buf), 1);
+        let decoded = decode(&buf).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].0, "B");
+        assert_eq!(decoded[0].1, "KNOWS");
+        assert_eq!(decoded[0].2.weight, 1.0);
+        assert!(decoded[0].2.properties.is_none());
+    }
+
+    #[test]
+    fn many_edges_roundtrip() {
+        let d1 = default_data();
+        let d2 = weighted_data(0.5);
+        let d3 = data_with_props();
+        let edges: Vec<(&str, &str, &EdgeData)> = vec![
+            ("B", "KNOWS", &d1),
+            ("C", "LIKES", &d2),
+            ("D", "WORKS_WITH", &d3),
+        ];
+        let buf = encode(&edges);
+        assert_eq!(edge_count(&buf), 3);
+        let decoded = decode(&buf).unwrap();
+        assert_eq!(decoded.len(), 3);
+        assert_eq!(decoded[0], ("B".to_string(), "KNOWS".to_string(), d1));
+        assert_eq!(decoded[1], ("C".to_string(), "LIKES".to_string(), d2));
+        assert_eq!(decoded[2].0, "D");
+        assert_eq!(decoded[2].1, "WORKS_WITH");
+        assert!((decoded[2].2.weight - 0.75).abs() < f64::EPSILON);
+        assert!(decoded[2].2.properties.is_some());
+    }
+
+    #[test]
+    fn append_to_empty() {
+        let mut buf = empty();
+        append_edge(&mut buf, "X", "E", &default_data()).unwrap();
+        assert_eq!(edge_count(&buf), 1);
+        let decoded = decode(&buf).unwrap();
+        assert_eq!(decoded[0].0, "X");
+    }
+
+    #[test]
+    fn append_multiple() {
+        let mut buf = empty();
+        append_edge(&mut buf, "A", "E1", &default_data()).unwrap();
+        append_edge(&mut buf, "B", "E2", &weighted_data(2.0)).unwrap();
+        append_edge(&mut buf, "C", "E3", &data_with_props()).unwrap();
+        assert_eq!(edge_count(&buf), 3);
+        let decoded = decode(&buf).unwrap();
+        assert_eq!(decoded.len(), 3);
+        assert_eq!(decoded[0].0, "A");
+        assert_eq!(decoded[1].0, "B");
+        assert_eq!(decoded[2].0, "C");
+    }
+
+    #[test]
+    fn find_edge_present() {
+        let d = weighted_data(0.42);
+        let buf = encode(&[("B", "KNOWS", &default_data()), ("C", "LIKES", &d)]);
+        let found = find_edge(&buf, "C", "LIKES").unwrap();
+        assert!((found.weight - 0.42).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn find_edge_missing() {
+        let buf = encode(&[("B", "KNOWS", &default_data())]);
+        assert!(find_edge(&buf, "C", "KNOWS").is_none());
+        assert!(find_edge(&buf, "B", "LIKES").is_none());
+    }
+
+    #[test]
+    fn find_edge_empty() {
+        let buf = empty();
+        assert!(find_edge(&buf, "A", "E").is_none());
+    }
+
+    #[test]
+    fn remove_edge_present() {
+        let d1 = default_data();
+        let d2 = weighted_data(0.5);
+        let buf = encode(&[("B", "KNOWS", &d1), ("C", "LIKES", &d2)]);
+        let new_buf = remove_edge(&buf, "B", "KNOWS").unwrap();
+        assert_eq!(edge_count(&new_buf), 1);
+        let decoded = decode(&new_buf).unwrap();
+        assert_eq!(decoded[0].0, "C");
+        assert_eq!(decoded[0].1, "LIKES");
+    }
+
+    #[test]
+    fn remove_edge_missing() {
+        let buf = encode(&[("B", "KNOWS", &default_data())]);
+        assert!(remove_edge(&buf, "X", "KNOWS").is_none());
+    }
+
+    #[test]
+    fn remove_last_edge() {
+        let buf = encode(&[("B", "KNOWS", &default_data())]);
+        let new_buf = remove_edge(&buf, "B", "KNOWS").unwrap();
+        assert_eq!(edge_count(&new_buf), 0);
+        let decoded = decode(&new_buf).unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn remove_middle_edge() {
+        let d = default_data();
+        let buf = encode(&[("A", "E1", &d), ("B", "E2", &d), ("C", "E3", &d)]);
+        let new_buf = remove_edge(&buf, "B", "E2").unwrap();
+        assert_eq!(edge_count(&new_buf), 2);
+        let decoded = decode(&new_buf).unwrap();
+        assert_eq!(decoded[0].0, "A");
+        assert_eq!(decoded[1].0, "C");
+    }
+
+    #[test]
+    fn properties_roundtrip() {
+        let d = data_with_props();
+        let buf = encode(&[("B", "E", &d)]);
+        let decoded = decode(&buf).unwrap();
+        assert_eq!(decoded[0].2.properties, d.properties);
+    }
+
+    #[test]
+    fn truncated_buffer_errors() {
+        assert!(decode(&[]).is_err());
+        assert!(decode(&[1, 0, 0]).is_err());
+        // Valid header saying 1 edge but no data
+        assert!(decode(&[1, 0, 0, 0]).is_err());
+    }
+
+    #[test]
+    fn edge_count_on_short_buffer() {
+        assert_eq!(edge_count(&[]), 0);
+        assert_eq!(edge_count(&[1, 2]), 0);
+    }
+
+    #[test]
+    fn unicode_edge_type_and_target_roundtrip() {
+        let d = default_data();
+        let buf = encode(&[("nœud_ünîcödé", "关系类型", &d)]);
+        let decoded = decode(&buf).unwrap();
+        assert_eq!(decoded[0].0, "nœud_ünîcödé");
+        assert_eq!(decoded[0].1, "关系类型");
+    }
+
+    #[test]
+    fn duplicate_edges_preserved() {
+        // Same (target, edge_type) can appear multiple times — packed format allows it
+        let d1 = weighted_data(1.0);
+        let d2 = weighted_data(2.0);
+        let buf = encode(&[("B", "E", &d1), ("B", "E", &d2)]);
+        assert_eq!(edge_count(&buf), 2);
+        let decoded = decode(&buf).unwrap();
+        assert_eq!(decoded.len(), 2);
+        assert!((decoded[0].2.weight - 1.0).abs() < f64::EPSILON);
+        assert!((decoded[1].2.weight - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn find_edge_returns_correct_properties() {
+        let d1 = EdgeData {
+            weight: 1.0,
+            properties: Some(serde_json::json!({"label": "first"})),
+        };
+        let d2 = EdgeData {
+            weight: 2.0,
+            properties: Some(serde_json::json!({"label": "second"})),
+        };
+        let buf = encode(&[("B", "E1", &d1), ("C", "E2", &d2)]);
+        let found = find_edge(&buf, "C", "E2").unwrap();
+        assert!((found.weight - 2.0).abs() < f64::EPSILON);
+        assert_eq!(
+            found.properties.unwrap()["label"],
+            serde_json::json!("second")
+        );
+    }
+
+    #[test]
+    fn remove_edge_preserves_remaining_data() {
+        let d1 = weighted_data(1.0);
+        let d2 = data_with_props();
+        let d3 = weighted_data(3.0);
+        let buf = encode(&[("A", "E1", &d1), ("B", "E2", &d2), ("C", "E3", &d3)]);
+        let new_buf = remove_edge(&buf, "B", "E2").unwrap();
+        let decoded = decode(&new_buf).unwrap();
+        assert_eq!(decoded.len(), 2);
+        // First edge preserved
+        assert_eq!(decoded[0].0, "A");
+        assert!((decoded[0].2.weight - 1.0).abs() < f64::EPSILON);
+        assert!(decoded[0].2.properties.is_none());
+        // Third edge preserved
+        assert_eq!(decoded[1].0, "C");
+        assert!((decoded[1].2.weight - 3.0).abs() < f64::EPSILON);
+        assert!(decoded[1].2.properties.is_none());
+    }
+
+    #[test]
+    fn remove_edge_with_duplicates_removes_only_first() {
+        let d1 = weighted_data(1.0);
+        let d2 = weighted_data(2.0);
+        let buf = encode(&[("B", "E", &d1), ("B", "E", &d2)]);
+        let new_buf = remove_edge(&buf, "B", "E").unwrap();
+        assert_eq!(edge_count(&new_buf), 1);
+        let decoded = decode(&new_buf).unwrap();
+        // Second occurrence (weight 2.0) should remain
+        assert!((decoded[0].2.weight - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn append_edge_overflow_does_not_corrupt_buffer() {
+        // Build a buffer just under the limit, then try to add a huge edge
+        let mut buf = empty();
+        append_edge(&mut buf, "A", "E", &default_data()).unwrap();
+        let count_before = edge_count(&buf);
+        let len_before = buf.len();
+
+        // Create an edge with a massive properties blob that would exceed 16 MB
+        let big_props = serde_json::json!({"data": "x".repeat(MAX_ADJ_LIST_BYTES + 1)});
+        let big_data = EdgeData {
+            weight: 1.0,
+            properties: Some(big_props),
+        };
+        let result = append_edge(&mut buf, "B", "E2", &big_data);
+        assert!(result.is_err());
+        // Buffer should be unchanged
+        assert_eq!(edge_count(&buf), count_before);
+        assert_eq!(buf.len(), len_before);
+    }
+
+    #[test]
+    fn empty_strings_roundtrip() {
+        // Edge type and target_id can technically be empty strings
+        let d = default_data();
+        let buf = encode(&[("", "", &d)]);
+        let decoded = decode(&buf).unwrap();
+        assert_eq!(decoded[0].0, "");
+        assert_eq!(decoded[0].1, "");
+    }
+
+    #[test]
+    fn find_edge_with_duplicates_returns_first() {
+        let d1 = weighted_data(1.0);
+        let d2 = weighted_data(2.0);
+        let buf = encode(&[("B", "E", &d1), ("B", "E", &d2)]);
+        let found = find_edge(&buf, "B", "E").unwrap();
+        assert!((found.weight - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn append_then_find() {
+        let mut buf = empty();
+        let d1 = weighted_data(1.0);
+        let d2 = weighted_data(2.0);
+        append_edge(&mut buf, "A", "E1", &d1).unwrap();
+        append_edge(&mut buf, "B", "E2", &d2).unwrap();
+        assert!(find_edge(&buf, "A", "E1").is_some());
+        assert!(find_edge(&buf, "B", "E2").is_some());
+        assert!(find_edge(&buf, "A", "E2").is_none());
+    }
+
+    #[test]
+    fn append_then_remove_then_decode() {
+        let mut buf = empty();
+        append_edge(&mut buf, "A", "E1", &default_data()).unwrap();
+        append_edge(&mut buf, "B", "E2", &weighted_data(0.5)).unwrap();
+        append_edge(&mut buf, "C", "E3", &data_with_props()).unwrap();
+        let buf = remove_edge(&buf, "B", "E2").unwrap();
+        let decoded = decode(&buf).unwrap();
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded[0].0, "A");
+        assert_eq!(decoded[1].0, "C");
+        assert!(decoded[1].2.properties.is_some());
+    }
+}

--- a/crates/engine/src/graph/snapshot.rs
+++ b/crates/engine/src/graph/snapshot.rs
@@ -97,6 +97,9 @@ mod tests {
         let (_db, gs) = setup();
         let b = branch();
         gs.create_graph(b, "g", None).unwrap();
+        gs.add_node(b, "g", "A", NodeData::default()).unwrap();
+        gs.add_node(b, "g", "B", NodeData::default()).unwrap();
+        gs.add_node(b, "g", "C", NodeData::default()).unwrap();
         gs.add_edge(
             b,
             "g",
@@ -127,6 +130,9 @@ mod tests {
         let (_db, gs) = setup();
         let b = branch();
         gs.create_graph(b, "g", None).unwrap();
+        gs.add_node(b, "g", "A", NodeData::default()).unwrap();
+        gs.add_node(b, "g", "B", NodeData::default()).unwrap();
+        gs.add_node(b, "g", "C", NodeData::default()).unwrap();
         gs.add_edge(b, "g", "A", "B", "E", EdgeData::default())
             .unwrap();
         gs.add_edge(b, "g", "A", "C", "E", EdgeData::default())
@@ -146,6 +152,8 @@ mod tests {
         let (_db, gs) = setup();
         let b = branch();
         gs.create_graph(b, "g", None).unwrap();
+        gs.add_node(b, "g", "A", NodeData::default()).unwrap();
+        gs.add_node(b, "g", "B", NodeData::default()).unwrap();
         gs.add_edge(b, "g", "A", "B", "KNOWS", EdgeData::default())
             .unwrap();
 
@@ -164,6 +172,8 @@ mod tests {
         let (_db, gs) = setup();
         let b = branch();
         gs.create_graph(b, "g", None).unwrap();
+        gs.add_node(b, "g", "X", NodeData::default()).unwrap();
+        gs.add_node(b, "g", "Y", NodeData::default()).unwrap();
         gs.add_edge(b, "g", "X", "Y", "E", EdgeData::default())
             .unwrap();
 

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -1156,6 +1156,8 @@ mod tests {
     fn test_graph_edge_crud() {
         let db = create_strata();
         db.graph_create("eg").unwrap();
+        db.graph_add_node("eg", "A", None, None).unwrap();
+        db.graph_add_node("eg", "B", None, None).unwrap();
 
         db.graph_add_edge("eg", "A", "B", "KNOWS", None, None)
             .unwrap();
@@ -1175,6 +1177,9 @@ mod tests {
     fn test_graph_bfs() {
         let db = create_strata();
         db.graph_create("bg").unwrap();
+        for id in &["A", "B", "C", "D"] {
+            db.graph_add_node("bg", id, None, None).unwrap();
+        }
 
         db.graph_add_edge("bg", "A", "B", "E", None, None).unwrap();
         db.graph_add_edge("bg", "B", "C", "E", None, None).unwrap();
@@ -1429,6 +1434,8 @@ mod tests {
     fn test_graph_edge_with_weight_and_properties() {
         let db = create_strata();
         db.graph_create("wg").unwrap();
+        db.graph_add_node("wg", "A", None, None).unwrap();
+        db.graph_add_node("wg", "B", None, None).unwrap();
 
         db.graph_add_edge(
             "wg",
@@ -1454,6 +1461,9 @@ mod tests {
     fn test_graph_bfs_with_max_depth() {
         let db = create_strata();
         db.graph_create("bg").unwrap();
+        for id in &["A", "B", "C", "D"] {
+            db.graph_add_node("bg", id, None, None).unwrap();
+        }
 
         // A → B → C → D
         db.graph_add_edge("bg", "A", "B", "E", None, None).unwrap();
@@ -1471,6 +1481,9 @@ mod tests {
     fn test_graph_bfs_depths_correct() {
         let db = create_strata();
         db.graph_create("dg").unwrap();
+        for id in &["A", "B", "C"] {
+            db.graph_add_node("dg", id, None, None).unwrap();
+        }
 
         db.graph_add_edge("dg", "A", "B", "E", None, None).unwrap();
         db.graph_add_edge("dg", "B", "C", "E", None, None).unwrap();


### PR DESCRIPTION
## Summary

- **New `packed.rs` module**: Binary encode/decode for adjacency lists — stores all edges from/to a node in a single `Value::Bytes` KV entry instead of one entry per edge
- **27x entry count reduction**: For graph500-22 (2.4M nodes, 64M edges), reduces KV entries from 128M to ~4.8M, estimated RSS from ~34 GB to ~3-4 GB
- **All edge operations rewritten**: `add_edge`, `get_edge`, `remove_edge`, `remove_node`, `outgoing_neighbors`, `incoming_neighbors`, `all_edges`, `bulk_insert` now use read-modify-write on packed lists
- **`bulk_insert` merges correctly**: Reads existing adjacency lists before appending, preserving edges from prior inserts
- **`append_edge` overflow safety**: Size check happens before buffer mutation, preventing corruption on 16MB limit overflow

## Test plan

- [x] 25 packed module unit tests (roundtrip, unicode, duplicates, overflow safety, properties, remove/find correctness)
- [x] 357 graph tests pass (16 new edge-case tests for remove_node with self-loops/multi-edges, bulk_insert merging)
- [x] 296 executor integration tests pass
- [x] clippy clean (`-D warnings`)
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)