### PR TITLE
Add db.understand(): semantic data profiling via LLM

### DIFF
--- a/docs/design/search/README.md
+++ b/docs/design/search/README.md
@@ -17,6 +17,7 @@
 | [`v0.7-implementation.md`](v0.7-implementation.md) | Implementation plan: AutoResearch (db.experiment, metrics, branch-per-recipe). |
 | [`v0.8-implementation.md`](v0.8-implementation.md) | Implementation plan: multi-model routing (provider:model per operation). |
 | [`v0.9-implementation.md`](v0.9-implementation.md) | Implementation plan: agent hints (describe, recipe schema, actionable hints). |
+| [`epics-v0.0.md`](epics-v0.0.md) | Detailed implementation specs for v0.0 issues #2139–#2146. |
 | [`known-gaps.md`](known-gaps.md) | Known gaps and future optimizations. None are blockers. |
 
 ## Related

--- a/docs/design/search/README.md
+++ b/docs/design/search/README.md
@@ -18,6 +18,7 @@
 | [`v0.8-implementation.md`](v0.8-implementation.md) | Implementation plan: multi-model routing (provider:model per operation). |
 | [`v0.9-implementation.md`](v0.9-implementation.md) | Implementation plan: agent hints (describe, recipe schema, actionable hints). |
 | [`epics-v0.0.md`](epics-v0.0.md) | Detailed implementation specs for v0.0 issues #2139–#2146. |
+| [`elasticsearch-comparison.md`](elasticsearch-comparison.md) | ES knobs vs Strata recipe: what's covered, missing, unnecessary. |
 | [`known-gaps.md`](known-gaps.md) | Known gaps and future optimizations. None are blockers. |
 
 ## Related

