### PR TITLE
Fix #1768: Surface embedding progress in search() stats

### DIFF
--- a/crates/executor/src/handlers/search.rs
+++ b/crates/executor/src/handlers/search.rs
@@ -187,6 +187,19 @@ pub fn search(
         SearchMode::Vector => "vector",
     };
     let model_name = p.db.config().model.map(|m| m.model.clone());
+
+    // Surface embedding progress when auto-embed is active with pending items
+    let embed_status = crate::handlers::embed_hook::embed_status(p);
+    let (embedding_pending, embedding_total) =
+        if embed_status.auto_embed && embed_status.pending > 0 {
+            (
+                Some(embed_status.pending as u64),
+                Some(embed_status.total_queued),
+            )
+        } else {
+            (None, None)
+        };
+
     let stats = SearchStatsOutput {
         elapsed_ms: response.stats.elapsed_micros as f64 / 1000.0,
         candidates_considered: response.stats.candidates_considered,
@@ -207,6 +220,8 @@ pub fn search(
             None
         },
         rerank_model: if rerank_used { model_name } else { None },
+        embedding_pending,
+        embedding_total,
     };
 
     // Convert SearchResponse hits to SearchResultHit

--- a/crates/executor/src/tests/search.rs
+++ b/crates/executor/src/tests/search.rs
@@ -218,3 +218,136 @@ fn test_search_with_expand_rerank_disabled() {
     });
     assert!(result.is_ok());
 }
+
+/// Issue #1768: search stats should include embedding progress when auto-embed
+/// is enabled and items are still pending.
+#[cfg(feature = "embed")]
+#[test]
+fn test_issue_1768_search_stats_include_embedding_progress() {
+    let db = Database::cache().unwrap();
+    db.set_auto_embed(true);
+    let executor = Executor::new(db);
+
+    // Insert several KV entries — with auto_embed on, these queue into the
+    // EmbedBuffer. Default batch_size=256, so they stay pending.
+    for i in 0..5 {
+        executor
+            .execute(Command::KvPut {
+                branch: None,
+                space: None,
+                key: format!("embed-key-{}", i),
+                value: Value::String(format!("text for embedding test {}", i)),
+            })
+            .unwrap();
+    }
+
+    // Search — stats should include embedding progress
+    let result = executor.execute(Command::Search {
+        branch: None,
+        space: None,
+        search: SearchQuery {
+            query: "test".to_string(),
+            k: None,
+            primitives: None,
+            time_range: None,
+            mode: None,
+            expand: Some(false),
+            rerank: Some(false),
+            precomputed_embedding: None,
+        },
+    });
+
+    match result {
+        Ok(Output::SearchResults { stats, .. }) => {
+            assert!(
+                stats.embedding_pending.is_some(),
+                "Should report pending embeds when auto-embed is on with queued items"
+            );
+            assert!(
+                stats.embedding_pending.unwrap() > 0,
+                "Should have pending > 0"
+            );
+            assert!(
+                stats.embedding_total.is_some(),
+                "Should report total queued embeds"
+            );
+            assert!(stats.embedding_total.unwrap() > 0, "Should have total > 0");
+        }
+        other => panic!("Expected SearchResults, got {:?}", other),
+    }
+}
+
+/// Issue #1768: search stats should NOT include embedding progress when
+/// auto-embed is enabled but nothing is pending (all embedded).
+#[test]
+fn test_issue_1768_search_stats_no_embedding_when_nothing_pending() {
+    let db = Database::cache().unwrap();
+    db.set_auto_embed(true);
+    let executor = Executor::new(db);
+
+    // No KV inserts → nothing pending in the embed buffer
+    let result = executor.execute(Command::Search {
+        branch: None,
+        space: None,
+        search: SearchQuery {
+            query: "test".to_string(),
+            k: None,
+            primitives: None,
+            time_range: None,
+            mode: None,
+            expand: Some(false),
+            rerank: Some(false),
+            precomputed_embedding: None,
+        },
+    });
+
+    match result {
+        Ok(Output::SearchResults { stats, .. }) => {
+            assert_eq!(
+                stats.embedding_pending, None,
+                "Should not report embedding progress when nothing is pending"
+            );
+            assert_eq!(
+                stats.embedding_total, None,
+                "Should not report embedding total when nothing is pending"
+            );
+        }
+        other => panic!("Expected SearchResults, got {:?}", other),
+    }
+}
+
+/// Issue #1768: search stats should NOT include embedding progress when
+/// auto-embed is disabled.
+#[test]
+fn test_issue_1768_search_stats_no_embedding_when_disabled() {
+    let executor = create_executor();
+
+    let result = executor.execute(Command::Search {
+        branch: None,
+        space: None,
+        search: SearchQuery {
+            query: "test".to_string(),
+            k: None,
+            primitives: None,
+            time_range: None,
+            mode: None,
+            expand: Some(false),
+            rerank: Some(false),
+            precomputed_embedding: None,
+        },
+    });
+
+    match result {
+        Ok(Output::SearchResults { stats, .. }) => {
+            assert_eq!(
+                stats.embedding_pending, None,
+                "Should not report embedding progress when auto-embed is off"
+            );
+            assert_eq!(
+                stats.embedding_total, None,
+                "Should not report embedding total when auto-embed is off"
+            );
+        }
+        other => panic!("Expected SearchResults, got {:?}", other),
+    }
+}

