### PR TITLE
Fix #1762: Clean up all clippy warnings across workspace

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -769,8 +769,8 @@ mod tests {
         let v2 = handle2.join().unwrap().unwrap();
 
         // Both commits should succeed with unique versions
-        assert!(v1 >= 1 && v1 <= 2);
-        assert!(v2 >= 1 && v2 <= 2);
+        assert!((1..=2).contains(&v1));
+        assert!((1..=2).contains(&v2));
         assert_ne!(v1, v2); // Versions must be unique
 
         // Both keys should be in storage

--- a/crates/core/src/contract/entity_ref.rs
+++ b/crates/core/src/contract/entity_ref.rs
@@ -466,14 +466,12 @@ mod tests {
         let branch_id = BranchId::new();
 
         // Create one of each type
-        let refs = vec![
-            EntityRef::kv(branch_id, "k"),
+        let refs = [EntityRef::kv(branch_id, "k"),
             EntityRef::event(branch_id, 0),
             EntityRef::state(branch_id, "s"),
             EntityRef::branch(branch_id),
             EntityRef::json(branch_id, "j"),
-            EntityRef::vector(branch_id, "c", "k"),
-        ];
+            EntityRef::vector(branch_id, "c", "k")];
 
         // Verify they map to all 6 primitive types
         let types: std::collections::HashSet<_> = refs.iter().map(|r| r.primitive_type()).collect();

--- a/crates/core/src/contract/versioned.rs
+++ b/crates/core/src/contract/versioned.rs
@@ -462,9 +462,9 @@ mod tests {
         assert!(v_int.is_int());
         assert_eq!(v_int.as_int(), Some(42));
 
-        let v_float = Versioned::new(Value::Float(3.14), Version::txn(1));
+        let v_float = Versioned::new(Value::Float(2.78), Version::txn(1));
         assert!(v_float.is_float());
-        assert!((v_float.as_float().unwrap() - 3.14).abs() < f64::EPSILON);
+        assert!((v_float.as_float().unwrap() - 2.78).abs() < f64::EPSILON);
 
         let v_str = Versioned::new(Value::String("hello".into()), Version::txn(1));
         assert!(v_str.is_string());

--- a/crates/core/src/limits.rs
+++ b/crates/core/src/limits.rs
@@ -704,7 +704,7 @@ mod tests {
         assert!(limits.validate_value_full(&Value::Int(42)).is_ok());
         assert!(limits.validate_value_full(&Value::Int(i64::MIN)).is_ok());
         assert!(limits.validate_value_full(&Value::Int(i64::MAX)).is_ok());
-        assert!(limits.validate_value_full(&Value::Float(3.14)).is_ok());
+        assert!(limits.validate_value_full(&Value::Float(2.78)).is_ok());
         assert!(limits.validate_value_full(&Value::Float(0.0)).is_ok());
         assert!(limits.validate_value_full(&Value::Float(-0.0)).is_ok());
     }

--- a/crates/core/src/primitives/json.rs
+++ b/crates/core/src/primitives/json.rs
@@ -1564,8 +1564,8 @@ mod tests {
 
     #[test]
     fn test_json_value_from_f64() {
-        let v = JsonValue::from(3.14f64);
-        assert!((v.as_f64().unwrap() - 3.14).abs() < f64::EPSILON);
+        let v = JsonValue::from(2.78f64);
+        assert!((v.as_f64().unwrap() - 2.78).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/core/src/primitives/vector.rs
+++ b/crates/core/src/primitives/vector.rs
@@ -961,7 +961,7 @@ mod tests {
         let s: JsonScalar = 42i32.into();
         assert!(matches!(s, JsonScalar::Number(_)));
 
-        let s: JsonScalar = 3.14f64.into();
+        let s: JsonScalar = 2.78f64.into();
         assert!(matches!(s, JsonScalar::Number(_)));
 
         let s: JsonScalar = "hello".into();

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -425,12 +425,12 @@ mod tests {
 
     #[test]
     fn test_value_float() {
-        let value = Value::Float(3.14);
+        let value = Value::Float(2.78);
         assert!(matches!(value, Value::Float(_)));
         assert!(value.is_float());
 
         if let Some(f) = value.as_float() {
-            assert!((f - 3.14).abs() < f64::EPSILON);
+            assert!((f - 2.78).abs() < f64::EPSILON);
         }
     }
 
@@ -494,7 +494,7 @@ mod tests {
             Value::Null,
             Value::Bool(true),
             Value::Int(42),
-            Value::Float(3.14),
+            Value::Float(2.78),
             Value::String("test".to_string()),
             Value::Bytes(vec![1, 2, 3]),
             Value::array(vec![Value::Int(1), Value::String("a".to_string())]),
@@ -574,8 +574,8 @@ mod tests {
 
     #[test]
     fn test_from_f64() {
-        let v: Value = 3.14f64.into();
-        assert!(matches!(v, Value::Float(f) if (f - 3.14).abs() < f64::EPSILON));
+        let v: Value = 2.78f64.into();
+        assert!(matches!(v, Value::Float(f) if (f - 2.78).abs() < f64::EPSILON));
     }
 
     #[test]

--- a/crates/durability/src/branch_bundle/wal_log.rs
+++ b/crates/durability/src/branch_bundle/wal_log.rs
@@ -439,7 +439,7 @@ mod tests {
     }
 
     fn make_test_payloads(branch_id_str: &str) -> Vec<BranchlogPayload> {
-        let branch_id = BranchId::from_string(branch_id_str).unwrap_or_else(|| BranchId::new());
+        let branch_id = BranchId::from_string(branch_id_str).unwrap_or_default();
         let ns = Arc::new(Namespace::for_branch(branch_id));
         vec![
             BranchlogPayload {

--- a/crates/durability/src/coordination.rs
+++ b/crates/durability/src/coordination.rs
@@ -470,7 +470,7 @@ mod tests {
         let cf = CounterFile::new(dir.path());
 
         // Write only 4 bytes (need 16) — simulates crash during write
-        std::fs::write(dir.path().join("counters"), &[0xAA; 4]).unwrap();
+        std::fs::write(dir.path().join("counters"), [0xAA; 4]).unwrap();
 
         // read_or_default should return Err because read_exact fails
         // (file exists so NotFound branch is not taken, but UnexpectedEof occurs)
@@ -488,7 +488,7 @@ mod tests {
         let cf = CounterFile::new(dir.path());
 
         // Write empty file — simulates crash right after file creation
-        std::fs::write(dir.path().join("counters"), &[]).unwrap();
+        std::fs::write(dir.path().join("counters"), []).unwrap();
 
         // read_or_default should return Err (file exists but empty)
         let result = cf.read_or_default();

--- a/crates/durability/src/recovery/coordinator.rs
+++ b/crates/durability/src/recovery/coordinator.rs
@@ -884,7 +884,7 @@ mod tests {
         for seg_num in 1..=3u64 {
             let meta = crate::format::segment_meta::SegmentMeta::read_from_file(&wal_dir, seg_num)
                 .unwrap()
-                .expect(&format!("Segment {} should have .meta", seg_num));
+                .unwrap_or_else(|| panic!("Segment {} should have .meta", seg_num));
             assert_eq!(meta.segment_number, seg_num);
             assert_eq!(meta.record_count, 3);
             let base_txn = (seg_num - 1) * 3 + 1;
@@ -967,10 +967,8 @@ mod tests {
         for seg_num in 1..=2u64 {
             let meta = crate::format::segment_meta::SegmentMeta::read_from_file(&wal_dir, seg_num)
                 .unwrap()
-                .expect(&format!(
-                    "Segment {} should have .meta after recovery",
-                    seg_num
-                ));
+                .unwrap_or_else(|| panic!("Segment {} should have .meta after recovery",
+                    seg_num));
             assert_eq!(meta.segment_number, seg_num);
             assert_eq!(meta.record_count, 1);
         }

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -612,7 +612,7 @@ mod tests {
         let wal_dir = dir.path().join("wal");
 
         let record = WalRecord::new(1, [1u8; 16], 12345, vec![1, 2, 3]);
-        write_records(&wal_dir, &[record.clone()]);
+        write_records(&wal_dir, std::slice::from_ref(&record));
 
         let reader = WalReader::new();
         let (records, _, _, _) = reader.read_segment(&wal_dir, 1).unwrap();

--- a/crates/engine/benches/transaction_benchmarks.rs
+++ b/crates/engine/benches/transaction_benchmarks.rs
@@ -14,8 +14,8 @@ use strata_core::value::Value;
 use strata_engine::Database;
 use tempfile::TempDir;
 
-fn create_ns(branch_id: BranchId) -> Namespace {
-    Namespace::new(branch_id, "default".to_string())
+fn create_ns(branch_id: BranchId) -> Arc<Namespace> {
+    Arc::new(Namespace::new(branch_id, "default".to_string()))
 }
 
 /// Benchmark: Single-threaded transactions (no contention)

--- a/crates/engine/src/bundle.rs
+++ b/crates/engine/src/bundle.rs
@@ -468,7 +468,7 @@ mod tests {
         assert!(format_micros(0).starts_with("1970-"));
 
         // Some timestamp in 2025
-        let ts = 1706_000_000_000_000u64; // approx Jan 2024
+        let ts = 1_706_000_000_000_000u64; // approx Jan 2024
         let formatted = format_micros(ts);
         assert!(!formatted.is_empty());
         assert!(formatted.ends_with('Z'));

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -2398,7 +2398,7 @@ mod tests {
     /// Helper: write a committed transaction to the segmented WAL
     fn write_wal_txn(
         wal_dir: &std::path::Path,
-        txn_id: u64,
+        _txn_id: u64,
         branch_id: BranchId,
         puts: Vec<(Key, Value)>,
         deletes: Vec<Key>,
@@ -3050,7 +3050,7 @@ mod tests {
 
         // Commit a few transactions to advance version well past 1
         for i in 0..5 {
-            let key = Key::new_kv(ns.clone(), &format!("key_{}", i));
+            let key = Key::new_kv(ns.clone(), format!("key_{}", i));
             db.transaction(branch_id, |txn| {
                 txn.put(key.clone(), Value::Int(i))?;
                 Ok(())
@@ -3064,7 +3064,7 @@ mod tests {
 
         // Commit two more transactions to advance version further
         for i in 5..7 {
-            let key = Key::new_kv(ns.clone(), &format!("key_{}", i));
+            let key = Key::new_kv(ns.clone(), format!("key_{}", i));
             db.transaction(branch_id, |t| {
                 t.put(key.clone(), Value::Int(i))?;
                 Ok(())
@@ -3615,7 +3615,7 @@ mod tests {
             let start = std::time::Instant::now();
 
             std::thread::scope(|s| {
-                for t in 0..num_threads {
+                for _t in 0..num_threads {
                     let db = &db;
                     let barrier = barrier.clone();
                     s.spawn(move || {

--- a/crates/engine/src/graph/ontology.rs
+++ b/crates/engine/src/graph/ontology.rs
@@ -2158,7 +2158,7 @@ mod tests {
         // float is not integer
         let bad = NodeData {
             object_type: Some("Counter".to_string()),
-            properties: Some(serde_json::json!({"count": 3.14})),
+            properties: Some(serde_json::json!({"count": 2.78})),
             ..Default::default()
         };
         let err = gs.add_node(b, "g", "c2", bad).unwrap_err();
@@ -2250,7 +2250,7 @@ mod tests {
         // float counts as number
         let float_data = NodeData {
             object_type: Some("Score".to_string()),
-            properties: Some(serde_json::json!({"score": 3.14})),
+            properties: Some(serde_json::json!({"score": 2.78})),
             ..Default::default()
         };
         assert!(gs.add_node(b, "g", "s2", float_data).is_ok());

--- a/crates/engine/src/graph/snapshot.rs
+++ b/crates/engine/src/graph/snapshot.rs
@@ -144,7 +144,7 @@ mod tests {
         let adj = snap.to_adjacency_list();
         assert_eq!(adj.get("A").unwrap().len(), 2);
         assert_eq!(adj.get("B").unwrap().len(), 1);
-        assert!(adj.get("C").is_none()); // C has no outgoing
+        assert!(!adj.contains_key("C")); // C has no outgoing
     }
 
     #[test]

--- a/crates/engine/src/primitives/event.rs
+++ b/crates/engine/src/primitives/event.rs
@@ -858,7 +858,7 @@ mod tests {
             .append(&branch_id, "default", "test", Value::Bool(true))
             .is_err());
         assert!(log
-            .append(&branch_id, "default", "test", Value::Float(3.14))
+            .append(&branch_id, "default", "test", Value::Float(2.78))
             .is_err());
     }
 

--- a/crates/engine/src/primitives/json.rs
+++ b/crates/engine/src/primitives/json.rs
@@ -874,8 +874,8 @@ mod tests {
         let branch2 = BranchId::new();
         let doc_id = "test-doc";
 
-        let key1 = store.key_for(&branch1, "default", &doc_id);
-        let key2 = store.key_for(&branch2, "default", &doc_id);
+        let key1 = store.key_for(&branch1, "default", doc_id);
+        let key2 = store.key_for(&branch2, "default", doc_id);
 
         // Keys for different branches should be different even for same doc_id
         assert_ne!(key1, key2);
@@ -889,8 +889,8 @@ mod tests {
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
 
-        let key1 = store.key_for(&branch_id, "default", &doc_id);
-        let key2 = store.key_for(&branch_id, "default", &doc_id);
+        let key1 = store.key_for(&branch_id, "default", doc_id);
+        let key2 = store.key_for(&branch_id, "default", doc_id);
 
         // Same branch and doc_id should produce same key
         assert_eq!(key1, key2);
@@ -1046,7 +1046,7 @@ mod tests {
         let doc_id = "test-doc";
 
         let version = store
-            .create(&branch_id, "default", &doc_id, JsonValue::from(42i64))
+            .create(&branch_id, "default", doc_id, JsonValue::from(42i64))
             .unwrap();
         assert_eq!(version, Version::counter(1));
     }
@@ -1064,7 +1064,7 @@ mod tests {
         })
         .into();
 
-        let version = store.create(&branch_id, "default", &doc_id, value).unwrap();
+        let version = store.create(&branch_id, "default", doc_id, value).unwrap();
         assert_eq!(version, Version::counter(1));
     }
 
@@ -1077,11 +1077,11 @@ mod tests {
 
         // First create succeeds
         store
-            .create(&branch_id, "default", &doc_id, JsonValue::from(1i64))
+            .create(&branch_id, "default", doc_id, JsonValue::from(1i64))
             .unwrap();
 
         // Second create with same ID fails
-        let result = store.create(&branch_id, "default", &doc_id, JsonValue::from(2i64));
+        let result = store.create(&branch_id, "default", doc_id, JsonValue::from(2i64));
         assert!(result.is_err());
     }
 
@@ -1095,10 +1095,10 @@ mod tests {
         let doc2 = "doc-2";
 
         let v1 = store
-            .create(&branch_id, "default", &doc1, JsonValue::from(1i64))
+            .create(&branch_id, "default", doc1, JsonValue::from(1i64))
             .unwrap();
         let v2 = store
-            .create(&branch_id, "default", &doc2, JsonValue::from(2i64))
+            .create(&branch_id, "default", doc2, JsonValue::from(2i64))
             .unwrap();
 
         assert_eq!(v1, Version::counter(1));
@@ -1116,10 +1116,10 @@ mod tests {
 
         // Same doc_id can be created in different branches
         let v1 = store
-            .create(&branch1, "default", &doc_id, JsonValue::from(1i64))
+            .create(&branch1, "default", doc_id, JsonValue::from(1i64))
             .unwrap();
         let v2 = store
-            .create(&branch2, "default", &doc_id, JsonValue::from(2i64))
+            .create(&branch2, "default", doc_id, JsonValue::from(2i64))
             .unwrap();
 
         assert_eq!(v1, Version::counter(1));
@@ -1134,7 +1134,7 @@ mod tests {
         let doc_id = "test-doc";
 
         let version = store
-            .create(&branch_id, "default", &doc_id, JsonValue::null())
+            .create(&branch_id, "default", doc_id, JsonValue::null())
             .unwrap();
         assert_eq!(version, Version::counter(1));
     }
@@ -1147,7 +1147,7 @@ mod tests {
         let doc_id = "test-doc";
 
         let version = store
-            .create(&branch_id, "default", &doc_id, JsonValue::object())
+            .create(&branch_id, "default", doc_id, JsonValue::object())
             .unwrap();
         assert_eq!(version, Version::counter(1));
     }
@@ -1160,7 +1160,7 @@ mod tests {
         let doc_id = "test-doc";
 
         let version = store
-            .create(&branch_id, "default", &doc_id, JsonValue::array())
+            .create(&branch_id, "default", doc_id, JsonValue::array())
             .unwrap();
         assert_eq!(version, Version::counter(1));
     }
@@ -1177,11 +1177,11 @@ mod tests {
         let doc_id = "test-doc";
 
         store
-            .create(&branch_id, "default", &doc_id, JsonValue::from(42i64))
+            .create(&branch_id, "default", doc_id, JsonValue::from(42i64))
             .unwrap();
 
         let value = store
-            .get(&branch_id, "default", &doc_id, &JsonPath::root())
+            .get(&branch_id, "default", doc_id, &JsonPath::root())
             .unwrap();
         assert_eq!(value.and_then(|v| v.as_i64()), Some(42));
     }
@@ -1199,10 +1199,10 @@ mod tests {
         })
         .into();
 
-        store.create(&branch_id, "default", &doc_id, value).unwrap();
+        store.create(&branch_id, "default", doc_id, value).unwrap();
 
         let name = store
-            .get(&branch_id, "default", &doc_id, &"name".parse().unwrap())
+            .get(&branch_id, "default", doc_id, &"name".parse().unwrap())
             .unwrap();
         assert_eq!(
             name.and_then(|v| v.as_str().map(String::from)),
@@ -1210,7 +1210,7 @@ mod tests {
         );
 
         let age = store
-            .get(&branch_id, "default", &doc_id, &"age".parse().unwrap())
+            .get(&branch_id, "default", doc_id, &"age".parse().unwrap())
             .unwrap();
         assert_eq!(age.and_then(|v| v.as_i64()), Some(30));
     }
@@ -1231,13 +1231,13 @@ mod tests {
         })
         .into();
 
-        store.create(&branch_id, "default", &doc_id, value).unwrap();
+        store.create(&branch_id, "default", doc_id, value).unwrap();
 
         let name = store
             .get(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &"user.profile.name".parse().unwrap(),
             )
             .unwrap();
@@ -1259,10 +1259,10 @@ mod tests {
         })
         .into();
 
-        store.create(&branch_id, "default", &doc_id, value).unwrap();
+        store.create(&branch_id, "default", doc_id, value).unwrap();
 
         let item = store
-            .get(&branch_id, "default", &doc_id, &"items[1]".parse().unwrap())
+            .get(&branch_id, "default", doc_id, &"items[1]".parse().unwrap())
             .unwrap();
         assert_eq!(
             item.and_then(|v| v.as_str().map(String::from)),
@@ -1278,7 +1278,7 @@ mod tests {
         let doc_id = "test-doc";
 
         let result = store
-            .get(&branch_id, "default", &doc_id, &JsonPath::root())
+            .get(&branch_id, "default", doc_id, &JsonPath::root())
             .unwrap();
         assert!(result.is_none());
     }
@@ -1291,14 +1291,14 @@ mod tests {
         let doc_id = "test-doc";
 
         store
-            .create(&branch_id, "default", &doc_id, JsonValue::object())
+            .create(&branch_id, "default", doc_id, JsonValue::object())
             .unwrap();
 
         let result = store
             .get(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &"nonexistent".parse().unwrap(),
             )
             .unwrap();
@@ -1312,13 +1312,13 @@ mod tests {
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
 
-        assert!(!store.exists(&branch_id, "default", &doc_id).unwrap());
+        assert!(!store.exists(&branch_id, "default", doc_id).unwrap());
 
         store
-            .create(&branch_id, "default", &doc_id, JsonValue::from(42i64))
+            .create(&branch_id, "default", doc_id, JsonValue::from(42i64))
             .unwrap();
 
-        assert!(store.exists(&branch_id, "default", &doc_id).unwrap());
+        assert!(store.exists(&branch_id, "default", doc_id).unwrap());
     }
 
     #[test]
@@ -1331,12 +1331,12 @@ mod tests {
         let doc_id = "test-doc";
 
         store
-            .create(&branch1, "default", &doc_id, JsonValue::from(42i64))
+            .create(&branch1, "default", doc_id, JsonValue::from(42i64))
             .unwrap();
 
         // Document exists in branch1 but not in branch2
-        assert!(store.exists(&branch1, "default", &doc_id).unwrap());
-        assert!(!store.exists(&branch2, "default", &doc_id).unwrap());
+        assert!(store.exists(&branch1, "default", doc_id).unwrap());
+        assert!(!store.exists(&branch2, "default", doc_id).unwrap());
     }
 
     // ========================================
@@ -1351,14 +1351,14 @@ mod tests {
         let doc_id = "test-doc";
 
         store
-            .create(&branch_id, "default", &doc_id, JsonValue::from(42i64))
+            .create(&branch_id, "default", doc_id, JsonValue::from(42i64))
             .unwrap();
 
         let v2 = store
             .set(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &JsonPath::root(),
                 JsonValue::from(100i64),
             )
@@ -1366,7 +1366,7 @@ mod tests {
         assert_eq!(v2, Version::counter(2));
 
         let value = store
-            .get(&branch_id, "default", &doc_id, &JsonPath::root())
+            .get(&branch_id, "default", doc_id, &JsonPath::root())
             .unwrap();
         assert_eq!(value.and_then(|v| v.as_i64()), Some(100));
     }
@@ -1379,14 +1379,14 @@ mod tests {
         let doc_id = "test-doc";
 
         store
-            .create(&branch_id, "default", &doc_id, JsonValue::object())
+            .create(&branch_id, "default", doc_id, JsonValue::object())
             .unwrap();
 
         let v2 = store
             .set(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &"name".parse().unwrap(),
                 JsonValue::from("Alice"),
             )
@@ -1394,7 +1394,7 @@ mod tests {
         assert_eq!(v2, Version::counter(2));
 
         let name = store
-            .get(&branch_id, "default", &doc_id, &"name".parse().unwrap())
+            .get(&branch_id, "default", doc_id, &"name".parse().unwrap())
             .unwrap();
         assert_eq!(
             name.and_then(|v| v.as_str().map(String::from)),
@@ -1410,7 +1410,7 @@ mod tests {
         let doc_id = "test-doc";
 
         store
-            .create(&branch_id, "default", &doc_id, JsonValue::object())
+            .create(&branch_id, "default", doc_id, JsonValue::object())
             .unwrap();
 
         // Creates intermediate objects automatically
@@ -1418,7 +1418,7 @@ mod tests {
             .set(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &"user.profile.name".parse().unwrap(),
                 JsonValue::from("Bob"),
             )
@@ -1429,7 +1429,7 @@ mod tests {
             .get(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &"user.profile.name".parse().unwrap(),
             )
             .unwrap();
@@ -1447,7 +1447,7 @@ mod tests {
         let doc_id = "test-doc";
 
         let v1 = store
-            .create(&branch_id, "default", &doc_id, JsonValue::object())
+            .create(&branch_id, "default", doc_id, JsonValue::object())
             .unwrap();
         assert_eq!(v1, Version::counter(1));
 
@@ -1455,7 +1455,7 @@ mod tests {
             .set(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &"a".parse().unwrap(),
                 JsonValue::from(1i64),
             )
@@ -1466,7 +1466,7 @@ mod tests {
             .set(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &"b".parse().unwrap(),
                 JsonValue::from(2i64),
             )
@@ -1484,7 +1484,7 @@ mod tests {
         let result = store.set(
             &branch_id,
             "default",
-            &doc_id,
+            doc_id,
             &"name".parse().unwrap(),
             JsonValue::from("test"),
         );
@@ -1499,20 +1499,20 @@ mod tests {
         let doc_id = "test-doc";
 
         let value: JsonValue = serde_json::json!({ "name": "Alice" }).into();
-        store.create(&branch_id, "default", &doc_id, value).unwrap();
+        store.create(&branch_id, "default", doc_id, value).unwrap();
 
         store
             .set(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &"name".parse().unwrap(),
                 JsonValue::from("Bob"),
             )
             .unwrap();
 
         let name = store
-            .get(&branch_id, "default", &doc_id, &"name".parse().unwrap())
+            .get(&branch_id, "default", doc_id, &"name".parse().unwrap())
             .unwrap();
         assert_eq!(
             name.and_then(|v| v.as_str().map(String::from)),
@@ -1528,20 +1528,20 @@ mod tests {
         let doc_id = "test-doc";
 
         let value: JsonValue = serde_json::json!({ "items": [1, 2, 3] }).into();
-        store.create(&branch_id, "default", &doc_id, value).unwrap();
+        store.create(&branch_id, "default", doc_id, value).unwrap();
 
         store
             .set(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &"items[1]".parse().unwrap(),
                 JsonValue::from(999i64),
             )
             .unwrap();
 
         let item = store
-            .get(&branch_id, "default", &doc_id, &"items[1]".parse().unwrap())
+            .get(&branch_id, "default", doc_id, &"items[1]".parse().unwrap())
             .unwrap();
         assert_eq!(item.and_then(|v| v.as_i64()), Some(999));
     }
@@ -1562,22 +1562,22 @@ mod tests {
             "age": 30
         })
         .into();
-        store.create(&branch_id, "default", &doc_id, value).unwrap();
+        store.create(&branch_id, "default", doc_id, value).unwrap();
 
         // Delete the "age" field
         let v2 = store
-            .delete_at_path(&branch_id, "default", &doc_id, &"age".parse().unwrap())
+            .delete_at_path(&branch_id, "default", doc_id, &"age".parse().unwrap())
             .unwrap();
         assert_eq!(v2, Version::counter(2));
 
         // Verify "age" is gone but "name" remains
         assert!(store
-            .get(&branch_id, "default", &doc_id, &"age".parse().unwrap())
+            .get(&branch_id, "default", doc_id, &"age".parse().unwrap())
             .unwrap()
             .is_none());
         assert_eq!(
             store
-                .get(&branch_id, "default", &doc_id, &"name".parse().unwrap())
+                .get(&branch_id, "default", doc_id, &"name".parse().unwrap())
                 .unwrap()
                 .and_then(|v| v.as_str().map(String::from)),
             Some("Alice".to_string())
@@ -1600,14 +1600,14 @@ mod tests {
             }
         })
         .into();
-        store.create(&branch_id, "default", &doc_id, value).unwrap();
+        store.create(&branch_id, "default", doc_id, value).unwrap();
 
         // Delete nested field
         let v2 = store
             .delete_at_path(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &"user.profile.temp".parse().unwrap(),
             )
             .unwrap();
@@ -1618,7 +1618,7 @@ mod tests {
             .get(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &"user.profile.temp".parse().unwrap()
             )
             .unwrap()
@@ -1630,7 +1630,7 @@ mod tests {
                 .get(
                     &branch_id,
                     "default",
-                    &doc_id,
+                    doc_id,
                     &"user.profile.name".parse().unwrap()
                 )
                 .unwrap()
@@ -1650,17 +1650,17 @@ mod tests {
             "items": ["a", "b", "c"]
         })
         .into();
-        store.create(&branch_id, "default", &doc_id, value).unwrap();
+        store.create(&branch_id, "default", doc_id, value).unwrap();
 
         // Delete middle element
         let v2 = store
-            .delete_at_path(&branch_id, "default", &doc_id, &"items[1]".parse().unwrap())
+            .delete_at_path(&branch_id, "default", doc_id, &"items[1]".parse().unwrap())
             .unwrap();
         assert_eq!(v2, Version::counter(2));
 
         // Array should now be ["a", "c"]
         let items = store
-            .get(&branch_id, "default", &doc_id, &"items".parse().unwrap())
+            .get(&branch_id, "default", doc_id, &"items".parse().unwrap())
             .unwrap()
             .unwrap();
         let arr = items.as_array().unwrap();
@@ -1682,16 +1682,16 @@ mod tests {
             "c": 3
         })
         .into();
-        let v1 = store.create(&branch_id, "default", &doc_id, value).unwrap();
+        let v1 = store.create(&branch_id, "default", doc_id, value).unwrap();
         assert_eq!(v1, Version::counter(1));
 
         let v2 = store
-            .delete_at_path(&branch_id, "default", &doc_id, &"a".parse().unwrap())
+            .delete_at_path(&branch_id, "default", doc_id, &"a".parse().unwrap())
             .unwrap();
         assert_eq!(v2, Version::counter(2));
 
         let v3 = store
-            .delete_at_path(&branch_id, "default", &doc_id, &"b".parse().unwrap())
+            .delete_at_path(&branch_id, "default", doc_id, &"b".parse().unwrap())
             .unwrap();
         assert_eq!(v3, Version::counter(3));
     }
@@ -1704,7 +1704,7 @@ mod tests {
         let doc_id = "test-doc";
 
         let result =
-            store.delete_at_path(&branch_id, "default", &doc_id, &"field".parse().unwrap());
+            store.delete_at_path(&branch_id, "default", doc_id, &"field".parse().unwrap());
         assert!(result.is_err());
     }
 
@@ -1716,7 +1716,7 @@ mod tests {
         let doc_id = "test-doc";
 
         store
-            .create(&branch_id, "default", &doc_id, JsonValue::object())
+            .create(&branch_id, "default", doc_id, JsonValue::object())
             .unwrap();
 
         // Deleting a nonexistent path is idempotent (succeeds, increments version)
@@ -1724,7 +1724,7 @@ mod tests {
             .delete_at_path(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &"nonexistent".parse().unwrap(),
             )
             .unwrap();
@@ -1743,13 +1743,13 @@ mod tests {
         let doc_id = "test-doc";
 
         store
-            .create(&branch_id, "default", &doc_id, JsonValue::from(42i64))
+            .create(&branch_id, "default", doc_id, JsonValue::from(42i64))
             .unwrap();
-        assert!(store.exists(&branch_id, "default", &doc_id).unwrap());
+        assert!(store.exists(&branch_id, "default", doc_id).unwrap());
 
-        let existed = store.destroy(&branch_id, "default", &doc_id).unwrap();
+        let existed = store.destroy(&branch_id, "default", doc_id).unwrap();
         assert!(existed);
-        assert!(!store.exists(&branch_id, "default", &doc_id).unwrap());
+        assert!(!store.exists(&branch_id, "default", doc_id).unwrap());
     }
 
     #[test]
@@ -1759,7 +1759,7 @@ mod tests {
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
 
-        let existed = store.destroy(&branch_id, "default", &doc_id).unwrap();
+        let existed = store.destroy(&branch_id, "default", doc_id).unwrap();
         assert!(!existed);
     }
 
@@ -1774,18 +1774,18 @@ mod tests {
 
         // Create document in both branches
         store
-            .create(&branch1, "default", &doc_id, JsonValue::from(1i64))
+            .create(&branch1, "default", doc_id, JsonValue::from(1i64))
             .unwrap();
         store
-            .create(&branch2, "default", &doc_id, JsonValue::from(2i64))
+            .create(&branch2, "default", doc_id, JsonValue::from(2i64))
             .unwrap();
 
         // Destroy in branch1
-        store.destroy(&branch1, "default", &doc_id).unwrap();
+        store.destroy(&branch1, "default", doc_id).unwrap();
 
         // Document should be gone from branch1 but still exist in branch2
-        assert!(!store.exists(&branch1, "default", &doc_id).unwrap());
-        assert!(store.exists(&branch2, "default", &doc_id).unwrap());
+        assert!(!store.exists(&branch1, "default", doc_id).unwrap());
+        assert!(store.exists(&branch2, "default", doc_id).unwrap());
     }
 
     #[test]
@@ -1797,18 +1797,18 @@ mod tests {
 
         // Create, destroy, recreate
         store
-            .create(&branch_id, "default", &doc_id, JsonValue::from(1i64))
+            .create(&branch_id, "default", doc_id, JsonValue::from(1i64))
             .unwrap();
-        store.destroy(&branch_id, "default", &doc_id).unwrap();
+        store.destroy(&branch_id, "default", doc_id).unwrap();
 
         // Should be able to recreate with new value
         let version = store
-            .create(&branch_id, "default", &doc_id, JsonValue::from(2i64))
+            .create(&branch_id, "default", doc_id, JsonValue::from(2i64))
             .unwrap();
         assert_eq!(version, Version::counter(1)); // Fresh document starts at version 1
 
         let value = store
-            .get(&branch_id, "default", &doc_id, &JsonPath::root())
+            .get(&branch_id, "default", doc_id, &JsonPath::root())
             .unwrap();
         assert_eq!(value.and_then(|v| v.as_i64()), Some(2));
     }
@@ -1832,11 +1832,11 @@ mod tests {
             }
         })
         .into();
-        store.create(&branch_id, "default", &doc_id, value).unwrap();
+        store.create(&branch_id, "default", doc_id, value).unwrap();
 
-        let existed = store.destroy(&branch_id, "default", &doc_id).unwrap();
+        let existed = store.destroy(&branch_id, "default", doc_id).unwrap();
         assert!(existed);
-        assert!(!store.exists(&branch_id, "default", &doc_id).unwrap());
+        assert!(!store.exists(&branch_id, "default", doc_id).unwrap());
     }
 
     #[test]
@@ -1847,15 +1847,15 @@ mod tests {
         let doc_id = "test-doc";
 
         store
-            .create(&branch_id, "default", &doc_id, JsonValue::from(42i64))
+            .create(&branch_id, "default", doc_id, JsonValue::from(42i64))
             .unwrap();
 
         // First destroy returns true
-        assert!(store.destroy(&branch_id, "default", &doc_id).unwrap());
+        assert!(store.destroy(&branch_id, "default", doc_id).unwrap());
 
         // Subsequent destroys return false
-        assert!(!store.destroy(&branch_id, "default", &doc_id).unwrap());
-        assert!(!store.destroy(&branch_id, "default", &doc_id).unwrap());
+        assert!(!store.destroy(&branch_id, "default", doc_id).unwrap());
+        assert!(!store.destroy(&branch_id, "default", doc_id).unwrap());
     }
 
     // ========== Batch API Tests ==========
@@ -1958,7 +1958,7 @@ mod tests {
         // Build a path of depth 101 (exceeds MAX_NESTING_DEPTH=100)
         let mut path = JsonPath::root();
         for i in 0..101 {
-            path = path.key(&format!("k{}", i));
+            path = path.key(format!("k{}", i));
         }
 
         let result =
@@ -1995,7 +1995,7 @@ mod tests {
         let chunk = JsonValue::from("x".repeat(1_000_000));
         let mut last_err = None;
         for i in 0..20 {
-            let path = JsonPath::root().key(&format!("field_{}", i));
+            let path = JsonPath::root().key(format!("field_{}", i));
             match store.set(&branch_id, "default", "big", &path, chunk.clone()) {
                 Ok(_) => {}
                 Err(e) => {
@@ -2021,7 +2021,7 @@ mod tests {
 
         let mut path = JsonPath::root();
         for i in 0..101 {
-            path = path.key(&format!("k{}", i));
+            path = path.key(format!("k{}", i));
         }
 
         let result = store.set_or_create(

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -680,11 +680,11 @@ mod tests {
         );
 
         // Float
-        kv.put(&branch_id, "default", "float", Value::Float(3.14))
+        kv.put(&branch_id, "default", "float", Value::Float(2.78))
             .unwrap();
         assert_eq!(
             kv.get(&branch_id, "default", "float").unwrap(),
-            Some(Value::Float(3.14))
+            Some(Value::Float(2.78))
         );
 
         // Boolean
@@ -1141,7 +1141,7 @@ mod tests {
         kv.put(&branch_id, "default", "bool_doc", Value::Bool(true))
             .unwrap();
         // But JSON-serializable values should be
-        kv.put(&branch_id, "default", "float_doc", Value::Float(3.14))
+        kv.put(&branch_id, "default", "float_doc", Value::Float(2.78))
             .unwrap();
 
         let req = crate::SearchRequest::new(branch_id, "42");

--- a/crates/engine/src/primitives/vector/heap.rs
+++ b/crates/engine/src/primitives/vector/heap.rs
@@ -1245,8 +1245,8 @@ mod tests {
 
         // Check that the data at that offset is zeroed
         let data = heap.raw_data();
-        for i in offset..offset + 384 {
-            assert_eq!(data[i], 0.0, "Data should be zeroed after deletion");
+        for item in &data[offset..offset + 384] {
+            assert_eq!(*item, 0.0, "Data should be zeroed after deletion");
         }
     }
 
@@ -1307,8 +1307,8 @@ mod tests {
 
         let e1 = vec![1.0_f32; 384];
         let e2 = vec![2.0_f32; 384];
-        let id1 = heap.insert(&e1).unwrap();
-        let id2 = heap.insert(&e2).unwrap();
+        let _id1 = heap.insert(&e1).unwrap();
+        let _id2 = heap.insert(&e2).unwrap();
 
         // Collect in-memory iteration results
         let mem_entries: Vec<_> = heap.iter().collect();

--- a/crates/engine/src/primitives/vector/hnsw.rs
+++ b/crates/engine/src/primitives/vector/hnsw.rs
@@ -2831,7 +2831,7 @@ mod profiling_tests {
 
         // Build a HashMap mirror for comparison
         let hashmap_nodes: StdHashMap<VectorId, &CompactHnswNode> =
-            compact.iter_nodes().map(|(k, v)| (k, v)).collect();
+            compact.iter_nodes().collect();
 
         // Pre-generate random lookup IDs
         let lookup_ids: Vec<VectorId> = (0..num_lookups)

--- a/crates/engine/src/primitives/vector/mmap.rs
+++ b/crates/engine/src/primitives/vector/mmap.rs
@@ -428,7 +428,7 @@ mod tests {
         id_to_offset.insert(VectorId::new(1), 0usize);
         id_to_offset.insert(VectorId::new(3), 3usize);
 
-        let raw_data: Vec<f32> = vec![
+        let _raw_data: Vec<f32> = vec![
             1.0, 0.0, 0.0, // id=1 at offset 0
             0.0, 0.0, 0.0, // deleted slot (offset 3 would be id=2 but it's free)
             0.0, 1.0, 0.0, // id=3 at offset 3... wait, offset 3 maps to floats 3,4,5

--- a/crates/engine/src/primitives/vector/segmented.rs
+++ b/crates/engine/src/primitives/vector/segmented.rs
@@ -2328,7 +2328,7 @@ mod tests {
 
         // Write a manifest with an invalid size (not 8 + N*24)
         let manifest_path = dir.join("segments.manifest");
-        std::fs::write(&manifest_path, &[0u8; 13]).unwrap(); // 13 bytes — invalid
+        std::fs::write(&manifest_path, [0u8; 13]).unwrap(); // 13 bytes — invalid
 
         let mut backend = make_backend_with_threshold(3, DistanceMetric::Cosine, 3);
         let loaded = backend.load_graphs_from_disk(&dir).unwrap();
@@ -2456,7 +2456,7 @@ mod tests {
         // heap_flush_threshold=5: flush after 5 overlay vectors
         for i in 1..=6 {
             backend
-                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i as u64)
+                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i)
                 .unwrap();
         }
 
@@ -2466,7 +2466,7 @@ mod tests {
         // Insert more after flush
         for i in 7..=9 {
             backend
-                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i as u64)
+                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i)
                 .unwrap();
         }
 
@@ -2829,7 +2829,7 @@ mod tests {
         // Insert 3 → seal to segment 1
         for i in 1..=3 {
             backend
-                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i as u64)
+                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i)
                 .unwrap();
         }
         assert_eq!(backend.segment_count(), 1);
@@ -2837,7 +2837,7 @@ mod tests {
         // Insert 3 more → seal to segment 2
         for i in 4..=6 {
             backend
-                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i as u64)
+                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i)
                 .unwrap();
         }
         assert_eq!(backend.segment_count(), 2);
@@ -2845,7 +2845,7 @@ mod tests {
         // Insert 3 more → seal to segment 3 → exceeds threshold of 2 → compact to 1
         for i in 7..=9 {
             backend
-                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i as u64)
+                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i)
                 .unwrap();
         }
         assert_eq!(
@@ -2882,7 +2882,7 @@ mod tests {
         // Create 5 segments (15 vectors, seal every 3)
         for i in 1..=15 {
             backend
-                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i as u64)
+                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i)
                 .unwrap();
         }
         assert_eq!(
@@ -2900,7 +2900,7 @@ mod tests {
         // Insert 5 vectors → seal
         for i in 1..=5 {
             backend
-                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i as u64)
+                .insert_with_timestamp(VectorId::new(i), &[i as f32, 0.0, 0.0], i)
                 .unwrap();
         }
         assert_eq!(backend.segment_count(), 1);
@@ -2940,7 +2940,7 @@ mod tests {
         ];
         for &(id, score_component) in &embeddings {
             backend
-                .insert_with_timestamp(VectorId::new(id), &[score_component, 0.0, 0.0], id as u64)
+                .insert_with_timestamp(VectorId::new(id), &[score_component, 0.0, 0.0], id)
                 .unwrap();
         }
 

--- a/crates/engine/src/search/manifest.rs
+++ b/crates/engine/src/search/manifest.rs
@@ -242,7 +242,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("tiny.manifest");
 
-        std::fs::write(&path, &[0u8; 4]).unwrap();
+        std::fs::write(&path, [0u8; 4]).unwrap();
         assert!(load_manifest(&path).is_err());
     }
 }

--- a/crates/engine/tests/versioned_conformance_tests.rs
+++ b/crates/engine/tests/versioned_conformance_tests.rs
@@ -127,7 +127,7 @@ mod invariant_1_addressable {
         json.create(
             &branch_id,
             "default",
-            &doc_id,
+            doc_id,
             serde_json::json!({"data": 1}).into(),
         )
         .unwrap();
@@ -308,11 +308,11 @@ mod invariant_2_versioned {
         let json = JsonStore::new(db);
         let doc_id = "test-doc";
 
-        json.create(&branch_id, "default", &doc_id, serde_json::json!(42).into())
+        json.create(&branch_id, "default", doc_id, serde_json::json!(42).into())
             .unwrap();
 
         let value = json
-            .get(&branch_id, "default", &doc_id, &JsonPath::root())
+            .get(&branch_id, "default", doc_id, &JsonPath::root())
             .unwrap()
             .unwrap();
         assert_eq!(value.as_i64(), Some(42));
@@ -325,7 +325,7 @@ mod invariant_2_versioned {
         let doc_id = "test-doc";
 
         let version = json
-            .create(&branch_id, "default", &doc_id, serde_json::json!({}).into())
+            .create(&branch_id, "default", doc_id, serde_json::json!({}).into())
             .unwrap();
 
         assert!(matches!(version, Version::Counter(1)));
@@ -337,14 +337,14 @@ mod invariant_2_versioned {
         let json = JsonStore::new(db);
         let doc_id = "test-doc";
 
-        json.create(&branch_id, "default", &doc_id, serde_json::json!({}).into())
+        json.create(&branch_id, "default", doc_id, serde_json::json!({}).into())
             .unwrap();
 
         let version = json
             .set(
                 &branch_id,
                 "default",
-                &doc_id,
+                doc_id,
                 &JsonPath::root(),
                 serde_json::json!(100).into(),
             )
@@ -488,7 +488,7 @@ mod invariant_3_transactional {
         .unwrap();
 
         let json = JsonStore::new(db);
-        assert!(json.exists(&branch_id, "default", &doc_id).unwrap());
+        assert!(json.exists(&branch_id, "default", doc_id).unwrap());
     }
 
     #[test]
@@ -630,25 +630,25 @@ mod invariant_4_lifecycle {
         json.create(
             &branch_id,
             "default",
-            &doc_id,
+            doc_id,
             serde_json::json!({"v": 1}).into(),
         )
         .unwrap();
 
         // Exist
-        assert!(json.exists(&branch_id, "default", &doc_id).unwrap());
+        assert!(json.exists(&branch_id, "default", doc_id).unwrap());
 
         // Evolve (set)
         json.set(
             &branch_id,
             "default",
-            &doc_id,
+            doc_id,
             &JsonPath::root(),
             serde_json::json!({"v": 2}).into(),
         )
         .unwrap();
         let v = json
-            .get(&branch_id, "default", &doc_id, &JsonPath::root())
+            .get(&branch_id, "default", doc_id, &JsonPath::root())
             .unwrap()
             .unwrap();
         assert_eq!(v.get("v").and_then(|v| v.as_i64()), Some(2));
@@ -797,24 +797,24 @@ mod invariant_5_branch_scoped {
         json.create(
             &branch1,
             "default",
-            &doc_id,
+            doc_id,
             serde_json::json!({"branch": 1}).into(),
         )
         .unwrap();
         json.create(
             &branch2,
             "default",
-            &doc_id,
+            doc_id,
             serde_json::json!({"branch": 2}).into(),
         )
         .unwrap();
 
         let j1 = json
-            .get(&branch1, "default", &doc_id, &JsonPath::root())
+            .get(&branch1, "default", doc_id, &JsonPath::root())
             .unwrap()
             .unwrap();
         let j2 = json
-            .get(&branch2, "default", &doc_id, &JsonPath::root())
+            .get(&branch2, "default", doc_id, &JsonPath::root())
             .unwrap()
             .unwrap();
 
@@ -932,12 +932,12 @@ mod invariant_6_introspectable {
         let json = JsonStore::new(db);
         let doc_id = "test-doc";
 
-        assert!(!json.exists(&branch_id, "default", &doc_id).unwrap());
+        assert!(!json.exists(&branch_id, "default", doc_id).unwrap());
 
-        json.create(&branch_id, "default", &doc_id, serde_json::json!({}).into())
+        json.create(&branch_id, "default", doc_id, serde_json::json!({}).into())
             .unwrap();
 
-        assert!(json.exists(&branch_id, "default", &doc_id).unwrap());
+        assert!(json.exists(&branch_id, "default", doc_id).unwrap());
     }
 
     #[test]
@@ -1115,10 +1115,10 @@ mod invariant_7_read_write {
         let json = JsonStore::new(db.clone());
         let doc_id = "test-doc";
         let _ = json
-            .create(&branch_id, "default", &doc_id, serde_json::json!({}).into())
+            .create(&branch_id, "default", doc_id, serde_json::json!({}).into())
             .unwrap(); // write
         let _ = json
-            .get(&branch_id, "default", &doc_id, &JsonPath::root())
+            .get(&branch_id, "default", doc_id, &JsonPath::root())
             .unwrap(); // read
 
         // Vector
@@ -1200,7 +1200,7 @@ mod version_monotonicity {
         let json = JsonStore::new(db);
         let doc_id = "test-doc";
 
-        json.create(&branch_id, "default", &doc_id, serde_json::json!(0).into())
+        json.create(&branch_id, "default", doc_id, serde_json::json!(0).into())
             .unwrap();
 
         let mut last_version = 1u64;
@@ -1209,7 +1209,7 @@ mod version_monotonicity {
                 .set(
                     &branch_id,
                     "default",
-                    &doc_id,
+                    doc_id,
                     &JsonPath::root(),
                     serde_json::json!(i).into(),
                 )

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -2012,7 +2012,7 @@ mod tests {
         for i in 0..3 {
             db.event_append(
                 "paged",
-                Value::object([(format!("i"), Value::Int(i))].into_iter().collect()),
+                Value::object([("i".to_string(), Value::Int(i))].into_iter().collect()),
             )
             .unwrap();
         }

--- a/crates/executor/src/handlers/export.rs
+++ b/crates/executor/src/handlers/export.rs
@@ -598,9 +598,9 @@ mod tests {
 
     #[test]
     fn render_csv_float_value() {
-        let rows = vec![row("k", Value::Float(3.14))];
+        let rows = vec![row("k", Value::Float(2.78))];
         let csv = render_csv(&rows);
-        assert!(csv.contains("k,3.14"));
+        assert!(csv.contains("k,2.78"));
     }
 
     #[test]

--- a/crates/executor/src/handlers/graph.rs
+++ b/crates/executor/src/handlers/graph.rs
@@ -946,6 +946,13 @@ pub fn graph_sssp(
     Ok(Output::GraphScoreSummary(summary))
 }
 
+/// Convert serde_json::Value to strata_core::Value.
+fn serde_json_to_value(json: serde_json::Value) -> Result<Value> {
+    crate::bridge::serde_json_to_value_public(json).map_err(|e| Error::Serialization {
+        reason: e.to_string(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1312,11 +1319,4 @@ mod tests {
         let json = serde_json::to_string(&s).unwrap();
         assert!(!json.contains("\"all\""));
     }
-}
-
-/// Convert serde_json::Value to strata_core::Value.
-fn serde_json_to_value(json: serde_json::Value) -> Result<Value> {
-    crate::bridge::serde_json_to_value_public(json).map_err(|e| Error::Serialization {
-        reason: e.to_string(),
-    })
 }

--- a/crates/executor/src/tests/access_mode.rs
+++ b/crates/executor/src/tests/access_mode.rs
@@ -334,11 +334,8 @@ fn test_read_only_allows_all_reads() {
         let result = executor.execute(cmd);
         // Should not be AccessDenied — the actual result may be Ok or a
         // domain error (e.g. KeyNotFound), but never AccessDenied.
-        match &result {
-            Err(Error::AccessDenied { .. }) => {
-                panic!("read command {} was blocked by AccessDenied", name)
-            }
-            _ => {} // any other result is fine
+        if let Err(Error::AccessDenied { .. }) = &result {
+            panic!("read command {} was blocked by AccessDenied", name)
         }
     }
 }

--- a/crates/search/src/fuser.rs
+++ b/crates/search/src/fuser.rs
@@ -332,7 +332,7 @@ mod tests {
     /// Helper to create a KV EntityRef
     fn make_kv_doc_ref(branch_id: &BranchId, key: &str) -> EntityRef {
         EntityRef::Kv {
-            branch_id: branch_id.clone(),
+            branch_id: *branch_id,
             key: key.to_string(),
         }
     }

--- a/crates/storage/src/bloom.rs
+++ b/crates/storage/src/bloom.rs
@@ -282,7 +282,7 @@ mod tests {
         // Verify num_probes is correctly encoded
         let encoded_probes = u32::from_le_bytes(bytes[1..5].try_into().unwrap());
         assert_eq!(encoded_probes, filter.num_probes);
-        assert!(encoded_probes >= 1 && encoded_probes <= 30);
+        assert!((1..=30).contains(&encoded_probes));
         // bits portion must be 64-byte aligned
         assert_eq!((bytes.len() - 5) % BLOCK_BYTES, 0);
     }

--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -1454,7 +1454,7 @@ mod tests {
         mt.put(&kv_key("null"), 1, Value::Null, false);
         mt.put(&kv_key("bool"), 1, Value::Bool(true), false);
         mt.put(&kv_key("int"), 1, Value::Int(42), false);
-        mt.put(&kv_key("float"), 1, Value::Float(3.14), false);
+        mt.put(&kv_key("float"), 1, Value::Float(2.78), false);
         mt.put(&kv_key("string"), 1, Value::String("hello".into()), false);
         mt.put(
             &kv_key("bytes"),
@@ -1493,7 +1493,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .value,
-            Value::Float(3.14),
+            Value::Float(2.78),
         );
         assert_eq!(
             seg.point_lookup(&kv_key("string"), u64::MAX)
@@ -1728,7 +1728,7 @@ mod tests {
             let k = kv_key(&format!("k_{:08}", i));
             let e = seg
                 .point_lookup(&k, u64::MAX)
-                .expect(&format!("point lookup failed for k_{:08}", i))
+                .unwrap_or_else(|_| panic!("point lookup failed for k_{:08}", i))
                 .unwrap();
             assert_eq!(e.value, Value::Int(i as i64));
             assert_eq!(e.commit_id, i as u64 + 1);

--- a/crates/storage/src/segment_builder.rs
+++ b/crates/storage/src/segment_builder.rs
@@ -1266,6 +1266,166 @@ pub(crate) const FOOTER_SZ: usize = FOOTER_SIZE;
 pub(crate) const FRAME_OVERHEAD: usize = BLOCK_FRAME_OVERHEAD;
 pub(crate) const IDX_TYPE_PARTITIONED: u8 = INDEX_TYPE_PARTITIONED;
 
+// ---------------------------------------------------------------------------
+// SplittingSegmentBuilder — splits output at target file size
+// ---------------------------------------------------------------------------
+
+/// Builds multiple segment files, splitting at `target_file_size` boundaries.
+///
+/// Wraps `SegmentBuilder` and automatically finalizes the current segment
+/// and starts a new one when the output exceeds the target size. Splits
+/// only at key boundaries (never between versions of the same logical key).
+pub struct SplittingSegmentBuilder {
+    /// Underlying builder configuration.
+    inner: SegmentBuilder,
+    /// Target file size in bytes (default 64MB).
+    pub target_file_size: u64,
+}
+
+impl SplittingSegmentBuilder {
+    /// Create a new splitting builder with the given target file size.
+    pub fn new(target_file_size: u64) -> Self {
+        Self {
+            inner: SegmentBuilder::default(),
+            target_file_size,
+        }
+    }
+
+    /// Set the bloom filter bits per key for output segments.
+    pub fn with_bloom_bits(mut self, bits_per_key: usize) -> Self {
+        self.inner.bloom_bits_per_key = bits_per_key;
+        self
+    }
+
+    /// Set the compression codec for output segments.
+    pub fn with_compression(mut self, codec: CompressionCodec) -> Self {
+        self.inner.compression = codec;
+        self
+    }
+
+    /// Set a rate limiter for throttling data block writes during compaction.
+    pub fn with_rate_limiter(
+        mut self,
+        limiter: std::sync::Arc<crate::rate_limiter::RateLimiter>,
+    ) -> Self {
+        self.inner.rate_limiter = Some(limiter);
+        self
+    }
+
+    /// Build one or more segment files from a sorted iterator.
+    ///
+    /// Returns `(path, metadata)` for each output segment. The `path_fn`
+    /// closure is called with a split index (0, 1, 2, ...) to generate
+    /// the path for each output segment.
+    ///
+    /// Split points are chosen at logical key boundaries — all versions
+    /// of a given key stay in the same segment.
+    pub fn build_split<I, F>(
+        &self,
+        iter: I,
+        path_fn: F,
+    ) -> io::Result<Vec<(std::path::PathBuf, SegmentMeta)>>
+    where
+        I: Iterator<Item = (InternalKey, MemtableEntry)>,
+        F: Fn(usize) -> std::path::PathBuf,
+    {
+        self.build_split_with_predicate(iter, path_fn, |_| false)
+    }
+
+    /// Build one or more segment files, with an additional split predicate.
+    ///
+    /// In addition to splitting at `target_file_size` boundaries, the caller
+    /// can supply a `should_split` predicate that receives the typed_key_prefix
+    /// of each new logical key.  When the predicate returns `true`, a split is
+    /// forced even if the current segment hasn't reached `target_file_size`.
+    ///
+    /// This is used for grandparent-aware splitting during leveled compaction:
+    /// the predicate tracks cumulative overlap with L+2 files and forces a
+    /// split when the overlap exceeds a threshold.
+    pub fn build_split_with_predicate<I, F, P>(
+        &self,
+        iter: I,
+        path_fn: F,
+        mut should_split: P,
+    ) -> io::Result<Vec<(std::path::PathBuf, SegmentMeta)>>
+    where
+        I: Iterator<Item = (InternalKey, MemtableEntry)>,
+        F: Fn(usize) -> std::path::PathBuf,
+        P: FnMut(&[u8]) -> bool,
+    {
+        let mut results: Vec<(std::path::PathBuf, SegmentMeta)> = Vec::new();
+        let mut split_idx: usize = 0;
+
+        // Buffer entries for the current segment
+        let mut current_entries: Vec<(InternalKey, MemtableEntry)> = Vec::new();
+        let mut current_bytes: u64 = 0;
+        let mut last_typed_key: Option<Vec<u8>> = None;
+
+        for (ik, entry) in iter {
+            let typed_key = ik.typed_key_prefix().to_vec();
+
+            // At a key boundary (new logical key), check if we should split
+            if last_typed_key.as_ref() != Some(&typed_key)
+                && !current_entries.is_empty()
+                && (current_bytes >= self.target_file_size || should_split(&typed_key))
+            {
+                let path = path_fn(split_idx);
+                let meta = self
+                    .inner
+                    .build_from_iter(current_entries.drain(..), &path)?;
+                if meta.entry_count > 0 {
+                    results.push((path, meta));
+                    split_idx += 1;
+                }
+                current_bytes = 0;
+            }
+
+            last_typed_key = Some(typed_key);
+
+            // Estimate entry size: ik + 25 bytes header + value
+            let entry_size = ik.as_bytes().len() as u64 + 25 + estimate_value_size(&entry);
+            current_bytes += entry_size;
+            current_entries.push((ik, entry));
+        }
+
+        // Flush remaining entries
+        if !current_entries.is_empty() {
+            let path = path_fn(split_idx);
+            let meta = self
+                .inner
+                .build_from_iter(current_entries.drain(..), &path)?;
+            if meta.entry_count > 0 {
+                results.push((path, meta));
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+impl Default for SplittingSegmentBuilder {
+    fn default() -> Self {
+        Self::new(64 * 1024 * 1024) // 64MB
+    }
+}
+
+/// Estimate serialized value size without actually serializing.
+fn estimate_value_size(entry: &MemtableEntry) -> u64 {
+    if entry.is_tombstone {
+        0
+    } else {
+        match &entry.value {
+            strata_core::value::Value::Null => 1,
+            strata_core::value::Value::Bool(_) => 2,
+            strata_core::value::Value::Int(_) => 9,
+            strata_core::value::Value::Float(_) => 9,
+            strata_core::value::Value::String(s) => 8 + s.len() as u64,
+            strata_core::value::Value::Bytes(b) => 8 + b.len() as u64,
+            _ => 64, // arrays, objects — rough estimate
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1641,11 +1801,10 @@ mod tests {
         // Build a block buffer manually and verify trailer offsets
         let mut buf = Vec::new();
         let mut offsets = vec![0u32];
-        let mut entry_count = 0usize;
         let mut prev_key = Vec::new();
 
         // Write 32 entries, capturing offsets at restart boundaries
-        for i in 0..32u32 {
+        for (entry_count, i) in (0..32u32).enumerate() {
             let is_restart = entry_count > 0 && entry_count % RESTART_INTERVAL == 0;
             if is_restart {
                 offsets.push(buf.len() as u32);
@@ -1661,7 +1820,6 @@ mod tests {
             let is_restart_point = entry_count == 0 || is_restart;
             encode_entry_v4(&prev_key, &ik, &entry, &mut buf, is_restart_point);
             prev_key = ik.as_bytes().to_vec();
-            entry_count += 1;
         }
 
         assert_eq!(offsets.len(), 2); // offsets at entry 0 and entry 16
@@ -1683,9 +1841,8 @@ mod tests {
         let build_and_count_restarts = |n: u32| -> usize {
             let mut buf = Vec::new();
             let mut offsets = vec![0u32];
-            let mut count = 0usize;
             let mut prev_key = Vec::new();
-            for i in 0..n {
+            for (count, i) in (0..n).enumerate() {
                 let is_restart = count > 0 && count % RESTART_INTERVAL == 0;
                 if is_restart {
                     offsets.push(buf.len() as u32);
@@ -1701,7 +1858,6 @@ mod tests {
                 let is_restart_point = count == 0 || is_restart;
                 encode_entry_v4(&prev_key, &ik, &entry, &mut buf, is_restart_point);
                 prev_key = ik.as_bytes().to_vec();
-                count += 1;
             }
             append_restart_trailer(&mut buf, &offsets);
             let (_, num) = parse_restart_trailer(&buf).unwrap();
@@ -2438,166 +2594,6 @@ mod tests {
             let e = seg.point_lookup(&key(&format!("k_{:04}", i)), 200).unwrap();
             assert!(e.is_some());
             assert_eq!(e.unwrap().value, Value::Int(i as i64));
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// SplittingSegmentBuilder — splits output at target file size
-// ---------------------------------------------------------------------------
-
-/// Builds multiple segment files, splitting at `target_file_size` boundaries.
-///
-/// Wraps `SegmentBuilder` and automatically finalizes the current segment
-/// and starts a new one when the output exceeds the target size. Splits
-/// only at key boundaries (never between versions of the same logical key).
-pub struct SplittingSegmentBuilder {
-    /// Underlying builder configuration.
-    inner: SegmentBuilder,
-    /// Target file size in bytes (default 64MB).
-    pub target_file_size: u64,
-}
-
-impl SplittingSegmentBuilder {
-    /// Create a new splitting builder with the given target file size.
-    pub fn new(target_file_size: u64) -> Self {
-        Self {
-            inner: SegmentBuilder::default(),
-            target_file_size,
-        }
-    }
-
-    /// Set the bloom filter bits per key for output segments.
-    pub fn with_bloom_bits(mut self, bits_per_key: usize) -> Self {
-        self.inner.bloom_bits_per_key = bits_per_key;
-        self
-    }
-
-    /// Set the compression codec for output segments.
-    pub fn with_compression(mut self, codec: CompressionCodec) -> Self {
-        self.inner.compression = codec;
-        self
-    }
-
-    /// Set a rate limiter for throttling data block writes during compaction.
-    pub fn with_rate_limiter(
-        mut self,
-        limiter: std::sync::Arc<crate::rate_limiter::RateLimiter>,
-    ) -> Self {
-        self.inner.rate_limiter = Some(limiter);
-        self
-    }
-
-    /// Build one or more segment files from a sorted iterator.
-    ///
-    /// Returns `(path, metadata)` for each output segment. The `path_fn`
-    /// closure is called with a split index (0, 1, 2, ...) to generate
-    /// the path for each output segment.
-    ///
-    /// Split points are chosen at logical key boundaries — all versions
-    /// of a given key stay in the same segment.
-    pub fn build_split<I, F>(
-        &self,
-        iter: I,
-        path_fn: F,
-    ) -> io::Result<Vec<(std::path::PathBuf, SegmentMeta)>>
-    where
-        I: Iterator<Item = (InternalKey, MemtableEntry)>,
-        F: Fn(usize) -> std::path::PathBuf,
-    {
-        self.build_split_with_predicate(iter, path_fn, |_| false)
-    }
-
-    /// Build one or more segment files, with an additional split predicate.
-    ///
-    /// In addition to splitting at `target_file_size` boundaries, the caller
-    /// can supply a `should_split` predicate that receives the typed_key_prefix
-    /// of each new logical key.  When the predicate returns `true`, a split is
-    /// forced even if the current segment hasn't reached `target_file_size`.
-    ///
-    /// This is used for grandparent-aware splitting during leveled compaction:
-    /// the predicate tracks cumulative overlap with L+2 files and forces a
-    /// split when the overlap exceeds a threshold.
-    pub fn build_split_with_predicate<I, F, P>(
-        &self,
-        iter: I,
-        path_fn: F,
-        mut should_split: P,
-    ) -> io::Result<Vec<(std::path::PathBuf, SegmentMeta)>>
-    where
-        I: Iterator<Item = (InternalKey, MemtableEntry)>,
-        F: Fn(usize) -> std::path::PathBuf,
-        P: FnMut(&[u8]) -> bool,
-    {
-        let mut results: Vec<(std::path::PathBuf, SegmentMeta)> = Vec::new();
-        let mut split_idx: usize = 0;
-
-        // Buffer entries for the current segment
-        let mut current_entries: Vec<(InternalKey, MemtableEntry)> = Vec::new();
-        let mut current_bytes: u64 = 0;
-        let mut last_typed_key: Option<Vec<u8>> = None;
-
-        for (ik, entry) in iter {
-            let typed_key = ik.typed_key_prefix().to_vec();
-
-            // At a key boundary (new logical key), check if we should split
-            if last_typed_key.as_ref() != Some(&typed_key)
-                && !current_entries.is_empty()
-                && (current_bytes >= self.target_file_size || should_split(&typed_key))
-            {
-                let path = path_fn(split_idx);
-                let meta = self
-                    .inner
-                    .build_from_iter(current_entries.drain(..), &path)?;
-                if meta.entry_count > 0 {
-                    results.push((path, meta));
-                    split_idx += 1;
-                }
-                current_bytes = 0;
-            }
-
-            last_typed_key = Some(typed_key);
-
-            // Estimate entry size: ik + 25 bytes header + value
-            let entry_size = ik.as_bytes().len() as u64 + 25 + estimate_value_size(&entry);
-            current_bytes += entry_size;
-            current_entries.push((ik, entry));
-        }
-
-        // Flush remaining entries
-        if !current_entries.is_empty() {
-            let path = path_fn(split_idx);
-            let meta = self
-                .inner
-                .build_from_iter(current_entries.drain(..), &path)?;
-            if meta.entry_count > 0 {
-                results.push((path, meta));
-            }
-        }
-
-        Ok(results)
-    }
-}
-
-impl Default for SplittingSegmentBuilder {
-    fn default() -> Self {
-        Self::new(64 * 1024 * 1024) // 64MB
-    }
-}
-
-/// Estimate serialized value size without actually serializing.
-fn estimate_value_size(entry: &MemtableEntry) -> u64 {
-    if entry.is_tombstone {
-        0
-    } else {
-        match &entry.value {
-            strata_core::value::Value::Null => 1,
-            strata_core::value::Value::Bool(_) => 2,
-            strata_core::value::Value::Int(_) => 9,
-            strata_core::value::Value::Float(_) => 9,
-            strata_core::value::Value::String(s) => 8 + s.len() as u64,
-            strata_core::value::Value::Bytes(b) => 8 + b.len() as u64,
-            _ => 64, // arrays, objects — rough estimate
         }
     }
 }

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -558,7 +558,7 @@ fn flush_produces_valid_segment_file() {
     let sst_files: Vec<_> = std::fs::read_dir(&branch_dir)
         .unwrap()
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().map_or(false, |ext| ext == "sst"))
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "sst"))
         .collect();
     assert!(!sst_files.is_empty());
 
@@ -1660,7 +1660,7 @@ fn compact_concurrent_flush_preserves_new_segment() {
 #[test]
 fn apply_batch_equivalent_to_individual() {
     let store = SegmentedStore::new();
-    let b = branch();
+    let _b = branch();
 
     // Write some keys individually
     seed(&store, kv_key("a"), Value::Int(1), 1);
@@ -1713,7 +1713,7 @@ fn apply_batch_cross_branch() {
 #[test]
 fn apply_batch_with_deletes() {
     let store = SegmentedStore::new();
-    let b = branch();
+    let _b = branch();
 
     // Write first
     seed(&store, kv_key("a"), Value::Int(1), 1);

--- a/crates/storage/src/stored_value.rs
+++ b/crates/storage/src/stored_value.rs
@@ -315,7 +315,7 @@ mod tests {
     fn test_stored_value_with_timestamp() {
         let ts = Timestamp::from_micros(5_000_000);
         let sv = StoredValue::with_timestamp(
-            Value::Float(3.14),
+            Value::Float(2.78),
             Version::txn(10),
             ts,
             Some(Duration::from_secs(30)),


### PR DESCRIPTION
## Summary

- Resolve all clippy warnings so `cargo clippy --workspace --all-targets -- -D warnings` passes with zero errors
- 35 files changed across 8 crates: core, concurrency, durability, storage, engine, executor, search
- Fix 9 benchmark compile errors (`transaction_benchmarks.rs` — `Key::new_kv` now takes `Arc<Namespace>`)
- All changes are mechanical lint fixes; no behavioral changes

## Breakdown

| Fix | Count |
|-----|-------|
| Remove unnecessary deref/borrow | ~112 (auto-fixed) |
| Replace `3.14` with `2.78` in tests | 21 |
| Remove unnecessary `as u64` casts | 8 |
| Fix benchmark type mismatches | 9 |
| Replace manual `.contains()` / `get().is_none()` | 5 |
| Fix loop counters with `.enumerate()` | 2 |
| Move items above `#[cfg(test)]` module | 1 |
| Other (digit grouping, redundant closure, match→if let, clone→from_ref) | 6 |

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` returns zero errors
- [x] `cargo test --workspace --exclude strata-inference` — 1314 passed (2 pre-existing flaky concurrent registration tests unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)