### PR TITLE
Fix #1725: Return DurableButNotVisible error when apply_writes fails after WAL commit

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -324,9 +324,8 @@ impl TransactionManager {
         // Step 4: Apply to storage
         if let Err(e) = txn.apply_writes(store, commit_version) {
             if wal.is_some() {
-                // WAL says committed but storage failed - serious error
-                // Log error but return success since WAL is authoritative
-                // Recovery will replay the transaction anyway
+                // WAL says committed but storage failed — data is durable
+                // but NOT visible to reads until restart replays WAL (#1725).
                 tracing::error!(
                     target: "strata::txn",
                     txn_id = txn.txn_id,
@@ -334,6 +333,10 @@ impl TransactionManager {
                     error = %e,
                     "Storage application failed after WAL commit - will be recovered on restart"
                 );
+                return Err(CommitError::DurableButNotVisible(format!(
+                    "Storage application failed after WAL commit: {}",
+                    e
+                )));
             } else {
                 // No WAL - storage failure means data loss, return error
                 txn.status = TransactionStatus::Aborted {
@@ -457,6 +460,10 @@ impl TransactionManager {
                     error = %e,
                     "Storage application failed after WAL commit - will be recovered on restart"
                 );
+                return Err(CommitError::DurableButNotVisible(format!(
+                    "Storage application failed after WAL commit: {}",
+                    e
+                )));
             } else {
                 txn.status = TransactionStatus::Aborted {
                     reason: format!("Storage application failed: {}", e),
@@ -603,6 +610,10 @@ impl TransactionManager {
                     error = %e,
                     "Storage application failed after WAL commit - will be recovered on restart"
                 );
+                return Err(CommitError::DurableButNotVisible(format!(
+                    "Storage application failed after WAL commit: {}",
+                    e
+                )));
             } else {
                 txn.status = TransactionStatus::Aborted {
                     reason: format!("Storage application failed: {}", e),
@@ -2049,5 +2060,178 @@ mod tests {
         for h in handles {
             h.join().unwrap();
         }
+    }
+
+    /// Storage wrapper that always fails on apply_writes_atomic.
+    /// Used to simulate storage failure after WAL commit.
+    struct FailingApplyStorage {
+        inner: SegmentedStore,
+    }
+
+    impl Storage for FailingApplyStorage {
+        fn get_versioned(
+            &self,
+            key: &Key,
+            max_version: u64,
+        ) -> strata_core::error::StrataResult<Option<strata_core::contract::VersionedValue>>
+        {
+            self.inner.get_versioned(key, max_version)
+        }
+
+        fn get_history(
+            &self,
+            key: &Key,
+            limit: Option<usize>,
+            before_version: Option<u64>,
+        ) -> strata_core::error::StrataResult<Vec<strata_core::contract::VersionedValue>> {
+            self.inner.get_history(key, limit, before_version)
+        }
+
+        fn scan_prefix(
+            &self,
+            prefix: &Key,
+            max_version: u64,
+        ) -> strata_core::error::StrataResult<Vec<(Key, strata_core::contract::VersionedValue)>>
+        {
+            self.inner.scan_prefix(prefix, max_version)
+        }
+
+        fn current_version(&self) -> u64 {
+            self.inner.current_version()
+        }
+
+        fn put_with_version_mode(
+            &self,
+            key: Key,
+            value: Value,
+            version: u64,
+            ttl: Option<std::time::Duration>,
+            mode: strata_core::traits::WriteMode,
+        ) -> strata_core::error::StrataResult<()> {
+            self.inner
+                .put_with_version_mode(key, value, version, ttl, mode)
+        }
+
+        fn delete_with_version(
+            &self,
+            key: &Key,
+            version: u64,
+        ) -> strata_core::error::StrataResult<()> {
+            self.inner.delete_with_version(key, version)
+        }
+
+        fn apply_writes_atomic(
+            &self,
+            _writes: Vec<(Key, Value, strata_core::traits::WriteMode)>,
+            _deletes: Vec<Key>,
+            _version: u64,
+        ) -> strata_core::error::StrataResult<()> {
+            Err(strata_core::error::StrataError::storage(
+                "simulated storage failure",
+            ))
+        }
+    }
+
+    /// Issue #1725: apply_writes failure after WAL commit must NOT return Ok.
+    ///
+    /// When apply_writes fails after the WAL record is written, the data is
+    /// durable (will be recovered on restart) but NOT visible to reads in
+    /// the current process. Returning Ok misleads the caller into thinking
+    /// the data is immediately readable.
+    #[test]
+    fn test_issue_1725_apply_writes_failure_after_wal_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let mut wal = create_test_wal(dir.path());
+        let real_store = Arc::new(SegmentedStore::new());
+        let failing_store = FailingApplyStorage {
+            inner: SegmentedStore::new(),
+        };
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key = create_test_key(&ns, "invisible_key");
+
+        // Create a transaction with a write (blind write — skips validation)
+        let mut txn = TransactionContext::with_store(1, branch_id, real_store);
+        txn.put(key.clone(), Value::Int(42)).unwrap();
+
+        // Commit should return an error because apply_writes fails,
+        // even though WAL write succeeds.
+        let result = manager.commit(&mut txn, &failing_store, Some(&mut wal));
+        assert!(
+            result.is_err(),
+            "commit() must return Err when apply_writes fails after WAL write, got Ok({:?})",
+            result.unwrap()
+        );
+
+        // Verify it's the right error variant
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, CommitError::DurableButNotVisible(_)),
+            "Expected DurableButNotVisible error, got: {:?}",
+            err
+        );
+    }
+
+    /// Issue #1725: Same test for the commit_with_wal_arc path.
+    #[test]
+    fn test_issue_1725_apply_writes_failure_after_wal_arc_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let wal = Arc::new(ParkingMutex::new(create_test_wal(dir.path())));
+        let real_store = Arc::new(SegmentedStore::new());
+        let failing_store = FailingApplyStorage {
+            inner: SegmentedStore::new(),
+        };
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key = create_test_key(&ns, "invisible_key");
+
+        let mut txn = TransactionContext::with_store(2, branch_id, real_store);
+        txn.put(key.clone(), Value::Int(43)).unwrap();
+
+        let result = manager.commit_with_wal_arc(&mut txn, &failing_store, Some(&wal));
+        assert!(
+            result.is_err(),
+            "commit_with_wal_arc() must return Err when apply_writes fails after WAL write"
+        );
+
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, CommitError::DurableButNotVisible(_)),
+            "Expected DurableButNotVisible error, got: {:?}",
+            err
+        );
+    }
+
+    /// Issue #1725: Same test for the commit_with_version path.
+    #[test]
+    fn test_issue_1725_apply_writes_failure_after_wal_version_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let mut wal = create_test_wal(dir.path());
+        let real_store = Arc::new(SegmentedStore::new());
+        let failing_store = FailingApplyStorage {
+            inner: SegmentedStore::new(),
+        };
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key = create_test_key(&ns, "invisible_key");
+
+        let mut txn = TransactionContext::with_store(3, branch_id, real_store);
+        txn.put(key.clone(), Value::Int(44)).unwrap();
+
+        let result = manager.commit_with_version(&mut txn, &failing_store, Some(&mut wal), 42);
+        assert!(
+            result.is_err(),
+            "commit_with_version() must return Err when apply_writes fails after WAL write"
+        );
+
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, CommitError::DurableButNotVisible(_)),
+            "Expected DurableButNotVisible error, got: {:?}",
+            err
+        );
     }
 }

