### PR TITLE
Fix #1557: Security hardening — file permissions, env var overrides, cargo audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: cargo build --release --all
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+      - name: Run cargo audit
+        run: cargo audit

--- a/crates/durability/src/format/manifest.rs
+++ b/crates/durability/src/format/manifest.rs
@@ -245,6 +245,12 @@ impl ManifestManager {
         file.sync_all()?;
         drop(file);
 
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&temp_path, std::fs::Permissions::from_mode(0o600));
+        }
+
         // Atomic rename
         std::fs::rename(&temp_path, &self.path)?;
 

--- a/crates/durability/src/format/wal_record.rs
+++ b/crates/durability/src/format/wal_record.rs
@@ -213,6 +213,13 @@ impl WalSegment {
             .read(true)
             .open(&path)?;
 
+        // Restrict to owner-only (defense in depth for data files)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+        }
+
         // Write v2 header (36 bytes)
         let header = SegmentHeader::new(segment_number, database_uuid);
         file.write_all(&header.to_bytes())?;

--- a/crates/engine/src/database/compaction.rs
+++ b/crates/engine/src/database/compaction.rs
@@ -67,6 +67,12 @@ impl Database {
         // Create snapshots directory
         let snapshots_dir = self.data_dir.join("snapshots");
         std::fs::create_dir_all(&snapshots_dir).map_err(StrataError::from)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ =
+                std::fs::set_permissions(&snapshots_dir, std::fs::Permissions::from_mode(0o700));
+        }
 
         // Load or create MANIFEST
         let mut manifest = self.load_or_create_manifest()?;

--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -311,6 +311,27 @@ impl Default for StrataConfig {
     }
 }
 
+/// Restrict config file to owner-only read/write (0o600).
+///
+/// The config file may contain API keys, so we propagate permission
+/// errors rather than ignoring them.
+#[cfg(unix)]
+fn restrict_config_permissions(path: &std::path::Path) -> StrataResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
+        StrataError::internal(format!(
+            "Failed to restrict permissions on '{}': {}",
+            path.display(),
+            e
+        ))
+    })
+}
+
+#[cfg(not(unix))]
+fn restrict_config_permissions(_path: &std::path::Path) -> StrataResult<()> {
+    Ok(())
+}
+
 impl StrataConfig {
     /// Build a BM25 scorer using configured parameters (or defaults).
     pub fn bm25_scorer(&self) -> crate::search::BM25LiteScorer {
@@ -416,7 +437,7 @@ auto_embed = false
                 e
             ))
         })?;
-        let config: StrataConfig = toml::from_str(&content).map_err(|e| {
+        let mut config: StrataConfig = toml::from_str(&content).map_err(|e| {
             StrataError::invalid_input(format!(
                 "Failed to parse config file '{}': {}",
                 path.display(),
@@ -425,7 +446,27 @@ auto_embed = false
         })?;
         // Validate the durability value eagerly
         config.durability_mode()?;
+        // Environment variables override config file values (12-factor app pattern).
+        // This avoids storing secrets in plaintext config files.
+        config.apply_env_overrides();
         Ok(config)
+    }
+
+    /// Override API key fields with environment variables, if set.
+    ///
+    /// Recognized variables: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`.
+    fn apply_env_overrides(&mut self) {
+        for (env_var, field) in [
+            ("ANTHROPIC_API_KEY", &mut self.anthropic_api_key),
+            ("OPENAI_API_KEY", &mut self.openai_api_key),
+            ("GOOGLE_API_KEY", &mut self.google_api_key),
+        ] {
+            if let Ok(val) = std::env::var(env_var) {
+                if !val.is_empty() {
+                    *field = Some(SensitiveString::from(val));
+                }
+            }
+        }
     }
 
     /// Write the default config file if it does not already exist.
@@ -440,6 +481,7 @@ auto_embed = false
                     e
                 ))
             })?;
+            restrict_config_permissions(path)?;
         }
         Ok(())
     }
@@ -454,7 +496,8 @@ auto_embed = false
                 path.display(),
                 e
             ))
-        })
+        })?;
+        restrict_config_permissions(path)
     }
 }
 
