### PR TITLE
Fix #1571: COW-aware branch diff — O(W) fast path for parent-child branches

### DIFF
--- a/crates/engine/src/branch_ops.rs
+++ b/crates/engine/src/branch_ops.rs
@@ -404,13 +404,34 @@ pub fn diff_branches_with_options(
     branch_b: &str,
     options: DiffOptions,
 ) -> StrataResult<BranchDiffResult> {
-    let space_index = SpaceIndex::new(db.clone());
-
     // 1. Verify both branches exist and resolve IDs
     let id_a = resolve_and_verify(db, branch_a)?;
     let id_b = resolve_and_verify(db, branch_b)?;
 
+    let storage = db.storage();
+
+    // COW fast path: if one branch is a direct child of the other and no
+    // as_of timestamp, use O(W) diff instead of O(N) full scan.
+    // Checked early to avoid the O(spaces) space listing below.
+    if options.as_of.is_none() {
+        if let Some((parent, fv)) = storage.get_fork_info(&id_b) {
+            if parent == id_a {
+                return cow_diff_branches(
+                    db, id_a, id_b, id_b, id_a, fv, branch_a, branch_b, &options,
+                );
+            }
+        }
+        if let Some((parent, fv)) = storage.get_fork_info(&id_a) {
+            if parent == id_b {
+                return cow_diff_branches(
+                    db, id_a, id_b, id_a, id_b, fv, branch_a, branch_b, &options,
+                );
+            }
+        }
+    }
+
     // 2. List spaces in both branches
+    let space_index = SpaceIndex::new(db.clone());
     let spaces_a: HashSet<String> = space_index.list(id_a)?.into_iter().collect();
     let spaces_b: HashSet<String> = space_index.list(id_b)?.into_iter().collect();
 
@@ -446,7 +467,6 @@ pub fn diff_branches_with_options(
         None => DATA_TYPE_TAGS.to_vec(),
     };
 
-    let storage = db.storage();
     let mut space_diffs = Vec::new();
     let mut total_added = 0usize;
     let mut total_removed = 0usize;
@@ -564,6 +584,172 @@ pub fn diff_branches_with_options(
     Ok(BranchDiffResult {
         branch_a: branch_a.to_string(),
         branch_b: branch_b.to_string(),
+        spaces: space_diffs,
+        summary: DiffSummary {
+            total_added,
+            total_removed,
+            total_modified,
+            spaces_only_in_a,
+            spaces_only_in_b,
+        },
+    })
+}
+
+// =============================================================================
+// COW-Aware Diff (O(W) fast path for parent-child branches)
+// =============================================================================
+
+/// COW-aware diff: O(W) where W = writes since fork.
+///
+/// Only called when one branch is a direct child of the other (detected via
+/// `get_fork_info`) and no `as_of` timestamp is specified.
+///
+/// Algorithm:
+/// 1. Scan the child's own entries (memtable + own segments, no inherited layers).
+/// 2. Scan the parent's entries written after fork_version.
+/// 3. For each changed key, point-lookup both branches for the current visible value.
+/// 4. Classify as added/removed/modified using the same logic as the full-scan diff.
+#[allow(clippy::too_many_arguments)]
+fn cow_diff_branches(
+    db: &Arc<Database>,
+    id_a: BranchId,
+    id_b: BranchId,
+    child_id: BranchId,
+    parent_id: BranchId,
+    fork_version: u64,
+    branch_a_name: &str,
+    branch_b_name: &str,
+    options: &DiffOptions,
+) -> StrataResult<BranchDiffResult> {
+    let space_index = SpaceIndex::new(db.clone());
+    let storage = db.storage();
+
+    // 1. Space listing and filtering (same as full-scan path)
+    let spaces_a: HashSet<String> = space_index.list(id_a)?.into_iter().collect();
+    let spaces_b: HashSet<String> = space_index.list(id_b)?.into_iter().collect();
+
+    let space_filter: Option<HashSet<String>> = options
+        .filter
+        .as_ref()
+        .and_then(|f| f.spaces.as_ref())
+        .map(|s| s.iter().cloned().collect());
+
+    let mut spaces_only_in_a: Vec<String> = spaces_a.difference(&spaces_b).cloned().collect();
+    let mut spaces_only_in_b: Vec<String> = spaces_b.difference(&spaces_a).cloned().collect();
+
+    if let Some(ref allowed) = space_filter {
+        spaces_only_in_a.retain(|s| allowed.contains(s));
+        spaces_only_in_b.retain(|s| allowed.contains(s));
+    }
+
+    // 2. Determine which TypeTags to scan
+    let type_tags: HashSet<TypeTag> =
+        match options.filter.as_ref().and_then(|f| f.primitives.as_ref()) {
+            Some(prims) => prims
+                .iter()
+                .flat_map(|p| primitive_to_type_tags(*p))
+                .collect(),
+            None => DATA_TYPE_TAGS.iter().copied().collect(),
+        };
+
+    // 3. Scan only changed entries (child's own + parent's post-fork)
+    let child_own = storage.list_own_entries(&child_id, None);
+    let parent_post_fork = storage.list_own_entries(&parent_id, Some(fork_version));
+
+    // 4. Build the set of potentially changed keys, applying filters
+    let mut changed_keys: HashSet<(String, Vec<u8>, TypeTag)> = HashSet::new();
+
+    for entry in child_own.iter().chain(parent_post_fork.iter()) {
+        if !type_tags.contains(&entry.key.type_tag) {
+            continue;
+        }
+        if let Some(ref allowed) = space_filter {
+            if !allowed.contains(&entry.key.namespace.space) {
+                continue;
+            }
+        }
+        changed_keys.insert((
+            entry.key.namespace.space.clone(),
+            entry.key.user_key.to_vec(),
+            entry.key.type_tag,
+        ));
+    }
+
+    // 5. Point-lookup both branches for each changed key and classify
+    // (added, removed, modified) per space
+    type SpaceBuckets = (
+        Vec<BranchDiffEntry>,
+        Vec<BranchDiffEntry>,
+        Vec<BranchDiffEntry>,
+    );
+    let mut space_diffs_map: HashMap<String, SpaceBuckets> = HashMap::new();
+
+    // Cache Arc<Namespace> per (branch_id, space) to avoid repeated allocation
+    let mut ns_cache: HashMap<(BranchId, String), Arc<Namespace>> = HashMap::new();
+
+    for (space, user_key, type_tag) in &changed_keys {
+        let ns_a = ns_cache
+            .entry((id_a, space.clone()))
+            .or_insert_with(|| Arc::new(Namespace::for_branch_space(id_a, space)))
+            .clone();
+        let key_a = Key::new(ns_a, *type_tag, user_key.clone());
+        let val_a = storage.get_value_direct(&key_a)?;
+
+        let ns_b = ns_cache
+            .entry((id_b, space.clone()))
+            .or_insert_with(|| Arc::new(Namespace::for_branch_space(id_b, space)))
+            .clone();
+        let key_b = Key::new(ns_b, *type_tag, user_key.clone());
+        let val_b = storage.get_value_direct(&key_b)?;
+
+        let diff_entry = match (&val_a, &val_b) {
+            (None, None) => continue,
+            (Some(a), Some(b)) if a == b => continue,
+            _ => BranchDiffEntry {
+                key: format_user_key(user_key),
+                raw_key: user_key.clone(),
+                primitive: type_tag_to_primitive(*type_tag),
+                type_tag: *type_tag,
+                space: space.clone(),
+                value_a: val_a.clone(),
+                value_b: val_b.clone(),
+            },
+        };
+
+        let (added, removed, modified) = space_diffs_map.entry(space.clone()).or_default();
+
+        match (&diff_entry.value_a, &diff_entry.value_b) {
+            (Some(_), None) => removed.push(diff_entry),
+            (None, Some(_)) => added.push(diff_entry),
+            (Some(_), Some(_)) => modified.push(diff_entry),
+            _ => unreachable!(),
+        }
+    }
+
+    // 6. Assemble result
+    let mut total_added = 0usize;
+    let mut total_removed = 0usize;
+    let mut total_modified = 0usize;
+    let mut space_diffs = Vec::new();
+
+    for (space, (added, removed, modified)) in space_diffs_map {
+        total_added += added.len();
+        total_removed += removed.len();
+        total_modified += modified.len();
+
+        if !added.is_empty() || !removed.is_empty() || !modified.is_empty() {
+            space_diffs.push(SpaceDiff {
+                space,
+                added,
+                removed,
+                modified,
+            });
+        }
+    }
+
+    Ok(BranchDiffResult {
+        branch_a: branch_a_name.to_string(),
+        branch_b: branch_b_name.to_string(),
         spaces: space_diffs,
         summary: DiffSummary {
             total_added,
@@ -4113,5 +4299,246 @@ mod tests {
         .unwrap();
         assert_eq!(info.keys_applied, 0);
         assert!(info.cherry_pick_version.is_none());
+    }
+
+    // =========================================================================
+    // COW-Aware Diff Tests
+    // =========================================================================
+
+    #[test]
+    fn test_cow_diff_child_adds_key() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "existing", Value::Int(1));
+        fork_branch(&db, "parent", "child").unwrap();
+        write_kv(&db, "child", "default", "new_key", Value::Int(42));
+
+        let diff = diff_branches(&db, "parent", "child").unwrap();
+        assert_eq!(diff.summary.total_added, 1);
+        assert_eq!(diff.summary.total_removed, 0);
+        assert_eq!(diff.summary.total_modified, 0);
+
+        let space = &diff.spaces[0];
+        assert_eq!(space.added[0].key, "new_key");
+        assert!(space.added[0].value_a.is_none());
+        assert_eq!(space.added[0].value_b, Some(Value::Int(42)));
+    }
+
+    #[test]
+    fn test_cow_diff_child_modifies_key() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "k", Value::Int(1));
+        fork_branch(&db, "parent", "child").unwrap();
+        write_kv(&db, "child", "default", "k", Value::Int(2));
+
+        let diff = diff_branches(&db, "parent", "child").unwrap();
+        assert_eq!(diff.summary.total_modified, 1);
+        assert_eq!(diff.summary.total_added, 0);
+        assert_eq!(diff.summary.total_removed, 0);
+
+        let space = &diff.spaces[0];
+        assert_eq!(space.modified[0].key, "k");
+        assert_eq!(space.modified[0].value_a, Some(Value::Int(1)));
+        assert_eq!(space.modified[0].value_b, Some(Value::Int(2)));
+    }
+
+    #[test]
+    fn test_cow_diff_child_deletes_key() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "k", Value::Int(1));
+        fork_branch(&db, "parent", "child").unwrap();
+        delete_kv(&db, "child", "default", "k");
+
+        let diff = diff_branches(&db, "parent", "child").unwrap();
+        assert_eq!(diff.summary.total_removed, 1);
+        assert_eq!(diff.summary.total_added, 0);
+        assert_eq!(diff.summary.total_modified, 0);
+
+        let space = &diff.spaces[0];
+        assert_eq!(space.removed[0].key, "k");
+        assert_eq!(space.removed[0].value_a, Some(Value::Int(1)));
+        assert!(space.removed[0].value_b.is_none());
+    }
+
+    #[test]
+    fn test_cow_diff_parent_modifies_after_fork() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "k", Value::Int(1));
+        fork_branch(&db, "parent", "child").unwrap();
+        // Parent modifies after fork
+        write_kv(&db, "parent", "default", "k", Value::Int(99));
+
+        let diff = diff_branches(&db, "parent", "child").unwrap();
+        assert_eq!(diff.summary.total_modified, 1);
+
+        let space = &diff.spaces[0];
+        assert_eq!(space.modified[0].value_a, Some(Value::Int(99))); // parent's new value
+        assert_eq!(space.modified[0].value_b, Some(Value::Int(1))); // child still has old
+    }
+
+    #[test]
+    fn test_cow_diff_both_modify_same_key() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "k", Value::Int(1));
+        fork_branch(&db, "parent", "child").unwrap();
+        write_kv(&db, "parent", "default", "k", Value::Int(10));
+        write_kv(&db, "child", "default", "k", Value::Int(20));
+
+        let diff = diff_branches(&db, "parent", "child").unwrap();
+        assert_eq!(diff.summary.total_modified, 1);
+
+        let space = &diff.spaces[0];
+        assert_eq!(space.modified[0].value_a, Some(Value::Int(10)));
+        assert_eq!(space.modified[0].value_b, Some(Value::Int(20)));
+    }
+
+    #[test]
+    fn test_cow_diff_child_writes_same_value() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "k", Value::Int(1));
+        fork_branch(&db, "parent", "child").unwrap();
+        // Child writes same value — should NOT appear in diff
+        write_kv(&db, "child", "default", "k", Value::Int(1));
+
+        let diff = diff_branches(&db, "parent", "child").unwrap();
+        assert_eq!(diff.summary.total_added, 0);
+        assert_eq!(diff.summary.total_removed, 0);
+        assert_eq!(diff.summary.total_modified, 0);
+    }
+
+    #[test]
+    fn test_cow_diff_child_deletes_nonexistent() {
+        let (_temp, db) = setup_with_branch("parent");
+        // Parent must have at least one key for fork to succeed
+        write_kv(&db, "parent", "default", "exists", Value::Int(1));
+        fork_branch(&db, "parent", "child").unwrap();
+        // Child deletes a key that doesn't exist in parent — should NOT appear
+        delete_kv(&db, "child", "default", "phantom");
+
+        let diff = diff_branches(&db, "parent", "child").unwrap();
+        assert_eq!(diff.summary.total_added, 0);
+        assert_eq!(diff.summary.total_removed, 0);
+        assert_eq!(diff.summary.total_modified, 0);
+    }
+
+    #[test]
+    fn test_cow_diff_directionality() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "k", Value::Int(1));
+        fork_branch(&db, "parent", "child").unwrap();
+        write_kv(&db, "child", "default", "new", Value::Int(2));
+
+        // diff(parent, child): "new" is added (in child/b, not parent/a)
+        let diff_pc = diff_branches(&db, "parent", "child").unwrap();
+        assert_eq!(diff_pc.summary.total_added, 1);
+        assert_eq!(diff_pc.summary.total_removed, 0);
+
+        // diff(child, parent): "new" is removed (in child/a, not parent/b)
+        let diff_cp = diff_branches(&db, "child", "parent").unwrap();
+        assert_eq!(diff_cp.summary.total_added, 0);
+        assert_eq!(diff_cp.summary.total_removed, 1);
+    }
+
+    #[test]
+    fn test_cow_diff_with_space_filter() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "k1", Value::Int(1));
+        write_kv(&db, "parent", "other", "k2", Value::Int(2));
+        fork_branch(&db, "parent", "child").unwrap();
+        write_kv(&db, "child", "default", "k1", Value::Int(10));
+        write_kv(&db, "child", "other", "k2", Value::Int(20));
+
+        // Filter to "default" space only
+        let diff = diff_branches_with_options(
+            &db,
+            "parent",
+            "child",
+            DiffOptions {
+                filter: Some(DiffFilter {
+                    primitives: None,
+                    spaces: Some(vec!["default".to_string()]),
+                }),
+                as_of: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(diff.summary.total_modified, 1);
+        assert_eq!(diff.spaces.len(), 1);
+        assert_eq!(diff.spaces[0].space, "default");
+    }
+
+    #[test]
+    fn test_cow_diff_with_primitive_filter() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "kv_key", Value::Int(1));
+        fork_branch(&db, "parent", "child").unwrap();
+        write_kv(&db, "child", "default", "kv_key", Value::Int(2));
+
+        // Filter to KV only
+        let diff = diff_branches_with_options(
+            &db,
+            "parent",
+            "child",
+            DiffOptions {
+                filter: Some(DiffFilter {
+                    primitives: Some(vec![PrimitiveType::Kv]),
+                    spaces: None,
+                }),
+                as_of: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(diff.summary.total_modified, 1);
+    }
+
+    #[test]
+    fn test_cow_diff_as_of_falls_back() {
+        // When as_of is set, COW fast path should not be used (falls back to full scan).
+        // Verify correctness by checking the result matches expectations.
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "k", Value::Int(1));
+        fork_branch(&db, "parent", "child").unwrap();
+        write_kv(&db, "child", "default", "k", Value::Int(2));
+
+        // With as_of=0 (before any writes), diff should be empty
+        let diff = diff_branches_with_options(
+            &db,
+            "parent",
+            "child",
+            DiffOptions {
+                filter: None,
+                as_of: Some(0),
+            },
+        )
+        .unwrap();
+        assert_eq!(diff.summary.total_modified, 0);
+        assert_eq!(diff.summary.total_added, 0);
+        assert_eq!(diff.summary.total_removed, 0);
+    }
+
+    #[test]
+    fn test_cow_diff_no_changes() {
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "k", Value::Int(1));
+        fork_branch(&db, "parent", "child").unwrap();
+        // No changes on child — diff should be empty
+        let diff = diff_branches(&db, "parent", "child").unwrap();
+        assert_eq!(diff.summary.total_added, 0);
+        assert_eq!(diff.summary.total_removed, 0);
+        assert_eq!(diff.summary.total_modified, 0);
+    }
+
+    #[test]
+    fn test_cow_diff_both_delete_same_key() {
+        // Both branches delete the same key after fork → (None, None) → no diff
+        let (_temp, db) = setup_with_branch("parent");
+        write_kv(&db, "parent", "default", "k", Value::Int(1));
+        fork_branch(&db, "parent", "child").unwrap();
+        delete_kv(&db, "child", "default", "k");
+        delete_kv(&db, "parent", "default", "k");
+
+        let diff = diff_branches(&db, "parent", "child").unwrap();
+        assert_eq!(diff.summary.total_added, 0);
+        assert_eq!(diff.summary.total_removed, 0);
+        assert_eq!(diff.summary.total_modified, 0);
     }
 }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -157,6 +157,20 @@ pub struct VersionedEntry {
     pub commit_id: u64,
 }
 
