### PR TITLE
Fix #1721: Reset inherited layer status to Active during fork_branch

### DIFF
--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -1112,7 +1112,10 @@ impl SegmentedStore {
                     source_branch_id: l.source_branch_id,
                     fork_version: l.fork_version,
                     segments: Arc::clone(&l.segments),
-                    status: l.status,
+                    // Always reset to Active: the child has not started any
+                    // materialization.  Copying Materializing would permanently
+                    // block the child from materializing this layer (#1721).
+                    status: LayerStatus::Active,
                 })
                 .collect();
 

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -8712,3 +8712,87 @@ fn test_issue_1740_apply_recovery_atomic_preserves_ttl() {
         entry.ttl_ms
     );
 }
+
+// ===== Issue #1721: fork_branch must not copy Materializing status =====
+
+/// Regression test for issue #1721 (COW-M6).
+///
+/// When a source branch has an inherited layer with `Materializing` status,
+/// `fork_branch` must set the child's copy to `Active`. Otherwise the child
+/// can never materialize that layer (the `Materializing` check returns early).
+#[test]
+fn test_issue_1721_fork_resets_materializing_status() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    let grandparent = BranchId::from_bytes([10; 16]);
+    let gp_ns = Arc::new(Namespace::new(grandparent, "default".to_string()));
+
+    // 1. Seed grandparent with data and flush to segments.
+    for i in 0..10 {
+        let key = Key::new(
+            Arc::clone(&gp_ns),
+            TypeTag::KV,
+            format!("k{}", i).into_bytes(),
+        );
+        seed(&store, key, Value::Int(i as i64), 1);
+    }
+    store.rotate_memtable(&grandparent);
+    store.flush_oldest_frozen(&grandparent).unwrap();
+
+    // 2. Fork grandparent → parent.  Parent inherits grandparent's segments.
+    let parent = BranchId::from_bytes([20; 16]);
+    store
+        .branches
+        .entry(parent)
+        .or_insert_with(BranchState::new);
+    store.fork_branch(&grandparent, &parent).unwrap();
+
+    // 3. Simulate in-progress materialization on the parent's inherited layer.
+    {
+        let mut branch = store.branches.get_mut(&parent).unwrap();
+        assert!(
+            !branch.inherited_layers.is_empty(),
+            "parent should have inherited layers"
+        );
+        branch.inherited_layers[0].status = LayerStatus::Materializing;
+    }
+
+    // 4. Fork parent → child (grandchild).
+    let child = BranchId::from_bytes([30; 16]);
+    store.branches.entry(child).or_insert_with(BranchState::new);
+    store.fork_branch(&parent, &child).unwrap();
+
+    // 5. Verify ALL of child's inherited layers are Active.
+    {
+        let branch = store.branches.get(&child).unwrap();
+        assert!(
+            branch.inherited_layers.len() >= 2,
+            "child should have at least 2 inherited layers"
+        );
+        for (i, layer) in branch.inherited_layers.iter().enumerate() {
+            assert_eq!(
+                layer.status,
+                LayerStatus::Active,
+                "child inherited layer {} should be Active, got {:?}",
+                i,
+                layer.status
+            );
+        }
+    }
+
+    // 6. Verify child can materialize layer[1] (the one that was Materializing in parent).
+    //    Before the fix, materialize_layer returns early with 0 entries because
+    //    it sees Materializing status and assumes materialization is already running.
+    let result = store.materialize_layer(&child, 1).unwrap();
+    assert!(
+        result.entries_materialized > 0,
+        "child must be able to materialize layer that was Materializing in parent"
+    );
+
+    // 7. Verify data is still readable through the child.
+    let child_ns = Arc::new(Namespace::new(child, "default".to_string()));
+    let child_key = Key::new(Arc::clone(&child_ns), TypeTag::KV, b"k0".to_vec());
+    let val = store.get_versioned(&child_key, u64::MAX).unwrap().unwrap();
+    assert_eq!(val.value, Value::Int(0));
+}


### PR DESCRIPTION
## Summary
- `fork_branch` copied `LayerStatus` verbatim from the source's inherited layers to the child
- If the source had a `Materializing` layer, the child inherited that status, permanently blocking materialization of that layer (until restart)
- Fix: always set `status: LayerStatus::Active` when cloning inherited layers during fork — consistent with recovery semantics which also reset `Materializing` → `Active`

## Root Cause
In `fork_branch()`, line 1048 used `status: l.status` when copying the source's transitive inherited layers. The `materialize_layer()` function returns early (0 entries) when it sees `Materializing` status, assuming materialization is already in progress. Since no materialization was actually running on the child, the layer was stuck forever.

## Fix
Single-line change: `status: l.status` → `status: LayerStatus::Active` in the inherited layer copy loop within `fork_branch()`.

## Invariants Verified
COW-001, COW-002, COW-003, COW-004, COW-005, COW-006, ARCH-008 — all HOLD.

## Test Plan
- [x] `test_issue_1721_fork_resets_materializing_status` — regression test: grandparent→parent→child fork chain with Materializing status on parent, verifies child layers are Active and materializable
- [x] Full `strata-storage` crate tests pass (583 tests)
- [x] Full workspace tests pass (1323 passed, 1 pre-existing flaky `test_open_uses_registry`)
- [x] Clippy clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)