### PR TITLE
Vector robustness & validation: Epic #1324

### DIFF
--- a/crates/engine/src/primitives/vector/hnsw.rs
+++ b/crates/engine/src/primitives/vector/hnsw.rs
@@ -648,13 +648,11 @@ impl HnswGraph {
         self.nodes.insert(id, node);
 
         // First node
-        if self.entry_point.is_none() {
+        let Some(entry_id) = self.entry_point else {
             self.entry_point = Some(id);
             self.max_level = level;
             return;
-        }
-
-        let entry_id = self.entry_point.unwrap();
+        };
 
         // Paper lines 4-6: greedy search from top to level+1
         let mut current_entry = entry_id;
@@ -1164,6 +1162,8 @@ pub(crate) struct CompactHnswGraph {
     pub(crate) node_count: usize,
     pub(crate) entry_point: Option<VectorId>,
     pub(crate) max_level: usize,
+    /// Held to keep advisory shared lock for the struct lifetime (mmap-backed graphs only)
+    pub(crate) _lock_file: Option<std::fs::File>,
 }
 
 impl CompactHnswGraph {
@@ -1292,6 +1292,7 @@ impl CompactHnswGraph {
             node_count,
             entry_point: graph.entry_point,
             max_level: graph.max_level,
+            _lock_file: None,
         }
     }
 
@@ -2448,6 +2449,7 @@ mod tests {
             node_count,
             entry_point: Some(VectorId::new(100)),
             max_level: 0,
+            _lock_file: None,
         };
 
         // get_node should work with offset

--- a/crates/engine/src/primitives/vector/mmap.rs
+++ b/crates/engine/src/primitives/vector/mmap.rs
@@ -22,6 +22,9 @@
 //! gives byte offsets into the embeddings section (measured in f32 elements,
 //! not bytes, matching VectorHeap conventions).
 
+#[cfg(not(target_endian = "little"))]
+compile_error!("MmapVectorData requires little-endian architecture for zero-copy f32 access");
+
 use memmap2::Mmap;
 use std::collections::BTreeMap;
 use std::fs::{self, File};
@@ -112,6 +115,8 @@ pub(crate) struct MmapVectorData {
     free_slots: Vec<usize>,
     /// Byte offset where embeddings data starts in the mmap
     embeddings_offset: usize,
+    /// Held to keep advisory shared lock for the struct lifetime
+    _lock_file: File,
 }
 
 impl MmapVectorData {
@@ -120,6 +125,8 @@ impl MmapVectorData {
     /// Returns `None` if the file doesn't exist or is invalid (caller falls back to KV).
     pub(crate) fn open(path: &Path, expected_dimension: usize) -> Result<Self, VectorError> {
         let file = File::open(path).map_err(|e| VectorError::Io(e.to_string()))?;
+        fs2::FileExt::lock_shared(&file)
+            .map_err(|e| VectorError::Io(format!("failed to lock {}: {e}", path.display())))?;
         // SAFETY: We treat the mmap as read-only and the file is opened read-only.
         let mmap = unsafe { Mmap::map(&file) }.map_err(|e| VectorError::Io(e.to_string()))?;
 
@@ -210,6 +217,7 @@ impl MmapVectorData {
             index,
             free_slots,
             embeddings_offset,
+            _lock_file: file,
         })
     }
 
@@ -222,7 +230,11 @@ impl MmapVectorData {
             return None;
         }
         let slice = &self.mmap[byte_start..byte_end];
-        // SAFETY: f32 is 4 bytes, alignment is guaranteed by the file format,
+        assert!(
+            slice.as_ptr() as usize % std::mem::align_of::<f32>() == 0,
+            "mmap slice pointer is not aligned to f32"
+        );
+        // SAFETY: f32 is 4 bytes, alignment is asserted above,
         // and we've verified the bounds.
         let floats =
             unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const f32, self.dimension) };
@@ -237,6 +249,10 @@ impl MmapVectorData {
             return None;
         }
         let slice = &self.mmap[byte_start..byte_end];
