### PR TITLE
Fix --expand and --rerank to be bare boolean flags

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -741,12 +741,14 @@ fn build_search() -> Command {
         .arg(
             Arg::new("expand")
                 .long("expand")
-                .help("Enable/disable query expansion (true/false)"),
+                .action(clap::ArgAction::SetTrue)
+                .help("Enable query expansion"),
         )
         .arg(
             Arg::new("rerank")
                 .long("rerank")
-                .help("Enable/disable reranking (true/false)"),
+                .action(clap::ArgAction::SetTrue)
+                .help("Enable reranking"),
         )
 }
 

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -1656,12 +1656,16 @@ fn parse_search(matches: &ArgMatches, state: &SessionState) -> Result<CliAction,
     };
 
     let mode = matches.get_one::<String>("mode").cloned();
-    let expand = matches
-        .get_one::<String>("expand")
-        .map(|s| s.eq_ignore_ascii_case("true"));
-    let rerank = matches
-        .get_one::<String>("rerank")
-        .map(|s| s.eq_ignore_ascii_case("true"));
+    let expand = if matches.get_flag("expand") {
+        Some(true)
+    } else {
+        None
+    };
+    let rerank = if matches.get_flag("rerank") {
+        Some(true)
+    } else {
+        None
+    };
 
     Ok(CliAction::Execute(Command::Search {
         branch: branch(state),


### PR DESCRIPTION
## Summary
- Change `--expand` and `--rerank` from value-taking args (`--expand true/false`) to standard `SetTrue` boolean flags (`--expand` / `--rerank`)
- Matches standard CLI conventions for boolean toggles

Closes #1487

## Test plan
- [ ] `strata search "query" --expand` enables expansion
- [ ] `strata search "query" --rerank` enables reranking
- [ ] `strata search "query"` leaves both as None (auto-decide)
- [ ] `strata search "query" --expand --rerank` enables both

🤖 Generated with [Claude Code](https://claude.com/claude-code)