### PR TITLE
Search architecture design: retrieval substrate, intelligence layer, strategy

### DIFF
--- a/docs/design/search/README.md
+++ b/docs/design/search/README.md
@@ -1,0 +1,16 @@
+# Strata Retrieval Architecture
+
+## Documents
+
+| Document | Purpose |
+|----------|---------|
+| [`search-strategy.md`](search-strategy.md) | **Start here.** Philosophy, three-layer architecture, ablation study, implementation roadmap. |
+| [`retrieval-substrate.md`](retrieval-substrate.md) | Layer 1: Recipe schema, pipeline, invariants, operators, predicates, aggregations. |
+| [`intelligence-layer.md`](intelligence-layer.md) | Layer 2: Query-time flow, write-time enrichment, RAG, AutoResearch, Qwen3 usage. |
+
+## Related
+
+| Document | Purpose |
+|----------|---------|
+| [`../search-pipeline-implementation-plan.md`](../search-pipeline-implementation-plan.md) | Phase-by-phase search quality improvements |
+| [`../autoresearch-search-optimization.md`](../autoresearch-search-optimization.md) | Branch-parallel experimentation methodology |

--- a/docs/design/search/intelligence-layer.md
+++ b/docs/design/search/intelligence-layer.md
@@ -1,0 +1,470 @@
+# Intelligence Layer
+
+The optional layer between the user and the retrieval substrate. Powered by a local LLM (Qwen3 via strata-inference). Three features, each building on the substrate.
+
+For the retrieval substrate spec, see [`retrieval-substrate.md`](retrieval-substrate.md).
+For the overall strategy, see [`search-strategy.md`](search-strategy.md).
+
+---
+
+## 1. Three Features
+
+| Feature | What it does | Why it's unique |
+|---------|-------------|-----------------|
+| **RAG** | Ask a question, get a grounded answer with citations | Built into the database. One call. Zero infra. |
+| **Temporal Search** | Search at any point in time. Diff results across time. Explain what changed. | Requires MVCC + deterministic search + in-process LLM. No other database has all three. |
+| **AutoResearch** | The database tunes its own search recipe to your dataset | O(1) branching makes 1000s of experiments feasible. Architecturally impossible elsewhere. |
+
+Everything else — query expansion, reranking, auto-tagging, summarization, iterative refinement, data profiling — is future work. Get these three right first.
+
+---
+
+## 2. RAG
+
+### What the user sees
+
+```python
+results = db.search(
+    "What are the side effects of metformin?",
+    mode="rag"
+)
+
+# results.answer.text → "Common side effects of metformin include nausea,
+#   diarrhea, and stomach pain [1][3]. In rare cases, lactic acidosis
+#   may occur, particularly in elderly patients [5]."
+# results.answer.sources → [1, 3, 5]
+# results.hits → [...full ranked results...]
+```
+
+One call. The user gets a grounded answer with source citations AND the ranked hits. No external APIs, no pipeline of tools, no infrastructure.
+
+### How it works
+
+```
+User: db.search("What are the side effects of metformin?", mode="rag")
+  │
+  ▼
+1. EMBED query (intelligence layer, ~5ms)
+  │
+  ▼
+2. SUBSTRATE executes recipe (deterministic, ~15ms)
+   Returns ranked hits with snippets.
+  │
+  ▼
+3. GENERATE answer from top hits (Qwen3, ~200ms)
+   Prompt: system instructions + retrieved snippets + user question.
+   Output: grounded answer with [N] citations.
+  │
+  ▼
+Return: { hits, answer: {text, sources}, aggregations, groups, stats }
+```
+
+### Prompt design
+
+```
+System: Answer the question using ONLY the provided context.
+Cite sources using [1], [2], etc. If the context doesn't contain
+the answer, say so.
+
+Context:
+[1] {snippet from hit #1}
+[2] {snippet from hit #2}
+[3] {snippet from hit #3}
+[4] {snippet from hit #4}
+[5] {snippet from hit #5}
+
+Question: {user's query}
+```
+
+### Key properties
+
+- **Grounded** — the answer comes from retrieved context, not model knowledge
+- **Cited** — every claim references a source hit by index
+- **Honest** — if the context doesn't answer the question, it says so
+- **Deterministic retrieval** — the hits are always the same (substrate invariant). The generated answer may vary slightly (LLM is non-deterministic). This is acceptable — the user cares about answer quality, not byte-identical answers.
+
+### Configuration
+
+| Param | Default | What it controls |
+|-------|---------|-----------------|
+| `rag_context_hits` | 5 | How many hits to include in the prompt |
+| `rag_max_tokens` | 500 | Maximum answer length |
+
+### Graceful degradation
+
+If Qwen3 is unavailable or inference fails: `answer` is `null`, hits are still returned. The user gets standard search results. RAG enhances but never blocks.
+
+### Future: RLM evolution
+
+RAG is a single pass: retrieve → generate. In the future, this evolves naturally to RLM Tier 1 (iterative refinement): retrieve → generate → examine → refine query → retrieve again. The substrate doesn't change. The intelligence layer just calls it in a loop. The upgrade path is:
+
+```
+RAG (v1):  retrieve once → generate
+RLM (v2):  retrieve → examine → refine → retrieve → ... → generate
+```
+
+No architectural changes needed. The loop wraps around the same substrate call.
+
+---
+
+## 3. Temporal Search
+
+### What the user sees
+
+```python
+# Search as of a specific point in time
+results = db.search("metformin side effects", as_of="2025-01-01")
+
+# Diff: what changed between two points in time
+results = db.search("metformin side effects",
+    diff=("2024-01-01", "2025-06-01"))
+
+# Temporal RAG: explain what changed
+results = db.search(
+    "How has our understanding of metformin side effects evolved?",
+    mode="rag",
+    diff=("2024-01-01", "2025-06-01")
+)
+```
+
+### How it works
+
+**Point-in-time search (`as_of`):**
+
+```
+1. Set snapshot_version to the MVCC version at the given timestamp
+2. Execute recipe at that snapshot (substrate, deterministic)
+3. Return results as they would have appeared at that time
+```
+
+This is straightforward — the substrate already supports `snapshot_version` in the recipe's control section. The intelligence layer just resolves a timestamp to a snapshot version.
+
+**Temporal diff (`diff`):**
+
+```
+1. Execute recipe at snapshot T1 → results_before
+2. Execute recipe at snapshot T2 → results_after
+3. Compute diff:
+   - new_hits: in results_after but not results_before
+   - removed_hits: in results_before but not results_after
+   - changed_hits: in both but score changed significantly
+   - stable_hits: in both with similar scores
+4. Return structured diff
+```
+
+**Temporal RAG (`diff` + `mode="rag"`):**
+
+```
+1. Compute diff (as above)
+2. Construct prompt with diff context:
+   "These results are NEW since {T1}: [snippets]"
+   "These results were REMOVED since {T1}: [snippets]"
+   "These results CHANGED in ranking: [snippets]"
+3. Qwen3 generates explanation of what changed
+4. Return: answer + diff + hits from both snapshots
+```
+
+### Response format
+
+Same fixed structure, with temporal fields populated:
+
+```json
+{
+  "hits": [/* results at T2 (latest snapshot) */],
+
+  "answer": {
+    "text": "Since January 2024, two new studies on metformin side effects have been added [1][2]. The GI-related side effects remain the most documented [3], but a new finding on vitamin B12 deficiency [1] has entered the top results.",
+    "sources": [1, 2, 3]
+  },
+
+  "diff": {
+    "before_snapshot": 38201,
+    "after_snapshot": 42891,
+    "new_hits": [
+      {"entity_ref": {...}, "score": 0.82, "rank": 2}
+    ],
+    "removed_hits": [
+      {"entity_ref": {...}, "previous_score": 0.65, "previous_rank": 4}
+    ],
+    "changed_hits": [
+      {"entity_ref": {...}, "score": 0.91, "previous_score": 0.78, "rank": 1, "previous_rank": 3}
+    ]
+  },
+
+  "aggregations": null,
+  "groups": null,
+  "stats": {/* includes timing for both snapshot queries */}
+}
+```
+
+Wait — this adds a `diff` field to the response. That breaks the "fixed structure" rule.
+
+**Resolution:** `diff` is always present in the response, `null` when not a temporal query. Same as `answer`, `aggregations`, `groups`. The fixed structure becomes:
+
+```json
+{
+  "hits": [],
+  "answer": null,
+  "diff": null,
+  "aggregations": null,
+  "groups": null,
+  "stats": {}
+}
+```
+
+Six fields. Always present. Populated or null.
+
+### Why only Strata can do this
+
+1. **MVCC snapshots at every write** — Strata can search at any historical state, not just "now"
+2. **Deterministic recipes** — the same recipe at two snapshots produces a meaningful diff. If search were non-deterministic, the diff would be noise.
+3. **In-process LLM** — Qwen3 explains the diff in natural language. Without it, the user gets raw before/after lists and has to interpret them.
+
+No other database has all three. Elasticsearch doesn't snapshot. Pinecone doesn't do time-travel. Even databases with MVCC (Postgres) don't have search recipes or in-process LLMs.
+
+### Use cases
+
+| Use case | Query |
+|----------|-------|
+| Compliance | "What did we know about this drug interaction on March 15th?" |
+| Research | "How has our data about climate impacts evolved this year?" |
+| Auditing | "When did this document first appear in search results?" |
+| Debugging | "Why did search quality change after the last data load?" |
+| Change monitoring | "What's new in our legal corpus since last review?" |
+
+---
+
+## 4. AutoResearch
+
+### What the user sees
+
+```python
+# User provides evaluation pairs (what good results look like)
+eval_set = [
+    {"query": "metformin side effects", "relevant": ["doc:123", "doc:456"]},
+    {"query": "drug interactions warfarin", "relevant": ["doc:789"]},
+    # ... 50-100 pairs
+]
+
+# One call. Database optimizes its own search.
+result = db.optimize_search(eval_set, budget=1000)
+
+# result.baseline_ndcg → 0.42
+# result.optimized_ndcg → 0.68
+# result.experiments_run → 847
+# result.winning_recipe → {...}  (automatically saved as default)
+```
+
+### How it works
+
+```
+1. User provides eval_set (query → relevant docs pairs)
+2. Evaluate current recipe → baseline metrics
+3. Loop:
+   a. Qwen3 proposes N recipe variants (mutations of current best)
+   b. For each variant:
+      - Fork a branch
+      - Store variant recipe
+      - substrate.evaluate(variant, eval_set) → metrics
+   c. If best variant > current best → adopt it
+   d. If no improvement for 5 rounds → stop
+4. Save winning recipe as database default
+5. Return results: baseline → optimized metrics, experiments run, winning recipe
+```
+
+### What gets tuned
+
+Every parameter in the recipe is a candidate:
+
+| Parameter | Range | What it affects |
+|-----------|-------|----------------|
+| `bm25.k1` | 0.5 — 2.0 | Term frequency saturation |
+| `bm25.b` | 0.1 — 1.0 | Document length normalization |
+| `bm25.field_weights.*` | 0.0 — 5.0 | Per-field importance |
+| `bm25.stemmer` | porter / snowball / none | Tokenization |
+| `bm25.stopwords` | lucene33 / smart571 / none | Term filtering |
+| `bm25.phrase_boost` | 0.0 — 5.0 | Exact phrase importance |
+| `bm25.proximity_boost` | 0.0 — 2.0 | Term proximity importance |
+| `vector.k` | 10 — 200 | Vector candidate count |
+| `vector.ef_search` | 50 — 500 | HNSW recall vs speed |
+| `graph.damping` | 0.1 — 0.9 | PPR exploration depth |
+| `graph.max_hops` | 1 — 5 | Neighborhood traversal depth |
+| `fusion.k` | 10 — 200 | RRF smoothing constant |
+| `fusion.weights.*` | 0.0 — 3.0 | Per-source importance |
+
+### Experiment planning (Qwen3's role)
+
+Qwen3 doesn't do random search. It reads previous experiment results and plans the next batch intelligently:
+
+- **Round 1:** Broad exploration — sweep major parameters (k1, b, fusion weights)
+- **Round 5:** Narrow in — focus on parameters that showed sensitivity
+- **Round 10:** Fine-tune — small adjustments around the current best
+- **Ablation:** Periodically disable one component to measure its contribution
+
+The prompt includes the experiment history and asks: "Given these results, what should we try next?"
+
+### Why it requires user-provided eval pairs
+
+The database doesn't know what "good results" means for your data. A medical corpus needs different relevance judgments than a legal corpus. The user provides 50-100 (query, relevant_docs) pairs that define their quality standard. This is the only human input required.
+
+AutoResearch optimizes the recipe to maximize NDCG@10 (or another metric) on these eval pairs.
+
+### Cost
+
+- Each experiment: one `evaluate()` call (~100 queries × ~50ms = ~5 seconds)
+- 1000 experiments: ~80 minutes sequential, faster with CPU parallelism
+- Qwen3 planning: ~3 seconds per round, negligible vs experiment time
+
+### Graceful degradation
+
+If Qwen3 is unavailable: fall back to grid search over the parameter space (no intelligent planning, but still works). If evaluate() fails: abort and return the best recipe found so far.
+
+---
+
+## 5. Search Quality Knobs
+
+Query expansion and reranking are not features — they're tunable configuration that makes search better. No new API. The user turns them on, `db.search()` returns better results.
+
+### 5.1 Query Expansion
+
+When enabled, the intelligence layer expands the query before calling the substrate.
+
+| Strategy | What it does | Routed to |
+|----------|-------------|-----------|
+| `lex` | Keyword synonyms ("metformin" → "glucophage") | BM25 |
+| `vec` | Semantic variants ("side effects" → "adverse reactions") | Vector |
+| `hyde` | Hypothetical document | Vector |
+
+**Strong signal skip:** BM25 probe first. If top score ≥ threshold with clear gap → skip expansion. Saves ~100ms on easy queries.
+
+**Hallucination guard:** Discard variants sharing fewer than 2 stemmed terms with the original query.
+
+### 5.2 Reranking
+
+When enabled, the intelligence layer re-scores the top-N results after the substrate returns them.
+
+- **Cross-encoder:** Feed (query, passage) pairs to a cross-encoder model. Deterministic, fast (~100ms for 20 candidates).
+- **LLM-as-judge:** Feed all candidates to Qwen3, ask for relevance scores. Less calibrated but doesn't need a separate model (~200ms).
+
+### 5.3 Configuration
+
+```python
+db.configure(
+    expansion=True,           # on/off
+    expansion_strategy="lex", # lex, vec, hyde, full
+    reranking=True,           # on/off
+    rerank_top_n=20,          # how many to rerank
+)
+```
+
+These knobs are also tunable by AutoResearch — it can discover whether expansion helps on your specific dataset and which strategy works best.
+
+---
+
+## 6. What's NOT in v1
+
+These come later, once the core features and knobs are solid:
+
+| Feature | Why not now |
+|---------|-----------|
+| Auto-tagging | Requires user-defined tag categories. Extra configuration surface. |
+| Summarization | Useful for long docs but not critical path. |
+| Iterative refinement (RLM) | Natural evolution of RAG. Single-pass must work first. |
+| Data profiling | Nice-to-have. Manual recipes work fine. |
+| Recipe suggestion | User can start with defaults. |
+| Synthetic eval generation | LLM-generated evals at 1.7B quality are too pattern-y to trust. |
+
+The upgrade path is additive. Each feature wraps around the existing flow without changing the substrate or the response format.
+
+---
+
+## 7. Graceful Degradation
+
+The intelligence layer never blocks search. Every feature fails silently.
+
+| If this fails... | What happens |
+|-----------------|-------------|
+| Qwen3 unavailable | RAG returns `answer: null`. Temporal diff returns raw diff, no explanation. AutoResearch falls back to grid search. |
+| Embedding model unavailable | Vector search disabled. BM25 still works. |
+| Inference timeout | Feature skipped. Results returned without that enhancement. |
+| Everything fails | You get substrate-only results. Same as if intelligence layer wasn't installed. |
+
+**Principle:** The substrate always works. The intelligence layer enhances but never blocks.
+
+---
+
+## 8. Configuration
+
+Minimal for v1.
+
+```python
+db.configure(
+    # Auto-embedding (already exists, on by default)
+    auto_embed=True,
+    embed_model="miniLM",
+
+    # Search quality knobs
+    expansion=False,          # off by default
+    expansion_strategy="lex",
+    reranking=False,          # off by default
+    rerank_top_n=20,
+
+    # RAG
+    rag_context_hits=5,       # hits included in RAG prompt
+    rag_max_tokens=500,       # max answer length
+
+    # AutoResearch — no config needed, just call db.optimize_search()
+)
+```
+
+Feature gating:
+- `cargo build` — substrate only. `db.search()` works. No RAG, no AutoResearch.
+- `cargo build --features embed` — intelligence layer available. All three features work.
+
+---
+
+## 9. API Summary
+
+```python
+# Search (always available)
+results = db.search("query")
+results = db.search("query", recipe="custom")
+results = db.search("query", mode="rag")
+results = db.search("query", as_of="2025-01-01")
+results = db.search("query", diff=("2024-01-01", "2025-06-01"))
+results = db.search("query", mode="rag", diff=("2024-01-01", "2025-06-01"))
+
+# AutoResearch (requires eval pairs)
+result = db.optimize_search(eval_set, budget=1000)
+```
+
+Two methods. That's it.
+
+---
+
+## 10. Response Format
+
+Fixed structure. Six fields. Always present. Populated or null.
+
+```json
+{
+  "hits": [],
+  "answer": null,
+  "diff": null,
+  "aggregations": null,
+  "groups": null,
+  "stats": {}
+}
+```
+
+One parser for every mode, every recipe, every feature combination.
+
+---
+
+## 11. References
+
+- [`retrieval-substrate.md`](retrieval-substrate.md) — Recipe schema, pipeline, invariants
+- [`search-strategy.md`](search-strategy.md) — Overall strategy, architecture, ablation study
+- [`../autoresearch-search-optimization.md`](../autoresearch-search-optimization.md) — Detailed AutoResearch methodology
+- #1633 — AutoResearch RFC
+- #1644 — Bayesian optimization for search parameters

