### PR TITLE
Fix #1685: Key-encoding helpers return errors instead of panicking on malformed input

### DIFF
--- a/crates/storage/src/key_encoding.rs
+++ b/crates/storage/src/key_encoding.rs
@@ -88,6 +88,11 @@ fn decode_escaped(src: &[u8]) -> Option<(Vec<u8>, usize)> {
 /// The encoding preserves the lexicographic ordering of `Key`:
 /// namespace (branch_id, then space) → type_tag → user_key.
 pub fn encode_typed_key(key: &Key) -> Vec<u8> {
+    assert!(
+        !key.namespace.space.as_bytes().contains(&0x00),
+        "encode_typed_key: space name must not contain NUL bytes (space={:?})",
+        key.namespace.space,
+    );
     let mut buf =
         Vec::with_capacity(16 + key.namespace.space.len() + 1 + 1 + key.user_key.len() + 2);
     // Branch ID: 16 bytes, big-endian UUID
@@ -185,6 +190,11 @@ impl InternalKey {
 
     /// Extract the TypedKeyBytes portion (everything except trailing 8-byte commit_id).
     pub fn typed_key_prefix(&self) -> &[u8] {
+        assert!(
+            self.0.len() >= 8,
+            "InternalKey too short for typed_key_prefix: {} bytes (need ≥8)",
+            self.0.len()
+        );
         &self.0[..self.0.len() - 8]
     }
 
@@ -238,6 +248,11 @@ impl InternalKey {
     /// into the child branch's namespace, so that `MvccIterator` can group
     /// own + inherited entries by the same `typed_key_prefix`.
     pub fn with_rewritten_branch_id(&self, new_branch_id: &BranchId) -> Self {
+        assert!(
+            self.0.len() >= 16,
+            "InternalKey too short for branch rewrite: {} bytes (need ≥16)",
+            self.0.len()
+        );
         let mut bytes = self.0.clone();
         bytes[..16].copy_from_slice(new_branch_id.as_bytes());
         InternalKey(bytes)
@@ -249,17 +264,15 @@ impl InternalKey {
 /// Used by COW branching point lookups to rewrite a child's `typed_key`
 /// into the source branch's namespace for bloom probes and index searches.
 ///
-/// # Panics
-/// Panics if `encoded` is shorter than 16 bytes.
-pub fn rewrite_branch_id_bytes(encoded: &[u8], new_branch_id: &BranchId) -> Vec<u8> {
-    debug_assert!(
-        encoded.len() >= 16,
-        "rewrite_branch_id_bytes: encoded key too short ({} bytes, need ≥16)",
-        encoded.len()
-    );
+/// Returns `None` if `encoded` is shorter than 16 bytes (e.g., corrupt
+/// segment data), instead of panicking.
+pub fn rewrite_branch_id_bytes(encoded: &[u8], new_branch_id: &BranchId) -> Option<Vec<u8>> {
+    if encoded.len() < 16 {
+        return None;
+    }
     let mut rewritten = encoded.to_vec();
     rewritten[..16].copy_from_slice(new_branch_id.as_bytes());
-    rewritten
+    Some(rewritten)
 }
 
 impl Ord for InternalKey {
@@ -591,6 +604,35 @@ mod tests {
         let ik_null = InternalKey::encode(&k_null, 1);
         let ik_one = InternalKey::encode(&k_one, 1);
         assert!(ik_null < ik_one, "\\x00 should sort before \\x01");
+    }
+
+    // ===== Issue #1685: Malformed input handling =====
+
+    #[test]
+    fn test_issue_1685_rewrite_branch_id_returns_none_on_short_input() {
+        // rewrite_branch_id_bytes must return None for input shorter than 16 bytes,
+        // not panic. Corrupt segment data could produce short encoded keys.
+        let branch = BranchId::new();
+        assert!(rewrite_branch_id_bytes(&[1, 2, 3], &branch).is_none());
+        assert!(rewrite_branch_id_bytes(&[], &branch).is_none());
+        assert!(rewrite_branch_id_bytes(&[0u8; 15], &branch).is_none());
+        // Exactly 16 bytes should succeed
+        assert!(rewrite_branch_id_bytes(&[0u8; 16], &branch).is_some());
+        // Normal-length input should succeed
+        assert!(rewrite_branch_id_bytes(&[0u8; 28], &branch).is_some());
+    }
+
+    #[test]
+    #[should_panic(expected = "NUL")]
+    fn test_issue_1685_encode_typed_key_rejects_nul_in_space() {
+        // Space names containing NUL bytes break the encoding format because
+        // NUL is the space field terminator. encode_typed_key must reject them.
+        let ns = Arc::new(Namespace {
+            branch_id: BranchId::new(),
+            space: "bad\x00space".to_string(),
+        });
+        let key = Key::new(ns, TypeTag::KV, b"test".to_vec());
+        encode_typed_key(&key);
     }
 
     // ===== Property tests =====

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -727,8 +727,11 @@ impl SegmentedStore {
 
                     let typed_key = ik.typed_key_prefix();
 
-                    // Rewrite branch_id: source → child
-                    let child_typed_key = rewrite_branch_id_bytes(typed_key, child_branch_id);
+                    // Rewrite branch_id: source → child (skip corrupt keys)
+                    let Some(child_typed_key) = rewrite_branch_id_bytes(typed_key, child_branch_id)
+                    else {
+                        continue;
+                    };
 
                     // Shadow detection (cached per logical key)
                     let is_shadowed = if last_shadow_key.as_deref() == Some(&child_typed_key) {
@@ -755,8 +758,12 @@ impl SegmentedStore {
                         continue;
                     }
 
-                    // Rewrite full internal key: source → child
-                    let child_ik_bytes = rewrite_branch_id_bytes(ik.as_bytes(), child_branch_id);
+                    // Rewrite full internal key: source → child (skip corrupt keys)
+                    let Some(child_ik_bytes) =
+                        rewrite_branch_id_bytes(ik.as_bytes(), child_branch_id)
+                    else {
+                        continue;
+                    };
                     let child_ik = InternalKey::from_bytes(child_ik_bytes);
 
                     entries.push((child_ik, segment_entry_to_memtable_entry(se)));
@@ -900,7 +907,10 @@ impl SegmentedStore {
         fork_version: u64,
     ) -> bool {
         // Rewrite typed_key from child → source namespace
-        let src_typed_key = rewrite_branch_id_bytes(child_typed_key, &source_branch_id);
+        let Some(src_typed_key) = rewrite_branch_id_bytes(child_typed_key, &source_branch_id)
+        else {
+            return false; // Corrupt key can't exist
+        };
         let src_seek_ik = InternalKey::from_typed_key_bytes(&src_typed_key, u64::MAX);
         let src_seek_bytes = src_seek_ik.as_bytes();
 
@@ -2408,7 +2418,10 @@ impl SegmentedStore {
             }
             let effective_version = max_version.min(layer.fork_version);
             // Rewrite typed_key: child branch_id → source branch_id
-            let src_typed_key = rewrite_branch_id_bytes(&typed_key, &layer.source_branch_id);
+            let Some(src_typed_key) = rewrite_branch_id_bytes(&typed_key, &layer.source_branch_id)
+            else {
+                continue; // Skip layer if key is corrupt
+            };
             let src_seek_ik = InternalKey::from_typed_key_bytes(&src_typed_key, u64::MAX);
             let src_seek_bytes = src_seek_ik.as_bytes();
 


### PR DESCRIPTION
## Summary

- `rewrite_branch_id_bytes()` used `debug_assert!` (no-op in release) for its 16-byte minimum length check — corrupt segment data would panic the process in release builds
- `encode_typed_key()` documented but did not enforce the no-NUL-in-space invariant
- `typed_key_prefix()` and `with_rewritten_branch_id()` lacked defensive length guards

## Root Cause

`rewrite_branch_id_bytes` is a standalone function accepting raw `&[u8]` from segment data. Its only guard was `debug_assert!(encoded.len() >= 16)`, which compiles away in release. The 4 call sites (materialization, shadow check, point lookup) would panic on corrupt keys.

## Fix

- **`rewrite_branch_id_bytes()`**: Changed return type from `Vec<u8>` to `Option<Vec<u8>>` with a real length check. Updated all 4 callers to skip corrupt entries gracefully (`continue` / `return false`).
- **`encode_typed_key()`**: Added runtime `assert!` that space contains no NUL bytes (encoding invariant — NUL is the space terminator).
- **`typed_key_prefix()` / `with_rewritten_branch_id()`**: Added defensive `assert!` for minimum length (currently impossible to trigger via constructors, but guards against future changes).

## Invariants Verified

LSM-001, LSM-003, LSM-005, COW-003, COW-004, MVCC-001, MVCC-002 — all HOLDS.

## Test Plan

- [x] `test_issue_1685_rewrite_branch_id_returns_none_on_short_input` — boundary values (0, 3, 15, 16, 28 bytes)
- [x] `test_issue_1685_encode_typed_key_rejects_nul_in_space` — NUL in space name triggers panic
- [x] Full storage crate suite (581 passed)
- [x] Full workspace suite (2,598 passed, excluding strata-inference)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)