### PR TITLE
Epic 1: Storage primitives for lazy scan pipeline (#2183)

### DIFF
--- a/crates/storage/src/memtable.rs
+++ b/crates/storage/src/memtable.rs
@@ -292,6 +292,25 @@ impl Memtable {
             .take_while(move |(ik, _)| ik.typed_key_prefix().starts_with(&match_prefix))
     }
 
+    /// Iterate entries starting from `start_key`, filtered by `match_prefix`.
+    ///
+    /// Unlike `iter_prefix`, this separates the seek target from the match filter,
+    /// enabling efficient range scans where `start_key` > `match_prefix`.
+    /// When `start_key` equals `match_prefix`, behavior is identical to `iter_prefix`.
+    pub fn iter_range<'a>(
+        &'a self,
+        start_key: &Key,
+        match_prefix: &Key,
+    ) -> impl Iterator<Item = (InternalKey, MemtableEntry)> + 'a {
+        let seek_key = InternalKey::encode(start_key, u64::MAX);
+        let match_prefix = encode_typed_key_prefix(match_prefix);
+
+        self.map
+            .range(seek_key..)
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .take_while(move |(ik, _)| ik.typed_key_prefix().starts_with(&match_prefix))
+    }
+
     /// Iterate ALL entries in sorted order (for flush to segment).
     pub fn iter_all(&self) -> impl Iterator<Item = (InternalKey, MemtableEntry)> + '_ {
         self.map
@@ -539,6 +558,61 @@ mod tests {
         let prefix = key_typed(TypeTag::KV, "k");
         let results: Vec<_> = mt.iter_prefix(&prefix).collect();
         assert_eq!(results.len(), 1);
+    }
+
+    // ===== Range Scan (iter_range) =====
+
+    #[test]
+    fn iter_range_seeks_to_start_key() {
+        let mt = Memtable::new(0);
+        mt.put(&key("a"), 1, Value::Int(1), false);
+        mt.put(&key("b"), 1, Value::Int(2), false);
+        mt.put(&key("c"), 1, Value::Int(3), false);
+        mt.put(&key("d"), 1, Value::Int(4), false);
+        mt.put(&key("e"), 1, Value::Int(5), false);
+
+        // Start from "c", prefix matches all KV keys in namespace
+        let start = key("c");
+        let prefix = key("");
+        let results: Vec<_> = mt.iter_range(&start, &prefix).collect();
+        assert_eq!(results.len(), 3, "should return c, d, e");
+        // Verify actual keys returned (user_key_string extracts the user key)
+        let keys: Vec<String> = results
+            .iter()
+            .filter_map(|(ik, _)| {
+                let (k, _) = ik.decode()?;
+                k.user_key_string()
+            })
+            .collect();
+        assert_eq!(keys, vec!["c", "d", "e"]);
+    }
+
+    #[test]
+    fn iter_range_with_start_equals_prefix_matches_iter_prefix() {
+        let mt = Memtable::new(0);
+        mt.put(&key("a"), 1, Value::Int(1), false);
+        mt.put(&key("b"), 1, Value::Int(2), false);
+        mt.put(&key("c"), 1, Value::Int(3), false);
+
+        let prefix = key("");
+        let range_results: Vec<_> = mt.iter_range(&prefix, &prefix).collect();
+        let prefix_results: Vec<_> = mt.iter_prefix(&prefix).collect();
+        assert_eq!(range_results.len(), prefix_results.len());
+        for (r, p) in range_results.iter().zip(prefix_results.iter()) {
+            assert_eq!(r.0.as_bytes(), p.0.as_bytes());
+        }
+    }
+
+    #[test]
+    fn iter_range_past_all_keys_returns_empty() {
+        let mt = Memtable::new(0);
+        mt.put(&key("a"), 1, Value::Int(1), false);
+        mt.put(&key("b"), 1, Value::Int(2), false);
+
+        let start = key("z");
+        let prefix = key("");
+        let results: Vec<_> = mt.iter_range(&start, &prefix).collect();
+        assert!(results.is_empty());
     }
 
     // ===== Freeze =====

--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -1029,6 +1029,10 @@ pub struct OwnedSegmentIter {
     raw_values: bool,
     /// Set to true if iteration was stopped by a corruption error (#1677).
     corruption_detected: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// Optional prefix filter for seek-based iteration. When set, entries
+    /// whose typed_key_prefix doesn't start with this are skipped; entries
+    /// past it stop iteration. `None` = iterate all (existing behavior).
+    prefix_bytes: Option<Vec<u8>>,
 }
 
 impl OwnedSegmentIter {
@@ -1047,6 +1051,41 @@ impl OwnedSegmentIter {
             global_block_idx: 0,
             raw_values: false,
             corruption_detected: None,
+            prefix_bytes: None,
+        }
+    }
+
+    /// Create a streaming iterator that seeks to `start_key` and filters
+    /// by `prefix_bytes`.
+    ///
+    /// Combines the seek capability of [`KVSegment::iter_seek`] with the
+    /// `Arc` ownership of `OwnedSegmentIter`. Enables lazy iteration
+    /// without borrowing the segment.
+    pub fn new_seek(
+        segment: Arc<KVSegment>,
+        start_key: &Key,
+        prefix_bytes: Vec<u8>,
+    ) -> Self {
+        let done = segment.index.is_empty();
+        let (partition_idx, block_within_partition) = if done {
+            (0, 0)
+        } else {
+            let seek_ik = InternalKey::encode(start_key, u64::MAX);
+            segment.index.seek_position(seek_ik.as_bytes())
+        };
+        Self {
+            segment,
+            partition_idx,
+            block_within_partition,
+            block_offset: 0,
+            block_data_end: 0,
+            block_data: None,
+            done,
+            prev_key: Vec::new(),
+            global_block_idx: 0,
+            raw_values: false,
+            corruption_detected: None,
+            prefix_bytes: Some(prefix_bytes),
         }
     }
 
