### PR TITLE
Fix #1974: Add TypeTag::Graph and PrimitiveType::Graph (Epic 1)

### DIFF
--- a/crates/core/src/contract/entity_ref.rs
+++ b/crates/core/src/contract/entity_ref.rs
@@ -90,6 +90,14 @@ pub enum EntityRef {
         /// Key within collection
         key: String,
     },
+
+    /// Reference to a graph entry (node, edge, or metadata)
+    Graph {
+        /// Branch scope
+        branch_id: BranchId,
+        /// Graph name and key (e.g., "mygraph/n/node1")
+        key: String,
+    },
 }
 
 impl EntityRef {
@@ -127,6 +135,14 @@ impl EntityRef {
         EntityRef::Json { branch_id, doc_id }
     }
 
+    /// Create a graph entity reference
+    pub fn graph(branch_id: BranchId, key: impl Into<String>) -> Self {
+        EntityRef::Graph {
+            branch_id,
+            key: key.into(),
+        }
+    }
+
     /// Create a vector entity reference
     pub fn vector(
         branch_id: BranchId,
@@ -161,6 +177,7 @@ impl EntityRef {
             EntityRef::Branch { branch_id } => *branch_id,
             EntityRef::Json { branch_id, .. } => *branch_id,
             EntityRef::Vector { branch_id, .. } => *branch_id,
+            EntityRef::Graph { branch_id, .. } => *branch_id,
         }
     }
 
@@ -172,6 +189,7 @@ impl EntityRef {
             EntityRef::Branch { .. } => PrimitiveType::Branch,
             EntityRef::Json { .. } => PrimitiveType::Json,
             EntityRef::Vector { .. } => PrimitiveType::Vector,
+            EntityRef::Graph { .. } => PrimitiveType::Graph,
         }
     }
 
@@ -202,6 +220,11 @@ impl EntityRef {
     /// Check if this is a vector reference
     pub fn is_vector(&self) -> bool {
         matches!(self, EntityRef::Vector { .. })
+    }
+
+    /// Check if this is a graph reference
+    pub fn is_graph(&self) -> bool {
+        matches!(self, EntityRef::Graph { .. })
     }
 
     // =========================================================================
@@ -241,6 +264,14 @@ impl EntityRef {
             _ => None,
         }
     }
+
+    /// Get the graph key if this is a graph reference
+    pub fn graph_key(&self) -> Option<&str> {
+        match self {
+            EntityRef::Graph { key, .. } => Some(key),
+            _ => None,
+        }
+    }
 }
 
 impl std::fmt::Display for EntityRef {
@@ -267,6 +298,9 @@ impl std::fmt::Display for EntityRef {
                 key,
             } => {
                 write!(f, "vector://{}/{}/{}", branch_id, collection, key)
+            }
+            EntityRef::Graph { branch_id, key } => {
+                write!(f, "graph://{}/{}", branch_id, key)
             }
         }
     }
@@ -337,6 +371,18 @@ mod tests {
     }
 
     #[test]
