### PR TITLE
Security: AES-256-GCM encryption at rest & credential safety (#1321)

### DIFF
--- a/crates/durability/Cargo.toml
+++ b/crates/durability/Cargo.toml
@@ -19,6 +19,8 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 crc32fast = "1.3"
 fs2 = "0.4"
+aes-gcm = "0.10"
+rand = { workspace = true }
 
 # RunBundle support
 tar = { workspace = true }

--- a/crates/durability/src/codec/aes_gcm.rs
+++ b/crates/durability/src/codec/aes_gcm.rs
@@ -1,0 +1,232 @@
+//! AES-256-GCM authenticated encryption codec.
+//!
+//! Provides encryption at rest using AES-256-GCM. The encryption key is
+//! sourced from the `STRATA_ENCRYPTION_KEY` environment variable (64 hex
+//! characters = 32 bytes).
+//!
+//! Wire format: `nonce (12 bytes) || ciphertext + tag (data_len + 16 bytes)`
+
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes256Gcm, Nonce};
+use rand::RngCore;
+
+use super::traits::{CodecError, StorageCodec};
+
+/// AES-256-GCM authenticated encryption codec.
+pub struct AesGcmCodec {
+    key: [u8; 32],
+}
+
+impl AesGcmCodec {
+    /// Create a new codec with the given 32-byte key.
+    pub fn new(key: [u8; 32]) -> Self {
+        AesGcmCodec { key }
+    }
+
+    /// Parse a 64-character hex string into a 32-byte key.
+    pub fn key_from_hex(hex: &str) -> Result<[u8; 32], CodecError> {
+        let hex = hex.trim();
+        if hex.len() != 64 {
+            return Err(CodecError::DecodeError {
+                detail: format!(
+                    "STRATA_ENCRYPTION_KEY must be exactly 64 hex chars (32 bytes), got {}",
+                    hex.len()
+                ),
+                codec_id: "aes-gcm-256".to_string(),
+                data_len: 0,
+            });
+        }
+        let mut key = [0u8; 32];
+        for i in 0..32 {
+            key[i] = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).map_err(|_| {
+                CodecError::DecodeError {
+                    detail: format!("Invalid hex at position {}", i * 2),
+                    codec_id: "aes-gcm-256".to_string(),
+                    data_len: 0,
+                }
+            })?;
+        }
+        Ok(key)
+    }
+}
+
+impl StorageCodec for AesGcmCodec {
+    fn encode(&self, data: &[u8]) -> Vec<u8> {
+        let cipher = Aes256Gcm::new((&self.key).into());
+
+        let mut nonce_bytes = [0u8; 12];
+        rand::thread_rng().fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+
+        let ciphertext = cipher
+            .encrypt(nonce, data)
+            .expect("AES-GCM encryption should not fail");
+
+        // Wire format: nonce (12) || ciphertext+tag
+        let mut output = Vec::with_capacity(12 + ciphertext.len());
+        output.extend_from_slice(&nonce_bytes);
+        output.extend_from_slice(&ciphertext);
+        output
+    }
+
+    fn decode(&self, data: &[u8]) -> Result<Vec<u8>, CodecError> {
+        if data.len() < 12 + 16 {
+            return Err(CodecError::decode(
+                format!(
+                    "Ciphertext too short: need at least 28 bytes (12 nonce + 16 tag), got {}",
+                    data.len()
+                ),
+                "aes-gcm-256",
+                data.len(),
+            ));
+        }
+
+        let (nonce_bytes, ciphertext) = data.split_at(12);
+        let nonce = Nonce::from_slice(nonce_bytes);
+
+        let cipher = Aes256Gcm::new((&self.key).into());
+        cipher.decrypt(nonce, ciphertext).map_err(|_| {
+            CodecError::decode(
+                "Decryption failed (wrong key or corrupted data)",
+                "aes-gcm-256",
+                data.len(),
+            )
+        })
+    }
+
+    fn codec_id(&self) -> &str {
+        "aes-gcm-256"
+    }
+
+    fn clone_box(&self) -> Box<dyn StorageCodec> {
+        Box::new(AesGcmCodec { key: self.key })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_key() -> [u8; 32] {
+        let mut key = [0u8; 32];
+        for (i, byte) in key.iter_mut().enumerate() {
+            *byte = i as u8;
+        }
+        key
+    }
+
+    #[test]
+    fn roundtrip() {
+        let codec = AesGcmCodec::new(test_key());
+        let data = b"hello world, this is a test of AES-256-GCM encryption";
+        let encoded = codec.encode(data);
+        let decoded = codec.decode(&encoded).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn roundtrip_empty_data() {
+        let codec = AesGcmCodec::new(test_key());
+        let data = b"";
+        let encoded = codec.encode(data);
+        assert_eq!(encoded.len(), 12 + 16); // nonce + tag only
+        let decoded = codec.decode(&encoded).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn roundtrip_large_data() {
+        let codec = AesGcmCodec::new(test_key());
+        let data: Vec<u8> = (0..1_000_000).map(|i| (i % 256) as u8).collect();
+        let encoded = codec.encode(&data);
+        assert_eq!(encoded.len(), 12 + data.len() + 16);
+        let decoded = codec.decode(&encoded).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn wrong_key_fails_decode() {
+        let codec1 = AesGcmCodec::new(test_key());
+        let mut wrong_key = test_key();
+        wrong_key[0] ^= 0xFF;
+        let codec2 = AesGcmCodec::new(wrong_key);
+
+        let encoded = codec1.encode(b"secret data");
+        let result = codec2.decode(&encoded);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("Decryption failed"));
+    }
+
+    #[test]
+    fn truncated_data_fails() {
+        let codec = AesGcmCodec::new(test_key());
+        let result = codec.decode(&[0u8; 10]); // too short
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too short"));
+    }
+
+    #[test]
+    fn corrupted_ciphertext_fails() {
+        let codec = AesGcmCodec::new(test_key());
+        let mut encoded = codec.encode(b"data");
+        // Corrupt a byte in the ciphertext area
+        let last = encoded.len() - 1;
+        encoded[last] ^= 0xFF;
+        assert!(codec.decode(&encoded).is_err());
+    }
+
+    #[test]
+    fn codec_id_is_correct() {
+        let codec = AesGcmCodec::new(test_key());
+        assert_eq!(codec.codec_id(), "aes-gcm-256");
+    }
+
+    #[test]
+    fn clone_preserves_key() {
+        let codec = AesGcmCodec::new(test_key());
+        let cloned = codec.clone_box();
+
+        let data = b"clone test";
+        let encoded = codec.encode(data);
+        let decoded = cloned.decode(&encoded).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn each_encode_produces_different_output() {
+        let codec = AesGcmCodec::new(test_key());
+        let data = b"determinism check";
+        let enc1 = codec.encode(data);
+        let enc2 = codec.encode(data);
+        // Different nonces → different ciphertext
+        assert_ne!(enc1, enc2);
+        // But both decrypt to the same plaintext
+        assert_eq!(codec.decode(&enc1).unwrap(), data);
+        assert_eq!(codec.decode(&enc2).unwrap(), data);
+    }
+
+    #[test]
+    fn key_from_hex_valid() {
+        let hex = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+        let key = AesGcmCodec::key_from_hex(hex).unwrap();
+        assert_eq!(key, test_key());
+    }
+
+    #[test]
+    fn key_from_hex_wrong_length() {
+        assert!(AesGcmCodec::key_from_hex("0011").is_err());
+    }
+
+    #[test]
+    fn key_from_hex_invalid_chars() {
+        let hex = "zz0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+        assert!(AesGcmCodec::key_from_hex(hex).is_err());
+    }
+
+    #[test]
+    fn is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<AesGcmCodec>();
+    }
+}

--- a/crates/durability/src/codec/identity.rs
+++ b/crates/durability/src/codec/identity.rs
@@ -39,6 +39,10 @@ impl StorageCodec for IdentityCodec {
     fn codec_id(&self) -> &str {
         "identity"
     }
+
+    fn clone_box(&self) -> Box<dyn StorageCodec> {
+        Box::new(IdentityCodec)
+    }
 }
 
 #[cfg(test)]

--- a/crates/durability/src/codec/mod.rs
+++ b/crates/durability/src/codec/mod.rs
@@ -27,9 +27,11 @@
 //! assert_eq!(data.as_slice(), decoded.as_slice());
 //! ```
 
+mod aes_gcm;
 mod identity;
 mod traits;
 
+pub use aes_gcm::AesGcmCodec;
 pub use identity::IdentityCodec;
 pub use traits::{CodecError, StorageCodec};
 
@@ -48,6 +50,19 @@ pub use traits::{CodecError, StorageCodec};
 pub fn get_codec(codec_id: &str) -> Result<Box<dyn StorageCodec>, CodecError> {
     match codec_id {
         "identity" => Ok(Box::new(IdentityCodec)),
+        "aes-gcm-256" => {
+            let hex = std::env::var("STRATA_ENCRYPTION_KEY").map_err(|_| {
+                CodecError::DecodeError {
+                    detail: "STRATA_ENCRYPTION_KEY environment variable not set. \
+                             Set it to a 64 hex-character (32-byte) key."
+                        .to_string(),
+                    codec_id: "aes-gcm-256".to_string(),
+                    data_len: 0,
+                }
+            })?;
+            let key = AesGcmCodec::key_from_hex(&hex)?;
+            Ok(Box::new(AesGcmCodec::new(key)))
+        }
         _ => Err(CodecError::UnknownCodec(codec_id.to_string())),
     }
 }
@@ -66,5 +81,48 @@ mod tests {
     fn test_get_unknown_codec() {
         let result = get_codec("unknown");
         assert!(matches!(result, Err(CodecError::UnknownCodec(_))));
+    }
+
+    #[test]
+    fn test_get_aes_gcm_codec_without_env_var() {
+        // Ensure the env var is unset for this test
+        std::env::remove_var("STRATA_ENCRYPTION_KEY");
+        let result = get_codec("aes-gcm-256");
+        match result {
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("STRATA_ENCRYPTION_KEY"),
+                    "Error should mention the env var: {}",
+                    msg
+                );
+            }
+            Ok(_) => panic!("Expected error when env var is not set"),
+        }
+    }
+
+    #[test]
+    fn test_get_aes_gcm_codec_with_valid_env_var() {
+        let hex = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+        std::env::set_var("STRATA_ENCRYPTION_KEY", hex);
+        let result = get_codec("aes-gcm-256");
+        // Clean up immediately
+        std::env::remove_var("STRATA_ENCRYPTION_KEY");
+        let codec = result.expect("Should create codec from valid env var");
+        assert_eq!(codec.codec_id(), "aes-gcm-256");
+
+        // Verify it actually works
+        let data = b"roundtrip via get_codec";
+        let encoded = codec.encode(data);
+        let decoded = codec.decode(&encoded).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn test_get_aes_gcm_codec_with_invalid_env_var() {
+        std::env::set_var("STRATA_ENCRYPTION_KEY", "too-short");
+        let result = get_codec("aes-gcm-256");
+        std::env::remove_var("STRATA_ENCRYPTION_KEY");
+        assert!(result.is_err());
     }
 }

--- a/crates/durability/src/codec/mod.rs
+++ b/crates/durability/src/codec/mod.rs
@@ -51,15 +51,14 @@ pub fn get_codec(codec_id: &str) -> Result<Box<dyn StorageCodec>, CodecError> {
     match codec_id {
         "identity" => Ok(Box::new(IdentityCodec)),
         "aes-gcm-256" => {
-            let hex = std::env::var("STRATA_ENCRYPTION_KEY").map_err(|_| {
-                CodecError::DecodeError {
+            let hex =
+                std::env::var("STRATA_ENCRYPTION_KEY").map_err(|_| CodecError::DecodeError {
                     detail: "STRATA_ENCRYPTION_KEY environment variable not set. \
                              Set it to a 64 hex-character (32-byte) key."
                         .to_string(),
                     codec_id: "aes-gcm-256".to_string(),
                     data_len: 0,
-                }
-            })?;
+                })?;
             let key = AesGcmCodec::key_from_hex(&hex)?;
             Ok(Box::new(AesGcmCodec::new(key)))
         }

--- a/crates/durability/src/codec/traits.rs
+++ b/crates/durability/src/codec/traits.rs
@@ -33,6 +33,12 @@ pub trait StorageCodec: Send + Sync {
     /// This is stored in the MANIFEST to ensure the correct codec
     /// is used when reopening a database.
     fn codec_id(&self) -> &str;
+
+    /// Clone this codec into a new boxed trait object.
+    ///
+    /// This preserves internal state (e.g., encryption keys) that
+    /// would be lost by reconstructing from `codec_id()` alone.
+    fn clone_box(&self) -> Box<dyn StorageCodec>;
 }
 
 /// Codec errors.

--- a/crates/durability/src/database/handle.rs
+++ b/crates/durability/src/database/handle.rs
@@ -81,13 +81,13 @@ impl DatabaseHandle {
             database_uuid,
             config.durability,
             config.wal_config.clone(),
-            clone_codec(codec.as_ref())?,
+            clone_codec(codec.as_ref()),
         )?;
 
         // Create checkpoint coordinator
         let checkpoint_coordinator = CheckpointCoordinator::new(
             paths.snapshots_dir(),
-            clone_codec(codec.as_ref())?,
+            clone_codec(codec.as_ref()),
             database_uuid,
         )?;
 
@@ -137,7 +137,7 @@ impl DatabaseHandle {
             database_uuid,
             config.durability,
             config.wal_config.clone(),
-            clone_codec(codec.as_ref())?,
+            clone_codec(codec.as_ref()),
         )?;
 
         // Create checkpoint coordinator with existing watermark
@@ -153,7 +153,7 @@ impl DatabaseHandle {
 
         let checkpoint_coordinator = CheckpointCoordinator::with_watermark(
             paths.snapshots_dir(),
-            clone_codec(codec.as_ref())?,
+            clone_codec(codec.as_ref()),
             database_uuid,
             watermark,
         )?;
@@ -198,7 +198,7 @@ impl DatabaseHandle {
     {
         let coordinator = RecoveryCoordinator::new(
             self.paths.root().to_path_buf(),
-            clone_codec(self.codec.as_ref())?,
+            clone_codec(self.codec.as_ref()),
         );
 
         coordinator.recover(on_snapshot, on_record)
@@ -373,11 +373,9 @@ fn generate_uuid() -> [u8; 16] {
     uuid
 }
 
-/// Clone a boxed codec
-fn clone_codec(
-    codec: &dyn StorageCodec,
-) -> Result<Box<dyn StorageCodec>, crate::codec::CodecError> {
-    get_codec(codec.codec_id())
+/// Clone a boxed codec, preserving internal state (e.g., encryption keys).
+fn clone_codec(codec: &dyn StorageCodec) -> Box<dyn StorageCodec> {
+    codec.clone_box()
 }
 
 #[cfg(test)]

--- a/crates/durability/src/recovery/coordinator.rs
+++ b/crates/durability/src/recovery/coordinator.rs
@@ -145,7 +145,7 @@ impl RecoveryCoordinator {
 
         // Load snapshot if exists
         if let Some(snapshot_path) = &plan.snapshot_path {
-            let snapshot_reader = SnapshotReader::new(clone_codec(self.codec.as_ref())?);
+            let snapshot_reader = SnapshotReader::new(clone_codec(self.codec.as_ref()));
             let loaded = snapshot_reader.load(snapshot_path)?;
 
             // D-5: Validate watermark consistency between MANIFEST and snapshot
@@ -170,7 +170,7 @@ impl RecoveryCoordinator {
         }
 
         // Replay WAL using effective watermark (conservative — replays extra rather than skipping)
-        let replayer = WalReplayer::new(plan.wal_dir.clone(), clone_codec(self.codec.as_ref())?);
+        let replayer = WalReplayer::new(plan.wal_dir.clone(), clone_codec(self.codec.as_ref()));
         let replay_stats = replayer.replay_after(effective_watermark, |record| {
             on_record(record).map_err(|e| WalReplayError::Apply(e.to_string()))
         })?;
@@ -204,7 +204,7 @@ impl RecoveryCoordinator {
             return Ok(0);
         }
 
-        let reader = crate::wal::WalReader::new(clone_codec(self.codec.as_ref())?);
+        let reader = crate::wal::WalReader::new(clone_codec(self.codec.as_ref()));
         let segments = reader.list_segments(&wal_dir)?;
         let mut rebuilt = 0usize;
 
@@ -266,7 +266,7 @@ impl RecoveryCoordinator {
     /// - In Always mode, committed transactions are fsynced
     /// - In Standard mode, some data loss is expected on crash
     pub fn truncate_partial_records(&self, wal_dir: &Path) -> Result<u64, RecoveryError> {
-        let reader = crate::wal::WalReader::new(clone_codec(self.codec.as_ref())?);
+        let reader = crate::wal::WalReader::new(clone_codec(self.codec.as_ref()));
 
         // Get all segments
         let segments = reader.list_segments(wal_dir)?;
@@ -384,9 +384,9 @@ impl RecoveryError {
     }
 }
 
-/// Helper to clone a boxed codec
-fn clone_codec(codec: &dyn StorageCodec) -> Result<Box<dyn StorageCodec>, CodecError> {
-    crate::codec::get_codec(codec.codec_id())
+/// Clone a boxed codec, preserving internal state (e.g., encryption keys).
+fn clone_codec(codec: &dyn StorageCodec) -> Box<dyn StorageCodec> {
+    codec.clone_box()
 }
 
 #[cfg(test)]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -18,6 +18,7 @@ strata-core = { path = "../core" }
 strata-storage = { path = "../storage" }
 strata-concurrency = { path = "../concurrency" }
 strata-durability = { path = "../durability" }
+strata-security = { path = "../security" }
 dashmap = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use strata_core::{StrataError, StrataResult};
 use strata_durability::wal::DurabilityMode;
+use strata_security::SensitiveString;
 
 // ============================================================================
 // Shadow Collection Names
@@ -38,7 +39,7 @@ pub struct ModelConfig {
     pub model: String,
     /// Optional API key for authenticated endpoints
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub api_key: Option<String>,
+    pub api_key: Option<SensitiveString>,
     /// Request timeout in milliseconds (default: 5000)
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u64,
@@ -134,13 +135,13 @@ pub struct StrataConfig {
     pub default_model: Option<String>,
     /// Anthropic (Claude) API key.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub anthropic_api_key: Option<String>,
+    pub anthropic_api_key: Option<SensitiveString>,
     /// OpenAI (GPT) API key.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub openai_api_key: Option<String>,
+    pub openai_api_key: Option<SensitiveString>,
     /// Google (Gemini) API key.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub google_api_key: Option<String>,
+    pub google_api_key: Option<SensitiveString>,
     /// Storage layer resource limits.
     #[serde(default)]
     pub storage: StorageConfig,
@@ -411,7 +412,7 @@ mod tests {
             model: Some(ModelConfig {
                 endpoint: "http://localhost:11434/v1".to_string(),
                 model: "qwen3:1.7b".to_string(),
-                api_key: Some("sk-test".to_string()),
+                api_key: Some(SensitiveString::from("sk-test")),
                 timeout_ms: 3000,
             }),
             ..StrataConfig::default()
@@ -425,7 +426,7 @@ mod tests {
         let model = parsed.model.unwrap();
         assert_eq!(model.endpoint, "http://localhost:11434/v1");
         assert_eq!(model.model, "qwen3:1.7b");
-        assert_eq!(model.api_key, Some("sk-test".to_string()));
+        assert_eq!(model.api_key.as_deref(), Some("sk-test"));
         assert_eq!(model.timeout_ms, 3000);
     }
 
@@ -567,7 +568,7 @@ auto_embed = false
         let config = StrataConfig {
             provider: "anthropic".to_string(),
             default_model: Some("claude-sonnet-4-20250514".to_string()),
-            anthropic_api_key: Some("sk-ant-test-key".to_string()),
+            anthropic_api_key: Some(SensitiveString::from("sk-ant-test-key")),
             ..StrataConfig::default()
         };
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -587,9 +588,9 @@ auto_embed = false
         let config = StrataConfig {
             provider: "openai".to_string(),
             default_model: Some("gpt-4".to_string()),
-            anthropic_api_key: Some("sk-ant-key".to_string()),
-            openai_api_key: Some("sk-openai-key".to_string()),
-            google_api_key: Some("AIza-key".to_string()),
+            anthropic_api_key: Some(SensitiveString::from("sk-ant-key")),
+            openai_api_key: Some(SensitiveString::from("sk-openai-key")),
+            google_api_key: Some(SensitiveString::from("AIza-key")),
             ..StrataConfig::default()
         };
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -694,7 +695,7 @@ auto_embed = true
         let config = StrataConfig {
             provider: "google".to_string(),
             default_model: Some("gemini-pro".to_string()),
-            google_api_key: Some("AIza-test".to_string()),
+            google_api_key: Some(SensitiveString::from("AIza-test")),
             ..StrataConfig::default()
         };
         config.write_to_file(&path).unwrap();

--- a/crates/executor/src/handlers/config.rs
+++ b/crates/executor/src/handlers/config.rs
@@ -319,7 +319,10 @@ pub fn configure_get_key(p: &Arc<Primitives>, key: String) -> Result<Output> {
         "embed_batch_size" => cfg.embed_batch_size.map(|v| v.to_string()),
         "model_endpoint" => cfg.model.as_ref().map(|m| m.endpoint.clone()),
         "model_name" => cfg.model.as_ref().map(|m| m.model.clone()),
-        "model_api_key" => cfg.model.as_ref().and_then(|m| m.api_key.as_deref().map(mask_api_key)),
+        "model_api_key" => cfg
+            .model
+            .as_ref()
+            .and_then(|m| m.api_key.as_deref().map(mask_api_key)),
         "model_timeout_ms" => cfg.model.as_ref().map(|m| m.timeout_ms.to_string()),
         _ => unreachable!(),
     };

--- a/crates/executor/src/handlers/config.rs
+++ b/crates/executor/src/handlers/config.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use crate::bridge::Primitives;
 use crate::{Error, Output, Result};
+use strata_security::SensitiveString;
 
 /// Handle ConfigGet command: return the current database configuration.
 pub fn config_get(p: &Arc<Primitives>) -> Result<Output> {
@@ -247,7 +248,7 @@ pub fn configure_set(p: &Arc<Primitives>, key: String, value: String) -> Result<
             match key_lower.as_str() {
                 "model_endpoint" => model.endpoint = value.clone(),
                 "model_name" => model.model = value.clone(),
-                "model_api_key" => model.api_key = Some(value.clone()),
+                "model_api_key" => model.api_key = Some(SensitiveString::from(value.clone())),
                 "model_timeout_ms" => {
                     model.timeout_ms = value.trim().parse().unwrap_or(5000);
                 }
@@ -261,9 +262,9 @@ pub fn configure_set(p: &Arc<Primitives>, key: String, value: String) -> Result<
     p.db.update_config(|cfg| match key_lower.as_str() {
         "provider" => cfg.provider = value.clone(),
         "default_model" => cfg.default_model = Some(value.clone()),
-        "anthropic_api_key" => cfg.anthropic_api_key = Some(value.clone()),
-        "openai_api_key" => cfg.openai_api_key = Some(value.clone()),
-        "google_api_key" => cfg.google_api_key = Some(value.clone()),
+        "anthropic_api_key" => cfg.anthropic_api_key = Some(SensitiveString::from(value.clone())),
+        "openai_api_key" => cfg.openai_api_key = Some(SensitiveString::from(value.clone())),
+        "google_api_key" => cfg.google_api_key = Some(SensitiveString::from(value.clone())),
         "embed_model" => {
             cfg.embed_model = canonical_embed_model
                 .clone()
@@ -307,9 +308,9 @@ pub fn configure_get_key(p: &Arc<Primitives>, key: String) -> Result<Output> {
     let value = match key_lower.as_str() {
         "provider" => Some(cfg.provider.clone()),
         "default_model" => cfg.default_model.clone(),
-        "anthropic_api_key" => cfg.anthropic_api_key.clone(),
-        "openai_api_key" => cfg.openai_api_key.clone(),
-        "google_api_key" => cfg.google_api_key.clone(),
+        "anthropic_api_key" => cfg.anthropic_api_key.as_deref().map(mask_api_key),
+        "openai_api_key" => cfg.openai_api_key.as_deref().map(mask_api_key),
+        "google_api_key" => cfg.google_api_key.as_deref().map(mask_api_key),
         "embed_model" => Some(cfg.embed_model.clone()),
         "durability" => Some(cfg.durability.clone()),
         "auto_embed" => Some(cfg.auto_embed.to_string()),
@@ -318,10 +319,20 @@ pub fn configure_get_key(p: &Arc<Primitives>, key: String) -> Result<Output> {
         "embed_batch_size" => cfg.embed_batch_size.map(|v| v.to_string()),
         "model_endpoint" => cfg.model.as_ref().map(|m| m.endpoint.clone()),
         "model_name" => cfg.model.as_ref().map(|m| m.model.clone()),
-        "model_api_key" => cfg.model.as_ref().and_then(|m| m.api_key.clone()),
+        "model_api_key" => cfg.model.as_ref().and_then(|m| m.api_key.as_deref().map(mask_api_key)),
         "model_timeout_ms" => cfg.model.as_ref().map(|m| m.timeout_ms.to_string()),
         _ => unreachable!(),
     };
 
     Ok(Output::ConfigValue(value))
+}
+
+/// Mask an API key for display: show first 4 characters + "***".
+fn mask_api_key(key: &str) -> String {
+    if key.chars().count() <= 4 {
+        "***".to_string()
+    } else {
+        let prefix: String = key.chars().take(4).collect();
+        format!("{}***", prefix)
+    }
 }

--- a/crates/executor/src/handlers/configure_model.rs
+++ b/crates/executor/src/handlers/configure_model.rs
@@ -22,7 +22,7 @@ pub fn configure_model(
         cfg.model = Some(ModelConfig {
             endpoint,
             model,
-            api_key,
+            api_key: api_key.map(strata_security::SensitiveString::from),
             timeout_ms: timeout_ms.unwrap_or(5000),
         });
     })

--- a/crates/executor/src/handlers/generate.rs
+++ b/crates/executor/src/handlers/generate.rs
@@ -92,8 +92,12 @@ pub fn generate(
             }
         })?;
 
-        GenerateModelState::create_cloud_engine(provider_kind, api_key.into_inner(), &resolved_model)
-            .map_err(|e| Error::Internal { reason: e })?
+        GenerateModelState::create_cloud_engine(
+            provider_kind,
+            api_key.into_inner(),
+            &resolved_model,
+        )
+        .map_err(|e| Error::Internal { reason: e })?
     };
 
     let request = strata_intelligence::GenerateRequest {

--- a/crates/executor/src/handlers/generate.rs
+++ b/crates/executor/src/handlers/generate.rs
@@ -92,7 +92,7 @@ pub fn generate(
             }
         })?;
 
-        GenerateModelState::create_cloud_engine(provider_kind, api_key, &resolved_model)
+        GenerateModelState::create_cloud_engine(provider_kind, api_key.into_inner(), &resolved_model)
             .map_err(|e| Error::Internal { reason: e })?
     };
 

--- a/crates/executor/src/tests/config.rs
+++ b/crates/executor/src/tests/config.rs
@@ -60,10 +60,10 @@ fn configure_set_and_get_default_model() {
 fn configure_set_and_get_api_keys() {
     let executor = create_test_executor();
 
-    for (key, value) in [
-        ("anthropic_api_key", "sk-ant-test-123"),
-        ("openai_api_key", "sk-test-456"),
-        ("google_api_key", "AIza-test-789"),
+    for (key, value, masked) in [
+        ("anthropic_api_key", "sk-ant-test-123", "sk-a***"),
+        ("openai_api_key", "sk-test-456", "sk-t***"),
+        ("google_api_key", "AIza-test-789", "AIza***"),
     ] {
         executor
             .execute(Command::ConfigureSet {
@@ -75,7 +75,7 @@ fn configure_set_and_get_api_keys() {
         let result = executor
             .execute(Command::ConfigureGetKey { key: key.into() })
             .unwrap();
-        assert_eq!(result, Output::ConfigValue(Some(value.into())));
+        assert_eq!(result, Output::ConfigValue(Some(masked.into())));
     }
 }
 
@@ -416,7 +416,7 @@ fn configure_set_visible_in_full_config() {
     match result {
         Output::Config(cfg) => {
             assert_eq!(cfg.provider, "openai");
-            assert_eq!(cfg.openai_api_key, Some("sk-test".into()));
+            assert_eq!(cfg.openai_api_key.as_deref(), Some("sk-test"));
         }
         _ => panic!("Expected Config output"),
     }
@@ -1189,7 +1189,7 @@ fn configure_set_model_api_key() {
             key: "model_api_key".into(),
         })
         .unwrap();
-    assert_eq!(result, Output::ConfigValue(Some("sk-test-key".into())));
+    assert_eq!(result, Output::ConfigValue(Some("sk-t***".into())));
 }
 
 #[test]
@@ -1279,6 +1279,91 @@ fn configure_set_model_fields_visible_in_full_config() {
         }
         _ => panic!("Expected Config output"),
     }
+}
+
+// =============================================================================
+// CONFIG GET (full config) vs CONFIGURE GET key (masked)
+// =============================================================================
+
+#[test]
+fn config_get_returns_real_values_while_configure_get_key_masks() {
+    let executor = create_test_executor();
+
+    executor
+        .execute(Command::ConfigureSet {
+            key: "anthropic_api_key".into(),
+            value: "sk-ant-secret-key-12345".into(),
+        })
+        .unwrap();
+
+    // CONFIG GET returns the full StrataConfig with real SensitiveString values
+    let full = executor.execute(Command::ConfigGet).unwrap();
+    match full {
+        Output::Config(cfg) => {
+            // Deref through SensitiveString gives the actual value
+            assert_eq!(cfg.anthropic_api_key.as_deref(), Some("sk-ant-secret-key-12345"));
+        }
+        _ => panic!("Expected Config output"),
+    }
+
+    // CONFIGURE GET key returns a masked string
+    let masked = executor
+        .execute(Command::ConfigureGetKey {
+            key: "anthropic_api_key".into(),
+        })
+        .unwrap();
+    assert_eq!(masked, Output::ConfigValue(Some("sk-a***".into())));
+}
+
+// =============================================================================
+// mask_api_key edge cases (via CONFIGURE GET key)
+// =============================================================================
+
+#[test]
+fn configure_get_key_masks_short_api_keys() {
+    let executor = create_test_executor();
+
+    // 1-char key → masked as "***"
+    executor
+        .execute(Command::ConfigureSet {
+            key: "openai_api_key".into(),
+            value: "x".into(),
+        })
+        .unwrap();
+    let result = executor
+        .execute(Command::ConfigureGetKey {
+            key: "openai_api_key".into(),
+        })
+        .unwrap();
+    assert_eq!(result, Output::ConfigValue(Some("***".into())));
+
+    // Exactly 4 chars → still masked as "***" (not enough to reveal)
+    executor
+        .execute(Command::ConfigureSet {
+            key: "openai_api_key".into(),
+            value: "abcd".into(),
+        })
+        .unwrap();
+    let result = executor
+        .execute(Command::ConfigureGetKey {
+            key: "openai_api_key".into(),
+        })
+        .unwrap();
+    assert_eq!(result, Output::ConfigValue(Some("***".into())));
+
+    // 5 chars → shows first 4 + "***"
+    executor
+        .execute(Command::ConfigureSet {
+            key: "openai_api_key".into(),
+            value: "abcde".into(),
+        })
+        .unwrap();
+    let result = executor
+        .execute(Command::ConfigureGetKey {
+            key: "openai_api_key".into(),
+        })
+        .unwrap();
+    assert_eq!(result, Output::ConfigValue(Some("abcd***".into())));
 }
 
 // =============================================================================

--- a/crates/executor/src/tests/config.rs
+++ b/crates/executor/src/tests/config.rs
@@ -1301,7 +1301,10 @@ fn config_get_returns_real_values_while_configure_get_key_masks() {
     match full {
         Output::Config(cfg) => {
             // Deref through SensitiveString gives the actual value
-            assert_eq!(cfg.anthropic_api_key.as_deref(), Some("sk-ant-secret-key-12345"));
+            assert_eq!(
+                cfg.anthropic_api_key.as_deref(),
+                Some("sk-ant-secret-key-12345")
+            );
         }
         _ => panic!("Expected Config output"),
     }

--- a/crates/security/Cargo.toml
+++ b/crates/security/Cargo.toml
@@ -11,3 +11,7 @@ description = "Access control and configuration for Strata database"
 
 [dependencies]
 serde = { workspace = true }
+zeroize = "1"
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -5,6 +5,10 @@
 
 #![warn(missing_docs)]
 
+mod sensitive;
+
+pub use sensitive::SensitiveString;
+
 use serde::{Deserialize, Serialize};
 
 /// Controls whether the database allows writes or is read-only.

--- a/crates/security/src/sensitive.rs
+++ b/crates/security/src/sensitive.rs
@@ -1,0 +1,187 @@
+//! Sensitive string wrapper with zeroize-on-drop and redacted Debug output.
+//!
+//! `SensitiveString` wraps a `String` that contains secrets (API keys,
+//! passwords, tokens). It provides:
+//!
+//! - **Zeroize on drop**: The inner bytes are overwritten with zeros when
+//!   the value is dropped, preventing secrets from lingering in freed memory.
+//! - **Redacted Debug**: `Debug` output shows `[REDACTED]` instead of the
+//!   actual value, preventing accidental logging.
+//! - **Transparent access**: `Deref<Target=str>` gives seamless `&str` access
+//!   for comparisons, formatting, and API calls.
+
+use serde::{Deserialize, Serialize};
+use std::ops::Deref;
+use zeroize::Zeroize;
+
+/// A string that holds sensitive data (API keys, passwords, tokens).
+///
+/// The inner bytes are zeroized on drop and `Debug` shows `[REDACTED]`.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SensitiveString(String);
+
+impl SensitiveString {
+    /// Consume the wrapper and return the inner `String`.
+    ///
+    /// Use this when you must pass the raw value to an external API.
+    /// The returned `String` is NOT zeroized — the caller assumes
+    /// responsibility for the secret's lifetime.
+    pub fn into_inner(self) -> String {
+        let mut this = std::mem::ManuallyDrop::new(self);
+        // Take the String out, replacing it with an empty String.
+        // ManuallyDrop prevents our Drop (zeroize) from running.
+        // The empty String left behind has no heap allocation to leak.
+        std::mem::take(&mut this.0)
+    }
+
+    /// Borrow the inner value as `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Drop for SensitiveString {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl std::fmt::Debug for SensitiveString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}
+
+impl std::fmt::Display for SensitiveString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}
+
+impl Deref for SensitiveString {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl PartialEq for SensitiveString {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for SensitiveString {}
+
+impl From<String> for SensitiveString {
+    fn from(s: String) -> Self {
+        SensitiveString(s)
+    }
+}
+
+impl From<&str> for SensitiveString {
+    fn from(s: &str) -> Self {
+        SensitiveString(s.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_is_redacted() {
+        let s = SensitiveString::from("sk-ant-secret-key");
+        assert_eq!(format!("{:?}", s), "[REDACTED]");
+    }
+
+    #[test]
+    fn display_is_redacted() {
+        let s = SensitiveString::from("sk-ant-secret-key");
+        assert_eq!(format!("{}", s), "[REDACTED]");
+    }
+
+    #[test]
+    fn deref_gives_str_access() {
+        let s = SensitiveString::from("hello");
+        let borrowed: &str = &s;
+        assert_eq!(borrowed, "hello");
+        assert_eq!(s.len(), 5);
+        assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn as_str_works() {
+        let s = SensitiveString::from("test");
+        assert_eq!(s.as_str(), "test");
+    }
+
+    #[test]
+    fn into_inner_returns_value() {
+        let s = SensitiveString::from("secret");
+        let inner = s.into_inner();
+        assert_eq!(inner, "secret");
+    }
+
+    #[test]
+    fn clone_is_independent() {
+        let s1 = SensitiveString::from("original");
+        let s2 = s1.clone();
+        drop(s1);
+        // s2 should still be accessible after s1 is dropped
+        assert_eq!(s2.as_str(), "original");
+    }
+
+    #[test]
+    fn equality() {
+        let a = SensitiveString::from("same");
+        let b = SensitiveString::from("same");
+        let c = SensitiveString::from("different");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn from_string() {
+        let s = SensitiveString::from("test".to_string());
+        assert_eq!(s.as_str(), "test");
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let original = SensitiveString::from("sk-ant-secret");
+        let json = serde_json::to_string(&original).unwrap();
+        // Serialized form should contain the actual value (transparent)
+        assert_eq!(json, "\"sk-ant-secret\"");
+
+        let deserialized: SensitiveString = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.as_str(), "sk-ant-secret");
+    }
+
+    #[test]
+    fn zeroize_on_drop() {
+        // Create a string and get a pointer to its buffer
+        let s = SensitiveString::from("SENSITIVE_DATA_HERE");
+        let ptr = s.0.as_ptr();
+        let len = s.0.len();
+        drop(s);
+        // After drop, the memory at that location should be zeroed.
+        // NOTE: This is a best-effort check — the allocator may have
+        // reused the memory, but in practice this catches regressions.
+        let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+        // At least some bytes should be zero (zeroize overwrites all)
+        let all_nonzero = bytes.iter().all(|&b| b != 0);
+        assert!(
+            !all_nonzero,
+            "Expected at least some zeroed bytes after drop"
+        );
+    }
+
+    #[test]
+    fn is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SensitiveString>();
+    }
+}


### PR DESCRIPTION
## Summary

- **SEC-1: AES-256-GCM encryption at rest** — Implement `AesGcmCodec` with `StorageCodec::clone_box()` for key-preserving codec cloning. Key sourced from `STRATA_ENCRYPTION_KEY` env var (64 hex chars). Wire format: `nonce(12) || ciphertext+tag`.
- **SEC-2: Credential safety** — Add `SensitiveString` wrapper with zeroize-on-drop, redacted `Debug`/`Display`, and serde transparent serialization. Replace all 4 API key fields (`anthropic_api_key`, `openai_api_key`, `google_api_key`, `model.api_key`) from `Option<String>` to `Option<SensitiveString>`. `CONFIGURE GET <key>` now masks keys (first 4 chars + `"***"`).

## Test plan

- [x] AES-GCM: roundtrip, empty data, 1MB data, wrong key, truncated, corrupted, clone preserves key, nonce uniqueness, hex parsing, get_codec integration (env var present/absent/invalid)
- [x] SensitiveString: zeroize on drop, Debug/Display redacted, serde roundtrip, Deref, Clone independence, into_inner, Send+Sync
- [x] Executor: CONFIG GET returns real values vs CONFIGURE GET key returns masked, short key masking edge cases (1/4/5 chars)
- [x] All 2,286 tests pass across affected crates (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)