--- a/docs/design/search/retrieval-substrate.md
+++ b/docs/design/search/retrieval-substrate.md
@@ -1,0 +1,753 @@
+# Unified Retrieval Substrate
+
+## 1. One Operation: Retrieve
+
+A database is a box of data. Users ask for things from the box. Sometimes the ask is precise:
+
+> "Give me all red cricket balls."
+
+Sometimes it's fuzzy:
+
+> "Round object I can throw and hit with a wooden stick."
+
+Usually it's a mix:
+
+> "Round objects under $20 that I can use in a game, sorted by popularity."
+
+These are all the same operation: **retrieval**. The difference is the precision of the specification, not the nature of the request. A traditional database draws an artificial line — exact predicates go through the query engine, fuzzy intent goes through the search engine — and then struggles when users want both in the same request.
+
+Strata has one retrieval substrate. A **recipe** specifies what to retrieve and how. Exact predicates, fuzzy ranking, filtering, grouping, aggregation — these are all operators in the same pipeline. A "query" is a recipe with only exact operators. A "search" is a recipe with fuzzy operators. A filtered search uses both. There is no separate code path.
+
+---
+
+## 2. Invariants
+
+Non-negotiable. Every implementation decision must preserve these.
+
+**INV-1: Deterministic.** Same recipe + same request + same snapshot = identical response. Always. Tie-breaking is deterministic (score desc, entity_ref asc). No randomized algorithms in the retrieval path. No ambient state affects results.
+
+**INV-2: Declarative.** The recipe is the complete specification. No hidden config, no environment variables, no learned state modifies execution. Two users submitting the same recipe against the same snapshot get the same results.
+
+**INV-3: Snapshot-isolated.** Every retrieval executes against a consistent MVCC snapshot. Background processes may be writing concurrently, but the retrieval sees a point-in-time view.
+
+**INV-4: Budget-bounded.** Every retrieval respects its budget. If limits are hit, return the best results found so far. Partial results are always better than no results.
+
+---
+
+## 3. The Recipe
+
+A recipe is a JSON document. **Presence of a key means enabled. Absence means disabled.** Any section can be omitted — defaults apply.
+
+### 3.1 Schema
+
+```json
+{
+  "version": 1,
+
+  "retrieve": {
+    "scan": {
+      "sources": ["kv", "json", "event"],
+      "spaces": ["*"],
+      "predicates": [
+        {"field": "category", "op": "eq", "value": "pharmacology"},
+        {"field": "year", "op": "gte", "value": 2024}
+      ],
+      "logic": "and"
+    },
+
+    "bm25": {
+      "sources": ["kv", "json", "event"],
+      "spaces": ["*"],
+      "k": 50,
+      "k1": 0.9,
+      "b": 0.4,
+      "field_weights": {"title": 3.0, "body": 1.0},
+      "stemmer": "porter",
+      "stopwords": "lucene33",
+      "phrase_boost": 2.0,
+      "proximity_boost": 0.0
+    },
+
+    "vector": {
+      "collections": ["_system_embed_kv", "_system_embed_json"],
+      "k": 50,
+      "ef_search": 100
+    },
+
+    "graph": {
+      "graph": "medical_ontology",
+      "strategy": "ppr",
+      "k": 50,
+      "damping": 0.5,
+      "max_hops": 2,
+      "max_neighbors_per_hop": 50
+    }
+  },
+
+  "filter": {
+    "predicates": [
+      {"field": "year", "op": "gte", "value": 2020},
+      {"field": "status", "op": "in", "value": ["published", "preprint"]}
+    ],
+    "logic": "and",
+    "time_range": {"start": "2025-01-01T00:00:00Z", "end": null},
+    "score_threshold": 0.1
+  },
+
+  "fusion": {
+    "method": "rrf",
+    "k": 60,
+    "weights": {"bm25": 1.0, "vector": 1.0, "graph": 0.3, "scan": 1.0}
+  },
+
+  "transform": {
+    "sort": [{"by": "score", "order": "desc"}],
+    "group_by": {"field": "category", "top_k_per_group": 3},
+    "aggregate": [
+      {"name": "categories", "type": "count", "field": "category"},
+      {"name": "year_range", "type": "stats", "field": "year"}
+    ],
+    "deduplicate": "entity_ref",
+    "limit": 10,
+    "offset": 0
+  },
+
+  "control": {
+    "budget_ms": 5000,
+    "snapshot_version": null,
+    "include_metadata": true,
+    "include_snippets": true,
+    "include_stage_scores": false,
+    "snippet_length": 200
+  }
+}
+```
+
+### 3.2 What each section does
+
+**`retrieve`** — Which retrieval operators to run. Each produces a candidate list. They run in parallel.
+
+| Operator | What it does | Produces |
+|----------|-------------|----------|
+| `scan` | Evaluate exact predicates against indexes | Unranked candidate set |
+| `bm25` | Full-text keyword matching via inverted index | Ranked candidates with relevance scores |
+| `vector` | Dense embedding similarity via HNSW | Ranked candidates with similarity scores |
+| `graph` | Structural retrieval via graph traversal (PPR, neighborhood) | Ranked candidates with graph proximity scores |
+
+If a key is absent, that operator doesn't run. An empty object (`"bm25": {}`) enables the operator with all defaults.
+
+Scoping: `scan` and `bm25` accept `sources` (which primitives) and `spaces` (which spaces). `vector` accepts `collections` (which vector collections). `graph` accepts `graph` (which named graph). Defaults: all primitives, all spaces, all `_system_embed_*` collections.
+
+**`filter`** — Post-retrieval predicate filtering. Applied after fusion. Removes candidates that don't match. Separate from `scan` because `scan` is a retrieval operator (produces candidates), while `filter` is a narrowing step (removes candidates).
+
+**`fusion`** — Merges candidate lists from multiple retrieval operators into one ranked list. Only meaningful when multiple operators are enabled. Defaults to RRF with k=60 and equal weights.
+
+**`transform`** — Post-processing on the result set: sorting, grouping, aggregation, deduplication, pagination.
+
+**`control`** — Execution parameters: time budget, explicit snapshot version.
+
+### 3.3 The pipeline
+
+```
+1. Retrieve (parallel)
+   ├─ scan    → unranked candidates
+   ├─ bm25   → ranked candidates
+   ├─ vector  → ranked candidates
+   └─ graph   → ranked candidates
+
+2. Fuse → single ranked list
+
+3. Filter → narrow by predicates
+
+4. Transform → sort, group, aggregate, deduplicate, paginate
+
+5. Return
+```
+
+Every step except "return" is optional. A scan-only recipe skips fusion. A BM25-only recipe has trivial fusion (one list, nothing to merge). The pipeline is the same; the recipe controls which steps run.
+
+### 3.4 Defaults
+
+When a section or field is omitted:
+
+| Field | Default |
+|-------|---------|
+| `retrieve.*.sources` | All primitives (`["kv", "json", "event"]`) |
+| `retrieve.*.spaces` | All spaces (`["*"]`) |
+| `retrieve.bm25.k` | 50 |
+| `retrieve.bm25.k1` | 0.9 |
+| `retrieve.bm25.b` | 0.4 |
+| `retrieve.bm25.field_weights` | `{"body": 1.0}` |
+| `retrieve.bm25.stemmer` | `"porter"` (options: `"porter"`, `"snowball"`, `"none"`) |
+| `retrieve.bm25.stopwords` | `"lucene33"` (options: `"lucene33"`, `"smart571"`, `"none"`) |
+| `retrieve.bm25.phrase_boost` | 2.0 (multiplier for exact phrase matches; 0 = disabled) |
+| `retrieve.bm25.proximity_boost` | 0.0 (boost for terms appearing near each other; 0 = disabled) |
+| `retrieve.vector.collections` | All `_system_embed_*` collections |
+| `retrieve.vector.k` | 50 |
+| `retrieve.vector.ef_search` | 100 |
+| `retrieve.graph.graph` | Required (no default — user must name their graph) |
+| `retrieve.graph.strategy` | `"ppr"` |
+| `retrieve.graph.k` | 50 |
+| `retrieve.graph.damping` | 0.5 |
+| `retrieve.graph.max_hops` | 2 |
+| `retrieve.graph.max_neighbors_per_hop` | 50 |
+| `retrieve.scan.logic` | `"and"` |
+| `filter` | No filtering |
+| `filter.logic` | `"and"` |
+| `filter.score_threshold` | None (return all results regardless of score) |
+| `fusion.method` | `"rrf"` |
+| `fusion.k` | 60 |
+| `fusion.weights` | Equal weight (1.0) for all enabled operators |
+| `transform.sort` | `[{"by": "score", "order": "desc"}]` |
+| `transform.deduplicate` | `"entity_ref"` |
+| `transform.limit` | 10 |
+| `transform.offset` | 0 |
+| `control.budget_ms` | 5000 |
+| `control.snapshot_version` | Latest |
+| `control.include_metadata` | `true` |
+| `control.include_snippets` | `true` |
+| `control.include_stage_scores` | `false` |
+| `control.snippet_length` | 200 |
+
+### 3.5 Predicate operators
+
+Used in both `scan` and `filter`:
+
+| Operator | Meaning | Example |
+|----------|---------|---------|
+| `eq` | Equals | `{"field": "status", "op": "eq", "value": "active"}` |
+| `neq` | Not equals | `{"field": "status", "op": "neq", "value": "deleted"}` |
+| `gt`, `gte`, `lt`, `lte` | Comparisons | `{"field": "year", "op": "gte", "value": 2024}` |
+| `in` | Set membership | `{"field": "category", "op": "in", "value": ["A", "B"]}` |
+| `not_in` | Not in set | `{"field": "status", "op": "not_in", "value": ["deleted"]}` |
+| `contains` | Array contains | `{"field": "tags", "op": "contains", "value": "rust"}` |
+| `prefix` | String prefix | `{"field": "key", "op": "prefix", "value": "user:"}` |
+| `exists` | Field exists | `{"field": "author", "op": "exists", "value": true}` |
+
+Predicate logic: `"and"` (default) or `"or"`.
+
+### 3.6 Aggregation types
+
+| Type | Output |
+|------|--------|
+| `count` | Value frequencies: `{"A": 47, "B": 12}` |
+| `sum`, `avg`, `min`, `max` | Single number |
+| `stats` | `{"min": .., "max": .., "avg": .., "sum": .., "count": ..}` |
+| `histogram` | `[{"bucket": 2020, "count": 89}, ...]` (requires `interval`) |
+
+Aggregations run over the full result set after filtering but before limit/offset.
+
+---
+
+## 4. Recipe Examples
+
+### 4.1 Pure query
+
+"Get all active enterprise users, sorted by name."
+
+```json
+{
+  "retrieve": {
+    "scan": {
+      "predicates": [
+        {"field": "status", "op": "eq", "value": "active"},
+        {"field": "plan", "op": "eq", "value": "enterprise"}
+      ]
+    }
+  },
+  "transform": {
+    "sort": [{"by": "name", "order": "asc"}],
+    "limit": 50
+  }
+}
+```
+
+### 4.2 Keyword search
+
+"Find documents about metformin side effects."
+
+```json
+{
+  "retrieve": {
+    "bm25": {}
+  }
+}
+```
+
+Everything defaults. BM25 with standard parameters, top 10.
+
+### 4.3 Hybrid search
+
+"Find documents about metformin, using both keywords and semantic similarity."
+
+```json
+{
+  "retrieve": {
+    "bm25": {},
+    "vector": {}
+  }
+}
+```
+
+BM25 + vector, default RRF fusion, top 10.
+
+### 4.4 Filtered hybrid search
+
+"Find documents about metformin in pharmacology, published after 2020."
+
+```json
+{
+  "retrieve": {
+    "bm25": {"k": 100},
+    "vector": {"k": 100}
+  },
+  "filter": {
+    "predicates": [
+      {"field": "category", "op": "eq", "value": "pharmacology"},
+      {"field": "year", "op": "gt", "value": 2020}
+    ]
+  }
+}
+```
+
+### 4.5 Search with facets
+
+"Search for drug interactions. Show me category distribution and year histogram."
+
+```json
+{
+  "retrieve": {
+    "bm25": {"k": 200},
+    "vector": {"k": 200}
+  },
+  "transform": {
+    "aggregate": [
+      {"name": "categories", "type": "count", "field": "category"},
+      {"name": "by_year", "type": "histogram", "field": "year", "interval": 1}
+    ],
+    "limit": 10
+  }
+}
+```
+
+### 4.6 Grouped results
+
+"Find cancer treatment documents, top 3 per treatment type."
+
+```json
+{
+  "retrieve": {
+    "bm25": {"k": 200}
+  },
+  "transform": {
+    "group_by": {"field": "treatment_type", "top_k_per_group": 3}
+  }
+}
+```
+
+### 4.7 Scan + search combined
+
+"Among active enterprise users, find those most relevant to 'ML infrastructure', and show department distribution."
+
+```json
+{
+  "retrieve": {
+    "scan": {
+      "predicates": [
+        {"field": "status", "op": "eq", "value": "active"},
+        {"field": "plan", "op": "eq", "value": "enterprise"}
+      ]
+    },
+    "bm25": {"k": 100}
+  },
+  "transform": {
+    "aggregate": [
+      {"name": "departments", "type": "count", "field": "department"}
+    ],
+    "limit": 20
+  }
+}
+```
+
+### 4.8 Pure aggregation
+
+"How many documents per category? What's the date range?"
+
+```json
+{
+  "retrieve": {
+    "scan": {"predicates": []}
+  },
+  "transform": {
+    "aggregate": [
+      {"name": "categories", "type": "count", "field": "category"},
+      {"name": "dates", "type": "stats", "field": "created_at"}
+    ],
+    "limit": 0
+  }
+}
+```
+
+### 4.9 Scoped search
+
+"Search only JSON documents in the medical space."
+
+```json
+{
+  "retrieve": {
+    "bm25": {"sources": ["json"], "spaces": ["medical"]},
+    "vector": {}
+  }
+}
+```
+
+### 4.10 Graph-augmented search
+
+"Find information about metformin, including related drugs and conditions from the knowledge graph."
+
+```json
+{
+  "retrieve": {
+    "bm25": {"k": 50},
+    "vector": {},
+    "graph": {
+      "graph": "medical_ontology",
+      "strategy": "ppr",
+      "k": 50,
+      "damping": 0.5
+    }
+  },
+  "fusion": {
+    "weights": {"bm25": 1.0, "vector": 1.0, "graph": 0.3}
+  }
+}
+```
+
+The graph is user-created and lives on the user's branch. The substrate matches query terms against node labels in the graph, runs PPR from matched nodes, and returns structurally related entities as candidates. No model needed — anchor node resolution is string matching.
+
+### 4.11 Tuned recipe (AutoResearch output)
+
+What an optimized recipe might look like after AutoResearch tunes it for a medical corpus:
+
+```json
+{
+  "retrieve": {
+    "bm25": {
+      "k": 75,
+      "k1": 1.2,
+      "b": 0.62,
+      "field_weights": {"title": 4.2, "body": 1.0}
+    },
+    "vector": {
+      "k": 60,
+      "ef_search": 150
+    }
+  },
+  "fusion": {
+    "k": 45,
+    "weights": {"bm25": 0.8, "vector": 1.2}
+  },
+  "transform": {"limit": 10}
+}
+```
+
+Every parameter is slightly different from defaults because AutoResearch discovered these values work better for this specific dataset.
+
+---
+
+## 5. The Request
+
+```json
+{
+  "query": "side effects of metformin in elderly patients",
+  "recipe": "medical_hybrid_v2",
+  "mode": "rag",
+  "k": 10
+}
+```
+
+| Field | Purpose | Default |
+|-------|---------|---------|
+| `query` | Query text. Used by BM25 for scoring. Intelligence layer embeds it for vector search. | Required |
+| `recipe` | Name of a stored recipe, inline recipe object, or `null` for stored default. | Stored default |
+| `mode` | Output mode: `"standard"`, `"rag"`, `"aggregate"` | `"standard"` |
+| `k` | Shorthand override for `transform.limit`. | Recipe default |
+
+**Modes:**
+
+| Mode | What populates in the response |
+|------|-------------------------------|
+| `standard` | `hits` |
+| `rag` | `hits` + `answer` (intelligence layer generates answer from hits via Qwen3) |
+| `aggregate` | `aggregations` (hits still available but typically `limit: 0`) |
+
+The recipe controls *how* to retrieve. The mode controls *what you get back*. Same retrieval pipeline, different output shape.
+
+**Recipe resolution:** If `recipe` is null, use the stored default recipe for the database. If a named recipe is provided, look it up on `_system_`. If an inline recipe object is provided, use it directly (for experimentation/AutoResearch).
+
+---
+
+## 6. The Response
+
+The response has a **fixed structure**. Every field is always present. Unpopulated fields are `null` or empty. The consumer writes one parser and uses it for every mode and recipe.
+
+```json
+{
+  "hits": [
+    {
+      "entity_ref": {"type": "json", "branch": "main", "space": "default", "key": "doc:123"},
+      "score": 0.847,
+      "rank": 1,
+      "snippet": "Common side effects include nausea...",
+      "metadata": {"category": "pharmacology", "year": 2024}
+    }
+  ],
+
+  "answer": {
+    "text": "Common side effects of metformin include nausea, diarrhea, and stomach pain.",
+    "sources": [1, 3, 5]
+  },
+
+  "aggregations": {
+    "categories": {"pharmacology": 47, "toxicology": 12}
+  },
+
+  "groups": null,
+
+  "stats": {
+    "snapshot_version": 42891,
+    "recipe": "default",
+    "mode": "rag",
+    "elapsed_ms": 214.3,
+    "stages": {
+      "bm25": {"elapsed_ms": 3.1, "candidates": 50, "corpus_size": 127000},
+      "vector": {"elapsed_ms": 8.3, "candidates": 50, "corpus_size": 52000},
+      "graph": {"elapsed_ms": 4.1, "candidates": 30, "anchors_matched": 3},
+      "fusion": {"elapsed_ms": 0.4, "candidates_in": 130, "candidates_out": 94},
+      "filter": {"elapsed_ms": 0.1, "removed": 20},
+      "transform": {"elapsed_ms": 0.2},
+      "generation": {"elapsed_ms": 198.2, "tokens": 47}
+    },
+    "budget_exhausted": false
+  }
+}
+```
+
+| Field | Type | When populated |
+|-------|------|---------------|
+| `hits` | array | Always (empty if `limit: 0` or results grouped) |
+| `answer` | object or null | When `mode: "rag"` and intelligence layer available |
+| `diff` | object or null | When `diff` parameter provided (temporal search) |
+| `aggregations` | object or null | When `transform.aggregate` in recipe |
+| `groups` | array or null | When `transform.group_by` in recipe |
+| `stats` | object | Always |
+
+---
+
+## 7. The Evaluate Primitive
+
+`evaluate()` is a substrate operation. It runs a recipe against an eval set and returns metrics. Deterministic.
+
+```json
+// Request
+{
+  "recipe": "medical_hybrid_v2",
+  "eval_set": [
+    {"query": "side effects of metformin", "relevant": ["doc:123", "doc:456"]},
+    {"query": "warfarin interactions", "relevant": ["doc:789"]}
+  ],
+  "metrics": ["ndcg@10", "recall@10", "mrr"]
+}
+
+// Response
+{
+  "aggregate": {"ndcg@10": 0.634, "recall@10": 0.75, "mrr": 0.67},
+  "per_query": [
+    {"query": "side effects of metformin", "ndcg@10": 0.85, "recall@10": 1.0},
+    {"query": "warfarin interactions", "ndcg@10": 0.42, "recall@10": 0.5}
+  ]
+}
+```
+
+The user provides queries and expected results. The intelligence layer handles query embedding for vector search internally. The user never touches embeddings.
+
+This is the foundation for AutoResearch. Submit recipe variants, evaluate each, compare, iterate.
+
+---
+
+## 8. Raw Data Statistics
+
+The substrate exposes facts about the data. Not interpretations — just numbers. Agents and the intelligence layer read these to make decisions.
+
+```json
+{
+  "corpus": {
+    "kv": {"count": 127450, "avg_length_tokens": 342, "p95_length_tokens": 1847},
+    "json": {"count": 53200, "avg_length_tokens": 89},
+    "event": {"count": 892100, "event_types": 47}
+  },
+  "vocabulary": {"unique_terms": 184200, "hapax_ratio": 0.43},
+  "vector": {
+    "_system_embed_kv": {"count": 127450, "dimension": 384}
+  },
+  "indexes": {
+    "category": {"type": "tag", "cardinality": 12},
+    "year": {"type": "numeric", "min": 2018, "max": 2025}
+  }
+}
+```
+
+The `indexes` section tells agents which fields are indexed and their cardinality, so recipes can use efficient predicates.
+
+---
+
+## 9. The Boundary: What Needs a Model Lives Outside
+
+The rule is simple: **if it needs a model, it's not in the substrate.**
+
+The substrate is model-free. It executes recipes using indexes, scoring functions, and deterministic algorithms. Everything that requires loading a model — embedding, expansion, reranking — lives in the intelligence layer or the agent.
+
+| What | Where | Why |
+|------|-------|-----|
+| BM25 scoring | Substrate | Deterministic algorithm |
+| Vector search (HNSW) | Substrate | Deterministic algorithm, embeddings already stored |
+| Graph traversal (PPR) | Substrate | Deterministic algorithm, graph already built by user |
+| Scan / filter / aggregate | Substrate | Deterministic operations |
+| Fusion (RRF) | Substrate | Deterministic algorithm |
+| Query embedding | Intelligence layer | Needs a model |
+| Query expansion | Intelligence layer | Needs a model |
+| Reranking | Intelligence layer | Needs a model |
+| Auto-embedding at write time | Intelligence layer | Needs a model |
+
+The intelligence layer wraps the substrate:
+
+```
+1. Intelligence layer: embed query → [0.012, -0.034, ...]
+2. Intelligence layer: (optionally) expand query
+3. Substrate: execute recipe → candidates
+4. Intelligence layer: (optionally) rerank candidates
+```
+
+From the user's perspective, this is one call:
+
+```python
+results = db.search("metformin side effects", recipe=recipe)
+```
+
+The intelligence layer handles embedding and optional expansion/reranking transparently. The substrate does the retrieval. The user sends a query string and gets results.
+
+Note: graph retrieval does NOT involve the intelligence layer. The user builds the graph, the substrate matches query terms to node labels and traverses. No model needed.
+
+---
+
+## 10. User API
+
+Two entry points, both producing the same substrate call:
+
+```python
+# Simple — BM25-only, default recipe
+results = db.search("metformin side effects")
+
+# Full control — any recipe
+results = db.search("metformin side effects", recipe=recipe)
+results = db.retrieve("metformin side effects", recipe="medical_hybrid_v2")
+```
+
+`db.search(query)` is sugar for `db.retrieve(query, recipe=None)` which uses the baseline BM25 recipe.
+
+`db.retrieve(query, recipe)` accepts a recipe name (string) or inline recipe (dict/JSON). The intelligence layer handles query embedding for vector search and optional expansion/reranking. The user sends a query string and gets results.
+
+---
+
+## 11. Recipe Storage
+
+Recipes are stored as JSON documents on the `_system_` branch under `search/recipes/`. They are:
+
+- **Named** — each recipe has a unique name (e.g., `"default"`, `"medical_hybrid_v2"`)
+- **Versioned** — stored via normal Strata writes, so MVCC version history applies
+- **Portable** — a recipe is a JSON file that can be exported, shared, or committed to source control
+
+---
+
+## 12. Graph Anchor Node Resolution
+
+When the graph operator is enabled, the substrate needs to determine which graph nodes correspond to the query. The recipe controls this via the `strategy` field:
+
+**PPR strategy:**
+1. Tokenize the query text using the same tokenizer config as BM25 (stemmer, stopwords)
+2. Match tokens against node labels in the named graph (case-insensitive, stemmed match)
+3. Matched nodes become PPR seed nodes
+4. Run Personalized PageRank from seeds with configured damping
+5. Score documents connected to high-PPR nodes
+
+**Neighborhood strategy:**
+1. Same token-to-node matching as PPR
+2. BFS expansion from matched nodes up to `max_hops`
+3. Score documents by hop distance (closer = higher score)
+
+If no nodes match the query terms, the graph operator returns zero candidates. Fusion proceeds with the other operators only.
+
+---
+
+## 13. Extensibility
+
+The recipe schema is versioned (`"version": 1`). New retrieval operators (e.g., sparse vectors) are added as new keys under `retrieve`. New transform operations are added under `transform`. New fusion methods are added under `fusion.method`.
+
+Because presence means enabled and absence means disabled, adding new operators is backward compatible. Existing recipes continue to work unchanged. The version bumps only for breaking changes to existing fields.
+
+---
+
+## 14. Open Questions
+
+### 14.1 Scan semantics: pre-filter or candidate source?
+
+When `scan` and `bm25` are both enabled, there are two valid interpretations:
+
+**Option A: Scan as pre-filter.** Scan constrains what BM25 sees. Only documents matching scan predicates are scored by BM25. This matches the intent of "among active enterprise users, find those most relevant to X."
+
+```
+scan predicates → candidate set
+                      ↓
+               bm25 scores only these
+                      ↓
+               vector scores only these
+                      ↓
+               fusion (no scan list in fusion)
+```
+
+**Option B: Scan as candidate source.** Scan produces its own candidate list. BM25 produces its own. Fusion merges both via RRF. Documents found by both scan and BM25 get boosted. This matches the intent of "find documents that either match these predicates OR are relevant to this query."
+
+```
+scan  → candidate list (flat score 1.0)
+bm25  → candidate list (relevance scores)
+vector → candidate list (similarity scores)
+          ↓
+     fusion (RRF across all three)
+```
+
+Both are useful. Option A is more intuitive for constrained search ("search within X"). Option B is more useful for exploratory search ("find things matching X or related to Y").
+
+The recipe could support both via a `scan.mode` field:
+```json
+"scan": {
+  "mode": "prefilter",
+  "predicates": [...]
+}
+```
+vs
+```json
+"scan": {
+  "mode": "candidate",
+  "predicates": [...]
+}
+```
+
+**Decision deferred.** Implement both. Let AutoResearch discover which mode works better for which use cases.
+
+### 14.2 Predicate pushdown
+
+When `filter` predicates match indexed fields, should the substrate automatically push them into retrieval for efficiency? The results are identical either way — it's a pure optimization. Yes, do this, but it's an implementation detail, not a schema decision.
+
+### 14.3 Aggregation + grouping
+
+Current schema supports `group_by` or `aggregate` independently. Should we support per-group aggregations (equivalent to SQL `GROUP BY x ... aggregate per group`)? Defer — implement both independently first, compose later if needed.

