### PR TITLE
Fix CI: cargo fmt across workspace

### DIFF
--- a/crates/core/src/contract/entity_ref.rs
+++ b/crates/core/src/contract/entity_ref.rs
@@ -466,12 +466,14 @@ mod tests {
         let branch_id = BranchId::new();
 
         // Create one of each type
-        let refs = [EntityRef::kv(branch_id, "k"),
+        let refs = [
+            EntityRef::kv(branch_id, "k"),
             EntityRef::event(branch_id, 0),
             EntityRef::state(branch_id, "s"),
             EntityRef::branch(branch_id),
             EntityRef::json(branch_id, "j"),
-            EntityRef::vector(branch_id, "c", "k")];
+            EntityRef::vector(branch_id, "c", "k"),
+        ];
 
         // Verify they map to all 6 primitive types
         let types: std::collections::HashSet<_> = refs.iter().map(|r| r.primitive_type()).collect();

--- a/crates/durability/src/recovery/coordinator.rs
+++ b/crates/durability/src/recovery/coordinator.rs
@@ -967,8 +967,7 @@ mod tests {
         for seg_num in 1..=2u64 {
             let meta = crate::format::segment_meta::SegmentMeta::read_from_file(&wal_dir, seg_num)
                 .unwrap()
-                .unwrap_or_else(|| panic!("Segment {} should have .meta after recovery",
-                    seg_num));
+                .unwrap_or_else(|| panic!("Segment {} should have .meta after recovery", seg_num));
             assert_eq!(meta.segment_number, seg_num);
             assert_eq!(meta.record_count, 1);
         }

--- a/crates/engine/src/primitives/json.rs
+++ b/crates/engine/src/primitives/json.rs
@@ -1703,8 +1703,7 @@ mod tests {
         let branch_id = BranchId::new();
         let doc_id = "test-doc";
 
-        let result =
-            store.delete_at_path(&branch_id, "default", doc_id, &"field".parse().unwrap());
+        let result = store.delete_at_path(&branch_id, "default", doc_id, &"field".parse().unwrap());
         assert!(result.is_err());
     }
 

--- a/crates/engine/src/primitives/vector/hnsw.rs
+++ b/crates/engine/src/primitives/vector/hnsw.rs
@@ -2832,8 +2832,7 @@ mod profiling_tests {
         let (compact, _heap) = build_compact_graph(n, dim);
 
         // Build a HashMap mirror for comparison
-        let hashmap_nodes: StdHashMap<VectorId, &CompactHnswNode> =
-            compact.iter_nodes().collect();
+        let hashmap_nodes: StdHashMap<VectorId, &CompactHnswNode> = compact.iter_nodes().collect();
 
         // Pre-generate random lookup IDs
         let lookup_ids: Vec<VectorId> = (0..num_lookups)

--- a/crates/engine/src/primitives/vector/mmap.rs
+++ b/crates/engine/src/primitives/vector/mmap.rs
@@ -174,9 +174,9 @@ impl MmapVectorData {
 
         // Validate file is large enough before allocating (#1780).
         // Each id_to_offset entry is 16 bytes (VectorId u64 + offset u64).
-        let entries_bytes = count.checked_mul(16).ok_or_else(|| {
-            VectorError::Serialization("mmap count overflow".into())
-        })?;
+        let entries_bytes = count
+            .checked_mul(16)
+            .ok_or_else(|| VectorError::Serialization("mmap count overflow".into()))?;
         if HEADER_SIZE + entries_bytes > mmap.len() {
             return Err(VectorError::Serialization(format!(
                 "mmap claims {} entries but file is only {} bytes",
@@ -214,9 +214,9 @@ impl MmapVectorData {
         pos += 4;
 
         // Validate file can hold claimed free slots before allocating (#1780).
-        let free_slots_bytes = free_slots_count.checked_mul(8).ok_or_else(|| {
-            VectorError::Serialization("mmap free_slots_count overflow".into())
-        })?;
+        let free_slots_bytes = free_slots_count
+            .checked_mul(8)
+            .ok_or_else(|| VectorError::Serialization("mmap free_slots_count overflow".into()))?;
         if pos + free_slots_bytes > mmap.len() {
             return Err(VectorError::Serialization(format!(
                 "mmap claims {} free slots but only {} bytes remain",


### PR DESCRIPTION
## Summary

- Ran `cargo fmt --all` to fix pre-existing formatting issues failing the CI `cargo fmt --check` step
- 5 files with minor whitespace/line-break adjustments, no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)