### PR TITLE
Fix #2161: Add kv_scan — range query returning key-value pairs

### DIFF
--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -322,6 +322,11 @@ fn format_raw(output: &Output) -> String {
         }
         Output::KeysPage { keys, .. } => keys.join("\n"),
         Output::Keys(keys) => keys.join("\n"),
+        Output::KvScanResult(pairs) => pairs
+            .iter()
+            .map(|(k, v)| format!("{}\t{}", k, format_value_raw(v)))
+            .collect::<Vec<_>>()
+            .join("\n"),
         Output::JsonListResult { keys, .. } => keys.join("\n"),
         Output::VectorMatches(matches) => matches
             .iter()
@@ -678,6 +683,18 @@ fn format_human(output: &Output) -> String {
             out
         }
         Output::Keys(keys) => format_string_list(keys),
+        Output::KvScanResult(pairs) => {
+            if pairs.is_empty() {
+                "(empty list)".to_string()
+            } else {
+                pairs
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (k, v))| format!("{}) {} = {}", i + 1, k, format_value_human(v)))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
         Output::JsonListResult {
             keys,
             has_more,

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -276,6 +276,43 @@ impl KVStore {
         })
     }
 
+    /// Scan key-value pairs starting from a cursor key.
+    ///
+    /// Returns up to `limit` pairs where key >= start_key, sorted by key.
+    /// If `start` is None, scans from the beginning. If `limit` is None,
+    /// returns all matching pairs.
+    pub fn scan(
+        &self,
+        branch_id: &BranchId,
+        space: &str,
+        start: Option<&str>,
+        limit: Option<usize>,
+    ) -> StrataResult<Vec<(String, Value)>> {
+        self.db.transaction(*branch_id, |txn| {
+            let ns = self.namespace_for(branch_id, space);
+            let scan_prefix = Key::new_kv(ns, "");
+
+            let results = txn.scan_prefix(&scan_prefix)?;
+
+            let iter = results
+                .into_iter()
+                .filter_map(|(key, value)| key.user_key_string().map(|k| (k, value)));
+
+            let iter: Box<dyn Iterator<Item = (String, Value)>> = if let Some(s) = start {
+                let s_owned = s.to_string();
+                Box::new(iter.skip_while(move |(k, _)| k.as_str() < s_owned.as_str()))
+            } else {
+                Box::new(iter)
+            };
+
+            if let Some(lim) = limit {
+                Ok(iter.take(lim).collect())
+            } else {
+                Ok(iter.collect())
+            }
+        })
+    }
+
     /// Count keys matching an optional prefix without allocating user-key strings.
     ///
     /// Uses UTF-8 validity check directly on the raw key bytes instead of

--- a/crates/executor/src/api/kv.rs
+++ b/crates/executor/src/api/kv.rs
@@ -136,6 +136,40 @@ impl Strata {
     }
 
     // =========================================================================
+    // KV Range Scan
+    // =========================================================================
+
+    /// Scan key-value pairs starting from a cursor key.
+    ///
+    /// Returns up to `limit` pairs where key >= start, sorted by key.
+    /// If `start` is None, scans from the beginning. If `limit` is None,
+    /// returns all pairs.
+    ///
+    /// # Example
+    ///
+    /// ```text
+    /// // Scan all pairs
+    /// let pairs = db.kv_scan(None, None)?;
+    ///
+    /// // Scan from "c" onwards, max 10 results
+    /// let pairs = db.kv_scan(Some("c"), Some(10))?;
+    /// ```
+    pub fn kv_scan(&self, start: Option<&str>, limit: Option<u64>) -> Result<Vec<(String, Value)>> {
+        match self.execute_cmd(Command::KvScan {
+            branch: self.branch_id(),
+            space: self.space_id(),
+            start: start.map(|s| s.to_string()),
+            limit,
+        })? {
+            Output::KvScanResult(pairs) => Ok(pairs),
+            _ => Err(Error::Internal {
+                reason: "Unexpected output for KvScan".into(),
+                hint: Some("This is likely a bug. Please report it at https://github.com/stratalab/strata-core/issues".to_string()),
+            }),
+        }
+    }
+
+    // =========================================================================
     // KV as_of Variants
     // =========================================================================
 

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -2245,4 +2245,63 @@ mod tests {
         assert!(types.contains(&"Person".to_string()));
         assert!(types.contains(&"knows".to_string()));
     }
