### PR TITLE
Fix #1880: Secondary indexes on JSON document fields (Epic 1)

### DIFF
--- a/crates/engine/src/branch_ops.rs
+++ b/crates/engine/src/branch_ops.rs
@@ -575,7 +575,15 @@ pub fn diff_branches_with_options(
         if let Some((parent, fv)) = storage.get_fork_info(&id_b) {
             if parent == id_a {
                 return cow_diff_branches(
-                    db, id_a, id_b, id_b, id_a, fv, branch_a, branch_b, &options,
+                    db,
+                    id_a,
+                    id_b,
+                    id_b,
+                    id_a,
+                    fv,
+                    branch_a,
+                    branch_b,
+                    &options,
                     snapshot_version,
                 );
             }
@@ -583,7 +591,15 @@ pub fn diff_branches_with_options(
         if let Some((parent, fv)) = storage.get_fork_info(&id_a) {
             if parent == id_b {
                 return cow_diff_branches(
-                    db, id_a, id_b, id_a, id_b, fv, branch_a, branch_b, &options,
+                    db,
+                    id_a,
+                    id_b,
+                    id_a,
+                    id_b,
+                    fv,
+                    branch_a,
+                    branch_b,
+                    &options,
                     snapshot_version,
                 );
             }
@@ -4897,11 +4913,7 @@ mod tests {
 
         // Verify the values are snapshot-consistent
         let space = &diff.spaces[0];
-        let all_entries: Vec<_> = space
-            .added
-            .iter()
-            .chain(space.modified.iter())
-            .collect();
+        let all_entries: Vec<_> = space.added.iter().chain(space.modified.iter()).collect();
         for entry in &all_entries {
             if entry.key == "shared" {
                 assert_eq!(entry.value_a, Some(Value::Int(10)));

--- a/crates/engine/src/primitives/json/index.rs
+++ b/crates/engine/src/primitives/json/index.rs
@@ -1,0 +1,474 @@
+//! Secondary index support for JsonStore
+//!
+//! Indexes are stored as regular KV entries in the storage layer using reserved
+//! space names (`_idx_{space}_{index_name}`). This gives us branch-awareness,
+//! MVCC, compaction, and durability for free.
+//!
+//! Index metadata is stored in `_idx_meta_{space}` as JSON documents.
+
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use strata_core::primitives::json::{JsonPath, JsonValue};
+use strata_core::types::{BranchId, Key, Namespace, TypeTag};
+use strata_core::{StrataError, StrataResult};
+
+// =============================================================================
+// Index Types
+// =============================================================================
+
+/// Type of secondary index
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexType {
+    /// Index on numeric (f64) fields. Supports range queries.
+    Numeric,
+    /// Index on categorical/enum string fields. Supports exact match.
+    Tag,
+    /// Index on text string fields. Supports exact match and prefix queries.
+    Text,
+}
+
+impl std::fmt::Display for IndexType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IndexType::Numeric => write!(f, "numeric"),
+            IndexType::Tag => write!(f, "tag"),
+            IndexType::Text => write!(f, "text"),
+        }
+    }
+}
+
+/// Definition of a secondary index on a JSON collection
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IndexDef {
+    /// Index name (unique within a space)
+    pub name: String,
+    /// The space this index belongs to
+    pub collection_space: String,
+    /// JSON path to the indexed field (e.g., "$.price", "$.status")
+    pub field_path: String,
+    /// Type of index
+    pub index_type: IndexType,
+    /// Creation timestamp (microseconds since epoch)
+    pub created_at: u64,
+}
+
+impl IndexDef {
+    /// Create a new index definition with current timestamp
+    pub fn new(
+        name: impl Into<String>,
+        collection_space: impl Into<String>,
+        field_path: impl Into<String>,
+        index_type: IndexType,
+    ) -> Self {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_micros() as u64;
+        Self {
+            name: name.into(),
+            collection_space: collection_space.into(),
+            field_path: field_path.into(),
+            index_type,
+            created_at: now,
+        }
+    }
+
+    /// Parse the field_path into a JsonPath for value extraction
+    pub fn json_path(&self) -> StrataResult<JsonPath> {
+        // Strip leading "$." if present (we store paths like "$.price")
+        let path_str = self
+            .field_path
+            .strip_prefix("$.")
+            .unwrap_or(&self.field_path);
+        if path_str.is_empty() {
+            return Ok(JsonPath::root());
+        }
+        path_str
+            .parse()
+            .map_err(|e| StrataError::invalid_input(format!("Invalid field path: {}", e)))
+    }
+}
+
+// =============================================================================
+// Value Encoding — order-preserving byte representations
+// =============================================================================
+
+/// Separator byte between encoded value and doc_id in index keys.
+/// Using 0xFF which is greater than any byte-stuffed content (where 0x00
+/// is escaped as 0x00 0x01), ensuring encoded_value sorts before separator.
+const INDEX_KEY_SEPARATOR: u8 = 0xFF;
+
+/// Encode an f64 into 8 bytes with order-preserving properties.
+///
+/// Uses the standard IEEE 754 sign-bit flip technique:
+/// - Positive floats: flip the sign bit (0x80..) so they sort after negatives
+/// - Negative floats: flip ALL bits so more-negative sorts before less-negative
+///
+/// This maps the f64 total order to unsigned byte order.
+pub fn encode_numeric(val: f64) -> [u8; 8] {
+    let bits = val.to_bits();
+    let encoded = if bits & (1u64 << 63) != 0 {
+        // Negative: flip all bits
+        !bits
+    } else {
+        // Positive (or zero): flip sign bit
+        bits ^ (1u64 << 63)
+    };
+    encoded.to_be_bytes()
+}
+
+/// Decode 8 bytes back to f64, inverse of encode_numeric.
+pub fn decode_numeric(bytes: [u8; 8]) -> f64 {
+    let encoded = u64::from_be_bytes(bytes);
+    let bits = if encoded & (1u64 << 63) != 0 {
+        // Was positive: flip sign bit back
+        encoded ^ (1u64 << 63)
+    } else {
+        // Was negative: flip all bits back
+        !encoded
+    };
+    f64::from_bits(bits)
+}
+
+/// Encode a tag value: lowercase UTF-8 bytes.
+pub fn encode_tag(val: &str) -> Vec<u8> {
+    val.to_lowercase().into_bytes()
+}
+
+/// Encode a text value: lowercase UTF-8, truncated to 128 bytes at a char boundary.
+pub fn encode_text(val: &str) -> Vec<u8> {
+    let lower = val.to_lowercase();
+    if lower.len() <= 128 {
+        return lower.into_bytes();
+    }
+    // Truncate at a character boundary to avoid splitting multi-byte UTF-8.
+    // Walk backward from byte 128 to find a char boundary.
+    let mut end = 128;
+    while end > 0 && !lower.is_char_boundary(end) {
+        end -= 1;
+    }
+    lower.as_bytes()[..end].to_vec()
+}
+
+/// Encode a JSON value according to the index type.
+///
+/// Returns None if the value type doesn't match the index type
+/// (e.g., a string in a numeric index).
+pub fn encode_value(value: &JsonValue, index_type: IndexType) -> Option<Vec<u8>> {
+    match index_type {
+        IndexType::Numeric => {
+            let n = value.as_f64()?;
+            Some(encode_numeric(n).to_vec())
+        }
+        IndexType::Tag => {
+            let s = value.as_str()?;
+            Some(encode_tag(s))
+        }
+        IndexType::Text => {
+            let s = value.as_str()?;
+            Some(encode_text(s))
+        }
+    }
+}
+
+// =============================================================================
+// Index Key Construction
+// =============================================================================
+
+/// Build the space name used for index entries.
+/// Format: `_idx/{collection_space}/{index_name}`
+///
+/// Uses `/` as delimiter to avoid ambiguity when space or index names
+/// contain underscores (e.g., `_idx_a_b_c` is ambiguous, `_idx/a_b/c` is not).
+pub fn index_space_name(collection_space: &str, index_name: &str) -> String {
+    format!("_idx/{}/{}", collection_space, index_name)
+}
+
+/// Build the space name used for index metadata.
+/// Format: `_idx_meta/{collection_space}`
+pub fn index_meta_space_name(collection_space: &str) -> String {
+    format!("_idx_meta/{}", collection_space)
+}
+
+/// Build an index entry key.
+///
+/// The user_key portion is: `encoded_value ++ 0xFF ++ doc_id`
+/// This ensures entries sort by value, then by doc_id within the same value.
+pub fn index_entry_key(
+    branch_id: &BranchId,
+    collection_space: &str,
+    index_name: &str,
+    encoded_value: &[u8],
+    doc_id: &str,
+) -> Key {
+    let space = index_space_name(collection_space, index_name);
+    let ns = Arc::new(Namespace::for_branch_space(*branch_id, &space));
+
+    // Build composite user key: encoded_value ++ 0xFF ++ doc_id
+    let mut user_key = Vec::with_capacity(encoded_value.len() + 1 + doc_id.len());
+    user_key.extend_from_slice(encoded_value);
+    user_key.push(INDEX_KEY_SEPARATOR);
+    user_key.extend_from_slice(doc_id.as_bytes());
+
+    Key::new(ns, TypeTag::Json, user_key)
+}
+
+/// Build a prefix key for scanning all entries of an index.
+pub fn index_scan_prefix(branch_id: &BranchId, collection_space: &str, index_name: &str) -> Key {
+    let space = index_space_name(collection_space, index_name);
+    let ns = Arc::new(Namespace::for_branch_space(*branch_id, &space));
+    Key::new(ns, TypeTag::Json, vec![])
+}
+
+/// Build a prefix key for scanning index entries starting at a given value.
+pub fn index_value_prefix(
+    branch_id: &BranchId,
+    collection_space: &str,
+    index_name: &str,
+    encoded_value: &[u8],
+) -> Key {
+    let space = index_space_name(collection_space, index_name);
+    let ns = Arc::new(Namespace::for_branch_space(*branch_id, &space));
+    Key::new(ns, TypeTag::Json, encoded_value.to_vec())
+}
+
+/// Extract the doc_id from an index entry's user_key bytes.
+///
+/// The user key is: `encoded_value ++ 0xFF ++ doc_id`
+/// We find the last 0xFF separator and take everything after it.
+pub fn extract_doc_id_from_index_key(user_key: &[u8]) -> Option<String> {
+    // Find the last 0xFF separator
+    let sep_pos = user_key.iter().rposition(|&b| b == INDEX_KEY_SEPARATOR)?;
+    let doc_id_bytes = &user_key[sep_pos + 1..];
+    std::str::from_utf8(doc_id_bytes)
+        .ok()
+        .map(|s| s.to_string())
+}
+
+/// Extract the field value from a JSON document at the given path.
+pub fn extract_field_value(doc_value: &JsonValue, field_path: &str) -> Option<JsonValue> {
+    let path_str = field_path.strip_prefix("$.").unwrap_or(field_path);
+    if path_str.is_empty() {
+        return Some(doc_value.clone());
+    }
+    let path: JsonPath = path_str.parse().ok()?;
+    strata_core::primitives::json::get_at_path(doc_value, &path).cloned()
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Numeric encoding ---
+
+    #[test]
+    fn numeric_roundtrip() {
+        let values = vec![
+            0.0,
+            1.0,
+            -1.0,
+            42.5,
+            -42.5,
+            f64::MIN,
+            f64::MAX,
+            f64::EPSILON,
+            f64::MIN_POSITIVE,
+            1e-300,
+            1e300,
+        ];
+        for v in values {
+            let encoded = encode_numeric(v);
+            let decoded = decode_numeric(encoded);
+            assert_eq!(v, decoded, "roundtrip failed for {}", v);
+        }
+    }
+
+    #[test]
+    fn numeric_preserves_order() {
+        let ordered = vec![
+            f64::NEG_INFINITY,
+            -1e300,
+            -42.5,
+            -1.0,
+            -f64::MIN_POSITIVE,
+            -0.0,
+            0.0,
+            f64::MIN_POSITIVE,
+            1.0,
+            42.5,
+            1e300,
+            f64::INFINITY,
+        ];
+        for pair in ordered.windows(2) {
+            let a = encode_numeric(pair[0]);
+            let b = encode_numeric(pair[1]);
+            assert!(
+                a <= b,
+                "order violated: encode({}) = {:?} > encode({}) = {:?}",
+                pair[0],
+                a,
+                pair[1],
+                b
+            );
+        }
+    }
+
+    #[test]
+    fn numeric_nan_roundtrip() {
+        let encoded = encode_numeric(f64::NAN);
+        let decoded = decode_numeric(encoded);
+        assert!(decoded.is_nan());
+    }
+
+    #[test]
+    fn numeric_neg_zero_roundtrip() {
+        let encoded = encode_numeric(-0.0);
+        let decoded = decode_numeric(encoded);
+        assert_eq!(decoded.to_bits(), (-0.0f64).to_bits());
+    }
+
+    // --- Tag encoding ---
+
+    #[test]
+    fn tag_lowercases() {
+        assert_eq!(encode_tag("Active"), b"active".to_vec());
+        assert_eq!(encode_tag("PENDING"), b"pending".to_vec());
+        assert_eq!(encode_tag("active"), b"active".to_vec());
+    }
+
+    // --- Text encoding ---
+
+    #[test]
+    fn text_truncates_at_128_bytes() {
+        let long_str = "a".repeat(200);
+        let encoded = encode_text(&long_str);
+        assert_eq!(encoded.len(), 128);
+    }
+
+    #[test]
+    fn text_lowercases() {
+        assert_eq!(encode_text("Hello World"), b"hello world".to_vec());
+    }
+
+    #[test]
+    fn text_truncates_at_char_boundary() {
+        // 'é' is 2 bytes in UTF-8. Place it so it spans the 128-byte boundary.
+        let s = format!("{}{}", "a".repeat(127), "é"); // 127 + 2 = 129 bytes
+        let encoded = encode_text(&s);
+        // Should truncate to 127 bytes (before the 'é'), not split the character
+        assert_eq!(encoded.len(), 127);
+        assert!(std::str::from_utf8(&encoded).is_ok());
+    }
+
+    // --- encode_value ---
+
+    #[test]
+    fn encode_value_numeric_from_json() {
+        let val: JsonValue = serde_json::json!(42.5).into();
+        let encoded = encode_value(&val, IndexType::Numeric);
+        assert!(encoded.is_some());
+        assert_eq!(encoded.unwrap(), encode_numeric(42.5).to_vec());
+    }
+
+    #[test]
+    fn encode_value_type_mismatch_returns_none() {
+        let string_val: JsonValue = serde_json::json!("hello").into();
+        assert!(encode_value(&string_val, IndexType::Numeric).is_none());
+
+        let num_val: JsonValue = serde_json::json!(42).into();
+        assert!(encode_value(&num_val, IndexType::Tag).is_none());
+    }
+
+    // --- Index key construction ---
+
+    #[test]
+    fn index_space_name_format() {
+        assert_eq!(
+            index_space_name("default", "price_idx"),
+            "_idx/default/price_idx"
+        );
+        assert_eq!(
+            index_space_name("products", "status"),
+            "_idx/products/status"
+        );
+    }
+
+    #[test]
+    fn index_space_name_no_ambiguity() {
+        // These should produce different space names despite shared substrings
+        assert_ne!(index_space_name("a_b", "c"), index_space_name("a", "b_c"));
+    }
+
+    #[test]
+    fn index_meta_space_name_format() {
+        assert_eq!(index_meta_space_name("default"), "_idx_meta/default");
+    }
+
+    #[test]
+    fn extract_doc_id_from_key() {
+        // Simulate: encoded_value(8 bytes) ++ 0xFF ++ "doc-1"
+        let mut user_key = vec![0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // encoded 0.0
+        user_key.push(INDEX_KEY_SEPARATOR);
+        user_key.extend_from_slice(b"doc-1");
+
+        let doc_id = extract_doc_id_from_index_key(&user_key);
+        assert_eq!(doc_id, Some("doc-1".to_string()));
+    }
+
+    #[test]
+    fn extract_doc_id_no_separator() {
+        let user_key = b"noseparator";
+        assert_eq!(extract_doc_id_from_index_key(user_key), None);
+    }
+
+    // --- IndexDef ---
+
+    #[test]
+    fn index_def_json_roundtrip() {
+        let def = IndexDef::new("price_idx", "default", "$.price", IndexType::Numeric);
+        let json = serde_json::to_string(&def).unwrap();
+        let parsed: IndexDef = serde_json::from_str(&json).unwrap();
+        assert_eq!(def.name, parsed.name);
+        assert_eq!(def.field_path, parsed.field_path);
+        assert_eq!(def.index_type, parsed.index_type);
+    }
+
+    #[test]
+    fn index_def_json_path_parsing() {
+        let def = IndexDef::new("price_idx", "default", "$.price", IndexType::Numeric);
+        let path = def.json_path().unwrap();
+        assert_eq!(path.segments().len(), 1);
+
+        let def2 = IndexDef::new("name_idx", "default", "$.user.name", IndexType::Text);
+        let path2 = def2.json_path().unwrap();
+        assert_eq!(path2.segments().len(), 2);
+    }
+
+    // --- extract_field_value ---
+
+    #[test]
+    fn extract_field_value_simple() {
+        let doc: JsonValue = serde_json::json!({"price": 29.99, "name": "widget"}).into();
+        let val = extract_field_value(&doc, "$.price");
+        assert_eq!(val, Some(serde_json::json!(29.99).into()));
+    }
+
+    #[test]
+    fn extract_field_value_nested() {
+        let doc: JsonValue = serde_json::json!({"user": {"name": "Alice"}}).into();
+        let val = extract_field_value(&doc, "$.user.name");
+        assert_eq!(val, Some(serde_json::json!("Alice").into()));
+    }
+
+    #[test]
+    fn extract_field_value_missing() {
+        let doc: JsonValue = serde_json::json!({"price": 29.99}).into();
+        let val = extract_field_value(&doc, "$.nonexistent");
+        assert!(val.is_none());
+    }
+}

--- a/crates/engine/src/primitives/json/mod.rs
+++ b/crates/engine/src/primitives/json/mod.rs
@@ -30,6 +30,8 @@
 //! 5. WAL remains unified (entry types 0x20-0x23)
 //! 6. JSON API feels like other primitives
 
+pub mod index;
+
 use crate::database::Database;
 use crate::primitives::extensions::JsonStoreExt;
 use serde::{Deserialize, Serialize};
@@ -295,6 +297,21 @@ impl JsonStore {
 
             let serialized = Self::serialize_doc(&doc)?;
             txn.put(key.clone(), serialized)?;
+
+            // Update secondary indexes
+            let indexes = Self::load_indexes(txn, branch_id, space)?;
+            if !indexes.is_empty() {
+                Self::update_index_entries(
+                    txn,
+                    branch_id,
+                    space,
+                    doc_id,
+                    None,
+                    Some(&doc.value),
+                    &indexes,
+                )?;
+            }
+
             Ok(Version::counter(doc.version))
         })
     }
@@ -427,6 +444,7 @@ impl JsonStore {
     /// If `create_if_missing` is true and the document doesn't exist, creates it.
     /// Returns the resulting document version and the full document value
     /// (avoids a re-read when the caller needs the complete doc, e.g. for embedding).
+    #[allow(clippy::too_many_arguments)]
     fn set_in_txn(
         txn: &mut TransactionContext,
         key: &Key,
@@ -434,16 +452,37 @@ impl JsonStore {
         path: &JsonPath,
         value: JsonValue,
         create_if_missing: bool,
+        branch_id: &BranchId,
+        space: &str,
+        indexes: &[index::IndexDef],
     ) -> StrataResult<(Version, JsonValue)> {
         match txn.get(key)? {
             Some(stored) => {
                 let mut doc = Self::deserialize_doc(&stored)?;
+                let old_value = if !indexes.is_empty() {
+                    Some(doc.value.clone())
+                } else {
+                    None
+                };
                 set_at_path(&mut doc.value, path, value)
                     .map_err(|e| StrataError::invalid_input(format!("Path error: {}", e)))?;
                 doc.value.validate().map_err(limit_error_to_error)?;
                 doc.touch();
                 let serialized = Self::serialize_doc(&doc)?;
                 txn.put(key.clone(), serialized)?;
+
+                if !indexes.is_empty() {
+                    Self::update_index_entries(
+                        txn,
+                        branch_id,
+                        space,
+                        doc_id,
+                        old_value.as_ref(),
+                        Some(&doc.value),
+                        indexes,
+                    )?;
+                }
+
                 Ok((Version::counter(doc.version), doc.value))
             }
             None if create_if_missing => {
@@ -459,6 +498,19 @@ impl JsonStore {
                 let doc = JsonDoc::new(doc_id, initial);
                 let serialized = Self::serialize_doc(&doc)?;
                 txn.put(key.clone(), serialized)?;
+
+                if !indexes.is_empty() {
+                    Self::update_index_entries(
+                        txn,
+                        branch_id,
+                        space,
+                        doc_id,
+                        None,
+                        Some(&doc.value),
+                        indexes,
+                    )?;
+                }
+
                 Ok((Version::counter(doc.version), doc.value))
             }
             None => Err(StrataError::invalid_input(format!(
@@ -489,7 +541,10 @@ impl JsonStore {
 
         let key = self.key_for(branch_id, space, doc_id);
         self.db.transaction(*branch_id, |txn| {
-            Self::set_in_txn(txn, &key, doc_id, path, value, true)
+            let indexes = Self::load_indexes(txn, branch_id, space)?;
+            Self::set_in_txn(
+                txn, &key, doc_id, path, value, true, branch_id, space, &indexes,
+            )
         })
     }
 
@@ -518,10 +573,21 @@ impl JsonStore {
         }
 
         self.db.transaction(*branch_id, |txn| {
+            let indexes = Self::load_indexes(txn, branch_id, space)?;
             let mut results = Vec::with_capacity(entries.len());
             for (doc_id, path, value) in &entries {
                 let key = self.key_for(branch_id, space, doc_id);
-                let result = Self::set_in_txn(txn, &key, doc_id, path, value.clone(), true)?;
+                let result = Self::set_in_txn(
+                    txn,
+                    &key,
+                    doc_id,
+                    path,
+                    value.clone(),
+                    true,
+                    branch_id,
+                    space,
+                    &indexes,
+                )?;
                 results.push(result);
             }
             Ok(results)
@@ -621,7 +687,11 @@ impl JsonStore {
 
         let key = self.key_for(branch_id, space, doc_id);
         self.db.transaction(*branch_id, |txn| {
-            Self::set_in_txn(txn, &key, doc_id, path, value, false).map(|(version, _)| version)
+            let indexes = Self::load_indexes(txn, branch_id, space)?;
+            Self::set_in_txn(
+                txn, &key, doc_id, path, value, false, branch_id, space, &indexes,
+            )
+            .map(|(version, _)| version)
         })
     }
 
@@ -661,11 +731,18 @@ impl JsonStore {
         let key = self.key_for(branch_id, space, doc_id);
 
         self.db.transaction(*branch_id, |txn| {
+            let indexes = Self::load_indexes(txn, branch_id, space)?;
+
             // Load existing document
             let stored = txn.get(&key)?.ok_or_else(|| {
                 StrataError::invalid_input(format!("JSON document {} not found", doc_id))
             })?;
             let mut doc = Self::deserialize_doc(&stored)?;
+            let old_value = if !indexes.is_empty() {
+                Some(doc.value.clone())
+            } else {
+                None
+            };
 
             // Apply deletion
             delete_at_path(&mut doc.value, path)
@@ -675,6 +752,19 @@ impl JsonStore {
             // Store updated document
             let serialized = Self::serialize_doc(&doc)?;
             txn.put(key.clone(), serialized)?;
+
+            // Update secondary indexes
+            if !indexes.is_empty() {
+                Self::update_index_entries(
+                    txn,
+                    branch_id,
+                    space,
+                    doc_id,
+                    old_value.as_ref(),
+                    Some(&doc.value),
+                    &indexes,
+                )?;
+            }
 
             Ok(Version::counter(doc.version))
         })
@@ -705,9 +795,26 @@ impl JsonStore {
         let key = self.key_for(branch_id, space, doc_id);
 
         self.db.transaction(*branch_id, |txn| {
-            // Check if document exists
-            if txn.get(&key)?.is_none() {
-                return Ok(false);
+            let indexes = Self::load_indexes(txn, branch_id, space)?;
+
+            // Check if document exists and get value for index cleanup
+            let stored = match txn.get(&key)? {
+                Some(v) => v,
+                None => return Ok(false),
+            };
+
+            // Remove index entries before deleting the document
+            if !indexes.is_empty() {
+                let doc = Self::deserialize_doc(&stored)?;
+                Self::update_index_entries(
+                    txn,
+                    branch_id,
+                    space,
+                    doc_id,
+                    Some(&doc.value),
+                    None,
+                    &indexes,
+                )?;
             }
 
             // Delete the document
@@ -731,14 +838,30 @@ impl JsonStore {
         }
 
         self.db.transaction(*branch_id, |txn| {
+            let indexes = Self::load_indexes(txn, branch_id, space)?;
             let mut results = Vec::with_capacity(doc_ids.len());
             for doc_id in doc_ids {
                 let key = self.key_for(branch_id, space, doc_id);
-                if txn.get(&key)?.is_some() {
-                    txn.delete(key)?;
-                    results.push(true);
-                } else {
-                    results.push(false);
+                match txn.get(&key)? {
+                    Some(stored) => {
+                        if !indexes.is_empty() {
+                            let doc = Self::deserialize_doc(&stored)?;
+                            Self::update_index_entries(
+                                txn,
+                                branch_id,
+                                space,
+                                doc_id,
+                                Some(&doc.value),
+                                None,
+                                &indexes,
+                            )?;
+                        }
+                        txn.delete(key)?;
+                        results.push(true);
+                    }
+                    None => {
+                        results.push(false);
+                    }
                 }
             }
             Ok(results)
@@ -765,6 +888,7 @@ impl JsonStore {
         }
 
         self.db.transaction(*branch_id, |txn| {
+            let indexes = Self::load_indexes(txn, branch_id, space)?;
             let mut results = Vec::with_capacity(entries.len());
             for (doc_id, path) in entries {
                 let key = self.key_for(branch_id, space, doc_id);
@@ -773,11 +897,29 @@ impl JsonStore {
                         StrataError::invalid_input(format!("JSON document {} not found", doc_id))
                     })?;
                     let mut doc = Self::deserialize_doc(&stored)?;
+                    let old_value = if !indexes.is_empty() {
+                        Some(doc.value.clone())
+                    } else {
+                        None
+                    };
                     delete_at_path(&mut doc.value, path)
                         .map_err(|e| StrataError::invalid_input(format!("Path error: {}", e)))?;
                     doc.touch();
                     let serialized = Self::serialize_doc(&doc)?;
                     txn.put(key, serialized)?;
+
+                    if !indexes.is_empty() {
+                        Self::update_index_entries(
+                            txn,
+                            branch_id,
+                            space,
+                            doc_id,
+                            old_value.as_ref(),
+                            Some(&doc.value),
+                            &indexes,
+                        )?;
+                    }
+
                     Ok(Version::counter(doc.version))
                 })();
                 results.push(result);
@@ -1022,6 +1164,186 @@ impl JsonStore {
             doc_ids,
             next_cursor,
         })
+    }
+
+    // ========================================================================
+    // Secondary Index Operations
+    // ========================================================================
+
+    /// Create a secondary index on a JSON field.
+    ///
+    /// Index metadata is stored in `_idx_meta_{space}` and index entries
+    /// are stored in `_idx_{space}_{name}` — both in the KV layer.
+    ///
+    /// Returns error if an index with the same name already exists.
+    pub fn create_index(
+        &self,
+        branch_id: &BranchId,
+        space: &str,
+        name: &str,
+        field_path: &str,
+        index_type: index::IndexType,
+    ) -> StrataResult<index::IndexDef> {
+        // Validate index name
+        if name.is_empty() {
+            return Err(StrataError::invalid_input("Index name must not be empty"));
+        }
+        if name.contains('/') || name.contains('\0') {
+            return Err(StrataError::invalid_input(
+                "Index name must not contain '/' or null characters",
+            ));
+        }
+
+        // Validate the field path is parseable
+        let def = index::IndexDef::new(name, space, field_path, index_type);
+        def.json_path()?; // validates
+
+        let meta_space = index::index_meta_space_name(space);
+        let meta_key = Key::new_json(
+            Arc::new(Namespace::for_branch_space(*branch_id, &meta_space)),
+            name,
+        );
+
+        self.db.transaction(*branch_id, |txn| {
+            // Check if index already exists
+            if txn.get(&meta_key)?.is_some() {
+                return Err(StrataError::invalid_input(format!(
+                    "Index '{}' already exists in space '{}'",
+                    name, space
+                )));
+            }
+
+            // Store index metadata as a JSON document
+            let meta_json =
+                serde_json::to_vec(&def).map_err(|e| StrataError::serialization(e.to_string()))?;
+            txn.put(meta_key.clone(), Value::Bytes(meta_json))?;
+            Ok(def.clone())
+        })
+    }
+
+    /// Drop a secondary index, removing metadata and all index entries.
+    pub fn drop_index(&self, branch_id: &BranchId, space: &str, name: &str) -> StrataResult<bool> {
+        let meta_space = index::index_meta_space_name(space);
+        let meta_key = Key::new_json(
+            Arc::new(Namespace::for_branch_space(*branch_id, &meta_space)),
+            name,
+        );
+
+        self.db.transaction(*branch_id, |txn| {
+            // Check if index exists
+            if txn.get(&meta_key)?.is_none() {
+                return Ok(false);
+            }
+
+            // Delete metadata
+            txn.delete(meta_key.clone())?;
+
+            // Delete all index entries by scanning the index space
+            let scan_prefix = index::index_scan_prefix(branch_id, space, name);
+            let entries = txn.scan_prefix(&scan_prefix)?;
+            for (key, _) in entries {
+                txn.delete(key)?;
+            }
+
+            Ok(true)
+        })
+    }
+
+    /// List all secondary indexes defined on a collection space.
+    pub fn list_indexes(
+        &self,
+        branch_id: &BranchId,
+        space: &str,
+    ) -> StrataResult<Vec<index::IndexDef>> {
+        let meta_space = index::index_meta_space_name(space);
+        let meta_ns = Arc::new(Namespace::for_branch_space(*branch_id, &meta_space));
+        let scan_prefix = Key::new_json(meta_ns, "");
+
+        self.db.transaction(*branch_id, |txn| {
+            let entries = txn.scan_prefix(&scan_prefix)?;
+            let mut indexes = Vec::new();
+            for (_, value) in entries {
+                if let Value::Bytes(bytes) = &value {
+                    let def = serde_json::from_slice::<index::IndexDef>(bytes).map_err(|e| {
+                        StrataError::serialization(format!("corrupt index metadata: {}", e))
+                    })?;
+                    indexes.push(def);
+                }
+            }
+            Ok(indexes)
+        })
+    }
+
+    /// Load all index definitions for a space (internal helper).
+    fn load_indexes(
+        txn: &mut TransactionContext,
+        branch_id: &BranchId,
+        space: &str,
+    ) -> StrataResult<Vec<index::IndexDef>> {
+        let meta_space = index::index_meta_space_name(space);
+        let meta_ns = Arc::new(Namespace::for_branch_space(*branch_id, &meta_space));
+        let scan_prefix = Key::new_json(meta_ns, "");
+
+        let entries = txn.scan_prefix(&scan_prefix)?;
+        let mut indexes = Vec::new();
+        for (_, value) in entries {
+            if let Value::Bytes(bytes) = &value {
+                let def = serde_json::from_slice::<index::IndexDef>(bytes).map_err(|e| {
+                    StrataError::serialization(format!("corrupt index metadata: {}", e))
+                })?;
+                indexes.push(def);
+            }
+        }
+        Ok(indexes)
+    }
+
+    /// Update index entries for a document write.
+    ///
+    /// If `old_value` is Some, removes old index entries first (for updates).
+    /// Then writes new index entries for the new value.
+    fn update_index_entries(
+        txn: &mut TransactionContext,
+        branch_id: &BranchId,
+        space: &str,
+        doc_id: &str,
+        old_value: Option<&JsonValue>,
+        new_value: Option<&JsonValue>,
+        indexes: &[index::IndexDef],
+    ) -> StrataResult<()> {
+        for idx_def in indexes {
+            // Remove old index entry if updating/deleting
+            if let Some(old_val) = old_value {
+                if let Some(field_val) = index::extract_field_value(old_val, &idx_def.field_path) {
+                    if let Some(encoded) = index::encode_value(&field_val, idx_def.index_type) {
+                        let key = index::index_entry_key(
+                            branch_id,
+                            space,
+                            &idx_def.name,
+                            &encoded,
+                            doc_id,
+                        );
+                        txn.delete(key)?;
+                    }
+                }
+            }
+
+            // Write new index entry if creating/updating
+            if let Some(new_val) = new_value {
+                if let Some(field_val) = index::extract_field_value(new_val, &idx_def.field_path) {
+                    if let Some(encoded) = index::encode_value(&field_val, idx_def.index_type) {
+                        let key = index::index_entry_key(
+                            branch_id,
+                            space,
+                            &idx_def.name,
+                            &encoded,
+                            doc_id,
+                        );
+                        txn.put(key, Value::Bytes(vec![]))?;
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -967,6 +967,47 @@ pub enum Command {
         count: Option<usize>,
     },
 
+    /// Create a secondary index on a JSON document field.
+    /// Returns: `Output::IndexDef`
+    JsonCreateIndex {
+        /// Target branch.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Target space.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        space: Option<String>,
+        /// Index name (unique within the space).
+        name: String,
+        /// JSON field path to index (e.g., "$.price").
+        field_path: String,
+        /// Index type: "numeric", "tag", or "text".
+        index_type: String,
+    },
+
+    /// Drop a secondary index.
+    /// Returns: `Output::Bool`
+    JsonDropIndex {
+        /// Target branch.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Target space.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        space: Option<String>,
+        /// Index name to drop.
+        name: String,
+    },
+
+    /// List all secondary indexes on a space.
+    /// Returns: `Output::IndexList`
+    JsonListIndexes {
+        /// Target branch.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Target space.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        space: Option<String>,
+    },
+
     /// Sample vector entries for shape discovery (returns metadata, not embeddings).
     /// Returns: `Output::SampleResult`
     VectorSample {
@@ -1684,6 +1725,8 @@ impl Command {
                 | Command::NoteDelete { .. }
                 | Command::BranchRevert { .. }
                 | Command::BranchCherryPick { .. }
+                | Command::JsonCreateIndex { .. }
+                | Command::JsonDropIndex { .. }
         )
     }
 
@@ -1766,6 +1809,9 @@ impl Command {
             Command::JsonCount { .. } => "JsonCount",
             Command::KvSample { .. } => "KvSample",
             Command::JsonSample { .. } => "JsonSample",
+            Command::JsonCreateIndex { .. } => "JsonCreateIndex",
+            Command::JsonDropIndex { .. } => "JsonDropIndex",
+            Command::JsonListIndexes { .. } => "JsonListIndexes",
             Command::VectorSample { .. } => "VectorSample",
             Command::EmbedStatus => "EmbedStatus",
             Command::ReindexEmbeddings { .. } => "ReindexEmbeddings",
@@ -1883,6 +1929,9 @@ impl Command {
             | Command::JsonCount { branch, space, .. }
             | Command::KvSample { branch, space, .. }
             | Command::JsonSample { branch, space, .. }
+            | Command::JsonCreateIndex { branch, space, .. }
+            | Command::JsonDropIndex { branch, space, .. }
+            | Command::JsonListIndexes { branch, space, .. }
             | Command::VectorSample { branch, space, .. }
             // Export
             | Command::DbExport { branch, space, .. } => {
@@ -2044,6 +2093,9 @@ impl Command {
             | Command::JsonCount { branch, .. }
             | Command::KvSample { branch, .. }
             | Command::JsonSample { branch, .. }
+            | Command::JsonCreateIndex { branch, .. }
+            | Command::JsonDropIndex { branch, .. }
+            | Command::JsonListIndexes { branch, .. }
             | Command::VectorSample { branch, .. }
             | Command::DbExport { branch, .. } => branch.as_ref(),
 

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -1210,6 +1210,61 @@ impl Executor {
                     count.unwrap_or(5),
                 )
             }
+            Command::JsonCreateIndex {
+                branch,
+                space,
+                name,
+                field_path,
+                index_type,
+            } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                    hint: None,
+                })?;
+                let space = space.unwrap_or_else(|| "default".to_string());
+                self.ensure_space_registered(&branch, &space)?;
+                crate::handlers::json::json_create_index(
+                    &self.primitives,
+                    branch,
+                    space,
+                    name,
+                    field_path,
+                    index_type,
+                )
+            }
+            Command::JsonDropIndex {
+                branch,
+                space,
+                name,
+            } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                    hint: None,
+                })?;
+                let space = space.unwrap_or_else(|| "default".to_string());
+                self.ensure_space_registered(&branch, &space)?;
+                crate::handlers::json::json_drop_index(
+                    &self.primitives,
+                    branch,
+                    space,
+                    name,
+                )
+            }
+            Command::JsonListIndexes {
+                branch,
+                space,
+            } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                    hint: None,
+                })?;
+                let space = space.unwrap_or_else(|| "default".to_string());
+                crate::handlers::json::json_list_indexes(
+                    &self.primitives,
+                    branch,
+                    space,
+                )
+            }
             Command::VectorSample {
                 branch,
                 space,

--- a/crates/executor/src/handlers/json.rs
+++ b/crates/executor/src/handlers/json.rs
@@ -650,6 +650,72 @@ pub fn json_list_at(
     })
 }
 
+// ============================================================================
+// Secondary Index Handlers
+// ============================================================================
+
+/// Handle JsonCreateIndex command.
+pub fn json_create_index(
+    p: &Arc<Primitives>,
+    branch: BranchId,
+    space: String,
+    name: String,
+    field_path: String,
+    index_type_str: String,
+) -> Result<Output> {
+    use strata_engine::primitives::json::index::IndexType;
+
+    let branch_id = to_core_branch_id(&branch)?;
+    let index_type = match index_type_str.as_str() {
+        "numeric" => IndexType::Numeric,
+        "tag" => IndexType::Tag,
+        "text" => IndexType::Text,
+        other => {
+            return Err(crate::Error::InvalidInput {
+                reason: format!(
+                    "Invalid index type '{}'. Must be 'numeric', 'tag', or 'text'",
+                    other
+                ),
+                hint: None,
+            });
+        }
+    };
+
+    let def =
+        convert_result(
+            p.json
+                .create_index(&branch_id, &space, &name, &field_path, index_type),
+        )?;
+    let json_str = serde_json::to_string(&def).map_err(|e| crate::Error::Internal {
+        reason: format!("Failed to serialize IndexDef: {}", e),
+        hint: None,
+    })?;
+    Ok(Output::Maybe(Some(Value::String(json_str))))
+}
+
+/// Handle JsonDropIndex command.
+pub fn json_drop_index(
+    p: &Arc<Primitives>,
+    branch: BranchId,
+    space: String,
+    name: String,
+) -> Result<Output> {
+    let branch_id = to_core_branch_id(&branch)?;
+    let existed = convert_result(p.json.drop_index(&branch_id, &space, &name))?;
+    Ok(Output::Bool(existed))
+}
+
+/// Handle JsonListIndexes command.
+pub fn json_list_indexes(p: &Arc<Primitives>, branch: BranchId, space: String) -> Result<Output> {
+    let branch_id = to_core_branch_id(&branch)?;
+    let indexes = convert_result(p.json.list_indexes(&branch_id, &space))?;
+    let json_str = serde_json::to_string(&indexes).map_err(|e| crate::Error::Internal {
+        reason: format!("Failed to serialize index list: {}", e),
+        hint: None,
+    })?;
+    Ok(Output::Maybe(Some(Value::String(json_str))))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/graph/src/bulk.rs
+++ b/crates/graph/src/bulk.rs
@@ -1646,4 +1646,105 @@ mod tests {
             }
         }
     }
+
+    // =========================================================================
+    // Scale tests (Issue #1983)
+    // =========================================================================
+
+    #[test]
+    fn scale_10k_nodes_bulk_insert() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+        gs.create_graph(b, "g", None).unwrap();
+
+        let nodes: Vec<(String, NodeData)> = (0..10_000)
+            .map(|i| (format!("n{:05}", i), NodeData::default()))
+            .collect();
+        let edges: Vec<(String, String, String, EdgeData)> = (0..9_999)
+            .map(|i| {
+                (
+                    format!("n{:05}", i),
+                    format!("n{:05}", i + 1),
+                    "NEXT".to_string(),
+                    EdgeData::default(),
+                )
+            })
+            .collect();
+
+        let (ni, ei) = gs
+            .bulk_insert(b, "g", &nodes, &edges, Some(5_000))
+            .unwrap();
+        assert_eq!(ni, 10_000);
+        assert_eq!(ei, 9_999);
+
+        // Verify counts
+        let stats = gs.snapshot_stats(b, "g").unwrap();
+        assert_eq!(stats.node_count, 10_000);
+        assert_eq!(stats.edge_count, 9_999);
+
+        // Spot-check first, middle, and last
+        assert!(gs.get_node(b, "g", "n00000").unwrap().is_some());
+        assert!(gs.get_node(b, "g", "n05000").unwrap().is_some());
+        assert!(gs.get_node(b, "g", "n09999").unwrap().is_some());
+
+        // Verify edge at chunk boundary
+        assert!(gs
+            .get_edge(b, "g", "n04999", "n05000", "NEXT")
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn scale_high_degree_node_1000_edges() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+        gs.create_graph(b, "g", None).unwrap();
+
+        // Create hub node + 1000 leaf nodes
+        let mut nodes: Vec<(String, NodeData)> = vec![("hub".into(), NodeData::default())];
+        for i in 0..1_000 {
+            nodes.push((format!("leaf{:04}", i), NodeData::default()));
+        }
+        gs.bulk_insert(b, "g", &nodes, &[], None).unwrap();
+
+        // Add 1000 edges from hub to each leaf via batch
+        let edges: Vec<(String, String, String, EdgeData)> = (0..1_000)
+            .map(|i| {
+                (
+                    "hub".to_string(),
+                    format!("leaf{:04}", i),
+                    "CONNECTS".to_string(),
+                    EdgeData::default(),
+                )
+            })
+            .collect();
+        let inserted = gs.batch_add_edges(b, "g", &edges, Some(200)).unwrap();
+        assert_eq!(inserted, 1_000);
+
+        // Verify all outgoing edges
+        let out = gs.outgoing_neighbors(b, "g", "hub", None).unwrap();
+        assert_eq!(out.len(), 1_000);
+
+        // Verify reverse: each leaf has exactly 1 incoming
+        for i in [0, 499, 999] {
+            let inc = gs
+                .incoming_neighbors(b, "g", &format!("leaf{:04}", i), None)
+                .unwrap();
+            assert_eq!(inc.len(), 1);
+            assert_eq!(inc[0].node_id, "hub");
+        }
+
+        // Verify edge type counter
+        assert_eq!(gs.count_edges_by_type(b, "g", "CONNECTS").unwrap(), 1_000);
+
+        // Remove hub — should clean up all 1000 edges
+        gs.remove_node(b, "g", "hub").unwrap();
+        assert_eq!(gs.count_edges_by_type(b, "g", "CONNECTS").unwrap(), 0);
+
+        // Verify leaves have no incoming edges
+        let inc = gs
+            .incoming_neighbors(b, "g", "leaf0500", None)
+            .unwrap();
+        assert!(inc.is_empty());
+    }
 }

--- a/crates/graph/src/bulk.rs
+++ b/crates/graph/src/bulk.rs
@@ -1671,9 +1671,7 @@ mod tests {
             })
             .collect();
 
-        let (ni, ei) = gs
-            .bulk_insert(b, "g", &nodes, &edges, Some(5_000))
-            .unwrap();
+        let (ni, ei) = gs.bulk_insert(b, "g", &nodes, &edges, Some(5_000)).unwrap();
         assert_eq!(ni, 10_000);
         assert_eq!(ei, 9_999);
 
@@ -1742,9 +1740,7 @@ mod tests {
         assert_eq!(gs.count_edges_by_type(b, "g", "CONNECTS").unwrap(), 0);
 
         // Verify leaves have no incoming edges
-        let inc = gs
-            .incoming_neighbors(b, "g", "leaf0500", None)
-            .unwrap();
+        let inc = gs.incoming_neighbors(b, "g", "leaf0500", None).unwrap();
         assert!(inc.is_empty());
     }
 }

--- a/crates/graph/src/edges.rs
+++ b/crates/graph/src/edges.rs
@@ -879,4 +879,85 @@ mod tests {
         assert_eq!(gs.count_edges_by_type(b, "g", "KNOWS").unwrap(), 2);
         assert_eq!(gs.count_edges_by_type(b, "g", "TRUSTS").unwrap(), 1);
     }
+
+    // =========================================================================
+    // Concurrency tests (Issue #1983)
+    // =========================================================================
+
+    /// Concurrent add_edge to the same source node from multiple threads.
+    ///
+    /// Each thread adds edges from the same hub node to different targets.
+    /// The packed adjacency list is RMW (read-modify-write), so concurrent
+    /// writers will hit OCC conflicts. All edges should eventually succeed
+    /// (via OCC retry at the GraphStore level or serialized execution).
+    #[test]
+    fn concurrent_add_edge_same_source() {
+        use std::sync::Arc;
+
+        let db = Database::cache().unwrap();
+        let gs = Arc::new(GraphStore::new(db));
+        let b = BranchId::from_bytes([0u8; 16]);
+
+        gs.create_graph(b, "g", None).unwrap();
+
+        // Create hub + 40 target nodes
+        gs.add_node(b, "g", "hub", NodeData::default()).unwrap();
+        for i in 0..40 {
+            gs.add_node(b, "g", &format!("t{}", i), NodeData::default())
+                .unwrap();
+        }
+
+        // 4 threads, each adding 10 edges from hub to different targets.
+        // Since all threads write to hub's adjacency list, OCC conflicts are expected.
+        // Retry with exponential backoff to handle contention.
+        let handles: Vec<_> = (0..4)
+            .map(|thread_id| {
+                let gs = Arc::clone(&gs);
+                std::thread::spawn(move || {
+                    let start = thread_id * 10;
+                    for i in start..start + 10 {
+                        let target = format!("t{}", i);
+                        let edge_type = format!("E{}", i);
+                        let mut attempts = 0;
+                        loop {
+                            match gs.add_edge(
+                                b,
+                                "g",
+                                "hub",
+                                &target,
+                                &edge_type,
+                                EdgeData::default(),
+                            ) {
+                                Ok(_) => break,
+                                Err(_) if attempts < 20 => {
+                                    attempts += 1;
+                                    // Exponential backoff: 10µs, 20µs, 40µs, ...
+                                    std::thread::sleep(std::time::Duration::from_micros(
+                                        10 << attempts.min(10),
+                                    ));
+                                }
+                                Err(e) => panic!(
+                                    "Thread {} failed to add edge to {} after {} retries: {}",
+                                    thread_id, target, attempts, e
+                                ),
+                            }
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // All 40 edges should exist
+        let out = gs.outgoing_neighbors(b, "g", "hub", None).unwrap();
+        assert_eq!(
+            out.len(),
+            40,
+            "All 40 concurrent edges should be present, got {}",
+            out.len()
+        );
+    }
 }

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -116,8 +116,8 @@ impl strata_engine::search::Searchable for GraphStore {
         &self,
         req: &strata_engine::SearchRequest,
     ) -> StrataResult<strata_engine::SearchResponse> {
-        use strata_engine::search::{EntityRef, InvertedIndex, SearchHit, SearchStats};
         use std::time::Instant;
+        use strata_engine::search::{EntityRef, InvertedIndex, SearchHit, SearchStats};
 
         let start = Instant::now();
         let index = self.db.extension::<InvertedIndex>()?;
@@ -222,12 +222,7 @@ impl GraphStore {
     /// Remove a graph node from the inverted index.
     ///
     /// Called after successful remove_node/delete_graph commits.
-    pub(crate) fn deindex_node_for_search(
-        &self,
-        branch_id: BranchId,
-        graph: &str,
-        node_id: &str,
-    ) {
+    pub(crate) fn deindex_node_for_search(&self, branch_id: BranchId, graph: &str, node_id: &str) {
         let Ok(index) = self.db.extension::<strata_engine::search::InvertedIndex>() else {
             return;
         };

--- a/crates/graph/src/lifecycle.rs
+++ b/crates/graph/src/lifecycle.rs
@@ -676,4 +676,69 @@ mod tests {
         assert!(page.items.is_empty());
         assert!(page.next_cursor.is_none());
     }
+
+    // =========================================================================
+    // Scale tests (Issue #1983)
+    // =========================================================================
+
+    /// Delete a graph with 10K nodes and edges — exercises batched deletion.
+    #[test]
+    fn scale_delete_graph_10k_nodes() {
+        let (_db, gs) = setup();
+        let b = default_branch();
+
+        gs.create_graph(b, "big", None).unwrap();
+
+        // Bulk insert 10K nodes with entity_refs (exercises ref index cleanup)
+        let nodes: Vec<(String, NodeData)> = (0..10_000)
+            .map(|i| {
+                (
+                    format!("n{:05}", i),
+                    NodeData {
+                        entity_ref: Some(format!("kv://main/entity{}", i)),
+                        properties: Some(serde_json::json!({"idx": i})),
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect();
+        let edges: Vec<(String, String, String, EdgeData)> = (0..9_999)
+            .map(|i| {
+                (
+                    format!("n{:05}", i),
+                    format!("n{:05}", i + 1),
+                    "NEXT".to_string(),
+                    EdgeData::default(),
+                )
+            })
+            .collect();
+
+        gs.bulk_insert(b, "big", &nodes, &edges, Some(5_000))
+            .unwrap();
+
+        // Verify graph exists
+        assert_eq!(gs.snapshot_stats(b, "big").unwrap().node_count, 10_000);
+
+        // Delete — this triggers batched node deletion + ref index cleanup + prefix batched delete
+        gs.delete_graph(b, "big").unwrap();
+
+        // Verify everything is gone
+        assert!(gs.get_graph_meta(b, "big").unwrap().is_none());
+        assert!(gs.list_nodes(b, "big").unwrap().is_empty());
+        assert!(gs.list_graphs(b).unwrap().is_empty());
+
+        // Verify ref index entries are cleaned up (spot check)
+        assert!(gs
+            .nodes_for_entity(b, "kv://main/entity0")
+            .unwrap()
+            .is_empty());
+        assert!(gs
+            .nodes_for_entity(b, "kv://main/entity5000")
+            .unwrap()
+            .is_empty());
+        assert!(gs
+            .nodes_for_entity(b, "kv://main/entity9999")
+            .unwrap()
+            .is_empty());
+    }
 }

--- a/docs/design/json-secondary-indexes.md
+++ b/docs/design/json-secondary-indexes.md
@@ -1,0 +1,356 @@
+# Secondary Indexes on JSON Document Fields
+
+**Issue:** #1880
+**Status:** Design
+**Priority:** T1 — Table Stakes
+**Primitive:** JsonStore
+**Competitor baseline:** RediSearch `FT.CREATE ON JSON`, MongoDB `createIndex`, SurrealDB
+
+## Problem
+
+Every filter/sort query on JsonStore beyond full-text search is an O(n) scan over all documents. Without secondary indexes on JSON fields, JsonStore is impractical for any collection beyond a few thousand documents when queries need to filter by field value, numeric range, or tag.
+
+The primitive-capability-audit identifies three related T1 gaps:
+- **#13** Secondary index on JSON field
+- **#15** Field-level filtering (`@field:value`)
+- **#16** Numeric range filter (`@price:[100 200]`)
+
+## Architecture Decision: Search and Query Are Unified
+
+Strata does not introduce a separate query interface. Secondary indexes are an acceleration layer for the **Searchable trait**, which JsonStore currently stubs (returns empty). The unified model:
+
+```
+User search query ("price > 100 AND status:active AND 'wireless'")
+    |
+    v
+Searchable::search(SearchRequest)
+    |
+    +--> Secondary indexes (narrow candidate set by field predicates)
+    +--> Inverted index (BM25 score on text matches)
+    |
+    v
+Merged, ranked SearchResponse
+```
+
+This means:
+- No new `query()` method on JsonStore
+- `SearchRequest` gains structured filter predicates alongside the existing text query
+- JsonStore's `Searchable` impl goes from stub to real, using indexes
+- Field filters produce binary (match / no-match) scores; BM25 produces relevance scores; results merge naturally
+
+## Architecture Decision: Indexes Live in the KV Layer
+
+Secondary index entries are stored as regular KV entries in the storage layer using a reserved space prefix. This is a deliberate choice driven by Strata's branching model:
+
+**Why not a separate data structure:**
+- Every new data structure must be branch-aware (fork, merge, diff, materialization)
+- The KV layer already handles all of this correctly via `branch_id` in the key prefix
+- Segment-level reference counting, inherited layers, and compaction apply automatically
+- The performance difference at embedded scale is negligible (a few ms at most)
+
+**What we get for free:**
+- MVCC versioning (index entries are versioned like any other key)
+- Branch isolation (index on branch A doesn't affect branch B)
+- Time-travel (historical queries see the index state at that timestamp)
+- Compaction (stale index entries are garbage-collected normally)
+- Durability (WAL, segment persistence, mmap — all apply)
+
+## Index Key Encoding
+
+Index entries use the existing `InternalKey` encoding with a reserved space name pattern:
+
+```
+Document key (existing):
+  branch_id(16) || space\0 || 0x06(Json) || doc_id(escaped) || 0x00 0x00 || !commit_id(8)
+
+Index entry key:
+  branch_id(16) || _idx_{space}_{index_name}\0 || 0x06(Json) || encoded_value ++ 0xFF ++ doc_id(escaped) || 0x00 0x00 || !commit_id(8)
+```
+
+Where:
+- **Space** = `_idx_{collection_space}_{index_name}` — a reserved space name using the `_` prefix convention (similar to `_system_` for vector collections and `_graph_` for graph data)
+- **TypeTag** = `0x06` (Json) — indexes belong to the JSON primitive
+- **User key** = `encoded_value ++ 0xFF ++ doc_id` — the indexed value followed by separator and document ID for uniqueness
+- **Value** = empty or minimal (the index entry is the key itself; the doc_id in the key is the pointer back to the document)
+
+### Value Encoding for Sort Order
+
+Index entries must sort in the correct order for range scans to work via prefix iteration:
+
+| Index Type | Encoding | Sort Order |
+|---|---|---|
+| **Numeric** | IEEE 754 f64, sign-bit flipped, big-endian (8 bytes) | Natural numeric order |
+| **Tag** | UTF-8 string bytes, lowercased | Lexicographic |
+| **Text** | UTF-8 string bytes, lowercased, truncated to 128 bytes | Lexicographic prefix |
+
+**Numeric encoding detail:** Flip the sign bit of the IEEE 754 representation, then for negative numbers also flip all other bits. This maps the f64 total order to unsigned byte order. This is a well-known technique (used by FoundationDB, CockroachDB, etc.).
+
+### Example
+
+Collection `products` in space `default`, index `price_idx` on field `$.price`:
+
+```
+Document: { "id": "widget-1", "price": 29.99, "status": "active" }
+
+Document key:
+  {branch_id} || default\0 || 0x06 || widget-1 || \0\0 || !commit_id
+
+Index entry key:
+  {branch_id} || _idx_default_price_idx\0 || 0x06 || <f64_encoded(29.99)> 0xFF widget-1 || \0\0 || !commit_id
+
+Index entry value:
+  (empty — doc_id is embedded in the key)
+```
+
+Range query `price:[20 50]`:
+1. Encode lower bound: `f64_encode(20.0)`
+2. Encode upper bound: `f64_encode(50.0)`
+3. Prefix-scan `_idx_default_price_idx` space, iterate from lower to upper bound
+4. Extract `doc_id` from each matching key
+5. Fetch full documents by doc_id for scoring/returning
+
+## Index Metadata
+
+Index definitions are stored in a metadata space `_idx_meta_{space}` as JSON documents:
+
+```json
+{
+  "name": "price_idx",
+  "collection_space": "default",
+  "field_path": "$.price",
+  "index_type": "Numeric",
+  "created_at": 1711468800000000
+}
+```
+
+This is also in the KV layer, so it's branch-aware. Creating an index on branch A doesn't create it on branch B.
+
+## Index Maintenance
+
+**Synchronous, same-transaction updates.** When a document is written or deleted, all indexes on that collection are updated in the same transaction:
+
+1. **On document create/update:**
+   - Read index metadata for the collection
+   - For each index, extract the field value at `field_path` from the new document
+   - If updating, delete the old index entry (requires reading the old document to get the old field value)
+   - Write the new index entry
+
+2. **On document delete:**
+   - Read index metadata for the collection
+   - For each index, read the document to extract the current field value
+   - Delete the index entry
+
+This adds read amplification on writes (must read old doc on update/delete to compute old index key). At embedded scale this is acceptable. The alternative (async index maintenance) would introduce stale reads, which is worse.
+
+## Filter Predicate Model
+
+`SearchRequest` is extended with structured filter predicates:
+
+```rust
+/// A predicate on an indexed JSON field
+pub enum FieldPredicate {
+    /// Exact match: @status:{active}
+    Eq { field: String, value: JsonValue },
+    /// Range: @price:[100 200]
+    Range {
+        field: String,
+        lower: Option<JsonValue>,
+        upper: Option<JsonValue>,
+        lower_inclusive: bool,
+        upper_inclusive: bool,
+    },
+    /// Prefix match on text: @name:wire*
+    Prefix { field: String, prefix: String },
+}
+
+/// Compound filter with boolean logic
+pub enum FieldFilter {
+    Predicate(FieldPredicate),
+    And(Vec<FieldFilter>),
+    Or(Vec<FieldFilter>),
+}
+```
+
+`SearchRequest` gains an optional `field_filter: Option<FieldFilter>` field. When present, the JsonStore `Searchable` impl uses indexes to resolve it. When combined with a text query, the field filter narrows the candidate set before BM25 scoring.
+
+---
+
+## Epic 1: Index Primitives
+
+The plumbing. No user-facing query changes. After this epic, indexes exist and are maintained, but cannot be queried through search.
+
+### 1.1 Index Types and Metadata
+
+**File:** `crates/engine/src/primitives/json.rs` (or new submodule `json/index.rs`)
+
+- Define `IndexType` enum: `Numeric`, `Tag`, `Text`
+- Define `IndexDef` struct: name, collection_space, field_path, index_type, created_at
+- Serialization to/from JSON (stored as metadata docs in KV layer)
+
+### 1.2 Value Encoding
+
+**File:** `crates/engine/src/primitives/json/index.rs`
+
+- `encode_numeric(f64) -> [u8; 8]` — sign-flip IEEE 754 encoding
+- `decode_numeric([u8; 8]) -> f64` — inverse
+- `encode_tag(str) -> Vec<u8>` — lowercase UTF-8
+- `encode_index_key(index_name, space, encoded_value, doc_id) -> Key`
+- Round-trip tests for all encodings, including edge cases (NaN, -0, infinity, empty strings)
+
+### 1.3 Index CRUD API
+
+**File:** `crates/engine/src/primitives/json.rs`
+
+Methods on `JsonStore`:
+- `create_index(branch_id, space, name, field_path, index_type) -> Result<IndexDef>`
+  - Validates field_path syntax
+  - Writes index metadata to `_idx_meta_{space}`
+  - Returns error if index name already exists on this branch
+- `drop_index(branch_id, space, name) -> Result<()>`
+  - Deletes index metadata
+  - Deletes all index entries (scan + delete on `_idx_{space}_{name}`)
+- `list_indexes(branch_id, space) -> Result<Vec<IndexDef>>`
+  - Scans `_idx_meta_{space}` for all index definitions
+
+### 1.4 Synchronous Index Maintenance
+
+**File:** `crates/engine/src/primitives/json.rs`
+
+Modify document write and delete paths:
+- `set()` / `batch_set()`: after writing document, update all index entries
+- `delete()` / `batch_delete()`: before deleting document, remove index entries
+- Extract field value at `field_path` from JSON document using existing `JsonPath` machinery
+- Handle missing fields gracefully (no index entry if field absent)
+- Handle type mismatches (e.g., string value in numeric index → skip, log warning)
+
+### 1.5 Executor Commands
+
+**File:** `crates/executor/src/command.rs`, `crates/executor/src/handlers/json.rs`
+
+- `JsonCreateIndex { space, name, field_path, index_type }`
+- `JsonDropIndex { space, name }`
+- `JsonListIndexes { space }`
+- Handler implementations that delegate to `JsonStore`
+
+### 1.6 Tests
+
+- Create index, write documents, verify index entries exist in KV layer
+- Update document, verify old index entry removed and new one written
+- Delete document, verify index entry removed
+- Drop index, verify all entries cleaned up
+- Branch isolation: create index on branch A, verify not visible on branch B
+- Missing field: document without indexed field produces no index entry
+- Type mismatch: string in numeric index field is skipped
+
+---
+
+## Epic 2: Index-Backed Field Filtering via Searchable
+
+This is where indexes become useful. JsonStore's `Searchable` impl goes from stub to real.
+
+### 2.1 FieldPredicate and FieldFilter Types
+
+**File:** `crates/engine/src/search/types.rs`
+
+- Add `FieldPredicate` enum (Eq, Range, Prefix)
+- Add `FieldFilter` enum (Predicate, And, Or)
+- Add `field_filter: Option<FieldFilter>` to `SearchRequest`
+- Backward compatible — existing callers pass `None`
+
+### 2.2 Index Lookup Engine
+
+**File:** `crates/engine/src/primitives/json/index.rs`
+
+- `lookup_eq(branch_id, space, index_name, value) -> Vec<DocId>` — point lookup via prefix scan
+- `lookup_range(branch_id, space, index_name, lower, upper) -> Vec<DocId>` — range scan
+- `lookup_prefix(branch_id, space, index_name, prefix) -> Vec<DocId>` — prefix scan on text index
+- All operations are prefix scans on the KV layer — no new storage primitives
+
+### 2.3 Filter Resolution
+
+**File:** `crates/engine/src/primitives/json/index.rs`
+
+- `resolve_filter(branch_id, space, filter: &FieldFilter, indexes: &[IndexDef]) -> Result<HashSet<DocId>>`
+- Maps each `FieldPredicate` to the appropriate index lookup
+- AND = intersection of doc_id sets
+- Returns error if a predicate references a field with no index (no silent full-scan fallback)
+
+### 2.4 JsonStore Searchable Implementation
+
+**File:** `crates/engine/src/primitives/json.rs`
+
+Replace the stub with:
+1. If `field_filter` is present, resolve it to a candidate doc_id set via index lookups
+2. If text `query` is also present, score candidates with BM25 (via inverted index)
+3. If only `field_filter`, return matches ordered by doc_id (or indexed value for sorted results)
+4. If only text `query`, fall back to inverted index scoring (same as KVStore today)
+5. Build `SearchResponse` with hits, snippets, and stats (including `index_used: true`)
+
+### 2.5 Tests
+
+- Numeric range: create index on `price`, insert docs, search with `price:[10 50]`, verify correct results
+- Tag exact match: index on `status`, search `status:{active}`, verify filtering
+- AND compound: `price:[10 50] AND status:{active}`, verify intersection
+- Combined text + filter: text query "wireless" with `price:[0 100]`, verify BM25 scoring within filtered set
+- Empty result: filter that matches nothing returns empty SearchResponse
+- No index error: predicate on non-indexed field returns error
+- Branch isolation: index and docs on branch A, search on branch B returns empty
+
+---
+
+## Epic 3: Sorted Results and OR Logic
+
+### 3.1 Sort-by-Indexed-Field
+
+- Add `sort_by: Option<SortSpec>` to `SearchRequest` where `SortSpec = { field, direction }`
+- When sorting by an indexed numeric field, iterate the index in order instead of collecting + sorting
+- Integrates with pagination (cursor-based iteration on index)
+
+### 3.2 OR Filter Logic
+
+- `Or(Vec<FieldFilter>)` = union of doc_id sets
+- Combine with AND for expressions like `(status:active OR status:pending) AND price:[10 50]`
+
+### 3.3 Richer Scoring Integration
+
+- Field filter match as a scoring signal (boost factor for field matches)
+- Combine BM25 text score + field filter signals in unified ranking
+
+---
+
+## Epic 4: Composite Indexes and Aggregation
+
+### 4.1 Composite Indexes
+
+- Index on multiple fields: `create_index(space, name, [(field1, type1), (field2, type2)])`
+- Key encoding: concatenate encoded values in field order
+- Enables efficient compound equality + range queries (leftmost prefix rule, same as B-tree composite indexes)
+
+### 4.2 Aggregation Primitives
+
+- `Sum`, `Avg`, `Min`, `Max` over indexed numeric fields
+- `GroupBy` field + aggregation
+- Implemented as index scans — no full document reads needed for numeric aggregations
+- Exposed through a new `aggregate()` method on JsonStore (not through Searchable — aggregations aren't search)
+
+---
+
+## Non-Goals
+
+- **Background index building for existing documents** — not needed today (no pre-existing unindexed collections in production)
+- **Automatic index selection / query planner** — the caller specifies which indexes exist; predicates that reference non-indexed fields are rejected
+- **Partial indexes** (index only documents matching a condition) — future enhancement
+- **Full JSONPath filter expressions** (`$[?(@.x>5)]`) — separate issue (#5 in audit), orthogonal to secondary indexes
+- **TTL integration** — blocked on branch-aware GC (#1860)
+
+## References
+
+- `crates/engine/src/primitives/json.rs` — JsonStore implementation (2918 lines)
+- `crates/engine/src/search/searchable.rs` — Searchable trait, BM25LiteScorer
+- `crates/engine/src/search/types.rs` — SearchRequest, SearchResponse, SearchHit
+- `crates/engine/src/search/index.rs` — InvertedIndex (segmented, mmap-backed)
+- `crates/storage/src/key_encoding.rs` — InternalKey encoding scheme
+- `crates/core/src/primitives/json.rs` — JsonPath, JsonValue types
+- `docs/design/primitive-capability-audit.md` — Capability gaps #13, #15, #16
+- Issue #1860 — Branch-aware GC (blocks TTL, not indexes)
+- Issue #1878 — TTL (blocked on #1860)

--- a/tests/engine/primitives/jsonstore.rs
+++ b/tests/engine/primitives/jsonstore.rs
@@ -411,3 +411,675 @@ fn various_json_types() {
     let result_json: serde_json::Value = result.into();
     assert_eq!(result_json, doc);
 }
+
+// ============================================================================
+// Secondary Index Tests
+// ============================================================================
+
+use strata_engine::primitives::json::index::IndexType;
+
+#[test]
+fn create_index_and_list() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    let def = json
+        .create_index(
+            &test_db.branch_id,
+            "default",
+            "price_idx",
+            "$.price",
+            IndexType::Numeric,
+        )
+        .unwrap();
+    assert_eq!(def.name, "price_idx");
+    assert_eq!(def.field_path, "$.price");
+    assert_eq!(def.index_type, IndexType::Numeric);
+
+    let indexes = json.list_indexes(&test_db.branch_id, "default").unwrap();
+    assert_eq!(indexes.len(), 1);
+    assert_eq!(indexes[0].name, "price_idx");
+}
+
+#[test]
+fn create_index_duplicate_fails() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "idx1",
+        "$.price",
+        IndexType::Numeric,
+    )
+    .unwrap();
+    let result = json.create_index(
+        &test_db.branch_id,
+        "default",
+        "idx1",
+        "$.name",
+        IndexType::Text,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn drop_index_removes_metadata_and_entries() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+        "$.price",
+        IndexType::Numeric,
+    )
+    .unwrap();
+
+    // Write a document so index entries exist
+    let doc: JsonValue = serde_json::json!({"price": 29.99}).into();
+    json.create(&test_db.branch_id, "default", "doc1", doc)
+        .unwrap();
+
+    // Drop the index
+    let existed = json
+        .drop_index(&test_db.branch_id, "default", "price_idx")
+        .unwrap();
+    assert!(existed);
+
+    // Verify metadata removed
+    let indexes = json.list_indexes(&test_db.branch_id, "default").unwrap();
+    assert!(indexes.is_empty());
+
+    // Drop again returns false
+    let existed = json
+        .drop_index(&test_db.branch_id, "default", "price_idx")
+        .unwrap();
+    assert!(!existed);
+}
+
+#[test]
+fn index_entries_created_on_document_write() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    // Create index before writing documents
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+        "$.price",
+        IndexType::Numeric,
+    )
+    .unwrap();
+
+    // Write documents
+    let doc1: JsonValue = serde_json::json!({"price": 10.0, "name": "widget"}).into();
+    let doc2: JsonValue = serde_json::json!({"price": 50.0, "name": "gadget"}).into();
+    let doc3: JsonValue = serde_json::json!({"price": 30.0, "name": "thing"}).into();
+    json.create(&test_db.branch_id, "default", "doc1", doc1)
+        .unwrap();
+    json.create(&test_db.branch_id, "default", "doc2", doc2)
+        .unwrap();
+    json.create(&test_db.branch_id, "default", "doc3", doc3)
+        .unwrap();
+
+    // Verify index entries by scanning the index space
+    let scan_prefix = strata_engine::primitives::json::index::index_scan_prefix(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+    );
+    let entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&scan_prefix))
+        .unwrap();
+
+    // Should have 3 index entries
+    assert_eq!(entries.len(), 3);
+
+    // Entries should be in numeric order (10.0 < 30.0 < 50.0)
+    let doc_ids: Vec<String> = entries
+        .iter()
+        .filter_map(|(k, _)| {
+            strata_engine::primitives::json::index::extract_doc_id_from_index_key(&k.user_key)
+        })
+        .collect();
+    assert_eq!(doc_ids, vec!["doc1", "doc3", "doc2"]); // sorted by price
+}
+
+#[test]
+fn index_entries_updated_on_document_update() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+        "$.price",
+        IndexType::Numeric,
+    )
+    .unwrap();
+
+    // Create doc with price 10.0
+    let doc: JsonValue = serde_json::json!({"price": 10.0}).into();
+    json.create(&test_db.branch_id, "default", "doc1", doc)
+        .unwrap();
+
+    // Update price to 50.0
+    let new_val: JsonValue = serde_json::json!(50.0).into();
+    json.set(
+        &test_db.branch_id,
+        "default",
+        "doc1",
+        &jpath("price"),
+        new_val,
+    )
+    .unwrap();
+
+    // Scan index — should have exactly 1 entry (old removed, new added)
+    let scan_prefix = strata_engine::primitives::json::index::index_scan_prefix(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+    );
+    let entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&scan_prefix))
+        .unwrap();
+    assert_eq!(entries.len(), 1);
+
+    // The entry should point to doc1 with the new price
+    let doc_id = strata_engine::primitives::json::index::extract_doc_id_from_index_key(
+        &entries[0].0.user_key,
+    );
+    assert_eq!(doc_id, Some("doc1".to_string()));
+}
+
+#[test]
+fn index_entries_removed_on_document_destroy() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+        "$.price",
+        IndexType::Numeric,
+    )
+    .unwrap();
+
+    let doc: JsonValue = serde_json::json!({"price": 42.0}).into();
+    json.create(&test_db.branch_id, "default", "doc1", doc)
+        .unwrap();
+
+    // Verify index entry exists
+    let scan_prefix = strata_engine::primitives::json::index::index_scan_prefix(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+    );
+    let entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&scan_prefix))
+        .unwrap();
+    assert_eq!(entries.len(), 1);
+
+    // Destroy the document
+    json.destroy(&test_db.branch_id, "default", "doc1").unwrap();
+
+    // Index entry should be gone
+    let entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&scan_prefix))
+        .unwrap();
+    assert_eq!(entries.len(), 0);
+}
+
+#[test]
+fn index_missing_field_no_entry() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+        "$.price",
+        IndexType::Numeric,
+    )
+    .unwrap();
+
+    // Write a document WITHOUT a price field
+    let doc: JsonValue = serde_json::json!({"name": "no-price"}).into();
+    json.create(&test_db.branch_id, "default", "doc1", doc)
+        .unwrap();
+
+    // No index entry should be created
+    let scan_prefix = strata_engine::primitives::json::index::index_scan_prefix(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+    );
+    let entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&scan_prefix))
+        .unwrap();
+    assert_eq!(entries.len(), 0);
+}
+
+#[test]
+fn index_type_mismatch_no_entry() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    // Numeric index on price field
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+        "$.price",
+        IndexType::Numeric,
+    )
+    .unwrap();
+
+    // Write a document with a STRING price (type mismatch for numeric index)
+    let doc: JsonValue = serde_json::json!({"price": "expensive"}).into();
+    json.create(&test_db.branch_id, "default", "doc1", doc)
+        .unwrap();
+
+    // No index entry — string can't be encoded as numeric
+    let scan_prefix = strata_engine::primitives::json::index::index_scan_prefix(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+    );
+    let entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&scan_prefix))
+        .unwrap();
+    assert_eq!(entries.len(), 0);
+}
+
+#[test]
+fn index_tag_type_exact_match() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "status_idx",
+        "$.status",
+        IndexType::Tag,
+    )
+    .unwrap();
+
+    let doc1: JsonValue = serde_json::json!({"status": "Active", "name": "a"}).into();
+    let doc2: JsonValue = serde_json::json!({"status": "PENDING", "name": "b"}).into();
+    let doc3: JsonValue = serde_json::json!({"status": "active", "name": "c"}).into();
+    json.create(&test_db.branch_id, "default", "doc1", doc1)
+        .unwrap();
+    json.create(&test_db.branch_id, "default", "doc2", doc2)
+        .unwrap();
+    json.create(&test_db.branch_id, "default", "doc3", doc3)
+        .unwrap();
+
+    // Tags are lowercased, so "Active" and "active" produce same index value
+    let scan_prefix = strata_engine::primitives::json::index::index_scan_prefix(
+        &test_db.branch_id,
+        "default",
+        "status_idx",
+    );
+    let entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&scan_prefix))
+        .unwrap();
+    assert_eq!(entries.len(), 3);
+
+    // Should sort: "active" (doc1), "active" (doc3), "pending" (doc2)
+    let doc_ids: Vec<String> = entries
+        .iter()
+        .filter_map(|(k, _)| {
+            strata_engine::primitives::json::index::extract_doc_id_from_index_key(&k.user_key)
+        })
+        .collect();
+    assert_eq!(doc_ids, vec!["doc1", "doc3", "doc2"]);
+}
+
+#[test]
+fn index_branch_isolation() {
+    let mut test_db = TestDb::new();
+    let json = test_db.json();
+    let branch_a = test_db.branch_id;
+
+    // Create index on branch A
+    json.create_index(
+        &branch_a,
+        "default",
+        "price_idx",
+        "$.price",
+        IndexType::Numeric,
+    )
+    .unwrap();
+
+    // Create a new branch B
+    let branch_b = test_db.new_branch();
+
+    // Index should NOT be visible on branch B
+    let indexes_b = json.list_indexes(&branch_b, "default").unwrap();
+    assert!(indexes_b.is_empty());
+
+    // Index should still be on branch A
+    let indexes_a = json.list_indexes(&branch_a, "default").unwrap();
+    assert_eq!(indexes_a.len(), 1);
+}
+
+#[test]
+fn index_multiple_indexes_on_same_space() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+        "$.price",
+        IndexType::Numeric,
+    )
+    .unwrap();
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "status_idx",
+        "$.status",
+        IndexType::Tag,
+    )
+    .unwrap();
+
+    let indexes = json.list_indexes(&test_db.branch_id, "default").unwrap();
+    assert_eq!(indexes.len(), 2);
+
+    // Write a document — both indexes should be updated
+    let doc: JsonValue = serde_json::json!({"price": 25.0, "status": "active"}).into();
+    json.create(&test_db.branch_id, "default", "doc1", doc)
+        .unwrap();
+
+    // Check price index
+    let price_prefix = strata_engine::primitives::json::index::index_scan_prefix(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+    );
+    let price_entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&price_prefix))
+        .unwrap();
+    assert_eq!(price_entries.len(), 1);
+
+    // Check status index
+    let status_prefix = strata_engine::primitives::json::index::index_scan_prefix(
+        &test_db.branch_id,
+        "default",
+        "status_idx",
+    );
+    let status_entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&status_prefix))
+        .unwrap();
+    assert_eq!(status_entries.len(), 1);
+}
+
+#[test]
+fn index_batch_set_updates_indexes() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+        "$.price",
+        IndexType::Numeric,
+    )
+    .unwrap();
+
+    let entries = vec![
+        (
+            "doc1".to_string(),
+            jpath(""),
+            serde_json::json!({"price": 10.0}).into(),
+        ),
+        (
+            "doc2".to_string(),
+            jpath(""),
+            serde_json::json!({"price": 20.0}).into(),
+        ),
+        (
+            "doc3".to_string(),
+            jpath(""),
+            serde_json::json!({"price": 30.0}).into(),
+        ),
+    ];
+    json.batch_set_or_create(&test_db.branch_id, "default", entries)
+        .unwrap();
+
+    let scan_prefix = strata_engine::primitives::json::index::index_scan_prefix(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+    );
+    let index_entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&scan_prefix))
+        .unwrap();
+    assert_eq!(index_entries.len(), 3);
+}
+
+#[test]
+fn index_batch_destroy_removes_entries() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+        "$.price",
+        IndexType::Numeric,
+    )
+    .unwrap();
+
+    let doc1: JsonValue = serde_json::json!({"price": 10.0}).into();
+    let doc2: JsonValue = serde_json::json!({"price": 20.0}).into();
+    json.create(&test_db.branch_id, "default", "doc1", doc1)
+        .unwrap();
+    json.create(&test_db.branch_id, "default", "doc2", doc2)
+        .unwrap();
+
+    // Batch destroy both
+    json.batch_destroy(
+        &test_db.branch_id,
+        "default",
+        &["doc1".to_string(), "doc2".to_string()],
+    )
+    .unwrap();
+
+    let scan_prefix = strata_engine::primitives::json::index::index_scan_prefix(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+    );
+    let entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&scan_prefix))
+        .unwrap();
+    assert_eq!(entries.len(), 0);
+}
+
+#[test]
+fn index_delete_at_path_updates_entries() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+        "$.price",
+        IndexType::Numeric,
+    )
+    .unwrap();
+
+    let doc: JsonValue = serde_json::json!({"price": 42.0, "name": "widget"}).into();
+    json.create(&test_db.branch_id, "default", "doc1", doc)
+        .unwrap();
+
+    // Verify index entry exists
+    let scan_prefix = strata_engine::primitives::json::index::index_scan_prefix(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+    );
+    let entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&scan_prefix))
+        .unwrap();
+    assert_eq!(entries.len(), 1);
+
+    // Delete the price field from the document
+    json.delete_at_path(&test_db.branch_id, "default", "doc1", &jpath("price"))
+        .unwrap();
+
+    // Index entry for price should be gone (field no longer exists)
+    let entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&scan_prefix))
+        .unwrap();
+    assert_eq!(entries.len(), 0);
+}
+
+#[test]
+fn no_indexes_no_overhead() {
+    // Verify that without indexes, documents still work normally
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    // No indexes created — just normal CRUD
+    let doc: JsonValue = serde_json::json!({"price": 42.0}).into();
+    json.create(&test_db.branch_id, "default", "doc1", doc)
+        .unwrap();
+
+    let val = json
+        .get(&test_db.branch_id, "default", "doc1", &JsonPath::root())
+        .unwrap();
+    assert!(val.is_some());
+
+    json.destroy(&test_db.branch_id, "default", "doc1").unwrap();
+    let val = json
+        .get(&test_db.branch_id, "default", "doc1", &JsonPath::root())
+        .unwrap();
+    assert!(val.is_none());
+}
+
+#[test]
+fn index_numeric_handles_integers() {
+    // JSON integers (42) should be indexed correctly via as_f64()
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "qty_idx",
+        "$.quantity",
+        IndexType::Numeric,
+    )
+    .unwrap();
+
+    let doc: JsonValue = serde_json::json!({"quantity": 42}).into();
+    json.create(&test_db.branch_id, "default", "doc1", doc)
+        .unwrap();
+
+    let scan_prefix = strata_engine::primitives::json::index::index_scan_prefix(
+        &test_db.branch_id,
+        "default",
+        "qty_idx",
+    );
+    let entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&scan_prefix))
+        .unwrap();
+    assert_eq!(entries.len(), 1);
+}
+
+#[test]
+fn index_nested_field_path() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "city_idx",
+        "$.address.city",
+        IndexType::Tag,
+    )
+    .unwrap();
+
+    let doc: JsonValue =
+        serde_json::json!({"name": "Alice", "address": {"city": "Portland", "zip": "97201"}})
+            .into();
+    json.create(&test_db.branch_id, "default", "doc1", doc)
+        .unwrap();
+
+    let scan_prefix = strata_engine::primitives::json::index::index_scan_prefix(
+        &test_db.branch_id,
+        "default",
+        "city_idx",
+    );
+    let entries: Vec<_> = test_db
+        .db
+        .transaction(test_db.branch_id, |txn| txn.scan_prefix(&scan_prefix))
+        .unwrap();
+    assert_eq!(entries.len(), 1);
+
+    let doc_id = strata_engine::primitives::json::index::extract_doc_id_from_index_key(
+        &entries[0].0.user_key,
+    );
+    assert_eq!(doc_id, Some("doc1".to_string()));
+}
+
+#[test]
+fn create_index_empty_name_rejected() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    let result = json.create_index(
+        &test_db.branch_id,
+        "default",
+        "",
+        "$.price",
+        IndexType::Numeric,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn create_index_invalid_name_rejected() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    let result = json.create_index(
+        &test_db.branch_id,
+        "default",
+        "bad/name",
+        "$.price",
+        IndexType::Numeric,
+    );
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
- Adds secondary index infrastructure for JsonStore — index types (Numeric, Tag, Text), order-preserving value encoding, index CRUD API, and synchronous index maintenance on all 8 document write paths
- Indexes are stored as regular KV entries in reserved `_idx/` spaces, inheriting branching, MVCC, compaction, and durability for free — no new data structures
- Adds `JsonCreateIndex`, `JsonDropIndex`, `JsonListIndexes` executor commands with full dispatch wiring
- Includes design doc at `docs/design/json-secondary-indexes.md` covering all 4 epics

## What this does NOT include (future epics)
- **Epic 2**: Index-backed field filtering via Searchable trait
- **Epic 3**: Sorted results and OR logic
- **Epic 4**: Composite indexes and aggregation

## Design decisions
- **KV-layer storage** over separate data structure — branching makes every new structure 10x harder
- **Synchronous maintenance** — index entries updated in the same transaction as document writes
- **`/` delimiter** in index space names — avoids ambiguity with underscores in space/index names
- **Sign-flipped IEEE 754** for numeric encoding — standard order-preserving technique

## Test plan
- [x] 20 unit tests for encoding, key construction, field extraction, roundtrips
- [x] 19 integration tests: CRUD, write maintenance, update/delete cleanup, batch ops, branch isolation, missing fields, type mismatches, nested paths, validation
- [x] Full engine suite (210 tests) passes with zero regressions
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)