### PR TITLE
Fix #1753: Compute CRC32 on uncompressed block data for PCLMULQDQ acceleration

### DIFF
--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -22,9 +22,9 @@ use crate::bloom::BloomFilter;
 use crate::key_encoding::{encode_typed_key, encode_typed_key_prefix, InternalKey};
 use crate::segment_builder::{
     decode_entry_header_ref_v4, decode_entry_header_v4, decode_entry_v4, decode_entry_value,
-    parse_filter_index, parse_footer, parse_framed_block, parse_header, parse_index_block,
-    parse_properties_block, EntryHeader, FilterIndexEntry, Footer, IndexEntry, KVHeader,
-    PropertiesBlock, FOOTER_SZ, FRAME_OVERHEAD, HEADER_SIZE, IDX_TYPE_PARTITIONED,
+    parse_filter_index, parse_footer, parse_framed_block, parse_framed_block_raw, parse_header,
+    parse_index_block, parse_properties_block, EntryHeader, FilterIndexEntry, Footer, IndexEntry,
+    KVHeader, PropertiesBlock, FOOTER_SZ, FRAME_OVERHEAD, HEADER_SIZE, IDX_TYPE_PARTITIONED,
 };
 use strata_core::error::StrataError;
 use strata_core::types::Key;
@@ -575,13 +575,26 @@ impl KVSegment {
             ))
         })?;
 
-        let codec_byte = raw[1];
-        let (_, data) = parse_framed_block(&raw).ok_or_else(|| {
-            StrataError::corruption(format!(
-                "data block CRC mismatch or truncation at offset {} in {:?}",
-                block_offset, self.file_path
-            ))
-        })?;
+        let (_block_type, codec_byte, reserved, data, stored_crc) = parse_framed_block_raw(&raw)
+            .ok_or_else(|| {
+                StrataError::corruption(format!(
+                    "data block truncation at offset {} in {:?}",
+                    block_offset, self.file_path
+                ))
+            })?;
+
+        let pre_compression_crc = reserved & 1 == 1;
+
+        // For legacy blocks (reserved bit 0 = 0), verify CRC on compressed data
+        if !pre_compression_crc {
+            let computed_crc = crc32fast::hash(data);
+            if stored_crc != computed_crc {
+                return Err(StrataError::corruption(format!(
+                    "data block CRC mismatch at offset {} in {:?}",
+                    block_offset, self.file_path
+                )));
+            }
+        }
 
         let decompressed = match codec_byte {
             0 => data.to_vec(), // Uncompressed
@@ -598,6 +611,19 @@ impl KVSegment {
                 )));
             }
         };
+
+        // For new blocks (reserved bit 0 = 1), verify CRC on uncompressed data.
+        // This ensures the crc32fast buffer is always >= data_block_size (~4KB),
+        // above the 64-byte threshold for PCLMULQDQ hardware acceleration.
+        if pre_compression_crc {
+            let computed_crc = crc32fast::hash(&decompressed);
+            if stored_crc != computed_crc {
+                return Err(StrataError::corruption(format!(
+                    "data block CRC mismatch (pre-compression) at offset {} in {:?}",
+                    block_offset, self.file_path
+                )));
+            }
+        }
 
         // Cache the decompressed block
         Ok(cache.insert(self.file_id, block_offset, decompressed))

