### PR TITLE
Fix clippy: signal handler fn-to-int cast

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -480,8 +480,8 @@ fn ctrlc_handler(running: std::sync::Arc<std::sync::atomic::AtomicBool>) {
     let ptr = std::sync::Arc::into_raw(running) as *mut std::sync::atomic::AtomicBool;
     RUNNING_PTR.store(ptr, std::sync::atomic::Ordering::SeqCst);
     unsafe {
-        libc::signal(libc::SIGTERM, handle_signal as libc::sighandler_t);
-        libc::signal(libc::SIGINT, handle_signal as libc::sighandler_t);
+        libc::signal(libc::SIGTERM, handle_signal as usize as libc::sighandler_t);
+        libc::signal(libc::SIGINT, handle_signal as usize as libc::sighandler_t);
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix clippy `fn_to_numeric_cast` error in signal handler registration
- Cast `handle_signal` through `usize` before converting to `sighandler_t`, as required by newer clippy versions

## Test plan

- [x] `cargo clippy -p strata-cli` passes
- [x] `cargo clippy --workspace --exclude strata-inference` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)