--- a/docs/design/search/search-strategy.md
+++ b/docs/design/search/search-strategy.md
@@ -1,0 +1,342 @@
+# Search Strategy
+
+The overall plan for search in Strata: philosophy, architecture, and execution roadmap.
+
+For the retrieval substrate spec (recipe schema, pipeline, invariants), see [`retrieval-substrate.md`](retrieval-substrate.md).
+
+---
+
+## 1. Philosophy
+
+Every database treats search as a fixed pipeline with a few knobs. The designer picks parameters from papers, ships defaults, and hopes they work for everyone. In the age of AI agents, this is backwards. The data should drive how search is configured, not the database designer.
+
+Strata takes a different approach:
+
+- **The retrieval substrate** is a fully deterministic engine that accepts a recipe and executes it. It has no opinions. It does not try to be smart. Same recipe + same data + same snapshot = identical results, every time.
+
+- **The intelligence layer** provides optional convenience tools powered by a local LLM (Qwen3): query embedding, expansion, reranking, write-time enrichment, synthetic eval generation. Useful but removable.
+
+- **The AI agent** (user, application, or LLM) makes all decisions. It writes recipes, evaluates them, and iterates. The database gives tools — it doesn't reason by itself.
+
+---
+
+## 2. Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  AI Agent (user / application / LLM)                     │
+│  Makes all decisions. Writes recipes. Evaluates results. │
+└────────────────────────┬────────────────────────────────┘
+                         │
+┌────────────────────────▼────────────────────────────────┐
+│  Intelligence Layer (optional)                           │
+│                                                          │
+│  Write-time:  auto-embedding, tagging, summarization     │
+│  Query-time:  query embedding, expansion, reranking      │
+│  Tune-time:   data profiling, synthetic eval generation, │
+│               recipe suggestion, AutoResearch            │
+│                                                          │
+│  Enrichments written to _system_ branch.                 │
+│  Powered by local Qwen3 (strata-inference).              │
+│  Everything here is optional.                            │
+└────────────────────────┬────────────────────────────────┘
+                         │
+┌────────────────────────▼────────────────────────────────┐
+│  Retrieval Substrate (engine)                            │
+│                                                          │
+│  Accepts a recipe (JSON). Executes deterministically.    │
+│  Retrieval operators: scan, bm25, vector, graph.         │
+│  Post-processing: filter, fusion, transform.             │
+│  Primitives: evaluate(), statistics().                   │
+│                                                          │
+│  Model-free. If it needs a model, it's not here.         │
+└─────────────────────────────────────────────────────────┘
+```
+
+### What lives where
+
+| Concern | Layer | Why |
+|---------|-------|-----|
+| Execute retrieval given a recipe | Substrate | Deterministic, model-free |
+| Store and version recipes | Substrate (`_system_` branch) | Recipes are data |
+| Expose raw data statistics | Substrate | Statistics are facts |
+| `evaluate(recipe, eval_set)` | Substrate | Deterministic execution + metric computation |
+| Embed queries for vector search | Intelligence layer | Needs a model |
+| Expand queries | Intelligence layer | Needs a model |
+| Rerank results | Intelligence layer | Needs a model |
+| Auto-embed documents at write time | Intelligence layer | Needs a model |
+| Generate synthetic eval pairs | Intelligence layer | Needs a model |
+| Run AutoResearch | Intelligence layer | Orchestration + model |
+| Decide what recipe to use | Agent | Agent's decision |
+| Build the knowledge graph | User | User's domain knowledge |
+
+### The boundary
+
+**If it needs a model, it's not in the substrate.**
+
+The intelligence layer wraps the substrate:
+
+```
+1. Intelligence layer: embed query
+2. Intelligence layer: (optionally) expand query
+3. Substrate: execute recipe deterministically
+4. Intelligence layer: (optionally) rerank results
+```
+
+The user sees one call: `db.search("query")`. The intelligence layer handles steps 1, 2, 4 transparently.
+
+---
+
+## 3. The `_system_` Branch
+
+Strata uses `_system_` for derived/enriched data and search configuration. User data stays on user branches.
+
+```
+User branch:
+  KV, JSON, events              (user's raw data)
+  Graphs                        (user-built knowledge graphs with user-defined ontology)
+  Vector collections             (user-created embeddings, if any)
+
+_system_ branch:
+  embeddings/                   shadow vector collections (auto-embed)
+    _system_embed_kv
+    _system_embed_json
+    _system_embed_event
+  enrichments/                  write-time derived data
+    tags, summaries
+  search/
+    recipes/                    named recipe configurations
+    eval_sets/                  evaluation pairs
+    experiments/                AutoResearch history
+  statistics/                   raw data statistics
+```
+
+Key design decisions:
+
+- **Graphs live on user branches**, not `_system_`. The user defines the ontology and curates entities. One bad relationship screws up accuracy. The database doesn't auto-build graphs.
+- **Embeddings live on `_system_`**. They're automatically derived by the intelligence layer. The user doesn't manage them.
+- **Recipes live on `_system_`**. They're versioned, portable, and branchable.
+
+---
+
+## 4. The Intelligence Layer
+
+Three features, two knobs. Detailed design in [`intelligence-layer.md`](intelligence-layer.md).
+
+### 4.1 Features (public API)
+
+| Feature | API | What it does |
+|---------|-----|-------------|
+| **RAG** | `db.search("query", mode="rag")` | Grounded answer with citations from retrieved hits |
+| **Temporal Search** | `db.search("query", as_of=..., diff=...)` | Search at any point in time. Diff results across time. Explain what changed. |
+| **AutoResearch** | `db.optimize_search(eval_set)` | Branch-parallel recipe optimization against user-provided eval pairs |
+
+### 4.2 Knobs (configuration)
+
+| Knob | What it does |
+|------|-------------|
+| **Query expansion** | Generates query variants before substrate call. Improves recall. |
+| **Reranking** | Re-scores top-N results after substrate call. Improves precision. |
+
+Configured via `db.configure(expansion=True, reranking=True)`. No new API — `db.search()` just returns better results.
+
+### 4.3 Write-time enrichment
+
+Auto-embedding exists today. Auto-tagging and summarization are future.
+
+### 4.4 The intelligence layer is optional
+
+- Without `embed` feature: substrate only. BM25 works. No RAG, no AutoResearch.
+- With `embed` feature: all three features and both knobs available.
+- Users who provide their own embeddings or write recipes by hand never need the intelligence layer.
+
+### 4.5 Response format
+
+Fixed structure. Six fields. Always present. Populated or null.
+
+```json
+{"hits": [], "answer": null, "diff": null, "aggregations": null, "groups": null, "stats": {}}
+```
+
+One parser for every mode, recipe, and feature combination.
+
+---
+
+## 5. Ablation Study
+
+Validates that each layer of the pipeline contributes measurable improvement.
+
+### 5.1 Levels
+
+| Level | Recipe | What it measures |
+|-------|--------|-----------------|
+| **L0** | BM25 only | Baseline keyword retrieval |
+| **L1** | BM25 + Vector (RRF) | Value of semantic similarity |
+| **L2** | BM25 + Vector + Graph (RRF) | Value of ontology-guided structural signal |
+| **L3** | L2 + LLM expansion + LLM reranking | Value of LLM intelligence |
+| **L4** | AutoResearch-optimized L3 | Headroom from automated tuning |
+
+### 5.2 Level recipes
+
+**L0:**
+```json
+{"retrieve": {"bm25": {"k": 100}}}
+```
+
+**L1:**
+```json
+{"retrieve": {"bm25": {"k": 50}, "vector": {"k": 50}}}
+```
+
+**L2:**
+```json
+{
+  "retrieve": {
+    "bm25": {"k": 50},
+    "vector": {"k": 50},
+    "graph": {"graph": "domain_ontology", "strategy": "ppr", "k": 50, "damping": 0.5}
+  },
+  "fusion": {"weights": {"bm25": 1.0, "vector": 1.0, "graph": 0.3}}
+}
+```
+
+**L3:** Same recipe as L2. Expansion and reranking happen in the intelligence layer (outside the recipe).
+
+**L4:** AutoResearch-optimized recipe. All substrate parameters tuned via branch-parallel experimentation.
+
+### 5.3 Metrics
+
+| Metric | What it measures |
+|--------|-----------------|
+| NDCG@10 | Rank-aware relevance (primary) |
+| Recall@10, Recall@100 | Coverage |
+| MRR | First relevant result position |
+| MAP | Precision across recall levels |
+| Latency p50/p95/p99 | Performance cost |
+| Tokens consumed | LLM cost (L3, L4) |
+
+### 5.4 Datasets
+
+| Dataset | What it tests |
+|---------|--------------|
+| MS MARCO | Large-scale passage retrieval |
+| Natural Questions | Factoid questions |
+| TREC-COVID | Domain-specific, keyword-heavy |
+| FiQA | Semantic understanding |
+| SciFact | Precision-critical |
+| NFCorpus | Dense terminology |
+| HotpotQA | Multi-hop (tests graph value) |
+| MuSiQue | Multi-hop (tests graph value) |
+
+### 5.5 Hypothesis
+
+Ontology-guided retrieval (L2) will provide the most differentiated improvement on multi-hop and relational queries (HotpotQA, MuSiQue). BM25 finds documents containing query words. Vector finds semantically similar documents. The graph finds structurally related documents — a signal that's orthogonal to both text and embedding similarity.
+
+---
+
+## 6. Implementation Phases
+
+### Phase 1: Substrate foundation
+
+Build the recipe execution engine.
+
+1. Define `Recipe` struct (Rust, serde-deserializable from JSON)
+2. Implement recipe-driven retrieval: scan, bm25, vector operators
+3. Implement filter, fusion (RRF), transform (sort, group, aggregate, limit)
+4. Implement `evaluate()` and raw statistics
+5. Fix primitive stubs (JSON, Event search return empty — #1936, #1949)
+6. Store/retrieve recipes on `_system_` branch
+
+**Success:** Existing search tests pass through the recipe path. `db.search("query")` works.
+
+### Phase 2: Graph retrieval
+
+Add graph as a retrieval operator.
+
+1. Implement graph anchor node resolution (query terms → node label matching)
+2. Implement PPR retrieval strategy
+3. Wire graph into the recipe execution path
+4. Validate on a graph-structured dataset
+
+**Success:** L2 recipe returns graph-sourced hits alongside BM25 and vector hits.
+
+### Phase 3: Intelligence layer
+
+Build query-time and write-time tools.
+
+1. Generalize auto-embed into pluggable enrichment pipeline
+2. Add query embedding (already partially exists)
+3. Add expansion helper (already partially exists)
+4. Add reranking helper (already partially exists)
+5. Add synthetic eval generation
+6. Add data profiling
+
+**Success:** Intelligence layer embeds queries transparently, generates eval pairs from data.
+
+### Phase 4: AutoResearch
+
+Build the optimization loop.
+
+1. Branch-parallel experiment runner
+2. Recipe mutation strategies
+3. Qwen3 for experiment planning
+4. Convergence detection
+5. Wire `evaluate()` in the loop
+
+**Success:** AutoResearch produces a recipe that measurably outperforms defaults.
+
+### Phase 5: Ablation study
+
+Run the study and produce results.
+
+1. Prepare BEIR datasets in Strata
+2. Run L0–L4 against all datasets
+3. Produce result table
+4. Compare against published baselines (Pyserini, ColBERTv2, ELSER)
+
+**Success:** Publishable result table with consistent improvement across levels.
+
+---
+
+## 7. What's Innovative
+
+The individual retrieval techniques are borrowed — BM25, HNSW, RRF, PPR are all published algorithms. The innovation is in the system design:
+
+1. **O(1) branching makes search optimization cheap enough to automate.** 7,000 experiments overnight because branching costs microseconds. Architecturally impossible in any other search system.
+
+2. **Deterministic, declarative recipes as the complete search specification.** The recipe is the full contract. Agents can iterate on it programmatically.
+
+3. **Unified retrieval** — query and search are the same operation. Exact predicates, fuzzy ranking, filtering, aggregation all flow through one pipeline.
+
+4. **In-process LLM** changes the economics of write-time enrichment and query-time intelligence. Zero network overhead, zero API cost.
+
+The strongest claim: **branch-parallel experimentation is an architectural capability that requires copy-on-write storage. No existing search system has this.**
+
+---
+
+## 8. References
+
+### Internal
+
+- [`retrieval-substrate.md`](retrieval-substrate.md) — Recipe schema, pipeline, invariants
+- [`../search-pipeline-implementation-plan.md`](../search-pipeline-implementation-plan.md) — Phase-by-phase search quality improvements
+- [`../autoresearch-search-optimization.md`](../autoresearch-search-optimization.md) — Branch-parallel experimentation methodology
+
+### Issues
+
+- #1269 — Hybrid search pipeline
+- #1270 — Graph-augmented search RFC
+- #1322 — Query safety and score validation
+- #1484 — Search pipeline implementation plan
+- #1583 — BEIR validation suite
+- #1640 — HippoRAG PPR
+- #1872–#1876 — Primitive Searchable implementations
+- #2106 — Search gaps inventory
+- #2107 — Ablation study design
+
+### External
+
+- [BEIR](https://github.com/beir-cellar/beir) — Thakur et al., NeurIPS 2021
+- [HippoRAG](https://arxiv.org/abs/2405.14831) — Gutierrez et al., NeurIPS 2024
+- [RRF](https://dl.acm.org/doi/10.1145/1571941.1572114) — Cormack, Clarke, Buettcher, 2009
+- [Autoresearch](https://github.com/karpathy/autoresearch) — Karpathy, 2025


### PR DESCRIPTION
## Summary

Three-layer search architecture designed from first principles for AI-agent-driven retrieval.

- **Retrieval Substrate** (`retrieval-substrate.md`): Deterministic, declarative recipe-based engine. Unified pipeline for queries and search — scan, BM25, vector, graph operators with RRF fusion, filtering, and transform (sort/group/aggregate). Model-free. Same recipe + same snapshot = identical results.

- **Intelligence Layer** (`intelligence-layer.md`): Optional LLM-powered features. Three features: RAG (grounded answers with citations), Temporal Search (point-in-time and diff), AutoResearch (branch-parallel recipe optimization). Two knobs: query expansion and reranking. Powered by local Qwen3.

- **Strategy** (`search-strategy.md`): Philosophy, three-layer architecture, ablation study design (L0–L4), implementation roadmap.

Key design decisions:
- Recipes are stored config, not passed per-call
- One entry point: `db.search()`
- Fixed response format: `{hits, answer, diff, aggregations, groups, stats}`
- If it needs a model, it's not in the substrate
- Graphs live on user branches (user-defined ontology)
- Embeddings live on `_system_` (auto-derived)

## Related issues

- #1269 — Hybrid search pipeline
- #1270 — Graph-augmented search
- #1583 — BEIR validation suite
- #1632 — Composable search substrate
- #1633 — AutoResearch
- #1640 — HippoRAG PPR
- #2106 — Search gaps inventory
- #2107 — Ablation study design

## Test plan

- [ ] Review `docs/design/search/search-strategy.md` for overall coherence
- [ ] Review `docs/design/search/retrieval-substrate.md` for recipe schema completeness
- [ ] Review `docs/design/search/intelligence-layer.md` for feature scope
- [ ] Verify recipe examples are valid and self-consistent
- [ ] Verify response format is consistent across all docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)