### PR TITLE
Fix KV search snippet fetching to use correct space (#1424)

### DIFF
--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -361,7 +361,7 @@ impl crate::search::Searchable for KVStore {
             .filter_map(|scored| {
                 let entity_ref = index.resolve_doc_id(scored.doc_id)?;
                 let snippet = if let EntityRef::Kv { ref key, .. } = entity_ref {
-                    self.get(&req.branch_id, "default", key)
+                    self.get(&req.branch_id, &req.space, key)
                         .ok()
                         .flatten()
                         .map(|v| match &v {

--- a/crates/engine/src/search/types.rs
+++ b/crates/engine/src/search/types.rs
@@ -161,6 +161,9 @@ pub struct SearchRequest {
     /// Optional: precomputed query embedding (skip embedder call in hybrid search).
     /// Used by `search_expanded()` to batch-embed all expansion texts upfront.
     pub precomputed_embedding: Option<Vec<f32>>,
+
+    /// Space to search within (defaults to "default").
+    pub space: String,
 }
 
 impl SearchRequest {
@@ -185,6 +188,7 @@ impl SearchRequest {
             time_range: None,
             tags_any: vec![],
             precomputed_embedding: None,
+            space: "default".to_string(),
         }
     }
 
@@ -227,6 +231,12 @@ impl SearchRequest {
     /// Builder: set precomputed query embedding (avoids re-embedding in hybrid search)
     pub fn with_precomputed_embedding(mut self, embedding: Vec<f32>) -> Self {
         self.precomputed_embedding = Some(embedding);
+        self
+    }
+
+    /// Builder: set space to search within
+    pub fn with_space(mut self, space: impl Into<String>) -> Self {
+        self.space = space.into();
         self
     }
 

--- a/crates/executor/src/handlers/search.rs
+++ b/crates/executor/src/handlers/search.rs
@@ -58,7 +58,7 @@ fn parse_time_range(input: &TimeRangeInput) -> Result<(u64, u64)> {
 pub fn search(
     p: &Arc<Primitives>,
     branch: BranchId,
-    _space: String,
+    space: String,
     sq: SearchQuery,
 ) -> Result<Output> {
     let core_branch_id = to_core_branch_id(&branch)?;
@@ -82,7 +82,7 @@ pub fn search(
     // Parse time_range
     let parsed_time_range = sq.time_range.as_ref().map(parse_time_range).transpose()?;
 
-    let mut req = SearchRequest::new(core_branch_id, &sq.query);
+    let mut req = SearchRequest::new(core_branch_id, &sq.query).with_space(space);
     if let Some(top_k) = sq.k {
         req = req.with_k(top_k as usize);
     }


### PR DESCRIPTION
## Summary

- KV search hardcoded `"default"` space when fetching values for snippet generation — documents in non-default spaces got empty snippets silently
- Added `space` field to `SearchRequest` (defaults to `"default"` for backward compat)
- Executor search handler now passes the caller's space through to the search layer
- KV `Searchable::search()` uses `req.space` instead of hardcoded `"default"`

## Test plan

- [x] All engine, executor, and search tests pass
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)