### PR TITLE
Fix #1691: Resolve inherited layers directly from disk, not source branch state

### DIFF
--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -1804,14 +1804,6 @@ impl SegmentedStore {
         let mut deferred_inherited: Vec<(BranchId, Vec<crate::manifest::ManifestInheritedLayer>)> =
             Vec::new();
 
-        // All opened segments per branch, including orphans not in the manifest.
-        // Needed so the second pass (inherited layer resolution) can find segments
-        // that are orphans in the parent's active version but still needed by children.
-        let mut all_opened: std::collections::HashMap<
-            BranchId,
-            std::collections::HashMap<String, Arc<KVSegment>>,
-        > = std::collections::HashMap::new();
-
         for entry in std::fs::read_dir(segments_dir)? {
             let entry = entry?;
             let path = entry.path();
@@ -1856,17 +1848,20 @@ impl SegmentedStore {
             }
 
             // Try to read manifest for level assignments.
-            // A corrupt manifest is a fatal error — silently loading all files
-            // as L0 would introduce orphaned SSTs from failed compactions (#1680).
+            // A corrupt manifest means we cannot safely load this branch's own
+            // segments (loading all as L0 would reintroduce orphans — #1680).
+            // Skip the branch but do NOT abort: other branches (and children
+            // that inherit segments from this branch) can still recover (#1691).
             let manifest = match crate::manifest::read_manifest(&path) {
                 Ok(m) => m,
                 Err(e) => {
                     tracing::error!(
                         branch = %dir_name,
                         error = %e,
-                        "corrupt manifest, refusing to load segments without manifest authority"
+                        "corrupt manifest, skipping branch (own segments not loaded)"
                     );
-                    return Err(e);
+                    info.corrupt_manifest_branches += 1;
+                    continue;
                 }
             };
 
@@ -1877,19 +1872,6 @@ impl SegmentedStore {
             if branch_segments.is_empty() && !has_inherited {
                 continue;
             }
-
-            // Record all opened segments for this branch (including orphans)
-            // so inherited layer resolution can find them in the second pass.
-            let branch_seg_map: std::collections::HashMap<String, Arc<KVSegment>> = branch_segments
-                .iter()
-                .filter_map(|seg| {
-                    seg.file_path()
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .map(|name| (name.to_string(), Arc::clone(seg)))
-                })
-                .collect();
-            all_opened.insert(branch_id, branch_seg_map);
 
             // Partition segments into levels based on manifest.
             //
@@ -2005,40 +1987,46 @@ impl SegmentedStore {
             let mut inherited_layers = Vec::new();
 
             for ml in &manifest_layers {
-                // Look up ALL opened segments for the source branch, including
-                // orphans not loaded into its active version. This is critical
-                // for #1701: after parent compaction, the pre-compaction segments
-                // are orphans in the parent's manifest but still needed by
-                // children's inherited layers.
-                let source_segs = match all_opened.get(&ml.source_branch_id) {
-                    Some(segs) => segs,
-                    None => {
-                        tracing::warn!(
-                            child = %hex_encode_branch(&child_id),
-                            source = %hex_encode_branch(&ml.source_branch_id),
-                            "inherited layer references missing source branch, skipping"
-                        );
-                        info.layers_dropped.push((child_id, ml.source_branch_id));
-                        continue;
-                    }
-                };
-
-                // Build SegmentVersion from manifest entries using all opened
-                // segments (including orphans not in the source branch's active version).
+                // Open inherited segment files directly by path (#1691).
+                // The child's manifest has the source_branch_id and filename,
+                // which is enough to construct the full path.  This makes
+                // resolution independent of the source branch's recovery state
+                // (e.g. the source may have a corrupt manifest, or its
+                // directory may have been partially cleaned up).
+                let source_dir = segments_dir.join(hex_encode_branch(&ml.source_branch_id));
                 let mut layer_levels: Vec<Vec<Arc<KVSegment>>> = vec![Vec::new(); NUM_LEVELS];
+                let mut any_found = false;
 
                 for entry in &ml.entries {
                     let level = (entry.level as usize).min(NUM_LEVELS - 1);
-                    if let Some(seg) = source_segs.get(&entry.filename) {
-                        layer_levels[level].push(Arc::clone(seg));
-                    } else {
-                        tracing::warn!(
-                            child = %hex_encode_branch(&child_id),
-                            source = %hex_encode_branch(&ml.source_branch_id),
-                            segment = %entry.filename,
-                            "inherited layer segment not found in source branch"
-                        );
+                    let seg_path = source_dir.join(&entry.filename);
+                    match KVSegment::open(&seg_path) {
+                        Ok(seg) => {
+                            // Track segment ID to avoid collisions.
+                            if let Some(stem) = seg_path.file_stem().and_then(|s| s.to_str()) {
+                                if let Ok(file_seg_id) = stem.parse::<u64>() {
+                                    self.next_segment_id
+                                        .fetch_max(file_seg_id + 1, Ordering::Relaxed);
+                                }
+                            }
+                            layer_levels[level].push(Arc::new(seg));
+                            any_found = true;
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                child = %hex_encode_branch(&child_id),
+                                source = %hex_encode_branch(&ml.source_branch_id),
+                                segment = %entry.filename,
+                                error = %e,
+                                "inherited layer segment not found on disk"
+                            );
+                        }
                     }
+                }
+
+                if !any_found {
+                    info.layers_dropped.push((child_id, ml.source_branch_id));
+                    continue;
                 }
 
                 // Sort levels consistently
@@ -2520,6 +2508,10 @@ pub struct RecoverSegmentsInfo {
     /// These are skipped during recovery to prevent stale data from shadowing
     /// compacted data (#1701).
     pub orphans_skipped: usize,
+    /// Number of branches skipped because their manifest was corrupt (#1691).
+    /// Own segments for these branches are not loaded, but their segment
+    /// files remain on disk for children to open directly.
+    pub corrupt_manifest_branches: usize,
 }
 
 impl Default for SegmentedStore {

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -3115,12 +3115,22 @@ fn recover_manifest_corrupt_returns_error() {
     let manifest_path = branch_dir.join("segments.manifest");
     std::fs::write(&manifest_path, b"corrupted data!").unwrap();
 
-    // Recover — corrupt manifest must return error, not silently load all as L0 (#1680)
+    // Recover — corrupt manifest must NOT silently load all as L0 (#1680).
+    // The branch is skipped (own segments not loaded), but recovery itself
+    // succeeds so other branches are unaffected (#1691).
     let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
-    let result = store2.recover_segments();
+    let info = store2.recover_segments().unwrap();
     assert!(
-        result.is_err(),
-        "corrupt manifest must cause recovery error"
+        info.corrupt_manifest_branches > 0,
+        "corrupt manifest branch must be reported"
+    );
+    // The corrupt branch's data must NOT be accessible.
+    assert!(
+        store2
+            .get_versioned(&kv_key("a"), u64::MAX)
+            .unwrap()
+            .is_none(),
+        "corrupt-manifest branch must not have segments loaded"
     );
 }
 
@@ -7071,6 +7081,97 @@ fn test_issue_1701_recovery_inherited_layer_finds_orphan_segments() {
 }
 
 // =============================================================================
+// #1691: Inherited-layer recovery independent of source branch state
+// =============================================================================
+
+/// Recovery of child's inherited layers must not depend on the source branch's
+/// manifest being intact.  If the parent's manifest is corrupt, recovery should
+/// skip the parent (not load its own segments) but still open the inherited
+/// segment files directly so the child branch is unaffected.
+#[test]
+fn test_issue_1691_inherited_layer_recovery_independent_of_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // 1. Write parent data in two flushes → 2 L0 segments
+    seed(&store, parent_kv("a"), Value::Int(1), 1);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    seed(&store, parent_kv("b"), Value::Int(2), 2);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // 2. Fork parent → child (child inherits both segments)
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    let (_fork_ver, shared) = store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+    assert!(shared >= 2, "child should share at least 2 segments");
+
+    // Verify child can read inherited data before crash
+    let val_a = store
+        .get_versioned(&child_kv("a"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val_a.value, Value::Int(1));
+
+    // 3. Drop store (simulate crash)
+    drop(store);
+
+    // 4. Corrupt the PARENT's manifest — the child's manifest is intact.
+    //    This simulates a scenario where the source branch's recovery state
+    //    is broken, but the child's own data and the segment files are fine.
+    let parent_hex = super::hex_encode_branch(&parent_branch());
+    let parent_dir = dir.path().join(&parent_hex);
+    let manifest_path = parent_dir.join("segments.manifest");
+    let mut data = std::fs::read(&manifest_path).unwrap();
+    let mid = data.len() / 2;
+    data[mid] ^= 0xFF; // Flip a byte to cause CRC mismatch
+    std::fs::write(&manifest_path, &data).unwrap();
+
+    // 5. Recovery: should NOT fail entirely just because the parent's
+    //    manifest is corrupt.  The child's inherited segments should be
+    //    resolved directly from disk, independent of the source branch.
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let info = store2.recover_segments().unwrap();
+
+    // 6. Child must still see inherited data after recovery.
+    let val_a_recovered = store2.get_versioned(&child_kv("a"), u64::MAX).unwrap();
+    assert!(
+        val_a_recovered.is_some(),
+        "child should see inherited key 'a' after recovery"
+    );
+    assert_eq!(val_a_recovered.unwrap().value, Value::Int(1));
+
+    let val_b_recovered = store2.get_versioned(&child_kv("b"), u64::MAX).unwrap();
+    assert!(
+        val_b_recovered.is_some(),
+        "child should see inherited key 'b' after recovery"
+    );
+    assert_eq!(val_b_recovered.unwrap().value, Value::Int(2));
+
+    // 7. The parent branch should NOT have been loaded with its own
+    //    segments (corrupt manifest → skipped).  The parent's segment
+    //    files still exist on disk, so the child's direct opens worked.
+    assert!(
+        info.corrupt_manifest_branches > 0,
+        "should report parent's corrupt manifest"
+    );
+    // Parent branch must not have its own segments loaded.
+    assert!(
+        store2
+            .get_versioned(&parent_kv("a"), u64::MAX)
+            .unwrap()
+            .is_none(),
+        "parent branch own segments must not be loaded (corrupt manifest)"
+    );
+}
+
+// =============================================================================
 // #1703: Concurrent materialize_layer is serialized
 // =============================================================================
 
@@ -7516,11 +7617,25 @@ fn test_issue_1680_corrupt_manifest_rejects_orphan_loading() {
     data[mid] ^= 0xFF;
     std::fs::write(&manifest_path, &data).unwrap();
 
-    // Recovery should fail — NOT silently load all SSTs as L0.
+    // Recovery must NOT silently load all SSTs as L0 (#1680).
+    // The branch is skipped (own segments not loaded) but recovery succeeds
+    // so other branches remain functional (#1691).
     let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
-    let result = store2.recover_segments();
+    let info = store2.recover_segments().unwrap();
     assert!(
-        result.is_err(),
-        "corrupt manifest must cause recovery error, not silent all-L0 fallback"
+        info.corrupt_manifest_branches > 0,
+        "corrupt manifest must be reported, not silently load as L0"
+    );
+    // The orphan SST must NOT be accessible (no L0 fallback).
+    let orphan_val = store2.get_versioned(&kv_key("orphan"), u64::MAX).unwrap();
+    assert!(
+        orphan_val.is_none(),
+        "orphan segment must not be loaded when manifest is corrupt"
+    );
+    // The real segment must also not be accessible (branch skipped entirely).
+    let real_val = store2.get_versioned(&kv_key("real"), u64::MAX).unwrap();
+    assert!(
+        real_val.is_none(),
+        "no segments should be loaded for corrupt-manifest branch"
     );
 }


### PR DESCRIPTION
## Summary

- Inherited layer recovery now opens segment files directly by path (`segments_dir/hex(source_branch_id)/filename`) instead of cross-referencing an in-memory map built during the first recovery pass
- Corrupt manifests skip the affected branch (`continue`) instead of aborting entire recovery (`return Err`), so child branches can still recover their inherited segments
- Added `corrupt_manifest_branches` counter to `RecoverSegmentsInfo` for observability

## Root Cause

The second recovery pass resolved inherited layer segments via `all_opened[source_branch_id]`, a HashMap populated during the first pass. This created a fragile dependency:
1. If the source branch's manifest was corrupt, `return Err(e)` aborted the **entire** recovery — not just that branch
2. If the source branch directory was missing, the inherited layer was silently dropped

The child's manifest already contains all needed info (source_branch_id + filename), so the cross-reference was unnecessary.

## Fix

1. **First pass**: Corrupt manifest → `continue` (skip branch) instead of `return Err` (abort all). Own segments not loaded (preserves #1680 orphan safety). Counter incremented.
2. **Second pass**: Construct file path directly from manifest metadata and open via `KVSegment::open()`. Removed `all_opened` map entirely.
3. If no segments can be opened for a layer, it's reported in `layers_dropped` (existing behavior preserved).

## Invariants Verified

COW-005 (inherited layer resolution), COW-006 (refcount rebuild), COW-001 (shared segment deletion), ARCH-004 (recovery ordering), LSM-003 (read path ordering), LSM-006 (block cache keying) — all **HOLD**.

## Test Plan

- [x] `test_issue_1691_inherited_layer_recovery_independent_of_source` — corrupt parent manifest, verify child reads inherited data
- [x] Updated `recover_manifest_corrupt_returns_error` — corrupt manifest skips branch, data inaccessible
- [x] Updated `test_issue_1680_corrupt_manifest_rejects_orphan_loading` — no L0 fallback, branch skipped
- [x] `recovery_surfaces_missing_source_branch` — existing test still passes (source dir deleted → layer dropped)
- [x] `test_issue_1701_recovery_inherited_layer_finds_orphan_segments` — orphan segments still found via direct open
- [x] Full crate suite: 554 passed, 0 failed
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)