### PR TITLE
Add manifest fsync, recovery degraded state, materialization splitting, and COW benchmarks

### DIFF
--- a/crates/storage/src/manifest.rs
+++ b/crates/storage/src/manifest.rs
@@ -100,11 +100,25 @@ pub fn write_manifest(
     let crc = crc32fast::hash(&buf);
     buf.extend_from_slice(&crc.to_le_bytes());
 
-    // Atomic write: temp file + rename
+    // Atomic write: temp file + fsync + rename + dir fsync
     let final_path = dir.join(MANIFEST_FILENAME);
     let tmp_path = dir.join(format!("{}.tmp", MANIFEST_FILENAME));
-    std::fs::write(&tmp_path, &buf)?;
+
+    // Write and fsync the temp file before rename — ensures data is
+    // durable on disk, not just in the page cache.
+    {
+        let mut file = std::fs::File::create(&tmp_path)?;
+        std::io::Write::write_all(&mut file, &buf)?;
+        file.sync_all()?;
+    }
+
     std::fs::rename(&tmp_path, &final_path)?;
+
+    // Fsync the parent directory to make the rename durable.
+    // Failure here is non-fatal (rename already succeeded).
+    if let Ok(dir_fd) = std::fs::File::open(dir) {
+        let _ = dir_fd.sync_all();
+    }
 
     Ok(())
 }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -17,7 +17,7 @@ use crate::memtable::{Memtable, MemtableEntry};
 use crate::merge_iter::{MergeIterator, MvccIterator, RewritingIterator};
 use crate::pressure::{MemoryPressure, PressureLevel};
 use crate::segment::{KVSegment, SegmentEntry};
