### PR TITLE
Token-bucket compaction rate limiter (Epic 34)

### DIFF
--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -23,6 +23,7 @@ pub mod memory_stats;
 pub mod memtable;
 pub mod merge_iter;
 pub mod pressure;
+pub mod rate_limiter;
 pub mod segment;
 pub mod segment_builder;
 pub mod segmented;
@@ -34,6 +35,7 @@ pub use compaction::{CompactionIterator, CompactionScheduler, TierMergeCandidate
 pub use index::{BranchIndex, TypeIndex};
 pub use memory_stats::{BranchMemoryStats, StorageMemoryStats};
 pub use pressure::{MemoryPressure, PressureLevel};
+pub use rate_limiter::RateLimiter;
 pub use segment::{KVSegment, OwnedSegmentIter};
 pub use segment_builder::{CompressionCodec, SegmentBuilder, SegmentMeta, SplittingSegmentBuilder};
 pub use segmented::{CompactionResult, PickAndCompactResult, SegmentedStore};

--- a/crates/storage/src/rate_limiter.rs
+++ b/crates/storage/src/rate_limiter.rs
@@ -1,0 +1,221 @@
+//! Token-bucket rate limiter for compaction I/O throttling.
+//!
+//! Tokens represent bytes. The bucket refills continuously at
+//! `rate_bytes_per_sec` and is capped at one second of burst (i.e. the
+//! bucket never exceeds `rate_bytes_per_sec` tokens). When a caller
+//! acquires more bytes than available the bucket goes negative and the
+//! caller sleeps for the deficit duration *outside* the lock.
+
+use parking_lot::Mutex;
+use std::time::Instant;
+
+/// A token-bucket rate limiter that throttles I/O to a configurable bytes/sec ceiling.
+pub struct RateLimiter {
+    rate_bytes_per_sec: u64,
+    state: Mutex<RateLimiterState>,
+}
+
+struct RateLimiterState {
+    available_bytes: i64,
+    last_refill: Instant,
+}
+
+impl RateLimiter {
+    /// Create a new rate limiter with the given throughput ceiling.
+    ///
+    /// `rate_bytes_per_sec` must be > 0.
+    pub fn new(rate_bytes_per_sec: u64) -> Self {
+        assert!(rate_bytes_per_sec > 0, "rate must be > 0");
+        Self {
+            rate_bytes_per_sec,
+            state: Mutex::new(RateLimiterState {
+                available_bytes: rate_bytes_per_sec as i64,
+                last_refill: Instant::now(),
+            }),
+        }
+    }
+
+    /// Return the configured rate in bytes per second.
+    pub fn rate_bytes_per_sec(&self) -> u64 {
+        self.rate_bytes_per_sec
+    }
+
+    /// Acquire `bytes` tokens. If the bucket is exhausted, the calling
+    /// thread sleeps until enough tokens have been refilled.
+    ///
+    /// The lock is held only for the arithmetic — sleep happens outside
+    /// the lock so other threads are not blocked.
+    pub fn acquire(&self, bytes: u64) {
+        if bytes == 0 {
+            return;
+        }
+        let sleep_duration = {
+            let mut state = self.state.lock();
+            let now = Instant::now();
+            let elapsed = now.duration_since(state.last_refill);
+            let refill = (elapsed.as_secs_f64() * self.rate_bytes_per_sec as f64) as i64;
+            if refill > 0 {
+                state.available_bytes =
+                    (state.available_bytes + refill).min(self.rate_bytes_per_sec as i64);
+                state.last_refill = now;
+            }
+            state.available_bytes -= bytes as i64;
+            if state.available_bytes < 0 {
+                let deficit = (-state.available_bytes) as f64;
+                Some(std::time::Duration::from_secs_f64(
+                    deficit / self.rate_bytes_per_sec as f64,
+                ))
+            } else {
+                None
+            }
+        }; // lock dropped
+
+        if let Some(d) = sleep_duration {
+            std::thread::sleep(d);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn acquire_within_budget_no_sleep() {
+        let limiter = RateLimiter::new(1_000_000); // 1MB/s
+        let start = Instant::now();
+        limiter.acquire(100); // tiny request
+        assert!(start.elapsed() < Duration::from_millis(50));
+    }
+
+    #[test]
+    fn acquire_over_budget_sleeps() {
+        // 100KB/s — exhaust the budget then acquire more
+        let limiter = RateLimiter::new(100_000);
+        limiter.acquire(100_000);
+        let start = Instant::now();
+        limiter.acquire(50_000); // should sleep ~0.5s
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(400),
+            "expected >=400ms sleep, got {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed < Duration::from_millis(1500),
+            "expected <1500ms sleep, got {:?}",
+            elapsed
+        );
+    }
+
+    #[test]
+    fn burst_cap_prevents_accumulation() {
+        let limiter = RateLimiter::new(100_000); // 100KB/s, burst cap = 100KB
+
+        // Drain the budget completely
+        limiter.acquire(100_000);
+
+        // Idle 3 seconds. Without burst cap, 300KB would accumulate.
+        // With burst cap, only 100KB (1 second's worth) should be available.
+        std::thread::sleep(Duration::from_secs(3));
+
+        // Acquire 100KB — should succeed without sleeping (1s burst available)
+        let start = Instant::now();
+        limiter.acquire(100_000);
+        assert!(
+            start.elapsed() < Duration::from_millis(100),
+            "first acquire after idle should not sleep"
+        );
+
+        // Budget is now ~0. If burst cap was broken and 300KB had accumulated,
+        // there would still be ~200KB left and this wouldn't sleep.
+        // With correct cap (100KB), budget is ~0 and this should sleep ~500ms.
+        let start2 = Instant::now();
+        limiter.acquire(50_000);
+        assert!(
+            start2.elapsed() >= Duration::from_millis(400),
+            "second acquire should sleep ~500ms, got {:?}",
+            start2.elapsed()
+        );
+    }
+
+    #[test]
+    fn rate_bytes_per_sec_getter() {
+        let limiter = RateLimiter::new(42);
+        assert_eq!(limiter.rate_bytes_per_sec(), 42);
+    }
+
+    #[test]
+    fn multiple_acquires_accumulate() {
+        // 100KB/s — drain budget in small chunks
+        let limiter = RateLimiter::new(100_000);
+        for _ in 0..10 {
+            limiter.acquire(10_000);
+        }
+        // Budget should be ~0 now, next acquire should sleep
+        let start = Instant::now();
+        limiter.acquire(50_000);
+        assert!(
+            start.elapsed() >= Duration::from_millis(400),
+            "expected sleep after budget drained"
+        );
+    }
+
+    #[test]
+    fn acquire_zero_is_noop() {
+        let limiter = RateLimiter::new(100);
+        // Exhaust budget
+        limiter.acquire(100);
+        // acquire(0) should return immediately even though budget is exhausted
+        let start = Instant::now();
+        limiter.acquire(0);
+        assert!(start.elapsed() < Duration::from_millis(10));
+    }
+
+    #[test]
+    fn large_single_acquire_sleeps_proportionally() {
+        // Acquire more than the burst cap in one shot — should sleep for the deficit.
+        let limiter = RateLimiter::new(100_000); // 100KB/s, burst = 100KB
+        let start = Instant::now();
+        // Acquire 200KB: budget starts at 100KB, goes to -100KB, sleep = 1s
+        limiter.acquire(200_000);
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(800),
+            "expected ~1s sleep for 200KB at 100KB/s, got {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed < Duration::from_millis(2000),
+            "sleep too long: {:?}",
+            elapsed
+        );
+    }
+
+    #[test]
+    fn concurrent_threads_share_limiter() {
+        use std::sync::Arc;
+        use std::thread;
+
+        // 100KB/s — two threads each acquire 100KB, so the second must wait
+        let limiter = Arc::new(RateLimiter::new(100_000));
+        let l1 = Arc::clone(&limiter);
+        let l2 = Arc::clone(&limiter);
+
+        let start = Instant::now();
+        let t1 = thread::spawn(move || l1.acquire(100_000));
+        let t2 = thread::spawn(move || l2.acquire(100_000));
+        t1.join().unwrap();
+        t2.join().unwrap();
+        let elapsed = start.elapsed();
+
+        // One thread gets the full budget, the other must sleep ~1s.
+        // Total wall-clock should be at least ~800ms (one thread sleeps).
+        assert!(
+            elapsed >= Duration::from_millis(700),
+            "expected concurrent contention sleep, got {:?}",
+            elapsed
+        );
+    }
+}

--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -922,6 +922,13 @@ impl OwnedSegmentIter {
     }
 }
 
