### PR TITLE
Fix #1908: Add search index reconciliation after fast-path recovery

### DIFF
--- a/crates/engine/src/search/index.rs
+++ b/crates/engine/src/search/index.rs
@@ -388,6 +388,11 @@ impl InvertedIndex {
         self.version.load(Ordering::Acquire)
     }
 
+    /// Check if a document is already present in the index.
+    pub fn has_document(&self, doc_ref: &EntityRef) -> bool {
+        self.doc_id_map.get(doc_ref).is_some()
+    }
+
     /// Check if index is at least at given version
     pub fn is_at_version(&self, min_version: u64) -> bool {
         self.version.load(Ordering::Acquire) >= min_version

--- a/crates/engine/src/search/recovery.rs
+++ b/crates/engine/src/search/recovery.rs
@@ -80,6 +80,27 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
                     "Search index loaded from mmap cache (fast path)"
                 );
                 index.enable();
+
+                // Reconcile: re-index any KV/Event entries committed after the
+                // last freeze but before a crash (issue #1908).
+                let reconciled = reconcile_index(db, &index)?;
+                if reconciled > 0 {
+                    info!(
+                        target: "strata::search",
+                        reconciled,
+                        "Reconciled missing entries after fast-path load"
+                    );
+                    if !db.is_follower() {
+                        if let Err(e) = index.freeze_to_disk() {
+                            tracing::warn!(
+                                target: "strata::search",
+                                error = %e,
+                                "Failed to freeze search index after reconciliation"
+                            );
+                        }
+                    }
+                }
+
                 return Ok(());
             }
             Ok(false) => {
@@ -187,6 +208,78 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
     }
 
     Ok(())
+}
+
+/// Scan KV/Event entries and re-index any missing from the search index.
+///
+/// Returns the number of entries that were re-indexed. Entries already
+/// present in the DocIdMap are skipped (O(1) DashMap lookup per entry).
+fn reconcile_index(db: &Database, index: &InvertedIndex) -> StrataResult<u64> {
+    let system_branch_id = resolve_branch_name(SYSTEM_BRANCH);
+    let mut reconciled: u64 = 0;
+
+    for branch_id in db.storage().branch_ids() {
+        if branch_id == system_branch_id {
+            continue;
+        }
+
+        // --- KV entries ---
+        for (key, vv) in db.storage().list_by_type(&branch_id, TypeTag::KV) {
+            let user_key = match key.user_key_string() {
+                Some(k) => k,
+                None => continue,
+            };
+
+            let entity_ref = crate::search::EntityRef::Kv {
+                branch_id,
+                key: user_key,
+            };
+
+            if index.has_document(&entity_ref) {
+                continue;
+            }
+
+            let text = match extract_indexable_text(&vv.value) {
+                Some(t) => t,
+                None => continue,
+            };
+
+            index.index_document(&entity_ref, &text, None);
+            reconciled += 1;
+        }
+
+        // --- Event entries ---
+        for (key, vv) in db.storage().list_by_type(&branch_id, TypeTag::Event) {
+            if *key.user_key == *b"__meta__" || key.user_key.starts_with(b"__tidx__") {
+                continue;
+            }
+
+            let sequence = if key.user_key.len() == 8 {
+                u64::from_be_bytes((*key.user_key).try_into().unwrap_or([0; 8]))
+            } else {
+                continue;
+            };
+
+            let entity_ref = crate::search::EntityRef::Event {
+                branch_id,
+                sequence,
+            };
+
+            if index.has_document(&entity_ref) {
+                continue;
+            }
+
+            let text = match extract_indexable_text(&vv.value) {
+                Some(t) => t,
+                None => continue,
+            };
+
+            index.index_document(&entity_ref, &text, None);
+            reconciled += 1;
+        }
+    }
+
+    Ok(reconciled)
 }
 
 /// Register the InvertedIndex as a recovery participant.

--- a/crates/engine/tests/recovery_tests.rs
+++ b/crates/engine/tests/recovery_tests.rs
@@ -826,3 +826,119 @@ fn test_issue_1710_checkpoint_concurrent_writes_recovery() {
         }
     }
 }
