### PR TITLE
Fix #1718: Prevent duplicate segments from concurrent flush_oldest_frozen calls

### DIFF
--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -1932,27 +1932,40 @@ impl SegmentedStore {
             .branches
             .entry(*branch_id)
             .or_insert_with(BranchState::new);
-        if let Some(last) = branch.frozen.last() {
+        let popped = if let Some(last) = branch.frozen.last() {
             if last.id() == frozen_mt.id() {
                 branch.frozen.pop();
                 self.total_frozen_count.fetch_sub(1, Ordering::Relaxed);
+                true
+            } else {
+                false
             }
-        }
-        // Build new version with the new segment prepended (newest first).
-        let old_ver = branch.version.load();
-        let mut new_l0 = Vec::with_capacity(old_ver.l0_segments().len() + 1);
-        new_l0.push(Arc::new(segment));
-        new_l0.extend(old_ver.l0_segments().iter().cloned());
-        let mut new_levels = old_ver.levels.clone();
-        new_levels[0] = new_l0;
-        branch
-            .version
-            .store(Arc::new(SegmentVersion { levels: new_levels }));
-        refresh_level_targets(&mut branch, self.level_base_bytes());
+        } else {
+            false
+        };
 
-        // Persist level assignments
-        drop(branch);
-        self.write_branch_manifest(branch_id);
+        if popped {
+            // Build new version with the new segment prepended (newest first).
+            let old_ver = branch.version.load();
+            let mut new_l0 = Vec::with_capacity(old_ver.l0_segments().len() + 1);
+            new_l0.push(Arc::new(segment));
+            new_l0.extend(old_ver.l0_segments().iter().cloned());
+            let mut new_levels = old_ver.levels.clone();
+            new_levels[0] = new_l0;
+            branch
+                .version
+                .store(Arc::new(SegmentVersion { levels: new_levels }));
+            refresh_level_targets(&mut branch, self.level_base_bytes());
+
+            // Persist level assignments
+            drop(branch);
+            self.write_branch_manifest(branch_id);
+        } else {
+            // Another thread already flushed this memtable; discard the
+            // duplicate segment file we just built.
+            drop(branch);
+            let _ = std::fs::remove_file(&seg_path);
+        }
 
         Ok(true)
     }

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -8796,3 +8796,125 @@ fn test_issue_1721_fork_resets_materializing_status() {
     let val = store.get_versioned(&child_key, u64::MAX).unwrap().unwrap();
     assert_eq!(val.value, Value::Int(0));
 }
