### PR TITLE
Fix #1983: Add graph scale and concurrency tests

### DIFF
--- a/crates/engine/src/branch_ops.rs
+++ b/crates/engine/src/branch_ops.rs
@@ -575,7 +575,15 @@ pub fn diff_branches_with_options(
         if let Some((parent, fv)) = storage.get_fork_info(&id_b) {
             if parent == id_a {
                 return cow_diff_branches(
-                    db, id_a, id_b, id_b, id_a, fv, branch_a, branch_b, &options,
+                    db,
+                    id_a,
+                    id_b,
+                    id_b,
+                    id_a,
+                    fv,
+                    branch_a,
+                    branch_b,
+                    &options,
                     snapshot_version,
                 );
             }
@@ -583,7 +591,15 @@ pub fn diff_branches_with_options(
         if let Some((parent, fv)) = storage.get_fork_info(&id_a) {
             if parent == id_b {
                 return cow_diff_branches(
-                    db, id_a, id_b, id_a, id_b, fv, branch_a, branch_b, &options,
+                    db,
+                    id_a,
+                    id_b,
+                    id_a,
+                    id_b,
+                    fv,
+                    branch_a,
+                    branch_b,
+                    &options,
                     snapshot_version,
                 );
             }
@@ -4897,11 +4913,7 @@ mod tests {
 
         // Verify the values are snapshot-consistent
         let space = &diff.spaces[0];
-        let all_entries: Vec<_> = space
-            .added
-            .iter()
-            .chain(space.modified.iter())
-            .collect();
+        let all_entries: Vec<_> = space.added.iter().chain(space.modified.iter()).collect();
         for entry in &all_entries {
             if entry.key == "shared" {
                 assert_eq!(entry.value_a, Some(Value::Int(10)));

--- a/crates/graph/src/bulk.rs
+++ b/crates/graph/src/bulk.rs
@@ -1646,4 +1646,105 @@ mod tests {
             }
         }
     }
+
+    // =========================================================================
+    // Scale tests (Issue #1983)
+    // =========================================================================
+
+    #[test]
+    fn scale_10k_nodes_bulk_insert() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+        gs.create_graph(b, "g", None).unwrap();
+
+        let nodes: Vec<(String, NodeData)> = (0..10_000)
+            .map(|i| (format!("n{:05}", i), NodeData::default()))
+            .collect();
+        let edges: Vec<(String, String, String, EdgeData)> = (0..9_999)
+            .map(|i| {
+                (
+                    format!("n{:05}", i),
+                    format!("n{:05}", i + 1),
+                    "NEXT".to_string(),
+                    EdgeData::default(),
+                )
+            })
+            .collect();
+
+        let (ni, ei) = gs
+            .bulk_insert(b, "g", &nodes, &edges, Some(5_000))
+            .unwrap();
+        assert_eq!(ni, 10_000);
+        assert_eq!(ei, 9_999);
+
+        // Verify counts
+        let stats = gs.snapshot_stats(b, "g").unwrap();
+        assert_eq!(stats.node_count, 10_000);
+        assert_eq!(stats.edge_count, 9_999);
+
+        // Spot-check first, middle, and last
+        assert!(gs.get_node(b, "g", "n00000").unwrap().is_some());
+        assert!(gs.get_node(b, "g", "n05000").unwrap().is_some());
+        assert!(gs.get_node(b, "g", "n09999").unwrap().is_some());
+
+        // Verify edge at chunk boundary
+        assert!(gs
+            .get_edge(b, "g", "n04999", "n05000", "NEXT")
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn scale_high_degree_node_1000_edges() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+        gs.create_graph(b, "g", None).unwrap();
+
+        // Create hub node + 1000 leaf nodes
+        let mut nodes: Vec<(String, NodeData)> = vec![("hub".into(), NodeData::default())];
+        for i in 0..1_000 {
+            nodes.push((format!("leaf{:04}", i), NodeData::default()));
+        }
+        gs.bulk_insert(b, "g", &nodes, &[], None).unwrap();
+
+        // Add 1000 edges from hub to each leaf via batch
+        let edges: Vec<(String, String, String, EdgeData)> = (0..1_000)
+            .map(|i| {
+                (
+                    "hub".to_string(),
+                    format!("leaf{:04}", i),
+                    "CONNECTS".to_string(),
+                    EdgeData::default(),
+                )
+            })
+            .collect();
+        let inserted = gs.batch_add_edges(b, "g", &edges, Some(200)).unwrap();
+        assert_eq!(inserted, 1_000);
+
+        // Verify all outgoing edges
+        let out = gs.outgoing_neighbors(b, "g", "hub", None).unwrap();
+        assert_eq!(out.len(), 1_000);
+
+        // Verify reverse: each leaf has exactly 1 incoming
+        for i in [0, 499, 999] {
+            let inc = gs
+                .incoming_neighbors(b, "g", &format!("leaf{:04}", i), None)
+                .unwrap();
+            assert_eq!(inc.len(), 1);
+            assert_eq!(inc[0].node_id, "hub");
+        }
+
+        // Verify edge type counter
+        assert_eq!(gs.count_edges_by_type(b, "g", "CONNECTS").unwrap(), 1_000);
+
+        // Remove hub — should clean up all 1000 edges
+        gs.remove_node(b, "g", "hub").unwrap();
+        assert_eq!(gs.count_edges_by_type(b, "g", "CONNECTS").unwrap(), 0);
+
+        // Verify leaves have no incoming edges
+        let inc = gs
+            .incoming_neighbors(b, "g", "leaf0500", None)
+            .unwrap();
+        assert!(inc.is_empty());
+    }
 }

--- a/crates/graph/src/bulk.rs
+++ b/crates/graph/src/bulk.rs
@@ -1671,9 +1671,7 @@ mod tests {
             })
             .collect();
 
-        let (ni, ei) = gs
-            .bulk_insert(b, "g", &nodes, &edges, Some(5_000))
-            .unwrap();
+        let (ni, ei) = gs.bulk_insert(b, "g", &nodes, &edges, Some(5_000)).unwrap();
         assert_eq!(ni, 10_000);
         assert_eq!(ei, 9_999);
 
@@ -1742,9 +1740,7 @@ mod tests {
         assert_eq!(gs.count_edges_by_type(b, "g", "CONNECTS").unwrap(), 0);
 
         // Verify leaves have no incoming edges
-        let inc = gs
-            .incoming_neighbors(b, "g", "leaf0500", None)
-            .unwrap();
+        let inc = gs.incoming_neighbors(b, "g", "leaf0500", None).unwrap();
         assert!(inc.is_empty());
     }
 }

--- a/crates/graph/src/edges.rs
+++ b/crates/graph/src/edges.rs
@@ -879,4 +879,85 @@ mod tests {
         assert_eq!(gs.count_edges_by_type(b, "g", "KNOWS").unwrap(), 2);
         assert_eq!(gs.count_edges_by_type(b, "g", "TRUSTS").unwrap(), 1);
     }
+
+    // =========================================================================
+    // Concurrency tests (Issue #1983)
+    // =========================================================================
+
+    /// Concurrent add_edge to the same source node from multiple threads.
+    ///
+    /// Each thread adds edges from the same hub node to different targets.
+    /// The packed adjacency list is RMW (read-modify-write), so concurrent
+    /// writers will hit OCC conflicts. All edges should eventually succeed
+    /// (via OCC retry at the GraphStore level or serialized execution).
+    #[test]
+    fn concurrent_add_edge_same_source() {
+        use std::sync::Arc;
+
+        let db = Database::cache().unwrap();
+        let gs = Arc::new(GraphStore::new(db));
+        let b = BranchId::from_bytes([0u8; 16]);
+
+        gs.create_graph(b, "g", None).unwrap();
+
+        // Create hub + 40 target nodes
+        gs.add_node(b, "g", "hub", NodeData::default()).unwrap();
+        for i in 0..40 {
+            gs.add_node(b, "g", &format!("t{}", i), NodeData::default())
+                .unwrap();
+        }
+
+        // 4 threads, each adding 10 edges from hub to different targets.
+        // Since all threads write to hub's adjacency list, OCC conflicts are expected.
+        // Retry with exponential backoff to handle contention.
+        let handles: Vec<_> = (0..4)
+            .map(|thread_id| {
+                let gs = Arc::clone(&gs);
+                std::thread::spawn(move || {
+                    let start = thread_id * 10;
+                    for i in start..start + 10 {
+                        let target = format!("t{}", i);
+                        let edge_type = format!("E{}", i);
+                        let mut attempts = 0;
+                        loop {
+                            match gs.add_edge(
+                                b,
+                                "g",
+                                "hub",
+                                &target,
+                                &edge_type,
+                                EdgeData::default(),
+                            ) {
+                                Ok(_) => break,
+                                Err(_) if attempts < 20 => {
+                                    attempts += 1;
+                                    // Exponential backoff: 10µs, 20µs, 40µs, ...
+                                    std::thread::sleep(std::time::Duration::from_micros(
+                                        10 << attempts.min(10),
+                                    ));
+                                }
+                                Err(e) => panic!(
+                                    "Thread {} failed to add edge to {} after {} retries: {}",
+                                    thread_id, target, attempts, e
+                                ),
+                            }
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // All 40 edges should exist
+        let out = gs.outgoing_neighbors(b, "g", "hub", None).unwrap();
+        assert_eq!(
+            out.len(),
+            40,
+            "All 40 concurrent edges should be present, got {}",
+            out.len()
+        );
+    }
 }

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -116,8 +116,8 @@ impl strata_engine::search::Searchable for GraphStore {
         &self,
         req: &strata_engine::SearchRequest,
     ) -> StrataResult<strata_engine::SearchResponse> {
-        use strata_engine::search::{EntityRef, InvertedIndex, SearchHit, SearchStats};
         use std::time::Instant;
+        use strata_engine::search::{EntityRef, InvertedIndex, SearchHit, SearchStats};
 
         let start = Instant::now();
         let index = self.db.extension::<InvertedIndex>()?;
@@ -222,12 +222,7 @@ impl GraphStore {
     /// Remove a graph node from the inverted index.
     ///
     /// Called after successful remove_node/delete_graph commits.
-    pub(crate) fn deindex_node_for_search(
-        &self,
-        branch_id: BranchId,
-        graph: &str,
-        node_id: &str,
-    ) {
+    pub(crate) fn deindex_node_for_search(&self, branch_id: BranchId, graph: &str, node_id: &str) {
         let Ok(index) = self.db.extension::<strata_engine::search::InvertedIndex>() else {
             return;
         };

--- a/crates/graph/src/lifecycle.rs
+++ b/crates/graph/src/lifecycle.rs
@@ -676,4 +676,69 @@ mod tests {
         assert!(page.items.is_empty());
         assert!(page.next_cursor.is_none());
     }
+
+    // =========================================================================
+    // Scale tests (Issue #1983)
+    // =========================================================================
+
+    /// Delete a graph with 10K nodes and edges — exercises batched deletion.
+    #[test]
+    fn scale_delete_graph_10k_nodes() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+
+        gs.create_graph(b, "big", None).unwrap();
+
+        // Bulk insert 10K nodes with entity_refs (exercises ref index cleanup)
+        let nodes: Vec<(String, NodeData)> = (0..10_000)
+            .map(|i| {
+                (
+                    format!("n{:05}", i),
+                    NodeData {
+                        entity_ref: Some(format!("kv://main/entity{}", i)),
+                        properties: Some(serde_json::json!({"idx": i})),
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect();
+        let edges: Vec<(String, String, String, EdgeData)> = (0..9_999)
+            .map(|i| {
+                (
+                    format!("n{:05}", i),
+                    format!("n{:05}", i + 1),
+                    "NEXT".to_string(),
+                    EdgeData::default(),
+                )
+            })
+            .collect();
+
+        gs.bulk_insert(b, "big", &nodes, &edges, Some(5_000))
+            .unwrap();
+
+        // Verify graph exists
+        assert_eq!(gs.snapshot_stats(b, "big").unwrap().node_count, 10_000);
+
+        // Delete — this triggers batched node deletion + ref index cleanup + prefix batched delete
+        gs.delete_graph(b, "big").unwrap();
+
+        // Verify everything is gone
+        assert!(gs.get_graph_meta(b, "big").unwrap().is_none());
+        assert!(gs.list_nodes(b, "big").unwrap().is_empty());
+        assert!(gs.list_graphs(b).unwrap().is_empty());
+
+        // Verify ref index entries are cleaned up (spot check)
+        assert!(gs
+            .nodes_for_entity(b, "kv://main/entity0")
+            .unwrap()
+            .is_empty());
+        assert!(gs
+            .nodes_for_entity(b, "kv://main/entity5000")
+            .unwrap()
+            .is_empty());
+        assert!(gs
+            .nodes_for_entity(b, "kv://main/entity9999")
+            .unwrap()
+            .is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

- Adds 4 tests covering previously untested scenarios from the graph test coverage audit
- Total graph tests: 427 → 431

## New tests

| Test | Scenario | What it validates |
|---|---|---|
| `scale_10k_nodes_bulk_insert` | 10K nodes + 9,999 edges | Chunked bulk insert, cross-chunk-boundary edges, snapshot_stats counts |
| `scale_high_degree_node_1000_edges` | Hub with 1,000 edges | Packed adjacency list at scale, batch_add_edges chunking, counter accuracy, hub removal cleanup |
| `concurrent_add_edge_same_source` | 4 threads × 10 edges to same hub | OCC conflict handling on adjacency list RMW, retry with exponential backoff |
| `scale_delete_graph_10k_nodes` | Delete 10K-node graph with entity_refs | Batched deletion, ref index cleanup at scale |

## Test plan

- [x] All 431 graph tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)