### PR TITLE
Fix #2170: Ranking / cross-encoder API for strata-inference

### DIFF
--- a/crates/inference/src/lib.rs
+++ b/crates/inference/src/lib.rs
@@ -7,6 +7,9 @@ pub mod llama;
 #[cfg(feature = "local")]
 mod embed;
 
+#[cfg(feature = "local")]
+mod rank;
+
 #[cfg(any(
     feature = "local",
     feature = "anthropic",
@@ -28,6 +31,9 @@ pub use registry::{ModelInfo, ModelRegistry, ModelTask};
 
 #[cfg(feature = "local")]
 pub use embed::EmbeddingEngine;
+
+#[cfg(feature = "local")]
+pub use rank::RankingEngine;
 
 #[cfg(any(
     feature = "local",
@@ -173,6 +179,22 @@ pub trait InferenceEngine: Send + std::fmt::Debug {
     fn supports_embed(&self) -> bool {
         false
     }
+
+    /// Score passages against a query using cross-encoder reranking.
+    ///
+    /// Returns one relevance score per passage. Higher scores indicate
+    /// greater relevance. `scores[i]` corresponds to `passages[i]`.
+    fn rank(&self, query: &str, passages: &[&str]) -> Result<Vec<f32>, InferenceError> {
+        let _ = (query, passages);
+        Err(InferenceError::NotSupported(
+            "this engine does not support ranking".to_string(),
+        ))
+    }
+
+    /// Whether this engine supports ranking/reranking.
+    fn supports_rank(&self) -> bool {
+        false
+    }
 }
 
 /// Parse a `"provider:model_name"` spec into its components.
@@ -279,6 +301,29 @@ pub fn load_embedder(model_spec: &str) -> Result<Box<dyn InferenceEngine>, Infer
         ProviderKind::Local => Ok(Box::new(EmbeddingEngine::from_registry(&model)?)),
         other => Err(InferenceError::NotSupported(format!(
             "cloud embedding not yet supported (provider: {}). See #2171",
+            other
+        ))),
+    }
+}
+
+/// Load a ranking engine from a `"provider:model_name"` spec.
+///
+/// Currently only local cross-encoder models are supported.
+///
+/// # Examples
+///
+/// ```ignore
+/// let engine = strata_inference::load_ranker("local:jina-reranker-v1-tiny")?;
+/// let scores = engine.rank("query", &["passage 1", "passage 2"])?;
+/// ```
+#[cfg(feature = "local")]
+pub fn load_ranker(model_spec: &str) -> Result<Box<dyn InferenceEngine>, InferenceError> {
+    let (provider, model) = parse_model_spec(model_spec)?;
+
+    match provider {
+        ProviderKind::Local => Ok(Box::new(RankingEngine::from_registry(&model)?)),
+        other => Err(InferenceError::NotSupported(format!(
+            "cloud ranking not yet supported (provider: {})",
             other
         ))),
     }
@@ -702,6 +747,44 @@ mod tests {
             err.to_string().contains("not yet supported"),
             "cloud embedder should fail: {err}"
         );
+    }
+
+    // --- load_ranker ---
+
+    #[cfg(feature = "local")]
+    #[test]
+    fn load_ranker_cloud_not_supported() {
+        let err = load_ranker("openai:some-reranker").unwrap_err();
+        assert!(
+            err.to_string().contains("not yet supported"),
+            "cloud ranker should fail: {err}"
+        );
+    }
+
+    #[cfg(feature = "local")]
+    #[test]
+    fn load_ranker_unknown_model_returns_error() {
+        let err = load_ranker("local:nonexistent-reranker").unwrap_err();
+        assert!(
+            matches!(err, InferenceError::Registry(_)),
+            "should be Registry error, got: {err}"
+        );
+    }
+
+    // --- InferenceEngine rank defaults ---
+
+    #[cfg(any(feature = "anthropic", feature = "openai", feature = "google"))]
+    #[test]
+    fn trait_rank_default_returns_not_supported() {
+        std::env::set_var("OPENAI_API_KEY", "sk-test-key");
+        let engine: Box<dyn InferenceEngine> = load("openai:gpt-4o-mini").unwrap();
+        std::env::remove_var("OPENAI_API_KEY");
+        let err = engine.rank("query", &["passage"]).unwrap_err();
+        assert!(
+            err.to_string().contains("not supported"),
+            "rank on generation engine should be NotSupported: {err}"
+        );
+        assert!(!engine.supports_rank());
     }
 
     #[cfg(any(feature = "anthropic", feature = "openai", feature = "google"))]

