### PR TITLE
Fix #1577: Add length CRC to WAL record framing (torn write protection)

### DIFF
--- a/crates/durability/src/format/wal_record.rs
+++ b/crates/durability/src/format/wal_record.rs
@@ -16,18 +16,20 @@
 //! └────────────────────────────────────┘
 //! ```
 //!
-//! # Record Layout
+//! # Record Layout (v2, issue #1577)
 //!
 //! ```text
-//! ┌─────────────────┬──────────────────┬─────────────────────────┬──────────┐
-//! │ Length (4 bytes)│ Format Ver (1)   │ Payload (variable)      │ CRC32 (4)│
-//! └─────────────────┴──────────────────┴─────────────────────────┴──────────┘
+//! ┌──────────┬──────────────┬──────────────┬──────────────────────┬──────────┐
+//! │ Len (4B) │ FmtVer=2 (1) │ LenCRC (4B) │ Payload (variable)  │ CRC32 (4)│
+//! └──────────┴──────────────┴──────────────┴──────────────────────┴──────────┘
 //!
 //! Payload:
 //! ┌──────────────┬──────────────┬──────────────┬─────────────────────────────┐
 //! │ TxnId (8)    │ BranchId (16)   │ Timestamp (8)│ Writeset (variable)         │
 //! └──────────────┴──────────────┴──────────────┴─────────────────────────────┘
 //! ```
+//!
+//! v1 records (FmtVer=1) lack the LenCRC field and are still readable.
 
 use crc32fast::Hasher;
 use std::fs::{File, OpenOptions};
@@ -46,8 +48,8 @@ pub const SEGMENT_HEADER_SIZE: usize = 32;
 /// Size of v2 segment header in bytes (with CRC32)
 pub const SEGMENT_HEADER_SIZE_V2: usize = 36;
 
-/// Current WAL record format version
-pub const WAL_RECORD_FORMAT_VERSION: u8 = 1;
+/// Current WAL record format version (v2 adds length CRC — see issue #1577)
+pub const WAL_RECORD_FORMAT_VERSION: u8 = 2;
 
 /// WAL segment header (32 bytes for v1, 36 bytes for v2).
 ///
