### PR TITLE
v0.7: AutoResearch — db.experiment() with metrics and per-query breakdown

### DIFF
--- a/docs/design/search/README.md
+++ b/docs/design/search/README.md
@@ -14,6 +14,9 @@
 | [`v0.4-implementation.md`](v0.4-implementation.md) | Implementation plan: graph-augmented retrieval (PPR, typed traversal). |
 | [`v0.5-implementation.md`](v0.5-implementation.md) | Implementation plan: filter + budget + pagination (production readiness). |
 | [`v0.6-implementation.md`](v0.6-implementation.md) | Implementation plan: RAG (grounded answers, single model, citations). |
+| [`v0.7-implementation.md`](v0.7-implementation.md) | Implementation plan: AutoResearch (db.experiment, metrics, branch-per-recipe). |
+| [`v0.8-implementation.md`](v0.8-implementation.md) | Implementation plan: multi-model routing (provider:model per operation). |
+| [`v0.9-implementation.md`](v0.9-implementation.md) | Implementation plan: agent hints (describe, recipe schema, actionable hints). |
 
 ## Related
 

--- a/docs/design/search/v0.7-implementation.md
+++ b/docs/design/search/v0.7-implementation.md
@@ -1,0 +1,491 @@
+# v0.7 Implementation: AutoResearch
+
+Builds on v0.6 (complete search + RAG). All the building blocks are in place: the recipe controls every parameter, `db.search()` is the single entry point, the response format is fixed. AutoResearch is the formal API that lets users compare recipes and find the best one for their data.
+
+**Prerequisite:** v0.6 landed. The substrate handles BM25, vector, graph, expansion, reranking, temporal, filter, and RAG — all recipe-driven.
+
+---
+
+## 1. Scope
+
+**In:**
+- `db.experiment(recipes, eval_set, metric)` — compare recipes, return winner + rankings + details
+- Branch-per-recipe execution (internal)
+- Seven retrieval metrics (ndcg@10, recall@10, recall@100, mrr, map, precision@10, hit_rate@10, f1@10)
+- Rich result object (winner, rankings, per-query breakdown)
+- RAG mode support (return generated answers in details, no quality scoring)
+
+**Out (v0.8+):**
+- Multi-model routing (cloud providers in recipes)
+- Temporal RAG (diff + mode="rag")
+- Automated experiment planning (LLM proposes variants)
+- Convergence detection
+- Parallel branch execution
+- Caching of intermediate results
+
+---
+
+## 2. The API
+
+```python
+result = db.experiment(
+    recipes={
+        "baseline":    {"retrieve": {"bm25": {}}},
+        "hybrid":      {"retrieve": {"bm25": {}, "vector": {}}},
+        "tuned":       {"retrieve": {"bm25": {"k1": 1.2, "b": 0.65}, "vector": {}}, "fusion": {"k": 45}},
+        "with_graph":  {"retrieve": {"bm25": {}, "vector": {}, "graph": {"graph": "ontology"}}},
+    },
+    eval_set=db.json.get("eval/medical"),
+    metric="ndcg@10"
+)
+
+result.winner      # → the winning recipe (dict)
+result.rankings    # → all recipes ranked by chosen metric
+result.details     # → per-recipe, per-query breakdown
+```
+
+That's it. One call. Sync. Returns in seconds.
+
+---
+
+## 3. How It Works Internally
+
+```
+For each recipe (sequential):
+    1. Create a temporary branch from current branch
+    2. Store the recipe on the temp branch's _system_ space
+    3. For each query in eval_set:
+        a. db.search(query.text, recipe=recipe) on the temp branch
+        b. Compare hits to query.relevant docs
+        c. Record per-query metrics
+    4. Compute aggregate metrics for this recipe
+    5. Log results to _system_ space on the original branch
+    6. Delete the temporary branch
+
+Rank all recipes by the chosen metric
+Return result object
+```
+
+### Why branch per recipe?
+
+Most recipe changes (k1, b, fusion weights, k values) don't affect the index — they just change scoring. For these, branching is unnecessary. But some changes DO affect the index:
+- `stemmer` change → inverted index tokenizes differently
+- `stopwords` change → different terms indexed
+
+Branching ensures each recipe gets a clean execution environment. For non-index-affecting changes, the branch is a lightweight fork (COW, near-zero cost). For index-affecting changes, the branch could re-index (future optimization — v0.7 doesn't re-index, it just uses the existing index with the new scoring parameters).
+
+### Sequential execution
+
+v0.7 runs recipes one at a time. Three recipes × 50 eval queries × ~50ms per search = ~7.5 seconds. Fast enough.
+
+Parallel execution across branches is a future optimization. The architecture supports it (each branch is independent), but v0.7 keeps it simple.
+
+---
+
+## 4. Eval Set Format
+
+The user stores eval sets however they want — it's a database:
+
+```python
+db.json.set("eval/medical", [
+    {"query": "side effects of metformin", "relevant": ["doc:123", "doc:456"]},
+    {"query": "drug interactions with warfarin", "relevant": ["doc:789"]},
+    {"query": "diabetes treatment guidelines", "relevant": ["doc:012", "doc:345", "doc:678"]},
+])
+```
+
+Each entry:
+- `query` (string) — the search query
+- `relevant` (array of strings) — entity keys that are correct results for this query
+
+The `relevant` keys must match entity_ref keys in the database. The substrate resolves them during evaluation.
+
+### How many eval pairs?
+
+50-100 is sufficient for recipe optimization. More is better for statistical confidence but slower.
+
+---
+
+## 5. Metrics
+
+All seven metrics computed for every recipe. The `metric` parameter controls `.winner` and `.rankings` sort order.
+
+```rust
+pub struct MetricsResult {
+    pub ndcg_at_10: f64,
+    pub recall_at_10: f64,
+    pub recall_at_100: f64,
+    pub mrr: f64,
+    pub map: f64,
+    pub precision_at_10: f64,
+    pub hit_rate_at_10: f64,
+    pub f1_at_10: f64,
+}
+```
+
+### Metric implementations
+
+**NDCG@k** (Normalized Discounted Cumulative Gain):
+```
+DCG@k = Σ(i=1 to k) rel(i) / log2(i+1)
+IDCG@k = DCG@k for the ideal ranking
+NDCG@k = DCG@k / IDCG@k
+```
+Binary relevance: rel(i) = 1 if hit[i] is in relevant set, 0 otherwise.
+
+**Recall@k:**
+```
+Recall@k = |{relevant docs in top k}| / |{all relevant docs}|
+```
+
+**MRR** (Mean Reciprocal Rank):
+```
+MRR = mean over queries of 1/rank_of_first_relevant_hit
+```
+
+**MAP** (Mean Average Precision):
+```
+AP = (1/|relevant|) * Σ(k=1 to n) Precision@k * rel(k)
+MAP = mean of AP across queries
+```
+
+**Precision@k:**
+```
+Precision@k = |{relevant docs in top k}| / k
+```
+
+**Hit Rate@k:**
+```
+Hit Rate@k = 1 if any relevant doc in top k, else 0 (averaged across queries)
+```
+
+**F1@k:**
+```
+F1@k = 2 * (Precision@k * Recall@k) / (Precision@k + Recall@k)
+```
+
+---
+
+## 6. Result Object
+
+```python
+result.winner
+# → {"retrieve": {"bm25": {"k1": 1.2, "b": 0.65}, "vector": {}}, "fusion": {"k": 45}}
+
+result.rankings
+# → [
+#      {"name": "tuned",      "ndcg@10": 0.71, "recall@10": 0.83, "mrr": 0.69, "precision@10": 0.45, ...},
+#      {"name": "with_graph", "ndcg@10": 0.68, "recall@10": 0.80, "mrr": 0.65, ...},
+#      {"name": "hybrid",     "ndcg@10": 0.65, "recall@10": 0.78, "mrr": 0.62, ...},
+#      {"name": "baseline",   "ndcg@10": 0.52, "recall@10": 0.65, "mrr": 0.48, ...},
+#   ]
+
+result.details["tuned"]
+# → {
+#      "ndcg@10": 0.71,
+#      "per_query": [
+#          {"query": "side effects of metformin", "ndcg@10": 0.85, "relevant_found": 2, "relevant_total": 2, "hits": [...]},
+#          {"query": "drug interactions with warfarin", "ndcg@10": 0.42, "relevant_found": 1, "relevant_total": 2, "hits": [...]},
+#      ]
+#   }
+
+result.details["tuned"]["per_query"][0]["answer"]
+# → "Common side effects include nausea..." (when mode="rag", null otherwise)
+```
+
+### Per-query breakdown
+
+The per-query breakdown is the most valuable output. The agent (user, Claude Code, or a script) reads it to understand which queries each recipe struggles on and targets the next round of experiments:
+
+```python
+# Round 1: broad sweep
+result = db.experiment(recipes=broad_variants, eval_set=eval_set)
+
+# Analyze: which queries did the winner struggle on?
+weak_queries = [q for q in result.details[result.winner]["per_query"] if q["ndcg@10"] < 0.5]
+# → ["drug interactions with warfarin" scored 0.42]
+
+# Round 2: targeted — try different strategies for the weak queries
+# Agent proposes variants that might help with drug interaction queries
+result2 = db.experiment(recipes=targeted_variants, eval_set=eval_set)
+```
+
+---
+
+## 7. The AutoResearch Loop
+
+Strata provides `db.experiment()`. The agent provides the intelligence.
+
+```python
+current_best = db.get_recipe()
+eval_set = db.json.get("eval/medical")
+
+for round in range(10):
+    # Agent proposes variants (mutates current best)
+    variants = agent.propose_variants(current_best, previous_results)
+
+    # Strata compares them
+    result = db.experiment(recipes=variants, eval_set=eval_set)
+
+    # Agent decides whether to keep
+    if result.rankings[0]["ndcg@10"] > best_score:
+        current_best = result.winner
+        best_score = result.rankings[0]["ndcg@10"]
+        db.set_recipe(current_best)
+
+    # Agent analyzes weak queries for next round
+    previous_results = result
+```
+
+Strata doesn't plan experiments, propose mutations, or decide when to stop. The agent does all of that. Strata runs recipes and returns metrics.
+
+---
+
+## 8. Implementation
+
+### New files
+
+```
+crates/engine/src/search/experiment.rs
+├── run_experiment()          — main entry point
+├── evaluate_recipe()         — run all queries against one recipe
+├── compute_metrics()         — NDCG, recall, MRR, MAP, precision, hit_rate, F1
+└── types                     — ExperimentResult, Rankings, QueryResult
+```
+
+### Types
+
+```rust
+pub struct ExperimentRequest {
+    pub recipes: HashMap<String, Recipe>,
+    pub eval_set: Vec<EvalQuery>,
+    pub metric: String,           // "ndcg@10", "recall@10", etc.
+    pub mode: Option<String>,     // "rag" to also generate answers
+}
+
+pub struct EvalQuery {
+    pub query: String,
+    pub relevant: Vec<String>,    // entity keys
+}
+
+pub struct ExperimentResult {
+    pub winner: Recipe,
+    pub rankings: Vec<RankedRecipe>,
+    pub details: HashMap<String, RecipeDetail>,
+}
+
+pub struct RankedRecipe {
+    pub name: String,
+    pub metrics: MetricsResult,
+    pub elapsed_ms: f64,
+}
+
+pub struct RecipeDetail {
+    pub metrics: MetricsResult,
+    pub per_query: Vec<QueryResult>,
+}
+
+pub struct QueryResult {
+    pub query: String,
+    pub ndcg_at_10: f64,
+    pub relevant_found: usize,
+    pub relevant_total: usize,
+    pub hits: Vec<SearchHit>,
+    pub answer: Option<AnswerResponse>,  // when mode="rag"
+}
+```
+
+### Core logic
+
+```rust
+pub fn run_experiment(
+    db: &Database,
+    request: &ExperimentRequest,
+) -> StrataResult<ExperimentResult> {
+    let branch_id = db.current_branch();
+    let mut all_results: Vec<(String, RecipeDetail)> = Vec::new();
+
+    for (name, recipe) in &request.recipes {
+        // Resolve recipe: three-level merge (builtin → branch default → this variant)
+        let resolved = Recipe::resolve(&BUILTIN_DEFAULTS, &db.get_default_recipe(&branch_id)?, recipe);
+
+        // Create temp branch
+        let temp_branch = format!("_experiment_{}", name);
+        db.branch_create(&temp_branch, &branch_id)?;
+
+        // Evaluate all queries
+        let detail = evaluate_recipe(db, &temp_branch, &resolved, &request.eval_set, &request.mode)?;
+
+        // Clean up
+        db.branch_delete(&temp_branch)?;
+
+        all_results.push((name.clone(), detail));
+    }
+
+    // Rank by chosen metric
+    all_results.sort_by(|a, b| {
+        let score_a = a.1.metrics.get(&request.metric);
+        let score_b = b.1.metrics.get(&request.metric);
+        score_b.partial_cmp(&score_a).unwrap_or(Ordering::Equal)
+    });
+
+    let winner = request.recipes[&all_results[0].0].clone();
+    let rankings = all_results.iter().map(|(name, detail)| RankedRecipe {
+        name: name.clone(),
+        metrics: detail.metrics.clone(),
+        elapsed_ms: detail.elapsed_ms,
+    }).collect();
+    let details = all_results.into_iter().collect();
+
+    Ok(ExperimentResult { winner, rankings, details })
+}
+```
+
+### Metric computation
+
+```rust
+fn compute_metrics(hits: &[SearchHit], relevant: &HashSet<String>, k: usize) -> MetricsResult {
+    let relevant_in_top_k: Vec<bool> = hits.iter()
+        .take(k)
+        .map(|h| relevant.contains(&h.doc_ref.key()))
+        .collect();
+
+    let relevant_found = relevant_in_top_k.iter().filter(|&&r| r).count();
+
+    MetricsResult {
+        ndcg_at_10: compute_ndcg(&relevant_in_top_k, relevant.len()),
+        recall_at_10: relevant_found as f64 / relevant.len().max(1) as f64,
+        mrr: compute_mrr(&relevant_in_top_k),
+        map: compute_map(&relevant_in_top_k, relevant.len()),
+        precision_at_10: relevant_found as f64 / k as f64,
+        hit_rate_at_10: if relevant_found > 0 { 1.0 } else { 0.0 },
+        f1_at_10: compute_f1(relevant_found, k, relevant.len()),
+        recall_at_100: 0.0, // computed separately with k=100
+    }
+}
+```
+
+### Executor wiring
+
+New command:
+
+```
+EXPERIMENT <recipes_json> <eval_set_json> [--metric ndcg@10] [--mode rag]
+```
+
+Or via Python SDK:
+
+```python
+result = db.experiment(recipes, eval_set, metric="ndcg@10")
+```
+
+### Logging
+
+Experiment results logged to `_system_` space on the branch:
+
+```
+_system_ space:
+  experiment:{timestamp}    → ExperimentResult JSON
+```
+
+The agent can read past experiments to inform future rounds.
+
+---
+
+## 9. Testing
+
+### Metric correctness
+
+- Known result set → verify NDCG@10 matches hand-computed value
+- All relevant in top-1 → NDCG@10 = 1.0
+- No relevant in top-10 → NDCG@10 = 0.0
+- MRR with first relevant at position 3 → MRR = 0.333
+- Precision@10 with 3 relevant in top 10 → 0.3
+- Recall@10 with 3 of 5 relevant in top 10 → 0.6
+
+### Experiment correctness
+
+- Two identical recipes → same metrics (determinism)
+- Recipe A clearly better than B → A is winner
+- Single recipe → winner is that recipe
+- Empty eval set → error
+- Recipe with typo/invalid field → error with clear message
+
+### Branch isolation
+
+- Experiment creates temp branches → temp branches cleaned up after
+- Experiment doesn't modify the user's current branch
+- Concurrent searches on the main branch unaffected during experiment
+
+### RAG mode
+
+- mode="rag" → details include answer text per query
+- mode=None → details have answer: null
+- winner still based on retrieval metrics, not answer quality
+
+### Integration with BEIR
+
+```python
+# The ultimate test: run BEIR fast subset as an experiment
+eval_set = load_beir_as_eval_set("nfcorpus")
+
+result = db.experiment(
+    recipes={
+        "bm25":   {"retrieve": {"bm25": {}}},
+        "hybrid": {"retrieve": {"bm25": {}, "vector": {}}},
+    },
+    eval_set=eval_set,
+    metric="ndcg@10"
+)
+
+# Should match BEIR_RESULTS.md numbers
+assert result.rankings[0]["name"] == "hybrid"
+assert result.rankings[0]["ndcg@10"] > result.rankings[1]["ndcg@10"]
+```
+
+---
+
+## 10. Estimated Effort
+
+| Component | Lines |
+|---|---|
+| Experiment runner (run_experiment, evaluate_recipe) | ~150 |
+| Metric computation (NDCG, recall, MRR, MAP, precision, hit_rate, F1) | ~120 |
+| Types (ExperimentResult, Rankings, QueryResult, MetricsResult) | ~80 |
+| Executor command + SDK wiring | ~50 |
+| Experiment logging to _system_ | ~30 |
+| Tests | ~200 |
+| **Total** | **~630** |
+
+---
+
+## 11. Complete Roadmap
+
+```
+v0.0 — Prerequisites           ~1,300 lines
+v0.1 — Minimal Substrate         ~300 lines
+v0.2 — Expansion + Reranking     ~600 lines
+v0.3 — Temporal Search           ~520 lines
+v0.4 — Graph (PPR)               ~490 lines
+v0.5 — Filter + Budget           ~465 lines
+v0.6 — RAG                       ~375 lines
+v0.7 — AutoResearch              ~630 lines
+                               ──────────
+                               ~4,680 lines total
+```
+
+After v0.7, the full search architecture is implemented:
+- Retrieval substrate with four operators (BM25, vector, graph, expansion)
+- Intelligence layer with RAG and reranking
+- Temporal search (as_of, diff, version history)
+- Post-retrieval filtering with budget enforcement
+- Recipe-driven configuration with three-level merge
+- `db.experiment()` for recipe optimization
+- Fixed response format (hits, answer, diff, aggregations, groups, stats)
+
+What remains after v0.7:
+- Multi-model routing (cloud providers in recipes)
+- Temporal RAG (diff + mode="rag")
+- `db.experiment()` with parallel branch execution
+- Caching of intermediate results for fast AutoResearch
+- DataFusion integration for query/aggregation

--- a/docs/design/search/v0.8-implementation.md
+++ b/docs/design/search/v0.8-implementation.md
@@ -1,0 +1,321 @@
+# v0.8 Implementation: Multi-Model Routing
+
+Builds on v0.7 (complete search + RAG + AutoResearch). Unlocks the `models` section of the recipe — different models for different operations.
+
+**Prerequisite:** v0.7 landed. strata-inference supports local GGUF and Anthropic/OpenAI/Google API providers.
+
+---
+
+## 1. Scope
+
+**In:**
+- `models` section in the recipe: per-operation model assignment
+- `provider:model_name` format (local, anthropic, openai, google, any OpenAI-compatible)
+- Model routing for: embed, expansion, rerank, rag
+- Model assignment experimentable via `db.experiment()`
+- Graceful fallback: if a cloud model fails, fall back to local
+
+**Out (not building, not a search concern):**
+- Streaming responses
+- Multi-turn conversation
+- Chat history / context management
+- Model fine-tuning
+- Model download/management UI
+- Token counting / cost tracking dashboard
+
+Strata is not an inference engine. It routes to models. strata-inference does the work.
+
+---
+
+## 2. What Changes
+
+v0.6 hardcoded Qwen3 1.7B for RAG. v0.2 hardcoded Qwen3 1.7B for expansion and Qwen3-Reranker 0.6B for reranking. v0.8 makes all of these configurable via the recipe.
+
+### Before (v0.2–v0.6)
+
+```rust
+// Hardcoded in each module
+let engine = load_model("qwen3:1.7b")?;
+```
+
+### After (v0.8)
+
+```rust
+// Read from recipe
+let model_name = recipe.models.as_ref()
+    .and_then(|m| m.rag.as_deref())
+    .unwrap_or("local:qwen3:1.7b");
+let engine = inference::load(model_name)?;
+```
+
+That's the core change. Every place that loads a model reads the model name from the recipe instead of a hardcoded string.
+
+---
+
+## 3. Recipe Integration
+
+```json
+{
+    "retrieve": {"bm25": {}, "vector": {}},
+    "expansion": {"strategy": "full"},
+    "rerank": {"top_n": 20},
+    "models": {
+        "embed": "local:miniLM",
+        "expansion": "local:qwen3:1.7b",
+        "rerank": "local:qwen3-reranker:0.6b",
+        "rag": "anthropic:claude-sonnet-4-6"
+    }
+}
+```
+
+### Model specification format
+
+`provider:model_name`
+
+| Provider | Format | Examples |
+|---|---|---|
+| `local` | `local:model_name` | `local:qwen3:1.7b`, `local:miniLM`, `local:qwen3-reranker:0.6b` |
+| `anthropic` | `anthropic:model_id` | `anthropic:claude-sonnet-4-6`, `anthropic:claude-haiku-4-5` |
+| `openai` | `openai:model_id` | `openai:gpt-4o`, `openai:gpt-4o-mini` |
+| `google` | `google:model_id` | `google:gemini-2.5-flash` |
+
+Any OpenAI-compatible endpoint (Ollama, Together, etc.) uses the provider name configured in strata-inference.
+
+### Defaults
+
+If `models` is absent from the recipe, all operations use local models:
+
+| Operation | Default |
+|---|---|
+| `embed` | `local:miniLM` |
+| `expansion` | `local:qwen3:1.7b` |
+| `rerank` | `local:qwen3-reranker:0.6b` |
+| `rag` | `local:qwen3:1.7b` |
+
+Everything works out of the box with zero cost. The user upgrades specific operations to cloud models when they want better quality.
+
+---
+
+## 4. strata-inference Contract
+
+v0.8 depends on strata-inference providing a unified interface across providers:
+
+```rust
+// What the intelligence layer calls
+pub trait InferenceEngine {
+    fn generate(&self, prompt: &str, max_tokens: usize) -> Result<String>;
+    fn generate_with_grammar(&self, prompt: &str, grammar: &str, max_tokens: usize) -> Result<String>;
+    fn embed(&self, text: &str) -> Result<Vec<f32>>;
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>>;
+    fn rank(&self, query: &str, passages: &[&str]) -> Result<Vec<f32>>;
+}
+
+// What strata-inference provides
+pub fn load(model_spec: &str) -> Result<Box<dyn InferenceEngine>>;
+```
+
+`load("local:qwen3:1.7b")` returns a local GGUF engine. `load("anthropic:claude-sonnet-4-6")` returns a cloud API client. Same interface. The intelligence layer doesn't know or care which provider is behind it.
+
+### What strata-inference must handle
+
+| Concern | strata-inference's job | NOT the intelligence layer's job |
+|---|---|---|
+| API key management | Read from env vars or config | |
+| Rate limiting | Respect provider rate limits | |
+| Retry on transient errors | Retry with backoff | |
+| Token counting | Count tokens for budget management | |
+| Model loading/caching | Load GGUF once, cache in memory | |
+| Provider-specific prompt formats | Apply chat templates per provider | |
+
+The intelligence layer calls `engine.generate(prompt, max_tokens)`. Everything else is strata-inference's problem.
+
+---
+
+## 5. Model Assignment as an Experiment Variable
+
+The biggest unlock: AutoResearch can compare model assignments.
+
+```python
+result = db.experiment(
+    recipes={
+        "all_local": {
+            "retrieve": {"bm25": {}, "vector": {}},
+            "expansion": {"strategy": "full"},
+            "rerank": {"top_n": 20},
+        },
+        "cloud_rag": {
+            "retrieve": {"bm25": {}, "vector": {}},
+            "expansion": {"strategy": "full"},
+            "rerank": {"top_n": 20},
+            "models": {"rag": "anthropic:claude-sonnet-4-6"},
+        },
+        "cloud_rerank": {
+            "retrieve": {"bm25": {}, "vector": {}},
+            "expansion": {"strategy": "full"},
+            "rerank": {"top_n": 20},
+            "models": {"rerank": "anthropic:claude-haiku-4-5"},
+        },
+    },
+    eval_set=eval_set,
+    metric="ndcg@10"
+)
+```
+
+The experiment discovers: "Cloud reranking improved nDCG by 8% but added 500ms latency. Cloud RAG didn't affect nDCG (it's a retrieval metric) but the answer quality is visibly better in the details."
+
+---
+
+## 6. Graceful Fallback
+
+If a cloud model fails (API error, timeout, rate limit), fall back to the local default for that operation:
+
+```rust
+fn get_engine(model_spec: &str, operation: &str) -> Box<dyn InferenceEngine> {
+    match inference::load(model_spec) {
+        Ok(engine) => engine,
+        Err(e) => {
+            tracing::warn!(operation, model = model_spec, error = %e, "Cloud model failed, falling back to local");
+            let fallback = default_model_for(operation); // "local:qwen3:1.7b" etc.
+            inference::load(fallback).expect("local model must always be available")
+        }
+    }
+}
+```
+
+The user gets results with the local model rather than an error. `stats.stages` reports which model was actually used, so the user can see the fallback happened.
+
+---
+
+## 7. Implementation
+
+### Changes to existing files
+
+**`crates/intelligence/src/expand/mod.rs`:**
+```rust
+// Before (v0.2):
+let engine = load_model("qwen3:1.7b")?;
+
+// After (v0.8):
+let model = recipe.models.as_ref().and_then(|m| m.expansion.as_deref()).unwrap_or("local:qwen3:1.7b");
+let engine = get_engine(model, "expansion");
+```
+
+~5 lines changed.
+
+**`crates/intelligence/src/rerank/mod.rs`:** Same pattern. ~5 lines.
+
+**`crates/intelligence/src/rag/mod.rs`:** Same pattern. ~5 lines.
+
+**Embedding path (wherever query embedding happens):** Same pattern. ~5 lines.
+
+**`crates/engine/src/search/recipe.rs`:**
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ModelsConfig {
+    pub embed: Option<String>,
+    pub expansion: Option<String>,
+    pub rerank: Option<String>,
+    pub rag: Option<String>,
+}
+```
+
+Already defined in v0.0 types. Just ensure it's wired through.
+
+**`stats.stages`:** Report actual model used per operation:
+```json
+"generation": {"elapsed_ms": 980, "model": "anthropic:claude-sonnet-4-6", "tokens_out": 47}
+"expansion": {"elapsed_ms": 120, "model": "local:qwen3:1.7b"}
+"rerank": {"elapsed_ms": 150, "model": "local:qwen3-reranker:0.6b"}
+```
+
+### New code
+
+**`crates/intelligence/src/model_router.rs`:**
+```rust
+pub fn get_engine(model_spec: &str, operation: &str) -> Box<dyn InferenceEngine> {
+    // Try specified model, fall back to local default
+}
+
+fn default_model_for(operation: &str) -> &'static str {
+    match operation {
+        "embed" => "local:miniLM",
+        "expansion" => "local:qwen3:1.7b",
+        "rerank" => "local:qwen3-reranker:0.6b",
+        "rag" => "local:qwen3:1.7b",
+        _ => "local:qwen3:1.7b",
+    }
+}
+```
+
+~30 lines. The routing is trivial — parse the provider prefix, call strata-inference's `load()`.
+
+---
+
+## 8. Testing
+
+### Provider tests
+
+- `local:qwen3:1.7b` → loads GGUF, generates text
+- `anthropic:claude-sonnet-4-6` → calls API, generates text (requires API key)
+- `openai:gpt-4o-mini` → calls API, generates text (requires API key)
+- `google:gemini-2.5-flash` → calls API, generates text (requires API key)
+- Invalid provider → error with clear message
+
+### Fallback tests
+
+- Cloud model with invalid API key → falls back to local, results returned
+- Cloud model with timeout → falls back to local
+- Local model that doesn't exist → error (no fallback for missing local models)
+
+### Recipe routing tests
+
+- Recipe with `models.rag: "anthropic:claude-sonnet-4-6"` → RAG uses Claude, expansion uses local
+- Recipe with no `models` → all operations use local defaults
+- Recipe with only `models.rerank` specified → only reranking model overridden
+
+### Experiment tests
+
+- Two recipes differing only in `models.rag` → different models used, retrieval metrics may differ (if reranking model changes), answer text differs
+
+---
+
+## 9. Estimated Effort
+
+| Component | Lines |
+|---|---|
+| Model router (model_router.rs) | ~30 |
+| Wire routing into expand/rerank/rag/embed | ~20 (5 lines × 4 modules) |
+| Stats: report actual model used | ~20 |
+| Fallback logic | ~20 |
+| Tests | ~100 |
+| **Total** | **~190** |
+
+The smallest version. strata-inference does all the heavy lifting.
+
+---
+
+## 10. Complete Roadmap
+
+```
+v0.0 — Prerequisites           ~1,300 lines
+v0.1 — Minimal Substrate         ~300 lines
+v0.2 — Expansion + Reranking     ~600 lines
+v0.3 — Temporal Search           ~520 lines
+v0.4 — Graph (PPR)               ~490 lines
+v0.5 — Filter + Budget           ~465 lines
+v0.6 — RAG                       ~375 lines
+v0.7 — AutoResearch              ~630 lines
+v0.8 — Multi-Model Routing       ~190 lines
+                               ──────────
+                               ~4,870 lines total
+```
+
+After v0.8, the search architecture is feature-complete. Every design doc promise is delivered:
+- Retrieval substrate with recipe-driven everything ✓
+- Intelligence layer with RAG, expansion, reranking ✓
+- Temporal search ✓
+- Graph-augmented retrieval ✓
+- AutoResearch ✓
+- Multi-model routing ✓
+- Filter + budget + pagination ✓
+- Fixed response format ✓

--- a/docs/design/search/v0.9-implementation.md
+++ b/docs/design/search/v0.9-implementation.md
@@ -1,0 +1,401 @@
+# v0.9 Implementation: Agent Hints
+
+Builds on v0.8 (feature-complete search). Makes the search substrate self-describing so that AI agents (strata-ai, Claude Code, MCP clients) can discover capabilities, understand results, and make informed decisions — without reading documentation.
+
+**Prerequisite:** v0.8 landed. The search substrate is feature-complete.
+
+---
+
+## 1. The Problem
+
+An agent using Strata today has to know things upfront:
+- Which primitives have data
+- Which fields are indexed (for filtering)
+- Which vector collections exist (for hybrid search)
+- Which graphs exist (for graph retrieval)
+- What the current recipe is and what parameters it has
+- Whether a search returned bad results because the query was bad or because the recipe is misconfigured
+- What to try next when results are poor
+
+This knowledge comes from documentation, system prompts, or trial and error. An agent-friendly database should tell the agent all of this at runtime.
+
+---
+
+## 2. Scope
+
+**In:**
+- `db.describe()` — introspect the database: what's in it, what's indexed, what's searchable
+- Recipe introspection — what parameters exist, what are valid values, what's currently set
+- Actionable hints in search responses — "no index for this predicate", "expansion skipped (strong signal)", "embedding coverage is 40%"
+- Suggested next actions — "try adding a vector collection", "this query might benefit from expansion"
+
+**Out:**
+- Natural language explanation of results (that's RAG / strata-ai's job)
+- Automated recipe fixing (that's AutoResearch's job)
+- MCP tool schema generation (that's strata-ai's wiring)
+
+---
+
+## 3. `db.describe()`
+
+A single introspection call that tells the agent everything it needs to know about the database's search capabilities.
+
+```python
+info = db.describe()
+```
+
+```json
+{
+    "branch": "main",
+    "space": "default",
+
+    "primitives": {
+        "kv": {"count": 127450, "indexed": true},
+        "json": {"count": 53200, "indexed": true},
+        "event": {"count": 892100, "indexed": true},
+        "vector": {
+            "collections": {
+                "_system_embed_kv": {"count": 127450, "dimension": 384, "model": "miniLM"},
+                "_system_embed_json": {"count": 41800, "dimension": 384, "model": "miniLM"},
+                "custom_embeddings": {"count": 10000, "dimension": 768, "model": "nomic-embed"}
+            }
+        },
+        "graph": {
+            "graphs": {
+                "medical_ontology": {
+                    "nodes": 34200, "edges": 89100,
+                    "node_types": ["Drug", "Condition", "Procedure"],
+                    "edge_types": ["treats", "causes", "interacts_with"]
+                }
+            }
+        }
+    },
+
+    "indexes": {
+        "json": {
+            "category": {"type": "tag", "cardinality": 12},
+            "year": {"type": "numeric", "min": 2018, "max": 2025},
+            "title": {"type": "text", "indexed_docs": 53200}
+        }
+    },
+
+    "recipe": {
+        "name": "default",
+        "summary": "hybrid (bm25 + vector), no expansion, no reranking",
+        "operators": ["bm25", "vector"],
+        "models": {"embed": "local:miniLM", "rag": "local:qwen3:1.7b"}
+    },
+
+    "capabilities": {
+        "bm25": true,
+        "vector": true,
+        "graph": true,
+        "expansion": false,
+        "reranking": false,
+        "rag": true,
+        "temporal": true
+    },
+
+    "embedding_coverage": {
+        "kv": {"total": 127450, "embedded": 127450, "coverage": 1.0},
+        "json": {"total": 53200, "embedded": 41800, "coverage": 0.786},
+        "event": {"total": 892100, "embedded": 0, "coverage": 0.0}
+    },
+
+    "time_range": {
+        "oldest": "2024-01-10T00:00:00Z",
+        "latest": "2025-06-15T14:32:00Z"
+    }
+}
+```
+
+The agent reads this once at startup. It knows:
+- What data exists and how much
+- What indexes are available for filtering
+- What vector collections exist and their coverage
+- What graphs exist and their ontology
+- What the current recipe does
+- What capabilities are enabled
+- What temporal range is queryable
+
+### Implementation
+
+`db.describe()` assembles data from existing sources:
+- Primitive counts: `db.kv.count()`, `db.json.count()`, etc.
+- Vector collections: `db.vector.list_collections()`
+- Graph info: `db.graph.list()` + `db.graph.ontology_summary()`
+- Indexes: `db.json.list_indexes()`
+- Recipe: `db.get_recipe()`
+- Embedding coverage: compare primitive counts to vector collection counts
+- Time range: `db.time_range()`
+
+No new infrastructure. Just aggregation of existing APIs into one response.
+
+---
+
+## 4. Recipe Introspection
+
+The agent needs to know what it can tune.
+
+```python
+schema = db.recipe_schema()
+```
+
+```json
+{
+    "retrieve": {
+        "bm25": {
+            "k": {"type": "integer", "default": 50, "range": [1, 1000]},
+            "k1": {"type": "float", "default": 0.9, "range": [0.0, 3.0]},
+            "b": {"type": "float", "default": 0.4, "range": [0.0, 1.0]},
+            "stemmer": {"type": "enum", "default": "porter", "options": ["porter", "snowball", "none"]},
+            "stopwords": {"type": "enum", "default": "lucene33", "options": ["lucene33", "smart571", "none"]},
+            "phrase_boost": {"type": "float", "default": 0.0, "range": [0.0, 10.0]},
+            "proximity_boost": {"type": "float", "default": 0.0, "range": [0.0, 5.0]}
+        },
+        "vector": {
+            "k": {"type": "integer", "default": 50, "range": [1, 1000]},
+            "ef_search": {"type": "integer", "default": 100, "range": [10, 1000]},
+            "collections": {"type": "string[]", "default": "all _system_embed_* collections"}
+        },
+        "graph": {
+            "strategy": {"type": "enum", "default": "ppr", "options": ["ppr", "neighborhood"]},
+            "k": {"type": "integer", "default": 50},
+            "damping": {"type": "float", "default": 0.5, "range": [0.0, 1.0]},
+            "edge_types": {"type": "string[]", "default": "all"}
+        }
+    },
+    "expansion": {
+        "strategy": {"type": "enum", "default": "full", "options": ["lex", "vec", "hyde", "full"]},
+        "strong_signal_threshold": {"type": "float", "default": 0.85, "range": [0.0, 1.0]},
+        "strong_signal_gap": {"type": "float", "default": 0.15, "range": [0.0, 1.0]},
+        "min_shared_stems": {"type": "integer", "default": 2, "range": [0, 10]},
+        "original_weight": {"type": "float", "default": 2.0, "range": [0.5, 5.0]}
+    },
+    "rerank": {
+        "top_n": {"type": "integer", "default": 20, "range": [5, 100]},
+        "blending": {
+            "rank_1_3": {"type": "float", "default": 0.75, "range": [0.0, 1.0]},
+            "rank_4_10": {"type": "float", "default": 0.60, "range": [0.0, 1.0]},
+            "rank_11_plus": {"type": "float", "default": 0.40, "range": [0.0, 1.0]}
+        }
+    },
+    "fusion": {
+        "k": {"type": "integer", "default": 60, "range": [1, 500]},
+        "weights": {"type": "map<string, float>", "default": "equal"}
+    }
+}
+```
+
+The agent reads this to know what parameters exist, their types, defaults, and valid ranges. It can generate recipe variants for `db.experiment()` without hardcoded knowledge of the schema.
+
+---
+
+## 5. Actionable Hints in Search Responses
+
+The `stats` section of the response already reports per-stage timing. v0.9 adds `hints` — actionable observations that help the agent understand and improve results.
+
+```json
+{
+    "hits": [...],
+    "stats": {
+        "stages": {...},
+        "hints": [
+            {
+                "type": "no_index",
+                "message": "Filter predicate 'author' has no index. Full scan used. Create a JSON index for faster filtering.",
+                "field": "author",
+                "action": "db.json.create_index('author', type='tag')"
+            },
+            {
+                "type": "low_coverage",
+                "message": "Vector search covered 41,800 of 53,200 JSON documents (79%). 11,400 documents have no embeddings.",
+                "primitive": "json",
+                "coverage": 0.786
+            },
+            {
+                "type": "expansion_skipped",
+                "message": "Query expansion skipped — BM25 strong signal detected (score 0.92, gap 0.23).",
+                "reason": "strong_signal"
+            },
+            {
+                "type": "budget_exhausted",
+                "message": "Time budget exhausted after BM25 + vector. Reranking skipped.",
+                "skipped_stages": ["rerank"]
+            },
+            {
+                "type": "no_graph",
+                "message": "Recipe includes graph retrieval but no graph named 'ontology' exists on this branch.",
+                "graph": "ontology"
+            },
+            {
+                "type": "low_results",
+                "message": "Only 3 results found (requested 10). Consider broadening the query or enabling expansion.",
+                "found": 3,
+                "requested": 10
+            }
+        ]
+    }
+}
+```
+
+### Hint types
+
+| Type | When it fires | Actionable? |
+|---|---|---|
+| `no_index` | Filter predicate falls back to full scan | Yes — create an index |
+| `low_coverage` | Vector collection has <90% embedding coverage | Yes — wait for enrichment or trigger reindex |
+| `expansion_skipped` | Strong signal detected, expansion not run | Informational — system is working as designed |
+| `budget_exhausted` | Time limit hit, stages skipped | Yes — increase budget or simplify recipe |
+| `no_graph` | Recipe references a graph that doesn't exist | Yes — create the graph or remove from recipe |
+| `low_results` | Fewer hits than requested | Yes — broaden query, enable expansion, lower score_threshold |
+| `no_embeddings` | Vector search requested but no collections exist | Yes — enable auto_embed or create collections |
+| `model_fallback` | Cloud model failed, fell back to local | Informational — check API keys/quotas |
+
+### Implementation
+
+Hints are collected during pipeline execution. Each stage can append hints:
+
+```rust
+struct HintCollector {
+    hints: Vec<Hint>,
+}
+
+impl HintCollector {
+    fn add(&mut self, hint: Hint) { self.hints.push(hint); }
+}
+```
+
+Passed through the pipeline. Each stage checks relevant conditions and adds hints. Zero overhead when no hints are triggered (common case).
+
+---
+
+## 6. Suggested Next Actions
+
+For poor results, the hints suggest what the agent should try:
+
+```json
+{
+    "type": "low_results",
+    "message": "Only 3 results found (requested 10).",
+    "suggestions": [
+        "Enable query expansion: add 'expansion' section to recipe",
+        "Lower score_threshold: current 0.1 may be too aggressive",
+        "Broaden the query: try fewer or more general terms"
+    ]
+}
+```
+
+Suggestions are templates, not commands. The agent decides whether to act on them. This is the database providing information, not making decisions.
+
+---
+
+## 7. Implementation
+
+### New files
+
+```
+crates/engine/src/search/describe.rs   — db.describe() implementation
+crates/engine/src/search/schema.rs     — db.recipe_schema() implementation
+crates/engine/src/search/hints.rs      — hint collection and generation
+```
+
+### Changes to existing files
+
+**`crates/engine/src/search/substrate.rs`** — pass HintCollector through pipeline, attach hints to response stats.
+
+**Response types** — add `hints` to stats:
+```rust
+pub struct RetrievalStats {
+    pub snapshot_version: u64,
+    pub recipe_used: String,
+    pub elapsed_ms: f64,
+    pub stages: HashMap<String, StageStats>,
+    pub budget_exhausted: bool,
+    pub hints: Vec<Hint>,  // NEW
+}
+
+pub struct Hint {
+    pub hint_type: String,
+    pub message: String,
+    pub details: serde_json::Value,
+}
+```
+
+### Executor commands
+
+```
+DESCRIBE                     -- full database introspection
+RECIPE SCHEMA                -- recipe parameter schema with types and ranges
+```
+
+---
+
+## 8. Testing
+
+### Describe tests
+
+- Empty database → primitives all count 0, no collections, no graphs
+- Database with data → correct counts, collections listed, coverage calculated
+- After creating a graph → graph appears in describe output
+- After setting a recipe → recipe summary reflects current settings
+
+### Hint tests
+
+- Filter on unindexed field → `no_index` hint with correct field name and action
+- Low embedding coverage → `low_coverage` hint with correct percentage
+- Recipe references nonexistent graph → `no_graph` hint
+- Fewer results than limit → `low_results` hint
+- Budget exceeded → `budget_exhausted` hint listing skipped stages
+- Strong signal detected → `expansion_skipped` hint
+- All conditions fine → empty hints array
+
+### Schema tests
+
+- `recipe_schema()` returns all known parameters with types and ranges
+- All defaults in schema match actual defaults in recipe resolution
+- All enum values in schema match actual validation
+
+---
+
+## 9. Estimated Effort
+
+| Component | Lines |
+|---|---|
+| `describe.rs` (aggregation of existing APIs) | ~150 |
+| `schema.rs` (recipe parameter metadata) | ~100 |
+| `hints.rs` (hint types, collection, generation) | ~120 |
+| Substrate wiring (HintCollector through pipeline) | ~40 |
+| Response type changes | ~20 |
+| Executor commands | ~40 |
+| Tests | ~150 |
+| **Total** | **~620** |
+
+---
+
+## 10. Complete Roadmap
+
+```
+v0.0 — Prerequisites           ~1,300 lines
+v0.1 — Minimal Substrate         ~300 lines
+v0.2 — Expansion + Reranking     ~600 lines
+v0.3 — Temporal Search           ~520 lines
+v0.4 — Graph (PPR)               ~490 lines
+v0.5 — Filter + Budget           ~465 lines
+v0.6 — RAG                       ~375 lines
+v0.7 — AutoResearch              ~630 lines
+v0.8 — Multi-Model Routing       ~190 lines
+v0.9 — Agent Hints               ~620 lines
+                               ──────────
+                               ~5,490 lines total
+```
+
+After v0.9, the search substrate is not just feature-complete — it's agent-complete. An AI agent can:
+1. `db.describe()` — discover what's in the database and what's searchable
+2. `db.recipe_schema()` — learn what parameters exist and their ranges
+3. `db.search()` — search with recipe, get results + actionable hints
+4. `db.experiment()` — compare recipes, find the best one
+5. `db.set_recipe()` — save the winner
+6. Read `stats.hints` — understand why results are good or bad and what to try next
+
+No documentation needed. The database describes itself.


### PR DESCRIPTION
## Summary

Completes the search implementation roadmap. `db.experiment()` compares recipes against user-provided eval sets, returning winner + rankings + per-query breakdown.

Seven retrieval metrics: ndcg@10, recall@10, recall@100, mrr, map, precision@10, hit_rate@10, f1@10.

Branch-per-recipe execution (sequential). Rich result object feeds back into the agent's optimization loop.

Full roadmap now complete (v0.0–v0.7, ~4,680 lines):

| Version | What | Lines |
|---------|------|-------|
| v0.0 | Prerequisites | ~1,300 |
| v0.1 | Minimal substrate | ~300 |
| v0.2 | Expansion + reranking | ~600 |
| v0.3 | Temporal search | ~520 |
| v0.4 | Graph (PPR) | ~490 |
| v0.5 | Filter + budget | ~465 |
| v0.6 | RAG | ~375 |
| v0.7 | AutoResearch | ~630 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)