### PR TITLE
Add SystemBranch API for internal _system_ branch access

### DIFF
--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -44,6 +44,7 @@ mod graph;
 mod json;
 mod kv;
 mod state;
+mod system;
 mod vector;
 
 pub use branches::Branches;
@@ -51,6 +52,7 @@ pub use strata_engine::branch_ops::{
     BranchDiffEntry, BranchDiffResult, ConflictEntry, DiffFilter, DiffOptions, DiffSummary,
     ForkInfo, MergeInfo, MergeStrategy, SpaceDiff,
 };
+pub use system::SystemBranch;
 
 use std::path::Path;
 use std::sync::Arc;
@@ -341,6 +343,18 @@ impl Strata {
     /// ```
     pub fn branches(&self) -> Branches<'_> {
         Branches::new(&self.executor)
+    }
+
+    /// Get a handle to the `_system_` branch for internal operations.
+    ///
+    /// The returned handle bypasses the user-facing guard that rejects
+    /// access to reserved branches. It provides KV, JSON, state, and event
+    /// operations pre-bound to `_system_`.
+    ///
+    /// Intended for internal consumers (e.g., strata-ai) that need to
+    /// store private workspace data in the user's database.
+    pub fn system_branch(&self) -> SystemBranch<'_> {
+        SystemBranch::new(&self.executor)
     }
 
     /// Create a new [`Session`] for interactive transaction support.
@@ -1527,5 +1541,86 @@ mod tests {
             assert!(db.graph_add_node("rg", "n1", None, None).is_err());
             assert!(db.graph_add_edge("rg", "A", "B", "E", None, None).is_err());
         }