+/// Entry from a branch's own sources (excluding inherited layers).
+/// Used by COW-aware diff to identify writes since fork.
+#[derive(Debug, Clone)]
+pub struct OwnEntry {
+    /// The decoded user key.
+    pub key: Key,
+    /// The stored value (empty for tombstones).
+    pub value: Value,
+    /// Whether this entry is a deletion tombstone.
+    pub is_tombstone: bool,
+    /// The MVCC commit version that wrote this entry.
+    pub commit_id: u64,
+}
+
 // ---------------------------------------------------------------------------
 // SegmentVersion
 // ---------------------------------------------------------------------------
@@ -1418,6 +1432,73 @@ impl SegmentedStore {
             .into_iter()
             .filter(|(key, _)| key.type_tag == type_tag)
             .collect()
+    }
+
+    /// List entries from a branch's own sources only (active memtable, frozen
+    /// memtables, and own on-disk segments). **Excludes inherited layers.**
+    ///
+    /// When `min_commit_id` is `Some(v)`, only entries with `commit_id > v` are
+    /// returned (for scanning parent's post-fork writes). When `None`, all own
+    /// entries are returned (for scanning child's writes since fork).
+    ///
+    /// Unlike `list_by_type()`, this method preserves tombstones (needed for
+    /// COW-aware diff to detect deletions) and does NOT filter expired entries.
+    /// Returns MVCC-deduplicated entries (latest version per logical key).
+    pub fn list_own_entries(
+        &self,
+        branch_id: &BranchId,
+        min_commit_id: Option<u64>,
+    ) -> Vec<OwnEntry> {
+        let branch = match self.branches.get(branch_id) {
+            Some(b) => b,
+            None => return Vec::new(),
+        };
+
+        let mut sources: Vec<Box<dyn Iterator<Item = (InternalKey, MemtableEntry)>>> = Vec::new();
+
+        // Active memtable
+        let active_entries: Vec<_> = branch.active.iter_all().collect();
+        sources.push(Box::new(active_entries.into_iter()));
+
+        // Frozen memtables (newest first)
+        for frozen in &branch.frozen {
+            let entries: Vec<_> = frozen.iter_all().collect();
+            sources.push(Box::new(entries.into_iter()));
+        }
+
+        // On-disk segments — all levels (own segments only, NO inherited layers)
+        let ver = branch.version.load();
+        for level in &ver.levels {
+            for seg in level {
+                let entries: Vec<_> = seg
+                    .iter_seek_all()
+                    .map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se)))
+                    .collect();
+                sources.push(Box::new(entries.into_iter()));
+            }
+        }
+
+        // NOTE: inherited layers intentionally excluded — this is the whole point.
+
+        let merge = MergeIterator::new(sources);
+        let mvcc = MvccIterator::new(merge, u64::MAX);
+
+        mvcc.filter_map(|(ik, entry)| {
+            let (key, commit_id) = ik.decode()?;
+            // Apply min_commit_id filter if set
+            if let Some(min) = min_commit_id {
+                if commit_id <= min {
+                    return None;
+                }
+            }
+            Some(OwnEntry {
+                key,
+                value: entry.value.clone(),
+                is_tombstone: entry.is_tombstone,
+                commit_id,
+            })
+        })
+        .collect()
     }
 
     /// List entries filtered by type tag at a specific MVCC version, preserving tombstones.

