### PR TITLE
Fix #1602-#1605: version leak metric, put/CAS guard, assert_read

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -82,6 +82,10 @@ pub struct TransactionManager {
     /// Using per-branch locks allows parallel commits for different branches while
     /// still preventing TOCTOU within each branch.
     commit_locks: DashMap<BranchId, Mutex<()>>,
+    /// Count of versions allocated but never committed (e.g., WAL write failure
+    /// after `allocate_version()`). Useful for disk-pressure alerts.
+    /// Uses Relaxed ordering — purely observational metric.
+    leaked_versions: AtomicU64,
 }
 
 impl TransactionManager {
@@ -107,7 +111,13 @@ impl TransactionManager {
             // Start next_txn_id at max_txn_id + 1 to avoid conflicts
             next_txn_id: AtomicU64::new(max_txn_id + 1),
             commit_locks: DashMap::new(),
+            leaked_versions: AtomicU64::new(0),
         }
+    }
+
+    /// Number of versions allocated but never committed.
+    pub fn leaked_versions(&self) -> u64 {
+        self.leaked_versions.load(Ordering::Relaxed)
     }
 
     /// Get current global version
@@ -282,6 +292,7 @@ impl TransactionManager {
                     txn.status = TransactionStatus::Aborted {
                         reason: format!("WAL write failed: {}", e),
                     };
+                    self.leaked_versions.fetch_add(1, Ordering::Relaxed);
                     return Err(CommitError::WALError(e.to_string()));
                 }
 
