### PR TITLE
Fix #2110: Quiesce in-flight commits during fork_branch to prevent version gap

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -232,6 +232,16 @@ impl TransactionManager {
         self.version.load(Ordering::Acquire)
     }
 
+    /// Acquire the commit quiesce lock, blocking until all in-flight commits
+    /// have finished their `apply_writes`.
+    ///
+    /// The returned guard prevents new commits from starting (they need the
+    /// shared read side). Hold it across operations that require a stable
+    /// storage version, such as `fork_branch` (#2105).
+    pub fn quiesce_commits(&self) -> parking_lot::RwLockWriteGuard<'_, ()> {
+        self.commit_quiesce.write()
+    }
+
     /// Allocate next transaction ID
     ///
     /// Uses a single `fetch_add` (LOCK XADD on x86) instead of a CAS loop.

--- a/crates/engine/src/branch_ops.rs
+++ b/crates/engine/src/branch_ops.rs
@@ -480,9 +480,22 @@ pub fn fork_branch(db: &Arc<Database>, source: &str, destination: &str) -> Strat
         ));
     }
 
-    let (fork_version, _segments_shared) = storage
-        .fork_branch(&source_id, &dest_id)
-        .map_err(|e| StrataError::storage(format!("fork failed: {}", e)))?;
+    // Quiesce in-flight commits before forking (#2105).
+    //
+    // The global storage version is shared across branches. Without quiescing,
+    // a concurrent commit to ANY branch can advance storage.version while a
+    // commit to the SOURCE branch hasn't applied its writes yet. Fork would
+    // read the advanced version but miss the source's pending data.
+    //
+    // The write guard drains all in-flight commits (they hold the shared read
+    // side) and prevents new ones from starting until the storage fork completes.
+    // Scoped tightly: released before create_branch (which itself commits).
+    let (fork_version, _segments_shared) = {
+        let _quiesce_guard = db.quiesce_commits();
+        storage
+            .fork_branch(&source_id, &dest_id)
+            .map_err(|e| StrataError::storage(format!("fork failed: {}", e)))?
+    };
 
     // 5. Create destination branch in KV metadata (WAL-protected).
     //    If this fails, rollback the storage fork.

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -407,6 +407,15 @@ impl TransactionCoordinator {
         self.manager.quiesced_version()
     }
 
+    /// Acquire the commit quiesce lock (#2105).
+    ///
+    /// Blocks until all in-flight commits complete, then prevents new
+    /// commits from starting. Hold the guard across operations that
+    /// require a stable storage version (e.g., fork_branch).
+    pub fn quiesce_commits(&self) -> parking_lot::RwLockWriteGuard<'_, ()> {
+        self.manager.quiesce_commits()
+    }
+
     /// Get next transaction ID (for internal use).
     pub fn next_txn_id(&self) -> StrataResult<u64> {
         self.manager.next_txn_id().map_err(StrataError::from)

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -391,6 +391,15 @@ impl Database {
         self.coordinator.unmark_branch_deleting(branch_id);
     }
 
+    /// Acquire the commit quiesce lock (#2105).
+    ///
+    /// Blocks until all in-flight commits complete, then prevents new
+    /// commits from starting. Hold the guard across operations that
+    /// require a stable storage version (e.g., fork_branch).
+    pub fn quiesce_commits(&self) -> parking_lot::RwLockWriteGuard<'_, ()> {
+        self.coordinator.quiesce_commits()
+    }
+
     /// Get the commit lock Arc for a branch (#1916).
     ///
     /// Locking this serializes with in-flight commits on the branch.

--- a/crates/storage/src/segmented/tests/concurrency.rs
+++ b/crates/storage/src/segmented/tests/concurrency.rs
@@ -1390,3 +1390,131 @@ fn test_issue_1734_apply_recovery_atomic_does_not_bump_version() {
     );
     assert_eq!(visible.unwrap().value, Value::String("hello".into()));
 }
