### PR TITLE
Consolidate graph CLI: 31 → 15 top-level subcommands

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -949,7 +949,8 @@ fn build_graph() -> Command {
         .subcommand(
             Command::new("list-nodes")
                 .about("List all nodes in a graph")
-                .arg(Arg::new("graph").required(true).help("Graph name")),
+                .arg(Arg::new("graph").required(true).help("Graph name"))
+                .arg(Arg::new("type").long("type").help("Filter by object type")),
         )
         // Edges
         .subcommand(
@@ -1035,157 +1036,136 @@ fn build_graph() -> Command {
                         .help("Direction: outgoing, incoming, both"),
                 ),
         )
-        // Ontology — Object Types
+        // Ontology (nested)
         .subcommand(
-            Command::new("define-object-type")
-                .about("Define an object type in the ontology")
-                .arg(Arg::new("graph").required(true).help("Graph name"))
-                .arg(
-                    Arg::new("json")
-                        .required_unless_present("file")
-                        .help("Object type definition as JSON"),
+            Command::new("ontology")
+                .about("Ontology operations (define, get, list, delete, freeze, status, summary)")
+                .subcommand_required(true)
+                .subcommand(
+                    Command::new("define")
+                        .about("Define an object or link type (auto-detected from JSON)")
+                        .arg(Arg::new("graph").required(true).help("Graph name"))
+                        .arg(
+                            Arg::new("json")
+                                .required_unless_present("file")
+                                .help("Type definition as JSON"),
+                        )
+                        .arg(
+                            Arg::new("file")
+                                .long("file")
+                                .short('f')
+                                .value_name("PATH")
+                                .help("Read JSON from file ('-' for stdin)"),
+                        ),
                 )
-                .arg(
-                    Arg::new("file")
-                        .long("file")
-                        .short('f')
-                        .value_name("PATH")
-                        .help("Read JSON from file ('-' for stdin)"),
+                .subcommand(
+                    Command::new("get")
+                        .about("Get a type definition")
+                        .arg(Arg::new("graph").required(true).help("Graph name"))
+                        .arg(Arg::new("name").required(true).help("Type name"))
+                        .arg(
+                            Arg::new("kind")
+                                .long("kind")
+                                .help("Type kind: object or link (default: try object first)"),
+                        ),
+                )
+                .subcommand(
+                    Command::new("list")
+                        .about("List ontology types")
+                        .arg(Arg::new("graph").required(true).help("Graph name"))
+                        .arg(
+                            Arg::new("kind")
+                                .long("kind")
+                                .help("Type kind: object or link (default: list both)"),
+                        ),
+                )
+                .subcommand(
+                    Command::new("delete")
+                        .about("Delete a type definition")
+                        .arg(Arg::new("graph").required(true).help("Graph name"))
+                        .arg(Arg::new("name").required(true).help("Type name"))
+                        .arg(
+                            Arg::new("kind")
+                                .long("kind")
+                                .help("Type kind: object or link (default: try object first)"),
+                        ),
+                )
+                .subcommand(
+                    Command::new("freeze")
+                        .about("Freeze the graph ontology")
+                        .arg(Arg::new("graph").required(true).help("Graph name")),
+                )
+                .subcommand(
+                    Command::new("status")
+                        .about("Get ontology status")
+                        .arg(Arg::new("graph").required(true).help("Graph name")),
+                )
+                .subcommand(
+                    Command::new("summary")
+                        .about("Get ontology summary")
+                        .arg(Arg::new("graph").required(true).help("Graph name")),
                 ),
         )
+        // Analytics (nested)
         .subcommand(
-            Command::new("get-object-type")
-                .about("Get an object type definition")
-                .arg(Arg::new("graph").required(true).help("Graph name"))
-                .arg(Arg::new("name").required(true).help("Object type name")),
-        )
-        .subcommand(
-            Command::new("list-object-types")
-                .about("List all object types")
-                .arg(Arg::new("graph").required(true).help("Graph name")),
-        )
-        .subcommand(
-            Command::new("delete-object-type")
-                .about("Delete an object type")
-                .arg(Arg::new("graph").required(true).help("Graph name"))
-                .arg(Arg::new("name").required(true).help("Object type name")),
-        )
-        // Ontology — Link Types
-        .subcommand(
-            Command::new("define-link-type")
-                .about("Define a link type in the ontology")
-                .arg(Arg::new("graph").required(true).help("Graph name"))
-                .arg(
-                    Arg::new("json")
-                        .required_unless_present("file")
-                        .help("Link type definition as JSON"),
+            Command::new("analytics")
+                .about("Graph analytics algorithms (wcc, cdlp, pagerank, lcc, sssp)")
+                .subcommand_required(true)
+                .subcommand(
+                    Command::new("wcc")
+                        .about("Weakly Connected Components")
+                        .arg(Arg::new("graph").required(true).help("Graph name")),
                 )
-                .arg(
-                    Arg::new("file")
-                        .long("file")
-                        .short('f')
-                        .value_name("PATH")
-                        .help("Read JSON from file ('-' for stdin)"),
-                ),
-        )
-        .subcommand(
-            Command::new("get-link-type")
-                .about("Get a link type definition")
-                .arg(Arg::new("graph").required(true).help("Graph name"))
-                .arg(Arg::new("name").required(true).help("Link type name")),
-        )
-        .subcommand(
-            Command::new("list-link-types")
-                .about("List all link types")
-                .arg(Arg::new("graph").required(true).help("Graph name")),
-        )
-        .subcommand(
-            Command::new("delete-link-type")
-                .about("Delete a link type")
-                .arg(Arg::new("graph").required(true).help("Graph name"))
-                .arg(Arg::new("name").required(true).help("Link type name")),
-        )
-        // Ontology — Management
-        .subcommand(
-            Command::new("freeze-ontology")
-                .about("Freeze the graph ontology")
-                .arg(Arg::new("graph").required(true).help("Graph name")),
-        )
-        .subcommand(
-            Command::new("ontology-status")
-                .about("Get ontology status")
-                .arg(Arg::new("graph").required(true).help("Graph name")),
-        )
-        .subcommand(
-            Command::new("ontology-summary")
-                .about("Get ontology summary")
-                .arg(Arg::new("graph").required(true).help("Graph name")),
-        )
-        .subcommand(
-            Command::new("nodes-by-type")
-                .about("List nodes by object type")
-                .arg(Arg::new("graph").required(true).help("Graph name"))
-                .arg(
-                    Arg::new("object-type")
-                        .required(true)
-                        .help("Object type name"),
-                ),
-        )
-        // Analytics
-        .subcommand(
-            Command::new("wcc")
-                .about("Weakly Connected Components")
-                .arg(Arg::new("graph").required(true).help("Graph name")),
-        )
-        .subcommand(
-            Command::new("cdlp")
-                .about("Community Detection via Label Propagation")
-                .arg(Arg::new("graph").required(true).help("Graph name"))
-                .arg(
-                    Arg::new("max-iterations")
-                        .required(true)
-                        .help("Maximum iterations"),
+                .subcommand(
+                    Command::new("cdlp")
+                        .about("Community Detection via Label Propagation")
+                        .arg(Arg::new("graph").required(true).help("Graph name"))
+                        .arg(
+                            Arg::new("max-iterations")
+                                .required(true)
+                                .help("Maximum iterations"),
+                        )
+                        .arg(
+                            Arg::new("direction")
+                                .long("direction")
+                                .help("Direction: outgoing, incoming, both"),
+                        ),
                 )
-                .arg(
-                    Arg::new("direction")
-                        .long("direction")
-                        .help("Direction: outgoing, incoming, both"),
-                ),
-        )
-        .subcommand(
-            Command::new("pagerank")
-                .about("PageRank importance scoring")
-                .arg(Arg::new("graph").required(true).help("Graph name"))
-                .arg(
-                    Arg::new("damping")
-                        .long("damping")
-                        .help("Damping factor (default 0.85)"),
+                .subcommand(
+                    Command::new("pagerank")
+                        .about("PageRank importance scoring")
+                        .arg(Arg::new("graph").required(true).help("Graph name"))
+                        .arg(
+                            Arg::new("damping")
+                                .long("damping")
+                                .help("Damping factor (default 0.85)"),
+                        )
+                        .arg(
+                            Arg::new("max-iterations")
+                                .long("max-iterations")
+                                .help("Maximum iterations (default 20)"),
+                        )
+                        .arg(
+                            Arg::new("tolerance")
+                                .long("tolerance")
+                                .help("Convergence tolerance (default 1e-6)"),
+                        ),
                 )
-                .arg(
-                    Arg::new("max-iterations")
-                        .long("max-iterations")
-                        .help("Maximum iterations (default 20)"),
+                .subcommand(
+                    Command::new("lcc")
+                        .about("Local Clustering Coefficient")
+                        .arg(Arg::new("graph").required(true).help("Graph name")),
                 )
-                .arg(
-                    Arg::new("tolerance")
-                        .long("tolerance")
-                        .help("Convergence tolerance (default 1e-6)"),
-                ),
-        )
-        .subcommand(
-            Command::new("lcc")
-                .about("Local Clustering Coefficient")
-                .arg(Arg::new("graph").required(true).help("Graph name")),
-        )
-        .subcommand(
-            Command::new("sssp")
-                .about("Single-Source Shortest Path (Dijkstra)")
-                .arg(Arg::new("graph").required(true).help("Graph name"))
-                .arg(Arg::new("source").required(true).help("Source node ID"))
-                .arg(
-                    Arg::new("direction")
-                        .long("direction")
-                        .help("Direction: outgoing, incoming, both"),
+                .subcommand(
+                    Command::new("sssp")
+                        .about("Single-Source Shortest Path (Dijkstra)")
+                        .arg(Arg::new("graph").required(true).help("Graph name"))
+                        .arg(Arg::new("source").required(true).help("Source node ID"))
+                        .arg(
+                            Arg::new("direction")
+                                .long("direction")
+                                .help("Direction: outgoing, incoming, both"),
+                        ),
                 ),
         )
 }

--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -385,10 +385,7 @@ fn format_raw(output: &Output) -> String {
         Output::ConfigValue(Some(v)) => v.clone(),
         Output::GraphAnalyticsU64(result) => serde_json::to_string(&result).unwrap_or_default(),
         Output::GraphAnalyticsF64(result) => serde_json::to_string(&result).unwrap_or_default(),
-        Output::GraphPage {
-            items,
-            next_cursor,
-        } => {
+        Output::GraphPage { items, next_cursor } => {
             let page = serde_json::json!({ "items": items, "next_cursor": next_cursor });
             serde_json::to_string(&page).unwrap_or_default()
         }
@@ -849,10 +846,7 @@ fn format_human(output: &Output) -> String {
                 serde_json::to_string_pretty(&result).unwrap_or_default()
             )
         }
-        Output::GraphPage {
-            items,
-            next_cursor,
-        } => {
+        Output::GraphPage { items, next_cursor } => {
             let cursor_info = match next_cursor {
                 Some(c) => format!("  (next_cursor: {})", c),
                 None => "  (last page)".to_string(),

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -864,10 +864,18 @@ fn parse_graph(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, 
         }
         "list-nodes" => {
             let graph = m.get_one::<String>("graph").unwrap().clone();
-            Ok(CliAction::Execute(Command::GraphListNodes {
-                branch: branch(state),
-                graph,
-            }))
+            if let Some(object_type) = m.get_one::<String>("type").cloned() {
+                Ok(CliAction::Execute(Command::GraphNodesByType {
+                    branch: branch(state),
+                    graph,
+                    object_type,
+                }))
+            } else {
+                Ok(CliAction::Execute(Command::GraphListNodes {
+                    branch: branch(state),
+                    graph,
+                }))
+            }
         }
         // Edges
         "add-edge" => {
@@ -998,182 +1006,190 @@ fn parse_graph(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, 
                 direction,
             }))
         }
-        // Ontology — Object Types
-        "define-object-type" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            let definition = if let Some(file_path) = m.get_one::<String>("file") {
-                read_json_from_source(file_path)?
-            } else {
-                let raw = m.get_one::<String>("json").unwrap();
-                parse_json_value(raw)?
-            };
-            Ok(CliAction::Execute(Command::GraphDefineObjectType {
-                branch: branch(state),
-                graph,
-                definition,
-            }))
+        // Ontology (nested)
+        "ontology" => {
+            let (onto_sub, onto_m) = m.subcommand().ok_or("No ontology subcommand")?;
+            match onto_sub {
+                "define" => {
+                    let graph = onto_m.get_one::<String>("graph").unwrap().clone();
+                    let definition = if let Some(file_path) = onto_m.get_one::<String>("file") {
+                        read_json_from_source(file_path)?
+                    } else {
+                        let raw = onto_m.get_one::<String>("json").unwrap();
+                        parse_json_value(raw)?
+                    };
+                    // Auto-detect: if JSON has "source" and "target" keys, it's a link type
+                    let is_link = match &definition {
+                        Value::Object(map) => {
+                            map.contains_key("source") && map.contains_key("target")
+                        }
+                        _ => false,
+                    };
+                    if is_link {
+                        Ok(CliAction::Execute(Command::GraphDefineLinkType {
+                            branch: branch(state),
+                            graph,
+                            definition,
+                        }))
+                    } else {
+                        Ok(CliAction::Execute(Command::GraphDefineObjectType {
+                            branch: branch(state),
+                            graph,
+                            definition,
+                        }))
+                    }
+                }
+                "get" => {
+                    let graph = onto_m.get_one::<String>("graph").unwrap().clone();
+                    let name = onto_m.get_one::<String>("name").unwrap().clone();
+                    let kind = onto_m.get_one::<String>("kind").map(|s| s.as_str());
+                    match kind {
+                        Some("link") => Ok(CliAction::Execute(Command::GraphGetLinkType {
+                            branch: branch(state),
+                            graph,
+                            name,
+                        })),
+                        _ => Ok(CliAction::Execute(Command::GraphGetObjectType {
+                            branch: branch(state),
+                            graph,
+                            name,
+                        })),
+                    }
+                }
+                "list" => {
+                    let graph = onto_m.get_one::<String>("graph").unwrap().clone();
+                    let kind = onto_m.get_one::<String>("kind").map(|s| s.as_str());
+                    match kind {
+                        Some("object") => Ok(CliAction::Execute(Command::GraphListObjectTypes {
+                            branch: branch(state),
+                            graph,
+                        })),
+                        Some("link") => Ok(CliAction::Execute(Command::GraphListLinkTypes {
+                            branch: branch(state),
+                            graph,
+                        })),
+                        None => Ok(CliAction::Execute(Command::GraphListOntologyTypes {
+                            branch: branch(state),
+                            graph,
+                        })),
+                        Some(other) => Err(format!(
+                            "Invalid --kind '{}'. Use 'object' or 'link'.",
+                            other
+                        )),
+                    }
+                }
+                "delete" => {
+                    let graph = onto_m.get_one::<String>("graph").unwrap().clone();
+                    let name = onto_m.get_one::<String>("name").unwrap().clone();
+                    let kind = onto_m.get_one::<String>("kind").map(|s| s.as_str());
+                    match kind {
+                        Some("link") => Ok(CliAction::Execute(Command::GraphDeleteLinkType {
+                            branch: branch(state),
+                            graph,
+                            name,
+                        })),
+                        _ => Ok(CliAction::Execute(Command::GraphDeleteObjectType {
+                            branch: branch(state),
+                            graph,
+                            name,
+                        })),
+                    }
+                }
+                "freeze" => {
+                    let graph = onto_m.get_one::<String>("graph").unwrap().clone();
+                    Ok(CliAction::Execute(Command::GraphFreezeOntology {
+                        branch: branch(state),
+                        graph,
+                    }))
+                }
+                "status" => {
+                    let graph = onto_m.get_one::<String>("graph").unwrap().clone();
+                    Ok(CliAction::Execute(Command::GraphOntologyStatus {
+                        branch: branch(state),
+                        graph,
+                    }))
+                }
+                "summary" => {
+                    let graph = onto_m.get_one::<String>("graph").unwrap().clone();
+                    Ok(CliAction::Execute(Command::GraphOntologySummary {
+                        branch: branch(state),
+                        graph,
+                    }))
+                }
+                other => Err(format!("Unknown ontology subcommand: {}", other)),
+            }
         }
-        "get-object-type" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            let name = m.get_one::<String>("name").unwrap().clone();
-            Ok(CliAction::Execute(Command::GraphGetObjectType {
-                branch: branch(state),
-                graph,
-                name,
-            }))
-        }
-        "list-object-types" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            Ok(CliAction::Execute(Command::GraphListObjectTypes {
-                branch: branch(state),
-                graph,
-            }))
-        }
-        "delete-object-type" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            let name = m.get_one::<String>("name").unwrap().clone();
-            Ok(CliAction::Execute(Command::GraphDeleteObjectType {
-                branch: branch(state),
-                graph,
-                name,
-            }))
-        }
-        // Ontology — Link Types
-        "define-link-type" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            let definition = if let Some(file_path) = m.get_one::<String>("file") {
-                read_json_from_source(file_path)?
-            } else {
-                let raw = m.get_one::<String>("json").unwrap();
-                parse_json_value(raw)?
-            };
-            Ok(CliAction::Execute(Command::GraphDefineLinkType {
-                branch: branch(state),
-                graph,
-                definition,
-            }))
-        }
-        "get-link-type" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            let name = m.get_one::<String>("name").unwrap().clone();
-            Ok(CliAction::Execute(Command::GraphGetLinkType {
-                branch: branch(state),
-                graph,
-                name,
-            }))
-        }
-        "list-link-types" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            Ok(CliAction::Execute(Command::GraphListLinkTypes {
-                branch: branch(state),
-                graph,
-            }))
-        }
-        "delete-link-type" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            let name = m.get_one::<String>("name").unwrap().clone();
-            Ok(CliAction::Execute(Command::GraphDeleteLinkType {
-                branch: branch(state),
-                graph,
-                name,
-            }))
-        }
-        // Ontology — Management
-        "freeze-ontology" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            Ok(CliAction::Execute(Command::GraphFreezeOntology {
-                branch: branch(state),
-                graph,
-            }))
-        }
-        "ontology-status" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            Ok(CliAction::Execute(Command::GraphOntologyStatus {
-                branch: branch(state),
-                graph,
-            }))
-        }
-        "ontology-summary" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            Ok(CliAction::Execute(Command::GraphOntologySummary {
-                branch: branch(state),
-                graph,
-            }))
-        }
-        "nodes-by-type" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            let object_type = m.get_one::<String>("object-type").unwrap().clone();
-            Ok(CliAction::Execute(Command::GraphNodesByType {
-                branch: branch(state),
-                graph,
-                object_type,
-            }))
-        }
-        // Analytics
-        "wcc" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            Ok(CliAction::Execute(Command::GraphWcc {
-                branch: branch(state),
-                graph,
-            }))
-        }
-        "cdlp" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            let max_iterations = m
-                .get_one::<String>("max-iterations")
-                .unwrap()
-                .parse::<usize>()
-                .map_err(|e| format!("Invalid max-iterations: {}", e))?;
-            let direction = m.get_one::<String>("direction").cloned();
-            Ok(CliAction::Execute(Command::GraphCdlp {
-                branch: branch(state),
-                graph,
-                max_iterations,
-                direction,
-            }))
-        }
-        "pagerank" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            let damping = m
-                .get_one::<String>("damping")
-                .map(|s| s.parse::<f64>())
-                .transpose()
-                .map_err(|e| format!("Invalid damping: {}", e))?;
-            let max_iterations = m
-                .get_one::<String>("max-iterations")
-                .map(|s| s.parse::<usize>())
-                .transpose()
-                .map_err(|e| format!("Invalid max-iterations: {}", e))?;
-            let tolerance = m
-                .get_one::<String>("tolerance")
-                .map(|s| s.parse::<f64>())
-                .transpose()
-                .map_err(|e| format!("Invalid tolerance: {}", e))?;
-            Ok(CliAction::Execute(Command::GraphPagerank {
-                branch: branch(state),
-                graph,
-                damping,
-                max_iterations,
-                tolerance,
-            }))
-        }
-        "lcc" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            Ok(CliAction::Execute(Command::GraphLcc {
-                branch: branch(state),
-                graph,
-            }))
-        }
-        "sssp" => {
-            let graph = m.get_one::<String>("graph").unwrap().clone();
-            let source = m.get_one::<String>("source").unwrap().clone();
-            let direction = m.get_one::<String>("direction").cloned();
-            Ok(CliAction::Execute(Command::GraphSssp {
-                branch: branch(state),
-                graph,
-                source,
-                direction,
-            }))
+        // Analytics (nested)
+        "analytics" => {
+            let (alg_sub, alg_m) = m.subcommand().ok_or("No analytics subcommand")?;
+            match alg_sub {
+                "wcc" => {
+                    let graph = alg_m.get_one::<String>("graph").unwrap().clone();
+                    Ok(CliAction::Execute(Command::GraphWcc {
+                        branch: branch(state),
+                        graph,
+                    }))
+                }
+                "cdlp" => {
+                    let graph = alg_m.get_one::<String>("graph").unwrap().clone();
+                    let max_iterations = alg_m
+                        .get_one::<String>("max-iterations")
+                        .unwrap()
+                        .parse::<usize>()
+                        .map_err(|e| format!("Invalid max-iterations: {}", e))?;
+                    let direction = alg_m.get_one::<String>("direction").cloned();
+                    Ok(CliAction::Execute(Command::GraphCdlp {
+                        branch: branch(state),
+                        graph,
+                        max_iterations,
+                        direction,
+                    }))
+                }
+                "pagerank" => {
+                    let graph = alg_m.get_one::<String>("graph").unwrap().clone();
+                    let damping = alg_m
+                        .get_one::<String>("damping")
+                        .map(|s| s.parse::<f64>())
+                        .transpose()
+                        .map_err(|e| format!("Invalid damping: {}", e))?;
+                    let max_iterations = alg_m
+                        .get_one::<String>("max-iterations")
+                        .map(|s| s.parse::<usize>())
+                        .transpose()
+                        .map_err(|e| format!("Invalid max-iterations: {}", e))?;
+                    let tolerance = alg_m
+                        .get_one::<String>("tolerance")
+                        .map(|s| s.parse::<f64>())
+                        .transpose()
+                        .map_err(|e| format!("Invalid tolerance: {}", e))?;
+                    Ok(CliAction::Execute(Command::GraphPagerank {
+                        branch: branch(state),
+                        graph,
+                        damping,
+                        max_iterations,
+                        tolerance,
+                    }))
+                }
+                "lcc" => {
+                    let graph = alg_m.get_one::<String>("graph").unwrap().clone();
+                    Ok(CliAction::Execute(Command::GraphLcc {
+                        branch: branch(state),
+                        graph,
+                    }))
+                }
+                "sssp" => {
+                    let graph = alg_m.get_one::<String>("graph").unwrap().clone();
+                    let source = alg_m.get_one::<String>("source").unwrap().clone();
+                    let direction = alg_m.get_one::<String>("direction").cloned();
+                    Ok(CliAction::Execute(Command::GraphSssp {
+                        branch: branch(state),
+                        graph,
+                        source,
+                        direction,
+                    }))
+                }
+                other => Err(format!("Unknown analytics subcommand: {}", other)),
+            }
         }
         other => Err(format!("Unknown graph subcommand: {}", other)),
     }

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -492,23 +492,8 @@ fn subcommands_for(cmd: &str) -> &'static [&'static str] {
             "neighbors",
             "bulk-insert",
             "bfs",
-            "define-object-type",
-            "get-object-type",
-            "list-object-types",
-            "delete-object-type",
-            "define-link-type",
-            "get-link-type",
-            "list-link-types",
-            "delete-link-type",
-            "freeze-ontology",
-            "ontology-status",
-            "ontology-summary",
-            "nodes-by-type",
-            "wcc",
-            "cdlp",
-            "pagerank",
-            "lcc",
-            "sssp",
+            "ontology",
+            "analytics",
         ],
         "branch" => &[
             "create", "info", "get", "list", "exists", "del", "fork", "diff", "merge", "export",
@@ -517,6 +502,17 @@ fn subcommands_for(cmd: &str) -> &'static [&'static str] {
         "space" => &["list", "create", "del", "exists"],
         "txn" => &["info", "active"],
         "config" => &["set", "get", "list"],
+        _ => &[],
+    }
+}
+
+/// Known sub-subcommands for nested commands (3rd level).
+fn sub_subcommands_for(cmd: &str, sub: &str) -> &'static [&'static str] {
+    match (cmd, sub) {
+        ("graph", "ontology") => &[
+            "define", "get", "list", "delete", "freeze", "status", "summary",
+        ],
+        ("graph", "analytics") => &["wcc", "cdlp", "pagerank", "lcc", "sssp"],
         _ => &[],
     }
 }
