### PR TITLE
Add Phase 2 AI agent workflow primitives

### DIFF
--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -369,6 +369,18 @@ fn format_raw(output: &Output) -> String {
         Output::BranchMerged(info) => {
             format!("{}\t{}\t{}", info.source, info.target, info.keys_applied)
         }
+        Output::BranchReverted(info) => {
+            format!(
+                "{}\t{}\t{}\t{}",
+                info.branch, info.from_version, info.to_version, info.keys_reverted
+            )
+        }
+        Output::BranchCherryPicked(info) => {
+            format!(
+                "{}\t{}\t{}\t{}",
+                info.source, info.target, info.keys_applied, info.keys_deleted
+            )
+        }
         Output::Config(_) | Output::DurabilityCounters(_) => {
             serde_json::to_string(output).unwrap_or_default()
         }
@@ -520,6 +532,13 @@ fn format_raw(output: &Output) -> String {
             serde_json::to_string(&page).unwrap_or_default()
         }
         Output::Exported(r) => r.data.clone().unwrap_or_default(),
+        Output::ThreeWayDiff(result) => serde_json::to_string(&result).unwrap_or_default(),
+        Output::MergeBaseInfo(info) => serde_json::to_string(&info).unwrap_or_default(),
+        Output::TagCreated(info) => serde_json::to_string(&info).unwrap_or_default(),
+        Output::TagList(tags) => serde_json::to_string(&tags).unwrap_or_default(),
+        Output::MaybeTag(tag) => serde_json::to_string(&tag).unwrap_or_default(),
+        Output::NoteAdded(note) => serde_json::to_string(&note).unwrap_or_default(),
+        Output::NoteList(notes) => serde_json::to_string(&notes).unwrap_or_default(),
     }
 }
 
@@ -799,6 +818,23 @@ fn format_human(output: &Output) -> String {
             format!(
                 "Merged \"{}\" → \"{}\" ({} keys applied, {} spaces{})",
                 info.source, info.target, info.keys_applied, info.spaces_merged, conflict_msg
+            )
+        }
+        Output::BranchReverted(info) => {
+            format!(
+                "Reverted \"{}\" versions [{}, {}] ({} keys reverted)",
+                info.branch, info.from_version, info.to_version, info.keys_reverted
+            )
+        }
+        Output::BranchCherryPicked(info) => {
+            let delete_msg = if info.keys_deleted > 0 {
+                format!(", {} deleted", info.keys_deleted)
+            } else {
+                String::new()
+            };
+            format!(
+                "Cherry-picked \"{}\" → \"{}\" ({} keys applied{})",
+                info.source, info.target, info.keys_applied, delete_msg
             )
         }
         Output::Config(cfg) => {
@@ -1352,6 +1388,68 @@ fn format_human(output: &Output) -> String {
             }
             _ => format!("(exported) {} row(s)", r.row_count),
         },
