### PR TITLE
Fix #1880: OR filters and sort-by-indexed-field (Epic 3)

### DIFF
--- a/crates/engine/src/primitives/json/index.rs
+++ b/crates/engine/src/primitives/json/index.rs
@@ -358,6 +358,24 @@ pub fn lookup_prefix(
         .collect())
 }
 
+/// Scan all entries of an index in order, returning doc_ids in index value order.
+///
+/// Used for sort-by-indexed-field: the KV layer stores index entries in
+/// order-preserving byte order, so a prefix scan returns them sorted.
+pub fn scan_index_ordered(
+    txn: &mut TransactionContext,
+    branch_id: &BranchId,
+    space: &str,
+    index_name: &str,
+) -> StrataResult<Vec<String>> {
+    let prefix = index_scan_prefix(branch_id, space, index_name);
+    let entries = txn.scan_prefix(&prefix)?;
+    Ok(entries
+        .iter()
+        .filter_map(|(k, _)| extract_doc_id_from_index_key(&k.user_key))
+        .collect())
+}
+
 /// Resolve a FieldFilter against available indexes, returning matching doc_ids.
 ///
 /// Returns an error if a predicate references a field with no corresponding index.
@@ -382,6 +400,14 @@ pub fn resolve_filter(
                 });
             }
             Ok(result.unwrap_or_default())
+        }
+        FieldFilter::Or(filters) => {
+            let mut result = HashSet::new();
+            for f in filters {
+                let set = resolve_filter(txn, branch_id, space, f, indexes)?;
+                result.extend(set);
+            }
+            Ok(result)
         }
     }
 }
@@ -456,7 +482,10 @@ fn resolve_predicate(
 }
 
 /// Find the index definition that covers a given field path.
-fn find_index_for_field<'a>(field: &str, indexes: &'a [IndexDef]) -> StrataResult<&'a IndexDef> {
+pub fn find_index_for_field<'a>(
+    field: &str,
+    indexes: &'a [IndexDef],
+) -> StrataResult<&'a IndexDef> {
     indexes
         .iter()
         .find(|idx| idx.field_path == field)

