### PR TITLE
v1a Epic 4: CLI export wiring + integration tests

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -106,6 +106,7 @@ pub fn build_cli() -> Command {
         .subcommand(build_config())
         .subcommand(build_up())
         .subcommand(build_down())
+        .subcommand(build_db_export())
 }
 
 /// Build a command tree for REPL mode (no global flags).
@@ -138,6 +139,7 @@ pub fn build_repl_cmd() -> Command {
         .subcommand(build_detokenize())
         .subcommand(build_graph())
         .subcommand(build_config())
+        .subcommand(build_db_export())
 }
 
 // =========================================================================
@@ -1367,5 +1369,58 @@ fn build_down() -> Command {
         .long_about(
             "Stop a running Strata IPC server by reading the PID file and sending SIGTERM.\n\
              Cleans up the socket and PID files.",
+        )
+}
+
+// =========================================================================
+// Data Export
+// =========================================================================
+
+fn build_db_export() -> Command {
+    Command::new("export")
+        .about("Export data from a primitive to a file")
+        .arg(
+            Arg::new("primitive")
+                .required(true)
+                .help("Primitive to export: kv, json, events, vector, graph"),
+        )
+        .arg(
+            Arg::new("format")
+                .long("format")
+                .short('f')
+                .value_name("FMT")
+                .help("Output format: parquet, csv, jsonl, json (default: csv)"),
+        )
+        .arg(
+            Arg::new("output")
+                .long("output")
+                .short('o')
+                .value_name("FILE")
+                .help("Output file path (required for parquet)"),
+        )
+        .arg(
+            Arg::new("prefix")
+                .long("prefix")
+                .value_name("PREFIX")
+                .help("Key prefix filter (kv, json)"),
+        )
+        .arg(
+            Arg::new("collection")
+                .long("collection")
+                .value_name("NAME")
+                .help("Vector collection name (required for vector)"),
+        )
+        .arg(
+            Arg::new("graph")
+                .long("graph")
+                .value_name("NAME")
+                .help("Graph name (required for graph)"),
+        )
+        .arg(
+            Arg::new("limit")
+                .long("limit")
+                .value_name("N")
+                .value_parser(clap::value_parser!(u64))
+                .help("Maximum rows to export"),
         )
 }

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -12,7 +12,8 @@ use std::io::Read;
 use clap::ArgMatches;
 use strata_executor::{
     BatchVectorEntry, BranchId, BulkGraphEdge, BulkGraphNode, Command, DistanceMetric,
-    MergeStrategy, MetadataFilter, SearchQuery, TimeRangeInput, TxnOptions, Value,
+    ExportFormat, ExportPrimitive, MergeStrategy, MetadataFilter, SearchQuery, TimeRangeInput,
+    TxnOptions, Value,
 };
 
 use crate::state::SessionState;
@@ -178,6 +179,7 @@ pub fn matches_to_action(matches: &ArgMatches, state: &SessionState) -> Result<C
         "generate" => parse_generate(sub_matches),
         "tokenize" => parse_tokenize(sub_matches),
         "detokenize" => parse_detokenize(sub_matches),
+        "export" => parse_db_export(sub_matches, state),
         other => Err(unknown_subcommand(
             "",
             other,
@@ -209,6 +211,7 @@ pub fn matches_to_action(matches: &ArgMatches, state: &SessionState) -> Result<C
                 "generate",
                 "tokenize",
                 "detokenize",
+                "export",
             ],
         )),
     }
@@ -1467,6 +1470,50 @@ fn parse_search(matches: &ArgMatches, state: &SessionState) -> Result<CliAction,
             rerank,
             precomputed_embedding: None,
         },