@@ -536,25 +538,35 @@ impl WalRecord {
 
     /// Serialize record to bytes (for writing to WAL).
     ///
-    /// Format: length (4) + format_version (1) + payload + crc32 (4)
+    /// v2 format: length (4) + format_version=2 (1) + length_crc (4) + payload + crc32 (4)
     ///
-    /// The length field contains the size of (format_version + payload + crc32).
+    /// The length field contains the size of everything after it.
+    /// The length_crc protects the length field against torn writes (issue #1577).
+    /// The main CRC covers format_version + length_crc + txn_id + branch_id + timestamp + writeset.
     pub fn to_bytes(&self) -> Vec<u8> {
-        // Build payload: format_version + txn_id + branch_id + timestamp + writeset
-        let mut payload = Vec::with_capacity(33 + self.writeset.len());
-        payload.push(WAL_RECORD_FORMAT_VERSION);
+        // Build inner payload: format_version + [placeholder for length_crc] + fields
+        let mut payload = Vec::with_capacity(37 + self.writeset.len());
+        payload.push(WAL_RECORD_FORMAT_VERSION); // 1 byte: version = 2
+        payload.extend_from_slice(&[0u8; 4]); // 4 bytes: placeholder for length_crc
         payload.extend_from_slice(&self.txn_id.to_le_bytes());
         payload.extend_from_slice(&self.branch_id);
         payload.extend_from_slice(&self.timestamp.to_le_bytes());
         payload.extend_from_slice(&self.writeset);
 
-        // Calculate CRC32 of payload
+        // Total length = payload + main CRC
+        let total_len = payload.len() + 4;
+        let length_bytes = (total_len as u32).to_le_bytes();
+
+        // Fill in the length CRC (CRC32 of the 4-byte length field)
+        let length_crc = Self::compute_crc(&length_bytes);
+        payload[1..5].copy_from_slice(&length_crc.to_le_bytes());
+
+        // Main CRC covers the full payload (version + length_crc + fields)
         let crc = Self::compute_crc(&payload);
 
         // Build final record: length + payload + crc
-        let total_len = payload.len() + 4; // payload + crc
         let mut record = Vec::with_capacity(4 + total_len);
-        record.extend_from_slice(&(total_len as u32).to_le_bytes());
+        record.extend_from_slice(&length_bytes);
         record.extend_from_slice(&payload);
         record.extend_from_slice(&crc.to_le_bytes());
 
@@ -563,9 +575,11 @@ impl WalRecord {
 
     /// Deserialize record from bytes.
     ///
+    /// Handles both v1 (no length CRC) and v2 (with length CRC) formats.
     /// Returns (record, bytes_consumed) on success.
     pub fn from_bytes(bytes: &[u8]) -> Result<(Self, usize), WalRecordError> {
-        if bytes.len() < 4 {
+        // Need at least 5 bytes: 4 (length) + 1 (format_version)
+        if bytes.len() < 5 {
             return Err(WalRecordError::InsufficientData);
         }
 
@@ -576,54 +590,106 @@ impl WalRecord {
             return Err(WalRecordError::InvalidFormat);
         }
 
-        if bytes.len() < 4 + length {
+        // Peek at format version byte (always at offset 4, both v1 and v2)
+        let format_version = bytes[4];
+
+        if format_version == 2 {
+            // v2: verify length CRC BEFORE trusting the length field
+            if bytes.len() < 9 {
+                return Err(WalRecordError::InsufficientData);
+            }
+            let stored_length_crc = u32::from_le_bytes(bytes[5..9].try_into().unwrap());
+            let computed_length_crc = Self::compute_crc(&bytes[0..4]);
+            if stored_length_crc != computed_length_crc {
+                return Err(WalRecordError::LengthChecksumMismatch);
+            }
+        }
+
+        // Now trust the length (saturating add guards against usize overflow on 32-bit)
+        let total = 4usize.saturating_add(length);
+        if bytes.len() < total {
             return Err(WalRecordError::InsufficientData);
         }
 
-        let payload_with_crc = &bytes[4..4 + length];
+        let payload_with_crc = &bytes[4..total];
 
-        if length < 5 {
-            // Minimum: 1 byte format version + 4 bytes CRC
-            return Err(WalRecordError::InvalidFormat);
+        if format_version == 2 {
+            // v2 minimum: 1 (version) + 4 (length_crc) + 4 (main CRC) = 9
+            if length < 9 {
+                return Err(WalRecordError::InvalidFormat);
+            }
+
+            // Split payload and CRC
+            let payload = &payload_with_crc[..length - 4];
+            let stored_crc = u32::from_le_bytes(payload_with_crc[length - 4..].try_into().unwrap());
+
+            // Verify main CRC (covers version + length_crc + fields)
+            let computed_crc = Self::compute_crc(payload);
+            if computed_crc != stored_crc {
+                return Err(WalRecordError::ChecksumMismatch {
+                    expected: stored_crc,
+                    computed: computed_crc,
+                });
+            }
+
+            // Parse v2 payload: skip version (1) + length_crc (4) = 5 bytes
+            // Minimum: 5 + 8 (txn_id) + 16 (branch_id) + 8 (timestamp) = 37
+            if payload.len() < 37 {
+                return Err(WalRecordError::InvalidFormat);
+            }
+
+            let txn_id = u64::from_le_bytes(payload[5..13].try_into().unwrap());
+            let branch_id: [u8; 16] = payload[13..29].try_into().unwrap();
+            let timestamp = u64::from_le_bytes(payload[29..37].try_into().unwrap());
+            let writeset = payload[37..].to_vec();
+
+            Ok((
+                WalRecord {
+                    txn_id,
+                    branch_id,
+                    timestamp,
+                    writeset,
+                },
+                4 + length,
+            ))
+        } else if format_version == 1 {
+            // v1: original format without length CRC
+            if length < 5 {
+                return Err(WalRecordError::InvalidFormat);
+            }
+
+            let payload = &payload_with_crc[..length - 4];
+            let stored_crc = u32::from_le_bytes(payload_with_crc[length - 4..].try_into().unwrap());
+
+            let computed_crc = Self::compute_crc(payload);
+            if computed_crc != stored_crc {
+                return Err(WalRecordError::ChecksumMismatch {
+                    expected: stored_crc,
+                    computed: computed_crc,
+                });
+            }
+
+            if payload.len() < 33 {
+                return Err(WalRecordError::InvalidFormat);
+            }
+
+            let txn_id = u64::from_le_bytes(payload[1..9].try_into().unwrap());
+            let branch_id: [u8; 16] = payload[9..25].try_into().unwrap();
+            let timestamp = u64::from_le_bytes(payload[25..33].try_into().unwrap());
+            let writeset = payload[33..].to_vec();
+
+            Ok((
+                WalRecord {
+                    txn_id,
+                    branch_id,
+                    timestamp,
+                    writeset,
+                },
+                4 + length,
+            ))
+        } else {
+            Err(WalRecordError::UnsupportedVersion(format_version))
         }
-
-        // Split payload and CRC
-        let payload = &payload_with_crc[..length - 4];
-        let stored_crc = u32::from_le_bytes(payload_with_crc[length - 4..].try_into().unwrap());
-
-        // Verify CRC
-        let computed_crc = Self::compute_crc(payload);
-        if computed_crc != stored_crc {
-            return Err(WalRecordError::ChecksumMismatch {
-                expected: stored_crc,
-                computed: computed_crc,
-            });
-        }
-
-        // Parse payload
-        // Minimum payload size: 1 (version) + 8 (txn_id) + 16 (branch_id) + 8 (timestamp) = 33
-        if payload.len() < 33 {
-            return Err(WalRecordError::InvalidFormat);
-        }
-
-        let format_version = payload[0];
-        if format_version != WAL_RECORD_FORMAT_VERSION {
-            return Err(WalRecordError::UnsupportedVersion(format_version));
-        }
-
-        let txn_id = u64::from_le_bytes(payload[1..9].try_into().unwrap());
-        let branch_id: [u8; 16] = payload[9..25].try_into().unwrap();
-        let timestamp = u64::from_le_bytes(payload[25..33].try_into().unwrap());
-        let writeset = payload[33..].to_vec();
-
-        let record = WalRecord {
-            txn_id,
-            branch_id,
-            timestamp,
-            writeset,
-        };
-
-        Ok((record, 4 + length))
     }
 
     /// Compute CRC32 checksum of data.
@@ -633,30 +699,9 @@ impl WalRecord {
         hasher.finalize()
     }
 
-    /// Verify the checksum of serialized record bytes.
+    /// Verify the checksum of serialized record bytes (delegates to from_bytes).
     pub fn verify_checksum(bytes: &[u8]) -> Result<(), WalRecordError> {
-        if bytes.len() < 4 {
-            return Err(WalRecordError::InsufficientData);
-        }
-
-        let length = u32::from_le_bytes(bytes[0..4].try_into().unwrap()) as usize;
-
-        if bytes.len() < 4 + length || length < 5 {
-            return Err(WalRecordError::InsufficientData);
-        }
-
-        let payload = &bytes[4..4 + length - 4];
-        let stored_crc = u32::from_le_bytes(bytes[4 + length - 4..4 + length].try_into().unwrap());
-        let computed_crc = Self::compute_crc(payload);
-
-        if computed_crc != stored_crc {
-            return Err(WalRecordError::ChecksumMismatch {
-                expected: stored_crc,
-                computed: computed_crc,
-            });
-        }
-
-        Ok(())
+        Self::from_bytes(bytes).map(|_| ())
     }
 }
 
@@ -683,6 +728,10 @@ pub enum WalRecordError {
     /// Unsupported format version
     #[error("Unsupported format version: {0}")]
     UnsupportedVersion(u8),
+
+    /// Length field checksum mismatch (torn write to length prefix — issue #1577)
+    #[error("Length field checksum mismatch (possible torn write)")]
+    LengthChecksumMismatch,
 }
 
 #[cfg(test)]
@@ -825,6 +874,43 @@ mod tests {
         let mut corrupted = bytes.clone();
         corrupted[10] ^= 0xFF;
         assert!(WalRecord::verify_checksum(&corrupted).is_err());
+    }
+
+    /// Issue #1577: v1 records (written before the length CRC change) must still
+    /// be readable by the new from_bytes so recovery of existing databases works.
+    #[test]
+    fn test_v1_wal_record_still_readable() {
+        // Manually construct a v1 record (format_version=1, no length_crc)
+        let txn_id: u64 = 42;
+        let branch_id = [0xAB; 16];
+        let timestamp: u64 = 9999;
+        let writeset = vec![1, 2, 3, 4, 5];
+
+        let mut payload = Vec::new();
+        payload.push(1u8); // format_version = 1
+        payload.extend_from_slice(&txn_id.to_le_bytes());
+        payload.extend_from_slice(&branch_id);
+        payload.extend_from_slice(&timestamp.to_le_bytes());
+        payload.extend_from_slice(&writeset);
+
+        let crc = {
+            let mut h = Hasher::new();
+            h.update(&payload);
+            h.finalize()
+        };
+        let total_len = (payload.len() + 4) as u32;
+
+        let mut record_bytes = Vec::new();
+        record_bytes.extend_from_slice(&total_len.to_le_bytes());
+        record_bytes.extend_from_slice(&payload);
+        record_bytes.extend_from_slice(&crc.to_le_bytes());
+
+        let (parsed, consumed) = WalRecord::from_bytes(&record_bytes).unwrap();
+        assert_eq!(parsed.txn_id, txn_id);
+        assert_eq!(parsed.branch_id, branch_id);
+        assert_eq!(parsed.timestamp, timestamp);
+        assert_eq!(parsed.writeset, writeset);
+        assert_eq!(consumed, record_bytes.len());
     }
 
     #[test]

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -100,7 +100,11 @@ impl WalReader {
                     stop_reason = ReadStopReason::PartialRecord;
                     break;
                 }
-                Err(WalRecordError::ChecksumMismatch { .. }) => {
+                Err(
+                    WalRecordError::ChecksumMismatch { .. }
+                    | WalRecordError::LengthChecksumMismatch
+                    | WalRecordError::UnsupportedVersion(_),
+                ) => {
                     if !self.allow_lossy_recovery {
                         // Strict mode (default): mid-segment corruption is fatal.
                         return Err(WalReaderError::CorruptedSegment {
@@ -1562,5 +1566,74 @@ mod tests {
         // Records 1-2 before corruption and 4-6 after should be present
         let txn_ids: Vec<u64> = lossy_records.iter().map(|r| r.txn_id).collect();
         assert_eq!(txn_ids, vec![1, 2, 4, 5, 6]);
+    }
+
+    /// Issue #1577: A torn write to the 4-byte length prefix produces a garbage
+    /// length. The reader trusts this length, skips forward past all remaining
+    /// valid records, hits InsufficientData, and stops — losing every record
+    /// after the corruption point.
+    ///
+    /// The fix adds a per-record length CRC (v2 format) so the reader detects
+    /// the bad length immediately and scans forward to find subsequent valid
+    /// records.
+    #[test]
+    fn test_issue_1577_torn_length_field_recovery() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+
+        // Write 6 valid records into a single segment
+        let records: Vec<_> = (1..=6)
+            .map(|i| WalRecord::new(i, [1u8; 16], i * 1000, vec![i as u8; 20]))
+            .collect();
+        write_records(&wal_dir, &records);
+
+        // Compute byte offsets to find record 3's position
+        let record_bytes: Vec<Vec<u8>> = records.iter().map(|r| r.to_bytes()).collect();
+        let offset_of_record_3: usize = record_bytes[0].len() + record_bytes[1].len();
+
+        // Corrupt record 3's LENGTH field to a huge value (simulating a torn write)
+        let segment_path = WalSegment::segment_path(&wal_dir, 1);
+        let mut seg_data = std::fs::read(&segment_path).unwrap();
+        let hdr_size = 36; // v2 segment header
+        let length_offset = hdr_size + offset_of_record_3;
+
+        // Overwrite the 4-byte length prefix with 0x7FFFFFFF (2GB — way past EOF)
+        seg_data[length_offset..length_offset + 4].copy_from_slice(&0x7FFF_FFFFu32.to_le_bytes());
+        std::fs::write(&segment_path, &seg_data).unwrap();
+
+        // Lossy reader must detect the bad length and scan forward to records 4-6.
+        // Before the fix: reader hits InsufficientData at the garbage length and
+        // stops, returning only records 1-2.
+        let lossy_reader = WalReader::new().with_lossy_recovery();
+        let (lossy_records, _, _, skipped) = lossy_reader.read_segment(&wal_dir, 1).unwrap();
+        assert!(skipped > 0, "Lossy reader should report skipped corruption");
+        let txn_ids: Vec<u64> = lossy_records.iter().map(|r| r.txn_id).collect();
+        assert_eq!(
+            txn_ids,
+            vec![1, 2, 4, 5, 6],
+            "Records after the torn length must be recovered"
+        );
+    }
+
+    /// Issue #1577: The length CRC in v2 records catches torn lengths that happen
+    /// to be "reasonable" (within segment bounds but pointing to the wrong offset).
+    #[test]
+    fn test_issue_1577_length_crc_catches_plausible_torn_length() {
+        let record = WalRecord::new(42, [1u8; 16], 99999, vec![1, 2, 3, 4, 5]);
+        let bytes = record.to_bytes();
+
+        // Corrupt only the length field to a plausible but wrong value
+        let mut corrupted = bytes.clone();
+        let original_length = u32::from_le_bytes(corrupted[0..4].try_into().unwrap());
+        let bad_length = original_length + 1; // off by one — plausible but wrong
+        corrupted[0..4].copy_from_slice(&bad_length.to_le_bytes());
+
+        // from_bytes must detect this via LengthChecksumMismatch (not just InsufficientData)
+        let result = WalRecord::from_bytes(&corrupted);
+        assert!(
+            matches!(result, Err(WalRecordError::LengthChecksumMismatch)),
+            "Expected LengthChecksumMismatch for corrupted length, got: {:?}",
+            result
+        );
     }
 }


### PR DESCRIPTION
## Summary

- WAL record CRC32 covered payload but **not** the 4-byte length prefix — a torn write to the length field caused the reader to skip past all subsequent valid records (cascade data loss)
- Added v2 WAL record format with a per-record **length CRC** verified before trusting the length field
- Reader now treats `LengthChecksumMismatch` and `UnsupportedVersion` as corruption (scan-forward in lossy mode, fatal in strict mode)

## Root Cause

`WalRecord::to_bytes()` computed CRC32 over `format_version + payload` but excluded the 4-byte length prefix. In `from_bytes()`, a garbage length (from a torn write) caused `InsufficientData` — treated as a partial record at EOF — silently losing all records after the corruption point.

## Fix

**v2 record format** (`WAL_RECORD_FORMAT_VERSION = 2`):
```
length(4B) | fmt_ver=2(1B) | length_crc(4B) | payload(var) | main_crc(4B)
```

- `length_crc = CRC32(length_bytes)` — verified at bytes[5..9] before trusting the length
- `main_crc` covers `fmt_ver + length_crc + payload` (unchanged scope for v1 compat)
- v1 records (`fmt_ver=1`) remain fully readable — backward compatible
- Fixed latent `usize` overflow on 32-bit targets (`4 + length` → `saturating_add`)

## Invariants Verified

- **ACID-001**: Partial records detected by CRC — now includes torn length detection
- **ACID-005**: Recovery replay idempotency — unaffected (same record extraction)
- **ARCH-004**: Deterministic recovery — corruption detection improved, not weakened
- **SCALE-003**: On-disk format portability — all new fields use `u32` LE

## Test Plan

- [x] `test_issue_1577_torn_length_field_recovery` — corrupt length to 2GB, verify lossy reader recovers records 4-6
- [x] `test_issue_1577_length_crc_catches_plausible_torn_length` — corrupt length by +1, verify `LengthChecksumMismatch` (not `InsufficientData`)
- [x] `test_v1_wal_record_still_readable` — manually construct v1 record, verify new `from_bytes` parses it correctly
- [x] Full crate suite: 394 passed, 0 failed
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)