+        assert!(
+            slice.as_ptr() as usize % std::mem::align_of::<f32>() == 0,
+            "mmap slice pointer is not aligned to f32"
+        );
         let floats = unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const f32, dim) };
         Some(floats)
     }
@@ -308,6 +324,8 @@ pub(crate) fn write_mmap_file(
     // Write to temp file then rename for atomicity
     let temp_path = path.with_extension("vec.tmp");
     let mut file = File::create(&temp_path).map_err(|e| VectorError::Io(e.to_string()))?;
+    fs2::FileExt::lock_exclusive(&file)
+        .map_err(|e| VectorError::Io(format!("failed to lock {}: {e}", temp_path.display())))?;
 
     // Header
     file.write_all(MAGIC)

--- a/crates/engine/src/primitives/vector/mmap_graph.rs
+++ b/crates/engine/src/primitives/vector/mmap_graph.rs
@@ -88,6 +88,8 @@ pub(crate) fn write_graph_file(path: &Path, graph: &CompactHnswGraph) -> Result<
     // Write to temp file then rename for atomicity
     let temp_path = path.with_extension("hgr.tmp");
     let mut file = File::create(&temp_path).map_err(|e| VectorError::Io(e.to_string()))?;
+    fs2::FileExt::lock_exclusive(&file)
+        .map_err(|e| VectorError::Io(format!("failed to lock {}: {e}", temp_path.display())))?;
 
     // Header (48 bytes)
     file.write_all(MAGIC)
@@ -179,6 +181,8 @@ pub(crate) fn open_graph_file(
     vector_config: VectorConfig,
 ) -> Result<CompactHnswGraph, VectorError> {
     let file = File::open(path).map_err(|e| VectorError::Io(e.to_string()))?;
+    fs2::FileExt::lock_shared(&file)
+        .map_err(|e| VectorError::Io(format!("failed to lock {}: {e}", path.display())))?;
     // SAFETY: File is opened read-only; mmap is treated as immutable.
     let mmap = unsafe { Mmap::map(&file) }.map_err(|e| VectorError::Io(e.to_string()))?;
 
@@ -314,6 +318,7 @@ pub(crate) fn open_graph_file(
         node_count: actual_node_count,
         entry_point,
         max_level,
+        _lock_file: Some(file),
     })
 }
 
@@ -434,6 +439,7 @@ mod tests {
             node_count: 0,
             entry_point: None,
             max_level: 0,
+            _lock_file: None,
         };
 
         write_graph_file(&path, &graph).unwrap();
@@ -584,6 +590,7 @@ mod tests {
             node_count,
             entry_point: Some(VectorId::new(42)),
             max_level: 0,
+            _lock_file: None,
         };
 
         write_graph_file(&path, &graph).unwrap();

--- a/crates/engine/src/primitives/vector/segmented.rs
+++ b/crates/engine/src/primitives/vector/segmented.rs
@@ -110,7 +110,7 @@ static SEARCH_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
         .thread_name(|i| format!("strata-vsearch-{}", i))
         .stack_size(1024 * 1024) // 1 MB per thread (vs default 2 MB)
         .build()
-        .expect("failed to build vector search thread pool")
+        .unwrap_or_else(|e| panic!("failed to build vector search thread pool: {e}"))
 });
 
 /// Minimum number of sealed segments before using parallel search.

--- a/crates/engine/src/primitives/vector/store.rs
+++ b/crates/engine/src/primitives/vector/store.rs
@@ -41,7 +41,7 @@ use strata_core::contract::{Timestamp, Version, Versioned};
 use strata_core::types::{BranchId, Key, Namespace};
 use strata_core::value::Value;
 use strata_core::EntityRef;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Statistics from vector recovery
 #[derive(Debug, Default, Clone)]
@@ -82,6 +82,19 @@ impl Default for VectorBackendState {
             backends: RwLock::new(BTreeMap::new()),
         }
     }
