### PR TITLE
Fix #1880: Index-backed field filtering via Searchable (Epic 2)

### DIFF
--- a/crates/engine/src/primitives/json/index.rs
+++ b/crates/engine/src/primitives/json/index.rs
@@ -271,8 +271,13 @@ pub fn lookup_eq(
     index_name: &str,
     encoded_value: &[u8],
 ) -> StrataResult<Vec<String>> {
-    // Scan with the encoded value as prefix — matches all doc_ids with this value
-    let prefix = index_value_prefix(branch_id, space, index_name, encoded_value);
+    // Scan with encoded_value ++ separator as prefix, so "active" doesn't
+    // false-match "actively" (both start with "active" but only "active\xFF"
+    // matches "active\xFF<doc_id>").
+    let mut exact_prefix = Vec::with_capacity(encoded_value.len() + 1);
+    exact_prefix.extend_from_slice(encoded_value);
+    exact_prefix.push(INDEX_KEY_SEPARATOR);
+    let prefix = index_value_prefix(branch_id, space, index_name, &exact_prefix);
     let entries = txn.scan_prefix(&prefix)?;
     Ok(entries
         .iter()

--- a/crates/engine/src/primitives/json/index.rs
+++ b/crates/engine/src/primitives/json/index.rs
@@ -257,6 +257,213 @@ pub fn extract_field_value(doc_value: &JsonValue, field_path: &str) -> Option<Js
 }
 
 // =============================================================================
+// Index Lookup (for query execution)
+// =============================================================================
+
+use std::collections::HashSet;
+use strata_concurrency::TransactionContext;
+
+/// Look up all doc_ids matching an exact value in an index.
+pub fn lookup_eq(
+    txn: &mut TransactionContext,
+    branch_id: &BranchId,
+    space: &str,
+    index_name: &str,
+    encoded_value: &[u8],
+) -> StrataResult<Vec<String>> {
+    // Scan with the encoded value as prefix — matches all doc_ids with this value
+    let prefix = index_value_prefix(branch_id, space, index_name, encoded_value);
+    let entries = txn.scan_prefix(&prefix)?;
+    Ok(entries
+        .iter()
+        .filter_map(|(k, _)| extract_doc_id_from_index_key(&k.user_key))
+        .collect())
+}
+
+/// Look up all doc_ids in a value range [lower, upper].
+///
+/// Scans the full index and filters by encoded value bounds.
+/// Both bounds are optional (None = unbounded on that side).
+#[allow(clippy::too_many_arguments)]
+pub fn lookup_range(
+    txn: &mut TransactionContext,
+    branch_id: &BranchId,
+    space: &str,
+    index_name: &str,
+    lower: Option<&[u8]>,
+    upper: Option<&[u8]>,
+    lower_inclusive: bool,
+    upper_inclusive: bool,
+) -> StrataResult<Vec<String>> {
+    let prefix = index_scan_prefix(branch_id, space, index_name);
+    let entries = txn.scan_prefix(&prefix)?;
+
+    let mut doc_ids = Vec::new();
+    for (key, _) in &entries {
+        let user_key = &key.user_key;
+        // Find the separator to split value from doc_id
+        let sep_pos = match user_key.iter().rposition(|&b| b == INDEX_KEY_SEPARATOR) {
+            Some(pos) => pos,
+            None => continue,
+        };
+        let value_bytes = &user_key[..sep_pos];
+
+        // Check lower bound
+        if let Some(lo) = lower {
+            if lower_inclusive {
+                if value_bytes < lo {
+                    continue;
+                }
+            } else if value_bytes <= lo {
+                continue;
+            }
+        }
+
+        // Check upper bound
+        if let Some(hi) = upper {
+            if upper_inclusive {
+                if value_bytes > hi {
+                    continue;
+                }
+            } else if value_bytes >= hi {
+                continue;
+            }
+        }
+
+        if let Some(doc_id) = extract_doc_id_from_index_key(user_key) {
+            doc_ids.push(doc_id);
+        }
+    }
+    Ok(doc_ids)
+}
+
+/// Look up all doc_ids matching a text prefix in an index.
+pub fn lookup_prefix(
+    txn: &mut TransactionContext,
+    branch_id: &BranchId,
+    space: &str,
+    index_name: &str,
+    prefix_bytes: &[u8],
+) -> StrataResult<Vec<String>> {
+    let prefix = index_value_prefix(branch_id, space, index_name, prefix_bytes);
+    let entries = txn.scan_prefix(&prefix)?;
+    Ok(entries
+        .iter()
+        .filter_map(|(k, _)| extract_doc_id_from_index_key(&k.user_key))
+        .collect())
+}
+
+/// Resolve a FieldFilter against available indexes, returning matching doc_ids.
+///
+/// Returns an error if a predicate references a field with no corresponding index.
+pub fn resolve_filter(
+    txn: &mut TransactionContext,
+    branch_id: &BranchId,
+    space: &str,
+    filter: &crate::search::FieldFilter,
+    indexes: &[IndexDef],
+) -> StrataResult<HashSet<String>> {
+    use crate::search::FieldFilter;
+
+    match filter {
+        FieldFilter::Predicate(pred) => resolve_predicate(txn, branch_id, space, pred, indexes),
+        FieldFilter::And(filters) => {
+            let mut result: Option<HashSet<String>> = None;
+            for f in filters {
+                let set = resolve_filter(txn, branch_id, space, f, indexes)?;
+                result = Some(match result {
+                    Some(acc) => acc.intersection(&set).cloned().collect(),
+                    None => set,
+                });
+            }
+            Ok(result.unwrap_or_default())
+        }
+    }
+}
+
+/// Resolve a single predicate against indexes.
+fn resolve_predicate(
+    txn: &mut TransactionContext,
+    branch_id: &BranchId,
+    space: &str,
+    pred: &crate::search::FieldPredicate,
+    indexes: &[IndexDef],
+) -> StrataResult<HashSet<String>> {
+    use crate::search::FieldPredicate;
+
+    match pred {
+        FieldPredicate::Eq { field, value } => {
+            let idx = find_index_for_field(field, indexes)?;
+            let encoded = encode_value(value, idx.index_type).ok_or_else(|| {
+                StrataError::invalid_input(format!(
+                    "Value type mismatch for index '{}' (expected {})",
+                    idx.name, idx.index_type
+                ))
+            })?;
+            let doc_ids = lookup_eq(txn, branch_id, space, &idx.name, &encoded)?;
+            Ok(doc_ids.into_iter().collect())
+        }
+        FieldPredicate::Range {
+            field,
+            lower,
+            upper,
+            lower_inclusive,
+            upper_inclusive,
+        } => {
+            let idx = find_index_for_field(field, indexes)?;
+            let lo = match lower {
+                Some(v) => Some(encode_value(v, idx.index_type).ok_or_else(|| {
+                    StrataError::invalid_input(format!(
+                        "Lower bound type mismatch for index '{}'",
+                        idx.name
+                    ))
+                })?),
+                None => None,
+            };
+            let hi = match upper {
+                Some(v) => Some(encode_value(v, idx.index_type).ok_or_else(|| {
+                    StrataError::invalid_input(format!(
+                        "Upper bound type mismatch for index '{}'",
+                        idx.name
+                    ))
+                })?),
+                None => None,
+            };
+            let doc_ids = lookup_range(
+                txn,
+                branch_id,
+                space,
+                &idx.name,
+                lo.as_deref(),
+                hi.as_deref(),
+                *lower_inclusive,
+                *upper_inclusive,
+            )?;
+            Ok(doc_ids.into_iter().collect())
+        }
+        FieldPredicate::Prefix { field, prefix } => {
+            let idx = find_index_for_field(field, indexes)?;
+            let prefix_bytes = encode_text(prefix);
+            let doc_ids = lookup_prefix(txn, branch_id, space, &idx.name, &prefix_bytes)?;
+            Ok(doc_ids.into_iter().collect())
+        }
+    }
+}
+
+/// Find the index definition that covers a given field path.
+fn find_index_for_field<'a>(field: &str, indexes: &'a [IndexDef]) -> StrataResult<&'a IndexDef> {
+    indexes
+        .iter()
+        .find(|idx| idx.field_path == field)
+        .ok_or_else(|| {
+            StrataError::invalid_input(format!(
+                "No index found for field '{}'. Create one with create_index()",
+                field
+            ))
+        })
+}
+
+// =============================================================================
 // Tests
 // =============================================================================
 

