### PR TITLE
Fix #1979: Add Searchable implementation to GraphStore

### DIFF
--- a/crates/graph/src/bulk.rs
+++ b/crates/graph/src/bulk.rs
@@ -119,6 +119,11 @@ impl GraphStore {
                 Ok(())
             })?;
 
+            // Post-commit: update search index for this chunk
+            for (node_id, data) in chunk {
+                self.index_node_for_search(branch_id, graph, node_id, data);
+            }
+
             nodes_inserted += chunk.len();
         }
 

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -106,3 +106,189 @@ impl GraphStore {
         Ok(index)
     }
 }
+
+// =============================================================================
+// Searchable implementation
+// =============================================================================
+
+impl strata_engine::search::Searchable for GraphStore {
+    fn search(
+        &self,
+        req: &strata_engine::SearchRequest,
+    ) -> StrataResult<strata_engine::SearchResponse> {
+        use strata_engine::search::{EntityRef, InvertedIndex, SearchHit, SearchStats};
+        use std::time::Instant;
+
+        let start = Instant::now();
+        let index = self.db.extension::<InvertedIndex>()?;
+
+        if !index.is_enabled() || index.total_docs() == 0 {
+            return Ok(strata_engine::SearchResponse::empty());
+        }
+
+        let query_terms = strata_engine::search::tokenize(&req.query);
+        let scorer = self.db.config().bm25_scorer();
+
+        // Score all matching docs in the shared index, then filter to Graph refs.
+        // Request more than k to account for non-graph results being filtered out.
+        let top_k = index.score_top_k(
+            &query_terms,
+            &req.branch_id,
+            req.k.saturating_mul(4),
+            scorer.k1,
+            scorer.b,
+        );
+
+        let hits: Vec<SearchHit> = top_k
+            .into_iter()
+            .filter_map(|scored| {
+                let entity_ref = index.resolve_doc_id(scored.doc_id)?;
+
+                // Only include graph entity refs
+                if !entity_ref.is_graph() {
+                    return None;
+                }
+
+                // Extract snippet from graph node data.
+                // The key format is "{graph}/n/{node_id}" (from keys::node_key).
+                let snippet = if let EntityRef::Graph { ref key, .. } = entity_ref {
+                    self.extract_graph_snippet(&req.branch_id, key)
+                } else {
+                    None
+                };
+
+                Some(SearchHit {
+                    doc_ref: entity_ref,
+                    score: scored.score,
+                    rank: 0,
+                    snippet,
+                })
+            })
+            .take(req.k)
+            .enumerate()
+            .map(|(i, mut hit)| {
+                hit.rank = (i + 1) as u32;
+                hit
+            })
+            .collect();
+
+        let elapsed = start.elapsed().as_micros() as u64;
+        let mut stats = SearchStats::new(elapsed, hits.len());
+        stats = stats.with_index_used(true);
+
+        Ok(strata_engine::SearchResponse {
+            hits,
+            truncated: false,
+            stats,
+        })
+    }
+
+    fn primitive_kind(&self) -> strata_core::PrimitiveType {
+        strata_core::PrimitiveType::Graph
+    }
+}
+
+impl GraphStore {
+    // =========================================================================
+    // Search index helpers
+    // =========================================================================
+
+    /// Index a graph node's text into the inverted index for BM25 search.
+    ///
+    /// Called after successful add_node/bulk_insert commits.
+    pub(crate) fn index_node_for_search(
+        &self,
+        branch_id: BranchId,
+        graph: &str,
+        node_id: &str,
+        data: &NodeData,
+    ) {
+        let Ok(index) = self.db.extension::<strata_engine::search::InvertedIndex>() else {
+            return;
+        };
+        if !index.is_enabled() {
+            return;
+        }
+
+        let text = Self::build_node_search_text(node_id, data);
+        let user_key = keys::node_key(graph, node_id);
+        let entity_ref = strata_engine::search::EntityRef::Graph {
+            branch_id,
+            key: user_key,
+        };
+        index.index_document(&entity_ref, &text, None);
+    }
+
+    /// Remove a graph node from the inverted index.
+    ///
+    /// Called after successful remove_node/delete_graph commits.
+    pub(crate) fn deindex_node_for_search(
+        &self,
+        branch_id: BranchId,
+        graph: &str,
+        node_id: &str,
+    ) {
+        let Ok(index) = self.db.extension::<strata_engine::search::InvertedIndex>() else {
+            return;
+        };
+        if !index.is_enabled() {
+            return;
+        }
+
+        let user_key = keys::node_key(graph, node_id);
+        let entity_ref = strata_engine::search::EntityRef::Graph {
+            branch_id,
+            key: user_key,
+        };
+        index.remove_document(&entity_ref);
+    }
+
+    /// Build searchable text from a node's data.
+    fn build_node_search_text(node_id: &str, data: &NodeData) -> String {
+        let mut text = String::new();
+        text.push_str(node_id);
+        if let Some(ref ot) = data.object_type {
+            text.push(' ');
+            text.push_str(ot);
+        }
+        if let Some(ref props) = data.properties {
+            text.push(' ');
+            text.push_str(&serde_json::to_string(props).unwrap_or_default());
+        }
+        if let Some(ref uri) = data.entity_ref {
+            text.push(' ');
+            text.push_str(uri);
+        }
+        text
+    }
+
+    /// Extract a search snippet from a graph node's data.
+    ///
+    /// Parses the storage key to find the graph name and node ID,
+    /// fetches the node, and builds a snippet from object_type + properties.
+    fn extract_graph_snippet(&self, branch_id: &BranchId, storage_key: &str) -> Option<String> {
+        // Storage key format: "{graph}/n/{node_id}"
+        let parts: Vec<&str> = storage_key.splitn(3, '/').collect();
+        if parts.len() < 3 || parts[1] != "n" {
+            return None;
+        }
+        let graph = parts[0];
+        let node_id = parts[2];
+
+        let data = self.get_node(*branch_id, graph, node_id).ok()??;
+
+        let mut text = String::new();
+        if let Some(ref ot) = data.object_type {
+            text.push_str(ot);
+            text.push_str(": ");
+        }
+        if let Some(ref props) = data.properties {
+            text.push_str(&serde_json::to_string(props).unwrap_or_default());
+        } else if text.is_empty() {
+            // Fallback: use node_id if no type or properties
+            text.push_str(node_id);
+        }
+
+        Some(strata_engine::search::truncate_text(&text, 100))
+    }
+}