+    }))
+}
+
+fn parse_db_export(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, String> {
+    let primitive_str = matches.get_one::<String>("primitive").unwrap();
+    let primitive = match primitive_str.as_str() {
+        "kv" => ExportPrimitive::Kv,
+        "json" => ExportPrimitive::Json,
+        "events" => ExportPrimitive::Events,
+        "vector" => ExportPrimitive::Vector,
+        "graph" => ExportPrimitive::Graph,
+        other => {
+            return Err(format!(
+                "Unknown primitive '{other}'. Expected: kv, json, events, vector, graph"
+            ))
+        }
+    };
+
+    let format_str = matches
+        .get_one::<String>("format")
+        .map(|s| s.as_str())
+        .unwrap_or("csv");
+    let format = match format_str {
+        "csv" => ExportFormat::Csv,
+        "json" => ExportFormat::Json,
+        "jsonl" => ExportFormat::Jsonl,
+        "parquet" => ExportFormat::Parquet,
+        other => {
+            return Err(format!(
+                "Unknown format '{other}'. Expected: parquet, csv, jsonl, json"
+            ))
+        }
+    };
+
+    Ok(CliAction::Execute(Command::DbExport {
+        branch: branch(state),
+        space: space(state),
+        primitive,
+        format,
+        prefix: matches.get_one::<String>("prefix").cloned(),
+        limit: matches.get_one::<u64>("limit").copied(),
+        path: matches.get_one::<String>("output").cloned(),
+        collection: matches.get_one::<String>("collection").cloned(),
+        graph: matches.get_one::<String>("graph").cloned(),
     }))
 }
 

--- a/crates/executor/src/arrow/export.rs
+++ b/crates/executor/src/arrow/export.rs
@@ -2,7 +2,9 @@
 
 use std::sync::Arc;
 
-use arrow::array::{Float32Builder, Float64Builder, FixedSizeListBuilder, StringBuilder, UInt64Builder};
+use arrow::array::{
+    FixedSizeListBuilder, Float32Builder, Float64Builder, StringBuilder, UInt64Builder,
+};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 
@@ -123,8 +125,10 @@ fn value_to_json(v: &strata_core::Value) -> serde_json::Value {
             serde_json::Value::Array(arr.iter().map(value_to_json).collect())
         }
         strata_core::Value::Object(obj) => {
-            let map: serde_json::Map<String, serde_json::Value> =
-                obj.iter().map(|(k, v)| (k.clone(), value_to_json(v))).collect();
+            let map: serde_json::Map<String, serde_json::Value> = obj
+                .iter()
+                .map(|(k, v)| (k.clone(), value_to_json(v)))
+                .collect();
             serde_json::Value::Object(map)
         }
     }
