### PR TITLE
Fix #1916: Quiesce target branch before deletion to prevent data resurrection

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -29,7 +29,7 @@
 
 use crate::payload::TransactionPayload;
 use crate::{CommitError, TransactionContext, TransactionStatus};
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use parking_lot::{Mutex, RwLock};
 use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -108,6 +108,13 @@ pub struct TransactionManager {
     /// `mark_version_applied(V)` is called, V is removed and `visible_version`
     /// is advanced if the contiguous applied prefix grew.
     pending_versions: Mutex<BTreeSet<u64>>,
+
+    /// Branches currently being deleted (#1916).
+    ///
+    /// Commit paths check this set after acquiring the per-branch lock and
+    /// reject commits on branches that are mid-deletion. This prevents
+    /// concurrent commits from resurrecting data on a deleted branch.
+    deleting_branches: DashSet<BranchId>,
 }
 
 impl TransactionManager {
@@ -136,6 +143,7 @@ impl TransactionManager {
             commit_quiesce: RwLock::new(()),
             visible_version: AtomicU64::new(initial_version),
             pending_versions: Mutex::new(BTreeSet::new()),
+            deleting_branches: DashSet::new(),
         }
     }
 
@@ -338,6 +346,11 @@ impl TransactionManager {
             .clone(); // clone Arc, drop RefMut → releases shard lock (#1781)
         let _commit_guard = commit_mutex.lock();
 
+        // Reject commits on branches that are mid-deletion (#1916).
+        if self.deleting_branches.contains(&txn.branch_id) {
+            return Err(CommitError::BranchDeleting(txn.branch_id));
+        }
+
         // Skip OCC validation for blind writes (no reads, no CAS, no JSON snapshots)
         let can_skip_validation = txn.read_set.is_empty()
             && txn.cas_set.is_empty()
@@ -492,6 +505,11 @@ impl TransactionManager {
             .clone(); // clone Arc, drop RefMut → releases shard lock (#1781)
         let _commit_guard = commit_mutex.lock();
 
+        // Reject commits on branches that are mid-deletion (#1916).
+        if self.deleting_branches.contains(&txn.branch_id) {
+            return Err(CommitError::BranchDeleting(txn.branch_id));
+        }
+
         // Skip OCC validation for blind writes (no reads, no CAS, no JSON snapshots)
         let can_skip_validation = txn.read_set.is_empty()
             && txn.cas_set.is_empty()
@@ -627,6 +645,31 @@ impl TransactionManager {
         true
     }
 
+    /// Mark a branch as being deleted (#1916).
+    ///
+    /// Subsequent commits on this branch will be rejected with
+    /// `CommitError::BranchDeleting` after they acquire the per-branch lock.
+    pub fn mark_branch_deleting(&self, branch_id: &BranchId) {
+        self.deleting_branches.insert(*branch_id);
+    }
+
+    /// Remove the deleting mark for a branch (#1916).
+    pub fn unmark_branch_deleting(&self, branch_id: &BranchId) {
+        self.deleting_branches.remove(branch_id);
+    }
+
+    /// Clone the `Arc<Mutex<()>>` for a branch's commit lock (#1916).
+    ///
+    /// The caller can lock this to serialize with (and drain) in-flight
+    /// commits on the branch. Used by `delete_branch` to ensure no commit
+    /// is mid-apply before scanning and deleting branch data.
+    pub fn branch_commit_lock(&self, branch_id: &BranchId) -> Arc<Mutex<()>> {
+        self.commit_locks
+            .entry(*branch_id)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
     /// Advance the version counter to at least `v`.
     ///
     /// Used during multi-process refresh to ensure the local version counter
@@ -685,6 +728,11 @@ impl TransactionManager {
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone(); // clone Arc, drop RefMut → releases shard lock (#1781)
         let _commit_guard = commit_mutex.lock();
+
+        // Reject commits on branches that are mid-deletion (#1916).
+        if self.deleting_branches.contains(&txn.branch_id) {
+            return Err(CommitError::BranchDeleting(txn.branch_id));
+        }
 
         // Skip OCC validation for blind writes (no reads, no CAS, no JSON snapshots)
         let can_skip_validation = txn.read_set.is_empty()

--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -57,6 +57,12 @@ pub enum CommitError {
     /// on restart, but it is NOT visible to reads in the current process.
     /// The caller must not assume the data is immediately readable.
     DurableButNotVisible(String),
+
+    /// Branch is being deleted (#1916)
+    ///
+    /// The target branch has been marked for deletion. Commits are rejected
+    /// to prevent data resurrection on a deleted branch.
+    BranchDeleting(strata_core::types::BranchId),
 }
 
 impl std::fmt::Display for CommitError {
@@ -75,6 +81,9 @@ impl std::fmt::Display for CommitError {
                     "Durable but not visible (will recover on restart): {}",
                     msg
                 )
+            }
+            CommitError::BranchDeleting(branch_id) => {
+                write!(f, "Branch {} is being deleted", branch_id)
             }
         }
     }
@@ -104,6 +113,9 @@ impl From<CommitError> for StrataError {
             CommitError::DurableButNotVisible(msg) => StrataError::Storage {
                 message: format!("Durable but not visible (will recover on restart): {}", msg),
                 source: None,
+            },
+            CommitError::BranchDeleting(branch_id) => StrataError::TransactionAborted {
+                reason: format!("Branch {} is being deleted", branch_id),
             },
         }
     }

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -382,6 +382,28 @@ impl TransactionCoordinator {
         self.manager.remove_branch_lock(branch_id)
     }
 
+    /// Mark a branch as being deleted (#1916).
+    ///
+    /// Subsequent commits on this branch will be rejected.
+    pub fn mark_branch_deleting(&self, branch_id: &BranchId) {
+        self.manager.mark_branch_deleting(branch_id);
+    }
+
+    /// Remove the deleting mark for a branch (#1916).
+    pub fn unmark_branch_deleting(&self, branch_id: &BranchId) {
+        self.manager.unmark_branch_deleting(branch_id);
+    }
+
+    /// Get the commit lock Arc for a branch (#1916).
+    ///
+    /// Callers can lock this to serialize with in-flight commits.
+    pub fn branch_commit_lock(
+        &self,
+        branch_id: &BranchId,
+    ) -> std::sync::Arc<parking_lot::Mutex<()>> {
+        self.manager.branch_commit_lock(branch_id)
+    }
+
     /// Advance the version counter to at least `v`.
     ///
     /// Used during multi-process refresh to catch up with other processes.

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -373,6 +373,29 @@ impl Database {
         self.storage.clear_branch(branch_id);
     }
 
+    /// Mark a branch as being deleted (#1916).
+    ///
+    /// Blocks future commits on this branch. The caller must also acquire
+    /// `branch_commit_lock()` to drain in-flight commits.
+    pub fn mark_branch_deleting(&self, branch_id: &BranchId) {
+        self.coordinator.mark_branch_deleting(branch_id);
+    }
+
+    /// Remove the deleting mark for a branch (#1916).
+    pub fn unmark_branch_deleting(&self, branch_id: &BranchId) {
+        self.coordinator.unmark_branch_deleting(branch_id);
+    }
+
+    /// Get the commit lock Arc for a branch (#1916).
+    ///
+    /// Locking this serializes with in-flight commits on the branch.
+    pub fn branch_commit_lock(
+        &self,
+        branch_id: &BranchId,
+    ) -> std::sync::Arc<parking_lot::Mutex<()>> {
+        self.coordinator.branch_commit_lock(branch_id)
+    }
+
     /// Set subsystems for this database (called by DatabaseBuilder).
     pub(crate) fn set_subsystems(&self, subsystems: Vec<Box<dyn crate::recovery::Subsystem>>) {
         *self.subsystems.write() = subsystems;

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -316,11 +316,26 @@ impl BranchIndex {
 
         let meta_key = self.key_for(branch_id);
 
-        // Single atomic transaction for all delete operations (#974).
-        // Deletes branch data from all namespaces + metadata entry.
-        // Cross-branch access is safe here: the branch is being deleted,
-        // so no concurrent user transactions should target it (#1709).
-        self.db.transaction(global_branch_id(), |txn| {
+        // --- #1916: Quiesce the target branch before deletion ---
+        //
+        // 1. Mark as deleting → future commits on this branch are rejected.
+        // 2. Acquire the target branch's commit lock → waits for any
+        //    in-flight commit to finish.  While we hold the lock no new
+        //    commit can start (the mark rejects them after they acquire
+        //    the lock, so the lock is released immediately).
+        // 3. Run the delete transaction (on global_branch_id, cross-branch).
+        // 4. Clear storage.
+        // 5. Clean up the mark and commit lock entry.
+        self.db.mark_branch_deleting(&executor_branch_id);
+        if let Some(meta_id) = metadata_branch_id {
+            if meta_id != executor_branch_id {
+                self.db.mark_branch_deleting(&meta_id);
+            }
+        }
+        let target_lock = self.db.branch_commit_lock(&executor_branch_id);
+        let _target_guard = target_lock.lock();
+
+        let result = self.db.transaction(global_branch_id(), |txn| {
             txn.set_allow_cross_branch(true);
             // Delete data from the executor's namespace
             Self::delete_namespace_data(txn, executor_branch_id)?;
@@ -337,12 +352,29 @@ impl BranchIndex {
 
             info!(target: "strata::branch", %branch_id, "Branch deleted");
             Ok(())
-        })?;
+        });
+
+        if let Err(e) = result {
+            // Roll back the deleting mark on failure so the branch
+            // remains usable.
+            self.db.unmark_branch_deleting(&executor_branch_id);
+            if let Some(meta_id) = metadata_branch_id {
+                if meta_id != executor_branch_id {
+                    self.db.unmark_branch_deleting(&meta_id);
+                }
+            }
+            return Err(e);
+        }
 
         // Clean up storage-layer segments, manifest, and refcounts (#1702).
         // Must happen after logical deletion so in-progress reads see the
         // deletion before files disappear.
         self.db.clear_branch_storage(&executor_branch_id);
+
+        // Remove commit lock entry. The deleting mark is intentionally
+        // kept: any pre-existing transaction that tries to commit on
+        // this branch after deletion will be rejected (#1916).
+        self.db.remove_branch_lock(&executor_branch_id);
 
         Ok(())
     }
@@ -494,5 +526,113 @@ mod tests {
     #[test]
     fn test_branch_status_as_str() {
         assert_eq!(BranchStatus::Active.as_str(), "Active");
+    }
+
+    /// #1916: Concurrent commit on target branch must not resurrect data
+    /// after delete_branch() completes.
+    ///
+    /// Scenario: T1 starts a transaction on branch "victim", then T2
+    /// deletes "victim". If T1 commits after T2 finishes, T1's writes
+    /// must be rejected — otherwise data is resurrected on a deleted branch.
+    #[test]
+    fn test_issue_1916_delete_branch_rejects_concurrent_commit() {
+        let (_temp, db, ri) = setup();
+
+        // 1. Create the target branch and write initial data
+        ri.create_branch("victim").unwrap();
+        let branch_id = resolve_branch_name("victim");
+        let ns = Arc::new(Namespace::for_branch(branch_id));
+        let key_a = Key::new(ns.clone(), TypeTag::KV, b"key_a".to_vec());
+
+        db.transaction(branch_id, |txn| {
+            txn.put(key_a.clone(), Value::from("initial"))?;
+            Ok(())
+        })
+        .unwrap();
+
+        // 2. Start a transaction on the target branch (don't commit yet)
+        let mut inflight_txn = db.begin_transaction(branch_id).unwrap();
+        let key_b = Key::new(ns.clone(), TypeTag::KV, b"key_b".to_vec());
+        inflight_txn
+            .put(key_b.clone(), Value::from("resurrected"))
+            .unwrap();
+
+        // 3. Delete the branch (should mark as deleting, drain, then delete)
+        ri.delete_branch("victim").unwrap();
+
+        // 4. The in-flight transaction's commit must fail
+        let commit_result = db.commit_transaction(&mut inflight_txn);
+        db.end_transaction(inflight_txn);
+
+        assert!(
+            commit_result.is_err(),
+            "Commit on a deleted branch must be rejected, but it succeeded"
+        );
+
+        // 5. Verify no data leaked — branch should not exist
+        assert!(!ri.exists("victim").unwrap());
+    }
+
+    /// #1916: Stress test — concurrent writers vs delete_branch.
+    #[test]
+    fn test_issue_1916_delete_branch_concurrent_stress() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        let (_temp, db, ri) = setup();
+
+        ri.create_branch("stress-victim").unwrap();
+        let branch_id = resolve_branch_name("stress-victim");
+        let ns = Arc::new(Namespace::for_branch(branch_id));
+
+        // Seed initial data
+        db.transaction(branch_id, |txn| {
+            for i in 0..10 {
+                let key = Key::new(ns.clone(), TypeTag::KV, format!("k{i}").into_bytes());
+                txn.put(key, Value::Int(i))?;
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        let barrier = Arc::new(Barrier::new(6)); // 5 writers + 1 deleter
+        let db = Arc::new(db);
+        let ri = Arc::new(ri);
+
+        // Spawn 5 writer threads
+        let mut handles = Vec::new();
+        for t in 0..5u32 {
+            let db = Arc::clone(&db);
+            let ns = ns.clone();
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                let key = Key::new(ns, TypeTag::KV, format!("writer-{t}").into_bytes());
+                // This may succeed or fail — either is acceptable.
+                // What matters is that after delete completes, no data remains.
+                let _ = db.transaction(branch_id, |txn| {
+                    txn.put(key.clone(), Value::Int(t as i64))?;
+                    Ok(())
+                });
+            }));
+        }
+
+        // Spawn deleter thread
+        let ri_del = Arc::clone(&ri);
+        let barrier_del = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            barrier_del.wait();
+            ri_del.delete_branch("stress-victim").unwrap();
+        }));
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // After deletion completes, branch must not exist
+        assert!(
+            !ri.exists("stress-victim").unwrap(),
+            "Branch must not exist after delete_branch completes"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `delete_branch()` used `global_branch_id()` for its transaction, so the per-branch commit lock only covered the global branch — not the target branch being deleted
- Concurrent commits on the target branch could interleave with the delete, resurrecting data on a "deleted" branch
- Fix adds a `deleting_branches` DashSet to `TransactionManager` — all three commit paths check it after acquiring the per-branch lock and reject commits on branches mid-deletion
- `delete_branch()` now marks the target branch as deleting, acquires the target's commit lock (draining in-flight commits), then runs the delete transaction

## Root Cause

The cross-branch transaction pattern (`global_branch_id()` + `allow_cross_branch = true`) meant the commit lock serialization only covered `global_branch_id`. The target branch's commit lock was never held, allowing concurrent commits to write data that survived deletion.

## Fix

~30 lines of non-test code across 4 files:

1. **`TransactionManager`**: Added `deleting_branches: DashSet<BranchId>` + `mark_branch_deleting()`/`unmark_branch_deleting()`/`branch_commit_lock()` methods
2. **All 3 commit methods** (`commit`, `commit_with_wal_arc`, `commit_with_version`): Check `deleting_branches` after acquiring per-branch lock → return `CommitError::BranchDeleting`
3. **`CommitError`**: New `BranchDeleting(BranchId)` variant with `Display` and `From<CommitError> for StrataError`
4. **`delete_branch()`**: Mark target as deleting → acquire target commit lock → delete → clear storage → cleanup. Error path rolls back the deleting mark.

## Invariants Verified

- **ACID-003**: Per-branch lock still held continuously from validation through apply for non-rejected commits
- **ACID-004**: Blind writes also rejected on deleting branches (correct — no version allocated, no state leaked)
- **MVCC-003**: No version consumed for rejected commits (check fires before `allocate_version`)
- **MVCC-005**: `handle_commit_result` calls `record_abort` → `active_count` decremented → GC not pinned
- **ARCH-002**: Rejected transactions never get a version/WAL/apply — atomic boundary unaffected
- **ARCH-006**: No interaction with timeout path — both correctly decrement `active_count`

## Test Plan

- [x] `test_issue_1916_delete_branch_rejects_concurrent_commit` — sequential: start txn, delete branch, commit must fail
- [x] `test_issue_1916_delete_branch_concurrent_stress` — 5 writer threads + 1 deleter thread with barrier synchronization
- [x] Full engine crate tests pass (621 tests)
- [x] Full workspace tests pass (all crates except strata-inference which has pre-existing cmake issue)
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)