### PR TITLE
Fix graph anchor resolution: BM25 over node text, not token matching

### DIFF
--- a/docs/design/search/retrieval-substrate.md
+++ b/docs/design/search/retrieval-substrate.md
@@ -840,21 +840,24 @@ result = db.experiment(recipes, eval_set, metric="ndcg@10")
 
 ## 12. Graph Anchor Node Resolution
 
-When the graph operator is enabled, the substrate needs to determine which graph nodes correspond to the query. The recipe controls this via the `strategy` field:
+When the graph operator is enabled, the substrate resolves the query text to graph seed nodes using **BM25 over the graph's node text**. The graph already indexes node labels, properties, aliases, and descriptions via the InvertedIndex (GraphStore implements Searchable).
 
-**PPR strategy:**
-1. Tokenize the query text using the same tokenizer config as BM25 (stemmer, stopwords)
-2. Match tokens against node labels in the named graph (case-insensitive, stemmed match)
-3. Matched nodes become PPR seed nodes
-4. Run Personalized PageRank from seeds with configured damping
-5. Score documents connected to high-PPR nodes
+**How it works:**
+1. Run BM25 query against the graph's indexed node text (same InvertedIndex used by keyword search)
+2. Top `anchor_k` nodes (default 10) become PPR seeds, weighted by BM25 score
+3. Run Personalized PageRank from weighted seeds
+4. Score documents connected to high-PPR nodes
 
-**Neighborhood strategy:**
-1. Same token-to-node matching as PPR
-2. BFS expansion from matched nodes up to `max_hops`
-3. Score documents by hop distance (closer = higher score)
+**Why BM25 over node text (not token matching):**
+- Handles vocabulary mismatch: "heart attack" matches a node labeled "myocardial_infarction" if the node has `aliases: ["heart attack", "MI"]` or a description mentioning "heart attack"
+- BM25 handles stemming, partial matching, and TF-IDF weighting
+- Deterministic: same query → same seeds → same PPR results
+- Zero new infrastructure: calls `GraphStore::search()` which already exists
+- The user controls what text is indexed per node — richer node text = better anchor resolution
 
-If no nodes match the query terms, the graph operator returns zero candidates. Fusion proceeds with the other operators only.
+**Recipe parameter:** `graph.anchor_k` (default 10). Higher = more diverse seeds, noisier PPR. Lower = more focused. Tunable via `db.experiment()`.
+
+If BM25 finds zero matching nodes, the graph operator returns zero candidates. Fusion proceeds with the other operators only.
 
 ---
 

--- a/docs/design/search/v0.4-implementation.md
+++ b/docs/design/search/v0.4-implementation.md
@@ -52,13 +52,15 @@ Strata's existing `pagerank_with_index` needs one modification: accept a persona
 User query: "What drugs interact with metformin?"
                 │
                 ▼
-1. ANCHOR NODE RESOLUTION
-   Tokenize query → ["drug", "interact", "metformin"]
-   Match against node labels in graph → [node:metformin]
+1. ANCHOR NODE RESOLUTION (BM25 over graph node text)
+   Query "What drugs interact with metformin?" →
+   BM25 against graph node index →
+     node:metformin         score: 0.85
+     node:drug_interaction  score: 0.42
                 │
                 ▼
 2. PERSONALIZED PAGERANK
-   Seed: {metformin: 1.0}
+   Seeds: {metformin: 0.85, drug_interaction: 0.42} (BM25 scores as weights)
    Damping: 0.5 (from recipe)
    Edge type filter: ontology-guided (optional)
    Result: ranked nodes by PPR score
@@ -90,26 +92,40 @@ User query: "What drugs interact with metformin?"
 
 ### 3.2 Anchor node resolution
 
-The substrate needs to go from query text to graph seed nodes. Two strategies, both deterministic (no model needed):
+The substrate needs to go from query text to graph seed nodes. The naive approach (exact token matching on node labels) fails on vocabulary mismatch — "heart attack" won't find a node labeled "myocardial infarction."
 
-**Strategy A: Token matching (default)**
-1. Tokenize query using the recipe's BM25 tokenizer (stemmer, stopwords)
-2. For each token, check if a node with that label exists in the named graph
-3. Matching nodes become PPR seeds with equal weight
+**Solution: BM25 over node text.** The graph already indexes node labels, properties, aliases, and descriptions via the InvertedIndex (GraphStore implements Searchable). Use the same BM25 scoring to find seed nodes.
 
