### PR TITLE
Fix #1547: Audit atomic ordering on metric counters

### DIFF
--- a/crates/engine/src/background.rs
+++ b/crates/engine/src/background.rs
@@ -75,6 +75,21 @@ impl PartialOrd for TaskEnvelope {
     }
 }
 
+/// # Memory Ordering
+///
+/// The metric counters (`queue_depth`, `active_tasks`, `tasks_completed`) use
+/// mixed ordering depending on their role:
+///
+/// - `queue_depth` / `active_tasks` use `Release` on writes and `Acquire` on
+///   correctness-critical reads (backpressure check, drain wait) because they
+///   gate control flow decisions. The `stats()` snapshot reads them with
+///   `Relaxed` since approximate values are acceptable for monitoring.
+/// - `tasks_completed` uses `Relaxed` everywhere — it is purely observational
+///   and never gates any decision.
+/// - `active_tasks.fetch_sub` uses `AcqRel` in the drop guard because the
+///   preceding value determines whether to wake drain waiters.
+/// - `sequence` uses `Relaxed` — uniqueness is guaranteed by fetch_add
+///   atomicity; no ordering relationship is needed.
 struct SchedulerInner {
     queue: ParkingMutex<BinaryHeap<TaskEnvelope>>,
     work_ready: parking_lot::Condvar,
@@ -208,6 +223,13 @@ impl BackgroundScheduler {
     }
 
     /// Return a snapshot of scheduler metrics.
+    ///
+    /// All loads use `Relaxed` ordering. These counters are independent — no
+    /// counter gates another — so `Acquire` would not improve cross-counter
+    /// consistency. A snapshot may transiently show e.g. `active_tasks > 0`
+    /// with `queue_depth == 0`, which is normal during task execution.
+    /// Perfectly consistent snapshots would require a mutex, which is
+    /// unnecessary overhead for observational metrics.
     pub fn stats(&self) -> SchedulerStats {
         SchedulerStats {
             queue_depth: self.inner.queue_depth.load(AtomicOrdering::Relaxed),
@@ -229,7 +251,9 @@ struct ActiveTaskGuard<'a> {
 
 impl<'a> Drop for ActiveTaskGuard<'a> {
     fn drop(&mut self) {
+        // AcqRel: the previous value gates the drain-wakeup decision below.
         let prev_active = self.inner.active_tasks.fetch_sub(1, AtomicOrdering::AcqRel);
+        // Relaxed: purely observational counter — does not gate any decision.
         self.inner
             .tasks_completed
             .fetch_add(1, AtomicOrdering::Relaxed);

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -152,6 +152,9 @@ impl TransactionCoordinator {
         // Register in active_count BEFORE creating the snapshot so that a
         // concurrent drain (active_count → 0) cannot set gc_safe_version
         // past our about-to-be-created snapshot version.
+        //
+        // Relaxed: these are observational counters — the GC-critical
+        // synchronization is on the fetch_sub(AcqRel) in record_commit/abort.
         self.active_count.fetch_add(1, Ordering::Relaxed);
         self.total_started.fetch_add(1, Ordering::Relaxed);
 
@@ -259,6 +262,7 @@ impl TransactionCoordinator {
     /// * `_txn_id` - Unique transaction ID (unused, kept for API compat)
     /// * `_start_version` - Snapshot version at transaction start (unused)
     pub fn record_start(&self, _txn_id: u64, _start_version: u64) {
+        // Relaxed: observational counters only (see struct-level doc).
         self.active_count.fetch_add(1, Ordering::Relaxed);
         self.total_started.fetch_add(1, Ordering::Relaxed);
     }
@@ -285,6 +289,9 @@ impl TransactionCoordinator {
         // (record_start always precedes record_commit), so debug-assert.
         let prev = self.active_count.fetch_sub(1, Ordering::AcqRel);
         debug_assert!(prev > 0, "active_count underflow in record_commit");
+        // Relaxed: observational counter only — does not gate GC or any
+        // other correctness decision. The AcqRel on active_count above is
+        // the critical synchronization point.
         self.total_committed.fetch_add(1, Ordering::Relaxed);
         if prev == 1 {
             // All transactions drained — advance GC safe point
@@ -312,6 +319,7 @@ impl TransactionCoordinator {
         // (record_start always precedes record_abort), so debug-assert.
         let prev = self.active_count.fetch_sub(1, Ordering::AcqRel);
         debug_assert!(prev > 0, "active_count underflow in record_abort");
+        // Relaxed: observational counter only (same rationale as total_committed).
         self.total_aborted.fetch_add(1, Ordering::Relaxed);
         if prev == 1 {
             // All transactions drained — advance GC safe point
@@ -402,7 +410,18 @@ impl TransactionCoordinator {
     /// Get transaction metrics
     ///
     /// Returns current snapshot of transaction statistics.
+    ///
+    /// # Memory ordering
+    ///
+    /// All loads use `Relaxed` ordering. Since these counters are independent
+    /// (no counter gates another), `Acquire` would not improve cross-counter
+    /// consistency — the loads still happen at different instants, so a
+    /// snapshot can transiently show e.g. `total_committed > total_started`.
+    /// A perfectly consistent snapshot would require a mutex, which is
+    /// unnecessary overhead for observational metrics. On x86, `Relaxed`
+    /// and `Acquire` loads compile to the same `MOV` instruction anyway.
     pub fn metrics(&self) -> TransactionMetrics {
+        // Relaxed: purely observational, no synchronization role (see struct-level doc).
         let started = self.total_started.load(Ordering::Relaxed);
         let committed = self.total_committed.load(Ordering::Relaxed);
 

--- a/crates/engine/src/search/index.rs
+++ b/crates/engine/src/search/index.rs
@@ -232,6 +232,24 @@ const DEFAULT_SEAL_THRESHOLD: usize = 100_000;
 ///
 /// The version field tracks index state for consistency checking.
 /// Incremented on every update operation.
+///
+/// # Memory Ordering
+///
+/// The metric counters (`total_docs`, `total_doc_len`, `active_doc_count`) use
+/// `Relaxed` ordering for mutations (fetch_add/fetch_sub/store) because:
+/// 1. They are observational metrics — approximate counts are acceptable.
+/// 2. They do not synchronize any other memory operations.
+/// 3. Atomic RMW instructions guarantee no torn reads regardless of ordering.
+///
+/// The *read* side uses `Acquire` in BM25-scoring methods (`total_docs()`,
+/// `avg_doc_len()`, `compute_idf()`) for stronger visibility guarantees when
+/// computing scores that depend on these values. For internal bookkeeping reads
+/// (e.g. seal threshold checks), `Relaxed` is used since approximate values
+/// are sufficient.
+///
+/// The `sealing` flag uses `Acquire` on the CAS success path and `Release` on
+/// the subsequent store to establish a critical section that prevents concurrent
+/// auto-seals.
 pub struct InvertedIndex {
     // --- Active segment (DashMap-based, mutable) ---
     /// Term -> PostingList mapping (active segment)
@@ -333,6 +351,8 @@ impl InvertedIndex {
         self.doc_terms.write().unwrap().clear();
         self.doc_id_map.clear();
         self.sealed.write().unwrap().clear();
+        // Relaxed: clear() is called during logical reset — the subsequent
+        // version bump (Release) establishes the visibility fence.
         self.total_docs.store(0, Ordering::Relaxed);
         self.total_doc_len.store(0, Ordering::Relaxed);
         self.active_doc_count.store(0, Ordering::Relaxed);
@@ -718,13 +738,16 @@ impl InvertedIndex {
             lengths[idx] = Some(doc_len);
         }
 
+        // Relaxed: observational counters — the version bump below (Release)
+        // is the synchronization fence for readers checking index freshness.
         self.total_docs.fetch_add(1, Ordering::Relaxed);
         self.total_doc_len
             .fetch_add(doc_len as usize, Ordering::Relaxed);
         self.active_doc_count.fetch_add(1, Ordering::Relaxed);
         self.version.fetch_add(1, Ordering::Release);
 
-        // Check if we should seal the active segment
+        // Relaxed: approximate count is fine for threshold-based seal decisions.
+        // The actual sealing is guarded by the CAS on `sealing` (Acquire).
         let active_count = self.active_doc_count.load(Ordering::Relaxed);
         if active_count >= self.seal_threshold {
             self.try_seal_active();
@@ -797,6 +820,8 @@ impl InvertedIndex {
         }
 
         // Update global stats
+        // Relaxed: observational counters (see struct-level doc). The version
+        // bump (Release) is the synchronization fence for freshness checks.
         if active_removed || doc_len.is_some() {
             self.total_docs.fetch_sub(1, Ordering::Relaxed);
             if let Some(len) = doc_len {
@@ -818,11 +843,15 @@ impl InvertedIndex {
     ///
     /// Uses CAS on `sealing` to prevent concurrent auto-seals.
     fn try_seal_active(&self) {
+        // Relaxed: approximate count is sufficient for the threshold check.
+        // A slightly stale value just delays or advances the seal by one doc.
         let active_count = self.active_doc_count.load(Ordering::Relaxed);
         if active_count < self.seal_threshold {
             return;
         }
-        // Prevent concurrent auto-seals
+        // CAS with Acquire on success ensures all prior index writes are
+        // visible before we start reading the active segment for sealing.
+        // Relaxed on failure: we just bail, no ordering needed.
         if self
             .sealing
             .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
@@ -843,6 +872,7 @@ impl InvertedIndex {
     /// across seals, enabling re-index detection and accurate `total_doc_len`
     /// adjustment when removing docs from sealed segments.
     pub fn seal_active(&self) {
+        // Relaxed: early-exit check — exact count not needed.
         let active_count = self.active_doc_count.load(Ordering::Relaxed);
         if active_count == 0 {
             return;
@@ -880,6 +910,7 @@ impl InvertedIndex {
         }
         let actual_doc_count = seen_docs.len() as u32;
 
+        // Relaxed: uniqueness is guaranteed by fetch_add atomicity.
         let segment_id = self.next_segment_id.fetch_add(1, Ordering::Relaxed);
 
         // Build the sealed segment
@@ -907,6 +938,7 @@ impl InvertedIndex {
         // Subtract only the count of docs we actually drained, not reset to 0,
         // so concurrent inserts keep their active_doc_count contribution (#1738 / 9.5.B).
         self.sealed.write().unwrap().push(seg);
+        // Relaxed: observational bookkeeping (see struct-level doc).
         self.active_doc_count
             .fetch_sub(actual_doc_count as usize, Ordering::Relaxed);
     }
@@ -993,7 +1025,9 @@ impl InvertedIndex {
         // Restore DocIdMap
         self.doc_id_map.restore_from_vec(data.doc_id_map);
 
-        // Restore global stats
+        // Restore global stats.
+        // Relaxed: recovery runs single-threaded before the index is visible
+        // to other threads, so no ordering is needed.
         self.total_docs
             .store(data.total_docs as usize, Ordering::Relaxed);
         self.total_doc_len
@@ -1024,7 +1058,8 @@ impl InvertedIndex {
             }
         }
 
-        // Active segment starts empty
+        // Active segment starts empty after recovery.
+        // Relaxed: single-threaded recovery path (same as above).
         self.postings.clear();
         self.doc_freqs.clear();
         self.active_doc_count.store(0, Ordering::Relaxed);


### PR DESCRIPTION
## Summary
- Formally audits every `Relaxed` atomic ordering usage in `coordinator.rs`, `background.rs`, and `search/index.rs`
- All `Relaxed` orderings confirmed correct — no ordering changes needed
- Adds per-site documentation comments and struct-level `# Memory Ordering` sections explaining the design rationale

## Audit findings
- **coordinator.rs**: Metric counters (`active_count`, `total_started`, `total_committed`, `total_aborted`) correctly use `Relaxed` for observational increments; `AcqRel` on `active_count.fetch_sub` correctly gates GC safe point advancement
- **background.rs**: `tasks_completed` correctly uses `Relaxed` everywhere; `active_tasks.fetch_sub` correctly uses `AcqRel` for drain wakeup; `queue_depth` uses `Release`/`Acquire` for backpressure gating
- **search/index.rs**: Write-side `Relaxed` is correct for all metric mutations; read-side already uses `Acquire` for BM25 scoring; `sealing` CAS correctly uses `Acquire`/`Release`
- **Snapshot consistency**: `Acquire` on `metrics()`/`stats()` would not improve cross-counter consistency since counters are independent — documented this reasoning

## Test plan
- [x] `cargo build --all-features` passes
- [x] `cargo test -p strata-engine` — all tests pass
- [x] Documentation-only change — no behavioral changes

Closes #1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)