+
+    #[test]
+    fn test_kv_scan_returns_key_value_pairs() {
+        let db = create_strata();
+
+        // Insert 5 keys in sorted order
+        db.kv_put("a", "alpha").unwrap();
+        db.kv_put("b", "bravo").unwrap();
+        db.kv_put("c", "charlie").unwrap();
+        db.kv_put("d", "delta").unwrap();
+        db.kv_put("e", "echo").unwrap();
+
+        // Scan all — returns key-value pairs sorted by key
+        let pairs = db.kv_scan(None, None).unwrap();
+        assert_eq!(pairs.len(), 5);
+        assert_eq!(pairs[0].0, "a");
+        assert_eq!(pairs[0].1, Value::String("alpha".into()));
+        assert_eq!(pairs[4].0, "e");
+        assert_eq!(pairs[4].1, Value::String("echo".into()));
+
+        // Scan with start key — returns pairs where key >= start
+        let pairs = db.kv_scan(Some("c"), None).unwrap();
+        assert_eq!(pairs.len(), 3);
+        assert_eq!(pairs[0].0, "c");
+        assert_eq!(pairs[0].1, Value::String("charlie".into()));
+        assert_eq!(pairs[2].0, "e");
+
+        // Scan with limit — returns at most N pairs
+        let pairs = db.kv_scan(None, Some(2)).unwrap();
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0].0, "a");
+        assert_eq!(pairs[1].0, "b");
+
+        // Scan with start + limit
+        let pairs = db.kv_scan(Some("b"), Some(2)).unwrap();
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0].0, "b");
+        assert_eq!(pairs[0].1, Value::String("bravo".into()));
+        assert_eq!(pairs[1].0, "c");
+
+        // Scan on empty DB
+        let db2 = create_strata();
+        let pairs = db2.kv_scan(None, None).unwrap();
+        assert!(pairs.is_empty());
+
+        // Scan with start key beyond all keys returns empty
+        let pairs = db.kv_scan(Some("z"), None).unwrap();
+        assert!(pairs.is_empty());
+
+        // Scan with limit=0 returns empty
+        let pairs = db.kv_scan(None, Some(0)).unwrap();
+        assert!(pairs.is_empty());
+
+        // Deleted keys are not returned
+        db.kv_delete("c").unwrap();
+        let pairs = db.kv_scan(None, None).unwrap();
+        assert_eq!(pairs.len(), 4);
+        assert!(pairs.iter().all(|(k, _)| k != "c"));
+    }
 }

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -132,6 +132,24 @@ pub enum Command {
         as_of: Option<u64>,
     },
 
