### PR TITLE
Fix #1974: Add graph data to search indexing (Epic 4)

### DIFF
--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -250,6 +250,22 @@ impl Database {
                                 }
                             }
                         }
+                        TypeTag::Graph => {
+                            if key.user_key.starts_with(b"__")
+                                || key.user_key.windows(3).any(|w| w == b"/__")
+                            {
+                                continue;
+                            }
+                            if let Some(text) = crate::search::extract_indexable_text(value) {
+                                if let Some(user_key) = key.user_key_string() {
+                                    let entity_ref = strata_core::EntityRef::Graph {
+                                        branch_id,
+                                        key: user_key,
+                                    };
+                                    index.index_document(&entity_ref, &text, None);
+                                }
+                            }
+                        }
                         _ => {}
                     }
                 }
@@ -280,6 +296,20 @@ impl Database {
                                 let entity_ref = strata_core::EntityRef::Event {
                                     branch_id,
                                     sequence,
+                                };
+                                index.remove_document(&entity_ref);
+                            }
+                        }
+                        TypeTag::Graph => {
+                            if key.user_key.starts_with(b"__")
+                                || key.user_key.windows(3).any(|w| w == b"/__")
+                            {
+                                continue;
+                            }
+                            if let Some(user_key) = key.user_key_string() {
+                                let entity_ref = strata_core::EntityRef::Graph {
+                                    branch_id,
+                                    key: user_key,
                                 };
                                 index.remove_document(&entity_ref);
                             }

--- a/crates/engine/src/search/recovery.rs
+++ b/crates/engine/src/search/recovery.rs
@@ -182,6 +182,33 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
             index.index_document(&entity_ref, &text, None);
             docs_indexed += 1;
         }
+
+        // --- Graph entries (node data only) ---
+        for (key, vv) in db.storage().list_by_type(&branch_id, TypeTag::Graph) {
+            // Skip internal metadata keys (catalog, meta, type defs,
+            // edge counts, indexes). Covers both top-level (__catalog__)
+            // and graph-scoped ({graph}/__meta__, {graph}/__types__/, etc.)
+            if key.user_key.starts_with(b"__") || key.user_key.windows(3).any(|w| w == b"/__") {
+                continue;
+            }
+
+            let text = match extract_indexable_text(&vv.value) {
+                Some(t) => t,
+                None => continue,
+            };
+
+            let user_key = match key.user_key_string() {
+                Some(k) => k,
+                None => continue,
+            };
+
+            let entity_ref = crate::search::EntityRef::Graph {
+                branch_id,
+                key: user_key,
+            };
+            index.index_document(&entity_ref, &text, None);
+            docs_indexed += 1;
+        }
     }
 
     // Freeze to disk for next startup (fast path).
@@ -263,6 +290,35 @@ fn reconcile_index(db: &Database, index: &InvertedIndex) -> StrataResult<u64> {
             let entity_ref = crate::search::EntityRef::Event {
                 branch_id,
                 sequence,
+            };
+
+            if index.has_document(&entity_ref) {
+                continue;
+            }
+
+            let text = match extract_indexable_text(&vv.value) {
+                Some(t) => t,
+                None => continue,
+            };
+
+            index.index_document(&entity_ref, &text, None);
+            reconciled += 1;
+        }
+
+        // --- Graph entries ---
+        for (key, vv) in db.storage().list_by_type(&branch_id, TypeTag::Graph) {
+            if key.user_key.starts_with(b"__") {
+                continue;
+            }
+
+            let user_key = match key.user_key_string() {
+                Some(k) => k,
+                None => continue,
+            };
+
+            let entity_ref = crate::search::EntityRef::Graph {
+                branch_id,
+                key: user_key,
             };
 
             if index.has_document(&entity_ref) {

--- a/crates/executor/src/handlers/search.rs
+++ b/crates/executor/src/handlers/search.rs
@@ -73,6 +73,7 @@ pub fn search(
                 "event" => Some(PrimitiveType::Event),
                 "branch" => Some(PrimitiveType::Branch),
                 "vector" => Some(PrimitiveType::Vector),
+                "graph" => Some(PrimitiveType::Graph),
                 _ => None,
             })
             .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary

- Graph node properties are now discoverable by full-text search
- Search recovery scans `TypeTag::Graph` entries alongside KV/Event during index rebuild
- Search reconciliation repairs missing graph entries in the index
- Post-commit indexing handles Graph puts/deletes for incremental updates
- `"graph"` recognized as a primitive filter in search queries

Internal metadata keys (`__meta__`, `__catalog__`, `__types__/`, `__by_type__/`, `__edge_count__/`, `__ref__/`) are skipped. Binary adjacency lists (`Value::Bytes`) are naturally filtered by `extract_indexable_text()`.

This is **Epic 4 of 6** for GRF-DEBT-001.

## Test plan

- [x] `cargo test -p strata-engine -- search` — all search tests pass
- [x] `cargo build --workspace` — clean
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)