### PR TITLE
Add CLI strata import command and integration tests (v1b Epic 8)

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -107,6 +107,7 @@ pub fn build_cli() -> Command {
         .subcommand(build_up())
         .subcommand(build_down())
         .subcommand(build_db_export())
+        .subcommand(build_db_import())
 }
 
 /// Build a command tree for REPL mode (no global flags).
@@ -140,6 +141,7 @@ pub fn build_repl_cmd() -> Command {
         .subcommand(build_graph())
         .subcommand(build_config())
         .subcommand(build_db_export())
+        .subcommand(build_db_import())
 }
 
 // =========================================================================
@@ -1422,5 +1424,47 @@ fn build_db_export() -> Command {
                 .value_name("N")
                 .value_parser(clap::value_parser!(u64))
                 .help("Maximum rows to export"),
+        )
+}
+
+fn build_db_import() -> Command {
+    Command::new("import")
+        .about("Import data from a file into a primitive")
+        .arg(
+            Arg::new("file")
+                .required(true)
+                .help("Input file path (Parquet, CSV, or JSONL)"),
+        )
+        .arg(
+            Arg::new("into")
+                .long("into")
+                .required(true)
+                .value_name("PRIMITIVE")
+                .help("Target primitive: kv, json, vector"),
+        )
+        .arg(
+            Arg::new("key-column")
+                .long("key-column")
+                .value_name("COL")
+                .help("Column to use as key (auto-detected if omitted)"),
+        )
+        .arg(
+            Arg::new("value-column")
+                .long("value-column")
+                .value_name("COL")
+                .help("Column to use as value/document/embedding"),
+        )
+        .arg(
+            Arg::new("collection")
+                .long("collection")
+                .value_name("NAME")
+                .help("Vector collection name (required for vector)"),
+        )
+        .arg(
+            Arg::new("format")
+                .long("format")
+                .short('f')
+                .value_name("FMT")
+                .help("Override format detection (parquet, csv, jsonl)"),
         )
 }

--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -532,6 +532,13 @@ fn format_raw(output: &Output) -> String {
             serde_json::to_string(&page).unwrap_or_default()
         }
         Output::Exported(r) => r.data.clone().unwrap_or_default(),
+        Output::ArrowImported {
+            rows_imported,
+            rows_skipped,
+            ..
+        } => {
+            format!("{rows_imported}\t{rows_skipped}")
+        }
         Output::ThreeWayDiff(result) => serde_json::to_string(&result).unwrap_or_default(),
         Output::MergeBaseInfo(info) => serde_json::to_string(&info).unwrap_or_default(),
         Output::TagCreated(info) => serde_json::to_string(&info).unwrap_or_default(),
@@ -1380,6 +1387,16 @@ fn format_human(output: &Output) -> String {
                 items.len(),
                 cursor_info,
                 items.join("\n")
+            )
+        }
+        Output::ArrowImported {
+            rows_imported,
+            rows_skipped,
+            target,
+            file_path,
+        } => {
+            format!(
+                "Imported {rows_imported} row(s) into {target} from {file_path} ({rows_skipped} skipped)"
             )
         }
         Output::Exported(r) => match (&r.data, &r.path) {

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -180,6 +180,7 @@ pub fn matches_to_action(matches: &ArgMatches, state: &SessionState) -> Result<C
         "tokenize" => parse_tokenize(sub_matches),
         "detokenize" => parse_detokenize(sub_matches),
         "export" => parse_db_export(sub_matches, state),
+        "import" => parse_db_import(sub_matches, state),
         other => Err(unknown_subcommand(
             "",
             other,
@@ -212,6 +213,7 @@ pub fn matches_to_action(matches: &ArgMatches, state: &SessionState) -> Result<C
                 "tokenize",
                 "detokenize",
                 "export",
+                "import",
             ],
         )),
     }
@@ -1514,6 +1516,22 @@ fn parse_db_export(matches: &ArgMatches, state: &SessionState) -> Result<CliActi
         path: matches.get_one::<String>("output").cloned(),
         collection: matches.get_one::<String>("collection").cloned(),
         graph: matches.get_one::<String>("graph").cloned(),
+    }))
+}
+
+fn parse_db_import(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, String> {
+    let file_path = matches.get_one::<String>("file").unwrap().clone();
+    let target = matches.get_one::<String>("into").unwrap().clone();
+
+    Ok(CliAction::Execute(Command::ArrowImport {
+        branch: branch(state),
+        space: space(state),
+        file_path,
+        target,
+        key_column: matches.get_one::<String>("key-column").cloned(),
+        value_column: matches.get_one::<String>("value-column").cloned(),
+        collection: matches.get_one::<String>("collection").cloned(),
+        format: matches.get_one::<String>("format").cloned(),
     }))
 }
 

--- a/crates/executor/src/arrow/ingest.rs
+++ b/crates/executor/src/arrow/ingest.rs
@@ -143,13 +143,16 @@ pub fn ingest_json(
             };
 
             // Parse JSON string into JsonValue, upsert document.
-            let json_val: serde_json::Value =
-                serde_json::from_str(&doc_str).unwrap_or(serde_json::Value::String(doc_str.clone()));
+            let json_val: serde_json::Value = serde_json::from_str(&doc_str)
+                .unwrap_or(serde_json::Value::String(doc_str.clone()));
             let json_value = JsonValue::from(json_val);
 
             // Try create first; if doc already exists, overwrite at root.
             if convert_result(p.json.create(&branch_id, space, &key, json_value.clone())).is_err() {
-                convert_result(p.json.set(&branch_id, space, &key, &JsonPath::root(), json_value))?;
+                convert_result(
+                    p.json
+                        .set(&branch_id, space, &key, &JsonPath::root(), json_value),
+                )?;
             }
             result.rows_imported += 1;
         }
