### PR TITLE
Add engine invariant catalog and audit prompts

### DIFF
--- a/docs/audit/ENGINE_INVARIANTS.md
+++ b/docs/audit/ENGINE_INVARIANTS.md
@@ -1,0 +1,622 @@
+# StrataDB Engine Invariant Catalog
+
+> **Purpose**: Durable specification of correctness properties for the StrataDB engine.
+> Survives code refactors — anchored to architectural properties, not file paths or line numbers.
+> Used as a standing audit checklist: after any significant change, verify the relevant invariants.
+>
+> **How to use**: Each invariant has an **Audit** instruction. Execute it against the current codebase.
+> The instruction tells you *what to find*, not *where to find it*. If the code moved, the invariant
+> still applies — just search for it.
+>
+> **Maintenance**: Update when the *architecture* changes, not when code is refactored.
+> If a new compaction strategy is added, add invariants for it. If a function is renamed, do nothing.
+>
+> **Categories**: LSM (7), CMP (6), COW (6), MVCC (6), ACID (7), ARCH (8), SCALE (10) = 50 invariants
+
+---
+
+## LSM — Storage Engine Invariants
+
+### LSM-001: InternalKey sort order
+
+InternalKey byte ordering MUST produce ascending order by `(branch_id, space, type_tag, user_key)`
+and descending order by `commit_id` within the same logical key. This is achieved by bitwise-NOT
+encoding of the commit_id suffix. If this invariant is broken, every MVCC read, every merge
+iteration, and every compaction produces wrong results.
+
+**Audit**: Find the InternalKey encoding function. Verify that the commit_id is inverted (`!commit_id`)
+before big-endian encoding. Construct test cases: two keys with the same logical prefix but different
+commit_ids — verify the higher commit_id sorts first in byte order.
+
+### LSM-002: Byte-stuffing roundtrip
+
+The user_key encoding uses byte-stuffing (`0x00` → `0x00 0x01`, terminated by `0x00 0x00`) to preserve
+lexicographic ordering for arbitrary binary keys. Encoding then decoding MUST produce the original
+bytes for all inputs, including: empty input, input containing `0x00`, input containing `0x00 0x01`,
+input ending with `0x00`.
+
+**Audit**: Find `encode_escaped` and `decode_escaped`. Verify roundtrip correctness. Check that no
+valid encoded sequence is a prefix of another (unambiguous parsing). Verify the terminator `0x00 0x00`
+cannot appear within the encoded data.
+
+### LSM-003: Read path level ordering
+
+The read path MUST check sources in this order: active memtable → frozen memtables (newest first) →
+L0 segments (newest first) → L1 → L2 → ... → L6 → inherited COW layers (nearest ancestor first).
+The first match wins. This relies on the invariant that newer sources contain newer versions of any key.
+
+**Audit**: Find the main point-lookup function (e.g., `get_versioned_from_branch`). Trace the source
+ordering. Verify no early return skips a newer source. Verify L0 segments are ordered by commit_max
+descending. Verify L1+ levels are checked in ascending order.
+
+### LSM-004: Memtable rotation atomicity
+
+When the active memtable exceeds `write_buffer_size`, the freeze-and-swap MUST be atomic with respect
+to concurrent readers and writers. A reader must never see a state where both the old (frozen) and
+new (active) memtable are missing entries. A writer must never insert into a frozen memtable.
+
+**Audit**: Find the memtable rotation code (freeze + new active). Check if there is a window where
+a write could go to neither memtable. Verify the `frozen` flag prevents further writes. Verify
+concurrent readers see either the pre-rotation or post-rotation state, never an intermediate.
+
+### LSM-005: Bloom filter correctness with rewritten keys
+
+Bloom filters are built from `typed_key_prefix` bytes that include the branch_id. When a COW child
+queries an inherited segment, it rewrites the key to the source's branch_id before probing. The
+rewritten key MUST produce the exact same bytes that were used when building the bloom filter.
+Any divergence causes false negatives — data silently invisible.
+
+**Audit**: Find the bloom probe code path for inherited layer lookups. Verify the key rewrite function
+produces byte-identical output to what the segment builder used during bloom construction. Test with
+a key that exists in a parent segment — verify bloom returns `maybe_contains = true` after rewrite.
+
+### LSM-006: Block cache keying independence from branches
+
+The block cache is keyed by `(file_id, block_offset)` where `file_id` is derived from the file path.
+Shared segments (accessed from multiple branches via COW) MUST use the same cache entries regardless
+of which branch is accessing them. Cache keys MUST NOT include branch_id.
+
+**Audit**: Find the block cache key computation. Verify it uses only file-level identity (path hash),
+not caller identity. Verify a shared segment's blocks are cached once, not per-branch.
+
+### LSM-007: Segment file immutability
+
+Once a segment file is written and closed, it MUST NOT be modified. All reads use `pread` (positional
+read) against the immutable file. Compaction creates NEW segment files; it never modifies existing ones.
+This guarantees that concurrent readers holding Arc references to old segments always see consistent data.
+
+**Audit**: Grep for any `write`, `truncate`, or `set_len` call on segment `.sst` files outside of
+`SegmentBuilder`. Verify no compaction or maintenance operation modifies an existing segment.
+
+---
+
+## LSM — Compaction Invariants
+
+### CMP-001: Tombstone preservation in non-bottommost compaction
+
+A tombstone entry MUST NOT be dropped during compaction unless the compaction is bottommost
+(no lower levels contain data for this key range). Dropping a non-bottommost tombstone resurrects
+the entry it shadows in a lower level.
+
+**Audit**: Find all code paths that skip or drop tombstone entries during compaction output.
+For each, verify it is gated on a bottommost check. Cross-reference with RocksDB's
+`BottommostLevelCompaction` logic. Note: the `drop_expired` flag controls TTL cleanup (bottommost only),
+but tombstone cleanup for dead keys may be a separate code path — verify both.
+
+### CMP-002: Version pruning respects prune_floor
+
+The `CompactionIterator` (or equivalent) MUST:
+- Emit all entries with `commit_id ≥ prune_floor`
+- Emit exactly ONE entry below the floor per logical key (the "floor entry"), unless it's a tombstone
+- Skip all remaining below-floor entries
+- Respect `max_versions` cap
+
+When `prune_floor == 0`, all versions pass through unchanged (no pruning).
+
+**Audit**: Find the compaction iterator. Verify the pruning logic against these rules. Test edge cases:
+`prune_floor == 0`, `prune_floor == u64::MAX`, key with only tombstone below floor, key with only
+one version exactly at floor.
+
+### CMP-003: Grandparent overlap control
+
+When compacting L_n → L_{n+1}, output segment splitting MUST respect the `MAX_GRANDPARENT_OVERLAP`
+threshold to prevent pathological write amplification during the *next* compaction (L_{n+1} → L_{n+2}).
+The splitting predicate tracks cumulative overlap with L_{n+2} files and forces a split when exceeded.
+
+**Audit**: Find the grandparent-aware split predicate. Verify the byte accumulation is correct. Check
+what happens when the output key jumps past multiple grandparent files at once. Compare with RocksDB's
+`MaxGrandParentOverlapBytes`.
+
+### CMP-004: Compaction manifest-before-delete ordering
+
+The storage manifest MUST be updated BEFORE old segment files are deleted. If the system crashes after
+deleting old files but before writing the manifest, recovery would reference missing segments.
+
+**Audit**: Find every compaction method that deletes old segments. Verify `write_branch_manifest()` is
+called BEFORE any `delete_segment_if_unreferenced()` call. Verify the manifest write is crash-safe
+(temp file + rename).
+
+### CMP-005: Dynamic level sizing correctness
+
+The dynamic level target computation (based on RocksDB's `CalculateBaseBytes`) MUST:
+1. Find the largest non-empty non-L0 level
+2. Compute base = bottom_bytes / multiplier^(bottom_level - 1)
+3. Clamp base between MIN_BASE_BYTES and MAX_BASE_BYTES
+4. Forward-compute all targets with saturation
+
+Targets MUST be refreshed after every compaction and flush.
+
+**Audit**: Find the level target computation function. Step through the algorithm with concrete numbers.
+Verify it handles: empty database (all levels empty), single-level spike (L3 has 10GB, others empty),
+very small databases (< MIN_BASE_BYTES total). Verify refresh is called after every segment version swap.
+
+### CMP-006: Concurrent compaction and flush safety
+
+A flush may insert a new L0 segment while compaction is reading L0 segments. Compaction snapshots the
+segment list at start. The swap step filters out compacted segments (by Arc identity) and preserves
+any segments added concurrently by flush. New segments MUST NOT be lost or duplicated.
+
+**Audit**: Find the segment version swap in each compaction method. Verify the filter uses `Arc::ptr_eq`
+(identity, not value equality). Verify the new version includes both the compaction output AND any
+concurrently-flushed segments.
+
+---
+
+## COW — Copy-on-Write Branching Invariants
+
+### COW-001: Shared segment deletion requires zero refcount
+
+A segment file referenced by any branch's inherited layer MUST NOT be deleted. Every `.sst` file
+deletion path must check the `SegmentRefRegistry`. Untracked segments (refcount never incremented)
+are treated as unshared and can be deleted freely.
+
+**Audit**: Grep for every `fs::remove_file` call on `.sst` files. Verify each goes through
+`delete_segment_if_unreferenced` or equivalent refcount check. A single missing check means
+compaction on a parent branch can silently corrupt all child branches.
+
+### COW-002: Fork refcount increment before guard release
+
+During `fork_branch`, segment refcounts for all inherited segments MUST be incremented BEFORE the
+source branch's DashMap guard is released. If the guard is released first, a concurrent compaction
+on the source could delete a segment between guard release and refcount increment.
+
+**Audit**: Find the fork_branch implementation. Trace the ordering: source guard acquisition →
+segment snapshot → guard release → refcount increment. If there is a gap between release and
+increment, identify the race window and assess impact.
+
+### COW-003: Inherited layer version gate
+
+When reading through an inherited layer, the effective version ceiling is `min(max_version, fork_version)`.
+Entries with `commit_id > fork_version` MUST be invisible to the child branch. This ensures branch
+isolation — parent writes after the fork are invisible to the child.
+
+**Audit**: Find every read path that accesses inherited layers (point lookup, range scan, history,
+list). Verify each applies the `min(max_version, fork_version)` filter. Verify the RewritingIterator
+applies the version gate.
+
+### COW-004: Materialization preserves commit_ids
+
+When inherited entries are materialized into the child's own segments, the original `commit_id`
+MUST be preserved, not reassigned. Reassigning would break: (a) MVCC reads at the fork_version
+(the entries would be invisible), (b) merge base computation (ancestor state would be lost).
+
+**Audit**: Find the materialization function. Verify the InternalKey rewrite only changes the
+branch_id prefix (first 16 bytes) and preserves the commit_id suffix (last 8 bytes).
+
+### COW-005: Recovery resolves inherited layers after all branches are loaded
+
+Inherited layer resolution requires looking up source branch segments by filename. All source
+branches MUST be loaded (with their segments opened) before any child branch resolves its
+inherited layers. A two-pass recovery (first pass: load own segments; second pass: resolve
+inherited) satisfies this.
+
+**Audit**: Find the recovery/segment-loading code. Verify inherited layers are resolved in a
+second pass after all branches' own segments are loaded. Check: what happens if a source branch
+is missing (directory deleted)? Is this a hard error or a warning with data loss?
+
+### COW-006: Refcount rebuild on recovery
+
+After crash recovery, segment refcounts MUST be rebuilt from all branches' inherited layers.
+The rebuilt refcounts MUST match what they were before the crash (accounting for any in-flight
+operations that were not durable).
+
+**Audit**: Find the refcount rebuild code in recovery. Verify it iterates ALL branches' inherited
+layers and increments for each referenced segment. Verify no double-counting.
+
+---
+
+## MVCC — Multi-Version Concurrency Control Invariants
+
+### MVCC-001: Version visibility boundary
+
+A reader at snapshot version V MUST NEVER see an entry with `commit_id > V`. This holds across
+active memtable, frozen memtables, all segment levels, and inherited COW layers. This is the
+foundational guarantee for snapshot isolation.
+
+**Audit**: Find every point-lookup and scan code path. Verify each filters by `max_version` / `commit_id`.
+Check that no fallthrough path bypasses the filter. Check inherited layer reads apply the
+`min(max_version, fork_version)` ceiling.
+
+### MVCC-002: Tombstone semantics
+
+A tombstone at `commit_id = V` means "key deleted at version V." For readers at `max_version ≥ V`,
+the key MUST return "not found" — the tombstone shadows all older versions. For readers at
+`max_version < V`, the key exists at its previous version. Tombstones MUST be emitted by
+`MvccIterator` (the caller decides filtering). Point lookups MUST treat tombstones as "not found."
+History queries MUST include tombstones.
+
+**Audit**: Find the point lookup caller that checks for tombstones. Verify it returns `None` (not the
+tombstone value). Find the history query. Verify it includes tombstones. Find the scan/list path.
+Verify it filters out tombstones.
+
+### MVCC-003: Global version counter monotonicity
+
+The global version counter (`TransactionManager::version`) MUST be monotonically increasing.
+`allocate_version()` MUST return unique, increasing values. No two transactions may receive the
+same commit_version. Version gaps are acceptable (failed transactions).
+
+**Audit**: Find the version allocation function. Verify it uses `fetch_add(1)` or equivalent
+atomic operation. Verify the overflow check at `u64::MAX`. Verify recovery restores the counter
+to at least the maximum committed version from WAL replay.
+
+### MVCC-004: Snapshot capture happens before version allocation
+
+A transaction's snapshot version (`start_version`) MUST be captured BEFORE any concurrent
+transaction's `allocate_version()` could make new data visible. Otherwise, the snapshot
+could include data from a transaction that hasn't finished applying yet.
+
+**Audit**: Find where `start_version` is captured (transaction creation). Verify it reads
+`current_version()` which reflects only fully-applied transactions. Verify that a transaction's
+version is allocated AFTER its writes are validated but the writes are not yet visible.
+
+### MVCC-005: No snapshot pinning gap
+
+Active transactions pin the GC safe point. The `gc_safe_version` MUST be ≤ the minimum snapshot
+version of any active transaction. If GC prunes versions below `gc_safe_version`, and an active
+transaction holds a snapshot at a lower version, that transaction will see missing data.
+
+**Audit**: Find the `gc_safe_version` advancement logic. Verify it only advances when `active_count`
+drains to 0. Verify `gc_safe_point()` returns `min(current_version - 1, gc_safe_version)` and
+returns 0 when active transactions exist but no drain has occurred. Verify the prune_floor
+passed to compaction never exceeds `gc_safe_point()`.
+
+### MVCC-006: TTL expiration does not resurrect old versions
+
+When the newest visible version of a key has expired (TTL elapsed), the read path MUST return
+"not found" — it MUST NOT fall through to an older, non-expired version. The expired version
+is the authoritative state. (Design decision: expired = gone, not expired = reveal older.)
+
+**Audit**: Find the point lookup path. Verify that when the first matching entry is expired,
+the function returns `None` without checking older versions. Verify this is the intended semantic.
+
+---
+
+## ACID — Atomicity, Consistency, Isolation, Durability Invariants
+
+### ACID-001: Single WAL record per transaction
+
+Each transaction MUST produce exactly ONE `WalRecord` containing the complete writeset (all puts,
+deletes, CAS results). This ensures atomicity of recovery — a transaction is either fully replayed
+or not at all. Partial WAL records (truncated by crash) are detected by CRC32 and discarded.
+
+**Audit**: Find the WAL record construction in the commit protocol. Verify it bundles all writes
+into a single `TransactionPayload` → single `WalRecord`. Verify no code path writes multiple
+WAL records for a single transaction.
+
+### ACID-002: WAL before storage
+
+The commit protocol MUST write the WAL record BEFORE applying writes to storage. If storage
+application fails after WAL write, the transaction is still durable (recovery replays from WAL).
+If WAL write fails, the transaction MUST NOT be applied to storage.
+
+**Audit**: Find the commit method. Verify the ordering: validate → allocate version → WAL append →
+apply_writes. Verify that WAL failure causes abort (no storage application). Verify that storage
+failure after WAL is logged but the commit is still reported as successful.
+
+### ACID-003: Per-branch lock prevents TOCTOU
+
+For read-write transactions (non-blind-write), the per-branch commit lock MUST be held from
+validation through version allocation and storage application. Without this, a concurrent
+transaction could modify storage between validation and apply, causing a stale validation
+to be acted upon.
+
+**Audit**: Find the per-branch lock acquisition. Verify it is held continuously from validation
+start through apply_writes completion. Verify blind writes (empty read_set) correctly skip the
+lock without violating isolation.
+
+### ACID-004: Blind write safety
+
+Blind writes (no prior reads, no CAS, no JSON snapshots) skip the per-branch lock and validation.
+This is safe because: (a) each blind write gets a unique version via atomic `allocate_version()`,
+(b) concurrent blind writes create distinct versions — highest wins at read time, (c) MVCC
+prevents readers from seeing partially-applied blind writes (all entries share the same version).
+
+**Audit**: Find the blind write fast path. Verify it correctly identifies blind writes (all read-related
+sets empty). Verify no reader can snapshot at the blind write's version before apply completes.
+Specifically: `allocate_version()` increments the global counter. A concurrent `current_version()`
+call returns the new value. A reader creating a snapshot at this version would try to read data
+that might not be in the memtable yet. Verify whether this race exists and its impact.
+
+### ACID-005: Recovery replay is idempotent
+
+WAL replay MUST be idempotent — replaying the same record twice produces the same state as
+replaying it once. This is required because a crash during recovery could cause a second
+recovery to re-replay some records. Idempotence holds because memtable put with the same
+`(key, version)` overwrites with the same value.
+
+**Audit**: Find the WAL replay callback. Verify it uses `put_with_version_mode` with the original
+commit_version from the WAL record. Verify that inserting the same `(key, version)` pair twice
+into the SkipMap produces one entry, not two.
+
+### ACID-006: DurabilityMode::Always provides fsync-per-commit
+
+In `Always` mode, the WAL MUST be fsynced to stable storage before the commit returns.
+After the commit returns, a crash MUST NOT lose the transaction.
+
+**Audit**: Find the `maybe_sync` function. Verify that in `Always` mode, `segment.sync()` is called
+on every append. Verify `sync()` calls `flush()` (BufWriter → OS) then `sync_all()` or `sync_data()`
+(OS → disk). If `flush()` is missing, data in the BufWriter is lost on crash even after "fsync."
+
+### ACID-007: Standard mode durability window is bounded
+
+In `Standard` mode, fsync is periodic (every `interval_ms` or `batch_size` commits, whichever first).
+The data loss window MUST NOT exceed `interval_ms × 3` (the safety-net threshold). If the background
+flush thread stalls beyond 3× interval, an inline fsync MUST be triggered.
+
+**Audit**: Find the Standard mode logic in `maybe_sync`. Verify the safety-net threshold. Find the
+background flush thread (if it exists). Verify it calls `sync_if_overdue` periodically. If the
+background thread doesn't exist, verify the safety-net covers all cases.
+
+---
+
+## ARCH — Cross-Cutting Architectural Invariants
+
+### ARCH-001: One version domain for GC
+
+All data-bearing entries in KV storage (including EventLog events, StateCell values, JSON documents,
+Vector records, and Branch metadata) are stored as KV entries with a `Txn(u64)` commit_version.
+The GC safe point (`gc_safe_version`) is computed in the Txn version domain and protects ALL
+entries regardless of their primitive type.
+
+EventLog's `Sequence(u64)` and StateCell's `Counter(u64)` are metadata stored WITHIN the KV value,
+not independent version axes. GC prunes by Txn commit_version, which correctly prunes all types.
+
+**Audit**: Find where EventLog entries are stored in KV. Verify the KV entry has a Txn commit_version
+(from the transaction). Find where StateCell values are stored. Verify same. Verify that `gc_safe_point`
+and `prune_floor` operate in the Txn domain and that this correctly governs all primitive types.
+
+### ARCH-002: One atomic publication boundary
+
+All writes in a transaction share a single commit_version. A reader at `max_version < commit_version`
+sees NONE of them. A reader at `max_version ≥ commit_version` sees ALL of them. There is no
+intermediate state where some writes are visible and others are not.
+
+Secondary indexes (HNSW vector, BM25 search) are updated AFTER storage application and are
+NOT part of the atomic boundary. They are eventually consistent — a query through the search
+index may temporarily miss newly-committed entries. KV queries are always authoritative.
+
+**Audit**: Verify all entries in a transaction get the same commit_version. Verify no reader can
+snapshot at commit_version V while `apply_writes` for V is still in progress (for read-write
+transactions, the per-branch lock prevents this; for blind writes, verify the race analysis).
+Verify secondary index updates are documented as eventually consistent.
+
+### ARCH-003: KV storage is the single source of truth
+
+All persistent state lives in the `SegmentedStore`. Secondary indexes (HNSW, BM25) are derived
+and can be fully rebuilt from KV storage. Losing a secondary index MUST NOT lose any data —
+only search/query performance is affected until rebuild.
+
+**Audit**: For each secondary index (vector HNSW, search BM25), verify that a full rebuild from
+KV storage produces identical results. Find the recovery code for each — verify it scans KV
+and rebuilds from scratch. Verify no secondary index contains information that cannot be
+derived from KV.
+
+### ARCH-004: One recovery model with deterministic ordering
+
+Recovery follows a fixed sequence: MANIFEST → snapshot → WAL replay → segment recovery →
+inherited layer resolution → refcount rebuild → version counter restoration → secondary index rebuild.
+
+Each step's output MUST NOT depend on a later step's output (no circular dependencies).
+Replay MUST be deterministic: same WAL records → same final state. Replay MUST be idempotent:
+multiple recoveries → same result.
+
+**Audit**: Find the master recovery sequence (Database startup). Trace the ordering of each step.
+Verify no step reads state that a later step produces. Verify the WAL watermark (filtering by
+`txn_id`) is consistent with the version domain (commit_version) — specifically that txn_id
+ordering and commit_version ordering don't diverge in a way that causes missed or duplicate replays.
+
+### ARCH-005: GC respects active snapshots AND branch inheritance
+
+Compaction pruning (prune_floor) MUST be ≤ `gc_safe_point()`, which is ≤ the minimum active
+snapshot version. Additionally, COW inherited layers hold Arc references to old segment files,
+preventing their deletion. But compaction creates NEW segments with pruned entries — the pruning
+is safe because the old segments (with unpruned entries) remain accessible through the Arc references.
+
+**Audit**: Find where `prune_floor` is passed to compaction. Verify it comes from `gc_safe_point()`.
+Verify `gc_safe_point()` accounts for active transactions and returns 0 when safety requires it.
+Verify that COW children read from Arc'd segment snapshots (not the parent's current version),
+so compaction on the parent doesn't affect the child's view.
+
+### ARCH-006: Transaction timeout prevents GC starvation
+
+Long-running transactions pin `gc_safe_version`, preventing version pruning. The system MUST
+enforce a transaction timeout (default: 5 minutes) that rejects commits of expired transactions.
+Without this, a leaked transaction handle could cause unbounded version accumulation.
+
+**Audit**: Find the transaction timeout constant. Find where it's checked (commit path). Verify
+that an expired transaction's commit fails and its active_count is decremented, allowing
+gc_safe_version to advance.
+
+### ARCH-007: Manifest and WAL are separate authority domains
+
+The system has TWO manifest files that serve different purposes:
+1. **Durability MANIFEST** (database-level): UUID, codec, snapshot info, active WAL segment
+2. **Storage manifests** (per-branch): segment filenames, levels, inherited layers
+
+These MUST NOT conflict. The durability MANIFEST governs the recovery protocol (which snapshot, which
+WAL segments). Storage manifests govern segment loading (which files, which levels). Neither depends
+on the other's correctness — they are independent authority domains.
+
+**Audit**: Verify the two manifest systems are independent. Find each manifest's read and write paths.
+Verify no code reads a durability MANIFEST field to make a storage manifest decision, or vice versa.
+
+### ARCH-008: Fork_version creates an implicit retention floor for shared segments
+
+When branch B inherits segments from A at fork_version V, the entries in those segments with
+commit_id ≤ V MUST remain accessible to B. Since B holds Arc references to the OLD segment files
+(pre-compaction), and segment files are immutable (LSM-007), compaction on A does not modify
+the shared files. A's compaction creates new segments and tries to delete old ones — but the
+refcount check (COW-001) prevents deletion while B references them.
+
+**Audit**: Verify the complete chain: (1) B holds Arc to A's segments, (2) A's compaction creates
+new files, (3) old file deletion is blocked by refcount, (4) B reads from the unchanged old files.
+If any link breaks, B sees corrupted or missing data.
+
+---
+
+## SCALE — Scale-Span Invariants (Pi Zero to Billion-Key Server)
+
+### SCALE-001: No hardcoded constant assumes server-class resources
+
+Every memory-consuming default MUST be either configurable via `StorageConfig` or derived from a
+resource-aware computation (e.g., `auto_detect_capacity()`). No hardcoded constant should cause
+OOM on a 512MB device with default configuration.
+
+Specifically:
+- Block cache default MUST NOT exceed 25% of available RAM on the target device
+- Write buffer size MUST NOT exceed 10% of available RAM
+- `auto_detect_capacity()` MUST NOT clamp to a minimum that exceeds available RAM
+- Level sizing constants (`LEVEL_BASE_BYTES`, `MAX_GRANDPARENT_OVERLAP`) MUST be derived from
+  actual data size, not hardcoded to server-scale values
+
+**Audit**: Find every constant in the storage crate that controls a memory allocation size or
+threshold. For each, compute what percentage of 350MB (Pi Zero usable RAM) it represents at its
+default value. Flag any constant ≥ 25% of 350MB that is not configurable or auto-scaled.
+
+### SCALE-002: Memory budget propagates to all consumers
+
+A single `memory_budget` configuration (or equivalent set of `StorageConfig` fields) MUST control
+the total memory footprint. Setting `block_cache_size = 16MB` and `write_buffer_size = 4MB` MUST
+actually result in those limits being respected — no internal code path should override, ignore,
+or supplement these with additional uncapped allocations.
+
+**Audit**: For each `StorageConfig` field, trace from config parsing to the point where the value
+is consumed by the storage engine. Verify no intermediate code overrides the value. Verify there
+are no major memory consumers outside `StorageConfig` control (e.g., DashMap growth, segment index
+pinning, bloom filter pinning, HNSW index). For uncapped consumers, quantify their memory usage
+as a function of data size.
+
+### SCALE-003: On-disk format is word-size portable
+
+A database created on a 64-bit server MUST be openable on a 32-bit ARM device, and vice versa.
+All on-disk formats (segment files, WAL records, manifests, snapshots) MUST use fixed-width integer
+types (`u32`, `u64`), not `usize`. Endianness MUST be explicitly little-endian (`to_le_bytes`),
+never native (`to_ne_bytes`).
+
+**Audit**: Find every serialization/deserialization path in segment, WAL, manifest, and snapshot code.
+Grep for `usize` in any `to_bytes` / `from_bytes` / serialization function. Grep for `to_ne_bytes`.
+Verify all on-disk integers are explicit-width and explicit-endian.
+
+### SCALE-004: AtomicU64 operations are bounded per user operation
+
+On 32-bit ARM (Pi Zero 1 / ARMv6), `AtomicU64` is emulated via a global lock — every `fetch_add`,
+`load`, and `store` on any `AtomicU64` contends on the same mutex. The number of `AtomicU64`
+operations per read and per write MUST be bounded and small (ideally ≤ 5 per operation).
+
+**Audit**: Trace a single point-read (`get_versioned`) and a single write (`put_with_version_mode`)
+through the storage engine. Count every `AtomicU64` operation touched (version counter, memtable
+stats, block cache hit/miss counters, timestamp tracking). Assess whether the count is acceptable
+on a single-core ARM device with emulated atomics.
+
+### SCALE-005: Write amplification is bounded and documented
+
+LSM write amplification directly impacts SD card write endurance. The theoretical write amplification
+for the default configuration MUST be documented. On flash storage, total write amplification
+(user writes × LSM amplification × filesystem/FTL amplification) determines device lifetime.
+
+**Audit**: Calculate write amplification for the default config: L0 trigger=4, multiplier=10,
+7 levels. For each level transition, compute the amplification factor. Sum to get worst-case total.
+Then compute: for a 32GB SD card with 10K P/E cycles, how many total user bytes can be written
+before the card wears out? Is this acceptable for the target workload (10K keys, moderate write rate)?
+
+### SCALE-006: Compaction does not starve user operations on single-core
+
+On a single-core device, compaction I/O competes directly with user reads and writes. Compaction
+MUST be throttleable to prevent starvation. The `RateLimiter` (if used) MUST be configurable to
+a rate appropriate for SD card bandwidth.
+
+**Audit**: Find every compaction code path. Verify each uses the `RateLimiter` (if configured).
+Find where the rate limiter is instantiated — is the rate configurable via `StorageConfig`? What
+is the default rate? On a 10 MB/s SD card, is the default rate appropriate? Is there a way to
+pause compaction entirely (for burst write periods on slow storage)?
+
+### SCALE-007: Thread count is bounded and configurable
+
+On a single-core device, each background thread adds scheduling overhead and ~8MB stack memory.
+The total number of threads spawned by the engine MUST be bounded and should be configurable.
+On a Pi Zero, no more than 2-3 threads total (main + background flush + optional compaction).
+
+**Audit**: Find every `thread::spawn`, `thread::Builder`, `rayon`, or `tokio::spawn` call in the
+engine and storage crates. List all background threads. Verify they can be disabled or reduced
+on resource-constrained devices. Compute the total stack memory overhead.
+
+### SCALE-008: Billion-key segment metadata fits in memory
+
+At billion-key scale with thousands of segments, pinned segment metadata (bloom filter partitions,
+index blocks) must fit within the block cache budget. The total pinned memory MUST NOT exceed the
+pinned budget (10% of block cache capacity by default).
+
+**Audit**: For a dataset with 1B keys at 100 bytes each (100GB total data), calculate:
+- Number of segments across 7 levels at `TARGET_FILE_SIZE=64MB`
+- Pinned bloom filter memory per segment (at configured bits/key per level)
+- Pinned index block memory per segment
+- Total pinned memory vs pinned budget (10% of block cache)
+If pinned metadata exceeds the budget, assess whether bloom/index pinning degrades gracefully
+(evicted to non-pinned cache tier) or fails hard.
+
+### SCALE-009: MergeIterator scales to high source counts
+
+The `MergeIterator` uses linear scan (O(N) per `next()` call, where N = source count). This is
+optimal for 1-3 sources but degrades at higher counts. At billion-key scale, compaction merges
+can involve 10+ sources (L0 files + overlapping L1 files). The iterator MUST either switch to a
+heap-based merge at high source counts or document the performance cliff.
+
+**Audit**: Find the MergeIterator. Verify the source count at which linear scan becomes slower than
+a binary heap (typically N ≥ 6-8). Find the maximum source count that can occur in practice for
+each compaction type (compact_branch, compact_l0_to_l1, compact_level). If any can exceed 8 sources,
+assess the performance impact.
+
+### SCALE-010: Feature degradation is explicit, not OOM
+
+Features that require significant memory (HNSW vector indexes, BM25 search, auto-embed model
+loading) MUST be disableable without affecting core KV/JSON/Event/State functionality. Running
+out of memory MUST produce a clear error, not a silent crash or data corruption.
+
+**Audit**: For each optional feature (vector search, BM25 search, auto-embed), verify:
+1. It can be disabled via configuration
+2. Disabling it does not break core primitives
+3. Enabling it on a memory-constrained device produces a clear error if memory is insufficient,
+   rather than OOM-killing the process
+4. There is a brute-force fallback for vector search on small collections
+
+---
+
+## How to Use This Catalog
+
+### After a code change
+
+1. Identify which invariants the change could affect (use the category prefixes: LSM, CMP, COW, MVCC, ACID, ARCH, SCALE)
+2. Execute the **Audit** instruction for each affected invariant against the current codebase
+3. If an invariant is violated, fix the code — do not weaken the invariant
+
+### After an architectural change
+
+1. Review all invariants for relevance — some may need updating
+2. Add new invariants for new architectural properties
+3. Remove invariants for removed architectural properties
+4. The invariant IDs are stable — do not renumber (use gaps if removing)
+
+### During code review
+
+Reference invariants by ID: "This change could violate CMP-001 — verify tombstone handling
+in the new compaction path."

