### PR TITLE
Robustness: safe InternalKey parsing and O(1) time_range (Epic 18)

### DIFF
--- a/crates/storage/src/key_encoding.rs
+++ b/crates/storage/src/key_encoding.rs
@@ -152,6 +152,17 @@ impl InternalKey {
         InternalKey(bytes)
     }
 
+    /// Create an InternalKey from raw bytes, returning `None` if too short.
+    ///
+    /// Unlike [`from_bytes`](Self::from_bytes), this never panics on corrupt
+    /// or truncated data — callers can propagate the `None` gracefully.
+    pub fn try_from_bytes(bytes: Vec<u8>) -> Option<Self> {
+        if bytes.len() < 28 {
+            return None;
+        }
+        Some(InternalKey(bytes))
+    }
+
     /// Access the raw bytes.
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
@@ -516,6 +527,20 @@ mod tests {
     fn from_bytes_rejects_short_input() {
         let result = std::panic::catch_unwind(|| InternalKey::from_bytes(vec![1, 2, 3]));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn try_from_bytes_rejects_short_input() {
+        assert!(InternalKey::try_from_bytes(vec![1, 2, 3]).is_none());
+    }
+
+    #[test]
+    fn try_from_bytes_accepts_valid_input() {
+        let key = make_key("default", TypeTag::KV, "hello");
+        let ik = InternalKey::encode(&key, 42);
+        let bytes = ik.into_bytes();
+        let recovered = InternalKey::try_from_bytes(bytes).unwrap();
+        assert_eq!(recovered.commit_id(), 42);
     }
 
     #[test]

--- a/crates/storage/src/segment_builder.rs
+++ b/crates/storage/src/segment_builder.rs
@@ -293,7 +293,7 @@ pub(crate) fn decode_entry(data: &[u8]) -> Option<(InternalKey, bool, Value, u64
     if pos + ik_len > data.len() {
         return None;
     }
-    let ik = InternalKey::from_bytes(data[pos..pos + ik_len].to_vec());
+    let ik = InternalKey::try_from_bytes(data[pos..pos + ik_len].to_vec())?;
     pos += ik_len;
 
     if pos >= data.len() {

--- a/crates/storage/src/segmented.rs
+++ b/crates/storage/src/segmented.rs
@@ -58,6 +58,10 @@ struct BranchState {
     frozen: Vec<Arc<Memtable>>,
     /// On-disk KV segments, newest first.
     segments: Vec<Arc<KVSegment>>,
+    /// Minimum timestamp seen across all writes (for O(1) time_range).
+    min_timestamp: AtomicU64,
+    /// Maximum timestamp seen across all writes (for O(1) time_range).
+    max_timestamp: AtomicU64,
 }
 
 impl BranchState {
@@ -66,6 +70,8 @@ impl BranchState {
             active: Memtable::new(0),
             frozen: Vec::new(),
             segments: Vec::new(),
+            min_timestamp: AtomicU64::new(u64::MAX),
+            max_timestamp: AtomicU64::new(0),
         }
     }
 }
@@ -459,17 +465,20 @@ impl SegmentedStore {
     ///
     /// Returns `(oldest_ts, latest_ts)` in microseconds since epoch.
     /// Returns `None` if the branch has no data.
+    ///
+    /// This is an O(1) operation using cached atomic min/max timestamps
+    /// updated on every write. The range includes timestamps from all
+    /// writes (puts, deletes, tombstones), so it may extend beyond the
+    /// range of currently live (non-deleted) entries.
     pub fn time_range(&self, branch_id: BranchId) -> StrataResult<Option<(u64, u64)>> {
-        let entries = self.list_branch(&branch_id);
-        if entries.is_empty() {
-            return Ok(None);
-        }
-        let mut min_ts = u64::MAX;
-        let mut max_ts = 0u64;
-        for (_, vv) in &entries {
-            let ts = vv.timestamp.as_micros();
-            min_ts = min_ts.min(ts);
-            max_ts = max_ts.max(ts);
+        let branch = match self.branches.get(&branch_id) {
+            Some(b) => b,
+            None => return Ok(None),
+        };
+        let min_ts = branch.min_timestamp.load(Ordering::Relaxed);
+        let max_ts = branch.max_timestamp.load(Ordering::Relaxed);
+        if min_ts == u64::MAX {
+            return Ok(None); // No data written
         }
         Ok(Some((min_ts, max_ts)))
     }
@@ -1399,7 +1408,11 @@ impl Storage for SegmentedStore {
             timestamp: Timestamp::now(),
             ttl_ms,
         };
+        let ts = entry.timestamp.as_micros();
         branch.active.put_entry(&key, version, entry);
+        // Track timestamp for O(1) time_range
+        branch.min_timestamp.fetch_min(ts, Ordering::Relaxed);
+        branch.max_timestamp.fetch_max(ts, Ordering::Relaxed);
 
         // Rotate if active memtable exceeds threshold
         self.maybe_rotate_branch(branch_id, &mut branch);
@@ -1424,7 +1437,11 @@ impl Storage for SegmentedStore {
             timestamp: Timestamp::now(),
             ttl_ms: 0,
         };
+        let ts = entry.timestamp.as_micros();
         branch.active.put_entry(key, version, entry);
+        // Track timestamp for O(1) time_range
+        branch.min_timestamp.fetch_min(ts, Ordering::Relaxed);
+        branch.max_timestamp.fetch_max(ts, Ordering::Relaxed);
 
         // Rotate if active memtable exceeds threshold
         self.maybe_rotate_branch(branch_id, &mut branch);
@@ -1453,6 +1470,7 @@ impl Storage for SegmentedStore {
         }
 
         let timestamp = Timestamp::now();
+        let ts = timestamp.as_micros();
         for (branch_id, entries) in by_branch {
             let mut branch = self
                 .branches
@@ -1467,6 +1485,9 @@ impl Storage for SegmentedStore {
                 };
                 branch.active.put_entry(&key, version, entry);
             }
+            // Track timestamp for O(1) time_range
+            branch.min_timestamp.fetch_min(ts, Ordering::Relaxed);
+            branch.max_timestamp.fetch_max(ts, Ordering::Relaxed);
             self.maybe_rotate_branch(branch_id, &mut branch);
         }
 
@@ -1489,6 +1510,7 @@ impl Storage for SegmentedStore {
         }
 
         let timestamp = Timestamp::now();
+        let ts = timestamp.as_micros();
         for (branch_id, keys) in by_branch {
             let mut branch = self
                 .branches
@@ -1503,6 +1525,9 @@ impl Storage for SegmentedStore {
                 };
                 branch.active.put_entry(&key, version, entry);
             }
+            // Track timestamp for O(1) time_range
+            branch.min_timestamp.fetch_min(ts, Ordering::Relaxed);
+            branch.max_timestamp.fetch_max(ts, Ordering::Relaxed);
             self.maybe_rotate_branch(branch_id, &mut branch);
         }
 
@@ -3709,5 +3734,54 @@ mod tests {
                 .value,
             Value::Int(3)
         );
+    }
+
+    // ===== O(1) time_range tests =====
+
+    #[test]
+    fn time_range_empty_branch_returns_none() {
+        let store = SegmentedStore::new();
+        assert_eq!(store.time_range(branch()).unwrap(), None);
+    }
+
+    #[test]
+    fn time_range_o1_tracks_writes() {
+        let store = SegmentedStore::new();
+
+        // No data -> None
+        assert_eq!(store.time_range(branch()).unwrap(), None);
+
+        // Write some data
+        seed(&store, kv_key("a"), Value::Int(1), 1);
+        seed(&store, kv_key("b"), Value::Int(2), 2);
+
+        let range = store.time_range(branch()).unwrap().unwrap();
+        // min and max should be close to now (within last second)
+        assert!(range.0 > 0);
+        assert!(range.1 >= range.0);
+    }
+
+    #[test]
+    fn time_range_o1_includes_deletes() {
+        let store = SegmentedStore::new();
+        seed(&store, kv_key("a"), Value::Int(1), 1);
+        let range_before = store.time_range(branch()).unwrap().unwrap();
+
+        // Short sleep to ensure delete timestamp is strictly later
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        store.delete_with_version(&kv_key("a"), 2).unwrap();
+
+        let range_after = store.time_range(branch()).unwrap().unwrap();
+        // max should have advanced to include the delete timestamp
+        assert!(range_after.1 >= range_before.1);
+    }
+
+    #[test]
+    fn time_range_o1_nonexistent_branch_returns_none() {
+        let store = SegmentedStore::new();
+        // Write to one branch, query another
+        seed(&store, kv_key("a"), Value::Int(1), 1);
+        let other_branch = BranchId::from_bytes([99; 16]);
+        assert_eq!(store.time_range(other_branch).unwrap(), None);
     }
 }


### PR DESCRIPTION
## Summary

- **Safe InternalKey parsing:** `try_from_bytes()` returns `None` on truncated/corrupt input instead of panicking. `decode_entry()` uses it so corrupt segment entries are gracefully skipped.
- **O(1) time_range:** Per-branch `AtomicU64` min/max timestamps tracked on every write. `time_range()` reads atomics instead of scanning all entries.

## Test plan
- [x] `cargo test -p strata-storage` — 288 passed (6 new)
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)