+    /// Scan key-value pairs starting from a cursor key.
+    /// Returns up to `limit` pairs where key >= start, sorted by key.
+    /// Returns: `Output::KvScanResult`
+    KvScan {
+        /// Target branch (defaults to "default").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Target space (defaults to "default").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        space: Option<String>,
+        /// Start key (inclusive). If None, scans from the beginning.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        start: Option<String>,
+        /// Maximum number of pairs to return.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        limit: Option<u64>,
+    },
+
     /// Batch put multiple key-value pairs in a single transaction.
     /// Returns: `Output::BatchResults`
     KvBatchPut {
@@ -1875,6 +1893,7 @@ impl Command {
             Command::KvDelete { .. } => "KvDelete",
             Command::KvList { .. } => "KvList",
             Command::KvGetv { .. } => "KvGetv",
+            Command::KvScan { .. } => "KvScan",
             Command::JsonSet { .. } => "JsonSet",
             Command::JsonBatchSet { .. } => "JsonBatchSet",
             Command::JsonBatchGet { .. } => "JsonBatchGet",
@@ -2038,6 +2057,7 @@ impl Command {
             | Command::KvDelete { branch, space, .. }
             | Command::KvList { branch, space, .. }
             | Command::KvGetv { branch, space, .. }
+            | Command::KvScan { branch, space, .. }
             // JSON
             | Command::JsonSet { branch, space, .. }
             | Command::JsonBatchSet { branch, space, .. }
@@ -2215,6 +2235,7 @@ impl Command {
             | Command::KvDelete { branch, .. }
             | Command::KvList { branch, .. }
             | Command::KvGetv { branch, .. }
+            | Command::KvScan { branch, .. }
             | Command::JsonSet { branch, .. }
             | Command::JsonBatchSet { branch, .. }
             | Command::JsonBatchGet { branch, .. }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -423,6 +423,19 @@ impl Executor {
                     )
                 }
             }
+            Command::KvScan {
+                branch,
+                space,
+                start,
+                limit,
+            } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                    hint: None,
+                })?;
+                let space = space.unwrap_or_else(|| "default".to_string());
+                crate::handlers::kv::kv_scan(&self.primitives, branch, space, start, limit)
+            }
             // Note: as_of is intentionally ignored for getv — version history
             // always returns all versions, not a point-in-time snapshot.
             Command::KvGetv {

--- a/crates/executor/src/handlers/kv.rs
+++ b/crates/executor/src/handlers/kv.rs
@@ -487,6 +487,29 @@ fn enrich_kv_error(
     }
 }
 
