### PR TITLE
Fix #1920–#1924: Concurrency audit — snapshot isolation, GC advancement, timeout safety

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -598,6 +598,25 @@ pub enum StrataError {
         duration_ms: u64,
     },
 
+    /// Write stall timeout
+    ///
+    /// The write was stalled waiting for L0 compaction to reduce the segment
+    /// count below the stop-writes trigger, but the wait exceeded the
+    /// configured timeout.
+    ///
+    /// ## Example
+    /// ```no_run
+    /// # use strata_core::StrataError;
+    /// StrataError::WriteStallTimeout { stall_duration_ms: 30000, l0_count: 40 };
+    /// ```
+    #[error("write stall timeout after {stall_duration_ms}ms (L0 count: {l0_count})")]
+    WriteStallTimeout {
+        /// How long the write was stalled before giving up
+        stall_duration_ms: u64,
+        /// L0 segment count at the time of timeout
+        l0_count: usize,
+    },
+
     /// Transaction not active
     ///
     /// An operation was attempted on a transaction that has already
@@ -934,6 +953,20 @@ impl StrataError {
         StrataError::TransactionTimeout { duration_ms }
     }
 
+    /// Create a WriteStallTimeout error
+    ///
+    /// ## Example
+    /// ```no_run
+    /// # use strata_core::StrataError;
+    /// StrataError::write_stall_timeout(30000, 40);
+    /// ```
+    pub fn write_stall_timeout(stall_duration_ms: u64, l0_count: usize) -> Self {
+        StrataError::WriteStallTimeout {
+            stall_duration_ms,
+            l0_count,
+        }
+    }
+
     /// Create a TransactionNotActive error
     ///
     /// ## Example
