### PR TITLE
Simplify AutoResearch: db.experiment() returns winner in seconds

### DIFF
--- a/docs/design/search/intelligence-layer.md
+++ b/docs/design/search/intelligence-layer.md
@@ -270,89 +270,132 @@ Same fixed structure. `diff` field populated when temporal:
 ### What the user sees
 
 ```python
-# Store recipes and eval data however you want — it's a database
+# Store eval data however you want — it's a database
 db.json.set("eval/medical", [
     {"query": "metformin side effects", "relevant": ["doc:123", "doc:456"]},
     {"query": "drug interactions warfarin", "relevant": ["doc:789"]},
 ])
 
-# Compare recipes. Sync. Returns the winner in seconds.
-winner = db.experiment(
+# Compare recipes. Sync. Returns rich results in seconds.
+result = db.experiment(
     recipes={
         "baseline": {"retrieve": {"bm25": {}}},
         "tuned":    {"retrieve": {"bm25": {"k1": 1.2, "b": 0.65}}, "fusion": {"k": 45}},
         "hybrid":   {"retrieve": {"bm25": {}, "vector": {}}},
     },
-    eval_set=db.json.get("eval/medical")
+    eval_set=db.json.get("eval/medical"),
+    metric="ndcg@10"
 )
 
-# Set it as production
-db.set_recipe(winner)
+# Grab the winner, set it as production
+db.set_recipe(result.winner)
 ```
 
-Three lines that matter. Store eval data. Experiment. Set the winner.
+### Experiment output
+
+`db.experiment()` returns a rich result with everything the agent needs:
+
+```python
+result.winner
+# → {"retrieve": {"bm25": {"k1": 1.2, "b": 0.65}}, "fusion": {"k": 45}}
+
+result.rankings
+# → [
+#      {"name": "tuned",    "ndcg@10": 0.71, "recall@10": 0.83, "mrr": 0.69, "precision@10": 0.45, "elapsed_ms": 3800},
+#      {"name": "hybrid",   "ndcg@10": 0.68, "recall@10": 0.80, "mrr": 0.65, "precision@10": 0.42, "elapsed_ms": 4200},
+#      {"name": "baseline", "ndcg@10": 0.63, "recall@10": 0.75, "mrr": 0.58, "precision@10": 0.38, "elapsed_ms": 2800},
+#   ]
+
+result.details["tuned"]
+# → {
+#      "ndcg@10": 0.71,
+#      "per_query": [
+#          {"query": "metformin side effects", "ndcg@10": 0.85, "relevant_found": 2, "relevant_total": 2},
+#          {"query": "warfarin interactions",  "ndcg@10": 0.42, "relevant_found": 1, "relevant_total": 2},
+#      ]
+#   }
+```
+
+- `result.winner` — the winning recipe, ready to pass to `db.set_recipe()`
+- `result.rankings` — all recipes ranked by the chosen metric, with all metrics computed
+- `result.details[name]` — per-query breakdown per recipe, so the agent can see exactly which queries each recipe struggles on
+
+### Metrics
+
+All computed for every recipe. The `metric` parameter controls sort order and `.winner`.
+
+| Metric | What it measures | Default |
+|--------|-----------------|---------|
+| `ndcg@10` | Rank-aware relevance | **Yes** |
+| `recall@10` | Coverage at shallow depth | |
+| `recall@100` | Coverage at deep depth | |
+| `mrr` | First relevant result position | |
+| `map` | Precision across all recall levels | |
+| `precision@10` | Fraction of top-10 that are relevant | |
+| `hit_rate@10` | At least one relevant in top-10 (binary) | |
+| `f1@10` | Harmonic mean of precision and recall | |
+
+### Model variants
+
+Recipes can include `models` to test different model assignments:
+
+```python
+result = db.experiment(
+    recipes={
+        "local_only": {
+            "retrieve": {"bm25": {}, "vector": {}},
+        },
+        "cloud_rerank": {
+            "retrieve": {"bm25": {}, "vector": {}},
+            "models": {"rerank": "anthropic:claude-sonnet-4-6"},
+        },
+    },
+    eval_set=eval_set
+)
+```
+
+If `models` is omitted, uses the `db.configure()` defaults.
 
 ### How it works internally
 
 ```
-For each recipe:
+For each recipe (sequential in v1):
   1. Create a branch
   2. Run every eval query through db.search(query, recipe=variant)
   3. Compare results to expected relevant docs
-  4. Compute NDCG@10
+  4. Compute all metrics (ndcg, recall, mrr, map, precision, hit_rate, f1)
   5. Log results on _system_ branch
   6. Discard the branch
-Return the recipe with the highest NDCG@10
+Rank recipes by chosen metric
+Return result with winner, rankings, and per-query details
 ```
 