+impl OwnedSegmentIter {
+    /// Return the current data block index (used by `ThrottledSegmentIter`).
+    pub(crate) fn current_block_idx(&self) -> usize {
+        self.block_idx
+    }
+}
+
 impl Iterator for OwnedSegmentIter {
     type Item = (InternalKey, SegmentEntry);
 
@@ -995,6 +1002,47 @@ impl Iterator for OwnedSegmentIter {
 }
 
 // ---------------------------------------------------------------------------
+// ThrottledSegmentIter — rate-limited wrapper for compaction reads
+// ---------------------------------------------------------------------------
+
+/// Wraps an [`OwnedSegmentIter`] and charges a [`RateLimiter`] each time a
+/// new data block is loaded. Used during compaction to throttle read I/O.
+pub(crate) struct ThrottledSegmentIter {
+    inner: OwnedSegmentIter,
+    limiter: std::sync::Arc<crate::rate_limiter::RateLimiter>,
+    last_block_idx: usize,
+}
+
+impl ThrottledSegmentIter {
+    pub(crate) fn new(
+        inner: OwnedSegmentIter,
+        limiter: std::sync::Arc<crate::rate_limiter::RateLimiter>,
+    ) -> Self {
+        Self {
+            // Use usize::MAX so the first block load (block_idx == 0) is charged.
+            last_block_idx: usize::MAX,
+            inner,
+            limiter,
+        }
+    }
+}
+
+impl Iterator for ThrottledSegmentIter {
+    type Item = (InternalKey, SegmentEntry);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let result = self.inner.next()?;
+        let cur = self.inner.current_block_idx();
+        if cur != self.last_block_idx {
+            // Charge ~64 KiB per block transition (matches default data_block_size).
+            self.limiter.acquire(64 * 1024);
+            self.last_block_idx = cur;
+        }
+        Some(result)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -1025,6 +1073,7 @@ mod tests {
             data_block_size: 256,
             bloom_bits_per_key: 10,
             compression: crate::segment_builder::CompressionCodec::default(),
+            rate_limiter: None,
         };
         builder.build_from_iter(mt.iter_all(), path).unwrap();
     }
@@ -1492,6 +1541,7 @@ mod tests {
             data_block_size: 4096,
             bloom_bits_per_key: 10,
             compression: crate::segment_builder::CompressionCodec::default(),
+            rate_limiter: None,
         };
         builder.build_from_iter(mt.iter_all(), &path).unwrap();
 
@@ -1642,6 +1692,7 @@ mod tests {
             data_block_size: 4096,
             bloom_bits_per_key: 10,
             compression: crate::segment_builder::CompressionCodec::default(),
+            rate_limiter: None,
         };
         let meta = builder.build_from_iter(mt.iter_all(), &path).unwrap();
         assert_eq!(meta.entry_count, 200);

--- a/crates/storage/src/segment_builder.rs
+++ b/crates/storage/src/segment_builder.rs
@@ -113,6 +113,8 @@ pub struct SegmentBuilder {
     pub bloom_bits_per_key: usize,
     /// Compression codec for data blocks.
     pub compression: CompressionCodec,
+    /// Optional rate limiter for throttling data block writes (compaction).
+    pub rate_limiter: Option<std::sync::Arc<crate::rate_limiter::RateLimiter>>,
 }
 
 impl Default for SegmentBuilder {
@@ -121,6 +123,7 @@ impl Default for SegmentBuilder {
             data_block_size: 64 * 1024, // 64 KiB
             bloom_bits_per_key: 10,
             compression: CompressionCodec::default(),
+            rate_limiter: None,
         }
     }
 }
