### PR TITLE
Close remaining typed API gaps for Node SDK migration

### DIFF
--- a/crates/executor/src/api/event.rs
+++ b/crates/executor/src/api/event.rs
@@ -123,12 +123,13 @@ impl Strata {
     // Event Extended Variants
     // =========================================================================
 
-    /// Read events of a specific type with limit and pagination options.
+    /// Read events of a specific type with limit, pagination, and time-travel options.
     pub fn event_get_by_type_with_options(
         &self,
         event_type: &str,
         limit: Option<u64>,
         after_sequence: Option<u64>,
+        as_of: Option<u64>,
     ) -> Result<Vec<VersionedValue>> {
         match self.executor.execute(Command::EventGetByType {
             branch: self.branch_id(),
@@ -136,7 +137,7 @@ impl Strata {
             event_type: event_type.to_string(),
             limit,
             after_sequence,
-            as_of: None,
+            as_of,
         })? {
             Output::VersionedValues(events) => Ok(events),
             _ => Err(Error::Internal {

--- a/crates/executor/src/api/graph.rs
+++ b/crates/executor/src/api/graph.rs
@@ -286,6 +286,36 @@ impl Strata {
         }
     }
 
+    /// Bulk insert nodes and edges with full typed control.
+    ///
+    /// Unlike `graph_bulk_insert`, this accepts `BulkGraphNode` and `BulkGraphEdge`
+    /// structs directly, supporting `object_type` on nodes and configurable `chunk_size`.
+    ///
+    /// Returns `(nodes_inserted, edges_inserted)`.
+    pub fn graph_bulk_insert_typed(
+        &self,
+        graph: &str,
+        nodes: Vec<crate::types::BulkGraphNode>,
+        edges: Vec<crate::types::BulkGraphEdge>,
+        chunk_size: Option<usize>,
+    ) -> Result<(u64, u64)> {
+        match self.executor.execute(Command::GraphBulkInsert {
+            branch: self.branch_id(),
+            graph: graph.to_string(),
+            nodes,
+            edges,
+            chunk_size,
+        })? {
+            Output::GraphBulkInsertResult {
+                nodes_inserted,
+                edges_inserted,
+            } => Ok((nodes_inserted, edges_inserted)),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for GraphBulkInsert".into(),
+            }),
+        }
+    }
+
     // =========================================================================
     // Traversal
     // =========================================================================
@@ -495,6 +525,19 @@ impl Strata {
             Output::Maybe(v) => Ok(v),
             _ => Err(Error::Internal {
                 reason: "Unexpected output for GraphOntologySummary".into(),
+            }),
+        }
+    }
+
+    /// List all ontology type names (both object and link types).
+    pub fn graph_list_ontology_types(&self, graph: &str) -> Result<Vec<String>> {
+        match self.executor.execute(Command::GraphListOntologyTypes {
+            branch: self.branch_id(),
+            graph: graph.to_string(),
+        })? {
+            Output::Keys(names) => Ok(names),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for GraphListOntologyTypes".into(),
             }),
         }
     }

--- a/crates/executor/src/api/inference.rs
+++ b/crates/executor/src/api/inference.rs
@@ -35,12 +35,49 @@ impl Strata {
         }
     }
 
+    /// Generate text with full control over sampling parameters.
+    #[allow(clippy::too_many_arguments)]
+    pub fn generate_with_options(
+        &self,
+        model: &str,
+        prompt: &str,
+        max_tokens: Option<usize>,
+        temperature: Option<f32>,
+        top_k: Option<usize>,
+        top_p: Option<f32>,
+        seed: Option<u64>,
+        stop_tokens: Option<Vec<u32>>,
+        stop_sequences: Option<Vec<String>>,
+    ) -> Result<GenerationResult> {
+        match self.executor.execute(Command::Generate {
+            model: model.to_string(),
+            prompt: prompt.to_string(),
+            max_tokens,
+            temperature,
+            top_k,
+            top_p,
+            seed,
+            stop_tokens,
+            stop_sequences,
+        })? {
+            Output::Generated(result) => Ok(result),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for Generate".into(),
+            }),
+        }
+    }
+
     /// Tokenize text into token IDs using a model's tokenizer.
