### PR TITLE
Epic D: Background materialization for COW inherited layers

### DIFF
--- a/crates/engine/src/branch_ops.rs
+++ b/crates/engine/src/branch_ops.rs
@@ -692,6 +692,86 @@ pub fn merge_branches(
 }
 
 // =============================================================================
+// Materialize
+// =============================================================================
+
+/// Information returned after materializing inherited layers.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct MaterializeInfo {
+    /// Branch name
+    pub branch: String,
+    /// Total entries materialized across all layers
+    pub entries_materialized: u64,
+    /// Total new segments created
+    pub segments_created: usize,
+    /// Number of inherited layers collapsed
+    pub layers_collapsed: usize,
+}
+
+/// Materialize all inherited layers of a branch.
+///
+/// Collapses inherited layers deepest-first so that each layer's data
+/// becomes "own" data before shallower layers are processed (enabling
+/// shadow detection for subsequent layers).
+///
+/// # Errors
+///
+/// - Branch does not exist
+/// - Database is ephemeral
+pub fn materialize_branch(db: &Arc<Database>, branch_name: &str) -> StrataResult<MaterializeInfo> {
+    let branch_id = resolve_and_verify(db, branch_name)?;
+    let storage = db.storage();
+
+    if !storage.has_segments_dir() {
+        return Err(StrataError::invalid_input(
+            "materialize_branch requires a disk-backed database",
+        ));
+    }
+
+    let mut total_entries = 0u64;
+    let mut total_segments = 0usize;
+    let mut layers_collapsed = 0usize;
+
+    // Loop: materialize deepest layer first
+    loop {
+        let layer_count = storage.inherited_layer_count(&branch_id);
+        if layer_count == 0 {
+            break;
+        }
+        let deepest = layer_count - 1;
+        match storage.materialize_layer(&branch_id, deepest) {
+            Ok(result) => {
+                total_entries += result.entries_materialized;
+                total_segments += result.segments_created;
+                layers_collapsed += 1;
+            }
+            Err(e) => {
+                return Err(StrataError::storage(format!(
+                    "materialize_layer failed: {}",
+                    e
+                )));
+            }
+        }
+    }
+
+    info!(
+        target: "strata::branch_ops",
+        branch = branch_name,
+        entries_materialized = total_entries,
+        segments_created = total_segments,
+        layers_collapsed,
+        "Branch materialized"
+    );
+
+    Ok(MaterializeInfo {
+        branch: branch_name.to_string(),
+        entries_materialized: total_entries,
+        segments_created: total_segments,
+        layers_collapsed,
+    })
+}
+
+// =============================================================================
 // Tests
 // =============================================================================
 
@@ -1969,5 +2049,73 @@ mod tests {
             !vec_entries.is_empty(),
             "VectorConfig should be visible through inherited layers"
         );
+    }
+
+    #[test]
+    fn test_force_materialize_all_layers() {
+        let (_temp, db) = setup_with_branch("source");
+
+        // Write data to source
+        write_kv(&db, "source", "default", "k1", Value::Int(1));
+        write_kv(&db, "source", "default", "k2", Value::Int(2));
+
+        // Fork source → dest
+        let fork_info = fork_branch(&db, "source", "dest").unwrap();
+        assert!(fork_info.fork_version.is_some());
+
+        // Verify inherited layers exist
+        let dest_id = resolve_branch_name("dest");
+        let storage = db.storage();
+        assert!(
+            storage.inherited_layer_count(&dest_id) > 0,
+            "dest should have inherited layers"
+        );
+
+        // Materialize all layers
+        let mat_info = materialize_branch(&db, "dest").unwrap();
+        assert!(mat_info.layers_collapsed > 0);
+
+        // No inherited layers remain
+        assert_eq!(storage.inherited_layer_count(&dest_id), 0);
+
+        // Data still accessible
+        let val = read_kv(&db, "dest", "default", "k1");
+        assert_eq!(val, Some(Value::Int(1)));
+        let val = read_kv(&db, "dest", "default", "k2");
+        assert_eq!(val, Some(Value::Int(2)));
+    }
+
+    #[test]
+    fn test_materialize_then_diff_merge() {
+        let (_temp, db) = setup_with_branch("source");
+
+        // Write to source
+        write_kv(&db, "source", "default", "shared", Value::Int(1));
+
+        // Fork
+        fork_branch(&db, "source", "dest").unwrap();
+
+        // Write different data to dest
+        write_kv(&db, "dest", "default", "dest_only", Value::Int(42));
+
+        // Materialize dest
+        let mat_info = materialize_branch(&db, "dest").unwrap();
+        assert!(mat_info.layers_collapsed > 0);
+
+        // Diff should still work
+        let diff = diff_branches(&db, "source", "dest").unwrap();
+        assert_eq!(
+            diff.summary.total_added, 1,
+            "dest_only should show as added in dest"
+        );
+
+        // Merge dest → source should work
+        let merge_info =
+            merge_branches(&db, "dest", "source", MergeStrategy::LastWriterWins).unwrap();
+        assert!(merge_info.keys_applied > 0);
+
+        // Source should now have dest_only
+        let val = read_kv(&db, "source", "default", "dest_only");
+        assert_eq!(val, Some(Value::Int(42)));
     }
 }

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1787,6 +1787,33 @@ impl Database {
                 }
             }
         }