+        Output::ThreeWayDiff(result) => serde_json::to_string_pretty(&result).unwrap_or_default(),
+        Output::MergeBaseInfo(None) => "(nil)".to_string(),
+        Output::MergeBaseInfo(Some(info)) => {
+            format!("merge base: {} @ v{}", info.branch, info.version)
+        }
+        Output::TagCreated(info) => {
+            format!(
+                "Tag '{}' created on '{}' @ v{}",
+                info.name, info.branch, info.version
+            )
+        }
+        Output::TagList(tags) => {
+            if tags.is_empty() {
+                "(no tags)".to_string()
+            } else {
+                tags.iter()
+                    .map(|t| {
+                        format!(
+                            "  {} -> v{}{}",
+                            t.name,
+                            t.version,
+                            t.message
+                                .as_deref()
+                                .map(|m| format!(" ({})", m))
+                                .unwrap_or_default()
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        Output::MaybeTag(None) => "(nil)".to_string(),
+        Output::MaybeTag(Some(tag)) => {
+            format!("{} -> {} @ v{}", tag.name, tag.branch, tag.version)
+        }
+        Output::NoteAdded(note) => {
+            format!(
+                "Note added to '{}' @ v{}: {}",
+                note.branch, note.version, note.message
+            )
+        }
+        Output::NoteList(notes) => {
+            if notes.is_empty() {
+                "(no notes)".to_string()
+            } else {
+                notes
+                    .iter()
+                    .map(|n| {
+                        format!(
+                            "  v{}: {}{}",
+                            n.version,
+                            n.message,
+                            n.author
+                                .as_deref()
+                                .map(|a| format!(" [{}]", a))
+                                .unwrap_or_default()
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
     }
 }
 

--- a/crates/engine/src/branch_ops.rs
+++ b/crates/engine/src/branch_ops.rs
@@ -161,6 +161,47 @@ pub struct MergeInfo {
     pub merge_version: Option<u64>,
 }
 
+/// Result of three-way diff for a single key.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ThreeWayDiffEntry {
+    /// User key (UTF-8 or hex-encoded for binary keys)
+    pub key: String,
+    /// Raw user key bytes (for programmatic access, preserves binary keys)
+    pub raw_key: Vec<u8>,
+    /// Space this entry belongs to
+    pub space: String,
+    /// Primitive type of this entry
+    pub primitive: PrimitiveType,
+    /// Storage-level type tag
+    pub type_tag: TypeTag,
+    /// Classification of the change
+    pub change: ThreeWayChange,
+}
+
+/// Full three-way diff result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ThreeWayDiffResult {
+    /// Source branch name
+    pub source: String,
+    /// Target branch name
+    pub target: String,
+    /// Merge base branch name
+    pub merge_base_branch: String,
+    /// Merge base version
+    pub merge_base_version: u64,
+    /// Entries that differ (excludes Unchanged)
+    pub entries: Vec<ThreeWayDiffEntry>,
+}
+
+/// Merge base information.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MergeBaseInfo {
+    /// Branch name at the merge base
+    pub branch: String,
+    /// MVCC version at the merge base
+    pub version: u64,
+}
+
 /// Options for filtering and time-scoping a branch diff.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct DiffOptions {
@@ -548,30 +589,40 @@ struct MergeBase {
 }
 
 /// Classification of a key in a three-way merge.
-#[derive(Debug, Clone, PartialEq)]
-enum ThreeWayChange {
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ThreeWayChange {
     /// Key unchanged on both sides. No action.
     Unchanged,
     /// Key only changed on source side. Apply source value to target.
-    SourceChanged { value: Value },
+    SourceChanged {
+        /// The source branch's new value.
+        value: Value,
+    },
     /// Key only changed on target side. No action.
     TargetChanged,
     /// Key changed on both sides to the same value. No action.
     BothChangedSame,
     /// Key changed on both sides to different values. Conflict.
     Conflict {
+        /// Value on the source branch.
         source_value: Value,
+        /// Value on the target branch.
         target_value: Value,
     },
     /// Key added on source only. Apply.
-    SourceAdded { value: Value },
+    SourceAdded {
+        /// The source branch's value.
+        value: Value,
+    },
     /// Key added on target only. No action.
     TargetAdded,
     /// Key added on both sides with same value. No action.
     BothAddedSame,
     /// Key added on both sides with different values. Conflict.
     BothAddedDifferent {
+        /// Value on the source branch.
         source_value: Value,
+        /// Value on the target branch.
         target_value: Value,
     },
     /// Key deleted on source, unchanged on target. Delete on target.
@@ -581,9 +632,15 @@ enum ThreeWayChange {
     /// Key deleted on both sides. No action.
     BothDeleted,
     /// Key deleted on source, modified on target. Conflict.
-    DeleteModifyConflict { target_value: Value },
+    DeleteModifyConflict {
+        /// Value on the target branch (source deleted it).
+        target_value: Value,
+    },
     /// Key modified on source, deleted on target. Conflict.
-    ModifyDeleteConflict { source_value: Value },
+    ModifyDeleteConflict {
+        /// Value on the source branch (target deleted it).
+        source_value: Value,
+    },
 }
 
 /// Classify a single key's change across ancestor, source, and target.
@@ -1060,6 +1117,215 @@ pub fn merge_branches(
 }
 
 // =============================================================================
+// Three-Way Diff (public entry point)
+// =============================================================================
+
+/// Compute the three-way diff between source and target branches.
+///
+/// Returns the raw classification for each key (14-case decision matrix)
+/// without applying any merge strategy. This is useful for inspection
+/// before deciding to merge.
+///
+/// The `merge_base_override` parameter is populated by the executor from DAG data,
+/// covering repeated merges and materialized branches where storage-level fork
+/// info is no longer available.
+///
+/// # Errors
+///
+/// - Either branch does not exist
+/// - No fork or merge relationship between branches
+pub fn diff_three_way(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+    merge_base_override: Option<(BranchId, u64)>,
+) -> StrataResult<ThreeWayDiffResult> {
+    let source_id = resolve_and_verify(db, source)?;
+    let target_id = resolve_and_verify(db, target)?;
+
+    // Compute merge base
+    let merge_base = compute_merge_base(db, source_id, target_id, merge_base_override);
+
+    let merge_base = match merge_base {
+        Some(mb) => mb,
+        None => {
+            return Err(StrataError::invalid_input(format!(
+                "Cannot compute three-way diff between '{}' and '{}': no fork or merge relationship found. \
+                 Branches must be related by fork or a previous merge.",
+                source, target
+            )));
+        }
+    };
+
+    // Resolve merge base branch_id back to a name.
+    // The merge base comes from either source_id or target_id (via compute_merge_base).
+    let merge_base_branch_name = if merge_base.branch_id == source_id {
+        source.to_string()
+    } else if merge_base.branch_id == target_id {
+        target.to_string()
+    } else {
+        // Fallback: try to find the branch name from the branch index
+        let branch_index = BranchIndex::new(db.clone());
+        let mut found_name = format!("{:?}", merge_base.branch_id);
+        if let Ok(names) = branch_index.list_branches() {
+            for name in names {
+                if resolve_branch_name(&name) == merge_base.branch_id {
+                    found_name = name;
+                    break;
+                }
+            }
+        }
+        found_name
+    };
+
+    // Collect spaces from both branches
+    let space_index = SpaceIndex::new(db.clone());
+    let source_spaces: HashSet<String> = space_index.list(source_id)?.into_iter().collect();
+    let target_spaces: HashSet<String> = space_index.list(target_id)?.into_iter().collect();
+    let all_spaces: Vec<String> = source_spaces.union(&target_spaces).cloned().collect();
+
+    let storage = db.storage();
+    let mut entries = Vec::new();
+
+    for space in &all_spaces {
+        for &type_tag in &DATA_TYPE_TAGS {
+            // 1. Ancestor state (at merge base version, WITH tombstones)
+            let ancestor_entries = storage.list_by_type_at_version(
+                &merge_base.branch_id,
+                type_tag,
+                merge_base.version,
+            );
+
+            // 2. Source current state (live keys only)
+            let source_entries = storage.list_by_type(&source_id, type_tag);
+
+            // 3. Target current state (live keys only)
+            let target_entries = storage.list_by_type(&target_id, type_tag);
+
+            // Build lookup maps
+            let mut ancestor_map: HashMap<Vec<u8>, Option<Value>> = HashMap::new();
+            for entry in &ancestor_entries {
+                if entry.key.namespace.space == *space {
+                    if entry.is_tombstone {
+                        ancestor_map.insert(entry.key.user_key.to_vec(), None);
+                    } else {
+                        ancestor_map.insert(entry.key.user_key.to_vec(), Some(entry.value.clone()));
+                    }
+                }
+            }
+
+            let mut source_map: HashMap<Vec<u8>, Value> = HashMap::new();
+            for (key, vv) in &source_entries {
+                if key.namespace.space == *space {
+                    source_map.insert(key.user_key.to_vec(), vv.value.clone());
+                }
+            }
+
+            let mut target_map: HashMap<Vec<u8>, Value> = HashMap::new();
+            for (key, vv) in &target_entries {
+                if key.namespace.space == *space {
+                    target_map.insert(key.user_key.to_vec(), vv.value.clone());
+                }
+            }
+
+            // Union all keys
+            let mut all_keys: HashSet<Vec<u8>> = HashSet::new();
+            for k in ancestor_map.keys() {
+                all_keys.insert(k.clone());
+            }
+            for k in source_map.keys() {
+                all_keys.insert(k.clone());
+            }
+            for k in target_map.keys() {
+                all_keys.insert(k.clone());
+            }
+
+            // Classify each key
+            for user_key in &all_keys {
+                let ancestor_val = ancestor_map.get(user_key).and_then(|opt| opt.as_ref());
+                let source_val = source_map.get(user_key);
+                let target_val = target_map.get(user_key);
+
+                let change = classify_change(ancestor_val, source_val, target_val);
+
+                // Only include non-Unchanged entries
+                if change != ThreeWayChange::Unchanged {
+                    entries.push(ThreeWayDiffEntry {
+                        key: format_user_key(user_key),
+                        raw_key: user_key.clone(),
+                        space: space.clone(),
+                        primitive: type_tag_to_primitive(type_tag),
+                        type_tag,
+                        change,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(ThreeWayDiffResult {
+        source: source.to_string(),
+        target: target.to_string(),
+        merge_base_branch: merge_base_branch_name,
+        merge_base_version: merge_base.version,
+        entries,
+    })
+}
+
+/// Get the merge base for two branches.
+///
+/// Returns `None` if the branches have no fork or merge relationship.
+///
+/// The `merge_base_override` parameter is populated by the executor from DAG data,
+/// covering repeated merges and materialized branches where storage-level fork
+/// info is no longer available.
+///
+/// # Errors
+///
+/// - Either branch does not exist
+pub fn get_merge_base(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+    merge_base_override: Option<(BranchId, u64)>,
+) -> StrataResult<Option<MergeBaseInfo>> {
+    let source_id = resolve_and_verify(db, source)?;
+    let target_id = resolve_and_verify(db, target)?;
+
+    let merge_base = compute_merge_base(db, source_id, target_id, merge_base_override);
+
+    match merge_base {
+        None => Ok(None),
+        Some(mb) => {
+            // Resolve merge base branch_id back to a name
+            let branch_name = if mb.branch_id == source_id {
+                source.to_string()
+            } else if mb.branch_id == target_id {
+                target.to_string()
+            } else {
+                // Fallback: scan branch index
+                let branch_index = BranchIndex::new(db.clone());
+                let mut found_name = format!("{:?}", mb.branch_id);
+                if let Ok(names) = branch_index.list_branches() {
+                    for name in names {
+                        if resolve_branch_name(&name) == mb.branch_id {
+                            found_name = name;
+                            break;
+                        }
+                    }
+                }
+                found_name
+            };
+
+            Ok(Some(MergeBaseInfo {
+                branch: branch_name,
+                version: mb.version,
+            }))
+        }
+    }
+}
+
+// =============================================================================
 // Materialize
 // =============================================================================
 
@@ -1146,6 +1412,735 @@ pub fn materialize_branch(db: &Arc<Database>, branch_name: &str) -> StrataResult
         entries_materialized: total_entries,
         segments_created: total_segments,
         layers_collapsed,
+    })
+}
+
+// =============================================================================
+// Tags
+// =============================================================================
+
+/// A named version bookmark on a branch.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TagInfo {
+    /// Tag name (e.g. "v1.0")
+    pub name: String,
+    /// Branch this tag belongs to
+    pub branch: String,
+    /// MVCC version this tag points to
+    pub version: u64,
+    /// Optional human-readable message
+    pub message: Option<String>,
+    /// Timestamp in microseconds since epoch
+    pub timestamp: u64,
+    /// Optional creator identifier
+    pub creator: Option<String>,
+}
+
+/// Create a tag on a branch at a specific version.
+///
+/// If `version` is `None`, tags the current database version.
+///
+/// # Errors
+///
+/// - Branch does not exist
+/// - Serialization failure (internal)
+pub fn create_tag(
+    db: &Arc<Database>,
+    branch: &str,
+    name: &str,
+    version: Option<u64>,
+    message: Option<&str>,
+    creator: Option<&str>,
+) -> StrataResult<TagInfo> {
+    resolve_and_verify(db, branch)?;
+
+    if branch.contains(':') {
+        return Err(StrataError::invalid_input("Branch name cannot contain ':'"));
+    }
+    if name.contains(':') {
+        return Err(StrataError::invalid_input("Tag name cannot contain ':'"));
+    }
+
+    if resolve_tag(db, branch, name)?.is_some() {
+        return Err(StrataError::invalid_input(format!(
+            "Tag '{}' already exists on branch '{}'",
+            name, branch
+        )));
+    }
+
+    let version = version.unwrap_or_else(|| db.current_version());
+    let timestamp = strata_core::contract::Timestamp::now().as_micros();
+
+    let tag_info = TagInfo {
+        name: name.to_string(),
+        branch: branch.to_string(),
+        version,
+        message: message.map(|s| s.to_string()),
+        timestamp,
+        creator: creator.map(|s| s.to_string()),
+    };
+
+    let system_id = resolve_branch_name("_system_");
+    let tag_key = format!("tag:{}:{}", branch, name);
+    let tag_value = serde_json::to_string(&tag_info)
+        .map_err(|e| StrataError::internal(format!("Failed to serialize tag: {}", e)))?;
+
+    db.transaction(system_id, |txn| {
+        let ns = Arc::new(Namespace::for_branch_space(system_id, "default"));
+        let key = Key::new(ns, TypeTag::KV, tag_key.as_bytes().to_vec());
+        txn.put(key, Value::String(tag_value.clone()))?;
+        Ok(())
+    })?;
+
+    Ok(tag_info)
+}
+
+/// Delete a tag.
+///
+/// Returns `true` if the tag existed and was deleted.
+pub fn delete_tag(db: &Arc<Database>, branch: &str, name: &str) -> StrataResult<bool> {
+    let system_id = resolve_branch_name("_system_");
+    let tag_key = format!("tag:{}:{}", branch, name);
+
+    let storage = db.storage();
+    let entries = storage.list_by_type(&system_id, TypeTag::KV);
+    let exists = entries
+        .iter()
+        .any(|(k, _)| k.namespace.space == "default" && *k.user_key == *tag_key.as_bytes());
+
+    if exists {
+        db.transaction(system_id, |txn| {
+            let ns = Arc::new(Namespace::for_branch_space(system_id, "default"));
+            let key = Key::new(ns, TypeTag::KV, tag_key.as_bytes().to_vec());
+            txn.delete(key)?;
+            Ok(())
+        })?;
+    }
+
+    Ok(exists)
+}
+
+/// List all tags on a branch.
+pub fn list_tags(db: &Arc<Database>, branch: &str) -> StrataResult<Vec<TagInfo>> {
+    let system_id = resolve_branch_name("_system_");
+    let prefix = format!("tag:{}:", branch);
+
+    let storage = db.storage();
+    let entries = storage.list_by_type(&system_id, TypeTag::KV);
+
+    let mut tags = Vec::new();
+    for (key, vv) in &entries {
+        if key.namespace.space == "default" {
+            let key_str = String::from_utf8_lossy(&key.user_key);
+            if key_str.starts_with(&prefix) {
+                if let Value::String(json_str) = &vv.value {
+                    if let Ok(tag) = serde_json::from_str::<TagInfo>(json_str) {
+                        tags.push(tag);
+                    }
+                }
+            }
+        }
+    }
+
+    tags.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+    Ok(tags)
+}
+
+/// Resolve a tag name to its info.
+pub fn resolve_tag(db: &Arc<Database>, branch: &str, name: &str) -> StrataResult<Option<TagInfo>> {
+    let system_id = resolve_branch_name("_system_");
+    let tag_key = format!("tag:{}:{}", branch, name);
+
+    let storage = db.storage();
+    let entries = storage.list_by_type(&system_id, TypeTag::KV);
+
+    for (key, vv) in &entries {
+        if key.namespace.space == "default" && *key.user_key == *tag_key.as_bytes() {
+            if let Value::String(json_str) = &vv.value {
+                if let Ok(tag) = serde_json::from_str::<TagInfo>(json_str) {
+                    return Ok(Some(tag));
+                }
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+// =============================================================================
+// Notes
+// =============================================================================
+
+/// A version-annotated note on a branch.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NoteInfo {
+    /// Branch this note belongs to
+    pub branch: String,
+    /// MVCC version this note is attached to
+    pub version: u64,
+    /// Human-readable message
+    pub message: String,
+    /// Optional author identifier
+    pub author: Option<String>,
+    /// Timestamp in microseconds since epoch
+    pub timestamp: u64,
+    /// Optional structured metadata
+    pub metadata: Option<Value>,
+}
+
+/// Add a note to a specific version of a branch.
+///
+/// # Errors
+///
+/// - Branch does not exist
+/// - Serialization failure (internal)
+pub fn add_note(
+    db: &Arc<Database>,
+    branch: &str,
+    version: u64,
+    message: &str,
+    author: Option<&str>,
+    metadata: Option<Value>,
+) -> StrataResult<NoteInfo> {
+    resolve_and_verify(db, branch)?;
+
+    if branch.contains(':') {
+        return Err(StrataError::invalid_input("Branch name cannot contain ':'"));
+    }
+
+    let timestamp = strata_core::contract::Timestamp::now().as_micros();
+    let note = NoteInfo {
+        branch: branch.to_string(),
+        version,
+        message: message.to_string(),
+        author: author.map(|s| s.to_string()),
+        timestamp,
+        metadata,
+    };
+
+    let system_id = resolve_branch_name("_system_");
+    let note_key = format!("note:{}:{}", branch, version);
+    let note_value = serde_json::to_string(&note)
+        .map_err(|e| StrataError::internal(format!("Failed to serialize note: {}", e)))?;
+
+    db.transaction(system_id, |txn| {
+        let ns = Arc::new(Namespace::for_branch_space(system_id, "default"));
+        let key = Key::new(ns, TypeTag::KV, note_key.as_bytes().to_vec());
+        txn.put(key, Value::String(note_value.clone()))?;
+        Ok(())
+    })?;
+
+    Ok(note)
+}
+
+/// Get notes for a branch, optionally filtered by version.
+///
+/// If `version` is `None`, returns all notes for the branch.
+/// If `version` is `Some(v)`, returns only the note at that version (if any).
+pub fn get_notes(
+    db: &Arc<Database>,
+    branch: &str,
+    version: Option<u64>,
+) -> StrataResult<Vec<NoteInfo>> {
+    let system_id = resolve_branch_name("_system_");
+    let prefix = format!("note:{}:", branch);
+    let exact_key = version.map(|v| format!("note:{}:{}", branch, v));
+
+    let storage = db.storage();
+    let entries = storage.list_by_type(&system_id, TypeTag::KV);
+
+    let mut notes = Vec::new();
+    for (key, vv) in &entries {
+        if key.namespace.space == "default" {
+            let key_str = String::from_utf8_lossy(&key.user_key);
+            let matches = match &exact_key {
+                Some(ek) => *key_str == **ek,
+                None => key_str.starts_with(&prefix),
+            };
+            if matches {
+                if let Value::String(json_str) = &vv.value {
+                    if let Ok(note) = serde_json::from_str::<NoteInfo>(json_str) {
+                        notes.push(note);
+                    }
+                }
+            }
+        }
+    }
+
+    notes.sort_by(|a, b| a.version.cmp(&b.version));
+    Ok(notes)
+}
+
+/// Delete a note at a specific version.
+///
+/// Returns `true` if the note existed and was deleted.
+pub fn delete_note(db: &Arc<Database>, branch: &str, version: u64) -> StrataResult<bool> {
+    let system_id = resolve_branch_name("_system_");
+    let note_key = format!("note:{}:{}", branch, version);
+
+    let storage = db.storage();
+    let entries = storage.list_by_type(&system_id, TypeTag::KV);
+    let exists = entries
+        .iter()
+        .any(|(k, _)| k.namespace.space == "default" && *k.user_key == *note_key.as_bytes());
+
+    if exists {
+        db.transaction(system_id, |txn| {
+            let ns = Arc::new(Namespace::for_branch_space(system_id, "default"));
+            let key = Key::new(ns, TypeTag::KV, note_key.as_bytes().to_vec());
+            txn.delete(key)?;
+            Ok(())
+        })?;
+    }
+
+    Ok(exists)
+}
+
+// =============================================================================
+// Revert
+// =============================================================================
+
+/// Information returned after reverting a version range.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RevertInfo {
+    /// Branch name
+    pub branch: String,
+    /// Start of the reverted range (inclusive)
+    pub from_version: u64,
+    /// End of the reverted range (inclusive)
+    pub to_version: u64,
+    /// Number of keys reverted
+    pub keys_reverted: u64,
+    /// MVCC version of the revert transaction
+    pub revert_version: Option<u64>,
+}
+
+/// Revert a version range on a branch.
+///
+/// For each key modified in [from_version, to_version], restores its value
+/// to what it was at (from_version - 1). Only reverts keys whose current
+/// value matches the state at to_version — keys modified after to_version
+/// are left untouched (preserving subsequent work).
+pub fn revert_version_range(
+    db: &Arc<Database>,
+    branch: &str,
+    from_version: u64,
+    to_version: u64,
+) -> StrataResult<RevertInfo> {
+    // Validate range
+    if from_version == 0 {
+        return Err(StrataError::invalid_input("from_version must be > 0"));
+    }
+    if from_version > to_version {
+        return Err(StrataError::invalid_input(format!(
+            "from_version ({}) must be <= to_version ({})",
+            from_version, to_version
+        )));
+    }
+    let current_version = db.current_version();
+    if to_version > current_version {
+        return Err(StrataError::invalid_input(format!(
+            "to_version ({}) exceeds current database version ({})",
+            to_version, current_version
+        )));
+    }
+
+    let branch_id = resolve_and_verify(db, branch)?;
+    let storage = db.storage();
+
+    let mut puts: Vec<(Key, Value)> = Vec::new();
+    let mut deletes: Vec<Key> = Vec::new();
+
+    for &type_tag in &DATA_TYPE_TAGS {
+        // 1. "before" state: what the branch looked like at (from_version - 1)
+        //    WITH tombstones, so we can distinguish "key existed" from "key absent"
+        let before_entries =
+            storage.list_by_type_at_version(&branch_id, type_tag, from_version.saturating_sub(1));
+
+        // 2. "after" state: what the branch looked like at to_version
+        //    WITH tombstones
+        let after_entries = storage.list_by_type_at_version(&branch_id, type_tag, to_version);
+
+        // 3. Current live state
+        let current_entries = storage.list_by_type(&branch_id, type_tag);
+
+        // Build maps keyed by (space, user_key_bytes)
+        // before_map: key → Option<Value> where None = absent/tombstone
+        let mut before_map: HashMap<(String, Vec<u8>), Option<Value>> = HashMap::new();
+        for entry in &before_entries {
+            if entry.is_tombstone {
+                before_map.insert(
+                    (
+                        entry.key.namespace.space.clone(),
+                        entry.key.user_key.to_vec(),
+                    ),
+                    None,
+                );
+            } else {
+                before_map.insert(
+                    (
+                        entry.key.namespace.space.clone(),
+                        entry.key.user_key.to_vec(),
+                    ),
+                    Some(entry.value.clone()),
+                );
+            }
+        }
+
+        // after_map: key → Option<Value> where None = tombstone
+        let mut after_map: HashMap<(String, Vec<u8>), Option<Value>> = HashMap::new();
+        for entry in &after_entries {
+            if entry.is_tombstone {
+                after_map.insert(
+                    (
+                        entry.key.namespace.space.clone(),
+                        entry.key.user_key.to_vec(),
+                    ),
+                    None,
+                );
+            } else {
+                after_map.insert(
+                    (
+                        entry.key.namespace.space.clone(),
+                        entry.key.user_key.to_vec(),
+                    ),
+                    Some(entry.value.clone()),
+                );
+            }
+        }
+
+        // current_map: key → Value (live only)
+        let mut current_map: HashMap<(String, Vec<u8>), Value> = HashMap::new();
+        for (key, vv) in &current_entries {
+            current_map.insert(
+                (key.namespace.space.clone(), key.user_key.to_vec()),
+                vv.value.clone(),
+            );
+        }
+
+        // Union of all keys in before and after
+        let mut all_keys: HashSet<(String, Vec<u8>)> = HashSet::new();
+        for k in before_map.keys() {
+            all_keys.insert(k.clone());
+        }
+        for k in after_map.keys() {
+            all_keys.insert(k.clone());
+        }
+
+        for compound_key in &all_keys {
+            let before_state = before_map.get(compound_key).cloned().flatten();
+            let after_state = after_map.get(compound_key).cloned().flatten();
+            let current_state = current_map.get(compound_key).cloned();
+
+            // If before == after: key wasn't modified in range, skip
+            if before_state == after_state {
+                continue;
+            }
+
+            // Key was modified in [from_version, to_version].
+            // Only revert if current state matches the "after" state.
+            if current_state == after_state {
+                let (space, user_key) = compound_key;
+                let ns = Arc::new(Namespace::for_branch_space(branch_id, space));
+                let key = Key::new(ns, type_tag, user_key.clone());
+
+                match &before_state {
+                    Some(value) => {
+                        // Restore to "before" value
+                        puts.push((key, value.clone()));
+                    }
+                    None => {
+                        // Key didn't exist before the range — delete it
+                        deletes.push(key);
+                    }
+                }
+            }
+            // else: current != after, meaning someone modified it after the range.
+            // Preserve subsequent work by skipping.
+        }
+    }
+
+    let keys_reverted = (puts.len() + deletes.len()) as u64;
+    let mut revert_version = None;
+
+    if !puts.is_empty() || !deletes.is_empty() {
+        let ((), version) = db.transaction_with_version(branch_id, |txn| {
+            for (key, value) in &puts {
+                txn.put(key.clone(), value.clone())?;
+            }
+            for key in &deletes {
+                txn.delete(key.clone())?;
+            }
+            Ok(())
+        })?;
+        revert_version = Some(version);
+    }
+
+    info!(
+        target: "strata::branch_ops",
+        branch,
+        from_version,
+        to_version,
+        keys_reverted,
+        ?revert_version,
+        "Version range reverted"
+    );
+
+    Ok(RevertInfo {
+        branch: branch.to_string(),
+        from_version,
+        to_version,
+        keys_reverted,
+        revert_version,
+    })
+}
+
+// =============================================================================
+// Cherry-Pick
+// =============================================================================
+
+/// Information returned after cherry-picking.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CherryPickInfo {
+    /// Source branch name
+    pub source: String,
+    /// Target branch name
+    pub target: String,
+    /// Number of keys applied (puts)
+    pub keys_applied: u64,
+    /// Number of keys deleted
+    pub keys_deleted: u64,
+    /// MVCC version of the cherry-pick transaction
+    pub cherry_pick_version: Option<u64>,
+}
+
+/// Filter for cherry-pick operations.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CherryPickFilter {
+    /// Only pick changes in these spaces.
+    pub spaces: Option<Vec<String>>,
+    /// Only pick changes for these keys (user_key strings).
+    pub keys: Option<Vec<String>>,
+    /// Only pick changes for these primitive types.
+    pub primitives: Option<Vec<PrimitiveType>>,
+}
+
+/// Cherry-pick specific keys from source branch to target branch.
+///
+/// Reads the current value of each specified key from source and writes
+/// it to target in a single transaction.
+pub fn cherry_pick_keys(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+    keys: &[(String, String)], // (space, key) pairs
+) -> StrataResult<CherryPickInfo> {
+    let source_id = resolve_and_verify(db, source)?;
+    let target_id = resolve_and_verify(db, target)?;
+    let storage = db.storage();
+    let space_index = SpaceIndex::new(db.clone());
+
+    let requested: HashSet<(&str, &str)> =
+        keys.iter().map(|(s, k)| (s.as_str(), k.as_str())).collect();
+
+    let mut puts: Vec<(Key, Value)> = Vec::new();
+
+    for &type_tag in &DATA_TYPE_TAGS {
+        let entries = storage.list_by_type(&source_id, type_tag);
+        for (key, vv) in &entries {
+            let space = &key.namespace.space;
+            let user_key_str = format_user_key(&key.user_key);
+            if requested.contains(&(space.as_str(), user_key_str.as_str())) {
+                // Ensure target has this space
+                if space != "default" {
+                    space_index.register(target_id, space)?;
+                }
+                let ns = Arc::new(Namespace::for_branch_space(target_id, space));
+                let target_key = Key::new(ns, type_tag, key.user_key.to_vec());
+                puts.push((target_key, vv.value.clone()));
+            }
+        }
+    }
+
+    let mut cherry_pick_version = None;
+    let keys_applied = puts.len() as u64;
+
+    if !puts.is_empty() {
+        let ((), version) = db.transaction_with_version(target_id, |txn| {
+            for (key, value) in &puts {
+                txn.put(key.clone(), value.clone())?;
+            }
+            Ok(())
+        })?;
+        cherry_pick_version = Some(version);
+    }
+
+    info!(
+        target: "strata::branch_ops",
+        source,
+        target,
+        keys_applied,
+        ?cherry_pick_version,
+        "Keys cherry-picked"
+    );
+
+    Ok(CherryPickInfo {
+        source: source.to_string(),
+        target: target.to_string(),
+        keys_applied,
+        keys_deleted: 0,
+        cherry_pick_version,
+    })
+}
+
+/// Cherry-pick from a three-way diff, applying only entries matching a filter.
+///
+/// This is a selective merge: computes the three-way diff between source and
+/// target, then applies only the changes that match the filter criteria.
+pub fn cherry_pick_from_diff(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+    filter: CherryPickFilter,
+    merge_base_override: Option<(BranchId, u64)>,
+) -> StrataResult<CherryPickInfo> {
+    let source_id = resolve_and_verify(db, source)?;
+    let target_id = resolve_and_verify(db, target)?;
+
+    // Compute merge base
+    let merge_base = compute_merge_base(db, source_id, target_id, merge_base_override);
+
+    let merge_base = match merge_base {
+        Some(mb) => mb,
+        None => {
+            return Err(StrataError::invalid_input(format!(
+                "Cannot cherry-pick from '{}' to '{}': no fork or merge relationship found. \
+                 Branches must be related by fork or a previous merge.",
+                source, target
+            )));
+        }
+    };
+
+    // Collect spaces from both branches
+    let space_index = SpaceIndex::new(db.clone());
+    let source_spaces: HashSet<String> = space_index.list(source_id)?.into_iter().collect();
+    let target_spaces: HashSet<String> = space_index.list(target_id)?.into_iter().collect();
+    let all_spaces: Vec<String> = source_spaces.union(&target_spaces).cloned().collect();
+
+    // Compute three-way diff with LastWriterWins (we'll filter the actions)
+    let (actions, _conflicts) = three_way_diff(
+        db,
+        source_id,
+        target_id,
+        &merge_base,
+        &all_spaces,
+        MergeStrategy::LastWriterWins,
+    )?;
+
+    // Filter by CherryPickFilter
+    let space_filter: Option<HashSet<&str>> = filter
+        .spaces
+        .as_ref()
+        .map(|s| s.iter().map(|x| x.as_str()).collect());
+    let key_filter: Option<HashSet<&str>> = filter
+        .keys
+        .as_ref()
+        .map(|k| k.iter().map(|x| x.as_str()).collect());
+    let prim_filter: Option<HashSet<PrimitiveType>> = filter
+        .primitives
+        .as_ref()
+        .map(|p| p.iter().copied().collect());
+
+    let filtered_actions: Vec<&MergeAction> = actions
+        .iter()
+        .filter(|action| {
+            // Space filter
+            if let Some(ref allowed) = space_filter {
+                if !allowed.contains(action.space.as_str()) {
+                    return false;
+                }
+            }
+            // Key filter
+            if let Some(ref allowed) = key_filter {
+                let key_str = format_user_key(&action.raw_key);
+                if !allowed.contains(key_str.as_str()) {
+                    return false;
+                }
+            }
+            // Primitive type filter
+            if let Some(ref allowed) = prim_filter {
+                let prim = type_tag_to_primitive(action.type_tag);
+                if !allowed.contains(&prim) {
+                    return false;
+                }
+            }
+            true
+        })
+        .collect();
+
+    // Register spaces and build puts/deletes
+    let mut puts: Vec<(Key, Value)> = Vec::new();
+    let mut deletes: Vec<Key> = Vec::new();
+    let mut spaces_touched: HashSet<String> = HashSet::new();
+
+    for action in &filtered_actions {
+        spaces_touched.insert(action.space.clone());
+    }
+    for space in &spaces_touched {
+        if space != "default" {
+            space_index.register(target_id, space)?;
+        }
+    }
+
+    for action in &filtered_actions {
+        let ns = Arc::new(Namespace::for_branch_space(target_id, &action.space));
+        let key = Key::new(ns, action.type_tag, action.raw_key.clone());
+        match &action.action {
+            MergeActionKind::Put(value) => {
+                puts.push((key, value.clone()));
+            }
+            MergeActionKind::Delete => {
+                deletes.push(key);
+            }
+        }
+    }
+
+    let keys_applied = puts.len() as u64;
+    let keys_deleted = deletes.len() as u64;
+    let mut cherry_pick_version = None;
+
+    if !puts.is_empty() || !deletes.is_empty() {
+        let ((), version) = db.transaction_with_version(target_id, |txn| {
+            for (key, value) in &puts {
+                txn.put(key.clone(), value.clone())?;
+            }
+            for key in &deletes {
+                txn.delete(key.clone())?;
+            }
+            Ok(())
+        })?;
+        cherry_pick_version = Some(version);
+    }
+
+    // Reload secondary index backends
+    reload_secondary_backends(db, target_id, source_id);
+
+    info!(
+        target: "strata::branch_ops",
+        source,
+        target,
+        keys_applied,
+        keys_deleted,
+        ?cherry_pick_version,
+        "Cherry-picked from diff"
+    );
+
+    Ok(CherryPickInfo {
+        source: source.to_string(),
+        target: target.to_string(),
+        keys_applied,
+        keys_deleted,
+        cherry_pick_version,
     })
 }
 
@@ -2838,5 +3833,285 @@ mod tests {
             info.merge_version.is_some(),
             "merge should return a version"
         );
+    }
+
+    // =========================================================================
+    // Tag Tests
+    // =========================================================================
+
+    #[test]
+    fn test_tag_create_and_resolve() {
+        let (_temp, db) = setup_with_branch("main");
+        write_kv(&db, "main", "default", "k", Value::Int(1));
+
+        let tag = create_tag(&db, "main", "v1.0", None, Some("release"), None).unwrap();
+        assert_eq!(tag.name, "v1.0");
+        assert_eq!(tag.branch, "main");
+        assert!(tag.version > 0);
+
+        let resolved = resolve_tag(&db, "main", "v1.0").unwrap();
+        assert_eq!(resolved, Some(tag));
+    }
+
+    #[test]
+    fn test_tag_list_and_delete() {
+        let (_temp, db) = setup_with_branch("main");
+        write_kv(&db, "main", "default", "k", Value::Int(1));
+
+        create_tag(&db, "main", "t1", None, None, None).unwrap();
+        create_tag(&db, "main", "t2", None, None, None).unwrap();
+
+        let tags = list_tags(&db, "main").unwrap();
+        assert_eq!(tags.len(), 2);
+
+        let deleted = delete_tag(&db, "main", "t1").unwrap();
+        assert!(deleted);
+
+        let tags = list_tags(&db, "main").unwrap();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].name, "t2");
+    }
+
+    // =========================================================================
+    // Note Tests
+    // =========================================================================
+
+    #[test]
+    fn test_note_add_and_get() {
+        let (_temp, db) = setup_with_branch("main");
+        write_kv(&db, "main", "default", "k", Value::Int(1));
+
+        let note = add_note(&db, "main", 1, "initial state", Some("ai"), None).unwrap();
+        assert_eq!(note.message, "initial state");
+        assert_eq!(note.version, 1);
+
+        let notes = get_notes(&db, "main", None).unwrap();
+        assert_eq!(notes.len(), 1);
+
+        let notes_at_v = get_notes(&db, "main", Some(1)).unwrap();
+        assert_eq!(notes_at_v.len(), 1);
+    }
+
+    #[test]
+    fn test_note_delete() {
+        let (_temp, db) = setup_with_branch("main");
+
+        add_note(&db, "main", 1, "note1", None, None).unwrap();
+        add_note(&db, "main", 2, "note2", None, None).unwrap();
+
+        assert!(delete_note(&db, "main", 1).unwrap());
+
+        let notes = get_notes(&db, "main", None).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].version, 2);
+    }
+
+    // =========================================================================
+    // Three-Way Diff API Tests
+    // =========================================================================
+
+    #[test]
+    fn test_diff_three_way_disjoint_changes() {
+        // Fork, make disjoint changes, verify classification
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "a", Value::Int(1));
+        write_kv(&db, "parent", "default", "b", Value::Int(2));
+
+        fork_branch(&db, "parent", "child").unwrap();
+        write_kv(&db, "parent", "default", "a", Value::Int(10));
+        write_kv(&db, "child", "default", "b", Value::Int(20));
+
+        let result = diff_three_way(&db, "child", "parent", None).unwrap();
+
+        // Should see: a=TargetChanged, b=SourceChanged
+        let a_entry = result.entries.iter().find(|e| e.key == "a").unwrap();
+        assert!(matches!(a_entry.change, ThreeWayChange::TargetChanged));
+
+        let b_entry = result.entries.iter().find(|e| e.key == "b").unwrap();
+        assert!(matches!(
+            b_entry.change,
+            ThreeWayChange::SourceChanged { .. }
+        ));
+    }
+
+    #[test]
+    fn test_get_merge_base() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "a", Value::Int(1));
+
+        let fork_info = fork_branch(&db, "parent", "child").unwrap();
+
+        let base = get_merge_base(&db, "child", "parent", None).unwrap();
+        assert!(base.is_some());
+        let base = base.unwrap();
+        assert_eq!(base.version, fork_info.fork_version.unwrap());
+    }
+
+    #[test]
+    fn test_get_merge_base_unrelated() {
+        let (_temp, db) = setup_with_branch("a");
+        let branch_index = BranchIndex::new(db.clone());
+        branch_index.create_branch("b").unwrap();
+
+        let base = get_merge_base(&db, "a", "b", None).unwrap();
+        assert!(base.is_none());
+    }
+
+    // =========================================================================
+    // Revert Tests
+    // =========================================================================
+
+    #[test]
+    fn test_revert_single_version() {
+        let (_temp, db) = setup_with_branch("main");
+
+        write_kv(&db, "main", "default", "a", Value::Int(1)); // v1
+        write_kv(&db, "main", "default", "a", Value::Int(2)); // v2
+        write_kv(&db, "main", "default", "b", Value::Int(10)); // v3
+
+        // Get current version
+        let current = db.current_version();
+
+        // Revert the last write (v3 = b:10)
+        let info = revert_version_range(&db, "main", current, current).unwrap();
+        assert_eq!(info.keys_reverted, 1); // only "b" was changed in that version
+
+        // "a" should still be 2 (unchanged in range)
+        assert_eq!(read_kv(&db, "main", "default", "a"), Some(Value::Int(2)));
+        // "b" should be gone (didn't exist before v3)
+        assert_eq!(read_kv(&db, "main", "default", "b"), None);
+    }
+
+    #[test]
+    fn test_revert_preserves_subsequent_work() {
+        let (_temp, db) = setup_with_branch("main");
+
+        write_kv(&db, "main", "default", "a", Value::Int(1)); // v_start
+        let v_start = db.current_version();
+        write_kv(&db, "main", "default", "a", Value::Int(2)); // v_change
+        let v_change = db.current_version();
+        write_kv(&db, "main", "default", "a", Value::Int(3)); // v_after (after range)
+
+        // Revert [v_start+1, v_change] — but "a" was modified after the range
+        let info = revert_version_range(&db, "main", v_start + 1, v_change).unwrap();
+        assert_eq!(
+            info.keys_reverted, 0,
+            "should skip keys modified after range"
+        );
+
+        // "a" should still be 3 (subsequent work preserved)
+        assert_eq!(read_kv(&db, "main", "default", "a"), Some(Value::Int(3)));
+    }
+
+    #[test]
+    fn test_revert_invalid_range() {
+        let (_temp, db) = setup_with_branch("main");
+
+        // from_version > to_version
+        let result = revert_version_range(&db, "main", 5, 3);
+        assert!(result.is_err());
+
+        // from_version == 0
+        let result = revert_version_range(&db, "main", 0, 3);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_revert_restores_deleted_key() {
+        let (_temp, db) = setup_with_branch("main");
+        write_kv(&db, "main", "default", "a", Value::Int(1));
+        let v_before = db.current_version();
+
+        // Delete "a" in the revert range
+        delete_kv(&db, "main", "default", "a");
+        let v_delete = db.current_version();
+
+        // Verify it's gone
+        assert_eq!(read_kv(&db, "main", "default", "a"), None);
+
+        // Revert the deletion
+        let info = revert_version_range(&db, "main", v_before + 1, v_delete).unwrap();
+        assert_eq!(info.keys_reverted, 1);
+
+        // Key should be restored
+        assert_eq!(read_kv(&db, "main", "default", "a"), Some(Value::Int(1)));
+    }
+
+    // =========================================================================
+    // Cherry-Pick Tests
+    // =========================================================================
+
+    #[test]
+    fn test_cherry_pick_specific_keys() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "a", Value::Int(1));
+        write_kv(&db, "parent", "default", "b", Value::Int(2));
+
+        fork_branch(&db, "parent", "source").unwrap();
+        write_kv(&db, "source", "default", "a", Value::Int(10));
+        write_kv(&db, "source", "default", "b", Value::Int(20));
+        write_kv(&db, "source", "default", "c", Value::Int(30));
+
+        // Cherry-pick only "a" from source to parent
+        let info = cherry_pick_keys(
+            &db,
+            "source",
+            "parent",
+            &[("default".to_string(), "a".to_string())],
+        )
+        .unwrap();
+        assert_eq!(info.keys_applied, 1);
+
+        // "a" should have source's value
+        assert_eq!(read_kv(&db, "parent", "default", "a"), Some(Value::Int(10)));
+        // "b" should be unchanged (not cherry-picked)
+        assert_eq!(read_kv(&db, "parent", "default", "b"), Some(Value::Int(2)));
+        // "c" should not exist on parent
+        assert_eq!(read_kv(&db, "parent", "default", "c"), None);
+    }
+
+    #[test]
+    fn test_cherry_pick_from_diff_with_filter() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "a", Value::Int(1));
+        write_kv(&db, "parent", "default", "b", Value::Int(2));
+
+        fork_branch(&db, "parent", "child").unwrap();
+        write_kv(&db, "child", "default", "a", Value::Int(10));
+        write_kv(&db, "child", "default", "b", Value::Int(20));
+        write_kv(&db, "child", "default", "c", Value::Int(30));
+
+        // Cherry-pick from diff, only key "b"
+        let filter = CherryPickFilter {
+            keys: Some(vec!["b".to_string()]),
+            spaces: None,
+            primitives: None,
+        };
+        let info = cherry_pick_from_diff(&db, "child", "parent", filter, None).unwrap();
+        assert_eq!(info.keys_applied, 1);
+
+        // Only "b" should be changed
+        assert_eq!(read_kv(&db, "parent", "default", "a"), Some(Value::Int(1)));
+        assert_eq!(read_kv(&db, "parent", "default", "b"), Some(Value::Int(20)));
+    }
+
+    #[test]
+    fn test_cherry_pick_empty_keys() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "a", Value::Int(1));
+
+        fork_branch(&db, "parent", "source").unwrap();
+        write_kv(&db, "source", "default", "a", Value::Int(10));
+
+        // Cherry-pick with no matching keys
+        let info = cherry_pick_keys(
+            &db,
+            "source",
+            "parent",
+            &[("default".to_string(), "nonexistent".to_string())],
+        )
+        .unwrap();
+        assert_eq!(info.keys_applied, 0);
+        assert!(info.cherry_pick_version.is_none());
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -111,8 +111,9 @@ pub use bundle::{BundleInfo, ExportInfo, ImportInfo};
 
 // Re-export branch_ops types at crate root
 pub use branch_ops::{
-    BranchDiffEntry, BranchDiffResult, ConflictEntry, DiffFilter, DiffOptions, DiffSummary,
-    ForkInfo, MergeInfo, MergeStrategy, SpaceDiff,
+    BranchDiffEntry, BranchDiffResult, CherryPickFilter, CherryPickInfo, ConflictEntry, DiffFilter,
+    DiffOptions, DiffSummary, ForkInfo, MergeBaseInfo, MergeInfo, MergeStrategy, NoteInfo,
+    RevertInfo, SpaceDiff, TagInfo, ThreeWayChange, ThreeWayDiffEntry, ThreeWayDiffResult,
 };
 
 // Re-export branch_dag types from core at crate root for convenience