+
+// =====================================================================
+// Issue #2110 / #2105: Fork version gap — deterministic reproduction
+// =====================================================================
+
+/// Deterministic proof that fork_branch can produce a child whose
+/// fork_version includes a version whose data was never captured.
+///
+/// Uses `mpsc` channels to force this exact interleaving:
+///
+///   1. Writer: next_version()            → allocates V, global counter = V
+///   2. Writer: signals "allocated"
+///   3. Fork:   receives signal
+///   4. Fork:   fork_branch(parent, child)
+///              → acquires DashMap lock
+///              → inline-flushes memtable (does NOT contain V's data)
+///              → fork_version = self.version.load() = V
+///              → captures snapshot, releases lock
+///   5. Fork:   signals "forked"
+///   6. Writer: receives signal
+///   7. Writer: put_with_version_mode(V)  → data at V enters parent's memtable
+///
+/// Result: fork_version >= V but child is missing V's data.
+///
+/// NOTE: This test asserts the BUG exists at the storage level. When the
+/// engine-level fix (#2105) is applied (quiescing commits before fork),
+/// this storage-level race is prevented by the engine, but the raw
+/// storage API still exhibits it.
+#[test]
+fn test_issue_2110_fork_version_gap_deterministic() {
+    use std::sync::mpsc;
+    use std::sync::Arc;
+    use std::thread;
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+
+    // Seed parent branch with initial data so it exists with segments
+    seed(&store, parent_kv("init"), Value::Int(0), 1);
+    store.rotate_memtable(&parent_branch());
+    store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+    // Channels for deterministic ordering
+    let (tx_allocated, rx_allocated) = mpsc::channel::<u64>();
+    let (tx_forked, rx_forked) = mpsc::channel::<()>();
+
+    let store_writer = Arc::clone(&store);
+    let store_forker = Arc::clone(&store);
+
+    // Writer thread: allocate version, signal, wait for fork, then write data
+    let writer = thread::spawn(move || {
+        // Step 1: allocate version (advances self.version but no data yet)
+        let v = store_writer.next_version();
+        // Step 2: signal the forker that version is allocated
+        tx_allocated.send(v).unwrap();
+        // Step 6: wait for fork to complete
+        rx_forked.recv().unwrap();
+        // Step 7: NOW write the data (too late for the fork to capture)
+        store_writer
+            .put_with_version_mode(
+                parent_kv("gap_key"),
+                Value::Int(999),
+                v,
+                None,
+                WriteMode::Append,
+            )
+            .unwrap();
+        v
+    });
+
+    // Forker thread: wait for version allocation, then fork
+    let fork_branch_id = BranchId::from_bytes([77; 16]);
+    let forker = thread::spawn(move || {
+        store_forker
+            .branches
+            .entry(fork_branch_id)
+            .or_insert_with(BranchState::new);
+
+        // Step 3: wait for writer to allocate version
+        let allocated_version = rx_allocated.recv().unwrap();
+        // Step 4: fork (captures memtable that does NOT contain gap_key)
+        let (fork_version, _) = store_forker
+            .fork_branch(&parent_branch(), &fork_branch_id)
+            .unwrap();
+        // Step 5: signal writer that fork is done
+        tx_forked.send(()).unwrap();
+        (fork_version, allocated_version)
+    });
+
+    let writer_version = writer.join().unwrap();
+    let (fork_version, allocated_version) = forker.join().unwrap();
+
+    assert_eq!(writer_version, allocated_version);
+
+    // The bug: fork_version >= allocated_version because next_version()
+    // bumped self.version BEFORE put_with_version_mode wrote the data.
+    assert!(
+        fork_version >= allocated_version,
+        "fork_version ({}) should be >= allocated version ({}) — \
+         next_version() bumps the counter before data is written",
+        fork_version,
+        allocated_version,
+    );
+
+    // Parent has the data (writer wrote it after fork)
+    let parent_val = store
+        .get_versioned(&parent_kv("gap_key"), u64::MAX)
+        .unwrap();
+    assert_eq!(
+        parent_val.map(|e| e.value),
+        Some(Value::Int(999)),
+        "parent must have the gap_key data"
+    );
+
+    // Child is MISSING the data — this is the version gap bug.
+    // fork_version claims to include allocated_version, but the data
+    // was not in the memtable when the fork captured it.
+    let child_ns = Arc::new(Namespace::new(fork_branch_id, "default".to_string()));
+    let child_key = Key::new(child_ns, TypeTag::KV, b"gap_key".to_vec());
+    let child_val = store.get_versioned(&child_key, u64::MAX).unwrap();
+    assert!(
+        child_val.is_none(),
+        "child should be MISSING gap_key — this proves the version gap bug: \
+         fork_version={} >= allocated_version={} but data is absent",
+        fork_version,
+        allocated_version,
+    );
+}

