### PR TITLE
Fix #1535: Validate shadow collection dimension against embed model on startup

### DIFF
--- a/crates/engine/src/primitives/vector/store.rs
+++ b/crates/engine/src/primitives/vector/store.rs
@@ -1959,6 +1959,17 @@ impl VectorStore {
         Ok(state.backends.get(&cid).map(|b| b.len()).unwrap_or(0))
     }
 
+    /// Get the dimension of an existing system collection, or None if not found.
+    pub fn system_collection_dimension(
+        &self,
+        branch_id: BranchId,
+        collection: &str,
+    ) -> VectorResult<Option<usize>> {
+        Ok(self
+            .get_collection(branch_id, "default", collection)?
+            .map(|v| v.value.config.dimension))
+    }
+
     /// Search a system collection (internal use only)
     pub fn system_search(
         &self,

--- a/crates/executor/src/handlers/embed_hook.rs
+++ b/crates/executor/src/handlers/embed_hook.rs
@@ -819,6 +819,42 @@ mod tests {
             other => panic!("Expected EmbedStatus, got {:?}", other),
         }
     }
+
+    /// Issue #1535 Bug 3: If the embed model dimension differs from an existing
+    /// shadow collection's dimension, ensure_shadow_collection must NOT cache
+    /// the collection — effectively disabling embedding to prevent mixed-dimension
+    /// vectors in the same collection.
+    #[test]
+    fn test_issue_1535_dimension_mismatch_blocks_shadow_collection() {
+        use strata_core::primitives::VectorConfig;
+
+        let p = setup();
+        let branch_id = BranchId::default();
+        let collection_name = SHADOW_KV;
+
+        // Pre-create the shadow collection with dimension 3 (tiny, for testing).
+        let config = VectorConfig::for_embedding(3);
+        p.vector
+            .create_system_collection(branch_id, collection_name, config)
+            .expect("pre-create shadow collection with dim=3");
+
+        // Now call ensure_shadow_collection. The loaded model (or fallback)
+        // has dimension 384, which differs from the existing collection's dim=3.
+        ensure_shadow_collection(&p, branch_id, collection_name);
+
+        // The collection should NOT be cached because dimensions mismatch.
+        let state = p.db.extension::<AutoEmbedState>().unwrap();
+        let cache_key = format!(
+            "{:?}{}{}",
+            branch_id.as_bytes(),
+            SHADOW_KEY_SEP,
+            collection_name
+        );
+        assert!(
+            !state.contains(&cache_key),
+            "ensure_shadow_collection must NOT cache a collection with mismatched dimension"
+        );
+    }
 }
 
 /// Ensure a shadow collection exists, swallowing AlreadyExists errors.
@@ -870,8 +906,27 @@ fn ensure_shadow_collection(
             state.insert(cache_key);
         }
         Err(strata_engine::vector::VectorError::CollectionAlreadyExists { .. }) => {
-            // Already exists from a previous process run — mark as created
-            state.insert(cache_key);
+            // Already exists from a previous process run — verify dimension matches
+            match p.vector.system_collection_dimension(branch_id, name) {
+                Ok(Some(existing_dim)) if existing_dim != dim => {
+                    tracing::error!(
+                        target: "strata::embed",
+                        collection = name,
+                        existing_dim,
+                        model_dim = dim,
+                        "Shadow collection dimension mismatch: collection has {}-d vectors \
+                         but loaded model produces {}-d embeddings. Embedding disabled for \
+                         this collection. Re-index to fix.",
+                        existing_dim,
+                        dim,
+                    );
+                    // Do NOT cache — this disables embedding for this collection
+                    // until the user re-indexes with the correct model.
+                }
+                _ => {
+                    state.insert(cache_key);
+                }
+            }
         }
         Err(e) => {
             tracing::warn!(


### PR DESCRIPTION
## Summary

- When the embed model changes between restarts, `ensure_shadow_collection` now validates the existing collection's dimension against the loaded model's dimension
- On mismatch, embedding is disabled for that collection with an explicit error log, preventing mixed-dimension vectors in the same HNSW index

## Root Cause

`ensure_shadow_collection` handled `CollectionAlreadyExists` by silently marking the collection as ready. If the embed model changed (e.g., miniLM 384-d → nomic-embed 768-d), new embeddings would have wrong dimensions, causing search corruption or panics.

## Fix

- Added `VectorStore::system_collection_dimension()` (~5 lines) to query existing collection dimension
- In `ensure_shadow_collection`, on `CollectionAlreadyExists`, compare existing dimension to model dimension. On mismatch, log error and skip caching (disables embedding until re-index)

~15 lines of non-test code.

## Invariants Verified

- **ARCH-003** (KV is source of truth): HOLDS — read-only query, no writes changed
- **SCALE-010** (Feature degradation is explicit): STRENGTHENED — mismatch now logged instead of silent corruption

## Test Plan

- [x] `test_issue_1535_dimension_mismatch_blocks_shadow_collection` — pre-creates collection with dim=3, verifies ensure_shadow_collection refuses to cache when model dim=384
- [x] Full `strata-executor` test suite with embed (574 passed)
- [x] Full `strata-engine` test suite (1338 passed)
- [x] Full workspace test suite (all pass; one pre-existing failure unrelated)
- [x] Clippy clean on changed crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)