--- a/crates/executor/src/tests/serialization.rs
+++ b/crates/executor/src/tests/serialization.rs
@@ -627,6 +627,8 @@ fn test_output_search_results_with_stats() {
             rerank_used: false,
             expansion_model: None,
             rerank_model: None,
+            embedding_pending: None,
+            embedding_total: None,
         },
     });
 }
@@ -646,6 +648,29 @@ fn test_output_search_results_with_model_names() {
             rerank_used: true,
             expansion_model: Some("qwen3:1.7b".to_string()),
             rerank_model: Some("qwen3:1.7b".to_string()),
+            embedding_pending: None,
+            embedding_total: None,
+        },
+    });
+}
+
+#[test]
+fn test_output_search_results_with_embedding_progress() {
+    test_output_round_trip(Output::SearchResults {
+        hits: vec![],
+        stats: SearchStatsOutput {
+            elapsed_ms: 3.0,
+            candidates_considered: 10,
+            candidates_by_primitive: std::collections::HashMap::new(),
+            index_used: false,
+            truncated: false,
+            mode: "hybrid".to_string(),
+            expansion_used: false,
+            rerank_used: false,
+            expansion_model: None,
+            rerank_model: None,
+            embedding_pending: Some(42),
+            embedding_total: Some(100),
         },
     });
 }

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -683,6 +683,12 @@ pub struct SearchStatsOutput {
     /// Model name used for re-ranking (when rerank_used is true).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rerank_model: Option<String>,
+    /// Number of documents still waiting to be embedded (when auto-embed is active).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding_pending: Option<u64>,
+    /// Total number of documents queued for embedding (when auto-embed is active).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding_total: Option<u64>,
 }
 
 /// A single sample item from a primitive (key + value for shape discovery).


### PR DESCRIPTION
## Summary

- Adds `embedding_pending` and `embedding_total` optional fields to `SearchStatsOutput`
- Search handler queries `embed_status()` and populates these fields when auto-embed is active with pending items
- Fields are `None` (and omitted from JSON) when auto-embed is off or nothing is pending

## Root Cause

`search()` returned `SearchStatsOutput` with no embedding pipeline information. Users with auto-embed enabled who searched immediately after bulk inserts saw empty results with no indication that embeddings were still being processed.

## Fix

The search handler now calls `embed_status(p)` (an existing read-only function that loads atomic counters) and conditionally populates two new `Option<u64>` fields on `SearchStatsOutput`. The fields use `#[serde(default, skip_serializing_if = "Option::is_none")]` for backward-compatible serialization.

~15 lines of non-test code. Output-only change — no storage, MVCC, COW, or ACID paths touched.

## Invariants Verified

ARCH-002, ARCH-003 — all 50 invariants triaged; none affected (executor output-only change).

## Test Plan

- [x] `test_issue_1768_search_stats_include_embedding_progress` — embed feature: verifies fields populated when auto-embed on + items pending
- [x] `test_issue_1768_search_stats_no_embedding_when_disabled` — verifies fields are None when auto-embed off
- [x] `test_issue_1768_search_stats_no_embedding_when_nothing_pending` — verifies fields are None when auto-embed on but buffer empty
- [x] `test_output_search_results_with_embedding_progress` — serialization round-trip with Some values
- [x] Full executor test suite: 558 pass
- [x] Full workspace test suite: all pass
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)