### PR TITLE
Fix #1754: Add serde_bytes to Value::Bytes to eliminate per-byte deserialization overhead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1.35", features = ["full"] }
 
 # Serialization
+serde_bytes = "0.11"
 rmp-serde = "1.1"
 byteorder = "1.5"
 toml = "0.8"

--- a/crates/concurrency/src/payload.rs
+++ b/crates/concurrency/src/payload.rs
@@ -134,4 +134,34 @@ mod tests {
         let result = TransactionPayload::from_bytes(&[0xFF, 0x00, 0x01]);
         assert!(result.is_err());
     }
+
+    /// Issue #1754: Value::Bytes must use msgpack bin encoding, not array-of-u8.
+    ///
+    /// Without `serde_bytes`, rmp-serde encodes `Vec<u8>` as a msgpack array where
+    /// each byte > 127 becomes 2 bytes (type tag + value), and deserialization
+    /// calls `deserialize_u8` per byte — 32-36% of read latency at 1KB values.
+    ///
+    /// With `serde_bytes`, encoding uses msgpack bin (header + raw bulk copy) and
+    /// deserialization is a single `visit_bytes` + memcpy.
+    #[test]
+    fn test_issue_1754_value_bytes_uses_efficient_msgpack_encoding() {
+        // 256 bytes all > 127: without serde_bytes, each byte encodes as 2 bytes
+        // (0xcc prefix + value), roughly doubling the payload size.
+        let data = vec![0xFFu8; 256];
+        let value = Value::Bytes(data.clone());
+        let encoded = rmp_serde::to_vec(&value).unwrap();
+
+        // With serde_bytes (bin encoding): ~260 bytes (enum overhead + bin16 header + 256 raw)
+        // Without serde_bytes (array encoding): ~515 bytes (enum overhead + array16 header + 256×2)
+        assert!(
+            encoded.len() < 300,
+            "Value::Bytes encoded size {} indicates array-of-u8 encoding \
+             (expected bin encoding < 300 bytes for 256 high bytes)",
+            encoded.len()
+        );
+
+        // Verify round-trip correctness
+        let decoded: Value = rmp_serde::from_slice(&encoded).unwrap();
+        assert_eq!(decoded, Value::Bytes(vec![0xFFu8; 256]));
+    }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 [dependencies]
 uuid = { workspace = true }
 serde = { workspace = true }
+serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 bincode = { workspace = true }

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -60,6 +60,7 @@ pub enum Value {
     /// `Value::Bytes`. This means `Bytes` values do not survive a JSON roundtrip
     /// with their original type intact. Use binary serialization (e.g., bincode,
     /// MessagePack) for lossless `Bytes` roundtrips.
+    #[serde(with = "serde_bytes")]
     Bytes(Vec<u8>),
     /// Array of values
     ///


### PR DESCRIPTION
## Summary

- `Value::Bytes(Vec<u8>)` lacked `#[serde(with = "serde_bytes")]`, causing serde to treat it as a generic sequence — per-byte `deserialize_u8` dispatch consumed 32-36% of KV read latency at 1KB values
- Added `serde_bytes` annotation for bulk binary serialization/deserialization (single `visit_bytes` + memcpy instead of N visitor calls)
- Affects both rmp-serde paths (IPC protocol, WAL payloads) and bincode paths (segment files — same binary format, less CPU overhead)

## Root Cause

Without `serde_bytes`, rmp-serde encodes `Vec<u8>` as a msgpack array of integers. For bytes > 127, each byte becomes 2 bytes (0xcc prefix + value). Deserialization calls `deserialize_u8` per byte through serde's visitor pattern. With `serde_bytes`, encoding uses msgpack bin type (header + raw bulk copy) and deserialization is a single memcpy.

## Fix

One-line annotation on `Value::Bytes` in `crates/core/src/value.rs`:
```rust
#[serde(with = "serde_bytes")]
Bytes(Vec<u8>),
```

## Invariants Verified

- **ACID-001** (HOLDS): WAL record bundling unchanged
- **ACID-005** (WEAKENED — accepted): Old WAL records with `Value::Bytes` use array-of-u8 format; new code expects bin format. Only affects cross-version upgrade with unflushed WAL. Backward compatibility explicitly not required.
- **ARCH-004** (HOLDS): Recovery sequence unchanged
- **SCALE-003** (HOLDS): Bincode on-disk format is identical with/without serde_bytes (both encode as `u64 length LE + raw bytes`)

## Test Plan

- [x] `test_issue_1754_value_bytes_uses_efficient_msgpack_encoding` — verifies msgpack bin encoding (size < 300 bytes for 256 high bytes, vs 522 without fix) and round-trip correctness
- [x] Full concurrency crate tests pass (104/104)
- [x] Full workspace tests pass (excluding strata-inference — pre-existing CMake issue)
- [x] Clippy clean on changed crates
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)