### PR TITLE
Fix search recovery indexing _system_ branch entries

### DIFF
--- a/crates/engine/src/search/recovery.rs
+++ b/crates/engine/src/search/recovery.rs
@@ -22,7 +22,9 @@
 //! All mmap files are **caches** — if missing, corrupt, or version-mismatched,
 //! recovery falls back transparently to full KV-based rebuild with no data loss.
 
+use crate::branch_dag::SYSTEM_BRANCH;
 use crate::database::Database;
+use crate::primitives::branch::resolve_branch_name;
 use crate::recovery::{register_recovery_participant, RecoveryParticipant};
 use crate::search::InvertedIndex;
 use strata_core::types::TypeTag;
@@ -103,7 +105,14 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
     let mut docs_indexed: u64 = 0;
     let mut branches_scanned: u64 = 0;
 
+    // Skip the _system_ branch — its KV entries are internal graph
+    // infrastructure (DAG metadata, catalog, node data), not user content.
+    let system_branch_id = resolve_branch_name(SYSTEM_BRANCH);
+
     for branch_id in db.storage().branch_ids() {
+        if branch_id == system_branch_id {
+            continue;
+        }
         branches_scanned += 1;
 
         // --- KV entries ---


### PR DESCRIPTION
## Summary
- The BM25 recovery fix (c9bedf6, PR #1490) enabled the index before the slow-path KV scan, which was correct for user data but also caused the 3 internal KV entries from `init_system_branch` (graph meta, catalog, DAG node) to be indexed
- This made `test_state_delete_removes_from_index` see `total_docs=5` instead of `2`, failing CI on every build since (all 5 recent main builds are red)
- Fix: skip the `_system_` branch during search recovery — its entries are internal graph infrastructure, not user-searchable content

## Test plan
- [x] `test_state_delete_removes_from_index` passes (was the only failing test)
- [x] Full `cargo test -p strata-engine --lib` — 1290 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)