@@ -1211,6 +1244,7 @@ impl StrataError {
             StrataError::WriteConflict { .. } => ErrorCode::Conflict,
             StrataError::TransactionAborted { .. } => ErrorCode::Conflict,
             StrataError::TransactionTimeout { .. } => ErrorCode::Conflict,
+            StrataError::WriteStallTimeout { .. } => ErrorCode::Conflict,
             StrataError::TransactionNotActive { .. } => ErrorCode::Conflict,
 
             // ConstraintViolation errors (structural failures)
@@ -1289,6 +1323,12 @@ impl StrataError {
             StrataError::TransactionTimeout { duration_ms } => {
                 ErrorDetails::new().with_int("duration_ms", *duration_ms as i64)
             }
+            StrataError::WriteStallTimeout {
+                stall_duration_ms,
+                l0_count,
+            } => ErrorDetails::new()
+                .with_int("stall_duration_ms", *stall_duration_ms as i64)
+                .with_int("l0_count", *l0_count as i64),
             StrataError::TransactionNotActive { state } => {
                 ErrorDetails::new().with_string("state", state)
             }
@@ -1713,6 +1753,25 @@ mod strata_error_tests {
         assert!(!e.is_retryable());
         match e {
             StrataError::TransactionTimeout { duration_ms } => assert_eq!(duration_ms, 5000),
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_write_stall_timeout_constructor() {
+        let e = StrataError::write_stall_timeout(30000, 40);
+
+        assert!(!e.is_retryable(), "stall timeout is not retryable — write already committed");
+        assert!(!e.is_transaction_error());
+        assert_eq!(e.code(), ErrorCode::Conflict);
+        match e {
+            StrataError::WriteStallTimeout {
+                stall_duration_ms,
+                l0_count,
+            } => {
+                assert_eq!(stall_duration_ms, 30000);
+                assert_eq!(l0_count, 40);
+            }
             _ => panic!("Wrong variant"),
         }
     }
@@ -2547,6 +2606,7 @@ mod adversarial_error_tests {
             StrataError::write_conflict(entity.clone()),
             StrataError::transaction_aborted("reason"),
             StrataError::transaction_timeout(100),
+            StrataError::write_stall_timeout(30000, 40),
             StrataError::transaction_not_active("committed"),
             StrataError::invalid_operation(entity.clone(), "reason"),
             StrataError::invalid_input("bad"),
@@ -2565,7 +2625,7 @@ mod adversarial_error_tests {
             let _ = e.message(); // Should not panic
             let _ = e.details(); // Should not panic
         }
-        assert_eq!(errors.len(), 22, "Should test all 22 error constructors");
+        assert_eq!(errors.len(), 23, "Should test all 23 error constructors");
     }
 
     #[test]

--- a/crates/engine/src/branch_ops.rs
+++ b/crates/engine/src/branch_ops.rs
@@ -410,6 +410,9 @@ pub fn diff_branches_with_options(
 
     let storage = db.storage();
 
+    // Capture snapshot version for consistent reads (#1920)
+    let snapshot_version = db.current_version();
+
     // COW fast path: if one branch is a direct child of the other and no
     // as_of timestamp, use O(W) diff instead of O(N) full scan.
     // Checked early to avoid the O(spaces) space listing below.
@@ -477,9 +480,21 @@ pub fn diff_branches_with_options(
     let mut maps_b: HashMap<String, HashMap<(Vec<u8>, TypeTag), Value>> = HashMap::new();
 
     for type_tag in &type_tags {
-        let entries_a = match options.as_of {
+        let entries_a: Vec<(Key, VersionedValue)> = match options.as_of {
             Some(ts) => storage.list_by_type_at_timestamp(&id_a, *type_tag, ts),
-            None => storage.list_by_type(&id_a, *type_tag),
+            None => storage
+                .list_by_type_at_version(&id_a, *type_tag, snapshot_version)
+                .into_iter()
+                .filter(|e| !e.is_tombstone)
+                .map(|e| {
+                    let vv = VersionedValue {
+                        value: e.value,
+                        version: Version::Txn(e.commit_id),
+                        timestamp: strata_core::Timestamp::from_micros(0),
+                    };
+                    (e.key, vv)
+                })
+                .collect(),
         };
         for (key, vv) in entries_a {
             if space_filter
@@ -493,9 +508,21 @@ pub fn diff_branches_with_options(
             }
         }
 
-        let entries_b = match options.as_of {
+        let entries_b: Vec<(Key, VersionedValue)> = match options.as_of {
             Some(ts) => storage.list_by_type_at_timestamp(&id_b, *type_tag, ts),
-            None => storage.list_by_type(&id_b, *type_tag),
+            None => storage
+                .list_by_type_at_version(&id_b, *type_tag, snapshot_version)
+                .into_iter()
+                .filter(|e| !e.is_tombstone)
+                .map(|e| {
+                    let vv = VersionedValue {
+                        value: e.value,
+                        version: Version::Txn(e.commit_id),
+                        timestamp: strata_core::Timestamp::from_micros(0),
+                    };
+                    (e.key, vv)
+                })
+                .collect(),
         };
         for (key, vv) in entries_b {
             if space_filter
@@ -4837,5 +4864,36 @@ mod tests {
         assert_eq!(diff.summary.total_added, 0);
         assert_eq!(diff.summary.total_removed, 0);
         assert_eq!(diff.summary.total_modified, 0);
+    }
+
+    #[test]
+    fn test_issue_1920_diff_branches_snapshot_consistency() {
+        // Verify that diff_branches uses snapshot-isolated reads so that
+        // concurrent writes don't produce an inconsistent diff.
+        let (_temp, db) = setup();
+        let branch_index = BranchIndex::new(db.clone());
+        branch_index.create_branch("snap-a").unwrap();
+        branch_index.create_branch("snap-b").unwrap();
+
+        // Write different data to each branch
+        write_kv(&db, "snap-a", "default", "shared", Value::Int(1));
+        write_kv(&db, "snap-a", "default", "only-a", Value::Int(10));
+        write_kv(&db, "snap-b", "default", "shared", Value::Int(2));
+        write_kv(&db, "snap-b", "default", "only-b", Value::Int(20));
+
+        // Diff should succeed with consistent snapshot reads
+        let diff = diff_branches_with_options(
+            &db,
+            "snap-a",
+            "snap-b",
+            DiffOptions::default(),
+        )
+        .unwrap();
+
+        // "only-a" removed (in A, not in B), "only-b" added (in B, not in A),
+        // "shared" modified (different values)
+        assert_eq!(diff.summary.total_removed, 1, "only-a should be removed");
+        assert_eq!(diff.summary.total_added, 1, "only-b should be added");
+        assert_eq!(diff.summary.total_modified, 1, "shared should be modified");
     }
 }

--- a/crates/engine/src/bundle.rs
+++ b/crates/engine/src/bundle.rs
@@ -147,13 +147,21 @@ fn scan_branch_data(
 ) -> StrataResult<Vec<BranchlogPayload>> {
     let storage = db.storage();
 
+    // Capture snapshot version for consistent reads (#1920)
+    let snapshot_version = db.current_version();
+
     // Discover all current keys across all type tags
     let type_tags = [TypeTag::KV, TypeTag::Event, TypeTag::Json, TypeTag::Vector];
 
     let mut all_keys: Vec<Key> = Vec::new();
     for type_tag in type_tags {
-        let entries = storage.list_by_type(&core_branch_id, type_tag);
-        all_keys.extend(entries.into_iter().map(|(k, _)| k));
+        let entries = storage.list_by_type_at_version(&core_branch_id, type_tag, snapshot_version);
+        all_keys.extend(
+            entries
+                .into_iter()
+                .filter(|e| !e.is_tombstone)
+                .map(|e| e.key),
+        );
     }
 
     if all_keys.is_empty() {
@@ -466,5 +474,47 @@ mod tests {
         let formatted = format_micros(ts);
         assert!(!formatted.is_empty());
         assert!(formatted.ends_with('Z'));
+    }
+
+    #[test]
+    fn test_issue_1920_export_branch_snapshot_consistency() {
+        // Verify that export_branch uses snapshot-isolated reads so that
+        // the exported bundle captures a consistent point-in-time view.
+        let (temp_dir, db) = setup_with_branch("snap-export");
+
+        // Write data to the branch
+        let branch_index = BranchIndex::new(db.clone());
+        let meta = branch_index
+            .get_branch("snap-export")
+            .unwrap()
+            .unwrap()
+            .value;
+        let core_branch_id = crate::primitives::branch::resolve_branch_name(&meta.name);
+        let ns = Arc::new(Namespace::for_branch(core_branch_id));
+
+        db.transaction(core_branch_id, |txn| {
+            txn.put(
+                Key::new(ns.clone(), TypeTag::KV, b"k1".to_vec()),
+                strata_core::value::Value::String("v1".to_string()),
+            )?;
+            txn.put(
+                Key::new(ns.clone(), TypeTag::KV, b"k2".to_vec()),
+                strata_core::value::Value::Int(42),
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+        // Export should succeed with snapshot-isolated reads
+        let path = temp_dir.path().join("snap.branchbundle.tar.zst");
+        let info = export_branch(&db, "snap-export", &path).unwrap();
+
+        assert_eq!(info.branch_id, "snap-export");
+        assert!(info.entry_count > 0);
+        assert!(info.bundle_size > 0);
+
+        // Validate the bundle is well-formed
+        let bundle_info = validate_bundle(&path).unwrap();
+        assert!(bundle_info.checksums_valid);
     }
 }

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -10,6 +10,7 @@
 //! - Commit rate calculation
 
 use parking_lot::Mutex as ParkingMutex;
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -46,11 +47,17 @@ pub struct TransactionCoordinator {
     total_committed: AtomicU64,
     /// Total transactions aborted - uses Relaxed ordering
     total_aborted: AtomicU64,
-    /// Lock-free GC safe point: the version at which all prior transactions
-    /// have completed. Advances via `fetch_max` only when active_count drains
-    /// to 0, ensuring it is always ≤ the minimum active snapshot version.
-    /// Initialized to 0 (no drain has occurred yet).
+    /// GC safe point: the highest version at which all prior transactions
+    /// have completed. Advances incrementally as transactions finish (#1923):
+    /// - When active_snapshots is non-empty → `min(start_versions) - 1`
+    /// - When empty (full drain) → `current_version()`
+    ///
+    /// Always ≤ the minimum active snapshot version.
     gc_safe_version: AtomicU64,
+    /// Per-transaction snapshot tracking for incremental GC advancement (#1923).
+    /// Maps txn_id → start_version. Protected by Mutex; held only during
+    /// insert/remove (O(log n)), not during transaction lifetime.
+    active_snapshots: ParkingMutex<BTreeMap<u64, u64>>,
     /// Maximum entries in a transaction's write buffer (0 = unlimited).
     max_write_buffer_entries: AtomicUsize,
     /// Effective transaction timeout. Defaults to `TRANSACTION_TIMEOUT`.
@@ -79,6 +86,7 @@ impl TransactionCoordinator {
             total_committed: AtomicU64::new(0),
             total_aborted: AtomicU64::new(0),
             gc_safe_version: AtomicU64::new(0),
+            active_snapshots: ParkingMutex::new(BTreeMap::new()),
             max_write_buffer_entries: AtomicUsize::new(0),
             transaction_timeout: Self::TRANSACTION_TIMEOUT,
         }
@@ -106,6 +114,7 @@ impl TransactionCoordinator {
             total_committed: AtomicU64::new(0),
             total_aborted: AtomicU64::new(0),
             gc_safe_version: AtomicU64::new(0),
+            active_snapshots: ParkingMutex::new(BTreeMap::new()),
             max_write_buffer_entries: AtomicUsize::new(0),
             transaction_timeout: Self::TRANSACTION_TIMEOUT,
         }
@@ -126,6 +135,7 @@ impl TransactionCoordinator {
             total_committed: AtomicU64::new(0),
             total_aborted: AtomicU64::new(0),
             gc_safe_version: AtomicU64::new(0),
+            active_snapshots: ParkingMutex::new(BTreeMap::new()),
             max_write_buffer_entries: AtomicUsize::new(max_write_buffer_entries),
             transaction_timeout: Self::TRANSACTION_TIMEOUT,
         }
@@ -162,14 +172,39 @@ impl TransactionCoordinator {
 
         let mut txn = TransactionContext::with_store(txn_id, branch_id, Arc::clone(storage));
         txn.set_max_write_entries(self.max_write_buffer_entries.load(Ordering::Relaxed));
+
+        // Track per-transaction snapshot for incremental GC advancement (#1923).
+        self.active_snapshots
+            .lock()
+            .insert(txn.txn_id, txn.start_version);
+
         Ok(txn)
     }
 
-    /// Enforce the transaction timeout. If expired, records an abort
-    /// (decrementing active_count) and returns `TransactionTimeout`.
-    fn enforce_timeout(&self, txn: &TransactionContext) -> StrataResult<()> {
+    /// Enforce the transaction timeout. If expired, transitions the
+    /// transaction to Aborted (preventing double-decrement on retry)
+    /// and returns `TransactionTimeout`.
+    ///
+    /// # Safety (concurrency)
+    ///
+    /// `record_abort` is called at most once per transaction because
+    /// `mark_aborted` is idempotent on terminal states and we gate
+    /// the decrement on `is_active()`. This prevents the active_count
+    /// underflow described in #1922.
+    fn enforce_timeout(&self, txn: &mut TransactionContext) -> StrataResult<()> {
         if txn.is_expired(self.transaction_timeout) {
             let elapsed = txn.elapsed();
+            // Guard: only decrement active_count once. If the transaction
+            // is already aborted (e.g., from a prior timeout call), skip
+            // the bookkeeping — just return the error (#1922).
+            if txn.is_active() {
+                let _ = txn.mark_aborted(format!(
+                    "timeout after {}ms (limit: {}ms)",
+                    elapsed.as_millis(),
+                    self.transaction_timeout.as_millis()
+                ));
+                self.record_abort(txn.txn_id);
+            }
             warn!(
                 target: "strata::txn",
                 txn_id = txn.txn_id,
@@ -177,7 +212,6 @@ impl TransactionCoordinator {
                 timeout_ms = self.transaction_timeout.as_millis() as u64,
                 "Transaction expired — rejecting commit"
             );
-            self.record_abort(txn.txn_id);
             return Err(StrataError::transaction_timeout(elapsed.as_millis() as u64));
         }
         Ok(())
@@ -256,76 +290,92 @@ impl TransactionCoordinator {
 
     /// Record transaction start
     ///
-    /// Increments active count and total started count.
+    /// Increments active count and total started count, and tracks the
+    /// transaction's snapshot version for incremental GC advancement (#1923).
     ///
     /// # Arguments
-    /// * `_txn_id` - Unique transaction ID (unused, kept for API compat)
-    /// * `_start_version` - Snapshot version at transaction start (unused)
-    pub fn record_start(&self, _txn_id: u64, _start_version: u64) {
+    /// * `txn_id` - Unique transaction ID
+    /// * `start_version` - Snapshot version at transaction start
+    pub fn record_start(&self, txn_id: u64, start_version: u64) {
         // Relaxed: observational counters only (see struct-level doc).
         self.active_count.fetch_add(1, Ordering::Relaxed);
         self.total_started.fetch_add(1, Ordering::Relaxed);
+        self.active_snapshots.lock().insert(txn_id, start_version);
     }
 
     /// Record transaction commit
     ///
     /// Decrements active count, increments committed count,
-    /// and advances `gc_safe_version` when all transactions have drained.
+    /// and advances `gc_safe_version` incrementally (#1923).
     ///
     /// # Panics (debug only)
     /// Debug-asserts that `active_count > 0`. A zero active_count at this
     /// point indicates a bug (missing `record_start`).
     ///
     /// # Arguments
-    /// * `_txn_id` - Transaction ID (unused, kept for API compat)
-    pub fn record_commit(&self, _txn_id: u64) {
-        // Capture version BEFORE the decrement so gc_safe_version is always
-        // ≤ the snapshot version of any concurrently-starting transaction.
-        // A transaction that starts between our version read and the
-        // decrement will have a snapshot version ≥ drain_version.
-        let drain_version = self.manager.current_version();
-
-        // Single LOCK XADD instruction — no CAS loop. Underflow is a bug
-        // (record_start always precedes record_commit), so debug-assert.
-        let prev = self.active_count.fetch_sub(1, Ordering::AcqRel);
-        debug_assert!(prev > 0, "active_count underflow in record_commit");
-        // Relaxed: observational counter only — does not gate GC or any
-        // other correctness decision. The AcqRel on active_count above is
-        // the critical synchronization point.
+    /// * `txn_id` - Transaction ID (used for snapshot tracking)
+    pub fn record_commit(&self, txn_id: u64) {
         self.total_committed.fetch_add(1, Ordering::Relaxed);
-        if prev == 1 {
-            // All transactions drained — advance GC safe point
-            self.gc_safe_version
-                .fetch_max(drain_version, Ordering::Release);
-        }
+        self.finish_transaction(txn_id);
     }
 
     /// Record transaction abort
     ///
     /// Decrements active count, increments aborted count,
-    /// and advances `gc_safe_version` when all transactions have drained.
+    /// and advances `gc_safe_version` incrementally (#1923).
     ///
     /// # Panics (debug only)
     /// Debug-asserts that `active_count > 0`. A zero active_count at this
     /// point indicates a bug (missing `record_start`).
     ///
     /// # Arguments
-    /// * `_txn_id` - Transaction ID (unused, kept for API compat)
-    pub fn record_abort(&self, _txn_id: u64) {
-        // Capture version BEFORE the decrement (same rationale as record_commit)
+    /// * `txn_id` - Transaction ID (used for snapshot tracking)
+    pub fn record_abort(&self, txn_id: u64) {
+        self.total_aborted.fetch_add(1, Ordering::Relaxed);
+        self.finish_transaction(txn_id);
+    }
+
+    /// Remove a transaction from active tracking and advance gc_safe_version.
+    ///
+    /// Before #1923, gc_safe_version only advanced when active_count drained
+    /// to 0. Now it advances incrementally: when the oldest transaction
+    /// completes, gc_safe_version moves to `min(remaining start_versions) - 1`.
+    ///
+    /// # Memory ordering
+    ///
+    /// The Mutex on active_snapshots is held only for the brief
+    /// insert/remove + min() computation. The lock is released before the
+    /// atomic `fetch_max` to minimize contention.
+    fn finish_transaction(&self, txn_id: u64) {
+        // Capture version BEFORE the decrement so gc_safe_version is always
+        // ≤ the snapshot version of any concurrently-starting transaction.
         let drain_version = self.manager.current_version();
 
-        // Single LOCK XADD instruction — no CAS loop. Underflow is a bug
-        // (record_start always precedes record_abort), so debug-assert.
         let prev = self.active_count.fetch_sub(1, Ordering::AcqRel);
-        debug_assert!(prev > 0, "active_count underflow in record_abort");
-        // Relaxed: observational counter only (same rationale as total_committed).
-        self.total_aborted.fetch_add(1, Ordering::Relaxed);
-        if prev == 1 {
-            // All transactions drained — advance GC safe point
-            self.gc_safe_version
-                .fetch_max(drain_version, Ordering::Release);
-        }
+        debug_assert!(prev > 0, "active_count underflow in finish_transaction");
+
+        let new_gc_safe = {
+            let mut snapshots = self.active_snapshots.lock();
+            snapshots.remove(&txn_id);
+
+            if snapshots.is_empty() {
+                // All transactions drained — advance to current version
+                drain_version
+            } else {
+                // Advance to one below the oldest remaining snapshot.
+                // No active transaction reads data older than its start_version,
+                // so versions < min_start are safe to GC.
+                let min_start = *snapshots.values().min().unwrap();
+                if min_start > 0 {
+                    min_start - 1
+                } else {
+                    0
+                }
+            }
+        }; // lock released
+
+        self.gc_safe_version
+            .fetch_max(new_gc_safe, Ordering::Release);
     }
 
     /// Get current global version
@@ -1134,7 +1184,7 @@ mod tests {
 
     #[test]
     #[cfg(debug_assertions)]
-    #[should_panic(expected = "active_count underflow in record_commit")]
+    #[should_panic(expected = "active_count underflow in finish_transaction")]
     fn test_active_count_underflow_panics_in_debug_commit() {
         let coordinator = TransactionCoordinator::new(0);
         // Commit without a preceding start — should panic in debug builds
@@ -1143,7 +1193,7 @@ mod tests {
 
     #[test]
     #[cfg(debug_assertions)]
-    #[should_panic(expected = "active_count underflow in record_abort")]
+    #[should_panic(expected = "active_count underflow in finish_transaction")]
     fn test_active_count_underflow_panics_in_debug_abort() {
         let coordinator = TransactionCoordinator::new(0);
         // Abort without a preceding start — should panic in debug builds
@@ -1438,31 +1488,31 @@ mod tests {
     fn test_min_active_version_tracks_correctly() {
         let coordinator = TransactionCoordinator::new(10);
 
-        // Register 3 transactions
+        // Register 3 transactions at version 10
         coordinator.record_start(1, 10);
         coordinator.record_start(2, 10);
         coordinator.record_start(3, 10);
 
-        // While transactions are active, gc_safe_version hasn't advanced yet
-        // (no full drain has occurred), so min_active_version returns None
+        // While transactions are active but none have finished,
+        // gc_safe_version is still 0 (initial)
         assert_eq!(coordinator.min_active_version(), None);
 
-        // Committing first two doesn't cause a full drain (active_count stays > 0)
+        // Partial commit: gc_safe advances to min(remaining) - 1 = 9 (#1923)
         coordinator.record_commit(1);
         assert_eq!(
             coordinator.min_active_version(),
-            None,
-            "partial drain should not advance gc_safe_version"
+            Some(9),
+            "partial drain should advance gc_safe to min(snapshots) - 1"
         );
 
         coordinator.record_commit(2);
         assert_eq!(
             coordinator.min_active_version(),
-            None,
-            "still one active txn, no drain"
+            Some(9),
+            "txn3 still at version 10, gc_safe stays at 9"
         );
 
-        // Committing last → full drain → gc_safe_version advances to current_version (10)
+        // Full drain → gc_safe_version advances to current_version (10)
         coordinator.record_commit(3);
         assert_eq!(
             coordinator.min_active_version(),
@@ -1529,7 +1579,7 @@ mod tests {
     }
 
     #[test]
-    fn test_gc_safe_version_advances_on_full_drain() {
+    fn test_gc_safe_version_advances_incrementally() {
         let coordinator = TransactionCoordinator::new(10);
 
         // Start 3 transactions at version 10
@@ -1537,22 +1587,22 @@ mod tests {
         coordinator.record_start(2, 10);
         coordinator.record_start(3, 10);
 
-        // Partial commits don't trigger drain
+        // Partial commit: gc_safe = min(10, 10) - 1 = 9 (#1923)
         coordinator.record_commit(1);
         assert_eq!(
             coordinator.min_active_version(),
-            None,
-            "2 still active, no drain"
+            Some(9),
+            "gc_safe should be min(remaining_snapshots) - 1 = 9"
         );
 
         coordinator.record_commit(2);
         assert_eq!(
             coordinator.min_active_version(),
-            None,
-            "1 still active, no drain"
+            Some(9),
+            "gc_safe should still be 9 (txn3 still at version 10)"
         );
 
-        // Final commit → full drain → gc_safe_version = 10
+        // Final commit → full drain → gc_safe_version = current_version = 10
         coordinator.record_commit(3);
         assert_eq!(
             coordinator.min_active_version(),
@@ -1787,5 +1837,133 @@ mod tests {
             v, 3,
             "gc_safe_version should be 3 (current version at drain time)"
         );
+    }
+
+    // =========================================================================
+    // #1923 — incremental gc_safe_version advancement
+    // =========================================================================
+
+    #[test]
+    fn test_issue_1923_overlapping_txns_dont_pin_gc() {
+        let coordinator = TransactionCoordinator::new(100);
+
+        // Simulate the scenario from #1923: overlapping transactions
+        // where a new txn starts before the previous one completes.
+        // Use record_start with explicit versions to control snapshot points.
+        coordinator.record_start(1, 100); // txn1 at v100
+        coordinator.record_start(2, 200); // txn2 at v200
+        coordinator.record_start(3, 300); // txn3 at v300
+        assert_eq!(coordinator.active_count(), 3);
+
+        // Complete oldest (txn1). Before #1923, gc_safe would stay at 0
+        // because active_count > 0. Now it advances to min(200,300)-1 = 199.
+        coordinator.record_commit(1);
+        let v1 = coordinator.min_active_version();
+        assert!(
+            v1.is_some(),
+            "gc_safe_version should advance after oldest txn completes (#1923)"
+        );
+        assert_eq!(v1, Some(199));
+
+        // Start another txn — the overlapping pattern
+        coordinator.record_start(4, 400);
+
+        // Complete txn2 — gc_safe should advance: min(300,400)-1 = 299
+        coordinator.record_commit(2);
+        let v2 = coordinator.min_active_version().unwrap();
+        assert_eq!(v2, 299);
+        assert!(v2 > v1.unwrap(), "gc_safe must monotonically increase");
+
+        // Complete txn3 — gc_safe = min(400)-1 = 399
+        coordinator.record_commit(3);
+        let v3 = coordinator.min_active_version().unwrap();
+        assert_eq!(v3, 399);
+
+        // Complete final txn — full drain → gc_safe = current_version
+        coordinator.record_commit(4);
+        let v4 = coordinator.min_active_version().unwrap();
+        assert!(v4 >= v3, "full drain should advance gc_safe");
+        assert_eq!(coordinator.active_count(), 0);
+    }
+
+    #[test]
+    fn test_issue_1923_gc_advances_to_min_snapshot_minus_one() {
+        let coordinator = TransactionCoordinator::new(0);
+
+        // Use record_start with explicit, distinct versions
+        coordinator.record_start(1, 10); // txn1 at v10
+        coordinator.record_start(2, 20); // txn2 at v20
+        coordinator.record_start(3, 30); // txn3 at v30
+
+        // Complete txn1 (oldest). Remaining: txn2@20, txn3@30.
+        // gc_safe = min(20, 30) - 1 = 19
+        coordinator.record_commit(1);
+        let gc = coordinator.min_active_version().unwrap();
+        assert_eq!(gc, 19, "gc_safe should be min(remaining) - 1 = 20 - 1");
+
+        // Complete txn2. Remaining: txn3@30.
+        // gc_safe = 30 - 1 = 29
+        coordinator.record_commit(2);
+        let gc = coordinator.min_active_version().unwrap();
+        assert_eq!(gc, 29, "gc_safe should be min(remaining) - 1 = 30 - 1");
+
+        // Complete txn3 → full drain → gc_safe = current_version
+        coordinator.record_commit(3);
+        let gc = coordinator.min_active_version().unwrap();
+        assert!(gc > 0, "full drain should advance gc_safe to current_version");
+    }
+
+    // =========================================================================
+    // #1922 — double-decrement prevention
+    // =========================================================================
+
+    #[test]
+    fn test_issue_1922_expired_commit_no_double_decrement() {
+        let mut coordinator = TransactionCoordinator::new(0);
+        coordinator.set_transaction_timeout(Duration::from_millis(1));
+        let storage = create_test_storage();
+        let branch_id = BranchId::new();
+
+        let mut txn = coordinator
+            .start_transaction(branch_id, &storage)
+            .unwrap();
+        assert_eq!(coordinator.metrics().active_count, 1);
+
+        std::thread::sleep(Duration::from_millis(5));
+
+        // First commit attempt: should fail with timeout and decrement active_count
+        let r1 = coordinator.commit(&mut txn, storage.as_ref(), None);
+        assert!(r1.is_err());
+        assert_eq!(coordinator.metrics().active_count, 0);
+
+        // Second commit attempt: should fail again but NOT decrement further.
+        // Before #1922 fix, this would underflow active_count (debug_assert panic).
+        let r2 = coordinator.commit(&mut txn, storage.as_ref(), None);
+        assert!(r2.is_err());
+        assert_eq!(coordinator.metrics().active_count, 0);
+
+        // Transaction should be in Aborted state
+        assert!(!txn.is_active());
+    }
+
+    #[test]
+    fn test_issue_1922_timeout_marks_transaction_aborted() {
+        let mut coordinator = TransactionCoordinator::new(0);
+        coordinator.set_transaction_timeout(Duration::from_millis(1));
+        let storage = create_test_storage();
+        let branch_id = BranchId::new();
+
+        let mut txn = coordinator
+            .start_transaction(branch_id, &storage)
+            .unwrap();
+        assert!(txn.is_active());
+
+        std::thread::sleep(Duration::from_millis(5));
+
+        let _ = coordinator.commit(&mut txn, storage.as_ref(), None);
+        // enforce_timeout should have marked it aborted
+        assert!(!txn.is_active());
+        assert!(txn.abort_reason().is_some());
+        assert!(txn.abort_reason().unwrap().contains("timeout"));
     }
 }

--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -110,6 +110,11 @@ pub struct StorageConfig {
     /// On slow storage (SD cards), set to e.g. 5–10 MB/s to avoid starving user I/O.
     #[serde(default)]
     pub compaction_rate_limit: u64,
+    /// Maximum time (milliseconds) a write can be stalled waiting for L0 compaction.
+    /// If exceeded, the write returns an error instead of blocking indefinitely.
+    /// Default: 30000 (30 seconds). Set to 0 for unlimited (not recommended).
+    #[serde(default = "default_write_stall_timeout_ms")]
+    pub write_stall_timeout_ms: u64,
 }
 
 fn default_max_branches() -> usize {
@@ -158,6 +163,10 @@ fn default_bloom_bits_per_key() -> usize {
     10
 }
 
+fn default_write_stall_timeout_ms() -> u64 {
+    30_000 // 30 seconds
+}
+
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
@@ -175,6 +184,7 @@ impl Default for StorageConfig {
             data_block_size: default_data_block_size(),
             bloom_bits_per_key: default_bloom_bits_per_key(),
             compaction_rate_limit: 0,
+            write_stall_timeout_ms: default_write_stall_timeout_ms(),
         }
     }
 }

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -158,12 +158,13 @@ impl Database {
     /// 2. L0 count >= `l0_slowdown_writes_trigger` → yield 1 ms per write.
     /// 3. Memtable bytes > threshold → yield 1 ms (OOM protection).
     #[inline]
-    fn maybe_apply_write_backpressure(&self) {
+    fn maybe_apply_write_backpressure(&self) -> StrataResult<()> {
         let cfg = self.config.read();
 
         // L0-based stalling (protects read latency)
         let l0_stop = cfg.storage.l0_stop_writes_trigger;
         let l0_slow = cfg.storage.l0_slowdown_writes_trigger;
+        let timeout_ms = cfg.storage.write_stall_timeout_ms;
         drop(cfg); // release config lock before potential sleep
 
         let l0_count = self.storage.max_l0_segment_count();
@@ -172,18 +173,34 @@ impl Database {
             // Complete stall: wait on condvar until compaction drains L0.
             // Also trigger compaction in case none is running.
             self.schedule_flush_if_needed();
+            let stall_start = std::time::Instant::now();
+            let timeout = std::time::Duration::from_millis(timeout_ms);
+
             let mut guard = self.write_stall_mu.lock();
             // Re-check after acquiring lock (compaction may have finished)
             while self.storage.max_l0_segment_count() >= l0_stop {
+                if timeout_ms > 0 && stall_start.elapsed() >= timeout {
+                    let current_l0 = self.storage.max_l0_segment_count();
+                    tracing::warn!(
+                        target: "strata::backpressure",
+                        stall_ms = stall_start.elapsed().as_millis() as u64,
+                        l0_count = current_l0,
+                        "Write stall timeout — L0 compaction cannot keep up"
+                    );
+                    return Err(StrataError::write_stall_timeout(
+                        stall_start.elapsed().as_millis() as u64,
+                        current_l0,
+                    ));
+                }
                 self.write_stall_cv
                     .wait_for(&mut guard, std::time::Duration::from_millis(10));
             }
-            return;
+            return Ok(());
         }
 
         if l0_slow > 0 && l0_count >= l0_slow {
             std::thread::sleep(std::time::Duration::from_millis(1));
-            return;
+            return Ok(());
         }
 
         // Memtable-based stalling (protects memory usage)
@@ -191,13 +208,14 @@ impl Database {
         let wbs = cfg.storage.write_buffer_size as u64;
         let max_frozen = cfg.storage.max_immutable_memtables as u64;
         if wbs == 0 {
-            return;
+            return Ok(());
         }
         let threshold = wbs * (max_frozen + 2);
         let current = self.storage.total_memtable_bytes();
         if current > threshold {
             std::thread::sleep(std::time::Duration::from_millis(1));
         }
+        Ok(())
     }
 
     /// Update the MANIFEST flush watermark and truncate WAL segments below it.
@@ -302,7 +320,9 @@ impl Database {
                 // Schedule flush only for write transactions (reads skip entirely)
                 if had_writes {
                     self.schedule_flush_if_needed();
-                    self.maybe_apply_write_backpressure();
+                    // Best-effort: backpressure must not fail a committed txn (#1924).
+                    // The stall loop still bounds the delay; a timeout just logs.
+                    let _ = self.maybe_apply_write_backpressure();
                 }
                 Ok((value, commit_version))
             }
@@ -498,7 +518,8 @@ impl Database {
         let version = self.commit_internal(txn, self.durability_mode)?;
         if had_writes {
             self.schedule_flush_if_needed();
-            self.maybe_apply_write_backpressure();
+            // Best-effort: backpressure must not fail a committed txn (#1924).
+            let _ = self.maybe_apply_write_backpressure();
         }
         Ok(version)
     }

--- a/crates/engine/src/search/types.rs
+++ b/crates/engine/src/search/types.rs
@@ -164,6 +164,12 @@ pub struct SearchRequest {
 
     /// Space to search within (defaults to "default").
     pub space: String,
+
+    /// Optional: MVCC snapshot version for cross-primitive consistency (#1921).
+    /// When set, all primitive searches in a HybridSearch query share the same
+    /// snapshot. Primitives that support versioned reads use this bound; the
+    /// inverted index scoring is not yet version-bounded (future work).
+    pub snapshot_version: Option<u64>,
 }
 
 impl SearchRequest {
@@ -189,6 +195,7 @@ impl SearchRequest {
             tags_any: vec![],
             precomputed_embedding: None,
             space: "default".to_string(),
+            snapshot_version: None,
         }
     }
 
@@ -237,6 +244,12 @@ impl SearchRequest {
     /// Builder: set space to search within
     pub fn with_space(mut self, space: impl Into<String>) -> Self {
         self.space = space.into();
+        self
+    }
+
+    /// Builder: set MVCC snapshot version for consistent cross-primitive reads
+    pub fn with_snapshot_version(mut self, version: u64) -> Self {
+        self.snapshot_version = Some(version);
         self
     }
 
@@ -509,6 +522,17 @@ mod tests {
         assert!(req2.includes_primitive(PrimitiveType::Kv));
         assert!(req2.includes_primitive(PrimitiveType::Json));
         assert!(!req2.includes_primitive(PrimitiveType::Event));
+    }
+
+    #[test]
+    fn test_issue_1921_snapshot_version_in_request() {
+        let req = SearchRequest::new(BranchId::new(), "test query")
+            .with_snapshot_version(42);
+        assert_eq!(req.snapshot_version, Some(42));
+
+        // Default should be None
+        let req2 = SearchRequest::new(BranchId::new(), "test query");
+        assert_eq!(req2.snapshot_version, None);
     }
 
     // ========================================

--- a/crates/executor/src/convert.rs
+++ b/crates/executor/src/convert.rs
@@ -77,6 +77,16 @@ impl From<StrataError> for Error {
                 reason: format!("Transaction timeout after {}ms", duration_ms),
             },
 
+            StrataError::WriteStallTimeout {
+                stall_duration_ms,
+                l0_count,
+            } => Error::Conflict {
+                reason: format!(
+                    "Write stall timeout after {}ms (L0 count: {})",
+                    stall_duration_ms, l0_count
+                ),
+            },
+
             StrataError::TransactionNotActive { .. } => Error::TransactionNotActive { hint: None },
 
             // Validation errors

--- a/crates/search/src/hybrid.rs
+++ b/crates/search/src/hybrid.rs
@@ -139,11 +139,14 @@ impl HybridSearch {
     ///
     /// # Snapshot Consistency
     ///
-    /// Per Rule 4: Each primitive's search() uses its own snapshot.
-    /// For true cross-primitive consistency, primitives would need
-    /// search_with_snapshot() methods. This is acceptable for M6.
+    /// A unified `snapshot_version` is captured at the start of each search
+    /// and threaded through to all primitive searches via `SearchRequest` (#1921).
+    /// Primitives that perform post-scoring storage reads can use this version
+    /// for cross-primitive consistency. The inverted index scoring itself is
+    /// not yet version-bounded (future work).
     pub fn search(&self, req: &SearchRequest) -> StrataResult<SearchResponse> {
         let start = Instant::now();
+        let snapshot_version = self.db.current_version();
 
         // 1. Select primitives
         let primitives = self.select_primitives(req);
@@ -180,7 +183,7 @@ impl HybridSearch {
                             any_truncated = true;
                             break;
                         }
-                        let sub_req = req.clone().with_budget(*budget);
+                        let sub_req = req.clone().with_budget(*budget).with_snapshot_version(snapshot_version);
                         let result = self.search_primitive(*primitive, &sub_req)?;
                         total_candidates += result.stats.candidates_considered;
                         if result.truncated {
@@ -209,7 +212,7 @@ impl HybridSearch {
                         any_truncated = true;
                         break;
                     }
-                    let sub_req = req.clone().with_budget(*budget);
+                    let sub_req = req.clone().with_budget(*budget).with_snapshot_version(snapshot_version);
                     let result = self.search_primitive(*primitive, &sub_req)?;
                     total_candidates += result.stats.candidates_considered;
                     if result.truncated {


### PR DESCRIPTION
## Summary

- **#1920**: Snapshot-isolate `diff_branches()` and `export_branch()` — capture `current_version()` before scanning, use `list_by_type_at_version()` with tombstone filter instead of live-state `list_by_type()`
- **#1921**: Thread `snapshot_version` through `HybridSearch` — add field to `SearchRequest`, capture `db.current_version()` at search start, inject into all sub-requests for cross-primitive consistency plumbing
- **#1922**: Prevent double-decrement of `active_count` on timeout — change `enforce_timeout()` to take `&mut`, gate `record_abort()` on `is_active()`, mark transaction Aborted before decrementing
- **#1923**: Incremental `gc_safe_version` advancement — track per-transaction `start_version` in `BTreeMap`, advance gc_safe to `min(remaining)-1` on each commit/abort instead of waiting for full drain to zero
- **#1924**: Add timeout to write stall loop — new `WriteStallTimeout` error, configurable `write_stall_timeout_ms` (default 30s), `Instant`-based guard in condvar loop; backpressure errors are best-effort (logged, not propagated) since the transaction is already committed

## Test plan

- [x] 2,152 tests pass across strata-core, strata-engine, strata-search, strata-executor (0 failures)
- [x] Clippy clean on all affected crates
- [x] New tests for each issue:
  - `test_issue_1920_diff_branches_snapshot_consistency`
  - `test_issue_1920_export_branch_snapshot_consistency`
  - `test_issue_1921_snapshot_version_in_request`
  - `test_issue_1922_expired_commit_no_double_decrement`
  - `test_issue_1922_timeout_marks_transaction_aborted`
  - `test_issue_1923_overlapping_txns_dont_pin_gc`
  - `test_issue_1923_gc_advances_to_min_snapshot_minus_one`
  - `test_write_stall_timeout_constructor`
- [x] Post-implementation review caught and fixed: backpressure error after committed txn (now best-effort), removed `WriteStallTimeout` from `is_retryable()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)