### PR TITLE
Fix clippy: signal handler cast through raw pointer

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -480,8 +480,8 @@ fn ctrlc_handler(running: std::sync::Arc<std::sync::atomic::AtomicBool>) {
     let ptr = std::sync::Arc::into_raw(running) as *mut std::sync::atomic::AtomicBool;
     RUNNING_PTR.store(ptr, std::sync::atomic::Ordering::SeqCst);
     unsafe {
-        libc::signal(libc::SIGTERM, handle_signal as usize as libc::sighandler_t);
-        libc::signal(libc::SIGINT, handle_signal as usize as libc::sighandler_t);
+        libc::signal(libc::SIGTERM, handle_signal as *const () as usize as libc::sighandler_t);
+        libc::signal(libc::SIGINT, handle_signal as *const () as usize as libc::sighandler_t);
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix `function_casts_as_integer` clippy error by casting signal handler through `*const ()` then `usize` before `sighandler_t`, as clippy requires

## Test plan

- [x] `cargo clippy -p strata-cli` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)