### PR TITLE
Fix #1749: Surface corruption errors in scan and history paths

### DIFF
--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -442,6 +442,7 @@ impl KVSegment {
             block_data: None,
             done,
             prev_key: Vec::new(),
+            corruption_detected: false,
         }
     }
 
@@ -723,6 +724,7 @@ impl KVSegment {
             block_data: None,
             done: self.index.is_empty(),
             prev_key: Vec::new(),
+            corruption_detected: false,
         }
     }
 }
@@ -902,6 +904,15 @@ pub struct SegmentIter<'a> {
     done: bool,
     /// Buffer for v4 prefix-compressed key reconstruction (reused across entries).
     prev_key: Vec<u8>,
+    /// Set to true if iteration was stopped by a corruption error (#1749).
+    corruption_detected: bool,
+}
+
+impl SegmentIter<'_> {
+    /// Returns true if iteration was stopped early due to data block corruption.
+    pub fn corruption_detected(&self) -> bool {
+        self.corruption_detected
+    }
 }
 
 impl<'a> Iterator for SegmentIter<'a> {
@@ -932,6 +943,7 @@ impl<'a> Iterator for SegmentIter<'a> {
                     }
                     Err(e) => {
                         tracing::error!(error = %e, "segment iterator stopping due to corruption");
+                        self.corruption_detected = true;
                         self.done = true;
                         return None;
                     }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -31,7 +31,7 @@ use std::time::Duration;
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{BranchId, Key, TypeTag};
 use strata_core::value::Value;
-use strata_core::{StrataResult, Timestamp, VersionedValue};
+use strata_core::{StrataError, StrataResult, Timestamp, VersionedValue};
 
 // ---------------------------------------------------------------------------
 // Level configuration constants
@@ -1698,7 +1698,7 @@ impl SegmentedStore {
             Some(b) => b,
             None => return Ok(None),
         };
-        let all_versions = Self::get_all_versions_from_branch(&branch, key);
+        let all_versions = Self::get_all_versions_from_branch(&branch, key)?;
         for (commit_id, entry) in all_versions {
             if entry.timestamp.as_micros() > max_timestamp {
                 continue;
@@ -1746,10 +1746,16 @@ impl SegmentedStore {
                 if !segment_overlaps_prefix(seg, &prefix_bytes) {
                     continue;
                 }
-                let entries: Vec<_> = seg
-                    .iter_seek(prefix)
+                let mut iter = seg.iter_seek(prefix);
+                let entries: Vec<_> = iter
+                    .by_ref()
                     .map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se)))
                     .collect();
+                if iter.corruption_detected() {
+                    return Err(StrataError::corruption(
+                        "segment scan stopped due to data block corruption",
+                    ));
+                }
                 sources.push(Box::new(entries.into_iter()));
             }
         }
@@ -1766,10 +1772,16 @@ impl SegmentedStore {
                     if !segment_overlaps_prefix(seg, &src_prefix_bytes) {
                         continue;
                     }
-                    let entries: Vec<_> = seg
-                        .iter_seek(&src_prefix)
+                    let mut iter = seg.iter_seek(&src_prefix);
+                    let entries: Vec<_> = iter
+                        .by_ref()
                         .map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se)))
                         .collect();
