### PR TITLE
Fix #1730: WAL compaction ignores snapshot watermark to prevent data loss

### DIFF
--- a/crates/durability/src/compaction/wal_only.rs
+++ b/crates/durability/src/compaction/wal_only.rs
@@ -77,7 +77,7 @@ impl WalOnlyCompactor {
         let start_time = std::time::Instant::now();
         let mut info = CompactInfo::new(CompactMode::WALOnly);
 
-        // Get effective watermark from MANIFEST (min of snapshot and flush watermarks)
+        // Get effective watermark from MANIFEST (flush watermark only; see #1730)
         let (watermark, manifest_active) = {
             let manifest = self.manifest.lock();
             let m = manifest.manifest();
@@ -307,19 +307,12 @@ impl WalOnlyCompactor {
 
 /// Compute the effective watermark for WAL truncation.
 ///
-/// Uses the minimum of the snapshot watermark and the flush watermark,
-/// so WAL segments are only deleted when covered by both (if both exist).
-/// Returns `None` if neither watermark is available.
+/// Returns the flush watermark from the MANIFEST, ignoring the snapshot
+/// watermark. Snapshot-aware recovery is not yet implemented (#1730), so
+/// WAL segments must only be deleted when their data is persisted in
+/// on-disk SST segments (tracked by `flushed_through_commit_id`).
 fn effective_watermark(manifest: &crate::format::Manifest) -> Option<u64> {
-    match (
-        manifest.snapshot_watermark,
-        manifest.flushed_through_commit_id,
-    ) {
-        (Some(sw), Some(fw)) => Some(sw.min(fw)),
-        (Some(sw), None) => Some(sw),
-        (None, Some(fw)) => Some(fw),
-        (None, None) => None,
-    }
+    manifest.flushed_through_commit_id
 }
 
 /// Generate segment file path
@@ -420,10 +413,10 @@ mod tests {
         create_segment_with_records(&wal_dir, 2, &[4, 5, 6]).unwrap();
         create_segment_with_records(&wal_dir, 3, &[7, 8, 9]).unwrap();
 
-        // Set snapshot watermark at txn 6 and active segment at 4
+        // Set flush watermark at txn 6 and active segment at 4
         {
             let mut m = manifest.lock();
-            m.set_snapshot_watermark(1, 6).unwrap();
+            m.set_flush_watermark(6).unwrap();
             m.manifest_mut().active_wal_segment = 4;
             m.persist().unwrap();
         }
@@ -453,7 +446,7 @@ mod tests {
         // Set watermark high but active segment is 1
         {
             let mut m = manifest.lock();
-            m.set_snapshot_watermark(1, 100).unwrap();
+            m.set_flush_watermark(100).unwrap();
             m.manifest_mut().active_wal_segment = 1; // Segment 1 is active
             m.persist().unwrap();
         }
@@ -470,10 +463,10 @@ mod tests {
     fn test_compact_empty_wal() {
         let (_dir, wal_dir, manifest) = setup_test_env();
 
-        // Set snapshot watermark but no segments
+        // Set flush watermark but no segments
         {
             let mut m = manifest.lock();
-            m.set_snapshot_watermark(1, 100).unwrap();
+            m.set_flush_watermark(100).unwrap();
             m.persist().unwrap();
         }
 
@@ -498,7 +491,7 @@ mod tests {
         // Set watermark and active segment
         {
             let mut m = manifest.lock();
-            m.set_snapshot_watermark(1, 5).unwrap();
+            m.set_flush_watermark(5).unwrap();
             m.manifest_mut().active_wal_segment = 10;
             m.persist().unwrap();
         }
@@ -537,7 +530,7 @@ mod tests {
 
         {
             let mut m = manifest.lock();
-            m.set_snapshot_watermark(1, 10).unwrap();
+            m.set_flush_watermark(10).unwrap();
             m.manifest_mut().active_wal_segment = 10;
             m.persist().unwrap();
         }
@@ -580,7 +573,7 @@ mod tests {
         // Set watermark to cover segment 1 only
         {
             let mut m = manifest.lock();
-            m.set_snapshot_watermark(1, 3).unwrap();
+            m.set_flush_watermark(3).unwrap();
             m.manifest_mut().active_wal_segment = 10;
             m.persist().unwrap();
         }
@@ -616,7 +609,7 @@ mod tests {
         // Set watermark at exactly max_txn_id=3 and active segment high
         {
             let mut m = manifest.lock();
-            m.set_snapshot_watermark(1, 3).unwrap();
+            m.set_flush_watermark(3).unwrap();
             m.manifest_mut().active_wal_segment = 10;
             m.persist().unwrap();
         }
@@ -646,7 +639,7 @@ mod tests {
         // safe_active = max(3, 5) = 5. Segments >= 5 are protected.
         {
             let mut m = manifest.lock();
-            m.set_snapshot_watermark(1, 100).unwrap(); // high watermark covers all
+            m.set_flush_watermark(100).unwrap(); // high watermark covers all
             m.manifest_mut().active_wal_segment = 3;
             m.persist().unwrap();
         }
@@ -677,7 +670,7 @@ mod tests {
         // MANIFEST active=5, override=3 → max(5,3)=5
         {
             let mut m = manifest.lock();
-            m.set_snapshot_watermark(1, 100).unwrap();
+            m.set_flush_watermark(100).unwrap();
             m.manifest_mut().active_wal_segment = 5;
             m.persist().unwrap();
         }
@@ -699,7 +692,7 @@ mod tests {
 
         {
             let mut m = manifest.lock();
-            m.set_snapshot_watermark(1, 10).unwrap();
+            m.set_flush_watermark(10).unwrap();
             m.manifest_mut().active_wal_segment = 3;
             m.persist().unwrap();
         }
@@ -731,7 +724,7 @@ mod tests {
 
         {
             let mut m = manifest.lock();
-            m.set_snapshot_watermark(1, 5).unwrap();
+            m.set_flush_watermark(5).unwrap();
             m.manifest_mut().active_wal_segment = 2; // stale
             m.persist().unwrap();
         }
@@ -782,30 +775,30 @@ mod tests {
     }
 
     #[test]
-    fn test_wal_truncation_uses_min_of_both_watermarks() {
+    fn test_wal_truncation_ignores_snapshot_watermark() {
+        // Issue #1730: snapshot watermark must NOT drive WAL deletion because
+        // recovery is WAL-only and cannot load snapshots.
         let (_dir, wal_dir, manifest) = setup_test_env();
 
         create_segment_with_records(&wal_dir, 1, &[1, 2, 3]).unwrap();
         create_segment_with_records(&wal_dir, 2, &[4, 5, 6]).unwrap();
-        create_segment_with_records(&wal_dir, 3, &[7, 8, 9]).unwrap();
 
-        // Snapshot watermark at 6, flush watermark at 4 → effective = min(6, 4) = 4
+        // Set only snapshot watermark (no flush watermark)
         {
             let mut m = manifest.lock();
-            m.set_snapshot_watermark(1, 6).unwrap();
-            m.manifest_mut().flushed_through_commit_id = Some(4);
+            m.set_snapshot_watermark(1, 100).unwrap();
             m.manifest_mut().active_wal_segment = 10;
             m.persist().unwrap();
         }
 
         let compactor = WalOnlyCompactor::new(wal_dir.clone(), manifest);
-        let info = compactor.compact().unwrap();
+        let result = compactor.compact();
 
-        // Only segment 1 covered (max txn 3 <= 4)
-        assert_eq!(info.wal_segments_removed, 1);
-        assert!(!segment_path(&wal_dir, 1).exists());
+        // Must return NoSnapshot because snapshot watermark alone is not safe
+        assert!(matches!(result, Err(CompactionError::NoSnapshot)));
+        // WAL segments must NOT be deleted
+        assert!(segment_path(&wal_dir, 1).exists());
         assert!(segment_path(&wal_dir, 2).exists());
-        assert!(segment_path(&wal_dir, 3).exists());
     }
 
     #[test]
@@ -838,7 +831,7 @@ mod tests {
 
         {
             let mut m = manifest.lock();
-            m.set_snapshot_watermark(1, 10).unwrap(); // covers everything
+            m.set_flush_watermark(10).unwrap(); // covers everything
             m.manifest_mut().active_wal_segment = 2; // stale: writer is at 4
             m.persist().unwrap();
         }

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -2980,7 +2980,10 @@ mod tests {
     }
 
     #[test]
-    fn test_checkpoint_then_compact() {
+    fn test_checkpoint_then_compact_without_flush_fails() {
+        // Issue #1730: compact() after checkpoint-only must fail because
+        // recovery cannot load snapshots. WAL compaction is only safe
+        // when driven by the flush watermark (data in SST segments).
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("db");
         let db = Database::open(&db_path).unwrap();
@@ -2996,11 +2999,12 @@ mod tests {
         })
         .unwrap();
 
-        // Checkpoint first
+        // Checkpoint creates snapshot but no flush watermark
         assert!(db.checkpoint().is_ok());
 
-        // Now compact should succeed
-        assert!(db.compact().is_ok());
+        // Compact must fail — snapshot watermark alone is not safe
+        let result = db.compact();
+        assert!(result.is_err());
     }
 
     #[test]
@@ -3844,5 +3848,120 @@ mod tests {
 
         // Clean up reader
         db.coordinator.record_abort(reader.txn_id);
+    }
+
+    #[test]
+    fn test_issue_1730_checkpoint_compact_recovery_data_loss() {
+        // Issue #1730: checkpoint+compact deletes WAL segments, but recovery
+        // is WAL-only and never loads snapshots. This causes data loss.
+        //
+        // After the fix, compact() must refuse to delete WAL segments based
+        // on the snapshot watermark alone, since recovery cannot load snapshots.
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("db");
+
+        let branch_id = BranchId::new();
+
+        // Step 1: Write data
+        {
+            let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+            let ns = create_test_namespace(branch_id);
+            let key = Key::new_kv(ns, "critical_data");
+
+            db.transaction(branch_id, |txn| {
+                txn.put(key.clone(), Value::String("must_survive".to_string()))?;
+                Ok(())
+            })
+            .unwrap();
+
+            // Step 2: Checkpoint (creates snapshot, sets watermark in MANIFEST)
+            db.checkpoint().unwrap();
+
+            // Step 3: Compact — should NOT delete WAL segments since recovery
+            // cannot load snapshots. With the fix, this returns an error.
+            let compact_result = db.compact();
+            assert!(
+                compact_result.is_err(),
+                "compact() must fail when only snapshot watermark exists \
+                 (no flush watermark) because recovery cannot load snapshots"
+            );
+        }
+        // Database dropped (simulates clean shutdown)
+
+        // Clear the registry so reopen doesn't return the cached instance
+        OPEN_DATABASES.lock().clear();
+
+        // Step 4: Reopen — recovery replays WAL
+        {
+            let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+
+            let ns = create_test_namespace(branch_id);
+            let key = Key::new_kv(ns, "critical_data");
+
+            // Step 5: Data MUST still be present
+            let result = db.storage().get_versioned(&key, u64::MAX).unwrap();
+            assert!(
+                result.is_some(),
+                "CRITICAL: Data lost after checkpoint+compact+recovery! \
+                 WAL segments were deleted but recovery never loaded the snapshot."
+            );
+            assert_eq!(
+                result.unwrap().value,
+                Value::String("must_survive".to_string())
+            );
+        }
+    }
+
+    #[test]
+    fn test_issue_1730_standard_durability() {
+        // Same as above but with Standard durability mode (disk-based, batched fsync).
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("db");
+
+        let branch_id = BranchId::new();
+        let durability = DurabilityMode::Standard {
+            interval_ms: 100,
+            batch_size: 1,
+        };
+
+        {
+            let db = Database::open_with_durability(&db_path, durability).unwrap();
+            let ns = create_test_namespace(branch_id);
+            let key = Key::new_kv(ns, "standard_data");
+
+            db.transaction(branch_id, |txn| {
+                txn.put(key.clone(), Value::String("durable".to_string()))?;
+                Ok(())
+            })
+            .unwrap();
+
+            // Ensure WAL is flushed to disk
+            db.flush().unwrap();
+
+            db.checkpoint().unwrap();
+
+            // compact() must fail — only snapshot watermark, no flush watermark
+            let compact_result = db.compact();
+            assert!(
+                compact_result.is_err(),
+                "compact() after checkpoint-only must fail under Standard durability"
+            );
+        }
+
+        OPEN_DATABASES.lock().clear();
+
+        // Reopen and verify data survived
+        {
+            let db = Database::open_with_durability(&db_path, durability).unwrap();
+            let ns = create_test_namespace(branch_id);
+            let key = Key::new_kv(ns, "standard_data");
+
+            let result = db.storage().get_versioned(&key, u64::MAX).unwrap();
+            assert!(
+                result.is_some(),
+                "Data must survive checkpoint+failed-compact+recovery under Standard durability"
+            );
+            assert_eq!(result.unwrap().value, Value::String("durable".to_string()));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `effective_watermark()` previously included `snapshot_watermark` in WAL compaction decisions, but `RecoveryCoordinator::recover()` is WAL-only and never loads snapshots
- After `checkpoint()` + `compact()`, WAL segments were permanently deleted despite recovery being unable to restore their data from the snapshot
- Fix: `effective_watermark()` now returns only `flushed_through_commit_id`, which is backed by on-disk SST segments that recovery actually loads

## Root Cause

`effective_watermark()` in `wal_only.rs` combined `snapshot_watermark` and `flushed_through_commit_id` via `min()`. When only `snapshot_watermark` was set (from `checkpoint()`), it was used as the sole watermark, causing `compact()` to delete WAL segments whose data existed only in a snapshot that recovery could never load.

## Fix

Single function change — `effective_watermark()` now returns `manifest.flushed_through_commit_id` only. This means:
- `checkpoint()` still works (creates snapshots, updates MANIFEST — harmless)
- `compact()` after checkpoint-only returns `NoSnapshot` error (correct — nothing safe to compact)
- `compact()` after flush still works correctly via `flushed_through_commit_id`
- The flush-triggered `update_flush_watermark()` path is unaffected

## Invariants Verified

- **ACID-005**: Recovery replay unchanged; fix prevents WAL deletion that would make replay incomplete
- **ARCH-004**: Strengthened — WAL segments now survive until recovery can restore their data
- **ARCH-007**: `flushed_through_commit_id` stays within durability MANIFEST authority domain
- **CMP-004**: WAL deletion ordering unchanged

## Test Plan

- [x] `test_issue_1730_checkpoint_compact_recovery_data_loss` — end-to-end: write → checkpoint → compact (must fail) → reopen → data survives
- [x] `test_issue_1730_standard_durability` — same scenario under Standard durability mode
- [x] `test_wal_truncation_ignores_snapshot_watermark` — snapshot-only watermark returns `NoSnapshot`
- [x] `test_checkpoint_then_compact_without_flush_fails` — updated existing test
- [x] All 20 WAL compaction unit tests pass
- [x] All 404 durability crate tests pass
- [x] Full workspace tests pass (excluding strata-inference/vendor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)