### PR TITLE
Fix #1702: BranchIndex::delete_branch() now cleans up storage-layer segments

### DIFF
--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -332,7 +332,14 @@ impl BranchIndex {
 
             info!(target: "strata::branch", %branch_id, "Branch deleted");
             Ok(())
-        })
+        })?;
+
+        // Clean up storage-layer segments, manifest, and refcounts (#1702).
+        // Must happen after logical deletion so in-progress reads see the
+        // deletion before files disappear.
+        self.db.clear_branch_storage(&executor_branch_id);
+
+        Ok(())
     }
 
     /// Delete all branch-scoped data within an existing transaction context.

--- a/crates/engine/tests/branch_isolation_tests.rs
+++ b/crates/engine/tests/branch_isolation_tests.rs
@@ -8,7 +8,9 @@ use std::sync::Arc;
 use strata_core::contract::Version;
 use strata_core::types::BranchId;
 use strata_core::value::Value;
+use strata_engine::database::config::StorageConfig;
 use strata_engine::Database;
+use strata_engine::StrataConfig;
 use strata_engine::{BranchIndex, EventLog, KVStore, StateCell};
 use tempfile::TempDir;
 
@@ -436,4 +438,93 @@ fn test_event_log_chain_isolation() {
     // Verify chain lengths independently
     assert_eq!(event_log.len(&branch1, "default").unwrap(), 3);
     assert_eq!(event_log.len(&branch2, "default").unwrap(), 2);
+}
+
+/// #1702: BranchIndex::delete_branch() must clean up storage-layer segment files.
+///
+/// When a branch has been flushed to disk (producing .sst files), deleting the
+/// branch via the engine-level API must remove those files. Without the fix,
+/// only logical KV entries are removed — .sst files, manifests, and the branch
+/// directory leak on disk forever.
+#[test]
+fn test_issue_1702_delete_branch_cleans_up_segment_files() {
+    let temp_dir = TempDir::new().unwrap();
+
+    // Use a tiny write_buffer_size to force memtable rotation (and thus segment
+    // creation) on every write transaction commit.
+    let cfg = StrataConfig {
+        storage: StorageConfig {
+            write_buffer_size: 1, // 1 byte → rotates immediately
+            ..StorageConfig::default()
+        },
+        ..StrataConfig::default()
+    };
+    let db = Database::open_with_config(temp_dir.path(), cfg).unwrap();
+
+    let branch_index = BranchIndex::new(db.clone());
+    let kv = KVStore::new(db.clone());
+
+    // Create a branch and write data.
+    branch_index.create_branch("doomed").unwrap();
+    let branch_id = strata_engine::primitives::branch::resolve_branch_name("doomed");
+
+    // Each write triggers rotation → flush → .sst file on disk.
+    for i in 0..5 {
+        kv.put(&branch_id, "default", &format!("key{i}"), Value::Int(i))
+            .unwrap();
+    }
+
+    // Compute the branch's on-disk directory.
+    let segments_dir = temp_dir.path().join("segments");
+    let branch_hex = {
+        let bytes = branch_id.as_bytes();
+        let mut s = String::with_capacity(32);
+        for &b in bytes.iter() {
+            use std::fmt::Write;
+            let _ = write!(s, "{:02x}", b);
+        }
+        s
+    };
+    let branch_dir = segments_dir.join(&branch_hex);
+
+    // Collect .sst files for this branch before deletion.
+    let sst_count_before = std::fs::read_dir(&branch_dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "sst"))
+        .count();
+    assert!(
+        sst_count_before > 0,
+        "Expected .sst files in {:?} before delete, found none",
+        branch_dir,
+    );
+
+    // Delete the branch through the engine-level API.
+    branch_index.delete_branch("doomed").unwrap();
+
+    // Logical data should be gone.
+    assert!(kv.get(&branch_id, "default", "key0").unwrap().is_none());
+
+    // Storage-layer files should ALSO be gone.
+    let sst_after: Vec<_> = std::fs::read_dir(&branch_dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "sst"))
+        .collect();
+    assert!(
+        sst_after.is_empty(),
+        "Expected all .sst files to be cleaned up after delete_branch(), \
+         but found {} files: {:?}",
+        sst_after.len(),
+        sst_after.iter().map(|e| e.path()).collect::<Vec<_>>(),
+    );
+
+    // Branch directory should also be removed.
+    assert!(
+        !branch_dir.exists(),
+        "Branch directory {:?} should be removed after delete_branch()",
+        branch_dir,
+    );
 }


### PR DESCRIPTION
## Summary

- `BranchIndex::delete_branch()` only performed logical deletion (removing KV entries). Storage-layer artifacts (.sst files, manifests, branch directories, inherited layer refcounts) were never cleaned up.
- Added `self.db.clear_branch_storage()` call after logical deletion succeeds, matching what the executor handler already does for the SDK path.
- This also fixes storage leaks in `branch_ops.rs` rollback paths (fork failure cleanup).

## Root Cause

The engine-level `BranchIndex::delete_branch()` was a public API that only deleted KV entries via transaction. While the executor handler (`handlers/branch.rs`) had storage cleanup wired in for the SDK path (`Command::BranchDelete`), direct engine-level callers (like `branch_ops.rs` rollback) bypassed it, leaking `.sst` files, manifests, and branch directories on disk forever.

## Fix

3-line change in `crates/engine/src/primitives/branch/index.rs`: call `self.db.clear_branch_storage(&executor_branch_id)` after the logical deletion transaction commits. `BranchIndex` already holds `db: Arc<Database>`, so no new dependencies.

## Invariants Verified

- **COW-001**: All `.sst` deletion paths check `ref_registry.is_referenced()` — shared segments are never deleted while referenced by children.
- **COW-006**: `clear_branch()` properly decrements refcounts for inherited segments.
- **ARCH-008**: Deleting a parent branch preserves segments referenced by children via refcount check.
- **CMP-004**: Not affected (branch deletion, not compaction).
- **LSM-007**: Segment immutability preserved (files deleted, not modified).

## Test Plan

- [x] `test_issue_1702_delete_branch_cleans_up_segment_files` — creates branch, flushes data to `.sst` files, deletes branch, verifies files are cleaned up
- [x] Full engine crate test suite (1,453 tests pass)
- [x] Full workspace test suite passes (excluding strata-inference which has unrelated build dep issue)
- [x] Invariant check: all affected invariants HOLD
- [x] Code review: no must-fix or should-fix findings
- [x] Clippy clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)