@@ -593,6 +589,37 @@ impl Completer for StrataHelper {
                 })
                 .collect();
             Ok((start, candidates))
+        } else if parts.len() == 2 && trailing_space {
+            // Just typed "graph ontology ", completing sub-subcommand
+            let sub_subs = sub_subcommands_for(parts[0], parts[1]);
+            if !sub_subs.is_empty() {
+                let candidates: Vec<Pair> = sub_subs
+                    .iter()
+                    .map(|s| Pair {
+                        display: s.to_string(),
+                        replacement: s.to_string(),
+                    })
+                    .collect();
+                return Ok((pos, candidates));
+            }
+            Ok((pos, vec![]))
+        } else if parts.len() == 3 && !trailing_space {
+            // Completing partial sub-subcommand
+            let sub_subs = sub_subcommands_for(parts[0], parts[1]);
+            if !sub_subs.is_empty() {
+                let prefix = parts[2];
+                let start = pos - prefix.len();
+                let candidates: Vec<Pair> = sub_subs
+                    .iter()
+                    .filter(|s| s.starts_with(prefix))
+                    .map(|s| Pair {
+                        display: s.to_string(),
+                        replacement: s.to_string(),
+                    })
+                    .collect();
+                return Ok((start, candidates));
+            }
+            Ok((pos, vec![]))
         } else {
             Ok((pos, vec![]))
         }

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -1315,6 +1315,16 @@ pub enum Command {
         graph: String,
     },
 
