### PR TITLE
Fix rustfmt formatting in executor IPC module

### DIFF
--- a/crates/executor/src/ipc/client.rs
+++ b/crates/executor/src/ipc/client.rs
@@ -52,10 +52,9 @@ impl IpcClient {
             reason: format!("IPC write error: {}", e),
         })?;
 
-        let response_frame =
-            wire::read_frame(&mut self.reader).map_err(|e| crate::Error::Io {
-                reason: format!("IPC read error: {}", e),
-            })?;
+        let response_frame = wire::read_frame(&mut self.reader).map_err(|e| crate::Error::Io {
+            reason: format!("IPC read error: {}", e),
+        })?;
 
         let response: Response =
             protocol::decode(&response_frame).map_err(|e| crate::Error::Internal {

--- a/crates/executor/src/ipc/server.rs
+++ b/crates/executor/src/ipc/server.rs
@@ -33,11 +33,7 @@ impl IpcServer {
     ///
     /// Spawns a listener thread that accepts connections. Each connection
     /// gets a dedicated handler thread with its own `Session`.
-    pub fn start(
-        data_dir: &Path,
-        db: Arc<Database>,
-        access_mode: AccessMode,
-    ) -> io::Result<Self> {
+    pub fn start(data_dir: &Path, db: Arc<Database>, access_mode: AccessMode) -> io::Result<Self> {
         let socket_path = data_dir.join("strata.sock");
         let pid_path = data_dir.join("strata.pid");
 
@@ -61,17 +57,18 @@ impl IpcServer {
         let shutdown_clone = shutdown.clone();
         let socket_path_clone = socket_path.clone();
 
-        let listener_handle = thread::Builder::new()
-            .name("ipc-listener".into())
-            .spawn(move || {
-                Self::listener_loop(
-                    listener,
-                    db,
-                    access_mode,
-                    shutdown_clone,
-                    socket_path_clone,
-                );
-            })?;
+        let listener_handle =
+            thread::Builder::new()
+                .name("ipc-listener".into())
+                .spawn(move || {
+                    Self::listener_loop(
+                        listener,
+                        db,
+                        access_mode,
+                        shutdown_clone,
+                        socket_path_clone,
+                    );
+                })?;
 
         Ok(Self {
             socket_path,
@@ -156,15 +153,16 @@ impl IpcServer {
                     // Set a read timeout so handler threads can check the
                     // shutdown flag periodically instead of blocking forever.
                     stream.set_nonblocking(false).ok();
-                    stream.set_read_timeout(Some(std::time::Duration::from_secs(2))).ok();
+                    stream
+                        .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                        .ok();
                     let db = db.clone();
                     let shutdown = shutdown.clone();
                     match thread::Builder::new()
                         .name("ipc-handler".into())
                         .spawn(move || {
                             Self::handle_connection(stream, db, access_mode, shutdown);
-                        })
-                    {
+                        }) {
                         Ok(handle) => {
                             handler_threads.push(handle);
                         }

--- a/crates/executor/src/ipc/wire.rs
+++ b/crates/executor/src/ipc/wire.rs
@@ -14,7 +14,10 @@ pub fn write_frame(stream: &mut impl Write, payload: &[u8]) -> io::Result<()> {
     if len > MAX_FRAME_SIZE as usize {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("frame payload too large: {} bytes (max {})", len, MAX_FRAME_SIZE),
+            format!(
+                "frame payload too large: {} bytes (max {})",
+                len, MAX_FRAME_SIZE
+            ),
         ));
     }
     let len_bytes = (len as u32).to_be_bytes();

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -90,8 +90,8 @@ impl Session {
         // We need a dummy Database for the executor, but for IPC sessions
         // the executor is never used — all commands go through the IPC client.
         // Database::cache() is a lightweight in-memory DB used only as a placeholder.
-        let db = Database::cache()
-            .expect("failed to create in-memory placeholder DB (out of memory?)");
+        let db =
+            Database::cache().expect("failed to create in-memory placeholder DB (out of memory?)");
         Self {
             executor: Executor::new_with_mode(db.clone(), access_mode),
             db,


### PR DESCRIPTION
## Summary

- Apply `cargo fmt` to fix formatting issues in `crates/executor/src/ipc/` and `crates/executor/src/session.rs`
- These were introduced in #1560 and caused CI formatting checks to fail

## Test plan

- [x] `cargo fmt --all -- --check` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)