### PR TITLE
Dynamic level sizing at boundaries (Epic 33)

### DIFF
--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -17,53 +17,43 @@ pub(super) struct LevelTargets {
 
 /// Compute adaptive per-level byte targets from actual level sizes.
 ///
-/// Algorithm (inspired by RocksDB `CalculateBaseBytes`):
-/// 1. Start with static geometric baseline: L1=256MB, L2=2.56GB, etc.
-/// 2. Find the largest non-L0 level by actual bytes.
-/// 3. If that level exceeds its static target, anchor at the actual size and
-///    recompute backward using the multiplier, with `LEVEL_BASE_BYTES` as a
-///    floor for every level.
-/// 4. Recompute forward from anchor for levels beyond it.
+/// Algorithm (RocksDB `CalculateBaseBytes`):
+/// 1. Find the largest non-empty non-L0 level (the "bottom" level).
+/// 2. Compute base (L1 target) = bottom_bytes / multiplier^(bottom_level - 1).
+/// 3. Clamp base between MIN_BASE_BYTES (1MB) and MAX_BASE_BYTES (256MB).
+/// 4. Forward-compute all targets: target[i] = base * multiplier^(i-1).
+///
+/// For empty databases (no non-L0 data), uses MIN_BASE_BYTES as base.
 pub(super) fn recalculate_level_targets(level_bytes: &[u64; NUM_LEVELS]) -> LevelTargets {
-    // Static geometric baseline: L0 unused (count-based), L1=256MB, L2=2.56GB, ...
     let mut max_bytes = [0u64; NUM_LEVELS];
-    max_bytes[0] = 0; // L0 uses count-based trigger, not size
-    let mut target = LEVEL_BASE_BYTES;
-    for slot in max_bytes.iter_mut().skip(1) {
-        *slot = target;
-        target = target.saturating_mul(LEVEL_MULTIPLIER);
-    }
+    max_bytes[0] = 0; // L0 uses count-based trigger
 
-    // Find the largest non-L0 level that exceeds its static target
-    let mut anchor_level = 0usize;
-    let mut anchor_excess: u64 = 0;
-    for level in 1..NUM_LEVELS {
-        if level_bytes[level] > max_bytes[level] && level_bytes[level] > anchor_excess {
-            anchor_level = level;
-            anchor_excess = level_bytes[level];
+    // 1. Find the largest non-empty non-L0 level
+    let mut bottom_level = 0usize;
+    let mut bottom_bytes = 0u64;
+    for (level, &bytes) in level_bytes.iter().enumerate().skip(1) {
+        if bytes > bottom_bytes {
+            bottom_level = level;
+            bottom_bytes = bytes;
         }
     }
 
-    if anchor_level == 0 {
-        // No level exceeds its static target — use baseline
-        return LevelTargets { max_bytes };
-    }
+    // 2. Compute base
+    let base = if bottom_level == 0 {
+        MIN_BASE_BYTES
+    } else {
+        let mut b = bottom_bytes;
+        for _ in 1..bottom_level {
+            b /= LEVEL_MULTIPLIER;
+        }
+        b.clamp(MIN_BASE_BYTES, MAX_BASE_BYTES)
+    };
 
-    // Anchor at the actual size
-    max_bytes[anchor_level] = anchor_excess;
-
-    // Recompute backward from anchor (divide by multiplier, floored at LEVEL_BASE_BYTES)
-    let mut t = anchor_excess;
-    for level in (1..anchor_level).rev() {
-        t /= LEVEL_MULTIPLIER;
-        max_bytes[level] = t.max(LEVEL_BASE_BYTES);
-    }
-
-    // Recompute forward from anchor (multiply)
-    t = anchor_excess;
-    for slot in &mut max_bytes[(anchor_level + 1)..NUM_LEVELS] {
-        t = t.saturating_mul(LEVEL_MULTIPLIER);
-        *slot = t;
+    // 3. Forward-compute all targets
+    let mut target = base;
+    for slot in max_bytes.iter_mut().skip(1) {
+        *slot = target;
+        target = target.saturating_mul(LEVEL_MULTIPLIER);
     }
 
     LevelTargets { max_bytes }
@@ -89,7 +79,7 @@ impl SegmentedStore {
             actual_bytes[level] = segs.iter().map(|s| s.file_size()).sum();
         }
 
-        let targets = recalculate_level_targets(&actual_bytes);
+        let targets = &branch.level_targets;
 
         let mut scores = Vec::new();
 
@@ -222,7 +212,7 @@ impl SegmentedStore {
         // Swap: remove only the segments we compacted, insert the new one.
         // Any segments added by concurrent flushes (not in old_segments) are kept.
         {
-            let branch = self
+            let mut branch = self
                 .branches
                 .entry(*branch_id)
                 .or_insert_with(BranchState::new);
@@ -242,6 +232,7 @@ impl SegmentedStore {
             branch
                 .version
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
+            refresh_level_targets(&mut branch);
         }
 
         // Persist manifest BEFORE deleting old files — if we crash after
@@ -353,7 +344,7 @@ impl SegmentedStore {
         // Swap: remove only the segments we compacted, insert the new one.
         // Any segments added by concurrent flushes (not in selected_segments) are kept.
         {
-            let branch = self
+            let mut branch = self
                 .branches
                 .entry(*branch_id)
                 .or_insert_with(BranchState::new);
@@ -373,6 +364,7 @@ impl SegmentedStore {
             branch
                 .version
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
+            refresh_level_targets(&mut branch);
         }
 
         // Persist manifest BEFORE deleting old files (crash safety).
@@ -535,7 +527,7 @@ impl SegmentedStore {
 
         // Atomic swap: L0 = only concurrently-flushed segments, L1 = non-overlapping + new
         {
-            let branch = self
+            let mut branch = self
                 .branches
                 .entry(*branch_id)
                 .or_insert_with(BranchState::new);
@@ -561,6 +553,7 @@ impl SegmentedStore {
             branch
                 .version
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
+            refresh_level_targets(&mut branch);
         }
 
         // Persist manifest BEFORE deleting old files (crash safety).
@@ -705,6 +698,7 @@ impl SegmentedStore {
             branch
                 .version
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
+            refresh_level_targets(&mut branch);
             drop(branch);
             self.write_branch_manifest(branch_id);
 
@@ -821,6 +815,7 @@ impl SegmentedStore {
             branch
                 .version
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
+            refresh_level_targets(&mut branch);
         }
 
         // ── 5. Cleanup ─────────────────────────────────────────────────

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -53,6 +53,14 @@ const LEVEL_MULTIPLIER: u64 = 10;
 /// output split.  Set to 10 × TARGET_FILE_SIZE (640MB).
 const MAX_GRANDPARENT_OVERLAP: u64 = 10 * TARGET_FILE_SIZE;
 
+/// Minimum L1 target size for dynamic level sizing (1MB).
+/// Prevents degenerate zero-size targets on tiny embedded datasets.
+const MIN_BASE_BYTES: u64 = 1 << 20;
+
+/// Maximum L1 target size for dynamic level sizing.
+/// Equals LEVEL_BASE_BYTES (256MB) — the static default.
+const MAX_BASE_BYTES: u64 = LEVEL_BASE_BYTES;
+
 /// Monkey-optimal bloom bits per key for a given target level.
 ///
 /// Upper levels (checked on every read) get more bits for near-zero FPR.
@@ -184,6 +192,8 @@ struct BranchState {
     /// Per-level compact pointer for round-robin file selection.
     /// Each entry is the largest typed_key_prefix of the last compaction input.
     compact_pointers: Vec<Option<Vec<u8>>>,
+    /// Cached per-level byte targets, recomputed after compaction/flush.
+    level_targets: compaction::LevelTargets,
 }
 
 impl BranchState {
@@ -195,8 +205,19 @@ impl BranchState {
             min_timestamp: AtomicU64::new(u64::MAX),
             max_timestamp: AtomicU64::new(0),
             compact_pointers: vec![None; NUM_LEVELS],
+            level_targets: compaction::recalculate_level_targets(&[0u64; NUM_LEVELS]),
         }
     }
+}
+
+/// Recompute cached level targets from the current segment version.
+fn refresh_level_targets(branch: &mut BranchState) {
+    let ver = branch.version.load();
+    let mut actual_bytes = [0u64; NUM_LEVELS];
+    for (level, segs) in ver.levels.iter().enumerate() {
+        actual_bytes[level] = segs.iter().map(|s| s.file_size()).sum();
+    }
+    branch.level_targets = compaction::recalculate_level_targets(&actual_bytes);
 }
 
 // ---------------------------------------------------------------------------
@@ -822,6 +843,7 @@ impl SegmentedStore {
         branch
             .version
             .store(Arc::new(SegmentVersion { levels: new_levels }));
+        refresh_level_targets(&mut branch);
 
         // Persist level assignments
         drop(branch);
@@ -1027,7 +1049,7 @@ impl SegmentedStore {
                 level.sort_by(|a, b| a.key_range().0.cmp(b.key_range().0));
             }
 
-            let branch = self
+            let mut branch = self
                 .branches
                 .entry(branch_id)
                 .or_insert_with(BranchState::new);
@@ -1053,6 +1075,7 @@ impl SegmentedStore {
             branch
                 .version
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
+            refresh_level_targets(&mut branch);
 
             info.branches_recovered += 1;
         }

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -3546,60 +3546,216 @@ fn compact_level_ephemeral_returns_none() {
 fn recalculate_targets_empty_db() {
     let level_bytes = [0u64; NUM_LEVELS];
     let targets = recalculate_level_targets(&level_bytes);
+    // All levels derive from MIN_BASE_BYTES when no non-L0 data exists
     assert_eq!(targets.max_bytes[0], 0); // L0 unused (count-based)
-    assert_eq!(targets.max_bytes[1], 256 << 20); // 256MB
-    assert_eq!(targets.max_bytes[2], (256 << 20) * 10); // 2.56GB
-    assert_eq!(targets.max_bytes[3], (256 << 20) * 100); // 25.6GB
-    assert_eq!(targets.max_bytes[4], (256 << 20) * 1_000); // 256GB
-    assert_eq!(targets.max_bytes[5], (256 << 20) * 10_000); // 2.56TB
-    assert_eq!(targets.max_bytes[6], (256 << 20) * 100_000); // 25.6TB
+    assert_eq!(targets.max_bytes[1], MIN_BASE_BYTES); // 1MB
+    assert_eq!(targets.max_bytes[2], MIN_BASE_BYTES * 10);
+    assert_eq!(targets.max_bytes[3], MIN_BASE_BYTES * 100);
+    assert_eq!(targets.max_bytes[4], MIN_BASE_BYTES * 1_000);
+    assert_eq!(targets.max_bytes[5], MIN_BASE_BYTES * 10_000);
+    assert_eq!(targets.max_bytes[6], MIN_BASE_BYTES * 100_000);
 }
 
 #[test]
 fn recalculate_targets_small_db() {
     let mut level_bytes = [0u64; NUM_LEVELS];
-    level_bytes[1] = 100 << 20; // 100MB in L1, below 256MB target
+    level_bytes[1] = 100 << 20; // 100MB in L1
     let targets = recalculate_level_targets(&level_bytes);
-    // Targets unchanged — below static threshold
-    assert_eq!(targets.max_bytes[1], 256 << 20);
-    assert_eq!(targets.max_bytes[2], (256 << 20) * 10);
+    // Dynamic: base = 100MB (derived from bottom level L1)
+    assert_eq!(targets.max_bytes[0], 0);
+    assert_eq!(targets.max_bytes[1], 100 << 20);
+    assert_eq!(targets.max_bytes[2], (100 << 20) * 10);
+    assert_eq!(targets.max_bytes[3], (100 << 20) * 100);
+    assert_eq!(targets.max_bytes[4], (100 << 20) * 1_000);
+    assert_eq!(targets.max_bytes[5], (100 << 20) * 10_000);
+    assert_eq!(targets.max_bytes[6], (100 << 20) * 100_000);
 }
 
 #[test]
 fn recalculate_targets_scales_up() {
-    let anchor: u64 = 30 * (1 << 30); // 30 GiB in L3 (exceeds static ~25 GiB)
+    let data: u64 = 30 * (1 << 30); // 30 GiB in L3
     let mut level_bytes = [0u64; NUM_LEVELS];
-    level_bytes[3] = anchor;
+    level_bytes[3] = data;
     let targets = recalculate_level_targets(&level_bytes);
-    // Anchor level matches actual
-    assert_eq!(targets.max_bytes[3], anchor);
-    // Backward: divided by multiplier
-    assert_eq!(targets.max_bytes[2], anchor / 10); // 3 GiB
-    assert_eq!(targets.max_bytes[1], anchor / 100); // ~300 MiB
-    assert!(targets.max_bytes[1] >= LEVEL_BASE_BYTES);
-    // Forward: multiplied
-    assert_eq!(targets.max_bytes[4], anchor * 10); // 300 GiB
-    assert_eq!(targets.max_bytes[5], anchor * 100); // 3 TiB
-    assert_eq!(targets.max_bytes[6], anchor * 1_000); // 30 TiB
+    // base = 30GiB / 10^2 = ~307MB → clamped to MAX_BASE_BYTES (256MB)
+    assert_eq!(targets.max_bytes[1], MAX_BASE_BYTES);
+    assert_eq!(targets.max_bytes[2], MAX_BASE_BYTES * 10);
+    assert_eq!(targets.max_bytes[3], MAX_BASE_BYTES * 100);
+    assert_eq!(targets.max_bytes[4], MAX_BASE_BYTES * 1_000);
+    assert_eq!(targets.max_bytes[5], MAX_BASE_BYTES * 10_000);
+    assert_eq!(targets.max_bytes[6], MAX_BASE_BYTES * 100_000);
 }
 
 #[test]
 fn recalculate_targets_anchor_at_high_level() {
-    // Anchor at L5 — verifies backward chain across 4 levels and forward to L6.
-    let anchor: u64 = 3 * (1u64 << 40); // 3 TiB in L5 (exceeds static ~2.44 TiB)
+    // Data at L5 — verifies backward chain across 4 divisions and forward to L6.
+    let data: u64 = 3 * (1u64 << 40); // 3 TiB in L5
     let mut level_bytes = [0u64; NUM_LEVELS];
-    level_bytes[5] = anchor;
+    level_bytes[5] = data;
     let targets = recalculate_level_targets(&level_bytes);
-    assert_eq!(targets.max_bytes[5], anchor);
-    // Backward
-    assert_eq!(targets.max_bytes[4], anchor / 10);
-    assert_eq!(targets.max_bytes[3], anchor / 100);
-    assert_eq!(targets.max_bytes[2], anchor / 1_000);
-    assert_eq!(targets.max_bytes[1], anchor / 10_000);
-    // L1 should still be above LEVEL_BASE_BYTES (defensive floor)
-    assert!(targets.max_bytes[1] >= LEVEL_BASE_BYTES);
-    // Forward
-    assert_eq!(targets.max_bytes[6], anchor * 10);
+    // base = 3TiB / 10^4 = ~322MB → clamped to MAX_BASE_BYTES (256MB)
+    assert_eq!(targets.max_bytes[0], 0);
+    assert_eq!(targets.max_bytes[1], MAX_BASE_BYTES);
+    assert_eq!(targets.max_bytes[2], MAX_BASE_BYTES * 10);
+    assert_eq!(targets.max_bytes[3], MAX_BASE_BYTES * 100);
+    assert_eq!(targets.max_bytes[4], MAX_BASE_BYTES * 1_000);
+    assert_eq!(targets.max_bytes[5], MAX_BASE_BYTES * 10_000);
+    assert_eq!(targets.max_bytes[6], MAX_BASE_BYTES * 100_000);
+}
+
+#[test]
+fn recalculate_targets_tiny_db() {
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[1] = 10 << 20; // 10MB in L1
+    let targets = recalculate_level_targets(&level_bytes);
+    // base = 10MB — within [MIN, MAX], full geometric chain
+    assert_eq!(targets.max_bytes[0], 0);
+    assert_eq!(targets.max_bytes[1], 10 << 20);
+    assert_eq!(targets.max_bytes[2], (10 << 20) * 10);
+    assert_eq!(targets.max_bytes[3], (10 << 20) * 100);
+    assert_eq!(targets.max_bytes[4], (10 << 20) * 1_000);
+    assert_eq!(targets.max_bytes[5], (10 << 20) * 10_000);
+    assert_eq!(targets.max_bytes[6], (10 << 20) * 100_000);
+}
+
+#[test]
+fn recalculate_targets_sub_minimum() {
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[1] = 512 * 1024; // 512KB in L1
+    let targets = recalculate_level_targets(&level_bytes);
+    // 512KB < MIN_BASE_BYTES → clamped to 1MB, full chain from MIN
+    assert_eq!(targets.max_bytes[1], MIN_BASE_BYTES);
+    assert_eq!(targets.max_bytes[2], MIN_BASE_BYTES * 10);
+    assert_eq!(targets.max_bytes[6], MIN_BASE_BYTES * 100_000);
+}
+
+#[test]
+fn recalculate_targets_multi_level_data() {
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[1] = 200 << 20; // 200MB
+    level_bytes[2] = 2 << 30; // 2GB
+    level_bytes[3] = 15 << 30; // 15GB — largest non-L0 level
+    let targets = recalculate_level_targets(&level_bytes);
+    // base = 15GB / 10^2 = ~153MB → within [MIN, MAX] range
+    let expected_base: u64 = (15u64 << 30) / 100;
+    assert_eq!(targets.max_bytes[1], expected_base);
+    assert_eq!(targets.max_bytes[2], expected_base * 10);
+    assert_eq!(targets.max_bytes[3], expected_base * 100);
+    assert_eq!(targets.max_bytes[4], expected_base * 1_000);
+    assert_eq!(targets.max_bytes[5], expected_base * 10_000);
+    assert_eq!(targets.max_bytes[6], expected_base * 100_000);
+    // Verify L1 actual (200MB) exceeds target (~153MB) → score > 1
+    assert!(level_bytes[1] > targets.max_bytes[1]);
+}
+
+#[test]
+fn recalculate_targets_only_l0() {
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[0] = 500 << 20; // 500MB in L0 only
+    let targets = recalculate_level_targets(&level_bytes);
+    // L0 is ignored — no non-L0 data → uses MIN_BASE_BYTES
+    assert_eq!(targets.max_bytes[0], 0);
+    assert_eq!(targets.max_bytes[1], MIN_BASE_BYTES);
+    assert_eq!(targets.max_bytes[6], MIN_BASE_BYTES * 100_000);
+}
+
+#[test]
+fn recalculate_targets_empty_intermediate() {
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[4] = 100 << 30; // 100GB in L4 only (L1-L3 empty)
+    let targets = recalculate_level_targets(&level_bytes);
+    // base = 100GB / 10^3 = ~102MB
+    let expected_base: u64 = (100u64 << 30) / 1_000;
+    assert_eq!(targets.max_bytes[1], expected_base);
+    assert_eq!(targets.max_bytes[2], expected_base * 10);
+    assert_eq!(targets.max_bytes[3], expected_base * 100);
+    assert_eq!(targets.max_bytes[4], expected_base * 1_000);
+    assert_eq!(targets.max_bytes[5], expected_base * 10_000);
+    assert_eq!(targets.max_bytes[6], expected_base * 100_000);
+}
+
+#[test]
+fn recalculate_targets_data_at_l6() {
+    // L6 is the highest level — requires maximum backward divisions (5).
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[6] = 100u64 << 40; // 100 TiB in L6
+    let targets = recalculate_level_targets(&level_bytes);
+    // base = 100TiB / 10^5 = ~1.1GB → clamped to MAX_BASE_BYTES (256MB)
+    assert_eq!(targets.max_bytes[1], MAX_BASE_BYTES);
+    assert_eq!(targets.max_bytes[6], MAX_BASE_BYTES * 100_000);
+}
+
+#[test]
+fn recalculate_targets_data_at_l6_unclamped() {
+    // L6 with a value small enough that base stays within [MIN, MAX]
+    // 10^5 * 100MB = 10TB at L6 → base = 10TB / 10^5 = 100MB
+    let data: u64 = 10u64 * (1u64 << 40); // 10 TiB
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[6] = data;
+    let targets = recalculate_level_targets(&level_bytes);
+    let expected_base = data / 100_000;
+    assert!(expected_base > MIN_BASE_BYTES && expected_base < MAX_BASE_BYTES);
+    assert_eq!(targets.max_bytes[1], expected_base);
+    assert_eq!(targets.max_bytes[2], expected_base * 10);
+    assert_eq!(targets.max_bytes[6], expected_base * 100_000);
+}
+
+#[test]
+fn recalculate_targets_lower_level_dominates() {
+    // L2 has more data than L5 — the algorithm should pick L2 as the
+    // bottom level (largest by bytes), not L5 (highest by index).
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[2] = 50 << 30; // 50GB in L2
+    level_bytes[5] = 1 << 30; // 1GB in L5
+    let targets = recalculate_level_targets(&level_bytes);
+    // base = 50GB / 10^1 = 5GB → clamped to MAX_BASE_BYTES (256MB)
+    assert_eq!(targets.max_bytes[1], MAX_BASE_BYTES);
+    // L2 actual (50GB) vs target (2.56GB) → score ~19.5 → aggressive compaction
+    assert!(level_bytes[2] as f64 / targets.max_bytes[2] as f64 > 10.0);
+}
+
+#[test]
+fn recalculate_targets_base_exactly_at_min() {
+    // Construct a case where the computed base equals MIN_BASE_BYTES exactly.
+    // Data at L1 = 1MB → base = 1MB = MIN_BASE_BYTES.
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[1] = MIN_BASE_BYTES;
+    let targets = recalculate_level_targets(&level_bytes);
+    assert_eq!(targets.max_bytes[1], MIN_BASE_BYTES);
+}
+
+#[test]
+fn recalculate_targets_base_exactly_at_max() {
+    // Data at L1 = 256MB → base = 256MB = MAX_BASE_BYTES.
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[1] = MAX_BASE_BYTES;
+    let targets = recalculate_level_targets(&level_bytes);
+    assert_eq!(targets.max_bytes[1], MAX_BASE_BYTES);
+    assert_eq!(targets.max_bytes[2], MAX_BASE_BYTES * 10);
+}
+
+#[test]
+fn recalculate_targets_base_just_above_max_clamps() {
+    // Data at L1 = 300MB → base = 300MB > MAX_BASE_BYTES → clamped to 256MB.
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[1] = 300 << 20;
+    let targets = recalculate_level_targets(&level_bytes);
+    assert_eq!(targets.max_bytes[1], MAX_BASE_BYTES);
+}
+
+#[test]
+fn recalculate_targets_score_meaningful_for_small_db() {
+    // The motivating scenario: 10MB in L1 should produce score ~1.0,
+    // not 0.04 (which is what the old 256MB static target produced).
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[1] = 10 << 20; // 10MB
+    let targets = recalculate_level_targets(&level_bytes);
+    let score = level_bytes[1] as f64 / targets.max_bytes[1] as f64;
+    assert!(
+        (score - 1.0).abs() < 0.01,
+        "10MB in L1 should produce score ~1.0, got {}",
+        score
+    );
 }
 
 #[test]
@@ -3616,7 +3772,7 @@ fn compute_scores_l0_count() {
     let scores = store.compute_compaction_scores(&b);
     let l0 = scores.iter().find(|s| s.level == 0).unwrap();
     assert!((l0.score - 0.75).abs() < 0.01);
-    // L1-L5 scores should be ~0 (tiny data vs 256MB+ targets)
+    // L1-L5 scores should be ~0 (no data in L1+ yet, all data is in L0)
     for cs in scores.iter().filter(|s| s.level > 0) {
         assert!(
             cs.score < 0.01,


### PR DESCRIPTION
## Summary
- Implement RocksDB's `CalculateBaseBytes` algorithm to derive per-level byte targets from actual data sizes, scaling DOWN for small datasets instead of using static 256MB baselines
- Cache level targets in `BranchState` and recompute after every flush, compaction, and recovery to avoid redundant recalculation during scoring
- Add `MIN_BASE_BYTES` (1MB) and `MAX_BASE_BYTES` (256MB) constants to clamp the computed base

## Motivation
For small datasets (e.g. 10MB in L1), the old static 256MB target produced a compaction score of 0.04 — compaction never triggered, causing ~5x space amplification. With dynamic sizing, 10MB in L1 now produces score ~1.0, making compaction viable on embedded targets like Raspberry Pi Zero.

## Test plan
- [x] Updated 4 existing `recalculate_targets_*` tests for new dynamic behavior
- [x] Added 12 new tests covering: tiny DBs, sub-minimum clamping, multi-level data, L0-only, empty intermediate levels, L6 max divisions, lower-level-dominates, boundary values (exactly at min/max), and the motivating score scenario
- [x] `cargo test -p strata-storage` — 449 tests pass
- [x] `cargo clippy -p strata-storage` — no warnings
- [x] `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)