+    /// List all ontology types (both object and link types).
+    /// Returns: `Output::Keys`
+    GraphListOntologyTypes {
+        /// Target branch.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Graph name.
+        graph: String,
+    },
+
     /// Get all node IDs of a given object type.
     /// Returns: `Output::Keys`
     GraphNodesByType {
@@ -1560,6 +1570,7 @@ impl Command {
             Command::GraphDefineObjectType { .. } => "GraphDefineObjectType",
             Command::GraphGetObjectType { .. } => "GraphGetObjectType",
             Command::GraphListObjectTypes { .. } => "GraphListObjectTypes",
+            Command::GraphListOntologyTypes { .. } => "GraphListOntologyTypes",
             Command::GraphDeleteObjectType { .. } => "GraphDeleteObjectType",
             Command::GraphDefineLinkType { .. } => "GraphDefineLinkType",
             Command::GraphGetLinkType { .. } => "GraphGetLinkType",
@@ -1678,6 +1689,7 @@ impl Command {
             | Command::GraphDefineObjectType { branch, .. }
             | Command::GraphGetObjectType { branch, .. }
             | Command::GraphListObjectTypes { branch, .. }
+            | Command::GraphListOntologyTypes { branch, .. }
             | Command::GraphDeleteObjectType { branch, .. }
             | Command::GraphDefineLinkType { branch, .. }
             | Command::GraphGetLinkType { branch, .. }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -1241,6 +1241,12 @@ impl Executor {
                 })?;
                 crate::handlers::graph::graph_list_object_types(&self.primitives, branch, graph)
             }
+            Command::GraphListOntologyTypes { branch, graph } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                })?;
+                crate::handlers::graph::graph_list_ontology_types(&self.primitives, branch, graph)
+            }
             Command::GraphDeleteObjectType {
                 branch,
                 graph,

--- a/crates/executor/src/handlers/graph.rs
+++ b/crates/executor/src/handlers/graph.rs
@@ -518,6 +518,21 @@ pub fn graph_ontology_summary(
     }
 }
 
