### PR TITLE
Fix #1735: Pi Zero blockers: block cache min clamp + u64→usize truncation on 32-bit

### DIFF
--- a/crates/engine/src/primitives/vector/mmap.rs
+++ b/crates/engine/src/primitives/vector/mmap.rs
@@ -162,7 +162,12 @@ impl MmapVectorData {
         }
 
         // Count
-        let count = u64::from_le_bytes(data[12..20].try_into().unwrap()) as usize;
+        let count_u64 = u64::from_le_bytes(data[12..20].try_into().unwrap());
+        let count = usize::try_from(count_u64).map_err(|_| {
+            VectorError::Serialization(format!(
+                "mmap count {count_u64} exceeds platform pointer size"
+            ))
+        })?;
 
         // next_id
         let next_id = u64::from_le_bytes(data[20..28].try_into().unwrap());
@@ -202,7 +207,12 @@ impl MmapVectorData {
                     "mmap truncated in free_slots".into(),
                 ));
             }
-            let slot = u64::from_le_bytes(data[pos..pos + 8].try_into().unwrap()) as usize;
+            let slot_u64 = u64::from_le_bytes(data[pos..pos + 8].try_into().unwrap());
+            let slot = usize::try_from(slot_u64).map_err(|_| {
+                VectorError::Serialization(format!(
+                    "mmap free slot offset {slot_u64} exceeds platform pointer size"
+                ))
+            })?;
             free_slots.push(slot);
             pos += 8;
         }
