### PR TITLE
Fix #1972, #1973: Transaction event_append missing type index key & event_len returning 0

### DIFF
--- a/crates/engine/src/transaction/context.rs
+++ b/crates/engine/src/transaction/context.rs
@@ -250,6 +250,10 @@ impl<'a> TransactionOps for Transaction<'a> {
         })?;
         self.ctx.put(event_key, Value::String(event_json))?;
 
+        // Write per-type index key for efficient get_by_type lookups (#972, #1972)
+        let idx_key = Key::new_event_type_idx(self.namespace.clone(), event_type, sequence);
+        self.ctx.put(idx_key, Value::Null)?;
+
         // Write EventLogMeta — preserve streams from persisted meta (#1914)
         let mut streams = persisted_meta.streams;
         let ts_micros = timestamp.as_micros();
@@ -330,7 +334,17 @@ impl<'a> TransactionOps for Transaction<'a> {
     }
 
     fn event_len(&mut self) -> Result<u64, StrataError> {
-        // Base sequence from snapshot + pending events
+        // If no appends have occurred yet, base_sequence may still be the
+        // uninitialised default (0).  Read persisted meta to get the true
+        // committed count (#1973).
+        if self.pending_events.is_empty() {
+            let meta_key = Key::new_event_meta(self.namespace.clone());
+            if let Some(Value::String(s)) = self.ctx.get(&meta_key)? {
+                if let Ok(meta) = serde_json::from_str::<EventLogMeta>(&s) {
+                    return Ok(meta.next_sequence);
+                }
+            }
+        }
         Ok(self.base_sequence + self.pending_events.len() as u64)
     }
 