+
+/// Issue #1718 M-13: Two concurrent `flush_oldest_frozen` calls for the same
+/// branch must not install duplicate segments from the same frozen memtable.
+#[test]
+fn test_issue_1718_concurrent_flush_no_duplicate_segments() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+    let b = branch();
+
+    // Write data and rotate to create exactly one frozen memtable.
+    for i in 0..10u64 {
+        store
+            .put_with_version_mode(
+                kv_key(&format!("k{:04}", i)),
+                Value::Int(i as i64),
+                i + 1,
+                None,
+                WriteMode::Append,
+            )
+            .unwrap();
+    }
+    store.rotate_memtable(&b);
+    assert_eq!(store.branch_frozen_count(&b), 1);
+
+    // Launch two threads that both try to flush the same frozen memtable.
+    let barrier = Arc::new(std::sync::Barrier::new(2));
+    let handles: Vec<_> = (0..2)
+        .map(|_| {
+            let s = Arc::clone(&store);
+            let bar = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                bar.wait();
+                s.flush_oldest_frozen(&branch()).unwrap()
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // Exactly ONE segment should be installed (not two duplicates).
+    let seg_count = store.branch_segment_count(&b);
+    assert_eq!(
+        seg_count, 1,
+        "Expected 1 segment from the single frozen memtable, got {} (duplicate detected)",
+        seg_count
+    );
+
+    // The frozen list should be empty (memtable was consumed).
+    assert_eq!(store.branch_frozen_count(&b), 0);
+
+    // All data is readable.
+    for i in 0..10u64 {
+        let result = store
+            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.value, Value::Int(i as i64));
+    }
+}
+
+/// Issue #1718 M-13 stress: Many concurrent flushes must not produce duplicates.
+#[test]
+fn test_issue_1718_concurrent_flush_no_duplicate_segments_stress() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+    let b = branch();
+
+    // Create 3 frozen memtables.
+    for batch in 0..3u64 {
+        for i in 0..5u64 {
+            let key_idx = batch * 5 + i;
+            store
+                .put_with_version_mode(
+                    kv_key(&format!("k{:04}", key_idx)),
+                    Value::Int(key_idx as i64),
+                    key_idx + 1,
+                    None,
+                    WriteMode::Append,
+                )
+                .unwrap();
+        }
+        store.rotate_memtable(&b);
+    }
+    assert_eq!(store.branch_frozen_count(&b), 3);
+
+    // Launch 8 threads all racing to flush.
+    let barrier = Arc::new(std::sync::Barrier::new(8));
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            let s = Arc::clone(&store);
+            let bar = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                bar.wait();
+                while s.flush_oldest_frozen(&branch()).unwrap() {}
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // Exactly 3 segments (one per frozen memtable), no duplicates.
+    let seg_count = store.branch_segment_count(&b);
+    assert_eq!(
+        seg_count, 3,
+        "Expected 3 segments from 3 frozen memtables, got {} (duplicates detected)",
+        seg_count
+    );
+    assert_eq!(store.branch_frozen_count(&b), 0);
+
+    // All data readable.
+    for i in 0..15u64 {
+        let result = store
+            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.value, Value::Int(i as i64));
+    }
+}


### PR DESCRIPTION
## Summary

- **M-13 from issue #1718**: Two concurrent `flush_oldest_frozen` calls for the same branch could both clone the same frozen memtable, both build segments to disk, and both install them into L0 — producing duplicate segments.
- The existing ID check prevented double-pop of the frozen memtable, but segment installation was unconditional.
- Now segment installation is gated on successful memtable pop; the race loser discards its orphan segment file.

## Root Cause

In `flush_oldest_frozen`, the frozen memtable is cloned (Arc) under a short-lived DashMap read guard, then the segment is built outside any lock. When re-acquiring the exclusive guard, the ID check correctly prevents double-popping the frozen memtable — but lines 1868-1877 unconditionally installed the segment into the L0 version regardless of whether the pop succeeded.

## Fix

Made segment installation conditional on the `popped` flag (set inside the exclusive DashMap guard). When another thread already flushed the same memtable:
1. Skip segment installation and manifest write
2. Delete the orphan `.sst` file (best-effort; `gc_orphan_segments` is the safety net)
3. Return `Ok(true)` to allow the caller's loop to retry for remaining frozen memtables

~15 lines of non-test code changed.

## Invariants Verified

CMP-006 (concurrent flush safety), LSM-003 (read path ordering), LSM-004 (memtable rotation atomicity), LSM-007 (segment immutability), CMP-004 (manifest-before-delete), CMP-005 (dynamic level sizing), COW-001 (shared segment deletion)

## Test Plan

- [x] `test_issue_1718_concurrent_flush_no_duplicate_segments` — 2 threads race on 1 frozen memtable, asserts exactly 1 segment installed
- [x] `test_issue_1718_concurrent_flush_no_duplicate_segments_stress` — 8 threads race on 3 frozen memtables, asserts exactly 3 segments installed
- [x] Full `strata-storage` test suite (581 tests pass)
- [x] Full workspace test suite (all crates pass)
- [x] Clippy clean, fmt clean
- [x] Invariant check: all 7 affected invariants HOLD

🤖 Generated with [Claude Code](https://claude.com/claude-code)