### PR TITLE
Fix #1769: Use llama_encode() for BERT encoder-only models

### DIFF
--- a/crates/inference/src/llama/context.rs
+++ b/crates/inference/src/llama/context.rs
@@ -85,6 +85,12 @@ impl LlamaCppContext {
             512
         };
 
+        // Encoder-only models (BERT, NomicBERT, etc.) have no KV cache, so
+        // llama_get_kv_self returns null. llama_model_has_encoder only returns
+        // true for encoder-decoder models (T5), so we also check for a null
+        // KV cache to detect encoder-only architectures that need encode().
+        let has_encoder = has_encoder || api.kv_self_is_null(ctx);
+
         info!(
             n_embd = n_embd,
             vocab_size = vocab_size,
@@ -374,5 +380,31 @@ mod tests {
         let expected = Path::new("/tmp/../tmp/./model.gguf").to_str().unwrap();
         let cstr = result.unwrap();
         assert_eq!(cstr.to_str().unwrap(), expected);
+    }
+
+    /// Issue #1769: BERT (encoder-only) models must set has_encoder=true so that
+    /// embed() calls llama_encode() instead of llama_decode(). Without this,
+    /// llama.cpp logs "cannot decode batches with this context" per batch.
+    #[test]
+    #[ignore]
+    fn test_issue_1769_bert_model_uses_encode() {
+        let registry = crate::registry::ModelRegistry::new();
+        let path = match registry.resolve("miniLM") {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("skipping test_issue_1769: {e}");
+                return;
+            }
+        };
+        let ctx = LlamaCppContext::load_for_embedding(&path)
+            .expect("load_for_embedding should succeed for MiniLM");
+
+        // MiniLM is a BERT encoder-only model. It has no KV cache and must
+        // use llama_encode(), so has_encoder must be true.
+        assert!(
+            ctx.has_encoder,
+            "BERT/MiniLM should have has_encoder=true to use llama_encode(), \
+             but got false — llama_decode() will log 'cannot decode batches' warnings"
+        );
     }
 }

--- a/crates/inference/src/llama/ffi.rs
+++ b/crates/inference/src/llama/ffi.rs
@@ -164,7 +164,6 @@ extern "C" {
     pub fn llama_free(ctx: LlamaContext);
 
     // Memory (b5440 uses the older KV cache API -- called via shims above)
-    #[allow(dead_code)]
     pub fn llama_get_kv_self(ctx: LlamaContext) -> LlamaMemory;
     pub fn llama_kv_self_clear(ctx: LlamaContext);
 
@@ -362,6 +361,11 @@ impl LlamaCppApi {
 
     pub fn get_memory(&self, ctx: LlamaContext) -> LlamaMemory {
         unsafe { shim_get_memory(ctx) }
+    }
+
+    /// Returns true if the context has no KV cache (encoder-only models like BERT).
+    pub fn kv_self_is_null(&self, ctx: LlamaContext) -> bool {
+        unsafe { llama_get_kv_self(ctx) }.is_null()
     }
 
     pub fn memory_clear(&self, mem: LlamaMemory, data: bool) {


### PR DESCRIPTION
## Summary

- BERT/MiniLM embedding models triggered per-batch `cannot decode batches with this context (use llama_encode() instead)` warnings because `llama_model_has_encoder()` only returns `true` for T5 encoder-decoder models, not BERT encoder-only models
- Fixed by also checking `llama_get_kv_self()` after context creation — a null KV cache indicates an encoder-only architecture that needs `llama_encode()` instead of `llama_decode()`
- 3 lines of production code, scoped entirely to the inference crate

## Root Cause

`llama_model_has_encoder()` in the vendored llama.cpp (b44890df) only matches `LLM_ARCH_T5` and `LLM_ARCH_T5ENCODER`. BERT (`LLM_ARCH_BERT`) falls to `default: return false`. The embedding engine used this flag to choose between `encode()` and `decode()`, so BERT models always hit `decode()`. llama.cpp's `decode()` detects the missing KV cache (`if (!memory)`), logs the warning, and internally falls back to `encode()` — correct behavior but noisy.

## Fix

After context creation in `load_for_embedding()`, check if the KV cache is null via `llama_get_kv_self()`. Encoder-only models (BERT, NomicBERT, JinaBERT) have no KV cache, so this correctly identifies them as needing `encode()`. The detection covers both encoder-decoder models (T5, via `has_encoder`) and encoder-only models (BERT, via null KV cache).

## Invariants Verified

No engine invariants affected — change is entirely in the inference embedding layer, no interaction with storage, MVCC, WAL, compaction, or branching.

## Test Plan

- [x] `test_issue_1769_bert_model_uses_encode` — loads MiniLM BERT model, asserts `has_encoder=true` (failed before fix, passes after)
- [x] Full `strata-inference` crate tests pass (194 tests)
- [x] Full workspace tests pass (all crates)
- [x] Clippy clean on changed files
- [x] Existing embedding smoke tests (`smoke_embed_minilm`, `smoke_embed_batch_minilm`) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)