### PR TITLE
Batch JSON operations: JsonBatchGet + JsonBatchDelete (#1368)

### DIFF
--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -338,6 +338,15 @@ fn format_raw(output: &Output) -> String {
             })
             .collect::<Vec<_>>()
             .join("\n"),
+        Output::BatchGetResults(results) => results
+            .iter()
+            .map(|r| match (&r.error, &r.value) {
+                (Some(e), _) => format!("ERR:{}", e),
+                (_, Some(v)) => format_value_raw(v),
+                _ => String::new(),
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
         Output::Embedding(vec) => vec
             .iter()
             .map(|v| v.to_string())
@@ -715,6 +724,25 @@ fn format_human(output: &Output) -> String {
                         (Some(v), _) => format!("{}) OK (v{})", i + 1, v),
                         (_, Some(e)) => format!("{}) ERR: {}", i + 1, e),
                         _ => format!("{}) ERR", i + 1),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        Output::BatchGetResults(results) => {
+            if results.is_empty() {
+                "(empty list)".to_string()
+            } else {
+                results
+                    .iter()
+                    .enumerate()
+                    .map(|(i, r)| match (&r.error, &r.value) {
+                        (Some(e), _) => format!("{}) ERR: {}", i + 1, e),
+                        (_, Some(v)) => {
+                            let ver = r.version.map(|v| format!(" (v{})", v)).unwrap_or_default();
+                            format!("{}) {}{}", i + 1, format_value_human(v), ver)
+                        }
+                        _ => format!("{}) (not found)", i + 1),
                     })
                     .collect::<Vec<_>>()
                     .join("\n")

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -242,6 +242,32 @@ pub enum Command {
         entries: Vec<BatchJsonEntry>,
     },
 
+    /// Batch get multiple JSON document values.
+    /// Returns: `Output::BatchGetResults`
+    JsonBatchGet {
+        /// Target branch (defaults to "default").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Target space (defaults to "default").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        space: Option<String>,
+        /// JSON entries to get.
+        entries: Vec<BatchJsonGetEntry>,
+    },
+
+    /// Batch delete multiple JSON documents or paths.
+    /// Returns: `Output::BatchResults`
+    JsonBatchDelete {
+        /// Target branch (defaults to "default").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Target space (defaults to "default").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        space: Option<String>,
+        /// JSON entries to delete.
+        entries: Vec<BatchJsonDeleteEntry>,
+    },
+
     /// List JSON documents with cursor-based pagination.
     /// Returns: `Output::JsonListResult`
     JsonList {
@@ -1421,6 +1447,7 @@ impl Command {
                 | Command::KvDelete { .. }
                 | Command::JsonSet { .. }
                 | Command::JsonBatchSet { .. }
+                | Command::JsonBatchDelete { .. }
                 | Command::JsonDelete { .. }
                 | Command::EventAppend { .. }
                 | Command::EventBatchAppend { .. }
@@ -1481,6 +1508,8 @@ impl Command {
             Command::KvGetv { .. } => "KvGetv",
             Command::JsonSet { .. } => "JsonSet",
             Command::JsonBatchSet { .. } => "JsonBatchSet",
+            Command::JsonBatchGet { .. } => "JsonBatchGet",
+            Command::JsonBatchDelete { .. } => "JsonBatchDelete",
             Command::JsonGet { .. } => "JsonGet",
             Command::JsonDelete { .. } => "JsonDelete",
             Command::JsonGetv { .. } => "JsonGetv",
@@ -1619,6 +1648,8 @@ impl Command {
             // JSON
             | Command::JsonSet { branch, space, .. }
             | Command::JsonBatchSet { branch, space, .. }
+            | Command::JsonBatchGet { branch, space, .. }
+            | Command::JsonBatchDelete { branch, space, .. }
             | Command::JsonGet { branch, space, .. }
             | Command::JsonGetv { branch, space, .. }
             | Command::JsonDelete { branch, space, .. }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -340,6 +340,29 @@ impl Executor {
                 self.ensure_space_registered(&branch, &space)?;
                 crate::handlers::json::json_batch_set(&self.primitives, branch, space, entries)
             }
+            Command::JsonBatchGet {
+                branch,
+                space,
+                entries,
+            } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                })?;
+                let space = space.unwrap_or_else(|| "default".to_string());
+                crate::handlers::json::json_batch_get(&self.primitives, branch, space, entries)
+            }
+            Command::JsonBatchDelete {
+                branch,
+                space,
+                entries,
+            } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                })?;
+                let space = space.unwrap_or_else(|| "default".to_string());
+                self.ensure_space_registered(&branch, &space)?;
+                crate::handlers::json::json_batch_delete(&self.primitives, branch, space, entries)
+            }
             Command::JsonGet {
                 branch,
                 space,

--- a/crates/executor/src/handlers/json.rs
+++ b/crates/executor/src/handlers/json.rs
@@ -11,7 +11,7 @@ use crate::bridge::{
     value_to_json, Primitives,
 };
 use crate::convert::convert_result;
-use crate::types::{BranchId, VersionedValue};
+use crate::types::{BatchGetItemResult, BatchItemResult, BranchId, VersionedValue};
 use crate::{Error, Output, Result};
 
 /// Validate that a branch exists before performing a write operation (#951).
@@ -307,6 +307,181 @@ pub fn json_batch_set(
     for (j, orig_idx) in orig_indices.iter().enumerate() {
         if results[*orig_idx].version.is_some() {
             embed_full_doc(p, branch_id, &space, &keys[j]);
+        }
+    }
+
+    Ok(Output::BatchResults(results))
+}
+
+/// Handle JsonBatchGet command.
+///
+/// Loops over entries, calling `get_versioned()` for each. No engine batch
+/// method needed since reads are independent.
+pub fn json_batch_get(
+    p: &Arc<Primitives>,
+    branch: BranchId,
+    space: String,
+    entries: Vec<crate::types::BatchJsonGetEntry>,
+) -> Result<Output> {
+    let branch_id = to_core_branch_id(&branch)?;
+
+    if entries.is_empty() {
+        return Ok(Output::BatchGetResults(Vec::new()));
+    }
+
+    let n = entries.len();
+    let mut results: Vec<BatchGetItemResult> = Vec::with_capacity(n);
+
+    for entry in entries {
+        // Validate key
+        if let Err(e) = validate_key(&entry.key) {
+            results.push(BatchGetItemResult {
+                value: None,
+                version: None,
+                timestamp: None,
+                error: Some(e.to_string()),
+            });
+            continue;
+        }
+        // Parse path
+        let json_path = match parse_path(&entry.path) {
+            Ok(p) => p,
+            Err(e) => {
+                results.push(BatchGetItemResult {
+                    value: None,
+                    version: None,
+                    timestamp: None,
+                    error: Some(e.to_string()),
+                });
+                continue;
+            }
+        };
+        // Get from engine
+        match convert_result(
+            p.json
+                .get_versioned(&branch_id, &space, &entry.key, &json_path),
+        ) {
+            Ok(Some(versioned)) => match convert_result(json_to_value(versioned.value)) {
+                Ok(value) => {
+                    results.push(BatchGetItemResult {
+                        value: Some(value),
+                        version: Some(extract_version(&versioned.version)),
+                        timestamp: Some(versioned.timestamp.into()),
+                        error: None,
+                    });
+                }
+                Err(e) => {
+                    results.push(BatchGetItemResult {
+                        value: None,
+                        version: None,
+                        timestamp: None,
+                        error: Some(e.to_string()),
+                    });
+                }
+            },
+            Ok(None) => {
+                results.push(BatchGetItemResult {
+                    value: None,
+                    version: None,
+                    timestamp: None,
+                    error: None,
+                });
+            }
+            Err(e) => {
+                results.push(BatchGetItemResult {
+                    value: None,
+                    version: None,
+                    timestamp: None,
+                    error: Some(e.to_string()),
+                });
+            }
+        }
+    }
+
+    Ok(Output::BatchGetResults(results))
+}
+
+/// Handle JsonBatchDelete command.
+///
+/// Loops over entries. Root path deletes destroy the entire document;
+/// non-root deletes remove at the specified path. Reuses `BatchItemResult`
+/// with `version` as count (1=deleted, 0=not found).
+pub fn json_batch_delete(
+    p: &Arc<Primitives>,
+    branch: BranchId,
+    space: String,
+    entries: Vec<crate::types::BatchJsonDeleteEntry>,
+) -> Result<Output> {
+    require_branch_exists(p, &branch)?;
+    let branch_id = to_core_branch_id(&branch)?;
+
+    if entries.is_empty() {
+        return Ok(Output::BatchResults(Vec::new()));
+    }
+
+    let n = entries.len();
+    let mut results: Vec<BatchItemResult> = vec![
+        BatchItemResult {
+            version: None,
+            error: None,
+        };
+        n
+    ];
+
+    for (i, entry) in entries.into_iter().enumerate() {
+        if let Err(e) = validate_key(&entry.key) {
+            results[i].error = Some(e.to_string());
+            continue;
+        }
+        let json_path = match parse_path(&entry.path) {
+            Ok(p) => p,
+            Err(e) => {
+                results[i].error = Some(e.to_string());
+                continue;
+            }
+        };
+
+        if json_path.is_root() {
+            // Root delete — destroy entire document
+            match convert_result(p.json.destroy(&branch_id, &space, &entry.key)) {
+                Ok(deleted) => {
+                    results[i].version = Some(if deleted { 1 } else { 0 });
+                    if deleted {
+                        super::embed_hook::maybe_remove_embedding(
+                            p,
+                            branch_id,
+                            &space,
+                            super::embed_hook::SHADOW_JSON,
+                            &entry.key,
+                        );
+                    }
+                }
+                Err(e) => results[i].error = Some(e.to_string()),
+            }
+        } else {
+            // Non-root — delete at path
+            // Match single json_delete behavior: call without convert_result,
+            // then match on error variants directly.
+            match p
+                .json
+                .delete_at_path(&branch_id, &space, &entry.key, &json_path)
+            {
+                Ok(_version) => {
+                    results[i].version = Some(1);
+                    embed_full_doc(p, branch_id, &space, &entry.key);
+                }
+                Err(e) => {
+                    let err = crate::Error::from(e);
+                    match err {
+                        crate::Error::InvalidPath { .. } | crate::Error::InvalidInput { .. } => {
+                            results[i].version = Some(0);
+                        }
+                        other => {
+                            results[i].error = Some(other.to_string());
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/crates/executor/src/output.rs
+++ b/crates/executor/src/output.rs
@@ -90,6 +90,9 @@ pub enum Output {
     /// Per-item results for batch operations (positionally maps to input entries)
     BatchResults(Vec<BatchItemResult>),
 
+    /// Per-item results for batch get operations (includes values)
+    BatchGetResults(Vec<BatchGetItemResult>),
+
     // ==================== Branch-specific ====================
     /// Optional versioned branch info (for branch_get which may not find a branch)
     MaybeBranchInfo(Option<VersionedBranchInfo>),

--- a/crates/executor/src/tests/parity.rs
+++ b/crates/executor/src/tests/parity.rs
@@ -580,3 +580,608 @@ fn test_branch_isolation_parity() {
         _ => panic!("Expected value from branch-b"),
     }
 }
+
+// =============================================================================
+// JSON Batch Get Tests
+// =============================================================================
+
+#[test]
+fn test_json_batch_get_basic() {
+    let (executor, _p) = create_test_environment();
+
+    // Set 3 docs
+    for (key, name) in &[("d1", "Alice"), ("d2", "Bob"), ("d3", "Carol")] {
+        let r = executor.execute(Command::JsonSet {
+            branch: None,
+            space: None,
+            key: key.to_string(),
+            path: "".to_string(),
+            value: Value::object(
+                [("name".to_string(), Value::String((*name).into()))]
+                    .into_iter()
+                    .collect(),
+            ),
+        });
+        assert!(r.is_ok(), "JsonSet failed for {}", key);
+    }
+
+    // Batch get all 3
+    let result = executor
+        .execute(Command::JsonBatchGet {
+            branch: None,
+            space: None,
+            entries: vec![
+                BatchJsonGetEntry {
+                    key: "d1".to_string(),
+                    path: ".name".to_string(),
+                },
+                BatchJsonGetEntry {
+                    key: "d2".to_string(),
+                    path: ".name".to_string(),
+                },
+                BatchJsonGetEntry {
+                    key: "d3".to_string(),
+                    path: ".name".to_string(),
+                },
+            ],
+        })
+        .unwrap();
+
+    match result {
+        Output::BatchGetResults(results) => {
+            assert_eq!(results.len(), 3);
+            assert_eq!(results[0].value, Some(Value::String("Alice".into())));
+            assert_eq!(results[1].value, Some(Value::String("Bob".into())));
+            assert_eq!(results[2].value, Some(Value::String("Carol".into())));
+            // All should have versions and timestamps
+            for r in &results {
+                assert!(r.version.is_some());
+                assert!(r.timestamp.is_some());
+                assert!(r.error.is_none());
+            }
+        }
+        other => panic!("Expected BatchGetResults, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_json_batch_get_mixed() {
+    let (executor, _p) = create_test_environment();
+
+    // Set 2 docs, leave 1 missing
+    executor
+        .execute(Command::JsonSet {
+            branch: None,
+            space: None,
+            key: "exists1".to_string(),
+            path: "".to_string(),
+            value: Value::Int(10),
+        })
+        .unwrap();
+    executor
+        .execute(Command::JsonSet {
+            branch: None,
+            space: None,
+            key: "exists2".to_string(),
+            path: "".to_string(),
+            value: Value::Int(20),
+        })
+        .unwrap();
+
+    let result = executor
+        .execute(Command::JsonBatchGet {
+            branch: None,
+            space: None,
+            entries: vec![
+                BatchJsonGetEntry {
+                    key: "exists1".to_string(),
+                    path: "".to_string(),
+                },
+                BatchJsonGetEntry {
+                    key: "missing".to_string(),
+                    path: "".to_string(),
+                },
+                BatchJsonGetEntry {
+                    key: "exists2".to_string(),
+                    path: "".to_string(),
+                },
+            ],
+        })
+        .unwrap();
+
+    match result {
+        Output::BatchGetResults(results) => {
+            assert_eq!(results.len(), 3);
+            // First: found
+            assert_eq!(results[0].value, Some(Value::Int(10)));
+            assert!(results[0].error.is_none());
+            // Second: not found
+            assert!(results[1].value.is_none());
+            assert!(results[1].version.is_none());
+            assert!(results[1].error.is_none());
+            // Third: found
+            assert_eq!(results[2].value, Some(Value::Int(20)));
+            assert!(results[2].error.is_none());
+        }
+        other => panic!("Expected BatchGetResults, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_json_batch_get_invalid_key() {
+    let (executor, _p) = create_test_environment();
+
+    // Set a valid doc so we can verify errors don't abort the batch
+    executor
+        .execute(Command::JsonSet {
+            branch: None,
+            space: None,
+            key: "valid-key".to_string(),
+            path: "".to_string(),
+            value: Value::Int(42),
+        })
+        .unwrap();
+
+    let result = executor
+        .execute(Command::JsonBatchGet {
+            branch: None,
+            space: None,
+            entries: vec![
+                BatchJsonGetEntry {
+                    key: "".to_string(), // invalid empty key
+                    path: "".to_string(),
+                },
+                BatchJsonGetEntry {
+                    key: "valid-key".to_string(),
+                    path: "".to_string(),
+                },
+            ],
+        })
+        .unwrap();
+
+    match result {
+        Output::BatchGetResults(results) => {
+            assert_eq!(results.len(), 2);
+            // First: error for invalid key
+            assert!(results[0].error.is_some());
+            assert!(results[0].value.is_none());
+            // Second: found despite first entry having an error
+            assert!(results[1].error.is_none());
+            assert_eq!(results[1].value, Some(Value::Int(42)));
+        }
+        other => panic!("Expected BatchGetResults, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_json_batch_get_invalid_path() {
+    let (executor, _p) = create_test_environment();
+
+    executor
+        .execute(Command::JsonSet {
+            branch: None,
+            space: None,
+            key: "doc".to_string(),
+            path: "".to_string(),
+            value: Value::Int(1),
+        })
+        .unwrap();
+
+    let result = executor
+        .execute(Command::JsonBatchGet {
+            branch: None,
+            space: None,
+            entries: vec![
+                BatchJsonGetEntry {
+                    key: "doc".to_string(),
+                    path: "[invalid".to_string(), // bad path
+                },
+                BatchJsonGetEntry {
+                    key: "doc".to_string(),
+                    path: "".to_string(), // valid
+                },
+            ],
+        })
+        .unwrap();
+
+    match result {
+        Output::BatchGetResults(results) => {
+            assert_eq!(results.len(), 2);
+            // First: error for invalid path, doesn't abort batch
+            assert!(results[0].error.is_some());
+            assert!(results[0].value.is_none());
+            // Second: succeeds
+            assert!(results[1].error.is_none());
+            assert_eq!(results[1].value, Some(Value::Int(1)));
+        }
+        other => panic!("Expected BatchGetResults, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_json_batch_get_subpath() {
+    let (executor, _p) = create_test_environment();
+
+    // Set a nested doc
+    executor
+        .execute(Command::JsonSet {
+            branch: None,
+            space: None,
+            key: "deep".to_string(),
+            path: "".to_string(),
+            value: Value::object(
+                [(
+                    "outer".to_string(),
+                    Value::object(
+                        [("inner".to_string(), Value::String("found".into()))]
+                            .into_iter()
+                            .collect(),
+                    ),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+        })
+        .unwrap();
+
+    let result = executor
+        .execute(Command::JsonBatchGet {
+            branch: None,
+            space: None,
+            entries: vec![
+                BatchJsonGetEntry {
+                    key: "deep".to_string(),
+                    path: ".outer.inner".to_string(),
+                },
+                BatchJsonGetEntry {
+                    key: "deep".to_string(),
+                    path: ".outer".to_string(),
+                },
+                BatchJsonGetEntry {
+                    key: "deep".to_string(),
+                    path: ".nonexistent".to_string(),
+                },
+            ],
+        })
+        .unwrap();
+
+    match result {
+        Output::BatchGetResults(results) => {
+            assert_eq!(results.len(), 3);
+            // Deep path
+            assert_eq!(results[0].value, Some(Value::String("found".into())));
+            // Intermediate path returns sub-object
+            assert!(results[1].value.is_some());
+            // Non-existent path — not found (no error, just None)
+            assert!(results[2].value.is_none());
+            assert!(results[2].error.is_none());
+        }
+        other => panic!("Expected BatchGetResults, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_json_batch_get_empty() {
+    let (executor, _p) = create_test_environment();
+
+    let result = executor
+        .execute(Command::JsonBatchGet {
+            branch: None,
+            space: None,
+            entries: vec![],
+        })
+        .unwrap();
+
+    match result {
+        Output::BatchGetResults(results) => {
+            assert!(results.is_empty());
+        }
+        other => panic!("Expected empty BatchGetResults, got {:?}", other),
+    }
+}
+
+// =============================================================================
+// JSON Batch Delete Tests
+// =============================================================================
+
+#[test]
+fn test_json_batch_delete_basic() {
+    let (executor, _p) = create_test_environment();
+
+    // Set 3 docs
+    for key in &["del1", "del2", "del3"] {
+        executor
+            .execute(Command::JsonSet {
+                branch: None,
+                space: None,
+                key: key.to_string(),
+                path: "".to_string(),
+                value: Value::Int(42),
+            })
+            .unwrap();
+    }
+
+    // Batch delete all 3
+    let result = executor
+        .execute(Command::JsonBatchDelete {
+            branch: None,
+            space: None,
+            entries: vec![
+                BatchJsonDeleteEntry {
+                    key: "del1".to_string(),
+                    path: "".to_string(),
+                },
+                BatchJsonDeleteEntry {
+                    key: "del2".to_string(),
+                    path: "".to_string(),
+                },
+                BatchJsonDeleteEntry {
+                    key: "del3".to_string(),
+                    path: "".to_string(),
+                },
+            ],
+        })
+        .unwrap();
+
+    match result {
+        Output::BatchResults(results) => {
+            assert_eq!(results.len(), 3);
+            for r in &results {
+                assert_eq!(r.version, Some(1)); // 1 = deleted
+                assert!(r.error.is_none());
+            }
+        }
+        other => panic!("Expected BatchResults, got {:?}", other),
+    }
+
+    // Verify docs are gone
+    let get_result = executor
+        .execute(Command::JsonGet {
+            branch: None,
+            space: None,
+            key: "del1".to_string(),
+            path: "".to_string(),
+            as_of: None,
+        })
+        .unwrap();
+    assert!(matches!(get_result, Output::MaybeVersioned(None)));
+}
+
+#[test]
+fn test_json_batch_delete_mixed_paths() {
+    let (executor, _p) = create_test_environment();
+
+    // Set a doc with nested structure
+    executor
+        .execute(Command::JsonSet {
+            branch: None,
+            space: None,
+            key: "nested".to_string(),
+            path: "".to_string(),
+            value: Value::object(
+                [
+                    ("a".to_string(), Value::Int(1)),
+                    ("b".to_string(), Value::Int(2)),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        })
+        .unwrap();
+
+    // Set another doc for root delete
+    executor
+        .execute(Command::JsonSet {
+            branch: None,
+            space: None,
+            key: "whole".to_string(),
+            path: "".to_string(),
+            value: Value::Int(99),
+        })
+        .unwrap();
+
+    // Mix root and non-root deletes
+    let result = executor
+        .execute(Command::JsonBatchDelete {
+            branch: None,
+            space: None,
+            entries: vec![
+                BatchJsonDeleteEntry {
+                    key: "nested".to_string(),
+                    path: ".a".to_string(), // non-root
+                },
+                BatchJsonDeleteEntry {
+                    key: "whole".to_string(),
+                    path: "".to_string(), // root
+                },
+            ],
+        })
+        .unwrap();
+
+    match result {
+        Output::BatchResults(results) => {
+            assert_eq!(results.len(), 2);
+            assert_eq!(results[0].version, Some(1)); // path deleted
+            assert_eq!(results[1].version, Some(1)); // doc destroyed
+        }
+        other => panic!("Expected BatchResults, got {:?}", other),
+    }
+
+    // Verify "nested" still exists but without .a
+    let get = executor
+        .execute(Command::JsonGet {
+            branch: None,
+            space: None,
+            key: "nested".to_string(),
+            path: ".a".to_string(),
+            as_of: None,
+        })
+        .unwrap();
+    assert!(matches!(get, Output::MaybeVersioned(None)));
+
+    // .b should still exist
+    let get_b = executor
+        .execute(Command::JsonGet {
+            branch: None,
+            space: None,
+            key: "nested".to_string(),
+            path: ".b".to_string(),
+            as_of: None,
+        })
+        .unwrap();
+    match get_b {
+        Output::MaybeVersioned(Some(vv)) => assert_eq!(vv.value, Value::Int(2)),
+        other => panic!("Expected .b=2, got {:?}", other),
+    }
+
+    // "whole" should be gone
+    let get_w = executor
+        .execute(Command::JsonGet {
+            branch: None,
+            space: None,
+            key: "whole".to_string(),
+            path: "".to_string(),
+            as_of: None,
+        })
+        .unwrap();
+    assert!(matches!(get_w, Output::MaybeVersioned(None)));
+}
+
+#[test]
+fn test_json_batch_delete_nonexistent() {
+    let (executor, _p) = create_test_environment();
+
+    let result = executor
+        .execute(Command::JsonBatchDelete {
+            branch: None,
+            space: None,
+            entries: vec![
+                BatchJsonDeleteEntry {
+                    key: "nope1".to_string(),
+                    path: "".to_string(),
+                },
+                BatchJsonDeleteEntry {
+                    key: "nope2".to_string(),
+                    path: "".to_string(),
+                },
+            ],
+        })
+        .unwrap();
+
+    match result {
+        Output::BatchResults(results) => {
+            assert_eq!(results.len(), 2);
+            for r in &results {
+                assert_eq!(r.version, Some(0)); // 0 = not found
+                assert!(r.error.is_none());
+            }
+        }
+        other => panic!("Expected BatchResults, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_json_batch_delete_empty() {
+    let (executor, _p) = create_test_environment();
+
+    let result = executor
+        .execute(Command::JsonBatchDelete {
+            branch: None,
+            space: None,
+            entries: vec![],
+        })
+        .unwrap();
+
+    match result {
+        Output::BatchResults(results) => {
+            assert!(results.is_empty());
+        }
+        other => panic!("Expected empty BatchResults, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_json_batch_delete_invalid_key() {
+    let (executor, _p) = create_test_environment();
+
+    // Set a valid doc so we can verify errors don't abort the batch
+    executor
+        .execute(Command::JsonSet {
+            branch: None,
+            space: None,
+            key: "valid".to_string(),
+            path: "".to_string(),
+            value: Value::Int(1),
+        })
+        .unwrap();
+
+    let result = executor
+        .execute(Command::JsonBatchDelete {
+            branch: None,
+            space: None,
+            entries: vec![
+                BatchJsonDeleteEntry {
+                    key: "".to_string(), // invalid empty key
+                    path: "".to_string(),
+                },
+                BatchJsonDeleteEntry {
+                    key: "valid".to_string(),
+                    path: "".to_string(),
+                },
+            ],
+        })
+        .unwrap();
+
+    match result {
+        Output::BatchResults(results) => {
+            assert_eq!(results.len(), 2);
+            // First: error for invalid key
+            assert!(results[0].error.is_some());
+            assert!(results[0].version.is_none());
+            // Second: successfully deleted despite first entry error
+            assert_eq!(results[1].version, Some(1));
+            assert!(results[1].error.is_none());
+        }
+        other => panic!("Expected BatchResults, got {:?}", other),
+    }
+
+    // Verify the valid doc was actually deleted
+    let get = executor
+        .execute(Command::JsonGet {
+            branch: None,
+            space: None,
+            key: "valid".to_string(),
+            path: "".to_string(),
+            as_of: None,
+        })
+        .unwrap();
+    assert!(matches!(get, Output::MaybeVersioned(None)));
+}
+
+#[test]
+fn test_json_batch_delete_nonroot_nonexistent_doc() {
+    let (executor, _p) = create_test_environment();
+
+    // Delete at non-root path for a document that doesn't exist
+    let result = executor
+        .execute(Command::JsonBatchDelete {
+            branch: None,
+            space: None,
+            entries: vec![BatchJsonDeleteEntry {
+                key: "ghost".to_string(),
+                path: ".field".to_string(),
+            }],
+        })
+        .unwrap();
+
+    match result {
+        Output::BatchResults(results) => {
+            assert_eq!(results.len(), 1);
+            // Non-root delete on nonexistent doc should return 0 (not found),
+            // matching single json_delete behavior
+            assert_eq!(results[0].version, Some(0));
+            assert!(results[0].error.is_none());
+        }
+        other => panic!("Expected BatchResults, got {:?}", other),
+    }
+}

--- a/crates/executor/src/tests/serialization.rs
+++ b/crates/executor/src/tests/serialization.rs
@@ -743,3 +743,131 @@ fn test_output_durability_counters() {
         strata_engine::WalCounters::default(),
     ));
 }
+
+// =============================================================================
+// JSON Batch Get/Delete Serialization Tests
+// =============================================================================
+
+#[test]
+fn test_command_json_batch_get() {
+    test_command_round_trip(Command::JsonBatchGet {
+        branch: Some(BranchId::from("default")),
+        space: None,
+        entries: vec![
+            BatchJsonGetEntry {
+                key: "doc1".to_string(),
+                path: ".name".to_string(),
+            },
+            BatchJsonGetEntry {
+                key: "doc2".to_string(),
+                path: "".to_string(),
+            },
+        ],
+    });
+}
+
+#[test]
+fn test_command_json_batch_get_empty() {
+    test_command_round_trip(Command::JsonBatchGet {
+        branch: None,
+        space: None,
+        entries: vec![],
+    });
+}
+
+#[test]
+fn test_command_json_batch_delete() {
+    test_command_round_trip(Command::JsonBatchDelete {
+        branch: Some(BranchId::from("default")),
+        space: Some("custom".to_string()),
+        entries: vec![
+            BatchJsonDeleteEntry {
+                key: "doc1".to_string(),
+                path: "".to_string(),
+            },
+            BatchJsonDeleteEntry {
+                key: "doc2".to_string(),
+                path: ".field".to_string(),
+            },
+        ],
+    });
+}
+
+#[test]
+fn test_output_batch_get_results() {
+    // Found item
+    test_output_round_trip(Output::BatchGetResults(vec![BatchGetItemResult {
+        value: Some(Value::String("hello".to_string())),
+        version: Some(3),
+        timestamp: Some(1000),
+        error: None,
+    }]));
+
+    // Not found item (all None, no error)
+    test_output_round_trip(Output::BatchGetResults(vec![BatchGetItemResult {
+        value: None,
+        version: None,
+        timestamp: None,
+        error: None,
+    }]));
+
+    // Error item
+    test_output_round_trip(Output::BatchGetResults(vec![BatchGetItemResult {
+        value: None,
+        version: None,
+        timestamp: None,
+        error: Some("invalid key".to_string()),
+    }]));
+
+    // Mixed results
+    test_output_round_trip(Output::BatchGetResults(vec![
+        BatchGetItemResult {
+            value: Some(Value::Int(42)),
+            version: Some(1),
+            timestamp: Some(500),
+            error: None,
+        },
+        BatchGetItemResult {
+            value: None,
+            version: None,
+            timestamp: None,
+            error: None,
+        },
+        BatchGetItemResult {
+            value: None,
+            version: None,
+            timestamp: None,
+            error: Some("bad key".to_string()),
+        },
+    ]));
+
+    // Empty
+    test_output_round_trip(Output::BatchGetResults(vec![]));
+}
+
+#[test]
+fn test_output_batch_get_results_skip_serializing_none() {
+    // Verify skip_serializing_if = "Option::is_none" works: None fields
+    // should be absent in JSON (not "value": null)
+    let result = BatchGetItemResult {
+        value: None,
+        version: None,
+        timestamp: None,
+        error: None,
+    };
+    let json = serde_json::to_string(&result).unwrap();
+    assert_eq!(json, "{}");
+
+    // Found item should only have non-None fields
+    let result = BatchGetItemResult {
+        value: Some(Value::Int(1)),
+        version: Some(5),
+        timestamp: None,
+        error: None,
+    };
+    let json = serde_json::to_string(&result).unwrap();
+    assert!(!json.contains("timestamp"));
+    assert!(!json.contains("error"));
+    assert!(json.contains("value"));
+    assert!(json.contains("version"));
+}

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -259,6 +259,41 @@ pub struct BatchJsonEntry {
     pub value: Value,
 }
 
+/// Entry for batch JSON get operations.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BatchJsonGetEntry {
+    /// Document key.
+    pub key: String,
+    /// JSON path within the document.
+    pub path: String,
+}
+
+/// Entry for batch JSON delete operations.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BatchJsonDeleteEntry {
+    /// Document key.
+    pub key: String,
+    /// JSON path within the document.
+    pub path: String,
+}
+
+/// Per-item result for batch get operations (includes value, not just version).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BatchGetItemResult {
+    /// The retrieved value, if found.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<Value>,
+    /// Version of the retrieved value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<u64>,
+    /// Timestamp of the retrieved value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<u64>,
+    /// Error message if the item failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 /// Per-item result for batch operations.
 ///
 /// Positionally maps to input entries: `results[i]` corresponds to `entries[i]`.


### PR DESCRIPTION
## Summary

- Add `JsonBatchGet` command — loops over entries calling `get_versioned()` with per-item error isolation (invalid keys/paths produce per-item errors, not batch-level failures)
- Add `JsonBatchDelete` command — handles root (destroy) and non-root (delete_at_path) deletes with embed hooks, matching single `json_delete` error semantics via variant matching
- Add `BatchGetResults` output variant with `BatchGetItemResult` (value + version + timestamp + error)
- Add `BatchJsonGetEntry` and `BatchJsonDeleteEntry` types
- CLI formatting for `BatchGetResults` in both raw and human-readable modes
- 17 tests: 12 parity tests (get basic/mixed/invalid-key/invalid-path/subpath/empty, delete basic/mixed-paths/nonexistent/empty/invalid-key/nonroot-nonexistent) + 5 serialization round-trip tests

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p strata-executor -p strata-cli -- -D warnings` passes
- [x] `cargo test -p strata-executor` — 313 tests pass
- [x] Per-item error isolation verified (invalid entries don't abort batch)
- [x] Error matching uses enum variants, not string contains
- [x] Serde round-trip and `skip_serializing_if` behavior verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)