### PR TITLE
Fix #1726: Bump version counter from segment max during recovery

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -125,6 +125,16 @@ impl TransactionManager {
         self.version.load(Ordering::Acquire)
     }
 
+    /// Ensure the version counter is at least `floor` (#1726).
+    ///
+    /// Used after segment recovery to prevent version collisions when the WAL
+    /// has been fully compacted and contains no records.  Segments may hold
+    /// data at versions higher than what the WAL reports; this method bumps
+    /// the counter so that new transactions start above all existing data.
+    pub fn bump_version_floor(&self, floor: u64) {
+        self.version.fetch_max(floor, Ordering::AcqRel);
+    }
+
     /// Get the current version after draining all in-flight commits (#1710).
     ///
     /// Acquires the exclusive (write) side of `commit_quiesce`, which blocks

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -300,6 +300,14 @@ impl TransactionCoordinator {
         self.manager.current_version()
     }
 
+    /// Ensure the version counter is at least `floor` (#1726).
+    ///
+    /// Called after segment recovery to prevent version collisions when the
+    /// WAL has been fully compacted.
+    pub fn bump_version_floor(&self, floor: u64) {
+        self.manager.bump_version_floor(floor);
+    }
+
     /// Get the current version after draining all in-flight commits (#1710).
     ///
     /// Safe to use as a checkpoint watermark — no version ≤ the returned

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -474,6 +474,10 @@ impl Database {
                         errors_skipped = seg_info.errors_skipped,
                         "Recovered segments from disk");
                 }
+                // Bump version counter from segment data (#1726)
+                if seg_info.max_commit_id > 0 {
+                    coordinator.bump_version_floor(seg_info.max_commit_id);
+                }
             }
             Err(e) => {
                 warn!(target: "strata::db", error = %e, "Segment recovery failed");
@@ -648,6 +652,12 @@ impl Database {
                         segments = seg_info.segments_loaded,
                         errors_skipped = seg_info.errors_skipped,
                         "Recovered segments from disk");
+                }
+                // Bump version counter to at least the max commit_id in
+                // recovered segments, preventing version collisions when
+                // WAL has been fully compacted (#1726).
+                if seg_info.max_commit_id > 0 {
+                    coordinator.bump_version_floor(seg_info.max_commit_id);
                 }
             }
             Err(e) => {

--- a/crates/engine/tests/flush_pipeline_tests.rs
+++ b/crates/engine/tests/flush_pipeline_tests.rs
@@ -453,3 +453,60 @@ fn multi_level_compaction_cascades() {
         assert_eq!(result.value, Value::Int(i as i64));
     }
 }
+
+/// Issue #1726: When WAL is fully compacted (empty), recovery must still set the
+/// version counter above the max commit_id in existing segments.  Otherwise new
+/// transactions start at version 1, colliding with segment data.
+#[test]
+fn test_issue_1726_version_counter_from_segments() {
+    use strata_concurrency::RecoveryCoordinator;
+    use strata_engine::coordinator::TransactionCoordinator;
+
+    let dir = tempfile::tempdir().unwrap();
+    let wal_dir = dir.path().join("WAL");
+    std::fs::create_dir_all(&wal_dir).unwrap();
+    let segments_dir = dir.path().join("segments");
+
+    // Phase 1: Write data at versions 1..=100, flush to segments, then drop.
+    let store = SegmentedStore::with_dir(segments_dir.clone(), 0);
+    for i in 1..=100u64 {
+        seed(
+            &store,
+            kv_key(&format!("k{:04}", i)),
+            Value::Int(i as i64),
+            i,
+        );
+    }
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    // Segments on disk now have commit_max = 100.
+    assert_eq!(store.branch_segment_count(&branch()), 1);
+    drop(store);
+
+    // Phase 2: WAL is empty (simulating full compaction — no WAL files).
+    // RecoveryCoordinator with an empty WAL dir yields max_version = 0.
+    let recovery = RecoveryCoordinator::new(wal_dir).with_segments(segments_dir, 0);
+    let result = recovery.recover().unwrap();
+    assert_eq!(
+        result.stats.final_version, 0,
+        "WAL is empty so WAL max_version must be 0"
+    );
+
+    // Phase 3: Recover segments — this should report max_commit_id = 100.
+    let seg_info = result.storage.recover_segments().unwrap();
+    assert_eq!(seg_info.segments_loaded, 1);
+    assert_eq!(
+        seg_info.max_commit_id, 100,
+        "recover_segments must report max_commit_id from loaded segments",
+    );
+
+    // Phase 4: The version counter must be bumped to at least segment max.
+    let coordinator = TransactionCoordinator::from_recovery_with_limits(&result, 0);
+    coordinator.bump_version_floor(seg_info.max_commit_id);
+    assert_eq!(
+        coordinator.current_version(),
+        100,
+        "version counter must equal segment max_commit_id after bump",
+    );
+}

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -2014,6 +2014,8 @@ impl SegmentedStore {
                                     .fetch_max(file_seg_id + 1, Ordering::Relaxed);
                             }
                         }
