### PR TITLE
Fix #1716: Clean up partial .sst output files on compaction failure

### DIFF
--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -230,11 +230,26 @@ impl SegmentedStore {
         if let Some(ref l) = limiter {
             builder = builder.with_rate_limiter(Arc::clone(l));
         }
-        let meta = builder.build_from_iter(compaction_iter, &seg_path)?;
-        check_corruption_flags(&corruption_flags)?;
+        let meta = match builder.build_from_iter(compaction_iter, &seg_path) {
+            Ok(meta) => meta,
+            Err(e) => {
+                cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
+                return Err(e);
+            }
+        };
+        if let Err(e) = check_corruption_flags(&corruption_flags) {
+            cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
+            return Err(e);
+        }
 
         // Open the newly written segment.
-        let new_segment = KVSegment::open(&seg_path)?;
+        let new_segment = match KVSegment::open(&seg_path) {
+            Ok(seg) => seg,
+            Err(e) => {
+                cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
+                return Err(e);
+            }
+        };
 
         // Swap: remove only the segments we compacted, insert the new one.
         // Any segments added by concurrent flushes (not in old_segments) are kept.
@@ -372,10 +387,25 @@ impl SegmentedStore {
         if let Some(ref l) = limiter {
             builder = builder.with_rate_limiter(Arc::clone(l));
         }
-        let meta = builder.build_from_iter(compaction_iter, &seg_path)?;
-        check_corruption_flags(&corruption_flags)?;
+        let meta = match builder.build_from_iter(compaction_iter, &seg_path) {
+            Ok(meta) => meta,
+            Err(e) => {
+                cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
+                return Err(e);
+            }
+        };
+        if let Err(e) = check_corruption_flags(&corruption_flags) {
+            cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
+            return Err(e);
+        }
 
-        let new_segment = KVSegment::open(&seg_path)?;
+        let new_segment = match KVSegment::open(&seg_path) {
+            Ok(seg) => seg,
+            Err(e) => {
+                cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
+                return Err(e);
+            }
+        };
 
         // Swap: remove only the segments we compacted, insert the new one.
         // Any segments added by concurrent flushes (not in selected_segments) are kept.
@@ -548,6 +578,7 @@ impl SegmentedStore {
         std::fs::create_dir_all(&branch_dir)?;
 
         let next_id = &self.next_segment_id;
+        let start_id = next_id.load(Ordering::Relaxed);
         let bloom_bits = super::bloom_bits_for_level(1, 10);
         let compression = super::compression_for_level(1);
         let mut splitting_builder = crate::segment_builder::SplittingSegmentBuilder::default()
@@ -556,11 +587,23 @@ impl SegmentedStore {
         if let Some(ref l) = limiter {
             splitting_builder = splitting_builder.with_rate_limiter(Arc::clone(l));
         }
-        let outputs = splitting_builder.build_split(compaction_iter, |_split_idx| {
+        let outputs = match splitting_builder.build_split(compaction_iter, |_split_idx| {
             let id = next_id.fetch_add(1, Ordering::Relaxed);
             branch_dir.join(format!("{}.sst", id))
-        })?;
-        check_corruption_flags(&corruption_flags)?;
+        }) {
+            Ok(outputs) => outputs,
+            Err(e) => {
+                let end_id = next_id.load(Ordering::Relaxed);
+                cleanup_partial_compaction_outputs(&branch_dir, start_id, end_id);
+                return Err(e);
+            }
+        };
+        if let Err(e) = check_corruption_flags(&corruption_flags) {
+            for (path, _) in &outputs {
+                let _ = std::fs::remove_file(path);
+            }
+            return Err(e);
+        }
 
         let output_entries: u64 = outputs.iter().map(|(_, m)| m.entry_count).sum();
         let output_file_size: u64 = outputs.iter().map(|(_, m)| m.file_size).sum();
@@ -568,7 +611,15 @@ impl SegmentedStore {
         // Open all output segments
         let mut new_l1_segments: Vec<Arc<KVSegment>> = Vec::new();
         for (path, _meta) in &outputs {
-            new_l1_segments.push(Arc::new(KVSegment::open(path)?));
+            match KVSegment::open(path) {
+                Ok(seg) => new_l1_segments.push(Arc::new(seg)),
+                Err(e) => {
+                    for (p, _) in &outputs {
+                        let _ = std::fs::remove_file(p);
+                    }
+                    return Err(e);
+                }
+            }
         }
 
         // Atomic swap: L0 = only concurrently-flushed segments, L1 = non-overlapping + new
@@ -783,6 +834,7 @@ impl SegmentedStore {
         std::fs::create_dir_all(&branch_dir)?;
 
         let next_id = &self.next_segment_id;
+        let start_id = next_id.load(Ordering::Relaxed);
         let bloom_bits = super::bloom_bits_for_level(level + 1, 10);
         let compression = super::compression_for_level(level + 1);
         let mut splitting_builder = crate::segment_builder::SplittingSegmentBuilder::default()
@@ -824,15 +876,27 @@ impl SegmentedStore {
             false
         };
 
-        let outputs = splitting_builder.build_split_with_predicate(
+        let outputs = match splitting_builder.build_split_with_predicate(
             compaction_iter,
             |_split_idx| {
                 let id = next_id.fetch_add(1, Ordering::Relaxed);
                 branch_dir.join(format!("{}.sst", id))
             },
             should_split,
-        )?;
-        check_corruption_flags(&corruption_flags)?;
+        ) {
+            Ok(outputs) => outputs,
+            Err(e) => {
+                let end_id = next_id.load(Ordering::Relaxed);
+                cleanup_partial_compaction_outputs(&branch_dir, start_id, end_id);
+                return Err(e);
+            }
+        };
+        if let Err(e) = check_corruption_flags(&corruption_flags) {
+            for (path, _) in &outputs {
+                let _ = std::fs::remove_file(path);
+            }
+            return Err(e);
+        }
 
         let output_entries: u64 = outputs.iter().map(|(_, m)| m.entry_count).sum();
         let output_file_size: u64 = outputs.iter().map(|(_, m)| m.file_size).sum();
@@ -840,7 +904,15 @@ impl SegmentedStore {
         // Open all output segments
         let mut new_output_segments: Vec<Arc<KVSegment>> = Vec::new();
         for (path, _meta) in &outputs {
-            new_output_segments.push(Arc::new(KVSegment::open(path)?));
+            match KVSegment::open(path) {
+                Ok(seg) => new_output_segments.push(Arc::new(seg)),
+                Err(e) => {
+                    for (p, _) in &outputs {
+                        let _ = std::fs::remove_file(p);
+                    }
+                    return Err(e);
+                }
+            }
         }
 
         // ── 4. Atomic version swap ─────────────────────────────────────
@@ -924,6 +996,18 @@ fn streaming_sources(
         })
         .collect();
     (sources, corruption_flags)
+}
+
+/// Remove partial compaction output files left by a failed build.
+///
+/// Cleans up both `.sst` (fully written then renamed) and `.tmp` (partially
+/// written) files for segment IDs in `[start_id, end_id)`. Best-effort:
+/// errors are ignored because we're already on an error path.
+fn cleanup_partial_compaction_outputs(dir: &std::path::Path, start_id: u64, end_id: u64) {
+    for id in start_id..end_id {
+        let _ = std::fs::remove_file(dir.join(format!("{}.sst", id)));
+        let _ = std::fs::remove_file(dir.join(format!("{}.tmp", id)));
+    }
 }
 
 /// Check if any corruption flag was set during iteration.

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -8233,3 +8233,146 @@ fn test_issue_1698_get_at_timestamp_ttl_exact_expiry_boundary() {
         "Entry should be alive 1µs before expiry"
     );
 }
+
+/// Regression test: failed compaction must not leave partial .sst output files on disk.
+///
+/// When `build_from_iter` succeeds but corruption is detected (or the build itself
+/// fails due to disk full / I/O error), the compaction error path must clean up any
+/// output .sst or .tmp files. Otherwise, the files become orphans that waste disk
+/// space — critical when the disk is already full.
+#[test]
+fn test_issue_1716_compact_branch_cleans_up_on_failure() {
+    use crate::segment_builder::HEADER_SIZE;
+
+    let dir = tempfile::tempdir().unwrap();
+    let seg_dir = dir.path().join("segments");
+    let store = SegmentedStore::with_dir(seg_dir.clone(), 1024);
+    let bid = branch();
+
+    // Flush two L0 segments (compact_branch requires >= 2)
+    seed(&store, kv_key("a"), Value::Int(1), 1);
+    store.rotate_memtable(&bid);
+    store.flush_oldest_frozen(&bid).unwrap();
+
+    seed(&store, kv_key("b"), Value::Int(2), 2);
+    store.rotate_memtable(&bid);
+    store.flush_oldest_frozen(&bid).unwrap();
+
+    // Count .sst files before compaction attempt
+    let branch_hex = hex_encode_branch(&bid);
+    let branch_dir = seg_dir.join(&branch_hex);
+    let count_sst_files = |dir: &std::path::Path| -> usize {
+        std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .is_some_and(|ext| ext == "sst" || ext == "tmp")
+            })
+            .count()
+    };
+    let sst_before = count_sst_files(&branch_dir);
+    assert_eq!(sst_before, 2, "should have exactly 2 L0 .sst files");
+
+    // Corrupt the first segment's data-block CRC to trigger corruption detection
+    let mut sst_files: Vec<std::path::PathBuf> = std::fs::read_dir(&branch_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "sst"))
+        .collect();
+    sst_files.sort();
+    let target = &sst_files[0];
+    let data = std::fs::read(target).unwrap();
+    let data_len =
+        u32::from_le_bytes(data[HEADER_SIZE + 4..HEADER_SIZE + 8].try_into().unwrap()) as usize;
+    let crc_offset = HEADER_SIZE + 8 + data_len;
+    let mut corrupt = data.clone();
+    corrupt[crc_offset] ^= 0xFF;
+    std::fs::write(target, &corrupt).unwrap();
+
+    // Attempt compaction — should fail due to corruption
+    let result = store.compact_branch(&bid, 0);
+    assert!(result.is_err(), "compaction must fail on corrupt segment");
+
+    // After failed compaction, no new .sst or .tmp files should remain
+    let sst_after = count_sst_files(&branch_dir);
+    assert_eq!(
+        sst_after, sst_before,
+        "failed compaction must not leave orphan .sst/.tmp files on disk \
+         (before={sst_before}, after={sst_after})"
+    );
+}
+
+/// Regression test: failed compact_l0_to_l1 must not leave partial output files.
+///
+/// Uses two L0 segments and corrupts only one, so the output file is written
+/// from the good segment's data before corruption is detected by check_corruption_flags.
+#[test]
+fn test_issue_1716_compact_l0_to_l1_cleans_up_on_failure() {
+    use crate::segment_builder::HEADER_SIZE;
+
+    let dir = tempfile::tempdir().unwrap();
+    let seg_dir = dir.path().join("segments");
+    let store = SegmentedStore::with_dir(seg_dir.clone(), 1024);
+    let bid = branch();
+
+    // Flush two L0 segments so compact_l0_to_l1 has work to do and produces output
+    seed(&store, kv_key("a"), Value::Int(1), 1);
+    store.rotate_memtable(&bid);
+    store.flush_oldest_frozen(&bid).unwrap();
+
+    seed(&store, kv_key("b"), Value::Int(2), 2);
+    store.rotate_memtable(&bid);
+    store.flush_oldest_frozen(&bid).unwrap();
+
+    // Count files before
+    let branch_hex = hex_encode_branch(&bid);
+    let branch_dir = seg_dir.join(&branch_hex);
+    let count_files = |dir: &std::path::Path| -> usize {
+        std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .is_some_and(|ext| ext == "sst" || ext == "tmp")
+            })
+            .count()
+    };
+    let files_before = count_files(&branch_dir);
+    assert_eq!(files_before, 2, "should have exactly 2 L0 .sst files");
+
+    // Corrupt only one segment so data from the other flows through to output
+    let mut sst_files: Vec<std::path::PathBuf> = std::fs::read_dir(&branch_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "sst"))
+        .collect();
+    sst_files.sort();
+    let target = &sst_files[0];
+    let data = std::fs::read(target).unwrap();
+    let data_len =
+        u32::from_le_bytes(data[HEADER_SIZE + 4..HEADER_SIZE + 8].try_into().unwrap()) as usize;
+    let crc_offset = HEADER_SIZE + 8 + data_len;
+    let mut corrupt = data.clone();
+    corrupt[crc_offset] ^= 0xFF;
+    std::fs::write(target, &corrupt).unwrap();
+
+    // Attempt compact_l0_to_l1 — should fail due to corruption
+    let result = store.compact_l0_to_l1(&bid, 0);
+    assert!(
+        result.is_err(),
+        "compact_l0_to_l1 must fail on corrupt segment"
+    );
+
+    // No orphan files should remain
+    let files_after = count_files(&branch_dir);
+    assert_eq!(
+        files_after, files_before,
+        "failed compact_l0_to_l1 must not leave orphan files \
+         (before={files_before}, after={files_after})"
+    );
+}


