### PR TITLE
Fix #1984–#1994: Storage engine debt — 11 items from STG-DEBT audit

### DIFF
--- a/crates/storage/src/key_encoding.rs
+++ b/crates/storage/src/key_encoding.rs
@@ -227,13 +227,14 @@ impl InternalKey {
     /// Decode the full `(Key, commit_id)` pair.
     pub fn decode(&self) -> Option<(Key, u64)> {
         let buf = &self.0;
-        if buf.len() < 16 + 1 + 1 + 2 + 8 {
-            // minimum: 16 (branch) + 1 (space NUL) + 1 (tag) + 2 (user_key terminator) + 8 (commit)
+        if buf.len() < 16 + 1 + 1 + 2 + COMMIT_ID_SUFFIX_LEN {
+            // minimum: 16 (branch) + 1 (space NUL) + 1 (tag) + 2 (user_key terminator) + commit_id
             return None;
         }
 
-        let commit_id_start = buf.len() - 8;
-        let commit_id_bytes: [u8; 8] = buf[commit_id_start..].try_into().ok()?;
+        let commit_id_start = buf.len() - COMMIT_ID_SUFFIX_LEN;
+        let commit_id_bytes: [u8; COMMIT_ID_SUFFIX_LEN] =
+            buf[commit_id_start..].try_into().ok()?;
         let commit_id = !u64::from_be_bytes(commit_id_bytes);
 
         let typed = &buf[..commit_id_start];

--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -673,7 +673,7 @@ impl KVSegment {
             pos += hdr.total_len;
 
             // prev_key now holds the full reconstructed InternalKey bytes
-            if prev_key.len() < 8 {
+            if prev_key.len() < COMMIT_ID_SUFFIX_LEN {
                 return None;
             }
             let tkp = &prev_key[..prev_key.len() - COMMIT_ID_SUFFIX_LEN];

--- a/crates/storage/src/segment_builder.rs
+++ b/crates/storage/src/segment_builder.rs
@@ -1914,7 +1914,7 @@ mod tests {
             let (_, prev_max) = prev_seg.key_range();
             let (curr_min, _) = curr_seg.key_range();
             // Strip commit_id to compare typed_key_prefix
-            if prev_max.len() >= 8 && curr_min.len() >= 8 {
+            if prev_max.len() >= COMMIT_ID_SUFFIX_LEN && curr_min.len() >= COMMIT_ID_SUFFIX_LEN {
                 let prev_prefix = &prev_max[..prev_max.len() - COMMIT_ID_SUFFIX_LEN];
                 let curr_prefix = &curr_min[..curr_min.len() - COMMIT_ID_SUFFIX_LEN];
                 assert!(
@@ -2315,8 +2315,8 @@ mod tests {
 
         let result = shorten_index_key(&a, &b);
         // Prefix shortened: "abd", then u64::MAX suffix
-        assert!(result.len() >= 8);
-        let suffix = &result[result.len() - 8..];
+        assert!(result.len() >= COMMIT_ID_SUFFIX_LEN);
+        let suffix = &result[result.len() - COMMIT_ID_SUFFIX_LEN..];
         assert_eq!(suffix, &(!0_u64).to_be_bytes());
         let prefix = &result[..result.len() - COMMIT_ID_SUFFIX_LEN];
         assert_eq!(prefix, b"abd");

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -531,12 +531,12 @@ impl SegmentedStore {
             if seg_min.is_empty() && seg_max.is_empty() {
                 continue; // empty segment
             }
-            let seg_min_prefix = if seg_min.len() >= 8 {
+            let seg_min_prefix = if seg_min.len() >= COMMIT_ID_SUFFIX_LEN {
                 &seg_min[..seg_min.len() - COMMIT_ID_SUFFIX_LEN]
             } else {
                 seg_min
             };
-            let seg_max_prefix = if seg_max.len() >= 8 {
+            let seg_max_prefix = if seg_max.len() >= COMMIT_ID_SUFFIX_LEN {
                 &seg_max[..seg_max.len() - COMMIT_ID_SUFFIX_LEN]
             } else {
                 seg_max
@@ -567,12 +567,12 @@ impl SegmentedStore {
                     if seg_min.is_empty() && seg_max.is_empty() {
                         return false;
                     }
-                    let seg_min_prefix = if seg_min.len() >= 8 {
+                    let seg_min_prefix = if seg_min.len() >= COMMIT_ID_SUFFIX_LEN {
                         &seg_min[..seg_min.len() - COMMIT_ID_SUFFIX_LEN]
                     } else {
                         seg_min
                     };
-                    let seg_max_prefix = if seg_max.len() >= 8 {
+                    let seg_max_prefix = if seg_max.len() >= COMMIT_ID_SUFFIX_LEN {
                         &seg_max[..seg_max.len() - COMMIT_ID_SUFFIX_LEN]
                     } else {
                         seg_max
@@ -1076,7 +1076,7 @@ fn check_corruption_flags(flags: &[Arc<AtomicBool>]) -> io::Result<()> {
 /// Returns the full slice if shorter than 8 bytes.
 #[inline]
 fn typed_key_prefix_of(ik_bytes: &[u8]) -> &[u8] {
-    if ik_bytes.len() >= 8 {
+    if ik_bytes.len() >= COMMIT_ID_SUFFIX_LEN {
         &ik_bytes[..ik_bytes.len() - COMMIT_ID_SUFFIX_LEN]
     } else {
         ik_bytes

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -3414,7 +3414,7 @@ fn point_lookup_level_preencoded(
 
     let idx = l1_segments.partition_point(|seg| {
         let (_, max_ik) = seg.key_range();
-        if max_ik.len() < 8 {
+        if max_ik.len() < COMMIT_ID_SUFFIX_LEN {
             return true;
         }
         let max_prefix = &max_ik[..max_ik.len() - COMMIT_ID_SUFFIX_LEN];
@@ -3427,7 +3427,7 @@ fn point_lookup_level_preencoded(
 
     let seg = &l1_segments[idx];
     let (min_ik, _) = seg.key_range();
-    if min_ik.len() >= 8 {
+    if min_ik.len() >= COMMIT_ID_SUFFIX_LEN {
         let min_prefix = &min_ik[..min_ik.len() - COMMIT_ID_SUFFIX_LEN];
         if min_prefix > typed_key {
             return Ok(None);


### PR DESCRIPTION
## Summary

Addresses all 11 technical debt items from the storage engine audit (STG-DEBT-001 through STG-DEBT-011).

**Deduplication & helpers:**
- **#1984**: Extract `load_next_block()` shared by `SegmentIter` and `OwnedSegmentIter`
- **#1985**: Add `SegmentIndex::partition()` / `seek_position()` — eliminates 8 index vector clones per seek
- **#1986**: Extract `segment_overlaps_prefix()` — deduplicates 4 copies of overlap pruning
- **#1987**: Add `BranchState::track_timestamp()` — replaces 12 inline `fetch_min`/`fetch_max` pairs
- **#1988**: Extract `resolve_inherited_layers()` and `collect_unshadowed_entries()` from 270+ line methods
- **#1989**: Add `invalid_data!` macro — replaces 15 verbose `io::Error::new` calls
- **#1991**: Define `COMMIT_ID_SUFFIX_LEN` constant — replaces 30+ hardcoded `- 8` magic numbers across 5 files
- **#1993**: Extract `flush_data_block()` — deduplicates ~44 lines of block-flush logic

**Dead code & safety:**
- **#1990**: Document `pressure_level()` as intentionally future-use (for background scheduler)
- **#1992**: Remove dead `footer` field, `pin_bloom_partitions()`, `load_sub_index()`
- **#1994**: Replace panicking `unwrap`/`expect` in `restart_offset_at` and `strip_hash_index` with graceful error handling

Net: −44 lines, 0 new dependencies, all 622 storage tests pass.

## Test plan
- [x] `cargo check` — full project compiles with no warnings
- [x] `cargo test -p strata-storage` — all 622 tests pass
- [x] `cargo test` — full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)