### PR TITLE
Engine primitives P2/P3 cleanup (#1426)

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -38,9 +38,9 @@ pub use instrumentation::PerfTrace;
 pub use recovery::{
     recover_all_participants, register_recovery_participant, RecoveryFn, RecoveryParticipant,
 };
+pub use strata_concurrency::TransactionContext;
 pub use strata_durability::wal::DurabilityMode;
 pub use strata_durability::WalCounters;
-pub use strata_concurrency::TransactionContext;
 pub use transaction::{Transaction, TransactionPool, MAX_POOL_SIZE};
 pub use transaction_ops::TransactionOps;
 
@@ -81,7 +81,6 @@ pub use primitives::{
     CollectionRecord,
     DistanceMetric,
     Event,
-    EventHandle,
     EventLog,
     EventLogExt,
     FilterCondition,
@@ -92,7 +91,6 @@ pub use primitives::{
     // Index
     InvertedIndex,
     JsonDoc,
-    JsonHandle,
     JsonScalar,
     JsonStore,
     JsonStoreExt,
@@ -100,7 +98,6 @@ pub use primitives::{
     KVStore,
     // Extension traits
     KVStoreExt,
-    KvHandle,
     MetadataFilter,
     PostingEntry,
     PostingList,
@@ -115,7 +112,6 @@ pub use primitives::{
     State,
     StateCell,
     StateCellExt,
-    StateHandle,
     StorageDtype,
     VectorBackendState,
     // Vector types

--- a/crates/engine/src/primitives/branch/mod.rs
+++ b/crates/engine/src/primitives/branch/mod.rs
@@ -1,7 +1,7 @@
-//! Run module for run lifecycle management and handles
+//! Branch module for branch lifecycle management and handles
 //!
 //! This module contains:
-//! - `index`: BranchIndex for creating, deleting, and managing runs
+//! - `index`: BranchIndex for creating, deleting, and managing branches
 //! - `handle`: BranchHandle facade for branch-scoped operations
 
 mod handle;

--- a/crates/engine/src/primitives/json.rs
+++ b/crates/engine/src/primitives/json.rs
@@ -126,7 +126,7 @@ impl JsonDoc {
     /// Increment version and update timestamp
     ///
     /// Call this after any modification to the document.
-    pub fn touch(&mut self) {
+    pub(crate) fn touch(&mut self) {
         self.version += 1;
         self.updated_at = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -181,13 +181,13 @@ impl JsonStore {
     }
 
     /// Build namespace for branch+space-scoped operations
-    fn namespace_for(&self, branch_id: &BranchId, space: &str) -> Namespace {
-        Namespace::for_branch_space(*branch_id, space)
+    fn namespace_for(&self, branch_id: &BranchId, space: &str) -> Arc<Namespace> {
+        Arc::new(Namespace::for_branch_space(*branch_id, space))
     }
 
     /// Build key for JSON document
     fn key_for(&self, branch_id: &BranchId, space: &str, doc_id: &str) -> Key {
-        Key::new_json(Arc::new(self.namespace_for(branch_id, space)), doc_id)
+        Key::new_json(self.namespace_for(branch_id, space), doc_id)
     }
 
     // ========================================================================
@@ -651,7 +651,7 @@ impl JsonStore {
     ) -> StrataResult<JsonListResult> {
         let ns = self.namespace_for(branch_id, space);
         // Narrow scan at storage level: if prefix is given, only scan matching keys
-        let scan_prefix = Key::new_json(Arc::new(ns), prefix.unwrap_or(""));
+        let scan_prefix = Key::new_json(ns, prefix.unwrap_or(""));
 
         self.db.transaction(*branch_id, |txn| {
             let mut doc_ids = Vec::with_capacity(limit + 1);
@@ -731,7 +731,7 @@ impl JsonStore {
     ) -> StrataResult<Vec<String>> {
         let ns = self.namespace_for(branch_id, space);
         // Narrow scan at storage level: if prefix is given, only scan matching keys
-        let scan_key = Key::new_json(Arc::new(ns), prefix.unwrap_or(""));
+        let scan_key = Key::new_json(ns, prefix.unwrap_or(""));
         let results = self.db.scan_prefix_at_timestamp(&scan_key, as_of_ts)?;
         let mut doc_ids = Vec::new();
         for (key, _vv) in results {

--- a/crates/engine/src/primitives/space.rs
+++ b/crates/engine/src/primitives/space.rs
@@ -105,8 +105,8 @@ impl SpaceIndex {
 
     /// Check if a space has any data.
     ///
-    /// Scans all data TypeTags (KV, Event, State, Json, Vector) in the
-    /// space's namespace to determine if any keys exist.
+    /// **Note:** This is O(N) — scans all data TypeTags (KV, Event, State,
+    /// Json, Vector, VectorConfig) in the space's namespace. Not a cheap check.
     pub fn is_empty(&self, branch_id: BranchId, space: &str) -> StrataResult<bool> {
         self.db.transaction(branch_id, |txn| {
             let ns = Arc::new(Namespace::for_branch_space(branch_id, space));


### PR DESCRIPTION
## Summary

Safe subset of the P2/P3 cleanup items:

- Fix stale "Run" → "Branch" in branch/mod.rs doc comment
- Document `SpaceIndex::is_empty()` O(N) complexity
- Make `JsonDoc::touch()` `pub(crate)` — only used internally
- Fix JSON `namespace_for()` to return `Arc<Namespace>` matching KV pattern (removes redundant Arc wrapping at call sites)
- Remove `KvHandle`/`EventHandle`/`StateHandle`/`JsonHandle` from crate root exports — constructors are `pub(crate)` so external code can't construct them anyway

## Items deferred (not safe)

- **Searchable impls**: Can't remove — hybrid search dispatches `.search()` on all 5 primitives
- **Dead BranchMetadata fields**: Removing changes serialization of stored data
- **EventLog O(N) fallback + list_at()**: Both have production callers in executor

## Test plan

- [x] All engine tests pass
- [x] `cargo clippy` clean
- [x] Build succeeds for engine, executor, search, CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)