+/// Handle KvScan command — range query returning key-value pairs.
+pub fn kv_scan(
+    p: &Arc<Primitives>,
+    branch: BranchId,
+    space: String,
+    start: Option<String>,
+    limit: Option<u64>,
+) -> Result<Output> {
+    let branch_id = to_core_branch_id(&branch)?;
+    if let Some(ref s) = start {
+        if !s.is_empty() {
+            convert_result(validate_key(s))?;
+        }
+    }
+    let pairs = convert_result(p.kv.scan(
+        &branch_id,
+        &space,
+        start.as_deref(),
+        limit.map(|l| l as usize),
+    ))?;
+    Ok(Output::KvScanResult(pairs))
+}
+
 /// Handle KvList with as_of timestamp (time-travel read).
 pub fn kv_list_at(
     p: &Arc<Primitives>,

--- a/crates/executor/src/output.rs
+++ b/crates/executor/src/output.rs
@@ -134,6 +134,9 @@ pub enum Output {
         cursor: Option<String>,
     },
 
+    /// Key-value scan result (range query returning pairs)
+    KvScanResult(Vec<(String, Value)>),
+
     /// JSON list result with cursor
     JsonListResult {
         /// Matching document keys.

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -336,6 +336,7 @@ impl Session {
             | Command::KvDelete { space, .. }
             | Command::KvList { space, .. }
             | Command::KvGetv { space, .. }
+            | Command::KvScan { space, .. }
             | Command::EventAppend { space, .. }
             | Command::EventGet { space, .. }
             | Command::EventGetByType { space, .. }
@@ -402,6 +403,28 @@ impl Session {
                 } else {
                     Ok(Output::Keys(keys))
                 }
+            }
+
+            Command::KvScan { start, limit, .. } => {
+                let prefix_key = Key::new(ns, TypeTag::KV, vec![]);
+                let entries = ctx.scan_prefix(&prefix_key).map_err(Error::from)?;
+                let iter = entries
+                    .into_iter()
+                    .filter_map(|(k, v)| k.user_key_string().map(|key| (key, v)));
+
+                let iter: Box<dyn Iterator<Item = (String, strata_core::value::Value)>> =
+                    if let Some(s) = start {
+                        Box::new(iter.skip_while(move |(k, _)| k.as_str() < s.as_str()))
+                    } else {
+                        Box::new(iter)
+                    };
+
+                let pairs: Vec<(String, strata_core::value::Value)> = if let Some(lim) = limit {
+                    iter.take(lim as usize).collect()
+                } else {
+                    iter.collect()
+                };
+                Ok(Output::KvScanResult(pairs))
             }
 
             // === JSON reads — via ctx for snapshot fallback ===

--- a/crates/executor/src/tests/session.rs
+++ b/crates/executor/src/tests/session.rs
@@ -417,3 +417,75 @@ fn test_event_append_in_txn() {
 
     session.execute(Command::TxnCommit).unwrap();
 }
+
+#[test]
+fn test_kv_scan_sees_uncommitted_writes_in_txn() {
+    let mut session = create_test_session();
+
+    // Write some data before the transaction
+    session
+        .execute(Command::KvPut {
+            branch: None,
+            space: None,
+            key: "a".to_string(),
+            value: Value::String("alpha".into()),
+        })
+        .unwrap();
+
+    session
+        .execute(Command::TxnBegin {
+            branch: None,
+            options: None,
+        })
+        .unwrap();
+
+    // Write inside the transaction
+    session
+        .execute(Command::KvPut {
+            branch: None,
+            space: None,
+            key: "b".to_string(),
+            value: Value::String("bravo".into()),
+        })
+        .unwrap();
+
+    // KvScan should see both the committed "a" and uncommitted "b"
+    let result = session
+        .execute(Command::KvScan {
+            branch: None,
+            space: None,
+            start: None,
+            limit: None,
+        })
+        .unwrap();
+
+    match result {
+        Output::KvScanResult(pairs) => {
+            assert_eq!(pairs.len(), 2, "should see both committed and uncommitted");
+            assert_eq!(pairs[0].0, "a");
+            assert_eq!(pairs[1].0, "b");
+            assert_eq!(pairs[1].1, Value::String("bravo".into()));
+        }
+        other => panic!("Expected KvScanResult, got {:?}", other),
+    }
+
+    // KvScan with start key
+    let result = session
+        .execute(Command::KvScan {
+            branch: None,
+            space: None,
+            start: Some("b".to_string()),
+            limit: None,
+        })
+        .unwrap();
+
+    match result {
+        Output::KvScanResult(pairs) => {
+            assert_eq!(pairs.len(), 1);
+            assert_eq!(pairs[0].0, "b");
+        }
+        other => panic!("Expected KvScanResult, got {:?}", other),
+    }
+
+    session.execute(Command::TxnCommit).unwrap();
+}


### PR DESCRIPTION
## Summary

- Adds `kv_scan(start, limit)` API returning `Vec<(String, Value)>` in a single operation
- Eliminates the N round-trip workaround of `kv_list` + N × `kv_get` that caused benchmark hangs
- Full command layer: `Command::KvScan` → handler → `Output::KvScanResult` → public API
- Wired into session transaction dispatcher for read-your-writes consistency inside transactions

## Root Cause

No primitive existed to return key-value **pairs** from a range scan. The engine's `scan_prefix` already reads `(Key, Value)` pairs but `kv_list` discards the values. This forced O(N) individual `kv_get` calls per scan.

## Fix

Added `KVStore::scan()` at the engine level (reuses `txn.scan_prefix()`), then threaded through all layers: `Command::KvScan`, `Output::KvScanResult`, handler, executor dispatch, session transaction dispatch, and public `Strata::kv_scan()` API.

## Invariants Verified

- **LSM-003**: Reuses existing `txn.scan_prefix()` — same read path ordering as `list()`
- **MVCC-001**: Snapshot isolation via transaction `start_version`
- **MVCC-002**: Tombstones filtered by transaction `delete_set` and MvccIterator
- **ARCH-002**: Transaction snapshot prevents seeing uncommitted writes from other transactions

## Test Plan

- [x] `test_kv_scan_returns_key_value_pairs` — all combinations: full scan, start key, limit, start+limit, empty DB, beyond-range start, limit=0, deleted keys excluded
- [x] `test_kv_scan_sees_uncommitted_writes_in_txn` — verifies read-your-writes inside transactions
- [x] Full executor crate: 558 passed
- [x] Full workspace (excluding inference/cli): all pass
- [x] Invariant check: 4 affected invariants HOLD
- [x] `cargo fmt` clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)