### PR TITLE
Write stalling and WAL truncation after flush (Epics 14 & 15)

### DIFF
--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -73,7 +73,7 @@ pub struct StorageConfig {
     #[serde(default = "default_write_buffer_size")]
     pub write_buffer_size: usize,
     /// Maximum number of frozen (immutable) memtables allowed per branch before
-    /// write stalling kicks in. Default: 4. Reserved for future enforcement.
+    /// write stalling kicks in. Default: 4. Set to 0 for unlimited.
     #[serde(default = "default_max_immutable_memtables")]
     pub max_immutable_memtables: usize,
 }
@@ -293,7 +293,7 @@ auto_embed = false
 # max_write_buffer_entries = 500000
 # max_versions_per_key = 0    # 0 = unlimited; set to e.g. 100 to cap MVCC history
 # write_buffer_size = 134217728  # 128 MiB; memtable rotation threshold
-# max_immutable_memtables = 4   # max frozen memtables before stall (future)
+# max_immutable_memtables = 4   # max frozen memtables per branch before write stalling
 "#
     }
 

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -456,6 +456,7 @@ impl Database {
         let storage = Arc::new(result.storage);
         storage.set_max_branches(cfg.storage.max_branches);
         storage.set_max_versions_per_key(cfg.storage.max_versions_per_key);
+        storage.set_max_immutable_memtables(cfg.storage.max_immutable_memtables);
 
         // Recover previously flushed segments from disk
         match storage.recover_segments() {
@@ -472,7 +473,8 @@ impl Database {
                 warn!(target: "strata::db", error = %e, "Segment recovery failed");
                 if !cfg.allow_lossy_recovery {
                     return Err(StrataError::corruption(format!(
-                        "Segment recovery failed: {}", e
+                        "Segment recovery failed: {}",
+                        e
                     )));
                 }
             }
@@ -616,6 +618,7 @@ impl Database {
         let storage = Arc::new(result.storage);
         storage.set_max_branches(cfg.storage.max_branches);
         storage.set_max_versions_per_key(cfg.storage.max_versions_per_key);
+        storage.set_max_immutable_memtables(cfg.storage.max_immutable_memtables);
 
         // Recover previously flushed segments from disk
         match storage.recover_segments() {
@@ -632,7 +635,8 @@ impl Database {
                 warn!(target: "strata::db", error = %e, "Segment recovery failed");
                 if !cfg.allow_lossy_recovery {
                     return Err(StrataError::corruption(format!(
-                        "Segment recovery failed: {}", e
+                        "Segment recovery failed: {}",
+                        e
                     )));
                 }
             }
@@ -709,6 +713,7 @@ impl Database {
         let storage = SegmentedStore::new();
         storage.set_max_branches(cfg.storage.max_branches);
         storage.set_max_versions_per_key(cfg.storage.max_versions_per_key);
+        storage.set_max_immutable_memtables(cfg.storage.max_immutable_memtables);
 
         // Create coordinator starting at version 1 (no recovery needed), with write buffer limit
         let mut coordinator = TransactionCoordinator::new(1);
@@ -1723,52 +1728,57 @@ impl Database {
 
         for branch_id in branches {
             let storage = Arc::clone(&self.storage);
-            let submit_result = self.scheduler.submit(
-                crate::background::TaskPriority::High,
-                move || {
-                    match storage.flush_oldest_frozen(&branch_id) {
-                        Ok(true) => {
-                            tracing::debug!(
-                                target: "strata::flush",
-                                ?branch_id,
-                                "Flushed frozen memtable to segment"
-                            );
-                            // Post-flush: check if compaction is needed
-                            if storage.should_compact(&branch_id, 4) {
-                                match storage.compact_branch(&branch_id, 0) {
-                                    Ok(Some(result)) => {
-                                        tracing::debug!(
-                                            target: "strata::compact",
-                                            ?branch_id,
-                                            segments_merged = result.segments_merged,
-                                            entries_pruned = result.entries_pruned,
-                                            "Compaction complete"
-                                        );
-                                    }
-                                    Ok(None) => {}
-                                    Err(e) => {
-                                        tracing::warn!(
-                                            target: "strata::compact",
-                                            ?branch_id,
-                                            error = %e,
-                                            "Background compaction failed"
-                                        );
+            let data_dir = self.data_dir.clone();
+            let wal_dir = self.wal_dir.clone();
+            let submit_result =
+                self.scheduler
+                    .submit(crate::background::TaskPriority::High, move || {
+                        match storage.flush_oldest_frozen(&branch_id) {
+                            Ok(true) => {
+                                tracing::debug!(
+                                    target: "strata::flush",
+                                    ?branch_id,
+                                    "Flushed frozen memtable to segment"
+                                );
+
+                                // Update flush watermark and truncate WAL
+                                Self::update_flush_watermark(&storage, &data_dir, &wal_dir);
+
+                                // Post-flush: check if compaction is needed
+                                if storage.should_compact(&branch_id, 4) {
+                                    match storage.compact_branch(&branch_id, 0) {
+                                        Ok(Some(result)) => {
+                                            tracing::debug!(
+                                                target: "strata::compact",
+                                                ?branch_id,
+                                                segments_merged = result.segments_merged,
+                                                entries_pruned = result.entries_pruned,
+                                                "Compaction complete"
+                                            );
+                                        }
+                                        Ok(None) => {}
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                target: "strata::compact",
+                                                ?branch_id,
+                                                error = %e,
+                                                "Background compaction failed"
+                                            );
+                                        }
                                     }
                                 }
                             }
+                            Ok(false) => {}
+                            Err(e) => {
+                                tracing::warn!(
+                                    target: "strata::flush",
+                                    ?branch_id,
+                                    error = %e,
+                                    "Background flush failed"
+                                );
+                            }
                         }
-                        Ok(false) => {}
-                        Err(e) => {
-                            tracing::warn!(
-                                target: "strata::flush",
-                                ?branch_id,
-                                error = %e,
-                                "Background flush failed"
-                            );
-                        }
-                    }
-                },
-            );
+                    });
             if let Err(e) = submit_result {
                 tracing::debug!(
                     target: "strata::flush",
@@ -1776,6 +1786,115 @@ impl Database {
                     "Flush task rejected (queue full)"
                 );
                 break;
+            }
+        }
+    }
+
+    /// Update the MANIFEST flush watermark and truncate WAL segments below it.
+    ///
+    /// Computes the global flush watermark as the minimum `max_flushed_commit`
+    /// across all branches. WAL segments fully below this watermark are safe
+    /// to delete because their data is in segments.
+    ///
+    /// Best-effort: errors are logged, not propagated.
+    fn update_flush_watermark(storage: &SegmentedStore, data_dir: &Path, wal_dir: &Path) {
+        // Compute global flush watermark: min of max_flushed_commit across all branches
+        let branch_ids = storage.branch_ids();
+        if branch_ids.is_empty() {
+            return;
+        }
+
+        // Flush ALL branches so every branch's latest data is in segments.
+        // This ensures the watermark reflects the true minimum across all
+        // branches, including low-write branches like _system_ that never
+        // trigger automatic rotation.
+        for bid in &branch_ids {
+            storage.rotate_memtable(bid);
+            // Flush all frozen memtables for this branch (not just the oldest)
+            loop {
+                match storage.flush_oldest_frozen(bid) {
+                    Ok(true) => continue, // More frozen to flush
+                    Ok(false) => break,   // Done
+                    Err(e) => {
+                        tracing::debug!(
+                            target: "strata::flush",
+                            ?bid,
+                            error = %e,
+                            "Force-flush failed, skipping WAL truncation"
+                        );
+                        return; // Can't guarantee this branch's data is safe
+                    }
+                }
+            }
+        }
+
+        // Compute watermark: min of max_flushed_commit across all branches.
+        // After flushing above, every branch with data has segments.
+        let mut watermark = u64::MAX;
+        let mut has_any_segments = false;
+        for bid in &branch_ids {
+            match storage.max_flushed_commit(bid) {
+                Some(0) => {} // Empty segment — no real data, skip
+                Some(commit) => {
+                    watermark = watermark.min(commit);
+                    has_any_segments = true;
+                }
+                None => {
+                    if storage.has_frozen(bid) {
+                        return; // Unflushed data — WAL needed
+                    }
+                }
+            }
+        }
+        if !has_any_segments || watermark == u64::MAX {
+            return;
+        }
+
+        // Update MANIFEST
+        let manifest_path = data_dir.join("MANIFEST");
+        let mut mgr = match ManifestManager::load(manifest_path) {
+            Ok(mgr) => mgr,
+            Err(e) => {
+                tracing::debug!(
+                    target: "strata::flush",
+                    error = %e,
+                    "No MANIFEST found, skipping WAL truncation"
+                );
+                return;
+            }
+        };
+
+        if let Err(e) = mgr.set_flush_watermark(watermark) {
+            tracing::warn!(
+                target: "strata::flush",
+                error = %e,
+                watermark,
+                "Failed to update flush watermark in MANIFEST"
+            );
+            return; // Don't truncate WAL if watermark wasn't persisted
+        }
+
+        // Truncate WAL segments below watermark
+        let manifest_arc = Arc::new(ParkingMutex::new(mgr));
+        let compactor = WalOnlyCompactor::new(wal_dir.to_path_buf(), manifest_arc);
+        match compactor.compact() {
+            Ok(info) => {
+                if info.wal_segments_removed > 0 {
+                    tracing::debug!(
+                        target: "strata::wal",
+                        segments_removed = info.wal_segments_removed,
+                        bytes_reclaimed = info.reclaimed_bytes,
+                        watermark,
+                        "WAL segments truncated after flush"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "strata::wal",
+                    error = %e,
+                    "WAL compaction failed after flush"
+                );
             }
         }
     }

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -282,9 +282,7 @@ impl BranchIndex {
                 .filter_map(|(k, _)| {
                     let key_str = String::from_utf8(k.user_key.to_vec()).ok()?;
                     // Filter out index keys (legacy) and system branches
-                    if key_str.contains("__idx_")
-                        || crate::branch_dag::is_system_branch(&key_str)
-                    {
+                    if key_str.contains("__idx_") || crate::branch_dag::is_system_branch(&key_str) {
                         None
                     } else {
                         Some(key_str)

--- a/crates/storage/src/segment_builder.rs
+++ b/crates/storage/src/segment_builder.rs
@@ -713,8 +713,7 @@ mod tests {
         let mut buf = Vec::new();
         encode_entry(&ik, &entry, &mut buf);
 
-        let (decoded_ik, is_tomb, decoded_val, ts, ttl, consumed) =
-            decode_entry(&buf).unwrap();
+        let (decoded_ik, is_tomb, decoded_val, ts, ttl, consumed) = decode_entry(&buf).unwrap();
         assert_eq!(decoded_ik, ik);
         assert!(!is_tomb);
         assert_eq!(decoded_val, Value::String("world".into()));
@@ -736,8 +735,7 @@ mod tests {
         let mut buf = Vec::new();
         encode_entry(&ik, &entry, &mut buf);
 
-        let (decoded_ik, is_tomb, _, ts, ttl, consumed) =
-            decode_entry(&buf).unwrap();
+        let (decoded_ik, is_tomb, _, ts, ttl, consumed) = decode_entry(&buf).unwrap();
         assert_eq!(decoded_ik, ik);
         assert!(is_tomb);
         assert_eq!(ts, entry.timestamp.as_micros());

--- a/crates/storage/src/segmented.rs
+++ b/crates/storage/src/segmented.rs
@@ -99,6 +99,8 @@ pub struct SegmentedStore {
     max_versions_per_key: AtomicUsize,
     /// Total frozen memtable count across all branches (for O(1) "any frozen?" check).
     total_frozen_count: AtomicUsize,
+    /// Maximum frozen memtables per branch before rotation is skipped (0 = unlimited).
+    max_immutable_memtables: AtomicUsize,
 }
 
 impl SegmentedStore {
@@ -118,6 +120,7 @@ impl SegmentedStore {
             max_branches: AtomicUsize::new(0),
             max_versions_per_key: AtomicUsize::new(0),
             total_frozen_count: AtomicUsize::new(0),
+            max_immutable_memtables: AtomicUsize::new(0),
         }
     }
 
@@ -138,6 +141,7 @@ impl SegmentedStore {
             max_branches: AtomicUsize::new(0),
             max_versions_per_key: AtomicUsize::new(0),
             total_frozen_count: AtomicUsize::new(0),
+            max_immutable_memtables: AtomicUsize::new(0),
         }
     }
 
@@ -158,6 +162,7 @@ impl SegmentedStore {
             max_branches: AtomicUsize::new(0),
             max_versions_per_key: AtomicUsize::new(0),
             total_frozen_count: AtomicUsize::new(0),
+            max_immutable_memtables: AtomicUsize::new(0),
         }
     }
 
@@ -267,6 +272,15 @@ impl SegmentedStore {
     /// Pruning happens at compaction time, not at write time.
     pub fn set_max_versions_per_key(&self, max: usize) {
         self.max_versions_per_key.store(max, Ordering::Relaxed);
+    }
+
+    /// Set maximum frozen memtables per branch before write stalling (0 = unlimited).
+    ///
+    /// When the limit is reached, `maybe_rotate_branch` skips rotation and lets
+    /// the active memtable grow beyond `write_buffer_size`. Once a frozen
+    /// memtable is flushed, rotation resumes on the next write.
+    pub fn set_max_immutable_memtables(&self, max: usize) {
+        self.max_immutable_memtables.store(max, Ordering::Relaxed);
     }
 
     /// Direct single-key read returning only the Value (no VersionedValue).
@@ -778,6 +792,14 @@ impl SegmentedStore {
             && branch.active.approx_bytes() >= self.write_buffer_size
             && !self.bulk_load_branches.contains_key(&branch_id)
         {
+            // Write stalling: skip rotation if too many frozen memtables.
+            // The active memtable grows beyond write_buffer_size until a
+            // frozen memtable is flushed, then rotation resumes.
+            let max_frozen = self.max_immutable_memtables.load(Ordering::Relaxed);
+            if max_frozen > 0 && branch.frozen.len() >= max_frozen {
+                return;
+            }
+
             let next_id = self.next_segment_id.fetch_add(1, Ordering::Relaxed);
             let old = std::mem::replace(&mut branch.active, Memtable::new(next_id));
             old.freeze();
@@ -3338,5 +3360,73 @@ mod tests {
     fn shard_stats_detailed_missing_branch() {
         let store = SegmentedStore::new();
         assert!(store.shard_stats_detailed(&BranchId::new()).is_none());
+    }
+
+    // ===== Write stalling / backpressure tests =====
+
+    #[test]
+    fn write_stalling_skips_rotation_when_frozen_limit_reached() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SegmentedStore::with_dir(dir.path().join("segments"), 1024); // 1KB threshold
+        store.set_max_immutable_memtables(2);
+
+        let bid = branch();
+
+        // Write enough to trigger rotation 3 times (well over 1KB each time)
+        for round in 0..3 {
+            for i in 0..20 {
+                let key_name = format!("round{}_{}", round, i);
+                seed(
+                    &store,
+                    kv_key(&key_name),
+                    Value::String("x".repeat(100)),
+                    (round * 20 + i + 1) as u64,
+                );
+            }
+        }
+
+        // Should have exactly 2 frozen (the limit), 3rd rotation was blocked
+        assert_eq!(store.branch_frozen_count(&bid), 2);
+
+        // Flush one frozen memtable
+        store.flush_oldest_frozen(&bid).unwrap();
+
+        // Now rotation should work again on next write batch
+        for i in 0..20 {
+            seed(
+                &store,
+                kv_key(&format!("after_{}", i)),
+                Value::String("y".repeat(100)),
+                100 + i as u64,
+            );
+        }
+
+        // Data should still be readable
+        assert!(store
+            .get_versioned(&kv_key("round0_0"), u64::MAX)
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn write_stalling_disabled_when_max_is_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SegmentedStore::with_dir(dir.path().join("segments"), 1024);
+        store.set_max_immutable_memtables(0); // unlimited
+
+        let _bid = branch();
+
+        // Write enough to trigger many rotations
+        for i in 0..100 {
+            seed(
+                &store,
+                kv_key(&format!("k{}", i)),
+                Value::String("x".repeat(100)),
+                i as u64 + 1,
+            );
+        }
+
+        // Should have rotated freely — more than 2 frozen
+        assert!(store.branch_frozen_count(&branch()) > 2);
     }
 }


### PR DESCRIPTION
## Summary

- **Epic 14: Write Stalling** — Enforces `max_immutable_memtables` limit (default 4). When frozen memtable count reaches the limit, `maybe_rotate_branch()` skips rotation and lets the active memtable grow until a background flush clears space. Prevents OOM from unbounded frozen memtable accumulation.
- **Epic 15: WAL Truncation** — After each successful flush, computes the global flush watermark (min of max_flushed_commit across all branches), updates the MANIFEST, and runs `WalOnlyCompactor::compact()` to remove old WAL segments. Reclaims disk space and speeds up recovery.

### Key Design Decisions

- **No blocking/condvar for write stalling** — skip rotation instead of blocking inside DashMap guard to avoid deadlocks
- **WAL not truncated if MANIFEST update fails** — safety: WAL must be the recovery fallback
- **update_flush_watermark is a static method** — called from background task closure without `&self`

## Test plan

- [x] `cargo test -p strata-storage` — 268 passed (2 new write stalling tests)
- [x] `cargo check -p strata-engine` — compiles clean
- [x] 2 pre-existing WAL corruption test failures are unrelated (confirmed by running on base code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)