### PR TITLE
Fix #1733: Deduplicate history after WAL replay + segment recovery

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -4475,4 +4475,160 @@ mod tests {
         // Shutdown should complete within a reasonable time
         shutdown_handle.join().unwrap();
     }
+
+    #[test]
+    fn test_issue_1733_history_no_duplicates_after_recovery() {
+        // Issue #1733: WAL replay replays ALL records (including already-flushed
+        // ones) into memtables. After segment recovery loads the same data from
+        // disk, get_history() returns duplicate versions.
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("db");
+        let branch_id = BranchId::new();
+
+        // Phase 1: Write data and flush to segments
+        {
+            let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+            let ns = create_test_namespace(branch_id);
+            let key = Key::new_kv(ns, "history_key");
+
+            // Write 3 versions
+            blind_write(&db, key.clone(), Value::Int(1));
+            blind_write(&db, key.clone(), Value::Int(2));
+            blind_write(&db, key.clone(), Value::Int(3));
+
+            // Flush memtable to segment — data is now in BOTH WAL and segment
+            db.storage().rotate_memtable(&branch_id);
+            db.storage().flush_oldest_frozen(&branch_id).unwrap();
+
+            // Verify history has 3 versions before close
+            let history = db.get_history(&key, None, None).unwrap();
+            assert_eq!(history.len(), 3, "pre-close history should have 3 versions");
+        }
+
+        // Clear registry so reopen creates a fresh instance
+        OPEN_DATABASES.lock().clear();
+
+        // Phase 2: Reopen — WAL replays all records, then segments are loaded
+        {
+            let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+            let ns = create_test_namespace(branch_id);
+            let key = Key::new_kv(ns, "history_key");
+
+            let history = db.get_history(&key, None, None).unwrap();
+
+            // BUG: Without dedup, this returns 6 versions (3 from memtable + 3 from segment)
+            assert_eq!(
+                history.len(),
+                3,
+                "get_history() returned {} versions after recovery (expected 3 — duplicates detected)",
+                history.len()
+            );
+
+            // Verify correct values (newest first)
+            assert_eq!(history[0].value, Value::Int(3));
+            assert_eq!(history[1].value, Value::Int(2));
+            assert_eq!(history[2].value, Value::Int(1));
+
+            // Also verify point read returns the correct latest value (no regression)
+            let latest = db.storage().get_versioned(&key, u64::MAX).unwrap();
+            assert!(latest.is_some(), "point read should find the key");
+            assert_eq!(latest.unwrap().value, Value::Int(3));
+        }
+    }
+
+    #[test]
+    fn test_issue_1733_partial_flush_no_duplicates() {
+        // Variant: only some versions are flushed. After recovery, flushed
+        // versions appear in both memtable and segment; unflushed versions
+        // appear only in memtable. History must still have no duplicates.
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("db");
+        let branch_id = BranchId::new();
+
+        {
+            let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+            let ns = create_test_namespace(branch_id);
+            let key = Key::new_kv(ns, "partial_key");
+
+            // Write v1, v2 then flush
+            blind_write(&db, key.clone(), Value::Int(1));
+            blind_write(&db, key.clone(), Value::Int(2));
+            db.storage().rotate_memtable(&branch_id);
+            db.storage().flush_oldest_frozen(&branch_id).unwrap();
+
+            // Write v3 (not flushed — only in WAL)
+            blind_write(&db, key.clone(), Value::Int(3));
+        }
+
+        OPEN_DATABASES.lock().clear();
+
+        {
+            let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+            let ns = create_test_namespace(branch_id);
+            let key = Key::new_kv(ns, "partial_key");
+
+            let history = db.get_history(&key, None, None).unwrap();
+            assert_eq!(
+                history.len(),
+                3,
+                "partial flush: expected 3 versions, got {}",
+                history.len()
+            );
+            assert_eq!(history[0].value, Value::Int(3));
+            assert_eq!(history[1].value, Value::Int(2));
+            assert_eq!(history[2].value, Value::Int(1));
+        }
+    }
+
+    #[test]
+    fn test_issue_1733_tombstone_no_duplicate_after_recovery() {
+        // Variant: a delete (tombstone) was flushed. After recovery, history
+        // must show the tombstone exactly once, not twice.
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("db");
+        let branch_id = BranchId::new();
+
+        {
+            let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+            let ns = create_test_namespace(branch_id);
+            let key = Key::new_kv(ns.clone(), "tomb_key");
+
+            blind_write(&db, key.clone(), Value::Int(1));
+
+            // Delete the key (creates tombstone)
+            db.transaction(branch_id, |txn| {
+                txn.delete(key.clone())?;
+                Ok(())
+            })
+            .unwrap();
+
+            // Flush both versions to segment
+            db.storage().rotate_memtable(&branch_id);
+            db.storage().flush_oldest_frozen(&branch_id).unwrap();
+        }
+
+        OPEN_DATABASES.lock().clear();
+
+        {
+            let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+            let ns = create_test_namespace(branch_id);
+            let key = Key::new_kv(ns, "tomb_key");
+
+            let history = db.get_history(&key, None, None).unwrap();
+            // History includes tombstones: should be [tombstone@v2, put@v1]
+            assert_eq!(
+                history.len(),
+                2,
+                "tombstone dedup: expected 2 versions (tombstone + put), got {}",
+                history.len()
+            );
+
+            // Point read should return None (key is deleted)
+            let latest = db.storage().get_versioned(&key, u64::MAX).unwrap();
+            assert!(
+                latest.is_none(),
+                "deleted key should not be found via point read"
+            );
+        }
+    }
 }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -2557,8 +2557,11 @@ impl SegmentedStore {
             }
         }
 