--- a/crates/executor/src/api/branches.rs
+++ b/crates/executor/src/api/branches.rs
@@ -32,7 +32,11 @@
 use crate::ipc::Backend;
 use crate::types::BranchId;
 use crate::{Command, Error, Output, Result};
-use strata_engine::branch_ops::{BranchDiffResult, ForkInfo, MergeInfo, MergeStrategy};
+use strata_engine::branch_ops::{
+    BranchDiffResult, CherryPickFilter, CherryPickInfo, ForkInfo, MergeInfo, MergeStrategy,
+    NoteInfo, RevertInfo, TagInfo, ThreeWayDiffResult,
+};
+use strata_engine::MergeBaseInfo;
 
 /// Handle for branch management operations.
 ///
@@ -233,5 +237,289 @@ impl<'a> Branches<'a> {
                 hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
             }),
         }
+    }
+
+    /// Compute three-way diff between two branches.
+    ///
+    /// Returns the raw 14-case classification for each key without applying
+    /// any merge strategy. Useful for previewing changes before merging.
+    pub fn diff_three_way(&self, branch_a: &str, branch_b: &str) -> Result<ThreeWayDiffResult> {
+        match self.backend.execute(Command::BranchDiffThreeWay {
+            branch_a: branch_a.to_string(),
+            branch_b: branch_b.to_string(),
+        })? {
+            Output::ThreeWayDiff(result) => Ok(result),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for BranchDiffThreeWay".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    /// Get the merge base for two branches.
+    ///
+    /// Returns `None` if the branches have no fork or merge relationship.
+    pub fn merge_base(&self, branch_a: &str, branch_b: &str) -> Result<Option<MergeBaseInfo>> {
+        match self.backend.execute(Command::BranchMergeBase {
+            branch_a: branch_a.to_string(),
+            branch_b: branch_b.to_string(),
+        })? {
+            Output::MergeBaseInfo(result) => Ok(result),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for BranchMergeBase".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    // =========================================================================
+    // Revert
+    // =========================================================================
+
+    /// Revert a version range on a branch.
+    ///
+    /// Restores keys to their state before the range, preserving any changes
+    /// made after the range.
+    pub fn revert(&self, branch: &str, from_version: u64, to_version: u64) -> Result<RevertInfo> {
+        match self.backend.execute(Command::BranchRevert {
+            branch: branch.to_string(),
+            from_version,
+            to_version,
+        })? {
+            Output::BranchReverted(info) => Ok(info),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for BranchRevert".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    // =========================================================================
+    // Cherry-Pick
+    // =========================================================================
+
+    /// Cherry-pick specific keys from source branch to target branch.
+    pub fn cherry_pick(
+        &self,
+        source: &str,
+        target: &str,
+        keys: &[(String, String)],
+    ) -> Result<CherryPickInfo> {
+        match self.backend.execute(Command::BranchCherryPick {
+            source: source.to_string(),
+            target: target.to_string(),
+            keys: Some(keys.to_vec()),
+            filter_spaces: None,
+            filter_keys: None,
+            filter_primitives: None,
+        })? {
+            Output::BranchCherryPicked(info) => Ok(info),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for BranchCherryPick".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    /// Cherry-pick from a three-way diff with filter criteria.
+    pub fn cherry_pick_filtered(
+        &self,
+        source: &str,
+        target: &str,
+        filter: CherryPickFilter,
+    ) -> Result<CherryPickInfo> {
+        match self.backend.execute(Command::BranchCherryPick {
+            source: source.to_string(),
+            target: target.to_string(),
+            keys: None,
+            filter_spaces: filter.spaces,
+            filter_keys: filter.keys,
+            filter_primitives: filter.primitives,
+        })? {
+            Output::BranchCherryPicked(info) => Ok(info),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for BranchCherryPick".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    // =========================================================================
+    // Tags
+    // =========================================================================
+
+    /// Create a tag on a branch at the current version.
+    pub fn create_tag(&self, branch: &str, name: &str, message: Option<&str>) -> Result<TagInfo> {
+        match self.backend.execute(Command::TagCreate {
+            branch: branch.to_string(),
+            name: name.to_string(),
+            version: None,
+            message: message.map(|s| s.to_string()),
+            creator: None,
+        })? {
+            Output::TagCreated(info) => Ok(info),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for TagCreate".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    /// Create a tag on a branch at a specific version.
+    pub fn create_tag_at_version(
+        &self,
+        branch: &str,
+        name: &str,
+        version: u64,
+        message: Option<&str>,
+    ) -> Result<TagInfo> {
+        match self.backend.execute(Command::TagCreate {
+            branch: branch.to_string(),
+            name: name.to_string(),
+            version: Some(version),
+            message: message.map(|s| s.to_string()),
+            creator: None,
+        })? {
+            Output::TagCreated(info) => Ok(info),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for TagCreate".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    /// Delete a tag. Returns `true` if the tag existed.
+    pub fn delete_tag(&self, branch: &str, name: &str) -> Result<bool> {
+        match self.backend.execute(Command::TagDelete {
+            branch: branch.to_string(),
+            name: name.to_string(),
+        })? {
+            Output::Bool(deleted) => Ok(deleted),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for TagDelete".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    /// List all tags on a branch.
+    pub fn list_tags(&self, branch: &str) -> Result<Vec<TagInfo>> {
+        match self.backend.execute(Command::TagList {
+            branch: branch.to_string(),
+        })? {
+            Output::TagList(tags) => Ok(tags),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for TagList".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    /// Resolve a tag to its version info.
+    pub fn resolve_tag(&self, branch: &str, name: &str) -> Result<Option<TagInfo>> {
+        match self.backend.execute(Command::TagResolve {
+            branch: branch.to_string(),
+            name: name.to_string(),
+        })? {
+            Output::MaybeTag(tag) => Ok(tag),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for TagResolve".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    // =========================================================================
+    // Notes
+    // =========================================================================
+
+    /// Add a note to a specific version of a branch.
+    pub fn add_note(
+        &self,
+        branch: &str,
+        version: u64,
+        message: &str,
+        author: Option<&str>,
+    ) -> Result<NoteInfo> {
+        match self.backend.execute(Command::NoteAdd {
+            branch: branch.to_string(),
+            version,
+            message: message.to_string(),
+            author: author.map(|s| s.to_string()),
+            metadata: None,
+        })? {
+            Output::NoteAdded(note) => Ok(note),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for NoteAdd".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    /// Get notes for a branch, optionally filtered by version.
+    pub fn get_notes(&self, branch: &str, version: Option<u64>) -> Result<Vec<NoteInfo>> {
+        match self.backend.execute(Command::NoteGet {
+            branch: branch.to_string(),
+            version,
+        })? {
+            Output::NoteList(notes) => Ok(notes),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for NoteGet".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    /// Delete a note at a specific version. Returns `true` if the note existed.
+    pub fn delete_note(&self, branch: &str, version: u64) -> Result<bool> {
+        match self.backend.execute(Command::NoteDelete {
+            branch: branch.to_string(),
+            version,
+        })? {
+            Output::Bool(deleted) => Ok(deleted),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for NoteDelete".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    // =========================================================================
+    // Audit Log
+    // =========================================================================
+
+    /// Query the branch audit log.
+    ///
+    /// Returns recent branch lifecycle events (create, fork, merge, delete, tag,
+    /// note) in chronological order from the `_system_` branch.
+    pub fn log(&self, limit: Option<u64>) -> Result<Vec<strata_core::Value>> {
+        let mut all_events = Vec::new();
+        for event_type in &[
+            "branch.create",
+            "branch.fork",
+            "branch.merge",
+            "branch.delete",
+            "branch.revert",
+            "branch.cherry_pick",
+            "branch.tag",
+            "branch.note",
+        ] {
+            // Use execute_internal to bypass the _system_ branch guard.
+            if let Ok(Output::VersionedValues(events)) =
+                self.backend.execute_internal(Command::EventGetByType {
+                    branch: Some(BranchId::from("_system_")),
+                    space: Some("default".to_string()),
+                    event_type: event_type.to_string(),
+                    limit,
+                    after_sequence: None,
+                    as_of: None,
+                })
+            {
+                for event in events {
+                    all_events.push(event.value);
+                }
+            }
+        }
+        Ok(all_events)
     }
 }

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -50,8 +50,8 @@ mod vector;
 
 pub use branches::Branches;
 pub use strata_engine::branch_ops::{
-    BranchDiffEntry, BranchDiffResult, ConflictEntry, DiffFilter, DiffOptions, DiffSummary,
-    ForkInfo, MergeInfo, MergeStrategy, SpaceDiff,
+    BranchDiffEntry, BranchDiffResult, CherryPickFilter, CherryPickInfo, ConflictEntry, DiffFilter,
+    DiffOptions, DiffSummary, ForkInfo, MergeInfo, MergeStrategy, RevertInfo, SpaceDiff,
 };
 pub use system::SystemBranch;
 

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -605,6 +605,137 @@ pub enum Command {
         creator: Option<String>,
     },
 
+    /// Compute three-way diff between two branches.
+    /// Returns: `Output::ThreeWayDiff`
+    BranchDiffThreeWay {
+        /// First branch to compare (source).
+        branch_a: String,
+        /// Second branch to compare (target).
+        branch_b: String,
+    },
+
+    /// Get the merge base for two branches.
+    /// Returns: `Output::MergeBaseInfo`
+    BranchMergeBase {
+        /// First branch (source).
+        branch_a: String,
+        /// Second branch (target).
+        branch_b: String,
+    },
+
+    // ==================== Tags ====================
+    /// Create a tag (named version bookmark) on a branch.
+    /// Returns: `Output::TagCreated`
+    TagCreate {
+        /// Branch to tag.
+        branch: String,
+        /// Tag name (e.g. "v1.0").
+        name: String,
+        /// Version to tag. If omitted, tags the current version.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        version: Option<u64>,
+        /// Optional human-readable message.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+        /// Optional creator identifier.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        creator: Option<String>,
+    },
+
+    /// Delete a tag.
+    /// Returns: `Output::Bool`
+    TagDelete {
+        /// Branch the tag belongs to.
+        branch: String,
+        /// Tag name to delete.
+        name: String,
+    },
+
+    /// List all tags on a branch.
+    /// Returns: `Output::TagList`
+    TagList {
+        /// Branch to list tags for.
+        branch: String,
+    },
+
+    /// Resolve a tag to its version info.
+    /// Returns: `Output::MaybeTag`
+    TagResolve {
+        /// Branch the tag belongs to.
+        branch: String,
+        /// Tag name to resolve.
+        name: String,
+    },
+
+    // ==================== Notes ====================
+    /// Add a note to a specific version of a branch.
+    /// Returns: `Output::NoteAdded`
+    NoteAdd {
+        /// Branch to annotate.
+        branch: String,
+        /// Version to attach the note to.
+        version: u64,
+        /// Note message.
+        message: String,
+        /// Optional author identifier.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        author: Option<String>,
+        /// Optional structured metadata.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        metadata: Option<Value>,
+    },
+
+    /// Get notes for a branch, optionally filtered by version.
+    /// Returns: `Output::NoteList`
+    NoteGet {
+        /// Branch to query.
+        branch: String,
+        /// Optional version filter. If omitted, returns all notes.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        version: Option<u64>,
+    },
+
+    /// Delete a note at a specific version.
+    /// Returns: `Output::Bool`
+    NoteDelete {
+        /// Branch the note belongs to.
+        branch: String,
+        /// Version whose note to delete.
+        version: u64,
+    },
+
+    /// Revert a version range on a branch.
+    /// Returns: `Output::BranchReverted`
+    BranchRevert {
+        /// Branch to revert on.
+        branch: String,
+        /// Start of the version range (inclusive).
+        from_version: u64,
+        /// End of the version range (inclusive).
+        to_version: u64,
+    },
+
+    /// Cherry-pick specific keys or filtered changes from one branch to another.
+    /// Returns: `Output::BranchCherryPicked`
+    BranchCherryPick {
+        /// Source branch name.
+        source: String,
+        /// Target branch name.
+        target: String,
+        /// Specific (space, key) pairs for direct pick. Mutually exclusive with filter fields.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        keys: Option<Vec<(String, String)>>,
+        /// Filter: only pick changes in these spaces (for diff-based pick).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filter_spaces: Option<Vec<String>>,
+        /// Filter: only pick changes for these keys (for diff-based pick).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filter_keys: Option<Vec<String>>,
+        /// Filter: only pick changes for these primitive types (for diff-based pick).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filter_primitives: Option<Vec<strata_core::PrimitiveType>>,
+    },
+
     // ==================== Transaction (5) ====================
     /// Begin a new transaction.
     /// Returns: `Output::TxnBegun`
@@ -1547,6 +1678,12 @@ impl Command {
                 | Command::GraphDeleteLinkType { .. }
                 | Command::GraphFreezeOntology { .. }
                 | Command::ReindexEmbeddings { .. }
+                | Command::TagCreate { .. }
+                | Command::TagDelete { .. }
+                | Command::NoteAdd { .. }
+                | Command::NoteDelete { .. }
+                | Command::BranchRevert { .. }
+                | Command::BranchCherryPick { .. }
         )
     }
 
@@ -1591,7 +1728,18 @@ impl Command {
             Command::BranchDelete { .. } => "BranchDelete",
             Command::BranchFork { .. } => "BranchFork",
             Command::BranchDiff { .. } => "BranchDiff",
+            Command::BranchDiffThreeWay { .. } => "BranchDiffThreeWay",
+            Command::BranchMergeBase { .. } => "BranchMergeBase",
             Command::BranchMerge { .. } => "BranchMerge",
+            Command::TagCreate { .. } => "TagCreate",
+            Command::TagDelete { .. } => "TagDelete",
+            Command::TagList { .. } => "TagList",
+            Command::TagResolve { .. } => "TagResolve",
+            Command::NoteAdd { .. } => "NoteAdd",
+            Command::NoteGet { .. } => "NoteGet",
+            Command::NoteDelete { .. } => "NoteDelete",
+            Command::BranchRevert { .. } => "BranchRevert",
+            Command::BranchCherryPick { .. } => "BranchCherryPick",
             Command::TxnBegin { .. } => "TxnBegin",
             Command::TxnCommit => "TxnCommit",
             Command::TxnRollback => "TxnRollback",
@@ -1806,7 +1954,18 @@ impl Command {
             | Command::BranchDelete { .. }
             | Command::BranchFork { .. }
             | Command::BranchDiff { .. }
+            | Command::BranchDiffThreeWay { .. }
+            | Command::BranchMergeBase { .. }
             | Command::BranchMerge { .. }
+            | Command::TagCreate { .. }
+            | Command::TagDelete { .. }
+            | Command::TagList { .. }
+            | Command::TagResolve { .. }
+            | Command::NoteAdd { .. }
+            | Command::NoteGet { .. }
+            | Command::NoteDelete { .. }
+            | Command::BranchRevert { .. }
+            | Command::BranchCherryPick { .. }
             | Command::TxnCommit
             | Command::TxnRollback
             | Command::TxnInfo

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -882,6 +882,22 @@ impl Executor {
                 filter_spaces,
                 as_of,
             ),
+            Command::BranchDiffThreeWay {
+                branch_a,
+                branch_b,
+            } => crate::handlers::branch::branch_diff_three_way(
+                &self.primitives,
+                branch_a,
+                branch_b,
+            ),
+            Command::BranchMergeBase {
+                branch_a,
+                branch_b,
+            } => crate::handlers::branch::branch_merge_base(
+                &self.primitives,
+                branch_a,
+                branch_b,
+            ),
             Command::BranchMerge {
                 source,
                 target,
@@ -895,6 +911,81 @@ impl Executor {
                 strategy,
                 message,
                 creator,
+            ),
+
+            // Tag commands
+            Command::TagCreate {
+                branch,
+                name,
+                version,
+                message,
+                creator,
+            } => crate::handlers::branch::tag_create(
+                &self.primitives,
+                branch,
+                name,
+                version,
+                message,
+                creator,
+            ),
+            Command::TagDelete { branch, name } => {
+                crate::handlers::branch::tag_delete(&self.primitives, branch, name)
+            }
+            Command::TagList { branch } => {
+                crate::handlers::branch::tag_list(&self.primitives, branch)
+            }
+            Command::TagResolve { branch, name } => {
+                crate::handlers::branch::tag_resolve(&self.primitives, branch, name)
+            }
+
+            // Note commands
+            Command::NoteAdd {
+                branch,
+                version,
+                message,
+                author,
+                metadata,
+            } => crate::handlers::branch::note_add(
+                &self.primitives,
+                branch,
+                version,
+                message,
+                author,
+                metadata,
+            ),
+            Command::NoteGet { branch, version } => {
+                crate::handlers::branch::note_get(&self.primitives, branch, version)
+            }
+            Command::NoteDelete { branch, version } => {
+                crate::handlers::branch::note_delete(&self.primitives, branch, version)
+            }
+
+            Command::BranchRevert {
+                branch,
+                from_version,
+                to_version,
+            } => crate::handlers::branch::branch_revert(
+                &self.primitives,
+                branch,
+                from_version,
+                to_version,
+            ),
+
+            Command::BranchCherryPick {
+                source,
+                target,
+                keys,
+                filter_spaces,
+                filter_keys,
+                filter_primitives,
+            } => crate::handlers::branch::branch_cherry_pick(
+                &self.primitives,
+                source,
+                target,
+                keys,
+                filter_spaces,
+                filter_keys,
+                filter_primitives,
             ),
 
             // Transaction commands - handled by Session, not Executor

--- a/crates/executor/src/handlers/branch.rs
+++ b/crates/executor/src/handlers/branch.rs
@@ -14,6 +14,30 @@ use crate::types::{BranchId, BranchInfo, VersionedBranchInfo};
 use crate::{Error, Output, Result};
 
 // =============================================================================
+// Audit Log Helper
+// =============================================================================
+
+/// Emit an audit event on the `_system_` branch. Best-effort — failures are
+/// logged, never propagated.
+fn emit_audit_event(p: &Arc<Primitives>, event_type: &str, payload: serde_json::Value) {
+    let system_branch_id = strata_engine::primitives::branch::resolve_branch_name("_system_");
+    // Convert serde_json::Value (Object) to strata_core::Value (Object).
+    // Event payload must be a Value::Object for event log validation.
+    let core_value: strata_core::value::Value = payload.into();
+    if let Err(e) = p
+        .event
+        .append(&system_branch_id, "default", event_type, core_value)
+    {
+        tracing::warn!(
+            target: "strata::audit",
+            event_type,
+            error = %e,
+            "Failed to emit audit event"
+        );
+    }
+}
+
+// =============================================================================
 // Conversion Helpers
 // =============================================================================
 
@@ -120,6 +144,14 @@ pub fn branch_create(
         tracing::warn!(target: "strata::branch_dag", branch = %branch_str, error = %e, "Failed to record branch creation in DAG");
     }
 
+    emit_audit_event(
+        p,
+        "branch.create",
+        serde_json::json!({
+            "branch": branch_str,
+        }),
+    );
+
     Ok(Output::BranchWithVersion {
         info: metadata_to_branch_info(&versioned.value),
         version: extract_version(&versioned.version),
@@ -214,7 +246,49 @@ pub fn branch_delete(p: &Arc<Primitives>, branch: BranchId) -> Result<Output> {
         tracing::warn!(target: "strata::branch_dag", branch = %branch.as_str(), error = %e, "Failed to mark branch as deleted in DAG");
     }
 
+    emit_audit_event(
+        p,
+        "branch.delete",
+        serde_json::json!({
+            "branch": branch.as_str(),
+        }),
+    );
+
     Ok(Output::Unit)
+}
+
+// =============================================================================
+// Shared Helpers
+// =============================================================================
+
+/// Compute merge base override from DAG for two branches.
+///
+/// Checks for previous merge first (takes priority over fork), then falls
+/// back to fork relationship in the DAG.
+fn compute_merge_base_from_dag(
+    db: &Arc<strata_engine::Database>,
+    source: &str,
+    target: &str,
+) -> Option<(strata_core::types::BranchId, u64)> {
+    // Check for previous merge first (takes priority over fork)
+    match branch_dag::find_last_merge_version(db, source, target) {
+        Ok(Some(v)) => {
+            let target_id = strata_engine::primitives::branch::resolve_branch_name(target);
+            Some((target_id, v))
+        }
+        _ => {
+            // No previous merge — check for fork relationship in DAG
+            // (covers materialized branches where storage lost fork info)
+            match branch_dag::find_fork_version(db, source, target) {
+                Ok(Some((child_name, fork_version))) => {
+                    let child_id =
+                        strata_engine::primitives::branch::resolve_branch_name(&child_name);
+                    Some((child_id, fork_version))
+                }
+                _ => None, // Let engine try storage-level fork info
+            }
+        }
+    }
 }
 
 // =============================================================================
@@ -257,6 +331,16 @@ pub fn branch_fork(
     ) {
         tracing::warn!(target: "strata::branch_dag", source = %source, destination = %destination, error = %e, "Failed to record fork in DAG");
     }
+
+    emit_audit_event(
+        p,
+        "branch.fork",
+        serde_json::json!({
+            "parent": source,
+            "child": destination,
+            "fork_version": info.fork_version,
+        }),
+    );
 
     Ok(Output::BranchForked(info))
 }
@@ -308,27 +392,7 @@ pub fn branch_merge(
     }
 
     // Compute merge base override from DAG (for repeated merges and materialized branches)
-    let merge_base_override = {
-        // Check for previous merge first (takes priority over fork)
-        match branch_dag::find_last_merge_version(&p.db, &source, &target) {
-            Ok(Some(v)) => {
-                let target_id = strata_engine::primitives::branch::resolve_branch_name(&target);
-                Some((target_id, v))
-            }
-            _ => {
-                // No previous merge — check for fork relationship in DAG
-                // (covers materialized branches where storage lost fork info)
-                match branch_dag::find_fork_version(&p.db, &source, &target) {
-                    Ok(Some((child_name, fork_version))) => {
-                        let child_id =
-                            strata_engine::primitives::branch::resolve_branch_name(&child_name);
-                        Some((child_id, fork_version))
-                    }
-                    _ => None, // Let engine try storage-level fork info
-                }
-            }
-        }
-    };
+    let merge_base_override = compute_merge_base_from_dag(&p.db, &source, &target);
 
     let info = strata_engine::branch_ops::merge_branches(
         &p.db,
@@ -359,7 +423,143 @@ pub fn branch_merge(
         tracing::warn!(target: "strata::branch_dag", source = %source, target = %target, error = %e, "Failed to record merge in DAG");
     }
 
+    emit_audit_event(
+        p,
+        "branch.merge",
+        serde_json::json!({
+            "source": source,
+            "target": target,
+            "strategy": strategy_str,
+            "keys_applied": info.keys_applied,
+            "keys_deleted": info.keys_deleted,
+            "merge_version": info.merge_version,
+        }),
+    );
+
     Ok(Output::BranchMerged(info))
+}
+
+/// Handle BranchDiffThreeWay command.
+pub fn branch_diff_three_way(
+    p: &Arc<Primitives>,
+    branch_a: String,
+    branch_b: String,
+) -> Result<Output> {
+    let merge_base_override = compute_merge_base_from_dag(&p.db, &branch_a, &branch_b);
+
+    let result =
+        strata_engine::branch_ops::diff_three_way(&p.db, &branch_a, &branch_b, merge_base_override)
+            .map_err(|e| Error::Internal {
+                reason: e.to_string(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            })?;
+
+    Ok(Output::ThreeWayDiff(result))
+}
+
+/// Handle BranchMergeBase command.
+pub fn branch_merge_base(
+    p: &Arc<Primitives>,
+    branch_a: String,
+    branch_b: String,
+) -> Result<Output> {
+    let merge_base_override = compute_merge_base_from_dag(&p.db, &branch_a, &branch_b);
+
+    let result =
+        strata_engine::branch_ops::get_merge_base(&p.db, &branch_a, &branch_b, merge_base_override)
+            .map_err(|e| Error::Internal {
+                reason: e.to_string(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            })?;
+
+    Ok(Output::MergeBaseInfo(result))
+}
+
+// =============================================================================
+// Revert Handlers
+// =============================================================================
+
+/// Handle BranchRevert command.
+pub fn branch_revert(
+    p: &Arc<Primitives>,
+    branch: String,
+    from_version: u64,
+    to_version: u64,
+) -> Result<Output> {
+    crate::handlers::reject_system_branch(&crate::types::BranchId::from(branch.as_str()))?;
+    let info =
+        strata_engine::branch_ops::revert_version_range(&p.db, &branch, from_version, to_version)
+            .map_err(|e| Error::Internal {
+            reason: e.to_string(),
+            hint: None,
+        })?;
+
+    emit_audit_event(
+        p,
+        "branch.revert",
+        serde_json::json!({
+            "branch": branch,
+            "from_version": from_version,
+            "to_version": to_version,
+            "keys_reverted": info.keys_reverted,
+        }),
+    );
+
+    Ok(Output::BranchReverted(info))
+}
+
+// =============================================================================
+// Cherry-Pick Handlers
+// =============================================================================
+
+/// Handle BranchCherryPick command.
+pub fn branch_cherry_pick(
+    p: &Arc<Primitives>,
+    source: String,
+    target: String,
+    keys: Option<Vec<(String, String)>>,
+    filter_spaces: Option<Vec<String>>,
+    filter_keys: Option<Vec<String>>,
+    filter_primitives: Option<Vec<strata_core::PrimitiveType>>,
+) -> Result<Output> {
+    crate::handlers::reject_system_branch(&crate::types::BranchId::from(source.as_str()))?;
+    crate::handlers::reject_system_branch(&crate::types::BranchId::from(target.as_str()))?;
+    let info = if let Some(keys) = keys {
+        // Direct key pick
+        strata_engine::branch_ops::cherry_pick_keys(&p.db, &source, &target, &keys)
+    } else {
+        // Diff-based pick with filter
+        let merge_base_override = compute_merge_base_from_dag(&p.db, &source, &target);
+        let filter = strata_engine::branch_ops::CherryPickFilter {
+            spaces: filter_spaces,
+            keys: filter_keys,
+            primitives: filter_primitives,
+        };
+        strata_engine::branch_ops::cherry_pick_from_diff(
+            &p.db,
+            &source,
+            &target,
+            filter,
+            merge_base_override,
+        )
+    }
+    .map_err(|e| Error::Internal {
+        reason: e.to_string(),
+        hint: None,
+    })?;
+
+    emit_audit_event(
+        p,
+        "branch.cherry_pick",
+        serde_json::json!({
+            "source": source,
+            "target": target,
+            "keys_applied": info.keys_applied,
+            "keys_deleted": info.keys_deleted,
+        }),
+    );
+
+    Ok(Output::BranchCherryPicked(info))
 }
 
 // =============================================================================
@@ -421,6 +621,146 @@ pub fn branch_bundle_validate(path: String) -> Result<Output> {
             checksums_valid: info.checksums_valid,
         },
     ))
+}
+
+// =============================================================================
+// Tag Handlers
+// =============================================================================
+
+/// Handle TagCreate command.
+pub fn tag_create(
+    p: &Arc<Primitives>,
+    branch: String,
+    name: String,
+    version: Option<u64>,
+    message: Option<String>,
+    creator: Option<String>,
+) -> Result<Output> {
+    crate::handlers::reject_system_branch(&crate::types::BranchId::from(branch.as_str()))?;
+    let info = strata_engine::branch_ops::create_tag(
+        &p.db,
+        &branch,
+        &name,
+        version,
+        message.as_deref(),
+        creator.as_deref(),
+    )
+    .map_err(|e| Error::Internal {
+        reason: e.to_string(),
+        hint: None,
+    })?;
+
+    emit_audit_event(
+        p,
+        "branch.tag",
+        serde_json::json!({
+            "branch": branch,
+            "tag": name,
+            "version": info.version,
+            "message": message,
+        }),
+    );
+
+    Ok(Output::TagCreated(info))
+}
+
+/// Handle TagDelete command.
+pub fn tag_delete(p: &Arc<Primitives>, branch: String, name: String) -> Result<Output> {
+    crate::handlers::reject_system_branch(&crate::types::BranchId::from(branch.as_str()))?;
+    let deleted = strata_engine::branch_ops::delete_tag(&p.db, &branch, &name).map_err(|e| {
+        Error::Internal {
+            reason: e.to_string(),
+            hint: None,
+        }
+    })?;
+    Ok(Output::Bool(deleted))
+}
+
+/// Handle TagList command.
+pub fn tag_list(p: &Arc<Primitives>, branch: String) -> Result<Output> {
+    crate::handlers::reject_system_branch(&crate::types::BranchId::from(branch.as_str()))?;
+    let tags =
+        strata_engine::branch_ops::list_tags(&p.db, &branch).map_err(|e| Error::Internal {
+            reason: e.to_string(),
+            hint: None,
+        })?;
+    Ok(Output::TagList(tags))
+}
+
+/// Handle TagResolve command.
+pub fn tag_resolve(p: &Arc<Primitives>, branch: String, name: String) -> Result<Output> {
+    crate::handlers::reject_system_branch(&crate::types::BranchId::from(branch.as_str()))?;
+    let tag = strata_engine::branch_ops::resolve_tag(&p.db, &branch, &name).map_err(|e| {
+        Error::Internal {
+            reason: e.to_string(),
+            hint: None,
+        }
+    })?;
+    Ok(Output::MaybeTag(tag))
+}
+
+// =============================================================================
+// Note Handlers
+// =============================================================================
+
+/// Handle NoteAdd command.
+pub fn note_add(
+    p: &Arc<Primitives>,
+    branch: String,
+    version: u64,
+    message: String,
+    author: Option<String>,
+    metadata: Option<strata_core::Value>,
+) -> Result<Output> {
+    crate::handlers::reject_system_branch(&crate::types::BranchId::from(branch.as_str()))?;
+    let note = strata_engine::branch_ops::add_note(
+        &p.db,
+        &branch,
+        version,
+        &message,
+        author.as_deref(),
+        metadata,
+    )
+    .map_err(|e| Error::Internal {
+        reason: e.to_string(),
+        hint: None,
+    })?;
+
+    emit_audit_event(
+        p,
+        "branch.note",
+        serde_json::json!({
+            "branch": branch,
+            "version": version,
+            "message": message,
+        }),
+    );
+
+    Ok(Output::NoteAdded(note))
+}
+
+/// Handle NoteGet command.
+pub fn note_get(p: &Arc<Primitives>, branch: String, version: Option<u64>) -> Result<Output> {
+    crate::handlers::reject_system_branch(&crate::types::BranchId::from(branch.as_str()))?;
+    let notes = strata_engine::branch_ops::get_notes(&p.db, &branch, version).map_err(|e| {
+        Error::Internal {
+            reason: e.to_string(),
+            hint: None,
+        }
+    })?;
+    Ok(Output::NoteList(notes))
+}
+
+/// Handle NoteDelete command.
+pub fn note_delete(p: &Arc<Primitives>, branch: String, version: u64) -> Result<Output> {
+    crate::handlers::reject_system_branch(&crate::types::BranchId::from(branch.as_str()))?;
+    let deleted = strata_engine::branch_ops::delete_note(&p.db, &branch, version).map_err(|e| {
+        Error::Internal {
+            reason: e.to_string(),
+            hint: None,
+        }
+    })?;
+    Ok(Output::Bool(deleted))
 }
 
 #[cfg(test)]

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -73,8 +73,9 @@ mod tests;
 
 // Core types
 pub use api::{
-    BranchDiffEntry, BranchDiffResult, Branches, ConflictEntry, DiffFilter, DiffOptions,
-    DiffSummary, ForkInfo, MergeInfo, MergeStrategy, SpaceDiff, Strata, SystemBranch,
+    BranchDiffEntry, BranchDiffResult, Branches, CherryPickFilter, CherryPickInfo, ConflictEntry,
+    DiffFilter, DiffOptions, DiffSummary, ForkInfo, MergeInfo, MergeStrategy, RevertInfo,
+    SpaceDiff, Strata, SystemBranch,
 };
 pub use command::Command;
 pub use error::{Error, ErrorSeverity};

--- a/crates/executor/src/output.rs
+++ b/crates/executor/src/output.rs
@@ -6,7 +6,9 @@
 
 use serde::{Deserialize, Serialize};
 use strata_core::Value;
-use strata_engine::branch_ops::{BranchDiffResult, ForkInfo, MergeInfo};
+use strata_engine::branch_ops::{
+    BranchDiffResult, CherryPickInfo, ForkInfo, MergeInfo, NoteInfo, RevertInfo, TagInfo,
+};
 use strata_engine::{HealthReport, StrataConfig, SystemMetrics, WalCounters};
 
 use crate::types::*;
@@ -175,6 +177,34 @@ pub enum Output {
 
     /// Branch merge result
     BranchMerged(MergeInfo),
+
+    /// Three-way diff result
+    ThreeWayDiff(strata_engine::branch_ops::ThreeWayDiffResult),
+
+    /// Merge base info result
+    MergeBaseInfo(Option<strata_engine::branch_ops::MergeBaseInfo>),
+
+    /// Branch revert result
+    BranchReverted(RevertInfo),
+
+    /// Branch cherry-pick result
+    BranchCherryPicked(CherryPickInfo),
+
+    // ==================== Tags & Notes ====================
+    /// Tag creation result
+    TagCreated(TagInfo),
+
+    /// List of tags
+    TagList(Vec<TagInfo>),
+
+    /// Optional tag info (for resolve)
+    MaybeTag(Option<TagInfo>),
+
+    /// Note creation result
+    NoteAdded(NoteInfo),
+
+    /// List of notes
+    NoteList(Vec<NoteInfo>),
 
     /// Database configuration snapshot
     Config(StrataConfig),


### PR DESCRIPTION
## Summary

Six new capabilities that give Strata AI the same workflow powers Claude Code gets from git:

- **Three-Way Diff API** — inspect the 14-case decision matrix before merging (`diff_three_way`, `get_merge_base`)
- **Audit Log** — append-only event trail for every branch operation (create/fork/merge/delete/tag/revert/cherry-pick)
- **Tags** — named version bookmarks on branches (`create_tag`, `list_tags`, `resolve_tag`, `delete_tag`)
- **Notes** — AI-authored annotations on specific versions (`add_note`, `get_notes`, `delete_note`)
- **Revert** — undo a version range while preserving subsequent work (`revert_version_range`)
- **Cherry-Pick** — selective key copy or filtered three-way diff merge (`cherry_pick_keys`, `cherry_pick_from_diff`)

All features flow through the full stack: engine → command → handler → dispatch → API → CLI formatting.

## Key design decisions

- Audit events are best-effort (logged on failure, never propagated) — same pattern as DAG recording
- Tags and notes stored as KV on `_system_` branch with `tag:branch:name` / `note:branch:version` keys
- Revert only touches keys whose current state matches the "after" state (preserves subsequent work)
- Cherry-pick has two modes: direct key copy (simple) and diff-based with space/key/primitive filters (selective merge)
- All new handlers include `_system_` branch guards
- Tag names and branch refs validated to reject `:` (prevents key ambiguity)

## Test plan

- [x] 3 tests for three-way diff API (disjoint changes, merge base, unrelated branches)
- [x] 2 tests for tags (create/resolve, list/delete)
- [x] 2 tests for notes (add/get, delete)
- [x] 4 tests for revert (single version, preserves subsequent work, restores deleted key, invalid range)
- [x] 3 tests for cherry-pick (specific keys, diff-based filter, empty keys)
- [x] 606 engine tests, 556 executor tests, 28 integration branching tests — all pass
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)