### PR TITLE
Fix #1681: Add directory fsync after segment file rename for crash safety

### DIFF
--- a/crates/storage/src/segment_builder.rs
+++ b/crates/storage/src/segment_builder.rs
@@ -458,6 +458,13 @@ impl SegmentBuilder {
         // 9. Atomic rename
         std::fs::rename(&tmp_path, path)?;
 
+        // 10. Fsync parent directory so the rename is durable on crash.
+        if let Some(parent) = path.parent() {
+            if let Ok(dir_fd) = std::fs::File::open(parent) {
+                let _ = dir_fd.sync_all();
+            }
+        }
+
         Ok(SegmentMeta {
             entry_count,
             commit_min,
@@ -2439,6 +2446,45 @@ mod tests {
             assert!(e.is_some());
             assert_eq!(e.unwrap().value, Value::Int(i as i64));
         }
+    }
+
+    /// Verify that `build_from_iter` follows the crash-safe write protocol:
+    /// write temp → sync temp → rename → fsync parent directory.
+    ///
+    /// We cannot observe fsync calls directly in a unit test, but we verify:
+    /// 1. The final file exists and is valid (readable segment).
+    /// 2. No `.tmp` file remains after build (rename completed).
+    /// 3. The parent directory is sync-able (fsync succeeds).
+    #[test]
+    fn test_issue_1681_segment_build_dir_fsync_after_rename() {
+        use crate::segment::KVSegment;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("crash_safe.sst");
+        let tmp_path = path.with_extension("tmp");
+
+        let mt = Memtable::new(0);
+        mt.put(&key("a"), 1, Value::Int(1), false);
+        mt.put(&key("b"), 2, Value::Int(2), false);
+        mt.freeze();
+
+        let builder = SegmentBuilder::default();
+        builder.build_from_iter(mt.iter_all(), &path).unwrap();
+
+        // 1. Final file exists and is valid
+        assert!(path.exists(), "segment file must exist after build");
+        let seg = KVSegment::open(&path).unwrap();
+        assert_eq!(seg.entry_count(), 2);
+
+        // 2. Temp file is cleaned up (rename succeeded)
+        assert!(
+            !tmp_path.exists(),
+            "temp file must not exist after build (rename must have completed)"
+        );
+
+        // 3. Verify the parent directory is sync-able (non-trivial on some FS)
+        let dir_fd = std::fs::File::open(dir.path()).unwrap();
+        dir_fd.sync_all().unwrap();
     }
 }
 


### PR DESCRIPTION
## Summary

- `SegmentBuilder::build_from_iter` followed the write → sync → rename protocol but omitted the final step: fsync on the parent directory after rename
- On crash after rename but before OS writeback, the directory entry could be lost, leaving the storage manifest referencing a missing segment file
- Added directory fsync matching the pattern already used in `manifest.rs`, `mmap.rs`, and `mmap_graph.rs`

## Root Cause

`segment_builder.rs:459` performed `std::fs::rename(&tmp_path, path)` without a subsequent `fsync` on the parent directory. While the file data was durable (temp file synced at step 8), the directory metadata (the rename) was not. This is a known POSIX durability gap on ext4 and other filesystems.

## Fix

Added 5 lines after the rename (new step 10):
```rust
if let Some(parent) = path.parent() {
    if let Ok(dir_fd) = std::fs::File::open(parent) {
        let _ = dir_fd.sync_all();
    }
}
```

Best-effort (failure silently ignored since rename already succeeded), matching the codebase convention in `manifest.rs:119-121`, `mmap.rs:382-385`, `mmap_graph.rs:161-164`.

## Invariants Verified

- **CMP-004**: Manifest-before-delete ordering unchanged — HOLDS
- **LSM-007**: Segment file immutability — HOLDS (only opens dir read-only)
- **ARCH-004**: Recovery model — HOLDS (strengthened by making renames durable)
- **ARCH-007**: Manifest/WAL authority domains — HOLDS (no cross-domain dependency)

## Test Plan

- [x] `test_issue_1681_segment_build_dir_fsync_after_rename` — verifies crash-safe write protocol (file valid, no temp file, dir syncable)
- [x] Full `strata-storage` crate tests pass (550 passed)
- [x] Full workspace tests pass (excluding `strata-inference` which has a pre-existing build dep issue)
- [x] Invariant check: 4 affected invariants all HOLD
- [x] Clippy clean (no new warnings), `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)