### PR TITLE
Fix #1915: Record JSON missing-doc reads for OCC conflict detection

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -2832,4 +2832,156 @@ mod tests {
         manager.mark_version_applied(v3);
         assert_eq!(manager.visible_version(), v3);
     }
+
+    /// Issue #1915: json_exists(), json_get(), and json_set() don't record reads
+    /// for non-existent documents, making OCC blind to create-if-absent races.
+    ///
+    /// Scenario: T1 and T2 both call json_exists() → false, then json_set() to
+    /// create the doc. Both should record snapshot_version=0 for the missing doc.
+    /// T1 commits first (creating the doc). T2's commit must detect the conflict
+    /// because the doc now exists (version > 0) but T2 recorded version 0.
+    #[test]
+    fn test_issue_1915_json_missing_doc_read_invisible_to_occ() {
+        use strata_core::primitives::json::JsonPath;
+
+        let store = Arc::new(SegmentedStore::new());
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let json_key = Key::new_json(ns.clone(), "unique_doc");
+
+        // T1: check existence → false, then set the document
+        let mut txn1 = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        let exists1 = txn1.json_exists(&json_key).unwrap();
+        assert!(!exists1, "doc should not exist yet");
+
+        // T1 creates the document via json_set at root
+        let doc = serde_json::json!({"from": "txn1"});
+        txn1.json_set(&json_key, &JsonPath::root(), doc.into())
+            .unwrap();
+
+        // T2: also check existence → false, then set the document
+        let mut txn2 = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        let exists2 = txn2.json_exists(&json_key).unwrap();
+        assert!(!exists2, "doc should not exist yet for T2 either");
+
+        let doc2 = serde_json::json!({"from": "txn2"});
+        txn2.json_set(&json_key, &JsonPath::root(), doc2.into())
+            .unwrap();
+
+        // T1 commits first — should succeed
+        let v1 = manager.commit(&mut txn1, store.as_ref(), None);
+        assert!(v1.is_ok(), "T1 commit should succeed: {:?}", v1.err());
+
+        // T2 commits second — MUST fail with conflict because the doc now exists
+        // but T2 observed it as missing (snapshot_version=0, current_version > 0)
+        let v2 = manager.commit(&mut txn2, store.as_ref(), None);
+        assert!(
+            v2.is_err(),
+            "T2 commit must fail: json_exists() saw missing doc but T1 created it"
+        );
+    }
+
+    /// Issue #1915: json_get() for a non-existent document must record
+    /// snapshot_version=0 so that a concurrent create is detected.
+    #[test]
+    fn test_issue_1915_json_get_missing_doc_records_read() {
+        use strata_core::primitives::json::JsonPath;
+
+        let store = Arc::new(SegmentedStore::new());
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let json_key = Key::new_json(ns.clone(), "phantom_doc");
+
+        // T1: json_get on non-existent doc → None, then write something
+        let mut txn1 = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        let result = txn1.json_get(&json_key, &JsonPath::root()).unwrap();
+        assert!(result.is_none(), "doc should not exist");
+
+        // T1 creates the doc
+        let doc = serde_json::json!({"data": 1});
+        txn1.json_set(&json_key, &JsonPath::root(), doc.into())
+            .unwrap();
+
+        // T2: also json_get on non-existent doc → None, then create
+        let mut txn2 = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        let result2 = txn2.json_get(&json_key, &JsonPath::root()).unwrap();
+        assert!(result2.is_none(), "doc should not exist for T2");
+
+        let doc2 = serde_json::json!({"data": 2});
+        txn2.json_set(&json_key, &JsonPath::root(), doc2.into())
+            .unwrap();
+
+        // T1 commits
+        let v1 = manager.commit(&mut txn1, store.as_ref(), None);
+        assert!(v1.is_ok(), "T1 commit should succeed");
+
+        // T2 must fail — json_get saw doc as absent, but T1 created it
+        let v2 = manager.commit(&mut txn2, store.as_ref(), None);
+        assert!(
+            v2.is_err(),
+            "T2 commit must fail: json_get() saw missing doc but T1 created it"
+        );
+    }
+
+    /// Issue #1915: json_set() on a non-existent document must record
+    /// snapshot_version=0 so that concurrent creation is detected.
+    #[test]
+    fn test_issue_1915_json_set_missing_doc_records_read() {
+        use strata_core::primitives::json::JsonPath;
+
+        let store = Arc::new(SegmentedStore::new());
+        let manager = TransactionManager::new(0);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let json_key = Key::new_json(ns.clone(), "set_race_doc");
+
+        // T1: json_set on a non-existent doc (blind create)
+        let mut txn1 = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        let doc = serde_json::json!({"from": "txn1"});
+        txn1.json_set(&json_key, &JsonPath::root(), doc.into())
+            .unwrap();
+
+        // T2: also json_set on the same non-existent doc
+        let mut txn2 = TransactionContext::with_store(
+            manager.next_txn_id().unwrap(),
+            branch_id,
+            Arc::clone(&store),
+        );
+        let doc2 = serde_json::json!({"from": "txn2"});
+        txn2.json_set(&json_key, &JsonPath::root(), doc2.into())
+            .unwrap();
+
+        // T1 commits first
+        let v1 = manager.commit(&mut txn1, store.as_ref(), None);
+        assert!(v1.is_ok(), "T1 commit should succeed");
+
+        // T2 must fail — both read the doc as absent and tried to create it
+        let v2 = manager.commit(&mut txn2, store.as_ref(), None);
+        assert!(
+            v2.is_err(),
+            "T2 commit must fail: json_set() on missing doc but T1 created it"
+        );
+    }
 }