+/// Handle GraphListOntologyTypes command — lists both object and link types.
+pub fn graph_list_ontology_types(
+    p: &Arc<Primitives>,
+    branch: BranchId,
+    graph: String,
+) -> Result<Output> {
+    let core_branch = to_core_branch_id(&branch)?;
+    let mut names = convert_result(p.graph.list_object_types(core_branch, &graph))?;
+    let link_names = convert_result(p.graph.list_link_types(core_branch, &graph))?;
+    names.extend(link_names);
+    names.sort();
+    names.dedup();
+    Ok(Output::Keys(names))
+}
+
 /// Handle GraphNodesByType command.
 pub fn graph_nodes_by_type(
     p: &Arc<Primitives>,

--- a/docs/cookbook/graph-analytics.md
+++ b/docs/cookbook/graph-analytics.md
@@ -91,7 +91,7 @@ let components = db.graph_wcc("social")?;
 ```
 
 ```
-graph wcc social
+graph analytics wcc social
 ```
 
 Now remove the bridge and check again:
@@ -119,7 +119,7 @@ let communities = db.graph_cdlp("social", 10, None)?;
 ```
 
 ```
-graph cdlp social 10
+graph analytics cdlp social 10
 ```
 
 Try directed community detection:
@@ -130,7 +130,7 @@ let communities = db.graph_cdlp("social", 10, Some("outgoing"))?;
 ```
 
 ```
-graph cdlp social 10 --direction outgoing
+graph analytics cdlp social 10 --direction outgoing
 ```
 
 **Use case:** Interest-based user grouping, topic clustering, organizational structure detection.
@@ -147,7 +147,7 @@ let ranks = db.graph_pagerank("social", None, None, None)?;
 ```
 
 ```
-graph pagerank social
+graph analytics pagerank social
 ```
 
 Tune the algorithm:
@@ -158,7 +158,7 @@ let ranks = db.graph_pagerank("social", Some(0.95), Some(100), Some(1e-8))?;
 ```
 
 ```
-graph pagerank social --damping 0.95 --max-iterations 100 --tolerance 0.00000001
+graph analytics pagerank social --damping 0.95 --max-iterations 100 --tolerance 0.00000001
 ```
 
 **Use case:** Identifying key influencers, ranking documents, finding critical infrastructure nodes.
@@ -177,7 +177,7 @@ let coefficients = db.graph_lcc("social")?;
 ```
 
 ```
-graph lcc social
+graph analytics lcc social
 ```
 
 **Use case:** Identifying cliques, measuring social cohesion, spam detection (spammers tend to have low LCC).
@@ -193,7 +193,7 @@ let distances = db.graph_sssp("social", "alice", None)?;
 ```
 
 ```
-graph sssp social alice
+graph analytics sssp social alice
 ```
 
 With weighted edges:
@@ -217,7 +217,7 @@ let distances = db.graph_sssp("social", "dave", Some("incoming"))?;
 ```
 
 ```
-graph sssp social dave --direction incoming
+graph analytics sssp social dave --direction incoming
 ```
 
 **Use case:** Network routing, supply chain optimization, social distance measurement.

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -352,7 +352,7 @@ let result = db.graph_wcc("social")?;
 
 **CLI:**
 ```
-graph wcc social
+graph analytics wcc social
 ```
 
 ### CDLP — Community Detection via Label Propagation
@@ -373,8 +373,8 @@ let result = db.graph_cdlp("social", 10, Some("outgoing"))?;
 
 **CLI:**
 ```
-graph cdlp social 10
-graph cdlp social 10 --direction outgoing
+graph analytics cdlp social 10
+graph analytics cdlp social 10 --direction outgoing
 ```
 
 ### PageRank — Iterative Importance Scoring
@@ -396,8 +396,8 @@ let result = db.graph_pagerank("social", Some(0.90), Some(50), Some(1e-8))?;
 
 **CLI:**
 ```
-graph pagerank social
-graph pagerank social --damping 0.90 --max-iterations 50 --tolerance 0.00000001
+graph analytics pagerank social
+graph analytics pagerank social --damping 0.90 --max-iterations 50 --tolerance 0.00000001
 ```
 
 ### LCC — Local Clustering Coefficient
@@ -413,7 +413,7 @@ let result = db.graph_lcc("social")?;
 
 **CLI:**
 ```
-graph lcc social
+graph analytics lcc social
 ```
 
 ### SSSP — Single-Source Shortest Path
@@ -437,8 +437,8 @@ let result = db.graph_sssp("social", "alice", Some("both"))?;
 
 **CLI:**
 ```
-graph sssp social alice
-graph sssp social alice --direction both
+graph analytics sssp social alice
+graph analytics sssp social alice --direction both
 ```
 
 ### Direction Parameter


### PR DESCRIPTION
## Summary
- Group 12 ontology commands into nested `graph ontology {define,get,list,delete,freeze,status,summary}` with auto-detect (object vs link type) and `--kind` flag
- Group 5 analytics commands into nested `graph analytics {wcc,cdlp,pagerank,lcc,sssp}`
- Absorb `nodes-by-type` into `list-nodes --type`
- Add `GraphListOntologyTypes` executor command for unified `ontology list` (returns both object + link types)
- Extend REPL tab completion to support 3-level nested commands (`graph ontology <tab>`, `graph analytics <tab>`)
- Update CLI examples in docs/guides/graph.md and docs/cookbook/graph-analytics.md

## Test plan
- [x] `cargo clippy --all -- -D warnings` passes clean
- [x] `cargo test -p strata-engine --lib -- graph::` — 394 tests pass
- [x] `cargo test -p strata-executor --lib` — 296 tests pass
- [x] `cargo fmt --all -- --check` passes clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)