### PR TITLE
Fix #2143: Wire Event and JSON Searchable to InvertedIndex for BM25

### DIFF
--- a/crates/engine/src/primitives/event.rs
+++ b/crates/engine/src/primitives/event.rs
@@ -993,10 +993,74 @@ impl EventLog {
 impl crate::search::Searchable for EventLog {
     fn search(
         &self,
-        _req: &crate::SearchRequest,
+        req: &crate::SearchRequest,
     ) -> strata_core::StrataResult<crate::SearchResponse> {
-        // Search is handled by the intelligence layer, not the primitive
-        Ok(crate::SearchResponse::empty())
+        use crate::search::{truncate_text, EntityRef, InvertedIndex, SearchHit, SearchStats};
+        use std::time::Instant;
+
+        let start = Instant::now();
+        let index = self.db.extension::<InvertedIndex>()?;
+
+        if !index.is_enabled() || index.total_docs() == 0 {
+            return Ok(crate::SearchResponse::empty());
+        }
+
+        let query_terms = crate::search::tokenize(&req.query);
+        let scorer = self.db.config().bm25_scorer();
+
+        let top_k = index.score_top_k(&query_terms, &req.branch_id, req.k, scorer.k1, scorer.b);
+
+        let hits: Vec<SearchHit> = top_k
+            .into_iter()
+            .filter_map(|scored| {
+                let entity_ref = index.resolve_doc_id(scored.doc_id)?;
+                // Only include Event results from this primitive
+                if let EntityRef::Event {
+                    ref branch_id,
+                    sequence,
+                } = entity_ref
+                {
+                    let snippet = self
+                        .get(branch_id, &req.space, sequence)
+                        .ok()
+                        .flatten()
+                        .map(|v| {
+                            let event = v.value();
+                            truncate_text(
+                                &format!(
+                                    "[{}] {}",
+                                    event.event_type,
+                                    serde_json::to_string(&event.payload).unwrap_or_default()
+                                ),
+                                100,
+                            )
+                        });
+                    Some(SearchHit {
+                        doc_ref: entity_ref,
+                        score: scored.score,
+                        rank: 0,
+                        snippet,
+                    })
+                } else {
+                    None
+                }
+            })
+            .enumerate()
+            .map(|(i, mut hit)| {
+                hit.rank = (i + 1) as u32;
+                hit
+            })
+            .collect();
+
+        let elapsed = start.elapsed().as_micros() as u64;
+        let mut stats = SearchStats::new(elapsed, hits.len());
+        stats = stats.with_index_used(true);
+
+        Ok(crate::SearchResponse {
+            hits,
+            truncated: false,
+            stats,
+        })
     }
 
     fn primitive_kind(&self) -> strata_core::PrimitiveType {
@@ -1740,5 +1804,124 @@ mod tests {
 
         // Only 2 events should be persisted
         assert_eq!(log.len(&branch_id, "default").unwrap(), 2);
+    }
+
+    // ========== EventLog::search() BM25 integration tests ==========
+
+    #[test]
+    fn test_event_search_bm25() {
+        use crate::search::Searchable;
+
+        let (_temp, db, log) = setup();
+        let branch_id = BranchId::new();
+
+        // Verify index is enabled
+        let index = db.extension::<crate::search::InvertedIndex>().unwrap();
+        assert!(index.is_enabled());
+
+        log.append(
+            &branch_id,
+            "default",
+            "user.login",
+            payload_with("user", Value::String("alice logged in successfully".into())),
+        )
+        .unwrap();
+        log.append(
+            &branch_id,
+            "default",
+            "user.logout",
+            payload_with("user", Value::String("bob logged out".into())),
+        )
+        .unwrap();
+        log.append(
+            &branch_id,
+            "default",
+            "system.error",
+            payload_with("msg", Value::String("disk full error detected".into())),
+        )
+        .unwrap();
+
+        let req = crate::SearchRequest::new(branch_id, "logged");
+        let response = log.search(&req).unwrap();
+
+        assert!(
+            !response.is_empty(),
+            "Should find events containing 'logged'"
+        );
+        assert!(response.stats.index_used);
+        // Both login and logout events contain "logged"
+        assert_eq!(response.len(), 2);
+        assert_eq!(response.hits[0].rank, 1);
+        assert_eq!(response.hits[1].rank, 2);
+    }
+
+    #[test]
+    fn test_event_search_type_boost() {
+        use crate::search::Searchable;
+
+        let (_temp, _db, log) = setup();
+        let branch_id = BranchId::new();
+
+        // Event type "error" should be findable via BM25
+        log.append(
+            &branch_id,
+            "default",
+            "error",
+            payload_with("msg", Value::String("something went wrong".into())),
+        )
+        .unwrap();
+        log.append(
+            &branch_id,
+            "default",
+            "info",
+            payload_with("msg", Value::String("all systems normal".into())),
+        )
+        .unwrap();
+
+        // Search for "error" — should match the event with type "error"
+        let req = crate::SearchRequest::new(branch_id, "error");
+        let response = log.search(&req).unwrap();
+
+        assert!(!response.is_empty(), "Should find event with type 'error'");
+        // Only the "error" event contains the term "error"
+        assert_eq!(response.len(), 1, "Only one event should match 'error'");
+        // The event with type "error" should be the top hit
+        if let crate::search::EntityRef::Event { sequence, .. } = &response.hits[0].doc_ref {
+            assert_eq!(*sequence, 0, "First event (type=error) should be top hit");
+        } else {
+            panic!("Expected EntityRef::Event");
+        }
+    }
+
+    #[test]
+    fn test_event_search_empty_index() {
+        use crate::search::Searchable;
+
+        let (_temp, _db, log) = setup();
+        let branch_id = BranchId::new();
+
+        let req = crate::SearchRequest::new(branch_id, "anything");
+        let response = log.search(&req).unwrap();
+        assert!(response.is_empty());
+    }
+
+    #[test]
+    fn test_event_search_no_match() {
+        use crate::search::Searchable;
+
+        let (_temp, _db, log) = setup();
+        let branch_id = BranchId::new();
+
+        log.append(
+            &branch_id,
+            "default",
+            "ping",
+            payload_with("status", Value::String("ok".into())),
+        )
+        .unwrap();
+
+        let req = crate::SearchRequest::new(branch_id, "nonexistent");
+        let response = log.search(&req).unwrap();
+        assert!(response.is_empty());
     }
 }

--- a/crates/engine/src/primitives/json/mod.rs
+++ b/crates/engine/src/primitives/json/mod.rs
@@ -286,7 +286,7 @@ impl JsonStore {
         let key = self.key_for(branch_id, space, doc_id);
         let doc = JsonDoc::new(doc_id, value.clone());
 
-        self.db.transaction(*branch_id, |txn| {
+        let version = self.db.transaction(*branch_id, |txn| {
             // Check if document already exists
             if txn.get(&key)?.is_some() {
                 return Err(StrataError::invalid_input(format!(
@@ -313,7 +313,12 @@ impl JsonStore {
             }
 
             Ok(Version::counter(doc.version))
-        })
+        })?;
+
+        // Update inverted index for BM25 search (zero overhead when disabled)
+        Self::index_json_doc(&self.db, branch_id, doc_id, &value)?;
+
+        Ok(version)
     }
 
     // ========================================================================
@@ -438,6 +443,26 @@ impl JsonStore {
         Ok(VersionedHistory::new(versions))
     }
 
+    /// Index a JSON document into the InvertedIndex for BM25 search.
+    /// Zero overhead when the index is disabled.
+    fn index_json_doc(
+        db: &Arc<Database>,
+        branch_id: &BranchId,
+        doc_id: &str,
+        value: &JsonValue,
+    ) -> StrataResult<()> {
+        let idx = db.extension::<crate::search::InvertedIndex>()?;
+        if idx.is_enabled() {
+            let text = serde_json::to_string(value.as_inner()).unwrap_or_default();
+            let entity_ref = crate::search::EntityRef::Json {
+                branch_id: *branch_id,
+                doc_id: doc_id.to_string(),
+            };
+            idx.index_document(&entity_ref, &text, None);
+        }
+        Ok(())
+    }
+
     /// Core read-modify-write for a single JSON document within a transaction.
     ///
     /// If the document exists, applies `set_at_path` and increments version.
@@ -540,12 +565,17 @@ impl JsonStore {
         value.validate().map_err(limit_error_to_error)?;
 
         let key = self.key_for(branch_id, space, doc_id);
-        self.db.transaction(*branch_id, |txn| {
+        let result = self.db.transaction(*branch_id, |txn| {
             let indexes = Self::load_indexes(txn, branch_id, space)?;
             Self::set_in_txn(
                 txn, &key, doc_id, path, value, true, branch_id, space, &indexes,
             )
-        })
+        })?;
+
+        // Update inverted index for BM25 search
+        Self::index_json_doc(&self.db, branch_id, doc_id, &result.1)?;
+
+        Ok(result)
     }
 
     /// Set multiple documents in a single transaction.
@@ -572,7 +602,10 @@ impl JsonStore {
             value.validate().map_err(limit_error_to_error)?;
         }
 
-        self.db.transaction(*branch_id, |txn| {
+        // Keep doc_ids for post-commit indexing
+        let doc_ids: Vec<String> = entries.iter().map(|(id, _, _)| id.clone()).collect();
+
+        let results = self.db.transaction(*branch_id, |txn| {
             let indexes = Self::load_indexes(txn, branch_id, space)?;
             let mut results = Vec::with_capacity(entries.len());
             for (doc_id, path, value) in &entries {
@@ -591,7 +624,14 @@ impl JsonStore {
                 results.push(result);
             }
             Ok(results)
-        })
+        })?;
+
+        // Post-commit: update inverted index for BM25 search
+        for (doc_id, (_, doc_value)) in doc_ids.iter().zip(results.iter()) {
+            Self::index_json_doc(&self.db, branch_id, doc_id, doc_value)?;
+        }
+
+        Ok(results)
     }
 
     /// Get multiple documents in a single transaction.
@@ -686,13 +726,17 @@ impl JsonStore {
         value.validate().map_err(limit_error_to_error)?;
 
         let key = self.key_for(branch_id, space, doc_id);
-        self.db.transaction(*branch_id, |txn| {
+        let (version, doc_value) = self.db.transaction(*branch_id, |txn| {
             let indexes = Self::load_indexes(txn, branch_id, space)?;
             Self::set_in_txn(
                 txn, &key, doc_id, path, value, false, branch_id, space, &indexes,
             )
-            .map(|(version, _)| version)
-        })
+        })?;
+
+        // Update inverted index for BM25 search
+        Self::index_json_doc(&self.db, branch_id, doc_id, &doc_value)?;
+
+        Ok(version)
     }
 
     /// Delete value at path in a document
@@ -1349,6 +1393,76 @@ impl JsonStore {
 
 // ========== Searchable Trait Implementation ==========
 
+impl JsonStore {
+    /// BM25 search via InvertedIndex — same pattern as KV.
+    fn search_bm25(
+        &self,
+        req: &crate::SearchRequest,
+    ) -> strata_core::StrataResult<crate::SearchResponse> {
+        use crate::search::{truncate_text, EntityRef, InvertedIndex, SearchHit, SearchStats};
+        use std::time::Instant;
+
+        let start = Instant::now();
+        let index = self.db.extension::<InvertedIndex>()?;
+
+        if !index.is_enabled() || index.total_docs() == 0 {
+            return Ok(crate::SearchResponse::empty());
+        }
+
+        let query_terms = crate::search::tokenize(&req.query);
+        let scorer = self.db.config().bm25_scorer();
+
+        let top_k = index.score_top_k(&query_terms, &req.branch_id, req.k, scorer.k1, scorer.b);
+
+        let hits: Vec<SearchHit> = top_k
+            .into_iter()
+            .filter_map(|scored| {
+                let entity_ref = index.resolve_doc_id(scored.doc_id)?;
+                // Only include Json results from this primitive
+                if let EntityRef::Json {
+                    ref branch_id,
+                    ref doc_id,
+                } = entity_ref
+                {
+                    let snippet = self
+                        .get(branch_id, &req.space, doc_id, &JsonPath::root())
+                        .ok()
+                        .flatten()
+                        .map(|v| {
+                            truncate_text(
+                                &serde_json::to_string(v.as_inner()).unwrap_or_default(),
+                                200,
+                            )
+                        });
+                    Some(SearchHit {
+                        doc_ref: entity_ref,
+                        score: scored.score,
+                        rank: 0,
+                        snippet,
+                    })
+                } else {
+                    None
+                }
+            })
+            .enumerate()
+            .map(|(i, mut hit)| {
+                hit.rank = (i + 1) as u32;
+                hit
+            })
+            .collect();
+
+        let elapsed = start.elapsed().as_micros() as u64;
+        let mut stats = SearchStats::new(elapsed, hits.len());
+        stats = stats.with_index_used(true);
+
+        Ok(crate::SearchResponse {
+            hits,
+            truncated: false,
+            stats,
+        })
+    }
+}
+
 impl crate::search::Searchable for JsonStore {
     fn search(
         &self,
@@ -1357,6 +1471,11 @@ impl crate::search::Searchable for JsonStore {
         use crate::search::{EntityRef, SearchHit, SearchStats, SortDirection};
         use std::collections::HashSet;
         use std::time::Instant;
+
+        // BM25 fallback: non-empty query with no field_filter → use InvertedIndex
+        if !req.query.is_empty() && req.field_filter.is_none() && req.sort_by.is_none() {
+            return self.search_bm25(req);
+        }
 
         let start = Instant::now();
 
@@ -3322,5 +3441,118 @@ mod tests {
         if let Value::Bytes(bytes) = &v2_value {
             assert_eq!(bytes[0], JsonStore::FORMAT_VERSION);
         }
+    }
+
+    // ========== JsonStore::search() BM25 integration tests ==========
+
+    #[test]
+    fn test_json_search_bm25() {
+        use crate::search::Searchable;
+        use std::str::FromStr;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let db = Database::open(temp.path()).unwrap();
+        let store = JsonStore::new(db.clone());
+        let branch_id = BranchId::new();
+
+        // Verify index is enabled
+        let index = db.extension::<crate::search::InvertedIndex>().unwrap();
+        assert!(index.is_enabled());
+
+        store
+            .create(
+                &branch_id,
+                "default",
+                "doc1",
+                JsonValue::from_str(r#"{"title":"rust programming","body":"learn rust basics"}"#)
+                    .unwrap(),
+            )
+            .unwrap();
+        store
+            .create(
+                &branch_id,
+                "default",
+                "doc2",
+                JsonValue::from_str(r#"{"title":"python scripting","body":"python is popular"}"#)
+                    .unwrap(),
+            )
+            .unwrap();
+        store
+            .create(
+                &branch_id,
+                "default",
+                "doc3",
+                JsonValue::from_str(
+                    r#"{"title":"go concurrency","body":"goroutines and channels"}"#,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+        let req = crate::SearchRequest::new(branch_id, "rust");
+        let response = store.search(&req).unwrap();
+
+        assert!(
+            !response.is_empty(),
+            "Should find JSON docs containing 'rust'"
+        );
+        assert!(response.stats.index_used);
+        // Only doc1 contains "rust"
+        assert_eq!(response.len(), 1);
+        if let crate::search::EntityRef::Json { ref doc_id, .. } = response.hits[0].doc_ref {
+            assert_eq!(doc_id, "doc1");
+        } else {
+            panic!("Expected EntityRef::Json");
+        }
+    }
+
+    #[test]
+    fn test_json_search_bm25_with_set_or_create() {
+        use crate::search::Searchable;
+        use std::str::FromStr;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let db = Database::open(temp.path()).unwrap();
+        let store = JsonStore::new(db.clone());
+        let branch_id = BranchId::new();
+
+        // Use set_or_create (creates if missing)
+        store
+            .set_or_create(
+                &branch_id,
+                "default",
+                "article1",
+                &JsonPath::root(),
+                JsonValue::from_str(r#"{"content":"database indexing techniques"}"#).unwrap(),
+            )
+            .unwrap();
+
+        let req = crate::SearchRequest::new(branch_id, "indexing");
+        let response = store.search(&req).unwrap();
+
+        assert!(
+            !response.is_empty(),
+            "set_or_create docs should be findable via BM25"
+        );
+        assert_eq!(response.len(), 1);
+        if let crate::search::EntityRef::Json { ref doc_id, .. } = response.hits[0].doc_ref {
+            assert_eq!(doc_id, "article1");
+        } else {
+            panic!("Expected EntityRef::Json");
+        }
+    }
+
+    #[test]
+    fn test_json_search_empty_index() {
+        use crate::search::Searchable;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let db = Database::open(temp.path()).unwrap();
+        let store = JsonStore::new(db);
+        let branch_id = BranchId::new();
+
+        let req = crate::SearchRequest::new(branch_id, "anything");
+        let response = store.search(&req).unwrap();
+        assert!(response.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- **Event search()**: Replaced empty stub with BM25 via shared InvertedIndex — same pattern as KV. Filters results to `EntityRef::Event` only. Snippets show `[event_type] payload`.
- **JSON write-path indexing**: Added `index_document` calls after `create()`, `set()`, `set_or_create()`, and `batch_set_or_create()` commit. Serializes full JSON value as indexed text.
- **JSON search() BM25 fallback**: When query is non-empty and no `field_filter`/`sort_by`, falls back to InvertedIndex BM25. Existing field-filter/sort path unchanged.

## Test plan

- [x] `test_event_search_bm25` — insert events, search by query term, verify BM25 hits
- [x] `test_event_search_type_boost` — event_type terms are matched, correct event is top hit
- [x] `test_event_search_empty_index` — no events → empty response
- [x] `test_event_search_no_match` — no matching terms → empty response
- [x] `test_json_search_bm25` — create JSON docs, search, verify correct doc_id returned
- [x] `test_json_search_bm25_with_set_or_create` — set_or_create indexes correctly
- [x] `test_json_search_empty_index` — empty DB → empty response
- [x] All existing search tests pass (including `test_search_with_primitive_filter` cross-primitive isolation)
- [x] Full workspace tests pass (excluding strata-inference build dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)