+}
+
+/// Validate that a query vector contains only finite f32 values.
+///
+/// NaN and Infinity values corrupt distance calculations and produce
+/// meaningless results. Rejecting them early gives a clear error message.
+fn validate_query_values(values: &[f32]) -> VectorResult<()> {
+    if values.iter().any(|v| !v.is_finite()) {
+        return Err(VectorError::InvalidEmbedding {
+            reason: "query vector contains NaN or infinite values".into(),
+        });
+    }
+    Ok(())
 }
 
 /// Vector storage and search primitive
@@ -857,6 +870,9 @@ impl VectorStore {
             return Ok(Vec::new());
         }
 
+        // Reject NaN/Infinity in query vector
+        validate_query_values(query)?;
+
         // Ensure collection is loaded
         self.ensure_collection_loaded(branch_id, space, collection)?;
 
@@ -1003,6 +1019,9 @@ impl VectorStore {
         filter: Option<MetadataFilter>,
         as_of_ts: u64,
     ) -> VectorResult<Vec<VectorMatch>> {
+        // Reject NaN/Infinity in query vector
+        validate_query_values(query)?;
+
         // Ensure collection is loaded
         self.ensure_collection_loaded(branch_id, space, collection)?;
 
@@ -1014,13 +1033,6 @@ impl VectorStore {
             return Err(VectorError::DimensionMismatch {
                 expected: config.dimension,
                 got: query.len(),
-            });
-        }
-
-        // Validate query values
-        if query.iter().any(|v| v.is_nan() || v.is_infinite()) {
-            return Err(VectorError::InvalidEmbedding {
-                reason: "query contains NaN or Infinity values".to_string(),
             });
         }
 
@@ -1109,6 +1121,18 @@ impl VectorStore {
 
     /// Initialize the index backend for a collection
     fn init_backend(&self, id: &CollectionId, config: &VectorConfig) -> Result<(), VectorError> {
+        let backend = self.create_backend(id, config)?;
+        let state = self.state()?;
+        state.backends.write().insert(id.clone(), backend);
+        Ok(())
+    }
+
+    /// Create and configure an index backend without inserting it into the map.
+    fn create_backend(
+        &self,
+        id: &CollectionId,
+        config: &VectorConfig,
+    ) -> Result<Box<dyn VectorIndexBackend>, VectorError> {
         let mut backend = self.backend_factory().create(config);
 
         // Set flush_path so the tiered heap can flush overlays during fresh
@@ -1118,14 +1142,22 @@ impl VectorStore {
         if !data_dir.as_os_str().is_empty() {
             let vec_path = super::recovery::mmap_path(data_dir, id.branch_id, &id.name);
             if let Some(parent) = vec_path.parent() {
-                let _ = std::fs::create_dir_all(parent);
+                if let Err(e) = std::fs::create_dir_all(parent) {
+                    warn!(
+                        "failed to create vector data directory {}: {e}",
+                        parent.display()
+                    );
+                }
             }
-            let _ = backend.flush_heap_to_disk_if_needed(&vec_path);
+            if let Err(e) = backend.flush_heap_to_disk_if_needed(&vec_path) {
+                warn!(
+                    "failed to flush heap to disk at {}: {e}",
+                    vec_path.display()
+                );
+            }
         }
 
-        let state = self.state()?;
-        state.backends.write().insert(id.clone(), backend);
-        Ok(())
+        Ok(backend)
     }
 
     /// Get collection config (required version that errors if not found)
@@ -1376,6 +1408,10 @@ impl VectorStore {
     ///
     /// If the collection exists in KV but not in memory (after recovery),
     /// this loads it and initializes the backend.
+    ///
+    /// Uses double-checked locking to avoid TOCTOU races: the read-lock fast
+    /// path avoids contention in the common case, while the write-lock slow
+    /// path re-checks to prevent duplicate initialization.
     pub(crate) fn ensure_collection_loaded(
         &self,
         branch_id: BranchId,
@@ -1383,27 +1419,27 @@ impl VectorStore {
         name: &str,
     ) -> VectorResult<()> {
         let collection_id = CollectionId::new(branch_id, name);
+        let state = self.state()?;
 
-        // Already loaded?
-        {
-            let state = self.state()?;
-            if state.backends.read().contains_key(&collection_id) {
-                return Ok(());
-            }
+        // Fast path: read lock check
+        if state.backends.read().contains_key(&collection_id) {
+            return Ok(());
         }
 
-        // Load from KV
+        // Slow path: load config and create backend outside lock
         let config = self
             .load_collection_config(branch_id, space, name)?
             .ok_or_else(|| VectorError::CollectionNotFound {
                 name: name.to_string(),
             })?;
+        let backend = self.create_backend(&collection_id, &config)?;
 
-        // Initialize backend
-        self.init_backend(&collection_id, &config)?;
-
-        // Note: Loading vectors into backend happens during recovery
-
+        // Double-check under write lock: another thread may have loaded it
+        let mut backends = state.backends.write();
+        if backends.contains_key(&collection_id) {
+            return Ok(());
+        }
+        backends.insert(collection_id, backend);
         Ok(())
     }
 
@@ -1716,6 +1752,9 @@ impl VectorStore {
             return Ok(Vec::new());
         }
 
+        // Reject NaN/Infinity in query vector
+        validate_query_values(query)?;
+
         // Ensure collection is loaded
         self.ensure_collection_loaded(branch_id, space, collection)?;
 
@@ -1820,6 +1859,9 @@ impl VectorStore {
         if k == 0 {
             return Ok(Vec::new());
         }
+
+        // Reject NaN/Infinity in query vector
+        validate_query_values(query)?;
 
         // Ensure collection is loaded
         self.ensure_collection_loaded(branch_id, space, collection)?;
@@ -3913,5 +3955,150 @@ mod tests {
                 .unwrap(),
             2
         );
+    }
+
+    // ========================================
+    // V-22: NaN/Infinity query validation
+    // ========================================
+
+    #[test]
+    fn test_search_nan_query_returns_error() {
+        let (_temp, _db, store) = setup();
+        let branch_id = BranchId::new();
+
+        let config = VectorConfig::for_minilm();
+        store
+            .create_collection(branch_id, "default", "test_nan", config)
+            .unwrap();
+
+        // Insert a valid vector
+        store
+            .insert(
+                branch_id,
+                "default",
+                "test_nan",
+                "k1",
+                &vec![1.0; 384],
+                None,
+            )
+            .unwrap();
+
+        // Search with NaN at first position should fail
+        let mut nan_query = vec![0.0; 384];
+        nan_query[0] = f32::NAN;
+        let result = store.search(branch_id, "default", "test_nan", &nan_query, 5, None);
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, VectorError::InvalidEmbedding { .. }),
+            "expected InvalidEmbedding for NaN at [0], got: {err}"
+        );
+
+        // Search with NaN at last position — verify full scan
+        let mut nan_last = vec![1.0; 384];
+        nan_last[383] = f32::NAN;
+        let result = store.search(branch_id, "default", "test_nan", &nan_last, 5, None);
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, VectorError::InvalidEmbedding { .. }),
+            "expected InvalidEmbedding for NaN at [383], got: {err}"
+        );
+
+        // Search with Infinity should also fail
+        let mut inf_query = vec![0.0; 384];
+        inf_query[0] = f32::INFINITY;
+        let result = store.search(branch_id, "default", "test_nan", &inf_query, 5, None);
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, VectorError::InvalidEmbedding { .. }),
+            "expected InvalidEmbedding for +Inf, got: {err}"
+        );
+
+        // Search with NEG_INFINITY should also fail
+        let mut neg_inf_query = vec![0.0; 384];
+        neg_inf_query[0] = f32::NEG_INFINITY;
+        let result = store.search(branch_id, "default", "test_nan", &neg_inf_query, 5, None);
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, VectorError::InvalidEmbedding { .. }),
+            "expected InvalidEmbedding for -Inf, got: {err}"
+        );
+
+        // All-NaN vector should fail
+        let all_nan = vec![f32::NAN; 384];
+        let result = store.search(branch_id, "default", "test_nan", &all_nan, 5, None);
+        assert!(
+            matches!(result, Err(VectorError::InvalidEmbedding { .. })),
+            "expected InvalidEmbedding for all-NaN"
+        );
+
+        // Valid search should still work
+        let valid_query = vec![1.0; 384];
+        let result = store.search(branch_id, "default", "test_nan", &valid_query, 5, None);
+        assert!(result.is_ok());
+
+        // k=0 with NaN should return empty (short-circuit before validation)
+        let result = store.search(branch_id, "default", "test_nan", &nan_query, 0, None);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    // ========================================
+    // V-16: Concurrent ensure_collection_loaded
+    // ========================================
+
+    #[test]
+    fn test_concurrent_ensure_collection_loaded() {
+        let (_temp, _db, store) = setup();
+        let branch_id = BranchId::new();
+
+        let config = VectorConfig::for_minilm();
+        store
+            .create_collection(branch_id, "default", "concurrent_test", config)
+            .unwrap();
+
+        // Insert a vector so the collection has data
+        store
+            .insert(
+                branch_id,
+                "default",
+                "concurrent_test",
+                "k1",
+                &vec![1.0; 384],
+                None,
+            )
+            .unwrap();
+
+        // Evict from memory to force re-loading
+        {
+            let state = store.state().unwrap();
+            let collection_id = CollectionId::new(branch_id, "concurrent_test");
+            state.backends.write().remove(&collection_id);
+        }
+
+        // Spawn multiple threads calling ensure_collection_loaded simultaneously
+        let store = Arc::new(store);
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                std::thread::spawn(move || {
+                    store.ensure_collection_loaded(branch_id, "default", "concurrent_test")
+                })
+            })
+            .collect();
+
+        // All threads should succeed without panic
+        for handle in handles {
+            let result = handle.join().expect("thread should not panic");
+            assert!(
+                result.is_ok(),
+                "ensure_collection_loaded failed: {:?}",
+                result.err()
+            );
+        }
+
+        // Verify exactly one backend exists
+        let state = store.state().unwrap();
+        let collection_id = CollectionId::new(branch_id, "concurrent_test");
+        assert!(state.backends.read().contains_key(&collection_id));
     }
 }