--- a/docs/design/search/elasticsearch-comparison.md
+++ b/docs/design/search/elasticsearch-comparison.md
@@ -1,0 +1,136 @@
+# Elasticsearch Comparison: What Strata Covers, What's Missing, What's Unnecessary
+
+Comprehensive mapping of Elasticsearch's search knobs against Strata's recipe schema. Organized by: covered, planned, future, and deliberately excluded.
+
+---
+
+## 1. Covered by Strata's Recipe
+
+These ES features have direct equivalents in `retrieval-substrate.md`.
+
+| ES Feature | ES Default | Strata Recipe Path | Strata Default | Notes |
+|---|---|---|---|---|
+| **BM25 k1** | 1.2 | `retrieve.bm25.k1` | 0.9 | Strata uses Anserini/Pyserini BEIR-optimized defaults |
+| **BM25 b** | 0.75 | `retrieve.bm25.b` | 0.4 | Same |
+| **Per-field weights** | via multi_match boost | `retrieve.bm25.field_weights` | `{"body": 1.0}` | ES uses `^` syntax; Strata uses map |
+| **Stemmer** | via analyzer chain | `retrieve.bm25.stemmer` | `"porter"` | ES has 40+ language stemmers; Strata has porter/snowball/none |
+| **Stopwords** | via analyzer chain | `retrieve.bm25.stopwords` | `"lucene33"` | ES has language-specific lists; Strata has lucene33/smart571/none |
+| **Phrase matching** | match_phrase, slop | `retrieve.bm25.phrase_boost` | 0.0 | ES has full phrase queries; Strata has boost multiplier |
+| **Proximity scoring** | span_near | `retrieve.bm25.proximity_boost` | 0.0 | ES has full span queries; Strata has boost multiplier |
+| **kNN search** | knn query | `retrieve.vector` | k=50, ef_search=100 | ES: num_candidates. Strata: ef_search (same concept). |
+| **kNN + filter** | knn.filter | `filter.predicates` | Post-retrieval | ES supports pre-filter in kNN; Strata does post-filter |
+| **Rescoring** | rescore query | `rerank` section | Disabled | ES: query rescore. Strata: cross-encoder rerank. |
+| **from/size** | from=0, size=10 | `transform.offset`, `transform.limit` | 0, 10 | Direct mapping |
+| **timeout** | No timeout | `control.budget_ms` | 5000 | ES can return partial results; Strata same (budget_exhausted flag) |
+| **_source filtering** | All fields | `control.include_metadata`, `control.include_snippets` | true, true | Different granularity — ES per-field, Strata per-category |
+| **Bool must/should/filter** | N/A | `filter.predicates` + `filter.logic` | "and" | ES: full bool query DSL. Strata: and/or predicate lists. |
+| **Range query** | gt/gte/lt/lte | `filter.predicates` with range ops | N/A | Direct mapping of operators |
+| **Term query** | Exact match | `filter.predicates` with eq | N/A | Same semantics |
+| **Terms query** | Set membership | `filter.predicates` with in | N/A | ES: terms. Strata: in/not_in. |
+| **Exists query** | Field exists | `filter.predicates` with exists | N/A | Direct mapping |
+| **Prefix query** | String prefix | `filter.predicates` with prefix | N/A | Direct mapping |
+| **Score threshold** | min_score in function_score | `filter.score_threshold` | None | Strata: simple threshold. ES: via function_score.min_score. |
+| **Field collapsing** | collapse.field | `transform.deduplicate` | entity_ref | Similar concept — Strata deduplicates by entity ref |
+| **RRF fusion** | rrf retriever | `fusion` section | RRF k=60 | ES 8.14+ has native RRF. Same algorithm. |
+| **Query expansion** | Via synonyms/LLM | `expansion` section | Disabled | ES: static synonym files or ELSER. Strata: runtime LLM expansion. |
+
+---
+
+## 2. Planned (reserved in recipe schema, not yet implemented)
+
+| ES Feature | Strata Recipe Path | Version |
+|---|---|---|
+| **Aggregations** (terms, histogram, stats, etc.) | `transform.aggregate` | Reserved for DataFusion |
+| **Group by** | `transform.group_by` | Reserved for DataFusion |
+| **Sort by field** | `transform.sort` | Reserved for DataFusion |
+| **Scan** (predicate-only retrieval) | `retrieve.scan` | Reserved for DataFusion |
+| **Sparse vector / ELSER** | `retrieve.sparse` | Reserved (no implementation date) |
+
+---
+
+## 3. Future Consideration (not in recipe, could be added)
+
+| ES Feature | What it does | Priority | How Strata would do it |
+|---|---|---|---|
+| **Fuzzy matching** | Levenshtein distance matching | Medium | `retrieve.bm25.fuzzy` with max_edit_distance. Needs inverted index support. (#1885) |
+| **Synonyms** | Map equivalent terms | Medium | `retrieve.bm25.synonyms` — list of synonym pairs, applied at tokenization. |
+| **Highlighting** | Mark matched terms in snippets | Medium | `control.highlight: true` — annotate snippet with match positions. |
+| **search_after cursor** | Efficient deep pagination | Medium | Better than offset for page 100+. Add `transform.search_after`. |
+| **match_phrase with slop** | Phrase with gaps | Low | Already partially covered by phrase_boost + proximity_boost. Full slop would need position index. |
+| **Boosting query** | Positive + negative boost | Low | Could be `filter.negative_boost` or a fusion weight modifier. |
+| **Decay functions** (gauss, exp, linear) | Score by distance from origin | Low | Useful for geo/date. `fusion.decay` or a boost modifier. |
+| **Suggesters** | Autocomplete / "did you mean" | Low | UX feature, not core retrieval. Could be intelligence layer. |
+| **Nested queries** | Query relationships | Low | Strata's graph primitive covers this differently. |
+| **Percolator** | Reverse search (match queries to docs) | Low | Niche. Could be a background alert system. |
+
+---
+
+## 4. Deliberately Excluded (Strata doesn't need these)
+
+| ES Feature | Why Strata doesn't need it |
+|---|---|
+| **Cluster settings** | Strata is embedded, single node. No clusters. |
+| **Shard routing / preference** | No shards. |
+| **Cross-cluster search** | No clusters. |
+| **Scroll API** | Use offset/limit. Strata datasets fit in memory. |
+| **Shard request cache** | MVCC snapshot handles consistency. No cache invalidation problem. |
+| **Node-level query cache** | Embedded — no network latency to optimize with caching. |
+| **Index lifecycle management** | Strata has segments + compaction, not index rotation. |
+| **Ingest pipelines** | Strata has write-time enrichment (intelligence layer). |
+| **Watcher / alerting** | Out of scope for an embedded DB. |
+| **Painless scripting** | No custom scoring scripts. BM25 + fusion weights cover it. |
+| **DFR/IB/LM similarity models** | BM25 is sufficient. Alternative models add complexity with marginal gain. AutoResearch can tune BM25 parameters instead. |
+| **Geo queries** | No geo data type in Strata. |
+| **Join queries (parent/child)** | Strata's graph primitive handles relationships natively. |
+| **Index templates** | Strata uses recipes, not index templates. |
+| **Mapping management** | Strata's primitives are schemaless. |
+| **Pipeline aggregations** | Query engine territory. DataFusion would handle this. |
+| **Significant terms/text** | Niche aggregation. DataFusion territory. |
+
+---
+
+## 5. Where Strata Has More Than Elasticsearch
+
+| Strata Feature | ES Equivalent |
+|---|---|
+| **Graph retrieval (PPR)** | None. ES has no graph traversal in search. |
+| **Temporal search (as_of, diff)** | None. ES has no MVCC time-travel. |
+| **Per-hit version history** | None. ES doesn't track document versions for search. |
+| **AutoResearch (db.experiment)** | None. ES has no automated recipe optimization. |
+| **Multi-model routing** | None. ES ELSER is one model, hardcoded. |
+| **RAG built-in** | None. ES returns hits, no answer generation. |
+| **Branch-scoped recipes** | None. ES index settings are global. |
+| **Recipe three-level merge** | Partial. ES has index templates with priority, but not per-query overrides merged with stored defaults. |
+| **In-process LLM** | None. ES ELSER runs in the cluster but isn't user-configurable per query. |
+
+---
+
+## 6. Strata Recipe Defaults vs. Elasticsearch Defaults
+
+| Parameter | Strata | Elasticsearch | Why different |
+|---|---|---|---|
+| BM25 k1 | **0.9** | 1.2 | Strata uses Anserini/Pyserini BEIR-optimized values |
+| BM25 b | **0.4** | 0.75 | Same — BEIR research shows lower b is better for mixed-length corpora |
+| RRF k | **60** | 60 | Same |
+| Result limit | **10** | 10 | Same |
+| Budget/timeout | **5000ms** | None | ES has no default timeout; Strata enforces by default |
+| Stemmer | **Porter** | Language-specific | ES auto-detects; Strata defaults to English Porter |
+| Stopwords | **Lucene 33** | Language-specific | Same philosophy, different set |
+| Vector ef_search | **100** | num_candidates auto | Strata exposes directly; ES abstracts behind num_candidates |
+
+---
+
+## 7. Key Architectural Differences
+
+| Concern | Elasticsearch | Strata |
+|---|---|---|
+| **Configuration model** | Per-index settings + per-query DSL | Recipe (per-branch, three-level merge, experimentable) |
+| **Analysis chain** | Index-time + search-time analyzers, configurable per field | Recipe-level stemmer/stopwords applied uniformly |
+| **Scoring** | Pluggable similarity (BM25, DFR, IB, LM, scripted) | BM25 only. Tune k1/b via AutoResearch instead of switching models. |
+| **Aggregations** | Built-in, 30+ types | Deferred to DataFusion. Search ≠ query engine. |
+| **Vector search** | kNN query with pre-filter + post-filter | HNSW with post-filter (adaptive over-fetch) |
+| **Reranking** | Query rescore (re-run a second query on top-N) | Cross-encoder / LLM reranking via intelligence layer |
+| **Expansion** | Static synonyms or ELSER sparse | Runtime LLM expansion (lex/vec/hyde) with grammar constraints |
+| **Experimentation** | Manual A/B testing of index settings | `db.experiment()` — branch-parallel recipe comparison |
+| **Graph** | None native (requires external graph DB) | Built-in PPR, typed traversal, ontology-guided |
+| **Temporal** | None (point-in-time API for scroll consistency only) | Full MVCC time-travel, diff, per-hit version history |

--- a/docs/design/search/epics-v0.0.md
+++ b/docs/design/search/epics-v0.0.md
@@ -1,0 +1,622 @@
+# v0.0 Epics: Search Prerequisites
+
+Eight work items that must land before v0.1. Detailed implementation specs for issues #2139–#2146.
+
+**Dependency graph:**
+```
+Start immediately (parallel):
+  #2139 — _system_ space
+  #2140 — Recipe types
+  #2143 — Event + JSON Searchable
+  #2144 — Vector Searchable
+  #2146 — Inference validation
+
+After #2139 + #2140:
+  #2141 — Default recipe + API
+
+After #2141:
+  #2142 — Config migration
+
+After #2139:
+  #2145 — Shadow collection migration
+```
+
+---
+
+## Epic 1: `_system_` Space (#2139)
+
+### What
+
+Hidden, internal-only space on every branch. Follows the `_graph_` pattern in `crates/graph/src/keys.rs:92-109`.
+
+### Why existing infrastructure makes this easy
+
+- Space validation in `crates/core/src/types.rs:489` already rejects `_system_*` names from users
+- Space isolation is provided by key encoding (different space = different bytes = invisible to other-space scans)
+- `_graph_` space shows the exact pattern: cached namespace via DashMap, fixed name, Key constructors
+- Internal writes bypass the executor (go through `Database` directly) — no API changes needed
+
+### Implementation
+
+**New file: `crates/engine/src/system_space.rs` (~40 lines)**
+
+```rust
+pub const SYSTEM_SPACE: &str = "_system_";
+
+static NS_CACHE: Lazy<DashMap<BranchId, Arc<Namespace>>> = Lazy::new(DashMap::new);
+
+pub fn system_namespace(branch_id: BranchId) -> Arc<Namespace> {
+    NS_CACHE
+        .entry(branch_id)
+        .or_insert_with(|| Arc::new(Namespace::for_branch_space(branch_id, SYSTEM_SPACE)))
+        .clone()
+}
+
+pub fn system_kv_key(branch_id: BranchId, key: &str) -> Key {
+    Key::new_kv(system_namespace(branch_id), key)
+}
+
+pub fn invalidate_cache(branch_id: &BranchId) { NS_CACHE.remove(branch_id); }
+```
+
+**Changes to existing files (~10 lines total):**
+
+| File | Change |
+|---|---|
+| `engine/src/lib.rs` | `pub mod system_space;` |
+| `engine/src/primitives/space.rs:62` | Add `space == SYSTEM_SPACE` to `exists()` short-circuit |
+| `engine/src/primitives/space.rs:81` | Add `.filter(\|s\| s != SYSTEM_SPACE)` to `list()` |
+| `executor/src/handlers/space.rs:36` | Add `space == SYSTEM_SPACE` to deletion rejection |
+| `engine/src/branch_ops.rs` | Call `system_space::invalidate_cache()` on branch delete |
+
+### Tests
+
+- Internal write to `_system_` → succeeds
+- User write to `_system_` → rejected (already works)
+- `SpaceIndex.list()` → doesn't include `_system_`
+- `SpaceIndex.exists("_system_")` → true
+- Fork branch → `_system_` data inherited via COW
+- Override on fork → parent unaffected
+- Delete `_system_` → rejected
+- `db.kv.list("default", None)` → doesn't show `_system_` entries (automatic from key encoding)
+
+### Effort: ~50 lines
+
+---
+
+## Epic 2: Recipe Types and Three-Level Merge (#2140)
+
+### What
+
+Rust types for the recipe schema. All fields `Option<T>`. Deep merge function.
+
+### Implementation
+
+**New file: `crates/engine/src/search/recipe.rs` (~300 lines)**
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Recipe {
+    pub version: Option<u32>,
+    pub retrieve: Option<RetrieveConfig>,
+    pub expansion: Option<ExpansionConfig>,
+    pub filter: Option<FilterConfig>,
+    pub fusion: Option<FusionConfig>,
+    pub rerank: Option<RerankConfig>,
+    pub transform: Option<TransformConfig>,
+    pub prompt: Option<String>,
+    pub rag_context_hits: Option<usize>,
+    pub rag_max_tokens: Option<usize>,
+    pub models: Option<ModelsConfig>,
+    pub version_output: Option<VersionOutputConfig>,
+    pub control: Option<ControlConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RetrieveConfig {
+    pub bm25: Option<BM25Config>,
+    pub vector: Option<VectorConfig>,
+    pub graph: Option<GraphConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BM25Config {
+    pub sources: Option<Vec<String>>,
+    pub spaces: Option<Vec<String>>,
+    pub k: Option<usize>,
+    pub k1: Option<f32>,
+    pub b: Option<f32>,
+    pub field_weights: Option<HashMap<String, f32>>,
+    pub stemmer: Option<String>,
+    pub stopwords: Option<String>,
+    pub phrase_boost: Option<f32>,
+    pub proximity_boost: Option<f32>,
+}
+
+// VectorConfig, GraphConfig, ExpansionConfig, FusionConfig, RerankConfig,
+// TransformConfig, ModelsConfig, ControlConfig, VersionOutputConfig, FilterConfig
+// — all follow the same pattern: every field Option<T>
+```
+
+**Merge function:**
+
+```rust
+impl Recipe {
+    pub fn merge(base: &Recipe, overlay: &Recipe) -> Recipe {
+        Recipe {
+            version: overlay.version.or(base.version),
+            retrieve: merge_option(&base.retrieve, &overlay.retrieve, RetrieveConfig::merge),
+            expansion: overlay.expansion.as_ref().or(base.expansion.as_ref()).cloned(),
+            // ... same pattern for all fields ...
+        }
+    }
+
+    pub fn resolve(builtin: &Recipe, branch: &Recipe, per_call: Option<&Recipe>) -> Recipe {
+        let merged = Recipe::merge(builtin, branch);
+        match per_call {
+            Some(o) => Recipe::merge(&merged, o),
+            None => merged,
+        }
+    }
+}
+```
+
+**Nested merge:** `RetrieveConfig::merge`, `BM25Config::merge` etc. — same pattern recursively. Field-by-field: overlay wins if `Some`, base fills if `None`.
+
+**Built-in defaults (constant):**
+```rust
+pub fn builtin_defaults() -> Recipe {
+    Recipe {
+        version: Some(1),
+        retrieve: Some(RetrieveConfig {
+            bm25: Some(BM25Config {
+                k: Some(50), k1: Some(0.9), b: Some(0.4),
+                stemmer: Some("porter".into()), stopwords: Some("lucene33".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        fusion: Some(FusionConfig { method: Some("rrf".into()), k: Some(60), ..Default::default() }),
+        transform: Some(TransformConfig { limit: Some(10), ..Default::default() }),
+        control: Some(ControlConfig { budget_ms: Some(5000), ..Default::default() }),
+        ..Default::default()
+    }
+}
+```
+
+### Tests
+
+- Deserialize `{}` → all None
+- Deserialize `{"retrieve": {"bm25": {}}}` → BM25 Some with all fields None
+- Merge: empty overlay → base unchanged
+- Merge: single nested field override → only that field changes
+- Resolve: three levels stacked correctly
+- `builtin_defaults()` has k1=0.9, b=0.4, limit=10
+- Round-trip: serialize → deserialize → identical
+
+### Effort: ~300 lines
+
+---
+
+## Epic 3: Default Recipe Storage + API (#2141)
+
+**Depends on:** #2139 (_system_ space), #2140 (Recipe types)
+
+### What
+
+Store/retrieve recipes in `_system_` space. Auto-create default on database open.
+
+### Implementation
+
+**Engine API — add to `Database` impl (~80 lines):**
+
+```rust
+impl Database {
+    pub fn set_recipe(&self, branch_id: &BranchId, name: &str, recipe: &Recipe) -> StrataResult<()> {
+        let key = system_kv_key(*branch_id, &format!("recipe:{}", name));
+        let json = serde_json::to_string(recipe)?;
+        self.put_with_version_mode(key, Value::String(json), VersionMode::Auto)?;
+        Ok(())
+    }
+
+    pub fn get_recipe(&self, branch_id: &BranchId, name: &str) -> StrataResult<Option<Recipe>> {
+        let key = system_kv_key(*branch_id, &format!("recipe:{}", name));
+        match self.get_versioned(&key, None)? {
+            Some(v) => Ok(Some(serde_json::from_str(v.value().as_str()?)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn get_default_recipe(&self, branch_id: &BranchId) -> StrataResult<Recipe> {
+        match self.get_recipe(branch_id, "default")? {
+            Some(r) => Ok(r),
+            None => {
+                let defaults = builtin_defaults();
+                self.set_recipe(branch_id, "default", &defaults)?;
+                Ok(defaults)
+            }
+        }
+    }
+
+    pub fn list_recipes(&self, branch_id: &BranchId) -> StrataResult<Vec<String>> {
+        let prefix = system_kv_key(*branch_id, "recipe:");
+        let results = self.scan_prefix(&prefix)?;
+        Ok(results.into_iter()
+            .filter_map(|(k, _)| k.user_key_string().map(|s| s.trim_start_matches("recipe:").to_string()))
+            .collect())
+    }
+}
+```
+
+**Executor commands (~100 lines):**
+
+| Command | Handler |
+|---|---|
+| `RECIPE SET <json>` | `set_recipe(branch, "default", parse(json))` |
+| `RECIPE SET <name> <json>` | `set_recipe(branch, name, parse(json))` |
+| `RECIPE GET` | `get_default_recipe(branch)` → JSON output |
+| `RECIPE GET <name>` | `get_recipe(branch, name)` → JSON output |
+| `RECIPE LIST` | `list_recipes(branch)` → list output |
+
+### Tests
+
+- Fresh database → `get_default_recipe()` creates and returns builtin defaults
+- `set_recipe("test", recipe)` → `get_recipe("test")` round-trip
+- `list_recipes()` returns all stored names
+- Fork branch → recipe inherited from parent
+- Override on fork → parent's recipe unchanged
+- `RECIPE SET '{"retrieve":{"bm25":{"k1":1.5}}}'` → stored, retrievable
+
+### Effort: ~180 lines
+
+---
+
+## Epic 4: Migrate Config from strata.toml (#2142)
+
+**Depends on:** #2141 (Recipe storage)
+
+### What
+
+Move `bm25_k1`, `bm25_b`, `embed_model` from `StrataConfig` to the default recipe. One-time auto-migration.
+
+### Implementation
+
+**File: `crates/engine/src/database/mod.rs` — in `Database::open()` (~60 lines)**
+
+```rust
+fn migrate_search_config_to_recipe(&self, branch_id: &BranchId, config: &StrataConfig) -> StrataResult<()> {
+    // Skip if recipe already exists (already migrated)
+    if self.get_recipe(branch_id, "default")?.is_some() {
+        return Ok(());
+    }
+
+    // Build recipe from TOML values
+    let mut recipe = builtin_defaults();
+    if let Some(k1) = config.bm25_k1 {
+        recipe.retrieve.as_mut().unwrap().bm25.as_mut().unwrap().k1 = Some(k1);
+    }
+    if let Some(b) = config.bm25_b {
+        recipe.retrieve.as_mut().unwrap().bm25.as_mut().unwrap().b = Some(b);
+    }
+    if config.embed_model != "miniLM" {
+        recipe.models = Some(ModelsConfig {
+            embed: Some(format!("local:{}", config.embed_model)),
+            ..Default::default()
+        });
+    }
+
+    self.set_recipe(branch_id, "default", &recipe)?;
+    info!(target: "strata::config", "Migrated search config from strata.toml to recipe");
+    Ok(())
+}
+```
+
+Called during `Database::open()` after reading config, before any search operations.
+
+**Cleanup:** Mark `bm25_k1`, `bm25_b` as deprecated in `default_toml()` template with comments pointing to recipe.
+
+### Tests
+
+- Database with `strata.toml` k1=1.2, b=0.7 → opens, recipe has k1=1.2, b=0.7
+- Database without custom settings → opens with builtin defaults
+- Second open → migration skipped (recipe already exists)
+- After migration, CONFIG SET bm25_k1 has no effect on search (recipe wins)
+
+### Effort: ~100 lines
+
+---
+
+## Epic 5: Wire Event + JSON Searchable to InvertedIndex (#2143)
+
+### What
+
+Two stubs that return empty. Fix both to query the InvertedIndex — same pattern as `kv.rs:538-608`.
+
+### Event implementation
+
+**File: `crates/engine/src/primitives/event.rs:993-1005`**
+
+Replace the stub with:
+
+```rust
+fn search(&self, req: &SearchRequest) -> StrataResult<SearchResponse> {
+    let start = std::time::Instant::now();
+    let index = match self.db.extension::<InvertedIndex>() {
+        Some(idx) => idx,
+        None => return Ok(SearchResponse::empty()),
+    };
+
+    let query_terms = tokenize(&req.query);
+    if query_terms.is_empty() {
+        return Ok(SearchResponse::empty());
+    }
+
+    let k1 = self.db.config().bm25_k1.unwrap_or(0.9);  // TODO: read from recipe after v0.1
+    let b = self.db.config().bm25_b.unwrap_or(0.4);
+    let scored = index.score_top_k(&query_terms, &req.branch_id, req.k, k1, b);
+
+    let hits: Vec<SearchHit> = scored.into_iter()
+        .filter_map(|sd| {
+            let entity_ref = index.resolve_doc_id(sd.doc_id)?;
+            match &entity_ref {
+                EntityRef::Event { .. } => Some(SearchHit {
+                    doc_ref: entity_ref,
+                    score: sd.score,
+                    rank: 0,
+                    snippet: None,  // TODO: fetch event payload for snippet
+                }),
+                _ => None,  // Filter to Event refs only
+            }
+        })
+        .collect();
+
+    Ok(SearchResponse::new(hits, false, SearchStats::new(
+        start.elapsed().as_micros() as u64,
+        hits.len(),
+    )))
+}
+```
+
+**Prerequisite verified:** Event already indexes on write at `event.rs:~371`: `index.index_document(&entity_ref, &text, None)`. The data is in the index. Just need to query it.
+
+### JSON implementation
+
+**File: `crates/engine/src/primitives/json/mod.rs:1352-1450`**
+
+Current code returns empty when no `field_filter` or `sort_by`. Add BM25 fallback:
+
+```rust
+fn search(&self, req: &SearchRequest) -> StrataResult<SearchResponse> {
+    // Existing: handle field_filter and sort_by if present
+    if req.field_filter.is_some() || req.sort_by.is_some() {
+        return self.search_by_index(req);  // existing code path
+    }
+
+    // NEW: BM25 keyword search via InvertedIndex
+    let index = match self.db.extension::<InvertedIndex>() {
+        Some(idx) => idx,
+        None => return Ok(SearchResponse::empty()),
+    };
+
+    // Same pattern as KV and Event...
+    let query_terms = tokenize(&req.query);
+    // ... score_top_k, filter to EntityRef::Json, resolve snippets ...
+}
+```
+
+**Prerequisite check needed:** Verify JSON documents are indexed in the InvertedIndex during `set()`. If the handler calls `index.index_document()` on JSON writes — good. If not, add it in `crates/executor/src/handlers/json.rs` alongside the auto-embed hook call.
+
+### Tests
+
+- Insert 3 JSON docs with text → `search("keyword")` → returns matching docs ranked by BM25
+- Insert 5 events → `search("error")` → returns matching events
+- Mixed: insert KV + JSON + events → search returns hits from all three primitives
+- Event with event_type "error" → event_type text contributes to BM25 score
+- All existing search tests still pass
+
+### Effort: ~100 lines (30 event + 50 JSON + 20 write-path if needed)
+
+---
+
+## Epic 6: Wire VectorStore Searchable (#2144)
+
+### What
+
+`VectorStore::search()` returns empty for all modes. Wire it to `search_by_embedding()`.
+
+### Implementation
+
+**File: `crates/vector/src/store/mod.rs:680-733`**
+
+Replace the stub:
+
+```rust
+fn search(&self, req: &SearchRequest) -> StrataResult<SearchResponse> {
+    let start = std::time::Instant::now();
+
+    match req.mode {
+        SearchMode::Keyword => {
+            // Vector doesn't do keyword search — correct to return empty
+            Ok(SearchResponse::empty())
+        }
+        SearchMode::Vector | SearchMode::Hybrid => {
+            let embedding = match &req.precomputed_embedding {
+                Some(e) => e,
+                None => return Ok(SearchResponse::empty()), // No embedding → can't search
+            };
+
+            // Search all _system_embed_* collections on this branch
+            let collections = self.list_collections(req.branch_id, &req.space)?;
+            let shadow_collections: Vec<_> = collections.iter()
+                .filter(|c| c.starts_with("_system_embed_"))
+                .collect();
+
+            let mut all_hits = Vec::new();
+            for collection in shadow_collections {
+                let matches = self.search(
+                    req.branch_id, &req.space, collection, embedding, req.k, None
+                )?;
+
+                for m in matches {
+                    all_hits.push(SearchHit {
+                        doc_ref: self.resolve_source_ref(req.branch_id, &req.space, collection, &m.key)
+                            .unwrap_or(EntityRef::Kv {
+                                branch_id: req.branch_id,
+                                key: m.key.clone(),
+                            }),
+                        score: m.score,
+                        rank: 0,
+                        snippet: None,
+                    });
+                }
+            }
+
+            // Sort by score desc, truncate to k
+            all_hits.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(Ordering::Equal));
+            all_hits.truncate(req.k);
+
+            Ok(SearchResponse::new(all_hits, false, SearchStats::new(
+                start.elapsed().as_micros() as u64,
+                all_hits.len(),
+            )))
+        }
+    }
+}
+```
+
+**Source ref resolution:** Shadow collections store `InlineMeta` with `source_ref: Option<EntityRef>`. Use this to map vector hits back to their source KV/JSON/Event documents. If no source_ref, fall back to the vector key as a KV EntityRef.
+
+### Tests
+
+- Insert data with auto_embed → search with embedding → hits returned via Searchable trait
+- Keyword mode → empty (correct)
+- No embedding provided → empty (correct)
+- Multiple shadow collections → results from all, merged and ranked
+- Source refs resolve to original KV/JSON entity refs
+
+### Effort: ~80 lines
+
+---
+
+## Epic 7: Move Shadow Collections to `_system_` Space (#2145)
+
+**Depends on:** #2139 (_system_ space)
+
+### What
+
+Move `_system_embed_*` collections from wherever they currently live to the `_system_` space on the user's branch. Currently they're in the "default" space.
+
+### What changes
+
+**Auto-embed write path** (`crates/executor/src/handlers/embed_hook.rs`):
+
+Currently, shadow collections are created and written in the "default" space:
+```rust
+p.vector.create_system_collection(branch_id, SHADOW_KV, config)  // default space
+```
+
+Change to use `_system_` space:
+```rust
+p.vector.create_system_collection_in_space(branch_id, SYSTEM_SPACE, SHADOW_KV, config)
+```
+
+Or: use the `system_namespace()` helper to construct collection keys in `_system_` space.
+
+**Vector search read path** (`crates/vector/src/store/search.rs`):
+
+Currently discovers collections in "default" space. Must also look in `_system_` space. Or: the substrate (v0.1) explicitly passes the collection list from the recipe, which includes `_system_` space collections.
+
+**Migration on database open:**
+
+1. Check if shadow collections exist in "default" space
+2. If yes, copy data to `_system_` space equivalents
+3. Delete originals from "default" space (or leave as tombstones)
+
+This is the highest-risk change — embeddings are on the critical path for hybrid search.
+
+### Tests
+
+- Existing database → migration copies embeddings to `_system_` space
+- Hybrid search works after migration (BEIR nDCG@10 unchanged)
+- New writes → embeddings go to `_system_` space
+- Fork branch after migration → embeddings available on fork via COW
+- Auto-embed on fork → new embeddings on fork's `_system_` space, parent unaffected
+
+### Effort: ~300 lines. High risk. Test thoroughly.
+
+---
+
+## Epic 8: Validate Inference Pipeline (#2146)
+
+### What
+
+Test that strata-inference works across all providers before building intelligence layer features.
+
+### Current API surface
+
+**Generate** (`crates/inference/src/generate.rs:237`):
+```rust
+pub fn generate(&mut self, request: &GenerateRequest) -> Result<GenerateResponse, InferenceError>
+```
+- `GenerateRequest`: prompt, max_tokens, temperature, top_k, top_p, seed, stop_sequences
+- `GenerateResponse`: text, stop_reason, prompt_tokens, completion_tokens
+
+**Embed** (`crates/inference/src/embed.rs:107`):
+```rust
+pub fn embed(&self, text: &str) -> Result<Vec<f32>, InferenceError>
+pub fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, InferenceError>
+```
+
+**Providers** (`crates/inference/src/lib.rs`): Local (llama.cpp), Anthropic, OpenAI, Google
+
+### Gaps found
+
+1. **Grammar-constrained generation** — NOT in current API. `GenerateRequest` has no grammar field. Must be added before v0.2 (expansion needs lex/vec/hyde grammar).
+2. **Ranking/cross-encoder API** — NOT in current API. Must be added before v0.2 (reranking).
+3. **Provider:model_name parsing** — NOT in current API. Must be added before v0.8 (multi-model routing). Currently models are loaded by name, not by `provider:model` spec.
+
+### Test plan
+
+**Deliverable:** Benchmark script (Rust or Python) that:
+
+1. **Local models:**
+   - Load MiniLM → embed 100 texts → report throughput (target: >100 embed/s)
+   - Load Qwen3 1.7B → generate 10 responses → report tok/s (target: >30) and TTFT (target: <500ms)
+   - Load Qwen3-Reranker → verify ranking API exists or identify gap
+   - Test context window: 2048 and 4096 tokens
+
+2. **Cloud providers (with API keys):**
+   - Anthropic Claude Sonnet → generate 5 responses → report latency
+   - OpenAI GPT-4o-mini → generate 5 responses → report latency
+   - Google Gemini Flash → generate 5 responses → report latency
+
+3. **Error handling:**
+   - Invalid model name → graceful error
+   - Timeout → graceful error
+   - Invalid API key → graceful error
+
+4. **Report:** JSON output with all metrics for comparison.
+
+### Gaps to file as separate issues
+
+- Grammar-constrained generation support in strata-inference
+- Ranking/cross-encoder API in strata-inference
+- Provider:model_name routing in strata-inference
+
+### Effort: ~1 day (test harness + model download + API key setup)
+
+---
+
+## Summary
+
+| Epic | Issue | Depends on | Effort | Risk |
+|---|---|---|---|---|
+| `_system_` space | #2139 | Nothing | ~50 lines | Low |
+| Recipe types | #2140 | Nothing | ~300 lines | Low |
+| Recipe storage + API | #2141 | #2139, #2140 | ~180 lines | Low |
+| Config migration | #2142 | #2141 | ~100 lines | Low |
+| Event + JSON Searchable | #2143 | Nothing | ~100 lines | Low |
+| Vector Searchable | #2144 | Nothing | ~80 lines | Medium |
+| Shadow collection migration | #2145 | #2139 | ~300 lines | **High** |
+| Inference validation | #2146 | Nothing | ~1 day | Low |
+| **Total** | | | **~1,110 lines + 1 day** | |

--- a/docs/design/search/v0.9-implementation.md
+++ b/docs/design/search/v0.9-implementation.md
@@ -25,7 +25,7 @@ This knowledge comes from documentation, system prompts, or trial and error. An 
 
 **In:**
 - `db.describe()` — introspect the database: live stats + stored semantic profile
-- `db.profile()` — LLM samples the data, writes a semantic understanding of what the data is
+- `db.understand()` — LLM samples the data, writes a semantic understanding of what the data is
 - Recipe introspection — what parameters exist, what are valid values, what's currently set
 - Actionable hints in search responses — "no index for this predicate", "expansion skipped (strong signal)", "embedding coverage is 40%"
 - Suggested next actions — "try adding a vector collection", "this query might benefit from expansion"
@@ -124,12 +124,12 @@ The agent reads this once and immediately knows:
 
 ---
 
-## 4. `db.profile()`
+## 4. `db.understand()`
 
 Generates the semantic profile. Run once when data is loaded, re-run when the data changes significantly.
 
 ```python
-db.profile()
+db.understand()
 ```
 
 ### How it works
@@ -161,18 +161,18 @@ Return JSON.
 
 - Sample 100 documents: ~1ms (100 random reads)
 - LLM call: ~2s local (Qwen3 1.7B with ~50K token context), ~$0.15 cloud (Claude Haiku)
-- Run once. Re-run on demand (`db.profile(force=True)`).
+- Run once. Re-run on demand (`db.understand(force=True)`).
 
 ### When to re-run
 
-The profile doesn't auto-refresh. It's stable — the semantic understanding of a medical corpus doesn't change when you add 100 more drug monographs. The user runs `db.profile()` when:
+The profile doesn't auto-refresh. It's stable — the semantic understanding of a medical corpus doesn't change when you add 100 more drug monographs. The user runs `db.understand()` when:
 - They first load a dataset
 - They load a fundamentally different dataset into the same database
 - They want to regenerate with a better model
 
 ### Recipe suggestion from profile
 
-Future: `db.profile()` could also suggest an initial recipe based on its understanding. "This corpus has high vocabulary mismatch — enable expansion. The 'phase' field has low cardinality — add a filter index." But that's a v1.0+ feature, not v0.9.
+Future: `db.understand()` could also suggest an initial recipe based on its understanding. "This corpus has high vocabulary mismatch — enable expansion. The 'phase' field has low cardinality — add a filter index." But that's a v1.0+ feature, not v0.9.
 
 ### Implementation
 
@@ -448,7 +448,7 @@ v0.9 — Agent Hints               ~720 lines
 
 After v0.9, the search substrate is not just feature-complete — it's agent-complete. An AI agent can:
 1. `db.describe()` — discover what's in the database, what's searchable, and what the data means
-2. `db.profile()` — ask the database to build a semantic understanding of its own data
+2. `db.understand()` — ask the database to build a semantic understanding of its own data
 3. `db.recipe_schema()` — learn what parameters exist and their ranges
 4. `db.search()` — search with recipe, get results + actionable hints
 5. `db.experiment()` — compare recipes, find the best one

--- a/docs/design/search/v0.9-implementation.md
+++ b/docs/design/search/v0.9-implementation.md
@@ -24,7 +24,8 @@ This knowledge comes from documentation, system prompts, or trial and error. An 
 ## 2. Scope
 
 **In:**
-- `db.describe()` — introspect the database: what's in it, what's indexed, what's searchable
+- `db.describe()` — introspect the database: live stats + stored semantic profile
+- `db.profile()` — LLM samples the data, writes a semantic understanding of what the data is
 - Recipe introspection — what parameters exist, what are valid values, what's currently set
 - Actionable hints in search responses — "no index for this predicate", "expansion skipped (strong signal)", "embedding coverage is 40%"
 - Suggested next actions — "try adding a vector collection", "this query might benefit from expansion"
@@ -38,7 +39,7 @@ This knowledge comes from documentation, system prompts, or trial and error. An 
 
 ## 3. `db.describe()`
 
-A single introspection call that tells the agent everything it needs to know about the database's search capabilities.
+Two parts: **live stats** (computed on call, always current) and **semantic profile** (LLM-generated, stored in `_system_` space, stable).
 
 ```python
 info = db.describe()
@@ -50,20 +51,18 @@ info = db.describe()
     "space": "default",
 
     "primitives": {
-        "kv": {"count": 127450, "indexed": true},
-        "json": {"count": 53200, "indexed": true},
-        "event": {"count": 892100, "indexed": true},
+        "kv": {"indexed": true},
+        "json": {"indexed": true},
+        "event": {"indexed": true},
         "vector": {
             "collections": {
-                "_system_embed_kv": {"count": 127450, "dimension": 384, "model": "miniLM"},
-                "_system_embed_json": {"count": 41800, "dimension": 384, "model": "miniLM"},
-                "custom_embeddings": {"count": 10000, "dimension": 768, "model": "nomic-embed"}
+                "_system_embed_kv": {"dimension": 384, "model": "miniLM"},
+                "custom_embeddings": {"dimension": 768, "model": "nomic-embed"}
             }
         },
         "graph": {
             "graphs": {
                 "medical_ontology": {
-                    "nodes": 34200, "edges": 89100,
                     "node_types": ["Drug", "Condition", "Procedure"],
                     "edge_types": ["treats", "causes", "interacts_with"]
                 }
@@ -73,9 +72,9 @@ info = db.describe()
 
     "indexes": {
         "json": {
-            "category": {"type": "tag", "cardinality": 12},
-            "year": {"type": "numeric", "min": 2018, "max": 2025},
-            "title": {"type": "text", "indexed_docs": 53200}
+            "category": {"type": "tag"},
+            "year": {"type": "numeric"},
+            "title": {"type": "text"}
         }
     },
 
@@ -96,44 +95,100 @@ info = db.describe()
         "temporal": true
     },
 
-    "embedding_coverage": {
-        "kv": {"total": 127450, "embedded": 127450, "coverage": 1.0},
-        "json": {"total": 53200, "embedded": 41800, "coverage": 0.786},
-        "event": {"total": 892100, "embedded": 0, "coverage": 0.0}
-    },
-
-    "time_range": {
-        "oldest": "2024-01-10T00:00:00Z",
-        "latest": "2025-06-15T14:32:00Z"
+    "profile": {
+        "description": "Medical research corpus. KV entries are drug monographs keyed by drug name. JSON documents are clinical trial results with structured fields (drug_name, condition, phase, outcome, year). Events are FDA adverse event reports.",
+        "key_entities": ["drugs", "conditions", "clinical trials", "adverse events"],
+        "relationships": "Drugs treat conditions. Trials test drugs. Adverse events reference drugs and patients.",
+        "search_guidance": {
+            "drug_name": "High cardinality. Good for exact match and graph anchor resolution.",
+            "condition": "Medium cardinality. Has synonyms — expansion helps. 'heart attack' ↔ 'myocardial infarction'.",
+            "phase": "Low cardinality (1-4). Good for filtering, not full-text.",
+            "year": "Numeric range 2018-2025. Good for time filtering.",
+            "outcome": "Free text narrative. Best searched via BM25 + vector."
+        },
+        "generated_at": "2026-03-29T14:00:00Z",
+        "model": "local:qwen3:1.7b",
+        "sample_size": 100
     }
 }
 ```
 
-The agent reads this once at startup. It knows:
-- What data exists and how much
-- What indexes are available for filtering
-- What vector collections exist and their coverage
-- What graphs exist and their ontology
-- What the current recipe does
-- What capabilities are enabled
-- What temporal range is queryable
+**No counts in the stored profile.** Counts change with every write. Use `db.kv.count()`, `db.json.count()` etc. for live numbers. The profile describes what the data IS, not how much of it there is.
 
-### Implementation
-
-`db.describe()` assembles data from existing sources:
-- Primitive counts: `db.kv.count()`, `db.json.count()`, etc.
-- Vector collections: `db.vector.list_collections()`
-- Graph info: `db.graph.list()` + `db.graph.ontology_summary()`
-- Indexes: `db.json.list_indexes()`
-- Recipe: `db.get_recipe()`
-- Embedding coverage: compare primitive counts to vector collection counts
-- Time range: `db.time_range()`
-
-No new infrastructure. Just aggregation of existing APIs into one response.
+The agent reads this once and immediately knows:
+- What the data is about (medical research, not e-commerce)
+- What entities matter and how they relate
+- How each field should be searched (exact match vs BM25 vs expansion)
+- What the recipe currently does
+- What capabilities are available
 
 ---
 
-## 4. Recipe Introspection
+## 4. `db.profile()`
+
+Generates the semantic profile. Run once when data is loaded, re-run when the data changes significantly.
+
+```python
+db.profile()
+```
+
+### How it works
+
+1. **Sample** — draw ~100 documents across primitives (KV, JSON, Event). Stratified by space if multiple spaces exist.
+2. **Inspect** — for JSON, extract field names, types, cardinality, and sample values. For KV, inspect key patterns and value structure. For events, inspect event types and payload structure.
+3. **Understand** — send samples + field metadata to the local LLM with a prompt:
+
+```
+You are analyzing a database. Here are 100 sample documents from this database.
+
+For each field, describe:
+- What it represents (not the type — the meaning)
+- How it should be searched (exact match, full-text, filtering, expansion)
+- Whether it has synonyms or vocabulary that needs expansion
+
+Also describe:
+- What this dataset is about (one paragraph)
+- What the key entities are
+- What relationships exist between entities
+- Any search guidance an AI agent would need
+
+Return JSON.
+```
+
+4. **Store** — write the profile to `_system_` space as `profile:default`. Stored alongside recipes.
+
+### Cost
+
+- Sample 100 documents: ~1ms (100 random reads)
+- LLM call: ~2s local (Qwen3 1.7B with ~50K token context), ~$0.15 cloud (Claude Haiku)
+- Run once. Re-run on demand (`db.profile(force=True)`).
+
+### When to re-run
+
+The profile doesn't auto-refresh. It's stable — the semantic understanding of a medical corpus doesn't change when you add 100 more drug monographs. The user runs `db.profile()` when:
+- They first load a dataset
+- They load a fundamentally different dataset into the same database
+- They want to regenerate with a better model
+
+### Recipe suggestion from profile
+
+Future: `db.profile()` could also suggest an initial recipe based on its understanding. "This corpus has high vocabulary mismatch — enable expansion. The 'phase' field has low cardinality — add a filter index." But that's a v1.0+ feature, not v0.9.
+
+### Implementation
+
+```
+crates/intelligence/src/profile/
+├── mod.rs       — public API: profile(db) → Profile
+├── sample.rs    — stratified sampling across primitives
+├── inspect.rs   — field metadata extraction (names, types, cardinality)
+└── understand.rs — LLM prompt construction + response parsing
+```
+
+~150 lines. The LLM does the hard work.
+
+---
+
+## 5. Recipe Introspection
 
 The agent needs to know what it can tune.
 
@@ -191,7 +246,7 @@ The agent reads this to know what parameters exist, their types, defaults, and v
 
 ---
 
-## 5. Actionable Hints in Search Responses
+## 6. Actionable Hints in Search Responses
 
 The `stats` section of the response already reports per-stage timing. v0.9 adds `hints` — actionable observations that help the agent understand and improve results.
 
@@ -270,7 +325,7 @@ Passed through the pipeline. Each stage checks relevant conditions and adds hint
 
 ---
 
-## 6. Suggested Next Actions
+## 7. Suggested Next Actions
 
 For poor results, the hints suggest what the agent should try:
 
@@ -290,7 +345,7 @@ Suggestions are templates, not commands. The agent decides whether to act on the
 
 ---
 
-## 7. Implementation
+## 8. Implementation
 
 ### New files
 
@@ -331,7 +386,7 @@ RECIPE SCHEMA                -- recipe parameter schema with types and ranges
 
 ---
 
-## 8. Testing
+## 9. Testing
 
 ### Describe tests
 
@@ -358,22 +413,23 @@ RECIPE SCHEMA                -- recipe parameter schema with types and ranges
 
 ---
 
-## 9. Estimated Effort
+## 10. Estimated Effort
 
 | Component | Lines |
 |---|---|
-| `describe.rs` (aggregation of existing APIs) | ~150 |
+| `describe.rs` (live stats aggregation) | ~100 |
+| `profile/` (sample, inspect, understand — LLM call) | ~150 |
 | `schema.rs` (recipe parameter metadata) | ~100 |
 | `hints.rs` (hint types, collection, generation) | ~120 |
 | Substrate wiring (HintCollector through pipeline) | ~40 |
 | Response type changes | ~20 |
 | Executor commands | ~40 |
 | Tests | ~150 |
-| **Total** | **~620** |
+| **Total** | **~720** |
 
 ---
 
-## 10. Complete Roadmap
+## 11. Complete Roadmap
 
 ```
 v0.0 — Prerequisites           ~1,300 lines
@@ -385,17 +441,18 @@ v0.5 — Filter + Budget           ~465 lines
 v0.6 — RAG                       ~375 lines
 v0.7 — AutoResearch              ~630 lines
 v0.8 — Multi-Model Routing       ~190 lines
-v0.9 — Agent Hints               ~620 lines
+v0.9 — Agent Hints               ~720 lines
                                ──────────
-                               ~5,490 lines total
+                               ~5,590 lines total
 ```
 
 After v0.9, the search substrate is not just feature-complete — it's agent-complete. An AI agent can:
-1. `db.describe()` — discover what's in the database and what's searchable
-2. `db.recipe_schema()` — learn what parameters exist and their ranges
-3. `db.search()` — search with recipe, get results + actionable hints
-4. `db.experiment()` — compare recipes, find the best one
-5. `db.set_recipe()` — save the winner
-6. Read `stats.hints` — understand why results are good or bad and what to try next
+1. `db.describe()` — discover what's in the database, what's searchable, and what the data means
+2. `db.profile()` — ask the database to build a semantic understanding of its own data
+3. `db.recipe_schema()` — learn what parameters exist and their ranges
+4. `db.search()` — search with recipe, get results + actionable hints
+5. `db.experiment()` — compare recipes, find the best one
+6. `db.set_recipe()` — save the winner
+7. Read `stats.hints` — understand why results are good or bad and what to try next
 
-No documentation needed. The database describes itself.
+No documentation needed. The database describes itself — not just structurally (what fields exist) but semantically (what the data means and how to search it).


### PR DESCRIPTION
## Summary

`db.understand()` — the database reads its own data and builds a semantic understanding. Samples ~100 documents, sends to LLM, writes a profile describing what the data is, what entities matter, and how each field should be searched.

Stored in `_system_` space. Stable — doesn't change when you add more documents of the same type. An agent reads it once and knows how to search effectively on the first try.

Also renamed `db.profile()` → `db.understand()` throughout v0.9 doc.

The five verbs:
```python
db.understand()    # build semantic understanding
db.describe()      # live stats + understanding
db.search()        # search with recipe
db.experiment()    # compare recipes
db.set_recipe()    # save the winner
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)