### PR TITLE
Clean up core crate: fix stale doc, remove unused chrono dep

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -13,7 +13,6 @@ uuid = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-chrono = { workspace = true }
 bincode = { workspace = true }
 
 [dev-dependencies]

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -2,7 +2,7 @@
 //!
 //! This module defines the foundational types:
 //! - BranchId: Unique identifier for agent branches
-//! - Namespace: Hierarchical namespace (tenant/app/agent/branch/space)
+//! - Namespace: Hierarchical namespace (branch_id/space)
 //! - TypeTag: Type discriminator for unified storage
 //! - Key: Composite key (namespace + type_tag + user_key)
 


### PR DESCRIPTION
## Summary

- Fix stale Namespace doc comment: "tenant/app/agent/branch/space" → "branch_id/space"
- Remove unused `chrono` dependency (zero references in crate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)