### PR TITLE
Fix #1680: Reject corrupt manifest during recovery instead of all-L0 fallback

### DIFF
--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -1855,16 +1855,18 @@ impl SegmentedStore {
                 }
             }
 
-            // Try to read manifest for level assignments
+            // Try to read manifest for level assignments.
+            // A corrupt manifest is a fatal error — silently loading all files
+            // as L0 would introduce orphaned SSTs from failed compactions (#1680).
             let manifest = match crate::manifest::read_manifest(&path) {
                 Ok(m) => m,
                 Err(e) => {
-                    tracing::warn!(
+                    tracing::error!(
                         branch = %dir_name,
                         error = %e,
-                        "corrupt manifest, falling back to all-L0"
+                        "corrupt manifest, refusing to load segments without manifest authority"
                     );
-                    None
+                    return Err(e);
                 }
             };
 

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -3102,7 +3102,7 @@ fn recover_without_manifest_all_l0() {
 }
 
 #[test]
-fn recover_manifest_corrupt_falls_back_to_l0() {
+fn recover_manifest_corrupt_returns_error() {
     let dir = tempfile::tempdir().unwrap();
     let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
     let b = branch();
@@ -3115,18 +3115,13 @@ fn recover_manifest_corrupt_falls_back_to_l0() {
     let manifest_path = branch_dir.join("segments.manifest");
     std::fs::write(&manifest_path, b"corrupted data!").unwrap();
 
-    // Recover — corrupt manifest falls back to all-L0
+    // Recover — corrupt manifest must return error, not silently load all as L0 (#1680)
     let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
-    store2.recover_segments().unwrap();
-
-    assert_eq!(store2.l0_segment_count(&b), 1);
-    assert_eq!(store2.l1_segment_count(&b), 0);
-
-    // Data still correct
-    assert!(store2
-        .get_versioned(&kv_key("a"), u64::MAX)
-        .unwrap()
-        .is_some());
+    let result = store2.recover_segments();
+    assert!(
+        result.is_err(),
+        "corrupt manifest must cause recovery error"
+    );
 }
 
 // ========================================================================
@@ -7470,5 +7465,62 @@ fn test_issue_1677_shadow_check_returns_true_on_corruption() {
     assert!(
         result,
         "shadow check must return true on corruption to prevent stale data resurrection"
+    );
+}
+
+// =============================================================================
+// #1680: Recovery must not load orphaned SSTs when manifest is corrupt
+// =============================================================================
+
+/// When a manifest file exists but is corrupt, recovery should return an error
+/// rather than silently loading all SSTs (including orphans) as L0.
+#[test]
+fn test_issue_1680_corrupt_manifest_rejects_orphan_loading() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Flush a real segment so we get a valid manifest + SST on disk.
+    seed(&store, kv_key("real"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    // Create an orphan SST (simulates a compaction output that crashed
+    // before the manifest was updated to include it).
+    let branch_hex = super::hex_encode_branch(&branch());
+    let branch_dir = dir.path().join(&branch_hex);
+
+    // Write a second real segment to act as the orphan.
+    seed(&store, kv_key("orphan"), Value::Int(999), 2);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    // Now read the manifest, remove the orphan entry, and write it back
+    // so the manifest only knows about the first segment.
+    let manifest = crate::manifest::read_manifest(&branch_dir)
+        .unwrap()
+        .unwrap();
+    assert!(
+        manifest.entries.len() >= 2,
+        "should have at least 2 segments"
+    );
+    // Keep only the first entry (the "real" segment)
+    let kept_entries = vec![manifest.entries[0].clone()];
+    crate::manifest::write_manifest(&branch_dir, &kept_entries, &manifest.inherited_layers)
+        .unwrap();
+
+    // Now corrupt the manifest file.
+    let manifest_path = branch_dir.join("segments.manifest");
+    let mut data = std::fs::read(&manifest_path).unwrap();
+    // Flip a byte in the middle to cause CRC mismatch.
+    let mid = data.len() / 2;
+    data[mid] ^= 0xFF;
+    std::fs::write(&manifest_path, &data).unwrap();
+
+    // Recovery should fail — NOT silently load all SSTs as L0.
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let result = store2.recover_segments();
+    assert!(
+        result.is_err(),
+        "corrupt manifest must cause recovery error, not silent all-L0 fallback"
     );
 }


### PR DESCRIPTION
## Summary

- When `read_manifest()` returned `Err` (corrupt manifest), `recover_segments()` silently fell back to loading **all** SST files as L0 — including orphans from failed compactions
- This could introduce stale/duplicate data into live database state, shadowing correctly-compacted entries
- Now propagates the error so the engine fails startup (or skips segment recovery if `allow_lossy_recovery` is set)

## Root Cause

In `recover_segments()`, the `Err(e)` arm of `read_manifest()` was caught and converted to `None`, which triggered the backward-compat "no manifest → all-L0" path. This conflated two distinct cases:
- **No manifest file** (`Ok(None)`) — correct backward-compat for pre-manifest databases
- **Corrupt manifest file** (`Err`) — should be a fatal error, not a silent fallback

## Fix

Changed the `Err(e)` handler from `{ warn!(); None }` to `return Err(e)`. The engine already handles this correctly via `allow_lossy_recovery` gating. ~5 lines of non-test code changed.

## Invariants Verified

ARCH-004, ARCH-007, CMP-004, COW-005, COW-006, LSM-003 — all HOLD.

## Test Plan

- [x] `test_issue_1680_corrupt_manifest_rejects_orphan_loading` — creates orphan SST + corrupt manifest, verifies recovery returns error
- [x] `recover_manifest_corrupt_returns_error` — updated existing test to expect error instead of silent fallback
- [x] `recover_without_manifest_all_l0` — existing test confirms backward-compat path (missing manifest) unchanged
- [x] Full `cargo test --workspace` passes (excluding strata-inference due to CUDA build dep)
- [x] Clippy clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)