-Sequential in v1. Each recipe takes a few seconds (eval queries × search time). Three recipes with 50 eval queries at ~50ms per search = ~7.5 seconds total. Fast enough.
-
-Parallel execution across branches is a future optimization — the architecture supports it, but v1 doesn't need it.
+Three recipes × 50 eval queries × ~50ms per search = ~7.5 seconds total. Fast enough for v1. Parallel execution across branches is a future optimization.
 
 ### The AutoResearch loop
 
-The external agent (user, Claude Code, a Python script) drives the optimization loop. Strata provides `db.experiment()` as the primitive. The agent provides the intelligence:
+The external agent drives the optimization loop. Strata provides `db.experiment()` as the primitive:
 
 ```python
-# The agent drives the loop. Strata runs the experiments.
 current_best = db.get_recipe()
 eval_set = db.json.get("eval/medical")
 
 for round in range(10):
     # Agent proposes variants (mutates current best)
-    variants = agent.propose_variants(current_best, history)
+    variants = agent.propose_variants(current_best, result.details)
 
     # Strata compares them
-    winner = db.experiment(recipes=variants, eval_set=eval_set)
+    result = db.experiment(recipes=variants, eval_set=eval_set)
 
     # Agent decides whether to keep
-    if agent.is_improvement(winner, current_best):
-        current_best = winner
+    if result.rankings[0]["ndcg@10"] > current_best_score:
+        current_best = result.winner
+        current_best_score = result.rankings[0]["ndcg@10"]
 
 db.set_recipe(current_best)
 ```
 
-Strata doesn't plan experiments, propose mutations, or decide when to stop. It runs recipes and returns the winner. The agent does the thinking.
-
-### What gets tuned
-
-Every parameter in the recipe:
-
-| Parameter | Range |
-|-----------|-------|
-| `bm25.k1` | 0.5 — 2.0 |
-| `bm25.b` | 0.1 — 1.0 |
-| `bm25.field_weights.*` | 0.0 — 5.0 |
-| `bm25.stemmer` | porter / snowball / none |
-| `bm25.stopwords` | lucene33 / smart571 / none |
-| `bm25.phrase_boost` | 0.0 — 5.0 |
-| `bm25.proximity_boost` | 0.0 — 2.0 |
-| `vector.k` | 10 — 200 |
-| `vector.ef_search` | 50 — 500 |
-| `graph.damping` | 0.1 — 0.9 |
-| `graph.max_hops` | 1 — 5 |
-| `fusion.k` | 10 — 200 |
-| `fusion.weights.*` | 0.0 — 3.0 |
+The per-query details feed back into the agent's next round — it can see which queries the winner still struggles on and target those specifically.
 
 ### Why it requires user-provided eval pairs
 
@@ -483,7 +526,10 @@ db.get_recipe()
 db.get_recipe("medical")
 
 # Experiments
-winner = db.experiment(recipes, eval_set)
+result = db.experiment(recipes, eval_set, metric="ndcg@10")
+result.winner      # winning recipe
+result.rankings    # all recipes ranked with all metrics
+result.details     # per-recipe, per-query breakdown
 
 # Configuration
 db.configure(models={...}, expansion=True, ...)


### PR DESCRIPTION
## Summary

Replaced the experiment lifecycle API (create/run/status/results/winner/promote — 6 methods) with one sync call:

```python
winner = db.experiment(recipes, eval_set)
db.set_recipe(winner)
```

Two lines. No lifecycle management. No async. No polling.

Internal flow: for each recipe sequentially, create branch → run eval queries via `db.search()` → compute NDCG@10 → log on `_system_` → discard branch → return best.

Recipes and eval sets are just data stored in the database (`db.json`, `db.kv`) — no special-purpose management APIs.

Follows up on #2111 (merged).

## Test plan

- [ ] Review AutoResearch section (section 5) for simplicity and completeness
- [ ] Verify API summary is consistent with the rest of the doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)