+    }
+
+    // =========================================================================
+    // SystemBranch Tests
+    // =========================================================================
+
+    #[test]
+    fn test_system_branch_kv_roundtrip() {
+        let db = Strata::cache().unwrap();
+        let sys = db.system_branch();
+
+        sys.kv_put("_ai:cache:abc", "cached-value").unwrap();
+        let val = sys.kv_get("_ai:cache:abc").unwrap();
+        assert_eq!(val, Some(Value::String("cached-value".into())));
+
+        let keys = sys.kv_list(Some("_ai:cache:")).unwrap();
+        assert!(keys.contains(&"_ai:cache:abc".to_string()));
+
+        sys.kv_delete("_ai:cache:abc").unwrap();
+        assert!(sys.kv_get("_ai:cache:abc").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_system_branch_json_roundtrip() {
+        let db = Strata::cache().unwrap();
+        let sys = db.system_branch();
+
+        sys.json_set(
+            "_ai:catalog:users",
+            "$",
+            Value::String(r#"{"columns":["id","name"]}"#.into()),
+        )
+        .unwrap();
+        let val = sys.json_get("_ai:catalog:users", "$").unwrap();
+        assert!(val.is_some());
+    }
+
+    #[test]
+    fn test_system_branch_state_roundtrip() {
+        let db = Strata::cache().unwrap();
+        let sys = db.system_branch();
+
+        sys.state_set("_ai:pref:theme", "dark").unwrap();
+        let val = sys.state_get("_ai:pref:theme").unwrap();
+        assert_eq!(val, Some(Value::String("dark".into())));
+    }
+
+    #[test]
+    fn test_system_branch_event_roundtrip() {
+        let db = Strata::cache().unwrap();
+        let sys = db.system_branch();
+
+        let payload = serde_json::json!({"action": "query executed"});
+        let seq = sys
+            .event_append("ai.activity", Value::from(payload))
+            .unwrap();
+
+        let event = sys.event_get(seq).unwrap();
+        assert!(event.is_some());
+    }
+
+    #[test]
+    fn test_system_branch_hidden_from_user_apis() {
+        let db = Strata::cache().unwrap();
+
+        // Write via system handle
+        let sys = db.system_branch();
+        sys.kv_put("secret", "hidden").unwrap();
+
+        // User-facing APIs should not see _system_
+        let branches = db.branches().list().unwrap();
+        assert!(!branches.iter().any(|b| b.starts_with("_system")));
+
+        // Direct access to _system_ via user API should fail
+        let result = db.executor.execute(Command::KvGet {
+            branch: Some(BranchId::from("_system_")),
+            space: Some("default".to_string()),
+            key: "secret".to_string(),
+            as_of: None,
+        });
+        assert!(result.is_err());
     }
 }

--- a/crates/executor/src/api/system.rs
+++ b/crates/executor/src/api/system.rs
@@ -1,0 +1,230 @@
+//! Internal API for the `_system_` branch.
+//!
+//! Access via `db.system_branch()`. Provides the same primitives (KV, JSON,
+//! state, events) routed to the `_system_` branch, bypassing the user-facing
+//! guard that normally rejects access to reserved branches.
+//!
+//! This is a capability-based design: having the handle *is* the authorization.
+
+use strata_engine::branch_dag::SYSTEM_BRANCH;
+
+use crate::types::{BranchId, VersionedValue};
+use crate::{Command, Error, Executor, Output, Result, Value};
+
+/// Handle for internal operations on the `_system_` branch.
+///
+/// Obtained via [`Strata::system_branch()`](super::Strata::system_branch).
+/// All operations are pre-bound to the `_system_` branch and `default` space.
+///
+/// This handle bypasses the `reject_system_branch` guard that prevents
+/// user-facing APIs from accessing reserved branches. It is intended for
+/// internal consumers (e.g., strata-ai) that need to store private workspace
+/// data alongside the user's database.
+pub struct SystemBranch<'a> {
+    executor: &'a Executor,
+}
+
+impl<'a> SystemBranch<'a> {
+    pub(crate) fn new(executor: &'a Executor) -> Self {
+        Self { executor }
+    }
+
+    fn branch_id(&self) -> Option<BranchId> {
+        Some(BranchId::from(SYSTEM_BRANCH))
+    }
+
+    fn space_id(&self) -> Option<String> {
+        Some("default".to_string())
+    }
+
+    // =========================================================================
+    // KV Operations
+    // =========================================================================
+
+    /// Put a value in the system branch KV store.
+    pub fn kv_put(&self, key: &str, value: impl Into<Value>) -> Result<u64> {
+        match self.executor.execute_internal(Command::KvPut {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            key: key.to_string(),
+            value: value.into(),
+        })? {
+            Output::WriteResult { version, .. } => Ok(version),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for KvPut".into(),
+            }),
+        }
+    }
+
+    /// Get a value from the system branch KV store.
+    pub fn kv_get(&self, key: &str) -> Result<Option<Value>> {
+        match self.executor.execute_internal(Command::KvGet {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            key: key.to_string(),
+            as_of: None,
+        })? {
+            Output::MaybeVersioned(v) => Ok(v.map(|vv| vv.value)),
+            Output::Maybe(v) => Ok(v),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for KvGet".into(),
+            }),
+        }
+    }
+
+    /// Delete a key from the system branch KV store.
+    pub fn kv_delete(&self, key: &str) -> Result<bool> {
+        match self.executor.execute_internal(Command::KvDelete {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            key: key.to_string(),
+        })? {
+            Output::DeleteResult { deleted, .. } => Ok(deleted),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for KvDelete".into(),
+            }),
+        }
+    }
+
+    /// List keys in the system branch KV store.
+    pub fn kv_list(&self, prefix: Option<&str>) -> Result<Vec<String>> {
+        match self.executor.execute_internal(Command::KvList {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            prefix: prefix.map(|s| s.to_string()),
+            cursor: None,
+            limit: None,
+            as_of: None,
+        })? {
+            Output::Keys(keys) => Ok(keys),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for KvList".into(),
+            }),
+        }
+    }
+
+    // =========================================================================
+    // JSON Operations
+    // =========================================================================
+
+    /// Set a JSON value at a path in the system branch.
+    ///
+    /// Use `"$"` as the path to set the entire document.
+    pub fn json_set(&self, key: &str, path: &str, value: impl Into<Value>) -> Result<u64> {
+        match self.executor.execute_internal(Command::JsonSet {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            key: key.to_string(),
+            path: path.to_string(),
+            value: value.into(),
+        })? {
+            Output::WriteResult { version, .. } => Ok(version),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for JsonSet".into(),
+            }),
+        }
+    }
+
+    /// Get a JSON value at a path from the system branch.
+    ///
+    /// Use `"$"` as the path to get the entire document.
+    pub fn json_get(&self, key: &str, path: &str) -> Result<Option<Value>> {
+        match self.executor.execute_internal(Command::JsonGet {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            key: key.to_string(),
+            path: path.to_string(),
+            as_of: None,
+        })? {
+            Output::MaybeVersioned(v) => Ok(v.map(|vv| vv.value)),
+            Output::Maybe(v) => Ok(v),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for JsonGet".into(),
+            }),
+        }
+    }
+
+    /// Delete a JSON value at a path from the system branch.
+    pub fn json_delete(&self, key: &str, path: &str) -> Result<u64> {
+        match self.executor.execute_internal(Command::JsonDelete {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            key: key.to_string(),
+            path: path.to_string(),
+        })? {
+            Output::Uint(count) => Ok(count),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for JsonDelete".into(),
+            }),
+        }
+    }
+
+    // =========================================================================
+    // State Operations
+    // =========================================================================
+
+    /// Set a state cell in the system branch.
+    pub fn state_set(&self, cell: &str, value: impl Into<Value>) -> Result<u64> {
+        match self.executor.execute_internal(Command::StateSet {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            cell: cell.to_string(),
+            value: value.into(),
+        })? {
+            Output::WriteResult { version, .. } => Ok(version),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for StateSet".into(),
+            }),
+        }
+    }
+
+    /// Get a state cell from the system branch.
+    pub fn state_get(&self, cell: &str) -> Result<Option<Value>> {
+        match self.executor.execute_internal(Command::StateGet {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            cell: cell.to_string(),
+            as_of: None,
+        })? {
+            Output::MaybeVersioned(v) => Ok(v.map(|vv| vv.value)),
+            Output::Maybe(v) => Ok(v),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for StateGet".into(),
+            }),
+        }
+    }
+
+    // =========================================================================
+    // Event Operations
+    // =========================================================================
+
+    /// Append an event to the system branch event log.
+    pub fn event_append(&self, event_type: &str, payload: Value) -> Result<u64> {
+        match self.executor.execute_internal(Command::EventAppend {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            event_type: event_type.to_string(),
+            payload,
+        })? {
+            Output::EventAppendResult { sequence, .. } => Ok(sequence),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for EventAppend".into(),
+            }),
+        }
+    }
+
+    /// Read an event by sequence number from the system branch.
+    pub fn event_get(&self, sequence: u64) -> Result<Option<VersionedValue>> {
+        match self.executor.execute_internal(Command::EventGet {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            sequence,
+            as_of: None,
+        })? {
+            Output::MaybeVersioned(v) => Ok(v),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for EventGet".into(),
+            }),
+        }
+    }
+}

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -175,6 +175,34 @@ impl Executor {
             crate::handlers::reject_system_branch(branch)?;
         }
 
