### PR TITLE
Add Arrow output format for search results

### DIFF
--- a/docs/design/search/retrieval-substrate.md
+++ b/docs/design/search/retrieval-substrate.md
@@ -674,6 +674,41 @@ The response has a **fixed structure**. Every field is always present. Unpopulat
 | `groups` | array or null | When `transform.group_by` in recipe |
 | `stats` | object | Always |
 
+### Arrow Output Format
+
+Search results are Arrow-compatible. The `hits` array maps to an Arrow RecordBatch for zero-copy transfer to Pandas, Polars, DuckDB, and any Arrow-native tool. See `docs/design/rfc-arrow-interoperability.md` for Strata's overall Arrow strategy.
+
+**Hits Arrow Schema:**
+
+```
+entity_type:    utf8 (not null)
+entity_branch:  utf8 (not null)
+entity_space:   utf8 (not null)
+entity_key:     utf8 (not null)
+score:          float64 (not null)
+rank:           uint32 (not null)
+snippet:        utf8 (nullable)
+metadata:       utf8 (JSON string, nullable)
+```
+
+**Python usage:**
+
+```python
+results = db.search("metformin side effects")
+
+# Zero-copy to PyArrow
+table = results.to_arrow()
+
+# Use with any Arrow-native tool
+import polars as pl
+df = pl.from_arrow(table)
+
+import duckdb
+duckdb.sql("SELECT * FROM table WHERE score > 0.5 ORDER BY score DESC")
+```
+
+The `answer`, `diff`, `aggregations`, `groups`, and `stats` fields are returned as structured metadata alongside the RecordBatch — they don't map to columnar format. The `hits` are the columnar payload; everything else is per-query metadata.
+
 ---
 
 ## 7. The Evaluate Primitive


### PR DESCRIPTION
## Summary

Search hits map to an Arrow RecordBatch for zero-copy transfer to Pandas, Polars, DuckDB, and any Arrow-native tool.

```python
results = db.search("metformin side effects")
table = results.to_arrow()  # zero-copy → pyarrow.Table
df = polars.from_arrow(table)
```

Arrow schema for hits:
```
entity_type, entity_branch, entity_space, entity_key: utf8
score: float64
rank: uint32
snippet: utf8 (nullable)
metadata: utf8 (JSON string, nullable)
```

Non-columnar fields (answer, diff, aggregations, groups, stats) returned as structured metadata alongside the RecordBatch.

References `docs/design/rfc-arrow-interoperability.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)