### PR TITLE
Fix #1914: Executor event append reads meta for OCC conflict detection

### DIFF
--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -2037,3 +2037,114 @@ fn test_issue_1733_tombstone_no_duplicate_after_recovery() {
         );
     }
 }
+
+// ========================================================================
+// Issue #1914: Executor event append bypasses OCC — hash chain corruption
+// ========================================================================
+
+/// Two concurrent transactions both appending events to the same branch
+/// must conflict at commit time. Before the fix, the meta_key was never
+/// read, so OCC validation had no read-set entry to detect the conflict.
+#[test]
+fn test_issue_1914_concurrent_event_append_occ_conflict() {
+    use crate::transaction::Transaction;
+    use crate::transaction_ops::TransactionOps;
+
+    let temp_dir = TempDir::new().unwrap();
+    let db = Database::open(temp_dir.path().join("db")).unwrap();
+    let branch_id = BranchId::new();
+
+    let ns = Arc::new(Namespace::for_branch(branch_id));
+
+    // Begin two transactions on the same branch at the same snapshot
+    let mut txn1 = db.begin_transaction(branch_id).unwrap();
+    let mut txn2 = db.begin_transaction(branch_id).unwrap();
+
+    // Both append an event using the Transaction wrapper (executor path)
+    {
+        let mut t1 = Transaction::new(&mut txn1, ns.clone());
+        t1.event_append("test_event", Value::String("from_t1".into()))
+            .unwrap();
+    }
+    {
+        let mut t2 = Transaction::new(&mut txn2, ns.clone());
+        t2.event_append("test_event", Value::String("from_t2".into()))
+            .unwrap();
+    }
+
+    // Commit T1 — should succeed
+    db.commit_transaction(&mut txn1).unwrap();
+    db.end_transaction(txn1);
+
+    // Commit T2 — MUST fail with a conflict.
+    // Both wrote to meta_key (event log metadata). If meta_key is in both
+    // read_sets, OCC detects that T1 modified it after T2's snapshot.
+    // Before the fix: both commit succeeds → duplicate sequence 0,
+    // corrupted hash chain.
+    let result = db.commit_transaction(&mut txn2);
+    db.end_transaction(txn2);
+
+    assert!(
+        result.is_err(),
+        "T2 must conflict: both transactions appended to the same event log \
+         but OCC did not detect the conflict because meta_key was never read"
+    );
+}
+
+/// Verify that after the fix, sequential event appends produce correct
+/// sequence numbers sourced from persisted metadata, not ephemeral defaults.
+#[test]
+fn test_issue_1914_sequence_from_persisted_meta() {
+    use crate::transaction::Transaction;
+    use crate::transaction_ops::TransactionOps;
+
+    let temp_dir = TempDir::new().unwrap();
+    let db = Database::open(temp_dir.path().join("db")).unwrap();
+    let branch_id = BranchId::new();
+
+    let ns = Arc::new(Namespace::for_branch(branch_id));
+
+    // First transaction: append event at sequence 0
+    let mut txn1 = db.begin_transaction(branch_id).unwrap();
+    {
+        let mut t = Transaction::new(&mut txn1, ns.clone());
+        let v = t
+            .event_append("evt", Value::String("first".into()))
+            .unwrap();
+        assert_eq!(v, strata_core::Version::seq(0));
+    }
+    db.commit_transaction(&mut txn1).unwrap();
+    db.end_transaction(txn1);
+
+    // Second transaction: should continue at sequence 1 (from persisted meta)
+    let mut txn2 = db.begin_transaction(branch_id).unwrap();
+    {
+        let mut t = Transaction::new(&mut txn2, ns.clone());
+        let v = t
+            .event_append("evt", Value::String("second".into()))
+            .unwrap();
+        // Before fix: base_sequence comes from ctx.event_sequence_count()
+        // which defaults to 0 → duplicate sequence 0.
+        // After fix: reads persisted meta.next_sequence = 1.
+        assert_eq!(
+            v,
+            strata_core::Version::seq(1),
+            "Second append must use sequence 1 from persisted meta, not 0"
+        );
+    }
+    db.commit_transaction(&mut txn2).unwrap();
+    db.end_transaction(txn2);
+
+    // Verify the hash chain: event 1's prev_hash must equal event 0's hash
+    let mut txn3 = db.begin_transaction(branch_id).unwrap();
+    {
+        let mut t = Transaction::new(&mut txn3, ns.clone());
+        let e0 = t.event_get(0).unwrap().expect("event 0 must exist");
+        let e1 = t.event_get(1).unwrap().expect("event 1 must exist");
+        assert_eq!(
+            e1.value.prev_hash, e0.value.hash,
+            "event 1's prev_hash must chain from event 0's hash"
+        );
+    }
+    db.end_transaction(txn3);
+}

