### PR TITLE
Fix #1697: Compaction max_versions_per_key now respects active snapshots

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1755,6 +1755,9 @@ impl Database {
             return;
         }
 
+        // Update snapshot floor so compaction respects active snapshots (#1697).
+        self.storage.set_snapshot_floor(self.gc_safe_point());
+
         // 1. Flush and compact branches that need it.
         let branches = self.storage.branches_needing_flush();
         for branch_id in branches {
@@ -3776,5 +3779,64 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Issue #1697: background compaction with max_versions_per_key must not
+    /// prune versions that active snapshots need.
+    #[test]
+    fn test_issue_1697_compaction_preserves_snapshot_versions() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut cfg = StrataConfig::default();
+        cfg.storage.max_versions_per_key = 1;
+        let db = Database::open_with_config(temp_dir.path().join("db"), cfg).unwrap();
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key = Key::new_kv(ns.clone(), "snap_key");
+
+        // Write version 1
+        blind_write(&db, key.clone(), Value::Int(1));
+
+        // Start a reader that pins the current snapshot
+        let reader = db.begin_read_only_transaction(branch_id).unwrap();
+        let pinned_version = reader.start_version;
+
+        // Write version 2 — now key has 2 versions, max_versions_per_key=1
+        blind_write(&db, key.clone(), Value::Int(2));
+
+        // Force data from memtable → segments so compaction can process it.
+        // Rotate twice to create 2 frozen memtables → flush both → compact.
+        db.storage().rotate_memtable(&branch_id);
+        db.storage().flush_oldest_frozen(&branch_id).unwrap();
+        // Need a second segment to trigger compaction (min 2 segments).
+        // Write a dummy key so the second memtable isn't empty.
+        blind_write(&db, Key::new_kv(ns.clone(), "dummy"), Value::Int(999));
+        db.storage().rotate_memtable(&branch_id);
+        db.storage().flush_oldest_frozen(&branch_id).unwrap();
+
+        // Now compact — this is where max_versions would drop the old version.
+        let compacted = db.storage().compact_branch(&branch_id, 0).unwrap();
+        assert!(compacted.is_some(), "compaction should have run");
+
+        // The reader's snapshot must still be able to find version 1
+        // via the storage layer at the pinned version.
+        let result = db.storage().get_versioned(&key, pinned_version).unwrap();
+        assert!(
+            result.is_some(),
+            "version at snapshot {} was pruned by compaction despite active reader",
+            pinned_version
+        );
+        assert_eq!(
+            result.unwrap().value,
+            Value::Int(1),
+            "snapshot read returned wrong value after compaction"
+        );
+
+        // Latest version must also be intact
+        let latest = db.storage().get_versioned(&key, u64::MAX).unwrap();
+        assert!(latest.is_some(), "latest version missing after compaction");
+        assert_eq!(latest.unwrap().value, Value::Int(2));
+
+        // Clean up reader
+        db.coordinator.record_abort(reader.txn_id);
     }
 }

--- a/crates/storage/src/compaction.rs
+++ b/crates/storage/src/compaction.rs
@@ -43,6 +43,10 @@ pub struct CompactionIterator<I: Iterator<Item = (InternalKey, MemtableEntry)>> 
     /// there are no lower levels with older puts to shadow.
     /// When false, below-floor tombstones must be preserved (#1678).
     is_bottommost: bool,
+    /// Snapshot-safe floor (#1697): versions with `commit_id >= snapshot_floor`
+    /// are protected from `max_versions` pruning because an active snapshot
+    /// might need them. When 0, no snapshot protection is applied.
+    snapshot_floor: u64,
 }
 
 impl<I: Iterator<Item = (InternalKey, MemtableEntry)>> CompactionIterator<I> {
@@ -60,6 +64,7 @@ impl<I: Iterator<Item = (InternalKey, MemtableEntry)>> CompactionIterator<I> {
             versions_emitted: 0,
             drop_expired: false,
             is_bottommost: true,
+            snapshot_floor: 0,
         }
     }
 
@@ -92,6 +97,16 @@ impl<I: Iterator<Item = (InternalKey, MemtableEntry)>> CompactionIterator<I> {
         self.is_bottommost = is_bottommost;
         self
     }