@@ -1081,5 +1124,48 @@ max_branches = 512
         assert_eq!(config.storage.data_block_size, 4096);
         assert_eq!(config.storage.bloom_bits_per_key, 10);
         assert_eq!(config.storage.compaction_rate_limit, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_to_file_sets_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(CONFIG_FILE_NAME);
+        let config = StrataConfig::default();
+        config.write_to_file(&path).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "strata.toml should be owner-only (0o600)");
+    }
+
+    #[test]
+    fn env_var_overrides_api_keys() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(
+            &path,
+            "durability = \"standard\"\nanthropic_api_key = \"file-key\"\n",
+        )
+        .unwrap();
+
+        // Set env vars
+        unsafe {
+            std::env::set_var("ANTHROPIC_API_KEY", "env-key");
+            std::env::set_var("OPENAI_API_KEY", "env-openai");
+        }
+
+        let config = StrataConfig::from_file(&path).unwrap();
+
+        unsafe {
+            std::env::remove_var("ANTHROPIC_API_KEY");
+            std::env::remove_var("OPENAI_API_KEY");
+        }
+
+        // Env var overrides file value
+        assert_eq!(config.anthropic_api_key.as_deref(), Some("env-key"));
+        // Env var sets value even when file had none
+        assert_eq!(config.openai_api_key.as_deref(), Some("env-openai"));
+        // Unset env var leaves file value alone
+        assert!(config.google_api_key.is_none());
     }
 }

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -31,6 +31,31 @@ fn apply_storage_config(storage: &SegmentedStore, cfg: &StorageConfig) {
 
 use strata_core::{StrataError, StrataResult};
 
+/// Restrict a directory to owner-only access (rwx------).
+/// Best-effort: logs a warning on failure but does not block database open.
+#[cfg(unix)]
+fn restrict_dir(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)) {
+        warn!(target: "strata::db", path = %path.display(), error = %e,
+            "Failed to restrict directory permissions");
+    }
+}
+
+#[cfg(not(unix))]
+fn restrict_dir(_path: &Path) {}
+
+/// Restrict a file to owner-only read/write (rw-------).
+/// Best-effort: ignores errors (defense in depth for data files).
+#[cfg(unix)]
+fn restrict_file(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn restrict_file(_path: &Path) {}
+
 use super::config::{self, StrataConfig};
 use super::registry::OPEN_DATABASES;
 use super::{Database, PersistenceMode};
@@ -141,6 +166,7 @@ impl Database {
         // Create directory first so we can canonicalize the path
         let data_dir = path.as_ref().to_path_buf();
         std::fs::create_dir_all(&data_dir).map_err(StrataError::from)?;
+        restrict_dir(&data_dir);
 
         // Canonicalize path for consistent registry keys
         let canonical_path = data_dir.canonicalize().map_err(StrataError::from)?;
@@ -163,6 +189,7 @@ impl Database {
             .write(true)
             .open(&lock_path)
             .map_err(|e| StrataError::storage(format!("failed to open lock file: {}", e)))?;
+        restrict_file(&lock_path);
         fs2::FileExt::try_lock_exclusive(&lock_file).map_err(|_| {
             StrataError::storage(format!(
                 "database at '{}' is already in use by another process",
@@ -422,10 +449,12 @@ impl Database {
         // Create WAL directory
         let wal_dir = canonical_path.join("wal");
         std::fs::create_dir_all(&wal_dir).map_err(StrataError::from)?;
+        restrict_dir(&wal_dir);
 
         // Create segments directory for on-disk segment storage
         let segments_dir = canonical_path.join("segments");
         std::fs::create_dir_all(&segments_dir).map_err(StrataError::from)?;
+        restrict_dir(&segments_dir);
 
         // Use RecoveryCoordinator for proper transaction-aware recovery
         // This reads all WalRecords from the segmented WAL directory

--- a/crates/storage/src/segment_builder.rs
+++ b/crates/storage/src/segment_builder.rs
@@ -172,6 +172,11 @@ impl SegmentBuilder {
 
         let tmp_path = path.with_extension("tmp");
         let file = std::fs::File::create(&tmp_path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600));
+        }
         let mut w = BufWriter::new(file);
 
         // Reuse a single Zstd compressor context across all blocks to avoid


### PR DESCRIPTION
## Summary

Five items from the pre-launch security review (#1557):

1. **strata.toml → 0o600** — config file contains API keys; now restricted to owner-only
2. **Database directories → 0o700** — data, wal, segments, snapshots dirs restricted
3. **Data files → 0o600** — WAL segments, SST files, MANIFEST, lock file restricted
4. **Env var override for API keys** — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY` override strata.toml values
5. **cargo audit in CI** — scans dependencies for known vulnerabilities

Deferred items (tracked separately): credential separation, CLI key validation, keychain integration.

## Test plan
- [x] `write_to_file_sets_owner_only_permissions` — verifies 0o600 on strata.toml
- [x] `env_var_overrides_api_keys` — verifies env vars override file values
- [x] Full engine test suite (690/690 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)