--- a/crates/engine/src/primitives/json/mod.rs
+++ b/crates/engine/src/primitives/json/mod.rs
@@ -1352,10 +1352,75 @@ impl JsonStore {
 impl crate::search::Searchable for JsonStore {
     fn search(
         &self,
-        _req: &crate::SearchRequest,
+        req: &crate::SearchRequest,
     ) -> strata_core::StrataResult<crate::SearchResponse> {
-        // Search is handled by the intelligence layer, not the primitive
-        Ok(crate::SearchResponse::empty())
+        use crate::search::{EntityRef, SearchHit, SearchStats};
+        use std::time::Instant;
+
+        let start = Instant::now();
+
+        // If no field filter, return empty (text search via intelligence layer)
+        let filter = match &req.field_filter {
+            Some(f) => f,
+            None => return Ok(crate::SearchResponse::empty()),
+        };
+
+        self.db.transaction(req.branch_id, |txn| {
+            let indexes = Self::load_indexes(txn, &req.branch_id, &req.space)?;
+            let matching_doc_ids =
+                index::resolve_filter(txn, &req.branch_id, &req.space, filter, &indexes)?;
+
+            // Fetch documents and build hits
+            let mut hits: Vec<SearchHit> = Vec::new();
+            for doc_id in &matching_doc_ids {
+                let key = self.key_for(&req.branch_id, &req.space, doc_id);
+                if let Some(stored) = txn.get(&key)? {
+                    let doc = Self::deserialize_doc(&stored)?;
+                    let snippet = crate::search::truncate_text(
+                        &serde_json::to_string(&doc.value).unwrap_or_default(),
+                        200,
+                    );
+                    hits.push(SearchHit {
+                        doc_ref: EntityRef::Json {
+                            branch_id: req.branch_id,
+                            doc_id: doc_id.clone(),
+                        },
+                        score: 1.0, // Binary match score for field filters
+                        rank: 0,    // Set below
+                        snippet: Some(snippet),
+                    });
+                }
+            }
+
+            // Sort by doc_id for deterministic ordering, then take top-k
+            hits.sort_by(|a, b| {
+                let a_key = match &a.doc_ref {
+                    EntityRef::Json { doc_id, .. } => doc_id.as_str(),
+                    _ => "",
+                };
+                let b_key = match &b.doc_ref {
+                    EntityRef::Json { doc_id, .. } => doc_id.as_str(),
+                    _ => "",
+                };
+                a_key.cmp(b_key)
+            });
+            hits.truncate(req.k);
+
+            // Assign ranks
+            for (i, hit) in hits.iter_mut().enumerate() {
+                hit.rank = (i + 1) as u32;
+            }
+
+            let elapsed = start.elapsed().as_micros() as u64;
+            let mut stats = SearchStats::new(elapsed, matching_doc_ids.len());
+            stats = stats.with_index_used(true);
+
+            Ok(crate::SearchResponse {
+                hits,
+                truncated: matching_doc_ids.len() > req.k,
+                stats,
+            })
+        })
     }
 
     fn primitive_kind(&self) -> strata_core::PrimitiveType {

--- a/crates/engine/src/search/mod.rs
+++ b/crates/engine/src/search/mod.rs
@@ -27,6 +27,6 @@ pub use searchable::{
 };
 pub use tokenizer::{tokenize, tokenize_unique};
 pub use types::{
-    EntityRef, PrimitiveType, SearchBudget, SearchHit, SearchMode, SearchRequest, SearchResponse,
-    SearchStats,
+    EntityRef, FieldFilter, FieldPredicate, PrimitiveType, SearchBudget, SearchHit, SearchMode,
+    SearchRequest, SearchResponse, SearchStats,
 };

--- a/crates/engine/src/search/types.rs
+++ b/crates/engine/src/search/types.rs
@@ -12,6 +12,7 @@
 //! See `the architecture documentation` for authoritative specification.
 
 use std::collections::HashMap;
+use strata_core::primitives::json::JsonValue;
 use strata_core::types::BranchId;
 
 // Re-export contract types
@@ -170,6 +171,10 @@ pub struct SearchRequest {
     /// snapshot. Primitives that support versioned reads use this bound; the
     /// inverted index scoring is not yet version-bounded (future work).
     pub snapshot_version: Option<u64>,
+
+    /// Optional: field filter for secondary index queries on JsonStore.
+    /// When present, only documents matching the filter are returned.
+    pub field_filter: Option<FieldFilter>,
 }
 
 impl SearchRequest {
@@ -196,7 +201,14 @@ impl SearchRequest {
             precomputed_embedding: None,
             space: "default".to_string(),
             snapshot_version: None,
+            field_filter: None,
         }
+    }
+
+    /// Builder: set field filter for secondary index queries
+    pub fn with_field_filter(mut self, filter: FieldFilter) -> Self {
+        self.field_filter = Some(filter);
+        self
     }
 
     /// Builder: set top-k results count
@@ -403,6 +415,58 @@ impl SearchResponse {
     pub fn len(&self) -> usize {
         self.hits.len()
     }
+}
+
+// ============================================================================
+// Field Filter Types (for secondary index queries)
+// ============================================================================
+
+/// A predicate on an indexed JSON field.
+///
+/// Each predicate maps to a scan on a secondary index.
+/// The `field` is the `field_path` from the index definition (e.g., "$.price").
+#[derive(Debug, Clone)]
+pub enum FieldPredicate {
+    /// Exact match: `@status:{active}`
+    Eq {
+        /// Field path (e.g., "$.status")
+        field: String,
+        /// Value to match
+        value: JsonValue,
+    },
+
+    /// Range query: `@price:[100 200]`
+    Range {
+        /// Field path (e.g., "$.price")
+        field: String,
+        /// Lower bound (None = unbounded)
+        lower: Option<JsonValue>,
+        /// Upper bound (None = unbounded)
+        upper: Option<JsonValue>,
+        /// Whether lower bound is inclusive
+        lower_inclusive: bool,
+        /// Whether upper bound is inclusive
+        upper_inclusive: bool,
+    },
+
+    /// Prefix match on text: `@name:wire*`
+    Prefix {
+        /// Field path (e.g., "$.name")
+        field: String,
+        /// Prefix to match
+        prefix: String,
+    },
+}
+
+/// Compound filter with boolean logic over field predicates.
+///
+/// Used to narrow the candidate set before text scoring.
+#[derive(Debug, Clone)]
+pub enum FieldFilter {
+    /// A single predicate
+    Predicate(FieldPredicate),
+    /// All sub-filters must match (intersection)
+    And(Vec<FieldFilter>),
 }
 
 // ============================================================================

--- a/tests/engine/primitives/jsonstore.rs
+++ b/tests/engine/primitives/jsonstore.rs
@@ -1334,3 +1334,72 @@ fn search_unbounded_range() {
     let ids = search_doc_ids(&json, &req);
     assert_eq!(ids, vec!["p3", "p4", "p5"]); // 50, 75, 100
 }
+
+#[test]
+fn search_tag_eq_no_prefix_collision() {
+    // Verify that exact match on "active" does NOT match "actively"
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "status_idx",
+        "$.status",
+        IndexType::Tag,
+    )
+    .unwrap();
+
+    let doc1: JsonValue = json!({"status": "active"}).into();
+    let doc2: JsonValue = json!({"status": "actively"}).into();
+    json.create(&test_db.branch_id, "default", "d1", doc1)
+        .unwrap();
+    json.create(&test_db.branch_id, "default", "d2", doc2)
+        .unwrap();
+
+    let req = SearchRequest::new(test_db.branch_id, "").with_field_filter(FieldFilter::Predicate(
+        FieldPredicate::Eq {
+            field: "$.status".to_string(),
+            value: json!("active").into(),
+        },
+    ));
+
+    let ids = search_doc_ids(&json, &req);
+    assert_eq!(ids, vec!["d1"]); // Only exact match, NOT "actively"
+}
+
+#[test]
+fn search_text_prefix() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "name_idx",
+        "$.name",
+        IndexType::Text,
+    )
+    .unwrap();
+
+    let doc1: JsonValue = json!({"name": "wireless mouse"}).into();
+    let doc2: JsonValue = json!({"name": "wired keyboard"}).into();
+    let doc3: JsonValue = json!({"name": "bluetooth speaker"}).into();
+    json.create(&test_db.branch_id, "default", "d1", doc1)
+        .unwrap();
+    json.create(&test_db.branch_id, "default", "d2", doc2)
+        .unwrap();
+    json.create(&test_db.branch_id, "default", "d3", doc3)
+        .unwrap();
+
+    let req = SearchRequest::new(test_db.branch_id, "").with_field_filter(FieldFilter::Predicate(
+        FieldPredicate::Prefix {
+            field: "$.name".to_string(),
+            prefix: "wire".to_string(),
+        },
+    ));
+
+    let ids = search_doc_ids(&json, &req);
+    // "wire" matches "wireless mouse" and "wired keyboard" (lowercased)
+    assert_eq!(ids, vec!["d1", "d2"]);
+}

