### PR TITLE
Add Arrow interoperability design docs and epic breakdowns

### DIFF
--- a/docs/design/arrow/arrow-v1-implementation-plan.md
+++ b/docs/design/arrow/arrow-v1-implementation-plan.md
@@ -1,0 +1,443 @@
+# Arrow v1 Implementation Plan
+
+**Status:** Draft
+**Scope:** CLI import/export with Parquet, CSV, JSONL via Apache Arrow
+**Estimated size:** ~2,000 lines (Rust)
+
+---
+
+## Goal
+
+One-command data import and export for Strata. A developer with a file can load data into Strata or extract it out without writing code.
+
+```bash
+strata import users.parquet --into kv --key-column id
+strata export kv --format parquet --output users.parquet
+```
+
+## Scope
+
+### In scope
+
+| | Import | Export |
+|---|--------|--------|
+| **KV** | Yes | Yes |
+| **JSON** | Yes | Yes |
+| **Vector** | Yes | Yes |
+| **Event** | — | Yes |
+| **Graph** | — | Yes (nodes + edges) |
+
+**Formats:** Parquet, CSV, JSONL
+
+### Out of scope
+
+- Graph and Event import (complex, lower demand)
+- NumPy, Arrow IPC formats
+- JSON document flattening on export (`--flatten`)
+- Python SDK Arrow API (Phase 2)
+- ADBC driver, DataFusion SQL (Phases 3-4)
+- Progress bars / speed reporting
+
+---
+
+## Architecture
+
+```
+crates/executor/src/arrow/
+├── mod.rs              — Feature gate, public re-exports
+├── schema.rs           — Column mapping: well-known names + overrides
+├── ingest.rs           — RecordBatch → KV/JSON/Vector batch writes
+├── export.rs           — Primitive scan → RecordBatch builders
+├── reader.rs           — File → RecordBatch (Parquet, CSV, JSONL)
+└── writer.rs           — RecordBatch → File (Parquet, CSV, JSONL)
+
+crates/cli/src/
+├── commands.rs         — Add `import` and `export_arrow` subcommands
+└── dispatch.rs         — Route new subcommands (or inline in main.rs)
+```
+
+Arrow code lives entirely in the executor crate behind a feature gate. The CLI crate forwards the feature.
+
+---
+
+## Step 1: Cargo dependencies and feature gate
+
+### `Cargo.toml` (workspace root)
+
+Add to `[workspace.dependencies]`:
+
+```toml
+arrow = { version = "54", default-features = false, features = ["prettyprint"] }
+parquet = { version = "54", default-features = false, features = ["arrow", "snap", "zstd", "lz4"] }
+```
+
+Pin `arrow` and `parquet` to the same version (they share the `arrow-*` subcrates). Use `default-features = false` to avoid pulling in unnecessary backends.
+
+### `crates/executor/Cargo.toml`
+
+```toml
+[features]
+arrow = ["dep:arrow", "dep:parquet"]
+
+[dependencies]
+arrow = { workspace = true, optional = true }
+parquet = { workspace = true, optional = true }
+```
+
+### `crates/cli/Cargo.toml`
+
+```toml
+[features]
+arrow = ["strata-executor/arrow"]
+```
+
+All Arrow code is gated with `#[cfg(feature = "arrow")]`. When disabled, the binary size is unaffected.
+
+---
+
+## Step 2: Column mapping conventions — `schema.rs`
+
+This module defines the well-known column names for each primitive and the logic for resolving user overrides.
+
+### Column conventions
+
+**KV:**
+- Required: `key` (utf8), `value` (utf8/binary/any)
+- No aliases — simple enough.
+
+**JSON:**
+- Required: `key` or `_id` (utf8)
+- Optional: `value` or `document` (utf8 JSON string or struct)
+- If no value/document column: remaining columns are serialized as a JSON object keyed by column name. This is the natural CSV→JSON mapping: `id, name, email` becomes `{name, email}` keyed by `id`.
+
+**Vector:**
+- Required: `key` (utf8), `embedding` or `vector` (list\<f32\> or fixed_size_list\<f32\>)
+- Optional: `metadata` (utf8 JSON) — if absent, remaining columns become metadata JSON.
+- Collection name comes from CLI flag (`--collection`), not from the file.
+
+**Event (export only):**
+- Columns: `sequence` (u64), `event_type` (utf8), `payload` (utf8 JSON), `timestamp` (u64)
+
+**Graph (export only):**
+- Nodes: `node_id` (utf8), `object_type` (utf8 nullable), `properties` (utf8 JSON)
+- Edges: `source` (utf8), `target` (utf8), `edge_type` (utf8), `weight` (f64), `properties` (utf8 JSON)
+
+### Key types
+
+```rust
+/// Resolved column mapping for a primitive import.
+pub struct ImportMapping {
+    pub key_column: String,           // Which column is the key
+    pub value_column: Option<String>, // Explicit value/document/embedding column
+    pub extra_columns: Vec<String>,   // Remaining columns → JSON metadata
+}
+
+/// Resolve column mapping from CLI flags + Arrow schema.
+pub fn resolve_mapping(
+    schema: &arrow::datatypes::Schema,
+    primitive: ImportPrimitive,
+    key_column: Option<&str>,
+    value_column: Option<&str>,
+) -> Result<ImportMapping>;
+```
+
+The resolver:
+1. If `--key-column` provided, use it; else try `key`, then `_id`, then `id`
+2. If `--value-column` provided, use it; else try convention names for the primitive
+3. Remaining columns become `extra_columns` (serialized as JSON for metadata)
+4. Error if required columns are missing
+
+---
+
+## Step 3: File readers — `reader.rs`
+
+Thin wrappers around Arrow's readers that produce `RecordBatch` iterators.
+
+```rust
+pub enum FileFormat {
+    Parquet,
+    Csv,
+    Jsonl,
+}
+
+/// Detect format from file extension.
+pub fn detect_format(path: &Path) -> Result<FileFormat>;
+
+/// Open a file and return a RecordBatch iterator + schema.
+pub fn open_file(path: &Path, format: FileFormat) -> Result<(Schema, Box<dyn RecordBatchReader>)>;
+```
+
+**Parquet:** `parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder` — reads row groups as RecordBatches. Schema comes from the Parquet file metadata.
+
+**CSV:** `arrow::csv::ReaderBuilder` — reads with schema inference from header + first N rows. We'll use `infer_schema_from_files` with the full file for accuracy.
+
+**JSONL:** `arrow::json::ReaderBuilder` — reads JSON objects per line. Schema inferred from a sample of lines.
+
+All three produce `impl RecordBatchReader`, so the rest of the pipeline is format-agnostic.
+
+---
+
+## Step 4: Ingest pipeline — `ingest.rs`
+
+Converts RecordBatches into primitive write operations. Processes in configurable batches (default: 10,000 rows).
+
+```rust
+/// Import a RecordBatch stream into a primitive.
+pub fn ingest(
+    primitives: &Arc<Primitives>,
+    branch_id: BranchId,
+    space: &str,
+    target: ImportTarget,
+    reader: Box<dyn RecordBatchReader>,
+    mapping: &ImportMapping,
+    batch_size: usize,
+) -> Result<ImportResult>;
+
+pub enum ImportTarget {
+    Kv,
+    Json,
+    Vector { collection: String },
+}
+
+pub struct ImportResult {
+    pub rows_imported: u64,
+    pub batches: u64,
+    pub errors: u64,
+}
+```
+
+### Per-primitive ingest logic
+
+**KV ingest:**
+For each row: extract `key` as String, extract `value` as `Value`. Use `p.kv.batch_put()` for the batch.
+
+Value coercion: utf8 → `Value::String`, int → `Value::Int`, float → `Value::Float`, bool → `Value::Bool`, binary → `Value::Bytes`. If no explicit value column and multiple extra columns exist, serialize the row (minus key) as a JSON object → `Value::String`.
+
+**JSON ingest:**
+For each row: extract `key` as String. If explicit `document` column exists (utf8), use it directly. Otherwise, serialize all non-key columns as a JSON object. Use `p.json.set()` per document (no batch API exists today — if this is a bottleneck, we can add one later).
+
+**Vector ingest:**
+For each row: extract `key`, extract `embedding` as `Vec<f32>` (from FixedSizeList or List column), extract optional `metadata` as JSON string. Use `p.vector.insert()` per vector (requires collection to exist — create it from the first batch's embedding dimension if it doesn't exist).
+
+### Transaction batching
+
+Each batch of N rows is processed as a unit. If a row fails (bad key, type coercion error), skip it and increment `errors`. Do not abort the batch — partial progress is better than all-or-nothing for large files.
+
+This differs from the RFC's "each batch is one transaction" proposal because Strata's primitives don't have an explicit multi-row transaction API for all types. We use `batch_put` for KV (which is transactional) and individual puts for JSON/Vector. If transactional batch APIs are added later, we upgrade seamlessly.
+
+---
+
+## Step 5: Export pipeline — `export.rs`
+
+Converts primitive data into RecordBatches. Replaces the existing `handlers/export.rs` string-based rendering for Arrow-format exports, while keeping the old export path for CSV/JSON/JSONL inline output.
+
+```rust
+/// Export primitive data as a stream of RecordBatches.
+pub fn export_to_batches(
+    primitives: &Arc<Primitives>,
+    branch_id: BranchId,
+    space: &str,
+    source: ExportSource,
+    limit: Option<usize>,
+) -> Result<(Schema, Vec<RecordBatch>)>;
+
+pub enum ExportSource {
+    Kv { prefix: Option<String> },
+    Json { prefix: Option<String> },
+    Event { event_type: Option<String> },
+    Vector { collection: String },
+    GraphNodes { graph: String },
+    GraphEdges { graph: String },
+}
+```
+
+### Per-primitive export logic
+
+**KV export:**
+Use `p.kv.list()` to get keys, then `p.kv.get_versioned()` for each key. Build Arrow arrays: `key` (StringArray), `value` (StringArray or BinaryArray depending on type), `version` (UInt64Array), `timestamp` (UInt64Array).
+
+Note: this is N+1 queries (list + N gets). The existing `export.rs` does exactly the same thing. For v1 this is fine. A future `scan_with_values()` method would eliminate the N gets.
+
+**JSON export:**
+Same pattern as KV. Use `p.json.list()` with cursor pagination, then `p.json.get()` per doc. Columns: `key`, `document` (as JSON string), `version`, `created_at`, `updated_at`.
+
+**Event export:**
+Use `p.event.range()` with sequence range 0..MAX. Columns: `sequence`, `event_type`, `payload` (JSON string), `timestamp`.
+
+**Vector export:**
+Use `p.vector.list_keys()` then `p.vector.get()` per key. Columns: `key`, `embedding` (FixedSizeList\<f32\>), `metadata` (JSON string), `version`.
+
+**Graph nodes export:**
+Use `p.graph.all_nodes()`. Columns: `node_id`, `object_type`, `properties` (JSON string).
+
+**Graph edges export:**
+Use `p.graph.all_edges()`. Columns: `source`, `target`, `edge_type`, `weight`, `properties` (JSON string).
+
+---
+
+## Step 6: File writers — `writer.rs`
+
+```rust
+pub fn write_file(
+    path: &Path,
+    format: FileFormat,
+    schema: &Schema,
+    batches: &[RecordBatch],
+) -> Result<u64>; // returns bytes written
+```
+
+**Parquet:** `parquet::arrow::ArrowWriter` with Snappy compression (good default: fast, reasonable ratio).
+
+**CSV:** `arrow::csv::Writer` — straightforward.
+
+**JSONL:** `arrow::json::LineDelimitedWriter` — one JSON object per line.
+
+---
+
+## Step 7: CLI commands
+
+### `strata import`
+
+```
+strata import <FILE> --into <PRIMITIVE> [OPTIONS]
+
+Arguments:
+  <FILE>                     Input file (Parquet, CSV, or JSONL)
+
+Required:
+  --into <PRIMITIVE>         Target primitive: kv, json, vector
+
+Options:
+  --key-column <COL>         Column to use as key (default: auto-detect)
+  --value-column <COL>       Column to use as value/document/embedding
+  --collection <NAME>        Vector collection name (required for --into vector)
+  --format <FMT>             File format override (auto-detected from extension)
+  --batch-size <N>           Rows per batch (default: 10000)
+  --branch <BRANCH>          Target branch (default: default)
+  --space <SPACE>            Target space (default: default)
+```
+
+Format auto-detection: `.parquet` → Parquet, `.csv` → CSV, `.jsonl`/`.json` → JSONL.
+
+### `strata export` (enhanced)
+
+The existing `strata export` command supports CSV/JSON/JSONL as inline string output. We extend it with Parquet support and file output:
+
+```
+strata export <PRIMITIVE> [OPTIONS]
+
+Arguments:
+  <PRIMITIVE>                Source: kv, json, events, vector, graph
+
+Options:
+  --format <FMT>             Output format: parquet, csv, jsonl (default: csv)
+  --output <FILE>            Output file path (if omitted, prints to stdout for csv/jsonl)
+  --prefix <PREFIX>          Key/name prefix filter
+  --collection <NAME>        Vector collection (required for vector export)
+  --graph <NAME>             Graph name (required for graph export)
+  --event-type <TYPE>        Filter events by type
+  --limit <N>                Maximum rows
+  --branch <BRANCH>          Source branch
+  --space <SPACE>            Source space
+```
+
+When `--format parquet` is used, `--output` is required (can't print binary to stdout). For CSV/JSONL, if `--output` is omitted, the existing inline string rendering is used (backward compatible).
+
+### Implementation approach for CLI
+
+The existing `export` CLI subcommand is under `branch export` (branch bundle export). The data export is handled via the `DbExport` command variant with `--format csv|json|jsonl`.
+
+For `import`: add a new top-level `import` subcommand in `commands.rs`. This is feature-gated behind `#[cfg(feature = "arrow")]`.
+
+For `export` with Parquet: extend the existing `DbExport` command to accept a `parquet` format variant. When the `arrow` feature is enabled, Parquet export goes through the Arrow pipeline. When disabled, attempting `--format parquet` returns an error with a hint to enable the `arrow` feature.
+
+### New Command variants
+
+```rust
+// command.rs
+#[cfg(feature = "arrow")]
+ArrowImport {
+    branch: Option<BranchId>,
+    space: Option<String>,
+    file_path: String,
+    target: ImportTarget,
+    key_column: Option<String>,
+    value_column: Option<String>,
+    collection: Option<String>,
+    format: Option<FileFormat>,
+    batch_size: Option<usize>,
+},
+```
+
+Export doesn't need a new Command variant — we extend `ExportFormat` with `Parquet` and route to the Arrow export pipeline when that format is selected.
+
+---
+
+## Step 8: Testing strategy
+
+### Unit tests (~15 tests in `arrow/` modules)
+
+- **schema.rs:** Column resolution for each primitive (auto-detect key column, missing required column errors, override flags)
+- **ingest.rs:** RecordBatch → Value coercion for each type (utf8, int, float, bool, binary, list→embedding)
+- **export.rs:** Primitive data → RecordBatch schema correctness for each primitive
+
+### Integration tests (~10 tests in `executor/tests/`)
+
+- Round-trip: import a Parquet file → export it back → compare schemas and row counts
+- Round-trip: import CSV → export CSV → diff
+- Round-trip: import JSONL → export JSONL → diff
+- KV import: verify keys and values are accessible via `kv get`
+- JSON import: verify documents are accessible via `json get`
+- Vector import: verify embeddings are searchable via `vector search`
+- Export all 5 primitives to Parquet: verify file is valid Parquet
+- Error cases: missing key column, wrong format, empty file, bad types
+
+### CLI tests (~5 tests)
+
+- `strata import file.parquet --into kv --key-column id` end-to-end
+- `strata export kv --format parquet --output out.parquet` end-to-end
+- Format auto-detection from extension
+- Error on `--format parquet` without `--output`
+
+---
+
+## Step 9: Implementation order
+
+| Order | Module | Description | Depends on |
+|-------|--------|-------------|------------|
+| 1 | Cargo.toml changes | Add arrow/parquet deps, feature gates | — |
+| 2 | `arrow/mod.rs` | Module skeleton + feature gate | 1 |
+| 3 | `arrow/schema.rs` | Column mapping + tests | 2 |
+| 4 | `arrow/reader.rs` | File → RecordBatch (Parquet, CSV, JSONL) | 2 |
+| 5 | `arrow/writer.rs` | RecordBatch → File (Parquet, CSV, JSONL) | 2 |
+| 6 | `arrow/ingest.rs` | RecordBatch → KV/JSON/Vector writes | 3 |
+| 7 | `arrow/export.rs` | All 5 primitives → RecordBatch | 3 |
+| 8 | Command/Output types | `ArrowImport` command, `Parquet` format | 6, 7 |
+| 9 | CLI subcommands | `import` + enhanced `export` | 8 |
+| 10 | Integration tests | Round-trip tests | 6, 7, 9 |
+
+Steps 3-5 can be developed in parallel. Steps 6-7 can be developed in parallel.
+
+---
+
+## Dependency impact
+
+The `arrow` crate (v54) and `parquet` crate (v54) are the only new external dependencies. Both are Apache-licensed, battle-tested, and widely used in the Rust ecosystem.
+
+With `default-features = false`:
+- `arrow`: ~15 subcrates (arrow-array, arrow-buffer, arrow-schema, etc.)
+- `parquet`: adds thrift, snap, zstd, lz4 compression codecs
+
+These are behind a feature gate, so the default binary is unaffected. When enabled, expect ~2-4MB binary size increase (compressed).
+
+---
+
+## Open decisions (minor, resolvable during implementation)
+
+1. **JSON import: set vs batch_set** — There is no `json.batch_set()` today. For v1, use individual `json.set()` calls. If profiling shows this is a bottleneck on large imports, add a batch API to the JSON primitive.
+
+2. **Vector collection auto-create** — If `--collection docs` doesn't exist, should import create it automatically (inferring dimension from the first embedding)? Recommendation: yes, auto-create with default metric (cosine).
+
+3. **ExportFormat::Parquet without arrow feature** — Return a clear error: `"Parquet export requires the 'arrow' feature. Rebuild with: cargo build --features arrow"`.
+
+4. **Graph export file layout** — Export graph as two RecordBatches (nodes + edges) written to separate files (`graph_nodes.parquet`, `graph_edges.parquet`) or a single file with a discriminator column? Recommendation: separate files, matching the RFC.

--- a/docs/design/arrow/arrow-v1a-export.md
+++ b/docs/design/arrow/arrow-v1a-export.md
@@ -1,0 +1,375 @@
+# Arrow v1a: Export
+
+**Status:** Draft
+**Scope:** Export all 5 primitives to Parquet, CSV, JSONL files via Apache Arrow
+**Estimated size:** ~1,000 lines
+**Prerequisite:** None
+**Unlocks:** v1b (import), Python SDK Arrow API (Phase 2)
+
+---
+
+## Goal
+
+A developer can extract data from Strata in one command, in a format any tool can read. No code, no SDK, no lock-in.
+
+```bash
+strata export kv --format parquet --output users.parquet
+strata export json --format csv --output orders.csv
+strata export events --format jsonl --output logs.jsonl
+strata export vector --collection docs --format parquet --output embeddings.parquet
+strata export graph --graph social --format csv --output-dir ./social/
+```
+
+## Why export first
+
+1. Export is read-only — no risk of data corruption, simpler error handling
+2. Answers the adoption-critical question: "Can I get my data out?"
+3. Builds the Arrow adapter layer (deps, feature gate, RecordBatch builders, file writers) that import reuses
+4. The existing `handlers/export.rs` already does the hard part (primitive scanning) — we're adding Arrow-native output on top
+
+---
+
+## Scope
+
+**Primitives:** All 5 (KV, JSON, Event, Vector, Graph)
+**Formats:** Parquet, CSV, JSONL
+**Output:** File only (Parquet requires file; CSV/JSONL also write to file for consistency with the new `--output` flag — existing inline CSV/JSON/JSONL export remains for backward compat)
+
+**Out of scope:** Import, JSON flattening, progress bars, Python SDK, ADBC
+
+---
+
+## Implementation
+
+### Step 1: Cargo dependencies and feature gate
+
+**Workspace root `Cargo.toml`** — add to `[workspace.dependencies]`:
+
+```toml
+arrow = { version = "54", default-features = false, features = ["prettyprint"] }
+parquet = { version = "54", default-features = false, features = ["arrow", "snap", "zstd", "lz4"] }
+```
+
+Pin both to the same version (shared `arrow-*` subcrates). `default-features = false` keeps the dependency footprint minimal.
+
+**`crates/executor/Cargo.toml`:**
+
+```toml
+[features]
+arrow = ["dep:arrow", "dep:parquet"]
+
+[dependencies]
+arrow = { workspace = true, optional = true }
+parquet = { workspace = true, optional = true }
+```
+
+**`crates/cli/Cargo.toml`:**
+
+```toml
+[features]
+arrow = ["strata-executor/arrow"]
+```
+
+All Arrow code gated with `#[cfg(feature = "arrow")]`. Default binary unaffected.
+
+---
+
+### Step 2: Module skeleton — `arrow/mod.rs`
+
+```
+crates/executor/src/arrow/
+├── mod.rs       — Feature gate, re-exports
+├── export.rs    — Primitive → RecordBatch builders
+└── writer.rs    — RecordBatch → File (Parquet, CSV, JSONL)
+```
+
+```rust
+// src/arrow/mod.rs
+#![cfg(feature = "arrow")]
+
+mod export;
+mod writer;
+
+pub use export::{export_to_batches, ExportSource};
+pub use writer::{write_file, FileFormat};
+```
+
+Registered in `src/lib.rs`:
+
+```rust
+#[cfg(feature = "arrow")]
+pub mod arrow;
+```
+
+---
+
+### Step 3: Export pipeline — `arrow/export.rs`
+
+Converts primitive data into Arrow RecordBatches. One function per primitive, unified under `export_to_batches`.
+
+```rust
+use arrow::array::*;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+
+pub enum ExportSource {
+    Kv { prefix: Option<String> },
+    Json { prefix: Option<String> },
+    Event { event_type: Option<String> },
+    Vector { collection: String },
+    GraphNodes { graph: String },
+    GraphEdges { graph: String },
+}
+
+pub fn export_to_batches(
+    primitives: &Arc<Primitives>,
+    branch_id: CoreBranchId,
+    space: &str,
+    source: ExportSource,
+    limit: Option<usize>,
+) -> Result<(Schema, Vec<RecordBatch>)>;
+```
+
+#### KV export
+
+Schema: `key: utf8, value: utf8, version: uint64, timestamp: uint64`
+
+Data access: `p.kv.list()` → keys, then `p.kv.get_versioned()` per key. This is the same N+1 pattern as the existing `handlers/export.rs`. Build `StringBuilder` for key/value, `UInt64Builder` for version/timestamp.
+
+Value rendering: all Value types are serialized to string (matching existing export behavior). Bytes → base64, Array/Object → JSON string, scalars → to_string().
+
+#### JSON export
+
+Schema: `key: utf8, document: utf8`
+
+Data access: `p.json.list()` with cursor pagination → doc IDs, then `p.json.get()` per doc. Document stored as JSON string column.
+
+No version/timestamp columns for now — the JSON primitive's `get()` returns the document value, not version metadata. Can be added later if there's demand.
+
+#### Event export
+
+Schema: `sequence: uint64, event_type: utf8, payload: utf8, timestamp: uint64`
+
+Data access: `p.event.range()` with `start_seq=0`, `end_seq=None`, optional type filter. Events come back as `Vec<Versioned<Event>>` — map directly to Arrow arrays.
+
+#### Vector export
+
+Schema: `key: utf8, embedding: fixed_size_list<f32>[dim], metadata: utf8`
+
+Data access: `p.vector.list_keys()` → keys, then `p.vector.get()` per key. The get returns `Versioned<VectorEntry>` with embedding Vec<f32> and metadata.
+
+The embedding dimension is known per collection (from `collection_info`). Use `FixedSizeListBuilder<Float32Builder>` for the embedding column.
+
+#### Graph nodes export
+
+Schema: `node_id: utf8, object_type: utf8, properties: utf8`
+
+Data access: `p.graph.all_nodes()` → `HashMap<String, NodeData>`. NodeData contains object_type and properties. Properties serialized as JSON string.
+
+#### Graph edges export
+
+Schema: `source: utf8, target: utf8, edge_type: utf8, weight: f64, properties: utf8`
+
+Data access: `p.graph.all_edges()` → `Vec<Edge>`. Edge contains src, dst, edge_type, and data (which includes weight and properties).
+
+#### Graph: two-batch output
+
+Graph export produces two separate RecordBatches (nodes and edges) with different schemas. The caller handles writing them to separate files.
+
+---
+
+### Step 4: File writers — `arrow/writer.rs`
+
+```rust
+pub enum FileFormat {
+    Parquet,
+    Csv,
+    Jsonl,
+}
+
+/// Detect format from file extension.
+pub fn detect_format(path: &Path) -> Result<FileFormat>;
+
+/// Write RecordBatches to a file. Returns bytes written.
+pub fn write_file(
+    path: &Path,
+    format: FileFormat,
+    batches: &[RecordBatch],
+) -> Result<u64>;
+```
+
+**Parquet:** `parquet::arrow::ArrowWriter` with Snappy compression (fast, reasonable ratio, widely supported). Schema inferred from the first RecordBatch.
+
+**CSV:** `arrow::csv::WriterBuilder` with header row. Straightforward — Arrow handles all type formatting.
+
+**JSONL:** `arrow::json::LineDelimitedWriter`. One JSON object per line, column names as keys.
+
+Format detection from extension: `.parquet` → Parquet, `.csv` → CSV, `.jsonl` → JSONL, `.json` → JSONL (JSONL is the natural per-record format; the existing JSON array export remains via the old path).
+
+---
+
+### Step 5: CLI wiring
+
+#### Extending the existing export command
+
+The existing `DbExport` command supports `ExportFormat::{Csv, Json, Jsonl}`. We add `Parquet` to `ExportFormat`:
+
+```rust
+// types.rs
+pub enum ExportFormat {
+    Csv,
+    Json,
+    Jsonl,
+    Parquet,  // new
+}
+```
+
+New CLI flags on the existing export subcommand:
+- `--output <FILE>` — required for Parquet, optional for CSV/JSONL
+- `--collection <NAME>` — required when exporting vectors
+- `--graph <NAME>` — required when exporting graph
+
+Add `vector` to `ExportPrimitive`:
+
+```rust
+pub enum ExportPrimitive {
+    Kv,
+    Json,
+    Events,
+    Graph,
+    Vector,  // new
+}
+```
+
+#### Dispatch routing
+
+In `handlers/export.rs` (or a new `handlers/arrow_export.rs`):
+
+```rust
+pub fn db_export(...) -> Result<Output> {
+    match format {
+        ExportFormat::Parquet => {
+            #[cfg(feature = "arrow")]
+            {
+                // Arrow export path
+                let source = to_export_source(primitive, prefix, collection, graph)?;
+                let (schema, batches) = arrow::export_to_batches(p, branch_id, &space, source, limit)?;
+                let path = path.ok_or_else(|| Error::InvalidArgument {
+                    reason: "Parquet export requires --output <FILE>".into(),
+                })?;
+                let bytes = arrow::write_file(Path::new(&path), FileFormat::Parquet, &batches)?;
+                Ok(Output::Exported(ExportResult { ... }))
+            }
+            #[cfg(not(feature = "arrow"))]
+            {
+                Err(Error::Internal {
+                    reason: "Parquet export requires the 'arrow' feature".into(),
+                    hint: Some("Rebuild with: cargo build --features arrow".into()),
+                })
+            }
+        }
+        // Existing CSV/JSON/JSONL path: file output through Arrow when feature enabled,
+        // inline string output through existing renderer when no --output flag
+        ExportFormat::Csv | ExportFormat::Jsonl if path.is_some() => {
+            #[cfg(feature = "arrow")]
+            {
+                // Arrow file export path (better: uses Arrow's CSV/JSONL writers)
+                let source = to_export_source(primitive, prefix, collection, graph)?;
+                let (_, batches) = arrow::export_to_batches(p, branch_id, &space, source, limit)?;
+                let fmt = match format {
+                    ExportFormat::Csv => FileFormat::Csv,
+                    ExportFormat::Jsonl => FileFormat::Jsonl,
+                    _ => unreachable!(),
+                };
+                let bytes = arrow::write_file(Path::new(path.as_ref().unwrap()), fmt, &batches)?;
+                Ok(Output::Exported(ExportResult { ... }))
+            }
+            #[cfg(not(feature = "arrow"))]
+            {
+                // Fall through to existing string-based export + write to file
+                // (existing behavior)
+            }
+        }
+        // Existing inline rendering path (no --output flag)
+        _ => {
+            // existing collect_* + render_* code path, unchanged
+        }
+    }
+}
+```
+
+This keeps full backward compatibility: the existing inline CSV/JSON/JSONL export works exactly as before. The Arrow path only activates for Parquet format, or when `--output` is provided with the arrow feature enabled.
+
+#### Graph export: two files
+
+When exporting graph with `--output`, we derive two file paths:
+- `--output social.parquet` → writes `social_nodes.parquet` and `social_edges.parquet`
+- `--output ./social/` (directory) → writes `social/nodes.parquet` and `social/edges.parquet`
+
+For CSV/JSONL graph export with `--output`, same pattern with the appropriate extension.
+
+---
+
+### Step 6: Testing
+
+#### Unit tests in `arrow/export.rs` (~8 tests)
+
+Test RecordBatch construction for each primitive. Create an in-memory database, populate with known data, export to RecordBatch, assert schema and values.
+
+1. `test_kv_export_schema` — verify columns and types
+2. `test_kv_export_values` — verify data round-trip
+3. `test_json_export` — verify documents as JSON strings
+4. `test_event_export` — verify sequence/type/payload/timestamp
+5. `test_vector_export` — verify embedding dimension and float values
+6. `test_graph_nodes_export` — verify node_id/type/properties
+7. `test_graph_edges_export` — verify source/target/edge_type/weight
+8. `test_export_with_limit` — verify row limiting
+
+#### Unit tests in `arrow/writer.rs` (~4 tests)
+
+Test file writing with known RecordBatches (no database needed).
+
+1. `test_write_parquet` — write + read back, verify schema and row count
+2. `test_write_csv` — write + verify header and row content
+3. `test_write_jsonl` — write + verify each line is valid JSON
+4. `test_detect_format` — extension → format mapping
+
+#### Integration tests (~3 tests in `executor/tests/arrow_export.rs`)
+
+End-to-end: populate database → export to temp file → read file back → verify.
+
+1. `test_kv_export_parquet_roundtrip` — export to Parquet, read with parquet crate, compare
+2. `test_all_primitives_csv` — export each primitive to CSV, verify non-empty valid CSV
+3. `test_parquet_without_output_flag_errors` — verify error message
+
+---
+
+## Implementation order
+
+| Order | File | Lines (est.) | Description |
+|-------|------|-------------|-------------|
+| 1 | Cargo.toml (3 files) | ~10 | Add deps + feature gates |
+| 2 | `arrow/mod.rs` | ~10 | Module skeleton |
+| 3 | `arrow/writer.rs` | ~100 | RecordBatch → Parquet/CSV/JSONL files |
+| 4 | `arrow/export.rs` | ~400 | 5 primitives → RecordBatch |
+| 5 | `types.rs` + `command.rs` | ~30 | Add Parquet format, Vector primitive |
+| 6 | `handlers/export.rs` | ~60 | Route Parquet to Arrow path |
+| 7 | `cli/commands.rs` | ~30 | Add --output, --collection, --graph flags |
+| 8 | Tests | ~350 | Unit + integration |
+| **Total** | | **~1,000** | |
+
+Steps 3-4 can be developed in parallel. Step 5-7 are sequential (types → handler → CLI).
+
+---
+
+## Decisions
+
+1. **Value rendering in KV export:** Serialize all Value types to utf8 string column (matching existing export behavior). This avoids a union-type column that most tools can't read. Binary values become base64.
+
+2. **JSON export schema:** Single `document` column as JSON string, not flattened. Flattening requires schema inference and produces inconsistent schemas across documents. JSON string is universally readable.
+
+3. **Graph two-file output:** Nodes and edges are separate files with different schemas. This matches how graph data is naturally consumed (load nodes, load edges, build graph).
+
+4. **Backward compatibility:** Existing `strata export kv --format csv` (inline string output) works exactly as before. Arrow path only activates for Parquet format or when `--output` is provided with the feature enabled.
+
+5. **No new Command variant:** We extend the existing `DbExport` command with new format and primitive options. This keeps the command surface clean and avoids duplicating dispatch logic.

--- a/docs/design/arrow/arrow-v1b-import.md
+++ b/docs/design/arrow/arrow-v1b-import.md
@@ -1,0 +1,428 @@
+# Arrow v1b: Import
+
+**Status:** Draft
+**Scope:** Import KV, JSON, Vector data from Parquet, CSV, JSONL files
+**Estimated size:** ~1,000 lines
+**Prerequisite:** v1a (export) — provides deps, feature gate, `arrow/` module, `FileFormat`, `writer.rs`
+
+---
+
+## Goal
+
+A developer with a file can load data into Strata in one command. No code, no SDK.
+
+```bash
+strata import users.parquet --into kv --key-column id
+strata import orders.csv --into json --key-column order_id
+strata import embeddings.parquet --into vector --collection docs --key-column doc_id
+```
+
+## Scope
+
+**Primitives:** KV, JSON, Vector (import)
+**Formats:** Parquet, CSV, JSONL
+
+**Out of scope:** Event import (append-by-nature, less demand for bulk load), Graph import (complex two-table relationship model), NumPy/Arrow IPC formats, progress bars
+
+---
+
+## Implementation
+
+### Step 1: File readers — `arrow/reader.rs`
+
+Thin wrappers around Arrow's built-in readers. All produce `RecordBatch` iterators so the ingest pipeline is format-agnostic.
+
+```rust
+use arrow::datatypes::Schema;
+use arrow::record_batch::RecordBatchReader;
+
+/// Open a file and return its schema + a RecordBatch iterator.
+pub fn open_file(
+    path: &Path,
+    format: FileFormat,  // reuse from writer.rs (v1a)
+) -> Result<(Schema, Box<dyn RecordBatchReader>)>;
+```
+
+**Parquet:** `ParquetRecordBatchReaderBuilder::try_new(File::open(path)?)?.build()?` — schema from file metadata, row groups as batches.
+
+**CSV:** `arrow::csv::ReaderBuilder::new(inferred_schema).build(file)?` — infer schema from header + first 100 rows via `arrow::csv::infer_schema_from_files`. Re-open file after inference.
+
+**JSONL:** `arrow::json::ReaderBuilder::new(inferred_schema).build(file)?` — infer schema from first 100 lines. The `arrow::json` reader handles one JSON object per line natively.
+
+Format detected from extension (reusing `detect_format` from v1a), overridable with `--format`.
+
+---
+
+### Step 2: Column mapping — `arrow/schema.rs`
+
+Resolves which columns in the input file map to which primitive fields.
+
+```rust
+pub enum ImportPrimitive {
+    Kv,
+    Json,
+    Vector,
+}
+
+pub struct ImportMapping {
+    /// Column index for the key field.
+    pub key_idx: usize,
+    /// Column index for the explicit value/document/embedding field (if any).
+    pub value_idx: Option<usize>,
+    /// Column indices for remaining fields (become JSON metadata).
+    pub extra_indices: Vec<usize>,
+    /// Column names for extra fields (for JSON serialization).
+    pub extra_names: Vec<String>,
+}
+
+/// Resolve column mapping from CLI flags + file schema.
+pub fn resolve_mapping(
+    schema: &Schema,
+    primitive: ImportPrimitive,
+    key_column: Option<&str>,
+    value_column: Option<&str>,
+) -> Result<ImportMapping>;
+```
+
+#### Resolution logic
+
+**Key column:**
+1. If `--key-column` provided → use it (error if not in schema)
+2. Else try in order: `key`, `_id`, `id` → use first match
+3. If none found → error: `"No key column found. Specify --key-column <COL>. Available columns: ..."`
+
+**Value column (KV):**
+1. If `--value-column` provided → use it
+2. Else try: `value`
+3. If not found and schema has exactly 2 columns → use the non-key column
+4. If not found and schema has >2 columns → no explicit value column; all non-key columns become a JSON object
+
+**Document column (JSON):**
+1. If `--value-column` provided → use it
+2. Else try: `document`, `value`, `doc`, `body`
+3. If not found → no explicit document column; all non-key columns become a JSON object (this is the natural CSV→JSON mapping)
+
+**Embedding column (Vector):**
+1. If `--value-column` provided → use it
+2. Else try: `embedding`, `vector`, `embeddings`, `emb`
+3. Must be a list type (FixedSizeList\<f32\> or List\<f32\>) → error if wrong type
+4. Remaining non-key, non-embedding columns → metadata JSON
+
+#### Error messages
+
+Column resolution errors should be actionable:
+```
+Error: No key column found in 'users.parquet'.
+  Available columns: name (utf8), email (utf8), age (int64)
+  Hint: specify --key-column <COL>
+```
+
+```
+Error: No embedding column found in 'data.parquet'.
+  Available columns: id (utf8), text (utf8), scores (list<f64>)
+  Hint: specify --value-column <COL> pointing to a float list column
+```
+
+---
+
+### Step 3: Type coercion — `arrow/schema.rs`
+
+Converts Arrow array values to Strata `Value` types for KV/JSON ingest.
+
+```rust
+/// Extract a single value from an Arrow array at the given row index.
+pub fn arrow_to_value(array: &dyn Array, row: usize) -> Result<Value>;
+```
+
+Mapping:
+
+| Arrow type | Strata Value |
+|------------|-------------|
+| Utf8, LargeUtf8 | `Value::String` |
+| Int8..Int64 | `Value::Int` |
+| UInt8..UInt64 | `Value::Int` (cast to i64) |
+| Float32, Float64 | `Value::Float` |
+| Boolean | `Value::Bool` |
+| Binary, LargeBinary | `Value::Bytes` |
+| Null | `Value::Null` |
+| List, Struct | `Value::String` (JSON-serialized) |
+
+For the "remaining columns → JSON object" path:
+
+```rust
+/// Serialize non-key, non-value columns of a row as a JSON object.
+pub fn row_to_json(
+    batch: &RecordBatch,
+    row: usize,
+    columns: &[(usize, String)],  // (column index, column name)
+) -> Result<String>;
+```
+
+---
+
+### Step 4: Ingest pipeline — `arrow/ingest.rs`
+
+Core import logic. Reads RecordBatches from the file reader, maps columns, writes to primitives.
+
+```rust
+pub struct ImportResult {
+    pub rows_imported: u64,
+    pub rows_skipped: u64,
+    pub batches_processed: u64,
+}
+
+pub fn ingest_kv(
+    primitives: &Arc<Primitives>,
+    branch_id: CoreBranchId,
+    space: &str,
+    reader: Box<dyn RecordBatchReader>,
+    mapping: &ImportMapping,
+) -> Result<ImportResult>;
+
+pub fn ingest_json(
+    primitives: &Arc<Primitives>,
+    branch_id: CoreBranchId,
+    space: &str,
+    reader: Box<dyn RecordBatchReader>,
+    mapping: &ImportMapping,
+) -> Result<ImportResult>;
+
+pub fn ingest_vector(
+    primitives: &Arc<Primitives>,
+    branch_id: CoreBranchId,
+    space: &str,
+    collection: &str,
+    reader: Box<dyn RecordBatchReader>,
+    mapping: &ImportMapping,
+) -> Result<ImportResult>;
+```
+
+#### KV ingest
+
+Per RecordBatch:
+1. Extract key strings from `key_idx` column
+2. If `value_idx` is Some → extract values via `arrow_to_value()`
+3. If `value_idx` is None → serialize extra columns as JSON object per row
+4. Collect `Vec<(String, Value)>`, call `p.kv.batch_put()`
+5. On per-row errors (null key, coercion failure), skip the row, increment `rows_skipped`
+
+Uses `batch_put` for efficiency — one engine call per RecordBatch rather than per row.
+
+#### JSON ingest
+
+Per RecordBatch:
+1. Extract key strings from `key_idx` column
+2. If `value_idx` is Some → use that column as the document string
+3. If `value_idx` is None → serialize extra columns as JSON object per row
+4. Call `p.json.set()` per document
+
+No batch API for JSON today. Individual `set()` calls. For typical import sizes (10K-100K docs), this is fine. If profiling shows a bottleneck, a `batch_set` can be added to the JSON primitive later.
+
+#### Vector ingest
+
+Per RecordBatch:
+1. Extract key strings from `key_idx` column
+2. Extract embeddings from `value_idx` column as `Vec<f32>` (downcast to FixedSizeListArray or ListArray, then to Float32Array)
+3. Extract optional metadata from extra columns as JSON string
+4. On first batch: if collection doesn't exist, create it with dimension inferred from the embedding length, default metric (cosine), default storage dtype (f32)
+5. Call `p.vector.insert()` per vector
+
+Individual inserts because the vector store doesn't have a batch API. The embedding dimension is validated against the collection config — mismatches error.
+
+#### Error handling
+
+Row-level errors (null key, type mismatch, dimension mismatch) skip the row and increment `rows_skipped`. The import continues. The final `ImportResult` reports both imported and skipped counts so the user knows if something went wrong.
+
+Batch-level errors (I/O failure reading the file, schema mismatch) abort the import with an error. Already-imported rows from previous batches remain committed — no rollback across batches.
+
+---
+
+### Step 5: Command and CLI
+
+#### New Command variant
+
+```rust
+// command.rs
+ArrowImport {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    branch: Option<BranchId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    space: Option<String>,
+    /// Path to the input file.
+    file_path: String,
+    /// Target primitive.
+    target: String,  // "kv", "json", "vector"
+    /// Column to use as key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    key_column: Option<String>,
+    /// Column to use as value/document/embedding.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    value_column: Option<String>,
+    /// Vector collection name (required for vector target).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    collection: Option<String>,
+    /// Override file format detection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    format: Option<String>,  // "parquet", "csv", "jsonl"
+},
+```
+
+The Command variant is always present in the enum (not feature-gated) so that serialization/deserialization works across feature configurations. The handler returns a feature-gate error when `arrow` is not enabled.
+
+#### New Output variant
+
+```rust
+// output.rs
+ArrowImported {
+    rows_imported: u64,
+    rows_skipped: u64,
+    target: String,
+    file_path: String,
+},
+```
+
+#### Handler — `handlers/arrow_import.rs`
+
+```rust
+#[cfg(feature = "arrow")]
+pub fn arrow_import(
+    p: &Arc<Primitives>,
+    branch: BranchId,
+    space: String,
+    file_path: String,
+    target: String,
+    key_column: Option<String>,
+    value_column: Option<String>,
+    collection: Option<String>,
+    format: Option<String>,
+) -> Result<Output> {
+    require_branch_exists(p, &branch)?;
+    let branch_id = to_core_branch_id(&branch)?;
+
+    let path = Path::new(&file_path);
+    let fmt = match format {
+        Some(f) => parse_format(&f)?,
+        None => detect_format(path)?,
+    };
+
+    let (schema, reader) = open_file(path, fmt)?;
+    let primitive = parse_import_primitive(&target)?;
+    let mapping = resolve_mapping(&schema, primitive, key_column.as_deref(), value_column.as_deref())?;
+
+    let result = match primitive {
+        ImportPrimitive::Kv => ingest_kv(p, branch_id, &space, reader, &mapping)?,
+        ImportPrimitive::Json => ingest_json(p, branch_id, &space, reader, &mapping)?,
+        ImportPrimitive::Vector => {
+            let coll = collection.ok_or_else(|| Error::InvalidArgument {
+                reason: "--collection is required for vector import".into(),
+            })?;
+            ingest_vector(p, branch_id, &space, &coll, reader, &mapping)?
+        }
+    };
+
+    Ok(Output::ArrowImported {
+        rows_imported: result.rows_imported,
+        rows_skipped: result.rows_skipped,
+        target,
+        file_path,
+    })
+}
+
+#[cfg(not(feature = "arrow"))]
+pub fn arrow_import(...) -> Result<Output> {
+    Err(Error::Internal {
+        reason: "Import requires the 'arrow' feature".into(),
+        hint: Some("Rebuild with: cargo build --features arrow".into()),
+    })
+}
+```
+
+#### CLI subcommand — `strata import`
+
+New top-level subcommand in `commands.rs`:
+
+```
+strata import <FILE> --into <PRIMITIVE> [OPTIONS]
+
+Arguments:
+  <FILE>                     Input file path
+
+Required:
+  --into <PRIMITIVE>         Target: kv, json, vector
+
+Options:
+  --key-column <COL>         Column to use as key (auto-detected if omitted)
+  --value-column <COL>       Column to use as value/document/embedding
+  --collection <NAME>        Vector collection name (required for vector)
+  --format <FMT>             Override format detection (parquet, csv, jsonl)
+  -b, --branch <BRANCH>     Target branch (default: default)
+  -s, --space <SPACE>        Target space (default: default)
+```
+
+---
+
+### Step 6: Testing
+
+#### Unit tests in `arrow/schema.rs` (~8 tests)
+
+1. `test_resolve_key_column_auto` — auto-detect `key` column
+2. `test_resolve_key_column_id_fallback` — fallback to `id` when no `key`
+3. `test_resolve_key_column_explicit` — `--key-column` override
+4. `test_resolve_key_column_missing` — error with available columns listed
+5. `test_resolve_value_column_kv` — auto-detect for KV
+6. `test_resolve_embedding_column` — auto-detect `embedding` column
+7. `test_resolve_embedding_wrong_type` — error on non-list column
+8. `test_resolve_extra_columns_as_json` — remaining columns collected
+
+#### Unit tests in `arrow/schema.rs` — type coercion (~5 tests)
+
+1. `test_arrow_to_value_string` — Utf8 → Value::String
+2. `test_arrow_to_value_int` — Int64 → Value::Int
+3. `test_arrow_to_value_float` — Float64 → Value::Float
+4. `test_arrow_to_value_bool` — Boolean → Value::Bool
+5. `test_arrow_to_value_null` — Null → Value::Null
+
+#### Integration tests (~6 tests in `executor/tests/arrow_import.rs`)
+
+1. `test_import_kv_from_parquet` — write Parquet with arrow crate → import → verify via `kv get`
+2. `test_import_kv_from_csv` — write CSV → import → verify
+3. `test_import_json_from_jsonl` — write JSONL → import → verify via `json get`
+4. `test_import_json_remaining_columns_as_document` — CSV with no `document` column → all non-key columns become JSON document
+5. `test_import_vector_from_parquet` — write Parquet with embedding column → import → verify via `vector search`
+6. `test_import_vector_auto_creates_collection` — collection doesn't exist → created with inferred dimension
+
+#### Round-trip tests (~2 tests)
+
+1. `test_roundtrip_kv_parquet` — populate KV → export Parquet (v1a) → import to new branch → compare
+2. `test_roundtrip_json_csv` — populate JSON → export CSV → import to new branch → compare
+
+---
+
+## Implementation order
+
+| Order | File | Lines (est.) | Description |
+|-------|------|-------------|-------------|
+| 1 | `arrow/reader.rs` | ~80 | File → RecordBatch (Parquet, CSV, JSONL) |
+| 2 | `arrow/schema.rs` | ~250 | Column mapping + type coercion |
+| 3 | `arrow/ingest.rs` | ~300 | RecordBatch → KV/JSON/Vector writes |
+| 4 | `command.rs` + `output.rs` | ~40 | ArrowImport command, ArrowImported output |
+| 5 | `handlers/arrow_import.rs` | ~60 | Handler dispatch |
+| 6 | `cli/commands.rs` | ~40 | `import` subcommand definition |
+| 7 | Tests | ~250 | Unit + integration + round-trip |
+| **Total** | | **~1,000** | |
+
+Steps 1-2 can be developed in parallel. Step 3 depends on both.
+
+---
+
+## Decisions
+
+1. **No batch API for JSON/Vector:** Use individual `set()`/`insert()` calls. Acceptable for v1 — most imports are 10K-100K rows. Batch APIs can be added to the engine primitives later without changing the import interface.
+
+2. **Vector collection auto-create:** If the collection doesn't exist, create it with dimension inferred from the first embedding, cosine metric, f32 storage. This is the lowest-friction path for "I have a Parquet file of embeddings and want to search them."
+
+3. **Row-level error tolerance:** Skip bad rows, report count. Don't abort the entire import for one malformed row. The user sees `Imported 9,997 rows (3 skipped)` and can investigate.
+
+4. **Command variant not feature-gated:** The `ArrowImport` variant exists in the Command enum regardless of feature flag. The handler returns a clear error when the feature is disabled. This avoids conditional compilation in the serialization layer.
+
+5. **No `--batch-size` flag for v1b:** RecordBatch sizes are determined by the file reader (Parquet: one batch per row group, CSV/JSONL: configurable in the reader builder, default ~1024 rows). This is sufficient. A user-facing batch size control can be added later if needed.

--- a/docs/design/arrow/rfc-arrow-interoperability.md
+++ b/docs/design/arrow/rfc-arrow-interoperability.md
@@ -1,0 +1,673 @@
+# RFC: Apache Arrow Interoperability — Universal Data I/O for Strata
+
+**Status:** Proposal
+**Priority:** Critical for adoption
+**Author:** Ani Joshi
+**Related Issues:** #1898 (bulk import/export), #1879 (hybrid search)
+
+---
+
+## Problem
+
+Strata stores data in custom binary formats (MessagePack, JSON strings, custom segments). Today, the only way to move data into or out of Strata is through the Strata SDK, CLI commands (one-at-a-time puts), or the branch bundle archive format (which is Strata-proprietary).
+
+This creates three adoption blockers:
+
+1. **Getting data in is hard.** A developer with a Parquet file of embeddings, a CSV of user records, or a Postgres table of events must write a custom ingestion script using the Strata SDK. There is no `strata import users.parquet` command.
+
+2. **Getting data out is hard.** Exporting Strata data into a format that Pandas, DuckDB, Spark, or any analytics tool can consume requires writing serialization code. There is no `strata export users --format parquet` command.
+
+3. **No interoperability standard.** Strata has no JDBC, ODBC, REST API, or any standard protocol for external tools to connect to. Data is locked inside Strata unless you use Strata's own SDK.
+
+These three problems reduce to one: **Strata is a data island.** Getting data in requires Strata-specific tooling. Getting data out requires Strata-specific tooling. No external tool can connect natively.
+
+For an embedded database targeting AI agents, this is a critical gap. Agents produce data that must flow to analytics pipelines, dashboards, training jobs, and other databases. If that flow requires custom code per destination, adoption stalls.
+
+---
+
+## Solution
+
+Adopt Apache Arrow as Strata's universal data interchange format and implement an ADBC (Arrow Database Connectivity) driver for standardized bidirectional access.
+
+Arrow is not a storage format — Strata keeps its custom LSM storage internally. Arrow is the **boundary format**: the representation used when data crosses the Strata boundary in either direction. Every external interaction (import, export, SDK data transfer, tool integration) speaks Arrow.
+
+### Design Principles
+
+1. **No lock-in.** A developer can import data from standard formats and export it back to standard formats. Strata never holds data hostage.
+
+2. **Zero-copy where possible.** Arrow's columnar memory layout enables zero-copy transfer to Pandas, Polars, DuckDB, and other Arrow-native tools. No serialization/deserialization overhead at the boundary.
+
+3. **Convention over configuration.** Column mapping between Arrow tables and Strata primitives uses well-known column names (`key`, `value`, `embedding`, `node_id`, `event_type`, `payload`). Overrides available but defaults work for 90% of cases.
+
+4. **Primitive-aware.** Strata has 5 primitives with different semantics. The Arrow layer understands all 5 and maps data appropriately — not a generic "dump to table" export.
+
+5. **Incremental adoption.** Each phase is independently useful. Phase 1 (CLI import/export) delivers value without Phase 2 (Arrow API) or Phase 3 (ADBC driver).
+
+---
+
+## Architecture
+
+```
+                    ┌─────────────────────────────────────┐
+                    │        External Ecosystem            │
+                    │                                      │
+                    │  Files:     Parquet, CSV, JSONL, NPY │
+                    │  Tools:     Pandas, Polars, DuckDB   │
+                    │  Databases: Postgres, Spark, BigQuery│
+                    │  Languages: Python, R, Go, Java, Rust│
+                    └──────────────┬──────────────────────┘
+                                   │
+                            Arrow RecordBatch
+                                   │
+              ┌────────────────────┼────────────────────┐
+              │                    │                     │
+    ┌─────────▼────────┐  ┌───────▼────────┐  ┌────────▼───────┐
+    │  Phase 1: CLI     │  │ Phase 2: SDK   │  │ Phase 3: ADBC  │
+    │  import/export    │  │ .to_arrow()    │  │ Driver         │
+    │  (files)          │  │ .from_arrow()  │  │ (universal)    │
+    └─────────┬────────┘  └───────┬────────┘  └────────┬───────┘
+              │                    │                     │
+              └────────────────────┼────────────────────┘
+                                   │
+                    ┌──────────────▼──────────────────────┐
+                    │      Arrow Adapter Layer             │
+                    │                                      │
+                    │  RecordBatch → Primitive (ingest)    │
+                    │  Primitive → RecordBatch (export)    │
+                    │  Column mapping + type coercion      │
+                    └──────────────┬──────────────────────┘
+                                   │
+                    ┌──────────────▼──────────────────────┐
+                    │        Strata Engine                  │
+                    │                                      │
+                    │  KV │ JSON │ Event │ Vector │ Graph  │
+                    └─────────────────────────────────────┘
+```
+
+---
+
+## Phase 1: CLI Import/Export
+
+**Goal:** A developer with a file and a terminal can load data into Strata or extract it out, in one command. No code, no SDK, no Python.
+
+### Import
+
+```bash
+# Parquet → KV (each row becomes a key-value pair)
+strata import users.parquet --into kv --key-column id
+
+# CSV → JSON documents (each row becomes a JSON document)
+strata import orders.csv --into json --key-column order_id
+
+# JSON Lines → Events (each line becomes an event)
+strata import logs.jsonl --into event --type-column level
+
+# Parquet → Vectors (requires embedding column)
+strata import embeddings.parquet --into vector --collection docs \
+    --key-column doc_id --embedding-column embedding
+
+# CSV → Graph nodes
+strata import people.csv --into graph.social.nodes \
+    --node-id-column person_id --type person
+
+# CSV → Graph edges
+strata import relationships.csv --into graph.social.edges \
+    --source-column from_id --target-column to_id --edge-type-column rel_type
+```
+
+### Export
+
+```bash
+# KV → Parquet
+strata export kv --format parquet --output users.parquet
+strata export kv --prefix "user:" --format parquet --output users.parquet
+
+# JSON documents → Parquet (flattened) or JSON Lines (nested)
+strata export json --format parquet --output orders.parquet
+strata export json --format jsonl --output orders.jsonl
+
+# Events → CSV
+strata export event --format csv --output events.csv
+strata export event --type order_created --format csv --output orders.csv
+
+# Vectors → Parquet (embedding as fixed-size list) or NumPy
+strata export vector --collection docs --format parquet --output docs.parquet
+strata export vector --collection docs --format npy --output embeddings.npy
+
+# Graph → CSV (separate node and edge files)
+strata export graph.social --format csv --output-dir ./social/
+# Produces: social/nodes.csv, social/edges.csv
+```
+
+### Supported File Formats
+
+| Format | Import | Export | Notes |
+|--------|--------|--------|-------|
+| **Parquet** | Yes | Yes | Primary format. Columnar, compressed, schema-preserving. |
+| **CSV** | Yes | Yes | Universal fallback. Header row defines columns. |
+| **JSON Lines** | Yes | Yes | One JSON object per line. Natural for events and documents. |
+| **NumPy (.npy)** | Yes (vectors only) | Yes (vectors only) | Dense float arrays. ML pipeline standard. |
+| **Arrow IPC (.arrow)** | Yes | Yes | Native Arrow format. Zero-overhead for tool chaining. |
+
+All formats are read/written via the `arrow` and `parquet` Rust crates. Strata never implements its own Parquet/CSV parser — it delegates to Arrow's battle-tested implementations.
+
+### Column Mapping Conventions
+
+Each primitive has well-known column names. If the input file uses these names, no `--column` flags are needed.
+
+**KV:**
+| Column | Type | Required | Default |
+|--------|------|----------|---------|
+| `key` | utf8 | Yes | — |
+| `value` | utf8 / binary / any | Yes | — |
+
+**JSON:**
+| Column | Type | Required | Default |
+|--------|------|----------|---------|
+| `key` or `_id` | utf8 | Yes | — |
+| `value` or `document` | utf8 (JSON) or struct | No | Entire row as JSON object |
+
+If no `value`/`document` column is specified, the entire row (minus the key column) is stored as a JSON object. This is the natural mapping: a CSV with columns `id, name, email, age` becomes JSON documents with `{name, email, age}` keyed by `id`.
+
+**Event:**
+| Column | Type | Required | Default |
+|--------|------|----------|---------|
+| `event_type` or `type` | utf8 | Yes | — |
+| `payload` | utf8 (JSON) or struct | No | Entire row as JSON object |
+| `timestamp` | timestamp / uint64 | No | Now |
+
+**Vector:**
+| Column | Type | Required | Default |
+|--------|------|----------|---------|
+| `key` | utf8 | Yes | — |
+| `embedding` or `vector` | fixed_size_list\<f32\> or list\<f32\> | Yes | — |
+| `metadata` | utf8 (JSON) or struct | No | Remaining columns as JSON |
+
+**Graph nodes:**
+| Column | Type | Required | Default |
+|--------|------|----------|---------|
+| `node_id` or `id` | utf8 | Yes | — |
+| `object_type` or `type` | utf8 | No | None |
+| `properties` | utf8 (JSON) or struct | No | Remaining columns as JSON |
+
+**Graph edges:**
+| Column | Type | Required | Default |
+|--------|------|----------|---------|
+| `source` or `from` | utf8 | Yes | — |
+| `target` or `to` | utf8 | Yes | — |
+| `edge_type` or `type` | utf8 | Yes | — |
+| `weight` | f64 | No | 1.0 |
+| `properties` | utf8 (JSON) or struct | No | Remaining columns as JSON |
+
+### Batch Size and Transactions
+
+Import processes data in configurable batches (default: 10,000 rows per transaction). Each batch is one atomic transaction — if it fails, that batch is rolled back but previous batches are committed.
+
+```bash
+strata import large_file.parquet --into kv --key-column id --batch-size 50000
+```
+
+Progress reporting:
+```
+Importing users.parquet → kv (default space)
+  Format: Parquet (3 columns: id, name, email)
+  Rows: 1,000,000
+  Mapping: key=id, value={name, email} as JSON
+  Progress: [████████████████████░░░░] 850,000 / 1,000,000 (85%)
+  Speed: 125,000 rows/sec
+```
+
+### Implementation
+
+```
+crates/executor/src/arrow/
+├── mod.rs              — Feature gate, public API
+├── schema.rs           — Column mapping conventions + type coercion
+├── ingest.rs           — RecordBatch → primitive batch operations
+├── export.rs           — Primitive scan → RecordBatch builders
+├── format_readers.rs   — Parquet/CSV/JSONL/NPY → Arrow RecordBatch
+└── format_writers.rs   — Arrow RecordBatch → Parquet/CSV/JSONL/NPY
+
+crates/cli/src/
+├── import.rs           — `strata import` command
+└── export_arrow.rs     — `strata export` command (Arrow-powered)
+```
+
+**Cargo feature:** `arrow` (optional, default off for minimal binary size)
+```toml
+[features]
+arrow = ["dep:arrow", "dep:parquet"]
+```
+
+**Estimated scope:** ~2,500 lines
+
+---
+
+## Phase 2: Arrow API in Python SDK
+
+**Goal:** Python developers can move data between Strata and the PyData ecosystem with zero-copy Arrow transfers.
+
+### Read Path
+
+```python
+import strata
+
+db = strata.open("./mydata")
+
+# Each primitive exposes .to_arrow()
+kv_table = db.kv.to_arrow(prefix="user:")
+# → pyarrow.Table(key: utf8, value: utf8, version: uint64, timestamp: uint64)
+
+json_table = db.json.to_arrow(prefix="order:")
+# → pyarrow.Table(key: utf8, document: utf8, version: uint64,
+#                  created_at: uint64, updated_at: uint64)
+
+event_table = db.events.to_arrow(event_type="order_created")
+# → pyarrow.Table(sequence: uint64, event_type: utf8, payload: utf8,
+#                  timestamp: uint64, hash: binary)
+
+vector_table = db.vectors.to_arrow("my_collection")
+# → pyarrow.Table(key: utf8, embedding: fixed_size_list<f32>[384],
+#                  metadata: utf8, version: uint64)
+
+graph_nodes = db.graph.nodes_to_arrow("social")
+# → pyarrow.Table(node_id: utf8, object_type: utf8, properties: utf8)
+
+graph_edges = db.graph.edges_to_arrow("social")
+# → pyarrow.Table(source: utf8, target: utf8, edge_type: utf8,
+#                  weight: f64, properties: utf8)
+
+# Use with any Arrow-compatible tool — zero copy
+import polars as pl
+df = pl.from_arrow(kv_table)
+
+import duckdb
+result = duckdb.query("SELECT * FROM json_table WHERE json_extract(document, '$.total') > 100")
+```
+
+### Write Path
+
+```python
+import pyarrow as pa
+
+# From PyArrow table
+users = pa.table({"key": ["u1", "u2"], "value": ['{"name":"Alice"}', '{"name":"Bob"}']})
+db.kv.from_arrow(users)
+
+# From Pandas DataFrame
+import pandas as pd
+df = pd.DataFrame({"order_id": ["o1", "o2"], "total": [99.99, 149.50], "status": ["shipped", "pending"]})
+db.json.from_pandas(df, key_column="order_id")
+# → Creates JSON documents: o1 → {"total": 99.99, "status": "shipped"}, etc.
+
+# From numpy (vectors)
+import numpy as np
+keys = ["doc1", "doc2", "doc3"]
+embeddings = np.random.randn(3, 384).astype(np.float32)
+db.vectors.from_numpy("my_collection", keys, embeddings)
+
+# From Polars DataFrame
+import polars as pl
+events = pl.DataFrame({"event_type": ["click", "view"], "payload": ['{"page":"home"}', '{"page":"about"}']})
+db.events.from_arrow(events.to_arrow())
+```
+
+### Implementation
+
+```
+strata-python/src/
+├── arrow_export.rs    — Rust → PyArrow RecordBatch (via arrow-rs + pyo3)
+├── arrow_ingest.rs    — PyArrow RecordBatch → Rust batch operations
+└── arrow_utils.rs     — Schema inference, type coercion, numpy bridge
+```
+
+The Python SDK uses `pyo3` with the `arrow` feature of `pyo3-arrow` for zero-copy transfer between Rust `arrow::RecordBatch` and Python `pyarrow.Table`.
+
+**Estimated scope:** ~1,500 lines (Rust) + ~500 lines (Python wrappers)
+
+---
+
+## Phase 3: ADBC Driver
+
+**Goal:** Any tool in any language that speaks ADBC can connect to Strata for both reads and writes. One driver replaces the need for JDBC, ODBC, and REST.
+
+### What is ADBC
+
+Arrow Database Connectivity (ADBC) is the Apache Arrow project's replacement for JDBC/ODBC. It provides a standard API for database access with Arrow as the native data format. It works in-process (no server needed) and is supported by DuckDB, SQLite, PostgreSQL, Snowflake, and Flight SQL.
+
+### Usage
+
+```python
+# Python (via adbc_driver_manager)
+import adbc_driver_strata.dbapi as strata_dbapi
+
+conn = strata_dbapi.connect("/path/to/data")
+cursor = conn.cursor()
+
+# Read
+cursor.execute("SCAN kv PREFIX 'user:'")
+table = cursor.fetch_arrow_table()
+
+# Write
+cursor.adbc_ingest("json.orders", orders_arrow_table, mode="create_append")
+
+# SQL (if DataFusion enabled)
+cursor.execute("SELECT key, json_extract(document, '$.total') as total FROM json.orders WHERE total > 100")
+table = cursor.fetch_arrow_table()
+
+conn.close()
+```
+
+```go
+// Go
+import "github.com/stratadb/adbc-driver-strata"
+
+drv := strata.NewDriver()
+db, _ := drv.NewDatabase(map[string]string{"path": "/path/to/data"})
+conn, _ := db.Open(context.Background())
+
+stmt, _ := conn.NewStatement()
+stmt.SetSQLQuery("SCAN event TYPE 'order_created' LIMIT 1000")
+reader, _, _ := stmt.ExecuteQuery(context.Background())
+// reader is an Arrow RecordReader — works with any Go Arrow library
+```
+
+```java
+// Java (via ADBC JDBC bridge — gets JDBC for free)
+AdbcDriver driver = new StrataDriver();
+AdbcDatabase db = driver.open("/path/to/data");
+AdbcConnection conn = db.connect();
+AdbcStatement stmt = conn.createStatement();
+stmt.setSqlQuery("SCAN json PREFIX 'order:'");
+ArrowReader reader = stmt.executeQuery();
+```
+
+### Strata Query Language for ADBC
+
+ADBC requires a statement interface. Since Strata doesn't have SQL (yet), we define a minimal query language for ADBC statements:
+
+```sql
+-- Reads
+SCAN kv [PREFIX 'prefix'] [LIMIT n]
+SCAN json [PREFIX 'prefix'] [LIMIT n]
+SCAN event [TYPE 'type'] [AFTER seq] [LIMIT n]
+SCAN vector collection [LIMIT n]
+SCAN graph.name.nodes [TYPE 'type'] [LIMIT n]
+SCAN graph.name.edges [LIMIT n]
+
+-- Writes (alternative to adbc_ingest)
+-- Writes are primarily done via adbc_ingest(), not statements
+
+-- Search
+SEARCH 'query text' [IN kv,json,event] [LIMIT n]
+
+-- Metadata
+DESCRIBE
+DESCRIBE kv
+DESCRIBE json.orders
+DESCRIBE vector.my_collection
+DESCRIBE graph.social
+```
+
+If DataFusion is enabled (Phase 4), full SQL is available via standard `SELECT` / `INSERT` statements and the Strata query language becomes a compatibility fallback.
+
+### Implementation
+
+The ADBC driver implements three traits from the `adbc_core` Rust crate:
+
+```rust
+impl AdbcDriver for StrataDriver {
+    fn new_database(&self, options: &HashMap<String, String>) -> Result<Box<dyn AdbcDatabase>>;
+}
+
+impl AdbcDatabase for StrataDatabase {
+    fn new_connection(&self) -> Result<Box<dyn AdbcConnection>>;
+}
+
+impl AdbcConnection for StrataConnection {
+    fn new_statement(&self) -> Result<Box<dyn AdbcStatement>>;
+    fn get_table_types(&self) -> Result<RecordBatch>;        // Returns primitive types
+    fn get_objects(&self, ...) -> Result<RecordBatch>;       // Returns collections/spaces
+}
+
+impl AdbcStatement for StrataStatement {
+    fn set_sql_query(&mut self, query: &str) -> Result<()>;
+    fn execute_query(&mut self) -> Result<ArrowArrayStream>;  // Read path
+    fn execute_update(&mut self) -> Result<i64>;              // Write path
+    fn bind_stream(&mut self, stream: ArrowArrayStream);      // Bulk ingest
+}
+```
+
+**Estimated scope:** ~2,000 lines
+
+---
+
+## Phase 4: DataFusion SQL (Optional)
+
+**Goal:** Full SQL access to Strata data via Apache DataFusion, an embeddable Rust query engine.
+
+### Usage
+
+```sql
+-- Query JSON documents with SQL
+SELECT key, json_extract(document, '$.name') as name,
+       json_extract(document, '$.email') as email
+FROM json.users
+WHERE json_extract(document, '$.age') > 25
+ORDER BY key
+LIMIT 100;
+
+-- Join KV with JSON
+SELECT k.key, j.document
+FROM kv.sessions k
+JOIN json.users j ON json_extract(j.document, '$.session_id') = k.value;
+
+-- Aggregate events
+SELECT event_type, COUNT(*) as count, MIN(timestamp) as first, MAX(timestamp) as last
+FROM event.default
+GROUP BY event_type
+ORDER BY count DESC;
+
+-- Vector search (extension function)
+SELECT key, strata_vector_search(embedding, ?, 10) as score
+FROM vector.my_collection
+ORDER BY score DESC;
+
+-- Insert from query
+INSERT INTO json.archive
+SELECT * FROM json.orders WHERE json_extract(document, '$.status') = 'completed';
+```
+
+### Implementation
+
+DataFusion integration requires implementing the `TableProvider` trait for each primitive:
+
+```rust
+impl TableProvider for StrataKvTable {
+    fn schema(&self) -> SchemaRef;                    // Arrow schema
+    fn scan(&self, ...) -> Result<Arc<dyn ExecutionPlan>>;  // Scan with filter pushdown
+}
+```
+
+Filter pushdown maps SQL `WHERE` clauses to Strata's native prefix scan and range operations, avoiding full table scans where possible.
+
+**Estimated scope:** ~1,500 lines
+**Dependency:** DataFusion crate (~large, feature-gated)
+
+---
+
+## Schema for Each Primitive
+
+### KV Arrow Schema
+
+```
+key:        utf8 (not null)
+value:      utf8 | binary (depends on Value type)
+value_type: utf8 (null, bool, int, float, string, bytes, array, object)
+version:    uint64
+timestamp:  uint64 (microseconds since epoch)
+```
+
+### JSON Arrow Schema
+
+```
+key:         utf8 (not null)
+document:    utf8 (JSON string) | struct (if flattened)
+version:     uint64
+created_at:  uint64
+updated_at:  uint64
+```
+
+**Flatten option:** For Parquet/CSV export, JSON documents can be optionally flattened to columnar form (top-level fields become Arrow columns). This requires schema inference from a sample of documents.
+
+### Event Arrow Schema
+
+```
+sequence:    uint64 (not null)
+event_type:  utf8 (not null)
+payload:     utf8 (JSON string)
+timestamp:   uint64
+prev_hash:   fixed_size_binary(32)
+hash:        fixed_size_binary(32)
+```
+
+### Vector Arrow Schema
+
+```
+key:         utf8 (not null)
+embedding:   fixed_size_list<float32>[dimension] (not null)
+metadata:    utf8 (JSON string, nullable)
+version:     uint64
+created_at:  uint64
+updated_at:  uint64
+```
+
+### Graph Node Arrow Schema
+
+```
+node_id:     utf8 (not null)
+object_type: utf8 (nullable)
+properties:  utf8 (JSON string)
+entity_ref:  utf8 (nullable)
+```
+
+### Graph Edge Arrow Schema
+
+```
+source:      utf8 (not null)
+target:      utf8 (not null)
+edge_type:   utf8 (not null)
+weight:      float64
+properties:  utf8 (JSON string, nullable)
+```
+
+---
+
+## What This Enables
+
+### For the Developer Evaluating Strata
+
+```bash
+# "Can I get my data in?"
+strata import my_existing_data.parquet --into json --key-column id
+# Yes. One command.
+
+# "Can I get it out if Strata doesn't work?"
+strata export json --format parquet --output my_data_back.parquet
+# Yes. One command. No lock-in.
+```
+
+### For the Data Engineer
+
+```python
+# Stream data from Postgres to Strata
+pg_conn = adbc_driver_postgresql.connect("postgres://...")
+strata_conn = adbc_driver_strata.connect("./agent_data")
+
+cursor = pg_conn.cursor()
+cursor.execute("SELECT * FROM users")
+strata_conn.cursor().adbc_ingest("json.users", cursor.fetch_arrow_table())
+
+# Query Strata data with DuckDB
+import duckdb
+table = strata_conn.cursor().execute("SCAN json").fetch_arrow_table()
+duckdb.sql("SELECT * FROM table WHERE json_extract(document, '$.age') > 30")
+```
+
+### For the ML Engineer
+
+```python
+# Export embeddings for training
+vectors = db.vectors.to_arrow("documents")
+embeddings = vectors.column("embedding").to_numpy()  # zero-copy
+# → Use in scikit-learn, PyTorch, etc.
+
+# Import embeddings from a training pipeline
+new_embeddings = model.encode(documents)  # numpy array
+db.vectors.from_numpy("documents", keys, new_embeddings)
+```
+
+### For the AI Agent
+
+```python
+# Agent stores observations
+db.event_append("observation", {"entity": "server-1", "cpu": 92.5, "status": "warning"})
+
+# Human analyst queries with SQL
+# (via DuckDB connected to Strata through ADBC)
+SELECT event_type, COUNT(*), AVG(json_extract(payload, '$.cpu'))
+FROM event.default
+WHERE event_type = 'observation'
+  AND timestamp > now() - interval '1 hour'
+GROUP BY event_type
+```
+
+---
+
+## Phased Rollout
+
+| Phase | Scope | Lines | Dependency | User Value |
+|-------|-------|-------|------------|------------|
+| **1: CLI Import/Export** | File-based I/O via CLI | ~2,500 | `arrow`, `parquet` crates | **Adoption unblocked** — no code needed to move data |
+| **2: Python Arrow API** | `.to_arrow()` / `.from_arrow()` on SDK | ~2,000 | Phase 1 + `pyo3-arrow` | Zero-copy DataFrame integration |
+| **3: ADBC Driver** | Universal database connectivity | ~2,000 | Phase 1 | Every ADBC tool in every language works |
+| **4: DataFusion SQL** | Embedded SQL engine | ~1,500 | Phase 1 + `datafusion` | SQL queries over Strata data |
+| **Total** | | **~8,000** | | |
+
+**Phase 1 is the critical path.** It delivers the adoption message ("your data is not locked in") and builds the Arrow adapter layer that Phases 2-4 reuse.
+
+Phases 2-4 are independently valuable and can be prioritized based on user demand. Phase 2 matters most for the Python/AI audience. Phase 3 matters most for enterprise/tool integration. Phase 4 matters most for analytics use cases.
+
+---
+
+## Alternatives Considered
+
+### JDBC/ODBC
+
+Rejected. Requires C ABI, complex driver lifecycle, row-oriented data transfer (no zero-copy). Designed for client-server databases, not embedded. ADBC supersedes both for modern use cases, and ADBC includes a JDBC bridge for legacy tools.
+
+### REST API
+
+Rejected. Strata is an embedded database — adding an HTTP server contradicts the core positioning. REST also requires serialization to JSON (no zero-copy), doesn't support bulk ingest efficiently, and adds a network stack dependency.
+
+### Custom Wire Protocol
+
+Rejected. Inventing a protocol means writing clients for every language. ADBC already has clients for Python, R, Go, Java, C/C++, and Rust. Building on ADBC gives us all of them for free.
+
+### Parquet as Storage Format
+
+Rejected. Parquet is a columnar analytics format, not a database storage format. Strata's LSM tree requires byte-level control for MVCC, compaction, bloom filters, and zero-copy iteration. Parquet belongs at the boundary (import/export), not in the storage engine.
+
+---
+
+## Open Questions
+
+1. **JSON document flattening:** When exporting JSON documents to Parquet, should we flatten top-level fields into columns (requires schema inference) or store the entire document as a JSON string column? Recommendation: default to JSON string column, offer `--flatten` flag that infers schema from a sample.
+
+2. **Vector embedding format:** Arrow `FixedSizeList<f32>` vs `List<f32>` for variable-dimension support. Recommendation: `FixedSizeList` within a collection (dimension is fixed per collection), `List<f32>` for cross-collection exports.
+
+3. **Transaction semantics for import:** Should `strata import` be all-or-nothing (one transaction) or batched? Recommendation: batched with configurable batch size. All-or-nothing for small files (< 10K rows), batched for large files.
+
+4. **DataFusion table naming:** How do we map Strata's `primitive.namespace` to SQL table names? Recommendation: `kv`, `json`, `event` for default space; `kv_spacename`, `json_spacename` for non-default spaces. Vector: `vector_collectionname`. Graph: `graph_name_nodes`, `graph_name_edges`.
+
+5. **Feature gating:** Should Arrow support be default-on or default-off? Recommendation: default-off in the Rust crate (`--features arrow`), default-on in the Python SDK (most users want it), and default-on in the CLI binary.

--- a/docs/design/arrow/v1a-epics.md
+++ b/docs/design/arrow/v1a-epics.md
@@ -1,0 +1,193 @@
+# v1a Epics: Arrow Export
+
+Four epics, each independently testable. Each builds on the previous.
+
+---
+
+## Epic 1: Arrow scaffold + file writers
+
+**Goal:** `cargo build --features arrow` compiles. Can write a synthetic RecordBatch to Parquet, CSV, and JSONL files.
+
+**Files:**
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` (workspace root) | Add `arrow` v54 and `parquet` v54 to `[workspace.dependencies]` |
+| `crates/executor/Cargo.toml` | Add `arrow` feature gate, optional deps |
+| `crates/cli/Cargo.toml` | Add `arrow` feature forwarding to executor |
+| `crates/executor/src/lib.rs` | Register `#[cfg(feature = "arrow")] pub mod arrow;` |
+| `crates/executor/src/arrow/mod.rs` | Module skeleton, re-exports |
+| `crates/executor/src/arrow/writer.rs` | `FileFormat` enum, `detect_format()`, `write_file()` |
+
+**Details:**
+
+`writer.rs` implements three writers:
+- **Parquet:** `parquet::arrow::ArrowWriter` with Snappy compression
+- **CSV:** `arrow::csv::WriterBuilder` with header
+- **JSONL:** `arrow::json::LineDelimitedWriter`
+
+`detect_format()` maps extensions: `.parquet` → Parquet, `.csv` → CSV, `.jsonl`/`.json` → JSONL.
+
+**Tests (4):**
+- `test_write_parquet` — write synthetic RecordBatch, read back with Parquet reader, verify schema + row count
+- `test_write_csv` — write, read file contents, verify header + data rows
+- `test_write_jsonl` — write, verify each line is valid JSON with correct keys
+- `test_detect_format` — extension → format mapping, unknown extension → error
+
+**Estimated size:** ~120 lines
+**Acceptance:** `cargo test --features arrow` passes, writer tests green.
+
+---
+
+## Epic 2: Export KV, JSON, Event to RecordBatch
+
+**Goal:** Can convert KV, JSON, and Event primitive data into Arrow RecordBatches.
+
+**Files:**
+
+| File | Change |
+|------|--------|
+| `crates/executor/src/arrow/mod.rs` | Add `pub mod export;` |
+| `crates/executor/src/arrow/export.rs` | `ExportSource` enum, `export_to_batches()`, KV/JSON/Event export functions |
+
+**Details:**
+
+`export.rs` scaffolding:
+- `ExportSource` enum with variants for all 5 primitives (Vector and Graph variants exist but are unimplemented in this epic)
+- `export_to_batches()` dispatch function
+- `value_to_string()` helper — serializes any `Value` to a string for Arrow columns (reuses logic from existing `handlers/export.rs`)
+
+KV export:
+- Schema: `key: utf8, value: utf8, version: uint64, timestamp: uint64`
+- `p.kv.list()` → keys, `p.kv.get_versioned()` per key
+- All Value types rendered as utf8 strings
+
+JSON export:
+- Schema: `key: utf8, document: utf8`
+- `p.json.list()` with cursor pagination, `p.json.get()` per doc
+- Document stored as JSON string
+
+Event export:
+- Schema: `sequence: uint64, event_type: utf8, payload: utf8, timestamp: uint64`
+- `p.event.range(start_seq=0, end_seq=None)` with optional type filter
+
+**Tests (5):**
+- `test_kv_export_schema` — in-memory DB, put 3 KV pairs, export, verify Arrow schema
+- `test_kv_export_values` — verify key/value/version/timestamp data matches
+- `test_json_export` — set 2 JSON docs, export, verify key + document columns
+- `test_event_export` — append 3 events, export, verify sequence/type/payload/timestamp
+- `test_export_with_limit` — put 10 KV pairs, export with limit=3, verify 3 rows
+
+**Estimated size:** ~300 lines
+**Acceptance:** All export tests green. Can programmatically call `export_to_batches(ExportSource::Kv { .. })` and get a valid RecordBatch.
+
+---
+
+## Epic 3: Export Vector + Graph to RecordBatch
+
+**Goal:** All 5 primitives export to RecordBatch. Graph produces two batches (nodes + edges).
+
+**Files:**
+
+| File | Change |
+|------|--------|
+| `crates/executor/src/arrow/export.rs` | Add Vector, GraphNodes, GraphEdges export functions |
+
+**Details:**
+
+Vector export:
+- Schema: `key: utf8, embedding: fixed_size_list<f32>[dim], metadata: utf8`
+- `p.vector.list_keys()` → keys, `p.vector.get()` per key
+- Dimension from `collection_info()`. Use `FixedSizeListBuilder<Float32Builder>`.
+- Metadata as JSON string column (nullable)
+
+Graph nodes export:
+- Schema: `node_id: utf8, object_type: utf8, properties: utf8`
+- `p.graph.all_nodes()` → `HashMap<String, NodeData>`
+- Properties serialized as JSON string
+
+Graph edges export:
+- Schema: `source: utf8, target: utf8, edge_type: utf8, weight: f64, properties: utf8`
+- `p.graph.all_edges()` → `Vec<Edge>`
+
+Graph two-batch return:
+- `export_to_batches` for `GraphNodes` returns nodes only
+- `export_to_batches` for `GraphEdges` returns edges only
+- The caller (Epic 4) is responsible for invoking both and writing separate files
+
+**Tests (3):**
+- `test_vector_export` — create collection, upsert 3 vectors with metadata, export, verify embedding dimension + float values + metadata
+- `test_graph_nodes_export` — add nodes with types and properties, export, verify columns
+- `test_graph_edges_export` — add edges with weights, export, verify source/target/type/weight
+
+**Estimated size:** ~200 lines
+**Acceptance:** All 5 primitives produce valid RecordBatches. `cargo test --features arrow` green.
+
+---
+
+## Epic 4: CLI wiring + integration tests
+
+**Goal:** `strata export kv --format parquet --output users.parquet` works end-to-end. Full backward compatibility with existing export.
+
+**Files:**
+
+| File | Change |
+|------|--------|
+| `crates/executor/src/types.rs` | Add `ExportFormat::Parquet`, `ExportPrimitive::Vector` |
+| `crates/executor/src/command.rs` | Update `DbExport` with `collection` and `graph` fields |
+| `crates/executor/src/handlers/export.rs` | Route Parquet format + file output to Arrow path |
+| `crates/cli/src/commands.rs` | Add `--output`, `--collection`, `--graph`, `--format parquet` flags |
+| `crates/executor/src/arrow/mod.rs` | Re-export anything needed by handlers |
+
+**Details:**
+
+Type changes:
+- `ExportFormat`: add `Parquet` variant
+- `ExportPrimitive`: add `Vector` variant
+- `ExportResult`: no changes needed (already has `path` and `size_bytes`)
+
+Command changes:
+- `DbExport`: add optional `collection: Option<String>` and `graph: Option<String>` fields
+
+Handler routing in `db_export()`:
+- `ExportFormat::Parquet` → require `--output`, build `ExportSource` from primitive/prefix/collection/graph, call `export_to_batches()` + `write_file()`
+- `ExportFormat::Csv | Jsonl` with `--output` and arrow feature → same Arrow path with CSV/JSONL writer
+- All other cases → existing string-based rendering (unchanged)
+- `ExportFormat::Parquet` without arrow feature → clear error with rebuild hint
+
+Graph export CLI:
+- `--output social.parquet` → derive `social_nodes.parquet` and `social_edges.parquet`
+- Call `export_to_batches` twice (GraphNodes + GraphEdges), write two files
+- Report both files in output
+
+Vector export CLI:
+- `--collection` required when primitive is `vector`
+- Error if missing: `"--collection is required for vector export"`
+
+CLI flags:
+- `--output <FILE>` on the existing export subcommand
+- `--collection <NAME>` on the existing export subcommand
+- `--graph <NAME>` on the existing export subcommand
+- `--format` extended with `parquet` option
+
+**Tests (5):**
+- `test_kv_export_parquet_roundtrip` — populate KV → export to temp Parquet → read with parquet crate → compare row count + values
+- `test_json_export_csv_file` — populate JSON → export to temp CSV → verify valid CSV with header
+- `test_event_export_jsonl_file` — populate events → export to temp JSONL → verify each line valid JSON
+- `test_parquet_requires_output_flag` — `--format parquet` without `--output` → error
+- `test_vector_requires_collection` — export vector without `--collection` → error
+
+**Estimated size:** ~350 lines
+**Acceptance:** Full end-to-end: `strata export <primitive> --format parquet --output file.parquet` for all 5 primitives. Existing `strata export kv --format csv` (inline) unchanged. All tests green.
+
+---
+
+## Summary
+
+| Epic | Scope | Lines | Cumulative |
+|------|-------|-------|------------|
+| 1 | Scaffold + file writers | ~120 | ~120 |
+| 2 | KV, JSON, Event → RecordBatch | ~300 | ~420 |
+| 3 | Vector, Graph → RecordBatch | ~200 | ~620 |
+| 4 | CLI wiring + integration tests | ~350 | ~970 |
+| **Total** | | | **~970** |

--- a/docs/design/arrow/v1b-epics.md
+++ b/docs/design/arrow/v1b-epics.md
@@ -1,0 +1,235 @@
+# v1b Epics: Arrow Import
+
+Four epics. Requires v1a to be complete (deps, feature gate, `arrow/` module, `FileFormat`, `writer.rs`).
+
+---
+
+## Epic 5: File readers
+
+**Goal:** Can open Parquet, CSV, and JSONL files and iterate over their contents as Arrow RecordBatches.
+
+**Files:**
+
+| File | Change |
+|------|--------|
+| `crates/executor/src/arrow/mod.rs` | Add `pub mod reader;` |
+| `crates/executor/src/arrow/reader.rs` | `open_file()` for Parquet, CSV, JSONL |
+
+**Details:**
+
+`reader.rs` implements three readers, all returning `(Schema, Box<dyn RecordBatchReader>)`:
+
+- **Parquet:** `ParquetRecordBatchReaderBuilder::try_new(File::open(path)?)?.build()?` — schema from Parquet metadata, row groups as batches.
+- **CSV:** Infer schema from header + first 100 rows via `arrow::csv::infer_schema_from_files`. Re-open file, build reader with inferred schema.
+- **JSONL:** Infer schema from first 100 lines via `arrow::json::infer_json_schema_from_seekable`. Build `ReaderBuilder` with inferred schema.
+
+Reuses `FileFormat` and `detect_format()` from `writer.rs` (v1a Epic 1).
+
+**Tests (3):**
+- `test_read_parquet` — write a Parquet file with known data (using writer from v1a), read back, verify schema + row count + values
+- `test_read_csv` — write CSV string to temp file, read, verify schema inference and data
+- `test_read_jsonl` — write JSONL string to temp file, read, verify schema inference and data
+
+**Estimated size:** ~100 lines
+**Acceptance:** All three formats read successfully, schema inferred correctly, tests green.
+
+---
+
+## Epic 6: Column mapping + type coercion
+
+**Goal:** Given a file's Arrow schema and CLI flags, resolve which columns map to key/value/embedding/metadata. Convert Arrow array values to Strata `Value` types.
+
+**Files:**
+
+| File | Change |
+|------|--------|
+| `crates/executor/src/arrow/mod.rs` | Add `pub mod schema;` |
+| `crates/executor/src/arrow/schema.rs` | `ImportPrimitive`, `ImportMapping`, `resolve_mapping()`, `arrow_to_value()`, `row_to_json()` |
+
+**Details:**
+
+Column resolution (`resolve_mapping`):
+- Key column: `--key-column` override, else try `key` → `_id` → `id`
+- KV value: `--value-column` override, else try `value`, else 2-column shortcut, else remaining columns → JSON
+- JSON document: `--value-column` override, else try `document` → `value` → `doc` → `body`, else remaining → JSON
+- Vector embedding: `--value-column` override, else try `embedding` → `vector` → `embeddings` → `emb`, must be list<f32> type
+
+Type coercion (`arrow_to_value`):
+- Utf8/LargeUtf8 → `Value::String`
+- Int8..Int64 → `Value::Int`
+- UInt8..UInt64 → `Value::Int` (cast to i64)
+- Float32/Float64 → `Value::Float`
+- Boolean → `Value::Bool`
+- Binary/LargeBinary → `Value::Bytes`
+- Null → `Value::Null`
+- List/Struct → `Value::String` (JSON-serialized)
+
+Row-to-JSON helper (`row_to_json`):
+- Serializes specified columns of a row as `{"col_name": value, ...}` JSON string
+- Used when no explicit value/document column exists
+
+Error messages must be actionable — list available columns on resolution failure.
+
+**Tests (13):**
+
+Column resolution (8):
+- `test_resolve_key_column_auto` — finds `key` column
+- `test_resolve_key_column_id_fallback` — falls back to `id`
+- `test_resolve_key_column_explicit` — `--key-column` override works
+- `test_resolve_key_column_missing` — error lists available columns
+- `test_resolve_value_column_kv` — auto-detect `value`
+- `test_resolve_embedding_column` — auto-detect `embedding`
+- `test_resolve_embedding_wrong_type` — error on non-list column
+- `test_resolve_extra_columns_as_json` — remaining columns collected correctly
+
+Type coercion (5):
+- `test_arrow_to_value_string` — Utf8 → Value::String
+- `test_arrow_to_value_int` — Int64 → Value::Int
+- `test_arrow_to_value_float` — Float64 → Value::Float
+- `test_arrow_to_value_bool` — Boolean → Value::Bool
+- `test_arrow_to_value_null` — Null → Value::Null
+
+**Estimated size:** ~250 lines
+**Acceptance:** Column resolution works for all three primitives (KV, JSON, Vector) with both auto-detect and explicit overrides. Type coercion covers all Arrow→Value mappings.
+
+---
+
+## Epic 7: Ingest pipeline — KV, JSON, Vector
+
+**Goal:** Can read a file and write its contents into Strata primitives. Core import logic.
+
+**Files:**
+
+| File | Change |
+|------|--------|
+| `crates/executor/src/arrow/mod.rs` | Add `pub mod ingest;` |
+| `crates/executor/src/arrow/ingest.rs` | `ImportResult`, `ingest_kv()`, `ingest_json()`, `ingest_vector()` |
+
+**Details:**
+
+KV ingest:
+- Per RecordBatch: extract keys from `key_idx`, extract values via `arrow_to_value()` or serialize extra columns as JSON
+- Use `p.kv.batch_put()` per batch for efficiency
+- Skip rows with null keys, increment `rows_skipped`
+
+JSON ingest:
+- Per RecordBatch: extract keys, extract document string from `value_idx` or serialize extra columns as JSON object
+- Use `p.json.set()` per document (no batch API exists)
+- Skip rows with null keys
+
+Vector ingest:
+- Per RecordBatch: extract keys, extract embeddings as `Vec<f32>` from FixedSizeList/List column, extract metadata from extra columns
+- On first batch: auto-create collection if it doesn't exist (dimension from first embedding, cosine metric, f32 storage)
+- Use `p.vector.insert()` per vector (no batch API)
+- Validate embedding dimension against collection config
+
+Error handling:
+- Row-level errors (null key, type mismatch, dimension mismatch) → skip row, increment `rows_skipped`
+- Batch-level errors (I/O, schema mismatch) → abort, return error
+- Already-committed rows from prior batches are not rolled back
+
+**Tests (6):**
+- `test_ingest_kv` — create in-memory DB, build RecordBatch with key/value columns, ingest, verify via `kv get`
+- `test_ingest_kv_extra_columns_as_json` — RecordBatch with 3 columns (id, name, email), no `value` column → KV values are JSON objects
+- `test_ingest_json` — build RecordBatch with key/document columns, ingest, verify via `json get`
+- `test_ingest_json_from_columns` — RecordBatch with no `document` column → extra columns become JSON document
+- `test_ingest_vector` — build RecordBatch with key + FixedSizeList<f32> embedding, ingest, verify via `vector get`
+- `test_ingest_vector_auto_creates_collection` — collection doesn't exist → created with correct dimension
+
+**Estimated size:** ~300 lines
+**Acceptance:** All three primitives ingest from RecordBatches correctly. Auto-create vector collection works. Row-level errors are skipped gracefully.
+
+---
+
+## Epic 8: CLI `strata import` command + integration tests
+
+**Goal:** `strata import users.parquet --into kv --key-column id` works end-to-end.
+
+**Files:**
+
+| File | Change |
+|------|--------|
+| `crates/executor/src/command.rs` | Add `ArrowImport` variant |
+| `crates/executor/src/output.rs` | Add `ArrowImported` variant |
+| `crates/executor/src/executor.rs` | Dispatch `ArrowImport` → handler |
+| `crates/executor/src/handlers/mod.rs` | Register `arrow_import` module |
+| `crates/executor/src/handlers/arrow_import.rs` | Handler: parse args → open file → resolve mapping → ingest |
+| `crates/cli/src/commands.rs` | Add `import` top-level subcommand |
+| `crates/cli/src/main.rs` (or dispatch) | Route `import` subcommand → `ArrowImport` command |
+
+**Details:**
+
+Command variant (always present, not feature-gated):
+```rust
+ArrowImport {
+    branch: Option<BranchId>,
+    space: Option<String>,
+    file_path: String,
+    target: String,         // "kv", "json", "vector"
+    key_column: Option<String>,
+    value_column: Option<String>,
+    collection: Option<String>,
+    format: Option<String>, // override auto-detect
+}
+```
+
+Output variant:
+```rust
+ArrowImported {
+    rows_imported: u64,
+    rows_skipped: u64,
+    target: String,
+    file_path: String,
+}
+```
+
+Handler (`arrow_import.rs`):
+- Feature-gated: `#[cfg(feature = "arrow")]` for the real implementation, `#[cfg(not(feature = "arrow"))]` returns error with rebuild hint
+- Validates branch exists, resolves branch ID
+- Opens file with reader, resolves column mapping, dispatches to ingest function
+- Returns `ArrowImported` output
+
+CLI subcommand:
+```
+strata import <FILE> --into <PRIMITIVE> [OPTIONS]
+  --key-column <COL>
+  --value-column <COL>
+  --collection <NAME>
+  --format <FMT>
+  -b, --branch
+  -s, --space
+```
+
+Human-readable output:
+```
+Imported 10,000 rows into kv from users.parquet (0 skipped)
+```
+
+**Tests (8):**
+
+Integration (6):
+- `test_import_kv_from_parquet` — write Parquet → import → verify `kv get`
+- `test_import_kv_from_csv` — write CSV → import → verify
+- `test_import_json_from_jsonl` — write JSONL → import → verify `json get`
+- `test_import_json_remaining_columns_as_document` — CSV with columns (id, name, email) → JSON documents
+- `test_import_vector_from_parquet` — write Parquet with embeddings → import → verify `vector search`
+- `test_import_vector_auto_creates_collection` — collection auto-created
+
+Round-trip (2):
+- `test_roundtrip_kv_parquet` — populate KV → export Parquet (v1a) → import to new branch → compare
+- `test_roundtrip_json_csv` — populate JSON → export CSV → import to new branch → compare
+
+**Estimated size:** ~350 lines
+**Acceptance:** `strata import` works for all three primitives, all three formats. Round-trip tests prove import and export are compatible. `cargo test --features arrow` all green.
+
+---
+
+## Summary
+
+| Epic | Scope | Lines | Cumulative (with v1a) |
+|------|-------|-------|-----------------------|
+| 5 | File readers | ~100 | ~1,070 |
+| 6 | Column mapping + type coercion | ~250 | ~1,320 |
+| 7 | KV, JSON, Vector ingest | ~300 | ~1,620 |
+| 8 | CLI `import` + integration tests | ~350 | ~1,970 |
+| **v1b Total** | | **~1,000** | |


### PR DESCRIPTION
## Summary

- RFC for Apache Arrow as Strata's universal data interchange format
- Phased implementation plans: v1a (export) and v1b (import)
- 8 epic breakdowns with acceptance criteria and test lists
- Tracking issue: #2126

## Documents

| File | Purpose |
|------|---------|
| `docs/design/arrow/rfc-arrow-interoperability.md` | Full vision: CLI, Python SDK, ADBC, DataFusion |
| `docs/design/arrow/arrow-v1-implementation-plan.md` | Combined plan (superseded by v1a/v1b split) |
| `docs/design/arrow/arrow-v1a-export.md` | v1a: export all 5 primitives to Parquet/CSV/JSONL |
| `docs/design/arrow/arrow-v1b-import.md` | v1b: import KV/JSON/Vector from Parquet/CSV/JSONL |
| `docs/design/arrow/v1a-epics.md` | 4 epics for export (#2127-#2130) |
| `docs/design/arrow/v1b-epics.md` | 4 epics for import (#2131-#2134) |

## Test plan

- [ ] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)