+        self.dispatch(cmd)
+    }
+
+    /// Execute a command targeting the `_system_` branch.
+    ///
+    /// Skips the `reject_system_branch` guard, but still enforces access mode.
+    /// Used by [`SystemBranch`](crate::api::SystemBranch) to provide internal
+    /// access to the system branch.
+    pub(crate) fn execute_internal(&self, mut cmd: Command) -> Result<Output> {
+        if self.access_mode == AccessMode::ReadOnly && cmd.is_write() {
+            warn!(target: "strata::command", command = %cmd.name(), "Write rejected in read-only mode");
+            let hint = if self.primitives.db.is_follower() {
+                Some("This database is a read-only follower. Writes must go through the primary instance.".to_string())
+            } else {
+                Some("Database is in read-only mode.".to_string())
+            };
+            return Err(Error::AccessDenied {
+                command: cmd.name().to_string(),
+                hint,
+            });
+        }
+
+        cmd.resolve_defaults();
+        self.dispatch(cmd)
+    }
+
+    /// Internal dispatch — shared by `execute` and `execute_internal`.
+    fn dispatch(&self, cmd: Command) -> Result<Output> {
         let cmd_name = cmd.name();
         let start = Instant::now();
 

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -74,7 +74,7 @@ mod tests;
 // Core types
 pub use api::{
     BranchDiffEntry, BranchDiffResult, Branches, ConflictEntry, DiffFilter, DiffOptions,
-    DiffSummary, ForkInfo, MergeInfo, MergeStrategy, SpaceDiff, Strata,
+    DiffSummary, ForkInfo, MergeInfo, MergeStrategy, SpaceDiff, Strata, SystemBranch,
 };
 pub use command::Command;
 pub use error::Error;


### PR DESCRIPTION
## Summary

- Add `db.system_branch()` — returns a `SystemBranch` handle pre-bound to `_system_`
- The handle bypasses the user-facing `reject_system_branch` guard
- Exposes KV, JSON, state, and event operations on the system branch
- Capability-based design: having the handle is the authorization

## Design

The `Executor` gains an internal `execute_internal()` method that shares the same dispatch logic as `execute()` but skips the system branch rejection check. `SystemBranch` wraps this, hardcoding the branch to `_system_` and space to `default`.

No way to escape to other branches from this handle.

## Test plan

- [x] KV roundtrip (put/get/list/delete)
- [x] JSON roundtrip (set/get)
- [x] State roundtrip (set/get)
- [x] Event roundtrip (append/get)
- [x] Verify `_system_` stays hidden from user-facing APIs (branch list, direct KvGet)
- [x] All 494 executor tests pass

Closes #1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)