### PR TITLE
Fix #2145: Add _system_ space on every branch

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -53,6 +53,7 @@ pub mod branch_ops;
 pub mod bundle;
 pub mod primitives;
 pub mod search;
+pub mod system_space;
 
 // Re-export search types at crate root for convenience
 pub use search::{SearchBudget, SearchHit, SearchMode, SearchRequest, SearchResponse, SearchStats};

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -369,6 +369,7 @@ impl BranchIndex {
         // Evict cached namespaces for the deleted branch to prevent unbounded
         // growth of the global NS_CACHE (SCALE-001).
         crate::primitives::kv::invalidate_kv_namespace_cache(&executor_branch_id);
+        crate::system_space::invalidate_cache(&executor_branch_id);
 
         // Clean up storage-layer segments, manifest, and refcounts (#1702).
         // Must happen after logical deletion so in-progress reads see the

--- a/crates/engine/src/primitives/space.rs
+++ b/crates/engine/src/primitives/space.rs
@@ -59,7 +59,7 @@ impl SpaceIndex {
     ///
     /// Returns `true` for "default" without hitting storage.
     pub fn exists(&self, branch_id: BranchId, space: &str) -> StrataResult<bool> {
-        if space == "default" {
+        if space == "default" || space == crate::system_space::SYSTEM_SPACE {
             return Ok(true);
         }
         self.db.transaction(branch_id, |txn| {
@@ -79,6 +79,7 @@ impl SpaceIndex {
             let mut spaces: Vec<String> = results
                 .into_iter()
                 .filter_map(|(k, _)| String::from_utf8(k.user_key.to_vec()).ok())
+                .filter(|s| s != crate::system_space::SYSTEM_SPACE)
                 .collect();
 
             // Always include "default"
@@ -239,5 +240,44 @@ mod tests {
         assert!(spaces.contains(&"alpha".to_string()));
         assert!(spaces.contains(&"beta".to_string()));
         assert!(spaces.contains(&"gamma".to_string()));
+    }
+
+    #[test]
+    fn test_system_space_exists() {
+        let (_temp, _db, si) = setup();
+        let bid = default_branch();
+
+        // _system_ should always exist without explicit registration
+        assert!(si.exists(bid, crate::system_space::SYSTEM_SPACE).unwrap());
+    }
+
+    #[test]
+    fn test_system_space_hidden_from_list() {
+        let (_temp, _db, si) = setup();
+        let bid = default_branch();
+
+        let spaces = si.list(bid).unwrap();
+        assert!(!spaces.contains(&crate::system_space::SYSTEM_SPACE.to_string()));
+    }
+
+    #[test]
+    fn test_internal_write_to_system_space() {
+        let (_temp, db, _si) = setup();
+        let bid = default_branch();
+
+        // Internal code can write to _system_ via system_kv_key
+        let key = crate::system_space::system_kv_key(bid, "recipe:default");
+        db.transaction(bid, |txn| {
+            txn.put(key.clone(), Value::String("{\"version\":1}".into()))?;
+            Ok(())
+        })
+        .unwrap();
+
+        // Read it back and verify content
+        let val = db
+            .transaction(bid, |txn| Ok(txn.get(&key)?))
+            .unwrap()
+            .expect("system space value should be readable");
+        assert_eq!(val.as_str().unwrap(), "{\"version\":1}");
     }
 }

--- a/crates/engine/src/system_space.rs
+++ b/crates/engine/src/system_space.rs
@@ -1,0 +1,87 @@
+//! System space: hidden, internal-only namespace on every branch.
+//!
+//! Follows the `_graph_` pattern in `crates/graph/src/keys.rs`. Used to store
+//! recipes, semantic profiles, and other internal metadata per-branch.
+//!
+//! - Users cannot write to `_system_` (validation rejects the name)
+//! - `SpaceIndex::list()` filters it out
+//! - `SpaceIndex::exists("_system_")` returns true
+//! - Internal code uses `system_kv_key()` to write directly via `Database`
+
+use dashmap::DashMap;
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+use strata_core::types::{BranchId, Key, Namespace};
+
+/// The reserved space name for internal system data.
+pub const SYSTEM_SPACE: &str = "_system_";
+
+/// Global cache of `Arc<Namespace>` per branch — one heap allocation per branch.
+static NS_CACHE: Lazy<DashMap<BranchId, Arc<Namespace>>> = Lazy::new(DashMap::new);
+
+/// Build a namespace for system operations on a given branch.
+///
+/// Returns a cached `Arc<Namespace>` — one heap allocation per branch, ever.
+/// Subsequent calls return `Arc::clone()` (atomic refcount bump only).
+pub fn system_namespace(branch_id: BranchId) -> Arc<Namespace> {
+    NS_CACHE
+        .entry(branch_id)
+        .or_insert_with(|| Arc::new(Namespace::for_branch_space(branch_id, SYSTEM_SPACE)))
+        .clone()
+}
+
+/// Build a KV key in the `_system_` space for a given branch.
+pub fn system_kv_key(branch_id: BranchId, key: &str) -> Key {
+    Key::new_kv(system_namespace(branch_id), key)
+}
+
+/// Remove cached namespace entry for a branch (call on branch deletion).
+pub fn invalidate_cache(branch_id: &BranchId) {
+    NS_CACHE.remove(branch_id);
+}
+
+// ========== Tests ==========
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_system_namespace_cached() {
+        let branch = BranchId::new();
+        let ns1 = system_namespace(branch);
+        let ns2 = system_namespace(branch);
+        // Same Arc (pointer equality)
+        assert!(Arc::ptr_eq(&ns1, &ns2));
+        assert_eq!(ns1.space, SYSTEM_SPACE);
+    }
+
+    #[test]
+    fn test_system_namespace_different_branches() {
+        let b1 = BranchId::new();
+        let b2 = BranchId::new();
+        let ns1 = system_namespace(b1);
+        let ns2 = system_namespace(b2);
+        assert!(!Arc::ptr_eq(&ns1, &ns2));
+        assert_eq!(ns1.space, SYSTEM_SPACE);
+        assert_eq!(ns2.space, SYSTEM_SPACE);
+    }
+
+    #[test]
+    fn test_system_kv_key() {
+        let branch = BranchId::new();
+        let key = system_kv_key(branch, "recipe:default");
+        assert_eq!(key.user_key_string(), Some("recipe:default".to_string()));
+    }
+
+    #[test]
+    fn test_invalidate_cache() {
+        let branch = BranchId::new();
+        let ns_before = system_namespace(branch);
+        invalidate_cache(&branch);
+        let ns_after = system_namespace(branch);
+        // Same value, different allocation
+        assert_eq!(*ns_before, *ns_after);
+        assert!(!Arc::ptr_eq(&ns_before, &ns_after));
+    }
+}

--- a/crates/executor/src/handlers/space.rs
+++ b/crates/executor/src/handlers/space.rs
@@ -32,10 +32,10 @@ pub fn space_delete(
     space: String,
     force: bool,
 ) -> Result<Output> {
-    // Cannot delete the default space
-    if space == "default" {
+    // Cannot delete the default or _system_ space
+    if space == "default" || space == strata_engine::system_space::SYSTEM_SPACE {
         return Err(Error::ConstraintViolation {
-            reason: "Cannot delete the default space".into(),
+            reason: format!("Cannot delete the '{}' space", space),
         });
     }
 


### PR DESCRIPTION
## Summary
- New `system_space` module in engine crate: `SYSTEM_SPACE` constant, cached `system_namespace()`, `system_kv_key()` helper, `invalidate_cache()` — follows the `_graph_` pattern
- `SpaceIndex::exists("_system_")` returns `true` (always exists, no registration needed)
- `SpaceIndex::list()` filters `_system_` out (hidden from users)
- `space_delete("_system_")` rejected at executor layer
- Namespace cache evicted on branch deletion (prevents unbounded growth)

Closes #2145

## Test plan
- [x] 4 unit tests in `system_space.rs` (caching, key construction, invalidation, cross-branch isolation)
- [x] 3 integration tests in `space.rs` (exists=true, hidden from list, internal write+read round-trip with value verification)
- [x] All 11 existing space tests pass (no regressions)
- [x] Full `cargo build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)