### PR TITLE
GC old MVCC versions in packed adj list bulk_insert (#1356)

### DIFF
--- a/crates/engine/src/graph/mod.rs
+++ b/crates/engine/src/graph/mod.rs
@@ -869,6 +869,12 @@ impl GraphStore {
             })?;
         }
 
+        // GC old version chain entries — each read-modify-write above created a
+        // new version for adj list keys that already existed from prior batches.
+        // Without this, the MVCC layer keeps all intermediate versions, negating
+        // the entry-count reduction from packed adjacency lists.
+        self.db.run_gc();
+
         let edges_inserted = edges.len();
 
         // Shard diagnostics


### PR DESCRIPTION
## Summary

- The packed adjacency list PR (#1357) reduced unique key count from 128M to ~4.8M, but each read-modify-write created a new MVCC version. With 64 batches, each key accumulated ~27 versions — same total entry count as before
- Add `db.run_gc()` after edge batch writes to prune superseded version chain entries, collapsing each key to a single version
- Expected: ~130M version entries → ~4.8M entries after GC

## Test plan

- [x] 357 graph tests pass
- [x] 296 executor tests pass
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)