@@ -135,6 +138,15 @@ impl SegmentBuilder {
     /// Set the compression codec for data blocks.
     pub fn with_compression(mut self, codec: CompressionCodec) -> Self {
         self.compression = codec;
+        self
+    }
+
+    /// Set a rate limiter for throttling data block writes during compaction.
+    pub fn with_rate_limiter(
+        mut self,
+        limiter: std::sync::Arc<crate::rate_limiter::RateLimiter>,
+    ) -> Self {
+        self.rate_limiter = Some(limiter);
         self
     }
 
@@ -264,6 +276,9 @@ impl SegmentBuilder {
                     self.compression,
                 )?;
                 let on_disk_data_len = (framed_size - BLOCK_FRAME_OVERHEAD) as u32;
+                if let Some(ref limiter) = self.rate_limiter {
+                    limiter.acquire(framed_size as u64);
+                }
                 pending_index = Some((block_last, file_offset, on_disk_data_len));
                 file_offset += framed_size as u64;
                 block_buf.clear();
@@ -306,6 +321,9 @@ impl SegmentBuilder {
                 self.compression,
             )?;
             let on_disk_data_len = (framed_size - BLOCK_FRAME_OVERHEAD) as u32;
+            if let Some(ref limiter) = self.rate_limiter {
+                limiter.acquire(framed_size as u64);
+            }
             let shortened = shorten_final_index_key(&block_last);
             index_entries.push((shortened, file_offset, on_disk_data_len));
             file_offset += framed_size as u64;
@@ -1728,6 +1746,7 @@ mod tests {
             data_block_size: 4096, // small blocks for test
             bloom_bits_per_key: 10,
             compression: CompressionCodec::default(),
+            rate_limiter: None,
         };
         let meta = builder.build_from_iter(mt.iter_all(), &path).unwrap();
         assert_eq!(meta.entry_count, 2000);
@@ -1881,6 +1900,7 @@ mod tests {
             data_block_size: 4096,
             bloom_bits_per_key: 10,
             compression: CompressionCodec::default(),
+            rate_limiter: None,
         };
         let meta = builder.build_from_iter(mt.iter_all(), &path).unwrap();
         assert_eq!(meta.entry_count, 500);
@@ -2535,6 +2555,7 @@ mod tests {
             data_block_size: 512,
             bloom_bits_per_key: 10,
             compression: CompressionCodec::default(),
+            rate_limiter: None,
         };
         builder.build_from_iter(mt.iter_all(), &path).unwrap();
 
@@ -2568,6 +2589,7 @@ mod tests {
             data_block_size: 512,
             bloom_bits_per_key: 10,
             compression: CompressionCodec::default(),
+            rate_limiter: None,
         };
         builder.build_from_iter(mt.iter_all(), &path).unwrap();
 
@@ -2624,6 +2646,7 @@ mod tests {
             data_block_size: 512,
             bloom_bits_per_key: 10,
             compression: CompressionCodec::default(),
+            rate_limiter: None,
         };
         builder.build_from_iter(mt.iter_all(), &path).unwrap();
 
@@ -2674,6 +2697,7 @@ mod tests {
             data_block_size: 512,
             bloom_bits_per_key: 10,
             compression: CompressionCodec::default(),
+            rate_limiter: None,
         };
 
         let path_v3 = dir.path().join("full_keys.sst");
@@ -2724,6 +2748,7 @@ mod tests {
             data_block_size: 512,
             bloom_bits_per_key: 10,
             compression: CompressionCodec::None,
+            rate_limiter: None,
         };
         builder_none
             .build_from_iter(mt.iter_all(), &path_none)
@@ -2733,6 +2758,7 @@ mod tests {
             data_block_size: 512,
             bloom_bits_per_key: 10,
             compression: CompressionCodec::Zstd(3),
+            rate_limiter: None,
         };
         builder_zstd
             .build_from_iter(mt.iter_all(), &path_zstd)
@@ -2791,6 +2817,7 @@ mod tests {
                 data_block_size: 512,
                 bloom_bits_per_key: 10,
                 compression: CompressionCodec::Zstd(zstd_level),
+                rate_limiter: None,
             };
             builder.build_from_iter(mt.iter_all(), &path).unwrap();
 
@@ -2835,6 +2862,7 @@ mod tests {
                 data_block_size: 512,
                 bloom_bits_per_key: 10,
                 compression: CompressionCodec::Zstd(zstd_level),
+                rate_limiter: None,
             };
             builder.build_from_iter(mt.iter_all(), &path).unwrap();
             sizes.push((zstd_level, std::fs::metadata(&path).unwrap().len()));
@@ -2922,6 +2950,15 @@ impl SplittingSegmentBuilder {
     /// Set the compression codec for output segments.
     pub fn with_compression(mut self, codec: CompressionCodec) -> Self {
         self.inner.compression = codec;
+        self
+    }
+
+    /// Set a rate limiter for throttling data block writes during compaction.
+    pub fn with_rate_limiter(
+        mut self,
+        limiter: std::sync::Arc<crate::rate_limiter::RateLimiter>,
+    ) -> Self {
+        self.inner.rate_limiter = Some(limiter);
         self
     }
 

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -195,15 +195,19 @@ impl SegmentedStore {
         let seg_path = branch_dir.join(format!("{}.sst", seg_id));
 
         // Build streaming source iterators from each segment.
-        let sources = streaming_sources(&old_segments);
+        let limiter = self.compaction_rate_limiter.load_full();
+        let sources = streaming_sources(&old_segments, &limiter);
 
         let merge = MergeIterator::new(sources);
         let max_versions = self.max_versions_per_key.load(Ordering::Relaxed);
         let compaction_iter =
             CompactionIterator::new(merge, prune_floor).with_max_versions(max_versions);
 
-        let builder = SegmentBuilder::default()
+        let mut builder = SegmentBuilder::default()
             .with_compression(crate::segment_builder::CompressionCodec::None);
+        if let Some(ref l) = limiter {
+            builder = builder.with_rate_limiter(Arc::clone(l));
+        }
         let meta = builder.build_from_iter(compaction_iter, &seg_path)?;
 
         // Open the newly written segment.
@@ -328,15 +332,19 @@ impl SegmentedStore {
         std::fs::create_dir_all(&branch_dir)?;
         let seg_path = branch_dir.join(format!("{}.sst", seg_id));
 
-        let sources = streaming_sources(&selected_segments);
+        let limiter = self.compaction_rate_limiter.load_full();
+        let sources = streaming_sources(&selected_segments, &limiter);
 
         let merge = MergeIterator::new(sources);
         let max_versions = self.max_versions_per_key.load(Ordering::Relaxed);
         let compaction_iter =
             CompactionIterator::new(merge, prune_floor).with_max_versions(max_versions);
 
-        let builder = SegmentBuilder::default()
+        let mut builder = SegmentBuilder::default()
             .with_compression(crate::segment_builder::CompressionCodec::None);
+        if let Some(ref l) = limiter {
+            builder = builder.with_rate_limiter(Arc::clone(l));
+        }
         let meta = builder.build_from_iter(compaction_iter, &seg_path)?;
 
         let new_segment = KVSegment::open(&seg_path)?;
@@ -494,7 +502,8 @@ impl SegmentedStore {
         all_inputs.extend(l0_segs.iter().cloned());
         all_inputs.extend(overlapping_l1.iter().cloned());
 
-        let sources = streaming_sources(&all_inputs);
+        let limiter = self.compaction_rate_limiter.load_full();
+        let sources = streaming_sources(&all_inputs, &limiter);
         let merge = MergeIterator::new(sources);
         let max_versions = self.max_versions_per_key.load(Ordering::Relaxed);
         let compaction_iter =
@@ -508,9 +517,12 @@ impl SegmentedStore {
         let next_id = &self.next_segment_id;
         let bloom_bits = super::bloom_bits_for_level(1, 10);
         let compression = super::compression_for_level(1);
-        let splitting_builder = crate::segment_builder::SplittingSegmentBuilder::default()
+        let mut splitting_builder = crate::segment_builder::SplittingSegmentBuilder::default()
             .with_bloom_bits(bloom_bits)
             .with_compression(compression);
+        if let Some(ref l) = limiter {
+            splitting_builder = splitting_builder.with_rate_limiter(Arc::clone(l));
+        }
         let outputs = splitting_builder.build_split(compaction_iter, |_split_idx| {
             let id = next_id.fetch_add(1, Ordering::Relaxed);
             branch_dir.join(format!("{}.sst", id))
@@ -722,7 +734,8 @@ impl SegmentedStore {
         all_inputs.extend(input_segs.iter().cloned());
         all_inputs.extend(overlap_segs.iter().cloned());
 
-        let sources = streaming_sources(&all_inputs);
+        let limiter = self.compaction_rate_limiter.load_full();
+        let sources = streaming_sources(&all_inputs, &limiter);
         let merge = MergeIterator::new(sources);
         let max_versions = self.max_versions_per_key.load(Ordering::Relaxed);
         let compaction_iter =
@@ -735,9 +748,12 @@ impl SegmentedStore {
         let next_id = &self.next_segment_id;
         let bloom_bits = super::bloom_bits_for_level(level + 1, 10);
         let compression = super::compression_for_level(level + 1);
-        let splitting_builder = crate::segment_builder::SplittingSegmentBuilder::default()
+        let mut splitting_builder = crate::segment_builder::SplittingSegmentBuilder::default()
             .with_bloom_bits(bloom_bits)
             .with_compression(compression);
+        if let Some(ref l) = limiter {
+            splitting_builder = splitting_builder.with_rate_limiter(Arc::clone(l));
+        }
 
         // Build grandparent-aware split predicate.
         //
@@ -845,13 +861,21 @@ impl SegmentedStore {
 
 fn streaming_sources(
     segments: &[Arc<KVSegment>],
+    rate_limiter: &Option<Arc<crate::rate_limiter::RateLimiter>>,
 ) -> Vec<Box<dyn Iterator<Item = (InternalKey, MemtableEntry)>>> {
     segments
         .iter()
         .map(|seg| {
-            let iter = crate::segment::OwnedSegmentIter::new(Arc::clone(seg));
-            Box::new(iter.map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se))))
-                as Box<dyn Iterator<Item = (InternalKey, MemtableEntry)>>
+            let owned = crate::segment::OwnedSegmentIter::new(Arc::clone(seg));
+            if let Some(ref limiter) = rate_limiter {
+                let throttled =
+                    crate::segment::ThrottledSegmentIter::new(owned, Arc::clone(limiter));
+                Box::new(throttled.map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se))))
+                    as Box<dyn Iterator<Item = (InternalKey, MemtableEntry)>>
+            } else {
+                Box::new(owned.map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se))))
+                    as Box<dyn Iterator<Item = (InternalKey, MemtableEntry)>>
+            }
         })
         .collect()
 }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -251,6 +251,8 @@ pub struct SegmentedStore {
     total_frozen_count: AtomicUsize,
     /// Maximum frozen memtables per branch before rotation is skipped (0 = unlimited).
     max_immutable_memtables: AtomicUsize,
+    /// Optional rate limiter for compaction I/O (read + write).
+    compaction_rate_limiter: arc_swap::ArcSwapOption<crate::rate_limiter::RateLimiter>,
 }
 
 impl SegmentedStore {
@@ -271,6 +273,7 @@ impl SegmentedStore {
             max_versions_per_key: AtomicUsize::new(0),
             total_frozen_count: AtomicUsize::new(0),
             max_immutable_memtables: AtomicUsize::new(0),
+            compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
         }
     }
 
@@ -292,6 +295,7 @@ impl SegmentedStore {
             max_versions_per_key: AtomicUsize::new(0),
             total_frozen_count: AtomicUsize::new(0),
             max_immutable_memtables: AtomicUsize::new(0),
+            compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
         }
     }
 
@@ -313,6 +317,7 @@ impl SegmentedStore {
             max_versions_per_key: AtomicUsize::new(0),
             total_frozen_count: AtomicUsize::new(0),
             max_immutable_memtables: AtomicUsize::new(0),
+            compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
         }
     }
 
