### PR TITLE
Fix #1677: Compaction aborts on corrupt segments, shadow check is conservative

### DIFF
--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -994,6 +994,8 @@ pub struct OwnedSegmentIter {
     prev_key: Vec<u8>,
     /// Monotonically increasing global block counter (for ThrottledSegmentIter).
     global_block_idx: usize,
+    /// Set to true if iteration was stopped by a corruption error (#1677).
+    corruption_detected: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
 }
 
 impl OwnedSegmentIter {
@@ -1020,7 +1022,19 @@ impl OwnedSegmentIter {
             done,
             prev_key: Vec::new(),
             global_block_idx: 0,
+            corruption_detected: None,
         }
+    }
+
+    /// Attach a shared corruption flag that will be set if a data block
+    /// cannot be read due to corruption (#1677). Callers (e.g., compaction)
+    /// check this flag after consuming the iterator.
+    pub fn with_corruption_flag(
+        mut self,
+        flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) -> Self {
+        self.corruption_detected = Some(flag);
+        self
     }
 
     /// Advance to the next partition. Returns `false` if no more partitions.
@@ -1074,6 +1088,9 @@ impl Iterator for OwnedSegmentIter {
                     }
                     Err(e) => {
                         tracing::error!(error = %e, "segment iterator stopping due to corruption");
+                        if let Some(ref flag) = self.corruption_detected {
+                            flag.store(true, std::sync::atomic::Ordering::Relaxed);
+                        }
                         self.done = true;
                         return None;
                     }

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -8,6 +8,7 @@
 //! - Multi-level compaction helpers
 
 use super::*;
+use std::sync::atomic::AtomicBool;
 
 /// Per-level byte targets, computed dynamically from actual data sizes.
 #[derive(Debug, Clone)]
@@ -212,7 +213,7 @@ impl SegmentedStore {
 
         // Build streaming source iterators from each segment.
         let limiter = self.compaction_rate_limiter.load_full();
-        let sources = streaming_sources(&old_segments, &limiter);
+        let (sources, corruption_flags) = streaming_sources(&old_segments, &limiter);
 
         let merge = MergeIterator::new(sources);
         let max_versions = self.max_versions_per_key.load(Ordering::Relaxed);
@@ -227,6 +228,7 @@ impl SegmentedStore {
             builder = builder.with_rate_limiter(Arc::clone(l));
         }
         let meta = builder.build_from_iter(compaction_iter, &seg_path)?;
+        check_corruption_flags(&corruption_flags)?;
 
         // Open the newly written segment.
         let new_segment = KVSegment::open(&seg_path)?;
@@ -351,7 +353,7 @@ impl SegmentedStore {
         let seg_path = branch_dir.join(format!("{}.sst", seg_id));
 
         let limiter = self.compaction_rate_limiter.load_full();
-        let sources = streaming_sources(&selected_segments, &limiter);
+        let (sources, corruption_flags) = streaming_sources(&selected_segments, &limiter);
 
         let merge = MergeIterator::new(sources);
         let max_versions = self.max_versions_per_key.load(Ordering::Relaxed);
@@ -366,6 +368,7 @@ impl SegmentedStore {
             builder = builder.with_rate_limiter(Arc::clone(l));
         }
         let meta = builder.build_from_iter(compaction_iter, &seg_path)?;
+        check_corruption_flags(&corruption_flags)?;
 
         let new_segment = KVSegment::open(&seg_path)?;
 
@@ -524,7 +527,7 @@ impl SegmentedStore {
         all_inputs.extend(overlapping_l1.iter().cloned());
 
         let limiter = self.compaction_rate_limiter.load_full();
-        let sources = streaming_sources(&all_inputs, &limiter);
+        let (sources, corruption_flags) = streaming_sources(&all_inputs, &limiter);
         let merge = MergeIterator::new(sources);
         let max_versions = self.max_versions_per_key.load(Ordering::Relaxed);
         let compaction_iter = CompactionIterator::new(merge, prune_floor)
@@ -550,6 +553,7 @@ impl SegmentedStore {
             let id = next_id.fetch_add(1, Ordering::Relaxed);
             branch_dir.join(format!("{}.sst", id))
         })?;
+        check_corruption_flags(&corruption_flags)?;
 
         let output_entries: u64 = outputs.iter().map(|(_, m)| m.entry_count).sum();
         let output_file_size: u64 = outputs.iter().map(|(_, m)| m.file_size).sum();
@@ -757,7 +761,7 @@ impl SegmentedStore {
         all_inputs.extend(overlap_segs.iter().cloned());
 
         let limiter = self.compaction_rate_limiter.load_full();
-        let sources = streaming_sources(&all_inputs, &limiter);
+        let (sources, corruption_flags) = streaming_sources(&all_inputs, &limiter);
         let merge = MergeIterator::new(sources);
         let max_versions = self.max_versions_per_key.load(Ordering::Relaxed);
         let compaction_iter = CompactionIterator::new(merge, prune_floor)
@@ -819,6 +823,7 @@ impl SegmentedStore {
             },
             should_split,
         )?;
+        check_corruption_flags(&corruption_flags)?;
 
         let output_entries: u64 = outputs.iter().map(|(_, m)| m.entry_count).sum();
         let output_file_size: u64 = outputs.iter().map(|(_, m)| m.file_size).sum();
@@ -881,14 +886,23 @@ impl SegmentedStore {
     }
 }
 
+type StreamingSources = (
+    Vec<Box<dyn Iterator<Item = (InternalKey, MemtableEntry)>>>,
+    Vec<Arc<AtomicBool>>,
+);
+
 fn streaming_sources(
     segments: &[Arc<KVSegment>],
     rate_limiter: &Option<Arc<crate::rate_limiter::RateLimiter>>,
-) -> Vec<Box<dyn Iterator<Item = (InternalKey, MemtableEntry)>>> {
-    segments
+) -> StreamingSources {
+    let mut corruption_flags = Vec::with_capacity(segments.len());
+    let sources = segments
         .iter()
         .map(|seg| {
-            let owned = crate::segment::OwnedSegmentIter::new(Arc::clone(seg));
+            let flag = Arc::new(AtomicBool::new(false));
+            corruption_flags.push(Arc::clone(&flag));
+            let owned =
+                crate::segment::OwnedSegmentIter::new(Arc::clone(seg)).with_corruption_flag(flag);
             if let Some(ref limiter) = rate_limiter {
                 let throttled =
                     crate::segment::ThrottledSegmentIter::new(owned, Arc::clone(limiter));
@@ -899,7 +913,20 @@ fn streaming_sources(
                     as Box<dyn Iterator<Item = (InternalKey, MemtableEntry)>>
             }
         })
-        .collect()
+        .collect();
+    (sources, corruption_flags)
+}
+
+/// Check if any corruption flag was set during iteration.
+/// If so, return an error to abort the compaction (#1677).
+fn check_corruption_flags(flags: &[Arc<AtomicBool>]) -> io::Result<()> {
+    if flags.iter().any(|f| f.load(Ordering::Relaxed)) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "compaction aborted: source segment has corrupt data block (#1677)",
+        ));
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -850,7 +850,7 @@ impl SegmentedStore {
                 Ok(None) => {}
                 Err(e) => {
                     tracing::error!(error = %e, "corruption during materialization shadow check");
-                    return false;
+                    return true; // Conservative: assume shadowed to prevent stale data resurrection
                 }
             }
         }
