### PR TITLE
Fix #1718: Detect version counter overflow instead of silent wraparound (M-11)

### DIFF
--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -419,14 +419,20 @@ impl SegmentedStore {
     }
 
     /// Increment version and return new value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the version counter is at `u64::MAX`. This is consistent
+    /// with `TransactionManager::allocate_version()` which returns
+    /// `Err(CounterOverflow)` at the same boundary.
     #[inline]
     pub fn next_version(&self) -> u64 {
-        self.version
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |v| {
-                Some(v.wrapping_add(1))
-            })
-            .unwrap()
-            .wrapping_add(1)
+        let prev = self
+            .version
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |v| v.checked_add(1))
+            .expect("version counter overflow: u64::MAX versions exhausted");
+        // Safe: checked_add succeeded, so prev < u64::MAX and prev + 1 won't overflow.
+        prev + 1
     }
 
     /// Set version (used during recovery).

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -213,6 +213,21 @@ fn version_next_version_set_version() {
 }
 
 #[test]
+#[should_panic(expected = "version counter overflow")]
+fn test_issue_1718_next_version_overflow_panics() {
+    // M-11: next_version() must detect u64::MAX overflow instead of
+    // silently wrapping to 0, which would corrupt MVCC ordering.
+    // This is consistent with TransactionManager::allocate_version()
+    // which returns Err(CounterOverflow) at u64::MAX.
+    let store = SegmentedStore::new();
+    store.set_version(u64::MAX - 1);
+    // Advances from MAX-1 to MAX — should succeed
+    assert_eq!(store.next_version(), u64::MAX);
+    // Advances from MAX — should panic (overflow)
+    store.next_version();
+}
+
+#[test]
 fn branch_ids_and_clear() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("k"), Value::Int(1), 1);


### PR DESCRIPTION
## Summary

- `SegmentedStore::next_version()` used `wrapping_add(1)` which silently wraps `u64::MAX` → `0`, breaking all MVCC ordering invariants
- Replaced with `checked_add(1)` that panics on overflow, consistent with `TransactionManager::allocate_version()` which returns `Err(CounterOverflow)` at the same boundary
- While u64 overflow is practically unreachable (~584 years at 1B ops/sec), silent wraparound is a correctness hazard that should be detected

## Root Cause

Finding M-11 from the comprehensive LSM audit (#1718): the storage layer's version counter lacked the overflow detection that the coordinator already had. The `wrapping_add(1)` in `next_version()` would silently produce version 0 after `u64::MAX`, corrupting MVCC sort order.

## Fix

Replace `wrapping_add(1)` with `checked_add(1)` in `SegmentedStore::next_version()`. The `fetch_update` closure now returns `None` at `u64::MAX`, causing `expect()` to panic with a clear message. The subsequent `prev + 1` is safe because `checked_add` guarantees `prev < u64::MAX`.

## Invariants Verified

- **MVCC-003** (Global version counter monotonicity): HOLDS — overflow now detected instead of wrapping
- **SCALE-004** (AtomicU64 operations bounded): HOLDS — same operation count

## Test Plan

- [x] `test_issue_1718_next_version_overflow_panics` — verifies MAX-1→MAX succeeds and MAX→overflow panics
- [x] Existing `version_next_version_set_version` — verifies normal operation unchanged
- [x] Full `strata-storage` test suite (603 tests pass)
- [x] Clippy clean, fmt clean
- [x] Invariant check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)