--- a/docs/audit/prompts/invariant-check.md
+++ b/docs/audit/prompts/invariant-check.md
@@ -1,0 +1,139 @@
+# Engine Invariant Check
+
+You are reviewing a code change to StrataDB, a Rust-based embedded database with an LSM tree storage engine, COW branching, MVCC versioning, and ACID transactions.
+
+Your job is to determine whether this change violates any engine invariant — and if it does, fix it.
+
+## Instructions
+
+1. Read the engine invariant catalog at `docs/audit/ENGINE_INVARIANTS.md`. This defines 28 correctness properties organized into 7 categories (LSM, CMP, COW, MVCC, ACID, ARCH). Each invariant has an **Audit** instruction.
+
+2. Read the git diff provided below (or attached).
+
+3. **Triage**: For each invariant, assess whether the changed code could affect it. An invariant is "affected" if the diff touches code that participates in the property — even indirectly. Err on the side of inclusion. List the affected invariants by ID.
+
+4. **Verify**: For each affected invariant, execute its Audit instruction against the **current codebase** (post-change). Read the actual source files — do not rely on the diff alone, because the diff shows what changed but not the surrounding context that the invariant depends on.
+
+5. **Report**: For each affected invariant, state one of:
+   - **HOLDS** — the invariant is satisfied. State why in one sentence.
+   - **WEAKENED** — the invariant is not violated but the safety margin is reduced (see step 6).
+   - **VIOLATED** — the invariant is broken (see step 6).
+   - **INCONCLUSIVE** — you cannot determine compliance without more context. State what you need.
+
+6. **Fix violations**: For every invariant that is VIOLATED or WEAKENED:
+
+   a. **Diagnose root cause.** Identify the exact code that violates the invariant. Show a concrete
+      scenario — a sequence of operations with version numbers, branch names, and crash points — that
+      triggers the bug. Do not speculate; demonstrate.
+
+   b. **Design the fix.** The fix must:
+      - Restore the invariant without weakening any other invariant. Check the dependency chain:
+        a compaction fix (CMP-*) must not break MVCC visibility (MVCC-001) or COW safety (COW-001).
+      - Be minimal — change only what is necessary to restore the invariant. Do not refactor
+        surrounding code, add features, or "improve" unrelated logic.
+      - Preserve existing tests. If existing tests relied on the buggy behavior, those tests were
+        wrong — fix them too, but call it out explicitly.
+
+   c. **Implement the fix.** Write the corrected code. Use the Edit tool to apply changes to the
+      actual source files.
+
+   d. **Write a regression test.** The test must:
+      - Reproduce the exact scenario from step (a) — if the fix were reverted, the test would fail.
+      - Be named to reference the invariant: `test_cmp001_tombstone_preserved_in_non_bottommost`.
+      - Live in the appropriate test module (storage tests for LSM/CMP, integration tests for ARCH).
+
+   e. **Re-verify.** After applying the fix, re-run the Audit instruction for the fixed invariant
+      AND for every invariant that shares code with the fix. Confirm no new violations were introduced.
+
+## Output Format
+
+```
+## Triage
+
+Affected invariants: LSM-003, CMP-001, CMP-002, MVCC-001, ARCH-005
+Not affected: [all others — no code in this diff participates in those properties]
+
+## Verification
+
+### LSM-003: Read path level ordering
+**HOLDS** — The read path in get_versioned_from_branch still checks sources in the
+correct order (active → frozen → L0 → L1-L6 → inherited). The change does not
+alter source ordering.
+
+### CMP-001: Tombstone preservation in non-bottommost compaction
+**VIOLATED**
+
+**Bug**: The new compaction path in compact_level() drops tombstones unconditionally:
+    if entry.is_tombstone && commit_id < prune_floor {
+        continue; // BUG: no bottommost check
+    }
+
+**Scenario**: Key K has value@3 in L2 and tombstone@5 in L1. compact_level(1, ...)
+drops tombstone@5 (below prune_floor=6). L2 still has value@3. Next read of K
+returns value@3 — resurrecting deleted data.
+
+**Fix**: Gate tombstone drop on `is_bottommost`:
+    if entry.is_tombstone && commit_id < prune_floor && is_bottommost {
+        continue;
+    }
+
+**Regression test**: test_cmp001_tombstone_preserved_in_non_bottommost
+  - Write value@3 to L2 (via compaction)
+  - Write tombstone@5 to L1
+  - Compact L1 with prune_floor=6, is_bottommost=false
+  - Assert tombstone@5 exists in output
+  - Read key K — assert returns None (not value@3)
+
+**Cross-check**: Fix does not affect CMP-002 (pruning logic) or MVCC-001
+(version visibility). The tombstone is preserved, so shadowing is intact.
+
+### CMP-002: Version pruning respects prune_floor
+**HOLDS** — Pruning logic unchanged; only the segment selection code was modified.
+
+[... etc ...]
+
+## Summary
+
+| Result | Count | Invariants |
+|--------|-------|------------|
+| HOLDS | 3 | LSM-003, CMP-002, ARCH-005 |
+| VIOLATED | 1 | CMP-001 |
+| WEAKENED | 1 | MVCC-001 |
+| INCONCLUSIVE | 0 | — |
+
+## Fixes Applied
+
+| Invariant | File(s) changed | Test added |
+|-----------|-----------------|------------|
+| CMP-001 | crates/storage/src/segmented/compaction.rs | test_cmp001_tombstone_preserved_in_non_bottommost |
+```
+
+## Important
+
+- **Read the actual source files.** The diff shows the change; the source shows the context. An invariant can be violated by code the diff didn't touch if the change alters assumptions that code relies on.
+- **Second-order effects matter.** A change to key encoding (LSM-001) affects bloom filter probes (LSM-005), MVCC reads (MVCC-001), COW rewriting (COW-003), and compaction (CMP-002). Follow the dependency chain.
+- **Do not weaken invariants.** If the code violates an invariant, the code is wrong — not the invariant. Invariants change only when the architecture changes.
+- **Fixes must not introduce new violations.** After every fix, re-verify the fixed invariant AND its neighbors. A fix to CMP-001 that breaks MVCC-001 is not a fix.
+- **Be specific.** "This might cause issues" is not useful. Show the exact code path, the exact version numbers, the exact failure mode.
+- **Minimal fixes only.** Do not refactor, do not add features, do not improve code quality. Restore the invariant and nothing else.
+
+## The Diff
+
+```
+<PASTE GIT DIFF HERE>
+```
+
+To generate the diff for the most recent commit:
+```bash
+git diff HEAD~1
+```
+
+For a specific commit:
+```bash
+git show <commit-hash>
+```
+
+For a PR branch against main:
+```bash
+git diff main...HEAD
+```

