### PR TITLE
Fix #1722: TTL-expired entries in timestamp queries shadow older versions

### DIFF
--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -1323,7 +1323,11 @@ impl SegmentedStore {
             if found_for_current {
                 continue;
             }
-            if entry.is_expired_at(max_ts) || entry.timestamp.as_micros() > max_ts {
+            if entry.is_expired_at(max_ts) {
+                found_for_current = true;
+                continue;
+            }
+            if entry.timestamp.as_micros() > max_ts {
                 continue;
             }
             found_for_current = true;
@@ -1354,8 +1358,11 @@ impl SegmentedStore {
         };
         let all_versions = Self::get_all_versions_from_branch(&branch, key);
         for (commit_id, entry) in all_versions {
-            if entry.is_expired_at(max_timestamp) {
+            if entry.timestamp.as_micros() > max_timestamp {
                 continue;
+            }
+            if entry.is_expired_at(max_timestamp) {
+                return Ok(None);
             }
             if entry.timestamp.as_micros() <= max_timestamp {
                 if entry.is_tombstone {
@@ -1463,7 +1470,11 @@ impl SegmentedStore {
             if found_for_current {
                 continue;
             }
-            if entry.is_expired_at(max_timestamp) || entry.timestamp.as_micros() > max_timestamp {
+            if entry.is_expired_at(max_timestamp) {
+                found_for_current = true;
+                continue;
+            }
+            if entry.timestamp.as_micros() > max_timestamp {
                 continue;
             }
             found_for_current = true;

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -8376,3 +8376,98 @@ fn test_issue_1716_compact_l0_to_l1_cleans_up_on_failure() {
          (before={files_before}, after={files_after})"
     );
 }
+
+// ===== Issue #1722: TTL-expired entries don't shadow older versions in timestamp queries =====
+
+/// When the newest version of a key is TTL-expired at the query timestamp,
+/// older non-expired versions must NOT bleed through (ghost resurrection).
+#[test]
+fn test_issue_1722_get_at_timestamp_expired_shadows_older() {
+    let store = SegmentedStore::new();
+    let key = kv_key("k");
+
+    // v1: written at t=100s, no TTL
+    let ts_v1 = Timestamp::from_micros(100_000_000);
+    seed_with_timestamp_and_ttl(&store, key.clone(), Value::Int(1), 5, ts_v1, 0);
+
+    // v2: written at t=200s, TTL=60s (expires at t=260s)
+    let ts_v2 = Timestamp::from_micros(200_000_000);
+    seed_with_timestamp_and_ttl(&store, key.clone(), Value::Int(2), 10, ts_v2, 60_000);
+
+    // Query at t=230s — v2 still alive, should return v2
+    let pre_expiry = 230_000_000u64;
+    let alive = store.get_at_timestamp(&key, pre_expiry).unwrap();
+    assert_eq!(
+        alive.as_ref().map(|v| &v.value),
+        Some(&Value::Int(2)),
+        "Before expiry, v2 should be returned",
+    );
+
+    // Query at t=300s — v2 is expired. Must NOT fall through to v1.
+    let query_ts = 300_000_000u64;
+    let result = store.get_at_timestamp(&key, query_ts).unwrap();
+    assert!(
+        result.is_none(),
+        "Expired v2 must shadow v1 — got {:?} (ghost resurrection)",
+        result,
+    );
+}
+
+#[test]
+fn test_issue_1722_list_by_type_at_timestamp_expired_shadows_older() {
+    let store = SegmentedStore::new();
+    let key = kv_key("k");
+
+    // v1: written at t=100s, no TTL
+    let ts_v1 = Timestamp::from_micros(100_000_000);
+    seed_with_timestamp_and_ttl(&store, key.clone(), Value::Int(1), 5, ts_v1, 0);
+
+    // v2: written at t=200s, TTL=60s (expires at t=260s)
+    let ts_v2 = Timestamp::from_micros(200_000_000);
+    seed_with_timestamp_and_ttl(&store, key.clone(), Value::Int(2), 10, ts_v2, 60_000);
+
+    // Query at t=230s — v2 still alive, should appear
+    let pre_expiry = 230_000_000u64;
+    let alive = store.list_by_type_at_timestamp(&branch(), TypeTag::KV, pre_expiry);
+    assert_eq!(alive.len(), 1, "Before expiry, v2 should appear in list");
+    assert_eq!(alive[0].1.value, Value::Int(2));
+
+    // Query at t=300s — v2 is expired. Key must not appear at all.
+    let query_ts = 300_000_000u64;
+    let results = store.list_by_type_at_timestamp(&branch(), TypeTag::KV, query_ts);
+    assert!(
+        results.is_empty(),
+        "Expired v2 must shadow v1 in list — got {} result(s) (ghost resurrection)",
+        results.len(),
+    );
+}
+
+#[test]
+fn test_issue_1722_scan_prefix_at_timestamp_expired_shadows_older() {
+    let store = SegmentedStore::new();
+    let key = kv_key("k");
+
+    // v1: written at t=100s, no TTL
+    let ts_v1 = Timestamp::from_micros(100_000_000);
+    seed_with_timestamp_and_ttl(&store, key.clone(), Value::Int(1), 5, ts_v1, 0);
+
+    // v2: written at t=200s, TTL=60s (expires at t=260s)
+    let ts_v2 = Timestamp::from_micros(200_000_000);
+    seed_with_timestamp_and_ttl(&store, key.clone(), Value::Int(2), 10, ts_v2, 60_000);
+
+    // Query at t=230s — v2 still alive, should appear
+    let pre_expiry = 230_000_000u64;
+    let prefix = kv_key("k");
+    let alive = store.scan_prefix_at_timestamp(&prefix, pre_expiry).unwrap();
+    assert_eq!(alive.len(), 1, "Before expiry, v2 should appear in scan");
+    assert_eq!(alive[0].1.value, Value::Int(2));
+
+    // Query at t=300s — v2 is expired. Key must not appear at all.
+    let query_ts = 300_000_000u64;
+    let results = store.scan_prefix_at_timestamp(&prefix, query_ts).unwrap();
+    assert!(
+        results.is_empty(),
+        "Expired v2 must shadow v1 in scan — got {} result(s) (ghost resurrection)",
+        results.len(),
+    );
+}


### PR DESCRIPTION
## Summary

- TTL-expired entries in `list_by_type_at_timestamp`, `get_at_timestamp`, and `scan_prefix_at_timestamp` were skipped without marking the key as "found," allowing older non-expired versions to bleed through (ghost resurrection)
- Expired entries now act as authoritative shadows, consistent with `get_versioned` behavior
- 14 lines of fix code across 3 functions; 3 regression tests added

## Root Cause

The three timestamp-based query functions used a combined check:
```rust
if entry.is_expired_at(max_ts) || entry.timestamp.as_micros() > max_ts {
    continue;  // Does NOT set found_for_current
}
```

When an expired entry was the newest version of a key, `continue` skipped it without setting `found_for_current = true`, so the loop proceeded to check older versions — resurrecting data that should be logically dead.

## Fix

Split the combined check. Expired entries now set `found_for_current = true` (in list/scan) or return `Ok(None)` (in get) before continuing, preventing older versions from bleeding through.

## Invariants Verified

- **MVCC-006** (HOLDS): Expired entries shadow older versions in all read paths
- **MVCC-002** (HOLDS): Tombstone semantics preserved
- **MVCC-001** (HOLDS): Version visibility unchanged
- **LSM-003** (HOLDS): Source ordering unchanged

## Test Plan

- [x] `test_issue_1722_get_at_timestamp_expired_shadows_older` — verifies get returns None when newest version is TTL-expired
- [x] `test_issue_1722_list_by_type_at_timestamp_expired_shadows_older` — verifies list excludes key when newest version is TTL-expired
- [x] `test_issue_1722_scan_prefix_at_timestamp_expired_shadows_older` — verifies scan excludes key when newest version is TTL-expired
- [x] All tests include pre-expiry assertions (v2 still alive → returned correctly)
- [x] Full `strata-storage` crate suite passes (573 tests)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)