### PR TITLE
Fix #1701: Recovery inherited layer resolution finds orphan segments

### DIFF
--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -1804,6 +1804,14 @@ impl SegmentedStore {
         let mut deferred_inherited: Vec<(BranchId, Vec<crate::manifest::ManifestInheritedLayer>)> =
             Vec::new();
 
+        // All opened segments per branch, including orphans not in the manifest.
+        // Needed so the second pass (inherited layer resolution) can find segments
+        // that are orphans in the parent's active version but still needed by children.
+        let mut all_opened: std::collections::HashMap<
+            BranchId,
+            std::collections::HashMap<String, Arc<KVSegment>>,
+        > = std::collections::HashMap::new();
+
         for entry in std::fs::read_dir(segments_dir)? {
             let entry = entry?;
             let path = entry.path();
@@ -1867,6 +1875,19 @@ impl SegmentedStore {
             if branch_segments.is_empty() && !has_inherited {
                 continue;
             }
+
+            // Record all opened segments for this branch (including orphans)
+            // so inherited layer resolution can find them in the second pass.
+            let branch_seg_map: std::collections::HashMap<String, Arc<KVSegment>> = branch_segments
+                .iter()
+                .filter_map(|seg| {
+                    seg.file_path()
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|name| (name.to_string(), Arc::clone(seg)))
+                })
+                .collect();
+            all_opened.insert(branch_id, branch_seg_map);
 
             // Partition segments into levels based on manifest.
             //
@@ -1982,8 +2003,13 @@ impl SegmentedStore {
             let mut inherited_layers = Vec::new();
 
             for ml in &manifest_layers {
-                let source_branch = match self.branches.get(&ml.source_branch_id) {
-                    Some(b) => b,
+                // Look up ALL opened segments for the source branch, including
+                // orphans not loaded into its active version. This is critical
+                // for #1701: after parent compaction, the pre-compaction segments
+                // are orphans in the parent's manifest but still needed by
+                // children's inherited layers.
+                let source_segs = match all_opened.get(&ml.source_branch_id) {
+                    Some(segs) => segs,
                     None => {
                         tracing::warn!(
                             child = %hex_encode_branch(&child_id),
@@ -1995,29 +2021,15 @@ impl SegmentedStore {
                     }
                 };
 
-                // Build SegmentVersion from manifest entries using source branch's
-                // segments (they are already opened and Arc'd).
-                let source_ver = source_branch.version.load();
+                // Build SegmentVersion from manifest entries using all opened
+                // segments (including orphans not in the source branch's active version).
                 let mut layer_levels: Vec<Vec<Arc<KVSegment>>> = vec![Vec::new(); NUM_LEVELS];
 
                 for entry in &ml.entries {
                     let level = (entry.level as usize).min(NUM_LEVELS - 1);
-                    // Find the matching segment in the source branch's version
-                    let mut found = false;
-                    for source_level in &source_ver.levels {
-                        for seg in source_level {
-                            let seg_name = seg
-                                .file_path()
-                                .file_name()
-                                .and_then(|n| n.to_str())
-                                .unwrap_or("");
-                            if seg_name == entry.filename {
-                                layer_levels[level].push(Arc::clone(seg));
-                                found = true;
-                            }
-                        }
-                    }
-                    if !found {
+                    if let Some(seg) = source_segs.get(&entry.filename) {
+                        layer_levels[level].push(Arc::clone(seg));
+                    } else {
                         tracing::warn!(
                             child = %hex_encode_branch(&child_id),
                             source = %hex_encode_branch(&ml.source_branch_id),

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -6904,6 +6904,94 @@ fn recovery_skips_orphan_sst_not_in_manifest() {
     assert_eq!(result.value, Value::Int(1));
 }
 
+/// #1701: After fork → parent compaction → crash → recovery, the child's
+/// inherited layer must still find the orphaned (pre-compaction) segments.
+/// Without the fix, inherited layer resolution looks only at the parent's
+/// active version (which skips orphans), so the child loses its data.
+#[test]
+fn test_issue_1701_recovery_inherited_layer_finds_orphan_segments() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // 1. Write parent data in two flushes → 2 L0 segments
+    seed(&store, parent_kv("a"), Value::Int(1), 1);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    seed(&store, parent_kv("b"), Value::Int(2), 2);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // 2. Fork parent → child (child inherits both segments)
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    let (_fork_ver, shared) = store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+    assert!(shared >= 2, "child should share at least 2 segments");
+
+    // Verify child can read inherited data before compaction
+    let val_a = store
+        .get_versioned(&child_kv("a"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val_a.value, Value::Int(1));
+
+    // 3. Compact parent L0 → L1. Old segments kept on disk (refcount > 0).
+    store
+        .compact_l0_to_l1(&parent_branch(), 0)
+        .unwrap()
+        .expect("compaction should produce output");
+
+    // Parent's L0 should be empty, data now in L1
+    let parent_state = store.branches.get(&parent_branch()).unwrap();
+    assert_eq!(
+        parent_state.version.load().l0_segments().len(),
+        0,
+        "parent L0 should be empty after compaction"
+    );
+    drop(parent_state);
+
+    // Verify child still reads correctly (in-memory Arcs are alive)
+    let val_b = store
+        .get_versioned(&child_kv("b"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val_b.value, Value::Int(2));
+
+    // 4. Drop store (simulate crash) and recover
+    drop(store);
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let info = store2.recover_segments().unwrap();
+    assert!(info.branches_recovered >= 2, "both branches should recover");
+
+    // 5. Child must still see inherited data after recovery
+    //    This is the bug: without the fix, inherited layer resolution can't
+    //    find the orphan segments because they're not in the parent's version.
+    let val_a_recovered = store2.get_versioned(&child_kv("a"), u64::MAX).unwrap();
+    assert!(
+        val_a_recovered.is_some(),
+        "child should see inherited key 'a' after recovery (orphan segment)"
+    );
+    assert_eq!(val_a_recovered.unwrap().value, Value::Int(1));
+
+    let val_b_recovered = store2.get_versioned(&child_kv("b"), u64::MAX).unwrap();
+    assert!(
+        val_b_recovered.is_some(),
+        "child should see inherited key 'b' after recovery (orphan segment)"
+    );
+    assert_eq!(val_b_recovered.unwrap().value, Value::Int(2));
+
+    // Parent should still read the compacted data
+    let parent_a = store2
+        .get_versioned(&parent_kv("a"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(parent_a.value, Value::Int(1));
+}
+
 // =============================================================================
 // #1703: Concurrent materialize_layer is serialized
 // =============================================================================


### PR DESCRIPTION
## Summary

- The prior #1701 fix made recovery manifest-driven — orphan SSTs on disk but not in the manifest are correctly skipped from the parent's active version, preventing stale data from shadowing compacted segments
- However, the inherited layer resolution (second pass) still looked only at the source branch's active version, which **excludes** orphan segments
- After parent compaction → crash → recovery, the child's inherited layer could not find its pre-compaction segments (they were orphans in the parent), causing **child data loss**
- Fix: maintain a per-branch map of ALL opened segments (including orphans) during recovery, and use this map for inherited layer resolution

## Root Cause

In `recover_segments()`, the second pass resolved inherited layer segment references by searching the source branch's `version.levels` (active version). But the first-pass #1701 fix correctly excluded orphan segments from the active version. This meant segments that were orphans in the parent (pre-compaction segments kept on disk because a child had refcount > 0) could not be found during inherited layer resolution.

**Trigger sequence:** Parent has segment S → fork child (child inherits S) → parent compacts S → S' → crash → recovery → child's inherited layer references S → S not in parent's active version → child loses data.

## Fix

- Build a `HashMap<BranchId, HashMap<String, Arc<KVSegment>>>` of ALL opened segments per branch (including orphans) during the first pass
- In the second pass, look up inherited layer segments from this map instead of the source branch's active version
- This allows orphan segments to be available for children's inherited layers without loading them into the parent's active version

## Invariants Verified

COW-005, COW-006, COW-001, ARCH-004, ARCH-008, LSM-003 — all HOLD

## Test Plan

- [x] `test_issue_1701_recovery_inherited_layer_finds_orphan_segments` — end-to-end: fork → compact → crash → recovery → child reads inherited data
- [x] `recovery_skips_orphan_sst_not_in_manifest` — existing test still passes (parent-side orphan skipping)
- [x] Full `strata-storage` test suite (545 passed, 0 failed)
- [x] Full workspace test suite (4,531 passed, 0 failed)
- [x] Invariant check: all 6 affected invariants HOLD

🤖 Generated with [Claude Code](https://claude.com/claude-code)