--- a/docs/audit/prompts/scale-span-audit.md
+++ b/docs/audit/prompts/scale-span-audit.md
@@ -1,0 +1,282 @@
+# Part 6: Scale-Span Audit — Raspberry Pi Zero to Billion-Key Server
+
+## Context
+
+StrataDB's core product vision is **one binary that scales from a $15 Raspberry Pi Zero (512MB RAM, SD card, single-core ARM) to a bare-metal server (64GB+ RAM, NVMe, 32+ cores) running a billion keys.** Same API, same on-disk format, same ACID guarantees — tuned by `memory_budget` and `StorageConfig`.
+
+This audit verifies that the architecture actually supports both extremes without being over-indexed on either. The question is not "does it work on a Pi Zero today" — it's "is there anything in the core architecture that *fundamentally prevents* it from working, or that would require an architectural rewrite rather than tuning?"
+
+### Target Hardware Spectrum
+
+| | Pi Zero (floor) | Pi Zero 2 W | Laptop (dev) | Server (ceiling) |
+|---|---|---|---|---|
+| **CPU** | ARM11 (ARMv6), 1 core | Cortex-A53 (ARMv8), 4 cores | x86_64, 8 cores | x86_64, 32+ cores |
+| **RAM** | 512MB total (~350MB usable) | 512MB total (~350MB usable) | 16GB | 64-256GB |
+| **Storage** | SD card (10-25 MB/s, limited write endurance) | SD card | NVMe SSD (3 GB/s) | NVMe RAID |
+| **Word size** | 32-bit | 64-bit | 64-bit | 64-bit |
+| **Workload** | 10K keys, 1-3 branches | 50K keys, 5 branches | 1M keys, 10 branches | 1B keys, 1000 branches |
+
+### The `memory_budget` Principle
+
+All memory-consuming structures should be configurable and derive their sizing from a single `memory_budget` parameter (or `StorageConfig` fields). A 64MB budget on a Pi means smaller block cache, smaller memtables, fewer bloom filter bits pinned — but the same algorithms, same format, same correctness.
+
+---
+
+## Audit Categories
+
+### 1. HARDCODED CONSTANTS THAT ASSUME SERVER-CLASS HARDWARE
+
+Find every hardcoded constant in the storage and engine crates. For each, assess whether the default
+is appropriate for a Pi Zero, or if it would consume disproportionate resources.
+
+**Known constants to examine:**
+
+| Constant | Value | File | Pi Zero impact |
+|----------|-------|------|----------------|
+| `DEFAULT_CAPACITY_BYTES` (block cache) | 256 MiB | `block_cache.rs` | 73% of usable RAM |
+| `auto_detect_capacity()` minimum | 256 MiB | `block_cache.rs` | Clamps to 256 MiB even if only 350MB available |
+| `default_write_buffer_size` | 128 MiB | `config.rs` | 37% of usable RAM for ONE memtable |
+| `TARGET_FILE_SIZE` | 64 MiB | `segmented/mod.rs` | A single segment file = 18% of RAM |
+| `LEVEL_BASE_BYTES` (L1 target) | 256 MiB | `segmented/mod.rs` | 73% of usable RAM |
+| `MAX_GRANDPARENT_OVERLAP` | 640 MiB | `segmented/mod.rs` | 183% of usable RAM |
+| `MAX_BASE_BYTES` | 256 MiB | `segmented/mod.rs` | Clamp ceiling = 73% of RAM |
+| `NUM_SHARDS` (block cache) | 16 | `block_cache.rs` | 16 shards for 1 core |
+| `default_max_immutable_memtables` | 4 | `config.rs` | 4 × 128 MiB = 512 MiB pending |
+| `BLOOM_PARTITION_BLOCK_COUNT` | 16 | `segment_builder.rs` | Fine |
+| `INDEX_PARTITION_BLOCK_COUNT` | 128 | `segment_builder.rs` | Fine |
+| `NUM_LEVELS` | 7 | `segmented/mod.rs` | 7 levels for 10K keys is wasteful but harmless |
+| `L0_COMPACTION_TRIGGER` | 4 | `segmented/mod.rs` | Fine |
+| `MAX_INHERITED_LAYERS` | 4 | `segmented/mod.rs` | Fine |
+
+**Audit**: For each constant, answer:
+1. Is it configurable via `StorageConfig` or `StrataConfig`, or hardcoded?
+2. If hardcoded, does the auto-detection or default work at 350MB usable RAM?
+3. If configurable, does the default cause OOM on a Pi Zero?
+4. What should the Pi Zero value be?
+
+### 2. MEMORY BUDGETING — IS THERE A SINGLE KNOB?
+
+The vision says `memory_budget` controls everything. Verify whether this exists and whether it
+actually propagates to all memory-consuming structures.
+
+**Audit**:
+- Find the `memory_budget` config field (if it exists). Trace how it flows to:
+  - Block cache capacity
+  - Write buffer size (memtable rotation threshold)
+  - Maximum frozen memtables
+  - Bloom filter memory (pinned partitions)
+  - Index memory (pinned sub-indexes)
+  - HNSW vector index memory
+  - Search index memory
+  - DashMap overhead (per-branch state)
+- If `memory_budget` doesn't exist, find what knobs DO exist (`StorageConfig` fields) and assess
+  whether a user on a Pi Zero can set them coherently without expert knowledge.
+- Is there a preset/profile system? (e.g., `storage.profile = "embedded"` that sets all fields
+  to Pi-friendly values)
+
+### 3. 32-BIT ARCHITECTURE COMPATIBILITY (Pi Zero 1)
+
+The original Pi Zero is 32-bit ARMv6. StrataDB uses `u64` extensively.
+
+**Audit**:
+- `AtomicU64`: Available on 32-bit ARM? On ARMv6, `AtomicU64` operations are emulated via locks
+  (not lock-free). Every `fetch_add`, `load`, `store` on the version counter, memtable stats,
+  block cache counters, and timestamp tracking becomes a mutex operation. Quantify how many
+  `AtomicU64` operations occur per read and per write.
+- `usize` vs `u64`: On 32-bit, `usize` is 4 bytes. Any code that casts `u64` to `usize` for
+  memory allocation sizes could truncate. Find all `as usize` casts on u64 values. Are any of
+  them for sizes that could exceed 4GB? (Not on a Pi, but the code should not panic.)
+- Address space: 32-bit ARM has a 3GB user-space address space (with 1GB kernel). The block cache
+  at 256 MiB + memtables + segment indexes + bloom filters could exceed this. Is there an
+  address space budget?
+- `mmap`: The vector mmap code (`mmap.rs`, `mmap_graph.rs`) has compile-time checks for little-endian
+  (`#[cfg(not(target_endian = "little"))]`). ARM is little-endian, so this is fine. But are there
+  any 64-bit alignment assumptions in the mmap code? On 32-bit, pointers are 4 bytes. Verify
+  `u64` reinterpretation from mmap'd memory works on 32-bit.
+- `crossbeam_skiplist`: Does it compile and work correctly on 32-bit ARM? It uses atomics
+  extensively. Verify the Cargo.toml target compatibility.
+
+### 4. SD CARD STORAGE CHARACTERISTICS
+
+SD cards are fundamentally different from SSDs/HDDs:
+- Random write: 0.1-1 MB/s (100-1000× slower than SSD)
+- Sequential write: 10-25 MB/s
+- Write endurance: 10K-100K erase cycles per block
+- No TRIM support in most configurations
+- Write amplification from the FTL (Flash Translation Layer)
+
+**Audit**:
+- **LSM write amplification**: Calculate the theoretical write amplification for the default config
+  (L0 trigger=4, multiplier=10, 7 levels). Each byte of user data is written to: memtable → WAL →
+  L0 segment → L1 (compaction) → L2 → ... → L6. With multiplier=10, worst-case write amp is
+  ~10× per level × 6 levels = 60×. On a device with 100K write cycles and 32GB SD card, this
+  translates to approximately how many total user bytes before the card wears out?
+- **WAL write pattern**: Every commit writes a WAL record. In `Always` mode, every commit also
+  fsyncs. On SD card, fsync can take 50-200ms. At what commit rate does WAL become the bottleneck?
+  Is `Standard` mode's default interval (100ms) appropriate for SD card latency?
+- **Compaction I/O**: Compaction reads all input segments and writes output segments. On a 10 MB/s
+  SD card, compacting a 64MB segment takes ~13 seconds (read + write). During this time, the
+  single core is largely blocked on I/O. Is there I/O prioritization? Does the `RateLimiter`
+  help, or is it designed for fast storage?
+- **Segment file size**: `TARGET_FILE_SIZE` is 64MB. On a Pi with 10K keys (average 100 bytes each),
+  total data is ~1MB. A single segment file would be ~1MB, not 64MB. Is the splitting logic
+  correct for very small datasets? Does it produce many tiny files instead?
+- **Directory fsync**: After creating a new segment file, is the parent directory fsynced?
+  On ext4 (common on Pi SD cards), this is required for crash safety. Verify.
+
+### 5. SINGLE-CORE PERFORMANCE
+
+The Pi Zero has ONE core. All concurrency primitives become overhead, not acceleration.
+
+**Audit**:
+- **DashMap**: 64 shards by default. On a single core, shard contention is zero but the memory
+  overhead of 64 shard locks is wasted. Is the shard count configurable?
+- **Block cache shards**: 16 shards with `parking_lot::RwLock`. Same issue — 16 locks for one core.
+- **crossbeam SkipMap**: Lock-free data structure. On single core, lock-free is equivalent to
+  single-threaded but with higher constant factors (atomic operations instead of plain loads/stores).
+  The skip list has ~70 bytes overhead per node. For 10K entries, that's 700KB of overhead.
+  Acceptable?
+- **Compaction**: Is compaction synchronous (blocking the main thread) or asynchronous (background
+  thread)? On a single core, a background compaction thread competes with user operations for the
+  single core. Is there priority control?
+- **Thread count**: How many threads does StrataDB spawn during normal operation? Background flush,
+  compaction scheduler, WAL sync, search indexing? Each thread adds ~8MB stack + scheduling overhead.
+  On a Pi Zero, more than 2-3 threads is counterproductive.
+
+### 6. MEMORY OVERHEAD PER ENTITY
+
+On a Pi Zero with 10K keys, per-entry overhead dominates. Calculate the actual memory cost per entry.
+
+**Audit**:
+- **Memtable entry**: `InternalKey` size + `MemtableEntry` size + SkipMap node overhead (~70 bytes).
+  For a key "user:123" with value "hello", what is the total per-entry memory cost?
+- **Segment index (pinned)**: Top-level index entries + sub-index entries are pinned in memory at
+  segment open. For a segment with 10K entries, how much memory is pinned?
+- **Bloom filter (pinned)**: Bloom partitions are pinned in memory. At 10 bits/key for 10K keys,
+  that's ~12KB. Acceptable. But at 20 bits/key (upper levels), it's ~24KB. Still fine.
+- **DashMap entry**: Each branch in `DashMap<BranchId, BranchState>` has overhead. BranchState
+  includes: Memtable, Vec<Arc<Memtable>>, ArcSwap<SegmentVersion>, 2× AtomicU64, Vec<Option<Vec<u8>>>,
+  LevelTargets, Vec<InheritedLayer>. For 3 branches, what's the baseline memory before any data?
+- **Block cache entries**: Each cached block is wrapped in `ClockEntry` (Arc<Vec<u8>> + usize +
+  Priority + AtomicU8). Per-entry overhead beyond the data itself?
+- **Total baseline**: What is the minimum memory footprint of an empty StrataDB instance with
+  default settings? (Block cache + DashMap + global structures + thread stacks)
+
+### 7. LARGE-SCALE (BILLION-KEY) CONSTRAINTS
+
+At the other extreme, does the architecture support 1 billion keys?
+
+**Audit**:
+- **Segment count**: With `TARGET_FILE_SIZE=64MB` and 1B keys at ~100 bytes each, total data is
+  ~100GB. That's ~1600 segments across 7 levels. Each segment has pinned bloom filters and index
+  blocks. How much memory is consumed by pinned metadata for 1600 segments?
+- **DashMap with 1000 branches**: Each branch has its own BranchState with full segment version.
+  1000 branches × 7 levels × average segments per level = how many Arc<KVSegment> references?
+- **Block cache sizing**: At 4GB block cache with 4KB blocks, that's ~1M entries in the CLOCK cache.
+  Is the HashMap per-shard efficient at ~62K entries per shard?
+- **Compaction throughput**: At 100GB total data, L6 could be ~90GB. An L5→L6 compaction reads and
+  writes tens of GB. Is there sub-compaction (parallelism within a single compaction)?
+- **MergeIterator scalability**: The linear-scan MergeIterator is designed for "1-3 sources." At
+  billion scale, a compaction could merge 4 L0 files + overlapping L1 files = potentially 10+
+  sources. At what point does linear scan become a bottleneck vs a binary heap?
+- **Global version counter**: At 1B keys with average 3 versions each, that's 3B version allocations.
+  At `u64::MAX` capacity, this is not a concern numerically, but the `AtomicU64::fetch_add` on the
+  version counter becomes a contention point at 32+ cores. Is there per-core batching?
+- **File descriptor limits**: 1600 open segment files requires ulimit -n > 1600. Is this documented?
+  Does the system degrade gracefully if it runs out of file descriptors?
+
+### 8. CONFIG-DRIVEN SCALING
+
+Verify that a single `strata.toml` (or equivalent) can tune the engine across the full range.
+
+**Audit**:
+- Write a `strata.toml` for Pi Zero (64MB budget):
+  ```toml
+  [storage]
+  block_cache_size = 16_777_216    # 16 MiB
+  write_buffer_size = 4_194_304    # 4 MiB
+  max_immutable_memtables = 2
+  max_versions_per_key = 3
+  max_branches = 8
+  ```
+  Does this config actually work? Trace each value through to the storage engine. Are there
+  hardcoded minimums that override these values? Does `auto_detect_capacity()` ignore
+  `block_cache_size` if it's set?
+
+- Write a `strata.toml` for billion-key server:
+  ```toml
+  [storage]
+  block_cache_size = 17_179_869_184  # 16 GiB
+  write_buffer_size = 268_435_456    # 256 MiB
+  max_immutable_memtables = 8
+  max_versions_per_key = 0           # unlimited
+  max_branches = 0                   # unlimited
+  ```
+  Does this config work? Are there hardcoded maximums that cap these values?
+
+- For each `StorageConfig` field, find where it's consumed in the engine. Is there a field that
+  exists in config but is silently ignored in code?
+
+### 9. ON-DISK FORMAT PORTABILITY
+
+The same binary runs on both platforms. The on-disk format must be portable.
+
+**Audit**:
+- **Endianness**: Segment files, WAL records, and manifests use `to_le_bytes()` / `from_le_bytes()`.
+  ARM is little-endian. x86 is little-endian. No issue. But verify there are no `to_ne_bytes()`
+  (native endian) calls that would break cross-platform portability.
+- **Pointer-size fields**: Are any fields in the on-disk format `usize`-sized (which would differ
+  between 32-bit and 64-bit)? All on-disk sizes should be explicit (`u32`, `u64`), not `usize`.
+  Find any `usize` serialization in segment/WAL/manifest formats.
+- **Alignment**: The mmap graph format requires 8-byte alignment for u64 reinterpretation. On 32-bit
+  ARM, is `mmap` guaranteed to return 8-byte-aligned addresses? (Usually yes, but verify.)
+- **File format version**: If a database is created on a 64-bit server and then copied to a 32-bit
+  Pi (or vice versa), will it open correctly? The format versions should be the same. Verify no
+  platform-specific format differences.
+
+### 10. FEATURE DEGRADATION STRATEGY
+
+Not all features need to work at both extremes. But the degradation should be explicit, not a crash.
+
+**Audit**:
+- **Vector search**: HNSW indexes consume significant memory. On a Pi Zero with 10K 384-dim vectors
+  (MiniLM), the embedding data alone is 10K × 384 × 4 bytes = ~15MB. The HNSW graph adds overhead.
+  Is there a brute-force fallback for small collections that avoids building the graph?
+- **Search index (BM25)**: The inverted index uses DashMap + mmap-backed sealed segments. On a Pi,
+  is it meaningful to run search on 10K documents? Is there an option to disable the search index?
+- **Auto-embed**: MiniLM model loading requires ~100MB of RAM. On a Pi with 350MB usable, this is
+  28% of RAM. Is auto-embed configurable/disableable? (It is — `auto_embed: false`.)
+- **COW branching**: COW fork is O(segments). On a Pi with few segments, this is cheap. But
+  materialization iterates all inherited entries — on a Pi with SD card storage, this could be
+  slow. Is there a way to skip materialization and tolerate deeper inherited layer chains?
+- **Compaction**: On a Pi, compaction competes with user operations for the single core and the
+  slow SD card. Is there a way to throttle compaction more aggressively? The `RateLimiter` exists
+  but is it used for all compaction paths?
+
+---
+
+## Deliverables
+
+For each finding, state:
+
+1. **Scale end affected**: Pi Zero / Server / Both
+2. **Category**: Which audit category (1-10)
+3. **Severity**: Blocker (prevents operation), High (severe degradation), Medium (suboptimal), Low (minor)
+4. **Description**: What the issue is
+5. **Current behavior at the affected scale**: What happens today
+6. **Recommended fix**: Concrete change (config default, code change, feature gate)
+
+At the end, provide:
+
+1. **Pi Zero readiness assessment**: Can StrataDB run on a Pi Zero today with correct config? If not, what are the blockers?
+
+2. **Billion-key readiness assessment**: Can StrataDB handle 1B keys today? If not, what are the blockers?
+
+3. **The scale-span gap**: What is the hardest problem in supporting both extremes simultaneously? Is it a config problem (different defaults) or an architectural problem (different algorithms needed)?
+
+4. **Recommended `StorageConfig` presets**: Provide concrete configs for:
+   - `embedded` (Pi Zero, 64MB budget)
+   - `desktop` (laptop, 2GB budget)
+   - `server` (dedicated, 16GB budget)
+
+5. **Constants that must become configurable**: List every hardcoded constant that prevents scaling and recommend whether it should be a `StorageConfig` field, derived from `memory_budget`, or left hardcoded with a different default.