--- a/crates/inference/src/llama/context.rs
+++ b/crates/inference/src/llama/context.rs
@@ -21,7 +21,6 @@ pub(crate) struct LlamaCppContext {
     pub n_ctx: usize,
     pub n_seq_max: usize,
     pub vocab_size: usize,
-    #[allow(dead_code)]
     pub bos_id: LlamaToken,
     #[allow(dead_code)]
     pub eos_id: LlamaToken,
@@ -34,14 +33,34 @@ unsafe impl Send for LlamaCppContext {}
 impl LlamaCppContext {
     /// Load a model configured for embedding (pooling enabled).
     pub fn load_for_embedding(path: &Path) -> Result<Self, InferenceError> {
+        Self::load_pooled(path, LLAMA_POOLING_TYPE_MEAN, 512, "embedding")
+    }
+
+    /// Load a model configured for cross-encoder ranking.
+    ///
+    /// Uses `LLAMA_POOLING_TYPE_RANK`, which causes `get_embeddings_seq` to
+    /// return a single relevance score instead of an embedding vector.
+    pub fn load_for_ranking(path: &Path) -> Result<Self, InferenceError> {
+        // One (query, passage) pair at a time. Batched ranking (multiple
+        // pairs per encode call) would need n_seq_max > 1 plus per-token
+        // seq_id assignment in rank_single.
+        Self::load_pooled(path, LLAMA_POOLING_TYPE_RANK, 1, "ranking")
+    }
+
+    /// Shared loader for embedding and ranking models.
+    fn load_pooled(
+        path: &Path,
+        pooling_type: i32,
+        n_seq_max: u32,
+        mode: &str,
+    ) -> Result<Self, InferenceError> {
         let api = Arc::new(LlamaCppApi::load().map_err(InferenceError::LlamaCpp)?);
 
         let c_path = path_to_cstring(path)?;
 
-        // Model params: default (use mmap, no GPU layers needed for small models)
         let mparams = api.model_default_params();
 
-        info!(path = %path.display(), "Loading model via llama.cpp");
+        info!(path = %path.display(), mode = mode, "Loading model via llama.cpp");
         let model = api
             .model_load_from_file(&c_path, mparams)
             .map_err(InferenceError::LlamaCpp)?;
@@ -62,18 +81,14 @@ impl LlamaCppContext {
         let n_embd = n_embd_raw as usize;
         let vocab_size = vocab_size_raw as usize;
 
-        // Context params: enable embeddings, set pooling to MEAN
         let mut cparams = api.context_default_params();
         cparams.embeddings = true;
-        cparams.pooling_type = LLAMA_POOLING_TYPE_MEAN;
-        // Use model's training context size
-        cparams.n_ctx = 0; // 0 = from model
-                           // Allow batched embedding with multiple sequences per encode call
-        cparams.n_seq_max = 512;
+        cparams.pooling_type = pooling_type;
+        cparams.n_ctx = 0; // from model
+        cparams.n_seq_max = n_seq_max;
         let n_seq_max = cparams.n_seq_max as usize;
 
         let ctx = api.init_from_model(model, cparams).map_err(|e| {
-            // Free model on context creation failure to avoid leak
             api.model_free(model);
             InferenceError::LlamaCpp(e)
         })?;
@@ -97,7 +112,8 @@ impl LlamaCppContext {
             n_ctx = n_ctx,
             n_seq_max = n_seq_max,
             has_encoder = has_encoder,
-            "llama.cpp embedding context created"
+            mode = mode,
+            "llama.cpp {mode} context created"
         );
 
         Ok(Self {

--- a/crates/inference/src/llama/ffi.rs
+++ b/crates/inference/src/llama/ffi.rs
@@ -31,6 +31,7 @@ pub const LLAMA_POOLING_TYPE_NONE: i32 = 0;
 pub const LLAMA_POOLING_TYPE_MEAN: i32 = 1;
 pub const LLAMA_POOLING_TYPE_CLS: i32 = 2;
 pub const LLAMA_POOLING_TYPE_LAST: i32 = 3;
+pub const LLAMA_POOLING_TYPE_RANK: i32 = 4;
 
 // ---------------------------------------------------------------------------
 // #[repr(C)] struct definitions matching llama.h
@@ -649,6 +650,7 @@ mod tests {
         assert_eq!(LLAMA_POOLING_TYPE_MEAN, 1);
         assert_eq!(LLAMA_POOLING_TYPE_CLS, 2);
         assert_eq!(LLAMA_POOLING_TYPE_LAST, 3);
+        assert_eq!(LLAMA_POOLING_TYPE_RANK, 4);
     }
 
     #[test]
@@ -698,6 +700,7 @@ mod tests {
         assert_eq!(LLAMA_POOLING_TYPE_NONE + 1, LLAMA_POOLING_TYPE_MEAN);
         assert_eq!(LLAMA_POOLING_TYPE_MEAN + 1, LLAMA_POOLING_TYPE_CLS);
         assert_eq!(LLAMA_POOLING_TYPE_CLS + 1, LLAMA_POOLING_TYPE_LAST);
+        assert_eq!(LLAMA_POOLING_TYPE_LAST + 1, LLAMA_POOLING_TYPE_RANK);
     }
 
     #[test]

--- a/crates/inference/src/rank.rs
+++ b/crates/inference/src/rank.rs
@@ -1,0 +1,365 @@
+//! Ranking engine: cross-encoder reranking via llama.cpp.
+//!
+//! [`RankingEngine`] provides a high-level API for scoring (query, passage) pairs
+//! using a cross-encoder model. Used by the reranking stage to re-score candidates
+//! after initial retrieval.
+//!
+//! The pipeline: for each passage, tokenize (query, passage) → truncate → encode →
+//! extract relevance score.
+//!
+//! Thread-safe via internal `Mutex` (llama.cpp contexts are not thread-safe).
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use tracing::info;
+
+use crate::llama::context::LlamaCppContext;
+use crate::InferenceError;
+
+/// High-level ranking engine backed by llama.cpp.
+///
+/// Wraps a GGUF cross-encoder model, exposing a simple
+/// `rank(query, passages) -> Vec<f32>` interface. Thread-safe via internal `Mutex`.
+///
+/// # Example
+///
+/// ```no_run
+/// use strata_inference::RankingEngine;
+///
+/// let engine = RankingEngine::from_gguf("reranker.gguf")?;
+/// let scores = engine.rank("what is rust?", &["Rust is a language", "Python is great"])?;
+/// assert_eq!(scores.len(), 2);
+/// # Ok::<(), strata_inference::InferenceError>(())
+/// ```
+pub struct RankingEngine {
+    ctx: Mutex<LlamaCppContext>,
+}
+
+impl std::fmt::Debug for RankingEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let vocab_size = match self.ctx.lock() {
+            Ok(ctx) => ctx.vocab_size,
+            Err(_) => 0,
+        };
+        f.debug_struct("RankingEngine")
+            .field("vocab_size", &vocab_size)
+            .finish()
+    }
+}
+
+impl RankingEngine {
+    /// Load a ranking engine from a GGUF file.
+    ///
+    /// The model is loaded with `embeddings=true` and `pooling_type=RANK`.
+    pub fn from_gguf(path: impl AsRef<Path>) -> Result<Self, InferenceError> {
+        let path = path.as_ref();
+        info!(path = %path.display(), "Loading ranking engine from GGUF");
+        let ctx = LlamaCppContext::load_for_ranking(path)?;
+        info!(
+            vocab_size = ctx.vocab_size,
+            n_ctx = ctx.n_ctx,
+            "Ranking engine ready"
+        );
+        Ok(Self {
+            ctx: Mutex::new(ctx),
+        })
+    }
+
+    /// Load a ranking engine by model name from the registry.
+    ///
+    /// Resolves the name (e.g., `"jina-reranker-v1-tiny"`) to a local GGUF file path,
+    /// automatically downloading from HuggingFace if the model is not
+    /// present locally.
+    pub fn from_registry(name: &str) -> Result<Self, InferenceError> {
+        let registry = crate::registry::ModelRegistry::new();
+
+        #[cfg(feature = "download")]
+        let path = registry.resolve_or_pull(name)?;
+
+        #[cfg(not(feature = "download"))]
+        let path = registry.resolve(name)?;
+
+        match Self::from_gguf(&path) {
+            Ok(engine) => Ok(engine),
+            Err(e) => {
+                registry.check_and_clean_corrupt(name, &path);
+                Err(e)
+            }
+        }
+    }
+
+    /// Score each passage against the query using cross-encoder inference.
+    ///
+    /// Returns one relevance score per passage. Higher scores indicate
+    /// greater relevance. Passages are scored independently — each
+    /// (query, passage) pair is a separate inference call.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` — the search query
+    /// * `passages` — candidate passages to score
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<f32>` of length `passages.len()`, where `scores[i]` is the
+    /// relevance score for `passages[i]`.
+    pub fn rank(&self, query: &str, passages: &[&str]) -> Result<Vec<f32>, InferenceError> {
+        if passages.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let ctx = self
+            .ctx
+            .lock()
+            .map_err(|e| InferenceError::LlamaCpp(format!("mutex poisoned: {}", e)))?;
+
+        let mut scores = Vec::with_capacity(passages.len());
+
+        for passage in passages {
+            let score = Self::rank_single(&ctx, query, passage)?;
+            scores.push(score);
+        }
+
+        Ok(scores)
+    }
+
+    /// Score a single (query, passage) pair.
+    fn rank_single(
+        ctx: &LlamaCppContext,
+        query: &str,
+        passage: &str,
+    ) -> Result<f32, InferenceError> {
+        // Cross-encoder models expect: [CLS] query [SEP] passage [SEP]
+        // We tokenize query and passage separately, then join with a SEP
+        // token to produce proper two-segment input.
+        let mut query_tokens = ctx.tokenize(query, true); // adds [CLS] ... [SEP]
+        let passage_tokens = ctx.tokenize(passage, true); // adds [CLS] ... [SEP]
+
+        if query_tokens.is_empty() && passage_tokens.is_empty() {
+            return Ok(0.0);
+        }
+
+        // Strip the leading [CLS] from the passage tokens (the query
+        // already provides it) so we get: [CLS] query [SEP] passage [SEP]
+        let passage_start = if !passage_tokens.is_empty() && passage_tokens[0] == ctx.bos_id {
+            1
+        } else {
+            0
+        };
+        query_tokens.extend_from_slice(&passage_tokens[passage_start..]);
+        let mut tokens = query_tokens;
+
+        // Truncate to context size
+        if tokens.len() > ctx.n_ctx {
+            tokens.truncate(ctx.n_ctx);
+        }
+
+        // Run inference
+        let batch = ctx.api.batch_get_one(&mut tokens);
+        let inference_result = if ctx.has_encoder {
+            ctx.api.encode(ctx.ctx, batch)
+        } else {
+            ctx.api.decode(ctx.ctx, batch)
+        };
+        if let Err(e) = inference_result {
+            ctx.clear_memory();
+            return Err(InferenceError::LlamaCpp(e));
+        }
+
+        // Extract relevance score.
+        // With LLAMA_POOLING_TYPE_RANK, get_embeddings_seq returns a pointer
+        // to a single float: the relevance score for this sequence.
+        let score_ptr = ctx.api.get_embeddings_seq(ctx.ctx, 0);
+        if score_ptr.is_null() {
+            ctx.clear_memory();
+            return Err(InferenceError::LlamaCpp(
+                "get_embeddings_seq returned null — model may not support ranking".to_string(),
+            ));
+        }
+
+        // SAFETY: score_ptr is non-null, points to at least 1 float owned by
+        // llama.cpp's context, which we hold via the Mutex lock.
+        let score = unsafe { *score_ptr };
+
+        // Clear memory for next call
+        ctx.clear_memory();
+
+        Ok(score)
+    }
+
+    /// Check whether the internal llama.cpp context is healthy.
+    pub fn is_healthy(&self) -> bool {
+        !self.ctx.is_poisoned()
+    }
+}
+
+impl crate::InferenceEngine for RankingEngine {
+    fn rank(&self, query: &str, passages: &[&str]) -> Result<Vec<f32>, crate::InferenceError> {
+        RankingEngine::rank(self, query, passages)
+    }
+
+    fn supports_rank(&self) -> bool {
+        true
+    }
+}
+
+// Compile-time verify Send + Sync.
+const _: () = {
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+    fn assert_both() {
+        assert_send::<RankingEngine>();
+        assert_sync::<RankingEngine>();
+    }
+    let _ = assert_both;
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // RankingEngine constructor tests (no libllama needed for error paths)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn from_registry_unknown_model_returns_registry_error() {
+        let result = RankingEngine::from_registry("nonexistent-reranker");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, InferenceError::Registry(_)),
+            "should be Registry error, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("Unknown model"),
+            "error should mention unknown model: {err}"
+        );
+    }
+
+    #[test]
+    fn from_registry_empty_name_returns_error() {
+        let result = RankingEngine::from_registry("");
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), InferenceError::Registry(_)));
+    }
+
+    #[test]
+    fn from_gguf_nonexistent_file_returns_descriptive_error() {
+        let result = RankingEngine::from_gguf("/nonexistent/path/reranker.gguf");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            matches!(err, InferenceError::LlamaCpp(_)),
+            "should be LlamaCpp error, got: {msg}"
+        );
+        assert!(!msg.is_empty(), "error message should not be empty");
+    }
+
+    #[test]
+    fn from_gguf_accepts_path_types() {
+        let r1 = RankingEngine::from_gguf("/tmp/reranker.gguf");
+        let r2 = RankingEngine::from_gguf(String::from("/tmp/reranker.gguf"));
+        let r3 = RankingEngine::from_gguf(std::path::PathBuf::from("/tmp/reranker.gguf"));
+        assert!(r1.is_err(), "&str path should fail without libllama");
+        assert!(r2.is_err(), "String path should fail without libllama");
+        assert!(r3.is_err(), "PathBuf path should fail without libllama");
+    }
+
+    // -----------------------------------------------------------------------
+    // Compile-time trait assertions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ranking_engine_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<RankingEngine>();
+    }
+
+    #[test]
+    fn debug_format_compiles() {
+        fn assert_debug<T: std::fmt::Debug>() {}
+        assert_debug::<RankingEngine>();
+    }
+
+    #[test]
+    fn is_healthy_method_exists() {
+        fn _check(e: &RankingEngine) -> bool {
+            e.is_healthy()
+        }
+    }
+
+    #[test]
+    fn rank_signature_returns_correct_type() {
+        fn _check(e: &RankingEngine) -> Result<Vec<f32>, crate::InferenceError> {
+            e.rank("query", &[])
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Smoke tests (require libllama + downloaded model)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[ignore]
+    fn smoke_rank_jina_reranker() {
+        let engine = match RankingEngine::from_registry("jina-reranker-v1-tiny") {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("skipping smoke_rank_jina_reranker: {e}");
+                return;
+            }
+        };
+
+        // Empty passages
+        let empty = engine.rank("test", &[]).expect("empty should succeed");
+        assert!(empty.is_empty());
+
+        // Single passage
+        let scores = engine
+            .rank("what is rust?", &["Rust is a systems programming language"])
+            .expect("single passage should succeed");
+        assert_eq!(scores.len(), 1);
+        assert!(scores[0].is_finite(), "score should be finite");
+
+        // Multiple passages — relevant one should score higher
+        let passages = &[
+            "Rust is a systems programming language focused on safety",
+            "The weather today is sunny with a high of 75",
+            "Rust provides memory safety without garbage collection",
+        ];
+        let scores = engine
+            .rank("what is rust?", passages)
+            .expect("multi passage should succeed");
+        assert_eq!(scores.len(), 3);
+        for (i, s) in scores.iter().enumerate() {
+            assert!(s.is_finite(), "score[{i}] should be finite: {s}");
+        }
+        // Relevant passages (0, 2) should score higher than irrelevant (1)
+        assert!(
+            scores[0] > scores[1],
+            "relevant passage should score higher: {} vs {}",
+            scores[0],
+            scores[1]
+        );
+        assert!(
+            scores[2] > scores[1],
+            "relevant passage should score higher: {} vs {}",
+            scores[2],
+            scores[1]
+        );
+
+        // Same query scored twice should produce deterministic results
+        let scores2 = engine
+            .rank("what is rust?", passages)
+            .expect("repeat should succeed");
+        for (i, (a, b)) in scores.iter().zip(scores2.iter()).enumerate() {
+            assert!(
+                (a - b).abs() < 1e-6,
+                "scores should be deterministic, passage {i}: {a} vs {b}"
+            );
+        }
+    }
+}

--- a/crates/inference/src/rank.rs
+++ b/crates/inference/src/rank.rs
@@ -131,28 +131,41 @@ impl RankingEngine {
         passage: &str,
     ) -> Result<f32, InferenceError> {
         // Cross-encoder models expect: [CLS] query [SEP] passage [SEP]
-        // We tokenize query and passage separately, then join with a SEP
-        // token to produce proper two-segment input.
-        let mut query_tokens = ctx.tokenize(query, true); // adds [CLS] ... [SEP]
+        // We tokenize query and passage separately, then join them.
+        let query_tokens = ctx.tokenize(query, true); // adds [CLS] ... [SEP]
         let passage_tokens = ctx.tokenize(passage, true); // adds [CLS] ... [SEP]
 
         if query_tokens.is_empty() && passage_tokens.is_empty() {
             return Ok(0.0);
         }
 
-        // Strip the leading [CLS] from the passage tokens (the query
-        // already provides it) so we get: [CLS] query [SEP] passage [SEP]
-        let passage_start = if !passage_tokens.is_empty() && passage_tokens[0] == ctx.bos_id {
-            1
-        } else {
-            0
-        };
-        query_tokens.extend_from_slice(&passage_tokens[passage_start..]);
+        // Build combined token sequence: [CLS] query [SEP] passage [SEP]
+        // Strip the leading [CLS] from the passage tokens only when the
+        // query already provides one (non-empty query_tokens starts with BOS).
         let mut tokens = query_tokens;
+        let has_query_bos = !tokens.is_empty() && tokens[0] == ctx.bos_id;
+        let passage_start =
+            if has_query_bos && !passage_tokens.is_empty() && passage_tokens[0] == ctx.bos_id {
+                1
+            } else {
+                0
+            };
+        tokens.extend_from_slice(&passage_tokens[passage_start..]);
 
-        // Truncate to context size
+        // Truncate to context size, preserving the trailing [SEP] when
+        // possible so the model sees a proper segment boundary.
         if tokens.len() > ctx.n_ctx {
+            let last_token = tokens.last().copied();
             tokens.truncate(ctx.n_ctx);
+            // If truncation removed the trailing SEP (eos), replace the
+            // last token with it so the model sees a complete segment.
+            if let Some(sep) = last_token {
+                if sep == ctx.eos_id && tokens.last().copied() != Some(sep) {
+                    if let Some(last) = tokens.last_mut() {
+                        *last = sep;
+                    }
+                }
+            }
         }
 
         // Run inference
@@ -296,6 +309,26 @@ mod tests {
         fn _check(e: &RankingEngine) -> Result<Vec<f32>, crate::InferenceError> {
             e.rank("query", &[])
         }
+    }
+
+    /// Verify RankingEngine does NOT support embed or generate via the trait.
+    #[test]
+    fn trait_does_not_support_embed_or_generate() {
+        // Compile-time proof: these trait methods exist and return the
+        // expected defaults. Can't construct an engine without libllama,
+        // so we verify via function signatures.
+        fn _check_embed(e: &dyn crate::InferenceEngine) -> bool {
+            !e.supports_embed() && !e.supports_generate() && e.supports_rank()
+        }
+        // Also verify the return type signatures compile
+        fn _check_embed_err(
+            e: &dyn crate::InferenceEngine,
+        ) -> Result<Vec<f32>, crate::InferenceError> {
+            e.embed("text")?;
+            unreachable!()
+        }
+        let _ = _check_embed;
+        let _ = _check_embed_err;
     }
 
     // -----------------------------------------------------------------------

--- a/crates/inference/src/registry/catalog.rs
+++ b/crates/inference/src/registry/catalog.rs
@@ -65,6 +65,37 @@ pub static CATALOG: &[CatalogEntry] = &[
         architecture: "gemma3",
         embedding_dim: 768,
     },
+    // ===== Ranking Models =====
+    CatalogEntry {
+        name: "jina-reranker-v1-tiny",
+        aliases: &["jina-reranker-tiny", "jina-reranker"],
+        task: ModelTask::Rank,
+        hf_repo: "stratalab-org/jina-reranker-v1-tiny-en-GGUF",
+        default_quant: "f16",
+        variants: &[QuantVariant {
+            name: "f16",
+            hf_file: "jina-reranker-v1-tiny-en.F16.gguf",
+            size_bytes: 66_000_000,
+            sha256: None,
+        }],
+        architecture: "jina-bert-v2",
+        embedding_dim: 0,
+    },
+    CatalogEntry {
+        name: "bge-reranker-v2-m3",
+        aliases: &["bge-reranker"],
+        task: ModelTask::Rank,
+        hf_repo: "stratalab-org/bge-reranker-v2-m3-GGUF",
+        default_quant: "q8_0",
+        variants: &[QuantVariant {
+            name: "q8_0",
+            hf_file: "bge-reranker-v2-m3-Q8_0.gguf",
+            size_bytes: 580_000_000,
+            sha256: None,
+        }],
+        architecture: "xlm-roberta",
+        embedding_dim: 0,
+    },
     // ===== Generation Models =====
     CatalogEntry {
         name: "gpt2",
@@ -400,6 +431,54 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn ranking_models_have_zero_embedding_dim() {
+        for entry in CATALOG {
+            if entry.task == ModelTask::Rank {
+                assert_eq!(
+                    entry.embedding_dim, 0,
+                    "Ranking model '{}' should have embedding_dim=0",
+                    entry.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ranking_models_exist_in_catalog() {
+        let rank_count = CATALOG.iter().filter(|e| e.task == ModelTask::Rank).count();
+        assert!(
+            rank_count >= 1,
+            "catalog should have at least one ranking model"
+        );
+    }
+
+    #[test]
+    fn find_entry_jina_reranker() {
+        let entry = find_entry("jina-reranker-v1-tiny").unwrap();
+        assert_eq!(entry.task, ModelTask::Rank);
+    }
+
+    #[test]
+    fn find_entry_jina_reranker_alias() {
+        let entry = find_entry("jina-reranker").unwrap();
+        assert_eq!(entry.name, "jina-reranker-v1-tiny");
+        assert_eq!(entry.task, ModelTask::Rank);
+    }
+
+    #[test]
+    fn find_entry_bge_reranker() {
+        let entry = find_entry("bge-reranker-v2-m3").unwrap();
+        assert_eq!(entry.task, ModelTask::Rank);
+    }
+
+    #[test]
+    fn find_entry_bge_reranker_alias() {
+        let entry = find_entry("bge-reranker").unwrap();
+        assert_eq!(entry.name, "bge-reranker-v2-m3");
+        assert_eq!(entry.task, ModelTask::Rank);
     }
 
     #[test]

--- a/crates/inference/src/registry/mod.rs
+++ b/crates/inference/src/registry/mod.rs
@@ -31,6 +31,7 @@ use crate::error::InferenceError;
 pub enum ModelTask {
     Embed,
     Generate,
+    Rank,
 }
 
 impl std::fmt::Display for ModelTask {
@@ -38,6 +39,7 @@ impl std::fmt::Display for ModelTask {
         match self {
             ModelTask::Embed => write!(f, "embed"),
             ModelTask::Generate => write!(f, "generate"),
+            ModelTask::Rank => write!(f, "rank"),
         }
     }
 }
@@ -73,7 +75,7 @@ pub struct CatalogEntry {
     pub variants: &'static [QuantVariant],
     /// Model architecture: "qwen3", "llama", "bert"
     pub architecture: &'static str,
-    /// Embedding dimension (0 for generation models).
+    /// Embedding dimension (0 for generation and ranking models).
     pub embedding_dim: usize,
 }
 
@@ -914,13 +916,17 @@ mod tests {
     fn model_task_display() {
         assert_eq!(ModelTask::Embed.to_string(), "embed");
         assert_eq!(ModelTask::Generate.to_string(), "generate");
+        assert_eq!(ModelTask::Rank.to_string(), "rank");
     }
 
     #[test]
     fn model_task_equality() {
         assert_eq!(ModelTask::Embed, ModelTask::Embed);
         assert_eq!(ModelTask::Generate, ModelTask::Generate);
+        assert_eq!(ModelTask::Rank, ModelTask::Rank);
         assert_ne!(ModelTask::Embed, ModelTask::Generate);
+        assert_ne!(ModelTask::Embed, ModelTask::Rank);
+        assert_ne!(ModelTask::Generate, ModelTask::Rank);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `rank(query, passages) -> Vec<f32>` to `InferenceEngine` trait for cross-encoder reranking
- `RankingEngine` struct loads GGUF reranker models via llama.cpp with `LLAMA_POOLING_TYPE_RANK`
- `load_ranker("provider:model")` top-level constructor (local-only, matches `load_embedder` pattern)
- `ModelTask::Rank` variant with catalog entries for `jina-reranker-v1-tiny` and `bge-reranker-v2-m3`
- Refactored `load_for_embedding`/`load_for_ranking` into shared `load_pooled()` helper

## Test plan

- [x] 227 unit tests pass (`cargo test -p strata-inference --features local --lib`)
- [x] Clippy clean (`cargo clippy -p strata-inference --features local --all-targets -- -D warnings`)
- [x] `cargo fmt --all -- --check` clean
- [ ] Smoke test with downloaded jina-reranker GGUF (`cargo test -p strata-inference --features local smoke_rank -- --ignored`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)