@@ -228,13 +231,14 @@ pub fn ingest_vector(
                 let cols_ref: Vec<(usize, &str)> =
                     extra_cols.iter().map(|(i, n)| (*i, n.as_str())).collect();
                 let json_str = row_to_json(batch, row, &cols_ref)?;
-                let val: serde_json::Value = serde_json::from_str(&json_str)
-                    .unwrap_or(serde_json::Value::Null);
+                let val: serde_json::Value =
+                    serde_json::from_str(&json_str).unwrap_or(serde_json::Value::Null);
                 Some(val)
             };
 
             convert_vector_result(
-                p.vector.insert(branch_id, space, collection, &key, &embedding, metadata),
+                p.vector
+                    .insert(branch_id, space, collection, &key, &embedding, metadata),
                 branch_id,
             )?;
             result.rows_imported += 1;
@@ -276,9 +280,7 @@ fn extract_embedding(col: &dyn Array, row: usize) -> Option<Vec<f32>> {
 
     let inner = match col.data_type() {
         arrow::datatypes::DataType::FixedSizeList(_, _) => {
-            let list = col
-                .as_any()
-                .downcast_ref::<array::FixedSizeListArray>()?;
+            let list = col.as_any().downcast_ref::<array::FixedSizeListArray>()?;
             list.value(row)
         }
         arrow::datatypes::DataType::List(_) => {
@@ -307,10 +309,8 @@ fn auto_create_collection(
     dimension: usize,
 ) -> Result<()> {
     // Check if collection already exists.
-    let collections = convert_vector_result(
-        p.vector.list_collections(branch_id, space),
-        branch_id,
-    )?;
+    let collections =
+        convert_vector_result(p.vector.list_collections(branch_id, space), branch_id)?;
     if collections.iter().any(|c| c.name == collection) {
         return Ok(());
     }
@@ -322,7 +322,8 @@ fn auto_create_collection(
     };
 
     convert_vector_result(
-        p.vector.create_collection(branch_id, space, collection, config),
+        p.vector
+            .create_collection(branch_id, space, collection, config),
         branch_id,
     )?;
 
@@ -426,7 +427,9 @@ mod tests {
         let result = ingest_kv(&p, branch_id, "default", &[batch], &mapping).unwrap();
         assert_eq!(result.rows_imported, 2);
 
-        let v = convert_result(p.kv.get(&branch_id, "default", "u1")).unwrap().unwrap();
+        let v = convert_result(p.kv.get(&branch_id, "default", "u1"))
+            .unwrap()
+            .unwrap();
         if let Value::String(s) = &v {
             let parsed: serde_json::Value = serde_json::from_str(s).unwrap();
             assert_eq!(parsed["name"], "Alice");
@@ -466,11 +469,9 @@ mod tests {
         let result = ingest_json(&p, branch_id, "default", &[batch], &mapping).unwrap();
         assert_eq!(result.rows_imported, 2);
 
-        let doc = convert_result(
-            p.json.get(&branch_id, "default", "doc1", &JsonPath::root()),
-        )
-        .unwrap()
-        .unwrap();
+        let doc = convert_result(p.json.get(&branch_id, "default", "doc1", &JsonPath::root()))
+            .unwrap()
+            .unwrap();
         let s = doc.to_string();
         assert!(s.contains("Hello"), "got: {s}");
     }
@@ -504,11 +505,9 @@ mod tests {
         let result = ingest_json(&p, branch_id, "default", &[batch], &mapping).unwrap();
         assert_eq!(result.rows_imported, 1);
 
-        let doc = convert_result(
-            p.json.get(&branch_id, "default", "u1", &JsonPath::root()),
-        )
-        .unwrap()
-        .unwrap();
+        let doc = convert_result(p.json.get(&branch_id, "default", "u1", &JsonPath::root()))
+            .unwrap()
+            .unwrap();
         let s = doc.to_string();
         assert!(s.contains("Alice"), "got: {s}");
         assert!(s.contains("alice@example.com"), "got: {s}");
@@ -522,10 +521,7 @@ mod tests {
             Field::new("key", DataType::Utf8, false),
             Field::new(
                 "embedding",
-                DataType::FixedSizeList(
-                    Arc::new(Field::new("item", DataType::Float32, true)),
-                    3,
-                ),
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 3),
                 false,
             ),
         ]));
@@ -579,10 +575,7 @@ mod tests {
             Field::new("key", DataType::Utf8, false),
             Field::new(
                 "embedding",
-                DataType::FixedSizeList(
-                    Arc::new(Field::new("item", DataType::Float32, true)),
-                    4,
-                ),
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 4),
                 false,
             ),
         ]));
@@ -598,10 +591,7 @@ mod tests {
 
         let batch = RecordBatch::try_new(
             schema,
-            vec![
-                Arc::new(StringArray::from(vec!["vec1"])),
-                Arc::new(list),
-            ],
+            vec![Arc::new(StringArray::from(vec!["vec1"])), Arc::new(list)],
         )
         .unwrap();
 
@@ -618,11 +608,9 @@ mod tests {
         assert_eq!(result.rows_imported, 1);
 
         // Verify collection was created with dimension 4.
-        let collections = convert_vector_result(
-            p.vector.list_collections(branch_id, "default"),
-            branch_id,
-        )
-        .unwrap();
+        let collections =
+            convert_vector_result(p.vector.list_collections(branch_id, "default"), branch_id)
+                .unwrap();
         assert!(
             collections.iter().any(|c| c.name == "auto_col"),
             "collection should have been auto-created"

--- a/crates/executor/src/arrow/reader.rs
+++ b/crates/executor/src/arrow/reader.rs
@@ -33,13 +33,11 @@ pub fn read_file(path: &Path, format: FileFormat) -> Result<(Schema, Vec<RecordB
 
 fn read_parquet(path: &Path) -> Result<(Schema, Vec<RecordBatch>)> {
     let file = open_file(path)?;
-    let builder =
-        parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file).map_err(
-            |e| Error::Io {
-                reason: format!("failed to open Parquet file: {e}"),
-                hint: None,
-            },
-        )?;
+    let builder = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
+        .map_err(|e| Error::Io {
+            reason: format!("failed to open Parquet file: {e}"),
+            hint: None,
+        })?;
 
     let schema = builder.schema().as_ref().clone();
     let reader = builder.build().map_err(|e| Error::Io {
@@ -107,10 +105,12 @@ fn read_jsonl(path: &Path) -> Result<(Schema, Vec<RecordBatch>)> {
     let schema = Arc::new(schema);
 
     // Rewind and build reader with inferred schema.
-    buf_reader.seek(std::io::SeekFrom::Start(0)).map_err(|e| Error::Io {
-        reason: format!("failed to seek JSONL file: {e}"),
-        hint: None,
-    })?;
+    buf_reader
+        .seek(std::io::SeekFrom::Start(0))
+        .map_err(|e| Error::Io {
+            reason: format!("failed to seek JSONL file: {e}"),
+            hint: None,
+        })?;
 
     let reader = arrow::json::ReaderBuilder::new(schema.clone())
         .build(buf_reader)
@@ -270,7 +270,10 @@ mod tests {
 
     #[test]
     fn test_read_file_not_found() {
-        let result = read_file(Path::new("/tmp/nonexistent_12345.parquet"), FileFormat::Parquet);
+        let result = read_file(
+            Path::new("/tmp/nonexistent_12345.parquet"),
+            FileFormat::Parquet,
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("file not found"), "got: {err}");

--- a/crates/executor/src/arrow/schema.rs
+++ b/crates/executor/src/arrow/schema.rs
@@ -108,31 +108,19 @@ pub fn arrow_to_value(col: &dyn Array, row: usize) -> Result<Value> {
             Ok(Value::Int(arr.value(row) as i64))
         }
         DataType::Float32 => {
-            let arr = col
-                .as_any()
-                .downcast_ref::<array::Float32Array>()
-                .unwrap();
+            let arr = col.as_any().downcast_ref::<array::Float32Array>().unwrap();
             Ok(Value::Float(arr.value(row) as f64))
         }
         DataType::Float64 => {
-            let arr = col
-                .as_any()
-                .downcast_ref::<array::Float64Array>()
-                .unwrap();
+            let arr = col.as_any().downcast_ref::<array::Float64Array>().unwrap();
             Ok(Value::Float(arr.value(row)))
         }
         DataType::Boolean => {
-            let arr = col
-                .as_any()
-                .downcast_ref::<array::BooleanArray>()
-                .unwrap();
+            let arr = col.as_any().downcast_ref::<array::BooleanArray>().unwrap();
             Ok(Value::Bool(arr.value(row)))
         }
         DataType::Binary => {
-            let arr = col
-                .as_any()
-                .downcast_ref::<array::BinaryArray>()
-                .unwrap();
+            let arr = col.as_any().downcast_ref::<array::BinaryArray>().unwrap();
             Ok(Value::Bytes(arr.value(row).to_vec()))
         }
         DataType::LargeBinary => {
@@ -156,11 +144,7 @@ pub fn arrow_to_value(col: &dyn Array, row: usize) -> Result<Value> {
 }
 
 /// Serialize specified columns of a row as a JSON object string.
-pub fn row_to_json(
-    batch: &RecordBatch,
-    row: usize,
-    columns: &[(usize, &str)],
-) -> Result<String> {
+pub fn row_to_json(batch: &RecordBatch, row: usize, columns: &[(usize, &str)]) -> Result<String> {
     let mut map = serde_json::Map::new();
     for &(idx, name) in columns {
         let col = batch.column(idx);
@@ -296,29 +280,25 @@ fn resolve_vector_embedding(
                 "no embedding column found. Available columns: {}",
                 format_columns(schema)
             ),
-            hint: Some(
-                "Specify --value-column <COL> pointing to a float list column".into(),
-            ),
+            hint: Some("Specify --value-column <COL> pointing to a float list column".into()),
         })?
     };
 
     // Validate that the column is a list of floats.
     let field = schema.field(idx);
     match field.data_type() {
-        DataType::FixedSizeList(inner, _) | DataType::List(inner) => {
-            match inner.data_type() {
-                DataType::Float32 | DataType::Float64 => {}
-                dt => {
-                    return Err(Error::InvalidInput {
-                        reason: format!(
-                            "embedding column '{}' has inner type {dt}, expected Float32 or Float64",
-                            field.name()
-                        ),
-                        hint: None,
-                    });
-                }
+        DataType::FixedSizeList(inner, _) | DataType::List(inner) => match inner.data_type() {
+            DataType::Float32 | DataType::Float64 => {}
+            dt => {
+                return Err(Error::InvalidInput {
+                    reason: format!(
+                        "embedding column '{}' has inner type {dt}, expected Float32 or Float64",
+                        field.name()
+                    ),
+                    hint: None,
+                });
             }
-        }
+        },
         dt => {
             return Err(Error::InvalidInput {
                 reason: format!(
@@ -406,24 +386,15 @@ fn array_value_to_json(col: &dyn Array, row: usize) -> Result<serde_json::Value>
             Ok(serde_json::json!(arr.value(row)))
         }
         DataType::Float32 => {
-            let arr = col
-                .as_any()
-                .downcast_ref::<array::Float32Array>()
-                .unwrap();
+            let arr = col.as_any().downcast_ref::<array::Float32Array>().unwrap();
             Ok(serde_json::json!(arr.value(row)))
         }
         DataType::Float64 => {
-            let arr = col
-                .as_any()
-                .downcast_ref::<array::Float64Array>()
-                .unwrap();
+            let arr = col.as_any().downcast_ref::<array::Float64Array>().unwrap();
             Ok(serde_json::json!(arr.value(row)))
         }
         DataType::Boolean => {
-            let arr = col
-                .as_any()
-                .downcast_ref::<array::BooleanArray>()
-                .unwrap();
+            let arr = col.as_any().downcast_ref::<array::BooleanArray>().unwrap();
             Ok(serde_json::json!(arr.value(row)))
         }
         _ => {
@@ -479,10 +450,7 @@ mod tests {
 
     #[test]
     fn test_resolve_key_column_explicit() {
-        let s = schema(vec![
-            ("user_id", DataType::Utf8),
-            ("value", DataType::Utf8),
-        ]);
+        let s = schema(vec![("user_id", DataType::Utf8), ("value", DataType::Utf8)]);
         let m = resolve_mapping(&s, ImportPrimitive::Kv, Some("user_id"), None).unwrap();
         assert_eq!(m.key_idx, 0);
     }
@@ -493,7 +461,10 @@ mod tests {
         let err = resolve_mapping(&s, ImportPrimitive::Kv, None, None).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("no key column found"), "got: {msg}");
-        assert!(msg.contains("name"), "should list available columns, got: {msg}");
+        assert!(
+            msg.contains("name"),
+            "should list available columns, got: {msg}"
+        );
     }
 
     #[test]
@@ -510,10 +481,7 @@ mod tests {
             Field::new("key", DataType::Utf8, false),
             Field::new(
                 "embedding",
-                DataType::FixedSizeList(
-                    Arc::new(Field::new("item", DataType::Float32, true)),
-                    3,
-                ),
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 3),
                 false,
             ),
         ]);
@@ -523,10 +491,7 @@ mod tests {
 
     #[test]
     fn test_resolve_embedding_wrong_type() {
-        let s = schema(vec![
-            ("key", DataType::Utf8),
-            ("embedding", DataType::Utf8),
-        ]);
+        let s = schema(vec![("key", DataType::Utf8), ("embedding", DataType::Utf8)]);
         let err = resolve_mapping(&s, ImportPrimitive::Vector, None, None).unwrap_err();
         let msg = err.to_string();
         assert!(

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -987,6 +987,33 @@ pub enum Command {
         graph: Option<String>,
     },
 
+    /// Import data from a file (Parquet, CSV, JSONL) into a primitive.
+    /// Returns: `Output::ArrowImported`
+    ArrowImport {
+        /// Target branch (defaults to "default").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Target space (defaults to "default").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        space: Option<String>,
+        /// Path to the input file.
+        file_path: String,
+        /// Target primitive: "kv", "json", "vector".
+        target: String,
+        /// Column to use as key (auto-detected if omitted).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        key_column: Option<String>,
+        /// Column to use as value/document/embedding.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        value_column: Option<String>,
+        /// Vector collection name (required for vector target).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        collection: Option<String>,
+        /// Override file format detection (parquet, csv, jsonl).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        format: Option<String>,
+    },
+
     // ==================== Bundle (3) ====================
     /// Export a branch to a .branchbundle.tar.zst archive.
     /// Returns: `Output::BranchExported`
@@ -1944,6 +1971,7 @@ impl Command {
             Command::Describe { .. } => "Describe",
             Command::TimeRange { .. } => "TimeRange",
             Command::DbExport { .. } => "DbExport",
+            Command::ArrowImport { .. } => "ArrowImport",
             Command::BranchExport { .. } => "BranchExport",
             Command::BranchImport { .. } => "BranchImport",
             Command::BranchBundleValidate { .. } => "BranchBundleValidate",
@@ -2085,8 +2113,9 @@ impl Command {
             | Command::JsonDropIndex { branch, space, .. }
             | Command::JsonListIndexes { branch, space, .. }
             | Command::VectorSample { branch, space, .. }
-            // Export
-            | Command::DbExport { branch, space, .. } => {
+            // Export / Import
+            | Command::DbExport { branch, space, .. }
+            | Command::ArrowImport { branch, space, .. } => {
                 resolve_branch!(branch);
                 resolve_space!(space);
             }
@@ -2257,7 +2286,8 @@ impl Command {
             | Command::JsonDropIndex { branch, .. }
             | Command::JsonListIndexes { branch, .. }
             | Command::VectorSample { branch, .. }
-            | Command::DbExport { branch, .. } => branch.as_ref(),
+            | Command::DbExport { branch, .. }
+            | Command::ArrowImport { branch, .. } => branch.as_ref(),
 
             // Commands with branch only (no space)
             Command::RetentionApply { branch, .. }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -1197,6 +1197,37 @@ impl Executor {
                 )
             }
 
+            Command::ArrowImport {
+                branch,
+                space,
+                file_path,
+                target,
+                key_column,
+                value_column,
+                collection,
+                format,
+            } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                    hint: None,
+                })?;
+                let space = space.ok_or(Error::InvalidInput {
+                    reason: "Space must be specified or resolved to default".into(),
+                    hint: None,
+                })?;
+                crate::handlers::arrow_import::arrow_import(
+                    &self.primitives,
+                    branch,
+                    space,
+                    file_path,
+                    target,
+                    key_column,
+                    value_column,
+                    collection,
+                    format,
+                )
+            }
+
             // Bundle commands
             Command::BranchExport { branch_id, path } => {
                 crate::handlers::branch::branch_export(&self.primitives, branch_id, path)

--- a/crates/executor/src/handlers/arrow_import.rs
+++ b/crates/executor/src/handlers/arrow_import.rs
@@ -1,0 +1,130 @@
+//! Handler for the `ArrowImport` command.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::bridge::Primitives;
+use crate::handlers::require_branch_exists;
+use crate::types::BranchId;
+use crate::{Error, Output, Result};
+
+/// Handle ArrowImport command.
+#[cfg(feature = "arrow")]
+#[allow(clippy::too_many_arguments)]
+pub fn arrow_import(
+    p: &Arc<Primitives>,
+    branch: BranchId,
+    space: String,
+    file_path: String,
+    target: String,
+    key_column: Option<String>,
+    value_column: Option<String>,
+    collection: Option<String>,
+    format: Option<String>,
+) -> Result<Output> {
+    use crate::arrow::{detect_format, read_file, resolve_mapping, ImportPrimitive};
+    use crate::bridge::to_core_branch_id;
+
+    require_branch_exists(p, &branch)?;
+    let branch_id = to_core_branch_id(&branch)?;
+
+    let path = Path::new(&file_path);
+
+    // Validate file exists.
+    if !path.exists() {
+        return Err(Error::InvalidInput {
+            reason: format!("file not found: '{}'", path.display()),
+            hint: None,
+        });
+    }
+
+    // Resolve format.
+    let fmt = match &format {
+        Some(f) => parse_format(f)?,
+        None => detect_format(path)?,
+    };
+
+    // Parse target primitive.
+    let primitive = match target.as_str() {
+        "kv" => ImportPrimitive::Kv,
+        "json" => ImportPrimitive::Json,
+        "vector" => ImportPrimitive::Vector,
+        other => {
+            return Err(Error::InvalidInput {
+                reason: format!("unknown import target '{other}'. Expected: kv, json, vector"),
+                hint: None,
+            });
+        }
+    };
+
+    // Vector requires --collection.
+    if primitive == ImportPrimitive::Vector && collection.is_none() {
+        return Err(Error::InvalidInput {
+            reason: "--collection is required for vector import".into(),
+            hint: None,
+        });
+    }
+
+    // Read file.
+    let (schema, batches) = read_file(path, fmt)?;
+
+    // Resolve column mapping.
+    let mapping = resolve_mapping(
+        &schema,
+        primitive,
+        key_column.as_deref(),
+        value_column.as_deref(),
+    )?;
+
+    // Dispatch to ingest.
+    let result = match primitive {
+        ImportPrimitive::Kv => crate::arrow::ingest_kv(p, branch_id, &space, &batches, &mapping)?,
+        ImportPrimitive::Json => {
+            crate::arrow::ingest_json(p, branch_id, &space, &batches, &mapping)?
+        }
+        ImportPrimitive::Vector => {
+            let coll = collection.unwrap(); // validated above
+            crate::arrow::ingest_vector(p, branch_id, &space, &coll, &batches, &mapping)?
+        }
+    };
+
+    Ok(Output::ArrowImported {
+        rows_imported: result.rows_imported,
+        rows_skipped: result.rows_skipped,
+        target,
+        file_path,
+    })
+}
+
+/// Handle ArrowImport when the arrow feature is not enabled.
+#[cfg(not(feature = "arrow"))]
+#[allow(clippy::too_many_arguments)]
+pub fn arrow_import(
+    _p: &Arc<Primitives>,
+    _branch: BranchId,
+    _space: String,
+    _file_path: String,
+    _target: String,
+    _key_column: Option<String>,
+    _value_column: Option<String>,
+    _collection: Option<String>,
+    _format: Option<String>,
+) -> Result<Output> {
+    Err(Error::Internal {
+        reason: "Import requires the 'arrow' feature".into(),
+        hint: Some("Rebuild with: cargo build --features arrow".into()),
+    })
+}
+
+#[cfg(feature = "arrow")]
+fn parse_format(s: &str) -> Result<crate::arrow::FileFormat> {
+    match s {
+        "parquet" => Ok(crate::arrow::FileFormat::Parquet),
+        "csv" => Ok(crate::arrow::FileFormat::Csv),
+        "jsonl" => Ok(crate::arrow::FileFormat::Jsonl),
+        other => Err(Error::InvalidInput {
+            reason: format!("unknown format '{other}'. Expected: parquet, csv, jsonl"),
+            hint: None,
+        }),
+    }
+}

--- a/crates/executor/src/handlers/mod.rs
+++ b/crates/executor/src/handlers/mod.rs
@@ -13,6 +13,7 @@
 //! | `retention` | 3 | RetentionSubstrate |
 //! | `database` | 4 | Database-level |
 
+pub mod arrow_import;
 pub mod branch;
 pub mod config;
 pub mod configure_model;

--- a/crates/executor/src/output.rs
+++ b/crates/executor/src/output.rs
@@ -406,6 +406,18 @@ pub enum Output {
 
     /// Data export result (CSV/JSON/JSONL).
     Exported(ExportResult),
+
+    /// Arrow import result.
+    ArrowImported {
+        /// Number of rows imported.
+        rows_imported: u64,
+        /// Number of rows skipped.
+        rows_skipped: u64,
+        /// Target primitive.
+        target: String,
+        /// Source file path.
+        file_path: String,
+    },
 }
 
 /// Snapshot of the embedding pipeline status.

--- a/crates/executor/src/tests/arrow_import.rs
+++ b/crates/executor/src/tests/arrow_import.rs
@@ -1,0 +1,471 @@
+//! Integration tests for the ArrowImport command.
+
+#![cfg(feature = "arrow")]
+
+use crate::types::*;
+use crate::Value;
+use crate::{Command, Executor, Output, Strata};
+
+fn import_cmd(
+    file_path: &str,
+    target: &str,
+    key_column: Option<&str>,
+    value_column: Option<&str>,
+    collection: Option<&str>,
+    format: Option<&str>,
+) -> Command {
+    Command::ArrowImport {
+        branch: None,
+        space: None,
+        file_path: file_path.to_string(),
+        target: target.to_string(),
+        key_column: key_column.map(String::from),
+        value_column: value_column.map(String::from),
+        collection: collection.map(String::from),
+        format: format.map(String::from),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// KV imports
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_import_kv_from_parquet() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("kv.parquet");
+
+    // Write a Parquet file with key/value columns.
+    write_kv_parquet(&path, &[("k1", "v1"), ("k2", "v2"), ("k3", "v3")]);
+
+    let strata = Strata::cache().unwrap();
+    let executor = Executor::new(strata.database());
+
+    let result = executor
+        .execute(import_cmd(
+            path.to_str().unwrap(),
+            "kv",
+            Some("key"),
+            Some("value"),
+            None,
+            None,
+        ))
+        .unwrap();
+
+    match result {
+        Output::ArrowImported {
+            rows_imported,
+            rows_skipped,
+            target,
+            ..
+        } => {
+            assert_eq!(rows_imported, 3);
+            assert_eq!(rows_skipped, 0);
+            assert_eq!(target, "kv");
+        }
+        other => panic!("expected ArrowImported, got {:?}", other),
+    }
+
+    // Verify data.
+    assert_eq!(
+        strata.kv_get("k1").unwrap(),
+        Some(Value::String("v1".into()))
+    );
+    assert_eq!(
+        strata.kv_get("k2").unwrap(),
+        Some(Value::String("v2".into()))
+    );
+}
+
+#[test]
+fn test_import_kv_from_csv() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("kv.csv");
+    std::fs::write(&path, "key,value\nk1,v1\nk2,v2\n").unwrap();
+
+    let strata = Strata::cache().unwrap();
+    let executor = Executor::new(strata.database());
+
+    let result = executor
+        .execute(import_cmd(
+            path.to_str().unwrap(),
+            "kv",
+            None,
+            None,
+            None,
+            None,
+        ))
+        .unwrap();
+
+    match result {
+        Output::ArrowImported { rows_imported, .. } => assert_eq!(rows_imported, 2),
+        other => panic!("expected ArrowImported, got {:?}", other),
+    }
+
+    assert_eq!(
+        strata.kv_get("k1").unwrap(),
+        Some(Value::String("v1".into()))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// JSON imports
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_import_json_from_jsonl() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("docs.jsonl");
+    std::fs::write(
+        &path,
+        r#"{"key":"d1","document":"{\"title\":\"Hello\"}"}
+{"key":"d2","document":"{\"title\":\"World\"}"}
+"#,
+    )
+    .unwrap();
+
+    let strata = Strata::cache().unwrap();
+    let executor = Executor::new(strata.database());
+
+    let result = executor
+        .execute(import_cmd(
+            path.to_str().unwrap(),
+            "json",
+            Some("key"),
+            Some("document"),
+            None,
+            None,
+        ))
+        .unwrap();
+
+    match result {
+        Output::ArrowImported { rows_imported, .. } => assert_eq!(rows_imported, 2),
+        other => panic!("expected ArrowImported, got {:?}", other),
+    }
+
+    let doc = strata.json_get("d1", "$").unwrap().unwrap();
+    let s = format!("{doc:?}");
+    assert!(s.contains("Hello"), "doc1 should contain 'Hello', got: {s}");
+}
+
+#[test]
+fn test_import_json_remaining_columns_as_document() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("users.csv");
+    std::fs::write(
+        &path,
+        "id,name,email\nu1,Alice,alice@example.com\nu2,Bob,bob@example.com\n",
+    )
+    .unwrap();
+
+    let strata = Strata::cache().unwrap();
+    let executor = Executor::new(strata.database());
+
+    let result = executor
+        .execute(import_cmd(
+            path.to_str().unwrap(),
+            "json",
+            Some("id"),
+            None,
+            None,
+            None,
+        ))
+        .unwrap();
+
+    match result {
+        Output::ArrowImported { rows_imported, .. } => assert_eq!(rows_imported, 2),
+        other => panic!("expected ArrowImported, got {:?}", other),
+    }
+
+    // Verify: extra columns (name, email) became the JSON document.
+    let doc = strata.json_get("u1", "$").unwrap().unwrap();
+    let s = format!("{doc:?}");
+    assert!(s.contains("Alice"), "got: {s}");
+    assert!(s.contains("alice@example.com"), "got: {s}");
+}
+
+// ---------------------------------------------------------------------------
+// Vector imports
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_import_vector_from_parquet() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("emb.parquet");
+
+    write_vector_parquet(
+        &path,
+        &[("v1", vec![1.0, 0.0, 0.0]), ("v2", vec![0.0, 1.0, 0.0])],
+    );
+
+    let strata = Strata::cache().unwrap();
+    let executor = Executor::new(strata.database());
+
+    let result = executor
+        .execute(import_cmd(
+            path.to_str().unwrap(),
+            "vector",
+            Some("key"),
+            Some("embedding"),
+            Some("test_coll"),
+            None,
+        ))
+        .unwrap();
+
+    match result {
+        Output::ArrowImported { rows_imported, .. } => assert_eq!(rows_imported, 2),
+        other => panic!("expected ArrowImported, got {:?}", other),
+    }
+
+    // Verify embedding data was actually stored.
+    let entry = strata
+        .vector_get("test_coll", "v1")
+        .expect("vector get should succeed");
+    assert!(entry.is_some(), "vector v1 should exist");
+}
+
+#[test]
+fn test_import_vector_auto_creates_collection() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("emb2.parquet");
+
+    write_vector_parquet(&path, &[("v1", vec![1.0, 2.0, 3.0, 4.0])]);
+
+    let strata = Strata::cache().unwrap();
+    let executor = Executor::new(strata.database());
+
+    let result = executor
+        .execute(import_cmd(
+            path.to_str().unwrap(),
+            "vector",
+            Some("key"),
+            Some("embedding"),
+            Some("auto_coll"),
+            None,
+        ))
+        .unwrap();
+
+    match result {
+        Output::ArrowImported { rows_imported, .. } => assert_eq!(rows_imported, 1),
+        other => panic!("expected ArrowImported, got {:?}", other),
+    }
+
+    // Collection was auto-created — verify via export listing.
+    let collections = executor
+        .execute(Command::VectorListCollections {
+            branch: None,
+            space: None,
+        })
+        .unwrap();
+    let s = format!("{collections:?}");
+    assert!(s.contains("auto_coll"), "collection not found in: {s}");
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_roundtrip_kv_parquet() {
+    // Populate KV.
+    let strata = Strata::cache().unwrap();
+    strata.kv_put("rt1", Value::String("hello".into())).unwrap();
+    strata.kv_put("rt2", Value::String("world".into())).unwrap();
+    let executor = Executor::new(strata.database());
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("roundtrip.parquet");
+    let path_str = path.to_str().unwrap().to_string();
+
+    // Export.
+    executor
+        .execute(Command::DbExport {
+            branch: None,
+            space: None,
+            primitive: ExportPrimitive::Kv,
+            format: ExportFormat::Parquet,
+            prefix: None,
+            limit: None,
+            path: Some(path_str.clone()),
+            collection: None,
+            graph: None,
+        })
+        .unwrap();
+
+    // Create a new DB and import.
+    let strata2 = Strata::cache().unwrap();
+    let executor2 = Executor::new(strata2.database());
+
+    let result = executor2
+        .execute(import_cmd(&path_str, "kv", None, None, None, None))
+        .unwrap();
+
+    match result {
+        Output::ArrowImported { rows_imported, .. } => assert_eq!(rows_imported, 2),
+        other => panic!("expected ArrowImported, got {:?}", other),
+    }
+
+    // Compare.
+    assert_eq!(
+        strata2.kv_get("rt1").unwrap(),
+        Some(Value::String("hello".into()))
+    );
+    assert_eq!(
+        strata2.kv_get("rt2").unwrap(),
+        Some(Value::String("world".into()))
+    );
+}
+
+#[test]
+fn test_roundtrip_json_csv() {
+    // Populate JSON.
+    let strata = Strata::cache().unwrap();
+    strata
+        .json_set("rd1", "$", Value::String(r#"{"name":"Alice"}"#.into()))
+        .unwrap();
+    strata
+        .json_set("rd2", "$", Value::String(r#"{"name":"Bob"}"#.into()))
+        .unwrap();
+    let executor = Executor::new(strata.database());
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("roundtrip.csv");
+    let path_str = path.to_str().unwrap().to_string();
+
+    // Export.
+    executor
+        .execute(Command::DbExport {
+            branch: None,
+            space: None,
+            primitive: ExportPrimitive::Json,
+            format: ExportFormat::Csv,
+            prefix: None,
+            limit: None,
+            path: Some(path_str.clone()),
+            collection: None,
+            graph: None,
+        })
+        .unwrap();
+
+    // Create a new DB and import.
+    let strata2 = Strata::cache().unwrap();
+    let executor2 = Executor::new(strata2.database());
+
+    let result = executor2
+        .execute(import_cmd(&path_str, "json", None, None, None, None))
+        .unwrap();
+
+    match result {
+        Output::ArrowImported { rows_imported, .. } => assert_eq!(rows_imported, 2),
+        other => panic!("expected ArrowImported, got {:?}", other),
+    }
+
+    // Verify docs exist with correct content.
+    let doc1 = strata2.json_get("rd1", "$").unwrap().unwrap();
+    let s1 = format!("{doc1:?}");
+    assert!(
+        s1.contains("Alice"),
+        "rd1 should contain 'Alice', got: {s1}"
+    );
+
+    let doc2 = strata2.json_get("rd2", "$").unwrap().unwrap();
+    let s2 = format!("{doc2:?}");
+    assert!(s2.contains("Bob"), "rd2 should contain 'Bob', got: {s2}");
+}
+
+// ---------------------------------------------------------------------------
+// Error paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_import_vector_requires_collection() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("emb.parquet");
+    write_vector_parquet(&path, &[("v1", vec![1.0, 0.0, 0.0])]);
+
+    let strata = Strata::cache().unwrap();
+    let executor = Executor::new(strata.database());
+
+    let err = executor
+        .execute(import_cmd(
+            path.to_str().unwrap(),
+            "vector",
+            Some("key"),
+            Some("embedding"),
+            None, // no --collection
+            None,
+        ))
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("--collection"), "got: {msg}");
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn write_kv_parquet(path: &std::path::Path, entries: &[(&str, &str)]) {
+    use arrow::array::StringArray;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use std::sync::Arc;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("key", DataType::Utf8, false),
+        Field::new("value", DataType::Utf8, false),
+    ]));
+
+    let keys: Vec<&str> = entries.iter().map(|(k, _)| *k).collect();
+    let values: Vec<&str> = entries.iter().map(|(_, v)| *v).collect();
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(keys)),
+            Arc::new(StringArray::from(values)),
+        ],
+    )
+    .unwrap();
+
+    crate::arrow::write_file(path, crate::arrow::FileFormat::Parquet, &[batch]).unwrap();
+}
+
+fn write_vector_parquet(path: &std::path::Path, entries: &[(&str, Vec<f32>)]) {
+    use arrow::array::{FixedSizeListArray, Float32Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use std::sync::Arc;
+
+    let dim = entries[0].1.len() as i32;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("key", DataType::Utf8, false),
+        Field::new(
+            "embedding",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+            false,
+        ),
+    ]));
+
+    let keys: Vec<&str> = entries.iter().map(|(k, _)| *k).collect();
+    let all_values: Vec<f32> = entries
+        .iter()
+        .flat_map(|(_, v)| v.iter().copied())
+        .collect();
+
+    let list = FixedSizeListArray::try_new(
+        Arc::new(Field::new("item", DataType::Float32, true)),
+        dim,
+        Arc::new(Float32Array::from(all_values)),
+        None,
+    )
+    .unwrap();
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(StringArray::from(keys)), Arc::new(list)],
+    )
+    .unwrap();
+
+    crate::arrow::write_file(path, crate::arrow::FileFormat::Parquet, &[batch]).unwrap();
+}

--- a/crates/executor/src/tests/mod.rs
+++ b/crates/executor/src/tests/mod.rs
@@ -1,6 +1,8 @@
 //! Test modules for the executor crate.
 
 pub mod access_mode;
+#[cfg(feature = "arrow")]
+pub mod arrow_import;
 pub mod config;
 pub mod describe;
 pub mod determinism;


### PR DESCRIPTION
## Summary
- Adds `ArrowImport` command variant and `ArrowImported` output variant
- Handler at `handlers/arrow_import.rs` with `#[cfg(feature = "arrow")]` gating
- CLI: `strata import <FILE> --into <PRIMITIVE>` with `--key-column`, `--value-column`, `--collection`, `--format` options
- Human-readable output: `Imported N row(s) into kv from file.parquet (0 skipped)`
- 8 integration tests: 2 KV (Parquet, CSV), 2 JSON (JSONL, CSV-columns), 2 Vector (Parquet, auto-create), 2 round-trip (KV→Parquet→KV, JSON→CSV→JSON)

Closes #2134

## Test plan
- [x] `cargo test --features arrow -p strata-executor tests::arrow_import` — 8/8 pass
- [x] `cargo clippy --features arrow -p strata-executor -p strata-cli` — clean
- [x] `cargo build -p strata-executor` (without arrow feature) — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)