### PR DESCRIPTION
## Summary

- When `build_from_iter`, `build_split`, or `check_corruption_flags` fails during compaction, partial output `.sst` and `.tmp` files were left on disk as orphans
- Added `cleanup_partial_compaction_outputs` helper that removes `.sst` and `.tmp` files by segment ID range
- All 4 compaction methods (`compact_branch`, `compact_tier`, `compact_l0_to_l1`, `compact_level`) now clean up on error, including `KVSegment::open` failure after successful build

## Root Cause

Compaction methods used `?` to propagate errors from `build_from_iter` and `check_corruption_flags` without removing the output files that were already written. Since `build_from_iter` uses a write-to-tmp-then-rename protocol, a build failure leaves a `.tmp` file and a corruption-check failure leaves a fully-written `.sst` file. These orphans waste disk space — critical when the disk is already full.

## Fix

Added error-path cleanup in all 4 compaction methods:
- **Single-segment paths** (`compact_branch`, `compact_tier`): cleanup by single segment ID
- **Splitting paths** (`compact_l0_to_l1`, `compact_level`): record `start_id` before build, cleanup range `[start_id, end_id)` on build error; cleanup via output paths on corruption-check error
- **`KVSegment::open` failure**: caught by code review — added cleanup for all 4 methods

## Invariants Verified

- **CMP-004** (manifest-before-delete): HOLDS — cleanup is on error path before any manifest write; output files were never registered
- **CMP-006** (concurrent flush safety): HOLDS — error path returns before version swap
- **COW-001** (shared segment deletion): HOLDS — cleaned files are freshly-created outputs never referenced by any branch
- **LSM-007** (segment immutability): HOLDS — files are removed, not modified

## Test Plan

- [x] `test_issue_1716_compact_branch_cleans_up_on_failure` — corrupts source segment, verifies no orphan after failed `compact_branch`
- [x] `test_issue_1716_compact_l0_to_l1_cleans_up_on_failure` — corrupts one of two source segments, verifies no orphan after failed `compact_l0_to_l1`
- [x] Full storage crate test suite (567 passed)
- [x] Full workspace test suite (all passed)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)