+
+/// Issue #1908: Events committed to KV but missing from search index after crash recovery.
+///
+/// Simulates a crash where the search manifest is stale (written before the latest
+/// events were committed). After recovery, the fast-path mmap load must reconcile
+/// against KV to re-index any missing entries.
+#[test]
+fn test_issue_1908_search_index_reconciles_after_crash() {
+    use strata_engine::search::Searchable;
+
+    let temp_dir = TempDir::new().unwrap();
+    let path = get_path(&temp_dir);
+    let branch_id = BranchId::new();
+    let search_manifest = path.join("search").join("search.manifest");
+
+    // Session 1: Write initial data and close cleanly (creates search manifest)
+    {
+        let db = Database::open(&path).unwrap();
+        let kv = KVStore::new(db.clone());
+
+        kv.put(
+            &branch_id,
+            "default",
+            "doc_initial",
+            Value::String("established baseline document for search".into()),
+        )
+        .unwrap();
+
+        // Also test events
+        let event_log = EventLog::new(db.clone());
+        event_log
+            .append(
+                &branch_id,
+                "default",
+                "sensor_reading",
+                string_payload("temperature humidity pressure"),
+            )
+            .unwrap();
+    }
+
+    // Save the search manifest (represents state before crash)
+    assert!(
+        search_manifest.exists(),
+        "search manifest should exist after clean close"
+    );
+    let stale_manifest = std::fs::read(&search_manifest).unwrap();
+
+    // Session 2: Add more data, close cleanly (manifest updated with new data)
+    {
+        let db = Database::open(&path).unwrap();
+        let kv = KVStore::new(db.clone());
+
+        kv.put(
+            &branch_id,
+            "default",
+            "doc_post_crash",
+            Value::String("quantum computing algorithm optimization".into()),
+        )
+        .unwrap();
+
+        let event_log = EventLog::new(db.clone());
+        event_log
+            .append(
+                &branch_id,
+                "default",
+                "alert",
+                string_payload("critical threshold exceeded anomaly"),
+            )
+            .unwrap();
+    }
+
+    // Simulate crash: revert search manifest to pre-session-2 state.
+    // KV still has session 2 data (WAL replay restores it), but the
+    // search index manifest is stale — missing session 2 entries.
+    std::fs::write(&search_manifest, &stale_manifest).unwrap();
+
+    // Session 3: Reopen — fast path loads stale manifest.
+    // Without the fix, session 2 data is in KV but invisible to search.
+    {
+        let db = Database::open(&path).unwrap();
+        let kv = KVStore::new(db.clone());
+
+        // KV data from session 2 must exist (WAL replay)
+        assert_eq!(
+            kv.get(&branch_id, "default", "doc_post_crash").unwrap(),
+            Some(Value::String(
+                "quantum computing algorithm optimization".into()
+            )),
+            "KV data from session 2 should survive via WAL replay"
+        );
+
+        // Search for session 1 data — should always work
+        let req = SearchRequest::new(branch_id, "baseline");
+        let response = kv.search(&req).unwrap();
+        assert!(
+            !response.hits.is_empty(),
+            "Session 1 KV data should be searchable"
+        );
+
+        // Search for session 2 KV data — fails without the fix
+        let req = SearchRequest::new(branch_id, "quantum");
+        let response = kv.search(&req).unwrap();
+        assert!(
+            !response.hits.is_empty(),
+            "Session 2 KV data should be searchable after crash recovery reconciliation"
+        );
+
+        // Search for session 2 event data — fails without the fix
+        let req = SearchRequest::new(branch_id, "anomaly");
+        let response = kv.search(&req).unwrap();
+        assert!(
+            !response.hits.is_empty(),
+            "Session 2 event data should be searchable after crash recovery reconciliation"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- After fast-path mmap recovery loads a stale search manifest, a reconciliation pass now scans KV/Event entries and re-indexes any missing from the DocIdMap
- Closes the crash window where events committed to KV (durable via WAL) could be invisible to search queries after recovery
- The reconciliation is O(N) with O(1) per-entry skip for already-indexed docs, preserving fast-path performance in the common (no-crash) case

## Root Cause

In `recovery.rs`, the fast-path loaded the search manifest and returned immediately without checking if KV contained entries committed after the last `freeze_to_disk()`. A crash between a transaction commit and the next freeze left events durable in KV but missing from the search index.

## Fix

Added `reconcile_index()` that runs after fast-path load. For each KV/Event entry, it checks `has_document()` (O(1) DashMap lookup) and only re-indexes entries missing from the index. If any entries were reconciled, the index is re-frozen to disk so subsequent opens don't need to reconcile again.

## Invariants Verified

- **ARCH-002**: Secondary index eventual consistency contract unchanged
- **ARCH-003**: KV remains single source of truth; index now reconciles against it
- **ARCH-004**: Recovery ordering preserved (reconciliation within secondary index rebuild step)
- **ACID-005**: Reconciliation is idempotent (has_document guard + index_document dedup)

## Test Plan

- [x] `test_issue_1908_search_index_reconciles_after_crash` — simulates stale manifest, verifies KV and event data are searchable after recovery
- [x] All 15 recovery integration tests pass
- [x] All 675+ engine tests pass (1 pre-existing flaky singleton test excluded)
- [x] Invariant check: all 4 affected invariants HOLD
- [x] Code review: no must-fix or should-fix findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)