### PR TITLE
Update embedded profile default to binary (RaBitQ) quantization

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -181,7 +181,7 @@ fn build_config(profile: Profile, hw: &HardwareInfo) -> strata_executor::StrataC
                 compaction_rate_limit: 5 * 1024 * 1024,
                 ..StorageConfig::default()
             };
-            cfg.default_vector_dtype = "int8".to_string();
+            cfg.default_vector_dtype = "binary".to_string();
         }
         Profile::Desktop => {
             cfg.storage = StorageConfig {


### PR DESCRIPTION
## Summary

- Changes embedded profile (<1GB RAM) default from `"int8"` (4x) to `"binary"` (32x compression)
- 384-dim vectors: 56 bytes/vector with RaBitQ vs 384 bytes with Int8 vs 1536 bytes with F32
- Critical for Pi Zero (512MB RAM) target where even Int8 can exhaust memory at scale

One-line change in `crates/cli/src/init.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)