### PR TITLE
Fix COW fork/compaction race and clear_branch segment leaks

### DIFF
--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -431,21 +431,46 @@ impl SegmentedStore {
         self.segments_dir.is_some()
     }
 
-    /// Remove all data for a branch, decrementing refcounts for inherited segments.
-    /// Deletes segment files when the last reference is released.
+    /// Remove all data for a branch, cleaning up own segments and inherited refcounts.
+    /// Own segment files and the branch manifest are deleted immediately.
+    /// Inherited segment files are NOT deleted — their refcounts are decremented
+    /// and lazy cleanup happens during parent compaction.
     /// Returns true if the branch existed.
     pub fn clear_branch(&self, branch_id: &BranchId) -> bool {
         if let Some((_, branch)) = self.branches.remove(branch_id) {
+            // 1. Clean up the branch's own segments (not refcounted — always delete).
+            let ver = branch.version.load();
+            for level in &ver.levels {
+                for seg in level {
+                    crate::block_cache::global_cache().invalidate_file(seg.file_id());
+                    let _ = std::fs::remove_file(seg.file_path());
+                }
+            }
+
+            // 2. Decrement refcounts for inherited (shared) segments.
+            // Do NOT delete files here — the parent branch may still own
+            // the segment in its version.levels. Files are cleaned up
+            // lazily when parent compaction calls delete_segment_if_unreferenced
+            // (which checks is_referenced after the segment leaves the
+            // parent's version).
             for layer in &branch.inherited_layers {
                 for level in &layer.segments.levels {
                     for seg in level {
-                        if self.ref_registry.decrement(seg.file_id()) {
-                            crate::block_cache::global_cache().invalidate_file(seg.file_id());
-                            let _ = std::fs::remove_file(seg.file_path());
-                        }
+                        self.ref_registry.decrement(seg.file_id());
                     }
                 }
             }
+
+            // 3. Remove manifest file and branch directory from disk.
+            if let Some(segments_dir) = &self.segments_dir {
+                let branch_hex = hex_encode_branch(branch_id);
+                let branch_dir = segments_dir.join(&branch_hex);
+                let _ = std::fs::remove_file(branch_dir.join("segments.manifest"));
+                // remove_dir only succeeds if empty (safe — won't delete
+                // files we missed).
+                let _ = std::fs::remove_dir(&branch_dir);
+            }
+
             true
         } else {
             false
@@ -661,13 +686,13 @@ impl SegmentedStore {
         // 2f. Cleanup
         self.write_branch_manifest(child_branch_id);
 
-        // Decrement refcounts for each segment in the removed layer
+        // Decrement refcounts for each segment in the removed layer.
+        // Do NOT delete files here — the parent may still own the segment.
+        // Lazy cleanup happens via delete_segment_if_unreferenced during
+        // parent compaction.
         for level in &layer_segments.levels {
             for seg in level {
-                if self.ref_registry.decrement(seg.file_id()) {
-                    crate::block_cache::global_cache().invalidate_file(seg.file_id());
-                    let _ = std::fs::remove_file(seg.file_path());
-                }
+                self.ref_registry.decrement(seg.file_id());
             }
         }
 
@@ -771,44 +796,59 @@ impl SegmentedStore {
         // 2. Capture fork_version
         let fork_version = self.version.load(Ordering::Acquire);
 
-        // 3. Snapshot source segments + clone inherited layers
-        let source = self
-            .branches
-            .get(source_id)
-            .expect("fork_branch: source branch must exist");
-        let source_segments = source.version.load_full();
-        let source_inherited: Vec<InheritedLayer> = source
-            .inherited_layers
-            .iter()
-            .map(|l| InheritedLayer {
-                source_branch_id: l.source_branch_id,
-                fork_version: l.fork_version,
-                segments: Arc::clone(&l.segments),
-                status: l.status,
-            })
-            .collect();
-        drop(source);
+        // 3. Snapshot source segments + clone inherited layers.
+        //
+        // CRITICAL: Increment refcounts BEFORE dropping the source guard.
+        // Without this, concurrent parent compaction can delete segments
+        // between the snapshot and the refcount increment (see #1662).
+        let (dest_layers, segments_shared) = {
+            let source = match self.branches.get(source_id) {
+                Some(b) => b,
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "fork_branch: source branch no longer exists",
+                    ))
+                }
+            };
+            let source_segments = source.version.load_full();
+            let source_inherited: Vec<InheritedLayer> = source
+                .inherited_layers
+                .iter()
+                .map(|l| InheritedLayer {
+                    source_branch_id: l.source_branch_id,
+                    fork_version: l.fork_version,
+                    segments: Arc::clone(&l.segments),
+                    status: l.status,
+                })
+                .collect();
 
-        // 4. Build dest layers: [source_own, ...source_inherited]
-        let mut dest_layers = Vec::with_capacity(1 + source_inherited.len());
-        dest_layers.push(InheritedLayer {
-            source_branch_id: *source_id,
-            fork_version,
-            segments: source_segments,
-            status: LayerStatus::Active,
-        });
-        dest_layers.extend(source_inherited);
+            // 4. Build dest layers: [source_own, ...source_inherited]
+            let mut layers = Vec::with_capacity(1 + source_inherited.len());
+            layers.push(InheritedLayer {
+                source_branch_id: *source_id,
+                fork_version,
+                segments: source_segments,
+                status: LayerStatus::Active,
+            });
+            layers.extend(source_inherited);
 
-        // 5. Increment refcounts for all shared segments
-        let mut segments_shared = 0usize;
-        for layer in &dest_layers {
-            for level in &layer.segments.levels {
-                for seg in level {
-                    self.ref_registry.increment(seg.file_id());
-                    segments_shared += 1;
+            // 5. Increment refcounts while source guard is still held.
+            // The DashMap (branches) and ref_registry are independent
+            // DashMaps, so no deadlock risk.
+            let mut shared = 0usize;
+            for layer in &layers {
+                for level in &layer.segments.levels {
+                    for seg in level {
+                        self.ref_registry.increment(seg.file_id());
+                        shared += 1;
+                    }
                 }
             }
-        }
+
+            (layers, shared)
+            // source DashMap guard drops here — segments are now protected
+        };
 
         // 6. Attach to dest branch, decrementing refcounts for any prior layers
         let mut dest = self

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -6109,3 +6109,304 @@ fn materialize_multi_level_inherited_layer() {
         .unwrap();
     assert_eq!(c.value, Value::Int(3));
 }
+
+// =====================================================================
+// Bug-fix regression tests (#1662, #1663, #1664)
+// =====================================================================
+
+/// #1663: clear_branch() must delete own segment files, manifest, and branch dir.
+#[test]
+fn clear_branch_deletes_own_segments_and_manifest() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Write data to child and flush to produce own segments
+    seed(&store, child_kv("x"), Value::Int(10), 1);
+    store.rotate_memtable(&child_branch());
+    store.flush_oldest_frozen(&child_branch()).unwrap();
+
+    seed(&store, child_kv("y"), Value::Int(20), 2);
+    store.rotate_memtable(&child_branch());
+    store.flush_oldest_frozen(&child_branch()).unwrap();
+
+    // Collect own segment file paths
+    let child_state = store.branches.get(&child_branch()).unwrap();
+    let own_paths: Vec<std::path::PathBuf> = child_state
+        .version
+        .load()
+        .levels
+        .iter()
+        .flat_map(|level| level.iter().map(|s| s.file_path().to_path_buf()))
+        .collect();
+    drop(child_state);
+    assert!(!own_paths.is_empty(), "should have own segment files");
+
+    // Verify manifest exists
+    let branch_hex = hex_encode_branch(&child_branch());
+    let branch_dir = dir.path().join(&branch_hex);
+    let manifest_path = branch_dir.join("segments.manifest");
+    assert!(manifest_path.exists(), "manifest should exist before clear");
+
+    // Clear the branch
+    assert!(store.clear_branch(&child_branch()));
+
+    // Own segment files must be deleted
+    for path in &own_paths {
+        assert!(
+            !path.exists(),
+            "Own segment {:?} should be deleted by clear_branch",
+            path
+        );
+    }
+
+    // Manifest must be deleted
+    assert!(
+        !manifest_path.exists(),
+        "manifest should be deleted by clear_branch"
+    );
+
+    // Branch directory should be removed (was empty after file cleanup)
+    assert!(
+        !branch_dir.exists(),
+        "branch directory should be removed by clear_branch"
+    );
+}
+
+/// #1663: clear_branch() must clean up inherited segment refcounts AND own segments.
+/// Inherited segment files must NOT be deleted when the parent still owns them.
+#[test]
+fn clear_branch_cleans_up_inherited_and_own_segments() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Set up parent with a segment
+    seed(&store, parent_kv("a"), Value::Int(1), 1);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // Fork parent → child (increments refcounts on parent segments)
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    // Write own data to child and flush
+    seed(&store, child_kv("b"), Value::Int(2), 2);
+    store.rotate_memtable(&child_branch());
+    store.flush_oldest_frozen(&child_branch()).unwrap();
+
+    // Collect paths
+    let child_state = store.branches.get(&child_branch()).unwrap();
+    let own_paths: Vec<std::path::PathBuf> = child_state
+        .version
+        .load()
+        .levels
+        .iter()
+        .flat_map(|level| level.iter().map(|s| s.file_path().to_path_buf()))
+        .collect();
+    let inherited_paths: Vec<std::path::PathBuf> = child_state
+        .inherited_layers
+        .iter()
+        .flat_map(|l| l.segments.levels.iter())
+        .flat_map(|level| level.iter().map(|s| s.file_path().to_path_buf()))
+        .collect();
+    let inherited_ids: Vec<u64> = child_state
+        .inherited_layers
+        .iter()
+        .flat_map(|l| l.segments.levels.iter())
+        .flat_map(|level| level.iter().map(|s| s.file_id()))
+        .collect();
+    drop(child_state);
+
+    assert!(!own_paths.is_empty());
+    assert!(!inherited_paths.is_empty());
+
+    // Clear child — parent has NOT compacted, so inherited segment files
+    // must survive (parent still owns them in its version.levels).
+    assert!(store.clear_branch(&child_branch()));
+
+    // Own segments must be gone
+    for path in &own_paths {
+        assert!(!path.exists(), "Own segment {:?} should be deleted", path);
+    }
+
+    // Inherited segment files must still exist (parent owns them)
+    for path in &inherited_paths {
+        assert!(
+            path.exists(),
+            "Inherited segment {:?} should still exist (parent owns it)",
+            path
+        );
+    }
+
+    // Refcounts should be released
+    for id in &inherited_ids {
+        assert!(
+            !store.ref_registry.is_referenced(*id),
+            "Inherited segment {} should have refcount=0 after clear",
+            id
+        );
+    }
+
+    // Parent can still read its data
+    let result = store
+        .get_versioned(&parent_kv("a"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.value, Value::Int(1));
+}
+
+/// #1664: Concurrent fork + compaction must not lose segments.
+///
+/// Validates the #1662 fix: refcount increments happen before the DashMap
+/// source guard is dropped, so concurrent parent compaction cannot delete
+/// segments that the fork just snapshotted.
+#[test]
+fn concurrent_fork_and_compaction_no_data_loss() {
+    use std::sync::{Arc, Barrier};
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+
+    // Write enough parent data to trigger compaction (need ≥2 L0 segments)
+    for i in 0..50 {
+        seed(
+            &store,
+            parent_kv(&format!("key{:04}", i)),
+            Value::Int(i as i64),
+            1,
+        );
+    }
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    for i in 50..100 {
+        seed(
+            &store,
+            parent_kv(&format!("key{:04}", i)),
+            Value::Int(i as i64),
+            2,
+        );
+    }
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // Ensure child branch exists
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+
+    // Run fork and compaction concurrently
+    let barrier = Arc::new(Barrier::new(2));
+
+    let store_fork = Arc::clone(&store);
+    let barrier_fork = Arc::clone(&barrier);
+    let fork_handle = std::thread::spawn(move || {
+        barrier_fork.wait();
+        store_fork
+            .fork_branch(&parent_branch(), &child_branch())
+            .unwrap()
+    });
+
+    let store_compact = Arc::clone(&store);
+    let barrier_compact = Arc::clone(&barrier);
+    let compact_handle = std::thread::spawn(move || {
+        barrier_compact.wait();
+        store_compact.compact_branch(&parent_branch(), 0)
+    });
+
+    let (_fork_ver, segments_shared) = fork_handle.join().unwrap();
+    let _compact_result = compact_handle.join().unwrap();
+
+    assert!(segments_shared > 0, "fork should share segments");
+
+    // The critical check: child must be able to read ALL inherited data
+    // without ENOENT errors on deleted segment files.
+    for i in 0..100 {
+        let key = child_kv(&format!("key{:04}", i));
+        let result = store.get_versioned(&key, u64::MAX).unwrap();
+        assert!(
+            result.is_some(),
+            "child should see inherited key {:04} — segment file must not be deleted",
+            i
+        );
+        assert_eq!(result.unwrap().value, Value::Int(i as i64));
+    }
+}
+
+/// #1664: Run multiple rounds of concurrent fork + compaction to increase
+/// the chance of hitting the race window.
+#[test]
+fn concurrent_fork_and_compaction_stress() {
+    use std::sync::{Arc, Barrier};
+
+    for round in 0..10 {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+
+        // Two L0 segments on parent
+        for i in 0..20 {
+            seed(
+                &store,
+                parent_kv(&format!("r{}k{:04}", round, i)),
+                Value::Int(i as i64),
+                1,
+            );
+        }
+        store.rotate_memtable(&parent_branch());
+        store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+        for i in 20..40 {
+            seed(
+                &store,
+                parent_kv(&format!("r{}k{:04}", round, i)),
+                Value::Int(i as i64),
+                2,
+            );
+        }
+        store.rotate_memtable(&parent_branch());
+        store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+        store
+            .branches
+            .entry(child_branch())
+            .or_insert_with(BranchState::new);
+
+        let barrier = Arc::new(Barrier::new(2));
+
+        let s1 = Arc::clone(&store);
+        let b1 = Arc::clone(&barrier);
+        let t1 = std::thread::spawn(move || {
+            b1.wait();
+            s1.fork_branch(&parent_branch(), &child_branch())
+        });
+
+        let s2 = Arc::clone(&store);
+        let b2 = Arc::clone(&barrier);
+        let t2 = std::thread::spawn(move || {
+            b2.wait();
+            s2.compact_branch(&parent_branch(), 0)
+        });
+
+        let fork_result = t1.join().unwrap().unwrap();
+        let _compact_result = t2.join().unwrap();
+
+        assert!(fork_result.1 > 0);
+
+        // Verify all data readable from child
+        for i in 0..40 {
+            let key = child_kv(&format!("r{}k{:04}", round, i));
+            let result = store.get_versioned(&key, u64::MAX).unwrap();
+            assert!(
+                result.is_some(),
+                "round {}: child missing key {:04}",
+                round,
+                i
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **#1662**: Close race window in `fork_branch` — refcount increments now happen inside the DashMap source guard, preventing concurrent compaction from deleting snapshotted segments
- **#1663**: `clear_branch` now deletes own segment files, `segments.manifest`, and branch directory (previously only handled inherited layers)
- **#1673**: Stop deleting inherited segment files when refcount hits zero in `clear_branch` and `materialize_layer` — parent branch may still own the segment; files cleaned up lazily via `delete_segment_if_unreferenced` during compaction
- **#1664**: Add 4 regression tests: concurrent fork+compaction (single + 10-round stress), clear_branch own-segment cleanup, clear_branch inherited-segment safety
- Replace `.expect()` with proper error return in `fork_branch` for concurrent `clear_branch` safety

Closes #1662, closes #1663, closes #1664

## Test plan

- [ ] `clear_branch_deletes_own_segments_and_manifest` — verifies own `.sst` files, manifest, and branch dir are removed
- [ ] `clear_branch_cleans_up_inherited_and_own_segments` — verifies inherited segment files survive when parent still owns them, refcounts released, parent reads still work
- [ ] `concurrent_fork_and_compaction_no_data_loss` — barrier-synchronized fork + compaction, verifies all 100 keys readable from child
- [ ] `concurrent_fork_and_compaction_stress` — 10 rounds of concurrent fork + compaction
- [ ] Full `segmented::tests` suite (232 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)