### PR TITLE
Fix #1781: Release DashMap shard lock before commit path to prevent cross-branch serialization

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -81,7 +81,7 @@ pub struct TransactionManager {
     ///
     /// Using per-branch locks allows parallel commits for different branches while
     /// still preventing TOCTOU within each branch.
-    commit_locks: DashMap<BranchId, Mutex<()>>,
+    commit_locks: DashMap<BranchId, Arc<Mutex<()>>>,
 
     /// Quiesce lock for checkpoint safety (#1710).
     ///
@@ -260,11 +260,12 @@ impl TransactionManager {
         // The lock MUST be held from validation through version allocation
         // and apply_writes — otherwise a concurrent transaction could validate
         // against stale state (TOCTOU).
-        let branch_lock = self
+        let commit_mutex = self
             .commit_locks
             .entry(txn.branch_id)
-            .or_insert_with(|| Mutex::new(()));
-        let _commit_guard = branch_lock.lock();
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone(); // clone Arc, drop RefMut → releases shard lock (#1781)
+        let _commit_guard = commit_mutex.lock();
 
         // Skip OCC validation for blind writes (no reads, no CAS, no JSON snapshots)
         let can_skip_validation = txn.read_set.is_empty()
@@ -391,11 +392,12 @@ impl TransactionManager {
         // through version allocation and apply_writes for ALL writers (including
         // blind writes) to prevent a concurrent writer from advancing the store
         // version while another transaction is mid-apply (#1708).
-        let branch_lock = self
+        let commit_mutex = self
             .commit_locks
             .entry(txn.branch_id)
-            .or_insert_with(|| Mutex::new(()));
-        let _commit_guard = branch_lock.lock();
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone(); // clone Arc, drop RefMut → releases shard lock (#1781)
+        let _commit_guard = commit_mutex.lock();
 
         // Skip OCC validation for blind writes (no reads, no CAS, no JSON snapshots)
         let can_skip_validation = txn.read_set.is_empty()
@@ -472,19 +474,19 @@ impl TransactionManager {
     /// Remove the per-branch commit lock for a deleted branch.
     ///
     /// Called during branch deletion to prevent unbounded growth of the
-    /// `commit_locks` map. Returns `true` if the lock was removed (or didn't
-    /// exist), `false` if a concurrent commit is in-flight and removal was
-    /// skipped.
+    /// `commit_locks` map. Always removes the entry and returns `true`.
     ///
-    /// If a concurrent commit holds the lock, removal is skipped to avoid
-    /// defeating the TOCTOU protection the lock provides. The stale entry
-    /// will be cleaned up on the next branch delete attempt or lazily collected.
+    /// If a concurrent commit is in-flight, it holds a cloned `Arc<Mutex>`
+    /// and is unaffected by the removal — the Mutex stays alive via the Arc
+    /// and the commit completes normally. The next commit on this branch
+    /// (if any) will recreate the entry via `entry().or_insert_with()`.
     pub fn remove_branch_lock(&self, branch_id: &BranchId) -> bool {
         // DashMap::remove() atomically acquires the shard write lock and
-        // removes the entry.  If a concurrent commit holds the shard lock
-        // (via `entry()`), this blocks until the commit finishes — then
-        // removes the now-unlocked entry.  The next commit will recreate
-        // the entry via `entry().or_insert_with()`.  (#1621)
+        // removes the entry.  A concurrent commit may still hold the
+        // Arc<Mutex> it cloned earlier — that's fine, the Mutex stays
+        // alive via the Arc and the commit completes normally.  The next
+        // commit on this branch will recreate the entry via
+        // `entry().or_insert_with()`.  (#1621, #1781)
         self.commit_locks.remove(branch_id);
         true
     }
@@ -538,11 +540,12 @@ impl TransactionManager {
         let _quiesce_guard = self.commit_quiesce.read();
 
         // Acquire per-branch lock — must be held through validation + apply.
-        let branch_lock = self
+        let commit_mutex = self
             .commit_locks
             .entry(txn.branch_id)
-            .or_insert_with(|| Mutex::new(()));
-        let _commit_guard = branch_lock.lock();
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone(); // clone Arc, drop RefMut → releases shard lock (#1781)
+        let _commit_guard = commit_mutex.lock();
 
         // Skip OCC validation for blind writes (no reads, no CAS, no JSON snapshots)
         let can_skip_validation = txn.read_set.is_empty()
@@ -1574,7 +1577,7 @@ mod tests {
         manager
             .commit_locks
             .entry(branch_id)
-            .or_insert_with(|| Mutex::new(()));
+            .or_insert_with(|| Arc::new(Mutex::new(())));
         assert!(manager.commit_locks.contains_key(&branch_id));
 
         // Removal should succeed since no one holds the lock
@@ -1603,7 +1606,7 @@ mod tests {
             let _entry = manager
                 .commit_locks
                 .entry(branch_id)
-                .or_insert_with(|| Mutex::new(()));
+                .or_insert_with(|| Arc::new(Mutex::new(())));
             // entry guard dropped here, releasing shard lock
         }
         assert!(manager.commit_locks.contains_key(&branch_id));
@@ -1617,7 +1620,7 @@ mod tests {
             let _entry = manager
                 .commit_locks
                 .entry(branch_id)
-                .or_insert_with(|| Mutex::new(()));
+                .or_insert_with(|| Arc::new(Mutex::new(())));
         }
         assert!(manager.commit_locks.contains_key(&branch_id));
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -866,7 +866,7 @@ CAS is validated independently from the read set. `expected_version=0` means
 pub struct TransactionManager {
     version: AtomicU64,
     next_txn_id: AtomicU64,
-    commit_locks: DashMap<BranchId, Mutex<()>>,
+    commit_locks: DashMap<BranchId, Arc<Mutex<()>>>,
 }
 ```
 

--- a/docs/architecture/concurrency-crate.md
+++ b/docs/architecture/concurrency-crate.md
@@ -162,7 +162,7 @@ Coordinates the commit protocol. Owns two atomic counters and per-branch commit 
 |-------|------|---------|
 | `version` | `AtomicU64` | Global monotonic version counter (shared across all branches) |
 | `next_txn_id` | `AtomicU64` | Next transaction ID (unique per TransactionManager) |
-| `commit_locks` | `DashMap<BranchId, Mutex<()>>` | Per-branch commit serialization |
+| `commit_locks` | `DashMap<BranchId, Arc<Mutex<()>>>` | Per-branch commit serialization (#1781: Arc decouples shard lock from commit duration) |
 
 ### 2.2 Counter Allocation
 

--- a/docs/architecture/concurrency-invariants.md
+++ b/docs/architecture/concurrency-invariants.md
@@ -213,13 +213,14 @@ Writes are invisible to all other transactions until commit step 4 (apply to sto
 ### commit_locks (manager.rs:83)
 
 ```rust
-let branch_lock = self.commit_locks
+let commit_mutex = self.commit_locks
     .entry(txn.branch_id)
-    .or_insert_with(|| Mutex::new(()));
-let _commit_guard = branch_lock.lock();
+    .or_insert_with(|| Arc::new(Mutex::new(())))
+    .clone(); // clone Arc, drop RefMut → releases shard lock (#1781)
+let _commit_guard = commit_mutex.lock();
 ```
 
-**Safe**: `entry().or_insert_with()` is atomic — DashMap guarantees at-most-once initialization. Two threads on the same branch both reach the Mutex, but one blocks on `lock()`.
+**Safe**: `entry().or_insert_with()` is atomic — DashMap guarantees at-most-once initialization. The `Arc::clone()` drops the `RefMut` (releasing the DashMap shard lock) while keeping the Mutex alive. Two threads on the same branch get the same `Arc<Mutex>`, so one blocks on `lock()`. Threads on different branches no longer contend on DashMap shard locks (#1781).
 
 ### shards (sharded.rs:234)
 


### PR DESCRIPTION
## Summary

- Change `commit_locks` from `DashMap<BranchId, Mutex<()>>` to `DashMap<BranchId, Arc<Mutex<()>>>` and `Arc::clone()` to release the DashMap shard write lock before entering the commit critical section
- Fixes cross-branch commit serialization when BranchIds hash to the same DashMap shard (near-deterministic deadlock on 2-core CI runners with ~4 shards)
- Applied to all 3 commit methods: `commit()`, `commit_with_wal_arc()`, `commit_blind()`
- Updated `remove_branch_lock` docstring to accurately reflect behavior (was claiming it could return `false` — it never did)
- Updated architecture docs to reflect the new type and pattern

## Invariants preserved

- **ACID-003**: Per-branch Mutex still held from validation through apply_writes (only the DashMap shard lock is released early)
- **ACID-004**: Blind write path unchanged — lock acquired before validation skip check
- **ARCH-002**: Atomic publication boundary unchanged — writer serialization via Mutex, not shard lock

## Test plan

- [x] All 105 concurrency crate tests pass, including `test_issue_1710_quiesced_version_concurrent_multi_branch` (the test that was deadlocking on CI)
- [x] Invariant check run against ACID-003, ACID-004, ARCH-002 — all HOLD
- [x] Code review verified Arc clone semantics, no partial failure risk, no race conditions under normal usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)