### PR TITLE
Fix BM25 search index not rebuilt on database reopen

### DIFF
--- a/crates/engine/src/search/recovery.rs
+++ b/crates/engine/src/search/recovery.rs
@@ -96,6 +96,10 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
     // ---------------------------------------------------------------
     // Slow path: rebuild from KV/State/Event entries
     // ---------------------------------------------------------------
+    // Enable the index before scanning so that index_document() calls
+    // are not silently dropped by the is_enabled() guard.
+    index.enable();
+
     let mut docs_indexed: u64 = 0;
     let mut branches_scanned: u64 = 0;
 

--- a/crates/engine/tests/recovery_tests.rs
+++ b/crates/engine/tests/recovery_tests.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use strata_core::contract::Version;
 use strata_core::types::BranchId;
 use strata_core::value::Value;
-use strata_engine::Database;
+use strata_engine::{Database, SearchRequest};
 use strata_engine::{BranchIndex, EventLog, KVStore, StateCell};
 use tempfile::TempDir;
 
@@ -693,5 +693,131 @@ fn test_all_primitives_recover_together() {
             .unwrap()
             .unwrap();
         assert_eq!(state, Value::Int(100));
+    }
+}
+
+/// Test BM25 search index survives recovery (#1486)
+#[test]
+fn test_search_index_survives_recovery() {
+    use strata_engine::search::Searchable;
+
+    let temp_dir = TempDir::new().unwrap();
+    let path = get_path(&temp_dir);
+    let branch_id = BranchId::new();
+
+    // Session 1: index documents and verify search works
+    {
+        let db = Database::open(&path).unwrap();
+        let kv = KVStore::new(db.clone());
+
+        kv.put(
+            &branch_id,
+            "default",
+            "doc1",
+            Value::String("breast cancer cholesterol statin drugs".into()),
+        )
+        .unwrap();
+        kv.put(
+            &branch_id,
+            "default",
+            "doc2",
+            Value::String("cardiovascular disease heart attack prevention".into()),
+        )
+        .unwrap();
+        kv.put(
+            &branch_id,
+            "default",
+            "doc3",
+            Value::String("machine learning neural network deep learning".into()),
+        )
+        .unwrap();
+
+        // Search works in same session
+        let req = SearchRequest::new(branch_id, "cholesterol");
+        let response = kv.search(&req).unwrap();
+        assert!(
+            !response.hits.is_empty(),
+            "Search should return results in same session"
+        );
+    }
+
+    // Session 2: reopen and verify search still works
+    {
+        let db = Database::open(&path).unwrap();
+        let kv = KVStore::new(db.clone());
+
+        // KV data survived
+        assert_eq!(
+            kv.get(&branch_id, "default", "doc1").unwrap(),
+            Some(Value::String(
+                "breast cancer cholesterol statin drugs".into()
+            ))
+        );
+
+        // Search index also survived
+        let req = SearchRequest::new(branch_id, "cholesterol");
+        let response = kv.search(&req).unwrap();
+        assert!(
+            !response.hits.is_empty(),
+            "Search should return results after reopen (index must survive recovery)"
+        );
+    }
+}
+
+/// Test search index survives multiple recovery cycles (#1486)
+#[test]
+fn test_search_index_survives_multiple_recoveries() {
+    use strata_engine::search::Searchable;
+
+    let temp_dir = TempDir::new().unwrap();
+    let path = get_path(&temp_dir);
+    let branch_id = BranchId::new();
+
+    // Cycle 1: Create initial data
+    {
+        let db = Database::open(&path).unwrap();
+        let kv = KVStore::new(db.clone());
+        kv.put(
+            &branch_id,
+            "default",
+            "doc1",
+            Value::String("database indexing search retrieval".into()),
+        )
+        .unwrap();
+    }
+
+    // Cycle 2: Add more data, verify previous data searchable
+    {
+        let db = Database::open(&path).unwrap();
+        let kv = KVStore::new(db.clone());
+
+        let req = SearchRequest::new(branch_id, "indexing");
+        let response = kv.search(&req).unwrap();
+        assert!(
+            !response.hits.is_empty(),
+            "Cycle 2: doc1 should be searchable"
+        );
+
+        kv.put(
+            &branch_id,
+            "default",
+            "doc2",
+            Value::String("information retrieval ranking algorithms".into()),
+        )
+        .unwrap();
+    }
+
+    // Cycle 3: Verify both documents searchable
+    {
+        let db = Database::open(&path).unwrap();
+        let kv = KVStore::new(db.clone());
+
+        let req = SearchRequest::new(branch_id, "retrieval");
+        let response = kv.search(&req).unwrap();
+        assert!(
+            response.hits.len() >= 2,
+            "Cycle 3: both docs should be searchable for 'retrieval', got {}",
+            response.hits.len()
+        );
     }
 }


### PR DESCRIPTION
## Summary

The BM25 inverted index was not rebuilt when a database was reopened, causing `search --mode keyword` to return 0 results on a reopened database that had indexed documents in a previous session.

**Root cause**: `InvertedIndex` starts with `enabled: false`. The slow-path recovery in `recovery.rs` called `index.index_document()` for every KV/State/Event entry, but `index_document()` returns immediately when disabled. The index was only enabled *after* recovery completed in `database/mod.rs`. The fast path (mmap manifest load) was unaffected because it called `enable()` correctly.

**Fix**: One line — call `index.enable()` before the slow-path scan, matching what the fast path already does.

**No load speed impact**: The slow path was already iterating all entries; now the `index_document()` calls actually do work instead of silently no-op'ing.

Closes #1486

## Test plan

- [x] `test_search_index_survives_recovery` — index + search in session 1, reopen in session 2, search returns results
- [x] `test_search_index_survives_multiple_recoveries` — 3 recovery cycles, documents accumulate and remain searchable
- [x] All 14 recovery tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)