### PR TITLE
Mark 7 profiling tests as #[ignore] to skip during CI and normal test runs

### DIFF
--- a/crates/engine/src/primitives/vector/distance.rs
+++ b/crates/engine/src/primitives/vector/distance.rs
@@ -984,6 +984,7 @@ mod profiling_tests {
     /// Times 100K distance computations via scalar vs SIMD-dispatched paths
     /// to confirm SIMD is actually activating and providing speedup.
     #[test]
+    #[ignore] // profiling test — run explicitly with `cargo test -- --ignored`
     fn profile_simd_vs_scalar() {
         let dim = 128;
         let num_pairs = 100_000;

--- a/crates/engine/src/primitives/vector/heap.rs
+++ b/crates/engine/src/primitives/vector/heap.rs
@@ -1939,6 +1939,7 @@ mod profiling_tests {
     /// Benchmarks the O(1) dense-offset path (get) against the
     /// BTreeMap-only path (get_btree) to quantify the acceleration ratio.
     #[test]
+    #[ignore] // profiling test — run explicitly with `cargo test -- --ignored`
     fn profile_heap_get_vs_get_btree() {
         let dim = 128;
         let n = 100_000;

--- a/crates/engine/src/primitives/vector/hnsw.rs
+++ b/crates/engine/src/primitives/vector/hnsw.rs
@@ -2742,6 +2742,7 @@ mod profiling_tests {
     /// - Full search_with_heap_ef (end-to-end)
     /// - Post-processing overhead (difference)
     #[test]
+    #[ignore] // profiling test — run explicitly with `cargo test -- --ignored`
     fn profile_search_path_breakdown() {
         let n = 10_000;
         let dim = 128;
@@ -2822,6 +2823,7 @@ mod profiling_tests {
     /// (a) Dense get_node() (current path — O(1) array index)
     /// (b) HashMap (rebuilt from iter_nodes for comparison)
     #[test]
+    #[ignore] // profiling test — run explicitly with `cargo test -- --ignored`
     fn profile_dense_vs_hashmap_lookup() {
         let n = 50_000;
         let dim = 128;
@@ -2885,6 +2887,7 @@ mod profiling_tests {
     /// - Method A: compute_similarity(q, v, Cosine) — recomputes norms
     /// - Method B: cosine_similarity_with_norms(q, v, q_norm, v_norm) — cached
     #[test]
+    #[ignore] // profiling test — run explicitly with `cargo test -- --ignored`
     fn profile_norm_cache_vs_recompute() {
         use crate::primitives::vector::distance::cosine_similarity_with_norms;
 
@@ -2967,6 +2970,7 @@ mod profiling_tests {
     /// - visited_checks / visited_marks
     /// - candidate_pushes / result_pushes
     #[test]
+    #[ignore] // profiling test — run explicitly with `cargo test -- --ignored`
     fn profile_operation_counts() {
         let n = 10_000;
         let dim = 128;

--- a/crates/engine/src/primitives/vector/segmented.rs
+++ b/crates/engine/src/primitives/vector/segmented.rs
@@ -3088,6 +3088,7 @@ mod profiling_tests {
     /// Times 100 queries. Then compact() into 1 segment, times same queries.
     /// Reports QPS and recall@10 for both configurations.
     #[test]
+    #[ignore] // profiling test — run explicitly with `cargo test -- --ignored`
     fn profile_segment_fanout_vs_compact() {
         use crate::primitives::vector::brute_force::BruteForceBackend;
 


### PR DESCRIPTION
## Summary

- Add `#[ignore]` to all 7 profiling tests across 4 vector primitive files
- These tests run 100K–1M iterations each (SIMD benchmarks, HNSW search path breakdown, heap lookup comparison, segment fanout analysis) and take 60+ seconds each
- They now show as `ignored` during `cargo test` and can be run explicitly with `cargo test -- --ignored`

## Files changed

| File | Tests ignored |
|------|--------------|
| `distance.rs` | `profile_simd_vs_scalar` |
| `heap.rs` | `profile_heap_get_vs_get_btree` |
| `hnsw.rs` | `profile_search_path_breakdown`, `profile_dense_vs_hashmap_lookup`, `profile_norm_cache_vs_recompute`, `profile_operation_counts` |
| `segmented.rs` | `profile_segment_fanout_vs_compact` |

## Test plan

- [x] `cargo test -p strata-engine --lib -- profiling_tests` shows all 7 as `ignored`
- [x] Tests still runnable via `cargo test -- --ignored`

🤖 Generated with [Claude Code](https://claude.com/claude-code)