### PR TITLE
Fix #2184: Track segment metadata in memory pressure and write backpressure

### DIFF
--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -207,14 +207,30 @@ impl Database {
         let cfg = self.config.read();
         let wbs = cfg.storage.write_buffer_size as u64;
         let max_frozen = cfg.storage.max_immutable_memtables as u64;
-        if wbs == 0 {
-            return Ok(());
+        drop(cfg);
+
+        if wbs > 0 {
+            let threshold = wbs * (max_frozen + 2);
+            let current = self.storage.total_memtable_bytes();
+            if current > threshold {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+                return Ok(());
+            }
         }
-        let threshold = wbs * (max_frozen + 2);
-        let current = self.storage.total_memtable_bytes();
-        if current > threshold {
-            std::thread::sleep(std::time::Duration::from_millis(1));
+
+        // Segment metadata stalling: bloom + index pinned outside block cache.
+        // When this overhead exceeds the block cache budget, stall to let
+        // compaction merge segments and reduce metadata footprint.
+        // Use the resolved global capacity (handles auto-detect when config is 0).
+        let cache_cap = strata_storage::block_cache::global_capacity() as u64;
+        if cache_cap > 0 {
+            let seg_meta = self.storage.total_segment_metadata_bytes();
+            if seg_meta > cache_cap {
+                self.schedule_flush_if_needed();
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
         }
+
         Ok(())
     }
 

--- a/crates/storage/src/block_cache.rs
+++ b/crates/storage/src/block_cache.rs
@@ -463,6 +463,11 @@ pub fn global_cache() -> &'static BlockCache {
     GLOBAL_CACHE.get_or_init(|| BlockCache::new(GLOBAL_CAPACITY.load(Ordering::Relaxed)))
 }
 
+/// Return the configured global block cache capacity in bytes.
+pub fn global_capacity() -> usize {
+    GLOBAL_CAPACITY.load(Ordering::Relaxed)
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------

--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -479,6 +479,48 @@ impl KVSegment {
         &self.file_path
     }
 
+    /// Approximate heap bytes used by eagerly-loaded segment metadata
+    /// (bloom filter partitions + index blocks). These are NOT tracked by
+    /// the block cache and contribute to RSS outside any configured budget.
+    pub fn metadata_bytes(&self) -> u64 {
+        let bloom: u64 = self
+            .bloom
+            .partitions
+            .iter()
+            .map(|p| p.len() as u64 + std::mem::size_of::<Arc<Vec<u8>>>() as u64)
+            .sum::<u64>()
+            + self
+                .bloom
+                .index
+                .iter()
+                .map(|e| e.max_key.len() as u64 + std::mem::size_of::<FilterIndexEntry>() as u64)
+                .sum::<u64>();
+
+        let index: u64 = match &self.index {
+            SegmentIndex::Monolithic(entries) => entries
+                .iter()
+                .map(|e| e.key.len() as u64 + std::mem::size_of::<IndexEntry>() as u64)
+                .sum(),
+            SegmentIndex::Partitioned {
+                top_level,
+                sub_indexes,
+            } => {
+                let top: u64 = top_level
+                    .iter()
+                    .map(|e| e.key.len() as u64 + std::mem::size_of::<IndexEntry>() as u64)
+                    .sum();
+                let subs: u64 = sub_indexes
+                    .iter()
+                    .flat_map(|sub| sub.iter())
+                    .map(|e| e.key.len() as u64 + std::mem::size_of::<IndexEntry>() as u64)
+                    .sum();
+                top + subs
+            }
+        };
+
+        bloom + index
+    }
+
     /// Format version from the segment header.
     #[cfg(test)]
     pub(crate) fn format_version(&self) -> u16 {

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -2670,12 +2670,45 @@ impl SegmentedStore {
         total
     }
 
+    /// Sum of `metadata_bytes()` across all open segments in all branches.
+    ///
+    /// This accounts for eagerly-loaded bloom filter partitions and index
+    /// blocks that are pinned in heap memory outside the block cache.
+    pub fn total_segment_metadata_bytes(&self) -> u64 {
+        let mut total: u64 = 0;
+        for entry in self.branches.iter() {
+            let version = entry.value().version.load();
+            for level in &version.levels {
+                for seg in level {
+                    total += seg.metadata_bytes();
+                }
+            }
+            // Include inherited COW layers — their segments are also in memory.
+            for layer in &entry.value().inherited_layers {
+                for level in &layer.segments.levels {
+                    for seg in level {
+                        total += seg.metadata_bytes();
+                    }
+                }
+            }
+        }
+        total
+    }
+
+    /// Total tracked memory: memtable bytes + segment metadata bytes.
+    ///
+    /// This is the correct input for memory pressure evaluation — it accounts
+    /// for ALL major heap consumers outside the block cache.
+    pub fn total_tracked_bytes(&self) -> u64 {
+        self.total_memtable_bytes() + self.total_segment_metadata_bytes()
+    }
+
     /// Check the current memory pressure level.
     ///
-    /// Currently unused in production — will be wired into the background
-    /// flush/compaction scheduler to trigger adaptive write stalling.
+    /// Includes both memtable bytes and segment metadata (bloom + index) in
+    /// the pressure calculation, ensuring segment accumulation is visible.
     pub fn pressure_level(&self) -> PressureLevel {
-        self.pressure.level(self.total_memtable_bytes())
+        self.pressure.level(self.total_tracked_bytes())
     }
 
     /// Returns `true` if any branch has frozen memtables pending flush.

--- a/crates/storage/src/segmented/tests/compact.rs
+++ b/crates/storage/src/segmented/tests/compact.rs
@@ -396,6 +396,113 @@ fn pressure_level_tracks_growth() {
 }
 
 #[test]
+fn pressure_includes_segment_metadata() {
+    use crate::pressure::MemoryPressure;
+    let dir = tempfile::tempdir().unwrap();
+    // Budget: 100 bytes — any segment's bloom + index metadata will exceed this.
+    let store = SegmentedStore::with_dir_and_pressure(
+        dir.path().to_path_buf(),
+        0,
+        MemoryPressure::new(100, 0.7, 0.9),
+    );
+    let b = branch();
+
+    // Write enough entries to produce a segment with non-trivial bloom/index metadata.
+    for i in 0..100u64 {
+        seed(
+            &store,
+            kv_key(&format!("key_{:04}", i)),
+            Value::String("x".repeat(100)),
+            i + 1,
+        );
+    }
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+
+    // After flush, memtable is nearly empty. But segment bloom + index metadata
+    // (loaded eagerly at open time) should be tracked. With a 100-byte budget,
+    // segment metadata (~500 bytes of bloom/index data) should push pressure up.
+    let level = store.pressure_level();
+    assert!(
+        level >= PressureLevel::Warning,
+        "pressure_level ignores segment metadata — reports {:?} even though \
+         segment bloom+index metadata far exceeds the 100-byte budget",
+        level
+    );
+}
+
+mod segment_metadata_tracking {
+    use super::*;
+
+    #[test]
+    fn segment_metadata_bytes_tracked_after_flush() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+        let b = branch();
+
+        assert_eq!(store.total_segment_metadata_bytes(), 0);
+
+        for i in 0..50u64 {
+            seed(
+                &store,
+                kv_key(&format!("key_{:04}", i)),
+                Value::String("x".repeat(100)),
+                i + 1,
+            );
+        }
+        store.rotate_memtable(&b);
+        store.flush_oldest_frozen(&b).unwrap();
+
+        let meta = store.total_segment_metadata_bytes();
+        assert!(
+            meta > 0,
+            "flushed segment should have non-zero metadata bytes (bloom + index)"
+        );
+    }
+
+    #[test]
+    fn total_tracked_bytes_includes_memtable_and_segments() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+        let b = branch();
+
+        // Write and flush to create segments
+        for i in 0..50u64 {
+            seed(
+                &store,
+                kv_key(&format!("key_{:04}", i)),
+                Value::String("x".repeat(100)),
+                i + 1,
+            );
+        }
+        store.rotate_memtable(&b);
+        store.flush_oldest_frozen(&b).unwrap();
+
+        // Write more to active memtable
+        for i in 50..60u64 {
+            seed(
+                &store,
+                kv_key(&format!("key_{:04}", i)),
+                Value::String("x".repeat(100)),
+                i + 1,
+            );
+        }
+
+        let memtable = store.total_memtable_bytes();
+        let seg_meta = store.total_segment_metadata_bytes();
+        let tracked = store.total_tracked_bytes();
+
+        assert!(memtable > 0, "active memtable should have data");
+        assert!(seg_meta > 0, "flushed segments should have metadata");
+        assert_eq!(
+            tracked,
+            memtable + seg_meta,
+            "total_tracked should be memtable + segment metadata"
+        );
+    }
+}
+
+#[test]
 fn branches_needing_flush_prioritization() {
     let store = SegmentedStore::new();
     let b1 = branch();


### PR DESCRIPTION
## Summary

- Segment bloom filter partitions and index blocks were eagerly loaded into heap memory but completely untracked by the memory pressure system
- With small write buffers (e.g., 4MB in 32MB budget profile), frequent flushes create many small segments whose untracked metadata dominated RSS — 254MB actual vs 32MB configured
- The `pressure_level()` function only counted memtable bytes, ignoring per-segment metadata entirely

## Root Cause

`SegmentedStore::pressure_level()` called `total_memtable_bytes()` which only sums active + frozen memtable sizes. Per-segment metadata (bloom partitions loaded via `Arc<Vec<u8>>` + index blocks loaded as `Vec<IndexEntry>`) is pinned in heap memory at segment open time, outside the block cache, with no tracking or budget enforcement.

## Fix

- **`KVSegment::metadata_bytes()`** — measures approximate heap size of bloom partitions + index blocks per segment
- **`SegmentedStore::total_segment_metadata_bytes()`** — sums metadata across all open segments (including inherited COW layers)
- **`SegmentedStore::total_tracked_bytes()`** — `memtable_bytes + segment_metadata_bytes`
- **`pressure_level()`** — now uses `total_tracked_bytes()` instead of just memtable bytes
- **`maybe_apply_write_backpressure()`** — adds segment metadata stall: when metadata exceeds the block cache capacity, yields 1ms per write + triggers flush/compaction
- **`block_cache::global_capacity()`** — new getter for the resolved (auto-detected) cache capacity

~40 lines of non-test production code.

## Invariants Verified

SCALE-001 (HOLDS), SCALE-002 (strengthened), SCALE-008 (strengthened), LSM-003, LSM-004, CMP-006, ACID-003, ACID-004 — all HOLDS. Full invariant check completed.

## Test Plan

- [x] `pressure_includes_segment_metadata` — verifies pressure reflects segment metadata after flush
- [x] `segment_metadata_bytes_tracked_after_flush` — verifies metadata tracking returns >0 after flush
- [x] `total_tracked_bytes_includes_memtable_and_segments` — verifies composition: tracked = memtable + segment metadata
- [x] Full storage crate tests (637 pass)
- [x] Full engine crate tests (37 pass)
- [x] Full workspace tests pass (excluding strata-inference CMake dep)
- [x] Clippy clean on changed crates
- [ ] Re-run `memory_efficiency` benchmark in strata-benchmarks to measure RSS improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)