@@ -340,6 +345,21 @@ impl SegmentedStore {
     /// Set version (used during recovery).
     pub fn set_version(&self, version: u64) {
         self.version.store(version, Ordering::Release);
+    }
+
+    /// Set (or clear) the compaction I/O rate limit.
+    ///
+    /// When `bytes_per_sec > 0`, compaction reads and writes are throttled to
+    /// at most that rate. When `bytes_per_sec == 0`, the rate limiter is
+    /// removed and compaction runs at full speed (the default).
+    pub fn set_compaction_rate_limit(&self, bytes_per_sec: u64) {
+        if bytes_per_sec == 0 {
+            self.compaction_rate_limiter.store(None);
+        } else {
+            self.compaction_rate_limiter.store(Some(std::sync::Arc::new(
+                crate::rate_limiter::RateLimiter::new(bytes_per_sec),
+            )));
+        }
     }
 
     /// Iterate over all branch IDs that have data.

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -3889,3 +3889,188 @@ fn compression_for_level_returns_expected_codecs() {
     assert_eq!(compression_for_level(6), CompressionCodec::Zstd(6));
     assert_eq!(compression_for_level(7), CompressionCodec::Zstd(6));
 }
+
+// ===== Rate limiter integration tests =====
+
+/// Helper: write many keys to produce multi-block segments (each ~64KiB block).
+/// Writes `count` keys with 1KiB values so ~64 keys per block.
+fn seed_many(store: &SegmentedStore, prefix: &str, count: usize, version: u64) {
+    let big_value = Value::Bytes(vec![0xAB; 1024]);
+    for i in 0..count {
+        seed(
+            store,
+            kv_key(&format!("{}{:06}", prefix, i)),
+            big_value.clone(),
+            version,
+        );
+    }
+}
+
+#[test]
+fn compaction_with_rate_limiter_multi_block() {
+    // Write enough data to span multiple data blocks (64KiB each),
+    // so the rate limiter is actually invoked for block transitions on
+    // both the read and write paths.
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    store.set_compaction_rate_limit(50 * 1024 * 1024); // 50 MB/s (fast enough to not stall)
+
+    // ~200 keys × 1KiB ≈ 200KiB → ~3 data blocks per segment
+    seed_many(&store, "a", 200, 1);
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+
+    seed_many(&store, "b", 200, 2);
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+
+    assert_eq!(store.branch_segment_count(&b), 2);
+
+    let result = store.compact_branch(&b, 0).unwrap().unwrap();
+    assert_eq!(result.segments_merged, 2);
+    assert_eq!(result.output_entries, 400);
+    assert_eq!(result.entries_pruned, 0);
+    assert_eq!(store.branch_segment_count(&b), 1);
+
+    // Verify data integrity: spot-check first, last, and middle keys
+    assert!(store
+        .get_versioned(&kv_key("a000000"), u64::MAX)
+        .unwrap()
+        .is_some());
+    assert!(store
+        .get_versioned(&kv_key("a000199"), u64::MAX)
+        .unwrap()
+        .is_some());
+    assert!(store
+        .get_versioned(&kv_key("b000100"), u64::MAX)
+        .unwrap()
+        .is_some());
+    assert!(store
+        .get_versioned(&kv_key("b000199"), u64::MAX)
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn rate_limiter_disabled_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    // No rate limiter set — compaction should work normally
+    seed_many(&store, "x", 100, 1);
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+
+    seed_many(&store, "y", 100, 2);
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+
+    let result = store.compact_branch(&b, 0).unwrap().unwrap();
+    assert_eq!(result.segments_merged, 2);
+    assert_eq!(result.output_entries, 200);
+
+    assert!(store
+        .get_versioned(&kv_key("x000000"), u64::MAX)
+        .unwrap()
+        .is_some());
+    assert!(store
+        .get_versioned(&kv_key("y000099"), u64::MAX)
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn set_compaction_rate_limit_zero_disables() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    // Enable then disable
+    store.set_compaction_rate_limit(1_000_000);
+    store.set_compaction_rate_limit(0);
+
+    seed_many(&store, "z", 100, 1);
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+
+    seed_many(&store, "w", 100, 2);
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+
+    // Compaction with no limiter should complete quickly and correctly
+    let result = store.compact_branch(&b, 0).unwrap().unwrap();
+    assert_eq!(result.segments_merged, 2);
+    assert_eq!(result.output_entries, 200);
+}
+
+#[test]
+fn rate_limiter_l0_to_l1_compaction() {
+    // Verify the rate limiter is threaded through the L0→L1 path.
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    store.set_compaction_rate_limit(50 * 1024 * 1024);
+
+    for i in 0..4 {
+        seed_many(&store, &format!("l0seg{}", i), 50, (i + 1) as u64);
+        store.rotate_memtable(&b);
+        store.flush_oldest_frozen(&b).unwrap();
+    }
+
+    let result = store.compact_l0_to_l1(&b, 0).unwrap().unwrap();
+    assert_eq!(result.segments_merged, 4);
+    assert_eq!(result.output_entries, 200);
+
+    // Spot-check data after L0→L1 compaction
+    assert!(store
+        .get_versioned(&kv_key("l0seg0000000"), u64::MAX)
+        .unwrap()
+        .is_some());
+    assert!(store
+        .get_versioned(&kv_key("l0seg3000049"), u64::MAX)
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn rate_limited_compaction_preserves_prune_semantics() {
+    // Verify that version pruning still works correctly with the limiter active.
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    store.set_compaction_rate_limit(50 * 1024 * 1024);
+
+    // Write two versions of the same keys (v1 and v5)
+    seed_many(&store, "k", 100, 1);
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+
+    seed_many(&store, "k", 100, 5);
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+
+    // prune_floor=6: both v1 and v5 are below floor.
+    // Only the newest below-floor version (v5) survives per key; v1 is pruned.
+    let result = store.compact_branch(&b, 6).unwrap().unwrap();
+    assert_eq!(result.segments_merged, 2);
+    assert_eq!(result.output_entries, 100); // only v5 per key survives
+    assert_eq!(result.entries_pruned, 100);
+
+    // Version 5 still readable
+    let val = store
+        .get_versioned(&kv_key("k000050"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val.version.as_u64(), 5);
+
+    // Version 1 was pruned
+    assert!(store
+        .get_versioned(&kv_key("k000050"), 1)
+        .unwrap()
+        .is_none());
+}


### PR DESCRIPTION
## Summary

- Add a token-bucket `RateLimiter` (`crates/storage/src/rate_limiter.rs`) that throttles compaction I/O to a configurable bytes/sec ceiling, preventing disk bandwidth saturation and user-read latency spikes
- **Read throttling:** `ThrottledSegmentIter` wraps `OwnedSegmentIter` during compaction, charging ~64KiB per data block transition
- **Write throttling:** `SegmentBuilder` charges the actual framed block size after each data block write
- Limiter stored as `ArcSwapOption<RateLimiter>` on `SegmentedStore`, threaded through all 4 compaction methods (`compact_branch`, `compact_tier`, `compact_l0_to_l1`, `compact_level`)
- Default: `None` (unlimited, fully backward compatible). Configurable via `set_compaction_rate_limit(bytes_per_sec)`

## Files changed

| File | Change |
|------|--------|
| `rate_limiter.rs` | **New** — Token-bucket with mutex-guarded state, sleep-outside-lock design |
| `lib.rs` | Register module + re-export |
| `segment.rs` | `current_block_idx()` accessor on `OwnedSegmentIter`; `ThrottledSegmentIter` wrapper |
| `segment_builder.rs` | `rate_limiter` field + `with_rate_limiter()` on both builders; `acquire()` after data block writes |
| `segmented/mod.rs` | `compaction_rate_limiter` field in `SegmentedStore` (3 constructors); `set_compaction_rate_limit()` |
| `segmented/compaction.rs` | Updated `streaming_sources()` + all 4 compaction methods to thread limiter |
| `segmented/tests.rs` | 6 integration tests (multi-block, default-disabled, enable/disable, L0→L1, prune semantics) |

## Test plan

- [x] `cargo test -p strata-storage` — 462 tests pass
- [x] `cargo clippy -p strata-storage` — 0 warnings
- [x] `cargo fmt` — clean
- [x] Unit tests: budget/no-sleep, over-budget/sleep, burst cap prevention, acquire(0) no-op, large single acquire, concurrent thread contention
- [x] Integration tests: multi-block compaction with limiter, disabled-by-default, enable-then-disable, L0→L1 path, prune semantics preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)