### PR TITLE
Fix #2169: Grammar-constrained generation

### DIFF
--- a/crates/inference/src/lib.rs
+++ b/crates/inference/src/lib.rs
@@ -51,6 +51,12 @@ pub struct GenerateRequest {
     pub seed: Option<u64>,
     pub stop_sequences: Vec<String>,
     pub stop_tokens: Vec<u32>,
+    /// Optional GBNF grammar string for constrained generation.
+    ///
+    /// For local models, this is passed to llama.cpp's grammar sampler.
+    /// For OpenAI, this enables JSON mode (`response_format: json_object`).
+    /// For Anthropic/Google, this field is silently ignored.
+    pub grammar: Option<String>,
 }
 
 impl Default for GenerateRequest {
@@ -64,6 +70,7 @@ impl Default for GenerateRequest {
             seed: None,
             stop_sequences: Vec::new(),
             stop_tokens: Vec::new(),
+            grammar: None,
         }
     }
 }
@@ -301,6 +308,40 @@ mod tests {
         assert!(req.stop_sequences.is_empty());
         assert!(req.stop_tokens.is_empty());
         assert!(req.prompt.is_empty());
+        assert!(req.grammar.is_none());
+    }
+
+    #[test]
+    fn grammar_field_default_is_none() {
+        let req = GenerateRequest::default();
+        assert!(req.grammar.is_none());
+    }
+
+    #[test]
+    fn grammar_field_can_be_set() {
+        let req = GenerateRequest {
+            prompt: "List colors as JSON".into(),
+            grammar: Some(
+                r#"root ::= "{" ws "\"colors\"" ws ":" ws "[" ws string ("," ws string)* "]" ws "}"
+ws ::= [ \t\n]*
+string ::= "\"" [a-zA-Z]+ "\""
+"#
+                .into(),
+            ),
+            ..Default::default()
+        };
+        assert!(req.grammar.is_some());
+        assert!(req.grammar.as_ref().unwrap().contains("root"));
+    }
+
+    #[test]
+    fn grammar_field_survives_clone() {
+        let req = GenerateRequest {
+            grammar: Some("root ::= \"hello\"".into()),
+            ..Default::default()
+        };
+        let cloned = req.clone();
+        assert_eq!(cloned.grammar, Some("root ::= \"hello\"".into()));
     }
 
     #[test]
@@ -314,6 +355,7 @@ mod tests {
             seed: Some(42),
             stop_sequences: vec!["STOP".into(), "\n\n".into()],
             stop_tokens: vec![1, 2, 50256],
+            grammar: Some("root ::= \"test\"".into()),
         };
         let cloned = req.clone();
         assert_eq!(cloned.prompt, "test prompt");

--- a/crates/inference/src/llama/ffi.rs
+++ b/crates/inference/src/llama/ffi.rs
@@ -228,6 +228,11 @@ extern "C" {
     pub fn llama_sampler_init_top_p(p: f32, min_keep: usize) -> LlamaSampler;
     pub fn llama_sampler_init_temp(t: f32) -> LlamaSampler;
     pub fn llama_sampler_init_min_p(p: f32, min_keep: usize) -> LlamaSampler;
+    pub fn llama_sampler_init_grammar(
+        vocab: LlamaVocab,
+        grammar_str: *const c_char,
+        grammar_root: *const c_char,
+    ) -> LlamaSampler;
 }
 
 // ---------------------------------------------------------------------------
@@ -570,6 +575,24 @@ impl LlamaCppApi {
 
     pub fn sampler_init_min_p(&self, p: f32, min_keep: usize) -> LlamaSampler {
         unsafe { llama_sampler_init_min_p(p, min_keep) }
+    }
+
+    pub fn sampler_init_grammar(
+        &self,
+        vocab: LlamaVocab,
+        grammar_str: &str,
+        grammar_root: &str,
+    ) -> Result<LlamaSampler, String> {
+        let c_grammar = std::ffi::CString::new(grammar_str)
+            .map_err(|e| format!("grammar string contains null byte: {e}"))?;
+        let c_root = std::ffi::CString::new(grammar_root)
+            .map_err(|e| format!("grammar root contains null byte: {e}"))?;
+        let sampler =
+            unsafe { llama_sampler_init_grammar(vocab, c_grammar.as_ptr(), c_root.as_ptr()) };
+        if sampler.is_null() {
+            return Err("llama_sampler_init_grammar returned null (invalid grammar?)".to_string());
+        }
+        Ok(sampler)
     }
 }
 