+
+    /// Set the snapshot-safe floor (#1697).
+    ///
+    /// When `snapshot_floor > 0`, versions with `commit_id >= snapshot_floor`
+    /// are protected from `max_versions` pruning because an active snapshot
+    /// may need them. When 0 (default), no snapshot protection is applied.
+    pub fn with_snapshot_floor(mut self, floor: u64) -> Self {
+        self.snapshot_floor = floor;
+        self
+    }
 }
 
 impl<I: Iterator<Item = (InternalKey, MemtableEntry)>> Iterator for CompactionIterator<I> {
@@ -119,9 +134,14 @@ impl<I: Iterator<Item = (InternalKey, MemtableEntry)>> Iterator for CompactionIt
             let commit_id = ik.commit_id();
 
             if commit_id >= self.prune_floor {
-                // Above floor: check max_versions limit
-                if self.max_versions > 0 && self.versions_emitted >= self.max_versions {
-                    continue; // Skip — already emitted enough versions
+                // Above floor: check max_versions limit.
+                // #1697: versions at or above snapshot_floor are protected from
+                // max_versions pruning because an active snapshot may need them.
+                if self.max_versions > 0
+                    && self.versions_emitted >= self.max_versions
+                    && (self.snapshot_floor == 0 || commit_id < self.snapshot_floor)
+                {
+                    continue; // Safe to skip — no snapshot needs this version
                 }
                 self.versions_emitted += 1;
                 return Some((ik, entry));
@@ -139,8 +159,11 @@ impl<I: Iterator<Item = (InternalKey, MemtableEntry)>> Iterator for CompactionIt
                     self.versions_emitted += 1;
                     return Some((ik, entry));
                 }
-                // Keep one floor entry, but respect max_versions
-                if self.max_versions > 0 && self.versions_emitted >= self.max_versions {
+                // Keep one floor entry, but respect max_versions (with snapshot safety #1697)
+                if self.max_versions > 0
+                    && self.versions_emitted >= self.max_versions
+                    && (self.snapshot_floor == 0 || commit_id < self.snapshot_floor)
+                {
                     continue;
                 }
                 self.versions_emitted += 1;
@@ -613,6 +636,96 @@ mod tests {
         assert_eq!(result[1].0.commit_id(), 8);
         assert!(result[2].1.is_tombstone);
         assert_eq!(result[2].0.commit_id(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // snapshot_floor tests (#1697)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_issue_1697_max_versions_respects_snapshot_floor() {
+        // Scenario from issue #1697:
+        // max_versions=1, snapshot_floor=6 (active snapshot at version 5)
+        // Key K has versions 6 and 5.
+        // Without snapshot_floor, version 5 would be dropped (only 1 allowed).
+        // With snapshot_floor=6, version 5 must be preserved because an active
+        // snapshot might need it.
+        let items = vec![
+            (InternalKey::encode(&key("k"), 6), entry(60)),
+            (InternalKey::encode(&key("k"), 5), entry(50)),
+        ];
+        let merge = MergeIterator::new(vec![items.into_iter()]);
+        let result: Vec<_> = CompactionIterator::new(merge, 0)
+            .with_max_versions(1)
+            .with_snapshot_floor(6)
+            .collect();
+        // Both versions must survive: version 5 is >= snapshot_floor is false,
+        // but it's needed because a snapshot at version 5 could read it.
+        // Actually snapshot_floor=6 means versions < 6 are safe to drop
+        // ONLY IF they exceed max_versions. But version 5 might be read by
+        // a snapshot pinned at version 5, so snapshot_floor should be the
+        // min_active_version (5), meaning versions >= 5 cannot be dropped.
+        // Let's use snapshot_floor=5 (the min active version).
+        let items2 = vec![
+            (InternalKey::encode(&key("k"), 6), entry(60)),
+            (InternalKey::encode(&key("k"), 5), entry(50)),
+        ];
+        let merge2 = MergeIterator::new(vec![items2.into_iter()]);
+        let result2: Vec<_> = CompactionIterator::new(merge2, 0)
+            .with_max_versions(1)
+            .with_snapshot_floor(5)
+            .collect();
+        assert_eq!(
+            result2.len(),
+            2,
+            "version 5 must survive: active snapshot at version 5 needs it"
+        );
+        assert_eq!(result2[0].0.commit_id(), 6);
+        assert_eq!(result2[1].0.commit_id(), 5);
+    }
+
+    #[test]
+    fn test_issue_1697_max_versions_drops_below_snapshot_floor() {
+        // Versions 10, 8, 5, 3 with max_versions=2, snapshot_floor=6
+        // Versions >= 6 are protected: 10, 8 (both above snapshot_floor)
+        // Versions < 6: 5, 3 can be dropped by max_versions since they're
+        // below the snapshot floor (no active snapshot needs them).
+        let items = vec![
+            (InternalKey::encode(&key("k"), 10), entry(100)),
+            (InternalKey::encode(&key("k"), 8), entry(80)),
+            (InternalKey::encode(&key("k"), 5), entry(50)),
+            (InternalKey::encode(&key("k"), 3), entry(30)),
+        ];
+        let merge = MergeIterator::new(vec![items.into_iter()]);
+        let result: Vec<_> = CompactionIterator::new(merge, 0)
+            .with_max_versions(2)
+            .with_snapshot_floor(6)
+            .collect();
+        // max_versions=2, and we already emitted 2 (versions 10, 8).
+        // Versions 5 and 3 are below snapshot_floor, so max_versions can drop them.
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].0.commit_id(), 10);
+        assert_eq!(result[1].0.commit_id(), 8);
+    }
+
+    #[test]
+    fn test_issue_1697_snapshot_floor_zero_no_protection() {
+        // snapshot_floor=0 means no active snapshots — max_versions applies normally.
+        let items = vec![
+            (InternalKey::encode(&key("k"), 6), entry(60)),
+            (InternalKey::encode(&key("k"), 5), entry(50)),
+        ];
+        let merge = MergeIterator::new(vec![items.into_iter()]);
+        let result: Vec<_> = CompactionIterator::new(merge, 0)
+            .with_max_versions(1)
+            .with_snapshot_floor(0)
+            .collect();
+        assert_eq!(
+            result.len(),
+            1,
+            "no snapshot protection, max_versions=1 keeps only newest"
+        );
+        assert_eq!(result[0].0.commit_id(), 6);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -216,8 +216,10 @@ impl SegmentedStore {
 
         let merge = MergeIterator::new(sources);
         let max_versions = self.max_versions_per_key.load(Ordering::Relaxed);
+        let snap_floor = self.snapshot_floor.load(Ordering::Relaxed);
         let compaction_iter = CompactionIterator::new(merge, prune_floor)
             .with_max_versions(max_versions)
+            .with_snapshot_floor(snap_floor)
             .with_drop_expired(is_bottommost)
             .with_is_bottommost(is_bottommost);
 
@@ -355,8 +357,10 @@ impl SegmentedStore {
 
         let merge = MergeIterator::new(sources);
         let max_versions = self.max_versions_per_key.load(Ordering::Relaxed);
+        let snap_floor = self.snapshot_floor.load(Ordering::Relaxed);
         let compaction_iter = CompactionIterator::new(merge, prune_floor)
             .with_max_versions(max_versions)
+            .with_snapshot_floor(snap_floor)
             .with_drop_expired(is_bottommost)
             .with_is_bottommost(is_bottommost);
 
@@ -527,8 +531,10 @@ impl SegmentedStore {
         let sources = streaming_sources(&all_inputs, &limiter);
         let merge = MergeIterator::new(sources);
         let max_versions = self.max_versions_per_key.load(Ordering::Relaxed);
+        let snap_floor = self.snapshot_floor.load(Ordering::Relaxed);
         let compaction_iter = CompactionIterator::new(merge, prune_floor)
             .with_max_versions(max_versions)
+            .with_snapshot_floor(snap_floor)
             .with_drop_expired(is_bottommost)
             .with_is_bottommost(is_bottommost);
 
@@ -760,8 +766,10 @@ impl SegmentedStore {
         let sources = streaming_sources(&all_inputs, &limiter);
         let merge = MergeIterator::new(sources);
         let max_versions = self.max_versions_per_key.load(Ordering::Relaxed);
+        let snap_floor = self.snapshot_floor.load(Ordering::Relaxed);
         let compaction_iter = CompactionIterator::new(merge, prune_floor)
             .with_max_versions(max_versions)
+            .with_snapshot_floor(snap_floor)
             .with_drop_expired(is_bottommost)
             .with_is_bottommost(is_bottommost);
 

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -301,6 +301,10 @@ pub struct SegmentedStore {
     max_branches: AtomicUsize,
     /// Maximum versions to keep per key (0 = unlimited, pruned at compaction).
     max_versions_per_key: AtomicUsize,
+    /// Snapshot-safe floor (#1697): versions at or above this commit_id are
+    /// protected from `max_versions_per_key` pruning during compaction.
+    /// Updated by the engine before compaction to reflect `gc_safe_point()`.
+    snapshot_floor: AtomicU64,
     /// Total frozen memtable count across all branches (for O(1) "any frozen?" check).
     total_frozen_count: AtomicUsize,
     /// Maximum frozen memtables per branch before rotation is skipped (0 = unlimited).
@@ -329,6 +333,7 @@ impl SegmentedStore {
             bulk_load_branches: DashMap::new(),
             max_branches: AtomicUsize::new(0),
             max_versions_per_key: AtomicUsize::new(0),
+            snapshot_floor: AtomicU64::new(0),
             total_frozen_count: AtomicUsize::new(0),
             max_immutable_memtables: AtomicUsize::new(0),
             compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
@@ -353,6 +358,7 @@ impl SegmentedStore {
             bulk_load_branches: DashMap::new(),
             max_branches: AtomicUsize::new(0),
             max_versions_per_key: AtomicUsize::new(0),
+            snapshot_floor: AtomicU64::new(0),
             total_frozen_count: AtomicUsize::new(0),
             max_immutable_memtables: AtomicUsize::new(0),
             compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
@@ -377,6 +383,7 @@ impl SegmentedStore {
             bulk_load_branches: DashMap::new(),
             max_branches: AtomicUsize::new(0),
             max_versions_per_key: AtomicUsize::new(0),
+            snapshot_floor: AtomicU64::new(0),
             total_frozen_count: AtomicUsize::new(0),
             max_immutable_memtables: AtomicUsize::new(0),
             compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
@@ -1114,6 +1121,15 @@ impl SegmentedStore {
     /// Pruning happens at compaction time, not at write time.
     pub fn set_max_versions_per_key(&self, max: usize) {
         self.max_versions_per_key.store(max, Ordering::Relaxed);
+    }
+
+    /// Set the snapshot-safe floor for compaction (#1697).
+    ///
+    /// Versions with `commit_id >= floor` are protected from `max_versions_per_key`
+    /// pruning during compaction. The engine should call this with `gc_safe_point()`
+    /// before triggering compaction so that active snapshots are not violated.
+    pub fn set_snapshot_floor(&self, floor: u64) {
+        self.snapshot_floor.store(floor, Ordering::Relaxed);
     }
 
     /// Set maximum frozen memtables per branch before write stalling (0 = unlimited).


### PR DESCRIPTION
## Summary

- Background compaction with `max_versions_per_key > 0` could prune versions still needed by active snapshot readers, violating MVCC snapshot isolation
- Added `snapshot_floor` parameter to `CompactionIterator` — versions at or above this floor are protected from `max_versions` pruning
- Engine now calls `set_snapshot_floor(gc_safe_point())` on storage before each compaction cycle, threading snapshot awareness into all 4 compaction code paths

## Root Cause

`schedule_flush_if_needed` always passed `prune_floor = 0` to compaction, meaning all versions were "above floor." The `max_versions` check then unconditionally dropped excess versions without checking whether active snapshots needed them. The engine's `gc_safe_point()` (which accounts for `min_active_version`) was only used by the explicit `run_gc()` path, never by background compaction.

## Fix

1. **`CompactionIterator`** (`compaction.rs`): Added `snapshot_floor: u64` field. When `max_versions` would drop a version, it now checks `commit_id >= snapshot_floor` — if true, the version is kept because an active snapshot may need it.
2. **`SegmentedStore`** (`segmented/mod.rs`): Added `snapshot_floor: AtomicU64` with `set_snapshot_floor()` setter, consistent with existing `max_versions_per_key` pattern.
3. **`segmented/compaction.rs`**: All 4 compaction paths (`compact_branch`, L0 compaction, L0→L1 promotion, Ln→Ln+1) now read and pass `snapshot_floor` to `CompactionIterator`.
4. **`Database`** (`database/mod.rs`): `schedule_flush_if_needed()` calls `set_snapshot_floor(gc_safe_point())` before flushing/compacting.

## Invariants Verified

- **MVCC-005**: Active transactions pin the GC safe point; compaction no longer prunes below it
- **CMP-002**: Version pruning now respects both `prune_floor` and snapshot safety

## Test Plan

- [x] `test_issue_1697_max_versions_respects_snapshot_floor` — unit test: snapshot_floor protects versions from max_versions
- [x] `test_issue_1697_max_versions_drops_below_snapshot_floor` — unit test: versions below snapshot_floor are still prunable
- [x] `test_issue_1697_snapshot_floor_zero_no_protection` — unit test: snapshot_floor=0 preserves old behavior
- [x] `test_issue_1697_compaction_preserves_snapshot_versions` — integration test: end-to-end with Database, active reader, flush, compact
- [x] Full `strata-storage` test suite (540 passed)
- [x] Full `strata-engine` test suite (all passed)
- [x] Full workspace test suite (all passed, excluding strata-inference CUDA build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)