### PR TITLE
Fix #1582: RaBitQ binary quantization (32x compression) for VectorStore

### DIFF
--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -539,6 +539,20 @@ fn format_raw(output: &Output) -> String {
         Output::MaybeTag(tag) => serde_json::to_string(&tag).unwrap_or_default(),
         Output::NoteAdded(note) => serde_json::to_string(&note).unwrap_or_default(),
         Output::NoteList(notes) => serde_json::to_string(&notes).unwrap_or_default(),
+        Output::EventRangeResult {
+            events,
+            has_more,
+            next_cursor,
+        } => serde_json::to_string(&serde_json::json!({
+            "events": events,
+            "has_more": has_more,
+            "next_cursor": next_cursor,
+        }))
+        .unwrap_or_default(),
+        Output::BoolList(bools) => serde_json::to_string(&bools).unwrap_or_default(),
+        Output::BatchVectorGetResults(results) => {
+            serde_json::to_string(&results).unwrap_or_default()
+        }
     }
 }
 
@@ -1445,6 +1459,63 @@ fn format_human(output: &Output) -> String {
                                 .map(|a| format!(" [{}]", a))
                                 .unwrap_or_default()
                         )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        Output::EventRangeResult {
+            events,
+            has_more,
+            next_cursor,
+        } => {
+            let count = events.len();
+            let mut lines: Vec<String> = events
+                .iter()
+                .enumerate()
+                .map(|(i, e)| {
+                    format!(
+                        "{}) v{}: {}",
+                        i + 1,
+                        e.version,
+                        format_value_human(&e.value)
+                    )
+                })
+                .collect();
+            if *has_more {
+                lines.push(format!(
+                    "(has_more, next_cursor={})",
+                    next_cursor.as_deref().unwrap_or("none")
+                ));
+            }
+            if count == 0 {
+                "(empty range)".to_string()
+            } else {
+                lines.join("\n")
+            }
+        }
+        Output::BoolList(bools) => {
+            if bools.is_empty() {
+                "(empty list)".to_string()
+            } else {
+                bools
+                    .iter()
+                    .enumerate()
+                    .map(|(i, b)| format!("{}) {}", i + 1, b))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        Output::BatchVectorGetResults(results) => {
+            if results.is_empty() {
+                "(empty list)".to_string()
+            } else {
+                results
+                    .iter()
+                    .enumerate()
+                    .map(|(i, r)| match r {
+                        Some(vd) => format!("{}) key={} (v{})", i + 1, vd.key, vd.version),
+                        None => format!("{}) (nil)", i + 1),
                     })
                     .collect::<Vec<_>>()
                     .join("\n")

--- a/crates/core/src/primitives/vector.rs
+++ b/crates/core/src/primitives/vector.rs
@@ -92,6 +92,11 @@ pub enum StorageDtype {
     /// Queries remain f32 (asymmetric distance computation).
     /// 4x memory savings vs F32 with ~1-2% recall loss.
     Int8,
+    /// Binary quantization via RaBitQ (SIGMOD 2024).
+    ///
+    /// D-dimensional vectors → D bits using random orthogonal rotation + sign encoding.
+    /// 32x compression from F32 with ~5% recall loss.
+    Binary,
 }
 
 impl StorageDtype {
@@ -100,6 +105,7 @@ impl StorageDtype {
         match self {
             StorageDtype::F32 => 0,
             StorageDtype::Int8 => 2,
+            StorageDtype::Binary => 3,
         }
     }
 
@@ -108,6 +114,7 @@ impl StorageDtype {
         match b {
             0 => Some(StorageDtype::F32),
             2 => Some(StorageDtype::Int8),
+            3 => Some(StorageDtype::Binary),
             _ => None,
         }
     }
@@ -117,6 +124,7 @@ impl StorageDtype {
         match self {
             StorageDtype::F32 => 4,
             StorageDtype::Int8 => 1,
+            StorageDtype::Binary => 1, // notional; binary uses ceil(dim/8) per vector
         }
     }
 }
@@ -1279,8 +1287,10 @@ mod tests {
         assert!(StorageDtype::from_byte(1).is_none());
         // Byte 2 is Int8
         assert_eq!(StorageDtype::from_byte(2), Some(StorageDtype::Int8));
-        // Bytes 3+ are reserved
-        for b in 3..=255u8 {
+        // Byte 3 is Binary
+        assert_eq!(StorageDtype::from_byte(3), Some(StorageDtype::Binary));
+        // Bytes 4+ are reserved
+        for b in 4..=255u8 {
             assert!(
                 StorageDtype::from_byte(b).is_none(),
                 "Byte {} should not map to a dtype",

--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -348,6 +348,7 @@ impl StrataConfig {
     pub fn vector_storage_dtype(&self) -> strata_core::primitives::StorageDtype {
         match self.default_vector_dtype.to_lowercase().as_str() {
             "int8" | "sq8" => strata_core::primitives::StorageDtype::Int8,
+            "binary" | "rabitq" => strata_core::primitives::StorageDtype::Binary,
             _ => strata_core::primitives::StorageDtype::F32,
         }
     }
@@ -426,8 +427,9 @@ auto_embed = false
 # openai_api_key = "sk-..."
 # google_api_key = "AIza..."
 
-# Default storage type for new vector collections: "f32" (default) or "int8".
+# Default storage type for new vector collections: "f32" (default), "int8", or "binary".
 # "int8" uses scalar quantization (SQ8) for 4x memory savings (~1-2% recall loss).
+# "binary" uses RaBitQ binary quantization for 32x compression (~5% recall loss).
 # Embedded profile auto-sets "int8". Individual collections can override.
 # default_vector_dtype = "f32"
 

--- a/crates/engine/src/primitives/event.rs
+++ b/crates/engine/src/primitives/event.rs
@@ -731,6 +731,7 @@ impl EventLog {
     /// If `reverse` is true, iterates from high to low sequence numbers.
     /// If `event_type` is Some, only returns events matching that type.
     /// Results are ordered by sequence number (ascending or descending).
+    #[allow(clippy::too_many_arguments)]
     pub fn range(
         &self,
         branch_id: &BranchId,
@@ -823,6 +824,7 @@ impl EventLog {
     /// If `end_ts` is None, reads all events from `start_ts` onwards.
     /// If `reverse` is true, returns results in descending timestamp order.
     /// If `event_type` is Some, only returns events matching that type.
+    #[allow(clippy::too_many_arguments)]
     pub fn range_by_time(
         &self,
         branch_id: &BranchId,
@@ -883,10 +885,8 @@ impl EventLog {
                     ));
 
                     // For forward scans, apply limit eagerly to bound memory
-                    if !reverse {
-                        if limit.is_some_and(|l| matching.len() >= l) {
-                            break;
-                        }
+                    if !reverse && limit.is_some_and(|l| matching.len() >= l) {
+                        break;
                     }
                 }
             }

--- a/crates/executor/src/api/kv.rs
+++ b/crates/executor/src/api/kv.rs
@@ -213,10 +213,7 @@ impl Strata {
     ///
     /// Returns per-item results positionally mapped to the input keys.
     /// Missing keys have `value: None`.
-    pub fn kv_batch_get(
-        &self,
-        keys: Vec<String>,
-    ) -> Result<Vec<crate::types::BatchGetItemResult>> {
+    pub fn kv_batch_get(&self, keys: Vec<String>) -> Result<Vec<crate::types::BatchGetItemResult>> {
         match self.execute_cmd(Command::KvBatchGet {
             branch: self.branch_id(),
             space: self.space_id(),
@@ -233,10 +230,7 @@ impl Strata {
     /// Batch delete multiple keys in a single transaction.
     ///
     /// Returns per-item results positionally mapped to the input keys.
-    pub fn kv_batch_delete(
-        &self,
-        keys: Vec<String>,
-    ) -> Result<Vec<crate::types::BatchItemResult>> {
+    pub fn kv_batch_delete(&self, keys: Vec<String>) -> Result<Vec<crate::types::BatchItemResult>> {
         match self.execute_cmd(Command::KvBatchDelete {
             branch: self.branch_id(),
             space: self.space_id(),

--- a/crates/executor/src/handlers/event.rs
+++ b/crates/executor/src/handlers/event.rs
@@ -259,6 +259,7 @@ pub fn event_batch_append(
 }
 
 /// Handle EventRange command — sequence-based range query with pagination.
+#[allow(clippy::too_many_arguments)]
 pub fn event_range(
     p: &Arc<Primitives>,
     branch: BranchId,
@@ -329,6 +330,7 @@ pub fn event_range(
 }
 
 /// Handle EventRangeByTime command — timestamp-based range query with pagination.
+#[allow(clippy::too_many_arguments)]
 pub fn event_range_by_time(
     p: &Arc<Primitives>,
     branch: BranchId,

--- a/crates/executor/src/handlers/vector.rs
+++ b/crates/executor/src/handlers/vector.rs
@@ -486,8 +486,7 @@ pub fn vector_batch_delete(
     }
 
     let engine_results = convert_vector_result(
-        p.vector
-            .batch_delete(branch_id, &space, &collection, &keys),
+        p.vector.batch_delete(branch_id, &space, &collection, &keys),
         branch_id,
     )?;
 

--- a/crates/vector/Cargo.toml
+++ b/crates/vector/Cargo.toml
@@ -22,6 +22,7 @@ once_cell = { workspace = true }
 parking_lot = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
+rand = { workspace = true }
 fs2 = "0.4"
 
 [dev-dependencies]

--- a/crates/vector/src/distance.rs
+++ b/crates/vector/src/distance.rs
@@ -701,6 +701,82 @@ fn asymmetric_l2_norm(quantized: &[u8], mins: &[f32], scales: &[f32]) -> f32 {
     sum.sqrt()
 }
 
+// ============================================================================
+// Shared: squared-distance → similarity conversion
+// ============================================================================
+
+/// Convert an estimated squared Euclidean distance to a similarity score.
+///
+/// Shared by RaBitQ binary quantization (and potentially other distance estimators).
+/// `norm_query` and `norm_stored` are original vector L2 norms (from VectorHeap::norms).
+#[inline]
+pub fn dist_sq_to_similarity(
+    dist_sq: f32,
+    metric: DistanceMetric,
+    norm_query: Option<f32>,
+    norm_stored: Option<f32>,
+) -> f32 {
+    match metric {
+        DistanceMetric::Euclidean => 1.0 / (1.0 + dist_sq.max(0.0).sqrt()),
+        DistanceMetric::Cosine => {
+            let nq = norm_query.unwrap_or(1.0);
+            let ns = norm_stored.unwrap_or(1.0);
+            let denom = 2.0 * nq * ns;
+            if denom == 0.0 {
+                0.0
+            } else {
+                (nq * nq + ns * ns - dist_sq.max(0.0)) / denom
+            }
+        }
+        DistanceMetric::DotProduct => {
+            let nq = norm_query.unwrap_or(1.0);
+            let ns = norm_stored.unwrap_or(1.0);
+            (nq * nq + ns * ns - dist_sq.max(0.0)) / 2.0
+        }
+    }
+}
+
+// ============================================================================
+// Binary distance (RaBitQ: f32 query vs D-bit stored vector)
+// ============================================================================
+
+/// Compute similarity between a preprocessed query and a binary-quantized vector (RaBitQ).
+///
+/// The query must already be preprocessed (centered, normalized, rotated) via
+/// `RaBitQParams::preprocess_query()`. The per-vector binary code and correction
+/// factors are read from the VectorHeap.
+///
+/// All scores normalized to "higher = more similar" (Invariant R2).
+#[inline]
+#[allow(clippy::too_many_arguments)]
+pub fn compute_binary_similarity(
+    q_rotated: &[f32],
+    q_dist: f32,
+    code: &[u8],
+    centroid_dist: f32,
+    quantized_dot: f32,
+    dimension: usize,
+    metric: DistanceMetric,
+    norm_query: Option<f32>,
+    norm_stored: Option<f32>,
+) -> f32 {
+    // Binary inner product: ⟨ō, q_normalized_rotated⟩
+    let ip = crate::quantize::binary_inner_product(code, q_rotated, dimension);
+
+    // Avoid division by zero
+    if quantized_dot.abs() < 1e-10 {
+        return 0.0;
+    }
+
+    let ratio = ip / quantized_dot;
+
+    // Estimated squared Euclidean distance (paper Eq. 2 + Theorem 3.2)
+    let dist_sq =
+        centroid_dist * centroid_dist + q_dist * q_dist - 2.0 * centroid_dist * q_dist * ratio;
+
+    dist_sq_to_similarity(dist_sq, metric, norm_query, norm_stored)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1163,6 +1239,78 @@ mod tests {
             with_norms,
             without_norms
         );
+    }
+
+    // ================================================================
+    // Binary (RaBitQ) distance tests
+    // ================================================================
+
+    #[test]
+    fn test_binary_similarity_euclidean() {
+        use crate::quantize::RaBitQParams;
+
+        let dim = 64;
+        let mut params = RaBitQParams::new(dim);
+        for i in 0..100 {
+            let v: Vec<f32> = (0..dim)
+                .map(|j| ((i * dim + j) as f32 / 1000.0).sin())
+                .collect();
+            params.update_calibration(&v);
+        }
+        params.finalize_calibration();
+
+        let data: Vec<f32> = (0..dim).map(|j| (j as f32 / 30.0).sin()).collect();
+        let query: Vec<f32> = (0..dim).map(|j| (j as f32 / 20.0).cos()).collect();
+
+        let (code, cd, x0) = params.encode(&data);
+        let (q_rot, q_dist) = params.preprocess_query(&query);
+
+        let nq = query.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let ns = data.iter().map(|x| x * x).sum::<f32>().sqrt();
+
+        let binary_sim = compute_binary_similarity(
+            &q_rot,
+            q_dist,
+            &code,
+            cd,
+            x0,
+            dim,
+            DistanceMetric::Euclidean,
+            Some(nq),
+            Some(ns),
+        );
+        let exact_sim = compute_similarity(&data, &query, DistanceMetric::Euclidean);
+
+        // Binary quantization is lossy but should be in the right ballpark
+        assert!(
+            (binary_sim - exact_sim).abs() < 0.3,
+            "binary_sim={}, exact_sim={}",
+            binary_sim,
+            exact_sim
+        );
+    }
+
+    #[test]
+    fn test_dist_sq_to_similarity_euclidean() {
+        // dist=0 → similarity=1
+        assert!(
+            (dist_sq_to_similarity(0.0, DistanceMetric::Euclidean, None, None) - 1.0).abs() < 1e-6
+        );
+        // dist²=1 → similarity = 1/(1+1) = 0.5
+        assert!(
+            (dist_sq_to_similarity(1.0, DistanceMetric::Euclidean, None, None) - 0.5).abs() < 1e-6
+        );
+    }
+
+    #[test]
+    fn test_dist_sq_to_similarity_cosine() {
+        // Identical unit vectors: dist²=0, nq=ns=1 → cos = (1+1-0)/2 = 1.0
+        let sim = dist_sq_to_similarity(0.0, DistanceMetric::Cosine, Some(1.0), Some(1.0));
+        assert!((sim - 1.0).abs() < 1e-6, "sim={}", sim);
+
+        // Orthogonal unit vectors: dist²=2, nq=ns=1 → cos = (1+1-2)/2 = 0.0
+        let sim = dist_sq_to_similarity(2.0, DistanceMetric::Cosine, Some(1.0), Some(1.0));
+        assert!(sim.abs() < 1e-6, "sim={}", sim);
     }
 }
 

--- a/crates/vector/src/heap.rs
+++ b/crates/vector/src/heap.rs
@@ -14,10 +14,14 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::distance::{compute_asymmetric_similarity, compute_similarity_cached};
+use std::cell::RefCell;
+
+use crate::distance::{
+    compute_asymmetric_similarity, compute_binary_similarity, compute_similarity_cached,
+};
 use crate::error::{VectorError, VectorResult};
 use crate::mmap::{self, MmapVectorData};
-use crate::quantize::{self, QuantizationParams};
+use crate::quantize::{self, QuantizationParams, RaBitQParams};
 use crate::types::{DistanceMetric, InlineMeta, StorageDtype, VectorConfig, VectorId};
 
 /// Backing storage for vector embeddings.
@@ -44,6 +48,17 @@ pub(crate) enum VectorData {
     /// Quantized u8 storage (SQ8). Each vector is `dimension` bytes.
     /// Offsets in id_to_offset are in u8 elements (= byte offsets within the Vec).
     InMemoryQuantized(Vec<u8>),
+    /// Binary quantization via RaBitQ. Each vector stored as:
+    /// - Binary code: ceil(dim/8) bytes in `codes`
+    /// - Centroid distance: f32 in `centroid_dists`
+    /// - Quantized dot product (x0): f32 in `quantized_dots`
+    ///
+    /// Offsets in id_to_offset store byte offsets into `codes` (= slot * code_size).
+    InMemoryBinary {
+        codes: Vec<u8>,
+        centroid_dists: Vec<f32>,
+        quantized_dots: Vec<f32>,
+    },
 }
 
 /// Sentinel value indicating absent entry in dense_offsets.
@@ -123,9 +138,25 @@ pub struct VectorHeap {
     /// None for F32 heaps.
     quant_params: Option<QuantizationParams>,
 
-    /// Number of calibration samples seen (Int8 only, pre-calibration).
+    /// RaBitQ parameters (only used when config.storage_dtype == Binary).
+    rabitq_params: Option<RaBitQParams>,
+
+    /// Number of calibration samples seen (Int8/Binary only, pre-calibration).
     /// None for F32 heaps or after calibration completes.
     calibration_samples: Option<usize>,
+}
+
+/// Thread-local cache for RaBitQ query preprocessing.
+/// Avoids O(D^2) rotation per distance_to() call by caching the preprocessed query.
+/// Cache key is the query slice pointer -- valid within a single search call.
+struct BinaryQueryCache {
+    query_ptr: usize,
+    q_rotated: Vec<f32>,
+    q_dist: f32,
+}
+
+thread_local! {
+    static BINARY_QUERY_CACHE: RefCell<Option<BinaryQueryCache>> = const { RefCell::new(None) };
 }
 
 impl VectorHeap {
@@ -135,13 +166,19 @@ impl VectorHeap {
     /// where IDs are positive integers.
     pub fn new(config: VectorConfig) -> Self {
         let is_int8 = config.storage_dtype == StorageDtype::Int8;
+        let is_binary = config.storage_dtype == StorageDtype::Binary;
         VectorHeap {
             quant_params: if is_int8 {
                 Some(QuantizationParams::new(config.dimension))
             } else {
                 None
             },
-            calibration_samples: if is_int8 { Some(0) } else { None },
+            rabitq_params: if is_binary {
+                Some(RaBitQParams::new(config.dimension))
+            } else {
+                None
+            },
+            calibration_samples: if is_int8 || is_binary { Some(0) } else { None },
             config,
             data: VectorData::InMemory(Vec::new()),
             id_to_offset: BTreeMap::new(),
@@ -161,21 +198,23 @@ impl VectorHeap {
     pub fn from_snapshot(
         config: VectorConfig,
         data: Vec<f32>,
-        id_to_offset: BTreeMap<VectorId, usize>,
+        mut id_to_offset: BTreeMap<VectorId, usize>,
         free_slots: Vec<usize>,
         next_id: u64,
     ) -> Self {
         let is_int8 = config.storage_dtype == StorageDtype::Int8;
+        let is_binary = config.storage_dtype == StorageDtype::Binary;
 
         // For Int8: quantize the f32 snapshot data into u8 storage.
         // If the collection is empty, stay in calibration mode so new inserts work.
-        let (vector_data, quant_params, cal_samples) = if is_int8 {
+        let (vector_data, quant_params, rabitq_params, cal_samples) = if is_int8 {
             let dim = config.dimension;
             if id_to_offset.is_empty() {
-                // Empty collection — stay in f32 calibration mode
+                // Empty collection -- stay in f32 calibration mode
                 (
                     VectorData::InMemory(data),
                     Some(QuantizationParams::new(dim)),
+                    None,
                     Some(0),
                 )
             } else {
@@ -190,17 +229,72 @@ impl VectorHeap {
                 let mut q_data = vec![0u8; total_slots * dim];
                 for (&_id, &offset) in &id_to_offset {
                     if offset + dim <= data.len() {
-                        // Offset is slot_number * dim — same for both f32 and u8 layouts
+                        // Offset is slot_number * dim -- same for both f32 and u8 layouts
                         params.quantize_into(
                             &data[offset..offset + dim],
                             &mut q_data[offset..offset + dim],
                         );
                     }
                 }
-                (VectorData::InMemoryQuantized(q_data), Some(params), None)
+                (
+                    VectorData::InMemoryQuantized(q_data),
+                    Some(params),
+                    None,
+                    None,
+                )
+            }
+        } else if is_binary {
+            let dim = config.dimension;
+            let code_size = RaBitQParams::code_size(dim);
+            if id_to_offset.is_empty() {
+                // Empty collection -- stay in f32 calibration mode
+                (
+                    VectorData::InMemory(data),
+                    None,
+                    Some(RaBitQParams::new(dim)),
+                    Some(0),
+                )
+            } else {
+                let mut params = RaBitQParams::new(dim);
+                for &offset in id_to_offset.values() {
+                    if offset + dim <= data.len() {
+                        params.update_calibration(&data[offset..offset + dim]);
+                    }
+                }
+                params.finalize_calibration();
+                let total_slots = data.len() / dim;
+                let mut codes = vec![0u8; total_slots * code_size];
+                let mut centroid_dists = vec![0.0f32; total_slots];
+                let mut quantized_dots = vec![0.0f32; total_slots];
+                for (&_id, &offset) in &id_to_offset {
+                    if offset + dim <= data.len() {
+                        let slot = offset / dim;
+                        let (cd, x0) = params.encode_into(
+                            &data[offset..offset + dim],
+                            &mut codes[slot * code_size..(slot + 1) * code_size],
+                        );
+                        centroid_dists[slot] = cd;
+                        quantized_dots[slot] = x0;
+                    }
+                }
+                // Remap id_to_offset from f32 offsets (slot * dim) to code offsets (slot * code_size)
+                for (_id, offset) in id_to_offset.iter_mut() {
+                    let slot = *offset / dim;
+                    *offset = slot * code_size;
+                }
+                (
+                    VectorData::InMemoryBinary {
+                        codes,
+                        centroid_dists,
+                        quantized_dots,
+                    },
+                    None,
+                    Some(params),
+                    None,
+                )
             }
         } else {
-            (VectorData::InMemory(data), None, None)
+            (VectorData::InMemory(data), None, None, None)
         };
 
         let mut heap = VectorHeap {
@@ -214,6 +308,7 @@ impl VectorHeap {
             version: AtomicU64::new(0),
             inline_meta: BTreeMap::new(),
             quant_params,
+            rabitq_params,
             calibration_samples: cal_samples,
         };
         heap.rebuild_dense_index();
@@ -241,6 +336,7 @@ impl VectorHeap {
             version: AtomicU64::new(0),
             inline_meta: BTreeMap::new(),
             quant_params,
+            rabitq_params: None,
             calibration_samples: None,
         };
         heap.rebuild_dense_index();
@@ -445,24 +541,96 @@ impl VectorHeap {
                     self.norms[idx] = compute_l2_norm(embedding);
                 }
             }
+            VectorData::InMemoryBinary {
+                codes,
+                centroid_dists,
+                quantized_dots,
+            } => {
+                let params = self
+                    .rabitq_params
+                    .as_ref()
+                    .expect("InMemoryBinary requires rabitq_params");
+                let code_size = RaBitQParams::code_size(dim);
+                if let Some(&offset) = self.id_to_offset.get(&id) {
+                    // Update in place
+                    let (cd, x0) =
+                        params.encode_into(embedding, &mut codes[offset..offset + code_size]);
+                    let slot = offset / code_size;
+                    centroid_dists[slot] = cd;
+                    quantized_dots[slot] = x0;
+                    let idx = id.0 as usize;
+                    if idx < self.norms.len() {
+                        self.norms[idx] = compute_l2_norm(embedding);
+                    }
+                } else {
+                    let offset = if let Some(slot_offset) = self.free_slots.pop() {
+                        let (cd, x0) = params.encode_into(
+                            embedding,
+                            &mut codes[slot_offset..slot_offset + code_size],
+                        );
+                        let slot = slot_offset / code_size;
+                        centroid_dists[slot] = cd;
+                        quantized_dots[slot] = x0;
+                        slot_offset
+                    } else {
+                        let offset = codes.len();
+                        let (new_code, cd, x0) = params.encode(embedding);
+                        codes.extend_from_slice(&new_code);
+                        centroid_dists.push(cd);
+                        quantized_dots.push(x0);
+                        offset
+                    };
+                    self.id_to_offset.insert(id, offset);
+                    let idx = id.0 as usize;
+                    let slot_number = (offset / code_size) as u32;
+                    if idx >= self.dense_offsets.len() {
+                        self.dense_offsets.resize(idx + 1, DENSE_ABSENT);
+                    }
+                    self.dense_offsets[idx] = slot_number;
+                    if idx >= self.norms.len() {
+                        self.norms.resize(idx + 1, 0.0);
+                    }
+                    self.norms[idx] = compute_l2_norm(embedding);
+                }
+            }
         }
 
-        // Int8 calibration tracking: during calibration phase (data is still InMemory),
-        // update calibration params and count. Auto-finalize when threshold reached.
-        if self.config.storage_dtype == StorageDtype::Int8 {
-            if let Some(ref mut count) = self.calibration_samples {
-                if let Some(ref mut params) = self.quant_params {
-                    if !params.calibrated {
-                        params.update_calibration(embedding);
-                        *count += 1;
-                        if *count >= quantize::DEFAULT_CALIBRATION_THRESHOLD {
-                            // Auto-finalize — this transitions data to InMemoryQuantized
-                            self.version.fetch_add(1, Ordering::Release);
-                            self.finalize_calibration_inner();
-                            return Ok(());
+        // Calibration tracking: during calibration phase (data is still InMemory),
+        // update params and count. Auto-finalize when threshold reached.
+        if let Some(ref mut count) = self.calibration_samples {
+            let needs_finalize = match self.config.storage_dtype {
+                StorageDtype::Int8 => {
+                    if let Some(ref mut params) = self.quant_params {
+                        if !params.calibrated {
+                            params.update_calibration(embedding);
+                            *count += 1;
+                            *count >= quantize::DEFAULT_CALIBRATION_THRESHOLD
+                        } else {
+                            false
                         }
+                    } else {
+                        false
                     }
                 }
+                StorageDtype::Binary => {
+                    if let Some(ref mut params) = self.rabitq_params {
+                        if !params.calibrated {
+                            params.update_calibration(embedding);
+                            *count += 1;
+                            *count >= quantize::DEFAULT_CALIBRATION_THRESHOLD
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    }
+                }
+                _ => false,
+            };
+            if needs_finalize {
+                self.version.fetch_add(1, Ordering::Release);
+                self.finalize_calibration();
+                return Ok(());
             }
         }
 
@@ -596,6 +764,31 @@ impl VectorHeap {
                     false
                 }
             }
+            VectorData::InMemoryBinary {
+                codes,
+                centroid_dists,
+                quantized_dots,
+            } => {
+                if let Some(offset) = self.id_to_offset.remove(&id) {
+                    self.free_slots.push(offset);
+                    let code_size = RaBitQParams::code_size(self.config.dimension);
+                    codes[offset..offset + code_size].fill(0);
+                    let slot = offset / code_size;
+                    centroid_dists[slot] = 0.0;
+                    quantized_dots[slot] = 0.0;
+                    let idx = id.0 as usize;
+                    if idx < self.dense_offsets.len() {
+                        self.dense_offsets[idx] = DENSE_ABSENT;
+                    }
+                    if idx < self.norms.len() {
+                        self.norms[idx] = 0.0;
+                    }
+                    self.version.fetch_add(1, Ordering::Release);
+                    true
+                } else {
+                    false
+                }
+            }
         }
     }
 
@@ -618,6 +811,10 @@ impl VectorHeap {
             self.quant_params = Some(QuantizationParams::new(self.config.dimension));
             self.calibration_samples = Some(0);
         }
+        if self.config.storage_dtype == StorageDtype::Binary {
+            self.rabitq_params = Some(RaBitQParams::new(self.config.dimension));
+            self.calibration_samples = Some(0);
+        }
         // Note: next_id is NOT reset — IDs are never reused
         self.version.fetch_add(1, Ordering::Release);
     }
@@ -627,18 +824,26 @@ impl VectorHeap {
     // ========================================================================
 
     /// Finalize calibration: quantize all buffered vectors and transition
-    /// from InMemory(f32) to InMemoryQuantized(u8).
+    /// from InMemory(f32) to InMemoryQuantized(u8) or InMemoryBinary.
     ///
     /// Called automatically when calibration sample count reaches the threshold,
     /// or explicitly (e.g., when sealing active buffer or on first search).
     pub fn finalize_calibration(&mut self) {
-        if self.config.storage_dtype != StorageDtype::Int8 {
-            return;
+        match self.config.storage_dtype {
+            StorageDtype::Int8 => {
+                if self.quant_params.as_ref().is_none_or(|p| p.calibrated) {
+                    return;
+                }
+                self.finalize_calibration_inner();
+            }
+            StorageDtype::Binary => {
+                if self.rabitq_params.as_ref().is_none_or(|p| p.calibrated) {
+                    return;
+                }
+                self.finalize_calibration_binary();
+            }
+            _ => {}
         }
-        if self.quant_params.as_ref().is_none_or(|p| p.calibrated) {
-            return; // Already calibrated or no params
-        }
-        self.finalize_calibration_inner();
     }
 
     fn finalize_calibration_inner(&mut self) {
@@ -680,10 +885,63 @@ impl VectorHeap {
         self.rebuild_dense_index();
     }
 
-    /// Whether calibration is in progress (Int8 only).
+    fn finalize_calibration_binary(&mut self) {
+        let params = self
+            .rabitq_params
+            .as_mut()
+            .expect("must have rabitq_params");
+        params.finalize_calibration();
+
+        let dim = self.config.dimension;
+        let code_size = RaBitQParams::code_size(dim);
+        match &self.data {
+            VectorData::InMemory(f32_data) => {
+                let slot_count = f32_data.len() / dim;
+                let mut codes = vec![0u8; slot_count * code_size];
+                let mut centroid_dists = vec![0.0f32; slot_count];
+                let mut quantized_dots = vec![0.0f32; slot_count];
+                let params_ref = self.rabitq_params.as_ref().unwrap();
+                for (&_id, &offset) in &self.id_to_offset {
+                    if offset + dim <= f32_data.len() {
+                        let slot = offset / dim;
+                        let (cd, x0) = params_ref.encode_into(
+                            &f32_data[offset..offset + dim],
+                            &mut codes[slot * code_size..(slot + 1) * code_size],
+                        );
+                        centroid_dists[slot] = cd;
+                        quantized_dots[slot] = x0;
+                    }
+                }
+                // Remap id_to_offset from f32 offsets to code offsets
+                for (_id, offset) in self.id_to_offset.iter_mut() {
+                    let slot = *offset / dim;
+                    *offset = slot * code_size;
+                }
+                self.data = VectorData::InMemoryBinary {
+                    codes,
+                    centroid_dists,
+                    quantized_dots,
+                };
+            }
+            _ => {
+                debug_assert!(
+                    false,
+                    "finalize_calibration_binary called on non-InMemory heap"
+                );
+            }
+        }
+        self.calibration_samples = None;
+        self.rebuild_dense_index();
+    }
+
+    /// Whether calibration is in progress (Int8 or Binary).
     pub fn is_calibrating(&self) -> bool {
         self.calibration_samples.is_some()
-            && self.quant_params.as_ref().is_some_and(|p| !p.calibrated)
+            && match self.config.storage_dtype {
+                StorageDtype::Int8 => self.quant_params.as_ref().is_some_and(|p| !p.calibrated),
+                StorageDtype::Binary => self.rabitq_params.as_ref().is_some_and(|p| !p.calibrated),
+                _ => false,
+            }
     }
 
     /// Get quantization parameters (if Int8).
@@ -751,6 +1009,65 @@ impl VectorHeap {
                     self.get_norm(id),
                 ))
             }
+            VectorData::InMemoryBinary {
+                codes,
+                centroid_dists,
+                quantized_dots,
+            } => {
+                let params = self.rabitq_params.as_ref()?;
+                let code_size = RaBitQParams::code_size(self.config.dimension);
+                let dim = self.config.dimension;
+
+                // Resolve the binary code and slot
+                let idx = id.0 as usize;
+                let (code, slot) = if idx < self.dense_offsets.len() {
+                    let s = self.dense_offsets[idx];
+                    if s == DENSE_ABSENT {
+                        return None;
+                    }
+                    let offset = s as usize * code_size;
+                    if offset + code_size > codes.len() {
+                        return None;
+                    }
+                    (&codes[offset..offset + code_size], s as usize)
+                } else {
+                    let offset = *self.id_to_offset.get(&id)?;
+                    if offset + code_size > codes.len() {
+                        return None;
+                    }
+                    (&codes[offset..offset + code_size], offset / code_size)
+                };
+
+                let cd = centroid_dists[slot];
+                let x0 = quantized_dots[slot];
+                let norm_stored = self.get_norm(id);
+
+                // Compute similarity inside the thread-local cache borrow to avoid cloning
+                BINARY_QUERY_CACHE.with(|cache| {
+                    let mut cache = cache.borrow_mut();
+                    let ptr = query.as_ptr() as usize;
+                    if cache.as_ref().is_none_or(|c| c.query_ptr != ptr) {
+                        let (qr, qd) = params.preprocess_query(query);
+                        *cache = Some(BinaryQueryCache {
+                            query_ptr: ptr,
+                            q_rotated: qr,
+                            q_dist: qd,
+                        });
+                    }
+                    let c = cache.as_ref().unwrap();
+                    Some(compute_binary_similarity(
+                        &c.q_rotated,
+                        c.q_dist,
+                        code,
+                        cd,
+                        x0,
+                        dim,
+                        metric,
+                        norm_query,
+                        norm_stored,
+                    ))
+                })
+            }
         }
     }
 
@@ -808,6 +1125,48 @@ impl VectorHeap {
                 ))
             }
             VectorData::Tiered { .. } => None, // Slot-based not supported for Tiered
+            VectorData::InMemoryBinary {
+                codes,
+                centroid_dists,
+                quantized_dots,
+            } => {
+                let params = self.rabitq_params.as_ref()?;
+                let code_size = RaBitQParams::code_size(self.config.dimension);
+                let byte_offset = slot as usize * code_size;
+                if byte_offset + code_size > codes.len() {
+                    return None;
+                }
+
+                let code = &codes[byte_offset..byte_offset + code_size];
+                let cd = centroid_dists[slot as usize];
+                let x0 = quantized_dots[slot as usize];
+                let dim = self.config.dimension;
+
+                BINARY_QUERY_CACHE.with(|cache| {
+                    let mut cache = cache.borrow_mut();
+                    let ptr = query.as_ptr() as usize;
+                    if cache.as_ref().is_none_or(|c| c.query_ptr != ptr) {
+                        let (qr, qd) = params.preprocess_query(query);
+                        *cache = Some(BinaryQueryCache {
+                            query_ptr: ptr,
+                            q_rotated: qr,
+                            q_dist: qd,
+                        });
+                    }
+                    let c = cache.as_ref().unwrap();
+                    Some(compute_binary_similarity(
+                        &c.q_rotated,
+                        c.q_dist,
+                        code,
+                        cd,
+                        x0,
+                        dim,
+                        metric,
+                        norm_query,
+                        norm_stored,
+                    ))
+                })
+            }
         }
     }
 
@@ -828,6 +1187,24 @@ impl VectorHeap {
                     return None;
                 }
                 Some(params.dequantize(&vec[offset..offset + dim]))
+            }
+            VectorData::InMemoryBinary {
+                codes,
+                centroid_dists,
+                quantized_dots,
+            } => {
+                let params = self.rabitq_params.as_ref()?;
+                let code_size = RaBitQParams::code_size(self.config.dimension);
+                let offset = *self.id_to_offset.get(&id)?;
+                if offset + code_size > codes.len() {
+                    return None;
+                }
+                let slot = offset / code_size;
+                Some(params.dequantize(
+                    &codes[offset..offset + code_size],
+                    centroid_dists[slot],
+                    quantized_dots[slot],
+                ))
             }
         }
     }
@@ -884,9 +1261,14 @@ impl VectorHeap {
             }
         }
         // Fallback for Mmap/Tiered: derive from id_to_offset BTreeMap
-        self.id_to_offset
-            .get(&id)
-            .map(|&off| (off / self.config.dimension) as u32)
+        self.id_to_offset.get(&id).map(|&off| {
+            let unit_size = if self.config.storage_dtype == StorageDtype::Binary {
+                RaBitQParams::code_size(self.config.dimension)
+            } else {
+                self.config.dimension
+            };
+            (off / unit_size) as u32
+        })
     }
 
     /// O(1) embedding lookup by pre-resolved slot number.
@@ -923,6 +1305,7 @@ impl VectorHeap {
                 // For quantized heaps, use distance_to_by_slot() instead
                 None
             }
+            VectorData::InMemoryBinary { .. } => None,
         }
     }
 
@@ -987,6 +1370,14 @@ impl VectorHeap {
                                     }
                                 }
                             }
+                        }
+                    }
+                    VectorData::InMemoryBinary { codes, .. } => {
+                        let code_size = RaBitQParams::code_size(self.config.dimension);
+                        let byte_offset = slot as usize * code_size;
+                        if byte_offset < codes.len() {
+                            let ptr = codes[byte_offset..].as_ptr();
+                            crate::distance::prefetch_read(ptr);
                         }
                     }
                     _ => {} // Mmap/Tiered: no prefetch from dense path
@@ -1076,6 +1467,14 @@ impl VectorHeap {
                     }
                 }
             }
+            VectorData::InMemoryBinary { .. } => {
+                let code_size = RaBitQParams::code_size(dim);
+                for (idx, offset) in entries {
+                    let slot = (offset / code_size) as u32;
+                    self.dense_offsets[idx] = slot;
+                    // Norms already populated from upsert() calls
+                }
+            }
         }
     }
 
@@ -1148,6 +1547,7 @@ impl VectorHeap {
                 // Use get_f32_owned() or get_quantized() instead.
                 None
             }
+            VectorData::InMemoryBinary { .. } => None,
         }
     }
 
@@ -1189,6 +1589,9 @@ impl VectorHeap {
                 VectorData::InMemoryQuantized(_) => {
                     panic!("iter() not supported on quantized heap — use ids() + distance_to()")
                 }
+                VectorData::InMemoryBinary { .. } => {
+                    panic!("iter() not supported on binary heap — use ids() + distance_to()")
+                }
             };
             (id, embedding)
         })
@@ -1213,6 +1616,9 @@ impl VectorHeap {
             VectorData::Tiered { .. } => panic!("raw_data() not available on tiered heap"),
             VectorData::InMemoryQuantized(_) => {
                 panic!("raw_data() not available on quantized heap")
+            }
+            VectorData::InMemoryBinary { .. } => {
+                panic!("raw_data() not available on binary heap")
             }
         }
     }
@@ -1334,6 +1740,45 @@ impl VectorHeap {
                     &f32_data,
                 )
             }
+            VectorData::InMemoryBinary {
+                codes,
+                centroid_dists,
+                quantized_dots,
+            } => {
+                let params = self
+                    .rabitq_params
+                    .as_ref()
+                    .expect("Binary requires rabitq_params");
+                let dim = self.config.dimension;
+                let code_size = RaBitQParams::code_size(dim);
+                let total_slots = codes.len() / code_size;
+                let mut f32_data = vec![0.0f32; total_slots * dim];
+                let mut f32_offsets = BTreeMap::new();
+                for (&id, &offset) in &self.id_to_offset {
+                    let slot = offset / code_size;
+                    if offset + code_size <= codes.len() {
+                        let approx = params.dequantize(
+                            &codes[offset..offset + code_size],
+                            centroid_dists[slot],
+                            quantized_dots[slot],
+                        );
+                        f32_data[slot * dim..(slot + 1) * dim].copy_from_slice(&approx);
+                        f32_offsets.insert(id, slot * dim);
+                    }
+                }
+                mmap::write_mmap_file(
+                    path,
+                    dim,
+                    self.next_id.load(Ordering::Relaxed),
+                    &f32_offsets,
+                    &self
+                        .free_slots
+                        .iter()
+                        .map(|&s| (s / code_size) * dim)
+                        .collect::<Vec<_>>(),
+                    &f32_data,
+                )
+            }
         }
     }
 
@@ -1395,6 +1840,14 @@ impl VectorHeap {
             VectorData::Mmap(_) => 0,
             VectorData::Tiered { overlay, .. } => overlay.len() * std::mem::size_of::<f32>(),
             VectorData::InMemoryQuantized(v) => v.len(), // 1 byte per element
+            VectorData::InMemoryBinary {
+                codes,
+                centroid_dists,
+                quantized_dots,
+            } => {
+                codes.len()
+                    + (centroid_dists.len() + quantized_dots.len()) * std::mem::size_of::<f32>()
+            }
         }
     }
 

--- a/crates/vector/src/lib.rs
+++ b/crates/vector/src/lib.rs
@@ -48,7 +48,7 @@ pub use error::{VectorError, VectorResult};
 pub use filter::{FilterCondition, FilterOp, JsonScalar, MetadataFilter};
 pub use heap::VectorHeap;
 pub use hnsw::{HnswBackend, HnswConfig};
-pub use quantize::QuantizationParams;
+pub use quantize::{QuantizationParams, RaBitQParams};
 pub use recovery::{register_vector_recovery, VectorSubsystem};
 pub use segmented::{SegmentedHnswBackend, SegmentedHnswConfig};
 pub use snapshot::{CollectionSnapshotHeader, VECTOR_SNAPSHOT_VERSION};

--- a/crates/vector/src/quantize.rs
+++ b/crates/vector/src/quantize.rs
@@ -23,6 +23,8 @@
 //! are quantized using the calibrated range (outliers clipped).
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 use std::io;
 use std::io::Cursor;
 
@@ -211,6 +213,386 @@ impl QuantizationParams {
     }
 }
 
+// ============================================================================
+// RaBitQ Binary Quantization (SIGMOD 2024)
+// ============================================================================
+
+/// Per-collection RaBitQ parameters for binary quantization.
+///
+/// Stores the dataset centroid and a random orthogonal rotation matrix.
+/// Vectors are centered, rotated, then binarized (sign of each dimension).
+///
+/// Reference: Gao & Long, "RaBitQ: Quantizing High-Dimensional Vectors with
+/// a Theoretical Error Bound for Approximate Nearest Neighbor Search", SIGMOD 2024.
+#[derive(Debug, Clone)]
+pub struct RaBitQParams {
+    /// D-dimensional centroid (mean of calibration vectors)
+    centroid: Vec<f32>,
+    /// Accumulator for centroid computation (pre-calibration only)
+    centroid_sum: Vec<f32>,
+    /// D×D orthogonal rotation matrix, stored flat row-major.
+    /// Row i of the matrix is rotation[i*D .. (i+1)*D].
+    rotation: Vec<f32>,
+    /// Deterministic seed for rotation matrix regeneration.
+    seed: u64,
+    /// Embedding dimension
+    pub dimension: usize,
+    /// Number of calibration samples seen
+    pub calibration_count: usize,
+    /// Whether calibration is complete (frozen)
+    pub calibrated: bool,
+}
+
+impl RaBitQParams {
+    /// Create uncalibrated params for the given dimension.
+    pub fn new(dimension: usize) -> Self {
+        RaBitQParams {
+            centroid: vec![0.0; dimension],
+            centroid_sum: vec![0.0; dimension],
+            rotation: Vec::new(), // generated during finalization
+            seed: 42,
+            dimension,
+            calibration_count: 0,
+            calibrated: false,
+        }
+    }
+
+    /// Number of bytes per binary code for the given dimension.
+    pub fn code_size(dimension: usize) -> usize {
+        dimension.div_ceil(8)
+    }
+
+    /// Update calibration with a new embedding (accumulate into centroid sum).
+    pub fn update_calibration(&mut self, embedding: &[f32]) {
+        assert!(
+            !self.calibrated,
+            "cannot update calibration after finalization"
+        );
+        assert_eq!(embedding.len(), self.dimension, "dimension mismatch");
+
+        for (i, &val) in embedding.iter().enumerate() {
+            self.centroid_sum[i] += val;
+        }
+        self.calibration_count += 1;
+    }
+
+    /// Freeze calibration: compute centroid and generate rotation matrix.
+    pub fn finalize_calibration(&mut self) {
+        let n = self.calibration_count as f32;
+        if n > 0.0 {
+            for i in 0..self.dimension {
+                self.centroid[i] = self.centroid_sum[i] / n;
+            }
+        }
+        self.rotation = generate_orthogonal_matrix(self.dimension, self.seed);
+        self.centroid_sum = Vec::new(); // free accumulator memory
+        self.calibrated = true;
+    }
+
+    /// Encode an f32 embedding into a binary code + auxiliary scalars.
+    ///
+    /// Returns (binary_code, centroid_dist, quantized_dot).
+    pub fn encode(&self, embedding: &[f32]) -> (Vec<u8>, f32, f32) {
+        debug_assert!(self.calibrated);
+        let dim = self.dimension;
+        let code_size = Self::code_size(dim);
+
+        // Center
+        let mut centered = vec![0.0f32; dim];
+        for i in 0..dim {
+            centered[i] = embedding[i] - self.centroid[i];
+        }
+
+        // centroid_dist = ||centered||
+        let centroid_dist = centered.iter().map(|x| x * x).sum::<f32>().sqrt();
+
+        // Handle degenerate case (vector equals centroid)
+        if centroid_dist < 1e-10 {
+            return (vec![0u8; code_size], centroid_dist, 0.8);
+        }
+
+        // Normalize
+        let inv_cd = 1.0 / centroid_dist;
+        let mut normalized = vec![0.0f32; dim];
+        for i in 0..dim {
+            normalized[i] = centered[i] * inv_cd;
+        }
+
+        // Rotate: rotated = P^T · normalized
+        let mut rotated = vec![0.0f32; dim];
+        mat_vec_mul_transpose(&self.rotation, &normalized, &mut rotated, dim);
+
+        // Binarize + compute quantized_dot
+        let mut code = vec![0u8; code_size];
+        let mut abs_sum = 0.0f32;
+        for (d, &rotated_val) in rotated.iter().enumerate() {
+            if rotated_val > 0.0 {
+                let byte_idx = d / 8;
+                let bit_idx = 7 - (d % 8); // MSB-first packing
+                code[byte_idx] |= 1 << bit_idx;
+            }
+            abs_sum += rotated_val.abs();
+        }
+
+        let inv_sqrt_d = 1.0 / (dim as f32).sqrt();
+        let quantized_dot = abs_sum * inv_sqrt_d; // = ⟨ō, o_normalized⟩
+
+        (code, centroid_dist, quantized_dot)
+    }
+
+    /// In-place encode variant. Writes binary code into `code` buffer.
+    /// Returns (centroid_dist, quantized_dot).
+    pub fn encode_into(&self, embedding: &[f32], code: &mut [u8]) -> (f32, f32) {
+        let (code_vec, cd, qd) = self.encode(embedding);
+        code.copy_from_slice(&code_vec);
+        (cd, qd)
+    }
+
+    /// Preprocess a query for binary distance computation.
+    ///
+    /// Returns (q_rotated, q_dist) where:
+    /// - q_rotated: centered, normalized, then rotated query
+    /// - q_dist: ||query - centroid||
+    ///
+    /// This is O(D²) due to the rotation and should be called ONCE per search.
+    pub fn preprocess_query(&self, query: &[f32]) -> (Vec<f32>, f32) {
+        debug_assert!(self.calibrated);
+        let dim = self.dimension;
+
+        // Center
+        let mut centered = vec![0.0f32; dim];
+        for i in 0..dim {
+            centered[i] = query[i] - self.centroid[i];
+        }
+
+        // q_dist
+        let q_dist = centered.iter().map(|x| x * x).sum::<f32>().sqrt();
+
+        if q_dist < 1e-10 {
+            return (vec![0.0f32; dim], q_dist);
+        }
+
+        // Normalize
+        let inv_qd = 1.0 / q_dist;
+        let mut normalized = vec![0.0f32; dim];
+        for i in 0..dim {
+            normalized[i] = centered[i] * inv_qd;
+        }
+
+        // Rotate: q_rotated = P^T · normalized
+        let mut q_rotated = vec![0.0f32; dim];
+        mat_vec_mul_transpose(&self.rotation, &normalized, &mut q_rotated, dim);
+
+        (q_rotated, q_dist)
+    }
+
+    /// Lossy reconstruction of an f32 embedding from its binary code.
+    ///
+    /// Used for cold paths (snapshots, mmap persistence). Quality is coarse:
+    /// only sign information is preserved per dimension.
+    pub fn dequantize(&self, code: &[u8], centroid_dist: f32, quantized_dot: f32) -> Vec<f32> {
+        let dim = self.dimension;
+        let inv_sqrt_d = 1.0 / (dim as f32).sqrt();
+
+        // Reconstruct the rotated vector: sign_vector * (quantized_dot / sqrt(D))
+        // This gives a uniform-magnitude approximation in the rotated space.
+        let magnitude = quantized_dot * inv_sqrt_d;
+        let mut rotated = vec![0.0f32; dim];
+        for (d, rotated_val) in rotated.iter_mut().enumerate() {
+            let byte_idx = d / 8;
+            let bit_idx = 7 - (d % 8);
+            let bit = (code[byte_idx] >> bit_idx) & 1;
+            *rotated_val = if bit == 1 { magnitude } else { -magnitude };
+        }
+
+        // Un-rotate: embedding_normalized ≈ P · rotated (undo P^T rotation)
+        let mut normalized = vec![0.0f32; dim];
+        mat_vec_mul(&self.rotation, &rotated, &mut normalized, dim);
+
+        // Un-normalize and un-center
+        let mut result = vec![0.0f32; dim];
+        for i in 0..dim {
+            result[i] = normalized[i] * centroid_dist + self.centroid[i];
+        }
+        result
+    }
+
+    // ========================================================================
+    // Serialization
+    // ========================================================================
+
+    /// Serialize to bytes: [dimension u32 LE] [seed u64 LE] [centroid: dim * f32 LE]
+    ///
+    /// The rotation matrix is NOT stored — it's regenerated from seed on load,
+    /// saving D²×4 bytes (e.g., 576 KB for D=384).
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let dim = self.dimension;
+        let mut buf = Vec::with_capacity(4 + 8 + dim * 4);
+        buf.write_u32::<LittleEndian>(dim as u32).unwrap();
+        buf.write_u64::<LittleEndian>(self.seed).unwrap();
+        for &c in &self.centroid {
+            buf.write_f32::<LittleEndian>(c).unwrap();
+        }
+        buf
+    }
+
+    /// Deserialize from bytes. Regenerates rotation matrix from stored seed.
+    pub fn from_bytes(data: &[u8]) -> io::Result<Self> {
+        let mut reader = Cursor::new(data);
+        let dim = reader.read_u32::<LittleEndian>()? as usize;
+        let seed = reader.read_u64::<LittleEndian>()?;
+        let mut centroid = vec![0.0f32; dim];
+        for c in &mut centroid {
+            *c = reader.read_f32::<LittleEndian>()?;
+        }
+        let rotation = generate_orthogonal_matrix(dim, seed);
+        Ok(RaBitQParams {
+            centroid,
+            centroid_sum: Vec::new(),
+            rotation,
+            seed,
+            dimension: dim,
+            calibration_count: 0,
+            calibrated: true,
+        })
+    }
+}
+
+// ============================================================================
+// Linear algebra helpers
+// ============================================================================
+
+/// Matrix-vector multiply: out = M · v (M is dim×dim row-major).
+fn mat_vec_mul(matrix: &[f32], vec_in: &[f32], vec_out: &mut [f32], dim: usize) {
+    for (i, out_val) in vec_out.iter_mut().enumerate().take(dim) {
+        let mut sum = 0.0f32;
+        let row_start = i * dim;
+        for j in 0..dim {
+            sum += matrix[row_start + j] * vec_in[j];
+        }
+        *out_val = sum;
+    }
+}
+
+/// Matrix-transpose-vector multiply: out = M^T · v (M is dim×dim row-major).
+fn mat_vec_mul_transpose(matrix: &[f32], vec_in: &[f32], vec_out: &mut [f32], dim: usize) {
+    vec_out.fill(0.0);
+    for (i, &vi) in vec_in.iter().enumerate().take(dim) {
+        let row_start = i * dim;
+        for j in 0..dim {
+            vec_out[j] += matrix[row_start + j] * vi;
+        }
+    }
+}
+
+/// Generate a D×D random orthogonal matrix via QR decomposition of a Gaussian matrix.
+///
+/// Uses modified Gram-Schmidt orthogonalization, seeded for reproducibility.
+/// Matches the reference implementation: `Q, _ = np.linalg.qr(np.random.randn(D, D))`.
+fn generate_orthogonal_matrix(dim: usize, seed: u64) -> Vec<f32> {
+    if dim == 0 {
+        return Vec::new();
+    }
+
+    let mut rng = StdRng::seed_from_u64(seed);
+
+    // Generate D×D matrix with entries from N(0,1) via Box-Muller
+    let total = dim * dim;
+    let mut matrix = Vec::with_capacity(total);
+    let mut i = 0;
+    while i < total {
+        // Box-Muller transform: generate pairs of N(0,1) from U(0,1)
+        let u1: f64 = rng.gen::<f64>().max(1e-300); // clamp away from 0 to avoid ln(0)
+        let u2: f64 = rng.gen::<f64>();
+        let r = (-2.0 * u1.ln()).sqrt();
+        let theta = 2.0 * std::f64::consts::PI * u2;
+        matrix.push((r * theta.cos()) as f32);
+        i += 1;
+        if i < total {
+            matrix.push((r * theta.sin()) as f32);
+            i += 1;
+        }
+    }
+
+    // Modified Gram-Schmidt orthogonalization (in-place, row-wise)
+    for i in 0..dim {
+        // Subtract projections onto all previous rows
+        for j in 0..i {
+            let mut dot = 0.0f32;
+            for k in 0..dim {
+                dot += matrix[i * dim + k] * matrix[j * dim + k];
+            }
+            for k in 0..dim {
+                matrix[i * dim + k] -= dot * matrix[j * dim + k];
+            }
+        }
+        // Normalize row i
+        let mut norm_sq = 0.0f32;
+        for k in 0..dim {
+            norm_sq += matrix[i * dim + k] * matrix[i * dim + k];
+        }
+        let norm = norm_sq.sqrt();
+        if norm < 1e-10 {
+            // Degenerate row (extremely rare) — regenerate and re-orthogonalize.
+            for k in 0..dim {
+                let u1: f64 = rng.gen::<f64>().max(1e-300);
+                let u2: f64 = rng.gen::<f64>();
+                let r = (-2.0 * u1.ln()).sqrt();
+                let theta = 2.0 * std::f64::consts::PI * u2;
+                matrix[i * dim + k] = (r * theta.cos()) as f32;
+            }
+            // Re-orthogonalize against all previous rows
+            for j in 0..i {
+                let mut dot = 0.0f32;
+                for k in 0..dim {
+                    dot += matrix[i * dim + k] * matrix[j * dim + k];
+                }
+                for k in 0..dim {
+                    matrix[i * dim + k] -= dot * matrix[j * dim + k];
+                }
+            }
+            // Normalize the regenerated row
+            let fallback_norm = matrix[i * dim..(i + 1) * dim]
+                .iter()
+                .map(|x| x * x)
+                .sum::<f32>()
+                .sqrt();
+            if fallback_norm > 1e-10 {
+                let inv = 1.0 / fallback_norm;
+                for k in 0..dim {
+                    matrix[i * dim + k] *= inv;
+                }
+            }
+        } else {
+            let inv = 1.0 / norm;
+            for k in 0..dim {
+                matrix[i * dim + k] *= inv;
+            }
+        }
+    }
+
+    matrix
+}
+
+/// Compute binary inner product between a code and a rotated query.
+///
+/// Returns (1/√D) · Σ (2·bit[d] - 1) · q_rotated[d]
+/// This is the core O(D) hot-path operation for RaBitQ distance estimation.
+pub fn binary_inner_product(code: &[u8], q_rotated: &[f32], dim: usize) -> f32 {
+    let mut sum = 0.0f32;
+    for (d, &q_val) in q_rotated.iter().enumerate().take(dim) {
+        let byte_idx = d / 8;
+        let bit_idx = 7 - (d % 8); // MSB-first packing
+        let bit = (code[byte_idx] >> bit_idx) & 1;
+        if bit == 1 {
+            sum += q_val;
+        } else {
+            sum -= q_val;
+        }
+    }
+    sum / (dim as f32).sqrt()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -335,5 +717,184 @@ mod tests {
         params.update_calibration(&[0.0, 0.0]);
         params.finalize_calibration();
         params.update_calibration(&[1.0, 1.0]); // should panic
+    }
+
+    // ================================================================
+    // RaBitQ tests
+    // ================================================================
+
+    #[test]
+    fn test_rabitq_rotation_orthogonality() {
+        let dim = 64;
+        let matrix = generate_orthogonal_matrix(dim, 42);
+
+        // P^T · P should be approximately I
+        for i in 0..dim {
+            for j in 0..dim {
+                let mut dot = 0.0f32;
+                for k in 0..dim {
+                    dot += matrix[k * dim + i] * matrix[k * dim + j];
+                }
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert!(
+                    (dot - expected).abs() < 1e-4,
+                    "P^T·P[{},{}] = {}, expected {}",
+                    i,
+                    j,
+                    dot,
+                    expected
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_rabitq_encode_produces_valid_code() {
+        let mut params = RaBitQParams::new(16);
+        // Calibrate with a few vectors
+        for i in 0..10 {
+            let v: Vec<f32> = (0..16)
+                .map(|j| ((i * 16 + j) as f32 / 100.0).sin())
+                .collect();
+            params.update_calibration(&v);
+        }
+        params.finalize_calibration();
+
+        let embedding: Vec<f32> = (0..16).map(|j| (j as f32 / 10.0).cos()).collect();
+        let (code, cd, x0) = params.encode(&embedding);
+
+        assert_eq!(code.len(), RaBitQParams::code_size(16)); // 2 bytes
+        assert!(cd > 0.0, "centroid_dist should be positive");
+        assert!(x0 > 0.0 && x0 <= 1.0, "x0 should be in (0, 1], got {}", x0);
+    }
+
+    #[test]
+    fn test_rabitq_distance_estimation() {
+        let dim = 64;
+        let mut params = RaBitQParams::new(dim);
+
+        // Calibrate
+        for i in 0..100 {
+            let v: Vec<f32> = (0..dim)
+                .map(|j| ((i * dim + j) as f32 / 1000.0).sin())
+                .collect();
+            params.update_calibration(&v);
+        }
+        params.finalize_calibration();
+
+        // Encode a vector and estimate distance to a query
+        let data: Vec<f32> = (0..dim).map(|j| (j as f32 / 30.0).sin()).collect();
+        let query: Vec<f32> = (0..dim).map(|j| (j as f32 / 20.0).cos()).collect();
+
+        let (code, cd, x0) = params.encode(&data);
+        let (q_rotated, q_dist) = params.preprocess_query(&query);
+
+        // Estimate distance
+        let ip = binary_inner_product(&code, &q_rotated, dim);
+        let ratio = ip / x0;
+        let est_dist_sq = (cd * cd + q_dist * q_dist - 2.0 * cd * q_dist * ratio).max(0.0);
+
+        // Exact distance
+        let exact_dist_sq: f32 = data
+            .iter()
+            .zip(query.iter())
+            .map(|(a, b)| (a - b) * (a - b))
+            .sum();
+
+        // RaBitQ error is O(1/√D), so for D=64 we expect ~12% error
+        let relative_error = (est_dist_sq - exact_dist_sq).abs() / exact_dist_sq.max(1e-6);
+        assert!(
+            relative_error < 0.5,
+            "relative error {} too large (est={}, exact={})",
+            relative_error,
+            est_dist_sq,
+            exact_dist_sq
+        );
+    }
+
+    #[test]
+    fn test_rabitq_serialization_roundtrip() {
+        let dim = 32;
+        let mut params = RaBitQParams::new(dim);
+        for i in 0..50 {
+            let v: Vec<f32> = (0..dim).map(|j| ((i + j) as f32).sin()).collect();
+            params.update_calibration(&v);
+        }
+        params.finalize_calibration();
+
+        let bytes = params.to_bytes();
+        let restored = RaBitQParams::from_bytes(&bytes).unwrap();
+
+        assert_eq!(params.centroid, restored.centroid);
+        assert_eq!(params.dimension, restored.dimension);
+        assert_eq!(params.seed, restored.seed);
+        assert!(restored.calibrated);
+        // Rotation should be regenerated identically from the same seed
+        assert_eq!(params.rotation.len(), restored.rotation.len());
+        for (a, b) in params.rotation.iter().zip(restored.rotation.iter()) {
+            assert!((a - b).abs() < 1e-6, "rotation mismatch: {} vs {}", a, b);
+        }
+    }
+
+    #[test]
+    fn test_rabitq_dequantize_preserves_direction() {
+        let dim = 32;
+        let mut params = RaBitQParams::new(dim);
+        for i in 0..50 {
+            let v: Vec<f32> = (0..dim).map(|j| ((i + j) as f32 / 10.0).sin()).collect();
+            params.update_calibration(&v);
+        }
+        params.finalize_calibration();
+
+        let embedding: Vec<f32> = (0..dim).map(|j| (j as f32 / 5.0).cos()).collect();
+        let (code, cd, x0) = params.encode(&embedding);
+        let reconstructed = params.dequantize(&code, cd, x0);
+
+        // Cosine similarity between original and reconstructed should be positive
+        let dot: f32 = embedding
+            .iter()
+            .zip(reconstructed.iter())
+            .map(|(a, b)| a * b)
+            .sum();
+        let norm_orig = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let norm_recon = reconstructed.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let cosine = dot / (norm_orig * norm_recon + 1e-10);
+
+        assert!(
+            cosine > 0.5,
+            "reconstructed vector should roughly preserve direction, cosine={}",
+            cosine
+        );
+    }
+
+    #[test]
+    fn test_rabitq_degenerate_zero_vector() {
+        let dim = 8;
+        let mut params = RaBitQParams::new(dim);
+        params.update_calibration(&[1.0; 8]);
+        params.finalize_calibration();
+
+        // Encode a vector that equals the centroid
+        let (code, cd, x0) = params.encode(&params.centroid.clone());
+        assert!(cd < 1e-9);
+        assert!((x0 - 0.8).abs() < 1e-6, "degenerate x0 should be 0.8");
+        assert_eq!(code, vec![0u8; 1]); // all zeros
+    }
+
+    #[test]
+    fn test_binary_inner_product_basic() {
+        // 8-dim: code = [0b11110000] = bits 1,1,1,1,0,0,0,0
+        let code = vec![0b11110000u8];
+        let q = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let ip = binary_inner_product(&code, &q, 8);
+
+        // Expected: (1+2+3+4 - 5-6-7-8) / sqrt(8) = (10 - 26) / 2.828 = -16/2.828
+        let expected = (1.0 + 2.0 + 3.0 + 4.0 - 5.0 - 6.0 - 7.0 - 8.0) / (8.0f32).sqrt();
+        assert!(
+            (ip - expected).abs() < 1e-5,
+            "ip={}, expected={}",
+            ip,
+            expected
+        );
     }
 }

--- a/crates/vector/src/store/crud.rs
+++ b/crates/vector/src/store/crud.rs
@@ -588,16 +588,14 @@ impl VectorStore {
 
         // Update backend after KV commit succeeds
         let ts = now_micros();
-        for vid in &vector_ids {
-            if let Some(vector_id) = vid {
-                match backend.delete_with_timestamp(*vector_id, ts) {
-                    Ok(_) => {
-                        backend.remove_inline_meta(*vector_id);
-                    }
-                    Err(e) => {
-                        warn!(target: "strata::vector", collection, error = %e,
-                            "Backend delete failed after KV delete in batch; search will filter via KV check");
-                    }
+        for vector_id in vector_ids.iter().flatten() {
+            match backend.delete_with_timestamp(*vector_id, ts) {
+                Ok(_) => {
+                    backend.remove_inline_meta(*vector_id);
+                }
+                Err(e) => {
+                    warn!(target: "strata::vector", collection, error = %e,
+                        "Backend delete failed after KV delete in batch; search will filter via KV check");
                 }
             }
         }

--- a/tests/engine/p0_concurrency.rs
+++ b/tests/engine/p0_concurrency.rs
@@ -519,7 +519,9 @@ fn test_issue_1910_event_hash_chain_under_contention() {
     );
 
     // 2. Verify hash chain integrity: every event's prev_hash == predecessor's hash
-    let all_events = event.range(&branch_id, "default", 0, None, None, false, None).unwrap();
+    let all_events = event
+        .range(&branch_id, "default", 0, None, None, false, None)
+        .unwrap();
     assert_eq!(all_events.len(), total_events);
 
     let mut prev_hash = [0u8; 32]; // First event's prev_hash should be zeros
@@ -632,7 +634,9 @@ fn test_issue_1910_event_hash_chain_concurrent() {
     );
 
     // Verify chain integrity
-    let all_events = event.range(&branch_id, "default", 0, None, None, false, None).unwrap();
+    let all_events = event
+        .range(&branch_id, "default", 0, None, None, false, None)
+        .unwrap();
     assert_eq!(
         all_events.len(),
         total_events,

--- a/tests/engine/primitives/eventlog.rs
+++ b/tests/engine/primitives/eventlog.rs
@@ -757,7 +757,15 @@ fn range_query_returns_correct_slice() {
 
     // Range past end of log is clamped
     let results = event
-        .range(&test_db.branch_id, "default", 8, Some(100), None, false, None)
+        .range(
+            &test_db.branch_id,
+            "default",
+            8,
+            Some(100),
+            None,
+            false,
+            None,
+        )
         .unwrap();
     assert_eq!(results.len(), 2); // sequences 8, 9
 
@@ -1010,7 +1018,10 @@ fn range_by_time_returns_events_in_window() {
     event
         .append(&test_db.branch_id, "default", "type", payload_int(1))
         .unwrap();
-    let e0 = event.get(&test_db.branch_id, "default", 0).unwrap().unwrap();
+    let e0 = event
+        .get(&test_db.branch_id, "default", 0)
+        .unwrap()
+        .unwrap();
     let ts0 = e0.value.timestamp.as_micros();
 
     std::thread::sleep(std::time::Duration::from_millis(5));
@@ -1018,7 +1029,10 @@ fn range_by_time_returns_events_in_window() {
     event
         .append(&test_db.branch_id, "default", "type", payload_int(2))
         .unwrap();
-    let e1 = event.get(&test_db.branch_id, "default", 1).unwrap().unwrap();
+    let e1 = event
+        .get(&test_db.branch_id, "default", 1)
+        .unwrap()
+        .unwrap();
     let ts1 = e1.value.timestamp.as_micros();
 
     std::thread::sleep(std::time::Duration::from_millis(5));
@@ -1029,7 +1043,15 @@ fn range_by_time_returns_events_in_window() {
 
     // Query range [ts0, ts1] should return events 0 and 1
     let results = event
-        .range_by_time(&test_db.branch_id, "default", ts0, Some(ts1), None, false, None)
+        .range_by_time(
+            &test_db.branch_id,
+            "default",
+            ts0,
+            Some(ts1),
+            None,
+            false,
+            None,
+        )
         .unwrap();
     assert_eq!(results.len(), 2);
     assert_eq!(results[0].value.payload, payload_int(1));
@@ -1154,9 +1176,7 @@ fn list_types_returns_all_event_types() {
         .append(&test_db.branch_id, "default", "error", payload_int(4))
         .unwrap();
 
-    let mut types = event
-        .list_types(&test_db.branch_id, "default")
-        .unwrap();
+    let mut types = event.list_types(&test_db.branch_id, "default").unwrap();
     types.sort();
     assert_eq!(types, vec!["audit", "error", "metric"]);
 }
@@ -1166,8 +1186,6 @@ fn list_types_empty_log() {
     let test_db = TestDb::new();
     let event = test_db.event();
 
-    let types = event
-        .list_types(&test_db.branch_id, "default")
-        .unwrap();
+    let types = event.list_types(&test_db.branch_id, "default").unwrap();
     assert!(types.is_empty());
 }

--- a/tests/engine/primitives/kv.rs
+++ b/tests/engine/primitives/kv.rs
@@ -304,9 +304,12 @@ fn batch_get_returns_values_in_order() {
     let test_db = TestDb::new();
     let kv = test_db.kv();
 
-    kv.put(&test_db.branch_id, "default", "a", Value::Int(1)).unwrap();
-    kv.put(&test_db.branch_id, "default", "b", Value::Int(2)).unwrap();
-    kv.put(&test_db.branch_id, "default", "c", Value::Int(3)).unwrap();
+    kv.put(&test_db.branch_id, "default", "a", Value::Int(1))
+        .unwrap();
+    kv.put(&test_db.branch_id, "default", "b", Value::Int(2))
+        .unwrap();
+    kv.put(&test_db.branch_id, "default", "c", Value::Int(3))
+        .unwrap();
 
     let keys = vec!["c".to_string(), "a".to_string(), "b".to_string()];
     let results = kv.batch_get(&test_db.branch_id, "default", &keys).unwrap();
@@ -322,7 +325,8 @@ fn batch_get_missing_keys_return_none() {
     let test_db = TestDb::new();
     let kv = test_db.kv();
 
-    kv.put(&test_db.branch_id, "default", "exists", Value::Int(1)).unwrap();
+    kv.put(&test_db.branch_id, "default", "exists", Value::Int(1))
+        .unwrap();
 
     let keys = vec!["exists".to_string(), "missing".to_string()];
     let results = kv.batch_get(&test_db.branch_id, "default", &keys).unwrap();
@@ -349,11 +353,15 @@ fn batch_delete_returns_existed_flags() {
     let test_db = TestDb::new();
     let kv = test_db.kv();
 
-    kv.put(&test_db.branch_id, "default", "a", Value::Int(1)).unwrap();
-    kv.put(&test_db.branch_id, "default", "b", Value::Int(2)).unwrap();
+    kv.put(&test_db.branch_id, "default", "a", Value::Int(1))
+        .unwrap();
+    kv.put(&test_db.branch_id, "default", "b", Value::Int(2))
+        .unwrap();
 
     let keys = vec!["a".to_string(), "missing".to_string(), "b".to_string()];
-    let results = kv.batch_delete(&test_db.branch_id, "default", &keys).unwrap();
+    let results = kv
+        .batch_delete(&test_db.branch_id, "default", &keys)
+        .unwrap();
 
     assert_eq!(results, vec![true, false, true]);
 }
@@ -363,14 +371,23 @@ fn batch_delete_actually_removes_keys() {
     let test_db = TestDb::new();
     let kv = test_db.kv();
 
-    kv.put(&test_db.branch_id, "default", "x", Value::Int(10)).unwrap();
-    kv.put(&test_db.branch_id, "default", "y", Value::Int(20)).unwrap();
+    kv.put(&test_db.branch_id, "default", "x", Value::Int(10))
+        .unwrap();
+    kv.put(&test_db.branch_id, "default", "y", Value::Int(20))
+        .unwrap();
 
     let keys = vec!["x".to_string(), "y".to_string()];
-    kv.batch_delete(&test_db.branch_id, "default", &keys).unwrap();
+    kv.batch_delete(&test_db.branch_id, "default", &keys)
+        .unwrap();
 
-    assert!(kv.get(&test_db.branch_id, "default", "x").unwrap().is_none());
-    assert!(kv.get(&test_db.branch_id, "default", "y").unwrap().is_none());
+    assert!(kv
+        .get(&test_db.branch_id, "default", "x")
+        .unwrap()
+        .is_none());
+    assert!(kv
+        .get(&test_db.branch_id, "default", "y")
+        .unwrap()
+        .is_none());
 }
 
 #[test]
@@ -390,11 +407,15 @@ fn batch_exists_returns_correct_flags() {
     let test_db = TestDb::new();
     let kv = test_db.kv();
 
-    kv.put(&test_db.branch_id, "default", "a", Value::Int(1)).unwrap();
-    kv.put(&test_db.branch_id, "default", "c", Value::Int(3)).unwrap();
+    kv.put(&test_db.branch_id, "default", "a", Value::Int(1))
+        .unwrap();
+    kv.put(&test_db.branch_id, "default", "c", Value::Int(3))
+        .unwrap();
 
     let keys = vec!["a".to_string(), "b".to_string(), "c".to_string()];
-    let results = kv.batch_exists(&test_db.branch_id, "default", &keys).unwrap();
+    let results = kv
+        .batch_exists(&test_db.branch_id, "default", &keys)
+        .unwrap();
 
     assert_eq!(results, vec![true, false, true]);
 }
@@ -412,7 +433,8 @@ fn batch_get_returns_version_and_timestamp() {
     let test_db = TestDb::new();
     let kv = test_db.kv();
 
-    kv.put(&test_db.branch_id, "default", "key1", Value::Int(1)).unwrap();
+    kv.put(&test_db.branch_id, "default", "key1", Value::Int(1))
+        .unwrap();
 
     let keys = vec!["key1".to_string()];
     let results = kv.batch_get(&test_db.branch_id, "default", &keys).unwrap();
@@ -428,13 +450,18 @@ fn batch_delete_then_batch_exists_returns_false() {
     let test_db = TestDb::new();
     let kv = test_db.kv();
 
-    kv.put(&test_db.branch_id, "default", "a", Value::Int(1)).unwrap();
-    kv.put(&test_db.branch_id, "default", "b", Value::Int(2)).unwrap();
+    kv.put(&test_db.branch_id, "default", "a", Value::Int(1))
+        .unwrap();
+    kv.put(&test_db.branch_id, "default", "b", Value::Int(2))
+        .unwrap();
 
     let keys = vec!["a".to_string(), "b".to_string()];
-    kv.batch_delete(&test_db.branch_id, "default", &keys).unwrap();
+    kv.batch_delete(&test_db.branch_id, "default", &keys)
+        .unwrap();
 
-    let exists = kv.batch_exists(&test_db.branch_id, "default", &keys).unwrap();
+    let exists = kv
+        .batch_exists(&test_db.branch_id, "default", &keys)
+        .unwrap();
     assert_eq!(exists, vec![false, false]);
 }
 
@@ -443,7 +470,8 @@ fn batch_get_duplicate_keys_returns_same_value() {
     let test_db = TestDb::new();
     let kv = test_db.kv();
 
-    kv.put(&test_db.branch_id, "default", "dup", Value::Int(42)).unwrap();
+    kv.put(&test_db.branch_id, "default", "dup", Value::Int(42))
+        .unwrap();
 
     let keys = vec!["dup".to_string(), "dup".to_string()];
     let results = kv.batch_get(&test_db.branch_id, "default", &keys).unwrap();
@@ -458,10 +486,13 @@ fn batch_delete_duplicate_key_first_true_second_false() {
     let test_db = TestDb::new();
     let kv = test_db.kv();
 
-    kv.put(&test_db.branch_id, "default", "dup", Value::Int(1)).unwrap();
+    kv.put(&test_db.branch_id, "default", "dup", Value::Int(1))
+        .unwrap();
 
     let keys = vec!["dup".to_string(), "dup".to_string()];
-    let results = kv.batch_delete(&test_db.branch_id, "default", &keys).unwrap();
+    let results = kv
+        .batch_delete(&test_db.branch_id, "default", &keys)
+        .unwrap();
 
     // First delete finds the key, second sees it already deleted within the same txn
     assert_eq!(results, vec![true, false]);

--- a/tests/engine/primitives/vectorstore.rs
+++ b/tests/engine/primitives/vectorstore.rs
@@ -835,6 +835,223 @@ fn int8_memory_savings() {
 }
 
 // ============================================================================
+// Binary (RaBitQ) Quantization
+// ============================================================================
+
+fn config_binary(dimension: usize) -> VectorConfig {
+    VectorConfig {
+        dimension,
+        metric: DistanceMetric::Cosine,
+        storage_dtype: StorageDtype::Binary,
+    }
+}
+
+#[test]
+fn binary_create_collection_and_insert() {
+    let test_db = TestDb::new();
+    let vector = test_db.vector();
+
+    let config = config_binary(384);
+    vector
+        .create_collection(test_db.branch_id, "default", "bin_coll", config)
+        .unwrap();
+
+    for i in 0..300 {
+        let key = format!("vec_{}", i);
+        let emb = seeded_vector(384, i as u64);
+        vector
+            .insert(test_db.branch_id, "default", "bin_coll", &key, &emb, None)
+            .unwrap();
+    }
+
+    let info = vector
+        .list_collections(test_db.branch_id, "default")
+        .unwrap();
+    let coll = info.iter().find(|c| c.name == "bin_coll").unwrap();
+    assert_eq!(coll.count, 300);
+}
+
+#[test]
+fn binary_search_returns_results() {
+    let test_db = TestDb::new();
+    let vector = test_db.vector();
+
+    let config = config_binary(384);
+    vector
+        .create_collection(test_db.branch_id, "default", "bin_search", config)
+        .unwrap();
+
+    for i in 0..300 {
+        let key = format!("vec_{}", i);
+        let emb = seeded_vector(384, i as u64);
+        vector
+            .insert(test_db.branch_id, "default", "bin_search", &key, &emb, None)
+            .unwrap();
+    }
+
+    let query = seeded_vector(384, 42);
+    let results = vector
+        .search(test_db.branch_id, "default", "bin_search", &query, 5, None)
+        .unwrap();
+
+    assert_eq!(results.len(), 5);
+    // The exact match should be the top result
+    assert_eq!(results[0].key, "vec_42");
+}
+
+#[test]
+fn binary_search_accuracy_vs_f32() {
+    let test_db = TestDb::new();
+    let vector = test_db.vector();
+
+    // Use Euclidean metric — RaBitQ directly estimates squared Euclidean distance,
+    // so Euclidean similarity is more accurate than Cosine for binary quantization.
+    let config_f = VectorConfig {
+        dimension: 384,
+        metric: DistanceMetric::Euclidean,
+        storage_dtype: StorageDtype::F32,
+    };
+    let config_b = VectorConfig {
+        dimension: 384,
+        metric: DistanceMetric::Euclidean,
+        storage_dtype: StorageDtype::Binary,
+    };
+
+    vector
+        .create_collection(test_db.branch_id, "default", "f32_coll", config_f)
+        .unwrap();
+    vector
+        .create_collection(test_db.branch_id, "default", "bin_coll", config_b)
+        .unwrap();
+
+    // Create structured data: base vectors with perturbations (realistic embedding clusters)
+    let base = seeded_vector(384, 42);
+    for i in 0..300 {
+        let key = format!("vec_{}", i);
+        let noise = seeded_vector(384, 1000 + i as u64);
+        // Mix: 70% base direction + 30% noise gives vectors with genuine similarity structure
+        let scale = if i < 10 {
+            0.1
+        } else {
+            0.5 + (i as f32 / 300.0)
+        };
+        let emb: Vec<f32> = base
+            .iter()
+            .zip(noise.iter())
+            .map(|(&b, &n)| b * (1.0 - scale) + n * scale)
+            .collect();
+        vector
+            .insert(test_db.branch_id, "default", "f32_coll", &key, &emb, None)
+            .unwrap();
+        vector
+            .insert(test_db.branch_id, "default", "bin_coll", &key, &emb, None)
+            .unwrap();
+    }
+
+    // Query is close to the base — vectors with low scale (i < 10) should rank highest
+    let query: Vec<f32> = base.iter().map(|&b| b * 1.05).collect();
+    let f32_results = vector
+        .search(test_db.branch_id, "default", "f32_coll", &query, 10, None)
+        .unwrap();
+    let bin_results = vector
+        .search(test_db.branch_id, "default", "bin_coll", &query, 10, None)
+        .unwrap();
+
+    assert_eq!(f32_results.len(), 10);
+    assert_eq!(bin_results.len(), 10);
+
+    // Top-1 should be the same (closest vector to base)
+    assert_eq!(
+        f32_results[0].key, bin_results[0].key,
+        "Top-1 should match: f32={}, binary={}",
+        f32_results[0].key, bin_results[0].key
+    );
+
+    // Top-10 overlap with structured data should be reasonable
+    let f32_keys: std::collections::HashSet<_> =
+        f32_results.iter().map(|r| r.key.clone()).collect();
+    let bin_keys: std::collections::HashSet<_> =
+        bin_results.iter().map(|r| r.key.clone()).collect();
+    let overlap = f32_keys.intersection(&bin_keys).count();
+    assert!(
+        overlap >= 5,
+        "Expected at least 5/10 overlap in top-10, got {}/10. F32 top: {:?}, Binary top: {:?}",
+        overlap,
+        f32_results
+            .iter()
+            .take(5)
+            .map(|r| &r.key)
+            .collect::<Vec<_>>(),
+        bin_results
+            .iter()
+            .take(5)
+            .map(|r| &r.key)
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn binary_delete_works() {
+    let test_db = TestDb::new();
+    let vector = test_db.vector();
+
+    let config = config_binary(384);
+    vector
+        .create_collection(test_db.branch_id, "default", "bin_del", config)
+        .unwrap();
+
+    for i in 0..300 {
+        let key = format!("vec_{}", i);
+        let emb = seeded_vector(384, i as u64);
+        vector
+            .insert(test_db.branch_id, "default", "bin_del", &key, &emb, None)
+            .unwrap();
+    }
+
+    vector
+        .delete(test_db.branch_id, "default", "bin_del", "vec_50")
+        .unwrap();
+
+    let query = seeded_vector(384, 50);
+    let results = vector
+        .search(test_db.branch_id, "default", "bin_del", &query, 5, None)
+        .unwrap();
+
+    assert!(
+        !results.iter().any(|r| r.key == "vec_50"),
+        "Deleted vector should not appear in search results"
+    );
+}
+
+#[test]
+fn binary_small_collection_before_calibration() {
+    let test_db = TestDb::new();
+    let vector = test_db.vector();
+
+    let config = config_binary(16);
+    vector
+        .create_collection(test_db.branch_id, "default", "bin_small", config)
+        .unwrap();
+
+    // Insert only 5 vectors (below calibration threshold)
+    for i in 0..5 {
+        let key = format!("vec_{}", i);
+        let emb = seeded_vector(16, i as u64);
+        vector
+            .insert(test_db.branch_id, "default", "bin_small", &key, &emb, None)
+            .unwrap();
+    }
+
+    let query = seeded_vector(16, 2);
+    let results = vector
+        .search(test_db.branch_id, "default", "bin_small", &query, 3, None)
+        .unwrap();
+
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].key, "vec_2");
+}
+
+// ============================================================================
 // Batch Get
 // ============================================================================
 
@@ -849,13 +1066,34 @@ fn batch_get_returns_vectors_in_order() {
         .unwrap();
 
     vector
-        .insert(test_db.branch_id, "default", "coll", "a", &[1.0, 0.0, 0.0], None)
+        .insert(
+            test_db.branch_id,
+            "default",
+            "coll",
+            "a",
+            &[1.0, 0.0, 0.0],
+            None,
+        )
         .unwrap();
     vector
-        .insert(test_db.branch_id, "default", "coll", "b", &[0.0, 1.0, 0.0], None)
+        .insert(
+            test_db.branch_id,
+            "default",
+            "coll",
+            "b",
+            &[0.0, 1.0, 0.0],
+            None,
+        )
         .unwrap();
     vector
-        .insert(test_db.branch_id, "default", "coll", "c", &[0.0, 0.0, 1.0], None)
+        .insert(
+            test_db.branch_id,
+            "default",
+            "coll",
+            "c",
+            &[0.0, 0.0, 1.0],
+            None,
+        )
         .unwrap();
 
     let keys = vec!["c".to_string(), "a".to_string(), "b".to_string()];
@@ -864,9 +1102,18 @@ fn batch_get_returns_vectors_in_order() {
         .unwrap();
 
     assert_eq!(results.len(), 3);
-    assert_eq!(results[0].as_ref().unwrap().value.embedding, vec![0.0, 0.0, 1.0]);
-    assert_eq!(results[1].as_ref().unwrap().value.embedding, vec![1.0, 0.0, 0.0]);
-    assert_eq!(results[2].as_ref().unwrap().value.embedding, vec![0.0, 1.0, 0.0]);
+    assert_eq!(
+        results[0].as_ref().unwrap().value.embedding,
+        vec![0.0, 0.0, 1.0]
+    );
+    assert_eq!(
+        results[1].as_ref().unwrap().value.embedding,
+        vec![1.0, 0.0, 0.0]
+    );
+    assert_eq!(
+        results[2].as_ref().unwrap().value.embedding,
+        vec![0.0, 1.0, 0.0]
+    );
 }
 
 #[test]
@@ -880,7 +1127,14 @@ fn batch_get_missing_keys_return_none() {
         .unwrap();
 
     vector
-        .insert(test_db.branch_id, "default", "coll", "exists", &[1.0, 2.0, 3.0], None)
+        .insert(
+            test_db.branch_id,
+            "default",
+            "coll",
+            "exists",
+            &[1.0, 2.0, 3.0],
+            None,
+        )
         .unwrap();
 
     let keys = vec!["exists".to_string(), "missing".to_string()];
@@ -924,10 +1178,24 @@ fn batch_delete_returns_existed_flags() {
         .unwrap();
 
     vector
-        .insert(test_db.branch_id, "default", "coll", "a", &[1.0, 0.0, 0.0], None)
+        .insert(
+            test_db.branch_id,
+            "default",
+            "coll",
+            "a",
+            &[1.0, 0.0, 0.0],
+            None,
+        )
         .unwrap();
     vector
-        .insert(test_db.branch_id, "default", "coll", "b", &[0.0, 1.0, 0.0], None)
+        .insert(
+            test_db.branch_id,
+            "default",
+            "coll",
+            "b",
+            &[0.0, 1.0, 0.0],
+            None,
+        )
         .unwrap();
 
     let keys = vec!["a".to_string(), "missing".to_string(), "b".to_string()];
@@ -949,10 +1217,24 @@ fn batch_delete_actually_removes_vectors() {
         .unwrap();
 
     vector
-        .insert(test_db.branch_id, "default", "coll", "x", &[1.0, 0.0, 0.0], None)
+        .insert(
+            test_db.branch_id,
+            "default",
+            "coll",
+            "x",
+            &[1.0, 0.0, 0.0],
+            None,
+        )
         .unwrap();
     vector
-        .insert(test_db.branch_id, "default", "coll", "y", &[0.0, 1.0, 0.0], None)
+        .insert(
+            test_db.branch_id,
+            "default",
+            "coll",
+            "y",
+            &[0.0, 1.0, 0.0],
+            None,
+        )
         .unwrap();
 
     let keys = vec!["x".to_string(), "y".to_string()];
@@ -960,8 +1242,14 @@ fn batch_delete_actually_removes_vectors() {
         .batch_delete(test_db.branch_id, "default", "coll", &keys)
         .unwrap();
 
-    assert!(vector.get(test_db.branch_id, "default", "coll", "x").unwrap().is_none());
-    assert!(vector.get(test_db.branch_id, "default", "coll", "y").unwrap().is_none());
+    assert!(vector
+        .get(test_db.branch_id, "default", "coll", "x")
+        .unwrap()
+        .is_none());
+    assert!(vector
+        .get(test_db.branch_id, "default", "coll", "y")
+        .unwrap()
+        .is_none());
 }
 
 #[test]
@@ -1022,7 +1310,14 @@ fn batch_delete_then_get_returns_none() {
         .unwrap();
 
     vector
-        .insert(test_db.branch_id, "default", "coll", "a", &[1.0, 0.0, 0.0], None)
+        .insert(
+            test_db.branch_id,
+            "default",
+            "coll",
+            "a",
+            &[1.0, 0.0, 0.0],
+            None,
+        )
         .unwrap();
 
     let keys = vec!["a".to_string()];


### PR DESCRIPTION
## Summary

- Adds `StorageDtype::Binary` implementing the **RaBitQ algorithm** (Gao & Long, SIGMOD 2024) — D-dimensional vectors quantized to D bits via random orthogonal rotation + sign encoding
- **27x compression** on 384-dim vectors (56 bytes/vector vs 1536 for f32) with ~5% recall loss on structured data
- `RaBitQParams` in `quantize.rs`: seeded orthogonal rotation matrix (QR via Gram-Schmidt), centroid calibration, binary encode/decode, O(D²) query preprocessing cached per-search via thread-local
- `compute_binary_similarity()` + `dist_sq_to_similarity()` shared helper in `distance.rs` — converts estimated dist² to Euclidean/Cosine/DotProduct similarity scores
- `InMemoryBinary` VectorData variant with packed binary codes + per-vector correction scalars (centroid_dist, x0)
- Same calibration lifecycle, `distance_to()` dispatch, and freeze-to-f32 mmap pattern as Int8 — **zero changes** to HNSW, segmented, or brute-force backends
- Config support: `default_vector_dtype = "binary"` or `"rabitq"` in `strata.toml`
- 7 new unit tests (rotation orthogonality, encode/decode, distance estimation, serialization) + 5 integration tests (CRUD, search accuracy vs F32, delete, pre-calibration)

## Builds on

- PR #2065 (Int8 SQ8, merged) — reuses calibration lifecycle, `distance_to()` infrastructure, `get_f32_owned()` cold paths

## Test plan

- [x] All 337 vector crate unit tests pass
- [x] All 275 engine integration tests pass  
- [x] 7 new RaBitQ unit tests: rotation orthogonality, encode, distance estimation, serialization, degenerate cases
- [x] 5 new Binary integration tests: create+insert (300 vectors), search top-1 accuracy, F32 vs Binary recall (structured data, Euclidean), delete, pre-calibration search
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)