### PR TITLE
Fix CLI exhaustive match for GraphPage output (#1316)

### DIFF
--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -385,6 +385,13 @@ fn format_raw(output: &Output) -> String {
         Output::ConfigValue(Some(v)) => v.clone(),
         Output::GraphAnalyticsU64(result) => serde_json::to_string(&result).unwrap_or_default(),
         Output::GraphAnalyticsF64(result) => serde_json::to_string(&result).unwrap_or_default(),
+        Output::GraphPage {
+            items,
+            next_cursor,
+        } => {
+            let page = serde_json::json!({ "items": items, "next_cursor": next_cursor });
+            serde_json::to_string(&page).unwrap_or_default()
+        }
     }
 }
 
@@ -840,6 +847,21 @@ fn format_human(output: &Output) -> String {
                 result.algorithm,
                 result.result.len(),
                 serde_json::to_string_pretty(&result).unwrap_or_default()
+            )
+        }
+        Output::GraphPage {
+            items,
+            next_cursor,
+        } => {
+            let cursor_info = match next_cursor {
+                Some(c) => format!("  (next_cursor: {})", c),
+                None => "  (last page)".to_string(),
+            };
+            format!(
+                "{} item(s){}\n{}",
+                items.len(),
+                cursor_info,
+                items.join("\n")
             )
         }
     }


### PR DESCRIPTION
## Summary
- Adds missing `Output::GraphPage` match arms in CLI formatter (raw + human modes)
- Fixes build failure on main after #1362 squash merge

## Test plan
- [x] `cargo clippy -p strata-cli -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)