### PR TITLE
Fix #1847: Add REINDEX EMBEDDINGS command for embed model migration

### DIFF
--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -425,6 +425,18 @@ fn format_raw(output: &Output) -> String {
                 info.scheduler_queue_depth
             )
         }
+        Output::ReindexResult {
+            kv_queued,
+            json_queued,
+            event_queued,
+            state_queued,
+            new_dimension,
+        } => {
+            format!(
+                "{}\t{}\t{}\t{}\t{}",
+                kv_queued, json_queued, event_queued, state_queued, new_dimension
+            )
+        }
         Output::BatchResults(results) => results
             .iter()
             .map(|r| match (&r.version, &r.error) {
@@ -1018,6 +1030,19 @@ fn format_human(output: &Output) -> String {
                 info.total_failed,
                 info.scheduler_queue_depth,
                 info.scheduler_active_tasks
+            )
+        }
+        Output::ReindexResult {
+            kv_queued,
+            json_queued,
+            event_queued,
+            state_queued,
+            new_dimension,
+        } => {
+            let total = kv_queued + json_queued + event_queued + state_queued;
+            format!(
+                "Reindex started: {} items queued (kv: {}, json: {}, event: {}, state: {})\nNew dimension: {}\nRun EMBED STATUS to track progress.",
+                total, kv_queued, json_queued, event_queued, state_queued, new_dimension
             )
         }
         Output::BatchResults(results) => {

--- a/crates/engine/src/primitives/vector/store.rs
+++ b/crates/engine/src/primitives/vector/store.rs
@@ -1959,6 +1959,32 @@ impl VectorStore {
         Ok(state.backends.get(&cid).map(|b| b.len()).unwrap_or(0))
     }
 
+    /// Delete a system collection (idempotent — returns Ok if it doesn't exist).
+    pub fn delete_system_collection(&self, branch_id: BranchId, name: &str) -> VectorResult<()> {
+        use crate::primitives::vector::collection::validate_system_collection_name;
+        validate_system_collection_name(name)?;
+
+        if !self.collection_exists(branch_id, "default", name)? {
+            return Ok(());
+        }
+
+        self.delete_all_vectors(branch_id, "default", name)?;
+
+        let config_key = Key::new_vector_config(self.namespace_for(branch_id, "default"), name);
+        self.db
+            .transaction(branch_id, |txn| txn.delete(config_key.clone()))
+            .map_err(|e| VectorError::Storage(e.to_string()))?;
+
+        {
+            let state = self.state()?;
+            let collection_id = CollectionId::new(branch_id, name);
+            state.backends.remove(&collection_id);
+        }
+
+        info!(target: "strata::vector", collection = name, "System collection deleted");
+        Ok(())
+    }
+
     /// Get the dimension of an existing system collection, or None if not found.
     pub fn system_collection_dimension(
         &self,

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -1081,6 +1081,16 @@ pub enum Command {
     /// Returns: `Output::EmbedStatus`
     EmbedStatus,
 
+    /// Re-index all embeddings with the currently configured model.
+    /// Drops existing shadow collections, recreates with new dimensions,
+    /// and queues all data for re-embedding.
+    /// Returns: `Output::ReindexResult`
+    ReindexEmbeddings {
+        /// Target branch (defaults to current branch).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+    },
+
     /// Get the current database configuration.
     /// Returns: `Output::Config`
     ConfigGet,
@@ -1657,6 +1667,7 @@ impl Command {
                 | Command::GraphDefineLinkType { .. }
                 | Command::GraphDeleteLinkType { .. }
                 | Command::GraphFreezeOntology { .. }
+                | Command::ReindexEmbeddings { .. }
         )
     }
 
@@ -1736,6 +1747,7 @@ impl Command {
             Command::JsonSample { .. } => "JsonSample",
             Command::VectorSample { .. } => "VectorSample",
             Command::EmbedStatus => "EmbedStatus",
+            Command::ReindexEmbeddings { .. } => "ReindexEmbeddings",
             Command::ConfigGet => "ConfigGet",
             Command::ConfigureSet { .. } => "ConfigureSet",
             Command::ConfigureGetKey { .. } => "ConfigureGetKey",
@@ -1880,7 +1892,8 @@ impl Command {
             Command::SpaceList { branch, .. }
             | Command::SpaceCreate { branch, .. }
             | Command::SpaceDelete { branch, .. }
-            | Command::SpaceExists { branch, .. } => {
+            | Command::SpaceExists { branch, .. }
+            | Command::ReindexEmbeddings { branch, .. } => {
                 resolve_branch!(branch);
             }
 
@@ -2025,11 +2038,12 @@ impl Command {
             | Command::TimeRange { branch, .. }
             | Command::Describe { branch, .. } => branch.as_ref(),
 
-            // Space commands
+            // Space commands + reindex
             Command::SpaceList { branch, .. }
             | Command::SpaceCreate { branch, .. }
             | Command::SpaceDelete { branch, .. }
-            | Command::SpaceExists { branch, .. } => branch.as_ref(),
+            | Command::SpaceExists { branch, .. }
+            | Command::ReindexEmbeddings { branch, .. } => branch.as_ref(),
 
             // Graph commands
             Command::GraphCreate { branch, .. }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -243,6 +243,14 @@ impl Executor {
                 let info = crate::handlers::embed_hook::embed_status(&self.primitives);
                 Ok(Output::EmbedStatus(info))
             }
+            Command::ReindexEmbeddings { branch } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                    hint: None,
+                })?;
+                let branch_id = crate::bridge::to_core_branch_id(&branch)?;
+                crate::handlers::embed_hook::reindex_embeddings(&self.primitives, branch_id)
+            }
             Command::ConfigGet => crate::handlers::config::config_get(&self.primitives),
             Command::ConfigureSet { key, value } => {
                 crate::handlers::config::configure_set(&self.primitives, key, value)

--- a/crates/executor/src/handlers/embed_hook.rs
+++ b/crates/executor/src/handlers/embed_hook.rs
@@ -57,6 +57,13 @@ impl AutoEmbedState {
             .unwrap_or_else(|e| e.into_inner())
             .insert(key);
     }
+
+    fn remove_branch(&self, branch_prefix: &str) {
+        self.shadow_collections_created
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .retain(|k| !k.starts_with(branch_prefix));
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -133,7 +140,31 @@ pub fn maybe_embed_text(
     if !p.db.auto_embed_enabled() {
         return;
     }
+    queue_embed_text(
+        p,
+        branch_id,
+        space,
+        shadow_collection,
+        key,
+        text,
+        source_ref,
+    );
+}
 
+/// Queue text for embedding without checking the auto_embed flag.
+///
+/// Used by `reindex_embeddings` which is an explicit user action and must
+/// work even when auto-embed is disabled due to dimension mismatch.
+#[cfg(feature = "embed")]
+fn queue_embed_text(
+    p: &Arc<Primitives>,
+    branch_id: strata_core::types::BranchId,
+    space: &str,
+    shadow_collection: &'static str,
+    key: &str,
+    text: &str,
+    source_ref: strata_core::EntityRef,
+) {
     let buf = match p.db.extension::<EmbedBuffer>() {
         Ok(b) => b,
         Err(e) => {
@@ -166,7 +197,6 @@ pub fn maybe_embed_text(
             })
             .is_err()
         {
-            // Backpressure or shutdown — fall back to synchronous flush
             flush_embed_buffer(p);
         }
     }
@@ -414,6 +444,201 @@ pub fn extract_text(value: &strata_core::Value) -> Option<String> {
 #[cfg(not(feature = "embed"))]
 pub fn extract_text(_value: &strata_core::Value) -> Option<String> {
     None
+}
+
+/// Re-index all embeddings for a branch with the currently configured model.
+///
+/// Deletes all shadow collections, recreates with the new model's dimension,
+/// and queues all existing KV/JSON/Event/State data for re-embedding.
+#[cfg(feature = "embed")]
+pub fn reindex_embeddings(
+    p: &Arc<Primitives>,
+    branch_id: strata_core::types::BranchId,
+) -> crate::Result<crate::Output> {
+    use strata_core::primitives::json::JsonPath;
+
+    // 1. Determine new model dimension
+    let model_state =
+        p.db.extension::<strata_intelligence::embed::EmbedModelState>()
+            .map_err(|e| crate::Error::Internal {
+                reason: format!("Failed to get embed model state: {}", e),
+            })?;
+    let dim = model_state
+        .embedding_dim()
+        .ok_or_else(|| crate::Error::Internal {
+            reason: "Embedding model not loaded — cannot determine dimension".into(),
+        })?;
+
+    // 2. Delete all shadow collections for this branch
+    let shadow_names: &[&str] = &[SHADOW_KV, SHADOW_JSON, SHADOW_EVENT, SHADOW_STATE];
+    for name in shadow_names {
+        if let Err(e) = p.vector.delete_system_collection(branch_id, name) {
+            tracing::warn!(
+                target: "strata::embed",
+                collection = *name,
+                error = %e,
+                "Failed to delete shadow collection during reindex"
+            );
+        }
+    }
+
+    // 3. Clear AutoEmbedState cache for this branch
+    if let Ok(state) = p.db.extension::<AutoEmbedState>() {
+        let branch_prefix = format!("{:?}{}", branch_id.as_bytes(), SHADOW_KEY_SEP);
+        state.remove_branch(&branch_prefix);
+    }
+
+    // 4. Flush any pending embeds from the old model
+    flush_embed_buffer(p);
+
+    // 5. Enumerate all data across all spaces and queue for re-embedding
+    let spaces = p
+        .space
+        .list(branch_id)
+        .unwrap_or_else(|_| vec!["default".to_string()]);
+
+    let mut kv_queued: u64 = 0;
+    let mut json_queued: u64 = 0;
+    let mut event_queued: u64 = 0;
+    let mut state_queued: u64 = 0;
+
+    for space in &spaces {
+        // KV
+        if let Ok(keys) = p.kv.list(&branch_id, space, None) {
+            for key in &keys {
+                if let Ok(Some(value)) = p.kv.get(&branch_id, space, key) {
+                    if let Some(text) = extract_text(&value) {
+                        queue_embed_text(
+                            p,
+                            branch_id,
+                            space,
+                            SHADOW_KV,
+                            key,
+                            &text,
+                            strata_core::EntityRef::kv(branch_id, key),
+                        );
+                        kv_queued += 1;
+                    }
+                }
+            }
+        }
+
+        // JSON
+        let mut cursor: Option<String> = None;
+        loop {
+            let result = match p
+                .json
+                .list(&branch_id, space, None, cursor.as_deref(), 1000)
+            {
+                Ok(r) => r,
+                Err(_) => break,
+            };
+            for doc_id in &result.doc_ids {
+                if let Ok(Some(json_val)) = p.json.get(&branch_id, space, doc_id, &JsonPath::root())
+                {
+                    if let Ok(value) = crate::bridge::json_to_value(json_val) {
+                        if let Some(text) = extract_text(&value) {
+                            queue_embed_text(
+                                p,
+                                branch_id,
+                                space,
+                                SHADOW_JSON,
+                                doc_id,
+                                &text,
+                                strata_core::EntityRef::json(branch_id, doc_id),
+                            );
+                            json_queued += 1;
+                        }
+                    }
+                }
+            }
+            match result.next_cursor {
+                Some(c) => cursor = Some(c),
+                None => break,
+            }
+        }
+
+        // State
+        if let Ok(names) = p.state.list(&branch_id, space, None) {
+            for name in &names {
+                if let Ok(Some(value)) = p.state.get(&branch_id, space, name) {
+                    if let Some(text) = extract_text(&value) {
+                        queue_embed_text(
+                            p,
+                            branch_id,
+                            space,
+                            SHADOW_STATE,
+                            name,
+                            &text,
+                            strata_core::EntityRef::state(branch_id, name),
+                        );
+                        state_queued += 1;
+                    }
+                }
+            }
+        }
+
+        // Events
+        if let Ok(len) = p.event.len(&branch_id, space) {
+            for seq in 1..=len {
+                if let Ok(Some(versioned_event)) = p.event.get(&branch_id, space, seq) {
+                    let payload = strata_core::Value::String(
+                        serde_json::to_string(&versioned_event.value.payload).unwrap_or_default(),
+                    );
+                    if let Some(text) = extract_text(&payload) {
+                        let event_key = seq.to_string();
+                        queue_embed_text(
+                            p,
+                            branch_id,
+                            space,
+                            SHADOW_EVENT,
+                            &event_key,
+                            &text,
+                            strata_core::EntityRef::event(branch_id, seq),
+                        );
+                        event_queued += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    // 6. Trigger a flush to start processing
+    let p_clone = Arc::clone(p);
+    let _ =
+        p.db.scheduler()
+            .submit(strata_engine::TaskPriority::Normal, move || {
+                flush_embed_buffer(&p_clone)
+            });
+
+    tracing::info!(
+        target: "strata::embed",
+        kv_queued,
+        json_queued,
+        event_queued,
+        state_queued,
+        new_dimension = dim,
+        "Reindex embeddings started"
+    );
+
+    Ok(crate::Output::ReindexResult {
+        kv_queued,
+        json_queued,
+        event_queued,
+        state_queued,
+        new_dimension: dim,
+    })
+}
+
+/// Embed feature not compiled in.
+#[cfg(not(feature = "embed"))]
+pub fn reindex_embeddings(
+    _p: &Arc<Primitives>,
+    _branch_id: strata_core::types::BranchId,
+) -> crate::Result<crate::Output> {
+    Err(crate::Error::Internal {
+        reason: "The 'embed' feature is not enabled. Rebuild with --features embed".into(),
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -914,14 +1139,16 @@ fn ensure_shadow_collection(
                         collection = name,
                         existing_dim,
                         model_dim = dim,
-                        "Shadow collection dimension mismatch: collection has {}-d vectors \
-                         but loaded model produces {}-d embeddings. Embedding disabled for \
-                         this collection. Re-index to fix.",
+                        "Embed model dimension changed. Existing embeddings are {}-d \
+                         but configured model produces {}-d vectors. Auto-embed is \
+                         disabled. Either switch to a {}-d model or run \
+                         REINDEX EMBEDDINGS to replace all embeddings.",
                         existing_dim,
                         dim,
+                        existing_dim,
                     );
                     // Do NOT cache — this disables embedding for this collection
-                    // until the user re-indexes with the correct model.
+                    // until the user runs REINDEX EMBEDDINGS or switches models.
                 }
                 _ => {
                     state.insert(cache_key);

--- a/crates/executor/src/output.rs
+++ b/crates/executor/src/output.rs
@@ -302,6 +302,20 @@ pub enum Output {
     /// Embedding pipeline status
     EmbedStatus(EmbedStatusInfo),
 
+    /// Result of re-indexing all embeddings
+    ReindexResult {
+        /// KV entries queued for re-embedding
+        kv_queued: u64,
+        /// JSON documents queued for re-embedding
+        json_queued: u64,
+        /// Events queued for re-embedding
+        event_queued: u64,
+        /// State cells queued for re-embedding
+        state_queued: u64,
+        /// New embedding dimension
+        new_dimension: usize,
+    },
+
     /// Single embedding vector
     Embedding(Vec<f32>),
 


### PR DESCRIPTION
## Summary

- When the embed model changes to a different dimension, auto-embed is disabled with a clear, actionable error message
- New `ReindexEmbeddings` command provides recovery: drops old shadow collections, recreates with new dimension, queues all data for re-embedding
- Adds `delete_system_collection()` to VectorStore (bypasses `_` prefix restriction, idempotent)

## Root Cause

When `embed_model` changed in config (e.g., miniLM 384-d → nomic-embed 768-d), PR #1846 correctly detected the mismatch and disabled embedding. But there was no recovery path — no way to delete shadow collections (`_system_*` names blocked by validation) and no reindex command.

## Fix

1. **`VectorStore::delete_system_collection()`** — like `delete_collection()` but accepts `_system_*` names, idempotent
2. **`queue_embed_text()`** — like `maybe_embed_text()` but bypasses the `auto_embed_enabled()` check (reindex is explicit user action)
3. **`ReindexEmbeddings` command** — deletes 4 shadow collections, clears cache, enumerates all KV/JSON/Event/State data across all spaces, queues for re-embedding
4. **Improved error message** — tells user exact dimensions and says to run `REINDEX EMBEDDINGS` or switch models
5. **CLI formatting** — human-friendly output showing queued counts and new dimension

## Test Plan

- [x] `cargo test -p strata-executor --features embed` — 574 passed
- [x] `cargo test -p strata-engine` — 1338 passed
- [x] `cargo test --workspace --exclude strata-inference` — all pass (1 pre-existing failure)
- [x] Clippy clean on changed crates
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)