+
+        // Materialize inherited layers that exceed depth limit
+        for branch_id in self.storage.branches_needing_materialization() {
+            let layer_count = self.storage.inherited_layer_count(&branch_id);
+            if layer_count > 0 {
+                let deepest = layer_count - 1;
+                match self.storage.materialize_layer(&branch_id, deepest) {
+                    Ok(result) => {
+                        tracing::info!(
+                            target: "strata::materialize",
+                            ?branch_id,
+                            entries = result.entries_materialized,
+                            segments = result.segments_created,
+                            "materialized inherited layer"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "strata::materialize",
+                            ?branch_id,
+                            error = %e,
+                            "materialization failed"
+                        );
+                    }
+                }
+            }
+        }
     }
 
     /// Apply write backpressure when memtable memory exceeds safe limits.

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -55,6 +55,9 @@ pub mod search;
 // Re-export search types at crate root for convenience
 pub use search::{SearchBudget, SearchHit, SearchMode, SearchRequest, SearchResponse, SearchStats};
 
+// Re-export branch ops types at crate root for convenience
+pub use branch_ops::MaterializeInfo;
+
 // Re-export search recovery registration
 pub use search::register_search_recovery;
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -38,5 +38,5 @@ pub use pressure::{MemoryPressure, PressureLevel};
 pub use rate_limiter::RateLimiter;
 pub use segment::{KVSegment, OwnedSegmentIter};
 pub use segment_builder::{CompressionCodec, SegmentBuilder, SegmentMeta, SplittingSegmentBuilder};
