### PR TITLE
Implement three-way merge for branch operations

### DIFF
--- a/crates/core/src/branch_dag.rs
+++ b/crates/core/src/branch_dag.rs
@@ -130,6 +130,9 @@ pub struct MergeRecord {
     pub target: String,
     /// Timestamp in microseconds.
     pub timestamp: u64,
+    /// MVCC snapshot version at the time of merge (for three-way merge).
+    #[serde(default)]
+    pub merge_version: Option<u64>,
     /// Merge strategy used.
     pub strategy: Option<String>,
     /// Number of keys applied.

--- a/crates/engine/src/branch_ops.rs
+++ b/crates/engine/src/branch_ops.rs
@@ -149,10 +149,16 @@ pub struct MergeInfo {
     pub target: String,
     /// Number of keys written to target
     pub keys_applied: u64,
+    /// Number of keys deleted on target (via tombstone)
+    #[serde(default)]
+    pub keys_deleted: u64,
     /// Conflicts encountered (empty for LWW, populated for Strict failures)
     pub conflicts: Vec<ConflictEntry>,
     /// Number of spaces merged
     pub spaces_merged: u64,
+    /// MVCC version of the merge transaction (used as merge base for subsequent merges)
+    #[serde(default)]
+    pub merge_version: Option<u64>,
 }
 
 /// Options for filtering and time-scoping a branch diff.
@@ -529,139 +535,379 @@ pub fn diff_branches_with_options(
 }
 
 // =============================================================================
-// Merge
+// Three-Way Merge Infrastructure
 // =============================================================================
 
-/// Merge data from source branch into target branch.
+/// Common ancestor state for three-way merge.
+#[derive(Debug, Clone)]
+struct MergeBase {
+    /// Branch to read ancestor state from.
+    branch_id: BranchId,
+    /// MVCC version to read at.
+    version: u64,
+}
+
+/// Classification of a key in a three-way merge.
+#[derive(Debug, Clone, PartialEq)]
+enum ThreeWayChange {
+    /// Key unchanged on both sides. No action.
+    Unchanged,
+    /// Key only changed on source side. Apply source value to target.
+    SourceChanged { value: Value },
+    /// Key only changed on target side. No action.
+    TargetChanged,
+    /// Key changed on both sides to the same value. No action.
+    BothChangedSame,
+    /// Key changed on both sides to different values. Conflict.
+    Conflict {
+        source_value: Value,
+        target_value: Value,
+    },
+    /// Key added on source only. Apply.
+    SourceAdded { value: Value },
+    /// Key added on target only. No action.
+    TargetAdded,
+    /// Key added on both sides with same value. No action.
+    BothAddedSame,
+    /// Key added on both sides with different values. Conflict.
+    BothAddedDifferent {
+        source_value: Value,
+        target_value: Value,
+    },
+    /// Key deleted on source, unchanged on target. Delete on target.
+    SourceDeleted,
+    /// Key deleted on target, unchanged on source. No action.
+    TargetDeleted,
+    /// Key deleted on both sides. No action.
+    BothDeleted,
+    /// Key deleted on source, modified on target. Conflict.
+    DeleteModifyConflict { target_value: Value },
+    /// Key modified on source, deleted on target. Conflict.
+    ModifyDeleteConflict { source_value: Value },
+}
+
+/// Classify a single key's change across ancestor, source, and target.
 ///
-/// Uses `diff_branches(target, source)` to identify changes, then applies
-/// them to the target. Target is branch A (base), source is branch B (incoming).
+/// Implements the 14-case decision matrix used by git, Dolt, and lakeFS:
+/// - `ancestor`: None = key absent (or tombstoned) at ancestor
+/// - `source`: None = key absent in current source (live listing)
+/// - `target`: None = key absent in current target (live listing)
+fn classify_change(
+    ancestor: Option<&Value>,
+    source: Option<&Value>,
+    target: Option<&Value>,
+) -> ThreeWayChange {
+    match (ancestor, source, target) {
+        // All absent
+        (None, None, None) => ThreeWayChange::Unchanged,
+
+        // All present and equal
+        (Some(a), Some(s), Some(t)) if a == s && s == t => ThreeWayChange::Unchanged,
+
+        // Only source changed
+        (Some(a), Some(s), Some(t)) if a == t && a != s => {
+            ThreeWayChange::SourceChanged { value: s.clone() }
+        }
+        // Only target changed
+        (Some(a), Some(s), Some(t)) if a == s && a != t => ThreeWayChange::TargetChanged,
+        // Both changed to same value
+        (Some(a), Some(s), Some(t)) if a != s && s == t => ThreeWayChange::BothChangedSame,
+        // Both changed to different values → conflict
+        (Some(_), Some(s), Some(t)) => ThreeWayChange::Conflict {
+            source_value: s.clone(),
+            target_value: t.clone(),
+        },
+
+        // Source added (not in ancestor or target)
+        (None, Some(s), None) => ThreeWayChange::SourceAdded { value: s.clone() },
+        // Target added (not in ancestor or source)
+        (None, None, Some(_)) => ThreeWayChange::TargetAdded,
+        // Both added same value
+        (None, Some(s), Some(t)) if s == t => ThreeWayChange::BothAddedSame,
+        // Both added different values → conflict
+        (None, Some(s), Some(t)) => ThreeWayChange::BothAddedDifferent {
+            source_value: s.clone(),
+            target_value: t.clone(),
+        },
+
+        // Source deleted, target unchanged
+        (Some(a), None, Some(t)) if a == t => ThreeWayChange::SourceDeleted,
+        // Source deleted, target modified → conflict
+        (Some(_), None, Some(t)) => ThreeWayChange::DeleteModifyConflict {
+            target_value: t.clone(),
+        },
+        // Target deleted, source unchanged
+        (Some(a), Some(s), None) if a == s => ThreeWayChange::TargetDeleted,
+        // Source modified, target deleted → conflict
+        (Some(_), Some(s), None) => ThreeWayChange::ModifyDeleteConflict {
+            source_value: s.clone(),
+        },
+        // Both deleted
+        (Some(_), None, None) => ThreeWayChange::BothDeleted,
+    }
+}
+
+/// A merge action to apply to the target branch.
+struct MergeAction {
+    space: String,
+    raw_key: Vec<u8>,
+    type_tag: TypeTag,
+    action: MergeActionKind,
+}
+
+enum MergeActionKind {
+    Put(Value),
+    Delete,
+}
+
+/// Compute the merge base between two branches.
 ///
-/// - **Added entries** (in source but not target): written to target
-/// - **Modified entries** (in both, different values):
-///   - `LastWriterWins`: source value overwrites target (appends new version)
-///   - `Strict`: merge fails with conflict list (no writes)
-/// - **Removed entries** (in target but not source): left unchanged
-///
-/// Version history in the target is preserved — merged values are appended
-/// as new versions via `db.transaction()`.
-///
-/// # Errors
-///
-/// - Either branch does not exist
-/// - `Strict` strategy with conflicts
-pub fn merge_branches(
+/// Priority:
+/// 1. `merge_base_override` from the executor (DAG-derived, covers repeated merges
+///    and materialized branches).
+/// 2. Storage-level fork info from `InheritedLayer` (fast path for COW branches).
+/// 3. None (unrelated branches → two-way fallback).
+fn compute_merge_base(
     db: &Arc<Database>,
-    source: &str,
-    target: &str,
-    strategy: MergeStrategy,
-) -> StrataResult<MergeInfo> {
-    let space_index = SpaceIndex::new(db.clone());
-
-    // 1. Diff: target is A (base), source is B (incoming)
-    let diff = diff_branches(db, target, source)?;
-
-    // 2. Check for conflicts in Strict mode
-    if strategy == MergeStrategy::Strict && diff.summary.total_modified > 0 {
-        let conflicts: Vec<ConflictEntry> = diff
-            .spaces
-            .iter()
-            .flat_map(|sd| {
-                sd.modified.iter().map(|entry| ConflictEntry {
-                    key: entry.key.clone(),
-                    primitive: entry.primitive,
-                    space: entry.space.clone(),
-                    source_value: entry.value_b.clone(),
-                    target_value: entry.value_a.clone(),
-                })
-            })
-            .collect();
-
-        return Err(StrataError::invalid_input(format!(
-            "Merge conflict: {} keys differ between '{}' and '{}'. Use LastWriterWins strategy or resolve conflicts manually.",
-            conflicts.len(),
-            source,
-            target
-        )));
+    source_id: BranchId,
+    target_id: BranchId,
+    merge_base_override: Option<(BranchId, u64)>,
+) -> Option<MergeBase> {
+    // 1. Executor-provided override (from DAG)
+    if let Some((branch_id, version)) = merge_base_override {
+        return Some(MergeBase { branch_id, version });
     }
 
-    // Collect conflicts for reporting (LWW resolves them, Strict already returned error)
-    let conflicts: Vec<ConflictEntry> = if strategy == MergeStrategy::LastWriterWins {
-        diff.spaces
-            .iter()
-            .flat_map(|sd| {
-                sd.modified.iter().map(|entry| ConflictEntry {
-                    key: entry.key.clone(),
-                    primitive: entry.primitive,
-                    space: entry.space.clone(),
-                    source_value: entry.value_b.clone(),
-                    target_value: entry.value_a.clone(),
-                })
-            })
-            .collect()
-    } else {
-        vec![]
-    };
+    // 2. Check storage for fork relationship
+    let storage = db.storage();
 
-    // 3. Resolve IDs
-    let source_id = resolve_branch_name(source);
-    let target_id = resolve_branch_name(target);
-
-    let mut keys_applied = 0u64;
-    let mut spaces_merged = 0u64;
-
-    // 4. Apply changes
-    for space_diff in &diff.spaces {
-        let space = &space_diff.space;
-
-        // Ensure target has this space
-        if space != "default" {
-            space_index.register(target_id, space)?;
+    // Case A: source was forked from target (child merging into parent)
+    if let Some((parent_id, fork_version)) = storage.get_fork_info(&source_id) {
+        if parent_id == target_id {
+            // Ancestor is the target (parent) at fork_version.
+            // The child inherited from the parent at this version, so reading
+            // the child at fork_version returns the same data as the parent
+            // at fork_version (via inherited layers).
+            return Some(MergeBase {
+                branch_id: source_id,
+                version: fork_version,
+            });
         }
-        spaces_merged += 1;
+    }
 
-        // Collect entries to write from source: added + modified (for LWW)
-        let entries_to_apply: Vec<&BranchDiffEntry> = space_diff
-            .added
-            .iter()
-            .chain(if strategy == MergeStrategy::LastWriterWins {
-                space_diff.modified.iter()
-            } else {
-                [].iter()
-            })
-            .collect();
-
-        if entries_to_apply.is_empty() {
-            continue;
+    // Case B: target was forked from source (parent merging into child)
+    if let Some((parent_id, fork_version)) = storage.get_fork_info(&target_id) {
+        if parent_id == source_id {
+            return Some(MergeBase {
+                branch_id: target_id,
+                version: fork_version,
+            });
         }
+    }
 
-        // Write to target using values already present in the diff entries.
-        // Each diff entry corresponds to exactly one (user_key, type_tag) pair
-        // from the diff scan, so we use the type_tag directly.
-        let mut batch: Vec<(Key, Value)> = Vec::new();
-        for diff_entry in &entries_to_apply {
-            if let Some(value) = &diff_entry.value_b {
-                let target_ns = Arc::new(Namespace::for_branch_space(target_id, space));
-                let target_key =
-                    Key::new(target_ns, diff_entry.type_tag, diff_entry.raw_key.clone());
-                batch.push((target_key, value.clone()));
+    // No relationship found
+    None
+}
+
+/// Compute three-way diff and produce merge actions.
+///
+/// For each key across all spaces and data type tags, classifies the change
+/// using the 14-case decision matrix and produces Put/Delete actions.
+fn three_way_diff(
+    db: &Arc<Database>,
+    source_id: BranchId,
+    target_id: BranchId,
+    merge_base: &MergeBase,
+    spaces: &[String],
+    strategy: MergeStrategy,
+) -> StrataResult<(Vec<MergeAction>, Vec<ConflictEntry>)> {
+    let storage = db.storage();
+    let mut actions = Vec::new();
+    let mut conflicts = Vec::new();
+
+    for space in spaces {
+        for &type_tag in &DATA_TYPE_TAGS {
+            // 1. Ancestor state (at merge base version, WITH tombstones)
+            let ancestor_entries = storage.list_by_type_at_version(
+                &merge_base.branch_id,
+                type_tag,
+                merge_base.version,
+            );
+
+            // 2. Source current state (live keys only)
+            let source_entries = storage.list_by_type(&source_id, type_tag);
+
+            // 3. Target current state (live keys only)
+            let target_entries = storage.list_by_type(&target_id, type_tag);
+
+            // Build lookup maps: user_key_bytes → Value (or None for tombstone)
+            let mut ancestor_map: HashMap<Vec<u8>, Option<Value>> = HashMap::new();
+            for entry in &ancestor_entries {
+                if entry.key.namespace.space == *space {
+                    if entry.is_tombstone {
+                        ancestor_map.insert(entry.key.user_key.to_vec(), None);
+                    } else {
+                        ancestor_map.insert(entry.key.user_key.to_vec(), Some(entry.value.clone()));
+                    }
+                }
+            }
+
+            let mut source_map: HashMap<Vec<u8>, Value> = HashMap::new();
+            for (key, vv) in &source_entries {
+                if key.namespace.space == *space {
+                    source_map.insert(key.user_key.to_vec(), vv.value.clone());
+                }
+            }
+
+            let mut target_map: HashMap<Vec<u8>, Value> = HashMap::new();
+            for (key, vv) in &target_entries {
+                if key.namespace.space == *space {
+                    target_map.insert(key.user_key.to_vec(), vv.value.clone());
+                }
+            }
+
+            // Union all keys
+            let mut all_keys: HashSet<Vec<u8>> = HashSet::new();
+            for k in ancestor_map.keys() {
+                all_keys.insert(k.clone());
+            }
+            for k in source_map.keys() {
+                all_keys.insert(k.clone());
+            }
+            for k in target_map.keys() {
+                all_keys.insert(k.clone());
+            }
+
+            // Classify each key
+            for user_key in &all_keys {
+                // Ancestor: flatten Option<Option<Value>> → Option<&Value>
+                // ancestor_map entry = Some(None) means tombstone → treat as absent
+                // ancestor_map entry = Some(Some(v)) means live value
+                // ancestor_map entry = None means key never existed at ancestor
+                let ancestor_val = ancestor_map.get(user_key).and_then(|opt| opt.as_ref());
+                let source_val = source_map.get(user_key);
+                let target_val = target_map.get(user_key);
+
+                let change = classify_change(ancestor_val, source_val, target_val);
+
+                match change {
+                    ThreeWayChange::Unchanged
+                    | ThreeWayChange::TargetChanged
+                    | ThreeWayChange::BothChangedSame
+                    | ThreeWayChange::TargetAdded
+                    | ThreeWayChange::BothAddedSame
+                    | ThreeWayChange::TargetDeleted
+                    | ThreeWayChange::BothDeleted => {
+                        // No action needed — target already has the correct state
+                    }
+
+                    ThreeWayChange::SourceChanged { value }
+                    | ThreeWayChange::SourceAdded { value } => {
+                        actions.push(MergeAction {
+                            space: space.clone(),
+                            raw_key: user_key.clone(),
+                            type_tag,
+                            action: MergeActionKind::Put(value),
+                        });
+                    }
+
+                    ThreeWayChange::SourceDeleted => {
+                        actions.push(MergeAction {
+                            space: space.clone(),
+                            raw_key: user_key.clone(),
+                            type_tag,
+                            action: MergeActionKind::Delete,
+                        });
+                    }
+
+                    // Conflicts — always report, resolve per strategy
+                    ThreeWayChange::Conflict {
+                        source_value,
+                        target_value,
+                    } => {
+                        conflicts.push(ConflictEntry {
+                            key: format_user_key(user_key),
+                            primitive: type_tag_to_primitive(type_tag),
+                            space: space.clone(),
+                            source_value: Some(source_value.clone()),
+                            target_value: Some(target_value),
+                        });
+                        if strategy == MergeStrategy::LastWriterWins {
+                            actions.push(MergeAction {
+                                space: space.clone(),
+                                raw_key: user_key.clone(),
+                                type_tag,
+                                action: MergeActionKind::Put(source_value),
+                            });
+                        }
+                    }
+
+                    ThreeWayChange::BothAddedDifferent {
+                        source_value,
+                        target_value,
+                    } => {
+                        conflicts.push(ConflictEntry {
+                            key: format_user_key(user_key),
+                            primitive: type_tag_to_primitive(type_tag),
+                            space: space.clone(),
+                            source_value: Some(source_value.clone()),
+                            target_value: Some(target_value),
+                        });
+                        if strategy == MergeStrategy::LastWriterWins {
+                            actions.push(MergeAction {
+                                space: space.clone(),
+                                raw_key: user_key.clone(),
+                                type_tag,
+                                action: MergeActionKind::Put(source_value),
+                            });
+                        }
+                    }
+
+                    ThreeWayChange::ModifyDeleteConflict { source_value } => {
+                        conflicts.push(ConflictEntry {
+                            key: format_user_key(user_key),
+                            primitive: type_tag_to_primitive(type_tag),
+                            space: space.clone(),
+                            source_value: Some(source_value.clone()),
+                            target_value: None,
+                        });
+                        if strategy == MergeStrategy::LastWriterWins {
+                            actions.push(MergeAction {
+                                space: space.clone(),
+                                raw_key: user_key.clone(),
+                                type_tag,
+                                action: MergeActionKind::Put(source_value),
+                            });
+                        }
+                    }
+
+                    ThreeWayChange::DeleteModifyConflict { target_value } => {
+                        conflicts.push(ConflictEntry {
+                            key: format_user_key(user_key),
+                            primitive: type_tag_to_primitive(type_tag),
+                            space: space.clone(),
+                            source_value: None,
+                            target_value: Some(target_value),
+                        });
+                        if strategy == MergeStrategy::LastWriterWins {
+                            actions.push(MergeAction {
+                                space: space.clone(),
+                                raw_key: user_key.clone(),
+                                type_tag,
+                                action: MergeActionKind::Delete,
+                            });
+                        }
+                    }
+                }
             }
         }
-
-        let batch_len = batch.len() as u64;
-        if batch_len > 0 {
-            db.transaction(target_id, |txn| {
-                for (key, value) in &batch {
-                    txn.put(key.clone(), value.clone())?;
-                }
-                Ok(())
-            })?;
-            keys_applied += batch_len;
-        }
     }
 
-    // Reload secondary index backends (vector, etc.) for the target branch
-    // so that entries merged at the KV level become visible immediately.
+    Ok((actions, conflicts))
+}
+
+/// Reload secondary index backends after merge.
+fn reload_secondary_backends(db: &Arc<Database>, target_id: BranchId, source_id: BranchId) {
     if let Ok(hooks) = db.extension::<crate::database::refresh::RefreshHooks>() {
         for hook in hooks.hooks() {
             if let Err(e) = hook.post_merge_reload(db, target_id, Some(source_id)) {
@@ -673,23 +919,143 @@ pub fn merge_branches(
             }
         }
     }
+}
+
+// =============================================================================
+// Merge (public entry point)
+// =============================================================================
+
+/// Merge data from source branch into target branch using three-way merge.
+///
+/// Computes the common ancestor (merge base) from the fork/merge relationship
+/// between the branches, then classifies each key using a 14-case decision matrix.
+/// Correctly handles delete propagation and preserves target-only changes.
+///
+/// The `merge_base_override` parameter is populated by the executor from DAG data,
+/// covering repeated merges and materialized branches where storage-level fork
+/// info is no longer available.
+///
+/// # Errors
+///
+/// - Either branch does not exist
+/// - No fork or merge relationship between branches
+/// - `Strict` strategy with conflicts
+pub fn merge_branches(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+    strategy: MergeStrategy,
+    merge_base_override: Option<(BranchId, u64)>,
+) -> StrataResult<MergeInfo> {
+    let source_id = resolve_and_verify(db, source)?;
+    let target_id = resolve_and_verify(db, target)?;
+
+    // Compute merge base
+    let merge_base = compute_merge_base(db, source_id, target_id, merge_base_override);
+
+    let merge_base = match merge_base {
+        Some(mb) => mb,
+        None => {
+            return Err(StrataError::invalid_input(format!(
+                "Cannot merge '{}' into '{}': no fork or merge relationship found. \
+                 Branches must be related by fork or a previous merge.",
+                source, target
+            )));
+        }
+    };
+
+    // Collect spaces from both branches
+    let space_index = SpaceIndex::new(db.clone());
+    let source_spaces: HashSet<String> = space_index.list(source_id)?.into_iter().collect();
+    let target_spaces: HashSet<String> = space_index.list(target_id)?.into_iter().collect();
+    let all_spaces: Vec<String> = source_spaces.union(&target_spaces).cloned().collect();
+
+    // Three-way diff
+    let (actions, conflicts) =
+        three_way_diff(db, source_id, target_id, &merge_base, &all_spaces, strategy)?;
+
+    // If strict and conflicts exist, return error
+    if strategy == MergeStrategy::Strict && !conflicts.is_empty() {
+        return Err(StrataError::invalid_input(format!(
+            "Merge conflict: {} keys differ between '{}' and '{}'. Use LastWriterWins strategy or resolve conflicts manually.",
+            conflicts.len(),
+            source,
+            target
+        )));
+    }
+
+    // Apply actions
+    let mut keys_applied = 0u64;
+    let mut keys_deleted = 0u64;
+    let mut spaces_touched: HashSet<String> = HashSet::new();
+    let mut merge_version: Option<u64> = None;
+
+    // Group actions by space for space registration
+    for action in &actions {
+        spaces_touched.insert(action.space.clone());
+    }
+    for space in &spaces_touched {
+        if space != "default" {
+            space_index.register(target_id, space)?;
+        }
+    }
+
+    if !actions.is_empty() {
+        // Build puts and deletes
+        let mut puts: Vec<(Key, Value)> = Vec::new();
+        let mut deletes: Vec<Key> = Vec::new();
+
+        for action in &actions {
+            let ns = Arc::new(Namespace::for_branch_space(target_id, &action.space));
+            let key = Key::new(ns, action.type_tag, action.raw_key.clone());
+            match &action.action {
+                MergeActionKind::Put(value) => {
+                    puts.push((key, value.clone()));
+                    keys_applied += 1;
+                }
+                MergeActionKind::Delete => {
+                    deletes.push(key);
+                    keys_deleted += 1;
+                }
+            }
+        }
+
+        // Apply in a single transaction, capturing the merge version
+        let ((), version) = db.transaction_with_version(target_id, |txn| {
+            for (key, value) in &puts {
+                txn.put(key.clone(), value.clone())?;
+            }
+            for key in &deletes {
+                txn.delete(key.clone())?;
+            }
+            Ok(())
+        })?;
+        merge_version = Some(version);
+    }
+
+    // Reload secondary index backends
+    reload_secondary_backends(db, target_id, source_id);
 
     info!(
         target: "strata::branch_ops",
         source,
         target,
         keys_applied,
-        spaces_merged,
+        keys_deleted,
+        ?merge_version,
+        spaces_merged = spaces_touched.len(),
         strategy = ?strategy,
-        "Branches merged"
+        "Branches merged (three-way)"
     );
 
     Ok(MergeInfo {
         source: source.to_string(),
         target: target.to_string(),
         keys_applied,
+        keys_deleted,
         conflicts,
-        spaces_merged,
+        spaces_merged: spaces_touched.len() as u64,
+        merge_version,
     })
 }
 
@@ -1075,15 +1441,16 @@ mod tests {
 
     #[test]
     fn test_merge_lww() {
+        // Fork target → source, both modify "shared", source adds "new_key"
         let (_temp, db) = setup_with_branch("target");
-        let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("source").unwrap();
-
-        // Write conflicting data
         write_kv(&db, "target", "default", "shared", Value::Int(1));
-        write_kv(&db, "source", "default", "shared", Value::Int(2));
 
-        // Source-only key
+        fork_branch(&db, "target", "source").unwrap();
+
+        // Both modify "shared" (conflict under three-way: both changed from ancestor=1)
+        write_kv(&db, "target", "default", "shared", Value::Int(10));
+        write_kv(&db, "source", "default", "shared", Value::Int(2));
+        // Source adds a new key
         write_kv(
             &db,
             "source",
@@ -1092,15 +1459,18 @@ mod tests {
             Value::String("new".into()),
         );
 
-        let info = merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
-        assert!(info.keys_applied >= 2);
+        let info =
+            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins, None).unwrap();
+        assert!(
+            info.keys_applied >= 2,
+            "shared (conflict resolved) + new_key"
+        );
 
-        // Target should now have source's value for "shared"
+        // LWW: source wins on conflict → shared=2
         assert_eq!(
             read_kv(&db, "target", "default", "shared"),
             Some(Value::Int(2))
         );
-        // Target should have the new key
         assert_eq!(
             read_kv(&db, "target", "default", "new_key"),
             Some(Value::String("new".into()))
@@ -1109,18 +1479,17 @@ mod tests {
 
     #[test]
     fn test_merge_strict_no_conflicts() {
+        // Fork target → source, each writes a different key (no conflict)
         let (_temp, db) = setup_with_branch("target");
-        let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("source").unwrap();
+        write_kv(&db, "target", "default", "base_key", Value::Int(0)); // ensure branch in storage
+        fork_branch(&db, "target", "source").unwrap();
 
-        // Non-overlapping data (no conflicts)
         write_kv(&db, "target", "default", "target_key", Value::Int(1));
         write_kv(&db, "source", "default", "source_key", Value::Int(2));
 
-        let info = merge_branches(&db, "source", "target", MergeStrategy::Strict).unwrap();
+        let info = merge_branches(&db, "source", "target", MergeStrategy::Strict, None).unwrap();
         assert!(info.keys_applied >= 1);
 
-        // Target should have both keys
         assert_eq!(
             read_kv(&db, "target", "default", "target_key"),
             Some(Value::Int(1))
@@ -1133,15 +1502,16 @@ mod tests {
 
     #[test]
     fn test_merge_strict_with_conflicts() {
+        // Fork target → source, both modify same key → Strict fails
         let (_temp, db) = setup_with_branch("target");
-        let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("source").unwrap();
-
-        // Conflicting data
         write_kv(&db, "target", "default", "shared", Value::Int(1));
+
+        fork_branch(&db, "target", "source").unwrap();
+
+        write_kv(&db, "target", "default", "shared", Value::Int(10));
         write_kv(&db, "source", "default", "shared", Value::Int(2));
 
-        let result = merge_branches(&db, "source", "target", MergeStrategy::Strict);
+        let result = merge_branches(&db, "source", "target", MergeStrategy::Strict, None);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -1153,28 +1523,27 @@ mod tests {
         // Target should be unchanged (no writes happened)
         assert_eq!(
             read_kv(&db, "target", "default", "shared"),
-            Some(Value::Int(1))
+            Some(Value::Int(10))
         );
     }
 
     #[test]
-    fn test_merge_adds_without_deleting() {
+    fn test_merge_preserves_target_additions() {
+        // Fork target → source, target adds a key, source adds a different key
         let (_temp, db) = setup_with_branch("target");
-        let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("source").unwrap();
+        write_kv(&db, "target", "default", "base_key", Value::Int(0)); // ensure branch in storage
+        fork_branch(&db, "target", "source").unwrap();
 
-        // Target has keys that source doesn't
         write_kv(&db, "target", "default", "target_only", Value::Int(1));
         write_kv(&db, "source", "default", "source_only", Value::Int(2));
 
-        merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
+        merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins, None).unwrap();
 
-        // Target-only key should still exist
+        // Both keys should exist on target
         assert_eq!(
             read_kv(&db, "target", "default", "target_only"),
             Some(Value::Int(1))
         );
-        // Source-only key should now be in target
         assert_eq!(
             read_kv(&db, "target", "default", "source_only"),
             Some(Value::Int(2))
@@ -1183,12 +1552,13 @@ mod tests {
 
     #[test]
     fn test_merge_preserves_target_version_history() {
+        // Fork target → source, target writes multiple versions, source overwrites
         let (_temp, db) = setup_with_branch("target");
-        let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("source").unwrap();
-
-        // Write multiple versions to target
         write_kv(&db, "target", "default", "key", Value::Int(1));
+
+        fork_branch(&db, "target", "source").unwrap();
+
+        // Target writes more versions
         write_kv(&db, "target", "default", "key", Value::Int(2));
 
         // Source has different value
@@ -1201,8 +1571,8 @@ mod tests {
         let history_before = db.get_history(&history_key, None, None).unwrap();
         let versions_before = history_before.len();
 
-        // Merge
-        merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
+        // Merge (both modified from ancestor=1 → conflict, LWW takes source=99)
+        merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins, None).unwrap();
 
         // Check version history after merge — should have one more version
         let ns2 = Arc::new(Namespace::for_branch_space(target_id, "default"));
@@ -1224,9 +1594,10 @@ mod tests {
 
     #[test]
     fn test_merge_binary_keys() {
+        // Fork target → source, source writes a binary key (event)
         let (_temp, db) = setup_with_branch("target");
-        let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("source").unwrap();
+        write_kv(&db, "target", "default", "base_key", Value::Int(0)); // ensure branch in storage
+        fork_branch(&db, "target", "source").unwrap();
 
         let source_id = resolve_branch_name("source");
         let target_id = resolve_branch_name("target");
@@ -1244,7 +1615,8 @@ mod tests {
         .unwrap();
 
         // Merge source into target
-        let info = merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
+        let info =
+            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins, None).unwrap();
         assert_eq!(info.keys_applied, 1, "Binary key entry should be merged");
 
         // Verify the binary key data is in target
@@ -1261,15 +1633,14 @@ mod tests {
 
     #[test]
     fn test_merge_lww_reports_conflicts() {
+        // Fork target → source, both modify "shared" → LWW resolves but reports
         let (_temp, db) = setup_with_branch("target");
-        let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("source").unwrap();
-
-        // Write conflicting data
         write_kv(&db, "target", "default", "shared", Value::Int(1));
-        write_kv(&db, "source", "default", "shared", Value::Int(2));
 
-        // Source-only key (not a conflict)
+        fork_branch(&db, "target", "source").unwrap();
+
+        write_kv(&db, "target", "default", "shared", Value::Int(10));
+        write_kv(&db, "source", "default", "shared", Value::Int(2));
         write_kv(
             &db,
             "source",
@@ -1278,33 +1649,52 @@ mod tests {
             Value::String("new".into()),
         );
 
-        let info = merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
+        let info =
+            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins, None).unwrap();
 
         // Should report the conflict even though LWW resolved it
         assert_eq!(info.conflicts.len(), 1, "Should report 1 conflict");
         assert_eq!(info.conflicts[0].key, "shared");
         assert_eq!(info.conflicts[0].primitive, PrimitiveType::Kv);
-        // Verify conflict carries actual Values (source=B=incoming, target=A=base)
         assert_eq!(info.conflicts[0].source_value, Some(Value::Int(2)));
-        assert_eq!(info.conflicts[0].target_value, Some(Value::Int(1)));
+        assert_eq!(info.conflicts[0].target_value, Some(Value::Int(10)));
     }
 
     #[test]
     fn test_merge_no_vectors_is_noop() {
         // Merge with only KV data (no vectors) should not error
         let (_temp, db) = setup_with_branch("target");
-        let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("source").unwrap();
+        write_kv(&db, "target", "default", "base_key", Value::Int(0)); // ensure branch in storage
+        fork_branch(&db, "target", "source").unwrap();
 
         write_kv(&db, "source", "default", "k1", Value::String("v1".into()));
 
-        let info = merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
+        let info =
+            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins, None).unwrap();
         assert!(info.keys_applied >= 1);
-
-        // No vector collections means no error
         assert_eq!(
             read_kv(&db, "target", "default", "k1"),
             Some(Value::String("v1".into()))
+        );
+    }
+
+    #[test]
+    fn test_merge_unrelated_branches_errors() {
+        // Two branches with no fork relationship should fail
+        let (_temp, db) = setup_with_branch("a");
+        let branch_index = BranchIndex::new(db.clone());
+        branch_index.create_branch("b").unwrap();
+
+        write_kv(&db, "a", "default", "k1", Value::Int(1));
+        write_kv(&db, "b", "default", "k2", Value::Int(2));
+
+        let result = merge_branches(&db, "a", "b", MergeStrategy::LastWriterWins, None);
+        assert!(result.is_err(), "Merging unrelated branches should error");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("no fork or merge relationship"),
+            "Error: {}",
+            err
         );
     }
 
@@ -1706,13 +2096,16 @@ mod tests {
         // Write to source
         write_kv(&db, "source", "default", "shared", Value::Int(1));
 
-        // Fork
-        fork_branch(&db, "source", "dest").unwrap();
+        // Fork — capture fork_version for later (needed after materialization)
+        let fork_info = fork_branch(&db, "source", "dest").unwrap();
+        let fork_version = fork_info.fork_version.unwrap();
+        let dest_id = resolve_branch_name("dest");
 
         // Write different data to dest
         write_kv(&db, "dest", "default", "dest_only", Value::Int(42));
 
-        // Materialize dest
+        // Materialize dest — this removes inherited layers, so storage
+        // can no longer determine the fork relationship
         let mat_info = materialize_branch(&db, "dest").unwrap();
         assert!(mat_info.layers_collapsed > 0);
 
@@ -1723,9 +2116,16 @@ mod tests {
             "dest_only should show as added in dest"
         );
 
-        // Merge dest → source should work
-        let merge_info =
-            merge_branches(&db, "dest", "source", MergeStrategy::LastWriterWins).unwrap();
+        // Merge dest → source: must pass merge base explicitly since inherited
+        // layers are gone (in production, the executor reads this from the DAG)
+        let merge_info = merge_branches(
+            &db,
+            "dest",
+            "source",
+            MergeStrategy::LastWriterWins,
+            Some((dest_id, fork_version)),
+        )
+        .unwrap();
         assert!(merge_info.keys_applied > 0);
 
         // Source should now have dest_only
@@ -2154,6 +2554,289 @@ mod tests {
         assert!(
             !manifest.unwrap().inherited_layers.is_empty(),
             "forked branch must have inherited layers in manifest"
+        );
+    }
+
+    // =========================================================================
+    // Three-Way Merge: classify_change unit tests
+    // =========================================================================
+
+    #[test]
+    fn test_classify_all_absent() {
+        assert_eq!(classify_change(None, None, None), ThreeWayChange::Unchanged);
+    }
+
+    #[test]
+    fn test_classify_all_same() {
+        let v = Value::Int(1);
+        assert_eq!(
+            classify_change(Some(&v), Some(&v), Some(&v)),
+            ThreeWayChange::Unchanged
+        );
+    }
+
+    #[test]
+    fn test_classify_source_changed() {
+        let a = Value::Int(1);
+        let s = Value::Int(2);
+        assert_eq!(
+            classify_change(Some(&a), Some(&s), Some(&a)),
+            ThreeWayChange::SourceChanged {
+                value: Value::Int(2)
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_target_changed() {
+        let a = Value::Int(1);
+        let t = Value::Int(2);
+        assert_eq!(
+            classify_change(Some(&a), Some(&a), Some(&t)),
+            ThreeWayChange::TargetChanged
+        );
+    }
+
+    #[test]
+    fn test_classify_both_changed_same() {
+        let a = Value::Int(1);
+        let v = Value::Int(2);
+        assert_eq!(
+            classify_change(Some(&a), Some(&v), Some(&v)),
+            ThreeWayChange::BothChangedSame
+        );
+    }
+
+    #[test]
+    fn test_classify_conflict() {
+        let a = Value::Int(1);
+        let s = Value::Int(2);
+        let t = Value::Int(3);
+        assert_eq!(
+            classify_change(Some(&a), Some(&s), Some(&t)),
+            ThreeWayChange::Conflict {
+                source_value: Value::Int(2),
+                target_value: Value::Int(3),
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_source_added() {
+        let s = Value::Int(1);
+        assert_eq!(
+            classify_change(None, Some(&s), None),
+            ThreeWayChange::SourceAdded {
+                value: Value::Int(1)
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_target_added() {
+        let t = Value::Int(1);
+        assert_eq!(
+            classify_change(None, None, Some(&t)),
+            ThreeWayChange::TargetAdded
+        );
+    }
+
+    #[test]
+    fn test_classify_both_added_same() {
+        let v = Value::Int(1);
+        assert_eq!(
+            classify_change(None, Some(&v), Some(&v)),
+            ThreeWayChange::BothAddedSame
+        );
+    }
+
+    #[test]
+    fn test_classify_both_added_different() {
+        let s = Value::Int(1);
+        let t = Value::Int(2);
+        assert_eq!(
+            classify_change(None, Some(&s), Some(&t)),
+            ThreeWayChange::BothAddedDifferent {
+                source_value: Value::Int(1),
+                target_value: Value::Int(2),
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_source_deleted() {
+        let a = Value::Int(1);
+        assert_eq!(
+            classify_change(Some(&a), None, Some(&a)),
+            ThreeWayChange::SourceDeleted
+        );
+    }
+
+    #[test]
+    fn test_classify_target_deleted() {
+        let a = Value::Int(1);
+        assert_eq!(
+            classify_change(Some(&a), Some(&a), None),
+            ThreeWayChange::TargetDeleted
+        );
+    }
+
+    #[test]
+    fn test_classify_both_deleted() {
+        let a = Value::Int(1);
+        assert_eq!(
+            classify_change(Some(&a), None, None),
+            ThreeWayChange::BothDeleted
+        );
+    }
+
+    #[test]
+    fn test_classify_delete_modify_conflict() {
+        let a = Value::Int(1);
+        let t = Value::Int(2);
+        assert_eq!(
+            classify_change(Some(&a), None, Some(&t)),
+            ThreeWayChange::DeleteModifyConflict {
+                target_value: Value::Int(2),
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_modify_delete_conflict() {
+        let a = Value::Int(1);
+        let s = Value::Int(2);
+        assert_eq!(
+            classify_change(Some(&a), Some(&s), None),
+            ThreeWayChange::ModifyDeleteConflict {
+                source_value: Value::Int(2),
+            }
+        );
+    }
+
+    // =========================================================================
+    // Three-Way Merge: integration tests
+    // =========================================================================
+
+    fn delete_kv(db: &Arc<Database>, branch: &str, space: &str, key: &str) {
+        let branch_id = resolve_branch_name(branch);
+        let ns = Arc::new(Namespace::for_branch_space(branch_id, space));
+        db.transaction(branch_id, |txn| {
+            txn.delete(Key::new(ns.clone(), TypeTag::KV, key.as_bytes().to_vec()))?;
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_three_way_merge_delete_propagation() {
+        // #1537: Key deleted on source after fork → should be deleted on target after merge
+        let (_temp, db) = setup_with_branch("parent");
+
+        write_kv(&db, "parent", "default", "a", Value::Int(1));
+        write_kv(&db, "parent", "default", "b", Value::Int(2));
+
+        fork_branch(&db, "parent", "child").unwrap();
+
+        // Child deletes "b"
+        delete_kv(&db, "child", "default", "b");
+
+        // Merge child → parent
+        let info =
+            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins, None).unwrap();
+        assert!(info.keys_deleted >= 1, "should have deleted at least 1 key");
+
+        // Verify: "a" still exists, "b" is gone
+        assert_eq!(read_kv(&db, "parent", "default", "a"), Some(Value::Int(1)));
+        assert_eq!(read_kv(&db, "parent", "default", "b"), None);
+    }
+
+    #[test]
+    fn test_three_way_merge_preserves_target_only_changes() {
+        // #1692: Key added on target after fork → should NOT be deleted by merge
+        let (_temp, db) = setup_with_branch("parent");
+
+        write_kv(&db, "parent", "default", "a", Value::Int(1));
+
+        fork_branch(&db, "parent", "child").unwrap();
+
+        // Parent adds "b" after fork
+        write_kv(&db, "parent", "default", "b", Value::Int(2));
+
+        // Child does nothing. Merge child → parent.
+        let info =
+            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins, None).unwrap();
+        assert_eq!(info.keys_deleted, 0, "nothing should be deleted");
+
+        // Verify: both "a" and "b" still exist on parent
+        assert_eq!(read_kv(&db, "parent", "default", "a"), Some(Value::Int(1)));
+        assert_eq!(read_kv(&db, "parent", "default", "b"), Some(Value::Int(2)));
+    }
+
+    #[test]
+    fn test_three_way_merge_disjoint_changes() {
+        // Disjoint changes on parent and child merge cleanly
+        let (_temp, db) = setup_with_branch("parent");
+
+        write_kv(&db, "parent", "default", "a", Value::Int(1));
+        write_kv(&db, "parent", "default", "b", Value::Int(2));
+        write_kv(&db, "parent", "default", "c", Value::Int(3));
+
+        fork_branch(&db, "parent", "child").unwrap();
+
+        // Parent changes a, child changes b
+        write_kv(&db, "parent", "default", "a", Value::Int(10));
+        write_kv(&db, "child", "default", "b", Value::Int(20));
+
+        // Merge child → parent
+        merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins, None).unwrap();
+
+        // Verify: a=10 (parent's change preserved), b=20 (child's change applied), c=3 (unchanged)
+        assert_eq!(read_kv(&db, "parent", "default", "a"), Some(Value::Int(10)));
+        assert_eq!(read_kv(&db, "parent", "default", "b"), Some(Value::Int(20)));
+        assert_eq!(read_kv(&db, "parent", "default", "c"), Some(Value::Int(3)));
+    }
+
+    #[test]
+    fn test_three_way_merge_strict_conflict() {
+        // Both-modified conflict under Strict mode should fail
+        let (_temp, db) = setup_with_branch("parent");
+
+        write_kv(&db, "parent", "default", "a", Value::Int(1));
+
+        fork_branch(&db, "parent", "child").unwrap();
+
+        // Both sides change "a" to different values
+        write_kv(&db, "parent", "default", "a", Value::Int(10));
+        write_kv(&db, "child", "default", "a", Value::Int(20));
+
+        // Strict merge should fail
+        let result = merge_branches(&db, "child", "parent", MergeStrategy::Strict, None);
+        assert!(result.is_err(), "Strict merge should fail on conflict");
+
+        // Parent's value should be unchanged
+        assert_eq!(read_kv(&db, "parent", "default", "a"), Some(Value::Int(10)));
+
+        // LWW merge should succeed with source's value
+        let info =
+            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins, None).unwrap();
+        assert!(info.keys_applied >= 1);
+        assert_eq!(read_kv(&db, "parent", "default", "a"), Some(Value::Int(20)));
+    }
+
+    #[test]
+    fn test_three_way_merge_returns_merge_version() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "a", Value::Int(1));
+
+        fork_branch(&db, "parent", "child").unwrap();
+        write_kv(&db, "child", "default", "b", Value::Int(2));
+
+        let info =
+            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins, None).unwrap();
+        assert!(
+            info.merge_version.is_some(),
+            "merge should return a version"
         );
     }
 }

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -1126,13 +1126,14 @@ mod tests {
 
     #[test]
     fn test_branches_merge() {
-        let mut db = create_strata();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut db = Strata::open(temp_dir.path()).unwrap();
 
-        // Write data to default
+        // Write data to default before fork
         db.kv_put("base-key", "base-value").unwrap();
 
-        // Create and populate source branch
-        db.create_branch("source").unwrap();
+        // Fork default → source, then write on source
+        db.fork_branch("source").unwrap();
         db.set_branch("source").unwrap();
         db.kv_put("new-key", "new-value").unwrap();
 

--- a/crates/executor/src/handlers/branch.rs
+++ b/crates/executor/src/handlers/branch.rs
@@ -306,13 +306,43 @@ pub fn branch_merge(
             hint: Some("Branches starting with '_system' are internal.".to_string()),
         });
     }
-    let info = strata_engine::branch_ops::merge_branches(&p.db, &source, &target, strategy)
-        .map_err(|e| Error::Internal {
-            reason: e.to_string(),
-            hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
-        })?;
 
-    // Best-effort: record merge in the DAG
+    // Compute merge base override from DAG (for repeated merges and materialized branches)
+    let merge_base_override = {
+        // Check for previous merge first (takes priority over fork)
+        match branch_dag::find_last_merge_version(&p.db, &source, &target) {
+            Ok(Some(v)) => {
+                let target_id = strata_engine::primitives::branch::resolve_branch_name(&target);
+                Some((target_id, v))
+            }
+            _ => {
+                // No previous merge — check for fork relationship in DAG
+                // (covers materialized branches where storage lost fork info)
+                match branch_dag::find_fork_version(&p.db, &source, &target) {
+                    Ok(Some((child_name, fork_version))) => {
+                        let child_id =
+                            strata_engine::primitives::branch::resolve_branch_name(&child_name);
+                        Some((child_id, fork_version))
+                    }
+                    _ => None, // Let engine try storage-level fork info
+                }
+            }
+        }
+    };
+
+    let info = strata_engine::branch_ops::merge_branches(
+        &p.db,
+        &source,
+        &target,
+        strategy,
+        merge_base_override,
+    )
+    .map_err(|e| Error::Internal {
+        reason: e.to_string(),
+        hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+    })?;
+
+    // Best-effort: record merge in the DAG (merge_version now comes from MergeInfo)
     let strategy_str = match strategy {
         strata_engine::MergeStrategy::LastWriterWins => "last_writer_wins",
         strata_engine::MergeStrategy::Strict => "strict",

--- a/crates/executor/src/tests/serialization.rs
+++ b/crates/executor/src/tests/serialization.rs
@@ -963,8 +963,10 @@ fn test_output_branch_merged() {
         source: "experiment".to_string(),
         target: "main".to_string(),
         keys_applied: 5,
+        keys_deleted: 0,
         conflicts: vec![],
         spaces_merged: 1,
+        merge_version: None,
     }));
 }
 

--- a/crates/graph/src/branch_dag.rs
+++ b/crates/graph/src/branch_dag.rs
@@ -266,6 +266,9 @@ pub fn dag_record_merge(
         "spaces_merged": merge_info.spaces_merged,
         "conflicts": merge_info.conflicts.len() as u64,
     });
+    if let Some(mv) = merge_info.merge_version {
+        props["merge_version"] = serde_json::json!(mv);
+    }
     if let Some(s) = strategy {
         props["strategy"] = serde_json::json!(s);
     }
@@ -540,6 +543,9 @@ fn find_merge_history(db: &Arc<Database>, name: &str) -> StrataResult<Vec<MergeR
                     .and_then(|p| p.get("timestamp"))
                     .and_then(|v| v.as_u64())
                     .unwrap_or(0),
+                merge_version: props
+                    .and_then(|p| p.get("merge_version"))
+                    .and_then(|v| v.as_u64()),
                 strategy: props
                     .and_then(|p| p.get("strategy"))
                     .and_then(|v| v.as_str())
@@ -606,6 +612,58 @@ pub fn find_children(db: &Arc<Database>, name: &str) -> StrataResult<Vec<String>
         }
     }
     Ok(children)
+}
+
+/// Find the most recent `merge_version` between two branches (in either direction).
+///
+/// Checks merges where `source` merged into `target` and also where `target`
+/// merged into `source`, returning the highest `merge_version` found.
+pub fn find_last_merge_version(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+) -> StrataResult<Option<u64>> {
+    // Merges where source was the source branch
+    let forward = find_merge_history(db, source)?;
+    // Merges where target was the source branch (reverse direction)
+    let reverse = find_merge_history(db, target)?;
+
+    let best = forward
+        .iter()
+        .filter(|r| r.target == target)
+        .chain(reverse.iter().filter(|r| r.target == source))
+        .filter_map(|r| r.merge_version)
+        .max();
+
+    Ok(best)
+}
+
+/// Find the fork version between two branches.
+///
+/// Checks whether `source` was forked from `target` or `target` was forked
+/// from `source`. Returns `(child_branch_name, fork_version)` if found.
+pub fn find_fork_version(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+) -> StrataResult<Option<(String, u64)>> {
+    // Check if source was forked from target
+    if let Some(fork) = find_fork_origin(db, source)? {
+        if fork.parent == target {
+            if let Some(fv) = fork.fork_version {
+                return Ok(Some((source.to_string(), fv)));
+            }
+        }
+    }
+    // Check if target was forked from source
+    if let Some(fork) = find_fork_origin(db, target)? {
+        if fork.parent == source {
+            if let Some(fv) = fork.fork_version {
+                return Ok(Some((target.to_string(), fv)));
+            }
+        }
+    }
+    Ok(None)
 }
 
 /// Extract `DagBranchStatus` from node properties.
@@ -882,6 +940,8 @@ mod tests {
             keys_applied: 10,
             conflicts: vec![],
             spaces_merged: 2,
+            keys_deleted: 0,
+            merge_version: None,
         };
         let event_id = dag_record_merge(
             &db,
@@ -1002,6 +1062,8 @@ mod tests {
             keys_applied: 5,
             conflicts: vec![],
             spaces_merged: 1,
+            keys_deleted: 0,
+            merge_version: None,
         };
         dag_record_merge(
             &db,
@@ -1101,5 +1163,148 @@ mod tests {
             props.get("message").and_then(|v| v.as_str()),
             Some("hello world")
         );
+    }
+
+    #[test]
+    fn test_merge_version_round_trip() {
+        let db = setup();
+        dag_add_branch(&db, "mv-src", None, None).unwrap();
+        dag_add_branch(&db, "mv-tgt", None, None).unwrap();
+
+        let merge_info = strata_engine::branch_ops::MergeInfo {
+            source: "mv-src".to_string(),
+            target: "mv-tgt".to_string(),
+            keys_applied: 3,
+            conflicts: vec![],
+            spaces_merged: 1,
+            keys_deleted: 0,
+            merge_version: Some(42),
+        };
+        let event_id = dag_record_merge(
+            &db,
+            "mv-src",
+            "mv-tgt",
+            &merge_info,
+            Some("lww"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        // Verify the merge_version is stored in the DAG node
+        let graph_store = GraphStore::new(db.clone());
+        let branch_id = resolve_branch_name(SYSTEM_BRANCH);
+        let event_node = graph_store
+            .get_node(branch_id, BRANCH_DAG_GRAPH, event_id.as_str())
+            .unwrap()
+            .unwrap();
+        let props = event_node.properties.as_ref().unwrap();
+        assert_eq!(
+            props.get("merge_version").and_then(|v| v.as_u64()),
+            Some(42),
+            "merge_version should be persisted in DAG node properties"
+        );
+
+        // Verify it comes back via dag_get_branch_info -> merges
+        let info = dag_get_branch_info(&db, "mv-src").unwrap().unwrap();
+        assert_eq!(info.merges.len(), 1);
+        assert_eq!(info.merges[0].merge_version, Some(42));
+    }
+
+    #[test]
+    fn test_find_last_merge_version() {
+        let db = setup();
+        dag_add_branch(&db, "flmv-parent", None, None).unwrap();
+        dag_add_branch(&db, "flmv-child", None, None).unwrap();
+        dag_record_fork(&db, "flmv-parent", "flmv-child", Some(10), None, None).unwrap();
+
+        let merge_info = strata_engine::branch_ops::MergeInfo {
+            source: "flmv-child".to_string(),
+            target: "flmv-parent".to_string(),
+            keys_applied: 5,
+            conflicts: vec![],
+            spaces_merged: 1,
+            keys_deleted: 0,
+            merge_version: Some(20),
+        };
+        dag_record_merge(
+            &db,
+            "flmv-child",
+            "flmv-parent",
+            &merge_info,
+            Some("lww"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let result = find_last_merge_version(&db, "flmv-child", "flmv-parent").unwrap();
+        assert_eq!(result, Some(20));
+    }
+
+    #[test]
+    fn test_find_last_merge_version_both_directions() {
+        let db = setup();
+        dag_add_branch(&db, "bidir-a", None, None).unwrap();
+        dag_add_branch(&db, "bidir-b", None, None).unwrap();
+
+        // Merge A -> B with merge_version 10
+        let merge_info_ab = strata_engine::branch_ops::MergeInfo {
+            source: "bidir-a".to_string(),
+            target: "bidir-b".to_string(),
+            keys_applied: 2,
+            conflicts: vec![],
+            spaces_merged: 1,
+            keys_deleted: 0,
+            merge_version: Some(10),
+        };
+        dag_record_merge(&db, "bidir-a", "bidir-b", &merge_info_ab, None, None, None).unwrap();
+
+        // Merge B -> A with merge_version 25
+        let merge_info_ba = strata_engine::branch_ops::MergeInfo {
+            source: "bidir-b".to_string(),
+            target: "bidir-a".to_string(),
+            keys_applied: 3,
+            conflicts: vec![],
+            spaces_merged: 1,
+            keys_deleted: 0,
+            merge_version: Some(25),
+        };
+        dag_record_merge(&db, "bidir-b", "bidir-a", &merge_info_ba, None, None, None).unwrap();
+
+        // Both directions should find the max (25)
+        let fwd = find_last_merge_version(&db, "bidir-a", "bidir-b").unwrap();
+        assert_eq!(fwd, Some(25));
+        let rev = find_last_merge_version(&db, "bidir-b", "bidir-a").unwrap();
+        assert_eq!(rev, Some(25));
+    }
+
+    #[test]
+    fn test_find_fork_version() {
+        let db = setup();
+        dag_add_branch(&db, "fv-parent", None, None).unwrap();
+        dag_add_branch(&db, "fv-child", None, None).unwrap();
+        dag_record_fork(&db, "fv-parent", "fv-child", Some(55), None, None).unwrap();
+
+        // source=child, target=parent => child was forked from parent
+        let result = find_fork_version(&db, "fv-child", "fv-parent").unwrap();
+        assert_eq!(result, Some(("fv-child".to_string(), 55)));
+    }
+
+    #[test]
+    fn test_find_fork_version_reverse() {
+        let db = setup();
+        dag_add_branch(&db, "fvr-parent", None, None).unwrap();
+        dag_add_branch(&db, "fvr-child", None, None).unwrap();
+        dag_record_fork(&db, "fvr-parent", "fvr-child", Some(77), None, None).unwrap();
+
+        // source=parent, target=child => should still find that child was forked from parent
+        let result = find_fork_version(&db, "fvr-parent", "fvr-child").unwrap();
+        assert_eq!(result, Some(("fvr-child".to_string(), 77)));
+
+        // Unrelated branches should return None
+        dag_add_branch(&db, "fvr-unrelated", None, None).unwrap();
+        let result = find_fork_version(&db, "fvr-parent", "fvr-unrelated").unwrap();
+        assert_eq!(result, None);
     }
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -38,5 +38,7 @@ pub use pressure::{MemoryPressure, PressureLevel};
 pub use rate_limiter::RateLimiter;
 pub use segment::{KVSegment, OwnedSegmentIter};
 pub use segment_builder::{CompressionCodec, SegmentBuilder, SegmentMeta, SplittingSegmentBuilder};
-pub use segmented::{CompactionResult, MaterializeResult, PickAndCompactResult, SegmentedStore};
+pub use segmented::{
+    CompactionResult, MaterializeResult, PickAndCompactResult, SegmentedStore, VersionedEntry,
+};
 pub use ttl::TTLIndex;

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -140,6 +140,24 @@ pub struct MaterializeResult {
 }
 
 // ---------------------------------------------------------------------------
+// VersionedEntry — version-scoped listing with tombstone status
+// ---------------------------------------------------------------------------
+
+/// Entry from version-scoped listing that preserves tombstone status.
+/// Used by three-way merge to reconstruct ancestor state including deletions.
+#[derive(Debug, Clone)]
+pub struct VersionedEntry {
+    /// The decoded user key.
+    pub key: Key,
+    /// The stored value (empty for tombstones).
+    pub value: Value,
+    /// Whether this entry is a deletion tombstone.
+    pub is_tombstone: bool,
+    /// The MVCC commit version that wrote this entry.
+    pub commit_id: u64,
+}
+
+// ---------------------------------------------------------------------------
 // SegmentVersion
 // ---------------------------------------------------------------------------
 
@@ -667,6 +685,23 @@ impl SegmentedStore {
         self.branches
             .get(branch_id)
             .map_or(0, |b| b.inherited_layers.len())
+    }
+
+    /// Get the fork origin of a branch from its nearest active inherited layer.
+    ///
+    /// Returns the `(source_branch_id, fork_version)` of the first non-materialized
+    /// inherited layer, or `None` if the branch has no inherited layers (was never
+    /// forked, or all layers have been fully materialized).
+    pub fn get_fork_info(&self, branch_id: &BranchId) -> Option<(BranchId, u64)> {
+        let branch = self.branches.get(branch_id)?;
+        // Find first non-materialized layer (nearest ancestor with live data).
+        // Layers are ordered nearest-ancestor-first; skip any that have been
+        // fully materialized, as their fork info is no longer useful for reads.
+        branch
+            .inherited_layers
+            .iter()
+            .find(|l| l.status != LayerStatus::Materialized)
+            .map(|l| (l.source_branch_id, l.fork_version))
     }
 
     /// Return branch IDs where inherited layer depth exceeds `MAX_INHERITED_LAYERS`.
@@ -1383,6 +1418,87 @@ impl SegmentedStore {
             .into_iter()
             .filter(|(key, _)| key.type_tag == type_tag)
             .collect()
+    }
+
+    /// List entries filtered by type tag at a specific MVCC version, preserving tombstones.
+    ///
+    /// Unlike `list_by_type()`, this method:
+    /// - Uses `max_version` for MVCC visibility instead of `u64::MAX`
+    /// - Does NOT filter tombstones -- returns them with `is_tombstone: true`
+    /// - Does NOT filter expired entries
+    ///
+    /// This is required for three-way merge ancestor state reconstruction.
+    pub fn list_by_type_at_version(
+        &self,
+        branch_id: &BranchId,
+        type_tag: TypeTag,
+        max_version: u64,
+    ) -> Vec<VersionedEntry> {
+        let branch = match self.branches.get(branch_id) {
+            Some(b) => b,
+            None => return Vec::new(),
+        };
+
+        let mut sources: Vec<Box<dyn Iterator<Item = (InternalKey, MemtableEntry)>>> = Vec::new();
+
+        // Active memtable
+        let active_entries: Vec<_> = branch.active.iter_all().collect();
+        sources.push(Box::new(active_entries.into_iter()));
+
+        // Frozen memtables (newest first)
+        for frozen in &branch.frozen {
+            let entries: Vec<_> = frozen.iter_all().collect();
+            sources.push(Box::new(entries.into_iter()));
+        }
+
+        // On-disk segments -- all levels
+        let ver = branch.version.load();
+        for level in &ver.levels {
+            for seg in level {
+                let entries: Vec<_> = seg
+                    .iter_seek_all()
+                    .map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se)))
+                    .collect();
+                sources.push(Box::new(entries.into_iter()));
+            }
+        }
+
+        // Inherited layers (COW branching)
+        for layer in &branch.inherited_layers {
+            if layer.status == LayerStatus::Materialized {
+                continue;
+            }
+            for level in &layer.segments.levels {
+                for seg in level {
+                    let entries: Vec<_> = seg
+                        .iter_seek_all()
+                        .map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se)))
+                        .collect();
+                    sources.push(Box::new(RewritingIterator::new(
+                        entries.into_iter(),
+                        *branch_id,
+                        layer.fork_version,
+                    )));
+                }
+            }
+        }
+
+        let merge = MergeIterator::new(sources);
+        let mvcc = MvccIterator::new(merge, max_version);
+
+        mvcc.filter_map(|(ik, entry)| {
+            let (key, commit_id) = ik.decode()?;
+            if key.type_tag != type_tag {
+                return None;
+            }
+            Some(VersionedEntry {
+                key,
+                value: entry.value.clone(),
+                is_tombstone: entry.is_tombstone,
+                commit_id,
+            })
+        })
+        .collect()
     }
 
     /// List entries filtered by type tag with timestamp ≤ max_ts.

--- a/docs/design/branching/three-way-merge-implementation-plan.md
+++ b/docs/design/branching/three-way-merge-implementation-plan.md
@@ -1,0 +1,492 @@
+# Three-Way Merge Implementation Plan
+
+**Date:** 2026-03-24
+**Issues:** #1537, #1570, #1692
+**Prerequisites:** COW branching (complete), [Current State Analysis](current-state.md), [Implementation Design](implementation-design.md)
+**Status:** Implementation Plan
+
+---
+
+## Context
+
+Strata's merge is broken. `merge_branches()` uses a two-way diff that cannot distinguish "deleted on source" from "created on target after fork." This causes two critical bugs:
+- **#1537**: Deletes are not propagated (merge ignores `removed` entries entirely)
+- **#1692**: Target-only changes are overwritten by source's stale values under LWW
+
+COW branching is fully implemented (O(1) fork, inherited layers, RewritingIterator, materialization). The MVCC infrastructure already supports point-in-time reads. The only missing pieces are: (1) recording merge versions in the DAG, (2) a storage method that reads at a specific version without filtering tombstones, (3) the three-way diff/merge algorithm, and (4) wiring it together.
+
+### Research Validation
+
+Surveyed Dolt, lakeFS, git merge-ort, TardisDB, CouchDB, Neon, and academic literature (Decibel VLDB 2016, TARDiS SIGMOD 2016, OrpheusDB VLDB 2017).
+
+**Confirmed design decisions:**
+- **lakeFS** uses the identical 14-case decision matrix — our `classify_change()` is correct
+- **Dolt** confirms primary key = cross-version identity (matches our `(space, type_tag, user_key)` tuple)
+- **Git merge-ort**: tree-level only, no content merge for opaque values — exactly our case
+- All systems (Dolt, lakeFS, git) store merge metadata in a **separate DAG**, not inline
+- **Criss-cross merges**: safe to reject for now (Dolt also rejects; only git handles them via recursive base merging)
+- **Full-scan O(n)** for V1 is acceptable (Dolt started there, optimized to O(diff) later with Prolly Trees; lakeFS uses Merkle tree range skipping)
+- **Delete propagation via three-way** is the universal approach — no shortcut exists
+
+### Key Sources
+
+- [Dolt Cell-Level Three-Way Merge](https://www.dolthub.com/blog/2020-07-15-three-way-merge/)
+- [Dolt Efficient Diff on Prolly Trees](https://www.dolthub.com/blog/2020-06-16-efficient-diff-on-prolly-trees/)
+- [lakeFS Merge Internals](https://docs.lakefs.io/v1.61/understand/how/merge/)
+- [Git merge-ort scaling](https://github.blog/engineering/scaling-merge-ort-across-github/)
+- [Git trivial-merge decision table](https://github.com/git/git/blob/master/Documentation/technical/trivial-merge.adoc)
+- [Decibel: Version Control for Datasets (VLDB 2016)](http://www.vldb.org/pvldb/vol9/p624-maddox.pdf)
+
+---
+
+## Approach
+
+Replace `merge_branches()` with a three-way implementation. The function signature gains one parameter (`merge_base_override: Option<(BranchId, u64)>`) that the executor populates from the DAG. Merging requires a fork or merge relationship between branches — unrelated branches produce a clear error. The old two-way merge code has been fully excised.
+
+**Architecture**: The executor queries the DAG for the merge base version and passes it down to the engine. This cleanly separates concerns (engine doesn't depend on graph crate) and handles the "materialized branch lost fork info" edge case. The engine also checks storage-level `InheritedLayer` as a fast path for the common case.
+
+---
+
+## Phase 1: DAG — Add merge_version tracking
+
+### Step 1.1: Add `merge_version` to `MergeRecord`
+
+**File**: `crates/core/src/branch_dag.rs`
+
+Add field to `MergeRecord` struct (after line 127):
+```rust
+pub merge_version: Option<u64>,
+```
+`Option` for backward compat with existing DAG events that lack it.
+
+### Step 1.2: Store merge_version in `dag_record_merge()`
+
+**File**: `crates/graph/src/branch_dag.rs`
+
+In `dag_record_merge()` (~line 246): read `merge_info.merge_version` and store it in the event node properties JSON, same pattern as `fork_version` in `dag_record_fork()`.
+
+### Step 1.3: Extract merge_version in `find_merge_history()`
+
+**File**: `crates/graph/src/branch_dag.rs`
+
+In `find_merge_history()` (~line 501): extract `merge_version` from event node properties, same pattern as `fork_version` in `find_fork_origin()`.
+
+### Step 1.4: Add `find_last_merge_version()` helper
+
+**File**: `crates/graph/src/branch_dag.rs`
+
+New public function:
+```rust
+pub fn find_last_merge_version(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+) -> StrataResult<Option<u64>>
+```
+Walks merge history for `source`, filters for merges where target matches, returns most recent `merge_version`. Also checks reverse direction (target's merge history where source was the source).
+
+### Step 1.5: Add `find_fork_version()` helper
+
+**File**: `crates/graph/src/branch_dag.rs`
+
+New public function:
+```rust
+pub fn find_fork_version(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+) -> StrataResult<Option<(String, u64)>>  // (child_branch_name, fork_version)
+```
+Checks if source was forked from target or target from source. Returns the child name and fork_version. This is needed when inherited layers have been materialized (storage no longer has fork info).
+
+**Tests** (Phase 1): Record merge with merge_version, retrieve it, verify round-trip. Test `find_last_merge_version` with merges in both directions. Test `find_fork_version`.
+
+---
+
+## Phase 2: Storage — Version-scoped listing with tombstones
+
+### Step 2.1: Add `VersionedEntry` type
+
+**File**: `crates/storage/src/segmented/mod.rs`
+
+```rust
+/// Entry from version-scoped listing that preserves tombstone status.
+pub struct VersionedEntry {
+    pub key: Key,
+    pub value: Value,
+    pub is_tombstone: bool,
+    pub commit_id: u64,
+}
+```
+
+### Step 2.2: Add `list_by_type_at_version()`
+
+**File**: `crates/storage/src/segmented/mod.rs`
+
+New public method near `list_by_type()` (~line 1377):
+```rust
+pub fn list_by_type_at_version(
+    &self,
+    branch_id: &BranchId,
+    type_tag: TypeTag,
+    max_version: u64,
+) -> Vec<VersionedEntry>
+```
+
+Implementation: same as `list_branch_inner()` (lines 1251-1313) but:
+1. Uses `max_version` instead of `u64::MAX` in `MvccIterator::new(merge, max_version)`
+2. Does NOT filter tombstones — emits them with `is_tombstone: true`
+3. Filters by `type_tag` on decode (like `list_by_type()`)
+4. Does NOT filter expired entries (ancestor state may have TTL'd entries that are still relevant for diff)
+
+The merge iterator construction already handles inherited layers via `RewritingIterator` — this works transparently for COW branches.
+
+**Tests**: Write key, delete key, write new version. Call at different versions, verify tombstone visibility.
+
+---
+
+## Phase 3: Engine — Three-way diff and merge
+
+### Step 3.1: Add `MergeBase` struct
+
+**File**: `crates/engine/src/branch_ops.rs`
+
+```rust
+/// Common ancestor state for three-way merge.
+#[derive(Debug, Clone)]
+struct MergeBase {
+    /// Branch to read ancestor state from.
+    branch_id: BranchId,
+    /// MVCC version to read at.
+    version: u64,
+}
+```
+
+### Step 3.2: Add `compute_merge_base()`
+
+**File**: `crates/engine/src/branch_ops.rs`
+
+```rust
+fn compute_merge_base(
+    db: &Arc<Database>,
+    source_id: BranchId,
+    target_id: BranchId,
+    merge_base_override: Option<(BranchId, u64)>,
+) -> Option<MergeBase>
+```
+
+Logic:
+1. If `merge_base_override` is `Some((branch_id, v))`, return `MergeBase { branch_id, version: v }` directly. This is the executor-provided override from DAG data (covers repeated merges and materialized branches).
+2. Otherwise, check storage for fork relationship:
+   - `storage.get_fork_info(&source_id)` — if source's parent is target, return `MergeBase { branch_id: target_id, version: fork_version }`
+   - `storage.get_fork_info(&target_id)` — if target's parent is source, return `MergeBase { branch_id: source_id, version: fork_version }`
+3. Return `None` (unrelated branches → error).
+
+### Step 3.3: Add `get_fork_info()` to storage
+
+**File**: `crates/storage/src/segmented/mod.rs`
+
+```rust
+/// Get the fork origin of a branch from its nearest active inherited layer.
+/// Returns None if the branch has no inherited layers (never forked, or fully materialized).
+pub fn get_fork_info(&self, branch_id: &BranchId) -> Option<(BranchId, u64)> {
+    let branch = self.branches.get(branch_id)?;
+    let layer = branch.inherited_layers.first()?;
+    if layer.status == LayerStatus::Materialized {
+        return None;
+    }
+    Some((layer.source_branch_id, layer.fork_version))
+}
+```
+
+### Step 3.4: Add `ThreeWayChange` enum
+
+**File**: `crates/engine/src/branch_ops.rs`
+
+14-variant enum matching the decision matrix (same as git trivial-merge and lakeFS):
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+enum ThreeWayChange {
+    Unchanged,
+    SourceChanged { value: Value },
+    TargetChanged,
+    BothChangedSame,
+    Conflict { source_value: Value, target_value: Value },
+    SourceAdded { value: Value },
+    TargetAdded,
+    BothAddedSame,
+    BothAddedDifferent { source_value: Value, target_value: Value },
+    SourceDeleted,
+    TargetDeleted,
+    BothDeleted,
+    DeleteModifyConflict { target_value: Value },
+    ModifyDeleteConflict { source_value: Value },
+}
+```
+
+### Step 3.5: Add `classify_change()` — the decision matrix
+
+**File**: `crates/engine/src/branch_ops.rs`
+
+Pure function:
+```rust
+fn classify_change(
+    ancestor: Option<&Value>,  // None = absent or tombstoned at ancestor
+    source: Option<&Value>,    // None = absent in current source (live listing)
+    target: Option<&Value>,    // None = absent in current target (live listing)
+) -> ThreeWayChange
+```
+
+The 14-case match on `(ancestor, source, target)`:
+
+| Ancestor | Source | Target | Result |
+|----------|--------|--------|--------|
+| ∅ | ∅ | ∅ | Unchanged |
+| A | A | A | Unchanged |
+| A | **S** | A | SourceChanged |
+| A | A | **T** | TargetChanged |
+| A | **S** | **S** | BothChangedSame |
+| A | **S** | **T** | **Conflict** |
+| ∅ | S | ∅ | SourceAdded |
+| ∅ | ∅ | T | TargetAdded |
+| ∅ | S | S | BothAddedSame |
+| ∅ | **S** | **T** | **BothAddedDifferent** |
+| A | ∅ | A | SourceDeleted |
+| A | ∅ | **T** | **DeleteModifyConflict** |
+| A | A | ∅ | TargetDeleted |
+| A | **S** | ∅ | **ModifyDeleteConflict** |
+| A | ∅ | ∅ | BothDeleted |
+
+### Step 3.6: Add three-way diff and merge action types
+
+**File**: `crates/engine/src/branch_ops.rs`
+
+```rust
+struct MergeAction {
+    space: String,
+    raw_key: Vec<u8>,
+    type_tag: TypeTag,
+    action: MergeActionKind,
+}
+
+enum MergeActionKind {
+    Put(Value),
+    Delete,
+}
+```
+
+### Step 3.7: Add `three_way_diff()`
+
+**File**: `crates/engine/src/branch_ops.rs`
+
+```rust
+fn three_way_diff(
+    db: &Arc<Database>,
+    source_id: BranchId,
+    target_id: BranchId,
+    merge_base: &MergeBase,
+    spaces: &[String],
+    strategy: MergeStrategy,
+) -> StrataResult<(Vec<MergeAction>, Vec<ConflictEntry>)>
+```
+
+For each space × type_tag in `DATA_TYPE_TAGS`:
+1. **Ancestor**: `storage.list_by_type_at_version(&merge_base.branch_id, type_tag, merge_base.version)` — build HashMap keyed by user_key bytes; tombstoned entries map to None
+2. **Source**: `storage.list_by_type(&source_id, type_tag)` — build HashMap keyed by user_key bytes
+3. **Target**: `storage.list_by_type(&target_id, type_tag)` — build HashMap keyed by user_key bytes
+4. Union all keys across three maps
+5. For each key: `classify_change(ancestor, source, target)`
+6. Map results to actions:
+   - `SourceChanged{v}` / `SourceAdded{v}` → `MergeAction::Put(v)`
+   - `SourceDeleted` → `MergeAction::Delete`
+   - Conflict variants → resolved per strategy or added to conflicts list
+   - Everything else (Unchanged, TargetChanged, TargetAdded, TargetDeleted, BothDeleted, BothChangedSame, BothAddedSame) → no action needed
+
+### Step 3.8: Rewrite `merge_branches()` with three-way path
+
+**File**: `crates/engine/src/branch_ops.rs`
+
+Change signature:
+```rust
+pub fn merge_branches(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+    strategy: MergeStrategy,
+    merge_base_override: Option<(BranchId, u64)>,
+) -> StrataResult<MergeInfo>
+```
+
+New logic:
+1. Resolve branch IDs
+2. `compute_merge_base(db, source_id, target_id, merge_base_override)`
+3. **If merge base found**: run `three_way_diff()`, then apply actions
+4. **If no merge base**: return error (branches must be related by fork or merge)
+5. Apply puts + deletes in a single `transaction_with_version()` call
+6. Capture `merge_version` from the transaction return value
+7. Reload secondary index backends (existing behavior)
+8. Return `MergeInfo` with new fields
+
+Conflict handling per strategy:
+- `Strict`: any conflict → return error with conflict list, no writes
+- `LastWriterWins` (SourceWins): conflicts resolve to source's value (puts for Conflict/BothAddedDifferent/ModifyDeleteConflict, delete for DeleteModifyConflict)
+
+### Step 3.9: Update `MergeInfo`
+
+**File**: `crates/engine/src/branch_ops.rs`
+
+Add fields to struct:
+```rust
+pub merge_version: Option<u64>,
+pub keys_deleted: u64,
+```
+
+---
+
+## Phase 4: Executor — Wire DAG → engine
+
+### Step 4.1: Update `branch_merge` handler
+
+**File**: `crates/executor/src/handlers/branch.rs`
+
+In `branch_merge()` (~line 295):
+
+1. Before calling merge, compute the merge base version from DAG:
+```rust
+// Check for previous merge first (takes priority over fork)
+let merge_base_override = match branch_dag::find_last_merge_version(&p.db, &source, &target) {
+    Ok(Some(v)) => {
+        let target_id = resolve_branch_name(&target);
+        Some((target_id, v))
+    }
+    _ => {
+        // No previous merge — check for fork relationship in DAG
+        // (covers materialized branches where storage lost fork info)
+        match branch_dag::find_fork_version(&p.db, &source, &target) {
+            Ok(Some((child_name, fork_version))) => {
+                let child_id = resolve_branch_name(&child_name);
+                Some((child_id, fork_version))
+            }
+            _ => None,  // Let engine try storage-level fork info
+        }
+    }
+};
+```
+
+2. Pass to engine:
+```rust
+let info = strata_engine::branch_ops::merge_branches(
+    &p.db, &source, &target, strategy, merge_base_override
+)?;
+```
+
+3. DAG recording already passes `&info` which now includes `merge_version`.
+
+### Step 4.2: Public API
+
+**File**: `crates/executor/src/api/branches.rs`
+
+`merge()` and `merge_with_options()` return `MergeInfo` — the new fields (`merge_version`, `keys_deleted`) are automatically available. No signature changes needed.
+
+---
+
+## Phase 5: Tests
+
+### Step 5.1: Unit tests for `classify_change()` (14 cases)
+
+**File**: `crates/engine/src/branch_ops.rs` (test module)
+
+One test per row of the decision matrix. Pure function tests — no database needed.
+
+### Step 5.2: Delete propagation test (#1537)
+
+```
+Fork parent→child. Parent has {a:1, b:2}. Child deletes "b".
+Merge child→parent. Assert parent has {a:1}, b is gone.
+```
+
+### Step 5.3: Target-only changes preserved (#1692)
+
+```
+Fork parent→child. Parent has {a:1}. Parent adds b:2 after fork. Child unchanged.
+Merge child→parent. Assert parent has {a:1, b:2}.
+```
+
+### Step 5.4: Disjoint changes merge cleanly
+
+```
+Fork parent→child. Parent has {a:1, b:2, c:3}.
+Parent changes a→10. Child changes b→20.
+Merge child→parent. Assert {a:10, b:20, c:3}.
+```
+(This is the ignored test `cow_three_way_merge_with_inherited_layers` — remove `#[ignore]`)
+
+### Step 5.5: Both-modified conflict under Strict
+
+```
+Fork parent→child. Parent has {a:1}. Parent changes a→10. Child changes a→20.
+Strict merge → error with conflict. LWW merge → source wins (a=20).
+```
+
+### Step 5.6: Repeated merge
+
+```
+Fork→merge→modify more→merge again.
+Second merge uses first merge's version as base.
+Only changes after first merge are considered.
+```
+(This requires the full DAG flow: handler queries `find_last_merge_version`)
+
+### Step 5.7: Backward compat — existing tests pass
+
+All existing merge tests rewritten to use `fork_branch()` (three-way merge requires fork/merge relationship). Added `test_merge_unrelated_branches_errors` to verify unrelated branches are rejected.
+
+### Step 5.8: Enable ignored integration test
+
+**File**: `tests/integration/branching.rs:852`
+
+Remove `#[ignore = "three-way merge not yet implemented"]`.
+
+---
+
+## Critical Files
+
+| File | Changes |
+|------|---------|
+| `crates/core/src/branch_dag.rs` | Add `merge_version` to `MergeRecord` |
+| `crates/graph/src/branch_dag.rs` | Store/extract `merge_version`, add `find_last_merge_version()`, `find_fork_version()` |
+| `crates/storage/src/segmented/mod.rs` | Add `VersionedEntry`, `list_by_type_at_version()`, `get_fork_info()` |
+| `crates/engine/src/branch_ops.rs` | Core: `MergeBase`, `ThreeWayChange`, `classify_change()`, `three_way_diff()`, rewrite `merge_branches()`, update `MergeInfo` |
+| `crates/executor/src/handlers/branch.rs` | Query DAG for merge base, pass to engine |
+| `tests/integration/branching.rs` | Enable ignored test |
+
+## Verification
+
+1. `cargo test -p strata-engine -- branch` — all existing + new tests pass
+2. `cargo test -p strata-storage` — new `list_by_type_at_version` tests pass
+3. `cargo test -p strata-graph -- dag` — merge_version round-trip tests pass
+4. `cargo test --test branching` — integration tests including the previously-ignored three-way merge test
+5. Manual: fork → delete key on source → merge → verify key is deleted on target (the #1537 scenario)
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Ancestor versions GC'd by compaction | Low | High | No MVCC GC today; version pinning is future work (Epic 3.4) |
+| Full-scan perf for large branches | Medium | Medium | Acceptable for V1; optimize to O(diff) later with version-range scanning |
+| Materialized branch + no DAG data | Low | Medium | Executor queries DAG as primary source; storage fork info is fallback only |
+| Existing tests break | Low | Low | All merge tests rewritten to use fork; unrelated branch merge explicitly tested |
+
+---
+
+## Sources
+
+- [Current State Analysis](current-state.md)
+- [Git Reference Architecture](git-reference-architecture.md)
+- [Three-Way Merge Design](implementation-design.md)
+- [COW Branching Design](cow-branching.md)
+- [Implementation Plan (Epics)](implementation-plan-epics.md)
+- Issue #1537 — branch_merge does not propagate deletes
+- Issue #1570 — Branch merge lacks three-way merge
+- Issue #1692 — Branch merge is two-way diff/apply

--- a/tests/integration/branching.rs
+++ b/tests/integration/branching.rs
@@ -563,12 +563,18 @@ fn test_merge_branches_lww() {
     let kv = test_db.kv();
 
     branch_index.create_branch("target").unwrap();
-    branch_index.create_branch("source").unwrap();
     let target_id = strata_engine::primitives::branch::resolve_branch_name("target");
+
+    // Write initial data before fork
+    kv.put(&target_id, "default", "shared", Value::Int(1))
+        .unwrap();
+
+    // Fork target → source
+    branch_ops::fork_branch(&test_db.db, "target", "source").unwrap();
     let source_id = strata_engine::primitives::branch::resolve_branch_name("source");
 
-    // Write conflicting data
-    kv.put(&target_id, "default", "shared", Value::Int(1))
+    // Both modify "shared" (conflict), source adds a new key
+    kv.put(&target_id, "default", "shared", Value::Int(10))
         .unwrap();
     kv.put(&source_id, "default", "shared", Value::Int(2))
         .unwrap();
@@ -585,11 +591,12 @@ fn test_merge_branches_lww() {
         "source",
         "target",
         MergeStrategy::LastWriterWins,
+        None,
     )
     .unwrap();
     assert!(info.keys_applied >= 2);
 
-    // Target should have source's value for "shared"
+    // Target should have source's value for "shared" (LWW: source wins)
     assert_eq!(
         kv.get(&target_id, "default", "shared").unwrap(),
         Some(Value::Int(2))
@@ -608,24 +615,31 @@ fn test_merge_branches_strict() {
     let kv = test_db.kv();
 
     branch_index.create_branch("target").unwrap();
-    branch_index.create_branch("source").unwrap();
     let target_id = strata_engine::primitives::branch::resolve_branch_name("target");
+
+    // Write initial data before fork
+    kv.put(&target_id, "default", "shared", Value::Int(1))
+        .unwrap();
+
+    // Fork target → source
+    branch_ops::fork_branch(&test_db.db, "target", "source").unwrap();
     let source_id = strata_engine::primitives::branch::resolve_branch_name("source");
 
-    // Write conflicting data
-    kv.put(&target_id, "default", "shared", Value::Int(1))
+    // Both modify "shared" to different values (conflict)
+    kv.put(&target_id, "default", "shared", Value::Int(10))
         .unwrap();
     kv.put(&source_id, "default", "shared", Value::Int(2))
         .unwrap();
 
     // Strict merge should fail with conflicts
-    let result = branch_ops::merge_branches(&test_db.db, "source", "target", MergeStrategy::Strict);
+    let result =
+        branch_ops::merge_branches(&test_db.db, "source", "target", MergeStrategy::Strict, None);
     assert!(result.is_err());
 
     // Target should be unchanged
     assert_eq!(
         kv.get(&target_id, "default", "shared").unwrap(),
-        Some(Value::Int(1))
+        Some(Value::Int(10))
     );
 }
 
@@ -680,6 +694,7 @@ fn test_fork_diff_merge_roundtrip() {
         "fork",
         "original",
         MergeStrategy::LastWriterWins,
+        None,
     )
     .unwrap();
     assert!(info.keys_applied >= 2, "Should apply fork-only and shared");
@@ -818,18 +833,17 @@ fn cow_merge_lww_with_inherited_layers() {
         "child",
         "parent",
         MergeStrategy::LastWriterWins,
+        None,
     )
     .unwrap();
     assert!(info.keys_applied >= 1, "at least b should be applied");
 
-    // 5. Verify: b gets child's value, c unchanged.
-    //    Two-way LWW sees child's inherited a:1 vs parent's a:10 as
-    //    "modified" and overwrites with child's value. A true three-way
-    //    merge would preserve parent's a:10 (see cow_three_way_merge test).
+    // 5. Verify: a keeps parent's value (three-way merge recognizes this as
+    //    TargetChanged — ancestor was 1, child still has 1, parent changed to 10).
     assert_eq!(
         kv.get(&parent_id, "default", "a").unwrap(),
-        Some(Value::Int(1)),
-        "a: two-way LWW overwrites parent's 10 with child's inherited 1"
+        Some(Value::Int(10)),
+        "a: three-way merge preserves parent's change (ancestor=1, parent=10, child=1)"
     );
     assert_eq!(
         kv.get(&parent_id, "default", "b").unwrap(),
@@ -845,11 +859,9 @@ fn cow_merge_lww_with_inherited_layers() {
 
 /// #1666: Three-way merge with ancestor state from inherited layers.
 ///
-/// NOT YET IMPLEMENTED — three-way merge requires ancestor awareness
-/// (reading the fork point to determine which side actually changed a key).
-/// This test documents the desired behavior.
+/// Three-way merge with ancestor state from inherited layers.
+/// Verifies that disjoint changes merge cleanly without conflict.
 #[test]
-#[ignore = "three-way merge not yet implemented"]
 fn cow_three_way_merge_with_inherited_layers() {
     let test_db = TestDb::new();
     let branch_index = test_db.branch_index();
@@ -878,6 +890,7 @@ fn cow_three_way_merge_with_inherited_layers() {
         "child",
         "parent",
         MergeStrategy::LastWriterWins, // TODO: ThreeWay strategy
+        None,
     )
     .unwrap();
 
@@ -920,6 +933,7 @@ fn cow_repeated_merge_after_fork() {
         "child",
         "parent",
         MergeStrategy::LastWriterWins,
+        None,
     )
     .unwrap();
     assert_eq!(
@@ -934,6 +948,7 @@ fn cow_repeated_merge_after_fork() {
         "child",
         "parent",
         MergeStrategy::LastWriterWins,
+        None,
     )
     .unwrap();
     assert_eq!(
@@ -1459,6 +1474,7 @@ fn test_issue_1695_fork_disjoint_changes_merge() {
         "child",
         "parent",
         MergeStrategy::LastWriterWins,
+        None,
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary

- **Fixes #1537**: Delete propagation — keys deleted on the source branch are now correctly propagated to the target after merge
- **Fixes #1570**: Three-way merge — implements the 14-case decision matrix used by git, Dolt, and lakeFS, replacing the broken two-way merge
- **Fixes #1692**: Target-only changes — changes made only on the target after fork are preserved instead of being overwritten by stale ancestor values

## Design

Three-way merge uses the common ancestor (fork point or previous merge version) to classify each key:

| Ancestor | Source | Target | Action |
|----------|--------|--------|--------|
| A | A | A | Unchanged |
| A | **S** | A | Apply source |
| A | A | **T** | Keep target |
| A | **S** | **T** | Conflict |
| A | ∅ | A | Delete on target |
| ∅ | S | ∅ | Add to target |
| ... | ... | ... | (14 cases total) |

Architecture: executor queries DAG for merge base → passes to engine → engine also checks storage-level `InheritedLayer` as fast path. Two-way merge has been fully excised.

## Changes

| Layer | Files | What |
|-------|-------|------|
| DAG | `core/branch_dag.rs`, `graph/branch_dag.rs` | `merge_version` on `MergeRecord`, `find_last_merge_version()`, `find_fork_version()` |
| Storage | `storage/segmented/mod.rs`, `storage/lib.rs` | `VersionedEntry`, `list_by_type_at_version()`, `get_fork_info()` |
| Engine | `engine/branch_ops.rs` | `classify_change()`, `three_way_diff()`, rewritten `merge_branches()`, `MergeInfo` gains `merge_version`/`keys_deleted` |
| Executor | `executor/handlers/branch.rs`, `executor/api/mod.rs` | DAG lookup → merge base override wiring |
| Tests | `engine/branch_ops.rs`, `integration/branching.rs` | 25 new tests, 10 rewritten tests, 1 previously-ignored test enabled |

## Test plan

- [x] 15 `classify_change` unit tests covering all 14 decision matrix cases
- [x] `test_three_way_merge_delete_propagation` — #1537 scenario
- [x] `test_three_way_merge_preserves_target_only_changes` — #1692 scenario
- [x] `test_three_way_merge_disjoint_changes` — non-conflicting changes merge cleanly
- [x] `test_three_way_merge_strict_conflict` — Strict mode rejects, LWW resolves
- [x] `test_three_way_merge_returns_merge_version` — merge_version captured for repeated merges
- [x] `test_merge_unrelated_branches_errors` — unrelated branches produce clear error
- [x] `cow_three_way_merge_with_inherited_layers` — previously-ignored integration test now passes
- [x] All 8 existing merge tests rewritten to use fork (three-way requires fork relationship)
- [x] 5 new DAG tests for merge_version round-trip and lookup helpers
- [x] 592 engine tests, 427 graph tests, 556 executor tests, 28 integration branching tests — all pass
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)