--- a/crates/storage/src/segmented/tests/fork.rs
+++ b/crates/storage/src/segmented/tests/fork.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::HashSet;
 
 // ===== COW Branching Foundation Tests (Epic A) =====
 
@@ -1260,4 +1261,103 @@ fn fork_double_fork_same_dest_rejected() {
             id
         );
     }
+}
+
+// ===== list_own_entries tests (COW-aware diff support) =====
+
+#[test]
+fn list_own_entries_excludes_inherited() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 64 * 1024);
+    let pid = parent_branch();
+    let cid = child_branch();
+
+    // Write keys on parent
+    seed(&store, parent_kv("alpha"), Value::Int(1), 1);
+    seed(&store, parent_kv("beta"), Value::Int(2), 2);
+    store.rotate_memtable(&pid);
+    store.flush_oldest_frozen(&pid).unwrap();
+
+    // Fork child from parent at version 2
+    attach_inherited_layer(&store, pid, cid, 2);
+
+    // Write one key on the child
+    seed(&store, child_kv("gamma"), Value::Int(3), 3);
+
+    // list_own_entries on child should return ONLY gamma (not alpha/beta)
+    let own = store.list_own_entries(&cid, None);
+    assert_eq!(own.len(), 1);
+    assert_eq!(std::str::from_utf8(&own[0].key.user_key).unwrap(), "gamma");
+    assert_eq!(own[0].value, Value::Int(3));
+    assert!(!own[0].is_tombstone);
+}
+
+#[test]
+fn list_own_entries_includes_tombstones() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 64 * 1024);
+    let pid = parent_branch();
+    let cid = child_branch();
+
+    // Parent has key "alpha"
+    seed(&store, parent_kv("alpha"), Value::Int(1), 1);
+    store.rotate_memtable(&pid);
+    store.flush_oldest_frozen(&pid).unwrap();
+
+    // Fork child
+    attach_inherited_layer(&store, pid, cid, 1);
+
+    // Child deletes "alpha" (writes tombstone)
+    store.delete_with_version(&child_kv("alpha"), 2).unwrap();
+
+    // list_own_entries should include the tombstone
+    let own = store.list_own_entries(&cid, None);
+    assert_eq!(own.len(), 1);
+    assert_eq!(std::str::from_utf8(&own[0].key.user_key).unwrap(), "alpha");
+    assert!(own[0].is_tombstone);
+}
+
+#[test]
+fn list_own_entries_since_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 64 * 1024);
+    let pid = parent_branch();
+
+    // Parent writes before fork
+    seed(&store, parent_kv("pre_fork"), Value::Int(1), 1);
+    seed(&store, parent_kv("at_fork"), Value::Int(2), 2);
+
+    // Parent writes after fork
+    seed(&store, parent_kv("post_fork"), Value::Int(3), 3);
+    seed(&store, parent_kv("post_fork_2"), Value::Int(4), 4);
+
+    // list_own_entries with min_commit_id=2 should return only post-fork entries
+    let own = store.list_own_entries(&pid, Some(2));
+    assert_eq!(own.len(), 2);
+    let keys: HashSet<String> = own
+        .iter()
+        .map(|e| std::str::from_utf8(&e.key.user_key).unwrap().to_string())
+        .collect();
+    assert!(keys.contains("post_fork"));
+    assert!(keys.contains("post_fork_2"));
+    assert!(!keys.contains("pre_fork"));
+    assert!(!keys.contains("at_fork"));
+}
+
+#[test]
+fn list_own_entries_mvcc_dedup() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 64 * 1024);
+    let pid = parent_branch();
+
+    // Write same key multiple times at different versions
+    seed(&store, parent_kv("key"), Value::Int(1), 1);
+    seed(&store, parent_kv("key"), Value::Int(2), 2);
+    seed(&store, parent_kv("key"), Value::Int(3), 3);
+
+    // list_own_entries should return only the latest version
+    let own = store.list_own_entries(&pid, None);
+    assert_eq!(own.len(), 1);
+    assert_eq!(own[0].value, Value::Int(3));
+    assert_eq!(own[0].commit_id, 3);
 }