-**Strategy B: Prefix matching**
-1. Same tokenization
-2. Match tokens as prefixes against node labels (catches "metformin" matching "metformin_hydrochloride")
+```
+Query: "heart attack"
+  │
+  ▼
+BM25 against graph node index:
+  node:myocardial_infarction  score: 0.72  (properties include "aliases: heart attack, MI")
+  node:cardiac_arrest         score: 0.45  (description mentions "heart stops")
+  node:angina                 score: 0.31  (description mentions "chest pain, heart")
+  │
+  ▼
+PPR seeds (weighted by BM25 score):
+  {myocardial_infarction: 0.72, cardiac_arrest: 0.45, angina: 0.31}
+```
 
-Both are deterministic, O(tokens × graph_nodes) with a hash lookup. No LLM needed.
+**Why this works:**
+- GraphStore already indexes node text (labels + properties + descriptions) in the InvertedIndex
+- BM25 handles stemming ("attack" ↔ "attacks"), partial matching, and TF-IDF weighting
+- Node text can include synonyms and aliases — the user controls what's indexed per node
+- Deterministic. Same query → same BM25 scores → same seeds → same PPR results.
+- Zero new infrastructure. Calls `GraphStore::search()` which already exists (wired in v0.1).
+
+**The user's job:** Put good text on graph nodes. A node labeled "myocardial_infarction" with properties `{"aliases": ["heart attack", "MI", "acute MI"], "description": "Necrosis of heart muscle..."}` will match "heart attack" via BM25. The richer the node text, the better the anchor resolution.
 
 **Recipe parameter:**
 ```json
 "graph": {
-    "anchor_match": "token"
+    "anchor_k": 10
 }
 ```
-Options: `"token"` (exact stemmed match), `"prefix"` (prefix match).
+`anchor_k` controls how many nodes become PPR seeds (default 10). Higher = more diverse seeds but noisier PPR. Lower = more focused but might miss relevant subgraphs. Tunable via `db.experiment()`.
 
 ### 3.3 Personalized PageRank
 
@@ -225,7 +241,7 @@ The `retrieve.graph` section controls graph retrieval:
             "damping": 0.5,
             "max_hops": 2,
             "max_neighbors_per_hop": 50,
-            "anchor_match": "token",
+            "anchor_k": 10,
             "edge_types": ["treats", "causes", "interacts_with"]
         }
     },
@@ -245,7 +261,7 @@ All parameters from `retrieval-substrate.md` section 3.5:
 | `graph.damping` | 0.5 | PPR restart probability (lower = closer to seeds) |
 | `graph.max_hops` | 2 | For neighborhood strategy |
 | `graph.max_neighbors_per_hop` | 50 | For neighborhood strategy |
-| `graph.anchor_match` | `"token"` | How to resolve query → seed nodes |
+| `graph.anchor_k` | 10 | How many BM25-matched nodes become PPR seeds |
 | `graph.edge_types` | All | Ontology-constrained traversal |
 | `fusion.weights.graph` | 0.3 | Graph signal weight in RRF |
 
@@ -340,12 +356,13 @@ None. All changes are modifications to existing files.
 - Disconnected graph → PPR stays in seed's component
 - Empty graph → zero candidates, no crash
 
-### 7.2 Anchor resolution
+### 7.2 Anchor resolution (BM25 over node text)
 
-- Query "metformin" + graph has node "metformin" → anchor found
-- Query "metformin dosage" + graph has node "metformin" → "metformin" anchored, "dosage" not
-- No matching nodes → graph operator returns zero candidates, BM25/vector still work
-- Prefix matching: "metform" matches "metformin" node
+- Query "metformin" + node labeled "metformin" → high BM25 score, strong seed
+- Query "heart attack" + node "myocardial_infarction" with alias "heart attack" → BM25 matches via aliases, becomes seed
+- Query with no matching nodes → BM25 returns zero results, graph operator produces zero candidates, BM25/vector still work
+- anchor_k=1 → only the top BM25 node becomes a seed
+- anchor_k=20 → broader seed set, PPR explores more of the graph
 
 ### 7.3 Typed traversal
 


### PR DESCRIPTION
## Problem

Token matching for graph anchor resolution fails on vocabulary mismatch. "heart attack" won't find a node labeled "myocardial_infarction." This matters most on exactly the queries where graph retrieval should shine — domain-specific, multi-hop, where the terminology gap is widest.

## Solution

Use BM25 over the graph's indexed node text instead of token matching. GraphStore already implements Searchable and indexes node labels + properties + descriptions via the InvertedIndex.

Seeds are weighted by BM25 score (not equal weight). `anchor_k` (default 10) controls how many nodes become PPR seeds.

Zero new infrastructure — calls `GraphStore::search()` which already exists.

## The user's job

Put good text on graph nodes. A node with `{"aliases": ["heart attack", "MI"], "description": "Necrosis of heart muscle..."}` will match "heart attack" via BM25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)