--- a/crates/engine/src/transaction/context.rs
+++ b/crates/engine/src/transaction/context.rs
@@ -205,6 +205,24 @@ impl<'a> TransactionOps for Transaction<'a> {
     // =========================================================================
 
     fn event_append(&mut self, event_type: &str, payload: Value) -> Result<Version, StrataError> {
+        // Read persisted meta BEFORE writing — adds meta_key to the read_set
+        // so OCC detects concurrent appends (#1914).
+        // ctx.get() checks write_set first (our prior appends), then snapshot.
+        let meta_key = Key::new_event_meta(self.namespace.clone());
+        let persisted_meta: EventLogMeta = match self.ctx.get(&meta_key)? {
+            Some(Value::String(s)) => {
+                serde_json::from_str(&s).unwrap_or_else(|_| EventLogMeta::default())
+            }
+            _ => EventLogMeta::default(),
+        };
+
+        // On first append in this Transaction instance, initialize from
+        // persisted state instead of ephemeral defaults.
+        if self.pending_events.is_empty() {
+            self.base_sequence = persisted_meta.next_sequence;
+            self.last_hash = persisted_meta.head_hash;
+        }
+
         let sequence = self.next_sequence();
         let timestamp = Timestamp::now();
         let prev_hash = self.last_hash;
@@ -232,13 +250,31 @@ impl<'a> TransactionOps for Transaction<'a> {
         })?;
         self.ctx.put(event_key, Value::String(event_json))?;
 
-        // Write EventLogMeta so EventLog::len() and other readers see the update after commit
-        let meta_key = Key::new_event_meta(self.namespace.clone());
+        // Write EventLogMeta — preserve streams from persisted meta (#1914)
+        let mut streams = persisted_meta.streams;
+        let ts_micros = timestamp.as_micros();
+        if let Some(sm) = streams.get_mut(event_type) {
+            sm.count += 1;
+            sm.last_sequence = sequence;
+            sm.last_timestamp = ts_micros;
+        } else {
+            streams.insert(
+                event_type.to_string(),
+                crate::primitives::event::StreamMeta {
+                    count: 1,
+                    first_sequence: sequence,
+                    last_sequence: sequence,
+                    first_timestamp: ts_micros,
+                    last_timestamp: ts_micros,
+                },
+            );
+        }
+
         let meta = EventLogMeta {
             next_sequence: sequence + 1,
             head_hash: event.hash,
             hash_version: HASH_VERSION_SHA256,
-            streams: Default::default(),
+            streams,
         };
         let meta_json = serde_json::to_string(&meta).map_err(|e| StrataError::Serialization {
             message: e.to_string(),
@@ -621,11 +657,34 @@ mod tests {
 
     #[test]
     fn test_event_with_base_sequence() {
-        let ns = create_test_namespace();
-        let mut ctx = create_test_context(&ns);
+        use strata_core::traits::Storage;
+        use strata_core::WriteMode;
 
-        // Create transaction with existing events (simulating snapshot)
+        let ns = create_test_namespace();
+        let store = Arc::new(SegmentedStore::new());
+
+        // Pre-populate event meta in the store to simulate 100 existing events
         let last_hash = [42u8; 32];
+        let meta = EventLogMeta {
+            next_sequence: 100,
+            head_hash: last_hash,
+            hash_version: HASH_VERSION_SHA256,
+            streams: Default::default(),
+        };
+        let meta_json = serde_json::to_string(&meta).unwrap();
+        let meta_key = Key::new_event_meta(ns.clone());
+        let version = store.next_version();
+        store
+            .put_with_version_mode(
+                meta_key,
+                Value::String(meta_json),
+                version,
+                None,
+                WriteMode::Append,
+            )
+            .unwrap();
+
+        let mut ctx = TransactionContext::with_store(2, ns.branch_id, store);
         let mut txn = Transaction::with_base_sequence(&mut ctx, ns.clone(), 100, last_hash);
 
         // New events should continue from base


### PR DESCRIPTION
## Summary

- **Root Cause**: `Transaction::event_append()` wrote event metadata (sequence, hash, streams) via `ctx.put()` without first reading it via `ctx.get()`. The meta_key never entered the OCC read_set, so concurrent appends were treated as non-conflicting blind writes.
- **Impact**: Two concurrent transactions could both assign sequence 0, corrupting the hash chain. The `streams` field was also discarded on every append (`Default::default()`).
- **Fix**: Read persisted meta via `ctx.get(meta_key)` before writing. Initialize sequence/hash from persisted state on first append. Preserve and update stream metadata.

## Root Cause

The executor routes `Command::EventAppend` through `Transaction::event_append()` (context.rs), which:
1. Seeds `base_sequence` from ephemeral `ctx.event_sequence_count()` (defaults to 0)
2. Writes meta_key without reading it — meta_key never in read_set
3. OCC validation sees no read conflicts → both transactions commit

The safe path (`EventLogExt` in event.rs) correctly reads meta first via `self.get(&meta_key)?`.

## Fix

- `event_append()` now calls `self.ctx.get(&meta_key)?` before writing (adds to read_set)
- On first append in a Transaction instance, initializes `base_sequence` and `last_hash` from persisted `EventLogMeta`
- Preserves and updates `streams` from persisted meta instead of discarding

## Invariants Verified

- **ACID-003**: Meta_key in read_set → OCC detects conflicts under per-branch lock
- **ACID-004**: Event appends correctly transition from blind writes to read-write transactions
- **ARCH-001**: Event meta still stored as standard KV entry with Txn commit_version
- **ARCH-002**: All writes still share single commit_version within transaction

## Test Plan

- [x] `test_issue_1914_concurrent_event_append_occ_conflict` — two concurrent appends → second must conflict
- [x] `test_issue_1914_sequence_from_persisted_meta` — sequential appends use correct sequence + hash chain verified
- [x] Updated `test_event_with_base_sequence` — pre-populates store to match explicit state
- [x] Full engine crate suite: 621 passed, 0 failed
- [x] Full workspace suite: all passed
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)