### PR TITLE
Fix flush pipeline perf regression: skip read-only txn scheduling

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1711,6 +1711,11 @@ impl Database {
     /// Schedule background flush tasks for branches with frozen memtables.
     /// Best-effort: errors are logged, never propagated to the commit caller.
     fn schedule_flush_if_needed(&self) {
+        // Fast path: ephemeral databases never flush (no segments_dir)
+        if self.storage.segments_dir().is_none() {
+            return;
+        }
+
         let branches = self.storage.branches_needing_flush();
         if branches.is_empty() {
             return;
@@ -1790,9 +1795,12 @@ impl Database {
         match result {
             Ok(value) => {
                 // Commit on success
+                let had_writes = !txn.is_read_only();
                 let commit_version = self.commit_internal(txn, durability)?;
-                // Schedule flush for branches with frozen memtables (best-effort)
-                self.schedule_flush_if_needed();
+                // Schedule flush only for write transactions (reads skip entirely)
+                if had_writes {
+                    self.schedule_flush_if_needed();
+                }
                 Ok((value, commit_version))
             }
             Err(e) => {
@@ -1960,8 +1968,11 @@ impl Database {
     /// # Contract
     /// Returns the commit version (u64) assigned to all writes in this transaction.
     pub fn commit_transaction(&self, txn: &mut TransactionContext) -> StrataResult<u64> {
+        let had_writes = !txn.is_read_only();
         let version = self.commit_internal(txn, self.durability_mode)?;
-        self.schedule_flush_if_needed();
+        if had_writes {
+            self.schedule_flush_if_needed();
+        }
         Ok(version)
     }
 

--- a/crates/storage/src/segmented.rs
+++ b/crates/storage/src/segmented.rs
@@ -97,6 +97,8 @@ pub struct SegmentedStore {
     max_branches: AtomicUsize,
     /// Maximum versions to keep per key (0 = unlimited, pruned at compaction).
     max_versions_per_key: AtomicUsize,
+    /// Total frozen memtable count across all branches (for O(1) "any frozen?" check).
+    total_frozen_count: AtomicUsize,
 }
 
 impl SegmentedStore {
@@ -115,6 +117,7 @@ impl SegmentedStore {
             bulk_load_branches: DashMap::new(),
             max_branches: AtomicUsize::new(0),
             max_versions_per_key: AtomicUsize::new(0),
+            total_frozen_count: AtomicUsize::new(0),
         }
     }
 
@@ -134,6 +137,7 @@ impl SegmentedStore {
             bulk_load_branches: DashMap::new(),
             max_branches: AtomicUsize::new(0),
             max_versions_per_key: AtomicUsize::new(0),
+            total_frozen_count: AtomicUsize::new(0),
         }
     }
 
@@ -153,6 +157,7 @@ impl SegmentedStore {
             bulk_load_branches: DashMap::new(),
             max_branches: AtomicUsize::new(0),
             max_versions_per_key: AtomicUsize::new(0),
+            total_frozen_count: AtomicUsize::new(0),
         }
     }
 
@@ -576,6 +581,7 @@ impl SegmentedStore {
         let old = std::mem::replace(&mut branch.active, Memtable::new(next_id));
         old.freeze();
         branch.frozen.insert(0, Arc::new(old));
+        self.total_frozen_count.fetch_add(1, Ordering::Relaxed);
         true
     }
 
@@ -628,6 +634,7 @@ impl SegmentedStore {
         if let Some(last) = branch.frozen.last() {
             if last.id() == frozen_mt.id() {
                 branch.frozen.pop();
+                self.total_frozen_count.fetch_sub(1, Ordering::Relaxed);
             }
         }
         branch.segments.insert(0, Arc::new(segment));
@@ -779,6 +786,7 @@ impl SegmentedStore {
             let old = std::mem::replace(&mut branch.active, Memtable::new(next_id));
             old.freeze();
             branch.frozen.insert(0, Arc::new(old));
+            self.total_frozen_count.fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -961,10 +969,23 @@ impl SegmentedStore {
         self.pressure.level(self.total_memtable_bytes())
     }
 
+    /// Returns `true` if any branch has frozen memtables pending flush.
+    ///
+    /// O(1) check via atomic counter — no DashMap scan.
+    #[inline]
+    pub fn has_frozen_memtables(&self) -> bool {
+        self.total_frozen_count.load(Ordering::Relaxed) > 0
+    }
+
     /// Branch IDs with frozen memtables, ordered by frozen count descending.
     ///
     /// Useful for the caller to decide which branches to flush first.
     pub fn branches_needing_flush(&self) -> Vec<BranchId> {
+        // Fast path: no frozen memtables anywhere
+        if !self.has_frozen_memtables() {
+            return Vec::new();
+        }
+
         let mut branches: Vec<(BranchId, usize)> = self
             .branches
             .iter()


### PR DESCRIPTION
## Summary

- Skip `schedule_flush_if_needed()` for read-only transactions — reads don't produce frozen memtables
- Add O(1) `total_frozen_count` atomic to `SegmentedStore` — avoids full DashMap scan in `branches_needing_flush()` when no memtables are frozen
- Early exit for ephemeral databases — `segments_dir().is_none()` check

## Root Cause

Epic 10 called `schedule_flush_if_needed()` on every commit, including read-only transactions. Since `kv_get()` wraps reads in `db.transaction()`, every single read triggered `branches_needing_flush()` which iterates the entire `DashMap<BranchId, BranchState>`. This caused a 46-55% read throughput regression.

## Benchmark Results (Fix vs Epics 1-8 baseline)

| Operation | Regression (before fix) | After fix |
|-----------|------------------------|-----------|
| random_read 1K | -46% | -1.3% (noise) |
| random_read 10K | -55% | +5.0% (noise) |
| random_read 100K | -24% | +3.0% (noise) |
| random_write | -8% | +0.8% (noise) |
| load | -6% | +1.7% (noise) |

## Test plan

- [x] `cargo test -p strata-storage` — 261 passed
- [x] `cargo test -p strata-concurrency` — 91 passed
- [x] `cargo test -p strata-engine --lib` — 1,307 passed
- [x] Scaling benchmark confirms regression eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)