@@ -470,6 +480,54 @@ mod tests {
 
         let result = MmapVectorData::open(&path, 3);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_issue_1735_mmap_rejects_oversized_count() {
+        // Craft a valid-looking mmap file with count > u32::MAX.
+        // On 32-bit, this must error (not silently truncate).
+        // On 64-bit, this errors because the file is too small for the count.
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("big_count.vec");
+
+        let big_count: u64 = (u32::MAX as u64) + 1;
+        let mut data = Vec::new();
+        data.extend_from_slice(MAGIC); // 4B
+        data.extend_from_slice(&VERSION.to_le_bytes()); // 4B
+        data.extend_from_slice(&3u32.to_le_bytes()); // dimension 4B
+        data.extend_from_slice(&big_count.to_le_bytes()); // count 8B
+        data.extend_from_slice(&1u64.to_le_bytes()); // next_id 8B
+                                                     // No entries follow — file is truncated relative to count
+        data.extend(vec![0u8; 256]);
+
+        std::fs::write(&path, &data).unwrap();
+        let result = MmapVectorData::open(&path, 3);
+        assert!(result.is_err(), "should reject file with oversized count");
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn test_issue_1735_mmap_count_exceeds_32bit() {
+        // On 32-bit specifically, verify the error mentions platform size.
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("big_count_32.vec");
+
+        let big_count: u64 = (u32::MAX as u64) + 1;
+        let mut data = Vec::new();
+        data.extend_from_slice(MAGIC);
+        data.extend_from_slice(&VERSION.to_le_bytes());
+        data.extend_from_slice(&3u32.to_le_bytes());
+        data.extend_from_slice(&big_count.to_le_bytes());
+        data.extend_from_slice(&1u64.to_le_bytes());
+        data.extend(vec![0u8; 256]);
+
+        std::fs::write(&path, &data).unwrap();
+        let err = MmapVectorData::open(&path, 3).unwrap_err().to_string();
+        assert!(
+            err.contains("exceeds"),
+            "expected platform size error, got: {}",
+            err
+        );
     }
 
     // ====================================================================

--- a/crates/engine/src/primitives/vector/mmap_graph.rs
+++ b/crates/engine/src/primitives/vector/mmap_graph.rs
@@ -223,8 +223,18 @@ pub(crate) fn open_graph_file(
     let node_count = u32::from_le_bytes(data[20..24].try_into().unwrap()) as usize;
 
     // neighbor_data_len, node_section_size
-    let neighbor_data_len = u64::from_le_bytes(data[24..32].try_into().unwrap()) as usize;
-    let node_section_size = u64::from_le_bytes(data[32..40].try_into().unwrap()) as usize;
+    let neighbor_data_len_u64 = u64::from_le_bytes(data[24..32].try_into().unwrap());
+    let neighbor_data_len = usize::try_from(neighbor_data_len_u64).map_err(|_| {
+        VectorError::Serialization(format!(
+            "neighbor_data_len {neighbor_data_len_u64} exceeds platform pointer size"
+        ))
+    })?;
+    let node_section_size_u64 = u64::from_le_bytes(data[32..40].try_into().unwrap());
+    let node_section_size = usize::try_from(node_section_size_u64).map_err(|_| {
+        VectorError::Serialization(format!(
+            "node_section_size {node_section_size_u64} exceeds platform pointer size"
+        ))
+    })?;
     // reserved at 40..48 (ignored)
 
     // Validate file size (with overflow protection for untrusted file values)
@@ -505,6 +515,33 @@ mod tests {
         let config = VectorConfig::new(3, DistanceMetric::Cosine).unwrap();
         let result = open_graph_file(&path, HnswConfig::default(), config);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_issue_1735_graph_mmap_rejects_oversized_fields() {
+        // Craft a graph file with neighbor_data_len > u32::MAX.
+        // On 32-bit, try_from must reject. On 64-bit, size validation catches it.
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("big_neighbor.hgr");
+
+        let big_len: u64 = (u32::MAX as u64) + 1;
+        let mut data = vec![0u8; HEADER_SIZE + 64];
+        data[0..4].copy_from_slice(MAGIC);
+        data[4..8].copy_from_slice(&1u32.to_le_bytes()); // version
+        data[8..16].copy_from_slice(&NONE_SENTINEL.to_le_bytes()); // entry_point = None
+        data[16..20].copy_from_slice(&0u32.to_le_bytes()); // max_level
+        data[20..24].copy_from_slice(&0u32.to_le_bytes()); // node_count
+        data[24..32].copy_from_slice(&big_len.to_le_bytes()); // neighbor_data_len > u32::MAX
+        data[32..40].copy_from_slice(&0u64.to_le_bytes()); // node_section_size
+        data[40..48].copy_from_slice(&0u64.to_le_bytes()); // reserved
+
+        std::fs::write(&path, &data).unwrap();
+        let config = VectorConfig::new(3, DistanceMetric::Cosine).unwrap();
+        let result = open_graph_file(&path, HnswConfig::default(), config);
+        assert!(
+            result.is_err(),
+            "should reject file with oversized neighbor_data_len"
+        );
     }
 
     #[test]

--- a/crates/engine/src/primitives/vector/segmented.rs
+++ b/crates/engine/src/primitives/vector/segmented.rs
@@ -1401,8 +1401,12 @@ impl VectorIndexBackend for SegmentedHnswBackend {
         // Staleness check: if the heap vector count changed since the graphs
         // were frozen (e.g. vectors deleted via WAL replay), the graphs are
         // stale and must be rebuilt.
-        let frozen_heap_count =
-            u64::from_le_bytes(manifest_data[0..8].try_into().unwrap()) as usize;
+        let frozen_heap_count_u64 = u64::from_le_bytes(manifest_data[0..8].try_into().unwrap());
+        let frozen_heap_count = usize::try_from(frozen_heap_count_u64).map_err(|_| {
+            VectorError::Serialization(format!(
+                "frozen_heap_count {frozen_heap_count_u64} exceeds platform pointer size"
+            ))
+        })?;
         if frozen_heap_count != self.heap.len() {
             tracing::info!(
                 target: "strata::vector",
@@ -1421,9 +1425,13 @@ impl VectorIndexBackend for SegmentedHnswBackend {
             let offset = 8 + i * 24;
             let segment_id =
                 u64::from_le_bytes(manifest_data[offset..offset + 8].try_into().unwrap());
-            let live_count =
-                u64::from_le_bytes(manifest_data[offset + 8..offset + 16].try_into().unwrap())
-                    as usize;
+            let live_count_u64 =
+                u64::from_le_bytes(manifest_data[offset + 8..offset + 16].try_into().unwrap());
+            let live_count = usize::try_from(live_count_u64).map_err(|_| {
+                VectorError::Serialization(format!(
+                    "segment live_count {live_count_u64} exceeds platform pointer size"
+                ))
+            })?;
             // offset+16..offset+24 reserved
 
             let graph_path = dir.join(format!("seg_{}.hgr", segment_id));

--- a/crates/storage/src/block_cache.rs
+++ b/crates/storage/src/block_cache.rs
@@ -395,6 +395,12 @@ pub fn file_path_hash(path: &std::path::Path) -> u64 {
 #[allow(dead_code)]
 const MAX_AUTO_CACHE_BYTES: usize = 4 * 1024 * 1024 * 1024;
 
+/// Compute cache capacity from available memory in bytes (testable helper).
+fn compute_cache_from_available(available_bytes: usize) -> usize {
+    let quarter = available_bytes / 4;
+    quarter.min(MAX_AUTO_CACHE_BYTES)
+}
+
 /// Auto-detect a reasonable cache capacity based on available system memory.
 pub fn auto_detect_capacity() -> usize {
     #[cfg(target_os = "linux")]
@@ -404,8 +410,7 @@ pub fn auto_detect_capacity() -> usize {
                 if let Some(rest) = line.strip_prefix("MemAvailable:") {
                     if let Some(kb_str) = rest.split_whitespace().next() {
                         if let Ok(kb) = kb_str.parse::<usize>() {
-                            let quarter = (kb * 1024) / 4;
-                            return quarter.clamp(256 * 1024 * 1024, MAX_AUTO_CACHE_BYTES);
+                            return compute_cache_from_available(kb * 1024);
                         }
                     }
                 }
@@ -619,11 +624,34 @@ mod tests {
     #[test]
     fn auto_detect_returns_positive() {
         let cap = auto_detect_capacity();
-        assert!(
-            cap >= 256 * 1024 * 1024,
-            "auto-detect should return at least 256 MiB, got {}",
-            cap
+        assert!(cap > 0, "auto-detect should return positive value, got 0");
+    }
+
+    #[test]
+    fn test_issue_1735_no_minimum_cache_clamp() {
+        // Pi Zero scenario: 350 MB available → quarter = 87.5 MB
+        // Bug: clamp(256 MiB, ...) forces 256 MiB — 73% of usable RAM
+        let pi_available = 350 * 1024 * 1024; // 350 MB
+        let cap = compute_cache_from_available(pi_available);
+        let quarter = pi_available / 4;
+        assert_eq!(
+            cap, quarter,
+            "cache {} should be 25% of available ({}), not clamped up",
+            cap, quarter
         );
+    }
+
+    #[test]
+    fn test_issue_1735_max_cap_still_enforced() {
+        // 32 GB available → quarter = 8 GB, should be capped to 4 GB
+        let big_available = 32 * 1024 * 1024 * 1024;
+        let cap = compute_cache_from_available(big_available);
+        assert_eq!(cap, MAX_AUTO_CACHE_BYTES);
+    }
+
+    #[test]
+    fn test_issue_1735_zero_available_returns_zero() {
+        assert_eq!(compute_cache_from_available(0), 0);
     }
 
     /// Helper: find `count` file_ids that map to a given shard.


### PR DESCRIPTION
## Summary

- **S-B1**: `auto_detect_capacity()` enforced a 256 MiB minimum clamp, consuming 73% of RAM on a Pi Zero with 350 MB available. Removed the floor — cache is now 25% of available RAM with only the 4 GiB upper cap retained.
- **S-B2**: Six `u64 as usize` casts in mmap heap, graph, and manifest parsers silently truncate on 32-bit platforms. Files created on 64-bit are now safely rejected with a clear `VectorError` instead of causing memory corruption.

## Root Cause

- S-B1: `quarter.clamp(256 * 1024 * 1024, MAX_AUTO_CACHE_BYTES)` in `block_cache.rs` — the minimum was designed for servers but violates SCALE-001 on embedded devices.
- S-B2: `u64::from_le_bytes(...) as usize` in `mmap.rs`, `mmap_graph.rs`, `segmented.rs` — on 32-bit, `usize` is 32 bits so values > 4 GiB truncate silently, violating SCALE-003.

## Fix

- S-B1: Replaced `.clamp(min, max)` with `.min(max)` — one line.
- S-B2: Replaced all six `as usize` casts with `usize::try_from().map_err(...)` returning descriptive errors.

## Invariants Verified

SCALE-001, SCALE-002, SCALE-003, LSM-006 — all HOLD.

## Test Plan

- [x] `test_issue_1735_no_minimum_cache_clamp` — Pi Zero scenario (350 MB → 87 MB cache, not 256 MB)
- [x] `test_issue_1735_max_cap_still_enforced` — upper cap (32 GB → 4 GB) still works
- [x] `test_issue_1735_zero_available_returns_zero` — zero available memory edge case
- [x] `test_issue_1735_mmap_rejects_oversized_count` — crafted mmap with count > u32::MAX
- [x] `test_issue_1735_mmap_count_exceeds_32bit` — 32-bit specific error message check
- [x] `test_issue_1735_graph_mmap_rejects_oversized_fields` — crafted graph with oversized fields
- [x] Full storage suite (549 passed)
- [x] Full engine suite (1317 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)