--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -1886,7 +1886,9 @@ impl JsonStoreExt for TransactionContext {
         // Get the document from store (bounded by start_version)
         let versioned = store.get_versioned(key, self.start_version)?;
         let Some(vv) = versioned else {
-            // Document doesn't exist
+            // Document doesn't exist — record version 0 so OCC detects
+            // concurrent creation (mirrors KV get() behavior for missing keys)
+            self.record_json_snapshot_version(key.clone(), 0);
             return Ok(None);
         };
 
@@ -1925,8 +1927,14 @@ impl JsonStoreExt for TransactionContext {
         {
             // Try to get the document version from store
             if let Some(store) = &self.store {
-                if let Ok(Some(vv)) = store.get_versioned(key, self.start_version) {
-                    self.record_json_snapshot_version(key.clone(), vv.version.as_u64());
+                match store.get_versioned(key, self.start_version) {
+                    Ok(Some(vv)) => {
+                        self.record_json_snapshot_version(key.clone(), vv.version.as_u64());
+                    }
+                    Ok(None) => {
+                        self.record_json_snapshot_version(key.clone(), 0);
+                    }
+                    Err(_) => {}
                 }
             }
         }
@@ -1949,8 +1957,14 @@ impl JsonStoreExt for TransactionContext {
             .map_or(true, |v| !v.contains_key(key))
         {
             if let Some(store) = &self.store {
-                if let Ok(Some(vv)) = store.get_versioned(key, self.start_version) {
-                    self.record_json_snapshot_version(key.clone(), vv.version.as_u64());
+                match store.get_versioned(key, self.start_version) {
+                    Ok(Some(vv)) => {
+                        self.record_json_snapshot_version(key.clone(), vv.version.as_u64());
+                    }
+                    Ok(None) => {
+                        self.record_json_snapshot_version(key.clone(), 0);
+                    }
+                    Err(_) => {}
                 }
             }
         }
@@ -1999,7 +2013,16 @@ impl JsonStoreExt for TransactionContext {
             StrataError::invalid_input("Transaction has no store for reads".to_string())
         })?;
 
-        Ok(store.get_versioned(key, self.start_version)?.is_some())
+        match store.get_versioned(key, self.start_version)? {
+            Some(vv) => {
+                self.record_json_snapshot_version(key.clone(), vv.version.as_u64());
+                Ok(true)
+            }
+            None => {
+                self.record_json_snapshot_version(key.clone(), 0);
+                Ok(false)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- `json_get()`, `json_exists()`, `json_set()`, and `json_delete()` failed to record `snapshot_version=0` when a JSON document didn't exist, leaving OCC validation blind to concurrent create-if-absent races
- Now records version 0 for missing documents, mirroring the KV layer's `read_set.insert(key, 0)` pattern
- The existing `validate_json_set()` validator already handles version 0 correctly — no changes needed there

## Root Cause

The JSON layer omitted read tracking for the "document doesn't exist" case in four functions, while the KV layer correctly handled this at `transaction.rs:673`. Two concurrent transactions could both observe a document as absent, both create it, and both commit successfully — violating uniqueness guarantees.

## Fix

Four changes in `crates/concurrency/src/transaction.rs` (~25 lines of non-test code):

1. **`json_get()`**: Call `record_json_snapshot_version(key, 0)` before returning `None` for missing docs
2. **`json_exists()`**: Record version for both existing (`vv.version`) and missing (`0`) docs from store
3. **`json_set()`**: Add `Ok(None)` arm to record version 0 when doc doesn't exist
4. **`json_delete()`**: Same as `json_set()`

## Invariants Verified

- **ACID-003**: Per-branch lock scope unchanged; validation now correctly has data
- **ACID-004**: Blind-write classification unchanged; `json_set` always had writes
- **MVCC-001**: Version-bounded reads unchanged; only metadata tracking added
- **ARCH-002**: Write path and atomicity unchanged

## Test Plan

- [x] `test_issue_1915_json_missing_doc_read_invisible_to_occ` — concurrent `json_exists()` + `json_set()` race
- [x] `test_issue_1915_json_get_missing_doc_records_read` — concurrent `json_get()` + `json_set()` race
- [x] `test_issue_1915_json_set_missing_doc_records_read` — concurrent `json_set()` race (both on missing doc)
- [x] All 3 tests confirmed failing before fix, passing after
- [x] Full `strata-concurrency` suite: 123 passed
- [x] Full workspace suite: 4,546 passed, 0 failed
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)