### PR TITLE
Fix #1677: Segment corruption returns error, prevents stale data resurrection

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -801,7 +801,10 @@ impl Database {
     ///
     /// Skips Version enum and VersionedValue construction. Used by the
     /// KVStore::get() hot path where version metadata is not needed.
-    pub(crate) fn get_value_direct(&self, key: &Key) -> Option<strata_core::value::Value> {
+    pub(crate) fn get_value_direct(
+        &self,
+        key: &Key,
+    ) -> strata_core::StrataResult<Option<strata_core::value::Value>> {
         self.storage.get_value_direct(key)
     }
 

--- a/crates/engine/src/graph/mod.rs
+++ b/crates/engine/src/graph/mod.rs
@@ -1095,7 +1095,7 @@ impl GraphStore {
             for (node_id, new_edges) in chunk {
                 let uk = keys::forward_adj_key(graph, node_id);
                 let sk = Key::new_kv(ns.clone(), &uk);
-                let mut buf = match self.db.get_value_direct(&sk) {
+                let mut buf = match self.db.get_value_direct(&sk)? {
                     Some(Value::Bytes(existing)) => existing,
                     _ => packed::empty(),
                 };
@@ -1120,7 +1120,7 @@ impl GraphStore {
             for (node_id, new_edges) in chunk {
                 let uk = keys::reverse_adj_key(graph, node_id);
                 let sk = Key::new_kv(ns.clone(), &uk);
-                let mut buf = match self.db.get_value_direct(&sk) {
+                let mut buf = match self.db.get_value_direct(&sk)? {
                     Some(Value::Bytes(existing)) => existing,
                     _ => packed::empty(),
                 };

--- a/crates/engine/src/graph/traversal.rs
+++ b/crates/engine/src/graph/traversal.rs
@@ -76,7 +76,7 @@ impl GraphStore {
             super::keys::reverse_adj_key(graph, node_id)
         };
         let storage_key = super::keys::storage_key(branch_id, &user_key);
-        match self.db.get_value_direct(&storage_key) {
+        match self.db.get_value_direct(&storage_key)? {
             Some(strata_core::Value::Bytes(bytes)) => {
                 Ok(super::packed::edge_count(&bytes) as usize)
             }

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -85,7 +85,7 @@ impl KVStore {
     pub fn get(&self, branch_id: &BranchId, space: &str, key: &str) -> StrataResult<Option<Value>> {
         let storage_key = self.key_for(branch_id, space, key);
         // Direct value-only read — skips VersionedValue construction entirely
-        Ok(self.db.get_value_direct(&storage_key))
+        self.db.get_value_direct(&storage_key)
     }
 
     /// Get a value with its version metadata.

--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -26,6 +26,7 @@ use crate::segment_builder::{
     parse_properties_block, EntryHeader, FilterIndexEntry, Footer, IndexEntry, KVHeader,
     PropertiesBlock, FOOTER_SZ, FRAME_OVERHEAD, HEADER_SIZE, IDX_TYPE_PARTITIONED,
 };
+use strata_core::error::StrataError;
 use strata_core::types::Key;
 use strata_core::value::Value;
 
@@ -276,7 +277,11 @@ impl KVSegment {
     /// Returns `None` if:
     /// - Bloom filter says key is absent
     /// - No matching entry exists at or below the snapshot
-    pub fn point_lookup(&self, key: &Key, snapshot_commit: u64) -> Option<SegmentEntry> {
+    pub fn point_lookup(
+        &self,
+        key: &Key,
+        snapshot_commit: u64,
+    ) -> Result<Option<SegmentEntry>, StrataError> {
         let typed_key = encode_typed_key(key);
         let seek_ik = InternalKey::encode(key, u64::MAX);
         self.point_lookup_preencoded(&typed_key, seek_ik.as_bytes(), snapshot_commit)
@@ -289,10 +294,10 @@ impl KVSegment {
         typed_key: &[u8],
         seek_bytes: &[u8],
         snapshot_commit: u64,
-    ) -> Option<SegmentEntry> {
+    ) -> Result<Option<SegmentEntry>, StrataError> {
         // 1. Bloom check
         if !self.partitioned_bloom_check(typed_key) {
-            return None;
+            return Ok(None);
         }
 
         match &self.index {
@@ -328,11 +333,11 @@ impl KVSegment {
                         typed_key,
                         seek_bytes,
                         snapshot_commit,
-                    ) {
-                        return Some(entry);
+                    )? {
+                        return Ok(Some(entry));
                     }
                 }
-                None
+                Ok(None)
             }
         }
     }
@@ -344,7 +349,7 @@ impl KVSegment {
         typed_key: &[u8],
         seek_bytes: &[u8],
         snapshot_commit: u64,
-    ) -> Option<SegmentEntry> {
+    ) -> Result<Option<SegmentEntry>, StrataError> {
         let block_idx = match index.binary_search_by(|e| e.key.as_slice().cmp(seek_bytes)) {
             Ok(i) => i,
             Err(0) => 0,
@@ -366,11 +371,11 @@ impl KVSegment {
                 }
             }
 
-            if let Some(entry) = self.scan_block_for_key(ie, typed_key, snapshot_commit) {
-                return Some(entry);
+            if let Some(entry) = self.scan_block_for_key(ie, typed_key, snapshot_commit)? {
+                return Ok(Some(entry));
             }
         }
-        None
+        Ok(None)
     }
 
     /// Iterate entries starting from `prefix`, yielding `(InternalKey, SegmentEntry)` pairs.
@@ -552,42 +557,50 @@ impl KVSegment {
     ///
     /// On cache hit, returns the cached decompressed block (zero decompression cost).
     /// On cache miss, reads from file via pread, decompresses if needed, caches, and returns.
-    fn read_data_block(&self, ie: &IndexEntry) -> Option<Arc<Vec<u8>>> {
+    fn read_data_block(&self, ie: &IndexEntry) -> Result<Arc<Vec<u8>>, StrataError> {
         let cache = crate::block_cache::global_cache();
         let block_offset = ie.block_offset;
 
         // Check cache first
         if let Some(cached) = cache.get(self.file_id, block_offset) {
-            return Some(cached);
+            return Ok(cached);
         }
 
         // Cache miss: pread from file and decompress
         let framed_len = FRAME_OVERHEAD + ie.block_data_len as usize;
-        let raw = match pread_exact(&self.file, block_offset, framed_len) {
-            Ok(buf) => buf,
-            Err(e) => {
-                tracing::warn!(
-                    path = %self.file_path.display(),
-                    offset = block_offset,
-                    len = framed_len,
-                    error = %e,
-                    "pread failed reading data block"
-                );
-                return None;
+        let raw = pread_exact(&self.file, block_offset, framed_len).map_err(|e| {
+            StrataError::corruption(format!(
+                "pread failed reading data block at offset {} in {:?}: {}",
+                block_offset, self.file_path, e
+            ))
+        })?;
+
+        let codec_byte = raw[1];
+        let (_, data) = parse_framed_block(&raw).ok_or_else(|| {
+            StrataError::corruption(format!(
+                "data block CRC mismatch or truncation at offset {} in {:?}",
+                block_offset, self.file_path
+            ))
+        })?;
+
+        let decompressed = match codec_byte {
+            0 => data.to_vec(), // Uncompressed
+            1 => zstd::decode_all(data).map_err(|e| {
+                StrataError::corruption(format!(
+                    "zstd decompression failed at offset {} in {:?}: {}",
+                    block_offset, self.file_path, e
+                ))
+            })?,
+            other => {
+                return Err(StrataError::corruption(format!(
+                    "unknown compression codec {} at offset {} in {:?}",
+                    other, block_offset, self.file_path
+                )));
             }
         };
 
-        let codec_byte = raw[1];
-        let (_, data) = parse_framed_block(&raw)?;
-
-        let decompressed = match codec_byte {
-            0 => data.to_vec(),                // Uncompressed
-            1 => zstd::decode_all(data).ok()?, // Zstd
-            _ => return None,                  // Unknown codec
-        };
-
         // Cache the decompressed block
-        Some(cache.insert(self.file_id, block_offset, decompressed))
+        Ok(cache.insert(self.file_id, block_offset, decompressed))
     }
 
     /// Scan a single data block for the newest version of a typed key at or below snapshot.
@@ -603,7 +616,7 @@ impl KVSegment {
         ie: &IndexEntry,
         typed_key: &[u8],
         snapshot_commit: u64,
-    ) -> Option<SegmentEntry> {
+    ) -> Result<Option<SegmentEntry>, StrataError> {
         let block_data = self.read_data_block(ie)?;
         let data = &**block_data;
 
@@ -633,7 +646,7 @@ impl KVSegment {
             (0, block.len())
         };
 
-        self.linear_scan_block_v4(data, scan_start, data_end, typed_key, snapshot_commit)
+        Ok(self.linear_scan_block_v4(data, scan_start, data_end, typed_key, snapshot_commit))
     }
 
     /// Linear scan entries in `data[start..end]` for `typed_key` at or below `snapshot_commit`.
@@ -892,14 +905,15 @@ impl<'a> Iterator for SegmentIter<'a> {
                 }
                 let ie = &self.current_sub_index[self.block_within_partition];
                 match self.segment.read_data_block(ie) {
-                    Some(data) => {
+                    Ok(data) => {
                         let de = block_data_end(&data);
                         self.block_data_end = de;
                         self.block_data = Some(data);
                         self.block_offset = 0;
                         self.prev_key.clear();
                     }
-                    None => {
+                    Err(e) => {
+                        tracing::error!(error = %e, "segment iterator stopping due to corruption");
                         self.done = true;
                         return None;
                     }
@@ -1051,14 +1065,15 @@ impl Iterator for OwnedSegmentIter {
                 }
                 let ie = &self.current_sub_index[self.block_within_partition];
                 match self.segment.read_data_block(ie) {
-                    Some(data) => {
+                    Ok(data) => {
                         let de = block_data_end(&data);
                         self.block_data_end = de;
                         self.block_data = Some(data);
                         self.block_offset = 0;
                         self.prev_key.clear();
                     }
-                    None => {
+                    Err(e) => {
+                        tracing::error!(error = %e, "segment iterator stopping due to corruption");
                         self.done = true;
                         return None;
                     }
@@ -1240,14 +1255,14 @@ mod tests {
 
         let seg = KVSegment::open(&path).unwrap();
 
-        let e = seg.point_lookup(&kv_key("a"), u64::MAX).unwrap();
+        let e = seg.point_lookup(&kv_key("a"), u64::MAX).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(10));
         assert!(!e.is_tombstone);
 
-        let e = seg.point_lookup(&kv_key("b"), u64::MAX).unwrap();
+        let e = seg.point_lookup(&kv_key("b"), u64::MAX).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(20));
 
-        let e = seg.point_lookup(&kv_key("c"), u64::MAX).unwrap();
+        let e = seg.point_lookup(&kv_key("c"), u64::MAX).unwrap().unwrap();
         assert_eq!(e.value, Value::String("hello".into()));
     }
 
@@ -1262,7 +1277,7 @@ mod tests {
         build_segment(&mt, &path);
 
         let seg = KVSegment::open(&path).unwrap();
-        assert!(seg.point_lookup(&kv_key("z"), u64::MAX).is_none());
+        assert!(seg.point_lookup(&kv_key("z"), u64::MAX).unwrap().is_none());
     }
 
     #[test]
@@ -1280,22 +1295,22 @@ mod tests {
         let seg = KVSegment::open(&path).unwrap();
 
         // Snapshot at 10: see version 10
-        let e = seg.point_lookup(&kv_key("k"), 10).unwrap();
+        let e = seg.point_lookup(&kv_key("k"), 10).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(100));
         assert_eq!(e.commit_id, 10);
 
         // Snapshot at 7: see version 5
-        let e = seg.point_lookup(&kv_key("k"), 7).unwrap();
+        let e = seg.point_lookup(&kv_key("k"), 7).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(50));
         assert_eq!(e.commit_id, 5);
 
         // Snapshot at 1: see version 1
-        let e = seg.point_lookup(&kv_key("k"), 1).unwrap();
+        let e = seg.point_lookup(&kv_key("k"), 1).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(10));
         assert_eq!(e.commit_id, 1);
 
         // Snapshot at 0: nothing visible
-        assert!(seg.point_lookup(&kv_key("k"), 0).is_none());
+        assert!(seg.point_lookup(&kv_key("k"), 0).unwrap().is_none());
     }
 
     #[test]
@@ -1312,12 +1327,12 @@ mod tests {
         let seg = KVSegment::open(&path).unwrap();
 
         // Snapshot at 2: see tombstone
-        let e = seg.point_lookup(&kv_key("k"), 2).unwrap();
+        let e = seg.point_lookup(&kv_key("k"), 2).unwrap().unwrap();
         assert!(e.is_tombstone);
         assert_eq!(e.commit_id, 2);
 
         // Snapshot at 1: see the value
-        let e = seg.point_lookup(&kv_key("k"), 1).unwrap();
+        let e = seg.point_lookup(&kv_key("k"), 1).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(10));
     }
 
@@ -1436,27 +1451,45 @@ mod tests {
         let seg = KVSegment::open(&path).unwrap();
 
         assert_eq!(
-            seg.point_lookup(&kv_key("null"), u64::MAX).unwrap().value,
+            seg.point_lookup(&kv_key("null"), u64::MAX)
+                .unwrap()
+                .unwrap()
+                .value,
             Value::Null,
         );
         assert_eq!(
-            seg.point_lookup(&kv_key("bool"), u64::MAX).unwrap().value,
+            seg.point_lookup(&kv_key("bool"), u64::MAX)
+                .unwrap()
+                .unwrap()
+                .value,
             Value::Bool(true),
         );
         assert_eq!(
-            seg.point_lookup(&kv_key("int"), u64::MAX).unwrap().value,
+            seg.point_lookup(&kv_key("int"), u64::MAX)
+                .unwrap()
+                .unwrap()
+                .value,
             Value::Int(42),
         );
         assert_eq!(
-            seg.point_lookup(&kv_key("float"), u64::MAX).unwrap().value,
+            seg.point_lookup(&kv_key("float"), u64::MAX)
+                .unwrap()
+                .unwrap()
+                .value,
             Value::Float(3.14),
         );
         assert_eq!(
-            seg.point_lookup(&kv_key("string"), u64::MAX).unwrap().value,
+            seg.point_lookup(&kv_key("string"), u64::MAX)
+                .unwrap()
+                .unwrap()
+                .value,
             Value::String("hello".into()),
         );
         assert_eq!(
-            seg.point_lookup(&kv_key("bytes"), u64::MAX).unwrap().value,
+            seg.point_lookup(&kv_key("bytes"), u64::MAX)
+                .unwrap()
+                .unwrap()
+                .value,
             Value::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF]),
         );
     }
@@ -1481,17 +1514,29 @@ mod tests {
         assert_eq!(seg.entry_count(), 500);
 
         // Look up specific keys
-        let e = seg.point_lookup(&kv_key("key_000000"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("key_000000"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.commit_id, 1);
 
-        let e = seg.point_lookup(&kv_key("key_000250"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("key_000250"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.commit_id, 251);
 
-        let e = seg.point_lookup(&kv_key("key_000499"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("key_000499"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.commit_id, 500);
 
         // Non-existent key
-        assert!(seg.point_lookup(&kv_key("key_999999"), u64::MAX).is_none());
+        assert!(seg
+            .point_lookup(&kv_key("key_999999"), u64::MAX)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -1549,10 +1594,12 @@ mod tests {
 
         // Open should succeed (data blocks are lazily verified)
         let seg = KVSegment::open(&corrupt_path).unwrap();
-        // But point_lookup must fail because read_data_block checks CRC
+        // point_lookup must return an error because read_data_block checks CRC
+        let result = seg.point_lookup(&kv_key("k"), u64::MAX);
         assert!(
-            seg.point_lookup(&kv_key("k"), u64::MAX).is_none(),
-            "corrupt data block CRC should cause lookup to return None",
+            result.is_err(),
+            "corrupt data block CRC should cause lookup to return Err, got {:?}",
+            result,
         );
     }
 
@@ -1588,7 +1635,10 @@ mod tests {
         let seg = KVSegment::open(&path).unwrap();
         assert_eq!(seg.entry_count(), 0);
         assert_eq!(seg.commit_range(), (0, 0));
-        assert!(seg.point_lookup(&kv_key("anything"), u64::MAX).is_none());
+        assert!(seg
+            .point_lookup(&kv_key("anything"), u64::MAX)
+            .unwrap()
+            .is_none());
         assert_eq!(seg.iter_seek(&kv_key("")).collect::<Vec<_>>().len(), 0);
     }
 
@@ -1615,11 +1665,17 @@ mod tests {
         let seg = KVSegment::open(&path).unwrap();
 
         assert_eq!(
-            seg.point_lookup(&kv_key("arr"), u64::MAX).unwrap().value,
+            seg.point_lookup(&kv_key("arr"), u64::MAX)
+                .unwrap()
+                .unwrap()
+                .value,
             array_val,
         );
         assert_eq!(
-            seg.point_lookup(&kv_key("obj"), u64::MAX).unwrap().value,
+            seg.point_lookup(&kv_key("obj"), u64::MAX)
+                .unwrap()
+                .unwrap()
+                .value,
             object_val,
         );
     }
@@ -1655,7 +1711,8 @@ mod tests {
             let k = kv_key(&format!("k_{:08}", i));
             let e = seg
                 .point_lookup(&k, u64::MAX)
-                .expect(&format!("point lookup failed for k_{:08}", i));
+                .expect(&format!("point lookup failed for k_{:08}", i))
+                .unwrap();
             assert_eq!(e.value, Value::Int(i as i64));
             assert_eq!(e.commit_id, i as u64 + 1);
         }
@@ -1697,12 +1754,12 @@ mod tests {
 
         let seg = KVSegment::open(&path).unwrap();
 
-        let e = seg.point_lookup(&kv_key("k1"), u64::MAX).unwrap();
+        let e = seg.point_lookup(&kv_key("k1"), u64::MAX).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(42));
         assert_eq!(e.timestamp, 1_700_000_000_000_000);
         assert_eq!(e.ttl_ms, 30_000);
 
-        let e = seg.point_lookup(&kv_key("k2"), u64::MAX).unwrap();
+        let e = seg.point_lookup(&kv_key("k2"), u64::MAX).unwrap().unwrap();
         assert!(e.is_tombstone);
         assert_eq!(e.timestamp, 555);
         assert_eq!(e.ttl_ms, 10_000);
@@ -1768,9 +1825,15 @@ mod tests {
         let seg = KVSegment::open(&path).unwrap();
         assert_eq!(seg.entry_count(), 500);
         // Spot check a few entries
-        let e = seg.point_lookup(&kv_key("k_000000"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("k_000000"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.commit_id, 1);
-        let e = seg.point_lookup(&kv_key("k_000499"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("k_000499"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.commit_id, 500);
     }
 
@@ -1803,7 +1866,7 @@ mod tests {
         let seg = KVSegment::open(&path).unwrap();
         for i in 0..200u32 {
             let k = kv_key(&format!("key_{:06}", i));
-            let e = seg.point_lookup(&k, u64::MAX).unwrap();
+            let e = seg.point_lookup(&k, u64::MAX).unwrap().unwrap();
             assert_eq!(e.value, Value::String("A".repeat(500)));
         }
 
@@ -1941,7 +2004,10 @@ mod tests {
 
         let seg = KVSegment::open(&path).unwrap();
         // Look up a key in the first interval (entries 0-15)
-        let e = seg.point_lookup(&kv_key("k_0005"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("k_0005"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.value, Value::Int(5));
         assert_eq!(e.commit_id, 6);
     }
@@ -1966,7 +2032,10 @@ mod tests {
 
         let seg = KVSegment::open(&path).unwrap();
         // Key in last interval (entries 32-47)
-        let e = seg.point_lookup(&kv_key("k_0045"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("k_0045"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.value, Value::Int(45));
     }
 
@@ -1990,7 +2059,10 @@ mod tests {
 
         let seg = KVSegment::open(&path).unwrap();
         // Entry 16 is exactly at a restart point
-        let e = seg.point_lookup(&kv_key("k_0016"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("k_0016"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.value, Value::Int(16));
         assert_eq!(e.commit_id, 17);
     }
@@ -2021,17 +2093,17 @@ mod tests {
         let seg = KVSegment::open(&path).unwrap();
 
         // Snapshot at 5: see version 5
-        let e = seg.point_lookup(&kv_key("b_0000"), 5).unwrap();
+        let e = seg.point_lookup(&kv_key("b_0000"), 5).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(50));
         assert_eq!(e.commit_id, 5);
 
         // Snapshot at 3: see version 3
-        let e = seg.point_lookup(&kv_key("b_0000"), 3).unwrap();
+        let e = seg.point_lookup(&kv_key("b_0000"), 3).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(30));
         assert_eq!(e.commit_id, 3);
 
         // Snapshot at 1: see version 1
-        let e = seg.point_lookup(&kv_key("b_0000"), 1).unwrap();
+        let e = seg.point_lookup(&kv_key("b_0000"), 1).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(10));
     }
 
@@ -2053,8 +2125,14 @@ mod tests {
         build_segment(&mt, &path);
 
         let seg = KVSegment::open(&path).unwrap();
-        assert!(seg.point_lookup(&kv_key("zzz_missing"), u64::MAX).is_none());
-        assert!(seg.point_lookup(&kv_key("aaa_missing"), u64::MAX).is_none());
+        assert!(seg
+            .point_lookup(&kv_key("zzz_missing"), u64::MAX)
+            .unwrap()
+            .is_none());
+        assert!(seg
+            .point_lookup(&kv_key("aaa_missing"), u64::MAX)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -2104,16 +2182,28 @@ mod tests {
         assert_eq!(seg.entry_count(), 500);
 
         // Verify lookups across different blocks
-        let e = seg.point_lookup(&kv_key("key_000000"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("key_000000"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.commit_id, 1);
 
-        let e = seg.point_lookup(&kv_key("key_000250"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("key_000250"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.commit_id, 251);
 
-        let e = seg.point_lookup(&kv_key("key_000499"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("key_000499"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.commit_id, 500);
 
-        assert!(seg.point_lookup(&kv_key("key_999999"), u64::MAX).is_none());
+        assert!(seg
+            .point_lookup(&kv_key("key_999999"), u64::MAX)
+            .unwrap()
+            .is_none());
 
         // Verify iteration yields all entries
         let all: Vec<_> = seg.iter_seek_all().collect();
@@ -2196,13 +2286,17 @@ mod tests {
             let k = kv_key(&format!("key_{:06}", i));
             let e = seg
                 .point_lookup(&k, u64::MAX)
+                .unwrap()
                 .unwrap_or_else(|| panic!("missing key_{:06}", i));
             assert_eq!(e.value, Value::String(format!("val_{}", "x".repeat(50))));
             assert_eq!(e.commit_id, i as u64 + 1);
         }
 
         // Non-existent key
-        assert!(seg.point_lookup(&kv_key("key_999999"), u64::MAX).is_none());
+        assert!(seg
+            .point_lookup(&kv_key("key_999999"), u64::MAX)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -2322,7 +2416,7 @@ mod tests {
         // Point lookups should all succeed
         for i in 0..2000u32 {
             let k = kv_key(&format!("item_{:06}", i));
-            let e = seg.point_lookup(&k, u64::MAX);
+            let e = seg.point_lookup(&k, u64::MAX).unwrap();
             assert!(e.is_some(), "point lookup failed for item_{:06}", i);
             assert_eq!(e.unwrap().value, Value::Int(i as i64));
         }
@@ -2406,6 +2500,7 @@ mod tests {
             let k = kv_key(&format!("hk_{:06}", i));
             let e = seg
                 .point_lookup(&k, u64::MAX)
+                .unwrap()
                 .unwrap_or_else(|| panic!("key hk_{:06} not found", i));
             assert_eq!(e.value, Value::Int(i as i64));
             assert_eq!(e.commit_id, i as u64 + 1);
@@ -2430,14 +2525,23 @@ mod tests {
         let seg = KVSegment::open(&path).unwrap();
 
         // Keys that don't exist — various positions relative to existing keys
-        assert!(seg.point_lookup(&kv_key("aaa"), u64::MAX).is_none()); // before all
-        assert!(seg.point_lookup(&kv_key("exist_0050x"), u64::MAX).is_none()); // between
-        assert!(seg.point_lookup(&kv_key("zzz"), u64::MAX).is_none()); // after all
-                                                                       // Keys with similar prefixes to stress hash collisions
+        assert!(seg
+            .point_lookup(&kv_key("aaa"), u64::MAX)
+            .unwrap()
+            .is_none()); // before all
+        assert!(seg
+            .point_lookup(&kv_key("exist_0050x"), u64::MAX)
+            .unwrap()
+            .is_none()); // between
+        assert!(seg
+            .point_lookup(&kv_key("zzz"), u64::MAX)
+            .unwrap()
+            .is_none()); // after all
+                         // Keys with similar prefixes to stress hash collisions
         for i in 0..50u32 {
             let k = kv_key(&format!("exist_{:04}_GHOST", i));
             assert!(
-                seg.point_lookup(&k, u64::MAX).is_none(),
+                seg.point_lookup(&k, u64::MAX).unwrap().is_none(),
                 "ghost key exist_{:04}_GHOST should not exist",
                 i
             );
@@ -2466,6 +2570,7 @@ mod tests {
             let k = kv_key(&format!("col_{:06}", i));
             let e = seg
                 .point_lookup(&k, u64::MAX)
+                .unwrap()
                 .unwrap_or_else(|| panic!("key col_{:06} not found", i));
             assert_eq!(e.value, Value::Int(i as i64));
         }
@@ -2474,7 +2579,7 @@ mod tests {
         for i in 500..600u32 {
             let k = kv_key(&format!("col_{:06}", i));
             assert!(
-                seg.point_lookup(&k, u64::MAX).is_none(),
+                seg.point_lookup(&k, u64::MAX).unwrap().is_none(),
                 "absent key col_{:06} should not be found",
                 i
             );
@@ -2501,20 +2606,20 @@ mod tests {
         let seg = KVSegment::open(&path).unwrap();
 
         // Verify specific snapshot points
-        let e = seg.point_lookup(&k, 1).unwrap();
+        let e = seg.point_lookup(&k, 1).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(10));
         assert_eq!(e.commit_id, 1);
 
-        let e = seg.point_lookup(&k, 25).unwrap();
+        let e = seg.point_lookup(&k, 25).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(250));
         assert_eq!(e.commit_id, 25);
 
-        let e = seg.point_lookup(&k, u64::MAX).unwrap();
+        let e = seg.point_lookup(&k, u64::MAX).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(500));
         assert_eq!(e.commit_id, 50);
 
         // snapshot_commit=0 → no version visible
-        assert!(seg.point_lookup(&k, 0).is_none());
+        assert!(seg.point_lookup(&k, 0).unwrap().is_none());
     }
 
     #[test]
@@ -2528,10 +2633,16 @@ mod tests {
         build_segment(&mt, &path);
 
         let seg = KVSegment::open(&path).unwrap();
-        let e = seg.point_lookup(&kv_key("only"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("only"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.value, Value::Int(42));
         // Absent key in single-entry segment
-        assert!(seg.point_lookup(&kv_key("nope"), u64::MAX).is_none());
+        assert!(seg
+            .point_lookup(&kv_key("nope"), u64::MAX)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -2598,26 +2709,35 @@ mod tests {
 
         let seg = KVSegment::open(&path).unwrap();
 
-        let e = seg.point_lookup(&kv_key("alive"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("alive"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.value, Value::Int(1));
         assert!(!e.is_tombstone);
 
-        let e = seg.point_lookup(&kv_key("dead"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("dead"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert!(e.is_tombstone);
         assert_eq!(e.commit_id, 2);
 
         // "dead" at snapshot 1 → see the value
-        let e = seg.point_lookup(&kv_key("dead"), 1).unwrap();
+        let e = seg.point_lookup(&kv_key("dead"), 1).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(10));
         assert!(!e.is_tombstone);
 
         // "revived" at latest → see the re-put
-        let e = seg.point_lookup(&kv_key("revived"), u64::MAX).unwrap();
+        let e = seg
+            .point_lookup(&kv_key("revived"), u64::MAX)
+            .unwrap()
+            .unwrap();
         assert_eq!(e.value, Value::Int(30));
         assert!(!e.is_tombstone);
 
         // "revived" at snapshot 2 → see tombstone
-        let e = seg.point_lookup(&kv_key("revived"), 2).unwrap();
+        let e = seg.point_lookup(&kv_key("revived"), 2).unwrap().unwrap();
         assert!(e.is_tombstone);
     }
 
@@ -2708,14 +2828,21 @@ mod tests {
             let k = kv_key(&format!("pk_{:06}", i));
             let e = seg
                 .point_lookup(&k, u64::MAX)
+                .unwrap()
                 .unwrap_or_else(|| panic!("key pk_{:06} not found", i));
             assert_eq!(e.value, Value::Int(i as i64));
             assert_eq!(e.commit_id, i as u64 + 1);
         }
 
         // Missing keys return None
-        assert!(seg.point_lookup(&kv_key("pk_999999"), u64::MAX).is_none());
-        assert!(seg.point_lookup(&kv_key("zz_missing"), u64::MAX).is_none());
+        assert!(seg
+            .point_lookup(&kv_key("pk_999999"), u64::MAX)
+            .unwrap()
+            .is_none());
+        assert!(seg
+            .point_lookup(&kv_key("zz_missing"), u64::MAX)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -2838,7 +2965,7 @@ mod tests {
         // Point lookups still work
         for i in 0..10u32 {
             let k = kv_key(&format!("sm_{:04}", i));
-            let e = seg.point_lookup(&k, u64::MAX).unwrap();
+            let e = seg.point_lookup(&k, u64::MAX).unwrap().unwrap();
             assert_eq!(e.value, Value::Int(i as i64));
         }
 
@@ -2921,6 +3048,7 @@ mod tests {
             let k = kv_key(&format!("mv_{:06}", i));
             let e = seg
                 .point_lookup(&k, 1)
+                .unwrap()
                 .unwrap_or_else(|| panic!("key mv_{:06} not found at snapshot 1", i));
             assert_eq!(
                 e.value,
@@ -2936,6 +3064,7 @@ mod tests {
             let k = kv_key(&format!("mv_{:06}", i));
             let e = seg
                 .point_lookup(&k, 5)
+                .unwrap()
                 .unwrap_or_else(|| panic!("key mv_{:06} not found at snapshot 5", i));
             assert_eq!(
                 e.value,
@@ -2948,7 +3077,7 @@ mod tests {
 
         // Snapshot at commit 0 should find nothing
         let k = kv_key("mv_000000");
-        assert!(seg.point_lookup(&k, 0).is_none());
+        assert!(seg.point_lookup(&k, 0).unwrap().is_none());
     }
 
     #[test]
@@ -2977,6 +3106,7 @@ mod tests {
             let k = kv_key(&format!("tb_{:06}", i));
             let e = seg
                 .point_lookup(&k, u64::MAX)
+                .unwrap()
                 .unwrap_or_else(|| panic!("key tb_{:06} not found", i));
             if i % 2 == 0 {
                 assert!(e.is_tombstone, "key {} should be tombstone", i);
@@ -2991,7 +3121,7 @@ mod tests {
         // At snapshot 1: all keys should be non-tombstone values
         for i in (0..500u32).step_by(50) {
             let k = kv_key(&format!("tb_{:06}", i));
-            let e = seg.point_lookup(&k, 1).unwrap();
+            let e = seg.point_lookup(&k, 1).unwrap().unwrap();
             assert!(!e.is_tombstone);
             assert_eq!(e.value, Value::Int(i as i64));
         }
@@ -3116,6 +3246,7 @@ mod tests {
             let k = kv_key(&format!("b129_{:06}", i));
             let e = seg
                 .point_lookup(&k, u64::MAX)
+                .unwrap()
                 .unwrap_or_else(|| panic!("key b129_{:06} not found", i));
             assert_eq!(e.value, Value::Int(i as i64));
         }
@@ -3207,7 +3338,7 @@ mod tests {
         // Every key must be findable despite hash collisions
         for i in 0..500u32 {
             let k = kv_key(&format!("shared_prefix_collision_test_key_{:06}", i));
-            let e = seg.point_lookup(&k, u64::MAX).unwrap_or_else(|| {
+            let e = seg.point_lookup(&k, u64::MAX).unwrap().unwrap_or_else(|| {
                 panic!("key shared_prefix_collision_test_key_{:06} not found", i)
             });
             assert_eq!(e.value, Value::Int(i as i64));
@@ -3217,7 +3348,7 @@ mod tests {
         // Non-existent keys with similar prefix must not be found
         for i in 500..550u32 {
             let k = kv_key(&format!("shared_prefix_collision_test_key_{:06}", i));
-            assert!(seg.point_lookup(&k, u64::MAX).is_none());
+            assert!(seg.point_lookup(&k, u64::MAX).unwrap().is_none());
         }
     }
 
@@ -3261,6 +3392,7 @@ mod tests {
             ));
             let e = seg
                 .point_lookup(&k, u64::MAX)
+                .unwrap()
                 .unwrap_or_else(|| panic!("key ..._shortening_{:04} not found", i));
             // Key 150 was overwritten; others have their original value
             if i == 150 {
@@ -3271,11 +3403,11 @@ mod tests {
         }
 
         // MVCC: snapshot at commit 5 for the multi-version key
-        let e = seg.point_lookup(&multi_ver_key, 5).unwrap();
+        let e = seg.point_lookup(&multi_ver_key, 5).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(500)); // commit 5 * 100
 
         // MVCC: snapshot at commit 1 gets the original value
-        let e = seg.point_lookup(&multi_ver_key, 1).unwrap();
+        let e = seg.point_lookup(&multi_ver_key, 1).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(150)); // original from loop
     }
 

--- a/crates/storage/src/segment_builder.rs
+++ b/crates/storage/src/segment_builder.rs
@@ -1437,12 +1437,12 @@ mod tests {
 
         let seg = KVSegment::open(&path).unwrap();
 
-        let e = seg.point_lookup(&key("a"), u64::MAX).unwrap();
+        let e = seg.point_lookup(&key("a"), u64::MAX).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(10));
         assert_eq!(e.timestamp, 1_600_000_000_000_000);
         assert_eq!(e.ttl_ms, 60_000);
 
-        let e = seg.point_lookup(&key("b"), u64::MAX).unwrap();
+        let e = seg.point_lookup(&key("b"), u64::MAX).unwrap().unwrap();
         assert!(e.is_tombstone);
         assert_eq!(e.timestamp, 999);
         assert_eq!(e.ttl_ms, 0);
@@ -1472,7 +1472,7 @@ mod tests {
         let seg = KVSegment::open(&path).unwrap();
         for i in 0..100u32 {
             let k = key(&format!("key_{:06}", i));
-            let e = seg.point_lookup(&k, u64::MAX).unwrap();
+            let e = seg.point_lookup(&k, u64::MAX).unwrap().unwrap();
             assert_eq!(
                 e.value,
                 Value::String(format!("value_{}", "abcdefgh".repeat(20)))
@@ -1512,6 +1512,7 @@ mod tests {
             let k = key(&format!("key_{:06}", i));
             let e = seg
                 .point_lookup(&k, u64::MAX)
+                .unwrap()
                 .unwrap_or_else(|| panic!("missing key_{:06}", i));
             assert_eq!(
                 e.value,
@@ -1920,6 +1921,7 @@ mod tests {
             let k = key(&format!("key_{:06}", i));
             let e = seg
                 .point_lookup(&k, u64::MAX)
+                .unwrap()
                 .unwrap_or_else(|| panic!("missing key_{:06}", i));
             assert_eq!(e.value, Value::Int(i as i64));
             assert_eq!(e.commit_id, i as u64 + 1);
@@ -1945,19 +1947,19 @@ mod tests {
 
         let seg = KVSegment::open(&path).unwrap();
 
-        let e = seg.point_lookup(&k, 10).unwrap();
+        let e = seg.point_lookup(&k, 10).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(100));
         assert_eq!(e.commit_id, 10);
 
-        let e = seg.point_lookup(&k, 7).unwrap();
+        let e = seg.point_lookup(&k, 7).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(50));
         assert_eq!(e.commit_id, 5);
 
-        let e = seg.point_lookup(&k, 1).unwrap();
+        let e = seg.point_lookup(&k, 1).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(10));
         assert_eq!(e.commit_id, 1);
 
-        assert!(seg.point_lookup(&k, 0).is_none());
+        assert!(seg.point_lookup(&k, 0).unwrap().is_none());
     }
 
     // -----------------------------------------------------------------------
@@ -2139,7 +2141,7 @@ mod tests {
 
         for i in 0..200 {
             let k = key(&format!("key_{:04}", i));
-            let e = seg.point_lookup(&k, i as u64 + 1);
+            let e = seg.point_lookup(&k, i as u64 + 1).unwrap();
             assert!(e.is_some(), "key_{:04} not found", i);
             assert_eq!(e.unwrap().value, Value::Int(i as i64));
         }
@@ -2173,7 +2175,7 @@ mod tests {
 
         // Verify every version is accessible at its own snapshot
         for commit in 1..=200_u64 {
-            let e = seg.point_lookup(&k, commit);
+            let e = seg.point_lookup(&k, commit).unwrap();
             assert!(e.is_some(), "commit {} not found", commit);
             let entry = e.unwrap();
             assert_eq!(entry.value, Value::Int(commit as i64));
@@ -2181,7 +2183,7 @@ mod tests {
         }
 
         // Also verify the latest snapshot returns the newest version
-        let e = seg.point_lookup(&k, 200).unwrap();
+        let e = seg.point_lookup(&k, 200).unwrap().unwrap();
         assert_eq!(e.value, Value::Int(200));
     }
 
@@ -2231,19 +2233,19 @@ mod tests {
         // Check unique alpha keys
         for i in 0..50 {
             let k = key(&format!("alpha_{:04}", i));
-            let e = seg.point_lookup(&k, 1);
+            let e = seg.point_lookup(&k, 1).unwrap();
             assert!(e.is_some(), "alpha_{:04} not found", i);
         }
         // Check hot key versions
         for c in 1..=100_u64 {
-            let e = seg.point_lookup(&hot, c);
+            let e = seg.point_lookup(&hot, c).unwrap();
             assert!(e.is_some(), "beta_hot commit {} not found", c);
             assert_eq!(e.unwrap().commit_id, c);
         }
         // Check unique gamma keys
         for i in 0..50 {
             let k = key(&format!("gamma_{:04}", i));
-            let e = seg.point_lookup(&k, 1);
+            let e = seg.point_lookup(&k, 1).unwrap();
             assert!(e.is_some(), "gamma_{:04} not found", i);
         }
     }
@@ -2297,7 +2299,9 @@ mod tests {
         // Verify point lookups on the uncompressed segment
         let seg = KVSegment::open(&path_none).unwrap();
         for i in 0..200u64 {
-            let e = seg.point_lookup(&key(&format!("k_{:04}", i)), i + 1);
+            let e = seg
+                .point_lookup(&key(&format!("k_{:04}", i)), i + 1)
+                .unwrap();
             assert!(e.is_some(), "key k_{:04} not found with None codec", i);
             let expected = Value::String(format!("value_{:06}_padding_to_inflate_size", i));
             assert_eq!(e.unwrap().value, expected);
@@ -2311,7 +2315,7 @@ mod tests {
         // Verify MVCC snapshot isolation: looking up a key at an older snapshot
         // should not see newer versions
         let seg = KVSegment::open(&path_none).unwrap();
-        let e = seg.point_lookup(&key("k_0100"), 50);
+        let e = seg.point_lookup(&key("k_0100"), 50).unwrap();
         assert!(
             e.is_none(),
             "key k_0100 at commit 50 should not be visible (written at 101)"
@@ -2345,7 +2349,9 @@ mod tests {
 
             // Point lookups: first, last, and middle keys
             for &i in &[0u64, 99, 199] {
-                let e = seg.point_lookup(&key(&format!("k_{:04}", i)), i + 1);
+                let e = seg
+                    .point_lookup(&key(&format!("k_{:04}", i)), i + 1)
+                    .unwrap();
                 assert!(
                     e.is_some(),
                     "key k_{:04} not found with Zstd({})",
@@ -2423,13 +2429,13 @@ mod tests {
         let seg = KVSegment::open(&path).unwrap();
         // Even keys should have tombstone at commit 100+i
         for i in (0..20u64).step_by(2) {
-            let e = seg.point_lookup(&key(&format!("k_{:04}", i)), 200);
+            let e = seg.point_lookup(&key(&format!("k_{:04}", i)), 200).unwrap();
             assert!(e.is_some(), "tombstone k_{:04} should be visible", i);
             assert!(e.unwrap().is_tombstone, "k_{:04} should be a tombstone", i);
         }
         // Odd keys should still have their values
         for i in (1..20u64).step_by(2) {
-            let e = seg.point_lookup(&key(&format!("k_{:04}", i)), 200);
+            let e = seg.point_lookup(&key(&format!("k_{:04}", i)), 200).unwrap();
             assert!(e.is_some());
             assert_eq!(e.unwrap().value, Value::Int(i as i64));
         }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -845,25 +845,30 @@ impl SegmentedStore {
 
         // L0 segments (linear scan)
         for seg in own_version.l0_segments() {
-            if seg
-                .point_lookup_preencoded(typed_key, seek_bytes, u64::MAX)
-                .is_some()
-            {
-                return true;
+            match seg.point_lookup_preencoded(typed_key, seek_bytes, u64::MAX) {
+                Ok(Some(_)) => return true,
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::error!(error = %e, "corruption during materialization shadow check");
+                    return false;
+                }
             }
         }
 
         // L1+ segments (binary search per level)
         for level_idx in 1..own_version.levels.len() {
-            if point_lookup_level_preencoded(
+            match point_lookup_level_preencoded(
                 &own_version.levels[level_idx],
                 typed_key,
                 seek_bytes,
                 u64::MAX,
-            )
-            .is_some()
-            {
-                return true;
+            ) {
+                Ok(Some(_)) => return true,
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::error!(error = %e, "corruption during materialization shadow check");
+                    return false;
+                }
             }
         }
 
@@ -884,25 +889,30 @@ impl SegmentedStore {
 
         // L0 segments
         for seg in layer_segments.l0_segments() {
-            if seg
-                .point_lookup_preencoded(&src_typed_key, src_seek_bytes, fork_version)
-                .is_some()
-            {
-                return true;
+            match seg.point_lookup_preencoded(&src_typed_key, src_seek_bytes, fork_version) {
+                Ok(Some(_)) => return true,
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::error!(error = %e, "corruption during materialization shadow check");
+                    return false;
+                }
             }
         }
 
         // L1+ segments
         for level_idx in 1..layer_segments.levels.len() {
-            if point_lookup_level_preencoded(
+            match point_lookup_level_preencoded(
                 &layer_segments.levels[level_idx],
                 &src_typed_key,
                 src_seek_bytes,
                 fork_version,
-            )
-            .is_some()
-            {
-                return true;
+            ) {
+                Ok(Some(_)) => return true,
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::error!(error = %e, "corruption during materialization shadow check");
+                    return false;
+                }
             }
         }
 
@@ -1116,14 +1126,22 @@ impl SegmentedStore {
     }
 
     /// Direct single-key read returning only the Value (no VersionedValue).
-    pub fn get_value_direct(&self, key: &Key) -> Option<Value> {
+    pub fn get_value_direct(&self, key: &Key) -> StrataResult<Option<Value>> {
         let branch_id = key.namespace.branch_id;
-        let branch = self.branches.get(&branch_id)?;
-        let (_commit_id, entry) = Self::get_versioned_from_branch(&branch, key, u64::MAX)?;
-        if entry.is_tombstone || entry.is_expired() {
-            return None;
+        let branch = match self.branches.get(&branch_id) {
+            Some(b) => b,
+            None => return Ok(None),
+        };
+        match Self::get_versioned_from_branch(&branch, key, u64::MAX)? {
+            Some((_commit_id, entry)) => {
+                if entry.is_tombstone || entry.is_expired() {
+                    Ok(None)
+                } else {
+                    Ok(Some(entry.value))
+                }
+            }
+            None => Ok(None),
         }
-        Some(entry.value)
     }
 
     /// List all live entries for a branch filtered by type tag.
@@ -2132,7 +2150,7 @@ impl SegmentedStore {
         branch: &BranchState,
         key: &Key,
         max_version: u64,
-    ) -> Option<(u64, MemtableEntry)> {
+    ) -> StrataResult<Option<(u64, MemtableEntry)>> {
         // Encode once, reuse everywhere.
         let typed_key = encode_typed_key(key);
         let seek_ik = InternalKey::from_typed_key_bytes(&typed_key, u64::MAX);
@@ -2144,7 +2162,7 @@ impl SegmentedStore {
                 .active
                 .get_versioned_preencoded(&typed_key, seek_bytes, max_version)
         {
-            return Some(result);
+            return Ok(Some(result));
         }
 
         // 2. Frozen memtables (newest first)
@@ -2152,16 +2170,16 @@ impl SegmentedStore {
             if let Some(result) =
                 frozen.get_versioned_preencoded(&typed_key, seek_bytes, max_version)
             {
-                return Some(result);
+                return Ok(Some(result));
             }
         }
 
         // 3. L0 segments (newest first, overlapping — linear scan)
         let ver = branch.version.load();
         for seg in ver.l0_segments() {
-            if let Some(se) = seg.point_lookup_preencoded(&typed_key, seek_bytes, max_version) {
+            if let Some(se) = seg.point_lookup_preencoded(&typed_key, seek_bytes, max_version)? {
                 let commit_id = se.commit_id;
-                return Some((commit_id, segment_entry_to_memtable_entry(se)));
+                return Ok(Some((commit_id, segment_entry_to_memtable_entry(se))));
             }
         }
 
@@ -2172,9 +2190,9 @@ impl SegmentedStore {
                 &typed_key,
                 seek_bytes,
                 max_version,
-            ) {
+            )? {
                 let commit_id = se.commit_id;
-                return Some((commit_id, segment_entry_to_memtable_entry(se)));
+                return Ok(Some((commit_id, segment_entry_to_memtable_entry(se))));
             }
         }
 
@@ -2192,10 +2210,10 @@ impl SegmentedStore {
             // L0 segments (linear scan)
             for seg in layer.segments.l0_segments() {
                 if let Some(se) =
-                    seg.point_lookup_preencoded(&src_typed_key, src_seek_bytes, effective_version)
+                    seg.point_lookup_preencoded(&src_typed_key, src_seek_bytes, effective_version)?
                 {
                     let commit_id = se.commit_id;
-                    return Some((commit_id, segment_entry_to_memtable_entry(se)));
+                    return Ok(Some((commit_id, segment_entry_to_memtable_entry(se))));
                 }
             }
 
@@ -2206,14 +2224,14 @@ impl SegmentedStore {
                     &src_typed_key,
                     src_seek_bytes,
                     effective_version,
-                ) {
+                )? {
                     let commit_id = se.commit_id;
-                    return Some((commit_id, segment_entry_to_memtable_entry(se)));
+                    return Ok(Some((commit_id, segment_entry_to_memtable_entry(se))));
                 }
             }
         }
 
-        None
+        Ok(None)
     }
 
     /// Collect all versions of a key across all sources in a branch.
@@ -2501,7 +2519,7 @@ impl Storage for SegmentedStore {
             None => return Ok(None),
         };
 
-        match Self::get_versioned_from_branch(&branch, key, max_version) {
+        match Self::get_versioned_from_branch(&branch, key, max_version)? {
             Some((commit_id, entry)) => {
                 if entry.is_tombstone || entry.is_expired() {
                     Ok(None)
@@ -2724,7 +2742,7 @@ impl Storage for SegmentedStore {
             None => return Ok(None),
         };
 
-        match Self::get_versioned_from_branch(&branch, key, u64::MAX) {
+        match Self::get_versioned_from_branch(&branch, key, u64::MAX)? {
             Some((commit_id, entry)) => {
                 if entry.is_tombstone || entry.is_expired() {
                     Ok(None)
@@ -2776,7 +2794,7 @@ fn point_lookup_level(
     l1_segments: &[Arc<KVSegment>],
     key: &Key,
     max_version: u64,
-) -> Option<SegmentEntry> {
+) -> StrataResult<Option<SegmentEntry>> {
     let typed_key = encode_typed_key(key);
     let seek_ik = InternalKey::from_typed_key_bytes(&typed_key, u64::MAX);
     point_lookup_level_preencoded(l1_segments, &typed_key, seek_ik.as_bytes(), max_version)
@@ -2787,9 +2805,9 @@ fn point_lookup_level_preencoded(
     typed_key: &[u8],
     seek_bytes: &[u8],
     max_version: u64,
-) -> Option<SegmentEntry> {
+) -> StrataResult<Option<SegmentEntry>> {
     if l1_segments.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     let idx = l1_segments.partition_point(|seg| {
@@ -2802,7 +2820,7 @@ fn point_lookup_level_preencoded(
     });
 
     if idx >= l1_segments.len() {
-        return None;
+        return Ok(None);
     }
 
     let seg = &l1_segments[idx];
@@ -2810,7 +2828,7 @@ fn point_lookup_level_preencoded(
     if min_ik.len() >= 8 {
         let min_prefix = &min_ik[..min_ik.len() - 8];
         if min_prefix > typed_key {
-            return None;
+            return Ok(None);
         }
     }
 

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -1852,7 +1852,10 @@ fn get_value_direct_returns_latest() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("k"), Value::Int(10), 1);
     seed(&store, kv_key("k"), Value::Int(20), 2);
-    assert_eq!(store.get_value_direct(&kv_key("k")), Some(Value::Int(20)));
+    assert_eq!(
+        store.get_value_direct(&kv_key("k")).unwrap(),
+        Some(Value::Int(20))
+    );
 }
 
 #[test]
@@ -1860,13 +1863,13 @@ fn get_value_direct_skips_tombstone() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("k"), Value::Int(10), 1);
     store.delete_with_version(&kv_key("k"), 2).unwrap();
-    assert_eq!(store.get_value_direct(&kv_key("k")), None);
+    assert_eq!(store.get_value_direct(&kv_key("k")).unwrap(), None);
 }
 
 #[test]
 fn get_value_direct_nonexistent() {
     let store = SegmentedStore::new();
-    assert_eq!(store.get_value_direct(&kv_key("k")), None);
+    assert_eq!(store.get_value_direct(&kv_key("k")).unwrap(), None);
 }
 
 #[test]
@@ -7119,4 +7122,80 @@ fn gc_orphan_segments_cleans_leaked_files() {
     // Calling GC again should find nothing to delete.
     let deleted = store.gc_orphan_segments();
     assert_eq!(deleted, 0, "no orphans should remain after clear_branch GC");
+}
+
+// ===== Issue #1677: Corruption must not resurrect stale data =====
+
+/// Regression test for issue #1677.
+///
+/// When a newer L0 segment's data block is corrupt, `read_data_block()` must
+/// return an error — NOT `None`. Returning `None` causes the read path to
+/// silently fall through to an older segment, resurrecting stale data.
+#[test]
+fn test_issue_1677_corruption_does_not_resurrect_stale_data() {
+    use crate::segment_builder::HEADER_SIZE;
+
+    let dir = tempfile::tempdir().unwrap();
+    let seg_dir = dir.path().join("segments");
+    let store = SegmentedStore::with_dir(seg_dir.clone(), 1024);
+    let bid = branch();
+
+    // 1. Write old value and flush to L0 segment
+    seed(&store, kv_key("k"), Value::Int(100), 1);
+    store.rotate_memtable(&bid);
+    store.flush_oldest_frozen(&bid).unwrap();
+
+    // 2. Write newer value and flush to another L0 segment (prepended, i.e. newest-first)
+    seed(&store, kv_key("k"), Value::Int(200), 2);
+    store.rotate_memtable(&bid);
+    store.flush_oldest_frozen(&bid).unwrap();
+
+    // 3. Find the segment files. The newer segment has a higher numeric ID.
+    let branch_hex = hex_encode_branch(&bid);
+    let branch_dir = seg_dir.join(&branch_hex);
+    let mut sst_files: Vec<std::path::PathBuf> = std::fs::read_dir(&branch_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "sst"))
+        .collect();
+    sst_files.sort();
+    assert!(sst_files.len() >= 2, "expected at least 2 segment files");
+    let newer_path = sst_files.last().unwrap();
+
+    // 4. Corrupt the newer segment's data-block CRC.
+    //    Data block starts at HEADER_SIZE. Frame: type(1) + codec(1) + reserved(2) + data_len(4) + data(N) + crc(4).
+    let data = std::fs::read(newer_path).unwrap();
+    let data_len =
+        u32::from_le_bytes(data[HEADER_SIZE + 4..HEADER_SIZE + 8].try_into().unwrap()) as usize;
+    let crc_offset = HEADER_SIZE + 8 + data_len;
+    let mut corrupt = data.clone();
+    corrupt[crc_offset] ^= 0xFF;
+    std::fs::write(newer_path, &corrupt).unwrap();
+
+    // 5. Read must return a corruption error, NEVER the stale value (100).
+    //    Before this fix, corruption returned None which fell through to the
+    //    older segment and returned Value::Int(100) — a data-correctness violation.
+    let result = store.get_versioned(&kv_key("k"), u64::MAX);
+    match result {
+        Err(e) => {
+            assert!(
+                e.is_storage_error(),
+                "expected a storage/corruption error, got: {e}"
+            );
+        }
+        Ok(Some(v)) => {
+            panic!(
+                "corruption must not silently return data (got {:?}); \
+                 stale value resurrection detected",
+                v.value
+            );
+        }
+        Ok(None) => {
+            panic!(
+                "corruption must not be treated as 'key absent'; \
+                 this would cause stale data resurrection in multi-level reads"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- **Root Cause**: `read_data_block()` returned `Option`, collapsing corruption (CRC mismatch, pread failure, decompression failure) and absence into the same `None` value. The read path (`get_versioned_from_branch`) treated `None` as "key not found in this segment" and fell through to older segments, potentially resurrecting stale/shadowed values.
- **Fix**: Changed `read_data_block`, `scan_block_for_key`, `point_lookup_with_index`, `point_lookup`, and `point_lookup_preencoded` from `Option` to `Result<_, StrataError>`. Corruption now propagates as `StrataError::Corruption` through `get_versioned`, `get_value_direct`, and all callers.
- Iterators log corruption errors and stop iteration (the `Iterator` trait cannot propagate `Result`).
- Materialization shadow-detection logs corruption and treats it conservatively (copies the key, which is safe).

## Root Cause

`parse_framed_block()` returns `Option`, and `read_data_block()` used `?` to propagate `None` on CRC mismatch. All downstream callers interpreted `None` as "key absent", causing silent fall-through to older segments. The existing test `detects_data_block_crc_corruption` explicitly asserted `is_none()`, confirming this was the intended (but unsafe) design.

## Fix

~50 lines of non-test code changes:
1. `read_data_block()` → `Result<Arc<Vec<u8>>, StrataError>` with descriptive corruption errors
2. `scan_block_for_key()` → `Result<Option<SegmentEntry>, StrataError>`
3. `point_lookup_with_index()` → `Result<Option<SegmentEntry>, StrataError>`
4. `point_lookup()` / `point_lookup_preencoded()` → `Result<Option<SegmentEntry>, StrataError>`
5. `get_versioned_from_branch()` → `StrataResult<Option<(u64, MemtableEntry)>>`
6. `point_lookup_level_preencoded()` → `StrataResult<Option<SegmentEntry>>`
7. `get_value_direct()` → `StrataResult<Option<Value>>` (propagated through engine crate)

## Invariants Verified

- **LSM-003** (reads return newest visible version): corruption no longer silently falls through
- **MVCC-001/MVCC-002** (snapshot consistency): corrupt segment returns error, not stale data
- **LSM-005** (level ordering): level precedence maintained on corruption
- **ACID-001** (atomicity): read returns error instead of wrong data

## Test Plan

- [x] `test_issue_1677_corruption_does_not_resurrect_stale_data` — writes old value to L0 segment, newer value to another L0 segment, corrupts newer segment CRC, verifies read returns corruption error (not stale value)
- [x] Updated `detects_data_block_crc_corruption` to assert `is_err()` instead of `is_none()`
- [x] All 533 storage crate tests pass
- [x] All workspace tests pass (excluding inference/cli due to unrelated build deps)
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)