+    fn test_entity_ref_graph() {
+        let branch_id = BranchId::new();
+        let ref_ = EntityRef::graph(branch_id, "mygraph/n/node1");
+
+        assert!(ref_.is_graph());
+        assert!(!ref_.is_kv());
+        assert_eq!(ref_.branch_id(), branch_id);
+        assert_eq!(ref_.primitive_type(), PrimitiveType::Graph);
+        assert_eq!(ref_.graph_key(), Some("mygraph/n/node1"));
+    }
+
+    #[test]
     fn test_entity_ref_display() {
         let branch_id = BranchId::new();
 
@@ -354,6 +400,9 @@ mod tests {
 
         let vector = EntityRef::vector(branch_id, "col", "key");
         assert!(format!("{}", vector).starts_with("vector://"));
+
+        let graph = EntityRef::graph(branch_id, "g/n/1");
+        assert!(format!("{}", graph).starts_with("graph://"));
     }
 
     #[test]
@@ -391,6 +440,7 @@ mod tests {
             EntityRef::branch(branch_id),
             EntityRef::json(branch_id, "test-doc"),
             EntityRef::vector(branch_id, "col", "key"),
+            EntityRef::graph(branch_id, "g/n/1"),
         ];
 
         for ref_ in refs {
@@ -409,6 +459,7 @@ mod tests {
         assert!(kv_ref.event_sequence().is_none());
         assert!(kv_ref.json_doc_id().is_none());
         assert!(kv_ref.vector_location().is_none());
+        assert!(kv_ref.graph_key().is_none());
     }
 
     #[test]
@@ -422,11 +473,12 @@ mod tests {
             EntityRef::branch(branch_id),
             EntityRef::json(branch_id, "j"),
             EntityRef::vector(branch_id, "c", "k"),
+            EntityRef::graph(branch_id, "g/n/1"),
         ];
 
-        // Verify they map to all 5 primitive types
+        // Verify they map to all 6 primitive types
         let types: std::collections::HashSet<_> = refs.iter().map(|r| r.primitive_type()).collect();
-        assert_eq!(types.len(), 5);
+        assert_eq!(types.len(), 6);
     }
 
     #[test]
@@ -446,6 +498,7 @@ mod tests {
             EntityRef::branch(branch_id),
             EntityRef::json(branch_id, "j"),
             EntityRef::vector(branch_id, "c", "k"),
+            EntityRef::graph(branch_id, "g/n/1"),
         ];
 
         for r in &refs {
@@ -455,6 +508,7 @@ mod tests {
                 r.is_branch(),
                 r.is_json(),
                 r.is_vector(),
+                r.is_graph(),
             ];
             assert_eq!(
                 checks.iter().filter(|&&b| b).count(),

--- a/crates/core/src/contract/primitive_type.rs
+++ b/crates/core/src/contract/primitive_type.rs
@@ -3,9 +3,9 @@
 //! This type supports Invariant 6: Everything is Introspectable.
 //! Every entity can report what kind of primitive it is.
 //!
-//! ## The Five Primitives
+//! ## The Six Primitives
 //!
-//! The database has exactly five primitives:
+//! The database has exactly six primitives:
 //!
 //! | Primitive | Purpose | Versioning |
 //! |-----------|---------|------------|
@@ -14,17 +14,18 @@
 //! | Branch | Branch lifecycle management | TxnId |
 //! | Json | JSON document store | TxnId |
 //! | Vector | Vector similarity search | TxnId |
+//! | Graph | Property graph store | TxnId |
 
 use serde::{Deserialize, Serialize};
 
-/// The five primitive types in the database
+/// The six primitive types in the database
 ///
 /// This enum identifies which primitive a value or operation belongs to.
 /// Used for type discrimination, routing, and introspection.
 ///
 /// ## Invariant
 ///
-/// This enum MUST have exactly 5 variants - one for each primitive.
+/// This enum MUST have exactly 6 variants - one for each primitive.
 /// Adding a new primitive requires adding a variant here.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum PrimitiveType {
@@ -57,16 +58,23 @@ pub enum PrimitiveType {
     /// Vector similarity search with HNSW index.
     /// Versioning: TxnId
     Vector,
+
+    /// Graph store
+    ///
+    /// Property graph with nodes, edges, and traversal algorithms.
+    /// Versioning: TxnId
+    Graph,
 }
 
 impl PrimitiveType {
     /// All primitive types (for iteration)
-    pub const ALL: [PrimitiveType; 5] = [
+    pub const ALL: [PrimitiveType; 6] = [
         PrimitiveType::Kv,
         PrimitiveType::Event,
         PrimitiveType::Branch,
         PrimitiveType::Json,
         PrimitiveType::Vector,
+        PrimitiveType::Graph,
     ];
 
     /// Get all primitive types as a slice
@@ -82,6 +90,7 @@ impl PrimitiveType {
             PrimitiveType::Branch => "BranchIndex",
             PrimitiveType::Json => "JsonStore",
             PrimitiveType::Vector => "VectorStore",
+            PrimitiveType::Graph => "GraphStore",
         }
     }
 
@@ -93,6 +102,7 @@ impl PrimitiveType {
             PrimitiveType::Branch => "branch",
             PrimitiveType::Json => "json",
             PrimitiveType::Vector => "vector",
+            PrimitiveType::Graph => "graph",
         }
     }
 
@@ -104,6 +114,7 @@ impl PrimitiveType {
             "branch" => Some(PrimitiveType::Branch),
             "json" => Some(PrimitiveType::Json),
             "vector" => Some(PrimitiveType::Vector),
+            "graph" => Some(PrimitiveType::Graph),
             _ => None,
         }
     }
@@ -119,6 +130,7 @@ impl PrimitiveType {
             PrimitiveType::Branch => true,
             PrimitiveType::Json => true,
             PrimitiveType::Vector => true,
+            PrimitiveType::Graph => true,
         }
     }
 
@@ -142,6 +154,7 @@ impl PrimitiveType {
             PrimitiveType::Event => (0x30, 0x3F),
             PrimitiveType::Branch => (0x40, 0x4F),
             PrimitiveType::Vector => (0x50, 0x5F),
+            PrimitiveType::Graph => (0x60, 0x6F),
         }
     }
 
@@ -155,6 +168,7 @@ impl PrimitiveType {
             PrimitiveType::Event => 3,
             PrimitiveType::Branch => 4,
             PrimitiveType::Vector => 5,
+            PrimitiveType::Graph => 6,
         }
     }
 }
