### PR TITLE
Fix version counter overflow test to expect panic

### DIFF
--- a/tests/storage/mvcc_invariants.rs
+++ b/tests/storage/mvcc_invariants.rs
@@ -268,7 +268,7 @@ fn version_counter_monotonically_increases() {
 }
 
 #[test]
-fn version_counter_wraps_at_u64_max() {
+fn version_counter_panics_at_u64_max() {
     let store = SegmentedStore::new();
 
     // Set version close to MAX
@@ -280,12 +280,11 @@ fn version_counter_wraps_at_u64_max() {
     let v2 = store.next_version();
     assert_eq!(v2, u64::MAX);
 
-    // Should wrap to 0
-    let v3 = store.next_version();
-    assert_eq!(v3, 0, "Should wrap at u64::MAX");
-
-    let v4 = store.next_version();
-    assert_eq!(v4, 1);
+    // Overflow must panic — wrapping would corrupt MVCC ordering
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        store.next_version();
+    }));
+    assert!(result.is_err(), "next_version() should panic at u64::MAX");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The `version_counter_wraps_at_u64_max` test expected wrapping behavior (`u64::MAX → 0`) but `next_version()` deliberately panics on overflow to prevent MVCC ordering corruption. The test was wrong — not the implementation.

Renamed to `version_counter_panics_at_u64_max` and updated to verify the panic via `catch_unwind`.

## Test plan

- [x] `cargo test -p stratadb --test storage "version_counter_panics"` — passes
- [x] Matches existing unit test `test_issue_1718_next_version_overflow_panics` in storage crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)