@@ -710,6 +724,113 @@ mod tests {
         assert_eq!(pending.len(), 2);
         assert_eq!(pending[0].event_type, "e1");
         assert_eq!(pending[1].event_type, "e2");
+    }
+
+    // =========================================================================
+    // Regression: #1972 — event_append writes per-type index key
+    // =========================================================================
+
+    #[test]
+    fn test_event_append_writes_type_index_key() {
+        let ns = create_test_namespace();
+        let mut ctx = create_test_context(&ns);
+        let mut txn = Transaction::new(&mut ctx, ns.clone());
+
+        txn.event_append("user_created", Value::Int(1)).unwrap();
+        txn.event_append("order_placed", Value::Int(2)).unwrap();
+        txn.event_append("user_created", Value::Int(3)).unwrap();
+
+        // The type index keys should be in the write set (via ctx)
+        let idx_key_0 = Key::new_event_type_idx(ns.clone(), "user_created", 0);
+        let idx_key_1 = Key::new_event_type_idx(ns.clone(), "order_placed", 1);
+        let idx_key_2 = Key::new_event_type_idx(ns.clone(), "user_created", 2);
+
+        // All three index keys should be Null in the transaction context
+        assert_eq!(txn.ctx.get(&idx_key_0).unwrap(), Some(Value::Null));
+        assert_eq!(txn.ctx.get(&idx_key_1).unwrap(), Some(Value::Null));
+        assert_eq!(txn.ctx.get(&idx_key_2).unwrap(), Some(Value::Null));
+
+        // Non-existent type index should not be present
+        let missing = Key::new_event_type_idx(ns.clone(), "nonexistent", 0);
+        assert_eq!(txn.ctx.get(&missing).unwrap(), None);
+    }
+
+    // =========================================================================
+    // Regression: #1973 — event_len reads persisted meta before first append
+    // =========================================================================
+
+    #[test]
+    fn test_event_len_with_committed_events_no_appends() {
+        use strata_core::traits::Storage;
+        use strata_core::WriteMode;
+
+        let ns = create_test_namespace();
+        let store = Arc::new(SegmentedStore::new());
+
+        // Pre-populate 50 committed events in store metadata
+        let meta = EventLogMeta {
+            next_sequence: 50,
+            head_hash: [7u8; 32],
+            hash_version: HASH_VERSION_SHA256,
+            streams: Default::default(),
+        };
+        let meta_json = serde_json::to_string(&meta).unwrap();
+        let meta_key = Key::new_event_meta(ns.clone());
+        let version = store.next_version();
+        store
+            .put_with_version_mode(
+                meta_key,
+                Value::String(meta_json),
+                version,
+                None,
+                WriteMode::Append,
+            )
+            .unwrap();
+
+        let mut ctx = TransactionContext::with_store(2, ns.branch_id, store);
+        let mut txn = Transaction::new(&mut ctx, ns.clone());
+
+        // Before any append, event_len should reflect committed count
+        assert_eq!(txn.event_len().unwrap(), 50);
+    }
+
+    #[test]
+    fn test_event_len_with_committed_events_after_append() {
+        use strata_core::traits::Storage;
+        use strata_core::WriteMode;
+
+        let ns = create_test_namespace();
+        let store = Arc::new(SegmentedStore::new());
+
+        // Pre-populate 10 committed events in store metadata
+        let meta = EventLogMeta {
+            next_sequence: 10,
+            head_hash: [5u8; 32],
+            hash_version: HASH_VERSION_SHA256,
+            streams: Default::default(),
+        };
+        let meta_json = serde_json::to_string(&meta).unwrap();
+        let meta_key = Key::new_event_meta(ns.clone());
+        let version = store.next_version();
+        store
+            .put_with_version_mode(
+                meta_key,
+                Value::String(meta_json),
+                version,
+                None,
+                WriteMode::Append,
+            )
+            .unwrap();
+
+        let mut ctx = TransactionContext::with_store(2, ns.branch_id, store);
+        let mut txn = Transaction::new(&mut ctx, ns.clone());
+
+        // Before append: should read 10 from persisted meta
+        assert_eq!(txn.event_len().unwrap(), 10);
+
+        // After append: should be 11 (base_sequence gets initialized + 1 pending)
+        txn.event_append("new_event", Value::Int(1)).unwrap();
+        assert_eq!(txn.event_len().unwrap(), 11);
     }
 
     // =========================================================================

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -208,10 +208,11 @@ impl Session {
             // prefix scan, which is non-trivial. It reads from the committed
             // store even during an active transaction.
             | Command::JsonList { .. }
-            // EventGetByType filters events by type tag at the storage layer.
-            // The transaction write-set does not maintain per-type indexes, so
-            // this always reads from the committed store even during an active
-            // transaction.
+            // EventGetByType uses scan_prefix on per-type index keys.
+            // The transaction write-set has these keys (#1972), but
+            // scan_prefix is only available on the committed store, so
+            // this always reads from the committed store even during an
+            // active transaction.
             | Command::EventGetByType { .. } => self.executor.execute(cmd),
 
             // Data commands: route through txn if active, else delegate


### PR DESCRIPTION
## Summary

- **#1972**: `Transaction::event_append()` was not writing the per-type index key (`Key::new_event_type_idx`), so events appended through the executor transaction path were invisible to `EventGetByType` after commit.
- **#1973**: `Transaction::event_len()` returned 0 when committed events existed but no appends had occurred in the current Transaction, because `base_sequence` defaulted to 0 from `ctx.event_sequence_count()`.

## Root Cause

**#1972**: The safe path (`EventLogExt::event_append` in `event.rs:324`) writes a `Key::new_event_type_idx(ns, event_type, sequence) → Value::Null` entry for each append. The executor transaction path (`Transaction::event_append` in `context.rs`) was missing this write.

**#1973**: `Transaction::new()` initializes `base_sequence` from `ctx.event_sequence_count()` which defaults to 0 if no prior appends occurred in the `TransactionContext` session. `event_len()` returned `base_sequence + pending_events.len()` = `0 + 0` = `0` even when the store had committed events.

## Fix

- Added `ctx.put(Key::new_event_type_idx(...), Value::Null)` in `Transaction::event_append()`, matching the safe path.
- Changed `event_len()` to read persisted `EventLogMeta` from store when `pending_events` is empty, returning `meta.next_sequence` instead of the uninitialized `base_sequence`.
- Updated stale comment in `session.rs` about EventGetByType routing (previously said write-set doesn't maintain type indexes — now it does).

## Invariants Verified

ACID-001 (single WAL record), ACID-003 (per-branch lock), ACID-004 (blind write safety), ACID-005 (replay idempotency), ARCH-001 (one version domain), ARCH-002 (atomic publication boundary) — all **HOLDS**.

## Test Plan

- [x] `test_event_append_writes_type_index_key` — verifies idx keys are written with `Value::Null` for multiple event types
- [x] `test_event_len_with_committed_events_no_appends` — verifies `event_len()` returns 50 (not 0) with 50 committed events
- [x] `test_event_len_with_committed_events_after_append` — verifies transition from committed-only (10) to committed+pending (11)
- [x] Full engine crate: 679 passed, 0 failed
- [x] Full executor crate: 22 passed, 0 failed
- [x] Clippy clean on changed crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)