### PR DESCRIPTION
## Summary

- **V-2**: f32 alignment assertion before unsafe `from_raw_parts` in `mmap.rs` `get()`/`get_by_offset()` — prevents UB from corrupt/hand-crafted mmap files
- **V-3**: `compile_error!` on non-little-endian in `mmap.rs`, matching the guard already in `mmap_graph.rs`
- **V-4**: Advisory file locks (`fs2::FileExt`) — shared lock on read (held for struct lifetime), exclusive lock on write, for both `.vec` and `.hgr` mmap files
- **V-8**: Replace fragile `is_none()` + `unwrap()` with idiomatic `let-else` in `hnsw.rs` `insert_into_graph`
- **V-9**: Include OS error context in thread pool panic message (`segmented.rs`)
- **V-14**: Replace silent `let _ =` with `warn!` logging for `create_dir_all` and `flush_heap_to_disk_if_needed` failures
- **V-16**: Double-checked locking in `ensure_collection_loaded` — read-lock fast path, config+backend creation outside any lock, write-lock only for map insert with re-check
- **V-22**: `validate_query_values()` helper rejects NaN/Infinity on all 4 search paths (`search`, `search_at`, `search_with_sources`, `search_with_sources_in_range`)

## Skipped items (already resolved)

| Item | Reason |
|------|--------|
| V-10 | `inline_meta` BTreeMap bounded by vector count — not unbounded |
| V-19 | Already fixed in Epic #1317 (`debug_assert` → `assert`) |
| V-20 | Dimension validation already present in insert paths |

## Test plan

- [x] `test_search_nan_query_returns_error` — NaN at first/last position, +Inf, -Inf, all-NaN, k=0 short-circuit
- [x] `test_concurrent_ensure_collection_loaded` — 8 threads race to load, verify no panic and correct state
- [x] `cargo test -p strata-engine --lib -- vector` — 302 tests pass
- [x] `cargo test -p strata-engine --lib` — 1280 tests pass
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)