@@ -309,6 +320,7 @@ impl TransactionManager {
                 txn.status = TransactionStatus::Aborted {
                     reason: format!("Storage application failed: {}", e),
                 };
+                self.leaked_versions.fetch_add(1, Ordering::Relaxed);
                 return Err(CommitError::WALError(format!(
                     "Storage application failed (no WAL): {}",
                     e
@@ -394,6 +406,7 @@ impl TransactionManager {
                             txn.status = TransactionStatus::Aborted {
                                 reason: format!("WAL write failed: {}", e),
                             };
+                            self.leaked_versions.fetch_add(1, Ordering::Relaxed);
                             return Err(CommitError::WALError(e.to_string()));
                         }
                     }
@@ -414,6 +427,7 @@ impl TransactionManager {
                     txn.status = TransactionStatus::Aborted {
                         reason: format!("Storage application failed: {}", e),
                     };
+                    self.leaked_versions.fetch_add(1, Ordering::Relaxed);
                     return Err(CommitError::WALError(format!(
                         "Storage application failed (no WAL): {}",
                         e
@@ -464,6 +478,7 @@ impl TransactionManager {
                         txn.status = TransactionStatus::Aborted {
                             reason: format!("WAL write failed: {}", e),
                         };
+                        self.leaked_versions.fetch_add(1, Ordering::Relaxed);
                         return Err(CommitError::WALError(e.to_string()));
                     }
                 }
@@ -484,6 +499,7 @@ impl TransactionManager {
                 txn.status = TransactionStatus::Aborted {
                     reason: format!("Storage application failed: {}", e),
                 };
+                self.leaked_versions.fetch_add(1, Ordering::Relaxed);
                 return Err(CommitError::WALError(format!(
                     "Storage application failed (no WAL): {}",
                     e

--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -611,6 +611,31 @@ impl TransactionContext {
         self.read_from_snapshot(key)
     }
 
+    /// Add a key to the read set without needing its value.
+    ///
+    /// Use this to protect cross-key invariants under snapshot isolation.
+    /// Write skew occurs when two transactions each read disjoint keys and
+    /// write to the other's key — both pass validation because their reads
+    /// are disjoint from each other's writes. `assert_read()` closes this
+    /// gap by adding the key to the read set, ensuring that a concurrent
+    /// write to that key triggers a validation conflict.
+    ///
+    /// # Example: Protecting "balance_a + balance_b >= 0"
+    ///
+    /// ```text
+    /// let a = txn.get(&key_a)?;
+    /// txn.assert_read(&key_b)?;      // ← prevents write skew
+    /// txn.put(key_a, new_value_a)?;
+    /// ```
+    ///
+    /// Without `assert_read(&key_b)`, a concurrent transaction could modify
+    /// `key_b` and both would commit, potentially violating the invariant.
+    pub fn assert_read(&mut self, key: &Key) -> StrataResult<()> {
+        self.ensure_active()?;
+        self.read_from_snapshot(key)?;
+        Ok(())
+    }
+
     /// Read from store and track in read_set
     ///
     /// This is the core read path that tracks reads for conflict detection.
@@ -842,7 +867,21 @@ impl TransactionContext {
     /// # Semantics
     /// - If the key was previously deleted in this txn, remove from delete_set
     /// - Add/overwrite in write_set (latest value wins)
-    /// - Writes are "blind" - no read_set entry unless you explicitly read first
+    /// - Writes are "blind" — no read_set entry unless you explicitly read first
+    ///
+    /// # Concurrency: Last-Writer-Wins
+    ///
+    /// A blind `put()` does NOT guarantee your value persists. If another
+    /// transaction also blind-writes the same key, both commit successfully
+    /// and the higher version wins at read time (last-writer-wins). Neither
+    /// transaction is notified of the other's write.
+    ///
+    /// To protect against lost updates:
+    /// - **Read-modify-write**: call `get()` before `put()` to add the key to
+    ///   the read set — a concurrent write will then cause a validation conflict.
+    /// - **Create-if-not-exists**: use `cas(key, 0, value)`.
+    /// - **Update-at-version**: use `cas(key, expected_version, value)`.
+    /// - **Cross-key invariants**: use `assert_read()` on all keys involved.
     ///
     /// # Errors
     /// Returns `StrataError::invalid_input` if transaction is not active.
@@ -870,6 +909,16 @@ impl TransactionContext {
             ));
         }
         self.check_write_limit(Some(&key))?;
+
+        // Reject if this key already has a CAS operation — mixing put and CAS
+        // on the same key is almost certainly a caller bug (CAS value would
+        // silently override the put value at commit time).
+        if self.cas_set.iter().any(|op| op.key == key) {
+            return Err(StrataError::invalid_input(format!(
+                "Cannot put() key that already has a cas() in this transaction: {:?}",
+                key
+            )));
+        }
 
         // Remove from delete_set if previously deleted in this txn
         self.delete_set.remove(&key);
@@ -981,6 +1030,15 @@ impl TransactionContext {
         }
         self.check_write_limit(None)?;
 
+        // Reject if this key already has a blind write — mixing CAS and put
+        // on the same key is almost certainly a caller bug.
+        if self.write_set.contains_key(&key) {
+            return Err(StrataError::invalid_input(format!(
+                "Cannot cas() key that already has a put() in this transaction: {:?}",
+                key
+            )));
+        }
+
         self.cas_set.push(CASOperation {
             key,
             expected_version,
@@ -1007,6 +1065,15 @@ impl TransactionContext {
             ));
         }
         self.check_write_limit(None)?;
+
+        // Reject if this key already has a blind write
+        if self.write_set.contains_key(&key) {
+            return Err(StrataError::invalid_input(format!(
+                "Cannot cas_with_read() key that already has a put() in this transaction: {:?}",
+                key
+            )));
+        }
+
         self.read_from_snapshot(&key)?;
         self.cas_set.push(CASOperation {
             key,
@@ -2353,5 +2420,118 @@ mod tests {
             txn.read_set.is_empty(),
             "read_set should be empty after scan_prefix in read-only mode"
         );
+    }
+
+    // ========================================================================
+    // put/CAS overlap detection (#1603)
+    // ========================================================================
+
+    #[test]
+    fn test_put_then_cas_same_key_rejected() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let store = empty_store();
+        let mut txn = TransactionContext::with_store(1, branch_id, store);
+
+        let key = test_key(&ns, "overlap");
+        txn.put(key.clone(), Value::Int(1)).unwrap();
+
+        let result = txn.cas(key, 0, Value::Int(2));
+        assert!(result.is_err(), "cas() after put() on same key should fail");
+        assert!(
+            format!("{}", result.unwrap_err()).contains("put()"),
+            "Error should mention conflicting put()"
+        );
+    }
+
+    #[test]
+    fn test_cas_then_put_same_key_rejected() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let store = empty_store();
+        let mut txn = TransactionContext::with_store(1, branch_id, store);
+
+        let key = test_key(&ns, "overlap");
+        txn.cas(key.clone(), 0, Value::Int(1)).unwrap();
+
+        let result = txn.put(key, Value::Int(2));
+        assert!(result.is_err(), "put() after cas() on same key should fail");
+        assert!(
+            format!("{}", result.unwrap_err()).contains("cas()"),
+            "Error should mention conflicting cas()"
+        );
+    }
+
+    #[test]
+    fn test_cas_with_read_then_put_same_key_rejected() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let key = test_key(&ns, "overlap");
+        let store = store_with_key(&key, Value::Int(42), 1);
+        let mut txn = TransactionContext::with_store(1, branch_id, store);
+
+        txn.cas_with_read(key.clone(), 1, Value::Int(99)).unwrap();
+
+        let result = txn.put(key, Value::Int(2));
+        assert!(
+            result.is_err(),
+            "put() after cas_with_read() on same key should fail"
+        );
+    }
+
+    #[test]
+    fn test_put_and_cas_different_keys_allowed() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let store = empty_store();
+        let mut txn = TransactionContext::with_store(1, branch_id, store);
+
+        let key_a = test_key(&ns, "a");
+        let key_b = test_key(&ns, "b");
+        txn.put(key_a, Value::Int(1)).unwrap();
+        txn.cas(key_b, 0, Value::Int(2)).unwrap();
+        // Different keys — should succeed
+    }
+
+    // ========================================================================
+    // assert_read for write skew protection (#1605)
+    // ========================================================================
+
+    #[test]
+    fn test_assert_read_adds_to_read_set() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let key = test_key(&ns, "guarded");
+        let store = store_with_key(&key, Value::Int(10), 5);
+        let mut txn = TransactionContext::with_store(1, branch_id, store);
+
+        assert!(txn.read_set.is_empty());
+        txn.assert_read(&key).unwrap();
+        assert_eq!(txn.read_set.len(), 1);
+        assert_eq!(*txn.read_set.get(&key).unwrap(), 5);
+    }
+
+    #[test]
+    fn test_assert_read_nonexistent_key_tracks_version_zero() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let store = empty_store();
+        let mut txn = TransactionContext::with_store(1, branch_id, store);
+
+        let key = test_key(&ns, "missing");
+        txn.assert_read(&key).unwrap();
+        assert_eq!(*txn.read_set.get(&key).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_assert_read_rejects_non_active() {
+        let ns = test_namespace();
+        let branch_id = BranchId::new();
+        let store = empty_store();
+        let mut txn = TransactionContext::with_store(1, branch_id, store);
+        txn.mark_aborted("test".to_string()).unwrap();
+
+        let key = test_key(&ns, "k1");
+        assert!(txn.assert_read(&key).is_err());
     }
 }

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -374,6 +374,7 @@ impl TransactionCoordinator {
             total_started: started,
             total_committed: committed,
             total_aborted: self.total_aborted.load(Ordering::Relaxed),
+            leaked_versions: self.manager.leaked_versions(),
             commit_rate: if started > 0 {
                 committed as f64 / started as f64
             } else {
@@ -442,6 +443,9 @@ pub struct TransactionMetrics {
     pub total_committed: u64,
     /// Total number of transactions aborted
     pub total_aborted: u64,
+    /// Versions allocated but never committed (e.g., WAL write failure after
+    /// version allocation). Non-zero values may indicate disk pressure.
+    pub leaked_versions: u64,
     /// Commit success rate (committed / started)
     pub commit_rate: f64,
 }


### PR DESCRIPTION
## Summary
- **#1602** — `leaked_versions` counter: tracks versions allocated but never committed (WAL write failure, storage apply failure). Exposed via `TransactionMetrics` for disk-pressure alerting
- **#1603** — Put/CAS overlap guard: `put()` rejects if key has pending `cas()`, and vice versa. Previously the CAS value silently overwrote the put at commit time
- **#1604** — Last-writer-wins documentation: expanded `put()` doc comments explaining blind-write concurrency semantics and listing all mitigation strategies
- **#1605** — `assert_read(key)`: adds a key to the read set without needing its value, enabling write-skew protection for cross-key invariants under snapshot isolation

## Files changed
- `crates/concurrency/src/manager.rs` — `leaked_versions` counter at all 6 post-`allocate_version` error paths
- `crates/concurrency/src/transaction.rs` — put/CAS overlap checks, `assert_read()`, LWW docs, 7 new tests
- `crates/engine/src/coordinator.rs` — `leaked_versions` field in `TransactionMetrics`

## Test plan
- [x] 106 strata-concurrency unit tests pass (7 new: 4 for put/CAS guard, 3 for assert_read)
- [x] 12 strata-concurrency doc tests pass
- [x] Full workspace test suite (598 tests) passes with zero failures
- [x] No existing tests broken by put/CAS guard (no existing code mixed put+CAS on same key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)