### PR TITLE
Fix #1572: Hold per-collection write lock in delete() to prevent TOCTOU race

### DIFF
--- a/crates/vector/src/store/crud.rs
+++ b/crates/vector/src/store/crud.rs
@@ -289,8 +289,14 @@ impl VectorStore {
         let collection_id = CollectionId::new(branch_id, collection);
         let kv_key = Key::new_vector(self.namespace_for(branch_id, space), collection, key);
 
-        // Hold per-collection lock for entire check-then-delete (mirrors insert_inner fix #936)
+        // Hold per-collection write lock for entire check-then-delete to prevent
+        // TOCTOU race with concurrent insert (fixes #1572, mirrors insert_inner #936).
         let state = self.state()?;
+        let mut backend = state.backends.get_mut(&collection_id).ok_or_else(|| {
+            VectorError::CollectionNotFound {
+                name: collection.to_string(),
+            }
+        })?;
 
         let Some(record) = self.get_vector_record_by_key(&kv_key)? else {
             return Ok(false);
@@ -305,15 +311,13 @@ impl VectorStore {
 
         // Backend after KV succeeds. Non-fatal since KV is already deleted and
         // search verifies KV existence for candidates (Issue #1731).
-        if let Some(mut backend) = state.backends.get_mut(&collection_id) {
-            match backend.delete_with_timestamp(vector_id, now_micros()) {
-                Ok(_) => {
-                    backend.remove_inline_meta(vector_id);
-                }
-                Err(e) => {
-                    warn!(target: "strata::vector", collection, key, error = %e,
-                        "Backend delete failed after KV delete; search will filter via KV check");
-                }
+        match backend.delete_with_timestamp(vector_id, now_micros()) {
+            Ok(_) => {
+                backend.remove_inline_meta(vector_id);
+            }
+            Err(e) => {
+                warn!(target: "strata::vector", collection, key, error = %e,
+                    "Backend delete failed after KV delete; search will filter via KV check");
             }
         }
 
@@ -461,11 +465,13 @@ impl VectorStore {
         let version = self.db.storage().version();
 
         let state = self.state()?;
-        let backend = state.backends.get(&collection_id).ok_or_else(|| {
-            VectorError::CollectionNotFound {
-                name: collection.to_string(),
-            }
-        })?;
+        let backend =
+            state
+                .backends
+                .get(&collection_id)
+                .ok_or_else(|| VectorError::CollectionNotFound {
+                    name: collection.to_string(),
+                })?;
 
         let mut results = Vec::with_capacity(keys.len());
         for key in keys {
@@ -541,8 +547,14 @@ impl VectorStore {
 
         let collection_id = CollectionId::new(branch_id, collection);
 
-        // Hold per-collection lock for entire batch
+        // Hold per-collection write lock for entire check-then-delete batch to
+        // prevent TOCTOU race with concurrent insert (fixes #1572).
         let state = self.state()?;
+        let mut backend = state.backends.get_mut(&collection_id).ok_or_else(|| {
+            VectorError::CollectionNotFound {
+                name: collection.to_string(),
+            }
+        })?;
 
         // Check existence and collect records before committing
         let mut kv_keys = Vec::with_capacity(keys.len());
@@ -576,17 +588,15 @@ impl VectorStore {
 
         // Update backend after KV commit succeeds
         let ts = now_micros();
-        if let Some(mut backend) = state.backends.get_mut(&collection_id) {
-            for vid in &vector_ids {
-                if let Some(vector_id) = vid {
-                    match backend.delete_with_timestamp(*vector_id, ts) {
-                        Ok(_) => {
-                            backend.remove_inline_meta(*vector_id);
-                        }
-                        Err(e) => {
-                            warn!(target: "strata::vector", collection, error = %e,
-                                "Backend delete failed after KV delete in batch; search will filter via KV check");
-                        }
+        for vid in &vector_ids {
+            if let Some(vector_id) = vid {
+                match backend.delete_with_timestamp(*vector_id, ts) {
+                    Ok(_) => {
+                        backend.remove_inline_meta(*vector_id);
+                    }
+                    Err(e) => {
+                        warn!(target: "strata::vector", collection, error = %e,
+                            "Backend delete failed after KV delete in batch; search will filter via KV check");
                     }
                 }
             }

--- a/crates/vector/src/store/mod.rs
+++ b/crates/vector/src/store/mod.rs
@@ -3546,4 +3546,176 @@ mod tests {
             total_expected
         );
     }
+
+    /// Issue #1572: delete() does not hold the per-collection write lock during
+    /// KV existence check and KV delete, allowing a concurrent insert to be
+    /// silently clobbered.
+    ///
+    /// Scenario: Thread A deletes "key" while Thread B inserts "key".
+    /// If delete's KV read + KV delete happen without the write lock, the delete
+    /// can race ahead and delete the record that insert just committed.
+    ///
+    /// After both threads complete, KV and backend must agree: either both
+    /// see the key (insert serialized last) or neither does (delete serialized
+    /// last). A mismatch indicates a TOCTOU race.
+    #[test]
+    fn test_issue_1572_delete_insert_toctou() {
+        let db = Database::cache().unwrap();
+        let store = VectorStore::new(db);
+        let branch_id = BranchId::new();
+
+        let config = VectorConfig::new(4, DistanceMetric::Cosine).unwrap();
+        store
+            .create_collection(branch_id, "default", "race", config)
+            .unwrap();
+
+        let num_rounds = 100;
+        let mut inconsistencies = 0u32;
+
+        for _round in 0..num_rounds {
+            // Seed the key so delete has something to find
+            let emb_v1 = [1.0_f32, 0.0, 0.0, 0.0];
+            store
+                .insert(branch_id, "default", "race", "key", &emb_v1, None)
+                .unwrap();
+
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+
+            // Thread A: delete
+            let store_a = store.clone();
+            let barrier_a = barrier.clone();
+            let handle_a = std::thread::spawn(move || {
+                barrier_a.wait();
+                store_a.delete(branch_id, "default", "race", "key")
+            });
+
+            // Thread B: insert (upsert with new embedding)
+            let store_b = store.clone();
+            let barrier_b = barrier.clone();
+            let emb_v2 = [0.0_f32, 1.0, 0.0, 0.0];
+            let handle_b = std::thread::spawn(move || {
+                barrier_b.wait();
+                store_b.insert(branch_id, "default", "race", "key", &emb_v2, None)
+            });
+
+            let delete_result = handle_a.join().unwrap();
+            let insert_result = handle_b.join().unwrap();
+
+            // Both operations must succeed (no panics, no errors)
+            delete_result.unwrap();
+            insert_result.unwrap();
+
+            // KV and backend must agree on existence.
+            let kv_exists = store
+                .get(branch_id, "default", "race", "key")
+                .unwrap()
+                .is_some();
+            let search_results = store
+                .search(
+                    branch_id,
+                    "default",
+                    "race",
+                    &[0.0, 1.0, 0.0, 0.0],
+                    10,
+                    None,
+                )
+                .unwrap();
+            let search_finds_key = search_results.iter().any(|m| m.key == "key");
+
+            if kv_exists != search_finds_key {
+                inconsistencies += 1;
+            }
+        }
+
+        assert_eq!(
+            inconsistencies, 0,
+            "KV/backend inconsistency detected in {inconsistencies}/{num_rounds} rounds — TOCTOU race in delete"
+        );
+    }
+
+    /// Issue #1572 stress test: concurrent delete + insert on the SAME key.
+    ///
+    /// Under correct locking, exactly one serialization order applies per
+    /// iteration. If the TOCTOU bug is present, a significant fraction of
+    /// iterations will lose the insert's KV record while the backend retains
+    /// the entry (phantom) or vice versa.
+    #[test]
+    fn test_issue_1572_delete_insert_toctou_concurrent() {
+        let db = Database::cache().unwrap();
+        let store = VectorStore::new(db);
+        let branch_id = BranchId::new();
+
+        let config = VectorConfig::new(4, DistanceMetric::Cosine).unwrap();
+        store
+            .create_collection(branch_id, "default", "stress", config)
+            .unwrap();
+
+        let num_rounds = 100;
+        let num_threads = 4; // 2 inserters + 2 deleters per round
+        let mut inconsistencies = 0u32;
+
+        for _round in 0..num_rounds {
+            // Seed a vector
+            let seed_emb = [1.0_f32, 0.0, 0.0, 0.0];
+            store
+                .insert(branch_id, "default", "stress", "target", &seed_emb, None)
+                .unwrap();
+
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(num_threads));
+            let mut handles = Vec::new();
+
+            // 2 deleters
+            for _ in 0..2 {
+                let s = store.clone();
+                let b = barrier.clone();
+                handles.push(std::thread::spawn(move || {
+                    b.wait();
+                    let _ = s.delete(branch_id, "default", "stress", "target");
+                }));
+            }
+
+            // 2 inserters
+            for t in 0..2 {
+                let s = store.clone();
+                let b = barrier.clone();
+                let emb = [0.0, t as f32 + 1.0, 0.0, 0.0];
+                handles.push(std::thread::spawn(move || {
+                    b.wait();
+                    let _ = s.insert(branch_id, "default", "stress", "target", &emb, None);
+                }));
+            }
+
+            for h in handles {
+                h.join().unwrap();
+            }
+
+            // After all threads complete, check consistency between KV and backend.
+            let kv_exists = store
+                .get(branch_id, "default", "stress", "target")
+                .unwrap()
+                .is_some();
+            let search_results = store
+                .search(
+                    branch_id,
+                    "default",
+                    "stress",
+                    &[0.0, 1.0, 0.0, 0.0],
+                    10,
+                    None,
+                )
+                .unwrap();
+            let search_finds_target = search_results.iter().any(|m| m.key == "target");
+
+            // KV and search must agree: if KV says it exists, search should find it.
+            // If KV says it doesn't exist, search should not find it.
+            if kv_exists != search_finds_target {
+                inconsistencies += 1;
+            }
+        }
+
+        assert_eq!(
+            inconsistencies, 0,
+            "KV/backend inconsistency detected in {inconsistencies}/{num_rounds} rounds — TOCTOU race in delete"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `delete()` and `batch_delete()` in VectorStore performed KV existence checks and KV mutations **without** the per-collection DashMap write lock, allowing concurrent `insert_inner()` to be silently clobbered via TOCTOU
- Moved `state.backends.get_mut()` before KV operations in both methods, matching the locking discipline already used in `insert_inner()` and `batch_insert()`

## Root Cause

The comment in `delete()` said "Hold per-collection lock for entire check-then-delete" but only called `self.state()` (returns `Arc<VectorBackendState>`, no lock). The actual DashMap write lock (`state.backends.get_mut()`) was acquired **after** the KV existence check and KV delete transaction, creating a race window:

```
Thread A: delete("key")          Thread B: insert("key", new_emb)
1. read KV → exists
                                  2. acquire backend write lock
                                  3. KV commit (upsert)
                                  4. backend update, release lock
5. KV delete → clobbers B's write!
6. acquire backend lock
7. backend delete
```

Result: Thread B's insert is silently lost — both KV and backend show deleted.

## Fix

~10 lines of production code: acquire `get_mut()` **before** KV operations in `delete()` and `batch_delete()`, matching `insert_inner()`'s pattern.

## Invariants Verified

ACID-003, ARCH-002, ARCH-003, MVCC-001, MVCC-002 — all HOLD

## Test Plan

- [x] `test_issue_1572_delete_insert_toctou` — 100 rounds of concurrent insert+delete on same key, asserts KV/backend consistency
- [x] `test_issue_1572_delete_insert_toctou_concurrent` — 100 rounds with 4 threads (2 inserters + 2 deleters), asserts KV/backend consistency
- [x] Concurrent test **failed** (91/100 inconsistencies) before fix, **passes** after
- [x] Full `strata-vector` test suite: 315 passed
- [x] Full workspace test suite: all passed (excluding pre-existing inference/cli build issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)