### PR TITLE
Fix #1737: Make hardcoded storage constants and thread count configurable

### DIFF
--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -88,6 +88,30 @@ pub struct StorageConfig {
     /// Mirrors RocksDB's `level0_stop_writes_trigger`. Default: 36.
     #[serde(default = "default_l0_stop_writes_trigger")]
     pub l0_stop_writes_trigger: usize,
+    /// Number of background worker threads for compaction, flush, and maintenance.
+    /// Default: min(4, available CPU cores). On single-core devices set to 1.
+    #[serde(default = "default_background_threads")]
+    pub background_threads: usize,
+    /// Target size for a single output segment file in bytes.
+    /// Default: 64 MiB. On embedded devices (Pi), use 4–8 MiB.
+    #[serde(default = "default_target_file_size")]
+    pub target_file_size: u64,
+    /// Target total size for L1 in bytes. Higher levels are multiplied by 10×.
+    /// Default: 256 MiB. On embedded devices (Pi), use 32 MiB.
+    #[serde(default = "default_level_base_bytes")]
+    pub level_base_bytes: u64,
+    /// Data block size in bytes for segment files.
+    /// Default: 4096 (4 KiB). Larger blocks improve throughput at the cost of read amplification.
+    #[serde(default = "default_data_block_size")]
+    pub data_block_size: usize,
+    /// Bloom filter bits per key. Higher values reduce false positives but use more memory.
+    /// Default: 10.
+    #[serde(default = "default_bloom_bits_per_key")]
+    pub bloom_bits_per_key: usize,
+    /// Compaction I/O rate limit in bytes per second. 0 = unlimited (default).
+    /// On slow storage (SD cards), set to e.g. 5–10 MB/s to avoid starving user I/O.
+    #[serde(default)]
+    pub compaction_rate_limit: u64,
 }
 
 fn default_max_branches() -> usize {
@@ -114,6 +138,28 @@ fn default_l0_stop_writes_trigger() -> usize {
     0 // disabled by default until compaction throughput improves
 }
 
+fn default_background_threads() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get().min(4))
+        .unwrap_or(1)
+}
+
+fn default_target_file_size() -> u64 {
+    64 << 20 // 64 MiB
+}
+
+fn default_level_base_bytes() -> u64 {
+    256 << 20 // 256 MiB
+}
+
+fn default_data_block_size() -> usize {
+    4096 // 4 KiB
+}
+
+fn default_bloom_bits_per_key() -> usize {
+    10
+}
+
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
@@ -125,6 +171,12 @@ impl Default for StorageConfig {
             max_immutable_memtables: default_max_immutable_memtables(),
             l0_slowdown_writes_trigger: default_l0_slowdown_writes_trigger(),
             l0_stop_writes_trigger: default_l0_stop_writes_trigger(),
+            background_threads: default_background_threads(),
+            target_file_size: default_target_file_size(),
+            level_base_bytes: default_level_base_bytes(),
+            data_block_size: default_data_block_size(),
+            bloom_bits_per_key: default_bloom_bits_per_key(),
+            compaction_rate_limit: 0,
         }
     }
 }
@@ -318,6 +370,12 @@ auto_embed = false
 # block_cache_size = 0          # 0 = auto (max(256 MiB, available_ram / 4))
 # write_buffer_size = 134217728  # 128 MiB; memtable rotation threshold
 # max_immutable_memtables = 4   # max frozen memtables per branch before write stalling
+# background_threads = 4        # compaction/flush workers; default min(4, CPU cores)
+# target_file_size = 67108864   # 64 MiB; segment file target (Pi: 4-8 MiB)
+# level_base_bytes = 268435456  # 256 MiB; L1 target size (Pi: 32 MiB)
+# data_block_size = 4096        # 4 KiB; segment data block size
+# bloom_bits_per_key = 10       # bloom filter bits per key
+# compaction_rate_limit = 0     # 0 = unlimited; bytes/sec cap for compaction I/O
 "#
     }
 