@@ -176,7 +190,7 @@ mod tests {
     #[test]
     fn test_primitive_type_all() {
         let all = PrimitiveType::all();
-        assert_eq!(all.len(), 5);
+        assert_eq!(all.len(), 6);
 
         // Verify all variants are present
         assert!(all.contains(&PrimitiveType::Kv));
@@ -184,11 +198,12 @@ mod tests {
         assert!(all.contains(&PrimitiveType::Branch));
         assert!(all.contains(&PrimitiveType::Json));
         assert!(all.contains(&PrimitiveType::Vector));
+        assert!(all.contains(&PrimitiveType::Graph));
     }
 
     #[test]
     fn test_primitive_type_const_all() {
-        assert_eq!(PrimitiveType::ALL.len(), 5);
+        assert_eq!(PrimitiveType::ALL.len(), 6);
     }
 
     #[test]
@@ -198,6 +213,7 @@ mod tests {
         assert_eq!(PrimitiveType::Branch.name(), "BranchIndex");
         assert_eq!(PrimitiveType::Json.name(), "JsonStore");
         assert_eq!(PrimitiveType::Vector.name(), "VectorStore");
+        assert_eq!(PrimitiveType::Graph.name(), "GraphStore");
     }
 
     #[test]
@@ -207,6 +223,7 @@ mod tests {
         assert_eq!(PrimitiveType::Branch.id(), "branch");
         assert_eq!(PrimitiveType::Json.id(), "json");
         assert_eq!(PrimitiveType::Vector.id(), "vector");
+        assert_eq!(PrimitiveType::Graph.id(), "graph");
     }
 
     #[test]
@@ -222,6 +239,7 @@ mod tests {
             PrimitiveType::from_id("vector"),
             Some(PrimitiveType::Vector)
         );
+        assert_eq!(PrimitiveType::from_id("graph"), Some(PrimitiveType::Graph));
         assert_eq!(PrimitiveType::from_id("state"), None);
         assert_eq!(PrimitiveType::from_id("invalid"), None);
     }
@@ -249,6 +267,7 @@ mod tests {
         assert!(PrimitiveType::Branch.supports_crud());
         assert!(PrimitiveType::Json.supports_crud());
         assert!(PrimitiveType::Vector.supports_crud());
+        assert!(PrimitiveType::Graph.supports_crud());
 
         // Append-only (no delete/update)
         assert!(!PrimitiveType::Event.supports_crud());
@@ -262,6 +281,7 @@ mod tests {
         assert!(!PrimitiveType::Branch.is_append_only());
         assert!(!PrimitiveType::Json.is_append_only());
         assert!(!PrimitiveType::Vector.is_append_only());
+        assert!(!PrimitiveType::Graph.is_append_only());
     }
 
     #[test]
@@ -279,7 +299,7 @@ mod tests {
         for pt in PrimitiveType::all() {
             set.insert(*pt);
         }
-        assert_eq!(set.len(), 5, "All PrimitiveTypes should be unique");
+        assert_eq!(set.len(), 6, "All PrimitiveTypes should be unique");
     }
 
     #[test]
@@ -305,6 +325,7 @@ mod tests {
         assert_eq!(PrimitiveType::Event.entry_type_range(), (0x30, 0x3F));
         assert_eq!(PrimitiveType::Branch.entry_type_range(), (0x40, 0x4F));
         assert_eq!(PrimitiveType::Vector.entry_type_range(), (0x50, 0x5F));
+        assert_eq!(PrimitiveType::Graph.entry_type_range(), (0x60, 0x6F));
     }
 
     #[test]
@@ -314,6 +335,7 @@ mod tests {
         assert_eq!(PrimitiveType::Event.primitive_id(), 3);
         assert_eq!(PrimitiveType::Branch.primitive_id(), 4);
         assert_eq!(PrimitiveType::Vector.primitive_id(), 5);
+        assert_eq!(PrimitiveType::Graph.primitive_id(), 6);
     }
 
     #[test]
@@ -346,7 +368,7 @@ mod tests {
             .iter()
             .map(|pt| pt.primitive_id())
             .collect();
-        assert_eq!(ids.len(), 5, "All primitive IDs must be unique");
+        assert_eq!(ids.len(), 6, "All primitive IDs must be unique");
     }
 
     #[test]

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -142,8 +142,9 @@ impl PartialOrd for Namespace {
 /// - Space = 0x04
 /// - Vector = 0x05
 /// - Json = 0x06
+/// - Graph = 0x07
 ///
-/// Ordering: KV < Event < Branch < Space < Vector < Json
+/// Ordering: KV < Event < Branch < Space < Vector < Json < Graph
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum TypeTag {
@@ -159,6 +160,8 @@ pub enum TypeTag {
     Vector = 0x05,
     /// JSON document store entries
     Json = 0x06,
+    /// Graph store entries (nodes, edges, metadata under `_graph_` space)
+    Graph = 0x07,
 }
 
 impl TypeTag {
@@ -176,6 +179,7 @@ impl TypeTag {
             0x04 => Some(TypeTag::Space),
             0x05 => Some(TypeTag::Vector),
             0x06 => Some(TypeTag::Json),
+            0x07 => Some(TypeTag::Graph),
             _ => None,
         }
     }
@@ -249,6 +253,13 @@ impl Key {
     /// Helper that automatically sets type_tag to TypeTag::KV
     pub fn new_kv(namespace: Arc<Namespace>, key: impl AsRef<[u8]>) -> Self {
         Self::new(namespace, TypeTag::KV, key.as_ref().to_vec())
+    }
+
+    /// Create a Graph key
+    ///
+    /// Helper that automatically sets type_tag to TypeTag::Graph
+    pub fn new_graph(namespace: Arc<Namespace>, key: impl AsRef<[u8]>) -> Self {
+        Self::new(namespace, TypeTag::Graph, key.as_ref().to_vec())
     }
 
     /// Create an event key with sequence number
@@ -823,6 +834,7 @@ mod tests {
         assert!(TypeTag::Branch < TypeTag::Space);
         assert!(TypeTag::Space < TypeTag::Vector);
         assert!(TypeTag::Vector < TypeTag::Json);
+        assert!(TypeTag::Json < TypeTag::Graph);
 
         // Verify numeric values match spec
         assert_eq!(TypeTag::KV as u8, 0x01);
@@ -831,6 +843,7 @@ mod tests {
         assert_eq!(TypeTag::Space as u8, 0x04);
         assert_eq!(TypeTag::Vector as u8, 0x05);
         assert_eq!(TypeTag::Json as u8, 0x06);
+        assert_eq!(TypeTag::Graph as u8, 0x07);
     }
 
     #[test]
@@ -841,6 +854,7 @@ mod tests {
         assert_eq!(TypeTag::Space.as_byte(), 0x04);
         assert_eq!(TypeTag::Vector.as_byte(), 0x05);
         assert_eq!(TypeTag::Json.as_byte(), 0x06);
+        assert_eq!(TypeTag::Graph.as_byte(), 0x07);
     }
 
     #[test]
@@ -851,7 +865,7 @@ mod tests {
         assert_eq!(TypeTag::from_byte(0x04), Some(TypeTag::Space));
         assert_eq!(TypeTag::from_byte(0x05), Some(TypeTag::Vector));
         assert_eq!(TypeTag::from_byte(0x06), Some(TypeTag::Json));
-        assert_eq!(TypeTag::from_byte(0x07), None);
+        assert_eq!(TypeTag::from_byte(0x07), Some(TypeTag::Graph));
         assert_eq!(TypeTag::from_byte(0x00), None);
         assert_eq!(TypeTag::from_byte(0x08), None);
         assert_eq!(TypeTag::from_byte(0xFF), None);
@@ -867,6 +881,7 @@ mod tests {
             TypeTag::Space,
             TypeTag::Vector,
             TypeTag::Json,
+            TypeTag::Graph,
         ];
         let bytes: Vec<u8> = tags.iter().map(|t| t.as_byte()).collect();
         let unique: std::collections::HashSet<u8> = bytes.iter().cloned().collect();
@@ -883,6 +898,7 @@ mod tests {
             TypeTag::Space,
             TypeTag::Vector,
             TypeTag::Json,
+            TypeTag::Graph,
         ];
 
         for tag in tags {
@@ -900,8 +916,7 @@ mod tests {
     fn test_typetag_from_byte_gap_values_return_none() {
         // Bytes outside defined variants must return None (on-disk format safety)
         for byte in [
-            0x00, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x20, 0x80, 0xFE,
-            0xFF,
+            0x00, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x20, 0x80, 0xFE, 0xFF,
         ] {
             assert_eq!(
                 TypeTag::from_byte(byte),
@@ -922,6 +937,7 @@ mod tests {
             TypeTag::Space,
             TypeTag::Vector,
             TypeTag::Json,
+            TypeTag::Graph,
         ];
         for tag in all_tags {
             let byte = tag.as_byte();
@@ -946,6 +962,7 @@ mod tests {
             TypeTag::Space,
             TypeTag::Vector,
             TypeTag::Json,
+            TypeTag::Graph,
         ];
         for window in tags_in_order.windows(2) {
             assert!(
@@ -976,6 +993,19 @@ mod tests {
     // ========================================
     // Key Tests
     // ========================================
+
+    #[test]
+    fn test_key_new_graph() {
+        let branch_id = BranchId::new();
+        let ns = Arc::new(Namespace::for_branch(branch_id));
+        let key = Key::new_graph(ns.clone(), "test_key");
+        assert_eq!(key.type_tag, TypeTag::Graph);
+        assert_eq!(key.user_key_string(), Some("test_key".to_string()));
+
+        // Graph key must not match KV prefix
+        let kv_prefix = Key::new_kv(ns.clone(), "");
+        assert_ne!(key.type_tag, kv_prefix.type_tag);
+    }
 
     #[test]
     fn test_key_construction() {

--- a/crates/durability/src/format/primitive_tags.rs
+++ b/crates/durability/src/format/primitive_tags.rs
@@ -13,9 +13,11 @@ pub const BRANCH: u8 = 0x03;
 pub const JSON: u8 = 0x04;
 /// Vector embedding
 pub const VECTOR: u8 = 0x05;
+/// Graph store
+pub const GRAPH: u8 = 0x06;
 
 /// All valid primitive tags in order
-pub const ALL_TAGS: [u8; 5] = [KV, EVENT, BRANCH, JSON, VECTOR];
+pub const ALL_TAGS: [u8; 6] = [KV, EVENT, BRANCH, JSON, VECTOR, GRAPH];
 
 /// Get the tag name for display
 pub fn tag_name(tag: u8) -> &'static str {
@@ -25,6 +27,7 @@ pub fn tag_name(tag: u8) -> &'static str {
         BRANCH => "Branch",
         JSON => "Json",
         VECTOR => "Vector",
+        GRAPH => "Graph",
         _ => "Unknown",
     }
 }
@@ -49,12 +52,13 @@ mod tests {
         assert_eq!(tag_name(BRANCH), "Branch");
         assert_eq!(tag_name(JSON), "Json");
         assert_eq!(tag_name(VECTOR), "Vector");
+        assert_eq!(tag_name(GRAPH), "Graph");
         assert_eq!(tag_name(0xFF), "Unknown");
     }
 
     #[test]
     fn all_tags_complete() {
-        assert_eq!(ALL_TAGS.len(), 5);
-        assert_eq!(ALL_TAGS, [KV, EVENT, BRANCH, JSON, VECTOR]);
+        assert_eq!(ALL_TAGS.len(), 6);
+        assert_eq!(ALL_TAGS, [KV, EVENT, BRANCH, JSON, VECTOR, GRAPH]);
     }
 }

--- a/crates/durability/src/format/snapshot.rs
+++ b/crates/durability/src/format/snapshot.rs
@@ -322,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_all_tags() {
-        assert_eq!(primitive_tags::ALL_TAGS.len(), 5);
+        assert_eq!(primitive_tags::ALL_TAGS.len(), 6);
         assert_eq!(
             primitive_tags::ALL_TAGS,
             [
@@ -331,6 +331,7 @@ mod tests {
                 primitive_tags::BRANCH,
                 primitive_tags::JSON,
                 primitive_tags::VECTOR,
+                primitive_tags::GRAPH,
             ]
         );
     }

--- a/crates/durability/src/format/writeset.rs
+++ b/crates/durability/src/format/writeset.rs
@@ -316,6 +316,11 @@ impl Writeset {
                 Self::write_string(bytes, collection);
                 Self::write_string(bytes, key);
             }
+            EntityRef::Graph { branch_id, key } => {
+                bytes.push(primitive_tags::GRAPH);
+                bytes.extend_from_slice(branch_id.as_bytes());
+                Self::write_string(bytes, key);
+            }
         }
     }
 
@@ -376,6 +381,11 @@ impl Writeset {
                     },
                     cursor,
                 ))
+            }
+            primitive_tags::GRAPH => {
+                let (key, consumed) = Self::read_string(&bytes[cursor..])?;
+                cursor += consumed;
+                Ok((EntityRef::Graph { branch_id, key }, cursor))
             }
             _ => Err(WritesetError::InvalidEntityRefTag(tag)),
         }
@@ -553,6 +563,7 @@ mod tests {
             EntityRef::branch(branch_id),
             EntityRef::json(branch_id, "test-doc"),
             EntityRef::vector(branch_id, "collection", "vec-key"),
+            EntityRef::graph(branch_id, "mygraph/n/node1"),
         ];
 
         for entity_ref in refs {

--- a/crates/engine/src/branch_ops.rs
+++ b/crates/engine/src/branch_ops.rs
@@ -380,6 +380,7 @@ fn primitive_to_type_tags(prim: PrimitiveType) -> Vec<TypeTag> {
         PrimitiveType::Json => vec![TypeTag::Json],
         PrimitiveType::Vector => vec![TypeTag::Vector],
         PrimitiveType::Branch => vec![], // Branch metadata is not scanned in diffs
+        PrimitiveType::Graph => vec![TypeTag::Graph],
     }
 }
 
@@ -390,7 +391,8 @@ fn type_tag_to_primitive(tag: TypeTag) -> PrimitiveType {
         TypeTag::Event => PrimitiveType::Event,
         TypeTag::Json => PrimitiveType::Json,
         TypeTag::Vector => PrimitiveType::Vector,
-        _ => PrimitiveType::Kv, // fallback for Branch/Space/State/Trace metadata tags
+        TypeTag::Graph => PrimitiveType::Graph,
+        _ => PrimitiveType::Kv, // fallback for Branch/Space metadata tags
     }
 }
 

--- a/crates/executor/src/convert.rs
+++ b/crates/executor/src/convert.rs
@@ -33,6 +33,10 @@ impl From<StrataError> for Error {
                         stream: entity_str,
                         hint: None,
                     },
+                    EntityRef::Graph { .. } => Error::KeyNotFound {
+                        key: entity_str,
+                        hint: None,
+                    },
                 }
             }
 

--- a/crates/executor/src/handlers/search.rs
+++ b/crates/executor/src/handlers/search.rs
@@ -402,5 +402,6 @@ fn format_entity_ref(doc_ref: &strata_engine::search::EntityRef) -> (String, Str
             (uuid.to_string(), "branch".to_string())
         }
         strata_engine::search::EntityRef::Vector { key, .. } => (key.clone(), "vector".to_string()),
+        strata_engine::search::EntityRef::Graph { key, .. } => (key.clone(), "graph".to_string()),
     }
 }

--- a/crates/search/src/hybrid.rs
+++ b/crates/search/src/hybrid.rs
@@ -386,6 +386,8 @@ impl HybridSearch {
             // - For vector/hybrid search with embeddings, the orchestrator
             //   should call vector.search_response() directly with the embedding
             PrimitiveType::Vector => Searchable::search(&self.vector, req),
+            // Graph primitive search not yet implemented — return empty results
+            PrimitiveType::Graph => Ok(SearchResponse::empty()),
         }
     }
 

--- a/docs/design/graph-primitive-promotion.md
+++ b/docs/design/graph-primitive-promotion.md
@@ -1,0 +1,283 @@
+# Graph Primitive Promotion: TypeTag::Graph (GRF-DEBT-001)
+
+**Issue:** #1974
+**Status:** Design
+**Priority:** P0 architectural debt
+
+## Problem
+
+Graph stores all data as `TypeTag::KV (0x01)` under the `_graph_` namespace. The storage engine cannot distinguish graph data from user KV data. This means:
+
+- Branch diff shows graph entries mixed with regular KV
+- `describe()` must heuristically scan `_graph_` space
+- Export/import has no dedicated Graph section
+- No graph-aware compaction or statistics
+- Space deletion doesn't sweep graph keys
+- Checkpoint bundles graph data into KV section
+
+## Solution
+
+Add `TypeTag::Graph = 0x07` and `PrimitiveType::Graph`, making Graph a first-class primitive. No backward compatibility concerns.
+
+---
+
+## Epic 1: Core Type System
+
+**Scope:** Add the new enum variants, key constructor, and make the compiler tell us what's missing.
+
+### 1.1 TypeTag::Graph = 0x07
+
+**File:** `crates/core/src/types.rs`
+
+- Add `Graph = 0x07` to `TypeTag` enum
+- Add `0x07 => Some(TypeTag::Graph)` to `from_byte()`
+- Add `Key::new_graph(ns, user_key)` constructor
+- Update ordering doc comment
+
+**Tests to update:**
+- `test_typetag_from_byte` — `from_byte(0x07)` changes from `None` to `Some(Graph)`
+- `test_typetag_no_collisions` — add Graph to array
+- `test_typetag_as_byte` — add Graph assertion
+- `test_typetag_ordering` — add `Json < Graph`
+- `test_typetag_as_byte_from_byte_roundtrip_exhaustive` — 0x07 now returns Some
+- `test_typetag_ordering_matches_byte_values` — add Graph
+- Serialization/deserialization/hashset tests — add Graph variant
+
+**New tests:**
+- `test_key_new_graph()` — verify Key::new_graph produces TypeTag::Graph
+- `test_key_graph_does_not_match_kv_prefix()` — Graph and KV keys are distinct
+
+### 1.2 PrimitiveType::Graph
+
+**File:** `crates/core/src/contract/primitive_type.rs`
+
+- Add `Graph` variant to enum
+- Update module doc: "six primitives"
+- `ALL: [PrimitiveType; 6]`
+- Match arms: `name()` -> "GraphStore", `id()` -> "graph", `from_id("graph")`, `supports_crud()` -> true, `entry_type_range()` -> (0x60, 0x6F), `primitive_id()` -> 6
+
+**Tests to update:**
+- `test_primitive_type_all` — 5 -> 6
+- `test_primitive_type_const_all` — 5 -> 6
+- `test_primitive_type_hash` — 5 -> 6
+- `test_primitive_id_uniqueness` — 5 -> 6
+- Names/ids/from_id/roundtrip/entry_type_range/primitive_id — add Graph
+
+### 1.3 EntityRef::Graph
+
+**File:** `crates/core/src/contract/entity_ref.rs`
+
+- Add `Graph { branch_id, graph_key }` variant
+- Add match arms in `branch_id()`, `primitive_type()`, `Display`
+
+**Tests to update:**
+- `test_all_primitive_types_covered` — 5 -> 6
+
+### 1.4 Durability primitive tag
+
+**File:** `crates/durability/src/format/primitive_tags.rs`
+
+- Add `pub const GRAPH: u8 = 0x06;`
+- `ALL_TAGS: [u8; 6]`
+- `tag_name()` — add Graph
+
+**Tests to update:**
+- `all_tags_unique`, `all_tags_complete`, `tag_names`
+
+**Completion signal:** `cargo build --workspace` compiles. Non-exhaustive match warnings guide Epic 2.
+
+---
+
+## Epic 2: Graph Key Migration
+
+**Scope:** Switch graph crate from `TypeTag::KV` to `TypeTag::Graph`. This is the semantic core of the change.
+
+### 2.1 graph_key() constructor
+
+**File:** `crates/graph/src/keys.rs`
+
+- Line 113: `Key::new_kv(...)` -> `Key::new_graph(...)`
+
+**Tests to update:**
+- `assert_kv_tag` helper (line 362) -> `assert_graph_tag` / `TypeTag::Graph`
+- `storage_key_has_kv_type_tag` (line 504) -> expect `TypeTag::Graph`
+
+### 2.2 Direct Key::new_kv calls in lib.rs
+
+**File:** `crates/graph/src/lib.rs`
+
+- 14+ direct `Key::new_kv(ns, ...)` calls in bulk insert paths (lines ~1007-1325)
+- 8+ prefix scan calls building prefix keys
+- ALL must change to `Key::new_graph(...)` or `Key::new(ns, TypeTag::Graph, ...)`
+
+### 2.3 Ontology prefix scans
+
+**File:** `crates/graph/src/ontology.rs`
+
+- 3 prefix scan calls at lines ~78, 168, 783
+- These go through `storage_key()` -> `graph_key()` so auto-fix from 2.1
+
+### 2.4 Doc updates
+
+- `keys.rs` module doc: "KV-type keys" -> "Graph-type keys"
+- `lib.rs` module doc: update TypeTag::KV references
+
+**Completion signal:** `cargo test -p strata-graph` passes. Graph data now uses TypeTag::Graph.
+
+---
+
+## Epic 3: Cross-Cutting Iteration Sites
+
+**Scope:** Make graph data visible to diff, merge, space operations, and compaction.
+
+### 3.1 Branch operations
+
+**File:** `crates/engine/src/branch_ops.rs`
+
+- `DATA_TYPE_TAGS` -> `[TypeTag; 5]` adding `TypeTag::Graph`
+- `primitive_to_type_tags()`: add `PrimitiveType::Graph => vec![TypeTag::Graph]`
+- `type_tag_to_primitive()`: add `TypeTag::Graph => PrimitiveType::Graph`
+
+### 3.2 Space deletion sweep
+
+**File:** `crates/executor/src/handlers/space.rs` (line 60)
+
+- Add `TypeTag::Graph` to inline array
+
+### 3.3 Other inline TypeTag arrays (grep and fix)
+
+- `crates/engine/src/primitives/branch/index.rs` ~line 393 — branch deletion sweep
+- `crates/engine/src/primitives/space.rs` ~line 114 — space emptiness check
+- `crates/engine/src/bundle.rs` ~line 154 — bundle branchlog
+
+### 3.4 Checkpoint data collection
+
+**File:** `crates/engine/src/database/compaction.rs`
+
+- Add `TypeTag::Graph` loop alongside KV loop, pushing into same `kv_entries`
+
+### 3.5 Key encoding tests
+
+**File:** `crates/storage/src/key_encoding.rs`
+
+- Add `Just(TypeTag::Graph)` to property-based test arrays
+
+### 3.6 Module documentation
+
+**File:** `crates/engine/src/primitives/mod.rs`
+
+- Add "Graph storage is provided by the `strata-graph` crate."
+
+**Completion signal:** `cargo test -p strata-engine -p strata-storage` passes. Graph data appears in diffs and survives checkpoint.
+
+---
+
+## Epic 4: Search Integration
+
+**Scope:** Make graph node properties discoverable by full-text search.
+
+### 4.1 Search recovery
+
+**File:** `crates/engine/src/search/recovery.rs`
+
+- Add `TypeTag::Graph` loop in `recover_from_db()` (~line 140)
+- Add `TypeTag::Graph` loop in `reconcile_index()` (~line 227)
+- Skip graph metadata keys: `__meta__`, `__catalog__`, `__types__/`, `__by_type__/`, `__edge_count__/`, `__ref__/`
+
+### 4.2 Post-commit search indexing
+
+**File:** `crates/engine/src/database/lifecycle.rs`
+
+- Lines 222-230 and 259-264: Add `TypeTag::Graph` case
+- Same metadata key skip list as 4.1
+
+### 4.3 Search handler primitive parsing
+
+**File:** `crates/executor/src/handlers/search.rs`
+
+- Add `"graph" => Some(PrimitiveType::Graph)` (~line 70)
+
+**Completion signal:** Graph node properties are searchable. `cargo test -p strata-engine` search tests pass.
+
+---
+
+## Epic 5: Export & CLI
+
+**Scope:** Make graph data exportable and CLI-accessible.
+
+### 5.1 ExportPrimitive
+
+**File:** `crates/executor/src/types.rs`
+
+- Add `Graph` variant to `ExportPrimitive` enum (~line 799)
+
+### 5.2 Export handler
+
+**File:** `crates/executor/src/handlers/export.rs`
+
+- Add `ExportPrimitive::Graph => collect_graph(...)` case
+- Implement `collect_graph()` — scan `TypeTag::Graph` keys, return as ExportRows
+
+### 5.3 CLI support
+
+**Files:** `crates/cli/src/parse.rs`, `main.rs`, `repl.rs`
+
+- Add Graph to CLI primitive dispatch (if applicable)
+
+**Completion signal:** `EXPORT graph` command works. `cargo test --workspace` passes.
+
+---
+
+## Epic 6: Integration Tests & Cleanup
+
+**Scope:** Verify end-to-end correctness and fill test gaps.
+
+### 6.1 Test utilities
+
+- `tests/common/mod.rs` — update `all_primitive_types()` if exists
+- `tests/intelligence/architectural_invariants.rs` — currently expects 6 primitives (will auto-pass)
+
+### 6.2 New integration tests
+
+- `test_graph_data_in_branch_diff()` — graph changes appear in diff
+- `test_graph_data_survives_checkpoint()` — checkpoint/restore preserves graph data
+- `test_graph_data_deleted_with_space()` — space deletion sweep cleans up graph data
+
+### 6.3 Final sweep
+
+- `cargo fmt --all && cargo clippy --workspace` — clean
+- Verify no remaining `Key::new_kv` in graph crate
+- Verify no remaining `TypeTag::KV` assertions in graph tests
+
+**Completion signal:** `cargo test --workspace` green. `cargo clippy --workspace` clean.
+
+---
+
+## Epic Dependency Graph
+
+```
+Epic 1 (Core Types)
+    |
+    v
+Epic 2 (Graph Key Migration) -----> Epic 3 (Cross-Cutting)
+                                         |
+                                         v
+                              Epic 4 (Search) --> Epic 5 (Export/CLI)
+                                                      |
+                                                      v
+                                               Epic 6 (Integration)
+```
+
+Epics 1 and 2 are the foundation. Epic 3 can start once Epic 2 is done. Epics 4 and 5 are independent of each other but both depend on Epic 3. Epic 6 is the final sweep.
+
+## Files Touched (by epic)
+
+| Epic | Files | Estimate |
+|------|-------|----------|
+| 1 | `types.rs`, `primitive_type.rs`, `entity_ref.rs`, `primitive_tags.rs` | 4 files |
+| 2 | `graph/keys.rs`, `graph/lib.rs`, `graph/ontology.rs` | 3 files |
+| 3 | `branch_ops.rs`, `space.rs` (2), `bundle.rs`, `compaction.rs`, `key_encoding.rs`, `primitives/mod.rs`, `branch/index.rs` | 8 files |
+| 4 | `search/recovery.rs`, `lifecycle.rs`, `handlers/search.rs` | 3 files |
+| 5 | `types.rs`, `export.rs`, CLI files | 3-5 files |
+| 6 | `tests/` directory | 2-3 files |
+| **Total** | | **~23 files** |


### PR DESCRIPTION
## Summary

- Adds `TypeTag::Graph = 0x07` with `Key::new_graph()` constructor, making graph data distinguishable from user KV data at the storage layer
- Adds `PrimitiveType::Graph` with all method implementations (name, id, from_id, supports_crud, entry_type_range, primitive_id)
- Adds `EntityRef::Graph` variant with constructor, accessors, Display, and serialization support
- Adds `GRAPH = 0x06` durability primitive tag for snapshot format
- Fixes all non-exhaustive match arms across engine, executor, search crates
- Includes design doc (`docs/design/graph-primitive-promotion.md`) splitting the full migration into 6 epics

This is **Epic 1 of 6** for GRF-DEBT-001. Subsequent epics will:
- Epic 2: Switch graph crate from `Key::new_kv` to `Key::new_graph`
- Epic 3: Update `DATA_TYPE_TAGS`, space deletion, checkpoint, bundle
- Epic 4: Search recovery and post-commit indexing for graph data
- Epic 5: Export handler and CLI support
- Epic 6: Integration tests and cleanup

## Test plan

- [x] `cargo test -p strata-core` — all TypeTag, PrimitiveType, EntityRef tests pass (including new `test_key_new_graph`, `test_entity_ref_graph`)
- [x] `cargo test -p strata-durability` — primitive tags, snapshot, writeset roundtrip tests pass
- [x] `cargo test -p strata-engine -p strata-search -p strata-executor` — 678 pass (1 flaky unrelated lock test)
- [x] `cargo build --workspace` — clean (no non-exhaustive match errors)
- [x] `cargo fmt --all && cargo clippy --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)