--- a/tests/engine/primitives/jsonstore.rs
+++ b/tests/engine/primitives/jsonstore.rs
@@ -3,6 +3,7 @@
 //! Tests for JSON document storage with path-based operations.
 
 use crate::common::*;
+use serde_json::json;
 use std::str::FromStr;
 
 // Helper function to parse path or return root
@@ -1082,4 +1083,254 @@ fn create_index_invalid_name_rejected() {
         IndexType::Numeric,
     );
     assert!(result.is_err());
+}
+
+// ============================================================================
+// Search via Searchable Trait (Epic 2)
+// ============================================================================
+
+use strata_engine::search::{FieldFilter, FieldPredicate, SearchRequest, Searchable};
+
+fn setup_products(test_db: &TestDb) -> JsonStore {
+    let json = test_db.json();
+
+    // Create indexes
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "price_idx",
+        "$.price",
+        IndexType::Numeric,
+    )
+    .unwrap();
+    json.create_index(
+        &test_db.branch_id,
+        "default",
+        "status_idx",
+        "$.status",
+        IndexType::Tag,
+    )
+    .unwrap();
+
+    // Insert test documents
+    let docs = vec![
+        (
+            "p1",
+            json!({"price": 10.0, "status": "active", "name": "Widget A"}),
+        ),
+        (
+            "p2",
+            json!({"price": 25.0, "status": "active", "name": "Widget B"}),
+        ),
+        (
+            "p3",
+            json!({"price": 50.0, "status": "pending", "name": "Gadget C"}),
+        ),
+        (
+            "p4",
+            json!({"price": 75.0, "status": "active", "name": "Gadget D"}),
+        ),
+        (
+            "p5",
+            json!({"price": 100.0, "status": "inactive", "name": "Thing E"}),
+        ),
+    ];
+    for (id, val) in docs {
+        json.create(&test_db.branch_id, "default", id, val.into())
+            .unwrap();
+    }
+    json
+}
+
+fn search_doc_ids(json: &JsonStore, req: &SearchRequest) -> Vec<String> {
+    let response = json.search(req).unwrap();
+    response
+        .hits
+        .iter()
+        .map(|h| h.doc_ref.json_doc_id().unwrap().to_string())
+        .collect()
+}
+
+#[test]
+fn search_numeric_range() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    let req = SearchRequest::new(test_db.branch_id, "").with_field_filter(FieldFilter::Predicate(
+        FieldPredicate::Range {
+            field: "$.price".to_string(),
+            lower: Some(json!(20.0).into()),
+            upper: Some(json!(80.0).into()),
+            lower_inclusive: true,
+            upper_inclusive: true,
+        },
+    ));
+
+    let ids = search_doc_ids(&json, &req);
+    // price 25, 50, 75 are in [20, 80]
+    assert_eq!(ids, vec!["p2", "p3", "p4"]);
+}
+
+#[test]
+fn search_numeric_range_exclusive() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    let req = SearchRequest::new(test_db.branch_id, "").with_field_filter(FieldFilter::Predicate(
+        FieldPredicate::Range {
+            field: "$.price".to_string(),
+            lower: Some(json!(25.0).into()),
+            upper: Some(json!(75.0).into()),
+            lower_inclusive: false,
+            upper_inclusive: false,
+        },
+    ));
+
+    let ids = search_doc_ids(&json, &req);
+    // Exclusive: only price 50 is in (25, 75)
+    assert_eq!(ids, vec!["p3"]);
+}
+
+#[test]
+fn search_tag_exact_match() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    let req = SearchRequest::new(test_db.branch_id, "").with_field_filter(FieldFilter::Predicate(
+        FieldPredicate::Eq {
+            field: "$.status".to_string(),
+            value: json!("active").into(),
+        },
+    ));
+
+    let ids = search_doc_ids(&json, &req);
+    assert_eq!(ids, vec!["p1", "p2", "p4"]);
+}
+
+#[test]
+fn search_and_compound_filter() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    // active AND price in [20, 80]
+    let req = SearchRequest::new(test_db.branch_id, "").with_field_filter(FieldFilter::And(vec![
+        FieldFilter::Predicate(FieldPredicate::Eq {
+            field: "$.status".to_string(),
+            value: json!("active").into(),
+        }),
+        FieldFilter::Predicate(FieldPredicate::Range {
+            field: "$.price".to_string(),
+            lower: Some(json!(20.0).into()),
+            upper: Some(json!(80.0).into()),
+            lower_inclusive: true,
+            upper_inclusive: true,
+        }),
+    ]));
+
+    let ids = search_doc_ids(&json, &req);
+    // active AND [20,80] = p2 (25, active), p4 (75, active)
+    assert_eq!(ids, vec!["p2", "p4"]);
+}
+
+#[test]
+fn search_empty_result() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    let req = SearchRequest::new(test_db.branch_id, "").with_field_filter(FieldFilter::Predicate(
+        FieldPredicate::Eq {
+            field: "$.status".to_string(),
+            value: json!("deleted").into(),
+        },
+    ));
+
+    let response = json.search(&req).unwrap();
+    assert!(response.is_empty());
+    assert!(response.stats.index_used);
+}
+
+#[test]
+fn search_no_index_returns_error() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    // No indexes created — search with filter should fail
+    let req = SearchRequest::new(test_db.branch_id, "").with_field_filter(FieldFilter::Predicate(
+        FieldPredicate::Eq {
+            field: "$.nonexistent".to_string(),
+            value: json!("x").into(),
+        },
+    ));
+
+    let result = json.search(&req);
+    assert!(result.is_err());
+}
+
+#[test]
+fn search_without_filter_returns_empty() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    // No field filter — should return empty (text search handled elsewhere)
+    let req = SearchRequest::new(test_db.branch_id, "anything");
+    let response = json.search(&req).unwrap();
+    assert!(response.is_empty());
+}
+
+#[test]
+fn search_respects_top_k() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    let req = SearchRequest::new(test_db.branch_id, "")
+        .with_k(2)
+        .with_field_filter(FieldFilter::Predicate(FieldPredicate::Eq {
+            field: "$.status".to_string(),
+            value: json!("active").into(),
+        }));
+
+    let response = json.search(&req).unwrap();
+    assert_eq!(response.hits.len(), 2);
+    assert!(response.truncated);
+    // Ranks should be sequential
+    assert_eq!(response.hits[0].rank, 1);
+    assert_eq!(response.hits[1].rank, 2);
+}
+
+#[test]
+fn search_hits_have_snippets() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    let req = SearchRequest::new(test_db.branch_id, "").with_field_filter(FieldFilter::Predicate(
+        FieldPredicate::Eq {
+            field: "$.status".to_string(),
+            value: json!("inactive").into(),
+        },
+    ));
+
+    let response = json.search(&req).unwrap();
+    assert_eq!(response.hits.len(), 1);
+    let snippet = response.hits[0].snippet.as_ref().unwrap();
+    assert!(snippet.contains("Thing E"));
+}
+
+#[test]
+fn search_unbounded_range() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    // price >= 50 (no upper bound)
+    let req = SearchRequest::new(test_db.branch_id, "").with_field_filter(FieldFilter::Predicate(
+        FieldPredicate::Range {
+            field: "$.price".to_string(),
+            lower: Some(json!(50.0).into()),
+            upper: None,
+            lower_inclusive: true,
+            upper_inclusive: true,
+        },
+    ));
+
+    let ids = search_doc_ids(&json, &req);
+    assert_eq!(ids, vec!["p3", "p4", "p5"]); // 50, 75, 100
 }


### PR DESCRIPTION
## Summary
- Adds `FieldPredicate` (Eq, Range, Prefix) and `FieldFilter` (Predicate, And) types to `SearchRequest` — backward compatible, existing callers unaffected
- Implements index lookup engine: `lookup_eq`, `lookup_range`, `lookup_prefix` as KV-layer prefix scans, plus `resolve_filter` for compound AND logic
- Replaces JsonStore's `Searchable` stub with real implementation — field filters resolve against secondary indexes, returning `SearchHit`s with `EntityRef::Json`, snippets, and `index_used: true` stats
- No field filter = returns empty (text search still handled by intelligence layer)

## Design
- Queries error on non-indexed fields (no silent full-scan fallback)
- Range scans compare encoded byte values, leveraging Epic 1's order-preserving numeric encoding
- Results sorted by doc_id for deterministic ordering, respects top-k limit
- AND filters intersect doc_id sets from individual index lookups

## Test plan
- [x] 10 new integration tests via `Searchable::search()`: numeric range (inclusive + exclusive), tag exact match, AND compound filter, empty results, no-index error, no-filter returns empty, top-k truncation, snippet content, unbounded range
- [x] Full engine suite (220 tests) passes with zero regressions
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)