--- a/crates/storage/src/segment_builder.rs
+++ b/crates/storage/src/segment_builder.rs
@@ -957,24 +957,34 @@ fn write_framed_block_compressed<W: Write>(
     data: &[u8],
     codec: CompressionCodec,
 ) -> io::Result<usize> {
-    let (write_data, codec_byte) = match codec {
+    let (write_data, codec_byte, pre_compression_crc) = match codec {
         CompressionCodec::Zstd(level) if !data.is_empty() => {
             match zstd::encode_all(std::io::Cursor::new(data), level) {
                 Ok(compressed) if compressed.len() < data.len() => {
-                    (compressed, 1u8) // zstd compressed
+                    // CRC covers uncompressed data so the buffer passed to
+                    // crc32fast is always >= data_block_size, well above the
+                    // 64-byte threshold for PCLMULQDQ hardware acceleration.
+                    (compressed, 1u8, true)
                 }
-                _ => (data.to_vec(), 0u8), // fallback to uncompressed
+                _ => (data.to_vec(), 0u8, false),
             }
         }
-        _ => (data.to_vec(), 0u8),
+        _ => (data.to_vec(), 0u8, false),
+    };
+
+    // reserved bit 0 = 1 when CRC covers pre-compression (uncompressed) data
+    let reserved: u16 = if pre_compression_crc { 1 } else { 0 };
+    let crc = if pre_compression_crc {
+        crc32fast::hash(data)
+    } else {
+        crc32fast::hash(&write_data)
     };
 
     w.write_all(&[block_type])?;
     w.write_all(&[codec_byte])?;
-    w.write_all(&[0u8; 2])?; // reserved
+    w.write_all(&reserved.to_le_bytes())?;
     w.write_all(&(write_data.len() as u32).to_le_bytes())?;
     w.write_all(&write_data)?;
-    let crc = crc32fast::hash(&write_data);
     w.write_all(&crc.to_le_bytes())?;
     Ok(BLOCK_FRAME_OVERHEAD + write_data.len())
 }
@@ -982,23 +992,50 @@ fn write_framed_block_compressed<W: Write>(
 /// Parse a framed block from a byte slice. Returns `(block_type, data_slice)`.
 ///
 /// Verifies CRC32 integrity. Returns `None` on corruption or truncation.
+///
+/// For compressed blocks with `reserved & 1 == 1`, the CRC covers the
+/// **uncompressed** data; callers must use [`parse_framed_block_raw`] and
+/// verify CRC after decompression instead.
 pub(crate) fn parse_framed_block(raw: &[u8]) -> Option<(u8, &[u8])> {
     if raw.len() < BLOCK_FRAME_OVERHEAD {
         return None;
     }
     let block_type = raw[0];
-    // codec = raw[1], reserved = raw[2..4] — ignored for v1
+    let reserved = u16::from_le_bytes(raw[2..4].try_into().ok()?);
     let data_len = u32::from_le_bytes(raw[4..8].try_into().ok()?) as usize;
     if raw.len() < 8 + data_len + 4 {
         return None;
     }
     let data = &raw[8..8 + data_len];
     let stored_crc = u32::from_le_bytes(raw[8 + data_len..8 + data_len + 4].try_into().ok()?);
-    let computed_crc = crc32fast::hash(data);
-    if stored_crc != computed_crc {
-        return None;
+
+    // If reserved bit 0 is set, CRC covers uncompressed data — skip check here
+    // (caller must verify after decompression via parse_framed_block_raw path).
+    if reserved & 1 == 0 {
+        let computed_crc = crc32fast::hash(data);
+        if stored_crc != computed_crc {
+            return None;
+        }
     }
     Some((block_type, data))
+}
+
+/// Parse a framed block without verifying CRC. Returns all frame fields
+/// so the caller can verify CRC after decompression when `reserved & 1 == 1`.
+pub(crate) fn parse_framed_block_raw(raw: &[u8]) -> Option<(u8, u8, u16, &[u8], u32)> {
+    if raw.len() < BLOCK_FRAME_OVERHEAD {
+        return None;
+    }
+    let block_type = raw[0];
+    let codec = raw[1];
+    let reserved = u16::from_le_bytes(raw[2..4].try_into().ok()?);
+    let data_len = u32::from_le_bytes(raw[4..8].try_into().ok()?) as usize;
+    if raw.len() < 8 + data_len + 4 {
+        return None;
+    }
+    let data = &raw[8..8 + data_len];
+    let stored_crc = u32::from_le_bytes(raw[8 + data_len..8 + data_len + 4].try_into().ok()?);
+    Some((block_type, codec, reserved, data, stored_crc))
 }
 
 // ---------------------------------------------------------------------------
@@ -2641,5 +2678,189 @@ mod tests {
         // 3. Verify the parent directory is sync-able (non-trivial on some FS)
         let dir_fd = std::fs::File::open(dir.path()).unwrap();
         dir_fd.sync_all().unwrap();
+    }
+
+    /// Issue #1753: CRC32 should cover uncompressed block data so that the buffer
+    /// passed to crc32fast is always >= data_block_size (~4KB), well above the
+    /// 64-byte threshold for PCLMULQDQ hardware acceleration.
+    ///
+    /// Before the fix, CRC covered compressed data — which can be very small for
+    /// blocks of tiny values, forcing crc32fast into its scalar fallback.
+    #[test]
+    fn test_issue_1753_crc_covers_uncompressed_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("small_values.sst");
+
+        let mt = Memtable::new(0);
+        // Insert many small (8-byte) values that compress well
+        for i in 0..500u32 {
+            let k = key(&format!("key_{:06}", i));
+            let val = Value::Int(i as i64);
+            mt.put(&k, i as u64 + 1, val, false);
+        }
+        mt.freeze();
+
+        let builder = SegmentBuilder {
+            data_block_size: 4096,
+            bloom_bits_per_key: 10,
+            compression: CompressionCodec::Zstd(3),
+            rate_limiter: None,
+        };
+        builder.build_from_iter(mt.iter_all(), &path).unwrap();
+
+        // Read the raw segment file and inspect the first data block frame
+        let file_data = std::fs::read(&path).unwrap();
+        let block_start = HEADER_SIZE;
+        let block_type = file_data[block_start];
+        assert_eq!(block_type, BLOCK_TYPE_DATA);
+
+        let codec_byte = file_data[block_start + 1];
+        assert_eq!(codec_byte, 1, "block should be zstd compressed");
+
+        let reserved = u16::from_le_bytes(
+            file_data[block_start + 2..block_start + 4]
+                .try_into()
+                .unwrap(),
+        );
+
+        // After fix: reserved bit 0 must be set, indicating CRC covers pre-compression data
+        assert_eq!(
+            reserved & 1,
+            1,
+            "reserved bit 0 should indicate CRC covers uncompressed data"
+        );
+
+        let data_len = u32::from_le_bytes(
+            file_data[block_start + 4..block_start + 8]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let compressed_data = &file_data[block_start + 8..block_start + 8 + data_len];
+        let stored_crc = u32::from_le_bytes(
+            file_data[block_start + 8 + data_len..block_start + 8 + data_len + 4]
+                .try_into()
+                .unwrap(),
+        );
+
+        // Decompress and verify CRC matches uncompressed data
+        let decompressed = zstd::decode_all(std::io::Cursor::new(compressed_data)).unwrap();
+        let expected_crc = crc32fast::hash(&decompressed);
+        assert_eq!(
+            stored_crc, expected_crc,
+            "CRC should cover uncompressed data, not compressed"
+        );
+
+        // Verify end-to-end: segment is still readable
+        let seg = KVSegment::open(&path).unwrap();
+        for i in 0..500u32 {
+            let k = key(&format!("key_{:06}", i));
+            let e = seg.point_lookup(&k, u64::MAX).unwrap().unwrap();
+            assert_eq!(e.value, Value::Int(i as i64));
+        }
+    }
+
+    /// Issue #1753: Corruption in a compressed block with pre-compression CRC
+    /// (reserved bit 0 = 1) must be detected after decompression.
+    #[test]
+    fn test_issue_1753_corruption_detected_with_pre_compression_crc() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corrupt.sst");
+
+        let mt = Memtable::new(0);
+        for i in 0..200u32 {
+            let k = key(&format!("key_{:06}", i));
+            mt.put(&k, i as u64 + 1, Value::Int(i as i64), false);
+        }
+        mt.freeze();
+
+        let builder = SegmentBuilder {
+            data_block_size: 4096,
+            bloom_bits_per_key: 10,
+            compression: CompressionCodec::Zstd(3),
+            rate_limiter: None,
+        };
+        builder.build_from_iter(mt.iter_all(), &path).unwrap();
+
+        // Corrupt one byte in the compressed data of the first block
+        let mut file_data = std::fs::read(&path).unwrap();
+        let block_start = HEADER_SIZE;
+        let data_len = u32::from_le_bytes(
+            file_data[block_start + 4..block_start + 8]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        // Flip a byte in the middle of the compressed data
+        let corrupt_offset = block_start + 8 + data_len / 2;
+        file_data[corrupt_offset] ^= 0xFF;
+        std::fs::write(&path, &file_data).unwrap();
+
+        // Opening the segment should succeed (corruption is in data blocks,
+        // not metadata), but reading the corrupted block should fail
+        let seg = KVSegment::open(&path).unwrap();
+        let result = seg.point_lookup(&key("key_000000"), u64::MAX);
+        assert!(result.is_err(), "corrupted block must be detected");
+    }
+
+    /// Issue #1753: Legacy segments (written before fix, reserved=0, CRC on
+    /// compressed data) must still be readable.
+    #[test]
+    fn test_issue_1753_legacy_segment_backward_compat() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy.sst");
+
+        let mt = Memtable::new(0);
+        for i in 0..100u32 {
+            let k = key(&format!("key_{:06}", i));
+            mt.put(&k, i as u64 + 1, Value::Int(i as i64), false);
+        }
+        mt.freeze();
+
+        // Build a segment with the current code
+        let builder = SegmentBuilder {
+            data_block_size: 4096,
+            bloom_bits_per_key: 10,
+            compression: CompressionCodec::Zstd(3),
+            rate_limiter: None,
+        };
+        builder.build_from_iter(mt.iter_all(), &path).unwrap();
+
+        // Simulate a legacy segment by clearing the reserved field and
+        // rewriting the CRC to cover compressed data
+        let mut file_data = std::fs::read(&path).unwrap();
+        let mut offset = HEADER_SIZE;
+        while offset + BLOCK_FRAME_OVERHEAD <= file_data.len() {
+            let block_type = file_data[offset];
+            if block_type == 0 {
+                break; // past data blocks
+            }
+            let reserved =
+                u16::from_le_bytes(file_data[offset + 2..offset + 4].try_into().unwrap());
+            let data_len =
+                u32::from_le_bytes(file_data[offset + 4..offset + 8].try_into().unwrap()) as usize;
+            if offset + 8 + data_len + 4 > file_data.len() {
+                break;
+            }
+
+            if reserved & 1 == 1 {
+                // Clear reserved bit and rewrite CRC on compressed data
+                file_data[offset + 2] = 0;
+                file_data[offset + 3] = 0;
+                let compressed = &file_data[offset + 8..offset + 8 + data_len];
+                let legacy_crc = crc32fast::hash(compressed);
+                file_data[offset + 8 + data_len..offset + 8 + data_len + 4]
+                    .copy_from_slice(&legacy_crc.to_le_bytes());
+            }
+
+            offset += BLOCK_FRAME_OVERHEAD + data_len;
+        }
+        std::fs::write(&path, &file_data).unwrap();
+
+        // Verify the "legacy" segment is still readable
+        let seg = KVSegment::open(&path).unwrap();
+        for i in 0..100u32 {
+            let k = key(&format!("key_{:06}", i));
+            let e = seg.point_lookup(&k, u64::MAX).unwrap().unwrap();
+            assert_eq!(e.value, Value::Int(i as i64));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- CRC32 was computed on zstd-compressed block data; for small values, compressed blocks fall below the 64-byte `crc32fast` PCLMULQDQ threshold, causing ~8% read latency from scalar fallback
- Now CRC covers uncompressed block data (~4KB), always above the SIMD threshold
- Uses reserved field bit 0 to flag new format; legacy segments (reserved=0) use the old CRC-on-compressed path

## Root Cause

`write_framed_block_compressed` computed `crc32fast::hash(&compressed_data)`. At 10M+ keys with 8-byte values, zstd compresses 4KB blocks very efficiently, producing buffers below 64 bytes where `crc32fast` falls back to `baseline::update_fast_16` (scalar) instead of `pclmulqdq::calculate` (hardware-accelerated).

## Fix

- **Write path** (`write_framed_block_compressed`): CRC now covers uncompressed data when zstd compression is used; reserved field bit 0 is set to indicate this
- **Read path** (`read_data_block`): Uses `parse_framed_block_raw` to extract frame fields, checks reserved bit, verifies CRC after decompression for new blocks or before decompression for legacy blocks
- **Backward compatible**: Old segments with `reserved=0` continue to work via the legacy CRC path

## Invariants Verified

LSM-003 (read path ordering), LSM-006 (block cache keying), LSM-007 (segment immutability), ACID-001 (CRC integrity), SCALE-003 (on-disk portability) — all HOLD

## Test Plan

- [x] `test_issue_1753_crc_covers_uncompressed_data` — verifies reserved bit set, CRC matches uncompressed data, end-to-end reads work
- [x] `test_issue_1753_corruption_detected_with_pre_compression_crc` — verifies bit-flip in compressed data is caught by post-decompression CRC
- [x] `test_issue_1753_legacy_segment_backward_compat` — simulates legacy segment (reserved=0, CRC on compressed), verifies reads still work
- [x] Full storage crate: 582 passed, 0 failed
- [x] Full workspace (excluding strata-inference): all passed
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)