### PR TITLE
Fix #1694: Flush child memtables before materialization shadow detection

### DIFF
--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -722,6 +722,19 @@ impl SegmentedStore {
             branch_id: *child_branch_id,
         };
 
+        // 1b. Flush child memtables to disk so shadow detection sees all
+        //     child writes (#1694).  Same pattern as fork_branch.
+        {
+            let has_active = self
+                .branches
+                .get(child_branch_id)
+                .is_some_and(|b| !b.active.is_empty());
+            if has_active {
+                self.rotate_memtable(child_branch_id);
+            }
+        }
+        while self.flush_oldest_frozen(child_branch_id)? {}
+
         // 2a. Snapshot under read guard
         let (layer_segments, source_branch_id, fork_version, own_version, closer_layers) = {
             let branch = match self.branches.get(child_branch_id) {

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -9000,3 +9000,88 @@ fn test_issue_1718_concurrent_flush_no_duplicate_segments_stress() {
         assert_eq!(result.value, Value::Int(i as i64));
     }
 }
+
+/// #1694: Materialization shadow detection must consider child memtable writes.
+///
+/// If a child writes a key to its memtable (not yet flushed) that shadows an
+/// inherited key, the materializer should recognize the shadow and skip the
+/// inherited entry. Without the fix, the unflushed memtable write is invisible
+/// to shadow detection, causing unnecessary materialization.
+#[test]
+fn test_issue_1694_materialize_shadow_detection_ignores_memtable() {
+    let (_dir, store) = setup_parent_with_segments(&[("a", 1, 1), ("b", 2, 2)]);
+
+    // Fork child from parent — child inherits both "a" and "b"
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+    assert_eq!(store.inherited_layer_count(&child_branch()), 1);
+
+    // Write "a" to child's memtable at a newer version — shadows inherited "a".
+    // Crucially, do NOT flush — the write stays in the active memtable.
+    seed(&store, child_kv("a"), Value::Int(999), 10);
+
+    // Verify the memtable write is in the active memtable (not flushed)
+    assert!(!store.has_frozen(&child_branch()));
+    assert_eq!(store.branch_segment_count(&child_branch()), 0);
+
+    // Materialize the inherited layer
+    let result = store.materialize_layer(&child_branch(), 0).unwrap();
+
+    // Only "b" should be materialized — "a" is shadowed by the child's memtable write.
+    assert_eq!(
+        result.entries_materialized, 1,
+        "Only 'b' should be materialized; 'a' is shadowed by the child's memtable write"
+    );
+
+    // Verify reads return the child's value for "a" and the materialized value for "b"
+    let val_a = store
+        .get_versioned(&child_kv("a"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val_a.value, Value::Int(999), "child's memtable write wins");
+
+    let val_b = store
+        .get_versioned(&child_kv("b"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val_b.value, Value::Int(2), "inherited 'b' is materialized");
+}
+
+/// #1694 variant: shadow detection must also see frozen (unflushed) memtables.
+#[test]
+fn test_issue_1694_materialize_shadow_detection_ignores_frozen_memtable() {
+    let (_dir, store) = setup_parent_with_segments(&[("x", 10, 1), ("y", 20, 2)]);
+
+    store
+        .branches
+        .entry(child_branch())
+        .or_insert_with(BranchState::new);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    // Write "x" to child, then rotate so it lands in a frozen memtable (not flushed).
+    seed(&store, child_kv("x"), Value::Int(777), 10);
+    store.rotate_memtable(&child_branch());
+    assert!(store.has_frozen(&child_branch()));
+    assert_eq!(store.branch_segment_count(&child_branch()), 0);
+
+    let result = store.materialize_layer(&child_branch(), 0).unwrap();
+
+    // Only "y" should be materialized — "x" is shadowed by the frozen memtable.
+    assert_eq!(
+        result.entries_materialized, 1,
+        "Only 'y' should be materialized; 'x' is shadowed by child's frozen memtable"
+    );
+
+    let val_x = store
+        .get_versioned(&child_kv("x"), u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(val_x.value, Value::Int(777), "child's frozen write wins");
+}


### PR DESCRIPTION
## Summary

- `materialize_layer()` shadow detection only checked on-disk segments (`key_exists_in_own_segments`), ignoring the child's active and frozen memtables
- Unflushed child writes that shadow inherited entries were missed, causing unnecessary materialization (extra write amplification)
- Fix: flush child memtables to disk before the snapshot step, converting all in-memory data to segments so existing shadow detection works correctly

## Root Cause

`key_exists_in_own_segments()` iterates L0-L6 segments but never checks the active memtable or frozen memtables. When a child branch has written a key (shadowing an inherited entry) but hasn't flushed yet, the materializer copies the inherited entry into a new SST even though it's logically dead.

## Fix

Added `rotate_memtable` + `flush_oldest_frozen` loop at the start of `materialize_layer`, before the snapshot step. Same pattern as `fork_branch`. The `is_empty()` guard skips rotation when the active memtable has no data (avoids creating empty L0 segments).

## Invariants Verified

LSM-003, LSM-004, LSM-007, CMP-004, CMP-005, CMP-006, COW-001, COW-004, MVCC-001 — all HOLD.

## Test Plan

- [x] `test_issue_1694_materialize_shadow_detection_ignores_memtable` — active memtable shadow
- [x] `test_issue_1694_materialize_shadow_detection_ignores_frozen_memtable` — frozen memtable shadow
- [x] Full storage crate suite (583 tests pass)
- [x] Full workspace suite (2504+ tests pass, 1 pre-existing flake in `test_open_uses_registry`)
- [x] Clippy clean, fmt clean
- [x] Invariant check: all 9 affected invariants HOLD

🤖 Generated with [Claude Code](https://claude.com/claude-code)