### PR TITLE
Fix #1711: Fsync parent directory after WAL segment creation

### DIFF
--- a/crates/durability/src/format/wal_record.rs
+++ b/crates/durability/src/format/wal_record.rs
@@ -217,6 +217,11 @@ impl WalSegment {
         let header = SegmentHeader::new(segment_number, database_uuid);
         file.write_all(&header.to_bytes())?;
 
+        // Fsync the parent directory so the new file's directory entry is
+        // durable. Without this, a power loss can silently lose the entire
+        // segment even though the file contents were fsynced (issue #1711).
+        Self::fsync_parent_directory(dir)?;
+
         Ok(WalSegment {
             file,
             segment_number,
@@ -371,6 +376,24 @@ impl WalSegment {
             database_uuid: header.database_uuid,
             header_size: actual_header_size,
         })
+    }
+
+    /// Fsync a parent directory to make new directory entries durable.
+    /// Retries once on transient failure (matching disk_snapshot::fsync_directory).
+    fn fsync_parent_directory(dir: &Path) -> std::io::Result<()> {
+        let do_sync = || -> std::io::Result<()> {
+            let dir_file = File::open(dir)?;
+            dir_file.sync_all()
+        };
+        match do_sync() {
+            Ok(()) => Ok(()),
+            Err(first_err) => {
+                tracing::warn!(target: "strata::wal",
+                    error = %first_err, path = %dir.display(),
+                    "WAL directory fsync failed, retrying once");
+                do_sync()
+            }
+        }
     }
 
     /// Generate segment file path.
@@ -881,6 +904,53 @@ mod tests {
             result.is_none(),
             "Should reject v2 header with corrupted payload"
         );
+    }
+
+    /// Issue #1711: WalSegment::create() must fsync the parent directory so the
+    /// new segment's directory entry survives power loss.
+    ///
+    /// We cannot simulate power loss in a unit test, but we verify that:
+    /// 1. create() succeeds without error (including the directory fsync path)
+    /// 2. The segment file is immediately visible via directory listing
+    /// 3. Multiple segments in the same directory all remain visible after creation
+    #[test]
+    fn test_issue_1711_create_fsyncs_parent_directory() {
+        let dir = tempdir().unwrap();
+        let uuid = [0xAA; 16];
+
+        // Create several segments in the same directory — each must fsync the
+        // parent directory so its directory entry is durable.
+        for i in 1..=5 {
+            let segment = WalSegment::create(dir.path(), i, uuid).unwrap();
+            assert_eq!(segment.segment_number(), i);
+            drop(segment);
+
+            // Verify segment file is visible in the directory listing
+            let expected_path = WalSegment::segment_path(dir.path(), i);
+            assert!(
+                expected_path.exists(),
+                "Segment {} should exist after create()",
+                i
+            );
+        }
+
+        // Verify all segments are visible by listing the directory
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "seg"))
+            .collect();
+        assert_eq!(entries.len(), 5, "All 5 segments should be visible");
+
+        // Verify each segment can be reopened (directory entry intact)
+        for i in 1..=5 {
+            let segment = WalSegment::open_read(dir.path(), i).unwrap();
+            assert_eq!(segment.segment_number(), i);
+        }
+
+        // Verify the parent directory can be opened and synced (mechanism test)
+        let dir_fd = File::open(dir.path()).unwrap();
+        dir_fd.sync_all().unwrap();
     }
 
     #[test]

--- a/crates/durability/src/wal/writer.rs
+++ b/crates/durability/src/wal/writer.rs
@@ -1502,6 +1502,65 @@ mod tests {
         assert_eq!(usage.segment_count, 0);
     }
 
+    /// Issue #1711: Segment rotation must fsync the parent directory so the
+    /// new segment's directory entry survives power loss. Without the directory
+    /// fsync, the first record in a newly-rotated segment can be lost.
+    ///
+    /// This test exercises the full rotation path and verifies all segments
+    /// (including rotated ones) are discoverable and readable afterward.
+    #[test]
+    fn test_issue_1711_rotation_fsyncs_parent_directory() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+
+        // Use very small segment size to force many rotations
+        let config = WalConfig::new()
+            .with_segment_size(100)
+            .with_buffered_sync_bytes(50);
+
+        let mut writer = WalWriter::new(
+            wal_dir.clone(),
+            [1u8; 16],
+            DurabilityMode::Always,
+            config,
+            Box::new(IdentityCodec),
+        )
+        .unwrap();
+
+        // Write enough records to force several rotations
+        for i in 1..=20 {
+            writer
+                .append(&WalRecord::new(i, [1u8; 16], i * 1000, vec![0; 50]))
+                .unwrap();
+        }
+
+        let segments = writer.list_segments().unwrap();
+        assert!(
+            segments.len() >= 3,
+            "Expected at least 3 segments from rotation, got {}",
+            segments.len()
+        );
+
+        // Every segment file must be visible in the directory
+        for seg_num in &segments {
+            let path = WalSegment::segment_path(&wal_dir, *seg_num);
+            assert!(
+                path.exists(),
+                "Segment {} directory entry must be durable",
+                seg_num
+            );
+        }
+
+        // All records must be readable through the reader
+        let reader = crate::wal::WalReader::new();
+        let result = reader.read_all(&wal_dir).unwrap();
+        assert_eq!(
+            result.records.len(),
+            20,
+            "All 20 records must survive rotation"
+        );
+    }
+
     #[test]
     fn test_wal_disk_usage_ignores_non_segment_files() {
         let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary

- `WalSegment::create()` now fsyncs the parent WAL directory after creating a new segment file, ensuring the directory entry survives power loss
- Added single-retry logic matching the existing `disk_snapshot::fsync_directory` pattern
- Covers both initial segment creation (`WalWriter::new`) and rotation (`rotate_segment`) paths

## Root Cause

On Linux (ext4, XFS), `sync_all()` on a file does not guarantee persistence of the file's directory entry. After creating a new WAL segment and fsyncing its contents, a power loss could cause the directory entry to vanish — silently losing all records in that segment. This violates ACID-006 (Always mode fsync-per-commit) for the first record written to any newly-created segment.

## Fix

Added `WalSegment::fsync_parent_directory(dir)` called at the end of `WalSegment::create()`, before returning the new segment handle. The helper opens the parent directory and calls `sync_all()` with a single retry on transient failure. This is ~15 lines of non-test code.

## Invariants Verified

- **ACID-005**: Recovery replay idempotent — unaffected (write-path only change)
- **ACID-006**: Always mode fsync-per-commit — **strengthened** (directory entry now durable)
- **ACID-007**: Standard mode durability window — **strengthened** (same mechanism)
- **ARCH-004**: Recovery model ordering — unaffected (recovery uses `open_read`, not `create`)

## Test Plan

- [x] `test_issue_1711_create_fsyncs_parent_directory` — verifies segment creation with directory fsync succeeds, files visible, reopenable
- [x] `test_issue_1711_rotation_fsyncs_parent_directory` — exercises full rotation path with Always mode, verifies all segments discoverable and all records readable
- [x] Full `strata-durability` crate tests pass (406 tests)
- [x] Full workspace tests pass (excluding `strata-inference` — pre-existing CMake build issue)
- [x] Clippy clean, `cargo fmt` clean
- [x] Invariant check: all affected invariants HOLD

🤖 Generated with [Claude Code](https://claude.com/claude-code)