@@ -867,7 +867,7 @@ impl SegmentedStore {
                 Ok(None) => {}
                 Err(e) => {
                     tracing::error!(error = %e, "corruption during materialization shadow check");
-                    return false;
+                    return true; // Conservative: assume shadowed to prevent stale data resurrection
                 }
             }
         }
@@ -894,7 +894,7 @@ impl SegmentedStore {
                 Ok(None) => {}
                 Err(e) => {
                     tracing::error!(error = %e, "corruption during materialization shadow check");
-                    return false;
+                    return true; // Conservative: assume shadowed to prevent stale data resurrection
                 }
             }
         }
@@ -911,7 +911,7 @@ impl SegmentedStore {
                 Ok(None) => {}
                 Err(e) => {
                     tracing::error!(error = %e, "corruption during materialization shadow check");
-                    return false;
+                    return true; // Conservative: assume shadowed to prevent stale data resurrection
                 }
             }
         }

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -7199,3 +7199,105 @@ fn test_issue_1677_corruption_does_not_resurrect_stale_data() {
         }
     }
 }
+
+/// Regression test: compaction must abort when a source segment is corrupt.
+///
+/// Before this fix, `OwnedSegmentIter` silently returned `None` on corruption,
+/// causing the compacted output to permanently lose all entries after the
+/// corrupt data block.
+#[test]
+fn test_issue_1677_compaction_aborts_on_corrupt_segment() {
+    use crate::segment_builder::HEADER_SIZE;
+
+    let dir = tempfile::tempdir().unwrap();
+    let seg_dir = dir.path().join("segments");
+    let store = SegmentedStore::with_dir(seg_dir.clone(), 1024);
+    let bid = branch();
+
+    // Flush two L0 segments (compact_branch requires >= 2)
+    seed(&store, kv_key("a"), Value::Int(1), 1);
+    store.rotate_memtable(&bid);
+    store.flush_oldest_frozen(&bid).unwrap();
+
+    seed(&store, kv_key("b"), Value::Int(2), 2);
+    store.rotate_memtable(&bid);
+    store.flush_oldest_frozen(&bid).unwrap();
+
+    // Corrupt the first segment's data-block CRC
+    let branch_hex = hex_encode_branch(&bid);
+    let branch_dir = seg_dir.join(&branch_hex);
+    let mut sst_files: Vec<std::path::PathBuf> = std::fs::read_dir(&branch_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "sst"))
+        .collect();
+    sst_files.sort();
+    let target = &sst_files[0];
+
+    let data = std::fs::read(target).unwrap();
+    let data_len =
+        u32::from_le_bytes(data[HEADER_SIZE + 4..HEADER_SIZE + 8].try_into().unwrap()) as usize;
+    let crc_offset = HEADER_SIZE + 8 + data_len;
+    let mut corrupt = data.clone();
+    corrupt[crc_offset] ^= 0xFF;
+    std::fs::write(target, &corrupt).unwrap();
+
+    // Compaction must return an error, not silently drop entries
+    let result = store.compact_branch(&bid, 0);
+    assert!(
+        result.is_err(),
+        "compaction must abort on corrupt segment, not silently drop entries"
+    );
+}
+
+/// Regression test: materialization shadow check must return true (shadowed)
+/// on corruption, not false (unshadowed).
+///
+/// Returning false when corruption prevents reading a child segment would cause
+/// the materializer to copy stale parent entries into the child — data resurrection.
+#[test]
+fn test_issue_1677_shadow_check_returns_true_on_corruption() {
+    use crate::segment_builder::HEADER_SIZE;
+
+    let dir = tempfile::tempdir().unwrap();
+    let seg_dir = dir.path().join("segments");
+    let store = SegmentedStore::with_dir(seg_dir.clone(), 1024);
+    let bid = branch();
+
+    // Write a key and flush to a segment
+    seed(&store, kv_key("k"), Value::Int(42), 1);
+    store.rotate_memtable(&bid);
+    store.flush_oldest_frozen(&bid).unwrap();
+
+    // Corrupt the segment
+    let branch_hex = hex_encode_branch(&bid);
+    let branch_dir = seg_dir.join(&branch_hex);
+    let sst_files: Vec<std::path::PathBuf> = std::fs::read_dir(&branch_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "sst"))
+        .collect();
+    let target = &sst_files[0];
+
+    let data = std::fs::read(target).unwrap();
+    let data_len =
+        u32::from_le_bytes(data[HEADER_SIZE + 4..HEADER_SIZE + 8].try_into().unwrap()) as usize;
+    let crc_offset = HEADER_SIZE + 8 + data_len;
+    let mut corrupt = data.clone();
+    corrupt[crc_offset] ^= 0xFF;
+    std::fs::write(target, &corrupt).unwrap();
+
+    // key_exists_in_own_segments must return true (conservatively shadowed)
+    // when corruption prevents reading. Returning false would cause
+    // materialization to copy stale parent data.
+    let branch_state = store.branches.get(&bid).unwrap();
+    let ver = branch_state.version.load_full();
+    let typed_key = crate::key_encoding::encode_typed_key(&kv_key("k"));
+    let result = SegmentedStore::key_exists_in_own_segments(&ver, &typed_key);
+    assert!(
+        result,
+        "shadow check must return true on corruption to prevent stale data resurrection"
+    );
+}