-use crate::segment_builder::SegmentBuilder;
+use crate::segment_builder::{SegmentBuilder, SplittingSegmentBuilder};
 
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
@@ -634,26 +634,33 @@ impl SegmentedStore {
         // entries span L0 through L6). SegmentBuilder expects sorted input.
         entries.sort_by(|a, b| a.0.cmp(&b.0));
 
-        // 2d. Build segment file (no locks held)
-        let mut segments_created = 0usize;
-        let new_segment = if !entries.is_empty() {
-            let seg_id = self.next_segment_id.fetch_add(1, Ordering::Relaxed);
+        // 2d. Build segment file(s) (no locks held).
+        // Use SplittingSegmentBuilder to avoid creating oversized L0 segments
+        // from large inherited layers (#1671).
+        let new_segments: Vec<KVSegment> = if !entries.is_empty() {
             let branch_hex = hex_encode_branch(child_branch_id);
             let branch_dir = segments_dir.join(&branch_hex);
             std::fs::create_dir_all(&branch_dir)?;
-            let seg_path = branch_dir.join(format!("{}.sst", seg_id));
 
-            let builder = SegmentBuilder::default()
+            let next_id = &self.next_segment_id;
+            let builder = SplittingSegmentBuilder::new(TARGET_FILE_SIZE)
                 .with_compression(crate::segment_builder::CompressionCodec::None);
-            builder.build_from_iter(entries.into_iter(), &seg_path)?;
+            let built = builder.build_split(entries.into_iter(), |_split_idx| {
+                let seg_id = next_id.fetch_add(1, Ordering::Relaxed);
+                branch_dir.join(format!("{}.sst", seg_id))
+            })?;
 
-            let segment = KVSegment::open(&seg_path)?;
-            segment.pin_bloom_partitions();
-            segments_created = 1;
-            Some(segment)
+            let mut segments = Vec::with_capacity(built.len());
+            for (path, _meta) in built {
+                let seg = KVSegment::open(&path)?;
+                seg.pin_bloom_partitions();
+                segments.push(seg);
+            }
+            segments
         } else {
-            None
+            Vec::new()
         };
+        let segments_created = new_segments.len();
 
         // 2e. Atomic install (under DashMap write guard)
         {
@@ -662,11 +669,14 @@ impl SegmentedStore {
                 .entry(*child_branch_id)
                 .or_insert_with(BranchState::new);
 
-            // Prepend new segment to L0 (if we built one)
-            if let Some(seg) = new_segment {
+            // Prepend new segments to L0
+            if !new_segments.is_empty() {
                 let old_ver = branch.version.load();
-                let mut new_l0 = Vec::with_capacity(old_ver.l0_segments().len() + 1);
-                new_l0.push(Arc::new(seg));
+                let mut new_l0 =
+                    Vec::with_capacity(old_ver.l0_segments().len() + new_segments.len());
+                for seg in new_segments {
+                    new_l0.push(Arc::new(seg));
+                }
                 new_l0.extend(old_ver.l0_segments().iter().cloned());
                 let mut new_levels = old_ver.levels.clone();
                 new_levels[0] = new_l0;
@@ -1621,28 +1631,14 @@ impl SegmentedStore {
     pub fn recover_segments(&self) -> io::Result<RecoverSegmentsInfo> {
         let segments_dir = match &self.segments_dir {
             Some(d) => d,
-            None => {
-                return Ok(RecoverSegmentsInfo {
-                    branches_recovered: 0,
-                    segments_loaded: 0,
-                    errors_skipped: 0,
-                })
-            }
+            None => return Ok(RecoverSegmentsInfo::default()),
         };
 
         if !segments_dir.exists() {
-            return Ok(RecoverSegmentsInfo {
-                branches_recovered: 0,
-                segments_loaded: 0,
-                errors_skipped: 0,
-            });
+            return Ok(RecoverSegmentsInfo::default());
         }
 
-        let mut info = RecoverSegmentsInfo {
-            branches_recovered: 0,
-            segments_loaded: 0,
-            errors_skipped: 0,
-        };
+        let mut info = RecoverSegmentsInfo::default();
 
         // Collect inherited layer info for deferred resolution (second pass).
         let mut deferred_inherited: Vec<(BranchId, Vec<crate::manifest::ManifestInheritedLayer>)> =
@@ -1799,6 +1795,7 @@ impl SegmentedStore {
                             source = %hex_encode_branch(&ml.source_branch_id),
                             "inherited layer references missing source branch, skipping"
                         );
+                        info.layers_dropped.push((child_id, ml.source_branch_id));
                         continue;
                     }
                 };
@@ -2297,7 +2294,7 @@ impl SegmentedStore {
 }
 
 /// Statistics returned by [`SegmentedStore::recover_segments`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct RecoverSegmentsInfo {
     /// Number of branch subdirectories successfully loaded.
     pub branches_recovered: usize,
@@ -2305,6 +2302,11 @@ pub struct RecoverSegmentsInfo {
     pub segments_loaded: usize,
     /// Number of `.sst` files that failed to open (corrupt/invalid).
     pub errors_skipped: usize,
+    /// Inherited layers that were dropped because their source branch
+    /// was missing. Each entry is `(child_branch_id, source_branch_id)`.
+    /// Non-empty means the child branch may be missing data that was
+    /// visible before the crash.
+    pub layers_dropped: Vec<(BranchId, BranchId)>,
 }
 
 impl Default for SegmentedStore {

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -939,14 +939,7 @@ fn recover_segments_empty_dir_is_noop() {
     let dir = tempfile::tempdir().unwrap();
     let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
     let info = store.recover_segments().unwrap();
-    assert_eq!(
-        info,
-        super::RecoverSegmentsInfo {
-            branches_recovered: 0,
-            segments_loaded: 0,
-            errors_skipped: 0
-        }
-    );
+    assert_eq!(info, super::RecoverSegmentsInfo::default());
 }
 
 #[test]
@@ -6037,6 +6030,58 @@ fn materialize_crash_recovery_with_valid_orphan_segment() {
     }
 }
 
+/// #1670: Recovery surfaces dropped inherited layers when source branch is missing.
+#[test]
+fn recovery_surfaces_missing_source_branch() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Phase 1: Create parent and fork child
+    {
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+        seed(&store, parent_kv("a"), Value::Int(1), 1);
+        store.rotate_memtable(&parent_branch());
+        store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+        store
+            .branches
+            .entry(child_branch())
+            .or_insert_with(BranchState::new);
+        store
+            .fork_branch(&parent_branch(), &child_branch())
+            .unwrap();
+
+        // Write manifest for both branches
+        store.write_branch_manifest(&parent_branch());
+        store.write_branch_manifest(&child_branch());
+    }
+
+    // Sabotage: delete the parent's branch directory (simulating missing source)
+    let parent_hex = hex_encode_branch(&parent_branch());
+    let parent_dir = dir.path().join(&parent_hex);
+    std::fs::remove_dir_all(&parent_dir).unwrap();
+
+    // Phase 2: Recover — child's inherited layer should be dropped
+    {
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+        let info = store.recover_segments().unwrap();
+
+        // layers_dropped should report the missing parent
+        assert!(
+            !info.layers_dropped.is_empty(),
+            "should report dropped inherited layer"
+        );
+        assert_eq!(info.layers_dropped[0].0, child_branch());
+        assert_eq!(info.layers_dropped[0].1, parent_branch());
+
+        // Child should still exist but with no inherited layers
+        let child = store.branches.get(&child_branch()).unwrap();
+        assert!(
+            child.inherited_layers.is_empty(),
+            "inherited layer should be dropped (source missing)"
+        );
+    }
+}
+
 #[test]
 fn materialize_manifest_roundtrip() {
     let dir = tempfile::tempdir().unwrap();
@@ -6568,4 +6613,225 @@ fn concurrent_fork_and_compaction_stress() {
             );
         }
     }
+}
+
+// =====================================================================
+// Performance benchmarks (#1672)
+//
+// Run with: cargo test -p strata-storage --lib -- segmented::tests::bench_ --ignored --nocapture
+// =====================================================================
+
+/// #1672: Fork 1M-key branch — target: < 100ms.
+/// Verifies the O(1) fork claim holds in practice.
+#[test]
+#[ignore = "benchmark — run with --ignored --nocapture"]
+fn bench_fork_1m_keys() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Populate parent with 1M keys across multiple segments
+    let big_value = Value::Bytes(vec![0xAB; 64]);
+    let batch_size = 50_000;
+    let total_keys = 1_000_000;
+    for batch in 0..(total_keys / batch_size) {
+        for i in 0..batch_size {
+            let key_idx = batch * batch_size + i;
+            seed(
+                &store,
+                parent_kv(&format!("k{:08}", key_idx)),
+                big_value.clone(),
+                1,
+            );
+        }
+        store.rotate_memtable(&parent_branch());
+        store.flush_oldest_frozen(&parent_branch()).unwrap();
+    }
+
+    let parent_segs: usize = store
+        .branches
+        .get(&parent_branch())
+        .unwrap()
+        .version
+        .load()
+        .levels
+        .iter()
+        .map(|l| l.len())
+        .sum();
+    eprintln!("Parent: {} segments, {} keys", parent_segs, total_keys);
+
+    // Fork
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+
+    let start = std::time::Instant::now();
+    let (_fv, shared) = store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+    let elapsed = start.elapsed();
+
+    eprintln!(
+        "Fork: {} segments shared in {:.2}ms",
+        shared,
+        elapsed.as_secs_f64() * 1000.0
+    );
+    assert!(
+        elapsed.as_millis() < 500,
+        "Fork should be fast (was {}ms)",
+        elapsed.as_millis()
+    );
+    assert!(shared > 0);
+}
+
+/// #1672: 100 branches forked from same parent — verify fan-out scalability.
+#[test]
+#[ignore = "benchmark — run with --ignored --nocapture"]
+fn bench_100_branch_fanout() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = std::sync::Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+
+    // Populate parent
+    for i in 0..1000 {
+        seed(
+            &store,
+            parent_kv(&format!("k{:06}", i)),
+            Value::Int(i as i64),
+            1,
+        );
+    }
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // Second segment for compaction eligibility
+    for i in 1000..2000 {
+        seed(
+            &store,
+            parent_kv(&format!("k{:06}", i)),
+            Value::Int(i as i64),
+            2,
+        );
+    }
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // Fork 100 children
+    let start = std::time::Instant::now();
+    for c in 0..100 {
+        let child = BranchId::from_bytes([c as u8 + 50; 16]);
+        store.branches.entry(child).or_insert_with(BranchState::new);
+        store.fork_branch(&parent_branch(), &child).unwrap();
+    }
+    let fork_elapsed = start.elapsed();
+    eprintln!(
+        "100 forks in {:.2}ms ({:.2}ms/fork)",
+        fork_elapsed.as_secs_f64() * 1000.0,
+        fork_elapsed.as_secs_f64() * 10.0
+    );
+
+    // Compact parent — should NOT delete shared segments
+    store.compact_branch(&parent_branch(), 0).unwrap();
+
+    // Verify all 100 children can still read
+    let start = std::time::Instant::now();
+    for c in 0..100u8 {
+        let child = BranchId::from_bytes([c + 50; 16]);
+        for i in 0..2000 {
+            let key = Key::new(
+                std::sync::Arc::new(strata_core::types::Namespace::new(
+                    child,
+                    "default".to_string(),
+                )),
+                strata_core::types::TypeTag::KV,
+                format!("k{:06}", i).into_bytes(),
+            );
+            let val = store.get_versioned(&key, u64::MAX).unwrap();
+            assert!(val.is_some(), "child {} missing key {}", c, i);
+        }
+    }
+    let read_elapsed = start.elapsed();
+    eprintln!(
+        "200K reads across 100 children in {:.2}ms",
+        read_elapsed.as_secs_f64() * 1000.0
+    );
+}
+
+/// #1672: Fork chain depth trigger — fork A→B→C→D→E (4 layers on E).
+#[test]
+#[ignore = "benchmark — run with --ignored --nocapture"]
+fn bench_fork_chain_depth() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Create chain: A → B → C → D → E
+    let branches: Vec<BranchId> = (0..5)
+        .map(|i| BranchId::from_bytes([i as u8 + 100; 16]))
+        .collect();
+
+    // Populate first branch
+    let ns_a = std::sync::Arc::new(strata_core::types::Namespace::new(
+        branches[0],
+        "default".to_string(),
+    ));
+    for i in 0..1000 {
+        seed(
+            &store,
+            Key::new(
+                std::sync::Arc::clone(&ns_a),
+                strata_core::types::TypeTag::KV,
+                format!("k{:04}", i).into_bytes(),
+            ),
+            Value::Int(i as i64),
+            1,
+        );
+    }
+    store.rotate_memtable(&branches[0]);
+    store.flush_oldest_frozen(&branches[0]).unwrap();
+
+    // Fork chain
+    for i in 1..5 {
+        store
+            .branches
+            .entry(branches[i])
+            .or_insert_with(BranchState::new);
+        store.fork_branch(&branches[i - 1], &branches[i]).unwrap();
+    }
+
+    // Verify depth
+    let last = store.branches.get(&branches[4]).unwrap();
+    let depth = last.inherited_layers.len();
+    eprintln!("Fork chain depth on E: {} layers", depth);
+    assert_eq!(depth, 4, "E should have 4 inherited layers (A,B,C,D)");
+    drop(last);
+
+    // Verify E can read all data
+    let ns_e = std::sync::Arc::new(strata_core::types::Namespace::new(
+        branches[4],
+        "default".to_string(),
+    ));
+    for i in 0..1000 {
+        let key = Key::new(
+            std::sync::Arc::clone(&ns_e),
+            strata_core::types::TypeTag::KV,
+            format!("k{:04}", i).into_bytes(),
+        );
+        let val = store.get_versioned(&key, u64::MAX).unwrap();
+        assert!(val.is_some(), "E missing key {}", i);
+    }
+
+    // Materialize deepest layer on E
+    let start = std::time::Instant::now();
+    let result = store.materialize_layer(&branches[4], 0).unwrap();
+    let elapsed = start.elapsed();
+    eprintln!(
+        "Materialize: {} entries in {:.2}ms, {} segments created",
+        result.entries_materialized,
+        elapsed.as_secs_f64() * 1000.0,
+        result.segments_created
+    );
+    assert!(result.entries_materialized > 0);
+
+    // Depth should be reduced
+    let last = store.branches.get(&branches[4]).unwrap();
+    assert_eq!(last.inherited_layers.len(), 3);
 }