-        // Sort descending by commit_id (newest first)
+        // Sort descending by commit_id (newest first) and deduplicate.
+        // After recovery, the same (key, commit_id) may exist in both memtable
+        // (from WAL replay) and segments (from disk), producing duplicates (#1733).
         all_versions.sort_by(|a, b| b.0.cmp(&a.0));
+        all_versions.dedup_by_key(|entry| entry.0);
         all_versions
     }
 


### PR DESCRIPTION
## Summary

- WAL replay replays ALL records into memtables, including those already flushed to segments
- After `recover_segments()` loads those same entries from disk, `get_history()` returned duplicate versions (e.g., 6 instead of 3)
- Added `dedup_by_key(commit_id)` after sorting in `get_all_versions_from_branch()` — a 1-line fix

## Root Cause

`RecoveryCoordinator::recover()` uses `reader.iter_all()` which replays every WAL record. Then `storage.recover_segments()` loads previously-flushed segments. For any transaction that was flushed but whose WAL was retained (global WAL retention protects all branches), the same `(key, commit_id)` exists in both memtable and segment. `get_all_versions_from_branch()` collected from all sources without deduplication.

Point reads were unaffected (MvccIterator already deduplicates), but `get_history()` and `get_at_timestamp()` exposed the duplicates.

## Fix

Added `all_versions.dedup_by_key(|entry| entry.0)` after the existing sort in `get_all_versions_from_branch()`. This is safe because:
- The list is sorted by `commit_id` descending, so duplicates are adjacent
- Same `(key, commit_id)` can only arise from WAL/segment overlap with identical data (ACID-005 idempotence)
- A single transaction can only put OR delete a given key, never both — so dedup cannot remove a tombstone in favor of a put

## Invariants Verified

ACID-005, MVCC-001, MVCC-002, LSM-003, COW-003, ARCH-004

## Test Plan

- [x] `test_issue_1733_history_no_duplicates_after_recovery` — full flush, reopen, verify no duplicates
- [x] `test_issue_1733_partial_flush_no_duplicates` — partial flush (some versions unflushed), reopen
- [x] `test_issue_1733_tombstone_no_duplicate_after_recovery` — tombstone dedup + point read correctness
- [x] Full workspace test suite passes (1337 tests, 0 failures)
- [x] Invariant check: all 6 affected invariants HOLD
- [x] Code review: no must-fix or should-fix issues remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)