-pub use segmented::{CompactionResult, PickAndCompactResult, SegmentedStore};
+pub use segmented::{CompactionResult, MaterializeResult, PickAndCompactResult, SegmentedStore};
 pub use ttl::TTLIndex;

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -62,10 +62,13 @@ pub(super) fn recalculate_level_targets(level_bytes: &[u64; NUM_LEVELS]) -> Leve
 impl SegmentedStore {
     /// Delete a segment file if it is not referenced by any inherited layer.
     ///
-    /// Decrements the segment's refcount and deletes the file only when the
-    /// count reaches zero (or was never tracked — i.e., not shared via COW).
+    /// Checks if the segment is shared (referenced by child branches via COW
+    /// inherited layers). Shared segments are skipped — their files are only
+    /// deleted when the last child releases via `decrement` (in `clear_branch`
+    /// or `materialize_layer`). Untracked segments (not shared) are deleted
+    /// immediately.
     fn delete_segment_if_unreferenced(&self, seg: &KVSegment) {
-        if self.ref_registry.decrement(seg.file_id()) {
+        if !self.ref_registry.is_referenced(seg.file_id()) {
             crate::block_cache::global_cache().invalidate_file(seg.file_id());
             let _ = std::fs::remove_file(seg.file_path());
         }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -55,6 +55,9 @@ const LEVEL_MULTIPLIER: u64 = 10;
 /// output split.  Set to 10 × TARGET_FILE_SIZE (640MB).
 const MAX_GRANDPARENT_OVERLAP: u64 = 10 * TARGET_FILE_SIZE;
 
+/// Maximum inherited layer depth before background materialization is triggered.
+const MAX_INHERITED_LAYERS: usize = 4;
+
 /// Minimum L1 target size for dynamic level sizing (1MB).
 /// Prevents degenerate zero-size targets on tiny embedded datasets.
 const MIN_BASE_BYTES: u64 = 1 << 20;
@@ -132,6 +135,19 @@ pub struct CompactionResult {
 }
 
 // ---------------------------------------------------------------------------
+// MaterializeResult
+// ---------------------------------------------------------------------------
+
+/// Statistics returned by [`SegmentedStore::materialize_layer`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaterializeResult {
+    /// Number of entries copied from the inherited layer into own segments.
+    pub entries_materialized: u64,
+    /// Number of new segment files created (0 or 1).
+    pub segments_created: usize,
+}
+
+// ---------------------------------------------------------------------------
 // SegmentVersion
 // ---------------------------------------------------------------------------
 
@@ -185,7 +201,6 @@ enum LayerStatus {
     /// Layer is active — reads fall through to parent segments.
     Active,
     /// Materialization in progress (reset to Active on crash recovery).
-    #[allow(dead_code)] // Constructed in Epic C (COW materialization)
     Materializing,
     /// Layer has been fully materialized into own segments.
     Materialized,
@@ -417,13 +432,17 @@ impl SegmentedStore {
     }
 
     /// Remove all data for a branch, decrementing refcounts for inherited segments.
+    /// Deletes segment files when the last reference is released.
     /// Returns true if the branch existed.
     pub fn clear_branch(&self, branch_id: &BranchId) -> bool {
         if let Some((_, branch)) = self.branches.remove(branch_id) {
             for layer in &branch.inherited_layers {
                 for level in &layer.segments.levels {
                     for seg in level {
-                        self.ref_registry.decrement(seg.file_id());
+                        if self.ref_registry.decrement(seg.file_id()) {
+                            crate::block_cache::global_cache().invalidate_file(seg.file_id());
+                            let _ = std::fs::remove_file(seg.file_path());
+                        }
                     }
                 }
             }
@@ -431,6 +450,302 @@ impl SegmentedStore {
         } else {
             false
         }
+    }
+
+    /// Number of inherited layers for a branch.
+    pub fn inherited_layer_count(&self, branch_id: &BranchId) -> usize {
+        self.branches
+            .get(branch_id)
+            .map_or(0, |b| b.inherited_layers.len())
+    }
+
+    /// Return branch IDs where inherited layer depth exceeds `MAX_INHERITED_LAYERS`.
+    pub fn branches_needing_materialization(&self) -> Vec<BranchId> {
+        self.branches
+            .iter()
+            .filter_map(|entry| {
+                if entry.value().inherited_layers.len() > MAX_INHERITED_LAYERS {
+                    Some(*entry.key())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Materialize a single inherited layer into the child's own segments.
+    ///
+    /// Copies entries from `inherited_layers[layer_index]` that are not
+    /// shadowed by the child's own data or closer layers. Follows the same
+    /// snapshot → release → I/O → re-acquire pattern as `flush_oldest_frozen`.
+    ///
+    /// Returns `Err` on I/O failure, `Ok(result)` on success.
+    pub fn materialize_layer(
+        &self,
+        child_branch_id: &BranchId,
+        layer_index: usize,
+    ) -> io::Result<MaterializeResult> {
+        let segments_dir = match &self.segments_dir {
+            Some(d) => d,
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "materialize_layer requires a disk-backed store",
+                ))
+            }
+        };
+
+        // 2a. Snapshot under read guard
+        let (layer_segments, _source_branch_id, fork_version, own_version, closer_layers) = {
+            let branch = match self.branches.get(child_branch_id) {
+                Some(b) => b,
+                None => return Err(io::Error::new(io::ErrorKind::NotFound, "branch not found")),
+            };
+            if layer_index >= branch.inherited_layers.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "layer_index {} out of bounds (have {})",
+                        layer_index,
+                        branch.inherited_layers.len()
+                    ),
+                ));
+            }
+            let layer = &branch.inherited_layers[layer_index];
+            let layer_segments = Arc::clone(&layer.segments);
+            let source_branch_id = layer.source_branch_id;
+            let fork_version = layer.fork_version;
+            let own_version = branch.version.load_full();
+
+            // Snapshot closer inherited layers (indices 0..layer_index)
+            let closer_layers: Vec<(Arc<SegmentVersion>, BranchId, u64)> = branch.inherited_layers
+                [..layer_index]
+                .iter()
+                .map(|l| (Arc::clone(&l.segments), l.source_branch_id, l.fork_version))
+                .collect();
+
+            (
+                layer_segments,
+                source_branch_id,
+                fork_version,
+                own_version,
+                closer_layers,
+            )
+            // DashMap guard drops here
+        };
+
+        // 2b. Set status to Materializing
+        {
+            let mut branch = match self.branches.get_mut(child_branch_id) {
+                Some(b) => b,
+                None => return Err(io::Error::new(io::ErrorKind::NotFound, "branch not found")),
+            };
+            if layer_index < branch.inherited_layers.len() {
+                branch.inherited_layers[layer_index].status = LayerStatus::Materializing;
+            }
+        }
+        self.write_branch_manifest(child_branch_id);
+
+        // 2c. Build materialized entries (no locks held — I/O heavy)
+        let mut entries: Vec<(InternalKey, MemtableEntry)> = Vec::new();
+
+        // Cache shadow detection result per logical key (same typed_key_prefix).
+        // `iter_seek_all` yields entries sorted by key, so all versions of the
+        // same key are consecutive — one lookup per unique key suffices.
+        let mut last_shadow_key: Option<Vec<u8>> = None;
+        let mut last_shadow_result: bool = false; // true = shadowed (skip)
+
+        for level in &layer_segments.levels {
+            for seg in level {
+                for (ik, se) in seg.iter_seek_all() {
+                    // Filter: skip entries with commit_id > fork_version
+                    if se.commit_id > fork_version {
+                        continue;
+                    }
+
+                    let typed_key = ik.typed_key_prefix();
+
+                    // Rewrite branch_id: source → child
+                    let child_typed_key = rewrite_branch_id_bytes(typed_key, child_branch_id);
+
+                    // Shadow detection (cached per logical key)
+                    let is_shadowed = if last_shadow_key.as_deref() == Some(&child_typed_key) {
+                        last_shadow_result
+                    } else {
+                        let shadowed =
+                            Self::key_exists_in_own_segments(&own_version, &child_typed_key)
+                                || closer_layers.iter().any(
+                                    |(closer_segs, closer_source, closer_fork)| {
+                                        Self::key_exists_in_layer(
+                                            closer_segs,
+                                            *closer_source,
+                                            &child_typed_key,
+                                            *closer_fork,
+                                        )
+                                    },
+                                );
+                        last_shadow_key = Some(child_typed_key.clone());
+                        last_shadow_result = shadowed;
+                        shadowed
+                    };
+
+                    if is_shadowed {
+                        continue;
+                    }
+
+                    // Rewrite full internal key: source → child
+                    let child_ik_bytes = rewrite_branch_id_bytes(ik.as_bytes(), child_branch_id);
+                    let child_ik = InternalKey::from_bytes(child_ik_bytes);
+
+                    entries.push((child_ik, segment_entry_to_memtable_entry(se)));
+                }
+            }
+        }
+
+        let entries_materialized = entries.len() as u64;
+
+        // Sort entries by InternalKey — required because entries from multiple
+        // segments/levels are not globally sorted (L0 segments overlap, and
+        // entries span L0 through L6). SegmentBuilder expects sorted input.
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+        // 2d. Build segment file (no locks held)
+        let mut segments_created = 0usize;
+        let new_segment = if !entries.is_empty() {
+            let seg_id = self.next_segment_id.fetch_add(1, Ordering::Relaxed);
+            let branch_hex = hex_encode_branch(child_branch_id);
+            let branch_dir = segments_dir.join(&branch_hex);
+            std::fs::create_dir_all(&branch_dir)?;
+            let seg_path = branch_dir.join(format!("{}.sst", seg_id));
+
+            let builder = SegmentBuilder::default()
+                .with_compression(crate::segment_builder::CompressionCodec::None);
+            builder.build_from_iter(entries.into_iter(), &seg_path)?;
+
+            let segment = KVSegment::open(&seg_path)?;
+            segment.pin_bloom_partitions();
+            segments_created = 1;
+            Some(segment)
+        } else {
+            None
+        };
+
+        // 2e. Atomic install (under DashMap write guard)
+        {
+            let mut branch = self
+                .branches
+                .entry(*child_branch_id)
+                .or_insert_with(BranchState::new);
+
+            // Prepend new segment to L0 (if we built one)
+            if let Some(seg) = new_segment {
+                let old_ver = branch.version.load();
+                let mut new_l0 = Vec::with_capacity(old_ver.l0_segments().len() + 1);
+                new_l0.push(Arc::new(seg));
+                new_l0.extend(old_ver.l0_segments().iter().cloned());
+                let mut new_levels = old_ver.levels.clone();
+                new_levels[0] = new_l0;
+                branch
+                    .version
+                    .store(Arc::new(SegmentVersion { levels: new_levels }));
+            }
+
+            // Remove the inherited layer
+            if layer_index < branch.inherited_layers.len() {
+                branch.inherited_layers.remove(layer_index);
+            }
+
+            refresh_level_targets(&mut branch);
+        }
+
+        // 2f. Cleanup
+        self.write_branch_manifest(child_branch_id);
+
+        // Decrement refcounts for each segment in the removed layer
+        for level in &layer_segments.levels {
+            for seg in level {
+                if self.ref_registry.decrement(seg.file_id()) {
+                    crate::block_cache::global_cache().invalidate_file(seg.file_id());
+                    let _ = std::fs::remove_file(seg.file_path());
+                }
+            }
+        }
+
+        Ok(MaterializeResult {
+            entries_materialized,
+            segments_created,
+        })
+    }
+
+    /// Check if a key exists in the child's own segments.
+    fn key_exists_in_own_segments(own_version: &SegmentVersion, typed_key: &[u8]) -> bool {
+        let seek_ik = InternalKey::from_typed_key_bytes(typed_key, u64::MAX);
+        let seek_bytes = seek_ik.as_bytes();
+
+        // L0 segments (linear scan)
+        for seg in own_version.l0_segments() {
+            if seg
+                .point_lookup_preencoded(typed_key, seek_bytes, u64::MAX)
+                .is_some()
+            {
+                return true;
+            }
+        }
+
+        // L1+ segments (binary search per level)
+        for level_idx in 1..own_version.levels.len() {
+            if point_lookup_level_preencoded(
+                &own_version.levels[level_idx],
+                typed_key,
+                seek_bytes,
+                u64::MAX,
+            )
+            .is_some()
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Check if a key exists in a closer inherited layer's segments.
+    fn key_exists_in_layer(
+        layer_segments: &SegmentVersion,
+        source_branch_id: BranchId,
+        child_typed_key: &[u8], // in child namespace
+        fork_version: u64,
+    ) -> bool {
+        // Rewrite typed_key from child → source namespace
+        let src_typed_key = rewrite_branch_id_bytes(child_typed_key, &source_branch_id);
+        let src_seek_ik = InternalKey::from_typed_key_bytes(&src_typed_key, u64::MAX);
+        let src_seek_bytes = src_seek_ik.as_bytes();
+
+        // L0 segments
+        for seg in layer_segments.l0_segments() {
+            if seg
+                .point_lookup_preencoded(&src_typed_key, src_seek_bytes, fork_version)
+                .is_some()
+            {
+                return true;
+            }
+        }
+
+        // L1+ segments
+        for level_idx in 1..layer_segments.levels.len() {
+            if point_lookup_level_preencoded(
+                &layer_segments.levels[level_idx],
+                &src_typed_key,
+                src_seek_bytes,
+                fork_version,
+            )
+            .is_some()
+            {
+                return true;
+            }
+        }
+
+        false
     }
 
     /// Fork source branch onto destination via COW inherited layers.

--- a/crates/storage/src/segmented/ref_registry.rs
+++ b/crates/storage/src/segmented/ref_registry.rs
@@ -30,7 +30,6 @@ impl SegmentRefRegistry {
     /// Increment the reference count for `id`.
     ///
     /// Creates the entry with count 1 if it does not exist, otherwise adds 1.
-    #[allow(dead_code)] // Used in Epic C (COW fork recovery)
     pub(crate) fn increment(&self, id: SegmentId) {
         self.refs
             .entry(id)
@@ -83,7 +82,6 @@ impl SegmentRefRegistry {
     }
 
     /// Check if a segment is currently referenced (count > 0).
-    #[allow(dead_code)] // Used in Epic C (COW fork)
     pub(crate) fn is_referenced(&self, id: SegmentId) -> bool {
         self.refs
             .get(&id)

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -4185,7 +4185,7 @@ fn compaction_preserves_when_referenced() {
         .collect();
     assert!(sst_before.len() >= 2);
 
-    // Compact — this will call decrement, but refcount goes 2→1 (still referenced)
+    // Compact — uses is_referenced() (not decrement) so refcount stays at 2
     store.compact_branch(&bid, 0).unwrap();
 
     // The referenced segment file should still exist on disk
@@ -4194,8 +4194,8 @@ fn compaction_preserves_when_referenced() {
         "multiply-referenced segment should not be deleted during compaction"
     );
 
-    // Refcount should be 1 (was 2, compaction decremented once)
-    assert_eq!(store.ref_registry.ref_count(referenced_file_id), 1);
+    // Refcount unchanged — compaction checks is_referenced() but doesn't decrement
+    assert_eq!(store.ref_registry.ref_count(referenced_file_id), 2);
 
     // Verify non-referenced segments were deleted: should have the 1 new compacted
     // output + 1 surviving referenced segment = 2 total
@@ -5400,4 +5400,712 @@ fn fork_double_fork_same_dest_overwrites_layers() {
             id
         );
     }
+}
+
+// =====================================================================
+// Materialization tests
+// =====================================================================
+
+#[test]
+fn compaction_preserves_shared_segments() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Write parent data and flush to 2 segments (to trigger compaction)
+    seed(&store, parent_kv("a"), Value::Int(1), 1);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    seed(&store, parent_kv("b"), Value::Int(2), 2);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // Fork parent → child
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    // Collect shared segment file paths
+    let child_state = store.branches.get(&child_branch()).unwrap();
+    let shared_paths: Vec<std::path::PathBuf> = child_state
+        .inherited_layers
+        .iter()
+        .flat_map(|l| l.segments.levels.iter())
+        .flat_map(|level| level.iter().map(|s| s.file_path().to_path_buf()))
+        .collect();
+    drop(child_state);
+
+    assert!(!shared_paths.is_empty(), "should have shared segment files");
+
+    // Compact parent — should NOT delete shared segments
+    store.compact_branch(&parent_branch(), 0).unwrap();
+
+    // Verify shared segment files still exist
+    for path in &shared_paths {
+        assert!(
+            path.exists(),
+            "Shared segment {:?} should not be deleted by parent compaction",
+            path
+        );
+    }
+
+    // Child can still read inherited data
+    let result = store
+        .get_versioned(&child_kv("a"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.value, Value::Int(1));
+}
+
+#[test]
+fn materialize_collapses_layer() {
+    let (_dir, store) = setup_parent_with_segments(&[("a", 1, 1), ("b", 2, 2)]);
+
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    assert_eq!(store.inherited_layer_count(&child_branch()), 1);
+
+    let result = store.materialize_layer(&child_branch(), 0).unwrap();
+    assert_eq!(result.entries_materialized, 2);
+    assert_eq!(result.segments_created, 1);
+
+    // Layer removed
+    assert_eq!(store.inherited_layer_count(&child_branch()), 0);
+
+    // Data still accessible in own segments
+    let val = store
+        .get_versioned(&child_kv("a"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val.value, Value::Int(1));
+
+    let val = store
+        .get_versioned(&child_kv("b"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val.value, Value::Int(2));
+}
+
+#[test]
+fn materialize_preserves_commit_ids() {
+    let (_dir, store) = setup_parent_with_segments(&[("k", 42, 5)]);
+
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    store.materialize_layer(&child_branch(), 0).unwrap();
+
+    let val = store
+        .get_versioned(&child_kv("k"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val.value, Value::Int(42));
+    assert_eq!(val.version.as_u64(), 5, "commit_id should be preserved");
+}
+
+#[test]
+fn materialize_skips_post_fork_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Write entries at versions 1 and 100 into the same segment
+    seed(&store, parent_kv("early"), Value::Int(1), 1);
+    seed(&store, parent_kv("late"), Value::Int(2), 100);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // Manually attach inherited layer with fork_version=50
+    // so "early" (version 1 <= 50) passes but "late" (version 100 > 50) is filtered
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    attach_inherited_layer(&store, parent_branch(), child_branch(), 50);
+
+    // Increment refcounts for shared segments
+    {
+        let child = store.branches.get(&child_branch()).unwrap();
+        for layer in &child.inherited_layers {
+            for level in &layer.segments.levels {
+                for seg in level {
+                    store.ref_registry.increment(seg.file_id());
+                }
+            }
+        }
+    }
+
+    store.materialize_layer(&child_branch(), 0).unwrap();
+
+    // "early" (version 1 <= 50) should be materialized
+    let val = store
+        .get_versioned(&child_kv("early"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val.value, Value::Int(1));
+
+    // "late" (version 100 > 50) should NOT be materialized
+    assert!(
+        store
+            .get_versioned(&child_kv("late"), u64::MAX)
+            .unwrap()
+            .is_none(),
+        "post-fork entry should not be materialized"
+    );
+}
+
+#[test]
+fn materialize_skips_shadowed_by_own() {
+    let (_dir, store) = setup_parent_with_segments(&[("k", 1, 1)]);
+
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    // Write to child's own data (must be flushed to segments for shadow detection)
+    seed(&store, child_kv("k"), Value::Int(999), 11);
+    store.rotate_memtable(&child_branch());
+    store.flush_oldest_frozen(&child_branch()).unwrap();
+
+    let result = store.materialize_layer(&child_branch(), 0).unwrap();
+    assert_eq!(
+        result.entries_materialized, 0,
+        "inherited entry should be shadowed by own"
+    );
+
+    // Value should be child's own
+    let val = store
+        .get_versioned(&child_kv("k"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val.value, Value::Int(999));
+}
+
+#[test]
+fn materialize_skips_shadowed_by_closer_layer() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Grandparent has key "k"
+    let grandparent = BranchId::from_bytes([30; 16]);
+    let gp_ns = Arc::new(Namespace::new(grandparent, "default".to_string()));
+    let gp_key = Key::new(gp_ns.clone(), TypeTag::KV, b"k".to_vec());
+    seed(&store, gp_key, Value::Int(1), 1);
+    store.rotate_memtable(&grandparent);
+    store.flush_oldest_frozen(&grandparent).unwrap();
+
+    // Parent also has key "k" (different value)
+    seed(&store, parent_kv("k"), Value::Int(2), 2);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // Child has two inherited layers:
+    // layer 0 (closer): parent with "k"=2
+    // layer 1 (deeper): grandparent with "k"=1
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+
+    // Attach layers in order: closer first
+    attach_inherited_layer(&store, parent_branch(), child_branch(), 10);
+    attach_inherited_layer(&store, grandparent, child_branch(), 10);
+
+    // Increment refcounts
+    {
+        let child = store.branches.get(&child_branch()).unwrap();
+        for layer in &child.inherited_layers {
+            for level in &layer.segments.levels {
+                for seg in level {
+                    store.ref_registry.increment(seg.file_id());
+                }
+            }
+        }
+    }
+
+    // Materialize deepest layer (index 1 = grandparent)
+    let result = store.materialize_layer(&child_branch(), 1).unwrap();
+    assert_eq!(
+        result.entries_materialized, 0,
+        "grandparent's 'k' should be shadowed by closer parent layer"
+    );
+}
+
+#[test]
+fn materialize_deepest_first() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // A → B → C chain
+    let branch_a = BranchId::from_bytes([30; 16]);
+    let branch_b = parent_branch();
+    let branch_c = child_branch();
+
+    let ns_a = Arc::new(Namespace::new(branch_a, "default".to_string()));
+
+    // A has "a_key"
+    seed(
+        &store,
+        Key::new(ns_a.clone(), TypeTag::KV, b"a_key".to_vec()),
+        Value::Int(1),
+        1,
+    );
+    store.rotate_memtable(&branch_a);
+    store.flush_oldest_frozen(&branch_a).unwrap();
+
+    // B has "b_key"
+    seed(&store, parent_kv("b_key"), Value::Int(2), 2);
+    store.rotate_memtable(&branch_b);
+    store.flush_oldest_frozen(&branch_b).unwrap();
+
+    // C inherits from [B, A] (closer first)
+    store
+        .branches
+        .entry(branch_c)
+        .or_insert_with(BranchState::new);
+    attach_inherited_layer(&store, branch_b, branch_c, 10);
+    attach_inherited_layer(&store, branch_a, branch_c, 10);
+
+    // Increment refcounts
+    {
+        let child = store.branches.get(&branch_c).unwrap();
+        for layer in &child.inherited_layers {
+            for level in &layer.segments.levels {
+                for seg in level {
+                    store.ref_registry.increment(seg.file_id());
+                }
+            }
+        }
+    }
+
+    assert_eq!(store.inherited_layer_count(&branch_c), 2);
+
+    // Materialize deepest (index 1 = A)
+    let r1 = store.materialize_layer(&branch_c, 1).unwrap();
+    assert_eq!(r1.entries_materialized, 1); // "a_key"
+    assert_eq!(store.inherited_layer_count(&branch_c), 1);
+
+    // Materialize remaining (index 0 = B)
+    let r2 = store.materialize_layer(&branch_c, 0).unwrap();
+    assert_eq!(r2.entries_materialized, 1); // "b_key"
+    assert_eq!(store.inherited_layer_count(&branch_c), 0);
+
+    // All data accessible
+    let val = store
+        .get_versioned(&child_kv("a_key"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val.value, Value::Int(1));
+
+    let val = store
+        .get_versioned(&child_kv("b_key"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val.value, Value::Int(2));
+}
+
+#[test]
+fn materialize_empty_layer() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Parent branch with no segments (empty)
+    store
+        .branches
+        .entry(parent_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+
+    // Attach empty inherited layer
+    attach_inherited_layer(&store, parent_branch(), child_branch(), 10);
+
+    let result = store.materialize_layer(&child_branch(), 0).unwrap();
+    assert_eq!(result.entries_materialized, 0);
+    assert_eq!(result.segments_created, 0);
+    assert_eq!(store.inherited_layer_count(&child_branch()), 0);
+}
+
+#[test]
+fn materialize_refcount_decremented() {
+    let (_dir, store) = setup_parent_with_segments(&[("a", 1, 1)]);
+
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    // Collect segment IDs and check initial refcounts
+    let seg_ids: Vec<u64> = {
+        let child = store.branches.get(&child_branch()).unwrap();
+        child
+            .inherited_layers
+            .iter()
+            .flat_map(|l| l.segments.levels.iter())
+            .flat_map(|level| level.iter().map(|s| s.file_id()))
+            .collect()
+    };
+
+    for &id in &seg_ids {
+        assert!(
+            store.ref_registry.is_referenced(id),
+            "segment {} should be referenced before materialize",
+            id
+        );
+    }
+
+    store.materialize_layer(&child_branch(), 0).unwrap();
+
+    // After materialization, refcounts should be decremented
+    // (If no other child references them, they reach 0)
+    for &id in &seg_ids {
+        assert!(
+            !store.ref_registry.is_referenced(id),
+            "segment {} refcount should be decremented after materialize",
+            id
+        );
+    }
+}
+
+#[test]
+fn materialize_preserves_read_path() {
+    let (_dir, store) = setup_parent_with_segments(&[("x", 10, 1), ("y", 20, 2), ("z", 30, 3)]);
+
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    // Snapshot reads before materialization
+    let before: Vec<(String, Value)> = ["x", "y", "z"]
+        .iter()
+        .filter_map(|k| {
+            store
+                .get_versioned(&child_kv(k), u64::MAX)
+                .unwrap()
+                .map(|v| (k.to_string(), v.value))
+        })
+        .collect();
+
+    store.materialize_layer(&child_branch(), 0).unwrap();
+
+    // Reads after materialization should return same data
+    let after: Vec<(String, Value)> = ["x", "y", "z"]
+        .iter()
+        .filter_map(|k| {
+            store
+                .get_versioned(&child_kv(k), u64::MAX)
+                .unwrap()
+                .map(|v| (k.to_string(), v.value))
+        })
+        .collect();
+
+    assert_eq!(
+        before, after,
+        "reads must be identical before and after materialization"
+    );
+}
+
+#[test]
+fn materialize_crash_recovery_resets_status() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // First store: fork and start materializing (write manifest with Materializing status)
+    {
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+        seed(&store, parent_kv("a"), Value::Int(1), 1);
+        store.rotate_memtable(&parent_branch());
+        store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+        store
+            .branches
+            .entry(child_branch())
+            .or_insert_with(BranchState::new);
+        store
+            .fork_branch(&parent_branch(), &child_branch())
+            .unwrap();
+
+        // Manually set status to Materializing and write manifest
+        {
+            let mut child = store.branches.get_mut(&child_branch()).unwrap();
+            child.inherited_layers[0].status = LayerStatus::Materializing;
+        }
+        store.write_branch_manifest(&child_branch());
+    }
+
+    // Second store: recover from manifest — Materializing should reset to Active
+    {
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+        store.recover_segments().unwrap();
+
+        let child = store.branches.get(&child_branch()).unwrap();
+        assert_eq!(
+            child.inherited_layers.len(),
+            1,
+            "layer should still exist after crash"
+        );
+        assert_eq!(
+            child.inherited_layers[0].status,
+            LayerStatus::Active,
+            "Materializing status should reset to Active on recovery"
+        );
+    }
+}
+
+#[test]
+fn materialize_manifest_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let seg_ids_before: Vec<u64>;
+
+    {
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+        seed(&store, parent_kv("a"), Value::Int(1), 1);
+        store.rotate_memtable(&parent_branch());
+        store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+        store
+            .branches
+            .entry(child_branch())
+            .or_insert_with(BranchState::new);
+        store
+            .fork_branch(&parent_branch(), &child_branch())
+            .unwrap();
+
+        store.materialize_layer(&child_branch(), 0).unwrap();
+
+        // After materialization, child should have own segment and no inherited layers
+        let child = store.branches.get(&child_branch()).unwrap();
+        assert_eq!(child.inherited_layers.len(), 0);
+
+        seg_ids_before = child
+            .version
+            .load()
+            .levels
+            .iter()
+            .flat_map(|l| l.iter().map(|s| s.file_id()))
+            .collect();
+    }
+
+    // Recover and verify manifest reflects removed layer + new own segment
+    {
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+        store.recover_segments().unwrap();
+
+        let child = store.branches.get(&child_branch()).unwrap();
+        assert_eq!(
+            child.inherited_layers.len(),
+            0,
+            "no inherited layers after recovery"
+        );
+
+        let seg_ids_after: Vec<u64> = child
+            .version
+            .load()
+            .levels
+            .iter()
+            .flat_map(|l| l.iter().map(|s| s.file_id()))
+            .collect();
+
+        assert_eq!(
+            seg_ids_before.len(),
+            seg_ids_after.len(),
+            "same number of segments after recovery"
+        );
+    }
+}
+
+#[test]
+fn branches_needing_materialization_threshold() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Create a branch with many inherited layers (> MAX_INHERITED_LAYERS)
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+
+    // Initially no branches need materialization
+    assert!(store.branches_needing_materialization().is_empty());
+
+    // Add MAX_INHERITED_LAYERS layers (at threshold, not over)
+    {
+        let mut child = store.branches.get_mut(&child_branch()).unwrap();
+        for i in 0..super::MAX_INHERITED_LAYERS {
+            child.inherited_layers.push(InheritedLayer {
+                source_branch_id: BranchId::from_bytes([i as u8 + 40; 16]),
+                fork_version: 10,
+                segments: Arc::new(SegmentVersion::new()),
+                status: LayerStatus::Active,
+            });
+        }
+    }
+    assert!(
+        store.branches_needing_materialization().is_empty(),
+        "at threshold, not over"
+    );
+
+    // Add one more to exceed threshold
+    {
+        let mut child = store.branches.get_mut(&child_branch()).unwrap();
+        child.inherited_layers.push(InheritedLayer {
+            source_branch_id: BranchId::from_bytes([99; 16]),
+            fork_version: 10,
+            segments: Arc::new(SegmentVersion::new()),
+            status: LayerStatus::Active,
+        });
+    }
+    let needing = store.branches_needing_materialization();
+    assert_eq!(needing.len(), 1);
+    assert_eq!(needing[0], child_branch());
+}
+
+#[test]
+fn materialize_multi_segment_inherited_layer() {
+    // Regression test: parent has multiple L0 segments (overlapping).
+    // Materialization must sort entries globally before building the output
+    // segment, or binary search in the output would break.
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Flush three separate L0 segments with interleaved keys
+    seed(&store, parent_kv("b"), Value::Int(2), 1);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    seed(&store, parent_kv("a"), Value::Int(1), 2);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    seed(&store, parent_kv("c"), Value::Int(3), 3);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // Parent now has 3 L0 segments with keys b, a, c (NOT globally sorted)
+    assert_eq!(store.l0_segment_count(&parent_branch()), 3);
+
+    // Fork
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    // Materialize — without the sort fix, this produces a corrupt segment
+    let result = store.materialize_layer(&child_branch(), 0).unwrap();
+    assert_eq!(result.entries_materialized, 3);
+    assert_eq!(result.segments_created, 1);
+
+    // Verify ALL keys are readable via point lookup (would fail on corrupt segment)
+    let a = store
+        .get_versioned(&child_kv("a"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(a.value, Value::Int(1));
+
+    let b = store
+        .get_versioned(&child_kv("b"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(b.value, Value::Int(2));
+
+    let c = store
+        .get_versioned(&child_kv("c"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(c.value, Value::Int(3));
+
+    // Also verify list_branch works (scan path)
+    let all = store.list_branch(&child_branch());
+    assert_eq!(
+        all.len(),
+        3,
+        "all 3 entries should be visible after materialize"
+    );
+}
+
+#[test]
+fn materialize_multi_level_inherited_layer() {
+    // Parent has data in BOTH L0 and L1 (post-compaction + new writes).
+    // Materialization must correctly merge entries across levels.
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Phase 1: write data and compact to L1
+    seed(&store, parent_kv("a"), Value::Int(1), 1);
+    seed(&store, parent_kv("c"), Value::Int(3), 2);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+    store.compact_l0_to_l1(&parent_branch(), 0).unwrap();
+    assert_eq!(store.l0_segment_count(&parent_branch()), 0);
+    assert_eq!(store.l1_segment_count(&parent_branch()), 1);
+
+    // Phase 2: write more data to L0 (interleaved keys)
+    seed(&store, parent_kv("b"), Value::Int(2), 3);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+    assert_eq!(store.l0_segment_count(&parent_branch()), 1);
+
+    // Parent now has: L0=[b@3], L1=[a@1, c@2]
+
+    // Fork child
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    // Materialize — entries come from both L0 and L1
+    let result = store.materialize_layer(&child_branch(), 0).unwrap();
+    assert_eq!(result.entries_materialized, 3);
+
+    // All keys must be readable (verifies correct sort order in output segment)
+    let a = store
+        .get_versioned(&child_kv("a"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(a.value, Value::Int(1));
+
+    let b = store
+        .get_versioned(&child_kv("b"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(b.value, Value::Int(2));
+
+    let c = store
+        .get_versioned(&child_kv("c"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(c.value, Value::Int(3));
 }


### PR DESCRIPTION
## Summary

- **Fix compaction refcount bug**: Parent compaction could delete shared segment files still referenced by child branches. Changed `delete_segment_if_unreferenced` to use `is_referenced()` (read-only check) instead of `decrement()`. File cleanup now happens in `clear_branch` and `materialize_layer` when the last reference is released.
- **Add `materialize_layer()` on `SegmentedStore`**: Collapses a single inherited layer into the child's own segments. Uses snapshot → release → I/O → atomic install pattern (same as `flush_oldest_frozen`). Includes shadow detection against child's own segments and closer inherited layers, fork_version filtering, sorted output for correct SST index construction, and refcount cleanup.
- **Add `materialize_branch()` engine API**: Materializes all inherited layers deepest-first so each layer's data becomes "own" data before shallower layers are processed.
- **Add background scheduling trigger**: `schedule_flush_if_needed` now materializes the deepest inherited layer for branches exceeding `MAX_INHERITED_LAYERS` (4).

## Test plan

- [x] `compaction_preserves_shared_segments` — parent compaction doesn't delete segments inherited by child
- [x] `materialize_collapses_layer` — layer removed, data accessible in own segments
- [x] `materialize_preserves_commit_ids` — entries retain original commit_ids
- [x] `materialize_skips_post_fork_entries` — entries with commit_id > fork_version not materialized
- [x] `materialize_skips_shadowed_by_own` — child's own write shadows inherited entry
- [x] `materialize_skips_shadowed_by_closer_layer` — closer layer shadows deeper layer entry
- [x] `materialize_deepest_first` — chain A→B→C: materialize C's deepest, then next
- [x] `materialize_empty_layer` — layer with no visible entries removed cleanly
- [x] `materialize_refcount_decremented` — inherited segment refcounts decrease after materialization
- [x] `materialize_preserves_read_path` — reads return same data before and after materialization
- [x] `materialize_crash_recovery_resets_status` — Materializing status resets to Active on recovery
- [x] `materialize_manifest_roundtrip` — manifest reflects removed layer after materialization
- [x] `materialize_multi_segment_inherited_layer` — parent with multiple overlapping L0 segments
- [x] `materialize_multi_level_inherited_layer` — parent with data in both L0 and L1
- [x] `test_force_materialize_all_layers` — engine-level `materialize_branch` collapses all layers
- [x] `test_materialize_then_diff_merge` — fork → materialize → diff/merge still works
- [x] All 521 storage tests pass, all 36 engine branch_ops tests pass, full workspace green
- [x] Zero clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)