--- a/crates/engine/src/primitives/json/mod.rs
+++ b/crates/engine/src/primitives/json/mod.rs
@@ -1354,25 +1354,60 @@ impl crate::search::Searchable for JsonStore {
         &self,
         req: &crate::SearchRequest,
     ) -> strata_core::StrataResult<crate::SearchResponse> {
-        use crate::search::{EntityRef, SearchHit, SearchStats};
+        use crate::search::{EntityRef, SearchHit, SearchStats, SortDirection};
+        use std::collections::HashSet;
         use std::time::Instant;
 
         let start = Instant::now();
 
-        // If no field filter, return empty (text search via intelligence layer)
-        let filter = match &req.field_filter {
-            Some(f) => f,
-            None => return Ok(crate::SearchResponse::empty()),
-        };
+        // Need at least a field filter or sort_by to do anything
+        if req.field_filter.is_none() && req.sort_by.is_none() {
+            return Ok(crate::SearchResponse::empty());
+        }
 
         self.db.transaction(req.branch_id, |txn| {
             let indexes = Self::load_indexes(txn, &req.branch_id, &req.space)?;
-            let matching_doc_ids =
-                index::resolve_filter(txn, &req.branch_id, &req.space, filter, &indexes)?;
 
-            // Fetch documents and build hits
+            // Resolve field filter to candidate set (if present)
+            let filter_set: Option<HashSet<String>> = match &req.field_filter {
+                Some(filter) => Some(index::resolve_filter(
+                    txn,
+                    &req.branch_id,
+                    &req.space,
+                    filter,
+                    &indexes,
+                )?),
+                None => None,
+            };
+
+            // Determine ordered doc_ids
+            let ordered_doc_ids: Vec<String> = if let Some(sort) = &req.sort_by {
+                // Sort by indexed field: scan the index in order
+                let sort_idx = index::find_index_for_field(&sort.field, &indexes)?;
+                let mut sorted =
+                    index::scan_index_ordered(txn, &req.branch_id, &req.space, &sort_idx.name)?;
+
+                // If there's a filter, retain only matching docs (preserving sort order)
+                if let Some(ref fset) = filter_set {
+                    sorted.retain(|id| fset.contains(id));
+                }
+
+                if sort.direction == SortDirection::Desc {
+                    sorted.reverse();
+                }
+                sorted
+            } else {
+                // No sort — use filter set, sorted by doc_id for deterministic ordering
+                let mut ids: Vec<String> = filter_set.unwrap_or_default().into_iter().collect();
+                ids.sort();
+                ids
+            };
+
+            let total_matches = ordered_doc_ids.len();
+
+            // Fetch documents and build hits (take top-k from ordered list)
             let mut hits: Vec<SearchHit> = Vec::new();
-            for doc_id in &matching_doc_ids {
+            for doc_id in ordered_doc_ids.iter().take(req.k) {
                 let key = self.key_for(&req.branch_id, &req.space, doc_id);
                 if let Some(stored) = txn.get(&key)? {
                     let doc = Self::deserialize_doc(&stored)?;
@@ -1385,26 +1420,12 @@ impl crate::search::Searchable for JsonStore {
                             branch_id: req.branch_id,
                             doc_id: doc_id.clone(),
                         },
-                        score: 1.0, // Binary match score for field filters
-                        rank: 0,    // Set below
+                        score: 1.0,
+                        rank: 0,
                         snippet: Some(snippet),
                     });
                 }
             }
-
-            // Sort by doc_id for deterministic ordering, then take top-k
-            hits.sort_by(|a, b| {
-                let a_key = match &a.doc_ref {
-                    EntityRef::Json { doc_id, .. } => doc_id.as_str(),
-                    _ => "",
-                };
-                let b_key = match &b.doc_ref {
-                    EntityRef::Json { doc_id, .. } => doc_id.as_str(),
-                    _ => "",
-                };
-                a_key.cmp(b_key)
-            });
-            hits.truncate(req.k);
 
             // Assign ranks
             for (i, hit) in hits.iter_mut().enumerate() {
@@ -1412,12 +1433,12 @@ impl crate::search::Searchable for JsonStore {
             }
 
             let elapsed = start.elapsed().as_micros() as u64;
-            let mut stats = SearchStats::new(elapsed, matching_doc_ids.len());
+            let mut stats = SearchStats::new(elapsed, total_matches);
             stats = stats.with_index_used(true);
 
             Ok(crate::SearchResponse {
                 hits,
-                truncated: matching_doc_ids.len() > req.k,
+                truncated: total_matches > req.k,
                 stats,
             })
         })

--- a/crates/engine/src/search/mod.rs
+++ b/crates/engine/src/search/mod.rs
@@ -28,5 +28,5 @@ pub use searchable::{
 pub use tokenizer::{tokenize, tokenize_unique};
 pub use types::{
     EntityRef, FieldFilter, FieldPredicate, PrimitiveType, SearchBudget, SearchHit, SearchMode,
-    SearchRequest, SearchResponse, SearchStats,
+    SearchRequest, SearchResponse, SearchStats, SortDirection, SortSpec,
 };

--- a/crates/engine/src/search/types.rs
+++ b/crates/engine/src/search/types.rs
@@ -175,6 +175,11 @@ pub struct SearchRequest {
     /// Optional: field filter for secondary index queries on JsonStore.
     /// When present, only documents matching the filter are returned.
     pub field_filter: Option<FieldFilter>,
+
+    /// Optional: sort results by an indexed field instead of by score.
+    /// The field must have a secondary index. When set, results are returned
+    /// in index order rather than sorted by doc_id or score.
+    pub sort_by: Option<SortSpec>,
 }
 
 impl SearchRequest {
@@ -202,12 +207,22 @@ impl SearchRequest {
             space: "default".to_string(),
             snapshot_version: None,
             field_filter: None,
+            sort_by: None,
         }
     }
 
     /// Builder: set field filter for secondary index queries
     pub fn with_field_filter(mut self, filter: FieldFilter) -> Self {
         self.field_filter = Some(filter);
+        self
+    }
+
+    /// Builder: sort results by an indexed field
+    pub fn with_sort_by(mut self, field: impl Into<String>, direction: SortDirection) -> Self {
+        self.sort_by = Some(SortSpec {
+            field: field.into(),
+            direction,
+        });
         self
     }
 
@@ -467,6 +482,30 @@ pub enum FieldFilter {
     Predicate(FieldPredicate),
     /// All sub-filters must match (intersection)
     And(Vec<FieldFilter>),
+    /// Any sub-filter must match (union)
+    Or(Vec<FieldFilter>),
+}
+
+// ============================================================================
+// Sort Specification
+// ============================================================================
+
+/// Sort direction for index-backed ordering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortDirection {
+    /// Ascending (smallest first)
+    Asc,
+    /// Descending (largest first)
+    Desc,
+}
+
+/// Specification for sorting search results by an indexed field.
+#[derive(Debug, Clone)]
+pub struct SortSpec {
+    /// Field path to sort by (must have a secondary index)
+    pub field: String,
+    /// Sort direction
+    pub direction: SortDirection,
 }
 
 // ============================================================================

--- a/tests/engine/primitives/jsonstore.rs
+++ b/tests/engine/primitives/jsonstore.rs
@@ -1089,7 +1089,9 @@ fn create_index_invalid_name_rejected() {
 // Search via Searchable Trait (Epic 2)
 // ============================================================================
 
-use strata_engine::search::{FieldFilter, FieldPredicate, SearchRequest, Searchable};
+use strata_engine::search::{
+    FieldFilter, FieldPredicate, SearchRequest, Searchable, SortDirection,
+};
 
 fn setup_products(test_db: &TestDb) -> JsonStore {
     let json = test_db.json();
@@ -1402,4 +1404,146 @@ fn search_text_prefix() {
     let ids = search_doc_ids(&json, &req);
     // "wire" matches "wireless mouse" and "wired keyboard" (lowercased)
     assert_eq!(ids, vec!["d1", "d2"]);
+}
+
+// ============================================================================
+// Epic 3: OR Filters and Sort-by-Indexed-Field
+// ============================================================================
+
+#[test]
+fn search_or_filter() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    // status:active OR status:pending
+    let req = SearchRequest::new(test_db.branch_id, "").with_field_filter(FieldFilter::Or(vec![
+        FieldFilter::Predicate(FieldPredicate::Eq {
+            field: "$.status".to_string(),
+            value: json!("active").into(),
+        }),
+        FieldFilter::Predicate(FieldPredicate::Eq {
+            field: "$.status".to_string(),
+            value: json!("pending").into(),
+        }),
+    ]));
+
+    let ids = search_doc_ids(&json, &req);
+    // active: p1, p2, p4; pending: p3 → union sorted by doc_id
+    assert_eq!(ids, vec!["p1", "p2", "p3", "p4"]);
+}
+
+#[test]
+fn search_or_and_compound() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    // (status:active OR status:pending) AND price:[20, 60]
+    let req = SearchRequest::new(test_db.branch_id, "").with_field_filter(FieldFilter::And(vec![
+        FieldFilter::Or(vec![
+            FieldFilter::Predicate(FieldPredicate::Eq {
+                field: "$.status".to_string(),
+                value: json!("active").into(),
+            }),
+            FieldFilter::Predicate(FieldPredicate::Eq {
+                field: "$.status".to_string(),
+                value: json!("pending").into(),
+            }),
+        ]),
+        FieldFilter::Predicate(FieldPredicate::Range {
+            field: "$.price".to_string(),
+            lower: Some(json!(20.0).into()),
+            upper: Some(json!(60.0).into()),
+            lower_inclusive: true,
+            upper_inclusive: true,
+        }),
+    ]));
+
+    let ids = search_doc_ids(&json, &req);
+    // (active|pending) = {p1,p2,p3,p4}, price [20,60] = {p2,p3} → intersection
+    assert_eq!(ids, vec!["p2", "p3"]);
+}
+
+#[test]
+fn search_sort_by_price_asc() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    // All active, sorted by price ascending
+    let req = SearchRequest::new(test_db.branch_id, "")
+        .with_field_filter(FieldFilter::Predicate(FieldPredicate::Eq {
+            field: "$.status".to_string(),
+            value: json!("active").into(),
+        }))
+        .with_sort_by("$.price", SortDirection::Asc);
+
+    let ids = search_doc_ids(&json, &req);
+    // active: p1 (10), p2 (25), p4 (75) — sorted by price asc
+    assert_eq!(ids, vec!["p1", "p2", "p4"]);
+}
+
+#[test]
+fn search_sort_by_price_desc() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    // All active, sorted by price descending
+    let req = SearchRequest::new(test_db.branch_id, "")
+        .with_field_filter(FieldFilter::Predicate(FieldPredicate::Eq {
+            field: "$.status".to_string(),
+            value: json!("active").into(),
+        }))
+        .with_sort_by("$.price", SortDirection::Desc);
+
+    let ids = search_doc_ids(&json, &req);
+    // active: p4 (75), p2 (25), p1 (10) — sorted by price desc
+    assert_eq!(ids, vec!["p4", "p2", "p1"]);
+}
+
+#[test]
+fn search_sort_only_no_filter() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    // Sort all docs by price, no filter
+    let req = SearchRequest::new(test_db.branch_id, "").with_sort_by("$.price", SortDirection::Asc);
+
+    let ids = search_doc_ids(&json, &req);
+    // All 5 docs sorted by price: 10, 25, 50, 75, 100
+    assert_eq!(ids, vec!["p1", "p2", "p3", "p4", "p5"]);
+}
+
+#[test]
+fn search_sort_with_top_k() {
+    let test_db = TestDb::new();
+    let json = setup_products(&test_db);
+
+    // Sort by price desc, take top 2
+    let req = SearchRequest::new(test_db.branch_id, "")
+        .with_k(2)
+        .with_sort_by("$.price", SortDirection::Desc);
+
+    let response = json.search(&req).unwrap();
+    let ids: Vec<String> = response
+        .hits
+        .iter()
+        .map(|h| h.doc_ref.json_doc_id().unwrap().to_string())
+        .collect();
+    // Top 2 by price desc: p5 (100), p4 (75)
+    assert_eq!(ids, vec!["p5", "p4"]);
+    assert!(response.truncated);
+    assert_eq!(response.hits[0].rank, 1);
+    assert_eq!(response.hits[1].rank, 2);
+}
+
+#[test]
+fn search_sort_no_index_error() {
+    let test_db = TestDb::new();
+    let json = test_db.json();
+
+    // Sort by a field with no index
+    let req =
+        SearchRequest::new(test_db.branch_id, "").with_sort_by("$.nonexistent", SortDirection::Asc);
+
+    let result = json.search(&req);
+    assert!(result.is_err());
 }


### PR DESCRIPTION
## Summary
- Adds `Or(Vec<FieldFilter>)` variant for union-based compound queries (e.g., `status:active OR status:pending`)
- Adds `SortSpec` (field + Asc/Desc) and `sort_by` on `SearchRequest` for index-ordered results
- JsonStore Searchable iterates the sort index in KV-layer order, intersects with filter set — no post-hoc sort needed
- Sort-only queries (no filter) supported: returns all docs in index order
- Unified ranking (3.3) intentionally deferred — will be handled at the search layer

## Design
- OR = union of doc_id sets from sub-filters; composes with AND for `(A OR B) AND C`
- Sort uses `scan_index_ordered()` which leverages the KV layer's byte-order guarantee from Epic 1's order-preserving encoding
- Desc reverses the ordered list; top-k truncates before fetching documents (efficient)
- `find_index_for_field` made public for sort index validation

## Test plan
- [x] 7 new tests: OR filter, OR+AND compound, sort asc/desc, sort-only (no filter), sort + top-k pagination, sort no-index error
- [x] 12 existing Epic 2 tests pass unchanged
- [x] Full engine suite (229 tests) zero regressions
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)