--- a/docs/design/branching/efficient-diff.md
+++ b/docs/design/branching/efficient-diff.md
@@ -1,0 +1,383 @@
+# Efficient Branch Diff: From O(N) Full Scan to O(Δ) Change-Proportional
+
+**Issue**: [#1571](https://github.com/stratalab/strata-core/issues/1571)
+**Status**: Design
+**Date**: 2026-03-25
+
+## Problem
+
+`diff_branches_with_options()` and `three_way_diff()` in `branch_ops.rs` perform full scans of all entries in every branch involved, build complete `HashMap`s in memory, and compare key-by-key. This is **O(N)** in time and space where N = total entries across all branches — regardless of how many keys actually changed.
+
+For a database with 100M keys where a branch modifies 50, the diff scans all 100M+ entries to find those 50 changes.
+
+### Current Algorithm
+
+```
+diff_branches(branch_a, branch_b):
+  for each TypeTag (KV, Event, Json, Vector, VectorConfig):
+    for each space:
+      A_entries = storage.list_by_type(&branch_a, tag)   // Full scan
+      B_entries = storage.list_by_type(&branch_b, tag)   // Full scan
+      build HashMap(user_key → value) for each
+      compare all keys across both HashMaps
+
+three_way_diff(source, target, merge_base):
+  for each TypeTag and space:
+    ancestor = storage.list_by_type_at_version(base, tag, fork_version)  // Full scan
+    source   = storage.list_by_type(&source, tag)                        // Full scan
+    target   = storage.list_by_type(&target, tag)                        // Full scan
+    build three HashMaps, union all keys, classify each via 14-case matrix
+```
+
+`list_by_type()` traverses: active memtable → frozen memtables → all on-disk segments (L0–L6) → all inherited layers → MergeIterator → MvccIterator → tombstone filter → collect to Vec.
+
+---
+
+## State of the Art
+
+### Git: Merkle Trees with Recursive Subtree Skipping
+
+Git's object model is a content-addressed Merkle tree. Each tree node's SHA-1 is computed from its contents (entries + child hashes). Diffing two commits:
+
+1. Compare root tree hashes. If equal → identical, done.
+2. Walk both sorted entry lists in lockstep.
+3. For each entry: if hashes match → skip entire subtree in O(1).
+4. Only recurse into subtrees where hashes diverge.
+
+**Complexity**: O(changed_files × tree_depth). Changing 3 files in a 100K-file repo examines ~3 root-to-leaf paths, not 100K entries.
+
+**Three-way merge** operates entirely on 20-byte hash comparisons at the tree level:
+- base == ours && theirs differs → take theirs
+- base == theirs && ours differs → take ours
+- all three equal → unchanged
+- all three differ → conflict (read blobs only here)
+
+### Dolt: Prolly Trees with Content-Defined Chunking
+
+Dolt uses **Prolly Trees** — content-addressed B-trees where node boundaries are determined by a rolling hash (content-defined chunking). Critical property: **history independence** — the tree shape is a deterministic function of contents, not insertion order, guaranteeing maximum structural sharing.
+
+**Diff algorithm** (dual-cursor with `FastForwardUntilUnequal`):
+1. Two cursors walk left-to-right through both Prolly Trees.
+2. When values are equal, compare content addresses on cursor paths (root to leaf).
+3. Find deepest level where both paths share identical chunk addresses.
+4. Jump past the entire shared subtree via `NextAtLevel(level + 1)`.
+5. Only descend when hashes diverge.
+
+**Complexity**: O(d × log(n)) where d = differences, n = total data. For a 1M-row table with a single change, diff completes in ~698μs. A 5M-row three-way merge completes in ~0.01s with their node-level optimization.
+
+### lakeFS: Two-Layer Merkle Tree of Graveler Ranges
+
+lakeFS represents each committed state as:
+- **Ranges**: Immutable SSTables (1–8MB), each covering a contiguous sorted key range, named by content hash.
+- **MetaRange**: An SSTable listing all Range IDs, keyed by last key in each range. MetaRange hash derives from constituent range hashes.
+
+**Diff**: Walk two MetaRanges in parallel. If a range hash matches → skip the entire range (potentially thousands of keys) in O(1). Only open ranges where hashes differ.
+
+**Complexity**: O(changed_ranges × keys_per_range). For 200M objects where 5–20% of ranges change, only changed ranges are read.
+
+### Nessie: Per-Commit Change Manifests
+
+Nessie records which content keys changed in each commit entry. Diff = walk commit log from common ancestor to each tip, collect changed key sets. No full-scan needed.
+
+**Complexity**: O(commits_since_ancestor × keys_per_commit). Simple, no storage engine changes needed, but requires faithful recording of change sets.
+
+### TerminusDB: Immutable Layer Stack with Delta Encoding
+
+Each layer has a positive plane (+additions) and negative plane (-deletions). Diff = collect +/- planes from ancestor to each branch tip. Net change = union with cancellations.
+
+### Summary
+
+| System | Data Structure | Diff Complexity | Key Mechanism |
+|--------|---------------|----------------|---------------|
+| Git | Merkle tree of tree objects | O(Δ × depth) | Content-addressed subtree skipping |
+| Dolt | Prolly tree (content-chunked) | O(Δ × log N) | FastForward via cursor path comparison |
+| lakeFS | MetaRange/Range SSTables | O(changed_ranges) | Content-addressed range hashing |
+| Nessie | Commit log + key manifests | O(Σ commits × keys/commit) | Per-commit change journal |
+| TerminusDB | Layer stack with ±planes | O(Σ layers × changes/layer) | Explicit delta encoding |
+| **Strata** | **Full scan + HashMap** | **O(N total)** | **None** |
+
+---
+
+## Design: Segment-Hash Diff for Strata
+
+We propose a **two-tier approach** that delivers most of the benefit with minimal disruption to the existing storage engine.
+
+### Tier 1: Segment Content Hashing (lakeFS pattern)
+
+The core insight: Strata already partitions data into immutable, sorted segments. If each segment carries a content hash, two branches sharing segments (via COW inherited layers or identical compaction output) can skip shared segments during diff.
+
+#### 1.1 Segment Content Hash
+
+Add a **content hash** to every segment, computed at build time from the sorted key-value entries:
+
+```rust
+// In segment_builder.rs — PropertiesBlock extension
+struct PropertiesBlock {
+    entry_count: u64,
+    commit_min: u64,
+    commit_max: u64,
+    key_min: Vec<u8>,
+    key_max: Vec<u8>,
+    // NEW:
+    content_hash: [u8; 32],   // BLAKE3 hash of all (key, value, commit_id) entries
+}
+```
+
+**Hash computation**: Stream entries through BLAKE3 during segment build. BLAKE3 is ~3GB/s on modern CPUs — negligible overhead relative to I/O.
+
+**What to hash**: The hash covers `(typed_key, value_bytes, commit_id)` for every entry in sorted order. This means two segments with identical logical content (same keys, same values, same versions) produce the same hash, even if built at different times.
+
+**Branch-neutral hashing**: The typed key includes the branch ID prefix. For COW-inherited segments, the content hash is computed against the *source* branch's key namespace. When comparing across branches, the diff algorithm must account for this (see §1.3).
+
+#### 1.2 Branch Manifest
+
+Introduce a **branch manifest** — a compact summary of a branch's segment state at a point in time:
+
+```rust
+/// Ordered list of (key_range, content_hash) covering the branch's keyspace.
+/// Analogous to lakeFS MetaRange.
+struct BranchManifest {
+    branch_id: BranchId,
+    version: u64,
+    /// Segments sorted by key_min, with content hashes.
+    /// L1+ segments are non-overlapping by construction.
+    entries: Vec<ManifestEntry>,
+}
+
+struct ManifestEntry {
+    segment_id: SegmentId,
+    level: u8,
+    key_min: Vec<u8>,    // First typed_key in segment
+    key_max: Vec<u8>,    // Last typed_key in segment
+    content_hash: [u8; 32],
+    entry_count: u64,
+    commit_min: u64,
+    commit_max: u64,
+}
+```
+
+The manifest is derived from the existing `SegmentVersion` — no new persistence required for the manifest itself, only the content hash in each segment's properties block.
+
+#### 1.3 Segment-Level Diff Algorithm
+
+```
+segment_diff(branch_a, branch_b):
+  manifest_a = build_manifest(branch_a)  // From SegmentVersion + inherited layers
+  manifest_b = build_manifest(branch_b)
+
+  // Phase 1: Segment-level comparison (L1+ non-overlapping segments)
+  Walk manifest_a and manifest_b in key-sorted order:
+    If segments cover same key range AND content_hash matches:
+      SKIP — no changes in this range                          // O(1) per segment
+    If segments cover same key range AND content_hash differs:
+      DESCEND — diff entries within these segments only         // O(entries in segment)
+    If key ranges don't overlap:
+      Emit bulk add/remove for the non-overlapping range
+
+  // Phase 2: L0 segments and memtables (small, recent writes)
+  Scan L0 segments + memtables normally (these are small by definition)
+
+  // Phase 3: Inherited layer fast path
+  For COW-forked branches sharing inherited segments:
+    Inherited segments with no shadowing writes → SKIP entirely
+    Only diff the child's own segments against inherited baseline
+```
+
+**Complexity**: O(S + Δ) where S = number of segments (typically hundreds, not millions) and Δ = entries in changed segments. For a 100M-key database with 50 changed keys confined to 1–2 segments, the diff examines ~S segment hashes + entries in those 1–2 segments.
+
+#### 1.4 COW-Aware Fast Path
+
+For the common case of diffing a child branch against its parent (or two siblings):
+
+```
+cow_diff(child, parent):
+  // Child's own segments contain ALL of its modifications
+  // Inherited segments are by definition unchanged from parent
+  // Therefore: only scan child's own segments (memtable + L0 + compacted)
+
+  child_own_segments = child.segment_version  // Excludes inherited layers
+  for entry in scan(child_own_segments):
+    parent_value = point_lookup(parent, entry.key)
+    if entry.value != parent_value:
+      emit diff entry
+
+  // Also check: keys in parent that were deleted by child (tombstones in child's own segments)
+  for tombstone in scan_tombstones(child_own_segments):
+    if point_lookup(parent, tombstone.key).is_some():
+      emit deletion
+```
+
+**Complexity**: O(W) where W = entries written to the child branch since fork. This is optimal — you cannot do better than reading the entries that actually changed.
+
+**When applicable**: When `get_fork_info()` returns an active inherited layer for the child-parent relationship. This covers the most common agent workflow (fork → modify → diff → merge).
+
+### Tier 2: Per-Version Change Manifest (Nessie pattern)
+
+For scenarios where segment hashing is insufficient (e.g., both branches have undergone heavy compaction that destroys segment identity), maintain an explicit change journal.
+
+#### 2.1 Change Manifest
+
+Record the set of modified keys with each write batch:
+
+```rust
+/// Stored as a system KV entry: _system_:changelog:{branch}:{version}
+struct ChangeManifest {
+    version: u64,
+    branch_id: BranchId,
+    changes: Vec<ChangeEntry>,
+}
+
+struct ChangeEntry {
+    space: String,
+    key: Vec<u8>,
+    type_tag: TypeTag,
+    kind: ChangeKind,  // Put | Delete
+}
+```
+
+#### 2.2 Change-Manifest Diff Algorithm
+
+```
+manifest_diff(branch_a, branch_b, merge_base):
+  // Collect all change manifests from merge_base to each branch tip
+  changes_a = collect_changes(branch_a, merge_base.version..branch_a.version)
+  changes_b = collect_changes(branch_b, merge_base.version..branch_b.version)
+
+  // Net changes per branch (last-write-wins within each branch)
+  net_a = deduplicate(changes_a)  // key → final ChangeKind
+  net_b = deduplicate(changes_b)
+
+  // Three-way classification
+  for key in union(net_a.keys(), net_b.keys()):
+    match (net_a.get(key), net_b.get(key)):
+      (Some, None) → source-only change
+      (None, Some) → target-only change
+      (Some, Some) → potential conflict, read values for comparison
+```
+
+**Complexity**: O(C_a + C_b) where C = total change entries since merge base. For branches with thousands of modifications this is efficient; for branches that have diverged for millions of writes, the change manifest itself becomes large.
+
+#### 2.3 Storage Cost
+
+Each change entry is ~50–200 bytes (space string + key bytes + type tag + kind). For a transaction modifying 100 keys, the manifest is ~10–20KB — negligible relative to the data writes themselves.
+
+Manifests are stored as regular KV entries on the `_system_` branch and participate in normal compaction. Old manifests (below the oldest active merge base) can be pruned.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Segment Content Hashing (Tier 1.1 + 1.4)
+
+**Goal**: Enable O(W) COW-aware diff for the parent-child case.
+
+1. **Add content hash to PropertiesBlock**
+   - Extend `SegmentBuilder` to compute BLAKE3 hash during segment build
+   - Extend `PropertiesBlock` with `content_hash: Option<[u8; 32]>` (None for legacy segments)
+   - Bump properties block format version; graceful fallback for old segments
+
+2. **COW-aware diff fast path**
+   - New function `cow_diff()` in `branch_ops.rs`
+   - Detects parent-child relationship via `get_fork_info()`
+   - Scans only child's own segments (excludes inherited layers)
+   - For each entry in child's own segments, point-lookup parent for comparison
+   - Falls back to full scan if no fork relationship found
+
+3. **Wire into existing API**
+   - `diff_branches_with_options()` tries COW fast path first
+   - `three_way_diff()` uses COW fast path for source-vs-ancestor and target-vs-ancestor
+   - Transparent to callers — same `BranchDiffResult` / `ThreeWayDiffResult` types
+
+### Phase 2: Segment-Level Diff (Tier 1.2 + 1.3)
+
+**Goal**: Enable O(S + Δ) diff for branches that have diverged and been compacted.
+
+4. **Build BranchManifest from SegmentVersion**
+   - Extract `ManifestEntry` from each segment's PropertiesBlock
+   - Sort by key_min for L1+ (already non-overlapping)
+   - Handle L0 segments separately (overlapping, must be scanned)
+
+5. **Segment-level diff algorithm**
+   - Walk two manifests in lockstep
+   - Skip segments with matching content hashes
+   - Descend into segments with differing hashes for entry-level diff
+   - Handle key range gaps (bulk additions/removals)
+
+6. **Inherited layer segment identity**
+   - COW-shared segments have the same `SegmentId` and content hash on both branches
+   - After materialization, segments are rebuilt → new IDs, but content hash matches if data unchanged
+
+### Phase 3: Change Manifests (Tier 2)
+
+**Goal**: Enable O(C) diff using explicit change tracking.
+
+7. **Record change manifests on write**
+   - After each write batch commits, record `ChangeManifest` as `_system_` KV entry
+   - Keys: `_system_:changelog:{branch_id}:{version}`
+   - Best-effort (log warning on failure, never block writes)
+
+8. **Change-manifest diff path**
+   - Collect manifests between merge base version and branch tip
+   - Deduplicate to net changes per branch
+   - Three-way classify using net change sets
+   - Fall back to segment diff for pre-manifest data
+
+9. **Manifest pruning**
+   - Prune manifests below the oldest active merge base version
+   - Participate in normal compaction lifecycle
+
+### Phase 4: Streaming and Memory Optimization
+
+10. **Streaming diff iterator**
+    - Replace HashMap-based comparison with streaming merge of sorted iterators
+    - Emit diff entries one at a time instead of materializing entire result
+    - Enables early termination (e.g., `LIMIT` on diff queries)
+
+11. **Segment-level parallel diff**
+    - Independent segments can be diffed in parallel (rayon)
+    - Especially beneficial for L1+ non-overlapping segments
+
+---
+
+## Complexity Comparison
+
+| Scenario | Current | Phase 1 (COW) | Phase 2 (Segment) | Phase 3 (Manifest) |
+|----------|---------|---------------|-------------------|-------------------|
+| Child vs parent, W writes | O(N) | **O(W)** | O(W) | O(W) |
+| Siblings, W writes each | O(N) | O(N) fallback | **O(S + Δ)** | **O(C_a + C_b)** |
+| Diverged branches, heavy compaction | O(N) | O(N) fallback | **O(S + Δ)** | **O(C_a + C_b)** |
+| Unrelated branches | O(N) | O(N) fallback | O(N) worst case | N/A (no merge base) |
+
+Where: N = total entries, W = entries written since fork, S = number of segments, Δ = entries in changed segments, C = change manifest entries.
+
+---
+
+## Why Not Prolly Trees?
+
+Dolt's Prolly Tree approach delivers the theoretical optimum (O(Δ × log N) with history-independent structural sharing). However, it requires **replacing the storage engine's fundamental data structure**. Strata's LSM-based segment architecture is well-suited for high write throughput and the tiered storage project already underway. A Prolly Tree rewrite would:
+
+1. Conflict with the tiered storage project's segment-based design
+2. Sacrifice LSM write amplification advantages for workloads that are write-heavy
+3. Require rewriting compaction, recovery, mmap acceleration, and the entire read path
+
+The segment-hash approach captures ~90% of the benefit (O(S + Δ) vs O(Δ × log N)) with ~10% of the implementation cost, because it builds on the existing segment infrastructure rather than replacing it.
+
+Prolly Trees remain the right choice if Strata ever moves to a content-addressed storage engine. For now, the segment-hash approach is the pragmatic path.
+
+---
+
+## References
+
+- [Efficient Diff on Prolly-Trees (DoltHub, 2020)](https://www.dolthub.com/blog/2020-06-16-efficient-diff-on-prolly-trees/)
+- [Prolly Trees Architecture (DoltHub Docs)](https://docs.dolthub.com/architecture/storage-engine/prolly-tree)
+- [Dolt Diff vs SQLite Diff — O(d) vs O(n) (DoltHub, 2022)](https://www.dolthub.com/blog/2022-06-03-dolt-diff-vs-sqlite-diff/)
+- [Three-Way Merge in a SQL Database (DoltHub, 2024)](https://www.dolthub.com/blog/2024-06-19-threeway-merge/)
+- [Fast Merge via Node-Level Prolly Tree Operations (DoltHub, 2025)](https://www.dolthub.com/blog/2025-07-16-announcing-fast-merge/)
+- [lakeFS Versioning Internals — Graveler Ranges](https://docs.lakefs.io/understand/how/versioning-internals/)
+- [Concrete Graveler: Committing Data to Pebble SSTables (lakeFS, 2023)](https://lakefs.io/blog/concrete-graveler-committing-data-to-pebbledb-sstables/)
+- [Project Nessie Commit Kernel](https://projectnessie.org/develop/kernel/)
+- [TerminusDB Internals: Change is Gonna Come](https://terminusdb.com/blog/terminusdb-internals-2/)
+- [Git Internals — Tree Diff (tree-diff.c)](https://github.com/git/git/blob/master/tree-diff.c)
+- [Git Internals — Merge Base (commit-reach.c)](https://github.com/git/git/blob/master/commit-reach.c)
+- [Merkle-CRDTs: Merkle-DAGs meet CRDTs (arXiv, 2020)](https://arxiv.org/pdf/2004.00107)
+- [Decibel: The Relational Dataset Branching System (VLDB, 2016)](http://www.vldb.org/pvldb/vol9/p624-maddox.pdf)

--- a/tests/integration/branching.rs
+++ b/tests/integration/branching.rs
@@ -1503,3 +1503,99 @@ fn test_issue_1695_fork_disjoint_changes_merge() {
         "child-only change must be applied to parent by merge"
     );
 }
+
+/// COW-aware diff correctness oracle: set up a complex scenario with adds,
+/// modifies, deletes on both parent and child after fork, then verify the
+/// COW fast-path diff produces correct results by checking each entry.
+#[test]
+fn cow_diff_matches_expected_complex() {
+    let test_db = TestDb::new();
+    let branch_index = test_db.branch_index();
+    let kv = test_db.kv();
+
+    // 1. Parent with 5 keys
+    branch_index.create_branch("parent").unwrap();
+    let parent_id = strata_engine::primitives::branch::resolve_branch_name("parent");
+    kv.put(&parent_id, "default", "shared", Value::Int(1))
+        .unwrap();
+    kv.put(&parent_id, "default", "child_mod", Value::Int(2))
+        .unwrap();
+    kv.put(&parent_id, "default", "child_del", Value::Int(3))
+        .unwrap();
+    kv.put(&parent_id, "default", "parent_mod", Value::Int(4))
+        .unwrap();
+    kv.put(&parent_id, "default", "both_mod", Value::Int(5))
+        .unwrap();
+
+    // 2. Fork
+    branch_ops::fork_branch(&test_db.db, "parent", "child").unwrap();
+    let child_id = strata_engine::primitives::branch::resolve_branch_name("child");
+
+    // 3. Child: modify, delete, add
+    kv.put(&child_id, "default", "child_mod", Value::Int(20))
+        .unwrap();
+    kv.delete(&child_id, "default", "child_del").unwrap();
+    kv.put(&child_id, "default", "child_new", Value::Int(100))
+        .unwrap();
+    kv.put(&child_id, "default", "both_mod", Value::Int(50))
+        .unwrap();
+
+    // 4. Parent: modify after fork
+    kv.put(&parent_id, "default", "parent_mod", Value::Int(40))
+        .unwrap();
+    kv.put(&parent_id, "default", "both_mod", Value::Int(55))
+        .unwrap();
+    kv.put(&parent_id, "default", "parent_new", Value::Int(200))
+        .unwrap();
+
+    // 5. Diff parent → child
+    let diff = branch_ops::diff_branches(&test_db.db, "parent", "child").unwrap();
+
+    // Collect into maps for easy assertion
+    let space = diff.spaces.iter().find(|s| s.space == "default").unwrap();
+
+    let added_keys: std::collections::HashSet<&str> =
+        space.added.iter().map(|e| e.key.as_str()).collect();
+    let removed_keys: std::collections::HashSet<&str> =
+        space.removed.iter().map(|e| e.key.as_str()).collect();
+    let modified_keys: std::collections::HashSet<&str> =
+        space.modified.iter().map(|e| e.key.as_str()).collect();
+
+    // child_new: only in child → added
+    assert!(
+        added_keys.contains("child_new"),
+        "child_new should be added"
+    );
+    // parent_new: only in parent → removed (in A=parent, not in B=child)
+    assert!(
+        removed_keys.contains("parent_new"),
+        "parent_new should be removed (in parent, not child)"
+    );
+    // child_del: in parent, deleted in child → removed
+    assert!(
+        removed_keys.contains("child_del"),
+        "child_del should be removed"
+    );
+    // child_mod: different values → modified
+    assert!(
+        modified_keys.contains("child_mod"),
+        "child_mod should be modified"
+    );
+    // parent_mod: parent changed, child has old value → modified
+    assert!(
+        modified_keys.contains("parent_mod"),
+        "parent_mod should be modified"
+    );
+    // both_mod: both changed to different values → modified
+    assert!(
+        modified_keys.contains("both_mod"),
+        "both_mod should be modified"
+    );
+    // shared: unchanged on both sides → NOT in diff
+    assert!(!added_keys.contains("shared"), "shared should not appear");
+    assert!(!removed_keys.contains("shared"), "shared should not appear");
+    assert!(
+        !modified_keys.contains("shared"),
+        "shared should not appear"
+    );
+}


### PR DESCRIPTION
## Summary

- **O(W) diff for forked branches**: When one branch is a direct COW child of the other, diff now scans only the child's own entries + parent's post-fork writes, then point-lookups both branches for classification. Falls back to O(N) full scan for unrelated branches, `as_of` queries, or materialized layers.
- **New storage primitive**: `list_own_entries()` scans a branch's own memtable + frozen + segments excluding inherited layers, preserving tombstones for deletion detection.
- **Design document**: `docs/design/branching/efficient-diff.md` covers prior art (Dolt prolly trees, lakeFS graveler ranges, Nessie change manifests, git Merkle trees) and a 3-phase roadmap.

## Changes

| Layer | File | What |
|-------|------|------|
| Storage | `segmented/mod.rs` | `OwnEntry` struct, `list_own_entries()` method |
| Engine | `branch_ops.rs` | `cow_diff_branches()` fast path, early detection in `diff_branches_with_options()` |
| Tests | `tests/fork.rs` | 4 storage tests (excludes inherited, tombstones, version filter, MVCC dedup) |
| Tests | `branch_ops.rs` | 13 engine tests (adds, modifies, deletes, directionality, filters, fallback, edge cases) |
| Tests | `branching.rs` | 1 integration test (complex multi-operation correctness oracle) |
| Design | `efficient-diff.md` | Prior art research + phased implementation plan |

## Test plan

- [x] 4 storage-level tests for `list_own_entries` correctness
- [x] 13 engine-level tests covering all COW diff edge cases
- [x] 1 integration test with complex add/modify/delete scenario on both branches
- [x] All 16 pre-existing diff tests pass unchanged (full-scan path unaffected)
- [x] Full suite: 4,846 tests pass, 0 failures
- [x] `cargo clippy --all` clean, `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)