+                        // Track max commit_id for version counter restoration (#1726)
+                        info.max_commit_id = info.max_commit_id.max(seg.commit_range().1);
                         branch_segments.push(Arc::new(seg));
                     }
                     Err(_) => {
@@ -2184,6 +2186,8 @@ impl SegmentedStore {
                                         .fetch_max(file_seg_id + 1, Ordering::Relaxed);
                                 }
                             }
+                            // Track max commit_id for version counter (#1726)
+                            info.max_commit_id = info.max_commit_id.max(seg.commit_range().1);
                             layer_levels[level].push(Arc::new(seg));
                             any_found = true;
                         }
@@ -2687,6 +2691,10 @@ pub struct RecoverSegmentsInfo {
     /// Own segments for these branches are not loaded, but their segment
     /// files remain on disk for children to open directly.
     pub corrupt_manifest_branches: usize,
+    /// Maximum commit_id seen across all loaded segments (#1726).
+    /// Used to bump the version counter so new transactions don't collide
+    /// with data already persisted in segments.
+    pub max_commit_id: u64,
 }
 
 impl Default for SegmentedStore {


### PR DESCRIPTION
## Summary

- Recovery set the version counter exclusively from WAL records. When the WAL was fully compacted (empty), `max_version` was 0 — but segments could contain data up to version N. New transactions started at version 1, colliding with existing segment data.
- Added `max_commit_id` tracking to `RecoverSegmentsInfo` and `bump_version_floor()` to `TransactionManager`/`TransactionCoordinator` to ensure the version counter accounts for segment data.
- Fix applied to both `open_internal` and `open_follower_internal` paths.

## Root Cause

`RecoveryCoordinator::recover()` only scans WAL records for `max_version`. After full WAL compaction (all records below checkpoint watermark), the WAL is empty and `max_version = 0`. `recover_segments()` loads segments with `commit_max` up to N but never reported this to the version counter. The `TransactionManager` was initialized with version 0, so `allocate_version()` returned 1, 2, 3... — colliding with versions already in segments.

## Fix

1. `RecoverSegmentsInfo` now includes `max_commit_id` — the maximum `commit_range().1` across all loaded segments (own and inherited)
2. `TransactionManager::bump_version_floor(floor)` uses `fetch_max` to atomically ensure the counter is ≥ floor
3. `TransactionCoordinator::bump_version_floor()` delegates to the manager
4. Both `Database::open_internal` and `Database::open_follower_internal` call `coordinator.bump_version_floor(seg_info.max_commit_id)` after segment recovery

## Invariants Verified

- **MVCC-001** (Version visibility boundary): HOLDS — fix eliminates version collisions
- **MVCC-003** (Version counter monotonicity): HOLDS — `fetch_max` never decreases the counter
- **ACID-005** (Recovery idempotency): HOLDS — `fetch_max` is idempotent
- **ARCH-004** (Recovery ordering): HOLDS — version restoration now complete

## Test Plan

- [x] `test_issue_1726_version_counter_from_segments` — writes data at versions 1..=100, flushes to segments, recovers with empty WAL, verifies version counter bumped to 100
- [x] Full workspace test suite (0 failures)
- [x] Invariant check (4 invariants verified, all HOLD)
- [x] Code review (tightened test assertions from `>=` to `==`)
- [x] `cargo clippy` clean on changed crates
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)