### PR TITLE
Fix #1698: Evaluate TTL against query timestamp in time-travel APIs

### DIFF
--- a/crates/storage/src/memtable.rs
+++ b/crates/storage/src/memtable.rs
@@ -49,6 +49,20 @@ impl MemtableEntry {
         false
     }
 
+    /// Check if this entry was expired at a given timestamp (microseconds since epoch).
+    ///
+    /// Used by time-travel queries to evaluate TTL against the query timestamp
+    /// instead of wall-clock now.
+    pub fn is_expired_at(&self, query_ts_micros: u64) -> bool {
+        if self.ttl_ms != 0 {
+            let query = Timestamp::from_micros(query_ts_micros);
+            if let Some(age) = query.duration_since(self.timestamp) {
+                return age >= Duration::from_millis(self.ttl_ms);
+            }
+        }
+        false
+    }
+
     /// Convert to a `VersionedValue` using the given commit_id.
     pub fn to_versioned(&self, commit_id: u64) -> VersionedValue {
         VersionedValue {

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -1018,7 +1018,7 @@ impl SegmentedStore {
                     if source
                         .frozen
                         .last()
-                        .map_or(false, |last| last.id() == mt.id())
+                        .is_some_and(|last| last.id() == mt.id())
                     {
                         source.frozen.pop();
                         self.total_frozen_count.fetch_sub(1, Ordering::Relaxed);
@@ -1321,7 +1321,7 @@ impl SegmentedStore {
             if found_for_current {
                 continue;
             }
-            if entry.is_expired() || entry.timestamp.as_micros() > max_ts {
+            if entry.is_expired_at(max_ts) || entry.timestamp.as_micros() > max_ts {
                 continue;
             }
             found_for_current = true;
@@ -1352,7 +1352,7 @@ impl SegmentedStore {
         };
         let all_versions = Self::get_all_versions_from_branch(&branch, key);
         for (commit_id, entry) in all_versions {
-            if entry.is_expired() {
+            if entry.is_expired_at(max_timestamp) {
                 continue;
             }
             if entry.timestamp.as_micros() <= max_timestamp {
@@ -1461,7 +1461,7 @@ impl SegmentedStore {
             if found_for_current {
                 continue;
             }
-            if entry.is_expired() || entry.timestamp.as_micros() > max_timestamp {
+            if entry.is_expired_at(max_timestamp) || entry.timestamp.as_micros() > max_timestamp {
                 continue;
             }
             found_for_current = true;

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -7974,3 +7974,164 @@ fn test_issue_1682_segment_deletion_races_fork_refcount_concurrent() {
         }
     }
 }
+
+// ===== Issue #1698: Time-travel TTL evaluates against wall-clock now =====
+
+/// Insert a MemtableEntry with explicit timestamp and TTL into the store.
+fn seed_with_timestamp_and_ttl(
+    store: &SegmentedStore,
+    key: Key,
+    value: Value,
+    version: u64,
+    timestamp: Timestamp,
+    ttl_ms: u64,
+) {
+    let branch_id = key.namespace.branch_id;
+    let branch = store
+        .branches
+        .entry(branch_id)
+        .or_insert_with(BranchState::new);
+    let entry = MemtableEntry {
+        value,
+        is_tombstone: false,
+        timestamp,
+        ttl_ms,
+    };
+    branch.active.put_entry(&key, version, entry);
+}
+
+#[test]
+fn test_issue_1698_get_at_timestamp_ttl_uses_query_time() {
+    // Scenario from issue #1698:
+    // - Entry written at t=100s with TTL=60s (expires at t=160s)
+    // - Query at t=120s (entry alive at this time)
+    // - Query runs at wall-clock now >> 160s
+    // Expected: entry returned (alive at t=120s)
+    // Bug: is_expired() evaluates against now, skipping the entry
+    let store = SegmentedStore::new();
+    let key = kv_key("ttl_key");
+
+    let write_ts = Timestamp::from_micros(100_000_000); // 100 seconds
+    let ttl_ms = 60_000; // 60 seconds
+    seed_with_timestamp_and_ttl(&store, key.clone(), Value::Int(42), 1, write_ts, ttl_ms);
+
+    // Query at t=120s — entry should be alive (written at t=100, TTL=60s, expires at t=160s)
+    let query_ts = 120_000_000u64; // 120 seconds in microseconds
+    let result = store.get_at_timestamp(&key, query_ts).unwrap();
+    assert!(
+        result.is_some(),
+        "Entry should be visible at t=120s (TTL expires at t=160s, not yet expired)"
+    );
+    assert_eq!(result.unwrap().value, Value::Int(42));
+}
+
+#[test]
+fn test_issue_1698_get_at_timestamp_ttl_expired_at_query_time() {
+    // Entry written at t=100s with TTL=60s (expires at t=160s)
+    // Query at t=200s — entry should be expired at query time
+    let store = SegmentedStore::new();
+    let key = kv_key("ttl_key_expired");
+
+    let write_ts = Timestamp::from_micros(100_000_000);
+    let ttl_ms = 60_000;
+    seed_with_timestamp_and_ttl(&store, key.clone(), Value::Int(42), 1, write_ts, ttl_ms);
+
+    let query_ts = 200_000_000u64; // 200 seconds
+    let result = store.get_at_timestamp(&key, query_ts).unwrap();
+    assert!(
+        result.is_none(),
+        "Entry should be expired at t=200s (TTL expired at t=160s)"
+    );
+}
+
+#[test]
+fn test_issue_1698_list_by_type_at_timestamp_ttl_uses_query_time() {
+    let store = SegmentedStore::new();
+    let key = kv_key("ttl_list_key");
+
+    let write_ts = Timestamp::from_micros(100_000_000);
+    let ttl_ms = 60_000;
+    seed_with_timestamp_and_ttl(&store, key.clone(), Value::Int(99), 1, write_ts, ttl_ms);
+
+    // Query at t=120s — entry alive
+    let query_ts = 120_000_000u64;
+    let results = store.list_by_type_at_timestamp(&branch(), TypeTag::KV, query_ts);
+    assert_eq!(results.len(), 1, "Entry should be visible at t=120s");
+    assert_eq!(results[0].1.value, Value::Int(99));
+}
+
+#[test]
+fn test_issue_1698_scan_prefix_at_timestamp_ttl_uses_query_time() {
+    let store = SegmentedStore::new();
+    let key = kv_key("ttl_scan_key");
+
+    let write_ts = Timestamp::from_micros(100_000_000);
+    let ttl_ms = 60_000;
+    seed_with_timestamp_and_ttl(&store, key.clone(), Value::Int(77), 1, write_ts, ttl_ms);
+
+    // Query at t=120s — entry alive
+    let query_ts = 120_000_000u64;
+    let prefix = kv_key("ttl_scan");
+    let results = store.scan_prefix_at_timestamp(&prefix, query_ts).unwrap();
+    assert_eq!(results.len(), 1, "Entry should be visible at t=120s");
+    assert_eq!(results[0].1.value, Value::Int(77));
+}
+
+#[test]
+fn test_issue_1698_list_by_type_at_timestamp_ttl_expired_at_query_time() {
+    let store = SegmentedStore::new();
+    let key = kv_key("ttl_list_exp");
+
+    let write_ts = Timestamp::from_micros(100_000_000);
+    let ttl_ms = 60_000;
+    seed_with_timestamp_and_ttl(&store, key.clone(), Value::Int(99), 1, write_ts, ttl_ms);
+
+    // Query at t=200s — entry expired at query time
+    let query_ts = 200_000_000u64;
+    let results = store.list_by_type_at_timestamp(&branch(), TypeTag::KV, query_ts);
+    assert_eq!(results.len(), 0, "Entry should be expired at t=200s");
+}
+
+#[test]
+fn test_issue_1698_scan_prefix_at_timestamp_ttl_expired_at_query_time() {
+    let store = SegmentedStore::new();
+    let key = kv_key("ttl_scan_exp");
+
+    let write_ts = Timestamp::from_micros(100_000_000);
+    let ttl_ms = 60_000;
+    seed_with_timestamp_and_ttl(&store, key.clone(), Value::Int(77), 1, write_ts, ttl_ms);
+
+    // Query at t=200s — entry expired at query time
+    let query_ts = 200_000_000u64;
+    let prefix = kv_key("ttl_scan");
+    let results = store.scan_prefix_at_timestamp(&prefix, query_ts).unwrap();
+    assert_eq!(results.len(), 0, "Entry should be expired at t=200s");
+}
+
+#[test]
+fn test_issue_1698_get_at_timestamp_ttl_exact_expiry_boundary() {
+    // Entry written at t=100s with TTL=60s → expires at exactly t=160s
+    // Query at t=160s (exact boundary) — should be expired (>= semantics)
+    let store = SegmentedStore::new();
+    let key = kv_key("ttl_boundary");
+
+    let write_ts = Timestamp::from_micros(100_000_000);
+    let ttl_ms = 60_000; // 60s = 60_000_000 micros
+    seed_with_timestamp_and_ttl(&store, key.clone(), Value::Int(42), 1, write_ts, ttl_ms);
+
+    // Exact boundary: 100s + 60s = 160s
+    let query_ts = 160_000_000u64;
+    let result = store.get_at_timestamp(&key, query_ts).unwrap();
+    assert!(
+        result.is_none(),
+        "Entry should be expired at exact boundary t=160s (>= semantics)"
+    );
+
+    // One microsecond before boundary: still alive
+    let query_ts_before = 159_999_999u64;
+    let result_before = store.get_at_timestamp(&key, query_ts_before).unwrap();
+    assert!(
+        result_before.is_some(),
+        "Entry should be alive 1µs before expiry"
+    );
+}


### PR DESCRIPTION
## Summary

- Time-travel APIs (`get_at_timestamp`, `list_by_type_at_timestamp`, `scan_prefix_at_timestamp`) evaluated TTL expiration against wall-clock `now` instead of the query timestamp
- Added `MemtableEntry::is_expired_at(query_ts_micros)` to evaluate TTL at an arbitrary point in time
- Replaced `is_expired()` with `is_expired_at(max_timestamp)` in all three time-travel read paths

## Root Cause

`MemtableEntry::is_expired()` always uses `Timestamp::now()`. When called from time-travel APIs, this answers "is this entry expired **now**?" instead of "was this entry expired **at the requested historical timestamp**?" — causing alive-at-query-time entries to be incorrectly filtered out.

## Fix

Added `is_expired_at(query_ts_micros: u64)` which evaluates TTL against the provided timestamp instead of wall-clock now. The three time-travel methods now call this with their `max_timestamp` parameter. Current-state queries (`get_value_direct`, `list_branch`, etc.) continue using `is_expired()` unchanged.

## Invariants Verified

- **MVCC-001** (Version visibility boundary): HOLDS — version filtering unchanged
- **MVCC-002** (Tombstone semantics): HOLDS — tombstone handling unchanged
- **MVCC-006** (TTL expiration does not resurrect old versions): HOLDS — fall-through semantics unchanged (pre-existing)
- **LSM-003** (Read path level ordering): HOLDS — source ordering unchanged

## Test Plan

- [x] `test_issue_1698_get_at_timestamp_ttl_uses_query_time` — alive entry at query time returned
- [x] `test_issue_1698_get_at_timestamp_ttl_expired_at_query_time` — expired entry at query time filtered
- [x] `test_issue_1698_list_by_type_at_timestamp_ttl_uses_query_time` — list returns alive entry
- [x] `test_issue_1698_list_by_type_at_timestamp_ttl_expired_at_query_time` — list filters expired entry
- [x] `test_issue_1698_scan_prefix_at_timestamp_ttl_uses_query_time` — scan returns alive entry
- [x] `test_issue_1698_scan_prefix_at_timestamp_ttl_expired_at_query_time` — scan filters expired entry
- [x] `test_issue_1698_get_at_timestamp_ttl_exact_expiry_boundary` — exact boundary and 1µs-before
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] Full workspace test suite passes (558 storage tests, all workspace crates green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)