### PR TITLE
Fix #1737: Use configured target_file_size for compaction output splitting

### DIFF
--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -587,10 +587,11 @@ impl SegmentedStore {
         let start_id = next_id.load(Ordering::Relaxed);
         let bloom_bits = super::bloom_bits_for_level(1, self.bloom_bits_per_key());
         let compression = super::compression_for_level(1);
-        let mut splitting_builder = crate::segment_builder::SplittingSegmentBuilder::default()
-            .with_bloom_bits(bloom_bits)
-            .with_compression(compression)
-            .with_data_block_size(self.data_block_size());
+        let mut splitting_builder =
+            crate::segment_builder::SplittingSegmentBuilder::new(self.target_file_size())
+                .with_bloom_bits(bloom_bits)
+                .with_compression(compression)
+                .with_data_block_size(self.data_block_size());
         if let Some(ref l) = limiter {
             splitting_builder = splitting_builder.with_rate_limiter(Arc::clone(l));
         }
@@ -845,10 +846,11 @@ impl SegmentedStore {
         let start_id = next_id.load(Ordering::Relaxed);
         let bloom_bits = super::bloom_bits_for_level(level + 1, self.bloom_bits_per_key());
         let compression = super::compression_for_level(level + 1);
-        let mut splitting_builder = crate::segment_builder::SplittingSegmentBuilder::default()
-            .with_bloom_bits(bloom_bits)
-            .with_compression(compression)
-            .with_data_block_size(self.data_block_size());
+        let mut splitting_builder =
+            crate::segment_builder::SplittingSegmentBuilder::new(self.target_file_size())
+                .with_bloom_bits(bloom_bits)
+                .with_compression(compression)
+                .with_data_block_size(self.data_block_size());
         if let Some(ref l) = limiter {
             splitting_builder = splitting_builder.with_rate_limiter(Arc::clone(l));
         }


### PR DESCRIPTION
## Summary

- Replace `SplittingSegmentBuilder::default()` with `SplittingSegmentBuilder::new(self.target_file_size())` in `compact_l0_to_l1` and `compact_level`

## Root Cause

Found during post-merge review of #1815. The `SplittingSegmentBuilder::default()` constructor hardcodes 64 MiB as the target file size, ignoring the newly configurable `target_file_size` field. While bloom bits, compression, and data block size were correctly plumbed to the splitting builder, the target file size was missed.

## Fix

2-line change: `SplittingSegmentBuilder::default()` → `SplittingSegmentBuilder::new(self.target_file_size())` at both compaction output sites.

## Test Plan

- [x] 579 storage tests pass
- [x] No behavioral change at default config (default is 64 MiB, same as hardcoded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)