--- a/crates/graph/src/lifecycle.rs
+++ b/crates/graph/src/lifecycle.rs
@@ -154,6 +154,7 @@ impl GraphStore {
 
         // Step 1: Scan nodes, extract entity_refs, delete ref index entries (batched)
         loop {
+            let mut deleted_node_ids: Vec<String> = Vec::new();
             let done = self.db.transaction(branch_id, |txn| {
                 let results = txn.scan_prefix(&node_prefix_key)?;
                 if results.is_empty() {
@@ -165,10 +166,11 @@ impl GraphStore {
 
                 for (key, val) in &batch {
                     if let Some(user_key) = key.user_key_string() {
-                        if let Value::String(json) = val {
-                            if let Ok(data) = serde_json::from_str::<NodeData>(json) {
-                                if let Some(uri) = data.entity_ref {
-                                    if let Some(node_id) = keys::parse_node_key(graph, &user_key) {
+                        if let Some(node_id) = keys::parse_node_key(graph, &user_key) {
+                            deleted_node_ids.push(node_id.clone());
+                            if let Value::String(json) = val {
+                                if let Ok(data) = serde_json::from_str::<NodeData>(json) {
+                                    if let Some(uri) = data.entity_ref {
                                         let rk = keys::ref_index_key(&uri, graph, &node_id);
                                         txn.delete(keys::storage_key(branch_id, &rk))?;
                                     }
@@ -181,6 +183,11 @@ impl GraphStore {
 
                 Ok(is_last)
             })?;
+
+            // Post-commit: remove deleted nodes from search index
+            for node_id in &deleted_node_ids {
+                self.deindex_node_for_search(branch_id, graph, node_id);
+            }
 
             if done {
                 break;

--- a/crates/graph/src/nodes.rs
+++ b/crates/graph/src/nodes.rs
@@ -42,7 +42,7 @@ impl GraphStore {
             keys::storage_key(branch_id, &tk)
         });
 
-        self.db.transaction(branch_id, |txn| {
+        let result = self.db.transaction(branch_id, |txn| {
             // If updating, clean up old ref index and type index entries
             let old_val = txn.get(&storage_key)?;
             let created = old_val.is_none();
@@ -73,7 +73,12 @@ impl GraphStore {
                 txn.put(tk, Value::Null)?;
             }
             Ok(created)
-        })
+        })?;
+
+        // Post-commit: update search index
+        self.index_node_for_search(branch_id, graph, node_id, &data);
+
+        Ok(result)
     }
 
     /// Get node data, or None if node doesn't exist.
@@ -260,7 +265,12 @@ impl GraphStore {
             txn.delete(rev_adj_sk)?;
             txn.delete(node_storage_key.clone())?;
             Ok(())
-        })
+        })?;
+
+        // Post-commit: remove from search index
+        self.deindex_node_for_search(branch_id, graph, node_id);
+
+        Ok(())
     }
 
     /// Get all nodes with their data in a graph (for snapshot).

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -17,6 +17,7 @@ rerank = ["dep:ureq"]
 [dependencies]
 strata-core = { path = "../core" }
 strata-engine = { path = "../engine" }
+strata-graph = { path = "../graph" }
 strata-vector = { path = "../vector" }
 rayon = { workspace = true }
 serde = { workspace = true }

--- a/crates/search/src/hybrid.rs
+++ b/crates/search/src/hybrid.rs
@@ -27,6 +27,7 @@ use strata_engine::search::{
 };
 use strata_engine::Database;
 use strata_engine::{BranchIndex, EventLog, JsonStore, KVStore};
+use strata_graph::GraphStore;
 use strata_vector::VectorStore;
 
 /// Result type for BM25 search across primitives: (results, total_candidates, any_truncated)
@@ -89,6 +90,7 @@ pub struct HybridSearch {
     event: EventLog,
     branch_index: BranchIndex,
     vector: VectorStore,
+    graph: GraphStore,
 }
 
 impl HybridSearch {
@@ -103,6 +105,7 @@ impl HybridSearch {
             event: EventLog::new(db.clone()),
             branch_index: BranchIndex::new(db.clone()),
             vector: VectorStore::new(db.clone()),
+            graph: GraphStore::new(db.clone()),
             db,
             embedder: None,
             fuser: Arc::new(RRFFuser::default()),
@@ -117,6 +120,7 @@ impl HybridSearch {
             event: EventLog::new(db.clone()),
             branch_index: BranchIndex::new(db.clone()),
             vector: VectorStore::new(db.clone()),
+            graph: GraphStore::new(db.clone()),
             db,
             embedder: Some(embedder),
             fuser: Arc::new(RRFFuser::default()),
@@ -386,8 +390,7 @@ impl HybridSearch {
             // - For vector/hybrid search with embeddings, the orchestrator
             //   should call vector.search_response() directly with the embedding
             PrimitiveType::Vector => Searchable::search(&self.vector, req),
-            // Graph primitive search not yet implemented — return empty results
-            PrimitiveType::Graph => Ok(SearchResponse::empty()),
+            PrimitiveType::Graph => Searchable::search(&self.graph, req),
         }
     }
 
@@ -883,6 +886,142 @@ mod tests {
         assert!(
             response.stats.index_used,
             "BUG #1770: index_used flag lost during hybrid search fusion"
+        );
+    }
+
+    /// Graph nodes with properties should be discoverable via text search.
+    #[test]
+    fn test_graph_nodes_searchable() {
+        let db = test_db();
+        let gs = GraphStore::new(db.clone());
+        let branch_id = BranchId::new();
+
+        gs.create_graph(branch_id, "social", None).unwrap();
+        gs.add_node(
+            branch_id,
+            "social",
+            "alice",
+            strata_graph::types::NodeData {
+                entity_ref: None,
+                properties: Some(serde_json::json!({"name": "Alice", "department": "cardiology"})),
+                object_type: Some("Person".to_string()),
+            },
+        )
+        .unwrap();
+        gs.add_node(
+            branch_id,
+            "social",
+            "bob",
+            strata_graph::types::NodeData {
+                entity_ref: None,
+                properties: Some(serde_json::json!({"name": "Bob", "department": "neurology"})),
+                object_type: Some("Person".to_string()),
+            },
+        )
+        .unwrap();
+
+        let hybrid = HybridSearch::new(db);
+        let req = SearchRequest::new(branch_id, "cardiology");
+        let response = hybrid.search(&req).unwrap();
+
+        // Should find Alice's node (cardiology in properties)
+        assert!(
+            !response.hits.is_empty(),
+            "Graph node with 'cardiology' property should be discoverable"
+        );
+
+        let graph_hits: Vec<_> = response
+            .hits
+            .iter()
+            .filter(|h| h.doc_ref.is_graph())
+            .collect();
+        assert!(
+            !graph_hits.is_empty(),
+            "Should have at least one graph-type hit"
+        );
+    }
+
+    /// Graph search should not return results for non-graph data.
+    #[test]
+    fn test_graph_search_filters_non_graph() {
+        use strata_engine::Searchable;
+
+        let db = test_db();
+        let kv = KVStore::new(db.clone());
+        let gs = GraphStore::new(db.clone());
+        let branch_id = BranchId::new();
+
+        // Add KV data
+        kv.put(
+            &branch_id,
+            "default",
+            "doc1",
+            Value::String("important medical research".into()),
+        )
+        .unwrap();
+
+        // Add graph data
+        gs.create_graph(branch_id, "kg", None).unwrap();
+        gs.add_node(
+            branch_id,
+            "kg",
+            "study1",
+            strata_graph::types::NodeData {
+                entity_ref: None,
+                properties: Some(serde_json::json!({"title": "medical trial results"})),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        // Search via GraphStore.search() directly — should only return graph results
+        let req = SearchRequest::new(branch_id, "medical");
+        let response = Searchable::search(&gs, &req).unwrap();
+
+        for hit in &response.hits {
+            assert!(
+                hit.doc_ref.is_graph(),
+                "GraphStore.search() should only return graph EntityRefs, got: {:?}",
+                hit.doc_ref
+            );
+        }
+    }
+
+    /// Removed nodes should disappear from search results.
+    #[test]
+    fn test_graph_remove_node_deindexes() {
+        use strata_engine::Searchable;
+
+        let db = test_db();
+        let gs = GraphStore::new(db.clone());
+        let branch_id = BranchId::new();
+
+        gs.create_graph(branch_id, "g", None).unwrap();
+        gs.add_node(
+            branch_id,
+            "g",
+            "ephemeral",
+            strata_graph::types::NodeData {
+                properties: Some(serde_json::json!({"topic": "quantum_entanglement_research"})),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        // Verify it's searchable
+        let req = SearchRequest::new(branch_id, "quantum_entanglement_research");
+        let before = Searchable::search(&gs, &req).unwrap();
+        assert!(
+            !before.hits.is_empty(),
+            "Node should be searchable after add"
+        );
+
+        // Remove and verify it's gone
+        gs.remove_node(branch_id, "g", "ephemeral").unwrap();
+        let after = Searchable::search(&gs, &req).unwrap();
+        assert!(
+            after.hits.is_empty(),
+            "Node should not be searchable after removal"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Implements the `Searchable` trait for `GraphStore` — the last data primitive without one
- Graph nodes are now discoverable via hybrid search and `db.ask()`
- Adds write-time search indexing to `add_node`, `remove_node`, `bulk_insert`, `delete_graph`

## Details

**Query path**: `GraphStore::search()` queries the shared `InvertedIndex`, filters results to `EntityRef::Graph`, and extracts snippets from node `object_type` + `properties`.

**Write path**: Each mutation method now calls `index_node_for_search()` / `deindex_node_for_search()` post-commit, mirroring the `KVStore::put()` pattern. Node text includes: `node_id`, `object_type`, `properties` JSON, `entity_ref`.

**Wiring**: `HybridSearch` now holds a `GraphStore` field and delegates `PrimitiveType::Graph` search to it (was returning empty).

## Test plan

- [x] 427 graph crate tests pass
- [x] 80 search crate tests pass (2 new: `test_graph_nodes_searchable`, `test_graph_search_filters_non_graph`)
- [x] Clippy clean
- [x] Downstream `strata-executor` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)