### PR TITLE
Fix #1739: Wire JSON mutation path to apply/WAL/recovery; reject same-key put+CAS

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -302,9 +302,13 @@ impl TransactionManager {
         // Step 2: Allocate commit version
         let commit_version = self.allocate_version()?;
 
-        // Step 3: Write to WAL (durability) - only for transactions with mutations
-        // Skip WAL for read-only transactions (no writes, deletes, CAS ops, or JSON patches)
-        let has_mutations = !txn.is_read_only() || !txn.json_writes().is_empty();
+        // Step 2.5: Materialize JSON patches into write_set (#1739 OCC-H1)
+        txn.materialize_json_writes()
+            .map_err(|e| CommitError::WALError(format!("JSON materialization failed: {}", e)))?;
+
+        // Step 3: Write to WAL (durability) - only for transactions with mutations.
+        // After materialization, json_writes are in write_set, so is_read_only() covers all cases.
+        let has_mutations = !txn.is_read_only();
         if has_mutations {
             if let Some(wal) = wal.as_mut() {
                 let payload = TransactionPayload::from_transaction(txn, commit_version);
@@ -433,7 +437,11 @@ impl TransactionManager {
 
         let commit_version = self.allocate_version()?;
 
-        let has_mutations = !txn.is_read_only() || !txn.json_writes().is_empty();
+        // Materialize JSON patches into write_set (#1739 OCC-H1)
+        txn.materialize_json_writes()
+            .map_err(|e| CommitError::WALError(format!("JSON materialization failed: {}", e)))?;
+
+        let has_mutations = !txn.is_read_only();
         if has_mutations {
             if let Some(wal_arc) = wal_arc {
                 let payload = TransactionPayload::from_transaction(txn, commit_version);
@@ -588,8 +596,12 @@ impl TransactionManager {
         // Advance local counter so it stays in sync
         self.version.fetch_max(commit_version, Ordering::AcqRel);
 
+        // Materialize JSON patches into write_set (#1739 OCC-H1)
+        txn.materialize_json_writes()
+            .map_err(|e| CommitError::WALError(format!("JSON materialization failed: {}", e)))?;
+
         // Write to WAL
-        let has_mutations = !txn.is_read_only() || !txn.json_writes().is_empty();
+        let has_mutations = !txn.is_read_only();
         if has_mutations {
             if let Some(wal) = wal.as_mut() {
                 let payload = TransactionPayload::from_transaction(txn, commit_version);
@@ -661,7 +673,7 @@ impl Default for TransactionManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::TransactionContext;
+    use crate::{JsonStoreExt, TransactionContext};
     use parking_lot::Mutex as ParkingMutex;
     use std::sync::Arc;
     use strata_core::types::{Key, Namespace};
@@ -2242,6 +2254,257 @@ mod tests {
             matches!(err, CommitError::DurableButNotVisible(_)),
             "Expected DurableButNotVisible error, got: {:?}",
             err
+        );
+    }
+
+    // ========================================================================
+    // Issue #1739: OCC-H1 — JSON mutation path validates but never persists.
+    // json_writes are ignored by apply_writes() and TransactionPayload.
+    // ========================================================================
+
+    #[test]
+    fn test_issue_1739_json_writes_persisted_to_storage() {
+        use strata_core::primitives::json::JsonPath;
+
+        let store = Arc::new(SegmentedStore::new());
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let json_key = Key::new_json(ns.clone(), "doc1");
+
+        // Step 1: Store a base JSON document via a regular KV put.
+        let base_doc = serde_json::json!({"name": "alice", "age": 30});
+        let base_bytes = rmp_serde::to_vec(&base_doc).unwrap();
+        let mut txn0 = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        txn0.put(json_key.clone(), Value::Bytes(base_bytes))
+            .unwrap();
+        manager.commit(&mut txn0, store.as_ref(), None).unwrap();
+
+        // Step 2: Start a JSON-only transaction that modifies the document.
+        let mut txn1 = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        txn1.json_set(
+            &json_key,
+            &"age".parse::<JsonPath>().unwrap(),
+            serde_json::json!(31).into(),
+        )
+        .unwrap();
+
+        // Commit the JSON-only transaction.
+        let commit_v = manager.commit(&mut txn1, store.as_ref(), None).unwrap();
+
+        // Step 3: Read back from storage and verify the document was updated.
+        let result = store.get_versioned(&json_key, commit_v).unwrap();
+        assert!(
+            result.is_some(),
+            "JSON document must exist in storage after json_set commit"
+        );
+        let vv = result.unwrap();
+        let stored_bytes = match &vv.value {
+            Value::Bytes(b) => b,
+            other => panic!("Expected Value::Bytes, got {:?}", other),
+        };
+        let stored_doc: serde_json::Value = rmp_serde::from_slice(stored_bytes).unwrap();
+        assert_eq!(
+            stored_doc,
+            serde_json::json!({"name": "alice", "age": 31}),
+            "JSON document must reflect the json_set patch"
+        );
+    }
+
+    #[test]
+    fn test_issue_1739_json_writes_included_in_wal_payload() {
+        use strata_core::primitives::json::JsonPath;
+
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let mut wal = create_test_wal(&wal_dir);
+        let store = Arc::new(SegmentedStore::new());
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let json_key = Key::new_json(ns.clone(), "doc1");
+
+        // Store a base JSON document.
+        let base_doc = serde_json::json!({"x": 1});
+        let base_bytes = rmp_serde::to_vec(&base_doc).unwrap();
+        let mut txn0 = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        txn0.put(json_key.clone(), Value::Bytes(base_bytes))
+            .unwrap();
+        manager
+            .commit(&mut txn0, store.as_ref(), Some(&mut wal))
+            .unwrap();
+
+        // JSON-only transaction.
+        let mut txn1 = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        txn1.json_set(
+            &json_key,
+            &"x".parse::<JsonPath>().unwrap(),
+            serde_json::json!(99).into(),
+        )
+        .unwrap();
+        let commit_v = manager
+            .commit(&mut txn1, store.as_ref(), Some(&mut wal))
+            .unwrap();
+
+        // Read WAL and verify the payload contains the JSON put.
+        wal.flush().unwrap();
+        let reader = WalReader::new();
+        let records = reader.read_all_after_watermark(&wal_dir, 0).unwrap();
+        // Record[0] = base doc put, Record[1] = json_set commit
+        assert!(records.len() >= 2, "Expected at least 2 WAL records");
+        let payload = TransactionPayload::from_bytes(&records[1].writeset).unwrap();
+        assert_eq!(payload.version, commit_v);
+        assert!(
+            !payload.puts.is_empty(),
+            "WAL payload must contain the materialized JSON put"
+        );
+        assert_eq!(
+            payload.puts[0].0, json_key,
+            "WAL payload put key must match the JSON document key"
+        );
+        // Verify the WAL value is the correctly patched document, not just any bytes
+        let wal_bytes = match &payload.puts[0].1 {
+            Value::Bytes(b) => b,
+            other => panic!("Expected Value::Bytes in WAL payload, got {:?}", other),
+        };
+        let wal_doc: serde_json::Value = rmp_serde::from_slice(wal_bytes).unwrap();
+        assert_eq!(
+            wal_doc,
+            serde_json::json!({"x": 99}),
+            "WAL payload must contain the correctly patched document"
+        );
+    }
+
+    // ========================================================================
+    // Issue #1739: OCC-M1 — Same-key put + CAS must be rejected.
+    // ========================================================================
+
+    #[test]
+    fn test_issue_1739_cas_rejects_key_already_in_write_set() {
+        let store = Arc::new(SegmentedStore::new());
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key = create_test_key(&ns, "k1");
+
+        let mut txn = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        // First: put(K, v1)
+        txn.put(key.clone(), Value::Int(1)).unwrap();
+        // Then: cas(K, ...) on the same key — must be rejected
+        let result = txn.cas(key.clone(), 0, Value::Int(2));
+        assert!(
+            result.is_err(),
+            "cas() must reject a key already in write_set"
+        );
+    }
+
+    #[test]
+    fn test_issue_1739_put_rejects_key_already_in_cas_set() {
+        let store = Arc::new(SegmentedStore::new());
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key = create_test_key(&ns, "k1");
+
+        let mut txn = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        // First: cas(K, 0, v1)
+        txn.cas(key.clone(), 0, Value::Int(1)).unwrap();
+        // Then: put(K, v2) on the same key — must be rejected
+        let result = txn.put(key.clone(), Value::Int(2));
+        assert!(
+            result.is_err(),
+            "put() must reject a key already in cas_set"
+        );
+    }
+
+    #[test]
+    fn test_issue_1739_delete_rejects_key_already_in_cas_set() {
+        let store = Arc::new(SegmentedStore::new());
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key = create_test_key(&ns, "k1");
+
+        let mut txn = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        // First: cas(K, 0, v1)
+        txn.cas(key.clone(), 0, Value::Int(1)).unwrap();
+        // Then: delete(K) on the same key — must be rejected
+        let result = txn.delete(key.clone());
+        assert!(
+            result.is_err(),
+            "delete() must reject a key already in cas_set"
+        );
+    }
+
+    #[test]
+    fn test_issue_1739_cas_rejects_key_already_in_delete_set() {
+        let store = Arc::new(SegmentedStore::new());
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key = create_test_key(&ns, "k1");
+
+        let mut txn = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        // First: delete(K)
+        txn.delete(key.clone()).unwrap();
+        // Then: cas(K, ...) on the same key — must be rejected
+        let result = txn.cas(key.clone(), 0, Value::Int(2));
+        assert!(
+            result.is_err(),
+            "cas() must reject a key already in delete_set"
+        );
+    }
+
+    #[test]
+    fn test_issue_1739_cas_with_read_rejects_key_already_in_write_set() {
+        let store = Arc::new(SegmentedStore::new());
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key = create_test_key(&ns, "k1");
+
+        let mut txn = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        txn.put(key.clone(), Value::Int(1)).unwrap();
+        let result = txn.cas_with_read(key.clone(), 0, Value::Int(2));
+        assert!(
+            result.is_err(),
+            "cas_with_read() must reject a key already in write_set"
         );
     }
 }

--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -942,6 +942,14 @@ impl TransactionContext {
         }
         self.check_write_limit(Some(&key))?;
 
+        // Reject if the same key already has a CAS operation (#1739 OCC-M1)
+        if self.cas_set.iter().any(|op| op.key == key) {
+            return Err(StrataError::invalid_input(
+                "Key already has a CAS operation in this transaction; \
+                 mixing put/delete and CAS on the same key is ambiguous",
+            ));
+        }
+
         // Remove from delete_set if previously deleted in this txn
         self.delete_set.remove(&key);
 
@@ -1000,6 +1008,14 @@ impl TransactionContext {
         }
         self.check_write_limit(Some(&key))?;
 
+        // Reject if the same key already has a CAS operation (#1739 OCC-M1)
+        if self.cas_set.iter().any(|op| op.key == key) {
+            return Err(StrataError::invalid_input(
+                "Key already has a CAS operation in this transaction; \
+                 mixing put/delete and CAS on the same key is ambiguous",
+            ));
+        }
+
         // Remove from write_set if previously written in this txn
         self.write_set.remove(&key);
         // Clean up any write mode override for this key
@@ -1054,6 +1070,14 @@ impl TransactionContext {
         }
         self.check_write_limit(None)?;
 
+        // Reject if the same key already has a put or delete (#1739 OCC-M1)
+        if self.write_set.contains_key(&key) || self.delete_set.contains(&key) {
+            return Err(StrataError::invalid_input(
+                "Key already has a put/delete in this transaction; \
+                 mixing put/delete and CAS on the same key is ambiguous",
+            ));
+        }
+
         self.cas_set.push(CASOperation {
             key,
             expected_version,
@@ -1081,6 +1105,15 @@ impl TransactionContext {
             ));
         }
         self.check_write_limit(None)?;
+
+        // Reject if the same key already has a put or delete (#1739 OCC-M1)
+        if self.write_set.contains_key(&key) || self.delete_set.contains(&key) {
+            return Err(StrataError::invalid_input(
+                "Key already has a put/delete in this transaction; \
+                 mixing put/delete and CAS on the same key is ambiguous",
+            ));
+        }
+
         self.read_from_snapshot(&key)?;
         self.cas_set.push(CASOperation {
             key,
@@ -1539,6 +1572,71 @@ impl TransactionContext {
             deletes_applied: deletes_count,
             cas_applied: cas_count,
         })
+    }
+
+    /// Materialize JSON patches into the write_set as full-document puts.
+    ///
+    /// For each key in `json_writes`, reads the base document from the snapshot
+    /// store, applies all patches in order, serializes the result to msgpack bytes,
+    /// and inserts into `write_set`. After this call, `json_writes` is cleared and
+    /// the existing `TransactionPayload` / `apply_writes` path handles persistence.
+    ///
+    /// Must be called after validation but before building `TransactionPayload`.
+    pub fn materialize_json_writes(&mut self) -> StrataResult<()> {
+        use strata_core::primitives::json::{apply_patches, JsonValue};
+
+        let json_writes = match self.json_writes.take() {
+            Some(w) if !w.is_empty() => w,
+            _ => return Ok(()),
+        };
+
+        // Group patches by key, preserving insertion order.
+        let mut patches_by_key: Vec<(Key, Vec<strata_core::primitives::json::JsonPatch>)> =
+            Vec::new();
+        for entry in json_writes {
+            if let Some((_k, patches)) = patches_by_key.iter_mut().find(|(k, _)| *k == entry.key) {
+                patches.push(entry.patch);
+            } else {
+                patches_by_key.push((entry.key, vec![entry.patch]));
+            }
+        }
+
+        let store = self.store.as_ref().ok_or_else(|| {
+            StrataError::internal("Cannot materialize JSON writes: no snapshot store")
+        })?;
+
+        for (key, patches) in patches_by_key {
+            // Read the base document from the snapshot.
+            let mut doc: JsonValue =
+                if let Some(vv) = store.get_versioned(&key, self.start_version)? {
+                    match &vv.value {
+                        Value::Bytes(b) => rmp_serde::from_slice(b).map_err(|e| {
+                            StrataError::internal(format!(
+                                "Failed to deserialize JSON document for materialization: {}",
+                                e
+                            ))
+                        })?,
+                        _ => JsonValue::object(),
+                    }
+                } else {
+                    JsonValue::object()
+                };
+
+            apply_patches(&mut doc, &patches).map_err(|e| {
+                StrataError::internal(format!("Failed to apply JSON patches: {}", e))
+            })?;
+
+            let doc_bytes = rmp_serde::to_vec(&doc).map_err(|e| {
+                StrataError::internal(format!(
+                    "Failed to serialize materialized JSON document: {}",
+                    e
+                ))
+            })?;
+
+            self.write_set.insert(key, Value::Bytes(doc_bytes));
+        }
+
+        Ok(())
     }
 
     // === Introspection ===


### PR DESCRIPTION
## Summary

- **OCC-H1**: `apply_writes()` and `TransactionPayload` ignored `json_writes`, so JSON-only transactions validated and returned success but persisted nothing. Added `materialize_json_writes()` that converts JSON patches into `write_set` entries before WAL/storage application.
- **OCC-M1**: `put`/`delete` and `cas` on the same key produced two entries at the same `commit_version` with ambiguous final value. Added guards to reject same-key mixing between `write_set`/`delete_set` and `cas_set`.

## Root Cause

**OCC-H1**: The JSON path (`json_set`/`json_delete`) buffered patches in `json_writes` but the commit pipeline only drained `write_set`, `cas_set`, and `delete_set`. The manager correctly detected JSON mutations for the read-only fast path but never materialized them into the write path.

**OCC-M1**: No guard prevented the same key from appearing in both `write_set` and `cas_set`. Both were independently collected into the writes vector in `apply_writes()`, producing duplicate entries.

## Fix

1. `materialize_json_writes()` on `TransactionContext`: reads base documents from the snapshot store, applies all JSON patches per key via `apply_patches()`, serializes to msgpack, and inserts into `write_set`. Called in all three commit methods after validation, before `TransactionPayload` construction.
2. Guards in `put()`, `delete()`, `cas()`, `cas_with_read()` that reject same-key overlap between `write_set`/`delete_set` and `cas_set`.

## Invariants Verified

ACID-001, ACID-002, ACID-003, ACID-004, ACID-005, ARCH-002, MVCC-003 — all HOLD.

## Test Plan

- [x] `test_issue_1739_json_writes_persisted_to_storage` — json_set patch applied and readable from storage
- [x] `test_issue_1739_json_writes_included_in_wal_payload` — WAL record contains materialized JSON document with correct value
- [x] `test_issue_1739_cas_rejects_key_already_in_write_set` — cas() after put() on same key returns error
- [x] `test_issue_1739_put_rejects_key_already_in_cas_set` — put() after cas() on same key returns error
- [x] `test_issue_1739_delete_rejects_key_already_in_cas_set` — delete() after cas() on same key returns error
- [x] `test_issue_1739_cas_rejects_key_already_in_delete_set` — cas() after delete() on same key returns error
- [x] `test_issue_1739_cas_with_read_rejects_key_already_in_write_set` — cas_with_read() after put() returns error
- [x] Full concurrency crate: 114 tests pass, 12 doc-tests pass
- [x] Workspace: 1321+ tests pass (2 pre-existing flaky singleton tests excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)