### PR TITLE
Fix #1974: Switch graph crate to TypeTag::Graph (Epic 2)

### DIFF
--- a/crates/graph/src/keys.rs
+++ b/crates/graph/src/keys.rs
@@ -1,6 +1,6 @@
 //! Key construction and parsing for graph storage.
 //!
-//! All graph data is stored under the `_graph_` space using KV-type keys.
+//! All graph data is stored under the `_graph_` space using Graph-type keys.
 //! Key format uses `/` as a separator between path segments.
 
 use std::sync::Arc;
@@ -110,7 +110,7 @@ pub fn invalidate_namespace_cache(branch_id: &BranchId) {
 
 /// Build a full storage Key from a user_key string in the graph namespace.
 pub fn graph_key(branch_id: BranchId, user_key: &str) -> Key {
-    Key::new_kv(graph_namespace(branch_id), user_key)
+    Key::new_graph(graph_namespace(branch_id), user_key)
 }
 
 // --- Packed adjacency list keys ---
@@ -356,10 +356,10 @@ pub fn storage_key(branch_id: BranchId, user_key: &str) -> Key {
     graph_key(branch_id, user_key)
 }
 
-/// Check that a storage key has the expected TypeTag::KV.
+/// Check that a storage key has the expected TypeTag::Graph.
 #[cfg(test)]
-fn assert_kv_tag(key: &Key) {
-    assert_eq!(key.type_tag, TypeTag::KV);
+fn assert_graph_tag(key: &Key) {
+    assert_eq!(key.type_tag, TypeTag::Graph);
 }
 
 #[cfg(test)]
@@ -501,10 +501,10 @@ mod tests {
     }
 
     #[test]
-    fn storage_key_has_kv_type_tag() {
+    fn storage_key_has_graph_type_tag() {
         let branch = BranchId::from_bytes([0u8; 16]);
         let key = storage_key(branch, "test/key");
-        assert_kv_tag(&key);
+        assert_graph_tag(&key);
     }
 
     // --- URI encoding edge cases ---
@@ -786,7 +786,7 @@ mod tests {
     #[test]
     fn hoisted_namespace_key_equals_storage_key() {
         // Verify that the bulk_insert optimization path
-        // (Key::new_kv(ns.clone(), ...)) produces keys identical to
+        // (Key::new_graph(ns.clone(), ...)) produces keys identical to
         // the standard path (storage_key(branch_id, ...)).
         let branch =
             BranchId::from_bytes([0xCA, 0xCE, 0x06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
@@ -804,7 +804,7 @@ mod tests {
 
         for user_key in &user_keys {
             let via_storage = storage_key(branch, user_key);
-            let via_hoisted = Key::new_kv(ns.clone(), user_key);
+            let via_hoisted = Key::new_graph(ns.clone(), user_key);
             assert_eq!(
                 via_storage, via_hoisted,
                 "Key mismatch for user_key={user_key:?}"

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -128,7 +128,7 @@ impl GraphStore {
 
         // Fallback: scan for __meta__ keys (legacy data without catalog)
         let ns = keys::graph_namespace(branch_id);
-        let prefix_key = strata_core::types::Key::new_kv(ns, "");
+        let prefix_key = strata_core::types::Key::new_graph(ns, "");
 
         let graphs = self.db.transaction(branch_id, |txn| {
             let results = txn.scan_prefix(&prefix_key)?;
@@ -1004,7 +1004,7 @@ impl GraphStore {
                 }
 
                 let user_key = keys::node_key(graph, node_id);
-                let sk = Key::new_kv(ns.clone(), &user_key);
+                let sk = Key::new_graph(ns.clone(), &user_key);
 
                 let json = if data.entity_ref.is_none()
                     && data.properties.is_none()
@@ -1020,12 +1020,12 @@ impl GraphStore {
 
                 if let Some(uri) = &data.entity_ref {
                     let rk = keys::ref_index_key(uri, graph, node_id);
-                    ref_entries.push(Key::new_kv(ns.clone(), &rk));
+                    ref_entries.push(Key::new_graph(ns.clone(), &rk));
                 }
 
                 if let Some(ot) = &data.object_type {
                     let tk = keys::type_index_key(graph, ot, node_id);
-                    type_entries.push(Key::new_kv(ns.clone(), &tk));
+                    type_entries.push(Key::new_graph(ns.clone(), &tk));
                 }
             }
 
@@ -1033,16 +1033,16 @@ impl GraphStore {
                 // Clean up old index entries for nodes being re-inserted (upsert)
                 for (node_id, _data) in chunk {
                     let user_key = keys::node_key(graph, node_id);
-                    let sk = Key::new_kv(ns.clone(), &user_key);
+                    let sk = Key::new_graph(ns.clone(), &user_key);
                     if let Some(Value::String(old_json)) = txn.get(&sk)? {
                         if let Ok(old_data) = serde_json::from_str::<NodeData>(&old_json) {
                             if let Some(old_uri) = old_data.entity_ref {
                                 let old_rk = keys::ref_index_key(&old_uri, graph, node_id);
-                                txn.delete(Key::new_kv(ns.clone(), &old_rk))?;
+                                txn.delete(Key::new_graph(ns.clone(), &old_rk))?;
                             }
                             if let Some(old_ot) = old_data.object_type {
                                 let old_tk = keys::type_index_key(graph, &old_ot, node_id);
-                                txn.delete(Key::new_kv(ns.clone(), &old_tk))?;
+                                txn.delete(Key::new_graph(ns.clone(), &old_tk))?;
                             }
                         }
                     }
@@ -1102,7 +1102,7 @@ impl GraphStore {
             let mut bufs: Vec<(Key, Vec<u8>)> = Vec::with_capacity(chunk.len());
             for (node_id, new_edges) in chunk {
                 let uk = keys::forward_adj_key(graph, node_id);
-                let sk = Key::new_kv(ns.clone(), &uk);
+                let sk = Key::new_graph(ns.clone(), &uk);
                 let mut buf = match self.db.get_value_direct(&sk)? {
                     Some(Value::Bytes(existing)) => existing,
                     _ => packed::empty(),
@@ -1127,7 +1127,7 @@ impl GraphStore {
             let mut bufs: Vec<(Key, Vec<u8>)> = Vec::with_capacity(chunk.len());
             for (node_id, new_edges) in chunk {
                 let uk = keys::reverse_adj_key(graph, node_id);
-                let sk = Key::new_kv(ns.clone(), &uk);
+                let sk = Key::new_graph(ns.clone(), &uk);
                 let mut buf = match self.db.get_value_direct(&sk)? {
                     Some(Value::Bytes(existing)) => existing,
                     _ => packed::empty(),
@@ -1151,7 +1151,7 @@ impl GraphStore {
             self.db.transaction(branch_id, |txn| {
                 for (et, new_count) in &edge_type_counts {
                     let count_uk = keys::edge_type_count_key(graph, et);
-                    let count_sk = Key::new_kv(ns.clone(), &count_uk);
+                    let count_sk = Key::new_graph(ns.clone(), &count_uk);
                     let existing = Self::read_edge_type_count(txn, &count_sk)?;
                     Self::write_edge_type_count(txn, &count_sk, existing + new_count)?;
                 }
@@ -1282,7 +1282,7 @@ impl GraphStore {
             // Check all referenced nodes exist (once per unique node)
             for node_id in &unique_nodes {
                 let node_uk = keys::node_key(graph, node_id);
-                let node_sk = Key::new_kv(ns.clone(), &node_uk);
+                let node_sk = Key::new_graph(ns.clone(), &node_uk);
                 if txn.get(&node_sk)?.is_none() {
                     return Err(StrataError::invalid_input(format!(
                         "Node '{}' does not exist in graph '{}'",
@@ -1294,7 +1294,7 @@ impl GraphStore {
             // Write forward adjacency lists (1 read + 1 write per unique source)
             for (src, new_edges) in &fwd_map {
                 let fwd_uk = keys::forward_adj_key(graph, src);
-                let fwd_sk = Key::new_kv(ns.clone(), &fwd_uk);
+                let fwd_sk = Key::new_graph(ns.clone(), &fwd_uk);
                 let mut buf = match txn.get(&fwd_sk)? {
                     Some(Value::Bytes(b)) => b,
                     _ => packed::empty(),
@@ -1308,7 +1308,7 @@ impl GraphStore {
             // Write reverse adjacency lists (1 read + 1 write per unique destination)
             for (dst, new_edges) in &rev_map {
                 let rev_uk = keys::reverse_adj_key(graph, dst);
-                let rev_sk = Key::new_kv(ns.clone(), &rev_uk);
+                let rev_sk = Key::new_graph(ns.clone(), &rev_uk);
                 let mut buf = match txn.get(&rev_sk)? {
                     Some(Value::Bytes(b)) => b,
                     _ => packed::empty(),
@@ -1322,7 +1322,7 @@ impl GraphStore {
             // Update edge type counters (1 read-modify-write per unique edge type)
             for (et, new_count) in &edge_type_counts {
                 let count_uk = keys::edge_type_count_key(graph, et);
-                let count_sk = Key::new_kv(ns.clone(), &count_uk);
+                let count_sk = Key::new_graph(ns.clone(), &count_uk);
                 let existing = Self::read_edge_type_count(txn, &count_sk)?;
                 Self::write_edge_type_count(txn, &count_sk, existing + new_count)?;
             }


### PR DESCRIPTION
## Summary

- Switches all graph key construction from `Key::new_kv()` / `TypeTag::KV` to `Key::new_graph()` / `TypeTag::Graph`
- 15 call sites in `lib.rs` (bulk_insert, batch_add_edges, legacy catalog scan) + 1 in `keys.rs` (graph_key function)
- Updates test helper `assert_kv_tag` → `assert_graph_tag`
- Updates module doc and comments

This is **Epic 2 of 6** for GRF-DEBT-001. After this, all new graph data written to storage uses `TypeTag::Graph = 0x07` instead of `TypeTag::KV = 0x01`.

## Test plan

- [x] `cargo test -p strata-graph` — all 427 tests pass
- [x] `cargo build --workspace` — clean
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)