### PR TITLE
Fix #2002–#2009: Durability layer debt — 7 items from DUR-DEBT audit

### DIFF
--- a/crates/durability/Cargo.toml
+++ b/crates/durability/Cargo.toml
@@ -8,6 +8,10 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[features]
+default = []
+multi_process = []
+
 [dependencies]
 strata-core = { path = "../core" }
 parking_lot = { workspace = true }

--- a/crates/durability/src/codec/mod.rs
+++ b/crates/durability/src/codec/mod.rs
@@ -1,19 +1,37 @@
 //! Storage codec abstraction.
 //!
-//! The codec seam provides a hook point for future encryption-at-rest and
+//! The codec seam provides a hook point for encryption-at-rest and
 //! compression. All bytes passing through the storage layer go through the
 //! codec for encode/decode operations.
 //!
+//! # Available Codecs
 //!
+//! | Codec ID | Description | Status |
+//! |----------|-------------|--------|
+//! | `"identity"` | No-op pass-through | Default |
+//! | `"aes-gcm-256"` | AES-256-GCM authenticated encryption | Available |
 //!
-//! Uses `IdentityCodec` which performs no transformation. This establishes
-//! the codec seam without adding complexity. Future milestones can add:
+//! # Enabling Encryption
 //!
-//! - `AesGcmCodec`: AES-256-GCM encryption at rest
-//! - `Lz4Codec`: LZ4 compression
-//! - `ChainedCodec`: Compression + encryption pipeline
+//! To enable AES-256-GCM encryption at rest:
 //!
-//! # Usage
+//! 1. Set the `STRATA_ENCRYPTION_KEY` environment variable to a 64-character
+//!    hex string (32 bytes):
+//!    ```text
+//!    export STRATA_ENCRYPTION_KEY="000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+//!    ```
+//!
+//! 2. Use `"aes-gcm-256"` as the codec ID when creating a database:
+//!    ```text
+//!    let config = DatabaseConfig { codec_id: "aes-gcm-256".to_string(), .. };
+//!    ```
+//!
+//! 3. Or obtain a codec directly via [`get_codec("aes-gcm-256")`](get_codec).
+//!
+//! **Important:** A database created with one codec cannot be opened with a
+//! different codec — the MANIFEST records the codec ID and validates on open.
+//!
+//! # Identity Codec Example
 //!
 //! ```text
 //! use strata_durability::codec::{StorageCodec, IdentityCodec};
@@ -33,7 +51,7 @@ mod traits;
 
 use aes_gcm::AesGcmCodec;
 pub use identity::IdentityCodec;
-pub use traits::{CodecError, StorageCodec};
+pub use traits::{clone_codec, CodecError, StorageCodec};
 
 /// Get a codec by its identifier.
 ///
@@ -43,9 +61,12 @@ pub use traits::{CodecError, StorageCodec};
 ///
 /// - `"identity"`: No-op codec (pass-through)
 ///
+/// # Encryption
+///
+/// - `"aes-gcm-256"`: AES-256-GCM encryption (requires `STRATA_ENCRYPTION_KEY` env var)
+///
 /// # Future Codecs
 ///
