### PR TITLE
Add fork_version to DAG and COW integration tests

### DIFF
--- a/crates/engine/src/branch_dag.rs
+++ b/crates/engine/src/branch_dag.rs
@@ -120,6 +120,8 @@ pub struct ForkRecord {
     pub child: String,
     /// Timestamp in microseconds.
     pub timestamp: u64,
+    /// MVCC snapshot version at the time of fork.
+    pub fork_version: Option<u64>,
     /// Optional descriptive message.
     pub message: Option<String>,
     /// Optional creator identifier.
@@ -336,6 +338,7 @@ pub fn dag_record_fork(
     db: &Arc<Database>,
     parent: &str,
     child: &str,
+    fork_version: Option<u64>,
     message: Option<&str>,
     creator: Option<&str>,
 ) -> StrataResult<DagEventId> {
@@ -350,6 +353,9 @@ pub fn dag_record_fork(
     let mut props = serde_json::json!({
         "timestamp": now,
     });
+    if let Some(fv) = fork_version {
+        props["fork_version"] = serde_json::json!(fv);
+    }
     if let Some(msg) = message {
         props["message"] = serde_json::json!(msg);
     }
@@ -629,6 +635,9 @@ fn find_fork_origin(db: &Arc<Database>, name: &str) -> StrataResult<Option<ForkR
                         .and_then(|p| p.get("timestamp"))
                         .and_then(|v| v.as_u64())
                         .unwrap_or(0),
+                    fork_version: props
+                        .and_then(|p| p.get("fork_version"))
+                        .and_then(|v| v.as_u64()),
                     message: props
                         .and_then(|p| p.get("message"))
                         .and_then(|v| v.as_str())
@@ -930,8 +939,15 @@ mod tests {
         dag_add_branch(&db, "parent-branch", None, None).unwrap();
         dag_add_branch(&db, "child-branch", None, None).unwrap();
 
-        let event_id =
-            dag_record_fork(&db, "parent-branch", "child-branch", Some("fork msg"), None).unwrap();
+        let event_id = dag_record_fork(
+            &db,
+            "parent-branch",
+            "child-branch",
+            Some(42),
+            Some("fork msg"),
+            None,
+        )
+        .unwrap();
         assert!(event_id.is_fork());
         assert!(!event_id.is_merge());
 
@@ -953,6 +969,11 @@ mod tests {
             .get("timestamp")
             .and_then(|v| v.as_u64())
             .is_some());
+        assert_eq!(
+            event_props.get("fork_version").and_then(|v| v.as_u64()),
+            Some(42),
+            "fork_version should be persisted in DAG node properties"
+        );
 
         // Verify edges: parent --[parent]--> fork_event
         let parent_neighbors = graph_store
@@ -1097,7 +1118,15 @@ mod tests {
         let db = Database::cache().unwrap();
         dag_add_branch(&db, "info-parent", Some("parent branch"), Some("admin")).unwrap();
         dag_add_branch(&db, "info-child", None, None).unwrap();
-        dag_record_fork(&db, "info-parent", "info-child", Some("forked!"), None).unwrap();
+        dag_record_fork(
+            &db,
+            "info-parent",
+            "info-child",
+            Some(100),
+            Some("forked!"),
+            None,
+        )
+        .unwrap();
 
         let merge_info = crate::branch_ops::MergeInfo {
             source: "info-child".to_string(),
@@ -1132,6 +1161,7 @@ mod tests {
         let fork = child_info.forked_from.unwrap();
         assert_eq!(fork.parent, "info-parent");
         assert_eq!(fork.child, "info-child");
+        assert_eq!(fork.fork_version, Some(100));
         assert!(!child_info.merges.is_empty());
         assert_eq!(child_info.merges[0].target, "info-parent");
     }
@@ -1142,8 +1172,8 @@ mod tests {
         dag_add_branch(&db, "fc-parent", None, None).unwrap();
         dag_add_branch(&db, "fc-child1", None, None).unwrap();
         dag_add_branch(&db, "fc-child2", None, None).unwrap();
-        dag_record_fork(&db, "fc-parent", "fc-child1", None, None).unwrap();
-        dag_record_fork(&db, "fc-parent", "fc-child2", None, None).unwrap();
+        dag_record_fork(&db, "fc-parent", "fc-child1", None, None, None).unwrap();
+        dag_record_fork(&db, "fc-parent", "fc-child2", None, None, None).unwrap();
 
         let children = find_children(&db, "fc-parent").unwrap();
         assert!(children.contains(&"fc-child1".to_string()));

--- a/crates/executor/src/handlers/branch.rs
+++ b/crates/executor/src/handlers/branch.rs
@@ -246,6 +246,7 @@ pub fn branch_fork(
         &p.db,
         &source,
         &destination,
+        info.fork_version,
         message.as_deref(),
         creator.as_deref(),
     ) {

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -5878,6 +5878,165 @@ fn materialize_crash_recovery_resets_status() {
     }
 }
 
+/// #1668: Recovery after crash during materialization I/O.
+///
+/// Simulates a crash after the new `.sst` segment has been partially
+/// written but before the inherited layer was removed from BranchState.
+/// On recovery: Materializing status resets to Active, reads return
+/// correct data (dedup handles the duplicate entries).
+#[test]
+fn materialize_crash_recovery_with_partial_segment() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Phase 1: Set up fork, begin materialization (simulate crash mid-I/O)
+    {
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+        // Parent with data
+        seed(&store, parent_kv("a"), Value::Int(1), 1);
+        seed(&store, parent_kv("b"), Value::Int(2), 2);
+        store.rotate_memtable(&parent_branch());
+        store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+        // Fork parent → child
+        store
+            .branches
+            .entry(child_branch())
+            .or_insert_with(BranchState::new);
+        store
+            .fork_branch(&parent_branch(), &child_branch())
+            .unwrap();
+
+        // Simulate partial materialization:
+        // 1. Write an orphan .sst file in the child's branch dir
+        //    (as if the segment was written but install step never ran)
+        let child_hex = hex_encode_branch(&child_branch());
+        let child_dir = dir.path().join(&child_hex);
+        let orphan_path = child_dir.join("999999.sst");
+        // Write a small dummy file (not a valid segment — recovery should
+        // skip invalid files gracefully)
+        std::fs::write(&orphan_path, b"partial garbage").unwrap();
+
+        // 2. Mark the layer as Materializing in the manifest
+        {
+            let mut child = store.branches.get_mut(&child_branch()).unwrap();
+            child.inherited_layers[0].status = LayerStatus::Materializing;
+        }
+        store.write_branch_manifest(&child_branch());
+
+        // "crash" — store drops
+    }
+
+    // Phase 2: Recover and verify
+    {
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+        let info = store.recover_segments().unwrap();
+        assert!(info.branches_recovered >= 2, "both branches should recover");
+        assert!(
+            info.errors_skipped >= 1,
+            "corrupt orphan .sst should be skipped"
+        );
+
+        // Materializing status should be reset to Active
+        let child = store.branches.get(&child_branch()).unwrap();
+        assert_eq!(
+            child.inherited_layers.len(),
+            1,
+            "inherited layer should still exist"
+        );
+        assert_eq!(
+            child.inherited_layers[0].status,
+            LayerStatus::Active,
+            "Materializing should reset to Active on recovery"
+        );
+        drop(child);
+
+        // Data should be readable through inherited layers
+        let a = store
+            .get_versioned(&child_kv("a"), u64::MAX)
+            .unwrap()
+            .unwrap();
+        assert_eq!(a.value, Value::Int(1));
+
+        let b = store
+            .get_versioned(&child_kv("b"), u64::MAX)
+            .unwrap()
+            .unwrap();
+        assert_eq!(b.value, Value::Int(2));
+
+        // Parent data should also be intact
+        let pa = store
+            .get_versioned(&parent_kv("a"), u64::MAX)
+            .unwrap()
+            .unwrap();
+        assert_eq!(pa.value, Value::Int(1));
+    }
+}
+
+/// #1668: Recovery with a valid orphan segment (crash after segment write,
+/// before layer removal). The orphan segment gets loaded into the child's
+/// own version during recovery, and reads still succeed via MVCC dedup.
+#[test]
+fn materialize_crash_recovery_with_valid_orphan_segment() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Phase 1: Create a real scenario where a valid segment exists
+    // alongside inherited layers
+    {
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+        // Parent with data
+        seed(&store, parent_kv("x"), Value::Int(10), 1);
+        store.rotate_memtable(&parent_branch());
+        store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+        // Fork parent → child
+        store
+            .branches
+            .entry(child_branch())
+            .or_insert_with(BranchState::new);
+        store
+            .fork_branch(&parent_branch(), &child_branch())
+            .unwrap();
+
+        // Child writes own data and flushes (creates a real .sst in child dir)
+        seed(&store, child_kv("y"), Value::Int(20), 2);
+        store.rotate_memtable(&child_branch());
+        store.flush_oldest_frozen(&child_branch()).unwrap();
+
+        // Mark Materializing (simulating mid-materialization crash)
+        {
+            let mut child = store.branches.get_mut(&child_branch()).unwrap();
+            child.inherited_layers[0].status = LayerStatus::Materializing;
+        }
+        store.write_branch_manifest(&child_branch());
+    }
+
+    // Phase 2: Recover
+    {
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+        store.recover_segments().unwrap();
+
+        let child = store.branches.get(&child_branch()).unwrap();
+        assert_eq!(child.inherited_layers[0].status, LayerStatus::Active);
+        drop(child);
+
+        // Child's own data (from the valid segment) should be readable
+        let y = store
+            .get_versioned(&child_kv("y"), u64::MAX)
+            .unwrap()
+            .unwrap();
+        assert_eq!(y.value, Value::Int(20));
+
+        // Inherited data from parent should also be readable
+        let x = store
+            .get_versioned(&child_kv("x"), u64::MAX)
+            .unwrap()
+            .unwrap();
+        assert_eq!(x.value, Value::Int(10));
+    }
+}
+
 #[test]
 fn materialize_manifest_roundtrip() {
     let dir = tempfile::tempdir().unwrap();

--- a/tests/integration/branching.rs
+++ b/tests/integration/branching.rs
@@ -726,6 +726,241 @@ fn test_fork_diff_merge_roundtrip() {
 // Branch Isolation Stress Test
 // ============================================================================
 
+// ============================================================================
+// COW Inherited Layer Integration Tests (#1666, #1667)
+// ============================================================================
+
+/// #1667: Diff across inherited layers after COW fork.
+///
+/// After forking, the child inherits parent data through COW layers.
+/// Modifications and deletions on the child should appear correctly in diff.
+#[test]
+fn cow_diff_across_inherited_layers() {
+    let test_db = TestDb::new();
+    let branch_index = test_db.branch_index();
+    let kv = test_db.kv();
+
+    // 1. Create parent with keys {a: 1, b: 2, c: 3}
+    branch_index.create_branch("parent").unwrap();
+    let parent_id = strata_engine::primitives::branch::resolve_branch_name("parent");
+    kv.put(&parent_id, "default", "a", Value::Int(1)).unwrap();
+    kv.put(&parent_id, "default", "b", Value::Int(2)).unwrap();
+    kv.put(&parent_id, "default", "c", Value::Int(3)).unwrap();
+
+    // 2. COW fork parent → child
+    branch_ops::fork_branch(&test_db.db, "parent", "child").unwrap();
+    let child_id = strata_engine::primitives::branch::resolve_branch_name("child");
+
+    // 3. Child modifies b and deletes c
+    kv.put(&child_id, "default", "b", Value::Int(20)).unwrap();
+    kv.delete(&child_id, "default", "c").unwrap();
+
+    // 4. diff_branches(parent, child): b modified, c removed
+    let diff = branch_ops::diff_branches(&test_db.db, "parent", "child").unwrap();
+    assert_eq!(
+        diff.summary.total_modified, 1,
+        "b should be modified (2 → 20)"
+    );
+    assert_eq!(
+        diff.summary.total_removed, 1,
+        "c should be removed (in parent, deleted in child)"
+    );
+    assert_eq!(diff.summary.total_added, 0, "no new keys added in child");
+
+    // 5. Inverse diff: diff_branches(child, parent)
+    let inv = branch_ops::diff_branches(&test_db.db, "child", "parent").unwrap();
+    assert_eq!(inv.summary.total_modified, 1, "b modified in inverse");
+    assert_eq!(
+        inv.summary.total_added, 1,
+        "c appears as added (in parent, not in child)"
+    );
+    assert_eq!(
+        inv.summary.total_removed, 0,
+        "nothing removed from child→parent perspective"
+    );
+}
+
+/// #1667: Diff after COW fork with no changes should show empty diff.
+#[test]
+fn cow_diff_no_changes_is_empty() {
+    let test_db = TestDb::new();
+    let branch_index = test_db.branch_index();
+    let kv = test_db.kv();
+
+    branch_index.create_branch("parent").unwrap();
+    let parent_id = strata_engine::primitives::branch::resolve_branch_name("parent");
+    kv.put(&parent_id, "default", "x", Value::Int(1)).unwrap();
+    kv.put(&parent_id, "default", "y", Value::Int(2)).unwrap();
+
+    branch_ops::fork_branch(&test_db.db, "parent", "child").unwrap();
+
+    // No modifications — diff should be empty
+    let diff = branch_ops::diff_branches(&test_db.db, "parent", "child").unwrap();
+    assert_eq!(diff.summary.total_added, 0);
+    assert_eq!(diff.summary.total_removed, 0);
+    assert_eq!(diff.summary.total_modified, 0);
+}
+
+/// #1666: Two-way LWW merge after COW fork.
+///
+/// Current merge is two-way (no ancestor awareness). LWW applies ALL
+/// source (child) entries that differ from target (parent), including
+/// inherited values the child didn't actually modify.
+#[test]
+fn cow_merge_lww_with_inherited_layers() {
+    let test_db = TestDb::new();
+    let branch_index = test_db.branch_index();
+    let kv = test_db.kv();
+
+    // 1. Create parent with keys {a: 1, b: 2, c: 3}
+    branch_index.create_branch("parent").unwrap();
+    let parent_id = strata_engine::primitives::branch::resolve_branch_name("parent");
+    kv.put(&parent_id, "default", "a", Value::Int(1)).unwrap();
+    kv.put(&parent_id, "default", "b", Value::Int(2)).unwrap();
+    kv.put(&parent_id, "default", "c", Value::Int(3)).unwrap();
+
+    // 2. COW fork parent → child
+    branch_ops::fork_branch(&test_db.db, "parent", "child").unwrap();
+    let child_id = strata_engine::primitives::branch::resolve_branch_name("child");
+
+    // 3. Diverge: parent writes a: 10, child writes b: 20
+    kv.put(&parent_id, "default", "a", Value::Int(10)).unwrap();
+    kv.put(&child_id, "default", "b", Value::Int(20)).unwrap();
+
+    // 4. Merge child → parent (LWW)
+    let info = branch_ops::merge_branches(
+        &test_db.db,
+        "child",
+        "parent",
+        MergeStrategy::LastWriterWins,
+    )
+    .unwrap();
+    assert!(info.keys_applied >= 1, "at least b should be applied");
+
+    // 5. Verify: b gets child's value, c unchanged.
+    //    Two-way LWW sees child's inherited a:1 vs parent's a:10 as
+    //    "modified" and overwrites with child's value. A true three-way
+    //    merge would preserve parent's a:10 (see cow_three_way_merge test).
+    assert_eq!(
+        kv.get(&parent_id, "default", "a").unwrap(),
+        Some(Value::Int(1)),
+        "a: two-way LWW overwrites parent's 10 with child's inherited 1"
+    );
+    assert_eq!(
+        kv.get(&parent_id, "default", "b").unwrap(),
+        Some(Value::Int(20)),
+        "b should have child's merged value (20)"
+    );
+    assert_eq!(
+        kv.get(&parent_id, "default", "c").unwrap(),
+        Some(Value::Int(3)),
+        "c should be unchanged"
+    );
+}
+
+/// #1666: Three-way merge with ancestor state from inherited layers.
+///
+/// NOT YET IMPLEMENTED — three-way merge requires ancestor awareness
+/// (reading the fork point to determine which side actually changed a key).
+/// This test documents the desired behavior.
+#[test]
+#[ignore = "three-way merge not yet implemented"]
+fn cow_three_way_merge_with_inherited_layers() {
+    let test_db = TestDb::new();
+    let branch_index = test_db.branch_index();
+    let kv = test_db.kv();
+
+    // 1. Create parent with keys {a: 1, b: 2, c: 3}
+    branch_index.create_branch("parent").unwrap();
+    let parent_id = strata_engine::primitives::branch::resolve_branch_name("parent");
+    kv.put(&parent_id, "default", "a", Value::Int(1)).unwrap();
+    kv.put(&parent_id, "default", "b", Value::Int(2)).unwrap();
+    kv.put(&parent_id, "default", "c", Value::Int(3)).unwrap();
+
+    // 2. COW fork parent → child
+    branch_ops::fork_branch(&test_db.db, "parent", "child").unwrap();
+    let child_id = strata_engine::primitives::branch::resolve_branch_name("child");
+
+    // 3. Diverge: parent writes a: 10, child writes b: 20
+    kv.put(&parent_id, "default", "a", Value::Int(10)).unwrap();
+    kv.put(&child_id, "default", "b", Value::Int(20)).unwrap();
+
+    // 4. Three-way merge: ancestor is {a: 1, b: 2, c: 3}
+    //    Parent changed a (1→10), child changed b (2→20), neither changed c.
+    //    Expected result: {a: 10, b: 20, c: 3}
+    let _info = branch_ops::merge_branches(
+        &test_db.db,
+        "child",
+        "parent",
+        MergeStrategy::LastWriterWins, // TODO: ThreeWay strategy
+    )
+    .unwrap();
+
+    assert_eq!(
+        kv.get(&parent_id, "default", "a").unwrap(),
+        Some(Value::Int(10)),
+        "a should keep parent's change (ancestor was 1, parent changed to 10)"
+    );
+    assert_eq!(
+        kv.get(&parent_id, "default", "b").unwrap(),
+        Some(Value::Int(20)),
+        "b should get child's change (ancestor was 2, child changed to 20)"
+    );
+    assert_eq!(
+        kv.get(&parent_id, "default", "c").unwrap(),
+        Some(Value::Int(3)),
+        "c should be unchanged (neither side modified it)"
+    );
+}
+
+/// #1666: Repeated merge after COW fork (fork → merge → modify → merge again).
+#[test]
+fn cow_repeated_merge_after_fork() {
+    let test_db = TestDb::new();
+    let branch_index = test_db.branch_index();
+    let kv = test_db.kv();
+
+    branch_index.create_branch("parent").unwrap();
+    let parent_id = strata_engine::primitives::branch::resolve_branch_name("parent");
+    kv.put(&parent_id, "default", "k", Value::Int(1)).unwrap();
+
+    // Fork
+    branch_ops::fork_branch(&test_db.db, "parent", "child").unwrap();
+    let child_id = strata_engine::primitives::branch::resolve_branch_name("child");
+
+    // First round: child modifies, merge into parent
+    kv.put(&child_id, "default", "k", Value::Int(10)).unwrap();
+    branch_ops::merge_branches(
+        &test_db.db,
+        "child",
+        "parent",
+        MergeStrategy::LastWriterWins,
+    )
+    .unwrap();
+    assert_eq!(
+        kv.get(&parent_id, "default", "k").unwrap(),
+        Some(Value::Int(10))
+    );
+
+    // Second round: child modifies again, merge into parent again
+    kv.put(&child_id, "default", "k", Value::Int(100)).unwrap();
+    branch_ops::merge_branches(
+        &test_db.db,
+        "child",
+        "parent",
+        MergeStrategy::LastWriterWins,
+    )
+    .unwrap();
+    assert_eq!(
+        kv.get(&parent_id, "default", "k").unwrap(),
+        Some(Value::Int(100))
+    );
+}
+
+// ============================================================================
+// Branch Isolation Stress Test
+// ============================================================================
+
 #[test]
 fn concurrent_operations_across_branches() {
     use std::sync::{Arc, Barrier};


### PR DESCRIPTION
## Summary

- **#1665**: Add `fork_version: Option<u64>` to `dag_record_fork()` and `ForkRecord` — MVCC snapshot version is now persisted in DAG node properties and round-trips through `find_fork_origin()`
- **#1666**: Add COW merge integration tests — two-way LWW merge with inherited layers, repeated merge, and `#[ignore]` stub for three-way merge (not yet implemented)
- **#1667**: Add COW diff integration tests — diff across inherited layers (modify + delete), inverse diff, no-changes-is-empty
- **#1668**: Add materialization crash recovery tests — partial/invalid orphan segment, valid orphan with Materializing→Active status reset

Closes #1665, closes #1666, closes #1667, closes #1668

## Test plan

- [ ] `dag_record_fork_creates_event_and_edges` — verifies fork_version=42 persisted in node properties
- [ ] `dag_get_branch_info_assembles_full_record` — verifies fork_version=100 round-trips through ForkRecord
- [ ] `cow_diff_across_inherited_layers` — fork, modify b, delete c, verify diff + inverse
- [ ] `cow_diff_no_changes_is_empty` — fork with no modifications → empty diff
- [ ] `cow_merge_lww_with_inherited_layers` — two-way LWW merge applies child changes
- [ ] `cow_three_way_merge_with_inherited_layers` — ignored (documents desired three-way behavior)
- [ ] `cow_repeated_merge_after_fork` — fork → merge → modify → merge again
- [ ] `materialize_crash_recovery_with_partial_segment` — invalid orphan .sst + Materializing status
- [ ] `materialize_crash_recovery_with_valid_orphan_segment` — valid segment + inherited layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)