### PR DESCRIPTION
## Summary

- Compaction now aborts (returns error) when a source segment has a corrupt data block, preventing permanent entry loss
- Materialization shadow checks return `true` (conservatively shadowed) on corruption, preventing stale data resurrection
- Adds corruption flag (`Arc<AtomicBool>`) to `OwnedSegmentIter`, checked in all 4 compaction methods after output is written

## Root Cause

PR #1745 fixed point-lookup corruption propagation but left two gaps:
1. `OwnedSegmentIter::next()` swallowed `read_data_block()` errors as `None`, causing compaction's `MergeIterator` to silently skip remaining entries — permanent data loss
2. `key_exists_in_own_segments()` and `key_exists_in_layer()` returned `false` on corruption, causing materialization to copy stale parent entries

## Fix

1. **Iterator corruption tracking** (~12 lines): Added `corruption_detected: Option<Arc<AtomicBool>>` field to `OwnedSegmentIter`. Set on `read_data_block()` error. Callers attach a flag via `with_corruption_flag()`.

2. **Compaction abort** (~20 lines): `streaming_sources()` now creates per-segment corruption flags. After compaction output is built, `check_corruption_flags()` verifies none were set. If any were, the compaction returns `Err` — original segments remain intact.

3. **Shadow check** (4 lines): Changed `return false` → `return true` on corruption in all 4 handlers. Conservative: "if I can't read, assume shadowed." The entry stays in the inherited layer (no data loss).

## Invariants Verified

CMP-001, CMP-002, CMP-006, MVCC-002, LSM-003, COW-004 — all HOLD.

## Test Plan

- [x] `test_issue_1677_compaction_aborts_on_corrupt_segment` — corrupt L0 segment → compaction returns error
- [x] `test_issue_1677_shadow_check_returns_true_on_corruption` — corrupt segment → shadow check returns true
- [x] `test_issue_1677_corruption_does_not_resurrect_stale_data` — existing PR 1745 test still passes
- [x] All 539 storage crate tests pass
- [x] All workspace tests pass
- [x] No new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)