-/// - `"aes-gcm-256"`: AES-256-GCM encryption
 /// - `"lz4"`: LZ4 compression
 pub fn get_codec(codec_id: &str) -> Result<Box<dyn StorageCodec>, CodecError> {
     match codec_id {

--- a/crates/durability/src/codec/traits.rs
+++ b/crates/durability/src/codec/traits.rs
@@ -91,6 +91,14 @@ impl CodecError {
     }
 }
 
+/// Clone a boxed codec, preserving internal state (e.g., encryption keys).
+///
+/// Convenience wrapper around [`StorageCodec::clone_box()`] for use with
+/// `&dyn StorageCodec` references.
+pub fn clone_codec(codec: &dyn StorageCodec) -> Box<dyn StorageCodec> {
+    codec.clone_box()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/durability/src/database/handle.rs
+++ b/crates/durability/src/database/handle.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::warn;
 
-use crate::codec::{get_codec, StorageCodec};
+use crate::codec::{clone_codec, get_codec, StorageCodec};
 use crate::disk_snapshot::{CheckpointCoordinator, CheckpointData};
 use crate::format::{CheckpointInfo, Manifest, ManifestManager, SnapshotWatermark, WalRecord};
 use crate::recovery::{RecoveryCoordinator, RecoveryError, RecoveryResult, RecoverySnapshot};
@@ -371,11 +371,6 @@ fn generate_uuid() -> [u8; 16] {
     uuid[8..16].copy_from_slice(&random_seed.to_le_bytes());
 
     uuid
-}
-
-/// Clone a boxed codec, preserving internal state (e.g., encryption keys).
-fn clone_codec(codec: &dyn StorageCodec) -> Box<dyn StorageCodec> {
-    codec.clone_box()
 }
 
 #[cfg(test)]

--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -17,7 +17,8 @@
 pub mod branch_bundle; // Portable execution artifacts (BranchBundle)
 pub mod codec; // Storage codec abstraction (identity, future encryption/compression)
 pub mod compaction; // WAL segment cleanup and tombstone tracking
-pub mod coordination; // WAL file lock + counter file (currently unused, retained for future use)
+#[cfg(feature = "multi_process")]
+pub mod coordination; // WAL file lock + counter file (gated behind `multi_process` feature)
 pub mod database; // Database handle, config, paths (DatabaseHandle, DatabaseConfig, etc.)
 pub mod disk_snapshot; // Crash-safe snapshot I/O and checkpoint coordination
 pub mod format; // Binary on-disk formats (WAL segments, snapshots, manifest, writesets)
@@ -52,7 +53,7 @@ pub use branch_bundle::{
 };
 
 // Codec
-pub use codec::{get_codec, CodecError, IdentityCodec, StorageCodec};
+pub use codec::{clone_codec, get_codec, CodecError, IdentityCodec, StorageCodec};
 
 // Disk snapshot
 pub use disk_snapshot::{

--- a/crates/durability/src/recovery/coordinator.rs
+++ b/crates/durability/src/recovery/coordinator.rs
@@ -22,7 +22,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::codec::{CodecError, StorageCodec};
+use crate::codec::{clone_codec, CodecError, StorageCodec};
 use crate::disk_snapshot::{SnapshotReadError, SnapshotReader};
 use crate::format::manifest::{Manifest, ManifestError, ManifestManager};
 use crate::format::segment_meta::SegmentMeta;
@@ -382,11 +382,6 @@ impl RecoveryError {
     pub fn apply(msg: impl Into<String>) -> Self {
         RecoveryError::Apply(msg.into())
     }
-}
-
-/// Clone a boxed codec, preserving internal state (e.g., encryption keys).
-fn clone_codec(codec: &dyn StorageCodec) -> Box<dyn StorageCodec> {
-    codec.clone_box()
 }
 
 #[cfg(test)]

--- a/crates/durability/src/wal/config.rs
+++ b/crates/durability/src/wal/config.rs
@@ -2,6 +2,12 @@
 //!
 //! This module provides configuration for the Write-Ahead Log.
 
+/// Default maximum segment size: 64 MB.
+pub const DEFAULT_SEGMENT_SIZE: u64 = 64 * 1024 * 1024;
+
+/// Default bytes between fsyncs in Standard mode: 4 MB.
+pub const DEFAULT_BUFFERED_SYNC_BYTES: u64 = 4 * 1024 * 1024;
+
 /// WAL configuration parameters.
 #[derive(Debug, Clone)]
 pub struct WalConfig {
@@ -20,8 +26,8 @@ pub struct WalConfig {
 impl Default for WalConfig {
     fn default() -> Self {
         WalConfig {
-            segment_size: 64 * 1024 * 1024,       // 64MB
-            buffered_sync_bytes: 4 * 1024 * 1024, // 4MB
+            segment_size: DEFAULT_SEGMENT_SIZE,
+            buffered_sync_bytes: DEFAULT_BUFFERED_SYNC_BYTES,
         }
     }
 }

--- a/crates/durability/src/wal/mod.rs
+++ b/crates/durability/src/wal/mod.rs
@@ -17,3 +17,42 @@ pub use mode::DurabilityMode;
 pub use config::{WalConfig, WalConfigError};
 pub use reader::{ReadStopReason, TruncateInfo, WalReader, WalReaderError, WalRecordIterator};
 pub use writer::{WalCounters, WalDiskUsage, WalWriter};
+
+/// Parse a WAL segment number from a filename like `wal-NNNNNN.seg`.
+///
+/// Returns `None` if the filename does not match the expected pattern.
+pub fn parse_segment_number(filename: &str) -> Option<u64> {
+    let stem = filename.strip_prefix("wal-")?.strip_suffix(".seg")?;
+    if stem.is_empty() {
+        return None;
+    }
+    stem.parse::<u64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_standard_segment() {
+        assert_eq!(parse_segment_number("wal-000001.seg"), Some(1));
+        assert_eq!(parse_segment_number("wal-000042.seg"), Some(42));
+        assert_eq!(parse_segment_number("wal-999999.seg"), Some(999999));
+    }
+
+    #[test]
+    fn test_parse_large_segment_number() {
+        // Segment numbers > 999999 produce >6 digit filenames
+        assert_eq!(parse_segment_number("wal-1000000.seg"), Some(1000000));
+    }
+
+    #[test]
+    fn test_parse_rejects_non_wal_files() {
+        assert_eq!(parse_segment_number("wal-000001.meta"), None);
+        assert_eq!(parse_segment_number("snapshot-000001.seg"), None);
+        assert_eq!(parse_segment_number("wal-.seg"), None);
+        assert_eq!(parse_segment_number("wal-backup.seg"), None);
+        assert_eq!(parse_segment_number("random.txt"), None);
+        assert_eq!(parse_segment_number(""), None);
+    }
+}

--- a/crates/durability/src/wal/mode.rs
+++ b/crates/durability/src/wal/mode.rs
@@ -2,6 +2,12 @@
 //!
 //! Controls WAL sync behavior (Cache, Standard, Always).
 
+/// Default maximum time between fsyncs in Standard mode: 100 ms.
+pub const DEFAULT_SYNC_INTERVAL_MS: u64 = 100;
+
+/// Default maximum writes between fsyncs in Standard mode.
+pub const DEFAULT_SYNC_BATCH_SIZE: usize = 1000;
+
 /// Durability mode for WAL operations
 ///
 /// Controls when the WAL is fsynced to disk. This is orthogonal to
@@ -89,18 +95,17 @@ impl DurabilityMode {
     /// This is the recommended mode for production workloads.
     pub fn standard_default() -> Self {
         DurabilityMode::Standard {
-            interval_ms: 100,
-            batch_size: 1000,
+            interval_ms: DEFAULT_SYNC_INTERVAL_MS,
+            batch_size: DEFAULT_SYNC_BATCH_SIZE,
         }
     }
 }
 
 impl Default for DurabilityMode {
     fn default() -> Self {
-        // Default: standard with 100ms interval or 1000 commits
         DurabilityMode::Standard {
-            interval_ms: 100,
-            batch_size: 1000,
+            interval_ms: DEFAULT_SYNC_INTERVAL_MS,
+            batch_size: DEFAULT_SYNC_BATCH_SIZE,
         }
     }
 }

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -301,13 +301,8 @@ impl WalReader {
             let entry = entry.map_err(|e| WalReaderError::IoError(e.to_string()))?;
             let name = entry.file_name().to_string_lossy().to_string();
 
-            // Expected format: "wal-NNNNNN.seg" where NNNNNN is a 6-digit sequence number
-            // Minimum length: "wal-" (4) + 6 digits + ".seg" (4) = 14 chars
-            if name.starts_with("wal-") && name.ends_with(".seg") && name.len() >= 14 {
-                // Extract the 6-digit sequence number between "wal-" and ".seg"
-                if let Ok(num) = name[4..10].parse::<u64>() {
-                    segments.push(num);
-                }
+            if let Some(num) = super::parse_segment_number(&name) {
+                segments.push(num);
             }
         }
 

--- a/crates/durability/src/wal/writer.rs
+++ b/crates/durability/src/wal/writer.rs
@@ -200,49 +200,14 @@ impl WalWriter {
     /// - `Always`: Writes and fsyncs before returning
     /// - `Standard`: Writes, fsyncs periodically
     pub fn append(&mut self, record: &WalRecord) -> std::io::Result<()> {
-        // Cache mode: no persistence
         if !self.durability.requires_wal() {
             return Ok(());
         }
 
-        let segment = self
-            .segment
-            .as_mut()
-            .expect("Segment should exist for non-Cache mode");
-
-        // Serialize record
         let record_bytes = record.to_bytes();
-
-        // Encode through codec
         let encoded = self.codec.encode(&record_bytes);
-
-        // Check if we need to rotate before writing
-        if segment.size() + encoded.len() as u64 > self.config.segment_size {
-            self.rotate_segment()?;
-        }
-
-        // Write to segment
-        let segment = self.segment.as_mut().unwrap();
-        segment.write(&encoded)?;
-
-        // Track metadata for the current segment
-        if let Some(ref mut meta) = self.current_segment_meta {
-            meta.track_record(record.txn_id, record.timestamp);
-        }
-
-        self.total_wal_appends += 1;
-        self.total_bytes_written += encoded.len() as u64;
-
-        debug!(target: "strata::wal", txn_id = record.txn_id, record_bytes = encoded.len(), segment = self.current_segment_number, "WAL record appended");
-
-        self.bytes_since_sync += encoded.len() as u64;
-        self.writes_since_sync += 1;
-        self.has_unsynced_data = true;
-
-        // Handle sync based on durability mode
-        self.maybe_sync()?;
-
-        Ok(())
+        self.append_inner(&encoded, record.txn_id, record.timestamp)?;
+        self.maybe_sync()
     }
 
     /// Append a pre-serialized WAL record.
@@ -260,13 +225,26 @@ impl WalWriter {
             return Ok(());
         }
 
+        let encoded = self.codec.encode_cow(record_bytes);
+        self.append_inner(&encoded, txn_id, timestamp)?;
+        self.maybe_sync()
+    }
+
+    /// Core append logic shared by `append()`, `append_pre_serialized()`,
+    /// and `append_and_flush()`.
+    ///
+    /// Handles segment rotation, writing, metadata tracking, and counter updates.
+    /// Callers are responsible for encoding and post-write sync behavior.
+    fn append_inner(
+        &mut self,
+        encoded: &[u8],
+        txn_id: u64,
+        timestamp: u64,
+    ) -> std::io::Result<()> {
         let segment = self
             .segment
             .as_mut()
             .expect("Segment should exist for non-Cache mode");
-
-        // Encode through codec (identity codec: zero-copy borrow)
-        let encoded = self.codec.encode_cow(record_bytes);
 
         // Check if we need to rotate before writing
         if segment.size() + encoded.len() as u64 > self.config.segment_size {
@@ -275,7 +253,7 @@ impl WalWriter {
 
         // Write to segment
         let segment = self.segment.as_mut().unwrap();
-        segment.write(&encoded)?;
+        segment.write(encoded)?;
 
         // Track metadata for the current segment
         if let Some(ref mut meta) = self.current_segment_meta {
@@ -291,8 +269,6 @@ impl WalWriter {
         self.writes_since_sync += 1;
         self.has_unsynced_data = true;
 
-        self.maybe_sync()?;
-
         Ok(())
     }
 
@@ -301,13 +277,7 @@ impl WalWriter {
         match self.durability {
             DurabilityMode::Always => {
                 // Always sync immediately
-                if let Some(ref mut segment) = self.segment {
-                    let start = Instant::now();
-                    segment.sync()?;
-                    let elapsed = start.elapsed();
-                    self.total_sync_calls += 1;
-                    self.total_sync_nanos += elapsed.as_nanos() as u64;
-                }
+                self.perform_sync()?;
                 self.reset_sync_counters();
             }
             DurabilityMode::Standard {
@@ -337,13 +307,7 @@ impl WalWriter {
                             batch_size,
                             "Batch size reached — inline sync");
                     }
-                    if let Some(ref mut segment) = self.segment {
-                        let start = Instant::now();
-                        segment.sync()?;
-                        let elapsed = start.elapsed();
-                        self.total_sync_calls += 1;
-                        self.total_sync_nanos += elapsed.as_nanos() as u64;
-                    }
+                    self.perform_sync()?;
                     self.reset_sync_counters();
                 }
             }
@@ -352,6 +316,18 @@ impl WalWriter {
             }
         }
 
+        Ok(())
+    }
+
+    /// Sync the active segment to disk, tracking timing metrics.
+    fn perform_sync(&mut self) -> std::io::Result<()> {
+        if let Some(ref mut segment) = self.segment {
+            let start = Instant::now();
+            segment.sync()?;
+            let elapsed = start.elapsed();
+            self.total_sync_calls += 1;
+            self.total_sync_nanos += elapsed.as_nanos() as u64;
+        }
         Ok(())
     }
 
@@ -410,13 +386,7 @@ impl WalWriter {
     /// This ensures all written records are persisted, regardless of
     /// durability mode settings.
     pub fn flush(&mut self) -> std::io::Result<()> {
-        if let Some(ref mut segment) = self.segment {
-            let start = Instant::now();
-            segment.sync()?;
-            let elapsed = start.elapsed();
-            self.total_sync_calls += 1;
-            self.total_sync_nanos += elapsed.as_nanos() as u64;
-        }
+        self.perform_sync()?;
         self.reset_sync_counters();
         self.flush_active_meta();
         debug!(target: "strata::wal", segment = self.current_segment_number, "WAL flushed");
@@ -441,13 +411,7 @@ impl WalWriter {
             if self.last_sync_time.elapsed().as_millis() as u64 >= interval_ms
                 || self.writes_since_sync >= batch_size
             {
-                if let Some(ref mut segment) = self.segment {
-                    let start = Instant::now();
-                    segment.sync()?;
-                    let elapsed = start.elapsed();
-                    self.total_sync_calls += 1;
-                    self.total_sync_nanos += elapsed.as_nanos() as u64;
-                }
+                self.perform_sync()?;
                 self.reset_sync_counters();
                 debug!(target: "strata::wal", segment = self.current_segment_number, "WAL periodic sync");
                 return Ok(true);
@@ -526,7 +490,7 @@ impl WalWriter {
         if let Ok(entries) = std::fs::read_dir(&self.wal_dir) {
             for entry in entries.flatten() {
                 let name = entry.file_name().to_string_lossy().to_string();
-                if name.starts_with("wal-") && name.ends_with(".seg") {
+                if super::parse_segment_number(&name).is_some() {
                     if let Ok(metadata) = entry.metadata() {
                         total_bytes += metadata.len();
                         segment_count += 1;
@@ -599,13 +563,7 @@ impl WalWriter {
             .filter_map(|e| e.ok())
             .filter_map(|e| {
                 let name = e.file_name().to_string_lossy().to_string();
-                if name.starts_with("wal-") && name.ends_with(".seg") {
-                    // Extract segment number from "wal-NNNNNN.seg"
-                    let num_str = &name[4..10];
-                    num_str.parse::<u64>().ok()
-                } else {
-                    None
-                }
+                super::parse_segment_number(&name)
             })
             .max()
     }
@@ -617,10 +575,8 @@ impl WalWriter {
         for entry in std::fs::read_dir(&self.wal_dir)? {
             let entry = entry?;
             let name = entry.file_name().to_string_lossy().to_string();
-            if name.starts_with("wal-") && name.ends_with(".seg") {
-                if let Ok(num) = name[4..10].parse::<u64>() {
-                    segments.push(num);
-                }
+            if let Some(num) = super::parse_segment_number(&name) {
+                segments.push(num);
             }
         }
 
@@ -691,33 +647,12 @@ impl WalWriter {
 
         self.reopen_if_needed()?;
 
-        let segment = self
-            .segment
-            .as_mut()
-            .expect("Segment should exist for non-Cache mode");
-
         let record_bytes = record.to_bytes();
         let encoded = self.codec.encode(&record_bytes);
-
-        // Check if rotation is needed
-        if segment.size() + encoded.len() as u64 > self.config.segment_size {
-            self.rotate_segment()?;
-        }
-
-        let segment = self.segment.as_mut().unwrap();
-        segment.write(&encoded)?;
-
-        if let Some(ref mut meta) = self.current_segment_meta {
-            meta.track_record(record.txn_id, record.timestamp);
-        }
-
-        self.total_wal_appends += 1;
-        self.total_bytes_written += encoded.len() as u64;
+        self.append_inner(&encoded, record.txn_id, record.timestamp)?;
 
         // Immediately flush for cross-process visibility
-        self.flush()?;
-
-        Ok(())
+        self.flush()
     }
 
     /// Close the writer, ensuring all data is flushed.


### PR DESCRIPTION
## Summary

- **#2002** (DUR-DEBT-001): Extract `append_inner()` to deduplicate ~43 lines across `append()`, `append_pre_serialized()`, and `append_and_flush()`
- **#2003** (DUR-DEBT-002): Extract `perform_sync()` to deduplicate the 6-line sync timing pattern repeated at 4 sites
- **#2004** (DUR-DEBT-003): Add `parse_segment_number()` shared utility, replacing duplicated WAL filename parsing at 5 sites (uses `strip_prefix`/`strip_suffix` for robustness with segment numbers > 999999)
- **#2006** (DUR-DEBT-005): Feature-gate `coordination.rs` (521 unused lines) behind `multi_process` feature
- **#2007** (DUR-DEBT-006): Move `clone_codec()` to `codec/traits.rs`, removing duplicates from `coordinator.rs` and `handle.rs`
- **#2008** (DUR-DEBT-007): Add user-facing encryption documentation to codec module (enabling steps, codec table, env var)
- **#2009** (DUR-DEBT-008): Replace hardcoded WAL config literals with named constants (`DEFAULT_SEGMENT_SIZE`, `DEFAULT_BUFFERED_SYNC_BYTES`, `DEFAULT_SYNC_INTERVAL_MS`, `DEFAULT_SYNC_BATCH_SIZE`)

**Skipped**: #2005 (optional low-priority guard pattern), #2010 (requires engine-level coordination)

## Test plan

- [x] All 391 durability tests pass (388 base + 3 new `parse_segment_number` tests)
- [x] All 409 tests pass with `--features multi_process` (21 coordination tests)
- [x] Full workspace builds cleanly
- [x] Invariant check: ACID-006, ACID-007, SCALE-001 all HOLD
- [x] No behavioral changes — pure refactoring with identical sync semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)