+                    if iter.corruption_detected() {
+                        return Err(StrataError::corruption(
+                            "segment scan stopped due to data block corruption",
+                        ));
+                    }
                     sources.push(Box::new(RewritingIterator::new(
                         entries.into_iter(),
                         prefix.namespace.branch_id,
@@ -2771,7 +2783,10 @@ impl SegmentedStore {
     }
 
     /// Collect all versions of a key across all sources in a branch.
-    fn get_all_versions_from_branch(branch: &BranchState, key: &Key) -> Vec<(u64, MemtableEntry)> {
+    fn get_all_versions_from_branch(
+        branch: &BranchState,
+        key: &Key,
+    ) -> StrataResult<Vec<(u64, MemtableEntry)>> {
         let mut all_versions = Vec::new();
 
         // Active memtable
@@ -2787,11 +2802,17 @@ impl SegmentedStore {
         let ver = branch.version.load();
         for level in &ver.levels {
             for seg in level {
-                for (ik, se) in seg.iter_seek(key) {
+                let mut iter = seg.iter_seek(key);
+                for (ik, se) in iter.by_ref() {
                     if ik.typed_key_prefix() != typed_key.as_slice() {
                         break;
                     }
                     all_versions.push((se.commit_id, segment_entry_to_memtable_entry(se)));
+                }
+                if iter.corruption_detected() {
+                    return Err(StrataError::corruption(
+                        "segment scan stopped due to data block corruption",
+                    ));
                 }
             }
         }
@@ -2805,13 +2826,19 @@ impl SegmentedStore {
             let src_typed_key = encode_typed_key(&src_key);
             for level in &layer.segments.levels {
                 for seg in level {
-                    for (ik, se) in seg.iter_seek(&src_key) {
+                    let mut iter = seg.iter_seek(&src_key);
+                    for (ik, se) in iter.by_ref() {
                         if ik.typed_key_prefix() != src_typed_key.as_slice() {
                             break;
                         }
                         if se.commit_id <= layer.fork_version {
                             all_versions.push((se.commit_id, segment_entry_to_memtable_entry(se)));
                         }
+                    }
+                    if iter.corruption_detected() {
+                        return Err(StrataError::corruption(
+                            "segment scan stopped due to data block corruption",
+                        ));
                     }
                 }
             }
@@ -2822,7 +2849,7 @@ impl SegmentedStore {
         // (from WAL replay) and segments (from disk), producing duplicates (#1733).
         all_versions.sort_by(|a, b| b.0.cmp(&a.0));
         all_versions.dedup_by_key(|entry| entry.0);
-        all_versions
+        Ok(all_versions)
     }
 
     /// Build an MVCC-deduplicated prefix scan across all sources in a branch.
@@ -2830,7 +2857,7 @@ impl SegmentedStore {
         branch: &BranchState,
         prefix: &Key,
         max_version: u64,
-    ) -> Vec<(Key, VersionedValue)> {
+    ) -> StrataResult<Vec<(Key, VersionedValue)>> {
         let mut sources: Vec<Box<dyn Iterator<Item = (InternalKey, MemtableEntry)>>> = Vec::new();
 
         // Active memtable
@@ -2853,10 +2880,16 @@ impl SegmentedStore {
                 if !segment_overlaps_prefix(seg, &prefix_bytes) {
                     continue;
                 }
-                let entries: Vec<_> = seg
-                    .iter_seek(prefix)
+                let mut iter = seg.iter_seek(prefix);
+                let entries: Vec<_> = iter
+                    .by_ref()
                     .map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se)))
                     .collect();
+                if iter.corruption_detected() {
+                    return Err(StrataError::corruption(
+                        "segment scan stopped due to data block corruption",
+                    ));
+                }
                 sources.push(Box::new(entries.into_iter()));
             }
         }
@@ -2873,10 +2906,16 @@ impl SegmentedStore {
                     if !segment_overlaps_prefix(seg, &src_prefix_bytes) {
                         continue;
                     }
-                    let entries: Vec<_> = seg
-                        .iter_seek(&src_prefix)
+                    let mut iter = seg.iter_seek(&src_prefix);
+                    let entries: Vec<_> = iter
+                        .by_ref()
                         .map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se)))
                         .collect();
+                    if iter.corruption_detected() {
+                        return Err(StrataError::corruption(
+                            "segment scan stopped due to data block corruption",
+                        ));
+                    }
                     sources.push(Box::new(RewritingIterator::new(
                         entries.into_iter(),
                         prefix.namespace.branch_id,
@@ -2889,14 +2928,15 @@ impl SegmentedStore {
         let merge = MergeIterator::new(sources);
         let mvcc = MvccIterator::new(merge, max_version);
 
-        mvcc.filter_map(|(ik, entry)| {
-            if entry.is_tombstone || entry.is_expired() {
-                return None;
-            }
-            let (key, commit_id) = ik.decode()?;
-            Some((key, entry.to_versioned(commit_id)))
-        })
-        .collect()
+        Ok(mvcc
+            .filter_map(|(ik, entry)| {
+                if entry.is_tombstone || entry.is_expired() {
+                    return None;
+                }
+                let (key, commit_id) = ik.decode()?;
+                Some((key, entry.to_versioned(commit_id)))
+            })
+            .collect())
     }
 
     /// Write the manifest file for a branch, reflecting current level assignments
@@ -3064,7 +3104,7 @@ impl Storage for SegmentedStore {
             None => return Ok(Vec::new()),
         };
 
-        let all_versions = Self::get_all_versions_from_branch(&branch, key);
+        let all_versions = Self::get_all_versions_from_branch(&branch, key)?;
 
         let results: Vec<VersionedValue> = all_versions
             .into_iter()
@@ -3099,7 +3139,7 @@ impl Storage for SegmentedStore {
             None => return Ok(Vec::new()),
         };
 
-        Ok(Self::scan_prefix_from_branch(&branch, prefix, max_version))
+        Self::scan_prefix_from_branch(&branch, prefix, max_version)
     }
 
     fn current_version(&self) -> u64 {

--- a/crates/storage/src/segmented/tests/basic.rs
+++ b/crates/storage/src/segmented/tests/basic.rs
@@ -568,3 +568,99 @@ fn list_branch_nonexistent_branch() {
         .list_branch(&BranchId::from_bytes([99; 16]))
         .is_empty());
 }
+
+/// Issue #1749: scan_prefix must return an error (not silently truncated results)
+/// when a segment data block is corrupt.
+#[test]
+fn test_issue_1749_scan_prefix_returns_error_on_corruption() {
+    use crate::segment_builder::HEADER_SIZE;
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    // Insert entries and flush to a segment on disk.
+    seed(&store, kv_key("item_a"), Value::Int(1), 1);
+    seed(&store, kv_key("item_b"), Value::Int(2), 2);
+    seed(&store, kv_key("item_c"), Value::Int(3), 3);
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+
+    // Find the .sst file on disk.
+    let branch_dir = dir.path().join(hex_encode_branch(&b));
+    let sst_files: Vec<_> = std::fs::read_dir(&branch_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "sst"))
+        .collect();
+    assert_eq!(sst_files.len(), 1, "expected exactly one segment file");
+    let sst_path = sst_files[0].path();
+
+    // Read the segment file and corrupt the first data block's CRC.
+    // Frame layout: type(1) + codec(1) + reserved(2) + data_len(4) + data(N) + crc(4)
+    let data = std::fs::read(&sst_path).unwrap();
+    let data_len =
+        u32::from_le_bytes(data[HEADER_SIZE + 4..HEADER_SIZE + 8].try_into().unwrap()) as usize;
+    let crc_offset = HEADER_SIZE + 8 + data_len;
+    let mut corrupt = data.clone();
+    corrupt[crc_offset] ^= 0xFF; // flip a CRC byte
+    std::fs::write(&sst_path, &corrupt).unwrap();
+
+    // Re-open the store so it loads the corrupt segment file.
+    drop(store);
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    store2.recover_segments().unwrap();
+
+    // scan_prefix MUST return Err, not a silently truncated Vec.
+    let prefix = Key::new(ns(), TypeTag::KV, "item_".as_bytes().to_vec());
+    let result = store2.scan_prefix(&prefix, u64::MAX);
+    assert!(
+        result.is_err(),
+        "scan_prefix must return Err on corrupt segment, got {} entries",
+        result.unwrap().len(),
+    );
+}
+
+/// Issue #1749: get_history must return an error on segment corruption.
+#[test]
+fn test_issue_1749_get_history_returns_error_on_corruption() {
+    use crate::segment_builder::HEADER_SIZE;
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    seed(&store, kv_key("mykey"), Value::Int(10), 1);
+    seed(&store, kv_key("mykey"), Value::Int(20), 2);
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+
+    let branch_dir = dir.path().join(hex_encode_branch(&b));
+    let sst_files: Vec<_> = std::fs::read_dir(&branch_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "sst"))
+        .collect();
+    assert_eq!(sst_files.len(), 1);
+    let sst_path = sst_files[0].path();
+
+    let data = std::fs::read(&sst_path).unwrap();
+    let data_len =
+        u32::from_le_bytes(data[HEADER_SIZE + 4..HEADER_SIZE + 8].try_into().unwrap()) as usize;
+    let crc_offset = HEADER_SIZE + 8 + data_len;
+    let mut corrupt = data.clone();
+    corrupt[crc_offset] ^= 0xFF;
+    std::fs::write(&sst_path, &corrupt).unwrap();
+
+    drop(store);
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    store2.recover_segments().unwrap();
+
+    // get_history MUST return Err, not silently truncated results.
+    let result = store2.get_history(&kv_key("mykey"), None, None);
+    assert!(
+        result.is_err(),
+        "get_history must return Err on corrupt segment, got {} entries",
+        result.unwrap().len(),
+    );
+}


### PR DESCRIPTION
## Summary

- `SegmentIter` silently returned `None` on data block corruption (CRC mismatch, decompression failure), causing `scan_prefix`, `get_history`, and `get_at_timestamp` to return truncated results with no error signal
- Added `corruption_detected` flag to `SegmentIter` (mirrors `OwnedSegmentIter` pattern from PR #1747)
- Propagated corruption errors through `scan_prefix_from_branch`, `get_all_versions_from_branch`, and `scan_prefix_at_timestamp`

## Root Cause

`SegmentIter` implements `Iterator<Item = (InternalKey, SegmentEntry)>` — when `read_data_block()` returns `Err`, the iterator had no choice but to return `None`. Callers collected partial results without knowing data was missing.

## Fix

1. Added `corruption_detected: bool` field to `SegmentIter`, set when `load_next_block()` fails
2. Used `iter.by_ref()` pattern to check the flag after collecting entries
3. Changed `scan_prefix_from_branch` and `get_all_versions_from_branch` return types to `StrataResult<Vec<...>>`
4. Propagated errors through `scan_prefix`, `get_history`, `get_at_timestamp`, `scan_prefix_at_timestamp`

## Invariants Verified

- **LSM-003**: Source ordering preserved (active → frozen → L0-L6 → inherited)
- **COW-003**: Fork version gate unchanged (RewritingIterator + commit_id filter)
- **MVCC-001**: MvccIterator max_version filtering unchanged
- **MVCC-002**: Tombstone filtering unchanged
- **ARCH-003**: Strengthened — corruption is now surfaced rather than hidden

## Test Plan

- [x] `test_issue_1749_scan_prefix_returns_error_on_corruption` — corrupts segment CRC, verifies `scan_prefix` returns `Err`
- [x] `test_issue_1749_get_history_returns_error_on_corruption` — corrupts segment CRC, verifies `get_history` returns `Err`
- [x] Full storage crate suite (624 tests pass)
- [x] Full workspace suite (all pass, one pre-existing flaky timing test)
- [x] Clippy clean, fmt clean
- [x] Invariant check: all 5 affected invariants HOLD

🤖 Generated with [Claude Code](https://claude.com/claude-code)