### PR TITLE
Fix #1683: Add dynamic base_level to prevent tiny intermediate level targets

### DIFF
--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -18,13 +18,17 @@ pub(super) struct LevelTargets {
 
 /// Compute adaptive per-level byte targets from actual level sizes.
 ///
-/// Algorithm (RocksDB `CalculateBaseBytes`):
+/// Algorithm (RocksDB `CalculateBaseBytes` with dynamic base_level):
 /// 1. Find the largest non-empty non-L0 level (the "bottom" level).
-/// 2. Compute base (L1 target) = bottom_bytes / multiplier^(bottom_level - 1).
-/// 3. Clamp base between MIN_BASE_BYTES (1MB) and `max_base` (configurable, default 256MB).
-/// 4. Forward-compute all targets: target[i] = base * multiplier^(i-1).
+/// 2. Compute unclamped base = bottom_bytes / multiplier^(bottom_level - 1).
+/// 3. If unclamped base ≥ MIN_BASE_BYTES, use base_level = 1 and clamp base
+///    to [MIN_BASE_BYTES, `max_base`].
+/// 4. Otherwise, raise base_level until the base ≥ MIN_BASE_BYTES. Levels
+///    below base_level get `max_base` as a passive lower-bound clamp,
+///    preventing pathological "hourglass" shapes with tiny intermediate targets.
+/// 5. Forward-compute targets from base_level: target[i] = base * multiplier^(i - base_level).
 ///
-/// For empty databases (no non-L0 data), uses MIN_BASE_BYTES as base.
+/// For empty databases (no non-L0 data), uses MIN_BASE_BYTES as base from L1.
 pub(super) fn recalculate_level_targets(
     level_bytes: &[u64; NUM_LEVELS],
     max_base: u64,
@@ -43,27 +47,54 @@ pub(super) fn recalculate_level_targets(
         }
     }
 
-    // 2. Compute base
-    let base = if bottom_level == 0 {
-        MIN_BASE_BYTES
-    } else {
-        let mut b = bottom_bytes;
-        for _ in 1..bottom_level {
-            b /= LEVEL_MULTIPLIER;
+    if bottom_level == 0 {
+        // No non-L0 data — forward-compute from MIN_BASE_BYTES at L1.
+        let mut target = MIN_BASE_BYTES;
+        for slot in max_bytes.iter_mut().skip(1) {
+            *slot = target;
+            target = target.saturating_mul(LEVEL_MULTIPLIER);
         }
-        b.clamp(MIN_BASE_BYTES, max_base)
+        return LevelTargets { max_bytes };
+    }
+
+    // 2. Compute unclamped base (what L1 target would be without clamping)
+    let mut unclamped_base = bottom_bytes;
+    for _ in 1..bottom_level {
+        unclamped_base /= LEVEL_MULTIPLIER;
+    }
+
+    // 3. Determine dynamic base_level
+    let (base_level, base) = if unclamped_base >= MIN_BASE_BYTES {
+        // Base is large enough — use L1 as base_level (no inactive levels)
+        (1, unclamped_base.clamp(MIN_BASE_BYTES, max_base))
+    } else {
+        // Base too small — raise base_level until base ≥ MIN_BASE_BYTES
+        let mut bl = 1;
+        let mut b = unclamped_base;
+        while b < MIN_BASE_BYTES && bl < bottom_level {
+            b = b.saturating_mul(LEVEL_MULTIPLIER);
+            bl += 1;
+        }
+        (bl, b.clamp(MIN_BASE_BYTES, max_base))
     };
 
-    // 3. Forward-compute all targets
+    // 4. Lower-bound clamp: levels below base_level get passive max_base
+    for slot in max_bytes.iter_mut().take(base_level).skip(1) {
+        *slot = max_base;
+    }
+
+    // 5. Forward-compute targets from base_level
     let mut target = base;
-    for slot in max_bytes.iter_mut().skip(1) {
+    for slot in max_bytes.iter_mut().skip(base_level) {
         *slot = target;
         target = target.saturating_mul(LEVEL_MULTIPLIER);
     }
 
     LevelTargets { max_bytes }
 }
-
+///
+/// Checks if the segment is shared (referenced by child branches via COW
+/// inherited layers). Shared segments are skipped — their files are only
 impl SegmentedStore {
     /// Delete a segment file if it is not referenced by any inherited layer.
     ///

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -3923,6 +3923,138 @@ fn recalculate_targets_score_meaningful_for_small_db() {
 }
 
 #[test]
+fn test_issue_1683_dynamic_base_level_deep_small_data() {
+    // Bug: when data is concentrated in a deep level at a small size,
+    // the algorithm divides by multiplier^(level-1) producing a tiny base
+    // that clamps to MIN_BASE_BYTES. This gives L1 a target of just 1MB,
+    // causing any 2MB flush to trigger unnecessary compaction cascading
+    // through empty intermediate levels.
+    //
+    // Fix: raise base_level dynamically so levels below it get passive
+    // LEVEL_BASE_BYTES targets, preventing the cascading.
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[4] = 5 << 20; // 5MB in L4
+
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
+
+    // Without dynamic base_level: base = 5MB / 10^3 = 5KB → clamped to 1MB.
+    // L1 target = 1MB — trivially exceeded by any normal flush.
+    //
+    // With the fix: base_level raised to L4.
+    // L1-L3 get passive LEVEL_BASE_BYTES (256MB) targets.
+    assert_eq!(
+        targets.max_bytes[1], LEVEL_BASE_BYTES,
+        "L1 should have passive LEVEL_BASE_BYTES target when base_level > 1"
+    );
+    assert_eq!(
+        targets.max_bytes[2], LEVEL_BASE_BYTES,
+        "L2 should have passive LEVEL_BASE_BYTES target"
+    );
+    assert_eq!(
+        targets.max_bytes[3], LEVEL_BASE_BYTES,
+        "L3 should have passive LEVEL_BASE_BYTES target"
+    );
+
+    // L4 is the base_level — its target is derived from bottom_bytes via
+    // integer division and multiplication (5MB / 10^3 * 10^3), which may
+    // truncate slightly.
+    let expected_base: u64 = {
+        let mut b = 5u64 << 20;
+        for _ in 1..4 {
+            b /= LEVEL_MULTIPLIER;
+        }
+        for _ in 1..4 {
+            b = b.saturating_mul(LEVEL_MULTIPLIER);
+        }
+        b
+    };
+    assert_eq!(targets.max_bytes[4], expected_base);
+
+    // L5-L6 continue geometric progression from base_level
+    assert_eq!(targets.max_bytes[5], expected_base * 10);
+    assert_eq!(targets.max_bytes[6], expected_base * 100);
+}
+
+#[test]
+fn test_issue_1683_deep_level_small_data_l6() {
+    // Same issue but with data at L6 (maximum backward divisions).
+    // 500MB in L6: base = 500MB / 10^5 = 5242 → below MIN_BASE_BYTES.
+    // Multiply up: 5242 → 52420 → 524200 → 5242000 (bl=4).
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[6] = 500 << 20; // 500MB in L6
+
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
+
+    let expected_base: u64 = {
+        let mut b = 500u64 << 20;
+        for _ in 1..6 {
+            b /= LEVEL_MULTIPLIER;
+        }
+        // multiply back up until >= MIN_BASE_BYTES
+        while b < MIN_BASE_BYTES {
+            b = b.saturating_mul(LEVEL_MULTIPLIER);
+        }
+        b
+    };
+
+    // L1-L3 get passive LEVEL_BASE_BYTES targets (below base_level=4).
+    for level in 1..=3 {
+        assert_eq!(
+            targets.max_bytes[level], LEVEL_BASE_BYTES,
+            "L{level} should have passive LEVEL_BASE_BYTES target"
+        );
+    }
+
+    // L4 is the base_level with the data-derived target.
+    assert_eq!(targets.max_bytes[4], expected_base);
+    assert_eq!(targets.max_bytes[5], expected_base * 10);
+    assert_eq!(targets.max_bytes[6], expected_base * 100);
+}
+
+#[test]
+fn test_issue_1683_transition_empty_to_populated() {
+    // During transitions from empty to populated states, data may
+    // land in a deep level while shallow levels are empty. The
+    // shallow levels should not get tiny targets.
+    let mut level_bytes = [0u64; NUM_LEVELS];
+    level_bytes[5] = 1 << 30; // 1GB in L5
+
+    let targets = recalculate_level_targets(&level_bytes, LEVEL_BASE_BYTES);
+
+    // base = 1GB / 10^4 = 107374 (~100KB) → below MIN_BASE_BYTES.
+    // Multiply up: 107374 → 1073740 (bl=2). base_level = 2.
+    let expected_base: u64 = {
+        let mut b = 1u64 << 30;
+        for _ in 1..5 {
+            b /= LEVEL_MULTIPLIER;
+        }
+        for _ in 1..2 {
+            b = b.saturating_mul(LEVEL_MULTIPLIER);
+        }
+        b
+    };
+
+    // L1 gets passive LEVEL_BASE_BYTES target, not tiny 1MB.
+    assert_eq!(
+        targets.max_bytes[1], LEVEL_BASE_BYTES,
+        "L1 should have passive LEVEL_BASE_BYTES target during empty→populated transition"
+    );
+
+    // L2 is the base_level with the data-derived target.
+    assert_eq!(targets.max_bytes[2], expected_base);
+    assert_eq!(targets.max_bytes[3], expected_base * 10);
+    assert_eq!(targets.max_bytes[4], expected_base * 100);
+    assert_eq!(targets.max_bytes[5], expected_base * 1_000);
+    assert_eq!(targets.max_bytes[6], expected_base * 10_000);
+
+    // L5 target should not exceed actual data size
+    assert!(
+        targets.max_bytes[5] <= 1 << 30,
+        "L5 target should not exceed actual data size"
+    );
+}
+
+#[test]
 fn compute_scores_l0_count() {
     let dir = tempfile::tempdir().unwrap();
     let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);

--- a/docs/audit/ENGINE_INVARIANTS.md
+++ b/docs/audit/ENGINE_INVARIANTS.md
@@ -142,13 +142,16 @@ The dynamic level target computation (based on RocksDB's `CalculateBaseBytes`) M
 1. Find the largest non-empty non-L0 level
 2. Compute base = bottom_bytes / multiplier^(bottom_level - 1)
 3. Clamp base between MIN_BASE_BYTES and MAX_BASE_BYTES
-4. Forward-compute all targets with saturation
+4. If unclamped base < MIN_BASE_BYTES, raise base_level until base ≥ MIN_BASE_BYTES;
+   levels below base_level get MAX_BASE_BYTES as a passive lower-bound clamp
+5. Forward-compute targets from base_level with saturation
 
 Targets MUST be refreshed after every compaction and flush.
 
 **Audit**: Find the level target computation function. Step through the algorithm with concrete numbers.
 Verify it handles: empty database (all levels empty), single-level spike (L3 has 10GB, others empty),
-very small databases (< MIN_BASE_BYTES total). Verify refresh is called after every segment version swap.
+very small databases (< MIN_BASE_BYTES total), data concentrated in deep levels (tiny unclamped base).
+Verify refresh is called after every segment version swap.
 
 ### CMP-006: Concurrent compaction and flush safety
 


### PR DESCRIPTION
## Summary

- When data is concentrated in a deep level at small sizes, the level target algorithm produced tiny targets (1MB) for shallow levels, causing unnecessary compaction cascading
- Added dynamic `base_level` computation: when the unclamped base falls below `MIN_BASE_BYTES`, raises `base_level` and assigns `MAX_BASE_BYTES` as a passive lower-bound clamp to inactive levels
- Updated CMP-005 invariant specification to document the new step

## Root Cause

`recalculate_level_targets()` divided `bottom_bytes` by `multiplier^(bottom_level - 1)` and clamped to `MIN_BASE_BYTES` (1MB). For small data in deep levels (e.g., 5MB at L4: `5MB / 10^3 = 5KB → 1MB`), this gave L1 a 1MB target. Any flush > 1MB triggered compaction cascading through empty intermediate levels — pure write amplification for no benefit.

## Fix

When `unclamped_base < MIN_BASE_BYTES`, multiply back up by `LEVEL_MULTIPLIER` while incrementing `base_level` until `base >= MIN_BASE_BYTES`. Levels below `base_level` get `MAX_BASE_BYTES` (256MB) as a passive target, preventing unnecessary compaction. The fix is backward-compatible: when `unclamped_base >= MIN_BASE_BYTES`, behavior is identical to before (`base_level = 1`).

## Invariants Verified

- **CMP-005**: All 5 requirements verified against the new code
- **CMP-001**: Tombstone handling unchanged
- **CMP-003**: Grandparent overlap unchanged
- **SCALE-001**: No new memory allocations

## Test Plan

- [x] `test_issue_1683_dynamic_base_level_deep_small_data` — 5MB at L4, verifies L1-L3 passive targets and L4-L6 geometric chain
- [x] `test_issue_1683_deep_level_small_data_l6` — 500MB at L6 (max backward divisions), verifies base_level=4
- [x] `test_issue_1683_transition_empty_to_populated` — 1GB at L5, verifies base_level=2 during empty→populated transition
- [x] All 582 storage crate tests pass
- [x] All workspace tests pass (excluding inference/CUDA)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)