### PR TITLE
Fix COW audit findings: recovery, deletion, materialization, GC (#1701-#1705)

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -788,6 +788,15 @@ impl Database {
         &self.storage
     }
 
+    /// Clean up storage-layer segments for a deleted branch (#1702).
+    ///
+    /// Removes the branch's memtables, segment files, and decrements
+    /// inherited layer refcounts. Should be called after logical
+    /// deletion succeeds.
+    pub fn clear_branch_storage(&self, branch_id: &BranchId) {
+        self.storage.clear_branch(branch_id);
+    }
+
     /// Direct single-key read returning only the Value (no VersionedValue).
     ///
     /// Skips Version enum and VersionedValue construction. Used by the
@@ -1743,11 +1752,8 @@ impl Database {
             return;
         }
 
+        // 1. Flush and compact branches that need it.
         let branches = self.storage.branches_needing_flush();
-        if branches.is_empty() {
-            return;
-        }
-
         for branch_id in branches {
             // Flush all frozen memtables
             loop {
@@ -1788,7 +1794,8 @@ impl Database {
             }
         }
 
-        // Materialize inherited layers that exceed depth limit
+        // 2. Materialize inherited layers that exceed depth limit.
+        //    Decoupled from flush — runs even when no branches need flushing (#1704).
         for branch_id in self.storage.branches_needing_materialization() {
             let layer_count = self.storage.inherited_layer_count(&branch_id);
             if layer_count > 0 {

--- a/crates/executor/src/handlers/branch.rs
+++ b/crates/executor/src/handlers/branch.rs
@@ -189,6 +189,10 @@ pub fn branch_delete(p: &Arc<Primitives>, branch: BranchId) -> Result<Output> {
     // Cleanup: remove per-branch commit lock (#944)
     // Convert the executor BranchId to core BranchId for the lock cleanup
     if let Ok(core_branch_id) = crate::bridge::to_core_branch_id(&branch) {
+        // Clean up storage-layer segments (segment files, memtables, refcounts) (#1702).
+        // Must happen after logical deletion so in-progress reads see the deletion first.
+        p.db.clear_branch_storage(&core_branch_id);
+
         // Best-effort: if a concurrent commit holds the lock, skip removal.
         // The stale entry is harmless and will be cleaned up on next attempt.
         let _ = p.db.remove_branch_lock(&core_branch_id);

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -309,6 +309,8 @@ pub struct SegmentedStore {
     compaction_rate_limiter: arc_swap::ArcSwapOption<crate::rate_limiter::RateLimiter>,
     /// Reference count registry for shared segments (COW branching).
     ref_registry: ref_registry::SegmentRefRegistry,
+    /// Branches currently being materialized (prevents concurrent materialization #1703).
+    materializing_branches: DashMap<BranchId, ()>,
 }
 
 impl SegmentedStore {
@@ -331,6 +333,7 @@ impl SegmentedStore {
             max_immutable_memtables: AtomicUsize::new(0),
             compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
             ref_registry: ref_registry::SegmentRefRegistry::new(),
+            materializing_branches: DashMap::new(),
         }
     }
 
@@ -354,6 +357,7 @@ impl SegmentedStore {
             max_immutable_memtables: AtomicUsize::new(0),
             compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
             ref_registry: ref_registry::SegmentRefRegistry::new(),
+            materializing_branches: DashMap::new(),
         }
     }
 
@@ -377,6 +381,7 @@ impl SegmentedStore {
             max_immutable_memtables: AtomicUsize::new(0),
             compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
             ref_registry: ref_registry::SegmentRefRegistry::new(),
+            materializing_branches: DashMap::new(),
         }
     }
 
@@ -438,21 +443,23 @@ impl SegmentedStore {
     /// Returns true if the branch existed.
     pub fn clear_branch(&self, branch_id: &BranchId) -> bool {
         if let Some((_, branch)) = self.branches.remove(branch_id) {
-            // 1. Clean up the branch's own segments (not refcounted — always delete).
+            // 1. Clean up the branch's own segments.
+            // Check refcount before deleting — a child branch may still
+            // reference these segments through inherited layers (#1702).
             let ver = branch.version.load();
             for level in &ver.levels {
                 for seg in level {
                     crate::block_cache::global_cache().invalidate_file(seg.file_id());
-                    let _ = std::fs::remove_file(seg.file_path());
+                    if !self.ref_registry.is_referenced(seg.file_id()) {
+                        let _ = std::fs::remove_file(seg.file_path());
+                    }
                 }
             }
 
             // 2. Decrement refcounts for inherited (shared) segments.
-            // Do NOT delete files here — the parent branch may still own
-            // the segment in its version.levels. Files are cleaned up
-            // lazily when parent compaction calls delete_segment_if_unreferenced
-            // (which checks is_referenced after the segment leaves the
-            // parent's version).
+            // Do NOT delete files here — the parent may still own the segment
+            // in its version.levels. Orphaned files (parent compacted away the
+            // segment before this decrement) are cleaned up by gc_orphan_segments.
             for layer in &branch.inherited_layers {
                 for level in &layer.segments.levels {
                     for seg in level {
@@ -471,10 +478,86 @@ impl SegmentedStore {
                 let _ = std::fs::remove_dir(&branch_dir);
             }
 
+            // 4. Garbage-collect orphan segment files (#1705).
+            // Refcount decrements above may have released the last reference to
+            // segments whose parent already compacted them away. GC deletes
+            // any .sst on disk not referenced by a live branch or the refcount
+            // registry.
+            self.gc_orphan_segments();
+
             true
         } else {
             false
         }
+    }
+
+    /// Garbage-collect orphaned segment files (#1705).
+    ///
+    /// Scans all branch directories for `.sst` files that are not referenced
+    /// by any branch's current `version.levels` or inherited layers. Such
+    /// files arise when a parent compacts away a segment while a child still
+    /// references it, and the child later releases its reference (decrement
+    /// to 0) without being able to delete the file (the parent might still
+    /// own it at that time).
+    ///
+    /// Returns the number of files deleted.
+    pub fn gc_orphan_segments(&self) -> usize {
+        let segments_dir = match &self.segments_dir {
+            Some(d) => d,
+            None => return 0,
+        };
+
+        // Build the set of all segment file_id values currently live in any
+        // branch. file_id is a hash of the file path (see block_cache::file_path_hash).
+        let mut live_ids: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for branch in self.branches.iter() {
+            let ver = branch.version.load();
+            for level in &ver.levels {
+                for seg in level {
+                    live_ids.insert(seg.file_id());
+                }
+            }
+            for layer in &branch.inherited_layers {
+                for level in &layer.segments.levels {
+                    for seg in level {
+                        live_ids.insert(seg.file_id());
+                    }
+                }
+            }
+        }
+
+        let mut deleted = 0usize;
+
+        // Scan all branch directories.
+        let entries = match std::fs::read_dir(segments_dir) {
+            Ok(e) => e,
+            Err(_) => return 0,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let sst_entries = match std::fs::read_dir(&path) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            for sst_entry in sst_entries.flatten() {
+                let sst_path = sst_entry.path();
+                if sst_path.extension().and_then(|e| e.to_str()) != Some("sst") {
+                    continue;
+                }
+                // file_id is a hash of the full path, matching KVSegment::file_id().
+                let file_id = crate::block_cache::file_path_hash(&sst_path);
+                if !live_ids.contains(&file_id) && !self.ref_registry.is_referenced(file_id) {
+                    crate::block_cache::global_cache().invalidate_file(file_id);
+                    let _ = std::fs::remove_file(&sst_path);
+                    deleted += 1;
+                }
+            }
+        }
+
+        deleted
     }
 
     /// Number of inherited layers for a branch.
@@ -520,23 +603,62 @@ impl SegmentedStore {
             }
         };
 
+        // Serialize materialization per branch (#1703).
+        // Use atomic entry() API to prevent TOCTOU between check and insert.
+        {
+            use dashmap::mapref::entry::Entry;
+            match self.materializing_branches.entry(*child_branch_id) {
+                Entry::Occupied(_) => {
+                    return Ok(MaterializeResult {
+                        entries_materialized: 0,
+                        segments_created: 0,
+                    });
+                }
+                Entry::Vacant(e) => {
+                    e.insert(());
+                }
+            }
+        }
+
+        // RAII guard to remove entry on all exit paths.
+        struct MaterializeGuard<'a> {
+            store: &'a SegmentedStore,
+            branch_id: BranchId,
+        }
+        impl Drop for MaterializeGuard<'_> {
+            fn drop(&mut self) {
+                self.store.materializing_branches.remove(&self.branch_id);
+            }
+        }
+        let _guard = MaterializeGuard {
+            store: self,
+            branch_id: *child_branch_id,
+        };
+
         // 2a. Snapshot under read guard
-        let (layer_segments, _source_branch_id, fork_version, own_version, closer_layers) = {
+        let (layer_segments, source_branch_id, fork_version, own_version, closer_layers) = {
             let branch = match self.branches.get(child_branch_id) {
                 Some(b) => b,
                 None => return Err(io::Error::new(io::ErrorKind::NotFound, "branch not found")),
             };
             if layer_index >= branch.inherited_layers.len() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!(
-                        "layer_index {} out of bounds (have {})",
-                        layer_index,
-                        branch.inherited_layers.len()
-                    ),
-                ));
+                // Layer was already removed by a concurrent materialization that
+                // completed before we acquired the DashMap guard. Not an error.
+                return Ok(MaterializeResult {
+                    entries_materialized: 0,
+                    segments_created: 0,
+                });
             }
             let layer = &branch.inherited_layers[layer_index];
+
+            // Reject if already being materialized (#1703)
+            if layer.status == LayerStatus::Materializing {
+                return Ok(MaterializeResult {
+                    entries_materialized: 0,
+                    segments_created: 0,
+                });
+            }
+
             let layer_segments = Arc::clone(&layer.segments);
             let source_branch_id = layer.source_branch_id;
             let fork_version = layer.fork_version;
@@ -685,9 +807,13 @@ impl SegmentedStore {
                     .store(Arc::new(SegmentVersion { levels: new_levels }));
             }
 
-            // Remove the inherited layer
-            if layer_index < branch.inherited_layers.len() {
-                branch.inherited_layers.remove(layer_index);
+            // Remove the inherited layer by identity (source_branch_id + fork_version)
+            // instead of by index, since the index may have shifted if another
+            // layer was removed between snapshot and install (#1703).
+            if let Some(idx) = branch.inherited_layers.iter().position(|l| {
+                l.source_branch_id == source_branch_id && l.fork_version == fork_version
+            }) {
+                branch.inherited_layers.remove(idx);
             }
 
             refresh_level_targets(&mut branch);
@@ -697,9 +823,9 @@ impl SegmentedStore {
         self.write_branch_manifest(child_branch_id);
 
         // Decrement refcounts for each segment in the removed layer.
-        // Do NOT delete files here — the parent may still own the segment.
-        // Lazy cleanup happens via delete_segment_if_unreferenced during
-        // parent compaction.
+        // Do NOT delete files here — the parent may still own the segment
+        // in its version.levels. Orphaned files (parent compacted away the
+        // segment before this decrement) are cleaned up by gc_orphan_segments.
         for level in &layer_segments.levels {
             for seg in level {
                 self.ref_registry.decrement(seg.file_id());
@@ -1708,22 +1834,57 @@ impl SegmentedStore {
                 continue;
             }
 
-            // Partition segments into levels based on manifest
+            // Partition segments into levels based on manifest.
+            //
+            // IMPORTANT (#1701): When a manifest exists, ONLY load segments
+            // listed in the manifest. Files on disk but not in the manifest
+            // are orphans (e.g. shared segments kept for COW children) and
+            // must NOT be promoted to L0, as they could shadow compacted data.
             let mut level_segs: Vec<Vec<Arc<KVSegment>>> = vec![Vec::new(); NUM_LEVELS];
             if let Some(ref manifest) = manifest {
+                // Build a map of opened segments by filename for O(1) lookup.
+                let seg_by_name: std::collections::HashMap<String, Arc<KVSegment>> =
+                    branch_segments
+                        .iter()
+                        .filter_map(|seg| {
+                            seg.file_path()
+                                .file_name()
+                                .and_then(|n| n.to_str())
+                                .map(|name| (name.to_string(), Arc::clone(seg)))
+                        })
+                        .collect();
+
+                let mut manifest_filenames: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
+                for entry in &manifest.entries {
+                    manifest_filenames.insert(entry.filename.clone());
+                    let level = (entry.level as usize).min(NUM_LEVELS - 1);
+                    if let Some(seg) = seg_by_name.get(&entry.filename) {
+                        level_segs[level].push(Arc::clone(seg));
+                    } else {
+                        tracing::warn!(
+                            branch = %dir_name,
+                            segment = %entry.filename,
+                            "manifest references segment not found on disk"
+                        );
+                    }
+                }
+
+                // Log orphan files (on disk but not in manifest — not loaded).
                 for seg in branch_segments.iter() {
                     let filename = seg
                         .file_path()
                         .file_name()
                         .and_then(|n| n.to_str())
                         .unwrap_or("");
-                    let level = manifest
-                        .entries
-                        .iter()
-                        .find(|e| e.filename == filename)
-                        .map(|e| (e.level as usize).min(NUM_LEVELS - 1))
-                        .unwrap_or(0); // unknown → L0
-                    level_segs[level].push(Arc::clone(seg));
+                    if !manifest_filenames.contains(filename) {
+                        tracing::warn!(
+                            branch = %dir_name,
+                            segment = %filename,
+                            "orphan segment on disk (not in manifest), skipping"
+                        );
+                        info.orphans_skipped += 1;
+                    }
                 }
             } else {
                 // No manifest → all segments go to L0 (backward compat)
@@ -1746,7 +1907,7 @@ impl SegmentedStore {
                 .entry(branch_id)
                 .or_insert_with(BranchState::new);
 
-            info.segments_loaded += branch_segments.len();
+            info.segments_loaded += level_segs.iter().map(|l| l.len()).sum::<usize>();
 
             // Build new version: merge existing segments with recovered ones
             let old_ver = branch.version.load();
@@ -2307,6 +2468,10 @@ pub struct RecoverSegmentsInfo {
     /// Non-empty means the child branch may be missing data that was
     /// visible before the crash.
     pub layers_dropped: Vec<(BranchId, BranchId)>,
+    /// Number of orphan `.sst` files on disk that were not in the manifest.
+    /// These are skipped during recovery to prevent stale data from shadowing
+    /// compacted data (#1701).
+    pub orphans_skipped: usize,
 }
 
 impl Default for SegmentedStore {

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -6835,3 +6835,288 @@ fn bench_fork_chain_depth() {
     let last = store.branches.get(&branches[4]).unwrap();
     assert_eq!(last.inherited_layers.len(), 3);
 }
+
+// =============================================================================
+// #1701: Recovery skips orphan SSTs not in manifest
+// =============================================================================
+
+/// Recovery with a manifest must only load segments listed in the manifest.
+/// Files on disk but not in the manifest are orphans and must be skipped.
+#[test]
+fn recovery_skips_orphan_sst_not_in_manifest() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Write and flush parent data → creates segment + manifest
+    seed(&store, parent_kv("a"), Value::Int(1), 1);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // Verify 1 segment exists
+    let parent_state = store.branches.get(&parent_branch()).unwrap();
+    assert_eq!(parent_state.version.load().total_segment_count(), 1);
+    drop(parent_state);
+
+    // Create an orphan .sst in the parent directory (simulates a shared
+    // segment kept for a child that has since been deleted)
+    let branch_hex = hex_encode_branch(&parent_branch());
+    let branch_dir = dir.path().join(&branch_hex);
+    let orphan_path = branch_dir.join("999999.sst");
+    // Write a valid segment file using the correct builder API
+    let typed_key = crate::key_encoding::encode_typed_key(&parent_kv("orphan"));
+    let ik = crate::key_encoding::InternalKey::from_typed_key_bytes(&typed_key, 1);
+    let me = crate::memtable::MemtableEntry {
+        value: Value::Int(999),
+        is_tombstone: false,
+        timestamp: strata_core::Timestamp::from(0u64),
+        ttl_ms: 0,
+    };
+    let builder = crate::segment_builder::SegmentBuilder::default();
+    builder
+        .build_from_iter(std::iter::once((ik, me)), &orphan_path)
+        .unwrap();
+    assert!(orphan_path.exists());
+
+    // Drop store and recover
+    drop(store);
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let info = store2.recover_segments().unwrap();
+
+    // The orphan should be skipped (not loaded as L0)
+    assert!(info.orphans_skipped >= 1, "expected orphan to be counted");
+    let parent_state = store2.branches.get(&parent_branch()).unwrap();
+    // Should have exactly 1 segment (the real one), not 2
+    assert_eq!(
+        parent_state.version.load().total_segment_count(),
+        1,
+        "orphan SST should not be loaded"
+    );
+
+    // Data from the real segment should be readable
+    drop(parent_state);
+    let result = store2
+        .get_versioned(&parent_kv("a"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.value, Value::Int(1));
+}
+
+// =============================================================================
+// #1703: Concurrent materialize_layer is serialized
+// =============================================================================
+
+/// Two concurrent calls to materialize_layer on the same branch should
+/// not both proceed — one should return early with 0 entries.
+#[test]
+fn concurrent_materialize_serialized() {
+    use std::sync::{Arc, Barrier};
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+
+    // Write parent data and flush
+    for i in 0..100 {
+        seed(
+            &store,
+            parent_kv(&format!("k{:04}", i)),
+            Value::Int(i as i64),
+            1,
+        );
+    }
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // Fork → child gets inherited layer
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    assert_eq!(store.inherited_layer_count(&child_branch()), 1);
+
+    // Race two materializations
+    let barrier = Arc::new(Barrier::new(2));
+    let results: Vec<_> = (0..2)
+        .map(|_| {
+            let s = Arc::clone(&store);
+            let b = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                b.wait();
+                s.materialize_layer(&child_branch(), 0)
+            })
+        })
+        .collect();
+
+    let mut materialized_count = 0;
+    let mut skipped_count = 0;
+    for handle in results {
+        let result = handle.join().unwrap().unwrap();
+        if result.entries_materialized > 0 {
+            materialized_count += 1;
+        } else {
+            skipped_count += 1;
+        }
+    }
+
+    // Exactly one should have materialized, the other should have been skipped
+    assert_eq!(
+        materialized_count, 1,
+        "exactly one materialization should proceed"
+    );
+    assert_eq!(skipped_count, 1, "the other should be skipped");
+
+    // Layer should be removed
+    assert_eq!(store.inherited_layer_count(&child_branch()), 0);
+
+    // Data should be accessible
+    let result = store
+        .get_versioned(&child_kv("k0050"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.value, Value::Int(50));
+}
+
+// =============================================================================
+// #1702: clear_branch checks refcount before deleting own segments
+// =============================================================================
+
+/// When a parent's own segments are referenced by a child, deleting the parent
+/// must not remove those segment files.
+#[test]
+fn clear_branch_preserves_referenced_own_segments() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Write and flush parent data
+    seed(&store, parent_kv("a"), Value::Int(1), 1);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // Fork → child inherits parent's segments
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    // Collect parent's own segment paths
+    let parent_state = store.branches.get(&parent_branch()).unwrap();
+    let own_paths: Vec<std::path::PathBuf> = parent_state
+        .version
+        .load()
+        .levels
+        .iter()
+        .flat_map(|level| level.iter().map(|s| s.file_path().to_path_buf()))
+        .collect();
+    drop(parent_state);
+    assert!(!own_paths.is_empty());
+
+    // Clear (delete) parent — child still references parent's segments
+    assert!(store.clear_branch(&parent_branch()));
+
+    // Parent's own segment files should still exist (child references them)
+    for path in &own_paths {
+        assert!(
+            path.exists(),
+            "Parent segment {:?} should survive (child references it)",
+            path
+        );
+    }
+
+    // Child should still be able to read inherited data
+    let result = store
+        .get_versioned(&child_kv("a"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.value, Value::Int(1));
+}
+
+// =============================================================================
+// #1705: gc_orphan_segments cleans up leaked files
+// =============================================================================
+
+/// After parent compaction removes segment S and child releases its reference,
+/// gc_orphan_segments should delete the orphaned S.
+#[test]
+fn gc_orphan_segments_cleans_leaked_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Write TWO batches to parent so compaction can merge them
+    for i in 0..50 {
+        seed(
+            &store,
+            parent_kv(&format!("k{:04}", i)),
+            Value::Int(i as i64),
+            1,
+        );
+    }
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    for i in 50..100 {
+        seed(
+            &store,
+            parent_kv(&format!("k{:04}", i)),
+            Value::Int(i as i64),
+            2,
+        );
+    }
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // Fork → child inherits 2 segments, refcount=1 each
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    // Collect the inherited segment paths
+    let child_state = store.branches.get(&child_branch()).unwrap();
+    let inherited_paths: Vec<std::path::PathBuf> = child_state
+        .inherited_layers
+        .iter()
+        .flat_map(|l| l.segments.levels.iter())
+        .flat_map(|level| level.iter().map(|s| s.file_path().to_path_buf()))
+        .collect();
+    drop(child_state);
+    assert!(
+        inherited_paths.len() >= 2,
+        "expected at least 2 inherited segments"
+    );
+
+    // Parent compacts: S1 + S2 → S3. Old segments kept (refcount > 0).
+    store.compact_branch(&parent_branch(), 0).unwrap();
+    for path in &inherited_paths {
+        assert!(
+            path.exists(),
+            "segment should survive compaction (refcount > 0)"
+        );
+    }
+
+    // Child releases (clear_branch). refcount → 0.
+    // clear_branch runs gc_orphan_segments internally, which should clean up
+    // the orphaned files (parent already compacted them away, no references remain).
+    store.clear_branch(&child_branch());
+
+    // Orphaned segments should be deleted (GC ran as part of clear_branch).
+    for path in &inherited_paths {
+        assert!(
+            !path.exists(),
+            "orphaned segment {:?} should be deleted by GC after clear_branch",
+            path
+        );
+    }
+
+    // Calling GC again should find nothing to delete.
+    let deleted = store.gc_orphan_segments();
+    assert_eq!(deleted, 0, "no orphans should remain after clear_branch GC");
+}


### PR DESCRIPTION
## Summary

- **#1701 (Critical)**: Recovery now manifest-driven — orphan SSTs on disk but not in manifest are skipped instead of promoted to L0, preventing stale data from shadowing compacted segments after restart
- **#1702 (Critical)**: Wire `clear_branch()` into engine delete path; check refcount before deleting own segments so child branches don't lose inherited files
- **#1703 (Critical)**: Serialize `materialize_layer()` per branch with atomic DashMap entry guard, `LayerStatus` check, and identity-based layer removal to prevent concurrent corruption
- **#1704 (High)**: Decouple materialization from flush scheduling — remove early return so idle branches with deep inherited layers still get materialized
- **#1705 (High)**: Add `gc_orphan_segments()` to clean up leaked SST files after parent compaction + child release ordering

## Test plan

- [x] `recovery_skips_orphan_sst_not_in_manifest` — creates valid orphan segment, recovers, verifies only manifest-listed segments loaded
- [x] `concurrent_materialize_serialized` — barrier-synchronized race of two materializations, verifies exactly one proceeds
- [x] `clear_branch_preserves_referenced_own_segments` — verifies parent's files survive deletion when child references them
- [x] `gc_orphan_segments_cleans_leaked_files` — full lifecycle: parent writes → fork → compact → child clear → verify orphans GC'd
- [x] All 245 storage tests pass, 64 integration tests pass, clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)