### PR TITLE
Raise background compaction priority from Low to High

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1900,7 +1900,7 @@ impl Database {
 
         if self
             .scheduler
-            .submit(crate::background::TaskPriority::Low, move || {
+            .submit(crate::background::TaskPriority::High, move || {
                 // Compact all branches that are over target.
                 let branch_ids = storage.branch_ids();
                 for branch_id in &branch_ids {


### PR DESCRIPTION
## Summary

- Changes `TaskPriority::Low` to `TaskPriority::High` for background compaction tasks submitted in `schedule_background_compaction()`

## Root Cause

With `Low` priority, compaction was starved by other background tasks. L0 segments accumulated past the compaction trigger, degrading read latency since reads must scan all L0 segments.

## Test plan

- [x] `test_issue_1736_compaction_runs_in_background` passes
- [x] Full engine test suite passes (1332 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)