@@ -217,18 +221,20 @@ fn export_json(
     let mut cursor: Option<String> = None;
 
     loop {
-        let result = convert_result(
-            p.json
-                .list(&branch_id, space, prefix.as_deref(), cursor.as_deref(), 1000),
-        )?;
+        let result = convert_result(p.json.list(
+            &branch_id,
+            space,
+            prefix.as_deref(),
+            cursor.as_deref(),
+            1000,
+        ))?;
         let page_empty = result.doc_ids.is_empty();
 
         for doc_id in result.doc_ids {
             if count >= max {
                 break;
             }
-            if let Some(json_val) = convert_result(p.json.get(&branch_id, space, &doc_id, &root))?
-            {
+            if let Some(json_val) = convert_result(p.json.get(&branch_id, space, &doc_id, &root))? {
                 let doc_str =
                     serde_json::to_string(&json_val).unwrap_or_else(|_| "null".to_string());
                 key_builder.append_value(&doc_id);
@@ -306,8 +312,8 @@ fn export_event(
         let event = &versioned.value;
         seq_builder.append_value(event.sequence);
         type_builder.append_value(&event.event_type);
-        let payload_str =
-            serde_json::to_string(&value_to_json(&event.payload)).unwrap_or_else(|_| "null".to_string());
+        let payload_str = serde_json::to_string(&value_to_json(&event.payload))
+            .unwrap_or_else(|_| "null".to_string());
         payload_builder.append_value(&payload_str);
         ts_builder.append_value(event.timestamp.as_micros());
     }
@@ -359,10 +365,7 @@ fn export_vector(
         Field::new("key", DataType::Utf8, false),
         Field::new(
             "embedding",
-            DataType::FixedSizeList(
-                Arc::new(Field::new("item", DataType::Float32, true)),
-                dim,
-            ),
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
             false,
         ),
         Field::new("metadata", DataType::Utf8, true),
@@ -372,8 +375,7 @@ fn export_vector(
     let max = limit.unwrap_or(usize::MAX);
 
     let mut key_builder = StringBuilder::new();
-    let mut embedding_builder =
-        FixedSizeListBuilder::new(Float32Builder::new(), dim);
+    let mut embedding_builder = FixedSizeListBuilder::new(Float32Builder::new(), dim);
     let mut metadata_builder = StringBuilder::new();
 
     for key in keys.into_iter().take(max) {
@@ -650,10 +652,18 @@ mod tests {
     #[test]
     fn test_json_export() {
         let (p, branch_id) = setup_with(|db| {
-            db.json_set("u1", "$", Value::String(r#"{"name":"Alice","age":30}"#.into()))
-                .unwrap();
-            db.json_set("u2", "$", Value::String(r#"{"name":"Bob","age":25}"#.into()))
-                .unwrap();
+            db.json_set(
+                "u1",
+                "$",
+                Value::String(r#"{"name":"Alice","age":30}"#.into()),
+            )
+            .unwrap();
+            db.json_set(
+                "u2",
+                "$",
+                Value::String(r#"{"name":"Bob","age":25}"#.into()),
+            )
+            .unwrap();
         });
 
         let (schema, batches) = export_to_batches(
@@ -697,23 +707,32 @@ mod tests {
     #[test]
     fn test_event_export() {
         let (p, branch_id) = setup_with(|db| {
-            db.event_append("click", Value::object({
-                let mut m = std::collections::HashMap::new();
-                m.insert("page".to_string(), Value::String("home".into()));
-                m
-            }))
+            db.event_append(
+                "click",
+                Value::object({
+                    let mut m = std::collections::HashMap::new();
+                    m.insert("page".to_string(), Value::String("home".into()));
+                    m
+                }),
+            )
             .unwrap();
-            db.event_append("view", Value::object({
-                let mut m = std::collections::HashMap::new();
-                m.insert("page".to_string(), Value::String("about".into()));
-                m
-            }))
+            db.event_append(
+                "view",
+                Value::object({
+                    let mut m = std::collections::HashMap::new();
+                    m.insert("page".to_string(), Value::String("about".into()));
+                    m
+                }),
+            )
             .unwrap();
-            db.event_append("click", Value::object({
-                let mut m = std::collections::HashMap::new();
-                m.insert("page".to_string(), Value::String("contact".into()));
-                m
-            }))
+            db.event_append(
+                "click",
+                Value::object({
+                    let mut m = std::collections::HashMap::new();
+                    m.insert("page".to_string(), Value::String("contact".into()));
+                    m
+                }),
+            )
             .unwrap();
         });
 
@@ -793,25 +812,37 @@ mod tests {
 
     #[test]
     fn test_vector_export() {
-        use arrow::array::{Float32Array, FixedSizeListArray};
         use crate::types::DistanceMetric;
+        use arrow::array::{FixedSizeListArray, Float32Array};
 
         let (p, branch_id) = setup_with(|db| {
             db.vector_create_collection("docs", 3, DistanceMetric::Cosine)
                 .unwrap();
-            db.vector_upsert("docs", "v1", vec![1.0, 2.0, 3.0], Some(Value::String(r#"{"tag":"a"}"#.into())))
-                .unwrap();
+            db.vector_upsert(
+                "docs",
+                "v1",
+                vec![1.0, 2.0, 3.0],
+                Some(Value::String(r#"{"tag":"a"}"#.into())),
+            )
+            .unwrap();
             db.vector_upsert("docs", "v2", vec![4.0, 5.0, 6.0], None)
                 .unwrap();
-            db.vector_upsert("docs", "v3", vec![7.0, 8.0, 9.0], Some(Value::String(r#"{"tag":"c"}"#.into())))
-                .unwrap();
+            db.vector_upsert(
+                "docs",
+                "v3",
+                vec![7.0, 8.0, 9.0],
+                Some(Value::String(r#"{"tag":"c"}"#.into())),
+            )
+            .unwrap();
         });
 
         let (schema, batches) = export_to_batches(
             &p,
             branch_id,
             "default",
-            ExportSource::Vector { collection: "docs".into() },
+            ExportSource::Vector {
+                collection: "docs".into(),
+            },
             None,
         )
         .unwrap();
@@ -824,9 +855,21 @@ mod tests {
         let batch = &batches[0];
         assert_eq!(batch.num_rows(), 3);
 
-        let keys = batch.column(0).as_any().downcast_ref::<StringArray>().unwrap();
-        let embeddings = batch.column(1).as_any().downcast_ref::<FixedSizeListArray>().unwrap();
-        let metadata = batch.column(2).as_any().downcast_ref::<StringArray>().unwrap();
+        let keys = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let embeddings = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<FixedSizeListArray>()
+            .unwrap();
+        let metadata = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
 
         // Verify embedding dimension
         assert_eq!(embeddings.value_length(), 3);
@@ -851,15 +894,21 @@ mod tests {
         let (p, branch_id) = setup_with(|db| {
             db.graph_create("social").unwrap();
             db.graph_add_node_typed(
-                "social", "alice", None,
+                "social",
+                "alice",
+                None,
                 Some(Value::String(r#"{"age":30}"#.into())),
                 Some("Person"),
-            ).unwrap();
+            )
+            .unwrap();
             db.graph_add_node_typed(
-                "social", "bob", None,
+                "social",
+                "bob",
+                None,
                 Some(Value::String(r#"{"age":25}"#.into())),
                 Some("Person"),
-            ).unwrap();
+            )
+            .unwrap();
             db.graph_add_node("social", "acme", None, None).unwrap();
         });
 
@@ -867,7 +916,9 @@ mod tests {
             &p,
             branch_id,
             "default",
-            ExportSource::GraphNodes { graph: "social".into() },
+            ExportSource::GraphNodes {
+                graph: "social".into(),
+            },
             None,
         )
         .unwrap();
@@ -880,9 +931,21 @@ mod tests {
         let batch = &batches[0];
         assert_eq!(batch.num_rows(), 3);
 
-        let ids = batch.column(0).as_any().downcast_ref::<StringArray>().unwrap();
-        let types = batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
-        let props = batch.column(2).as_any().downcast_ref::<StringArray>().unwrap();
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let types = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let props = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
 
         let id_set: Vec<&str> = (0..ids.len()).map(|i| ids.value(i)).collect();
         assert!(id_set.contains(&"alice"));
@@ -908,15 +971,19 @@ mod tests {
             db.graph_add_node("social", "alice", None, None).unwrap();
             db.graph_add_node("social", "bob", None, None).unwrap();
             db.graph_add_node("social", "carol", None, None).unwrap();
-            db.graph_add_edge("social", "alice", "bob", "knows", Some(0.9), None).unwrap();
-            db.graph_add_edge("social", "bob", "carol", "knows", Some(0.5), None).unwrap();
+            db.graph_add_edge("social", "alice", "bob", "knows", Some(0.9), None)
+                .unwrap();
+            db.graph_add_edge("social", "bob", "carol", "knows", Some(0.5), None)
+                .unwrap();
         });
 
         let (schema, batches) = export_to_batches(
             &p,
             branch_id,
             "default",
-            ExportSource::GraphEdges { graph: "social".into() },
+            ExportSource::GraphEdges {
+                graph: "social".into(),
+            },
             None,
         )
         .unwrap();
@@ -931,10 +998,26 @@ mod tests {
         let batch = &batches[0];
         assert_eq!(batch.num_rows(), 2);
 
-        let sources = batch.column(0).as_any().downcast_ref::<StringArray>().unwrap();
-        let targets = batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
-        let edge_types = batch.column(2).as_any().downcast_ref::<StringArray>().unwrap();
-        let weights = batch.column(3).as_any().downcast_ref::<Float64Array>().unwrap();
+        let sources = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let targets = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let edge_types = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let weights = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
 
         // Verify both edges (order may vary)
         let src_set: Vec<&str> = (0..sources.len()).map(|i| sources.value(i)).collect();

--- a/crates/executor/src/arrow/writer.rs
+++ b/crates/executor/src/arrow/writer.rs
@@ -56,12 +56,10 @@ pub fn write_file(path: &Path, format: FileFormat, batches: &[RecordBatch]) -> R
             let props = parquet::file::properties::WriterProperties::builder()
                 .set_compression(parquet::basic::Compression::SNAPPY)
                 .build();
-            let mut writer =
-                parquet::arrow::ArrowWriter::try_new(file, schema, Some(props)).map_err(|e| {
-                    Error::Io {
-                        reason: format!("failed to create Parquet writer: {e}"),
-                        hint: None,
-                    }
+            let mut writer = parquet::arrow::ArrowWriter::try_new(file, schema, Some(props))
+                .map_err(|e| Error::Io {
+                    reason: format!("failed to create Parquet writer: {e}"),
+                    hint: None,
                 })?;
             for batch in batches {
                 writer.write(batch).map_err(|e| Error::Io {

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -979,6 +979,12 @@ pub enum Command {
         /// File path to write to. If omitted, data is returned inline.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         path: Option<String>,
+        /// Vector collection name (required when primitive is Vector).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        collection: Option<String>,
+        /// Graph name (required when primitive is Graph).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        graph: Option<String>,
     },
 
     // ==================== Bundle (3) ====================

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -1172,6 +1172,8 @@ impl Executor {
                 prefix,
                 limit,
                 path,
+                collection,
+                graph,
             } => {
                 let branch = branch.ok_or(Error::InvalidInput {
                     reason: "Branch must be specified or resolved to default".into(),
@@ -1190,6 +1192,8 @@ impl Executor {
                     prefix,
                     limit,
                     path,
+                    collection,
+                    graph,
                 )
             }
 

--- a/crates/executor/src/handlers/export.rs
+++ b/crates/executor/src/handlers/export.rs
@@ -371,29 +371,86 @@ pub fn db_export(
     prefix: Option<String>,
     limit: Option<u64>,
     path: Option<String>,
+    collection: Option<String>,
+    graph: Option<String>,
 ) -> Result<Output> {
     let branch_id = to_core_branch_id(&branch)?;
 
-    // 1. Collect rows
+    // Validate required fields for specific primitives
+    if primitive == ExportPrimitive::Vector && collection.is_none() {
+        return Err(Error::InvalidInput {
+            reason: "--collection is required for vector export".into(),
+            hint: None,
+        });
+    }
+    if primitive == ExportPrimitive::Graph && graph.is_none() {
+        return Err(Error::InvalidInput {
+            reason: "--graph is required for graph export".into(),
+            hint: None,
+        });
+    }
+
+    // Arrow file export path: Parquet always, or CSV/JSONL when --output is provided
+    // and the arrow feature is enabled.
+    #[cfg(feature = "arrow")]
+    {
+        let use_arrow = match format {
+            ExportFormat::Parquet => true,
+            ExportFormat::Csv | ExportFormat::Jsonl => path.is_some(),
+            ExportFormat::Json => false, // JSON array format uses existing renderer
+        };
+
+        if use_arrow {
+            let file_path = match &path {
+                Some(p) => p.clone(),
+                None if format == ExportFormat::Parquet => {
+                    return Err(Error::InvalidInput {
+                        reason: "Parquet export requires --output <FILE>".into(),
+                        hint: None,
+                    });
+                }
+                None => unreachable!(), // CSV/JSONL use_arrow requires path.is_some()
+            };
+
+            return arrow_export(
+                p, branch_id, &space, primitive, format, prefix, limit, &file_path, collection,
+                graph,
+            );
+        }
+    }
+
+    #[cfg(not(feature = "arrow"))]
+    if format == ExportFormat::Parquet {
+        return Err(Error::Internal {
+            reason: "Parquet export requires the 'arrow' feature".into(),
+            hint: Some("Rebuild with: cargo build --features arrow".into()),
+        });
+    }
+
+    // Existing string-based rendering path (inline output or file without arrow)
     let rows = match primitive {
         ExportPrimitive::Kv => collect_kv(p, branch_id, &space, prefix.as_deref(), limit)?,
         ExportPrimitive::Json => collect_json(p, branch_id, &space, prefix.as_deref(), limit)?,
         ExportPrimitive::Events => collect_events(p, branch_id, &space, limit)?,
         ExportPrimitive::Graph => collect_graph(p, branch_id, prefix.as_deref(), limit)?,
+        ExportPrimitive::Vector => {
+            return Err(Error::InvalidInput {
+                reason: "Vector export requires the 'arrow' feature and --output <FILE>".into(),
+                hint: Some("Rebuild with: cargo build --features arrow".into()),
+            });
+        }
     };
 
-    // 2. Render
     let rendered = match format {
         ExportFormat::Csv => render_csv(&rows),
         ExportFormat::Json => render_json(&rows),
         ExportFormat::Jsonl => render_jsonl(&rows),
+        ExportFormat::Parquet => unreachable!(), // handled above
     };
 
     let row_count = rows.len() as u64;
 
-    // 3. Output destination: file if path provided, otherwise inline
     if let Some(file_path) = path {
-        // Validate parent directory exists for explicit paths
         if let Some(parent) = std::path::Path::new(&file_path).parent() {
             if !parent.as_os_str().is_empty() && !parent.exists() {
                 return Err(Error::Io {
@@ -425,6 +482,145 @@ pub fn db_export(
             path: None,
             size_bytes: None,
         }))
+    }
+}
+
+/// Arrow-based file export (Parquet, CSV, JSONL).
+#[cfg(feature = "arrow")]
+#[allow(clippy::too_many_arguments)]
+fn arrow_export(
+    p: &Arc<Primitives>,
+    branch_id: strata_core::types::BranchId,
+    space: &str,
+    primitive: ExportPrimitive,
+    format: ExportFormat,
+    prefix: Option<String>,
+    limit: Option<u64>,
+    file_path: &str,
+    collection: Option<String>,
+    graph: Option<String>,
+) -> Result<Output> {
+    use crate::arrow::{export_to_batches, write_file, ExportSource};
+
+    // Validate parent directory exists
+    if let Some(parent) = std::path::Path::new(file_path).parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            return Err(Error::Io {
+                reason: format!("Parent directory '{}' does not exist", parent.display()),
+                hint: None,
+            });
+        }
+    }
+
+    let limit = limit.map(|l| l as usize);
+
+    // Build ExportSource from primitive + options
+    let source = match primitive {
+        ExportPrimitive::Kv => ExportSource::Kv { prefix },
+        ExportPrimitive::Json => ExportSource::Json { prefix },
+        ExportPrimitive::Events => ExportSource::Event { event_type: None },
+        ExportPrimitive::Vector => ExportSource::Vector {
+            collection: collection.unwrap(), // validated above
+        },
+        ExportPrimitive::Graph => {
+            let graph_name = graph.unwrap(); // validated above
+
+            // Graph exports produce two files: nodes + edges
+            let path = std::path::Path::new(file_path);
+            let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("graph");
+            let ext = path
+                .extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("parquet");
+            let parent = path.parent().unwrap_or(std::path::Path::new("."));
+
+            let nodes_path = parent.join(format!("{stem}_nodes.{ext}"));
+            let edges_path = parent.join(format!("{stem}_edges.{ext}"));
+
+            let arrow_format = to_arrow_format(format)?;
+
+            // Export nodes
+            let (_, node_batches) = export_to_batches(
+                p,
+                branch_id,
+                space,
+                ExportSource::GraphNodes {
+                    graph: graph_name.clone(),
+                },
+                limit,
+            )?;
+            let node_bytes = if node_batches.is_empty() {
+                0
+            } else {
+                write_file(&nodes_path, arrow_format, &node_batches)?
+            };
+
+            // Export edges
+            let (_, edge_batches) = export_to_batches(
+                p,
+                branch_id,
+                space,
+                ExportSource::GraphEdges { graph: graph_name },
+                limit,
+            )?;
+            let edge_bytes = if edge_batches.is_empty() {
+                0
+            } else {
+                write_file(&edges_path, arrow_format, &edge_batches)?
+            };
+
+            let node_rows = node_batches
+                .iter()
+                .map(|b| b.num_rows() as u64)
+                .sum::<u64>();
+            let edge_rows = edge_batches
+                .iter()
+                .map(|b| b.num_rows() as u64)
+                .sum::<u64>();
+
+            return Ok(Output::Exported(ExportResult {
+                row_count: node_rows + edge_rows,
+                format,
+                primitive,
+                data: None,
+                path: Some(file_path.to_string()),
+                size_bytes: Some(node_bytes + edge_bytes),
+            }));
+        }
+    };
+
+    let (_, batches) = export_to_batches(p, branch_id, space, source, limit)?;
+    let row_count: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
+
+    let arrow_format = to_arrow_format(format)?;
+    let size_bytes = if batches.is_empty() {
+        0
+    } else {
+        write_file(std::path::Path::new(file_path), arrow_format, &batches)?
+    };
+
+    Ok(Output::Exported(ExportResult {
+        row_count,
+        format,
+        primitive,
+        data: None,
+        path: Some(file_path.to_string()),
+        size_bytes: Some(size_bytes),
+    }))
+}
+
+/// Map ExportFormat to Arrow FileFormat.
+#[cfg(feature = "arrow")]
+fn to_arrow_format(format: ExportFormat) -> Result<crate::arrow::FileFormat> {
+    use crate::arrow::FileFormat;
+    match format {
+        ExportFormat::Parquet => Ok(FileFormat::Parquet),
+        ExportFormat::Csv => Ok(FileFormat::Csv),
+        ExportFormat::Jsonl => Ok(FileFormat::Jsonl),
+        ExportFormat::Json => Err(Error::InvalidInput {
+            reason: "JSON array format is not supported for Arrow file export".into(),
+            hint: Some("Use --format parquet, csv, or jsonl".into()),
+        }),
     }
 }
 

--- a/crates/executor/src/tests/access_mode.rs
+++ b/crates/executor/src/tests/access_mode.rs
@@ -284,6 +284,8 @@ fn test_read_only_allows_all_reads() {
             prefix: None,
             limit: None,
             path: None,
+            collection: None,
+            graph: None,
         },
     ];
 
@@ -600,6 +602,8 @@ fn test_is_write_classification() {
             prefix: None,
             limit: None,
             path: None,
+            collection: None,
+            graph: None,
         },
     ];
 

--- a/crates/executor/src/tests/export.rs
+++ b/crates/executor/src/tests/export.rs
@@ -33,6 +33,8 @@ fn export_kv_csv_inline() {
             prefix: None,
             limit: None,
             path: None,
+            collection: None,
+            graph: None,
         })
         .unwrap();
 
@@ -64,6 +66,8 @@ fn export_kv_json_inline() {
             prefix: None,
             limit: None,
             path: None,
+            collection: None,
+            graph: None,
         })
         .unwrap();
 
@@ -95,6 +99,8 @@ fn export_kv_jsonl_inline() {
             prefix: None,
             limit: None,
             path: None,
+            collection: None,
+            graph: None,
         })
         .unwrap();
 
@@ -126,6 +132,8 @@ fn export_kv_with_prefix() {
             prefix: Some("user:".to_string()),
             limit: None,
             path: None,
+            collection: None,
+            graph: None,
         })
         .unwrap();
 
@@ -149,6 +157,8 @@ fn export_kv_with_limit() {
             prefix: None,
             limit: Some(1),
             path: None,
+            collection: None,
+            graph: None,
         })
         .unwrap();
 
@@ -175,6 +185,8 @@ fn export_kv_to_file() {
             prefix: None,
             limit: None,
             path: Some(path.clone()),
+            collection: None,
+            graph: None,
         })
         .unwrap();
 
@@ -212,6 +224,8 @@ fn export_empty_kv() {
             prefix: None,
             limit: None,
             path: None,
+            collection: None,
+            graph: None,
         })
         .unwrap();
 
@@ -238,6 +252,8 @@ fn export_empty_json_format() {
             prefix: None,
             limit: None,
             path: None,
+            collection: None,
+            graph: None,
         })
         .unwrap();
 
@@ -264,6 +280,8 @@ fn export_empty_jsonl_format() {
             prefix: None,
             limit: None,
             path: None,
+            collection: None,
+            graph: None,
         })
         .unwrap();
 
@@ -300,6 +318,8 @@ fn export_events_json() {
             prefix: None,
             limit: None,
             path: None,
+            collection: None,
+            graph: None,
         })
         .unwrap();
 
@@ -338,6 +358,8 @@ fn export_events_with_limit() {
             prefix: None,
             limit: Some(2),
             path: None,
+            collection: None,
+            graph: None,
         })
         .unwrap();
 
@@ -387,6 +409,8 @@ fn export_json_docs() {
             prefix: None,
             limit: None,
             path: None,
+            collection: None,
+            graph: None,
         })
         .unwrap();
 
@@ -419,6 +443,8 @@ fn export_is_not_a_write() {
         prefix: None,
         limit: None,
         path: None,
+        collection: None,
+        graph: None,
     };
     assert!(!cmd.is_write());
 }
@@ -440,7 +466,207 @@ fn export_to_nonexistent_directory_fails() {
         prefix: None,
         limit: None,
         path: Some("/nonexistent/dir/file.csv".to_string()),
+        collection: None,
+        graph: None,
     });
 
     assert!(result.is_err());
+}
+
+// =============================================================================
+// Arrow export integration tests (feature-gated)
+// =============================================================================
+
+#[cfg(feature = "arrow")]
+mod arrow_integration {
+    use crate::types::*;
+    use crate::Value;
+    use crate::{Command, Executor, Output, Strata};
+
+    #[test]
+    fn test_kv_export_parquet_roundtrip() {
+        let strata = Strata::cache().unwrap();
+        strata.kv_put("u1", Value::String("Alice".into())).unwrap();
+        strata.kv_put("u2", Value::Int(42)).unwrap();
+        strata.kv_put("u3", Value::Bool(true)).unwrap();
+        let executor = Executor::new(strata.database());
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("kv.parquet");
+        let path_str = path.to_str().unwrap().to_string();
+
+        let result = executor
+            .execute(Command::DbExport {
+                branch: None,
+                space: None,
+                primitive: ExportPrimitive::Kv,
+                format: ExportFormat::Parquet,
+                prefix: None,
+                limit: None,
+                path: Some(path_str.clone()),
+                collection: None,
+                graph: None,
+            })
+            .unwrap();
+
+        match result {
+            Output::Exported(r) => {
+                assert_eq!(r.row_count, 3);
+                assert_eq!(r.format, ExportFormat::Parquet);
+                assert!(r.size_bytes.unwrap() > 0);
+                assert_eq!(r.path.unwrap(), path_str);
+            }
+            other => panic!("expected Exported, got {:?}", other),
+        }
+
+        // Verify the file is valid Parquet
+        let file = std::fs::File::open(&path).unwrap();
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let batches: Vec<_> = reader.map(|r| r.unwrap()).collect();
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 3);
+    }
+
+    #[test]
+    fn test_json_export_csv_file() {
+        let strata = Strata::cache().unwrap();
+        strata
+            .json_set("d1", "$", Value::String(r#"{"name":"Alice"}"#.into()))
+            .unwrap();
+        strata
+            .json_set("d2", "$", Value::String(r#"{"name":"Bob"}"#.into()))
+            .unwrap();
+        let executor = Executor::new(strata.database());
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("docs.csv");
+
+        let result = executor
+            .execute(Command::DbExport {
+                branch: None,
+                space: None,
+                primitive: ExportPrimitive::Json,
+                format: ExportFormat::Csv,
+                prefix: None,
+                limit: None,
+                path: Some(path.to_str().unwrap().to_string()),
+                collection: None,
+                graph: None,
+            })
+            .unwrap();
+
+        match result {
+            Output::Exported(r) => {
+                assert_eq!(r.row_count, 2);
+                assert!(r.size_bytes.unwrap() > 0);
+            }
+            other => panic!("expected Exported, got {:?}", other),
+        }
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("key"));
+        assert!(content.contains("document"));
+    }
+
+    #[test]
+    fn test_event_export_jsonl_file() {
+        let strata = Strata::cache().unwrap();
+        strata
+            .event_append(
+                "click",
+                Value::object({
+                    let mut m = std::collections::HashMap::new();
+                    m.insert("page".to_string(), Value::String("home".into()));
+                    m
+                }),
+            )
+            .unwrap();
+        let executor = Executor::new(strata.database());
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+
+        let result = executor
+            .execute(Command::DbExport {
+                branch: None,
+                space: None,
+                primitive: ExportPrimitive::Events,
+                format: ExportFormat::Jsonl,
+                prefix: None,
+                limit: None,
+                path: Some(path.to_str().unwrap().to_string()),
+                collection: None,
+                graph: None,
+            })
+            .unwrap();
+
+        match result {
+            Output::Exported(r) => {
+                assert_eq!(r.row_count, 1);
+            }
+            other => panic!("expected Exported, got {:?}", other),
+        }
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines.len(), 1);
+        let parsed: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(parsed["event_type"], "click");
+    }
+
+    #[test]
+    fn test_parquet_requires_output_flag() {
+        let strata = Strata::cache().unwrap();
+        let executor = Executor::new(strata.database());
+
+        let result = executor.execute(Command::DbExport {
+            branch: None,
+            space: None,
+            primitive: ExportPrimitive::Kv,
+            format: ExportFormat::Parquet,
+            prefix: None,
+            limit: None,
+            path: None, // no --output
+            collection: None,
+            graph: None,
+        });
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("--output") || err.contains("Parquet"),
+            "error should mention --output or Parquet, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_vector_requires_collection() {
+        let strata = Strata::cache().unwrap();
+        let executor = Executor::new(strata.database());
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vec.parquet");
+
+        let result = executor.execute(Command::DbExport {
+            branch: None,
+            space: None,
+            primitive: ExportPrimitive::Vector,
+            format: ExportFormat::Parquet,
+            prefix: None,
+            limit: None,
+            path: Some(path.to_str().unwrap().to_string()),
+            collection: None, // missing --collection
+            graph: None,
+        });
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("--collection"),
+            "error should mention --collection, got: {err}"
+        );
+    }
 }

--- a/crates/executor/src/tests/serialization.rs
+++ b/crates/executor/src/tests/serialization.rs
@@ -1324,6 +1324,8 @@ fn test_command_db_export() {
         prefix: Some("user:".to_string()),
         limit: Some(100),
         path: Some("/tmp/export.csv".to_string()),
+        collection: None,
+        graph: None,
     });
     test_command_round_trip(Command::DbExport {
         branch: None,
@@ -1333,6 +1335,8 @@ fn test_command_db_export() {
         prefix: None,
         limit: None,
         path: None,
+        collection: None,
+        graph: None,
     });
     test_command_round_trip(Command::DbExport {
         branch: None,
@@ -1342,6 +1346,8 @@ fn test_command_db_export() {
         prefix: None,
         limit: Some(50),
         path: None,
+        collection: None,
+        graph: None,
     });
 }
 

--- a/crates/executor/src/types.rs
+++ b/crates/executor/src/types.rs
@@ -802,6 +802,8 @@ pub enum ExportFormat {
     Json,
     /// Newline-delimited JSON (one object per line).
     Jsonl,
+    /// Apache Parquet (columnar, compressed). Requires `--features arrow`.
+    Parquet,
 }
 
 /// Which primitive to export data from.
@@ -816,6 +818,8 @@ pub enum ExportPrimitive {
     Events,
     /// Graph store.
     Graph,
+    /// Vector store.
+    Vector,
 }
 
 impl ExportPrimitive {
@@ -826,6 +830,7 @@ impl ExportPrimitive {
             ExportPrimitive::Json => "json",
             ExportPrimitive::Events => "events",
             ExportPrimitive::Graph => "graph",
+            ExportPrimitive::Vector => "vector",
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #2130. Final epic of the [v1a Arrow export phase](#2126).

**Type changes (types.rs, command.rs):**
- `ExportFormat::Parquet` variant
- `ExportPrimitive::Vector` variant  
- `collection: Option<String>` and `graph: Option<String>` fields on `DbExport`

**Handler routing (handlers/export.rs):**
- Parquet format always routes to Arrow path
- CSV/JSONL with `--output` routes to Arrow path (file output)
- CSV/JSON/JSONL without `--output` uses existing string renderer (inline, backward compatible)
- Graph exports produce two files: `{stem}_nodes.{ext}` + `{stem}_edges.{ext}`
- Parent directory validation on Arrow path
- Clear error on Parquet without `--features arrow`

**CLI (commands.rs, parse.rs):**
- New top-level `strata export <primitive>` subcommand
- Flags: `--format`, `--output`, `--prefix`, `--collection`, `--graph`, `--limit`

**Tests:** 5 new integration tests (feature-gated), 14 existing tests updated with new fields — 124 affected tests pass.

## Test plan

- [x] `cargo build --features arrow` — zero warnings
- [x] `cargo build` (no arrow feature) — zero warnings
- [x] `cargo test --features arrow -p strata-executor -- tests::export tests::serialization tests::access_mode` — 124/124 pass
- [x] `cargo test -p strata-executor -- tests::export` — 14/14 pass (without arrow)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)