### PR DESCRIPTION
## Summary

- 50 engine invariants across 8 categories defining correctness properties for StrataDB
- Per-commit invariant check protocol
- Scale-span audit prompt (Pi Zero to billion-key server)

## What's in this PR

### `docs/audit/ENGINE_INVARIANTS.md`
Standing specification of "correct" for the engine. 50 invariants organized into:

| Category | Count | What it protects |
|----------|-------|-----------------|
| LSM (001-007) | 7 | Key encoding, read ordering, memtable rotation, bloom correctness, file immutability |
| CMP (001-006) | 6 | Tombstone preservation, version pruning, grandparent overlap, manifest ordering |
| COW (001-006) | 6 | Refcount guards, fork race window, version gate, commit_id preservation |
| MVCC (001-006) | 6 | Version visibility, tombstone semantics, snapshot pinning, TTL interaction |
| ACID (001-007) | 7 | WAL atomicity, WAL-before-storage, TOCTOU lock, fsync guarantees |
| ARCH (001-008) | 8 | Version domain coherence, publication boundary, source of truth, recovery model |
| SCALE (001-010) | 10 | Hardcoded constants, memory budgeting, 32-bit compat, SD card, format portability |

Each invariant is:
- **Architecture-anchored** — says what must be true, not where in code it's implemented
- **Self-discovering** — Audit instructions tell you what to find, not which line to read
- **Refactor-proof** — renaming a function doesn't invalidate any invariant

### `docs/audit/prompts/invariant-check.md`
Protocol for checking invariants against a git diff. Triage → Verify → Report → Fix.

### `docs/audit/prompts/scale-span-audit.md`
Audit prompt for verifying StrataDB works across the full hardware range (Pi Zero 512MB to 64GB+ server).

## Test plan

- [x] Invariants are prose specifications — no code changes, no tests needed
- [x] Verified invariant IDs are unique and sequential within categories


🤖 Generated with [Claude Code](https://claude.com/claude-code)