--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -50,6 +50,13 @@ pub enum CommitError {
 
     /// Counter overflow (transaction ID or version counter reached u64::MAX)
     CounterOverflow(String),
+
+    /// Storage application failed after WAL commit (#1725)
+    ///
+    /// The transaction IS durable (WAL record written) and will be recovered
+    /// on restart, but it is NOT visible to reads in the current process.
+    /// The caller must not assume the data is immediately readable.
+    DurableButNotVisible(String),
 }
 
 impl std::fmt::Display for CommitError {
@@ -62,6 +69,13 @@ impl std::fmt::Display for CommitError {
             CommitError::WALError(msg) => write!(f, "WAL error: {}", msg),
             CommitError::StorageError(msg) => write!(f, "Storage error during validation: {}", msg),
             CommitError::CounterOverflow(msg) => write!(f, "Counter overflow: {}", msg),
+            CommitError::DurableButNotVisible(msg) => {
+                write!(
+                    f,
+                    "Durable but not visible (will recover on restart): {}",
+                    msg
+                )
+            }
         }
     }
 }
@@ -87,6 +101,10 @@ impl From<CommitError> for StrataError {
             CommitError::CounterOverflow(msg) => {
                 StrataError::capacity_exceeded(msg, usize::MAX, usize::MAX)
             }
+            CommitError::DurableButNotVisible(msg) => StrataError::Storage {
+                message: format!("Durable but not visible (will recover on restart): {}", msg),
+                source: None,
+            },
         }
     }
 }


### PR DESCRIPTION
## Summary

- When `apply_writes` failed after WAL commit, `Ok(commit_version)` was returned — the caller believed data was committed and readable, but it was only in the WAL (invisible until restart)
- Now returns `Err(CommitError::DurableButNotVisible)` in all three commit paths (`commit`, `commit_with_wal_arc`, `commit_with_version`)
- Added the `DurableButNotVisible` variant to `CommitError` with `Display` and `From<CommitError> for StrataError` implementations

## Root Cause

In `commit_with_wal_arc()` (and the other two commit methods), when `apply_writes` failed after the WAL record was written, the error was logged but execution fell through to `Ok(commit_version)`. The caller would then attempt reads expecting the data to be visible, but `get_versioned` would return `None`.

## Fix

Return `Err(CommitError::DurableButNotVisible(...))` instead of falling through to `Ok(commit_version)` when `apply_writes` fails after WAL write. The error message clearly communicates that the data IS durable (will recover on restart) but is NOT visible to reads in the current process.

## Invariants Verified

- **ACID-002**: WAL-before-storage ordering preserved; durability guarantee intact
- **ACID-003**: Per-branch lock held through apply_writes attempt; RAII drop on early return
- **ACID-004**: Blind write safety unaffected; version gap acceptable per MVCC-003
- **ARCH-002**: Atomic publication boundary preserved — no partial visibility
- **MVCC-003**: Version counter monotonicity maintained; gap from failed apply is allowed

## Test Plan

- [x] `test_issue_1725_apply_writes_failure_after_wal_returns_error` — `commit()` path
- [x] `test_issue_1725_apply_writes_failure_after_wal_arc_returns_error` — `commit_with_wal_arc()` path
- [x] `test_issue_1725_apply_writes_failure_after_wal_version_returns_error` — `commit_with_version()` path
- [x] All 3 tests confirmed to fail before fix, pass after
- [x] Full workspace test suite passes (1314 tests)
- [x] Invariant check: all 5 affected invariants HOLD
- [x] Code review: no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)