-    pub fn tokenize(&self, model: &str, text: &str) -> Result<TokenizeResult> {
+    pub fn tokenize(
+        &self,
+        model: &str,
+        text: &str,
+        add_special_tokens: Option<bool>,
+    ) -> Result<TokenizeResult> {
         match self.executor.execute(Command::Tokenize {
             model: model.to_string(),
             text: text.to_string(),
-            add_special_tokens: None,
+            add_special_tokens,
         })? {
             Output::TokenIds(result) => Ok(result),
             _ => Err(Error::Internal {

--- a/crates/executor/src/api/json.rs
+++ b/crates/executor/src/api/json.rs
@@ -231,6 +231,31 @@ impl Strata {
         }
     }
 
+    /// List JSON documents with cursor-based pagination at a specific point in time.
+    ///
+    /// `as_of` is a timestamp in microseconds since epoch.
+    pub fn json_list_as_of(
+        &self,
+        prefix: Option<String>,
+        cursor: Option<String>,
+        limit: u64,
+        as_of: Option<u64>,
+    ) -> Result<(Vec<String>, Option<String>)> {
+        match self.executor.execute(Command::JsonList {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            prefix,
+            cursor,
+            limit,
+            as_of,
+        })? {
+            Output::JsonListResult { keys, cursor, .. } => Ok((keys, cursor)),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for JsonList".into(),
+            }),
+        }
+    }
+
     // =========================================================================
     // JSON Batch Operations
     // =========================================================================

--- a/crates/executor/src/api/kv.rs
+++ b/crates/executor/src/api/kv.rs
@@ -154,14 +154,21 @@ impl Strata {
 
     /// List keys with optional prefix filter at a specific point in time.
     ///
+    /// Supports cursor-based pagination via `cursor` and `limit`.
     /// `as_of` is a timestamp in microseconds since epoch.
-    pub fn kv_list_as_of(&self, prefix: Option<&str>, as_of: Option<u64>) -> Result<Vec<String>> {
+    pub fn kv_list_as_of(
+        &self,
+        prefix: Option<&str>,
+        cursor: Option<&str>,
+        limit: Option<u64>,
+        as_of: Option<u64>,
+    ) -> Result<Vec<String>> {
         match self.executor.execute(Command::KvList {
             branch: self.branch_id(),
             space: self.space_id(),
             prefix: prefix.map(|s| s.to_string()),
-            cursor: None,
-            limit: None,
+            cursor: cursor.map(|s| s.to_string()),
+            limit,
             as_of,
         })? {
             Output::Keys(keys) => Ok(keys),

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -1666,7 +1666,7 @@ mod tests {
         db.kv_put("p:2", "b").unwrap();
 
         // as_of=None should list both keys
-        let keys = db.kv_list_as_of(Some("p:"), None).unwrap();
+        let keys = db.kv_list_as_of(Some("p:"), None, None, None).unwrap();
         assert_eq!(keys.len(), 2);
     }
 
@@ -1865,14 +1865,14 @@ mod tests {
 
         // Limit to 2
         let events = db
-            .event_get_by_type_with_options("paged", Some(2), None)
+            .event_get_by_type_with_options("paged", Some(2), None, None)
             .unwrap();
         assert_eq!(events.len(), 2);
 
         // After sequence of the first event
         let first_seq = events[0].version;
         let after = db
-            .event_get_by_type_with_options("paged", None, Some(first_seq))
+            .event_get_by_type_with_options("paged", None, Some(first_seq), None)
             .unwrap();
         // Should exclude the first event
         assert!(after.len() < 3);
@@ -1890,7 +1890,7 @@ mod tests {
 
         // No filter — should return both
         let matches = db
-            .vector_search_with_filter("fvecs", vec![1.0, 0.0, 0.0, 0.0], 10, None, None)
+            .vector_search_with_filter("fvecs", vec![1.0, 0.0, 0.0, 0.0], 10, None, None, None)
             .unwrap();
         assert_eq!(matches.len(), 2);
     }
@@ -2030,5 +2030,110 @@ mod tests {
         let counters = db.durability_counters().unwrap();
         // Cache databases return default (zero) counters
         let _ = counters;
+    }
+
+    // =========================================================================
+    // Tests for #1499 gap methods
+    // =========================================================================
+
+    #[test]
+    fn test_state_list_as_of() {
+        let db = create_strata();
+        db.state_set("sl:a", "1").unwrap();
+        db.state_set("sl:b", "2").unwrap();
+
+        let keys = db.state_list_as_of(Some("sl:"), None).unwrap();
+        assert_eq!(keys.len(), 2);
+    }
+
+    #[test]
+    fn test_json_list_as_of() {
+        let db = create_strata();
+        db.json_set("jl:1", "$", Value::Int(1)).unwrap();
+        db.json_set("jl:2", "$", Value::Int(2)).unwrap();
+
+        let (keys, cursor) = db
+            .json_list_as_of(Some("jl:".into()), None, 100, None)
+            .unwrap();
+        assert_eq!(keys.len(), 2);
+        assert!(cursor.is_none());
+    }
+
+    #[test]
+    fn test_vector_get_as_of() {
+        let db = create_strata();
+        db.vector_create_collection("vga", 2, DistanceMetric::Cosine)
+            .unwrap();
+        db.vector_upsert("vga", "k1", vec![1.0, 0.0], None).unwrap();
+
+        let data = db.vector_get_as_of("vga", "k1", None).unwrap();
+        assert!(data.is_some());
+
+        let missing = db.vector_get_as_of("vga", "nonexistent", None).unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[test]
+    fn test_graph_bulk_insert_typed() {
+        use crate::types::{BulkGraphEdge, BulkGraphNode};
+        let db = create_strata();
+        db.graph_create("gbi").unwrap();
+
+        let nodes = vec![
+            BulkGraphNode {
+                node_id: "n1".into(),
+                entity_ref: None,
+                properties: None,
+                object_type: Some("Person".into()),
+            },
+            BulkGraphNode {
+                node_id: "n2".into(),
+                entity_ref: None,
+                properties: None,
+                object_type: Some("Person".into()),
+            },
+        ];
+        let edges = vec![BulkGraphEdge {
+            src: "n1".into(),
+            dst: "n2".into(),
+            edge_type: "knows".into(),
+            weight: None,
+            properties: None,
+        }];
+
+        let (ni, ei) = db
+            .graph_bulk_insert_typed("gbi", nodes, edges, Some(100))
+            .unwrap();
+        assert_eq!(ni, 2);
+        assert_eq!(ei, 1);
+    }
+
+    #[test]
+    fn test_graph_list_ontology_types() {
+        let db = create_strata();
+        db.graph_create("glo").unwrap();
+
+        // Define an object type and a link type
+        let obj_def = Value::object(
+            [("name".to_string(), Value::String("Person".into()))]
+                .into_iter()
+                .collect(),
+        );
+        db.graph_define_object_type("glo", obj_def).unwrap();
+
+        let link_def = Value::object(
+            [
+                ("name".to_string(), Value::String("knows".into())),
+                ("source".to_string(), Value::String("Person".into())),
+                ("target".to_string(), Value::String("Person".into())),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        db.graph_define_link_type("glo", link_def).unwrap();
+
+        let types = db.graph_list_ontology_types("glo").unwrap();
+        assert!(types.contains(&"Person".to_string()));
+        assert!(types.contains(&"knows".to_string()));
     }
 }

--- a/crates/executor/src/api/state.rs
+++ b/crates/executor/src/api/state.rs
@@ -156,6 +156,27 @@ impl Strata {
         }
     }
 
+    /// List state cell names at a specific point in time.
+    ///
+    /// `as_of` is a timestamp in microseconds since epoch.
+    pub fn state_list_as_of(
+        &self,
+        prefix: Option<&str>,
+        as_of: Option<u64>,
+    ) -> Result<Vec<String>> {
+        match self.executor.execute(Command::StateList {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            prefix: prefix.map(|s| s.to_string()),
+            as_of,
+        })? {
+            Output::Keys(keys) => Ok(keys),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for StateList".into(),
+            }),
+        }
+    }
+
     // =========================================================================
     // State Batch Operations
     // =========================================================================

--- a/crates/executor/src/api/vector.rs
+++ b/crates/executor/src/api/vector.rs
@@ -172,7 +172,7 @@ impl Strata {
         }
     }
 
-    /// Search for similar vectors with optional filter and metric override.
+    /// Search for similar vectors with optional filter, metric override, and time-travel.
     pub fn vector_search_with_filter(
         &self,
         collection: &str,
@@ -180,6 +180,7 @@ impl Strata {
         k: u64,
         filter: Option<Vec<MetadataFilter>>,
         metric: Option<DistanceMetric>,
+        as_of: Option<u64>,
     ) -> Result<Vec<VectorMatch>> {
         match self.executor.execute(Command::VectorSearch {
             branch: self.branch_id(),
@@ -189,11 +190,34 @@ impl Strata {
             k,
             filter,
             metric,
-            as_of: None,
+            as_of,
         })? {
             Output::VectorMatches(matches) => Ok(matches),
             _ => Err(Error::Internal {
                 reason: "Unexpected output for VectorSearch".into(),
+            }),
+        }
+    }
+
+    /// Get a vector by key at a specific point in time.
+    ///
+    /// `as_of` is a timestamp in microseconds since epoch.
+    pub fn vector_get_as_of(
+        &self,
+        collection: &str,
+        key: &str,
+        as_of: Option<u64>,
+    ) -> Result<Option<VersionedVectorData>> {
+        match self.executor.execute(Command::VectorGet {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            collection: collection.to_string(),
+            key: key.to_string(),
+            as_of,
+        })? {
+            Output::VectorData(data) => Ok(data),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for VectorGet".into(),
             }),
         }
     }


### PR DESCRIPTION
## Summary

Closes #1499

Follow-up to #1498. Eliminates the last 12 `executor().execute()` bypass calls in the Node SDK by adding/extending typed methods on `Strata`.

### Changes

**New `as_of` variants (3):**
- `state_list_as_of(prefix, as_of)`
- `json_list_as_of(prefix, cursor, limit, as_of)`
- `vector_get_as_of(collection, key, as_of)`

**Extended signatures (4):**
- `kv_list_as_of` — added `cursor` and `limit` params
- `vector_search_with_filter` — added `as_of` param
- `event_get_by_type_with_options` — added `as_of` param
- `tokenize` — added `add_special_tokens` param

**New methods (3):**
- `generate_with_options` — full sampling control (top_k, top_p, seed, stop_tokens, stop_sequences)
- `graph_bulk_insert_typed` — accepts `Vec<BulkGraphNode>`/`Vec<BulkGraphEdge>` directly (supports `object_type` and `chunk_size`)
- `graph_list_ontology_types` — lists both object and link type names

### Files changed

| File | Change |
|------|--------|
| `api/kv.rs` | Extend `kv_list_as_of` with cursor + limit |
| `api/json.rs` | Add `json_list_as_of` |
| `api/state.rs` | Add `state_list_as_of` |
| `api/event.rs` | Add `as_of` to `event_get_by_type_with_options` |
| `api/vector.rs` | Add `as_of` to `vector_search_with_filter`, add `vector_get_as_of` |
| `api/graph.rs` | Add `graph_bulk_insert_typed`, `graph_list_ontology_types` |
| `api/inference.rs` | Add `generate_with_options`, extend `tokenize` |
| `api/mod.rs` | Fix test call sites + 5 new tests |

## Test plan

- [x] `cargo build -p strata-executor` — compiles
- [x] `cargo clippy -p strata-executor -- -D warnings` — clean
- [x] `cargo fmt --check -p strata-executor` — formatted
- [x] `cargo test -p strata-executor` — 526 tests pass (was 521)

🤖 Generated with [Claude Code](https://claude.com/claude-code)