### PR DESCRIPTION
## Summary

- **#1669**: Add `sync_all()` on temp file + directory fsync after rename in `write_manifest()` — ensures manifest data is durable on power loss
- **#1670**: Track dropped inherited layers in `RecoverSegmentsInfo::layers_dropped` when source branch is missing during recovery — callers can detect degraded state programmatically
- **#1671**: Use `SplittingSegmentBuilder` in `materialize_layer()` to split output at 64MB (`TARGET_FILE_SIZE`) boundaries — avoids oversized L0 segments from large inherited layers
- **#1672**: Add 3 performance benchmarks (run with `--ignored --nocapture`): fork 1M keys, 100-branch fan-out with compaction, fork chain depth with materialization

Closes #1669, closes #1670, closes #1671, closes #1672

## Test plan

- [ ] `recovery_surfaces_missing_source_branch` — deletes parent dir, verifies `layers_dropped` reports `(child, parent)`
- [ ] `materialize_collapses_layer` — existing test still passes with splitting builder
- [ ] `materialize_crash_recovery_*` — recovery tests still pass
- [ ] All 9 manifest tests pass (fsync change doesn't break roundtrip)
- [ ] Full segmented test suite: 235 passed, 3 ignored (benchmarks)
- [ ] Benchmarks: `cargo test -p strata-storage --lib -- segmented::tests::bench_ --ignored --nocapture`

🤖 Generated with [Claude Code](https://claude.com/claude-code)