### PR TITLE
Fix #1950–#1959: EventLog audit debt — 8 items from Event primitive dossier

### DIFF
--- a/crates/engine/src/primitives/event.rs
+++ b/crates/engine/src/primitives/event.rs
@@ -129,7 +129,7 @@ pub fn compute_event_hash(
     payload: &Value,
     timestamp: u64,
     prev_hash: &[u8; 32],
-) -> [u8; 32] {
+) -> StrataResult<[u8; 32]> {
     let mut hasher = Sha256::new();
 
     // Sequence (8 bytes, little-endian)
@@ -143,14 +143,16 @@ pub fn compute_event_hash(
     hasher.update(timestamp.to_le_bytes());
 
     // Payload as canonical JSON with length prefix
-    let payload_bytes = serde_json::to_vec(payload).unwrap_or_default();
+    let payload_bytes = serde_json::to_vec(payload).map_err(|e| {
+        StrataError::serialization(format!("failed to serialize event payload for hash: {}", e))
+    })?;
     hasher.update((payload_bytes.len() as u32).to_le_bytes());
     hasher.update(&payload_bytes);
 
     // Previous hash (32 bytes)
     hasher.update(prev_hash);
 
-    hasher.finalize().into()
+    Ok(hasher.finalize().into())
 }
 
 /// Validation error for EventLog operations
@@ -303,7 +305,7 @@ impl EventLog {
             payload,
             timestamp.as_micros(),
             &meta.head_hash,
-        );
+        )?;
 
         let event = Event {
             sequence,
@@ -358,7 +360,9 @@ impl EventLog {
         let result = self.db.transaction(*branch_id, |txn| {
             let meta_key = Key::new_event_meta(ns.clone());
             let mut meta: EventLogMeta = match txn.get(&meta_key)? {
-                Some(v) => from_stored_value(&v).unwrap_or_else(|_| EventLogMeta::default()),
+                Some(v) => from_stored_value(&v).map_err(|e| {
+                    StrataError::serialization(format!("corrupt EventLog metadata: {}", e))
+                })?,
                 None => EventLogMeta::default(),
             };
 
@@ -438,7 +442,9 @@ impl EventLog {
         let sequences = self.db.transaction(*branch_id, |txn| {
             let meta_key = Key::new_event_meta(ns.clone());
             let mut meta: EventLogMeta = match txn.get(&meta_key)? {
-                Some(v) => from_stored_value(&v).unwrap_or_else(|_| EventLogMeta::default()),
+                Some(v) => from_stored_value(&v).map_err(|e| {
+                    StrataError::serialization(format!("corrupt EventLog metadata: {}", e))
+                })?,
                 None => EventLogMeta::default(),
             };
 
@@ -524,7 +530,9 @@ impl EventLog {
             let meta_key = Key::new_event_meta(ns);
 
             let meta: EventLogMeta = match txn.get(&meta_key)? {
-                Some(v) => from_stored_value(&v).unwrap_or_else(|_| EventLogMeta::default()),
+                Some(v) => from_stored_value(&v).map_err(|e| {
+                    StrataError::serialization(format!("corrupt EventLog metadata: {}", e))
+                })?,
                 None => EventLogMeta::default(),
             };
 
@@ -542,7 +550,9 @@ impl EventLog {
             let meta_key = Key::new_event_meta(ns);
 
             let meta: EventLogMeta = match txn.get(&meta_key)? {
-                Some(v) => from_stored_value(&v).unwrap_or_else(|_| EventLogMeta::default()),
+                Some(v) => from_stored_value(&v).map_err(|e| {
+                    StrataError::serialization(format!("corrupt EventLog metadata: {}", e))
+                })?,
                 None => return Ok(Vec::new()),
             };
 
@@ -605,14 +615,18 @@ impl EventLog {
                 return Ok(results);
             }
 
-            // Fallback: O(N) scan for old data without type index keys
+            // Fallback: O(N) scan for old data without type index keys.
+            // Lazily migrates by writing missing index keys so subsequent queries use the fast path.
             let meta_key = Key::new_event_meta(ns.clone());
             let meta: EventLogMeta = match txn.get(&meta_key)? {
-                Some(v) => from_stored_value(&v).unwrap_or_else(|_| EventLogMeta::default()),
+                Some(v) => from_stored_value(&v).map_err(|e| {
+                    StrataError::serialization(format!("corrupt EventLog metadata: {}", e))
+                })?,
                 None => return Ok(Vec::new()),
             };
 
             let mut filtered = Vec::new();
+            let mut migrated_seqs = Vec::new();
             for seq in 0..meta.next_sequence {
                 if after_sequence.is_some_and(|after| seq <= after) {
                     continue;
@@ -623,6 +637,7 @@ impl EventLog {
                     let event: Event = from_stored_value(&v)
                         .map_err(|e| strata_core::StrataError::serialization(e.to_string()))?;
                     if event.event_type == event_type {
+                        migrated_seqs.push(seq);
                         filtered.push(Versioned::with_timestamp(
                             event.clone(),
                             Version::Sequence(seq),
@@ -636,6 +651,12 @@ impl EventLog {
                 }
             }
 
+            // Lazy migration: write missing type index keys for future fast-path lookups
+            for seq in &migrated_seqs {
+                let idx_key = Key::new_event_type_idx(ns.clone(), event_type, *seq);
+                txn.put(idx_key, Value::Null)?;
+            }
+
             Ok(filtered)
         })
     }
@@ -643,23 +664,37 @@ impl EventLog {
 
     /// List events up to a given timestamp.
     ///
-    /// Returns all events whose timestamp <= as_of_ts.
-    /// Optionally filtered by event_type.
+    /// Returns events whose timestamp <= as_of_ts.
+    /// Optionally filtered by event_type. Supports pagination via `limit`.
     pub fn list_at(
         &self,
         branch_id: &BranchId,
         space: &str,
         event_type: Option<&str>,
         as_of_ts: u64,
+        limit: Option<usize>,
     ) -> StrataResult<Vec<Event>> {
-        // Read metadata to get the total event count
+        if limit == Some(0) {
+            return Ok(Vec::new());
+        }
         use strata_core::Storage;
         let ns = self.namespace_for(branch_id, space);
         let meta_key = Key::new_event_meta(ns.clone());
         let meta: EventLogMeta = match self.db.storage().get_versioned(&meta_key, u64::MAX)? {
-            Some(vv) => from_stored_value(&vv.value).unwrap_or_else(|_| EventLogMeta::default()),
+            Some(vv) => from_stored_value(&vv.value).map_err(|e| {
+                StrataError::serialization(format!("corrupt EventLog metadata: {}", e))
+            })?,
             None => return Ok(Vec::new()),
         };
+
+        // Early skip: if filtering by type and the stream didn't exist at as_of_ts, return empty
+        if let Some(et) = event_type {
+            if let Some(stream_meta) = meta.streams.get(et) {
+                if stream_meta.first_timestamp > as_of_ts {
+                    return Ok(Vec::new());
+                }
+            }
+        }
 
         let mut events = Vec::new();
         for seq in 0..meta.next_sequence {
@@ -677,10 +712,160 @@ impl EventLog {
                     } else {
                         events.push(event);
                     }
+
+                    if limit.is_some_and(|l| events.len() >= l) {
+                        break;
+                    }
                 }
             }
         }
         Ok(events)
+    }
+
+    // ========== Range Query API ==========
+
+    /// Read events by sequence range.
+    ///
+    /// Returns events with sequence numbers in `[start_seq, end_seq)`.
+    /// If `end_seq` is None, reads to the end of the log.
+    /// Results are ordered by sequence number.
+    pub fn range(
+        &self,
+        branch_id: &BranchId,
+        space: &str,
+        start_seq: u64,
+        end_seq: Option<u64>,
+        limit: Option<usize>,
+    ) -> StrataResult<Vec<Versioned<Event>>> {
+        if limit == Some(0) {
+            return Ok(Vec::new());
+        }
+        self.db.transaction(*branch_id, |txn| {
+            let ns = self.namespace_for(branch_id, space);
+            let meta_key = Key::new_event_meta(ns.clone());
+            let meta: EventLogMeta = match txn.get(&meta_key)? {
+                Some(v) => from_stored_value(&v).map_err(|e| {
+                    StrataError::serialization(format!("corrupt EventLog metadata: {}", e))
+                })?,
+                None => return Ok(Vec::new()),
+            };
+
+            let upper = end_seq
+                .unwrap_or(meta.next_sequence)
+                .min(meta.next_sequence);
+            if start_seq >= upper {
+                return Ok(Vec::new());
+            }
+
+            let capacity = limit
+                .unwrap_or((upper - start_seq) as usize)
+                .min((upper - start_seq) as usize);
+            let mut results = Vec::with_capacity(capacity);
+
+            for seq in start_seq..upper {
+                let event_key = Key::new_event(ns.clone(), seq);
+                if let Some(v) = txn.get(&event_key)? {
+                    let event: Event = from_stored_value(&v)
+                        .map_err(|e| StrataError::serialization(e.to_string()))?;
+                    results.push(Versioned::with_timestamp(
+                        event.clone(),
+                        Version::Sequence(seq),
+                        event.timestamp,
+                    ));
+
+                    if limit.is_some_and(|l| results.len() >= l) {
+                        break;
+                    }
+                }
+            }
+
+            Ok(results)
+        })
+    }
+
+    // ========== Time-Travel Type Query ==========
+
+    /// Read events filtered by type up to a given timestamp.
+    ///
+    /// Pushes timestamp filtering to the engine level instead of fetching
+    /// all events and filtering in the handler.
+    pub fn get_by_type_at(
+        &self,
+        branch_id: &BranchId,
+        space: &str,
+        event_type: &str,
+        as_of_ts: u64,
+    ) -> StrataResult<Vec<Versioned<Event>>> {
+        self.db.transaction(*branch_id, |txn| {
+            let ns = self.namespace_for(branch_id, space);
+
+            // Try per-type index keys first (fast path)
+            let idx_prefix = Key::new_event_type_idx_prefix(ns.clone(), event_type);
+            let idx_entries = txn.scan_prefix(&idx_prefix)?;
+
+            if !idx_entries.is_empty() {
+                let mut results = Vec::new();
+                for (idx_key, _) in &idx_entries {
+                    let user_key = &idx_key.user_key;
+                    if user_key.len() >= 8 {
+                        let seq_bytes: [u8; 8] = user_key[user_key.len() - 8..].try_into().unwrap();
+                        let seq = u64::from_be_bytes(seq_bytes);
+
+                        let event_key = Key::new_event(ns.clone(), seq);
+                        if let Some(v) = txn.get(&event_key)? {
+                            let event: Event = from_stored_value(&v)
+                                .map_err(|e| StrataError::serialization(e.to_string()))?;
+                            if event.timestamp.as_micros() <= as_of_ts {
+                                results.push(Versioned::with_timestamp(
+                                    event.clone(),
+                                    Version::Sequence(seq),
+                                    event.timestamp,
+                                ));
+                            }
+                        }
+                    }
+                }
+                return Ok(results);
+            }
+
+            // Fallback: O(N) scan for old data without type index keys.
+            // Lazily migrates by writing missing index keys so subsequent queries use the fast path.
+            let meta_key = Key::new_event_meta(ns.clone());
+            let meta: EventLogMeta = match txn.get(&meta_key)? {
+                Some(v) => from_stored_value(&v).map_err(|e| {
+                    StrataError::serialization(format!("corrupt EventLog metadata: {}", e))
+                })?,
+                None => return Ok(Vec::new()),
+            };
+
+            let mut filtered = Vec::new();
+            let mut migrated_seqs = Vec::new();
+            for seq in 0..meta.next_sequence {
+                let event_key = Key::new_event(ns.clone(), seq);
+                if let Some(v) = txn.get(&event_key)? {
+                    let event: Event = from_stored_value(&v)
+                        .map_err(|e| StrataError::serialization(e.to_string()))?;
+                    if event.event_type == event_type {
+                        migrated_seqs.push(seq);
+                        if event.timestamp.as_micros() <= as_of_ts {
+                            filtered.push(Versioned::with_timestamp(
+                                event.clone(),
+                                Version::Sequence(seq),
+                                event.timestamp,
+                            ));
+                        }
+                    }
+                }
+            }
+
+            // Lazy migration: write missing type index keys for future fast-path lookups
+            for seq in &migrated_seqs {
+                let idx_key = Key::new_event_type_idx(ns.clone(), event_type, *seq);
+                txn.put(idx_key, Value::Null)?;
+            }
+
+            Ok(filtered)
+        })
     }
 }
 
@@ -703,17 +888,24 @@ impl crate::search::Searchable for EventLog {
 // ========== EventLogExt Implementation ==========
 
 impl EventLogExt for TransactionContext {
-    fn event_append(&mut self, event_type: &str, payload: Value) -> StrataResult<u64> {
+    fn event_append_in_space(
+        &mut self,
+        space: &str,
+        event_type: &str,
+        payload: Value,
+    ) -> StrataResult<u64> {
         // Validate inputs
         validate_event_type(event_type).map_err(|e| StrataError::invalid_input(e.to_string()))?;
         validate_payload(&payload).map_err(|e| StrataError::invalid_input(e.to_string()))?;
 
-        let ns = Arc::new(Namespace::for_branch(self.branch_id));
+        let ns = Arc::new(Namespace::for_branch_space(self.branch_id, space));
 
         // Read current metadata (or default)
         let meta_key = Key::new_event_meta(ns.clone());
         let mut meta: EventLogMeta = match self.get(&meta_key)? {
-            Some(v) => from_stored_value(&v).unwrap_or_else(|_| EventLogMeta::default()),
+            Some(v) => from_stored_value(&v).map_err(|e| {
+                StrataError::serialization(format!("corrupt EventLog metadata: {}", e))
+            })?,
             None => EventLogMeta::default(),
         };
 
@@ -727,7 +919,7 @@ impl EventLogExt for TransactionContext {
             &payload,
             timestamp.as_micros(),
             &meta.head_hash,
-        );
+        )?;
 
         // Build event
         let event = Event {
@@ -743,7 +935,7 @@ impl EventLogExt for TransactionContext {
         let event_key = Key::new_event(ns.clone(), sequence);
         self.put(event_key, to_stored_value(&event)?)?;
 
-        // Write per-type index key for efficient get_by_type lookups (#972)
+        // Write per-type index key for efficient get_by_type lookups
         let idx_key = Key::new_event_type_idx(ns.clone(), event_type, sequence);
         self.put(idx_key, Value::Null)?;
 
@@ -767,8 +959,8 @@ impl EventLogExt for TransactionContext {
         Ok(sequence)
     }
 
-    fn event_get(&mut self, sequence: u64) -> StrataResult<Option<Value>> {
-        let ns = Arc::new(Namespace::for_branch(self.branch_id));
+    fn event_get_in_space(&mut self, space: &str, sequence: u64) -> StrataResult<Option<Value>> {
+        let ns = Arc::new(Namespace::for_branch_space(self.branch_id, space));
         let event_key = Key::new_event(ns, sequence);
         self.get(&event_key)
     }
@@ -1099,35 +1291,43 @@ mod tests {
     #[test]
     fn test_sha256_hash_determinism() {
         // Same inputs should produce same hash
-        let hash1 = compute_event_hash(42, "test_event", &int_payload(100), 1234567890, &[0u8; 32]);
-        let hash2 = compute_event_hash(42, "test_event", &int_payload(100), 1234567890, &[0u8; 32]);
+        let hash1 = compute_event_hash(42, "test_event", &int_payload(100), 1234567890, &[0u8; 32])
+            .unwrap();
+        let hash2 = compute_event_hash(42, "test_event", &int_payload(100), 1234567890, &[0u8; 32])
+            .unwrap();
         assert_eq!(hash1, hash2);
     }
 
     #[test]
     fn test_sha256_hash_differs_for_different_inputs() {
-        let base = compute_event_hash(42, "test", &empty_payload(), 1234567890, &[0u8; 32]);
+        let base =
+            compute_event_hash(42, "test", &empty_payload(), 1234567890, &[0u8; 32]).unwrap();
 
         // Different sequence
-        let diff_seq = compute_event_hash(43, "test", &empty_payload(), 1234567890, &[0u8; 32]);
+        let diff_seq =
+            compute_event_hash(43, "test", &empty_payload(), 1234567890, &[0u8; 32]).unwrap();
         assert_ne!(base, diff_seq);
 
         // Different event type
-        let diff_type = compute_event_hash(42, "other", &empty_payload(), 1234567890, &[0u8; 32]);
+        let diff_type =
+            compute_event_hash(42, "other", &empty_payload(), 1234567890, &[0u8; 32]).unwrap();
         assert_ne!(base, diff_type);
 
         // Different timestamp
-        let diff_ts = compute_event_hash(42, "test", &empty_payload(), 1234567891, &[0u8; 32]);
+        let diff_ts =
+            compute_event_hash(42, "test", &empty_payload(), 1234567891, &[0u8; 32]).unwrap();
         assert_ne!(base, diff_ts);
 
         // Different prev_hash
-        let diff_prev = compute_event_hash(42, "test", &empty_payload(), 1234567890, &[1u8; 32]);
+        let diff_prev =
+            compute_event_hash(42, "test", &empty_payload(), 1234567890, &[1u8; 32]).unwrap();
         assert_ne!(base, diff_prev);
     }
 
     #[test]
     fn test_sha256_uses_full_32_bytes() {
-        let hash = compute_event_hash(42, "test", &empty_payload(), 1234567890, &[0u8; 32]);
+        let hash =
+            compute_event_hash(42, "test", &empty_payload(), 1234567890, &[0u8; 32]).unwrap();
 
         // SHA-256 should use all 32 bytes, not just the first 8 like DefaultHasher
         // Check that bytes beyond the first 8 are non-zero (statistically likely)

--- a/crates/engine/src/primitives/extensions.rs
+++ b/crates/engine/src/primitives/extensions.rs
@@ -74,13 +74,31 @@ pub trait KVStoreExt {
 
 /// Event log operations within a transaction
 ///
-/// Implemented in `event_log.rs`
+/// Implemented in `event.rs`.
+///
+/// The `_in_space` methods accept an explicit space parameter. The convenience
+/// methods (`event_append`, `event_get`) delegate to them with `"default"`.
 pub trait EventLogExt {
-    /// Append an event and return sequence number
-    fn event_append(&mut self, event_type: &str, payload: Value) -> StrataResult<u64>;
+    /// Append an event in the specified space and return sequence number
+    fn event_append_in_space(
+        &mut self,
+        space: &str,
+        event_type: &str,
+        payload: Value,
+    ) -> StrataResult<u64>;
 
-    /// Read an event by sequence number
-    fn event_get(&mut self, sequence: u64) -> StrataResult<Option<Value>>;
+    /// Read an event by sequence number in the specified space
+    fn event_get_in_space(&mut self, space: &str, sequence: u64) -> StrataResult<Option<Value>>;
+
+    /// Append an event (default space)
+    fn event_append(&mut self, event_type: &str, payload: Value) -> StrataResult<u64> {
+        self.event_append_in_space("default", event_type, payload)
+    }
+
+    /// Read an event by sequence number (default space)
+    fn event_get(&mut self, sequence: u64) -> StrataResult<Option<Value>> {
+        self.event_get_in_space("default", sequence)
+    }
 }
 
 /// JSON store operations within a transaction

--- a/crates/engine/src/primitives/json.rs
+++ b/crates/engine/src/primitives/json.rs
@@ -621,8 +621,7 @@ impl JsonStore {
 
         let key = self.key_for(branch_id, space, doc_id);
         self.db.transaction(*branch_id, |txn| {
-            Self::set_in_txn(txn, &key, doc_id, path, value, false)
-                .map(|(version, _)| version)
+            Self::set_in_txn(txn, &key, doc_id, path, value, false).map(|(version, _)| version)
         })
     }
 
@@ -2624,13 +2623,7 @@ mod tests {
 
         // Page 2: continue from cursor — "c" should be skipped
         let page2 = store
-            .list(
-                &branch_id,
-                "default",
-                None,
-                page1.next_cursor.as_deref(),
-                2,
-            )
+            .list(&branch_id, "default", None, page1.next_cursor.as_deref(), 2)
             .unwrap();
         assert_eq!(page2.doc_ids.len(), 2);
         assert_eq!(page2.doc_ids, vec!["d", "e"]);
@@ -2677,7 +2670,10 @@ mod tests {
         let result = store
             .get_at(&branch_id, "default", "doc1", &JsonPath::root(), ts_between)
             .unwrap();
-        assert!(result.is_some(), "Should find v1 at timestamp between v1 and v2");
+        assert!(
+            result.is_some(),
+            "Should find v1 at timestamp between v1 and v2"
+        );
         assert_eq!(result.unwrap(), JsonValue::from("v1"));
     }
 
@@ -2733,7 +2729,10 @@ mod tests {
 
             // Verify default space doesn't have it
             let default_result = txn.json_get("doc1", &JsonPath::root())?;
-            assert!(default_result.is_none(), "Default space should not have custom space doc");
+            assert!(
+                default_result.is_none(),
+                "Default space should not have custom space doc"
+            );
 
             Ok(())
         })
@@ -2765,10 +2764,7 @@ mod tests {
         store
             .create(&branch_id, "default", "other", JsonValue::object())
             .unwrap();
-        assert_eq!(
-            store.count(&branch_id, "default", Some("doc")).unwrap(),
-            5
-        );
+        assert_eq!(store.count(&branch_id, "default", Some("doc")).unwrap(), 5);
         assert_eq!(store.count(&branch_id, "default", None).unwrap(), 6);
     }
 
@@ -2869,13 +2865,27 @@ mod tests {
 
         // Page 2
         let page2 = store
-            .list_at(&branch_id, "default", None, ts, page1.next_cursor.as_deref(), 2)
+            .list_at(
+                &branch_id,
+                "default",
+                None,
+                ts,
+                page1.next_cursor.as_deref(),
+                2,
+            )
             .unwrap();
         assert_eq!(page2.doc_ids.len(), 2);
 
         // Page 3 (last page)
         let page3 = store
-            .list_at(&branch_id, "default", None, ts, page2.next_cursor.as_deref(), 2)
+            .list_at(
+                &branch_id,
+                "default",
+                None,
+                ts,
+                page2.next_cursor.as_deref(),
+                2,
+            )
             .unwrap();
         assert_eq!(page3.doc_ids.len(), 1);
         assert!(page3.next_cursor.is_none());
@@ -2886,8 +2896,7 @@ mod tests {
     fn test_format_version_backward_compat() {
         // Simulate v1 format (no version header — raw MessagePack)
         let doc = JsonDoc::new("test", JsonValue::from("hello"));
-        let raw_msgpack =
-            rmp_serde::to_vec(&doc).unwrap();
+        let raw_msgpack = rmp_serde::to_vec(&doc).unwrap();
         let v1_value = Value::Bytes(raw_msgpack);
 
         // v1 should deserialize successfully

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -321,9 +321,7 @@ impl KVStore {
             // Collect only user-key entries (filter out internal keys)
             let entries: Vec<(String, Value)> = results
                 .into_iter()
-                .filter_map(|(key, value)| {
-                    key.user_key_string().map(|k| (k, value))
-                })
+                .filter_map(|(key, value)| key.user_key_string().map(|k| (k, value)))
                 .collect();
 
             let total = entries.len() as u64;
@@ -1533,9 +1531,12 @@ mod tests {
     fn test_count_with_prefix() {
         let (_temp, _db, kv) = setup();
         let branch_id = BranchId::new();
-        kv.put(&branch_id, "default", "user:1", Value::Int(1)).unwrap();
-        kv.put(&branch_id, "default", "user:2", Value::Int(2)).unwrap();
-        kv.put(&branch_id, "default", "task:1", Value::Int(3)).unwrap();
+        kv.put(&branch_id, "default", "user:1", Value::Int(1))
+            .unwrap();
+        kv.put(&branch_id, "default", "user:2", Value::Int(2))
+            .unwrap();
+        kv.put(&branch_id, "default", "task:1", Value::Int(3))
+            .unwrap();
         assert_eq!(kv.count(&branch_id, "default", Some("user:")).unwrap(), 2);
         assert_eq!(kv.count(&branch_id, "default", Some("task:")).unwrap(), 1);
         assert_eq!(kv.count(&branch_id, "default", Some("none:")).unwrap(), 0);
@@ -1548,8 +1549,13 @@ mod tests {
         let (_temp, _db, kv) = setup();
         let branch_id = BranchId::new();
         for i in 0..10 {
-            kv.put(&branch_id, "default", &format!("key_{:02}", i), Value::Int(i))
-                .unwrap();
+            kv.put(
+                &branch_id,
+                "default",
+                &format!("key_{:02}", i),
+                Value::Int(i),
+            )
+            .unwrap();
         }
 
         // First page of 3
@@ -1568,8 +1574,13 @@ mod tests {
         let (_temp, _db, kv) = setup();
         let branch_id = BranchId::new();
         for i in 0..10 {
-            kv.put(&branch_id, "default", &format!("key_{:02}", i), Value::Int(i))
-                .unwrap();
+            kv.put(
+                &branch_id,
+                "default",
+                &format!("key_{:02}", i),
+                Value::Int(i),
+            )
+            .unwrap();
         }
 
         // Page after "key_04", limit 3
@@ -1644,13 +1655,8 @@ mod tests {
         let (_temp, _db, kv) = setup();
         let branch_id = BranchId::new();
         for i in 0..20 {
-            kv.put(
-                &branch_id,
-                "default",
-                &format!("k{:02}", i),
-                Value::Int(i),
-            )
-            .unwrap();
+            kv.put(&branch_id, "default", &format!("k{:02}", i), Value::Int(i))
+                .unwrap();
         }
         let (total, items) = kv.sample(&branch_id, "default", None, 5).unwrap();
         assert_eq!(total, 20);
@@ -1666,9 +1672,12 @@ mod tests {
     fn test_sample_with_prefix() {
         let (_temp, _db, kv) = setup();
         let branch_id = BranchId::new();
-        kv.put(&branch_id, "default", "user:1", Value::Int(1)).unwrap();
-        kv.put(&branch_id, "default", "user:2", Value::Int(2)).unwrap();
-        kv.put(&branch_id, "default", "task:1", Value::Int(3)).unwrap();
+        kv.put(&branch_id, "default", "user:1", Value::Int(1))
+            .unwrap();
+        kv.put(&branch_id, "default", "user:2", Value::Int(2))
+            .unwrap();
+        kv.put(&branch_id, "default", "task:1", Value::Int(3))
+            .unwrap();
         let (total, items) = kv.sample(&branch_id, "default", Some("user:"), 10).unwrap();
         assert_eq!(total, 2);
         assert_eq!(items.len(), 2);
@@ -1764,8 +1773,13 @@ mod tests {
         let (_temp, _db, kv) = setup();
         let branch_id = BranchId::new();
 
-        kv.put(&branch_id, "default", "", Value::String("empty-key-value".into()))
-            .unwrap();
+        kv.put(
+            &branch_id,
+            "default",
+            "",
+            Value::String("empty-key-value".into()),
+        )
+        .unwrap();
 
         let result = kv.get(&branch_id, "default", "").unwrap();
         assert_eq!(result, Some(Value::String("empty-key-value".into())));
@@ -1780,7 +1794,10 @@ mod tests {
         kv.put(&branch_id, "default", "a", Value::Int(1)).unwrap();
 
         let keys = kv.list(&branch_id, "default", None).unwrap();
-        assert!(keys.contains(&String::new()), "empty key must appear in list");
+        assert!(
+            keys.contains(&String::new()),
+            "empty key must appear in list"
+        );
         assert_eq!(keys.len(), 2);
     }
 
@@ -1840,7 +1857,11 @@ mod tests {
         // A far-future timestamp should see the latest value
         let far_future = u64::MAX;
         let result = kv.get_at(&branch_id, "default", "k", far_future).unwrap();
-        assert_eq!(result, Some(Value::Int(1)), "future timestamp must see latest value");
+        assert_eq!(
+            result,
+            Some(Value::Int(1)),
+            "future timestamp must see latest value"
+        );
     }
 
     #[test]
@@ -1854,7 +1875,11 @@ mod tests {
 
         let far_future = u64::MAX;
         let result = kv.get_at(&branch_id, "default", "k", far_future).unwrap();
-        assert_eq!(result, Some(Value::Int(2)), "future timestamp must see latest version");
+        assert_eq!(
+            result,
+            Some(Value::Int(2)),
+            "future timestamp must see latest version"
+        );
     }
 
     // --- Scenario 6: get_at() with timestamp before any writes ---
@@ -1876,8 +1901,13 @@ mod tests {
         let (_temp, _db, kv) = setup();
         let branch_id = BranchId::new();
 
-        let result = kv.get_at(&branch_id, "default", "missing", u64::MAX).unwrap();
-        assert_eq!(result, None, "nonexistent key must return None at any timestamp");
+        let result = kv
+            .get_at(&branch_id, "default", "missing", u64::MAX)
+            .unwrap();
+        assert_eq!(
+            result, None,
+            "nonexistent key must return None at any timestamp"
+        );
     }
 
     #[test]
@@ -1901,7 +1931,11 @@ mod tests {
         kv.put(&branch_id, "default", "b", Value::Int(2)).unwrap();
 
         let keys = kv.list_at(&branch_id, "default", None, u64::MAX).unwrap();
-        assert_eq!(keys.len(), 2, "list_at with future timestamp must see all keys");
+        assert_eq!(
+            keys.len(),
+            2,
+            "list_at with future timestamp must see all keys"
+        );
     }
 
     // --- Scenario 8: Search after batch_put() ---
@@ -1914,22 +1948,39 @@ mod tests {
         let branch_id = BranchId::new();
 
         let entries = vec![
-            ("doc1".to_string(), Value::String("alpha bravo charlie".into())),
-            ("doc2".to_string(), Value::String("delta echo foxtrot".into())),
+            (
+                "doc1".to_string(),
+                Value::String("alpha bravo charlie".into()),
+            ),
+            (
+                "doc2".to_string(),
+                Value::String("delta echo foxtrot".into()),
+            ),
             ("doc3".to_string(), Value::String("alpha delta golf".into())),
         ];
 
         let results = kv.batch_put(&branch_id, "default", entries).unwrap();
-        assert!(results.iter().all(|r| r.is_ok()), "all batch items must succeed");
+        assert!(
+            results.iter().all(|r| r.is_ok()),
+            "all batch items must succeed"
+        );
 
         // All batch_put items must be searchable immediately
         let req = crate::SearchRequest::new(branch_id, "alpha");
         let response = kv.search(&req).unwrap();
-        assert_eq!(response.len(), 2, "both docs containing 'alpha' must be found");
+        assert_eq!(
+            response.len(),
+            2,
+            "both docs containing 'alpha' must be found"
+        );
 
         let req = crate::SearchRequest::new(branch_id, "delta");
         let response = kv.search(&req).unwrap();
-        assert_eq!(response.len(), 2, "both docs containing 'delta' must be found");
+        assert_eq!(
+            response.len(),
+            2,
+            "both docs containing 'delta' must be found"
+        );
 
         let req = crate::SearchRequest::new(branch_id, "echo");
         let response = kv.search(&req).unwrap();
@@ -1944,8 +1995,14 @@ mod tests {
         let branch_id = BranchId::new();
 
         let entries = vec![
-            ("d1".to_string(), Value::String("searchable content here".into())),
-            ("d2".to_string(), Value::String("searchable data there".into())),
+            (
+                "d1".to_string(),
+                Value::String("searchable content here".into()),
+            ),
+            (
+                "d2".to_string(),
+                Value::String("searchable data there".into()),
+            ),
         ];
         kv.batch_put(&branch_id, "default", entries).unwrap();
 

--- a/crates/engine/src/transaction/context.rs
+++ b/crates/engine/src/transaction/context.rs
@@ -108,7 +108,7 @@ impl<'a> Transaction<'a> {
     }
 
     /// Compute hash for an event using the canonical hash function.
-    fn compute_event_hash(event: &Event) -> [u8; 32] {
+    fn compute_event_hash(event: &Event) -> strata_core::StrataResult<[u8; 32]> {
         crate::primitives::event::compute_event_hash(
             event.sequence,
             &event.event_type,
@@ -220,7 +220,7 @@ impl<'a> TransactionOps for Transaction<'a> {
         };
 
         // Compute and set the hash
-        event.hash = Self::compute_event_hash(&event);
+        event.hash = Self::compute_event_hash(&event)?;
 
         // Update last_hash for next event in chain
         self.last_hash = event.hash;

--- a/crates/executor/src/handlers/event.rs
+++ b/crates/executor/src/handlers/event.rs
@@ -139,6 +139,7 @@ pub fn event_get_by_type(
 /// Handle EventGetByType with as_of timestamp (time-travel read).
 ///
 /// Returns only events whose timestamp <= as_of_ts.
+/// Timestamp filtering is pushed down to the engine level for efficiency.
 pub fn event_get_by_type_at(
     p: &Arc<Primitives>,
     branch: BranchId,
@@ -150,14 +151,12 @@ pub fn event_get_by_type_at(
     let events =
         convert_result(
             p.event
-                .get_by_type(&core_branch_id, &space, &event_type, None, None),
+                .get_by_type_at(&core_branch_id, &space, &event_type, as_of_ts),
         )
         .map_err(|e| enrich_event_error(p, &core_branch_id, &space, e))?;
 
-    // Filter events by timestamp
     let versioned: Vec<VersionedValue> = events
         .into_iter()
-        .filter(|e| e.value.timestamp.as_micros() <= as_of_ts)
         .map(|e| VersionedValue {
             value: e.value.payload.clone(),
             version: bridge::extract_version(&e.version),

--- a/crates/executor/src/handlers/json.rs
+++ b/crates/executor/src/handlers/json.rs
@@ -427,8 +427,7 @@ pub fn json_batch_delete(
     // Batch root deletes in a single transaction
     if !root_deletes.is_empty() {
         let doc_ids: Vec<String> = root_deletes.iter().map(|(_, k)| k.clone()).collect();
-        let destroy_results =
-            convert_result(p.json.batch_destroy(&branch_id, &space, &doc_ids))?;
+        let destroy_results = convert_result(p.json.batch_destroy(&branch_id, &space, &doc_ids))?;
         for (j, (orig_idx, key)) in root_deletes.iter().enumerate() {
             let deleted = destroy_results[j];
             results[*orig_idx].version = Some(if deleted { 1 } else { 0 });
@@ -450,8 +449,11 @@ pub fn json_batch_delete(
             .iter()
             .map(|(_, k, p)| (k.clone(), p.clone()))
             .collect();
-        let del_results =
-            convert_result(p.json.batch_delete_at_path(&branch_id, &space, &engine_entries))?;
+        let del_results = convert_result(p.json.batch_delete_at_path(
+            &branch_id,
+            &space,
+            &engine_entries,
+        ))?;
         for (j, (orig_idx, key, _)) in path_deletes.iter().enumerate() {
             match &del_results[j] {
                 Ok(_version) => {

--- a/crates/executor/src/handlers/kv.rs
+++ b/crates/executor/src/handlers/kv.rs
@@ -306,10 +306,7 @@ pub fn kv_sample(
         .into_iter()
         .map(|(key, value)| crate::types::SampleItem { key, value })
         .collect();
-    Ok(Output::SampleResult {
-        total_count,
-        items,
-    })
+    Ok(Output::SampleResult { total_count, items })
 }
 
 /// Enrich a KV error with fuzzy-match suggestions for key-not-found errors.

--- a/tests/engine/primitives/eventlog.rs
+++ b/tests/engine/primitives/eventlog.rs
@@ -444,3 +444,378 @@ fn payload_must_be_object() {
     let result = event.append(&test_db.branch_id, "default", "type", payload_int(42));
     assert!(result.is_ok());
 }
+
+// ============================================================================
+// Audit Debt Tests — coverage gaps from Event primitive dossier
+// ============================================================================
+
+#[test]
+fn concurrent_appends_preserve_data_integrity() {
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    let test_db = TestDb::new();
+    let db = test_db.db.clone();
+    let branch_id = test_db.branch_id;
+    let barrier = Arc::new(Barrier::new(2));
+    let total_per_thread = 20;
+
+    let handles: Vec<_> = (0..2)
+        .map(|thread_idx| {
+            let db = db.clone();
+            let barrier = barrier.clone();
+            thread::spawn(move || {
+                let event = EventLog::new(db);
+                barrier.wait();
+                let mut successes = 0;
+                for i in 0..total_per_thread {
+                    let payload = Value::object(HashMap::from([
+                        ("thread".to_string(), Value::Int(thread_idx)),
+                        ("i".to_string(), Value::Int(i)),
+                    ]));
+                    // OCC may require retries; the engine handles this internally
+                    match event.append(&branch_id, "default", "concurrent", payload) {
+                        Ok(_) => successes += 1,
+                        Err(_) => {} // OCC conflict, acceptable
+                    }
+                }
+                successes
+            })
+        })
+        .collect();
+
+    let total_successes: i64 = handles.into_iter().map(|h| h.join().unwrap()).sum();
+    assert!(total_successes > 0, "at least some appends must succeed");
+
+    // Verify hash chain integrity for all successful appends
+    let event = test_db.event();
+    let len = event.len(&branch_id, "default").unwrap();
+    assert_eq!(len, total_successes as u64);
+
+    for seq in 1..len {
+        let prev = event.get(&branch_id, "default", seq - 1).unwrap().unwrap();
+        let curr = event.get(&branch_id, "default", seq).unwrap().unwrap();
+        assert_eq!(
+            curr.value.prev_hash, prev.value.hash,
+            "hash chain broken at sequence {}",
+            seq
+        );
+    }
+}
+
+#[test]
+fn large_batch_append_preserves_chain() {
+    let test_db = TestDb::new();
+    let event = test_db.event();
+
+    let entries: Vec<(String, Value)> = (0..200)
+        .map(|i| ("batch_type".to_string(), payload_int(i)))
+        .collect();
+
+    let results = event
+        .batch_append(&test_db.branch_id, "default", entries)
+        .unwrap();
+
+    // All should succeed
+    let success_count = results.iter().filter(|r| r.is_ok()).count();
+    assert_eq!(success_count, 200);
+
+    // Verify monotonic sequences
+    let seqs: Vec<u64> = results
+        .iter()
+        .filter_map(|r| r.as_ref().ok())
+        .map(|v| v.as_u64())
+        .collect();
+    let mut sorted = seqs.clone();
+    sorted.sort();
+    assert_eq!(seqs, sorted, "sequences must be monotonically increasing");
+    assert_eq!(seqs.len(), 200);
+    assert_eq!(seqs[0], 0);
+    assert_eq!(seqs[199], 199);
+
+    // Verify hash chain integrity
+    for seq in 1u64..200 {
+        let prev = event
+            .get(&test_db.branch_id, "default", seq - 1)
+            .unwrap()
+            .unwrap();
+        let curr = event
+            .get(&test_db.branch_id, "default", seq)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            curr.value.prev_hash, prev.value.hash,
+            "hash chain broken at sequence {}",
+            seq
+        );
+    }
+
+    // Verify stream metadata count
+    assert_eq!(event.len(&test_db.branch_id, "default").unwrap(), 200);
+}
+
+#[test]
+fn list_at_before_any_events_returns_empty() {
+    let test_db = TestDb::new();
+    let event = test_db.event();
+
+    // Append some events
+    event
+        .append(&test_db.branch_id, "default", "type", payload_int(1))
+        .unwrap();
+
+    // Query with timestamp 0 (before any events)
+    let result = event
+        .list_at(&test_db.branch_id, "default", None, 0, None)
+        .unwrap();
+    assert!(
+        result.is_empty(),
+        "list_at before any events should be empty"
+    );
+}
+
+#[test]
+fn list_at_between_events_returns_only_earlier() {
+    let test_db = TestDb::new();
+    let event = test_db.event();
+
+    // Append first event
+    event
+        .append(&test_db.branch_id, "default", "type", payload_int(1))
+        .unwrap();
+
+    // Wait and capture a midpoint timestamp (using wall clock, which the storage layer uses)
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    let mid_ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as u64;
+    std::thread::sleep(std::time::Duration::from_millis(10));
+
+    // Append second event
+    event
+        .append(&test_db.branch_id, "default", "type", payload_int(2))
+        .unwrap();
+
+    // Query at midpoint — should only see the first event
+    let result = event
+        .list_at(&test_db.branch_id, "default", None, mid_ts, None)
+        .unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].payload, payload_int(1));
+
+    // Query at u64::MAX — should see both events
+    let result = event
+        .list_at(&test_db.branch_id, "default", None, u64::MAX, None)
+        .unwrap();
+    assert_eq!(result.len(), 2);
+}
+
+#[test]
+fn list_at_with_limit() {
+    let test_db = TestDb::new();
+    let event = test_db.event();
+
+    for i in 0..10 {
+        event
+            .append(&test_db.branch_id, "default", "type", payload_int(i))
+            .unwrap();
+    }
+
+    let result = event
+        .list_at(&test_db.branch_id, "default", None, u64::MAX, Some(3))
+        .unwrap();
+    assert_eq!(result.len(), 3);
+    assert_eq!(result[0].payload, payload_int(0));
+    assert_eq!(result[2].payload, payload_int(2));
+}
+
+#[test]
+fn metadata_corruption_returns_error() {
+    let test_db = TestDb::new();
+    let event = test_db.event();
+
+    // Append an event so metadata exists
+    event
+        .append(&test_db.branch_id, "default", "type", payload_int(1))
+        .unwrap();
+
+    // Directly corrupt metadata by writing invalid data to the meta key
+    let ns = strata_core::types::Namespace::for_branch_space(test_db.branch_id, "default");
+    let meta_key = strata_core::types::Key::new_event_meta(std::sync::Arc::new(ns));
+    test_db
+        .db
+        .transaction(test_db.branch_id, |txn| {
+            txn.put(
+                meta_key.clone(),
+                Value::String("not valid json{{{".to_string()),
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    // Operations that read metadata should now return errors, not silently default
+    let result = event.len(&test_db.branch_id, "default");
+    assert!(
+        result.is_err(),
+        "corrupt metadata must return error, not silent default"
+    );
+
+    let result = event.append(&test_db.branch_id, "default", "type", payload_int(2));
+    assert!(
+        result.is_err(),
+        "append with corrupt metadata must return error"
+    );
+
+    let result = event.list_types(&test_db.branch_id, "default");
+    assert!(
+        result.is_err(),
+        "list_types with corrupt metadata must return error"
+    );
+}
+
+#[test]
+fn eventlog_ext_non_default_space() {
+    use strata_engine::primitives::extensions::EventLogExt;
+
+    let test_db = TestDb::new();
+
+    // Append in "custom" space via extension trait
+    test_db
+        .db
+        .transaction(test_db.branch_id, |txn| {
+            txn.event_append_in_space("custom", "my_type", payload_int(42))?;
+            txn.event_append_in_space("custom", "my_type", payload_int(43))?;
+            Ok(())
+        })
+        .unwrap();
+
+    // Append in "default" space
+    test_db
+        .db
+        .transaction(test_db.branch_id, |txn| {
+            txn.event_append("other_type", payload_int(99))?;
+            Ok(())
+        })
+        .unwrap();
+
+    // Verify isolation: custom space has 2 events, default has 1
+    let event = test_db.event();
+    assert_eq!(event.len(&test_db.branch_id, "custom").unwrap(), 2);
+    assert_eq!(event.len(&test_db.branch_id, "default").unwrap(), 1);
+
+    // Read back from custom space via extension trait
+    test_db
+        .db
+        .transaction(test_db.branch_id, |txn| {
+            let val = txn.event_get_in_space("custom", 0)?;
+            assert!(val.is_some());
+
+            // Default space should not see custom space's events at seq 1
+            let default_val = txn.event_get(1)?;
+            assert!(
+                default_val.is_none(),
+                "default space should not see custom space's seq 1"
+            );
+            Ok(())
+        })
+        .unwrap();
+}
+
+#[test]
+fn range_query_returns_correct_slice() {
+    let test_db = TestDb::new();
+    let event = test_db.event();
+
+    for i in 0..10 {
+        event
+            .append(&test_db.branch_id, "default", "type", payload_int(i))
+            .unwrap();
+    }
+
+    // Range [3, 7) should return sequences 3, 4, 5, 6
+    let results = event
+        .range(&test_db.branch_id, "default", 3, Some(7), None)
+        .unwrap();
+    assert_eq!(results.len(), 4);
+    assert_eq!(results[0].value.payload, payload_int(3));
+    assert_eq!(results[3].value.payload, payload_int(6));
+
+    // Range with limit
+    let results = event
+        .range(&test_db.branch_id, "default", 0, None, Some(2))
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].value.payload, payload_int(0));
+    assert_eq!(results[1].value.payload, payload_int(1));
+
+    // Empty range (start >= end)
+    let results = event
+        .range(&test_db.branch_id, "default", 5, Some(5), None)
+        .unwrap();
+    assert!(results.is_empty());
+
+    // Range past end of log is clamped
+    let results = event
+        .range(&test_db.branch_id, "default", 8, Some(100), None)
+        .unwrap();
+    assert_eq!(results.len(), 2); // sequences 8, 9
+
+    // Open-ended range (no end_seq)
+    let results = event
+        .range(&test_db.branch_id, "default", 7, None, None)
+        .unwrap();
+    assert_eq!(results.len(), 3); // sequences 7, 8, 9
+}
+
+#[test]
+fn get_by_type_at_filters_by_timestamp() {
+    let test_db = TestDb::new();
+    let event = test_db.event();
+
+    // Append first event
+    event
+        .append(&test_db.branch_id, "default", "audit", payload_int(1))
+        .unwrap();
+    let e0 = event
+        .get(&test_db.branch_id, "default", 0)
+        .unwrap()
+        .unwrap();
+    let ts0 = e0.value.timestamp.as_micros();
+
+    std::thread::sleep(std::time::Duration::from_millis(2));
+
+    // Append second event of same type
+    event
+        .append(&test_db.branch_id, "default", "audit", payload_int(2))
+        .unwrap();
+    let e1 = event
+        .get(&test_db.branch_id, "default", 1)
+        .unwrap()
+        .unwrap();
+    let ts1 = e1.value.timestamp.as_micros();
+
+    // Append event of different type
+    event
+        .append(&test_db.branch_id, "default", "other", payload_int(3))
+        .unwrap();
+
+    // get_by_type_at with ts0 should only return the first audit event
+    let results = event
+        .get_by_type_at(&test_db.branch_id, "default", "audit", ts0)
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].value.payload, payload_int(1));
+
+    // get_by_type_at with ts1 should return both audit events
+    let results = event
+        .get_by_type_at(&test_db.branch_id, "default", "audit", ts1)
+        .unwrap();
+    assert_eq!(results.len(), 2);
+
+    // get_by_type_at for "other" type at ts0 should return nothing (it was appended later)
+    let results = event
+        .get_by_type_at(&test_db.branch_id, "default", "other", ts0)
+        .unwrap();
+    assert!(results.is_empty());
+}


### PR DESCRIPTION
## Summary

- **#1950**: Metadata deserialization propagates errors at all 7 call sites instead of silently falling back to default (which caused sequence collisions and broken hash chains on corrupt metadata)
- **#1951**: `compute_event_hash` returns `StrataResult` instead of using `unwrap_or_default()` on payload serialization
- **#1952**: New `get_by_type_at()` pushes timestamp filtering to engine level; handler no longer fetches all events then filters post-hoc
- **#1953**: `list_at()` gains `limit` parameter and stream metadata early-skip
- **#1954**: `get_by_type` fallback lazily writes missing type index keys so subsequent queries use the O(K) fast path
- **#1957**: New `range(start_seq, end_seq, limit)` API for sequence range queries
- **#1958**: `EventLogExt` adds `_in_space` methods following KV/JSON pattern
- **#1959**: 9 new integration tests covering concurrent appends, batch chain integrity, time-travel edge cases, metadata corruption, space isolation, range queries, and timestamp-filtered type queries

Deferred: #1955 (audit trail migration to EventLog) and #1956 (MessagePack serialization) — both require architectural decisions.

## Test plan

- [x] 38 unit tests pass (`cargo test -p strata-engine --lib -- primitives::event::tests`)
- [x] 28 integration tests pass, including 9 new (`cargo test --test engine -- primitives::eventlog`)
- [x] 67 cross-crate integration tests pass (`cargo test --test integration`)
- [x] 41 durability tests pass (`cargo test --test durability`)
- [x] `cargo clippy` clean (pre-existing warnings only)
- [x] `cargo fmt` applied
- [x] Invariant check: ACID-001/002/003/004, ARCH-001/002 all HOLD

🤖 Generated with [Claude Code](https://claude.com/claude-code)