--- a/tests/engine/p0_concurrency.rs
+++ b/tests/engine/p0_concurrency.rs
@@ -519,7 +519,9 @@ fn test_issue_1910_event_hash_chain_under_contention() {
     );
 
     // 2. Verify hash chain integrity: every event's prev_hash == predecessor's hash
-    let all_events = event.range(&branch_id, "default", 0, None, None, false, None).unwrap();
+    let all_events = event
+        .range(&branch_id, "default", 0, None, None, false, None)
+        .unwrap();
     assert_eq!(all_events.len(), total_events);
 
     let mut prev_hash = [0u8; 32]; // First event's prev_hash should be zeros
@@ -632,7 +634,9 @@ fn test_issue_1910_event_hash_chain_concurrent() {
     );
 
     // Verify chain integrity
-    let all_events = event.range(&branch_id, "default", 0, None, None, false, None).unwrap();
+    let all_events = event
+        .range(&branch_id, "default", 0, None, None, false, None)
+        .unwrap();
     assert_eq!(
         all_events.len(),
         total_events,
@@ -653,5 +657,262 @@ fn test_issue_1910_event_hash_chain_concurrent() {
         total_conflicts > 0,
         "Expected OCC conflicts with {} concurrent writers, got 0",
         num_threads
+    );
+}
+
+// ============================================================================
+// Test 4: Fork version gap — child misses inflight writes (#2110 / #2105)
+// ============================================================================
+
+/// Verifies that fork_branch does not produce a child that is missing data
+/// the parent has at versions <= fork_version.
+///
+/// The bug (#2105): The global storage version is shared across all branches.
+/// A commit to branch B can advance the global version while a concurrent
+/// commit to the source branch hasn't applied its writes yet. Fork reads
+/// the advanced version (which includes B's commit) but the source branch's
+/// pending commit hasn't materialized in the memtable. Result: fork_version
+/// claims to include a version whose data for the source branch is missing.
+///
+/// Race scenario:
+///   1. Commit A (source): allocates version V, begins apply_writes
+///   2. Commit B (other):  allocates V+1, applies, fetch_max(V+1) → storage.version = V+1
+///   3. Fork: reads storage.version = V+1, acquires DashMap guard on source
+///   4. Commit A: blocked on DashMap guard (fork holds it)
+///   5. Fork: flushes memtable (V's data not yet present), fork_version = V+1
+///   6. Commit A: applies after fork releases → data at V in parent only
+///
+/// Invariants tested: COW-003, MVCC-001, ARCH-002
+#[test]
+fn test_issue_2110_fork_version_gap() {
+    let mut failures = Vec::new();
+
+    for iteration in 0..100 {
+        let test_db = TestDb::new();
+        let branch_index = test_db.branch_index();
+        let kv = test_db.kv();
+
+        // Create source + other branches
+        branch_index.create_branch("source").unwrap();
+        branch_index.create_branch("other").unwrap();
+        let source_id = strata_engine::primitives::branch::resolve_branch_name("source");
+        let other_id = strata_engine::primitives::branch::resolve_branch_name("other");
+
+        // Seed source branch
+        for i in 0..5 {
+            kv.put(&source_id, "default", &format!("seed_{}", i), Value::Int(i))
+                .unwrap();
+        }
+
+        let db = test_db.db.clone();
+        let barrier = Arc::new(Barrier::new(3));
+        let fork_version_slot = Arc::new(AtomicU64::new(0));
+
+        // Thread 1: writes to SOURCE branch
+        let db1 = db.clone();
+        let barrier1 = barrier.clone();
+        let write_source_handle = thread::spawn(move || {
+            let kv1 = KVStore::new(db1);
+            barrier1.wait();
+            for i in 0..50 {
+                let key = format!("src_{}", i);
+                let _ = kv1.put(&source_id, "default", &key, Value::Int(1000 + i));
+            }
+        });
+
+        // Thread 2: writes to OTHER branch (advances global version)
+        let db2 = db.clone();
+        let barrier2 = barrier.clone();
+        let write_other_handle = thread::spawn(move || {
+            let kv2 = KVStore::new(db2);
+            barrier2.wait();
+            for i in 0..50 {
+                let key = format!("oth_{}", i);
+                let _ = kv2.put(&other_id, "default", &key, Value::Int(2000 + i));
+            }
+        });
+
+        // Thread 3: fork SOURCE while both writers are active
+        let db3 = db.clone();
+        let barrier3 = barrier.clone();
+        let fv_slot = fork_version_slot.clone();
+        let fork_name = format!("child_{}", iteration);
+        let fork_handle = thread::spawn(move || {
+            barrier3.wait();
+            thread::yield_now();
+            match branch_ops::fork_branch(&db3, "source", &fork_name) {
+                Ok(info) => {
+                    fv_slot.store(info.fork_version.unwrap_or(0), Ordering::Release);
+                    true
+                }
+                Err(_) => false,
+            }
+        });
+
+        write_source_handle.join().unwrap();
+        write_other_handle.join().unwrap();
+        let fork_ok = fork_handle.join().unwrap();
+
+        if !fork_ok {
+            continue;
+        }
+
+        let fork_version = fork_version_slot.load(Ordering::Acquire);
+        if fork_version == 0 {
+            continue;
+        }
+
+        let child_name = format!("child_{}", iteration);
+        let child_id = strata_engine::primitives::branch::resolve_branch_name(&child_name);
+
+        // Verify: every key committed to SOURCE at version <= fork_version
+        // must be visible in the child through inherited layers.
+        for i in 0..50 {
+            let key = format!("src_{}", i);
+            let parent_versioned = kv.get_versioned(&source_id, "default", &key).unwrap();
+
+            if let Some(pv) = parent_versioned {
+                if pv.version <= Version::Txn(fork_version) {
+                    let child_val = kv.get(&child_id, "default", &key).unwrap();
+                    if child_val.is_none() {
+                        failures.push(format!(
+                            "iteration {}: key '{}' in source@{:?} (fork_version={}) MISSING in child",
+                            iteration, key, pv.version, fork_version
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Seed keys must always be visible
+        for i in 0..5 {
+            let key = format!("seed_{}", i);
+            let child_val = kv.get(&child_id, "default", &key).unwrap();
+            if child_val.is_none() {
+                failures.push(format!(
+                    "iteration {}: seed key '{}' MISSING in child (fork_version={})",
+                    iteration, key, fork_version
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Fork version gap detected in {} cases:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+/// Stress variant: higher contention with cross-branch writes.
+#[test]
+fn test_issue_2110_fork_version_gap_concurrent() {
+    let mut failures = Vec::new();
+
+    for iteration in 0..50 {
+        let test_db = TestDb::new();
+        let branch_index = test_db.branch_index();
+        let kv = test_db.kv();
+
+        branch_index.create_branch("source").unwrap();
+        let source_id = strata_engine::primitives::branch::resolve_branch_name("source");
+
+        // Create multiple other branches for cross-branch version advancement
+        let mut other_ids = Vec::new();
+        for t in 0..3u8 {
+            let name = format!("other_{}", t);
+            branch_index.create_branch(&name).unwrap();
+            other_ids.push(strata_engine::primitives::branch::resolve_branch_name(
+                &name,
+            ));
+        }
+
+        // Seed source
+        for i in 0..5 {
+            kv.put(&source_id, "default", &format!("base_{}", i), Value::Int(i))
+                .unwrap();
+        }
+
+        let db = test_db.db.clone();
+        let barrier = Arc::new(Barrier::new(5)); // 1 source writer + 3 other writers + 1 forker
+        let fork_version_slot = Arc::new(AtomicU64::new(0));
+
+        let mut handles = Vec::new();
+
+        // Source writer
+        let db_s = db.clone();
+        let barrier_s = barrier.clone();
+        handles.push(thread::spawn(move || {
+            let kv_s = KVStore::new(db_s);
+            barrier_s.wait();
+            for i in 0..30 {
+                let key = format!("src_{}", i);
+                let _ = kv_s.put(&source_id, "default", &key, Value::Int(1000 + i));
+            }
+        }));
+
+        // Other-branch writers (advance global version concurrently)
+        for (t, other_id) in other_ids.iter().enumerate() {
+            let db_o = db.clone();
+            let barrier_o = barrier.clone();
+            let oid = *other_id;
+            handles.push(thread::spawn(move || {
+                let kv_o = KVStore::new(db_o);
+                barrier_o.wait();
+                for i in 0..30 {
+                    let key = format!("o{}_{}", t, i);
+                    let _ = kv_o.put(&oid, "default", &key, Value::Int((t as i64) * 1000 + i));
+                }
+            }));
+        }
+
+        // Forker
+        let db_f = db.clone();
+        let barrier_f = barrier.clone();
+        let fv_slot = fork_version_slot.clone();
+        let fork_name = format!("child_{}", iteration);
+        handles.push(thread::spawn(move || {
+            barrier_f.wait();
+            thread::yield_now();
+            if let Ok(info) = branch_ops::fork_branch(&db_f, "source", &fork_name) {
+                fv_slot.store(info.fork_version.unwrap_or(0), Ordering::Release);
+            }
+        }));
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let fork_version = fork_version_slot.load(Ordering::Acquire);
+        if fork_version == 0 {
+            continue;
+        }
+
+        let child_id =
+            strata_engine::primitives::branch::resolve_branch_name(&format!("child_{}", iteration));
+
+        for i in 0..30 {
+            let key = format!("src_{}", i);
+            let parent_versioned = kv.get_versioned(&source_id, "default", &key).unwrap();
+            if let Some(pv) = parent_versioned {
+                if pv.version <= Version::Txn(fork_version) {
+                    let child_val = kv.get(&child_id, "default", &key).unwrap();
+                    if child_val.is_none() {
+                        failures.push(format!(
+                            "iteration {}: key '{}' source@{:?} (fork_version={}) MISSING in child",
+                            iteration, key, pv.version, fork_version
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Fork version gap detected in {} cases:\n{}",
+        failures.len(),
+        failures.join("\n")
     );
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `fork_branch` read `storage.version` without quiescing concurrent commits. A commit to any branch could advance the global version while a source-branch commit was still in `apply_writes`, causing the child's `fork_version` to include data not yet in the memtable snapshot.
- **Fix**: Hold the `commit_quiesce` write lock across `storage.fork_branch()`, draining all in-flight commits before capturing the version. Scoped tightly (block scope) to avoid deadlock with `create_branch` which itself commits.
- **Scope**: 4 production files (47 lines), 2 test files (388 lines). No storage API changes.

## Root Cause

The global `storage.version` is shared across branches. Consider:

1. Commit A (source): allocates version V, begins `apply_writes`
2. Commit B (other branch): allocates V+1, completes, `fetch_max(V+1)` → `storage.version = V+1`
3. Fork: reads `storage.version = V+1`, acquires DashMap guard on source
4. Commit A: blocked on DashMap guard (fork holds it)
5. Fork: flushes memtable (V's data not yet present), `fork_version = V+1`
6. Commit A: applies after fork releases → data at V in parent only

Child claims `fork_version = V+1` but is missing V's data for the source branch.

## Fix

```rust
let (fork_version, _segments_shared) = {
    let _quiesce_guard = db.quiesce_commits();  // drains all in-flight commits
    storage.fork_branch(&source_id, &dest_id)?
};
// quiesce guard dropped here — before create_branch which needs to commit
```

## Invariants Verified

COW-002, COW-003, MVCC-001, MVCC-003, ACID-003, ACID-004, ARCH-002, ARCH-008 — all HOLD.

## Test Plan

- [x] `test_issue_2110_fork_version_gap` — engine-level stress test: concurrent cross-branch writes + fork, verifies child sees all parent data at versions ≤ fork_version (100 iterations)
- [x] `test_issue_2110_fork_version_gap_concurrent` — stress variant: 4 writer threads across multiple branches + fork (50 iterations)
- [x] `test_issue_2110_fork_version_gap_deterministic` — storage-level deterministic reproduction using channels to force exact interleaving, proves the version gap exists at the raw storage API level
- [x] Full workspace tests pass (3000+ tests across all crates)
- [x] Invariant check: 8 affected invariants verified, all HOLD
- [x] Code review: no bugs, no edge case gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)