### PR TITLE
Fix #1734: Defer version bump in follower refresh until secondary indexes are updated

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1263,8 +1263,9 @@ impl Database {
 
             // Apply puts and deletes atomically with original WAL timestamp
             // and TTL. Combines #1699 (preserve commit timestamp for time-travel),
-            // #1707 (defer version bump until all entries installed), and
-            // #1740 (preserve TTL through WAL replay).
+            // #1707 (defer version bump until all entries installed),
+            // #1734 (defer version bump until secondary indexes are updated),
+            // and #1740 (preserve TTL through WAL replay).
             {
                 let writes: Vec<_> = payload
                     .puts
@@ -1448,6 +1449,11 @@ impl Database {
                     }
                 }
             }
+
+            // Issue #1734: Advance visible version AFTER secondary indexes are
+            // updated, so readers never see KV data without corresponding
+            // BM25/HNSW entries.
+            self.storage.advance_version(payload.version);
 
             applied += 1;
         }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -440,6 +440,15 @@ impl SegmentedStore {
         self.version.store(version, Ordering::Release);
     }
 
+    /// Monotonically advance the visible storage version.
+    ///
+    /// Used by the follower refresh path to bump version AFTER secondary
+    /// indexes (BM25/HNSW) have been updated, ensuring readers never see
+    /// KV data before the corresponding index entries exist (Issue #1734).
+    pub fn advance_version(&self, version: u64) {
+        self.version.fetch_max(version, Ordering::AcqRel);
+    }
+
     /// Set (or clear) the compaction I/O rate limit.
     ///
     /// When `bytes_per_sec > 0`, compaction reads and writes are throttled to
@@ -1799,8 +1808,10 @@ impl SegmentedStore {
             self.maybe_rotate_branch(branch_id, &mut branch);
         }
 
-        // Advance version only after ALL entries are installed.
-        self.version.fetch_max(version, Ordering::AcqRel);
+        // Version is NOT advanced here. The caller (Database::refresh) is
+        // responsible for calling advance_version() AFTER secondary indexes
+        // (BM25/HNSW) have been updated, so readers never observe KV data
+        // without corresponding index entries (Issue #1734).
         Ok(())
     }
 

--- a/crates/storage/src/segmented/tests.rs
+++ b/crates/storage/src/segmented/tests.rs
@@ -9217,3 +9217,59 @@ fn test_issue_1694_materialize_shadow_detection_ignores_frozen_memtable() {
         .unwrap();
     assert_eq!(val_x.value, Value::Int(777), "child's frozen write wins");
 }
+
+/// Issue #1734: apply_recovery_atomic must NOT bump the visible storage version.
+///
+/// The follower refresh path calls apply_recovery_atomic to install KV entries,
+/// then updates secondary indexes (BM25/HNSW), and only THEN should the version
+/// advance. If the version advances inside apply_recovery_atomic, a concurrent
+/// reader on the follower can see committed vectors via KV get() but miss them
+/// in search() because the HNSW backend hasn't been updated yet.
+#[test]
+fn test_issue_1734_apply_recovery_atomic_does_not_bump_version() {
+    let store = SegmentedStore::new();
+
+    // Seed an initial entry so the store has version 1
+    seed(&store, kv_key("existing"), Value::Int(1), 1);
+    assert_eq!(
+        store.version(),
+        1,
+        "precondition: version should be 1 after seed"
+    );
+
+    // apply_recovery_atomic installs entries at version 5.
+    // CORRECT BEHAVIOR: the storage version should remain at 1 (caller bumps later).
+    let writes = vec![(kv_key("new_key"), Value::String("hello".into()))];
+    store
+        .apply_recovery_atomic(writes, vec![], 5, 1_000_000, &[0])
+        .unwrap();
+
+    assert_eq!(
+        store.version(),
+        1,
+        "apply_recovery_atomic must NOT advance the visible version; \
+         the caller (refresh) is responsible for bumping it after secondary indexes are updated"
+    );
+
+    // The entry IS in the memtable but should be invisible at the current version (1)
+    let invisible = store
+        .get_versioned(&kv_key("new_key"), store.version())
+        .unwrap();
+    assert!(
+        invisible.is_none(),
+        "entry at version 5 should be invisible when storage version is 1"
+    );
+
+    // After the caller bumps the version, the entry becomes visible
+    store.advance_version(5);
+    assert_eq!(store.version(), 5);
+
+    let visible = store
+        .get_versioned(&kv_key("new_key"), store.version())
+        .unwrap();
+    assert!(
+        visible.is_some(),
+        "entry should be visible after advance_version(5)"
+    );
+    assert_eq!(visible.unwrap().value, Value::String("hello".into()));
+}


### PR DESCRIPTION
## Summary

- Follower `refresh()` previously bumped the storage version inside `apply_recovery_atomic`, making KV entries visible before HNSW/BM25 secondary indexes were updated
- A concurrent vector `search()` during this window could miss newly committed vectors that were already visible via `get()`
- The fix defers the version bump until after all secondary index updates complete

## Root Cause

`apply_recovery_atomic` called `self.version.fetch_max(version)` at the end, immediately making entries visible to readers using `storage.version()` as their snapshot boundary. The BM25 and HNSW index updates happened after this call returned, creating a visibility gap.

## Fix

- Removed `version.fetch_max()` from `apply_recovery_atomic` (only called from `refresh()`)
- Added `SegmentedStore::advance_version()` method using `fetch_max` with `AcqRel` ordering
- In `refresh()`, `advance_version(payload.version)` is called after both BM25 and HNSW updates complete

~15 lines of non-test code changed.

## Invariants Verified

- **MVCC-001** (Version visibility boundary): HOLDS — entries gated by version counter, now bumped later
- **MVCC-003** (Version counter monotonicity): HOLDS — `fetch_max` is inherently monotonic
- **ARCH-002** (One atomic publication boundary): HOLDS (strengthened on follower path)
- **ARCH-004** (Recovery model ordering): HOLDS — follower refresh ordering is deterministic
- **ACID-005** (Recovery replay idempotency): HOLDS — `fetch_max` is idempotent

## Test Plan

- [x] `test_issue_1734_apply_recovery_atomic_does_not_bump_version` — verifies version is not bumped inside `apply_recovery_atomic`, entry is invisible until `advance_version()`, then visible with correct value
- [x] Full `strata-storage` test suite (580 passed)
- [x] Full `strata-engine` test suite (1324 passed)
- [x] Full workspace test suite (all pass; one pre-existing flaky test unrelated to this change)
- [x] Clippy clean on changed crates
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)