### PR TITLE
Fix CI: cargo fmt + clippy across workspace

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -320,9 +320,7 @@ impl TransactionManager {
                 )));
             }
             txn.status = TransactionStatus::Committed;
-            return Ok(
-                external_version.unwrap_or_else(|| self.version.load(Ordering::Acquire))
-            );
+            return Ok(external_version.unwrap_or_else(|| self.version.load(Ordering::Acquire)));
         }
 
         #[cfg(feature = "perf-trace")]
@@ -400,8 +398,7 @@ impl TransactionManager {
             perf_time!(trace, wal_append_ns, {
                 match wal_mode {
                     WalMode::Direct(wal) => {
-                        let payload =
-                            TransactionPayload::from_transaction(txn, commit_version);
+                        let payload = TransactionPayload::from_transaction(txn, commit_version);
                         let record = WalRecord::new(
                             commit_version,
                             *txn.branch_id.as_bytes(),
@@ -418,8 +415,7 @@ impl TransactionManager {
                         tracing::debug!(target: "strata::txn", txn_id = txn.txn_id, commit_version, "WAL durable");
                     }
                     WalMode::Shared(wal_arc) => {
-                        let payload =
-                            TransactionPayload::from_transaction(txn, commit_version);
+                        let payload = TransactionPayload::from_transaction(txn, commit_version);
                         let timestamp = now_micros();
                         let record = WalRecord::new(
                             commit_version,
@@ -430,11 +426,9 @@ impl TransactionManager {
                         let record_bytes = record.to_bytes();
                         {
                             let mut wal = wal_arc.lock();
-                            if let Err(e) = wal.append_pre_serialized(
-                                &record_bytes,
-                                commit_version,
-                                timestamp,
-                            ) {
+                            if let Err(e) =
+                                wal.append_pre_serialized(&record_bytes, commit_version, timestamp)
+                            {
                                 txn.status = TransactionStatus::Aborted {
                                     reason: format!("WAL write failed: {}", e),
                                 };
@@ -643,7 +637,6 @@ impl TransactionManager {
         };
         self.commit_inner(txn, store, wal_mode, Some(version))
     }
-
 }
 
 impl Default for TransactionManager {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1761,7 +1761,10 @@ mod strata_error_tests {
     fn test_write_stall_timeout_constructor() {
         let e = StrataError::write_stall_timeout(30000, 40);
 
-        assert!(!e.is_retryable(), "stall timeout is not retryable — write already committed");
+        assert!(
+            !e.is_retryable(),
+            "stall timeout is not retryable — write already committed"
+        );
         assert!(!e.is_transaction_error());
         assert_eq!(e.code(), ErrorCode::Conflict);
         match e {

--- a/crates/durability/src/wal/writer.rs
+++ b/crates/durability/src/wal/writer.rs
@@ -235,12 +235,7 @@ impl WalWriter {
     ///
     /// Handles segment rotation, writing, metadata tracking, and counter updates.
     /// Callers are responsible for encoding and post-write sync behavior.
-    fn append_inner(
-        &mut self,
-        encoded: &[u8],
-        txn_id: u64,
-        timestamp: u64,
-    ) -> std::io::Result<()> {
+    fn append_inner(&mut self, encoded: &[u8], txn_id: u64, timestamp: u64) -> std::io::Result<()> {
         let segment = self
             .segment
             .as_mut()

--- a/crates/engine/src/branch_ops.rs
+++ b/crates/engine/src/branch_ops.rs
@@ -601,9 +601,11 @@ pub fn diff_branches_with_options(
     for type_tag in &type_tags {
         let entries_a: Vec<(Key, VersionedValue)> = match options.as_of {
             Some(ts) => storage.list_by_type_at_timestamp(&id_a, *type_tag, ts),
-            None => live_entries_from_versioned(
-                storage.list_by_type_at_version(&id_a, *type_tag, snapshot_version),
-            ),
+            None => live_entries_from_versioned(storage.list_by_type_at_version(
+                &id_a,
+                *type_tag,
+                snapshot_version,
+            )),
         };
         for (key, vv) in entries_a {
             if space_filter
@@ -619,9 +621,11 @@ pub fn diff_branches_with_options(
 
         let entries_b: Vec<(Key, VersionedValue)> = match options.as_of {
             Some(ts) => storage.list_by_type_at_timestamp(&id_b, *type_tag, ts),
-            None => live_entries_from_versioned(
-                storage.list_by_type_at_version(&id_b, *type_tag, snapshot_version),
-            ),
+            None => live_entries_from_versioned(storage.list_by_type_at_version(
+                &id_b,
+                *type_tag,
+                snapshot_version,
+            )),
         };
         for (key, vv) in entries_b {
             if space_filter
@@ -1092,14 +1096,18 @@ fn three_way_diff(
             );
 
             // 2. Source state at snapshot (consistent point-in-time, #1917)
-            let source_entries = live_entries_from_versioned(
-                storage.list_by_type_at_version(&source_id, type_tag, snapshot_version),
-            );
+            let source_entries = live_entries_from_versioned(storage.list_by_type_at_version(
+                &source_id,
+                type_tag,
+                snapshot_version,
+            ));
 
             // 3. Target state at snapshot (consistent point-in-time, #1917)
-            let target_entries = live_entries_from_versioned(
-                storage.list_by_type_at_version(&target_id, type_tag, snapshot_version),
-            );
+            let target_entries = live_entries_from_versioned(storage.list_by_type_at_version(
+                &target_id,
+                type_tag,
+                snapshot_version,
+            ));
 
             let ancestor_map = build_ancestor_map(&ancestor_entries, space);
             let source_map = build_live_map(&source_entries, space);
@@ -2051,11 +2059,8 @@ pub fn revert_version_range(
         let current_map = build_live_space_map(&current_entries);
 
         // Union of all keys in before and after
-        let all_keys: HashSet<(String, Vec<u8>)> = before_map
-            .keys()
-            .chain(after_map.keys())
-            .cloned()
-            .collect();
+        let all_keys: HashSet<(String, Vec<u8>)> =
+            before_map.keys().chain(after_map.keys()).cloned().collect();
 
         for compound_key in &all_keys {
             let before_state = before_map.get(compound_key).cloned().flatten();

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -1904,7 +1904,10 @@ mod tests {
         // Complete txn3 → full drain → gc_safe = current_version
         coordinator.record_commit(3);
         let gc = coordinator.min_active_version().unwrap();
-        assert!(gc > 0, "full drain should advance gc_safe to current_version");
+        assert!(
+            gc > 0,
+            "full drain should advance gc_safe to current_version"
+        );
     }
 
     // =========================================================================
@@ -1918,9 +1921,7 @@ mod tests {
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
-        let mut txn = coordinator
-            .start_transaction(branch_id, &storage)
-            .unwrap();
+        let mut txn = coordinator.start_transaction(branch_id, &storage).unwrap();
         assert_eq!(coordinator.metrics().active_count, 1);
 
         std::thread::sleep(Duration::from_millis(5));
@@ -1947,9 +1948,7 @@ mod tests {
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
-        let mut txn = coordinator
-            .start_transaction(branch_id, &storage)
-            .unwrap();
+        let mut txn = coordinator.start_transaction(branch_id, &storage).unwrap();
         assert!(txn.is_active());
 
         std::thread::sleep(Duration::from_millis(5));

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -161,19 +161,19 @@ impl Database {
         for record in &records {
             max_txn_id = max_txn_id.max(record.txn_id);
 
-            let payload =
-                match strata_concurrency::TransactionPayload::from_bytes(&record.writeset) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        warn!(
-                            target: "strata::db",
-                            txn_id = record.txn_id,
-                            error = %e,
-                            "Refresh: skipping WAL record with corrupt payload"
-                        );
-                        continue;
-                    }
-                };
+            let payload = match strata_concurrency::TransactionPayload::from_bytes(&record.writeset)
+            {
+                Ok(p) => p,
+                Err(e) => {
+                    warn!(
+                        target: "strata::db",
+                        txn_id = record.txn_id,
+                        error = %e,
+                        "Refresh: skipping WAL record with corrupt payload"
+                    );
+                    continue;
+                }
+            };
 
             max_version = max_version.max(payload.version);
 

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -1,5 +1,6 @@
 //! Database opening and initialization.
 
+use super::config::StorageConfig;
 use crate::background::BackgroundScheduler;
 use crate::coordinator::TransactionCoordinator;
 use dashmap::DashMap;
@@ -12,7 +13,6 @@ use strata_concurrency::RecoveryCoordinator;
 use strata_durability::codec::IdentityCodec;
 use strata_durability::wal::{DurabilityMode, WalConfig, WalWriter};
 use strata_storage::SegmentedStore;
-use super::config::StorageConfig;
 use tracing::{info, warn};
 
 /// Apply all storage configuration settings to a SegmentedStore.

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -2144,8 +2144,7 @@ fn test_issue_1733_tombstone_no_duplicate_after_recovery() {
 
         // After shutdown, the flush_shutdown flag should be set
         assert!(
-            db.flush_shutdown
-                .load(std::sync::atomic::Ordering::Relaxed),
+            db.flush_shutdown.load(std::sync::atomic::Ordering::Relaxed),
             "flush_shutdown flag must be set after shutdown"
         );
 

--- a/crates/engine/src/search/types.rs
+++ b/crates/engine/src/search/types.rs
@@ -526,8 +526,7 @@ mod tests {
 
     #[test]
     fn test_issue_1921_snapshot_version_in_request() {
-        let req = SearchRequest::new(BranchId::new(), "test query")
-            .with_snapshot_version(42);
+        let req = SearchRequest::new(BranchId::new(), "test query").with_snapshot_version(42);
         assert_eq!(req.snapshot_version, Some(42));
 
         // Default should be None

--- a/crates/executor/src/handlers/json.rs
+++ b/crates/executor/src/handlers/json.rs
@@ -354,8 +354,8 @@ pub fn json_batch_get(
 
     // Merge engine results
     for (j, orig_idx) in orig_indices.iter().enumerate() {
-        match &engine_results[j] {
-            Some(versioned) => match convert_result(json_to_value(versioned.value.clone())) {
+        if let Some(versioned) = &engine_results[j] {
+            match convert_result(json_to_value(versioned.value.clone())) {
                 Ok(value) => {
                     results[*orig_idx].value = Some(value);
                     results[*orig_idx].version = Some(extract_version(&versioned.version));
@@ -364,8 +364,7 @@ pub fn json_batch_get(
                 Err(e) => {
                     results[*orig_idx].error = Some(e.to_string());
                 }
-            },
-            None => {} // already initialized as None
+            }
         }
     }
 

--- a/crates/search/src/hybrid.rs
+++ b/crates/search/src/hybrid.rs
@@ -183,7 +183,10 @@ impl HybridSearch {
                             any_truncated = true;
                             break;
                         }
-                        let sub_req = req.clone().with_budget(*budget).with_snapshot_version(snapshot_version);
+                        let sub_req = req
+                            .clone()
+                            .with_budget(*budget)
+                            .with_snapshot_version(snapshot_version);
                         let result = self.search_primitive(*primitive, &sub_req)?;
                         total_candidates += result.stats.candidates_considered;
                         if result.truncated {
@@ -212,7 +215,10 @@ impl HybridSearch {
                         any_truncated = true;
                         break;
                     }
-                    let sub_req = req.clone().with_budget(*budget).with_snapshot_version(snapshot_version);
+                    let sub_req = req
+                        .clone()
+                        .with_budget(*budget)
+                        .with_snapshot_version(snapshot_version);
                     let result = self.search_primitive(*primitive, &sub_req)?;
                     total_candidates += result.stats.candidates_considered;
                     if result.truncated {

--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -199,8 +199,8 @@ impl KVSegment {
             .as_slice()
             .try_into()
             .map_err(|_| invalid_data!("header size mismatch"))?;
-        let header = parse_header(header_bytes)
-            .ok_or_else(|| invalid_data!("invalid segment header"))?;
+        let header =
+            parse_header(header_bytes).ok_or_else(|| invalid_data!("invalid segment header"))?;
 
         // Parse footer via pread (last FOOTER_SZ bytes)
         let footer_offset = file_size - FOOTER_SZ as u64;
@@ -232,8 +232,8 @@ impl KVSegment {
         let idx_buf = pread_exact(&file, idx_off, idx_len)?;
         let (_, idx_data) = parse_framed_block(&idx_buf)
             .ok_or_else(|| invalid_data!("index block CRC mismatch"))?;
-        let index_entries = parse_index_block(idx_data)
-            .ok_or_else(|| invalid_data!("malformed index block"))?;
+        let index_entries =
+            parse_index_block(idx_data).ok_or_else(|| invalid_data!("malformed index block"))?;
         let index = if footer.index_type == IDX_TYPE_PARTITIONED {
             // Eagerly load all sub-index partitions into memory.
             let mut sub_indexes = Vec::with_capacity(index_entries.len());
@@ -262,15 +262,15 @@ impl KVSegment {
         let fi_buf = pread_exact(&file, fi_off, fi_len)?;
         let (_, fi_data) = parse_framed_block(&fi_buf)
             .ok_or_else(|| invalid_data!("filter index block CRC mismatch"))?;
-        let filter_index = parse_filter_index(fi_data)
-            .ok_or_else(|| invalid_data!("malformed filter index"))?;
+        let filter_index =
+            parse_filter_index(fi_data).ok_or_else(|| invalid_data!("malformed filter index"))?;
 
         // Eagerly load all bloom partition data into memory.
         let mut bloom_partitions = Vec::with_capacity(filter_index.len());
         for entry in &filter_index {
             let raw = pread_exact(&file, entry.block_offset, entry.block_data_len as usize)?;
-            let (_, data) =
-                parse_framed_block(&raw).ok_or_else(|| invalid_data!("bloom partition CRC mismatch"))?;
+            let (_, data) = parse_framed_block(&raw)
+                .ok_or_else(|| invalid_data!("bloom partition CRC mismatch"))?;
             bloom_partitions.push(Arc::new(data.to_vec()));
         }
         let bloom = PartitionedBloom {
@@ -861,6 +861,7 @@ fn block_data_end(data: &[u8]) -> usize {
 ///
 /// Returns `Some(block_data)` on success, `None` if all partitions exhausted,
 /// or the corruption error string if a block read fails.
+#[allow(clippy::type_complexity)]
 fn load_next_block(
     segment: &KVSegment,
     partition_idx: &mut usize,

--- a/crates/storage/src/segment_builder.rs
+++ b/crates/storage/src/segment_builder.rs
@@ -291,7 +291,7 @@ impl SegmentBuilder {
                     &mut index_entries,
                 )?;
                 pending_index = Some((block_last, file_offset, on_disk_data_len));
-                file_offset += framed_size as u64;
+                file_offset += framed_size;
                 block_buf.clear();
                 restart_offsets.clear();
                 restart_offsets.push(0);
@@ -329,7 +329,7 @@ impl SegmentBuilder {
             )?;
             let shortened = shorten_final_index_key(&block_last);
             index_entries.push((shortened, file_offset, on_disk_data_len));
-            file_offset += framed_size as u64;
+            file_offset += framed_size;
             block_buf.clear();
         }
 
@@ -472,6 +472,7 @@ impl SegmentBuilder {
 /// index entry, write the compressed block, and apply rate limiting.
 ///
 /// Returns `(framed_size, on_disk_data_len)`.
+#[allow(clippy::too_many_arguments)]
 fn flush_data_block(
     w: &mut BufWriter<std::fs::File>,
     block_buf: &mut Vec<u8>,
@@ -492,13 +493,8 @@ fn flush_data_block(
         index_entries.push((shortened, offset, len));
     }
 
-    let framed_size = write_framed_block_compressed(
-        w,
-        BLOCK_TYPE_DATA,
-        block_buf,
-        compression,
-        zstd_compressor,
-    )?;
+    let framed_size =
+        write_framed_block_compressed(w, BLOCK_TYPE_DATA, block_buf, compression, zstd_compressor)?;
     let on_disk_data_len = (framed_size - BLOCK_FRAME_OVERHEAD) as u32;
     if let Some(limiter) = rate_limiter {
         limiter.acquire(framed_size as u64);

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -985,8 +985,7 @@ impl SegmentedStore {
                     }
 
                     let typed_key = ik.typed_key_prefix();
-                    let Some(child_typed_key) =
-                        rewrite_branch_id_bytes(typed_key, child_branch_id)
+                    let Some(child_typed_key) = rewrite_branch_id_bytes(typed_key, child_branch_id)
                     else {
                         continue;
                     };

--- a/crates/vector/src/store/mod.rs
+++ b/crates/vector/src/store/mod.rs
@@ -3189,7 +3189,11 @@ mod tests {
                 opts,
             )
             .unwrap();
-        assert_eq!(results.len(), 3, "Empty multipliers should fall back to [1]");
+        assert_eq!(
+            results.len(),
+            3,
+            "Empty multipliers should fall back to [1]"
+        );
     }
 
     // ========================================================================
@@ -3356,7 +3360,11 @@ mod tests {
 
         // Verify inline meta works (results have keys, not empty strings)
         for r in &results {
-            assert!(r.key.starts_with("vec"), "key should be populated: {}", r.key);
+            assert!(
+                r.key.starts_with("vec"),
+                "key should be populated: {}",
+                r.key
+            );
         }
     }
 
@@ -3404,11 +3412,7 @@ mod tests {
                 vec![0.0, 0.0, 1.0, 0.0],
                 None::<serde_json::Value>,
             ),
-            (
-                "existing2".to_string(),
-                vec![0.0, 0.0, 0.0, 1.0],
-                None,
-            ),
+            ("existing2".to_string(), vec![0.0, 0.0, 0.0, 1.0], None),
             ("new1".to_string(), vec![1.0, 1.0, 0.0, 0.0], None),
         ];
         store

--- a/crates/vector/src/types.rs
+++ b/crates/vector/src/types.rs
@@ -283,20 +283,15 @@ impl VectorMatchWithSource {
 ///
 /// Stored as a byte in `CollectionRecord` for persistence.
 /// Defaults to `SegmentedHnsw` (the most capable backend).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum IndexBackendType {
     /// Brute-force O(n) scan — lowest memory, best for small collections.
     BruteForce,
     /// Single-segment HNSW graph.
     Hnsw,
     /// Segmented HNSW with auto-sealing — default for all collections.
+    #[default]
     SegmentedHnsw,
-}
-
-impl Default for IndexBackendType {
-    fn default() -> Self {
-        IndexBackendType::SegmentedHnsw
-    }
 }
 
 impl IndexBackendType {


### PR DESCRIPTION
## Summary
- Runs `cargo fmt --all` to fix all formatting diffs that broke CI's "Check formatting" step
- Fixes 5 clippy warnings that broke CI's "Run clippy" step

## Changes
- **14 files reformatted** by `cargo fmt` (no logic changes)
- **clippy fixes** (5 warnings → 0):
  - `segment.rs`: `#[allow(clippy::type_complexity)]` on `load_next_block` return type
  - `segment_builder.rs`: Remove 2 unnecessary `as u64` casts, `#[allow(clippy::too_many_arguments)]` on `flush_data_block`
  - `types.rs`: Replace manual `Default` impl with `#[derive(Default)]` + `#[default]` on `IndexBackendType::SegmentedHnsw`
  - `json.rs`: Replace single-pattern `match` with `if let`

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes (excluding strata-inference build dep)
- [x] `cargo test --workspace` passes (678/679, 1 pre-existing flaky `test_open_uses_registry`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)