### PR TITLE
Fix #1974: Add TypeTag::Graph to cross-cutting iteration sites (Epic 3)

### DIFF
--- a/crates/engine/src/branch_ops.rs
+++ b/crates/engine/src/branch_ops.rs
@@ -28,7 +28,13 @@ use tracing::info;
 // Constants and key-format helpers
 // =============================================================================
 
-const DATA_TYPE_TAGS: [TypeTag; 4] = [TypeTag::KV, TypeTag::Event, TypeTag::Json, TypeTag::Vector];
+const DATA_TYPE_TAGS: [TypeTag; 5] = [
+    TypeTag::KV,
+    TypeTag::Event,
+    TypeTag::Json,
+    TypeTag::Vector,
+    TypeTag::Graph,
+];
 
 /// The well-known branch name used for internal metadata (tags, notes).
 const SYSTEM_BRANCH: &str = "_system_";

--- a/crates/engine/src/bundle.rs
+++ b/crates/engine/src/bundle.rs
@@ -151,7 +151,13 @@ fn scan_branch_data(
     let snapshot_version = db.current_version();
 
     // Discover all current keys across all type tags
-    let type_tags = [TypeTag::KV, TypeTag::Event, TypeTag::Json, TypeTag::Vector];
+    let type_tags = [
+        TypeTag::KV,
+        TypeTag::Event,
+        TypeTag::Json,
+        TypeTag::Vector,
+        TypeTag::Graph,
+    ];
 
     let mut all_keys: Vec<Key> = Vec::new();
     for type_tag in type_tags {

--- a/crates/engine/src/database/compaction.rs
+++ b/crates/engine/src/database/compaction.rs
@@ -235,6 +235,17 @@ impl Database {
                 });
             }
 
+            // Graph entries (same shape as KV — stored under _graph_ namespace)
+            for (key, vv) in self.storage.list_by_type(&branch_id, TypeTag::Graph) {
+                let value_bytes = serde_json::to_vec(&vv.value).unwrap_or_default();
+                kv_entries.push(KvSnapshotEntry {
+                    key: key.user_key_string().unwrap_or_default(),
+                    value: value_bytes,
+                    version: vv.version.as_u64(),
+                    timestamp: vv.timestamp.as_micros(),
+                });
+            }
+
             // Event entries
             for (key, vv) in self.storage.list_by_type(&branch_id, TypeTag::Event) {
                 // Skip metadata keys (internal implementation details, reconstructed on restore)

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -390,7 +390,13 @@ impl BranchIndex {
     ) -> StrataResult<()> {
         let ns = Arc::new(Namespace::for_branch(branch_id));
 
-        for type_tag in [TypeTag::KV, TypeTag::Event, TypeTag::Json, TypeTag::Vector] {
+        for type_tag in [
+            TypeTag::KV,
+            TypeTag::Event,
+            TypeTag::Json,
+            TypeTag::Vector,
+            TypeTag::Graph,
+        ] {
             let prefix = Key::new(ns.clone(), type_tag, vec![]);
             let entries = txn.scan_prefix(&prefix)?;
 

--- a/crates/engine/src/primitives/space.rs
+++ b/crates/engine/src/primitives/space.rs
@@ -106,12 +106,18 @@ impl SpaceIndex {
     /// Check if a space has any data.
     ///
     /// **Note:** This is O(N) — scans all data TypeTags (KV, Event,
-    /// Json, Vector) in the space's namespace. Not a cheap check.
+    /// Json, Vector, Graph) in the space's namespace. Not a cheap check.
     pub fn is_empty(&self, branch_id: BranchId, space: &str) -> StrataResult<bool> {
         self.db.transaction(branch_id, |txn| {
             let ns = Arc::new(Namespace::for_branch_space(branch_id, space));
 
-            for type_tag in [TypeTag::KV, TypeTag::Event, TypeTag::Json, TypeTag::Vector] {
+            for type_tag in [
+                TypeTag::KV,
+                TypeTag::Event,
+                TypeTag::Json,
+                TypeTag::Vector,
+                TypeTag::Graph,
+            ] {
                 let prefix = Key::new(ns.clone(), type_tag, vec![]);
                 let entries = txn.scan_prefix(&prefix)?;
                 if !entries.is_empty() {

--- a/crates/executor/src/handlers/space.rs
+++ b/crates/executor/src/handlers/space.rs
@@ -57,7 +57,13 @@ pub fn space_delete(
     // Delete all data in the space by scanning+deleting all TypeTag prefixes
     let ns = std::sync::Arc::new(Namespace::for_branch_space(core_branch_id, &space));
     convert_result(p.db.transaction(core_branch_id, |txn| {
-        for type_tag in [TypeTag::KV, TypeTag::Event, TypeTag::Json, TypeTag::Vector] {
+        for type_tag in [
+            TypeTag::KV,
+            TypeTag::Event,
+            TypeTag::Json,
+            TypeTag::Vector,
+            TypeTag::Graph,
+        ] {
             let prefix = Key::new(ns.clone(), type_tag, vec![]);
             let entries = txn.scan_prefix(&prefix)?;
             for (key, _) in entries {

--- a/crates/storage/src/key_encoding.rs
+++ b/crates/storage/src/key_encoding.rs
@@ -462,6 +462,7 @@ mod tests {
             TypeTag::Space,
             TypeTag::Vector,
             TypeTag::Json,
+            TypeTag::Graph,
         ] {
             let key = make_key("test", tag, "k");
             let ik = InternalKey::encode(&key, 1);
@@ -667,6 +668,7 @@ mod tests {
                 Just(TypeTag::Space),
                 Just(TypeTag::Vector),
                 Just(TypeTag::Json),
+                Just(TypeTag::Graph),
             ]
         }
 


### PR DESCRIPTION
## Summary

- Adds `TypeTag::Graph` to all inline TypeTag arrays across the codebase so graph data participates in diff, merge, space deletion, branch deletion, checkpoint, and bundle operations
- 5 inline arrays updated + 1 checkpoint collection loop added + 2 test arrays updated
- Graph checkpoint data piggybacks on the existing KV snapshot section (same key/value shape)

This is **Epic 3 of 6** for GRF-DEBT-001.

### Sites updated

| File | Site | Impact |
|------|------|--------|
| `branch_ops.rs` | `DATA_TYPE_TAGS` | Graph in branch diff/merge |
| `bundle.rs` | `scan_branch_data` | Graph in bundle export |
| `space.rs` | `is_empty()` | Graph counted in emptiness check |
| `branch/index.rs` | `delete_namespace_data` | Graph cleaned on branch delete |
| `handlers/space.rs` | space deletion | Graph cleaned on space delete |
| `compaction.rs` | `collect_checkpoint_data` | Graph survives checkpoint |
| `key_encoding.rs` | test + proptest | Graph in encoding roundtrip |

## Test plan

- [x] `cargo test -p strata-engine -p strata-storage -p strata-executor` — 678 pass (1 flaky unrelated)
- [x] `cargo build --workspace` — clean
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)