@@ -1074,6 +1113,13 @@ impl OwnedSegmentIter {
     /// Return a monotonically increasing block index (used by `ThrottledSegmentIter`).
     pub(crate) fn current_block_idx(&self) -> usize {
         self.global_block_idx
+    }
+
+    /// Returns true if iteration was halted by data block corruption.
+    pub fn corruption_detected(&self) -> bool {
+        self.corruption_detected
+            .as_ref()
+            .map_or(false, |f| f.load(std::sync::atomic::Ordering::Relaxed))
     }
 }
 
@@ -1131,6 +1177,17 @@ impl Iterator for OwnedSegmentIter {
                 match result {
                     Some((ik, is_tomb, raw_val, timestamp, ttl_ms, consumed)) => {
                         self.block_offset += consumed;
+
+                        if let Some(ref pb) = self.prefix_bytes {
+                            if !ik.typed_key_prefix().starts_with(pb) {
+                                if ik.typed_key_prefix() > pb.as_slice() {
+                                    self.done = true;
+                                    return None;
+                                }
+                                continue;
+                            }
+                        }
+
                         let commit_id = ik.commit_id();
                         return Some((
                             ik,
@@ -1159,6 +1216,17 @@ impl Iterator for OwnedSegmentIter {
             match result {
                 Some((ik, is_tomb, value, timestamp, ttl_ms, consumed)) => {
                     self.block_offset += consumed;
+
+                    if let Some(ref pb) = self.prefix_bytes {
+                        if !ik.typed_key_prefix().starts_with(pb) {
+                            if ik.typed_key_prefix() > pb.as_slice() {
+                                self.done = true;
+                                return None;
+                            }
+                            continue;
+                        }
+                    }
+
                     let commit_id = ik.commit_id();
                     return Some((
                         ik,
@@ -2046,6 +2114,133 @@ mod tests {
         let seg = Arc::new(KVSegment::open(&path).unwrap());
         let entries: Vec<_> = super::OwnedSegmentIter::new(seg).collect();
         assert!(entries.is_empty());
+    }
+
+    // ===== OwnedSegmentIter::new_seek tests =====
+
+    #[test]
+    fn owned_iter_new_seek_matches_iter_seek() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("owned_seek.sst");
+
+        let mt = Memtable::new(0);
+        for i in 0..50u32 {
+            mt.put(
+                &kv_key(&format!("key_{:04}", i)),
+                i as u64 + 1,
+                Value::Int(i as i64),
+                false,
+            );
+        }
+        mt.freeze();
+        build_segment(&mt, &path);
+
+        let seg = Arc::new(KVSegment::open(&path).unwrap());
+        let prefix = kv_key("");
+        let prefix_bytes = encode_typed_key_prefix(&prefix);
+
+        // Collect from borrowed iter_seek
+        let borrowed: Vec<_> = seg.iter_seek(&prefix).collect();
+
+        // Collect from owned new_seek
+        let owned: Vec<_> =
+            OwnedSegmentIter::new_seek(Arc::clone(&seg), &prefix, prefix_bytes).collect();
+
+        assert_eq!(
+            borrowed.len(),
+            owned.len(),
+            "new_seek and iter_seek should yield same count"
+        );
+        for (b, o) in borrowed.iter().zip(owned.iter()) {
+            assert_eq!(b.0.as_bytes(), o.0.as_bytes());
+            assert_eq!(b.1.commit_id, o.1.commit_id);
+            assert_eq!(b.1.value, o.1.value);
+        }
+    }
+
+    #[test]
+    fn owned_iter_new_seek_mid_key_skips_earlier_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("owned_seek_mid.sst");
+
+        let mt = Memtable::new(0);
+        for i in 0..50u32 {
+            mt.put(
+                &kv_key(&format!("key_{:04}", i)),
+                i as u64 + 1,
+                Value::Int(i as i64),
+                false,
+            );
+        }
+        mt.freeze();
+        build_segment(&mt, &path);
+
+        let seg = Arc::new(KVSegment::open(&path).unwrap());
+        let prefix = kv_key("");
+        let prefix_bytes = encode_typed_key_prefix(&prefix);
+
+        // Seek to "key_0025" — should skip key_0000..key_0024
+        let start = kv_key("key_0025");
+        let results: Vec<_> =
+            OwnedSegmentIter::new_seek(Arc::clone(&seg), &start, prefix_bytes).collect();
+
+        // Due to block-level seek, entries before key_0025 in the same block
+        // may be emitted. But no entry from a PRIOR block should appear.
+        // All entries should be in the namespace.
+        assert!(
+            !results.is_empty(),
+            "should yield entries from key_0025 onward"
+        );
+        // The LAST entry should always be key_0049 (no entries lost at the end)
+        let last_ik = &results.last().unwrap().0;
+        let (last_key, _) = last_ik.decode().unwrap();
+        assert_eq!(last_key.user_key_string().unwrap(), "key_0049");
+    }
+
+    #[test]
+    fn owned_iter_new_seek_stops_at_prefix_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("owned_seek_prefix.sst");
+
+        let mt = Memtable::new(0);
+        // Two key ranges: "aaa:*" and "bbb:*"
+        for i in 0..20u32 {
+            mt.put(
+                &kv_key(&format!("aaa:{:04}", i)),
+                i as u64 + 1,
+                Value::Int(i as i64),
+                false,
+            );
+        }
+        for i in 0..20u32 {
+            mt.put(
+                &kv_key(&format!("bbb:{:04}", i)),
+                i as u64 + 21,
+                Value::Int(i as i64 + 100),
+                false,
+            );
+        }
+        mt.freeze();
+        build_segment(&mt, &path);
+
+        let seg = Arc::new(KVSegment::open(&path).unwrap());
+
+        // Seek with prefix for "aaa:" only
+        let prefix = kv_key("aaa:");
+        let prefix_bytes = encode_typed_key_prefix(&prefix);
+        let results: Vec<_> =
+            OwnedSegmentIter::new_seek(Arc::clone(&seg), &prefix, prefix_bytes).collect();
+
+        assert_eq!(results.len(), 20, "should only yield aaa: entries");
+
+        // Verify all entries have the right prefix
+        for (ik, _) in &results {
+            let decoded_key = ik.typed_key_prefix();
+            assert!(
+                decoded_key.starts_with(&encode_typed_key_prefix(&kv_key("aaa:"))),
+                "entry should be in aaa: range"
+            );
+        }
     }
 
     // ===== Restart point binary search tests (v3 format) =====

--- a/docs/architecture/scan/epics.md
+++ b/docs/architecture/scan/epics.md
@@ -1,0 +1,219 @@
+# Scan Pipeline Epics — Implementation Roadmap
+
+> **Parent**: [lazy-iterator-design.md](lazy-iterator-design.md)
+>
+> Five epics, ordered by dependency. Each epic is independently shippable —
+> it leaves the codebase in a correct, tested state. Later epics build on
+> earlier ones but never invalidate them.
+
+---
+
+## Epic 1 — Storage primitives: `iter_range` + `OwnedSegmentIter::new_seek`
+
+**Goal**: The two building blocks that every later epic depends on. No consumer
+changes yet — existing behavior unchanged.
+
+**Scope**:
+
+| # | Task | File | Est. lines |
+|---|------|------|-----------|
+| 1a | Add `Memtable::iter_range(start_key, match_prefix)` | `crates/storage/src/memtable.rs` | ~15 |
+| 1b | Unit test: `iter_range` seeks to target, not prefix start | `crates/storage/src/memtable.rs` (tests) | ~30 |
+| 1c | Add `prefix_bytes: Option<Vec<u8>>` field to `OwnedSegmentIter` | `crates/storage/src/segment.rs` | ~5 |
+| 1d | Add `OwnedSegmentIter::new_seek(segment, start_key, prefix_bytes)` constructor | `crates/storage/src/segment.rs` | ~25 |
+| 1e | Add prefix matching to `OwnedSegmentIter::next()` (skip before, stop past) | `crates/storage/src/segment.rs` | ~15 |
+| 1f | Add `OwnedSegmentIter::corruption_detected()` convenience method | `crates/storage/src/segment.rs` | ~5 |
+| 1g | Existing `new()` sets `prefix_bytes: None` — verify compaction unchanged | `crates/storage/src/segment.rs` | ~2 |
+| 1h | Unit test: `new_seek` with prefix matches `iter_seek` output | `crates/storage/src/segment.rs` (tests) | ~40 |
+| 1i | Unit test: `new_seek` stops when past prefix range | `crates/storage/src/segment.rs` (tests) | ~25 |
+
+**Acceptance**:
+- `cargo test -p strata-storage` passes
+- `OwnedSegmentIter::new_seek` produces identical entries to `SegmentIter::iter_seek` on the same segment
+- Existing compaction tests unaffected (backward-compatible `new()`)
+
+**Invariants verified**: LSM-001 (key ordering preserved in seek), LSM-007 (segment files unchanged)
+
+---
+
+## Epic 2 — Lazy merge builder + consumer refactors
+
+**Goal**: Introduce `build_branch_merge_iter` and refactor all four eager-collect
+consumers to use it. This is the core performance fix — eliminates per-source
+`.collect()` across the entire scan pipeline.
+
+**Depends on**: Epic 1
+
+**Scope**:
+
+| # | Task | File | Est. lines |
+|---|------|------|-----------|
+| 2a | Add `check_corruption()` helper | `crates/storage/src/segmented/mod.rs` | ~10 |
+| 2b | Add `build_branch_merge_iter<'b>()` — lazy sources in LSM-003 order | `crates/storage/src/segmented/mod.rs` | ~80 |
+| 2c | Refactor `scan_prefix_from_branch` to use `build_branch_merge_iter` | `crates/storage/src/segmented/mod.rs` | ~20 (net reduction) |
+| 2d | Refactor `count_prefix_from_branch` to use `build_branch_merge_iter` | `crates/storage/src/segmented/mod.rs` | ~20 (net reduction) |
+| 2e | Refactor `scan_prefix_at_timestamp` to use `build_branch_merge_iter` | `crates/storage/src/segmented/mod.rs` | ~30 (net reduction) |
+| 2f | Verify: all existing storage tests pass | — | — |
+| 2g | Verify: all existing engine/executor tests pass | — | — |
+
+**Acceptance**:
+- `cargo test` — full suite passes (semantics preserved)
+- The three refactored functions produce byte-identical output to pre-refactor versions
+- No new public API — this is an internal refactor
+
+**Invariants verified**: LSM-003 (source ordering), MVCC-001 (version visibility),
+MVCC-002 (tombstone semantics), COW-003 (inherited layer version gate)
+
+**Performance impact**: Full prefix scans and counts no longer allocate intermediate
+`Vec`s per source. Memory usage drops from `sum(source_sizes) + final_vec` to
+`final_vec + K block_buffers`. Throughput improves for large datasets where
+source collection was the bottleneck.
+
+---
+
+## Epic 3 — Bounded range scan: `scan_range` + `KVStore::scan()` rewrite
+
+**Goal**: Add `scan_range` with seek + limit pushdown. Rewrite `KVStore::scan()`
+to bypass the transaction layer and use `current_version()` for snapshot
+isolation. This directly fixes #2183.
+
+**Depends on**: Epic 2
+
+**Scope**:
+
+| # | Task | File | Est. lines |
+|---|------|------|-----------|
+| 3a | Add `scan_range_from_branch` (merge → MVCC → start_key filter → take limit) | `crates/storage/src/segmented/mod.rs` | ~25 |
+| 3b | Add `SegmentedStore::scan_range()` public method | `crates/storage/src/segmented/mod.rs` | ~15 |
+| 3c | Add `Database::scan_range()` pass-through | `crates/engine/src/database/mod.rs` | ~10 |
+| 3d | Rewrite `KVStore::scan()` — bypass transaction, use `current_version()` | `crates/engine/src/primitives/kv.rs` | ~15 |
+| 3e | Unit test: `scan_range` returns exactly `limit` entries | `crates/storage/src/segmented/tests/` | ~30 |
+| 3f | Unit test: `scan_range` block imprecision — entries before `start_key` filtered | `crates/storage/src/segmented/tests/` | ~30 |
+| 3g | Unit test: `scan_range` with `start` past all keys returns empty | `crates/storage/src/segmented/tests/` | ~15 |
+| 3h | Unit test: `scan_range` with `limit=None` returns all from start | `crates/storage/src/segmented/tests/` | ~15 |
+| 3i | Unit test: `scan_range` across memtable + segments produces correct merge | `crates/storage/src/segmented/tests/` | ~40 |
+| 3j | Integration test: `kv_scan` with limit matches old behavior | `crates/engine/` tests | ~20 |
+
+**Acceptance**:
+- `cargo test` — full suite passes
+- `kv_scan(Some(mid_key), Some(10))` on 50K records: throughput jumps from ~20 ops/s to thousands
+- `cargo bench --bench memory_efficiency` in strata-benchmarks confirms improvement
+
+**Invariants verified**: MVCC-001 (`current_version()` snapshot), ARCH-002
+(consistent read boundary), block imprecision correctness
+
+---
+
+## Epic 4 — `Arc<Memtable>` + `BranchSnapshot`
+
+**Goal**: Structural change that enables persistent iterators. Change
+`BranchState.active` from `Memtable` to `Arc<Memtable>`. Add `BranchSnapshot`
+type and `snapshot_branch()` capture method.
+
+**Depends on**: Epic 2 (refactored consumers work with `Arc<Memtable>` transparently)
+
+**Scope**:
+
+| # | Task | File | Est. lines |
+|---|------|------|-----------|
+| 4a | Change `BranchState.active: Memtable` → `active: Arc<Memtable>` | `crates/storage/src/segmented/mod.rs` | ~5 |
+| 4b | Update `BranchState::new()` — wrap in `Arc::new()` | `crates/storage/src/segmented/mod.rs` | ~2 |
+| 4c | Update 3 rotation sites — remove `Arc::new(old)`, old is already Arc | `crates/storage/src/segmented/mod.rs` | ~6 |
+| 4d | Add `BranchSnapshot` struct | `crates/storage/src/segmented/mod.rs` | ~10 |
+| 4e | Add `SegmentedStore::snapshot_branch()` — capture under short guard | `crates/storage/src/segmented/mod.rs` | ~15 |
+| 4f | Add `build_snapshot_merge_iter()` — owned merge for persistent mode | `crates/storage/src/segmented/mod.rs` | ~60 |
+| 4g | Unit test: snapshot survives memtable rotation | `crates/storage/src/segmented/tests/` | ~40 |
+| 4h | Unit test: snapshot survives compaction (segment Arc pinning) | `crates/storage/src/segmented/tests/` | ~40 |
+| 4i | Verify: `cargo test` — full suite passes (Arc change transparent) | — | — |
+
+**Acceptance**:
+- `cargo test` — full suite passes
+- `BranchSnapshot` holds valid data after concurrent rotation and compaction
+- No public API change (snapshot_branch is `pub(crate)`)
+
+**Invariants verified**: LSM-004 (rotation atomicity preserved), COW-001
+(Arc pinning prevents segment deletion)
+
+---
+
+## Epic 5 — Persistent `StorageIterator` + `KVStore::scan_iter()`
+
+**Goal**: Public persistent iterator API for cursor-based pagination and
+streaming. Completes the RocksDB alignment.
+
+**Depends on**: Epic 4
+
+**Scope**:
+
+| # | Task | File | Est. lines |
+|---|------|------|-----------|
+| 5a | Add `StorageIterator` struct (snapshot + pipeline + corruption flags) | `crates/storage/src/segmented/mod.rs` | ~30 |
+| 5b | Implement `StorageIterator::new()` | `crates/storage/src/segmented/mod.rs` | ~10 |
+| 5c | Implement `StorageIterator::seek()` — rebuild pipeline from target | `crates/storage/src/segmented/mod.rs` | ~25 |
+| 5d | Implement `StorageIterator::next()` — advance pipeline | `crates/storage/src/segmented/mod.rs` | ~10 |
+| 5e | Implement `StorageIterator::valid()` + `check_corruption()` | `crates/storage/src/segmented/mod.rs` | ~15 |
+| 5f | Export `StorageIterator` from storage crate | `crates/storage/src/lib.rs` | ~2 |
+| 5g | Add `Database::storage_iterator()` pass-through | `crates/engine/src/database/mod.rs` | ~10 |
+| 5h | Add `KVStore::scan_iter()` — returns `StorageIterator` | `crates/engine/src/primitives/kv.rs` | ~15 |
+| 5i | Unit test: seek + 10 next calls returns correct sequence | `crates/storage/src/segmented/tests/` | ~40 |
+| 5j | Unit test: re-seek to different position works | `crates/storage/src/segmented/tests/` | ~30 |
+| 5k | Unit test: seek past all keys → valid() returns false | `crates/storage/src/segmented/tests/` | ~15 |
+| 5l | Unit test: cursor pagination — 5 pages of 10 entries each | `crates/storage/src/segmented/tests/` | ~40 |
+| 5m | Integration test: `scan_iter` matches `kv_scan` results | `crates/engine/` tests | ~25 |
+
+**Acceptance**:
+- `cargo test` — full suite passes
+- `StorageIterator` supports Seek → N×Next → re-Seek → N×Next pattern
+- Cursor pagination over 50K records works correctly
+- Iterator remains valid after concurrent writes/rotation (snapshot pinning)
+
+**Invariants verified**: All invariants from Epics 1–4, plus ARCH-002
+(atomic publication boundary via snapshot)
+
+---
+
+## Dependency Graph
+
+```
+Epic 1 ─── Storage primitives (iter_range, OwnedSegmentIter::new_seek)
+  │
+  v
+Epic 2 ─── Lazy merge builder + consumer refactors
+  │
+  ├──────────────────────┐
+  v                      v
+Epic 3                 Epic 4
+Bounded scan_range     Arc<Memtable> + BranchSnapshot
+(fixes #2183)            │
+                         v
+                       Epic 5
+                       Persistent StorageIterator
+```
+
+Epics 3 and 4 are independent of each other and can be worked in parallel.
+Epic 5 requires Epic 4.
+
+---
+
+## Estimated Effort
+
+| Epic | New/changed lines | Tests | Risk |
+|------|------------------|-------|------|
+| 1 | ~65 | ~95 | Low — additive, no existing code changed |
+| 2 | ~130 (net reduction ~80) | existing suite | Medium — refactors 3 hot-path functions |
+| 3 | ~65 | ~150 | Low — new code path, old path unchanged until KV rewrite |
+| 4 | ~140 | ~80 | Medium — structural change to BranchState |
+| 5 | ~105 | ~150 | Low — new API, no existing code changed |
+| **Total** | **~505** | **~475** | |
+
+---
+
+## Milestone: #2183 Resolved
+
+**Epic 3 completion** resolves the issue. At that point:
+- `kv_scan(start, limit=10)` on 50K records: ~20 ops/s → thousands ops/s
+- `scan_prefix` / `count_prefix` / `scan_at_timestamp`: no intermediate Vec allocations
+- All 50 engine invariants hold
+
+Epics 4–5 are the forward-looking investment for cursor pagination and the
+persistent iterator API.

--- a/docs/architecture/scan/lazy-iterator-design.md
+++ b/docs/architecture/scan/lazy-iterator-design.md
@@ -1,0 +1,486 @@
+# Lazy Iterator Architecture — RocksDB-Aligned Scan Pipeline
+
+> **Issue**: #2183 — `kv_scan` throughput bottleneck (~20 ops/s at 50K records)
+>
+> **Status**: Design document. Covers the full scan pipeline redesign: lazy merge,
+> `BranchSnapshot`, persistent `StorageIterator`, and all consumer refactors.
+
+---
+
+## Problem
+
+`kv_scan(Some(start_key), Some(10))` runs at ~20 ops/s on 50K records — orders of
+magnitude slower than point reads (~650K ops/s). The root cause is architectural:
+four separate functions duplicate an eager-collect pattern where every source
+(memtable, frozen memtables, segments, inherited layers) is `.collect()`'d into a
+`Vec` before being passed to `MergeIterator`.
+
+**Current hot path** (per scan call on 50K records):
+
+1. Storage collects ALL 50K entries from each source into `Vec`s
+2. `MergeIterator` + `MvccIterator` processes all 50K
+3. Transaction tracks all 50K in `read_set` for OCC conflict detection
+4. KV primitive applies `skip_while(start)` + `take(10)` — discards 49,990
+
+**Affected functions** (all share the same eager pattern):
+
+| Function | Location | Purpose |
+|---|---|---|
+| `scan_prefix_from_branch` | `segmented/mod.rs:2918` | MVCC prefix scan |
+| `count_prefix_from_branch` | `segmented/mod.rs:3019` | MVCC prefix count |
+| `scan_prefix_at_timestamp` | `segmented/mod.rs:1741` | Timestamp-based scan |
+| *(new)* `scan_range_from_branch` | — | Bounded range scan with limit |
+
+---
+
+## Design Goals
+
+1. **O(log N + limit × log K)** per bounded scan (vs. current O(N))
+2. **One abstraction, all consumers** — shared lazy merge builder
+3. **Persistent iterator API** for cursor-based pagination
+4. **RocksDB alignment** — `BranchSnapshot` ≈ SuperVersion, `StorageIterator` ≈ DBIter
+5. **Zero invariant violations** — all 50 engine invariants hold
+
+---
+
+## RocksDB Alignment
+
+| RocksDB Concept | Strata Equivalent | Notes |
+|---|---|---|
+| `SuperVersion` | `BranchSnapshot` | Captures `Arc<Memtable>` + `Arc<SegmentVersion>` via ref counting |
+| `ArenaWrappedDBIter` | `StorageIterator` | Persistent Seek/Next API over a snapshot |
+| `MergingIterator` (min-heap) | `MergeIterator` (existing) | Heap merge for >4 sources, linear for ≤4 |
+| `DBIter` (MVCC filter) | `MvccIterator` (existing) | Deduplicates by logical key, filters by version |
+| SST iterator (seeks block index) | `OwnedSegmentIter::new_seek` | Owns `Arc<KVSegment>`, seeks to block position |
+| Memtable iterator (live SkipList cursor) | `Memtable::iter_range` | Borrows from SkipMap; collected per-seek for persistent mode |
+| `GetReferencedSuperVersion` (thread-local caching) | `snapshot_branch` (short DashMap guard + Arc clone) | Guard released immediately after snapshot capture |
+| Snapshot sequence number | `current_version()` | Consistent read boundary without transaction overhead |
+
+**Patterns adopted from RocksDB**:
+- Seek-based positioning (binary search to block, not linear scan)
+- Lazy k-way merge with limit pushdown
+- Snapshot isolation via ref-counted pinning (Arc)
+- Source ordering: active → frozen → L0-L6 → inherited (LSM-003)
+- Corruption flag propagation (checked after collection)
+
+**Patterns deferred** (future optimization):
+- Arena allocation for cache locality
+- `IteratorWrapper` caching (eliminate virtual calls on `valid()`/`key()`)
+- `max_skip_` reseek (Seek instead of linear scan when many versions skipped)
+- Adaptive readahead / block prefetching
+
+---
+
+## Structural Prerequisite: `active: Memtable` → `active: Arc<Memtable>`
+
+RocksDB's `SuperVersion` pins the active memtable via reference counting. Our
+`BranchState.active` is currently `Memtable` (owned, not Arc), which prevents
+snapshot capture without holding the DashMap guard.
+
+**Change**: `active: Memtable` → `active: Arc<Memtable>`
+
+**Safety**: `Memtable` has zero `&mut self` methods. All writes use interior
+mutability (lock-free `crossbeam_skiplist::SkipMap` + atomics). `Arc<Memtable>`
+is a transparent, mechanical change.
+
+**Diff** (~15 lines across `segmented/mod.rs`):
+
+```rust
+// BranchState::new()
+- active: Memtable::new(0),
++ active: Arc::new(Memtable::new(0)),
+
+// Rotation (3 sites: rotate_memtable, maybe_rotate_branch, fork snapshot)
+- let old = std::mem::replace(&mut branch.active, Memtable::new(next_id));
+- old.freeze();
+- branch.frozen.insert(0, Arc::new(old));
++ let old = std::mem::replace(&mut branch.active, Arc::new(Memtable::new(next_id)));
++ old.freeze();
++ branch.frozen.insert(0, old);  // already Arc
+```
+
+All `branch.active.foo()` calls auto-deref through Arc — no other changes needed.
+
+**Invariant LSM-004 (memtable rotation atomicity)**: Holds. Rotation still occurs
+under DashMap write lock (`get_mut()` / `entry()`). The `Arc::new()` call is a
+local allocation that doesn't affect the atomicity of the replace+freeze+insert
+sequence.
+
+---
+
+## Core Types
+
+### `BranchSnapshot` — analogous to RocksDB's SuperVersion
+
+Captures the state of a branch at a point in time. Holds Arc references to
+prevent memtable rotation and compaction from invalidating the data.
+
+```rust
+pub(crate) struct BranchSnapshot {
+    /// Active memtable at capture time.
+    pub active: Arc<Memtable>,
+    /// Frozen memtables at capture time (newest first).
+    pub frozen: Vec<Arc<Memtable>>,
+    /// Segment version at capture time.
+    pub segments: Arc<SegmentVersion>,
+    /// Inherited COW layers at capture time.
+    pub inherited_layers: Vec<InheritedLayer>,
+}
+```
+
+**Capture** (under short DashMap read guard):
+
+```rust
+pub fn snapshot_branch(&self, branch_id: &BranchId) -> Option<BranchSnapshot> {
+    let branch = self.branches.get(branch_id)?;
+    Some(BranchSnapshot {
+        active: Arc::clone(&branch.active),
+        frozen: branch.frozen.clone(),         // Vec<Arc> — cheap
+        segments: branch.version.load_full(),  // Arc from ArcSwap
+        inherited_layers: branch.inherited_layers.clone(),
+    })
+    // DashMap guard drops here
+}
+```
+
+**Lifecycle**: Compaction creates new `SegmentVersion` and tries to delete old
+segment files. The `BranchSnapshot` holds `Arc<SegmentVersion>` which holds
+`Arc<KVSegment>` for each segment. Segment ref registry (COW-001) prevents
+deletion while any Arc reference exists. This is the same safety chain as
+RocksDB's SuperVersion → Version → FileMetaData ref counting.
+
+### `StorageIterator` — analogous to RocksDB's ArenaWrappedDBIter
+
+Persistent, seekable iterator over a branch snapshot. Supports multiple
+`seek()` + `next()` cycles without re-acquiring the DashMap guard.
+
+```rust
+pub struct StorageIterator {
+    snapshot: BranchSnapshot,
+    prefix: Key,
+    snapshot_version: u64,
+    /// Current merge pipeline. Fully self-contained (no borrows).
+    /// Rebuilt on each seek().
+    pipeline: Option<Box<dyn Iterator<Item = (Key, VersionedValue)>>>,
+    corruption_flags: Vec<Arc<AtomicBool>>,
+}
+
+impl StorageIterator {
+    /// Create from a branch snapshot.
+    pub fn new(snapshot: BranchSnapshot, prefix: Key, snapshot_version: u64) -> Self;
+
+    /// Seek to first entry >= target within prefix. O(log N) per source.
+    pub fn seek(&mut self, target: &Key) -> StrataResult<()>;
+
+    /// Advance to next live entry. O(log K) per call.
+    pub fn next(&mut self) -> Option<(Key, VersionedValue)>;
+
+    /// True if the last seek()/next() positioned at a valid entry.
+    pub fn valid(&self) -> bool;
+
+    /// Check if any segment reported corruption during iteration.
+    pub fn check_corruption(&self) -> StrataResult<()>;
+}
+```
+
+**Seek implementation**:
+1. Drop old pipeline
+2. Collect entries from `snapshot.active` and each `snapshot.frozen[i]` starting
+   from `target` position (bounded by write_buffer_size)
+3. Create `OwnedSegmentIter::new_seek(...)` for each overlapping segment
+4. Wrap inherited layer segments in `RewritingIterator`
+5. Build `MergeIterator` → `MvccIterator` → tombstone/TTL filter → start_key filter
+6. Store as `self.pipeline`
+
+**No self-referential problem**: Memtable entries consumed via `Vec::into_iter()`
+(owned). Segment entries via `OwnedSegmentIter` (owns Arc). All iterator sources
+are `'static`.
+
+**Next implementation**: `self.pipeline.as_mut()?.next()`
+
+---
+
+## Two Iteration Modes
+
+### Mode 1: One-shot (DashMap guard, fully lazy)
+
+Used by `scan_prefix`, `count_prefix`, `scan_prefix_at_timestamp`, `scan_range`.
+Holds DashMap read guard during iteration. Memtable iterators borrow from guard
+lifetime — zero collection overhead.
+
+```
+DashMap::get() → &BranchState (guard held for function duration)
+  → build_branch_merge_iter<'b>(branch, prefix, start_key)
+    Sources (all lazy):
+      active.iter_range(start_key, prefix)     — borrows 'b
+      frozen[i].iter_range(start_key, prefix)  — borrows 'b (through Arc deref)
+      OwnedSegmentIter::new_seek(Arc::clone)   — 'static
+      RewritingIterator(OwnedSegmentIter)      — 'static
+    → MergeIterator<Box<dyn Iterator + 'b>>
+  → MvccIterator → filter → .take(limit).collect()
+  → check_corruption()
+→ guard drops
+```
+
+**Lifetime**: `'b` ties to `&BranchState`. `OwnedSegmentIter` is `'static`, which
+satisfies any `'b`. Both coexist in `Vec<Box<dyn Iterator<...> + 'b>>`.
+
+**DashMap guard blocks rotation**: The read guard prevents concurrent `get_mut()`
+(memtable rotation, writes via `entry()`). For bounded scans (limit=10), the guard
+is held for microseconds. For full scans, the guard duration equals iteration time.
+This is acceptable — RocksDB's SuperVersion causes the same effect (old memtable
+pinned until iterator is destroyed).
+
+### Mode 2: Persistent (BranchSnapshot, Seek/Next API)
+
+Used by `StorageIterator`. Captures `BranchSnapshot` under short guard, releases
+immediately. Memtable entries collected per-`seek()` call (bounded).
+
+```
+DashMap::get() → BranchSnapshot (Arc clones) → guard drops immediately
+StorageIterator::seek(target)
+  → collect active/frozen entries from target (Vec::into_iter — owned)
+  → OwnedSegmentIter::new_seek per segment (owns Arc)
+  → MergeIterator → MvccIterator → pipeline stored in self
+StorageIterator::next()
+  → pipeline.next() — O(log K) per call
+```
+
+**When to use which**:
+
+| Use case | Mode | Why |
+|---|---|---|
+| `kv_scan(start, limit)` | One-shot | Fastest: fully lazy, no memtable collection |
+| `count_prefix` | One-shot | No allocation needed, just count |
+| Cursor pagination | Persistent | Multiple seeks, iterator reused |
+| Streaming large results | Persistent | Snapshot survives guard release |
+
+---
+
+## Shared Infrastructure
+
+### `build_branch_merge_iter<'b>()` — one-shot mode
+
+```rust
+fn build_branch_merge_iter<'b>(
+    branch: &'b BranchState,
+    prefix: &Key,
+    start_key: &Key,
+) -> StrataResult<(
+    MergeIterator<Box<dyn Iterator<Item = (InternalKey, MemtableEntry)> + 'b>>,
+    Vec<Arc<AtomicBool>>,  // corruption flags
+)>
+```
+
+Builds lazy merge from all sources in LSM-003 order. Corruption flags returned
+for post-iteration checking.
+
+### `build_snapshot_merge_iter()` — persistent mode
+
+```rust
+fn build_snapshot_merge_iter(
+    snapshot: &BranchSnapshot,
+    prefix: &Key,
+    start_key: &Key,
+) -> StrataResult<(
+    MergeIterator<Box<dyn Iterator<Item = (InternalKey, MemtableEntry)>>>,
+    Vec<Arc<AtomicBool>>,
+)>
+```
+
+Same ordering, but memtable entries collected (owned). All sources `'static`.
+
+### `check_corruption()` — shared helper
+
+```rust
+fn check_corruption(flags: &[Arc<AtomicBool>]) -> StrataResult<()> {
+    for flag in flags {
+        if flag.load(Ordering::Relaxed) {
+            return Err(StrataError::corruption(
+                "segment scan stopped due to data block corruption",
+            ));
+        }
+    }
+    Ok(())
+}
+```
+
+---
+
+## Consumer Refactors
+
+All four consumers delegate to `build_branch_merge_iter`:
+
+### `scan_prefix_from_branch` (refactored)
+
+```rust
+fn scan_prefix_from_branch(branch, prefix, max_version) {
+    let (merge, flags) = Self::build_branch_merge_iter(branch, prefix, prefix)?;
+    let mvcc = MvccIterator::new(merge, max_version);
+    let results: Vec<_> = mvcc
+        .filter_map(|(ik, entry)| {
+            if entry.is_tombstone || entry.is_expired() { return None; }
+            let (key, commit_id) = ik.decode()?;
+            Some((key, entry.to_versioned(commit_id)))
+        })
+        .collect();
+    check_corruption(&flags)?;
+    Ok(results)
+}
+```
+
+### `count_prefix_from_branch` (refactored)
+
+```rust
+fn count_prefix_from_branch(branch, prefix, max_version) {
+    let (merge, flags) = Self::build_branch_merge_iter(branch, prefix, prefix)?;
+    let mvcc = MvccIterator::new(merge, max_version);
+    let count = mvcc
+        .filter(|(_, entry)| !entry.is_tombstone && !entry.is_expired())
+        .filter(|(ik, _)| ik.decode().is_some())
+        .count() as u64;
+    check_corruption(&flags)?;
+    Ok(count)
+}
+```
+
+### `scan_prefix_at_timestamp` (refactored)
+
+```rust
+pub fn scan_prefix_at_timestamp(branch, prefix, max_timestamp) {
+    let (merge, flags) = Self::build_branch_merge_iter(branch, prefix, prefix)?;
+    // Existing custom timestamp-based dedup over the lazy merge
+    let mut results = Vec::new();
+    let mut last_typed_key: Option<Vec<u8>> = None;
+    let mut found_for_current = false;
+    for (ik, entry) in merge {
+        // ... existing timestamp filtering logic unchanged ...
+    }
+    check_corruption(&flags)?;
+    Ok(results)
+}
+```
+
+### `scan_range_from_branch` (new)
+
+```rust
+fn scan_range_from_branch(branch, prefix, start_key, max_version, limit) {
+    let (merge, flags) = Self::build_branch_merge_iter(branch, prefix, start_key)?;
+    let mvcc = MvccIterator::new(merge, max_version);
+    let filtered = mvcc
+        .filter_map(|(ik, entry)| {
+            if entry.is_tombstone || entry.is_expired() { return None; }
+            let (key, commit_id) = ik.decode()?;
+            Some((key, entry.to_versioned(commit_id)))
+        })
+        .filter(|(key, _)| key >= start_key);  // block seek imprecision
+    let results: Vec<_> = match limit {
+        Some(n) => filtered.take(n).collect(),
+        None => filtered.collect(),
+    };
+    check_corruption(&flags)?;
+    Ok(results)
+}
+```
+
+---
+
+## Block Seek Imprecision
+
+Segment iterators seek to a **block** position, not an exact entry. Entries before
+`start_key` within the same data block pass the prefix check and are emitted.
+
+**Fix**: `.filter(|(key, _)| key >= start_key)` applied after MVCC/tombstone
+filtering, before `.take(limit)`. `Key` implements `Ord` with ordering consistent
+with byte encoding (`types.rs:466`).
+
+Memtable `iter_range` uses SkipMap `range()` which is exact — no imprecision.
+
+---
+
+## Engine Layer Changes
+
+### `Database` (pass-throughs)
+
+```rust
+pub(crate) fn scan_range(&self, prefix, start_key, max_version, limit)
+    -> StrataResult<Vec<(Key, VersionedValue)>> {
+    self.storage.scan_range(prefix, start_key, max_version, limit)
+}
+
+pub(crate) fn storage_iterator(&self, branch_id, prefix, max_version)
+    -> Option<StorageIterator> {
+    let snapshot = self.storage.snapshot_branch(branch_id)?;
+    Some(StorageIterator::new(snapshot, prefix, max_version))
+}
+```
+
+### `KVStore::scan()` (rewritten)
+
+```rust
+pub fn scan(&self, branch_id, space, start, limit) -> StrataResult<Vec<(String, Value)>> {
+    let ns = self.namespace_for(branch_id, space);
+    let prefix = Key::new_kv(Arc::clone(&ns), "");
+    let start_key = Key::new_kv(ns, start.unwrap_or(""));
+    let snapshot = self.db.current_version();
+    let results = self.db.scan_range(&prefix, &start_key, snapshot, limit)?;
+    Ok(results.into_iter()
+        .filter_map(|(key, vv)| key.user_key_string().map(|k| (k, vv.value)))
+        .collect())
+}
+```
+
+### `KVStore::scan_iter()` (new — persistent iterator)
+
+```rust
+pub fn scan_iter(&self, branch_id: &BranchId, space: &str) -> StrataResult<StorageIterator> {
+    let ns = self.namespace_for(branch_id, space);
+    let prefix = Key::new_kv(ns, "");
+    let snapshot_version = self.db.current_version();
+    self.db.storage_iterator(branch_id, prefix, snapshot_version)
+        .ok_or_else(|| StrataError::branch_not_found(*branch_id))
+}
+```
+
+---
+
+## Invariant Verification
+
+| Invariant | Result | Rationale |
+|---|---|---|
+| LSM-003 | HOLDS | Source ordering (active→frozen→L0-L6→inherited) preserved in both build functions |
+| LSM-004 | HOLDS | Arc<Memtable> rotation still atomic under DashMap write lock |
+| LSM-007 | HOLDS | Segment files unchanged; OwnedSegmentIter reads via pread |
+| COW-001 | HOLDS | BranchSnapshot holds Arc<KVSegment> → refcount prevents deletion |
+| COW-003 | HOLDS | RewritingIterator applies fork_version gate in both modes |
+| MVCC-001 | HOLDS | `current_version()` provides snapshot; MvccIterator filters by it |
+| MVCC-002 | HOLDS | Tombstone filter preserved in all consumers |
+| MVCC-006 | HOLDS | `is_expired()` check preserved; MvccIterator dedup prevents resurrection |
+| ARCH-002 | HOLDS | Snapshot via `current_version()`; BranchSnapshot pins consistent state |
+| SCALE-009 | HOLDS | Same MergeIterator algorithm; Box<dyn Iterator + 'b> is transparent |
+
+---
+
+## Performance Expectations
+
+| Scenario | Before | After |
+|---|---|---|
+| `kv_scan(mid, limit=10)` on 50K keys | O(50K) — ~20 ops/s | O(log 50K + 10) — ~50K+ ops/s |
+| `scan_prefix` (full scan, 50K keys) | 2× O(50K) — per-source + merge | O(50K) — merge only, no intermediate Vecs |
+| `count_prefix` (50K keys) | 2× O(50K) + Vec alloc | O(50K) — count only, zero allocation |
+| Cursor pagination (100 pages × 10) | 100 × O(50K) | 1 snapshot + 100 × O(log N + 10) |
+
+---
+
+## Test Plan
+
+1. **`cargo test`** — all existing tests pass (refactored functions preserve semantics)
+2. **New unit tests**:
+   - `test_memtable_iter_range_seeks_correctly` — iter_range starts from target, not prefix start
+   - `test_owned_segment_iter_new_seek_with_prefix` — seek + prefix matching on OwnedSegmentIter
+   - `test_scan_range_with_limit` — bounded scan returns exactly limit entries
+   - `test_scan_range_block_imprecision_filtered` — entries before start_key not returned
+   - `test_branch_snapshot_survives_rotation` — snapshot valid after memtable rotation
+   - `test_storage_iterator_seek_next` — persistent iterator Seek + multiple Next calls
+   - `test_storage_iterator_reseek` — re-Seek to different position works correctly
+3. **Benchmark**: `cargo bench --bench memory_efficiency -- -q` — scan ops/s: ~20 → thousands


### PR DESCRIPTION
## Summary

- Add `Memtable::iter_range(start_key, match_prefix)` — decoupled seek/filter for efficient range scans
- Add `OwnedSegmentIter::new_seek(segment, start_key, prefix_bytes)` — Arc-owned seek iterator with prefix filtering
- Add `OwnedSegmentIter::corruption_detected()` convenience method
- Add design docs: `docs/architecture/scan/lazy-iterator-design.md` (full RocksDB-aligned architecture) and `docs/architecture/scan/epics.md` (5-epic roadmap)

Epic 1 of 5 for fixing #2183 (`kv_scan` throughput bottleneck). These are the storage-layer building blocks — no consumer changes, no behavior changes for existing callers.

## Design

See [`docs/architecture/scan/lazy-iterator-design.md`](docs/architecture/scan/lazy-iterator-design.md) for the full architecture (RocksDB-aligned: `BranchSnapshot` ≈ SuperVersion, `StorageIterator` ≈ ArenaWrappedDBIter).

See [`docs/architecture/scan/epics.md`](docs/architecture/scan/epics.md) for the 5-epic breakdown:
1. **Storage primitives** ← this PR
2. Lazy merge builder + consumer refactors
3. Bounded `scan_range` (resolves #2183)
4. `Arc<Memtable>` + `BranchSnapshot`
5. Persistent `StorageIterator`

## Test plan

- [x] `cargo test -p strata-storage` — 637 passed, 0 failed
- [x] 6 new tests: `iter_range` (3) + `OwnedSegmentIter::new_seek` (3)
- [x] Invariant check: LSM-001, LSM-003, LSM-007, SCALE-009 all HOLD
- [x] Backward compatible: `OwnedSegmentIter::new()` unchanged (`prefix_bytes: None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)