--- a/crates/inference/src/provider/local.rs
+++ b/crates/inference/src/provider/local.rs
@@ -72,7 +72,7 @@ impl LocalProvider {
         self.ctx.clear_memory();
 
         // 4. Build sampler chain
-        let sampler = self.build_sampler(request);
+        let sampler = self.build_sampler(request)?;
 
         // 5. Prefill: decode all prompt tokens at once
         let batch = self.ctx.api.batch_get_one(&mut prompt_tokens);
@@ -146,11 +146,24 @@ impl LocalProvider {
 
     /// Build a llama.cpp sampler chain from request parameters.
     ///
-    /// - `temperature <= 0.0` → greedy (argmax)
-    /// - `temperature > 0.0` → optional top_k + optional top_p + temp + dist(seed)
-    fn build_sampler(&self, request: &GenerateRequest) -> LlamaSampler {
+    /// - Grammar constraint first (masks invalid tokens)
+    /// - Then sampling strategy: greedy or top_k + top_p + temp + dist
+    fn build_sampler(
+        &self,
+        request: &GenerateRequest,
+    ) -> Result<LlamaSampler, crate::InferenceError> {
         let chain_params = self.ctx.api.sampler_chain_default_params();
         let chain = self.ctx.api.sampler_chain_init(chain_params);
+
+        // Grammar constraint first — masks tokens that violate the grammar
+        if let Some(grammar) = &request.grammar {
+            let grammar_sampler = self
+                .ctx
+                .api
+                .sampler_init_grammar(self.ctx.vocab, grammar, "root")
+                .map_err(|e| crate::InferenceError::LlamaCpp(e))?;
+            self.ctx.api.sampler_chain_add(chain, grammar_sampler);
+        }
 
         if request.temperature <= 0.0 {
             // Greedy sampling
@@ -179,7 +192,7 @@ impl LocalProvider {
                 .sampler_chain_add(chain, self.ctx.api.sampler_init_dist(seed));
         }
 
-        chain
+        Ok(chain)
     }
 
     /// Encode text to token IDs using the model's tokenizer.

--- a/crates/inference/src/provider/openai.rs
+++ b/crates/inference/src/provider/openai.rs
@@ -104,8 +104,14 @@ pub(crate) fn build_request_json(model: &str, request: &GenerateRequest) -> Stri
         obj["stop"] = serde_json::json!(request.stop_sequences);
     }
 
+    // Enable JSON mode when grammar is specified
+    if request.grammar.is_some() {
+        obj["response_format"] = serde_json::json!({"type": "json_object"});
+    }
+
     // top_k: silently ignored (not supported by OpenAI)
     // stop_tokens: silently ignored (token-level, local only)
+    // grammar: mapped to response_format above (GBNF string itself is not sent)
 
     obj.to_string()
 }
@@ -604,5 +610,30 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
         assert!(json.get("stop_tokens").is_none());
+    }
+
+    #[test]
+    fn request_json_grammar_enables_json_mode() {
+        let req = GenerateRequest {
+            prompt: "test".into(),
+            grammar: Some("root ::= \"{\" ... \"}\"".into()),
+            ..Default::default()
+        };
+        let json_str = build_request_json("gpt-4", &req);
+        let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(json["response_format"]["type"], "json_object");
+    }
+
+    #[test]
+    fn request_json_no_grammar_no_response_format() {
+        let req = GenerateRequest {
+            prompt: "test".into(),
+            ..Default::default()
+        };
+        let json_str = build_request_json("gpt-4", &req);
+        let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        assert!(json.get("response_format").is_none());
     }
 }


### PR DESCRIPTION
## Summary
- New `grammar: Option<String>` field on `GenerateRequest`
- **Local**: GBNF grammar passed to llama.cpp's `llama_sampler_init_grammar` — constrains token sampling to match the grammar
- **OpenAI**: grammar presence enables `response_format: {"type": "json_object"}` — constrains output to valid JSON
- **Anthropic/Google**: grammar silently ignored (no native GBNF support)

Closes #2169

## Test plan
- [x] `grammar_field_default_is_none` — default is None
- [x] `grammar_field_can_be_set` — GBNF grammar string accepted
- [x] `grammar_field_survives_clone` — clone preserves grammar
- [x] `request_json_grammar_enables_json_mode` — OpenAI gets response_format
- [x] `request_json_no_grammar_no_response_format` — no grammar = no response_format
- [x] Full crate: 270 passed, 0 failed
- [x] clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)