### PR TITLE
Fix #1729: Exempt EventLog entries from compaction pruning

### DIFF
--- a/crates/storage/src/compaction.rs
+++ b/crates/storage/src/compaction.rs
@@ -11,6 +11,7 @@
 
 use crate::key_encoding::InternalKey;
 use crate::memtable::MemtableEntry;
+use strata_core::types::TypeTag;
 
 /// Pruning iterator for segment compaction.
 ///
@@ -115,6 +116,14 @@ impl<I: Iterator<Item = (InternalKey, MemtableEntry)>> Iterator for CompactionIt
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let (ik, entry) = self.inner.next()?;
+
+            // Event entries are exempt from all pruning (#1729).
+            // EventLog relies on a SHA-256 hash chain for tamper evidence;
+            // dropping any event breaks chain verification.
+            if ik.type_tag_byte() == TypeTag::Event.as_byte() {
+                return Some((ik, entry));
+            }
+
             let prefix = ik.typed_key_prefix().to_vec();
 
             // New logical key — reset tracking
@@ -953,5 +962,100 @@ mod tests {
         assert_eq!(candidates[0].segment_indices.len(), 4);
         assert_eq!(candidates[1].tier, 1);
         assert_eq!(candidates[1].segment_indices.len(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #1729: EventLog entries must be exempt from compaction pruning
+    // -----------------------------------------------------------------------
+
+    /// Create a Key with TypeTag::Event (sequence-based event key).
+    fn event_key(sequence: u64) -> Key {
+        let ns = Arc::new(Namespace::new(branch(), "default".to_string()));
+        Key::new(ns, TypeTag::Event, sequence.to_be_bytes().to_vec())
+    }
+
+    #[test]
+    fn test_issue_1729_event_entries_exempt_from_version_pruning() {
+        // Event entries at commit_ids 1, 2, 3 with prune_floor=10.
+        // Normal KV entries below floor would be pruned to keep only the
+        // newest floor entry. But Event entries must ALL survive because
+        // dropping any event breaks the hash chain.
+        let items = vec![
+            (InternalKey::encode(&event_key(0), 1), entry(100)),
+            (InternalKey::encode(&event_key(1), 2), entry(200)),
+            (InternalKey::encode(&event_key(2), 3), entry(300)),
+        ];
+        let merge = MergeIterator::new(vec![items.into_iter()]);
+        let result: Vec<_> = CompactionIterator::new(merge, 10).collect();
+        assert_eq!(
+            result.len(),
+            3,
+            "all Event entries must survive compaction regardless of prune_floor"
+        );
+    }
+
+    #[test]
+    fn test_issue_1729_event_entries_exempt_from_max_versions() {
+        // Event metadata key updated multiple times (same key, different versions).
+        // max_versions=1 would normally keep only the newest. But Event entries
+        // must be exempt from max_versions pruning.
+        let meta_key = {
+            let ns = Arc::new(Namespace::new(branch(), "default".to_string()));
+            Key::new(ns, TypeTag::Event, b"__meta__".to_vec())
+        };
+        let items = vec![
+            (InternalKey::encode(&meta_key, 10), entry(100)),
+            (InternalKey::encode(&meta_key, 8), entry(80)),
+            (InternalKey::encode(&meta_key, 5), entry(50)),
+        ];
+        let merge = MergeIterator::new(vec![items.into_iter()]);
+        let result: Vec<_> = CompactionIterator::new(merge, 0)
+            .with_max_versions(1)
+            .collect();
+        assert_eq!(
+            result.len(),
+            3,
+            "Event entries must be exempt from max_versions pruning"
+        );
+    }
+
+    #[test]
+    fn test_issue_1729_event_entries_exempt_from_ttl_expiration() {
+        // An expired Event entry below prune_floor — normally dropped by
+        // drop_expired. But Event entries must never be dropped by TTL.
+        let items = vec![(InternalKey::encode(&event_key(0), 5), expired_entry(100))];
+        let merge = MergeIterator::new(vec![items.into_iter()]);
+        let result: Vec<_> = CompactionIterator::new(merge, 10)
+            .with_drop_expired(true)
+            .collect();
+        assert_eq!(
+            result.len(),
+            1,
+            "expired Event entry must NOT be dropped — hash chain integrity"
+        );
+    }
+
+    #[test]
+    fn test_issue_1729_kv_entries_still_pruned_normally() {
+        // Verify that KV entries are still subject to normal pruning rules
+        // when Event entries are exempt. Mix of KV and Event entries.
+        let kv = key("user:alice");
+        let ev = event_key(0);
+        let items = vec![
+            // KV entry below floor — should be kept as floor entry
+            (InternalKey::encode(&kv, 3), entry(30)),
+            (InternalKey::encode(&kv, 1), entry(10)),
+            // Event entry below floor — must be kept (exempt)
+            (InternalKey::encode(&ev, 2), entry(200)),
+        ];
+        let merge = MergeIterator::new(vec![items.into_iter()]);
+        let result: Vec<_> = CompactionIterator::new(merge, 10).collect();
+        // KV: keeps only floor entry (v3), prunes v1
+        // Event: keeps v2 (exempt from pruning)
+        assert_eq!(result.len(), 2, "KV pruned normally, Event exempt");
+        // The KV floor entry
+        assert_eq!(result[0].0.commit_id(), 3);
+        // The Event entry
+        assert_eq!(result[1].0.commit_id(), 2);
     }
 }

--- a/crates/storage/src/key_encoding.rs
+++ b/crates/storage/src/key_encoding.rs
@@ -188,6 +188,21 @@ impl InternalKey {
         &self.0[..self.0.len() - 8]
     }
 
+    /// Extract the TypeTag byte from the encoded key.
+    ///
+    /// Layout: `branch_id (16) | space (null-terminated) | type_tag (1) | ...`
+    /// Finds the first NUL after offset 16 (end of space) and returns the
+    /// byte immediately after it.
+    pub fn type_tag_byte(&self) -> u8 {
+        // Skip 16-byte branch_id, then find the NUL that terminates the space name.
+        let after_branch = &self.0[16..];
+        let nul_pos = after_branch
+            .iter()
+            .position(|&b| b == 0x00)
+            .expect("InternalKey missing space NUL terminator");
+        after_branch[nul_pos + 1]
+    }
+
     /// Extract the commit_id from the trailing 8 bytes.
     pub fn commit_id(&self) -> u64 {
         let len = self.0.len();


### PR DESCRIPTION
## Summary

- EventLog entries (`TypeTag::Event`) were subject to version pruning, `max_versions` limiting, and TTL expiration in `CompactionIterator`
- Dropping any event breaks the SHA-256 hash chain used for tamper evidence
- Added an early-return bypass in `CompactionIterator::next()` that unconditionally emits Event entries, plus a `type_tag_byte()` helper on `InternalKey` for efficient TypeTag extraction

## Root Cause

`CompactionIterator` applies pruning uniformly to all entry types. EventLog's hash chain requires every predecessor event to be present for verification. Three loss paths existed:
1. **TTL expiration**: expired Event entries below `prune_floor` silently dropped
2. **max_versions**: Event metadata key versions pruned beyond the limit
3. **Tombstone elision**: Event tombstones (if any) elided at bottommost level

## Fix

~10 lines of non-test code:
1. `InternalKey::type_tag_byte()` — efficiently extracts the TypeTag byte by finding the space NUL terminator
2. Early return in `CompactionIterator::next()` — if `TypeTag::Event`, emit unconditionally before any pruning logic

## Invariants Verified

CMP-001, CMP-002, MVCC-001, MVCC-002, ARCH-001, ARCH-005, LSM-001 — all HOLDS

## Test Plan

- [x] `test_issue_1729_event_entries_exempt_from_version_pruning` — Event entries survive below prune_floor
- [x] `test_issue_1729_event_entries_exempt_from_max_versions` — Event metadata versions survive max_versions=1
- [x] `test_issue_1729_event_entries_exempt_from_ttl_expiration` — Expired Event entries not dropped
- [x] `test_issue_1729_kv_entries_still_pruned_normally` — KV entries still follow normal pruning rules
- [x] All 50 compaction tests pass
- [x] Full workspace tests pass (1322 passed, 2 pre-existing flaky file-lock tests)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)