@@ -911,5 +969,93 @@ auto_embed = false
         let toml_str = toml::to_string_pretty(&config).unwrap();
         let parsed: StrataConfig = toml::from_str(&toml_str).unwrap();
         assert!(parsed.allow_lossy_recovery);
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #1737: Scale-span config gaps
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_issue_1737_background_threads_default_bounded() {
+        // S-H2: background_threads must default to min(4, available_parallelism)
+        let config = StorageConfig::default();
+        let cpus = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+        let expected = cpus.min(4);
+        assert_eq!(
+            config.background_threads, expected,
+            "background_threads should default to min(4, available_parallelism()={})",
+            cpus
+        );
+    }
+
+    #[test]
+    fn test_issue_1737_storage_constants_configurable() {
+        // S-H8: critical storage constants must be configurable via StorageConfig
+        let config = StorageConfig::default();
+        assert_eq!(config.target_file_size, 64 * 1024 * 1024); // 64 MiB
+        assert_eq!(config.level_base_bytes, 256 * 1024 * 1024); // 256 MiB
+        assert_eq!(config.data_block_size, 4096); // 4 KiB
+        assert_eq!(config.bloom_bits_per_key, 10);
+    }
+
+    #[test]
+    fn test_issue_1737_compaction_rate_limit_in_config() {
+        // S-M7: compaction_rate_limit must be configurable via strata.toml
+        let config = StorageConfig::default();
+        assert_eq!(config.compaction_rate_limit, 0, "default 0 = unlimited");
+    }
+
+    #[test]
+    fn test_issue_1737_config_round_trip() {
+        // All new fields must survive TOML serialization round-trip
+        let toml_str = r#"
+[storage]
+background_threads = 2
+target_file_size = 8388608
+level_base_bytes = 33554432
+data_block_size = 8192
+bloom_bits_per_key = 12
+compaction_rate_limit = 10485760
+"#;
+        let config: StrataConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.storage.background_threads, 2);
+        assert_eq!(config.storage.target_file_size, 8 * 1024 * 1024);
+        assert_eq!(config.storage.level_base_bytes, 32 * 1024 * 1024);
+        assert_eq!(config.storage.data_block_size, 8192);
+        assert_eq!(config.storage.bloom_bits_per_key, 12);
+        assert_eq!(config.storage.compaction_rate_limit, 10 * 1024 * 1024);
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let reparsed: StrataConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.storage.background_threads, 2);
+        assert_eq!(reparsed.storage.target_file_size, 8 * 1024 * 1024);
+        assert_eq!(reparsed.storage.level_base_bytes, 32 * 1024 * 1024);
+        assert_eq!(reparsed.storage.data_block_size, 8192);
+        assert_eq!(reparsed.storage.bloom_bits_per_key, 12);
+        assert_eq!(reparsed.storage.compaction_rate_limit, 10 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_issue_1737_backward_compat_missing_new_fields() {
+        // Old config files without the new fields must still parse with correct defaults
+        let old_toml = r#"
+durability = "standard"
+[storage]
+max_branches = 512
+"#;
+        let config: StrataConfig = toml::from_str(old_toml).unwrap();
+        assert_eq!(config.storage.max_branches, 512);
+        // New fields should have their defaults
+        let cpus = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+        assert_eq!(config.storage.background_threads, cpus.min(4));
+        assert_eq!(config.storage.target_file_size, 64 * 1024 * 1024);
+        assert_eq!(config.storage.level_base_bytes, 256 * 1024 * 1024);
+        assert_eq!(config.storage.data_block_size, 4096);
+        assert_eq!(config.storage.bloom_bits_per_key, 10);
+        assert_eq!(config.storage.compaction_rate_limit, 0);
     }
 }

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -468,6 +468,12 @@ impl Database {
         storage.set_max_branches(cfg.storage.max_branches);
         storage.set_max_versions_per_key(cfg.storage.max_versions_per_key);
         storage.set_max_immutable_memtables(cfg.storage.max_immutable_memtables);
+        storage.set_target_file_size(cfg.storage.target_file_size);
+        storage.set_level_base_bytes(cfg.storage.level_base_bytes);
+        storage.set_data_block_size(cfg.storage.data_block_size);
+        storage.set_bloom_bits_per_key(cfg.storage.bloom_bits_per_key);
+
+        let bg_threads = cfg.storage.background_threads.max(1);
 
         // Recover previously flushed segments from disk
         match storage.recover_segments() {
@@ -507,7 +513,7 @@ impl Database {
             config: parking_lot::RwLock::new(cfg),
             flush_shutdown: Arc::new(AtomicBool::new(false)),
             flush_handle: ParkingMutex::new(None), // No flush thread
-            scheduler: Arc::new(BackgroundScheduler::new(4, 4096)),
+            scheduler: Arc::new(BackgroundScheduler::new(bg_threads, 4096)),
             compaction_in_flight: Arc::new(AtomicBool::new(false)),
             write_stall_cv: Arc::new(parking_lot::Condvar::new()),
             write_stall_mu: parking_lot::Mutex::new(()),
@@ -648,6 +654,15 @@ impl Database {
         storage.set_max_branches(cfg.storage.max_branches);
         storage.set_max_versions_per_key(cfg.storage.max_versions_per_key);
         storage.set_max_immutable_memtables(cfg.storage.max_immutable_memtables);
+        storage.set_target_file_size(cfg.storage.target_file_size);
+        storage.set_level_base_bytes(cfg.storage.level_base_bytes);
+        storage.set_data_block_size(cfg.storage.data_block_size);
+        storage.set_bloom_bits_per_key(cfg.storage.bloom_bits_per_key);
+        if cfg.storage.compaction_rate_limit > 0 {
+            storage.set_compaction_rate_limit(cfg.storage.compaction_rate_limit);
+        }
+
+        let bg_threads = cfg.storage.background_threads.max(1);
 
         // Recover previously flushed segments from disk
         match storage.recover_segments() {
@@ -689,7 +704,7 @@ impl Database {
             config: parking_lot::RwLock::new(cfg),
             flush_shutdown,
             flush_handle: ParkingMutex::new(flush_handle),
-            scheduler: Arc::new(BackgroundScheduler::new(4, 4096)),
+            scheduler: Arc::new(BackgroundScheduler::new(bg_threads, 4096)),
             compaction_in_flight: Arc::new(AtomicBool::new(false)),
             write_stall_cv: Arc::new(parking_lot::Condvar::new()),
             write_stall_mu: parking_lot::Mutex::new(()),
@@ -753,6 +768,8 @@ impl Database {
         storage.set_max_versions_per_key(cfg.storage.max_versions_per_key);
         storage.set_max_immutable_memtables(cfg.storage.max_immutable_memtables);
 
+        let bg_threads = cfg.storage.background_threads.max(1);
+
         // Create coordinator starting at version 1 (no recovery needed), with write buffer limit
         let mut coordinator = TransactionCoordinator::new(1);
         coordinator.set_max_write_buffer_entries(cfg.storage.max_write_buffer_entries);
@@ -769,7 +786,7 @@ impl Database {
             config: parking_lot::RwLock::new(StrataConfig::default()),
             flush_shutdown: Arc::new(AtomicBool::new(false)),
             flush_handle: ParkingMutex::new(None),
-            scheduler: Arc::new(BackgroundScheduler::new(4, 4096)),
+            scheduler: Arc::new(BackgroundScheduler::new(bg_threads, 4096)),
             compaction_in_flight: Arc::new(AtomicBool::new(false)),
             write_stall_cv: Arc::new(parking_lot::Condvar::new()),
             write_stall_mu: parking_lot::Mutex::new(()),

--- a/crates/storage/src/segment_builder.rs
+++ b/crates/storage/src/segment_builder.rs
@@ -1310,6 +1310,12 @@ impl SplittingSegmentBuilder {
         self
     }
 
+    /// Set the data block size in bytes for output segments.
+    pub fn with_data_block_size(mut self, bytes: usize) -> Self {
+        self.inner.data_block_size = bytes;
+        self
+    }
+
     /// Set a rate limiter for throttling data block writes during compaction.
     pub fn with_rate_limiter(
         mut self,

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -21,11 +21,15 @@ pub(super) struct LevelTargets {
 /// Algorithm (RocksDB `CalculateBaseBytes`):
 /// 1. Find the largest non-empty non-L0 level (the "bottom" level).
 /// 2. Compute base (L1 target) = bottom_bytes / multiplier^(bottom_level - 1).
-/// 3. Clamp base between MIN_BASE_BYTES (1MB) and MAX_BASE_BYTES (256MB).
+/// 3. Clamp base between MIN_BASE_BYTES (1MB) and `max_base` (configurable, default 256MB).
 /// 4. Forward-compute all targets: target[i] = base * multiplier^(i-1).
 ///
 /// For empty databases (no non-L0 data), uses MIN_BASE_BYTES as base.
-pub(super) fn recalculate_level_targets(level_bytes: &[u64; NUM_LEVELS]) -> LevelTargets {
+pub(super) fn recalculate_level_targets(
+    level_bytes: &[u64; NUM_LEVELS],
+    max_base: u64,
+) -> LevelTargets {
+    let max_base = max_base.max(MIN_BASE_BYTES); // safety: never below minimum
     let mut max_bytes = [0u64; NUM_LEVELS];
     max_bytes[0] = 0; // L0 uses count-based trigger
 
@@ -47,7 +51,7 @@ pub(super) fn recalculate_level_targets(level_bytes: &[u64; NUM_LEVELS]) -> Leve
         for _ in 1..bottom_level {
             b /= LEVEL_MULTIPLIER;
         }
-        b.clamp(MIN_BASE_BYTES, MAX_BASE_BYTES)
+        b.clamp(MIN_BASE_BYTES, max_base)
     };
 
     // 3. Forward-compute all targets
@@ -225,7 +229,8 @@ impl SegmentedStore {
             .with_drop_expired(is_bottommost)
             .with_is_bottommost(is_bottommost);
 
-        let mut builder = SegmentBuilder::default()
+        let mut builder = self
+            .make_segment_builder()
             .with_compression(crate::segment_builder::CompressionCodec::None);
         if let Some(ref l) = limiter {
             builder = builder.with_rate_limiter(Arc::clone(l));
@@ -274,7 +279,7 @@ impl SegmentedStore {
             branch
                 .version
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
-            refresh_level_targets(&mut branch);
+            refresh_level_targets(&mut branch, self.level_base_bytes());
         }
 
         // Persist manifest BEFORE deleting old files — if we crash after
@@ -382,7 +387,8 @@ impl SegmentedStore {
             .with_drop_expired(is_bottommost)
             .with_is_bottommost(is_bottommost);
 
-        let mut builder = SegmentBuilder::default()
+        let mut builder = self
+            .make_segment_builder()
             .with_compression(crate::segment_builder::CompressionCodec::None);
         if let Some(ref l) = limiter {
             builder = builder.with_rate_limiter(Arc::clone(l));
@@ -430,7 +436,7 @@ impl SegmentedStore {
             branch
                 .version
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
-            refresh_level_targets(&mut branch);
+            refresh_level_targets(&mut branch, self.level_base_bytes());
         }
 
         // Persist manifest BEFORE deleting old files (crash safety).
@@ -579,11 +585,12 @@ impl SegmentedStore {
 
         let next_id = &self.next_segment_id;
         let start_id = next_id.load(Ordering::Relaxed);
-        let bloom_bits = super::bloom_bits_for_level(1, 10);
+        let bloom_bits = super::bloom_bits_for_level(1, self.bloom_bits_per_key());
         let compression = super::compression_for_level(1);
         let mut splitting_builder = crate::segment_builder::SplittingSegmentBuilder::default()
             .with_bloom_bits(bloom_bits)
-            .with_compression(compression);
+            .with_compression(compression)
+            .with_data_block_size(self.data_block_size());
         if let Some(ref l) = limiter {
             splitting_builder = splitting_builder.with_rate_limiter(Arc::clone(l));
         }
@@ -650,7 +657,7 @@ impl SegmentedStore {
             branch
                 .version
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
-            refresh_level_targets(&mut branch);
+            refresh_level_targets(&mut branch, self.level_base_bytes());
         }
 
         // Persist manifest BEFORE deleting old files (crash safety).
@@ -769,7 +776,8 @@ impl SegmentedStore {
         if level > 0
             && input_segs.len() == 1
             && overlap_segs.is_empty()
-            && grandparent_bytes_in_range(&grandparent_segs, &input_segs) <= MAX_GRANDPARENT_OVERLAP
+            && grandparent_bytes_in_range(&grandparent_segs, &input_segs)
+                <= self.target_file_size() * 10
         {
             // Metadata-only move: shift file to level+1 without I/O
             let moved_seg = Arc::clone(&input_segs[0]);
@@ -794,7 +802,7 @@ impl SegmentedStore {
             branch
                 .version
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
-            refresh_level_targets(&mut branch);
+            refresh_level_targets(&mut branch, self.level_base_bytes());
             drop(branch);
             self.write_branch_manifest(branch_id);
 
@@ -835,11 +843,12 @@ impl SegmentedStore {
 
         let next_id = &self.next_segment_id;
         let start_id = next_id.load(Ordering::Relaxed);
-        let bloom_bits = super::bloom_bits_for_level(level + 1, 10);
+        let bloom_bits = super::bloom_bits_for_level(level + 1, self.bloom_bits_per_key());
         let compression = super::compression_for_level(level + 1);
         let mut splitting_builder = crate::segment_builder::SplittingSegmentBuilder::default()
             .with_bloom_bits(bloom_bits)
-            .with_compression(compression);
+            .with_compression(compression)
+            .with_data_block_size(self.data_block_size());
         if let Some(ref l) = limiter {
             splitting_builder = splitting_builder.with_rate_limiter(Arc::clone(l));
         }
@@ -848,10 +857,11 @@ impl SegmentedStore {
         //
         // Tracks cumulative overlap: each time the output key advances past a
         // grandparent file's max key, that grandparent's file size is added to
-        // `gp_overlap_bytes`.  When the total exceeds MAX_GRANDPARENT_OVERLAP,
-        // a split is forced and the counter resets.  This limits how many
-        // grandparent files a single output segment will overlap during the
-        // *next* compaction (L+1 → L+2).
+        // `gp_overlap_bytes`.  When the total exceeds the max grandparent overlap
+        // threshold (target_file_size × 10), a split is forced and the counter
+        // resets.  This limits how many grandparent files a single output segment
+        // will overlap during the *next* compaction (L+1 → L+2).
+        let max_gp_overlap = self.target_file_size() * 10;
         let gp_segs = grandparent_segs;
         let mut gp_idx: usize = 0;
         let mut gp_overlap_bytes: u64 = 0;
@@ -869,7 +879,7 @@ impl SegmentedStore {
                     break;
                 }
             }
-            if gp_overlap_bytes > MAX_GRANDPARENT_OVERLAP {
+            if gp_overlap_bytes > max_gp_overlap {
                 gp_overlap_bytes = 0;
                 return true;
             }
@@ -941,7 +951,7 @@ impl SegmentedStore {
             branch
                 .version
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
-            refresh_level_targets(&mut branch);
+            refresh_level_targets(&mut branch, self.level_base_bytes());
         }
 
         // ── 5. Cleanup ─────────────────────────────────────────────────

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -51,20 +51,12 @@ const LEVEL_BASE_BYTES: u64 = 256 << 20;
 /// Size multiplier between adjacent levels.
 const LEVEL_MULTIPLIER: u64 = 10;
 
-/// Maximum cumulative overlap with grandparent (L+2) files before forcing an
-/// output split.  Set to 10 × TARGET_FILE_SIZE (640MB).
-const MAX_GRANDPARENT_OVERLAP: u64 = 10 * TARGET_FILE_SIZE;
-
 /// Maximum inherited layer depth before background materialization is triggered.
 const MAX_INHERITED_LAYERS: usize = 4;
 
 /// Minimum L1 target size for dynamic level sizing (1MB).
 /// Prevents degenerate zero-size targets on tiny embedded datasets.
 const MIN_BASE_BYTES: u64 = 1 << 20;
-
-/// Maximum L1 target size for dynamic level sizing.
-/// Equals LEVEL_BASE_BYTES (256MB) — the static default.
-const MAX_BASE_BYTES: u64 = LEVEL_BASE_BYTES;
 
 /// Monkey-optimal bloom bits per key for a given target level.
 ///
@@ -258,20 +250,23 @@ impl BranchState {
             min_timestamp: AtomicU64::new(u64::MAX),
             max_timestamp: AtomicU64::new(0),
             compact_pointers: vec![None; NUM_LEVELS],
-            level_targets: compaction::recalculate_level_targets(&[0u64; NUM_LEVELS]),
+            level_targets: compaction::recalculate_level_targets(
+                &[0u64; NUM_LEVELS],
+                LEVEL_BASE_BYTES,
+            ),
             inherited_layers: Vec::new(),
         }
     }
 }
 
 /// Recompute cached level targets from the current segment version.
-fn refresh_level_targets(branch: &mut BranchState) {
+fn refresh_level_targets(branch: &mut BranchState, max_base_bytes: u64) {
     let ver = branch.version.load();
     let mut actual_bytes = [0u64; NUM_LEVELS];
     for (level, segs) in ver.levels.iter().enumerate() {
         actual_bytes[level] = segs.iter().map(|s| s.file_size()).sum();
     }
-    branch.level_targets = compaction::recalculate_level_targets(&actual_bytes);
+    branch.level_targets = compaction::recalculate_level_targets(&actual_bytes, max_base_bytes);
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +310,15 @@ pub struct SegmentedStore {
     ref_registry: ref_registry::SegmentRefRegistry,
     /// Branches currently being materialized (prevents concurrent materialization #1703).
     materializing_branches: DashMap<BranchId, ()>,
+    /// Target size for a single output segment file. Default: 64 MiB.
+    target_file_size: AtomicU64,
+    /// Target total size for L1. Also used as MAX_BASE_BYTES for dynamic level sizing.
+    /// Default: 256 MiB.
+    level_base_bytes: AtomicU64,
+    /// Data block size in bytes for segment files. Default: 4096 (4 KiB).
+    data_block_size: AtomicUsize,
+    /// Bloom filter bits per key (base value). Default: 10.
+    bloom_bits_per_key: AtomicUsize,
 }
 
 impl SegmentedStore {
@@ -339,6 +343,10 @@ impl SegmentedStore {
             compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
             ref_registry: ref_registry::SegmentRefRegistry::new(),
             materializing_branches: DashMap::new(),
+            target_file_size: AtomicU64::new(TARGET_FILE_SIZE),
+            level_base_bytes: AtomicU64::new(LEVEL_BASE_BYTES),
+            data_block_size: AtomicUsize::new(4096),
+            bloom_bits_per_key: AtomicUsize::new(10),
         }
     }
 
@@ -364,6 +372,10 @@ impl SegmentedStore {
             compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
             ref_registry: ref_registry::SegmentRefRegistry::new(),
             materializing_branches: DashMap::new(),
+            target_file_size: AtomicU64::new(TARGET_FILE_SIZE),
+            level_base_bytes: AtomicU64::new(LEVEL_BASE_BYTES),
+            data_block_size: AtomicUsize::new(4096),
+            bloom_bits_per_key: AtomicUsize::new(10),
         }
     }
 
@@ -389,6 +401,10 @@ impl SegmentedStore {
             compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
             ref_registry: ref_registry::SegmentRefRegistry::new(),
             materializing_branches: DashMap::new(),
+            target_file_size: AtomicU64::new(TARGET_FILE_SIZE),
+            level_base_bytes: AtomicU64::new(LEVEL_BASE_BYTES),
+            data_block_size: AtomicUsize::new(4096),
+            bloom_bits_per_key: AtomicUsize::new(10),
         }
     }
 
@@ -430,6 +446,56 @@ impl SegmentedStore {
             self.compaction_rate_limiter.store(Some(std::sync::Arc::new(
                 crate::rate_limiter::RateLimiter::new(bytes_per_sec),
             )));
+        }
+    }
+
+    /// Set the target segment file size in bytes.
+    pub fn set_target_file_size(&self, bytes: u64) {
+        self.target_file_size.store(bytes, Ordering::Relaxed);
+    }
+
+    /// Get the configured target segment file size.
+    pub fn target_file_size(&self) -> u64 {
+        self.target_file_size.load(Ordering::Relaxed)
+    }
+
+    /// Set the L1 target size (level_base_bytes) in bytes.
+    pub fn set_level_base_bytes(&self, bytes: u64) {
+        self.level_base_bytes.store(bytes, Ordering::Relaxed);
+    }
+
+    /// Get the configured L1 target size.
+    pub fn level_base_bytes(&self) -> u64 {
+        self.level_base_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Set the data block size in bytes for new segments.
+    pub fn set_data_block_size(&self, bytes: usize) {
+        self.data_block_size.store(bytes, Ordering::Relaxed);
+    }
+
+    /// Get the configured data block size.
+    pub fn data_block_size(&self) -> usize {
+        self.data_block_size.load(Ordering::Relaxed)
+    }
+
+    /// Set the bloom filter bits per key for new segments.
+    pub fn set_bloom_bits_per_key(&self, bits: usize) {
+        self.bloom_bits_per_key.store(bits, Ordering::Relaxed);
+    }
+
+    /// Get the configured bloom bits per key.
+    pub fn bloom_bits_per_key(&self) -> usize {
+        self.bloom_bits_per_key.load(Ordering::Relaxed)
+    }
+
+    /// Create a `SegmentBuilder` pre-configured with this store's
+    /// `data_block_size` and `bloom_bits_per_key`.
+    fn make_segment_builder(&self) -> SegmentBuilder {
+        SegmentBuilder {
+            data_block_size: self.data_block_size(),
+            bloom_bits_per_key: self.bloom_bits_per_key(),
+            ..SegmentBuilder::default()
         }
     }
 
@@ -780,7 +846,7 @@ impl SegmentedStore {
             std::fs::create_dir_all(&branch_dir)?;
 
             let next_id = &self.next_segment_id;
-            let builder = SplittingSegmentBuilder::new(TARGET_FILE_SIZE)
+            let builder = SplittingSegmentBuilder::new(self.target_file_size())
                 .with_compression(crate::segment_builder::CompressionCodec::None);
             let built = builder.build_split(entries.into_iter(), |_split_idx| {
                 let seg_id = next_id.fetch_add(1, Ordering::Relaxed);
@@ -831,7 +897,7 @@ impl SegmentedStore {
                 branch.inherited_layers.remove(idx);
             }
 
-            refresh_level_targets(&mut branch);
+            refresh_level_targets(&mut branch, self.level_base_bytes());
         }
 
         // 2f. Cleanup
@@ -999,7 +1065,8 @@ impl SegmentedStore {
                     let branch_dir = segments_dir.join(&branch_hex);
                     std::fs::create_dir_all(&branch_dir)?;
                     let seg_path = branch_dir.join(format!("{}.sst", seg_id));
-                    let builder = SegmentBuilder::default()
+                    let builder = self
+                        .make_segment_builder()
                         .with_compression(crate::segment_builder::CompressionCodec::None);
                     builder.build_from_iter(mt.iter_all(), &seg_path)?;
                     let segment = KVSegment::open(&seg_path)?;
@@ -1028,7 +1095,7 @@ impl SegmentedStore {
                     source_manifest_dirty = true;
                 }
                 if source_manifest_dirty {
-                    refresh_level_targets(&mut source);
+                    refresh_level_targets(&mut source, self.level_base_bytes());
                 }
             }
 
@@ -1844,7 +1911,8 @@ impl SegmentedStore {
         let branch_dir = segments_dir.join(&branch_hex);
         std::fs::create_dir_all(&branch_dir)?;
         let seg_path = branch_dir.join(format!("{}.sst", seg_id));
-        let builder = SegmentBuilder::default()
+        let builder = self
+            .make_segment_builder()
             .with_compression(crate::segment_builder::CompressionCodec::None);
         builder.build_from_iter(frozen_mt.iter_all(), &seg_path)?;
 
@@ -1874,7 +1942,7 @@ impl SegmentedStore {
         branch
             .version
             .store(Arc::new(SegmentVersion { levels: new_levels }));
-        refresh_level_targets(&mut branch);
+        refresh_level_targets(&mut branch, self.level_base_bytes());
 
         // Persist level assignments
         drop(branch);
@@ -2152,7 +2220,7 @@ impl SegmentedStore {
             branch
                 .version
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
-            refresh_level_targets(&mut branch);
+            refresh_level_targets(&mut branch, self.level_base_bytes());
 
             // Collect inherited layer info for second pass (deferred resolution).
             if let Some(manifest) = manifest {

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -3629,7 +3629,7 @@ fn compact_level_ephemeral_returns_none() {
 #[test]
 fn recalculate_targets_empty_db() {
     let level_bytes = [0u64; NUM_LEVELS];
-    let targets = recalculate_level_targets(&level_bytes);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
     // All levels derive from MIN_BASE_BYTES when no non-L0 data exists
     assert_eq!(targets.max_bytes[0], 0); // L0 unused (count-based)
     assert_eq!(targets.max_bytes[1], MIN_BASE_BYTES); // 1MB
@@ -3644,7 +3644,7 @@ fn recalculate_targets_empty_db() {
 fn recalculate_targets_small_db() {
     let mut level_bytes = [0u64; NUM_LEVELS];
     level_bytes[1] = 100 << 20; // 100MB in L1
-    let targets = recalculate_level_targets(&level_bytes);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
     // Dynamic: base = 100MB (derived from bottom level L1)
     assert_eq!(targets.max_bytes[0], 0);
     assert_eq!(targets.max_bytes[1], 100 << 20);
@@ -3660,14 +3660,14 @@ fn recalculate_targets_scales_up() {
     let data: u64 = 30 * (1 << 30); // 30 GiB in L3
     let mut level_bytes = [0u64; NUM_LEVELS];
     level_bytes[3] = data;
-    let targets = recalculate_level_targets(&level_bytes);
-    // base = 30GiB / 10^2 = ~307MB → clamped to MAX_BASE_BYTES (256MB)
-    assert_eq!(targets.max_bytes[1], MAX_BASE_BYTES);
-    assert_eq!(targets.max_bytes[2], MAX_BASE_BYTES * 10);
-    assert_eq!(targets.max_bytes[3], MAX_BASE_BYTES * 100);
-    assert_eq!(targets.max_bytes[4], MAX_BASE_BYTES * 1_000);
-    assert_eq!(targets.max_bytes[5], MAX_BASE_BYTES * 10_000);
-    assert_eq!(targets.max_bytes[6], MAX_BASE_BYTES * 100_000);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
+    // base = 30GiB / 10^2 = ~307MB → clamped to LEVEL_BASE_BYTES (256MB)
+    assert_eq!(targets.max_bytes[1], LEVEL_BASE_BYTES);
+    assert_eq!(targets.max_bytes[2], LEVEL_BASE_BYTES * 10);
+    assert_eq!(targets.max_bytes[3], LEVEL_BASE_BYTES * 100);
+    assert_eq!(targets.max_bytes[4], LEVEL_BASE_BYTES * 1_000);
+    assert_eq!(targets.max_bytes[5], LEVEL_BASE_BYTES * 10_000);
+    assert_eq!(targets.max_bytes[6], LEVEL_BASE_BYTES * 100_000);
 }
 
 #[test]
@@ -3676,22 +3676,22 @@ fn recalculate_targets_anchor_at_high_level() {
     let data: u64 = 3 * (1u64 << 40); // 3 TiB in L5
     let mut level_bytes = [0u64; NUM_LEVELS];
     level_bytes[5] = data;
-    let targets = recalculate_level_targets(&level_bytes);
-    // base = 3TiB / 10^4 = ~322MB → clamped to MAX_BASE_BYTES (256MB)
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
+    // base = 3TiB / 10^4 = ~322MB → clamped to LEVEL_BASE_BYTES (256MB)
     assert_eq!(targets.max_bytes[0], 0);
-    assert_eq!(targets.max_bytes[1], MAX_BASE_BYTES);
-    assert_eq!(targets.max_bytes[2], MAX_BASE_BYTES * 10);
-    assert_eq!(targets.max_bytes[3], MAX_BASE_BYTES * 100);
-    assert_eq!(targets.max_bytes[4], MAX_BASE_BYTES * 1_000);
-    assert_eq!(targets.max_bytes[5], MAX_BASE_BYTES * 10_000);
-    assert_eq!(targets.max_bytes[6], MAX_BASE_BYTES * 100_000);
+    assert_eq!(targets.max_bytes[1], LEVEL_BASE_BYTES);
+    assert_eq!(targets.max_bytes[2], LEVEL_BASE_BYTES * 10);
+    assert_eq!(targets.max_bytes[3], LEVEL_BASE_BYTES * 100);
+    assert_eq!(targets.max_bytes[4], LEVEL_BASE_BYTES * 1_000);
+    assert_eq!(targets.max_bytes[5], LEVEL_BASE_BYTES * 10_000);
+    assert_eq!(targets.max_bytes[6], LEVEL_BASE_BYTES * 100_000);
 }
 
 #[test]
 fn recalculate_targets_tiny_db() {
     let mut level_bytes = [0u64; NUM_LEVELS];
     level_bytes[1] = 10 << 20; // 10MB in L1
-    let targets = recalculate_level_targets(&level_bytes);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
     // base = 10MB — within [MIN, MAX], full geometric chain
     assert_eq!(targets.max_bytes[0], 0);
     assert_eq!(targets.max_bytes[1], 10 << 20);
@@ -3706,7 +3706,7 @@ fn recalculate_targets_tiny_db() {
 fn recalculate_targets_sub_minimum() {
     let mut level_bytes = [0u64; NUM_LEVELS];
     level_bytes[1] = 512 * 1024; // 512KB in L1
-    let targets = recalculate_level_targets(&level_bytes);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
     // 512KB < MIN_BASE_BYTES → clamped to 1MB, full chain from MIN
     assert_eq!(targets.max_bytes[1], MIN_BASE_BYTES);
     assert_eq!(targets.max_bytes[2], MIN_BASE_BYTES * 10);
@@ -3719,7 +3719,7 @@ fn recalculate_targets_multi_level_data() {
     level_bytes[1] = 200 << 20; // 200MB
     level_bytes[2] = 2 << 30; // 2GB
     level_bytes[3] = 15 << 30; // 15GB — largest non-L0 level
-    let targets = recalculate_level_targets(&level_bytes);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
     // base = 15GB / 10^2 = ~153MB → within [MIN, MAX] range
     let expected_base: u64 = (15u64 << 30) / 100;
     assert_eq!(targets.max_bytes[1], expected_base);
@@ -3736,7 +3736,7 @@ fn recalculate_targets_multi_level_data() {
 fn recalculate_targets_only_l0() {
     let mut level_bytes = [0u64; NUM_LEVELS];
     level_bytes[0] = 500 << 20; // 500MB in L0 only
-    let targets = recalculate_level_targets(&level_bytes);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
     // L0 is ignored — no non-L0 data → uses MIN_BASE_BYTES
     assert_eq!(targets.max_bytes[0], 0);
     assert_eq!(targets.max_bytes[1], MIN_BASE_BYTES);
@@ -3747,7 +3747,7 @@ fn recalculate_targets_only_l0() {
 fn recalculate_targets_empty_intermediate() {
     let mut level_bytes = [0u64; NUM_LEVELS];
     level_bytes[4] = 100 << 30; // 100GB in L4 only (L1-L3 empty)
-    let targets = recalculate_level_targets(&level_bytes);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
     // base = 100GB / 10^3 = ~102MB
     let expected_base: u64 = (100u64 << 30) / 1_000;
     assert_eq!(targets.max_bytes[1], expected_base);
@@ -3763,10 +3763,10 @@ fn recalculate_targets_data_at_l6() {
     // L6 is the highest level — requires maximum backward divisions (5).
     let mut level_bytes = [0u64; NUM_LEVELS];
     level_bytes[6] = 100u64 << 40; // 100 TiB in L6
-    let targets = recalculate_level_targets(&level_bytes);
-    // base = 100TiB / 10^5 = ~1.1GB → clamped to MAX_BASE_BYTES (256MB)
-    assert_eq!(targets.max_bytes[1], MAX_BASE_BYTES);
-    assert_eq!(targets.max_bytes[6], MAX_BASE_BYTES * 100_000);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
+    // base = 100TiB / 10^5 = ~1.1GB → clamped to LEVEL_BASE_BYTES (256MB)
+    assert_eq!(targets.max_bytes[1], LEVEL_BASE_BYTES);
+    assert_eq!(targets.max_bytes[6], LEVEL_BASE_BYTES * 100_000);
 }
 
 #[test]
@@ -3776,9 +3776,9 @@ fn recalculate_targets_data_at_l6_unclamped() {
     let data: u64 = 10u64 * (1u64 << 40); // 10 TiB
     let mut level_bytes = [0u64; NUM_LEVELS];
     level_bytes[6] = data;
-    let targets = recalculate_level_targets(&level_bytes);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
     let expected_base = data / 100_000;
-    assert!(expected_base > MIN_BASE_BYTES && expected_base < MAX_BASE_BYTES);
+    assert!(expected_base > MIN_BASE_BYTES && expected_base < LEVEL_BASE_BYTES);
     assert_eq!(targets.max_bytes[1], expected_base);
     assert_eq!(targets.max_bytes[2], expected_base * 10);
     assert_eq!(targets.max_bytes[6], expected_base * 100_000);
@@ -3791,9 +3791,9 @@ fn recalculate_targets_lower_level_dominates() {
     let mut level_bytes = [0u64; NUM_LEVELS];
     level_bytes[2] = 50 << 30; // 50GB in L2
     level_bytes[5] = 1 << 30; // 1GB in L5
-    let targets = recalculate_level_targets(&level_bytes);
-    // base = 50GB / 10^1 = 5GB → clamped to MAX_BASE_BYTES (256MB)
-    assert_eq!(targets.max_bytes[1], MAX_BASE_BYTES);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
+    // base = 50GB / 10^1 = 5GB → clamped to LEVEL_BASE_BYTES (256MB)
+    assert_eq!(targets.max_bytes[1], LEVEL_BASE_BYTES);
     // L2 actual (50GB) vs target (2.56GB) → score ~19.5 → aggressive compaction
     assert!(level_bytes[2] as f64 / targets.max_bytes[2] as f64 > 10.0);
 }
@@ -3804,27 +3804,27 @@ fn recalculate_targets_base_exactly_at_min() {
     // Data at L1 = 1MB → base = 1MB = MIN_BASE_BYTES.
     let mut level_bytes = [0u64; NUM_LEVELS];
     level_bytes[1] = MIN_BASE_BYTES;
-    let targets = recalculate_level_targets(&level_bytes);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
     assert_eq!(targets.max_bytes[1], MIN_BASE_BYTES);
 }
 
 #[test]
 fn recalculate_targets_base_exactly_at_max() {
-    // Data at L1 = 256MB → base = 256MB = MAX_BASE_BYTES.
+    // Data at L1 = 256MB → base = 256MB = LEVEL_BASE_BYTES.
     let mut level_bytes = [0u64; NUM_LEVELS];
-    level_bytes[1] = MAX_BASE_BYTES;
-    let targets = recalculate_level_targets(&level_bytes);
-    assert_eq!(targets.max_bytes[1], MAX_BASE_BYTES);
-    assert_eq!(targets.max_bytes[2], MAX_BASE_BYTES * 10);
+    level_bytes[1] = LEVEL_BASE_BYTES;
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
+    assert_eq!(targets.max_bytes[1], LEVEL_BASE_BYTES);
+    assert_eq!(targets.max_bytes[2], LEVEL_BASE_BYTES * 10);
 }
 
 #[test]
 fn recalculate_targets_base_just_above_max_clamps() {
-    // Data at L1 = 300MB → base = 300MB > MAX_BASE_BYTES → clamped to 256MB.
+    // Data at L1 = 300MB → base = 300MB > LEVEL_BASE_BYTES → clamped to 256MB.
     let mut level_bytes = [0u64; NUM_LEVELS];
     level_bytes[1] = 300 << 20;
-    let targets = recalculate_level_targets(&level_bytes);
-    assert_eq!(targets.max_bytes[1], MAX_BASE_BYTES);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
+    assert_eq!(targets.max_bytes[1], LEVEL_BASE_BYTES);
 }
 
 #[test]
@@ -3833,7 +3833,7 @@ fn recalculate_targets_score_meaningful_for_small_db() {
     // not 0.04 (which is what the old 256MB static target produced).
     let mut level_bytes = [0u64; NUM_LEVELS];
     level_bytes[1] = 10 << 20; // 10MB
-    let targets = recalculate_level_targets(&level_bytes);
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
     let score = level_bytes[1] as f64 / targets.max_bytes[1] as f64;
     assert!(
         (score - 1.0).abs() < 0.01,


### PR DESCRIPTION
## Summary

- Add `background_threads`, `target_file_size`, `level_base_bytes`, `data_block_size`, `bloom_bits_per_key`, and `compaction_rate_limit` to `StorageConfig`
- Background thread count now defaults to `min(4, available_parallelism())` instead of hardcoded 4
- All new fields use `#[serde(default)]` for backward compatibility with existing `strata.toml` files
- Storage constants are plumbed through `SegmentedStore` fields to flush, compaction, and materialization paths

## Root Cause

Issue #1737 identified 6 scale-span configuration gaps from the audit:
- **S-H2**: `BackgroundScheduler::new(4, 4096)` hardcoded at 3 call sites — on a Pi Zero (1 core), this spawns 4 unnecessary threads (~8MB stack each)
- **S-H8**: `TARGET_FILE_SIZE` (64 MiB), `LEVEL_BASE_BYTES` (256 MiB), `data_block_size` (4 KiB), `bloom_bits_per_key` (10) were module-level constants with no config path
- **S-M7**: `set_compaction_rate_limit()` existed on `SegmentedStore` but was not wirable from `strata.toml`

## Fix

1. Added 6 new fields to `StorageConfig` with backward-compatible serde defaults matching the original constants
2. `background_threads` defaults to `min(4, available_parallelism())` with a `.max(1)` floor at usage sites
3. Replaced module constants `MAX_GRANDPARENT_OVERLAP` and `MAX_BASE_BYTES` with derived values from the configurable fields
4. Updated `recalculate_level_targets()` to accept a `max_base` parameter instead of using the removed `MAX_BASE_BYTES` constant
5. Added `make_segment_builder()` helper and `SplittingSegmentBuilder::with_data_block_size()` to ensure all segment construction paths use configured values
6. Applied `compaction_rate_limit` from config at database startup

## Invariants Verified

- **SCALE-001** (HOLDS — improved): Previously violated constants now configurable
- **SCALE-006** (HOLDS — improved): Compaction rate limit now in config
- **SCALE-007** (HOLDS — improved): Thread count bounded and configurable
- **CMP-003** (HOLDS): Grandparent overlap threshold derived identically
- **CMP-005** (HOLDS): Dynamic level sizing algorithm unchanged

## Test Plan

- [x] `test_issue_1737_background_threads_default_bounded` — verifies default = min(4, CPUs)
- [x] `test_issue_1737_storage_constants_configurable` — verifies default values match originals
- [x] `test_issue_1737_compaction_rate_limit_in_config` — verifies default 0 = unlimited
- [x] `test_issue_1737_config_round_trip` — verifies TOML parse → serialize → reparse
- [x] `test_issue_1737_backward_compat_missing_new_fields` — verifies old configs still parse
- [x] All 579 storage tests pass
- [x] All 1329+ engine lib tests pass
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)