### PR TITLE
Wire engine compaction to compact_level() with cascading L1-L5 triggers

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1755,20 +1755,17 @@ impl Database {
                                 // Update flush watermark and truncate WAL
                                 Self::update_flush_watermark(&storage, &data_dir, &wal_dir);
 
-                                // Post-flush: compact L0 → L1 when enough
-                                // L0 segments accumulate. Produces non-overlapping
-                                // L1 segments for O(log N) point lookups.
+                                // Post-flush: compact L0 → L1 when ≥ 4 L0 segments
                                 if storage.l0_segment_count(&branch_id) >= 4 {
-                                    match storage.compact_l0_to_l1(&branch_id, 0) {
+                                    match storage.compact_level(&branch_id, 0, 0) {
                                         Ok(Some(result)) => {
                                             tracing::debug!(
                                                 target: "strata::compact",
                                                 ?branch_id,
+                                                level = 0,
                                                 segments_merged = result.segments_merged,
                                                 entries_pruned = result.entries_pruned,
-                                                l0 = storage.l0_segment_count(&branch_id),
-                                                l1 = storage.l1_segment_count(&branch_id),
-                                                "L0 → L1 compaction complete"
+                                                "compaction complete"
                                             );
                                         }
                                         Ok(None) => {}
@@ -1776,11 +1773,44 @@ impl Database {
                                             tracing::warn!(
                                                 target: "strata::compact",
                                                 ?branch_id,
+                                                level = 0,
                                                 error = %e,
-                                                "Background L0 → L1 compaction failed"
+                                                "compaction failed"
                                             );
                                         }
                                     }
+                                }
+
+                                // L1-L5 → L(n+1): trigger when level bytes exceed threshold.
+                                // Mirrors storage::LEVEL_BASE_BYTES (256MB) and
+                                // LEVEL_MULTIPLIER (10×) for each subsequent level.
+                                let mut level_target: u64 = 256 << 20;
+                                for level in 1..6 {
+                                    if storage.level_bytes(&branch_id, level) > level_target {
+                                        match storage.compact_level(&branch_id, level, 0) {
+                                            Ok(Some(result)) => {
+                                                tracing::debug!(
+                                                    target: "strata::compact",
+                                                    ?branch_id,
+                                                    level,
+                                                    segments_merged = result.segments_merged,
+                                                    entries_pruned = result.entries_pruned,
+                                                    "compaction complete"
+                                                );
+                                            }
+                                            Ok(None) => {}
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    target: "strata::compact",
+                                                    ?branch_id,
+                                                    level,
+                                                    error = %e,
+                                                    "compaction failed"
+                                                );
+                                            }
+                                        }
+                                    }
+                                    level_target *= 10;
                                 }
                             }
                             Ok(false) => {}

--- a/crates/engine/tests/flush_pipeline_tests.rs
+++ b/crates/engine/tests/flush_pipeline_tests.rs
@@ -405,3 +405,51 @@ fn lifecycle_wal_truncation_after_flush() {
 
     assert_eq!(compact_info.snapshot_watermark, Some(max_commit));
 }
+
+#[test]
+fn multi_level_compaction_cascades() {
+    let dir = tempfile::tempdir().unwrap();
+    let segments_dir = dir.path().join("segments");
+    let store = SegmentedStore::with_dir(segments_dir, 0);
+    let b = branch();
+
+    // Flush several L0 segments, then compact L0 → L1
+    for commit in 1..=5u64 {
+        let key = kv_key(&format!("k{:04}", commit));
+        seed(&store, key, Value::Int(commit as i64), commit);
+        store.rotate_memtable(&b);
+        store.flush_oldest_frozen(&b).unwrap();
+    }
+    assert_eq!(store.l0_segment_count(&b), 5);
+
+    // L0 → L1
+    let r = store.compact_level(&b, 0, 0).unwrap().unwrap();
+    assert_eq!(r.segments_merged, 5);
+    assert_eq!(store.l0_segment_count(&b), 0);
+    assert_eq!(store.level_segment_count(&b, 1), 1);
+
+    // L1 → L2 (trivial move — single file, no overlap in L2)
+    let r = store.compact_level(&b, 1, 0).unwrap().unwrap();
+    assert_eq!(r.segments_merged, 1);
+    assert_eq!(r.output_entries, 5);
+    assert_eq!(r.entries_pruned, 0);
+    assert_eq!(store.level_segment_count(&b, 1), 0);
+    assert_eq!(store.level_segment_count(&b, 2), 1);
+
+    // L2 → L3 (trivial move)
+    let r = store.compact_level(&b, 2, 0).unwrap().unwrap();
+    assert_eq!(r.segments_merged, 1);
+    assert_eq!(r.output_entries, 5);
+    assert_eq!(r.entries_pruned, 0);
+    assert_eq!(store.level_segment_count(&b, 2), 0);
+    assert_eq!(store.level_segment_count(&b, 3), 1);
+
+    // All data still readable after cascading through levels
+    for i in 1..=5u64 {
+        let result = store
+            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .unwrap()
+            .unwrap_or_else(|| panic!("key k{:04} missing after cascade", i));
+        assert_eq!(result.value, Value::Int(i as i64));
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `compact_l0_to_l1()` call in post-flush path with `compact_level(&branch_id, 0, 0)`, using the unified multi-level compaction API
- Add inline cascading loop for L1-L5: after L0→L1, each level is checked against byte-based thresholds (256MB × 10^(level-1)) and compacted to the next level when exceeded
- Add integration test verifying L0→L1→L2→L3 cascade with full data correctness checks, including trivial-move path assertions

## Test plan
- [x] All 7 flush pipeline integration tests pass
- [x] `cargo clippy -p strata-engine -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] New `multi_level_compaction_cascades` test verifies 3-level cascade with exact segment counts, entry counts, and data readback

🤖 Generated with [Claude Code](https://claude.com/claude-code)