### PR TITLE
Fix #2140: Recipe types, three-level merge, storage + API

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -52,6 +52,7 @@ pub use transaction_ops::TransactionOps;
 pub mod branch_ops;
 pub mod bundle;
 pub mod primitives;
+pub mod recipe_store;
 pub mod search;
 pub mod system_space;
 

--- a/crates/engine/src/recipe_store.rs
+++ b/crates/engine/src/recipe_store.rs
@@ -150,4 +150,25 @@ mod tests {
         // Not visible on other branch
         assert!(get_recipe(&db, b2, "private").unwrap().is_none());
     }
+
+    #[test]
+    fn test_recipe_overwrite() {
+        let (_dir, db) = setup_db();
+        let bid = BranchId::new();
+
+        let v1 = Recipe {
+            version: Some(1),
+            ..Default::default()
+        };
+        let v2 = Recipe {
+            version: Some(2),
+            ..Default::default()
+        };
+
+        set_recipe(&db, bid, "test", &v1).unwrap();
+        set_recipe(&db, bid, "test", &v2).unwrap();
+
+        let loaded = get_recipe(&db, bid, "test").unwrap().unwrap();
+        assert_eq!(loaded.version, Some(2), "Last write should win");
+    }
 }

--- a/crates/engine/src/recipe_store.rs
+++ b/crates/engine/src/recipe_store.rs
@@ -1,0 +1,153 @@
+//! Recipe storage in the `_system_` space.
+//!
+//! Recipes are stored as JSON strings under `recipe:{name}` keys in the
+//! per-branch `_system_` space. The "default" recipe is auto-created with
+//! built-in defaults on first access.
+
+use crate::search::recipe::{builtin_defaults, Recipe};
+use crate::system_space::system_kv_key;
+use crate::Database;
+use strata_core::types::BranchId;
+use strata_core::value::Value;
+use strata_core::StrataResult;
+
+/// Store a named recipe on a branch.
+pub fn set_recipe(
+    db: &Database,
+    branch_id: BranchId,
+    name: &str,
+    recipe: &Recipe,
+) -> StrataResult<()> {
+    let key = system_kv_key(branch_id, &format!("recipe:{name}"));
+    let json = serde_json::to_string(recipe)?;
+    db.transaction(branch_id, |txn| {
+        txn.put(key.clone(), Value::String(json.clone().into()))
+    })?;
+    Ok(())
+}
+
+/// Retrieve a named recipe from a branch. Returns `None` if not found.
+pub fn get_recipe(db: &Database, branch_id: BranchId, name: &str) -> StrataResult<Option<Recipe>> {
+    let key = system_kv_key(branch_id, &format!("recipe:{name}"));
+    match db.get_value_direct(&key)? {
+        Some(Value::String(s)) => {
+            let recipe: Recipe = serde_json::from_str(&s)?;
+            Ok(Some(recipe))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Get the default recipe, auto-creating it with built-in defaults if absent.
+pub fn get_default_recipe(db: &Database, branch_id: BranchId) -> StrataResult<Recipe> {
+    match get_recipe(db, branch_id, "default")? {
+        Some(r) => Ok(r),
+        None => {
+            let defaults = builtin_defaults();
+            set_recipe(db, branch_id, "default", &defaults)?;
+            Ok(defaults)
+        }
+    }
+}
+
+/// List all recipe names on a branch.
+pub fn list_recipes(db: &Database, branch_id: BranchId) -> StrataResult<Vec<String>> {
+    use strata_core::traits::Storage;
+
+    let prefix = system_kv_key(branch_id, "recipe:");
+    let version = db.storage().version();
+    let entries = db.storage().scan_prefix(&prefix, version)?;
+
+    let mut names: Vec<String> = entries
+        .into_iter()
+        .filter_map(|(k, _)| {
+            k.user_key_string()
+                .and_then(|s| s.strip_prefix("recipe:").map(|n| n.to_string()))
+        })
+        .collect();
+    names.sort();
+    Ok(names)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_db() -> (tempfile::TempDir, std::sync::Arc<Database>) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = Database::open(dir.path()).unwrap();
+        (dir, db)
+    }
+
+    #[test]
+    fn test_set_get_recipe_roundtrip() {
+        let (_dir, db) = setup_db();
+        let bid = BranchId::new();
+
+        let recipe = Recipe {
+            version: Some(1),
+            retrieve: Some(crate::search::recipe::RetrieveConfig {
+                bm25: Some(crate::search::recipe::BM25Config {
+                    k1: Some(1.5),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        set_recipe(&db, bid, "test", &recipe).unwrap();
+        let loaded = get_recipe(&db, bid, "test").unwrap();
+        assert_eq!(loaded, Some(recipe));
+    }
+
+    #[test]
+    fn test_get_recipe_not_found() {
+        let (_dir, db) = setup_db();
+        let bid = BranchId::new();
+        let result = get_recipe(&db, bid, "nonexistent").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_get_default_recipe_auto_creates() {
+        let (_dir, db) = setup_db();
+        let bid = BranchId::new();
+
+        // First call auto-creates
+        let r1 = get_default_recipe(&db, bid).unwrap();
+        assert_eq!(r1, builtin_defaults());
+
+        // Second call returns the stored one
+        let r2 = get_default_recipe(&db, bid).unwrap();
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn test_list_recipes() {
+        let (_dir, db) = setup_db();
+        let bid = BranchId::new();
+
+        set_recipe(&db, bid, "alpha", &builtin_defaults()).unwrap();
+        set_recipe(&db, bid, "beta", &Recipe::default()).unwrap();
+
+        let names = list_recipes(&db, bid).unwrap();
+        assert_eq!(names, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn test_recipe_branch_isolation() {
+        let (_dir, db) = setup_db();
+        let b1 = BranchId::new();
+        let b2 = BranchId::new();
+
+        set_recipe(&db, b1, "private", &builtin_defaults()).unwrap();
+
+        // Not visible on other branch
+        assert!(get_recipe(&db, b2, "private").unwrap().is_none());
+    }
+}

--- a/crates/engine/src/search/mod.rs
+++ b/crates/engine/src/search/mod.rs
@@ -11,6 +11,7 @@
 
 mod index;
 pub(crate) mod manifest;
+pub mod recipe;
 pub(crate) mod recovery;
 mod searchable;
 pub(crate) mod segment;
@@ -19,6 +20,7 @@ pub mod tokenizer;
 mod types;
 
 pub use index::{InvertedIndex, PostingEntry, PostingList, ScoredDocId};
+pub use recipe::{builtin_defaults, Recipe};
 pub use recovery::{extract_indexable_text, register_search_recovery, SearchSubsystem};
 pub use searchable::{
     build_search_response, build_search_response_with_index, build_search_response_with_scorer,

--- a/crates/engine/src/search/recipe.rs
+++ b/crates/engine/src/search/recipe.rs
@@ -261,14 +261,10 @@ where
     F: FnOnce(&T, &T) -> T,
 {
     match (base, overlay) {
-        (_, Some(o)) if overlay.is_some() => match base {
-            Some(b) => Some(merge_fn(b, o)),
-            None => Some(o.clone()),
-        },
+        (Some(b), Some(o)) => Some(merge_fn(b, o)),
+        (None, Some(o)) => Some(o.clone()),
         (Some(b), None) => Some(b.clone()),
         (None, None) => None,
-        // Covered by the first arm, but needed for exhaustiveness
-        (_, Some(o)) => Some(o.clone()),
     }
 }
 

--- a/crates/engine/src/search/recipe.rs
+++ b/crates/engine/src/search/recipe.rs
@@ -1,0 +1,575 @@
+//! Recipe schema for search retrieval configuration.
+//!
+//! Recipes control all aspects of search behavior: BM25 tuning, vector search,
+//! fusion strategy, expansion, reranking, and more. Every field is `Option<T>`
+//! to support three-level merge: built-in defaults → branch recipe → per-call override.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ============================================================================
+// Top-level Recipe
+// ============================================================================
+
+/// Search recipe — controls all retrieval behavior.
+///
+/// All fields are `Option<T>` to support partial overrides via [`Recipe::merge`].
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct Recipe {
+    /// Schema version (currently 1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<u32>,
+
+    /// Retrieval stage configuration (BM25, vector, graph).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retrieve: Option<RetrieveConfig>,
+
+    /// Query expansion configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expansion: Option<ExpansionConfig>,
+
+    /// Pre-retrieval filter configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filter: Option<FilterConfig>,
+
+    /// Result fusion configuration (e.g., RRF).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fusion: Option<FusionConfig>,
+
+    /// Re-ranking configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rerank: Option<RerankConfig>,
+
+    /// Post-retrieval transform (limit, dedup).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transform: Option<TransformConfig>,
+
+    /// RAG prompt template.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+
+    /// Number of search hits to include in RAG context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rag_context_hits: Option<usize>,
+
+    /// Maximum token budget for RAG context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rag_max_tokens: Option<usize>,
+
+    /// Model routing configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub models: Option<ModelsConfig>,
+
+    /// Version output configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version_output: Option<VersionOutputConfig>,
+
+    /// Execution control (budget, timeouts).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub control: Option<ControlConfig>,
+}
+
+// ============================================================================
+// Sub-configs
+// ============================================================================
+
+/// Retrieval stage: which retrievers to use and how.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct RetrieveConfig {
+    /// BM25 keyword retrieval.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bm25: Option<BM25Config>,
+    /// Vector (embedding) retrieval.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vector: Option<VectorRetrieveConfig>,
+    /// Graph traversal retrieval.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graph: Option<GraphConfig>,
+}
+
+/// BM25 keyword retrieval parameters.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct BM25Config {
+    /// Which primitives to search (e.g., ["kv", "json", "event"]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sources: Option<Vec<String>>,
+    /// Which spaces to search.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spaces: Option<Vec<String>>,
+    /// Top-k candidates from BM25.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub k: Option<usize>,
+    /// Term frequency saturation (default 0.9).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub k1: Option<f32>,
+    /// Document length normalization (default 0.4).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub b: Option<f32>,
+    /// Per-field boost weights.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field_weights: Option<HashMap<String, f32>>,
+    /// Stemmer algorithm (e.g., "porter").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stemmer: Option<String>,
+    /// Stopword list (e.g., "lucene33").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stopwords: Option<String>,
+    /// Phrase proximity boost factor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phrase_boost: Option<f32>,
+    /// Term proximity boost factor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proximity_boost: Option<f32>,
+}
+
+/// Vector (embedding) retrieval parameters.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct VectorRetrieveConfig {
+    /// Which collections to search (default: all `_system_embed_*`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collections: Option<Vec<String>>,
+    /// Top-k candidates from vector search.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub k: Option<usize>,
+    /// Distance metric override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metric: Option<String>,
+}
+
+/// Graph traversal retrieval parameters.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct GraphConfig {
+    /// Named graph to traverse.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graph: Option<String>,
+    /// Maximum hops.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_hops: Option<usize>,
+    /// Top-k graph results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub k: Option<usize>,
+}
+
+/// Query expansion configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct ExpansionConfig {
+    /// Expansion method (e.g., "lex", "vec", "hyde").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    /// Number of expansion terms/queries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub count: Option<usize>,
+}
+
+/// Pre-retrieval filter configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct FilterConfig {
+    /// Time range filter (start_us, end_us).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub time_range: Option<(u64, u64)>,
+    /// Tag filter (match any).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags_any: Option<Vec<String>>,
+}
+
+/// Result fusion configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct FusionConfig {
+    /// Fusion method (e.g., "rrf", "linear").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    /// RRF k parameter (default 60).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub k: Option<usize>,
+    /// Per-source weights for linear fusion.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weights: Option<HashMap<String, f32>>,
+}
+
+/// Re-ranking configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct RerankConfig {
+    /// Whether reranking is enabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    /// Model to use for reranking (e.g., "local:qwen3-reranker").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Top-k after reranking.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<usize>,
+}
+
+/// Post-retrieval transform.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct TransformConfig {
+    /// Final result limit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    /// Deduplication strategy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dedup: Option<String>,
+}
+
+/// Model routing configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct ModelsConfig {
+    /// Embedding model (e.g., "local:miniLM").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embed: Option<String>,
+    /// Reranking model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rerank: Option<String>,
+    /// Generation model (for RAG).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generate: Option<String>,
+    /// Expansion model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expand: Option<String>,
+}
+
+/// Version output configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct VersionOutputConfig {
+    /// Include version metadata in results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_version: Option<bool>,
+    /// Include timestamps in results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_timestamp: Option<bool>,
+}
+
+/// Execution control.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct ControlConfig {
+    /// Total budget in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_ms: Option<u64>,
+    /// Maximum candidates per primitive.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_candidates: Option<usize>,
+}
+
+// ============================================================================
+// Merge
+// ============================================================================
+
+/// Merge two optional sub-configs using a merge function.
+fn merge_option<T, F>(base: &Option<T>, overlay: &Option<T>, merge_fn: F) -> Option<T>
+where
+    T: Clone,
+    F: FnOnce(&T, &T) -> T,
+{
+    match (base, overlay) {
+        (_, Some(o)) if overlay.is_some() => match base {
+            Some(b) => Some(merge_fn(b, o)),
+            None => Some(o.clone()),
+        },
+        (Some(b), None) => Some(b.clone()),
+        (None, None) => None,
+        // Covered by the first arm, but needed for exhaustiveness
+        (_, Some(o)) => Some(o.clone()),
+    }
+}
+
+impl Recipe {
+    /// Merge two recipes. Overlay fields win when `Some`; base fills gaps.
+    pub fn merge(base: &Recipe, overlay: &Recipe) -> Recipe {
+        Recipe {
+            version: overlay.version.or(base.version),
+            retrieve: merge_option(&base.retrieve, &overlay.retrieve, RetrieveConfig::merge),
+            expansion: overlay
+                .expansion
+                .as_ref()
+                .or(base.expansion.as_ref())
+                .cloned(),
+            filter: overlay.filter.as_ref().or(base.filter.as_ref()).cloned(),
+            fusion: merge_option(&base.fusion, &overlay.fusion, FusionConfig::merge),
+            rerank: overlay.rerank.as_ref().or(base.rerank.as_ref()).cloned(),
+            transform: merge_option(&base.transform, &overlay.transform, TransformConfig::merge),
+            prompt: overlay.prompt.as_ref().or(base.prompt.as_ref()).cloned(),
+            rag_context_hits: overlay.rag_context_hits.or(base.rag_context_hits),
+            rag_max_tokens: overlay.rag_max_tokens.or(base.rag_max_tokens),
+            models: merge_option(&base.models, &overlay.models, ModelsConfig::merge),
+            version_output: overlay
+                .version_output
+                .as_ref()
+                .or(base.version_output.as_ref())
+                .cloned(),
+            control: merge_option(&base.control, &overlay.control, ControlConfig::merge),
+        }
+    }
+
+    /// Three-level resolution: built-in defaults → branch recipe → per-call override.
+    pub fn resolve(builtin: &Recipe, branch: &Recipe, per_call: Option<&Recipe>) -> Recipe {
+        let merged = Recipe::merge(builtin, branch);
+        match per_call {
+            Some(o) => Recipe::merge(&merged, o),
+            None => merged,
+        }
+    }
+}
+
+impl RetrieveConfig {
+    fn merge(base: &Self, overlay: &Self) -> Self {
+        RetrieveConfig {
+            bm25: merge_option(&base.bm25, &overlay.bm25, BM25Config::merge),
+            vector: merge_option(&base.vector, &overlay.vector, VectorRetrieveConfig::merge),
+            graph: overlay.graph.as_ref().or(base.graph.as_ref()).cloned(),
+        }
+    }
+}
+
+impl BM25Config {
+    fn merge(base: &Self, overlay: &Self) -> Self {
+        BM25Config {
+            sources: overlay.sources.as_ref().or(base.sources.as_ref()).cloned(),
+            spaces: overlay.spaces.as_ref().or(base.spaces.as_ref()).cloned(),
+            k: overlay.k.or(base.k),
+            k1: overlay.k1.or(base.k1),
+            b: overlay.b.or(base.b),
+            field_weights: overlay
+                .field_weights
+                .as_ref()
+                .or(base.field_weights.as_ref())
+                .cloned(),
+            stemmer: overlay.stemmer.as_ref().or(base.stemmer.as_ref()).cloned(),
+            stopwords: overlay
+                .stopwords
+                .as_ref()
+                .or(base.stopwords.as_ref())
+                .cloned(),
+            phrase_boost: overlay.phrase_boost.or(base.phrase_boost),
+            proximity_boost: overlay.proximity_boost.or(base.proximity_boost),
+        }
+    }
+}
+
+impl VectorRetrieveConfig {
+    fn merge(base: &Self, overlay: &Self) -> Self {
+        VectorRetrieveConfig {
+            collections: overlay
+                .collections
+                .as_ref()
+                .or(base.collections.as_ref())
+                .cloned(),
+            k: overlay.k.or(base.k),
+            metric: overlay.metric.as_ref().or(base.metric.as_ref()).cloned(),
+        }
+    }
+}
+
+impl FusionConfig {
+    fn merge(base: &Self, overlay: &Self) -> Self {
+        FusionConfig {
+            method: overlay.method.as_ref().or(base.method.as_ref()).cloned(),
+            k: overlay.k.or(base.k),
+            weights: overlay.weights.as_ref().or(base.weights.as_ref()).cloned(),
+        }
+    }
+}
+
+impl TransformConfig {
+    fn merge(base: &Self, overlay: &Self) -> Self {
+        TransformConfig {
+            limit: overlay.limit.or(base.limit),
+            dedup: overlay.dedup.as_ref().or(base.dedup.as_ref()).cloned(),
+        }
+    }
+}
+
+impl ModelsConfig {
+    fn merge(base: &Self, overlay: &Self) -> Self {
+        ModelsConfig {
+            embed: overlay.embed.as_ref().or(base.embed.as_ref()).cloned(),
+            rerank: overlay.rerank.as_ref().or(base.rerank.as_ref()).cloned(),
+            generate: overlay
+                .generate
+                .as_ref()
+                .or(base.generate.as_ref())
+                .cloned(),
+            expand: overlay.expand.as_ref().or(base.expand.as_ref()).cloned(),
+        }
+    }
+}
+
+impl ControlConfig {
+    fn merge(base: &Self, overlay: &Self) -> Self {
+        ControlConfig {
+            budget_ms: overlay.budget_ms.or(base.budget_ms),
+            max_candidates: overlay.max_candidates.or(base.max_candidates),
+        }
+    }
+}
+
+// ============================================================================
+// Built-in Defaults
+// ============================================================================
+
+/// The built-in default recipe (level 0 of three-level merge).
+///
+/// These values match Anserini/Pyserini BEIR-tuned defaults.
+pub fn builtin_defaults() -> Recipe {
+    Recipe {
+        version: Some(1),
+        retrieve: Some(RetrieveConfig {
+            bm25: Some(BM25Config {
+                k: Some(50),
+                k1: Some(0.9),
+                b: Some(0.4),
+                stemmer: Some("porter".into()),
+                stopwords: Some("lucene33".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        fusion: Some(FusionConfig {
+            method: Some("rrf".into()),
+            k: Some(60),
+            ..Default::default()
+        }),
+        transform: Some(TransformConfig {
+            limit: Some(10),
+            ..Default::default()
+        }),
+        control: Some(ControlConfig {
+            budget_ms: Some(5000),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_recipe_deserialize_empty() {
+        let recipe: Recipe = serde_json::from_str("{}").unwrap();
+        assert_eq!(recipe, Recipe::default());
+        assert!(recipe.version.is_none());
+        assert!(recipe.retrieve.is_none());
+    }
+
+    #[test]
+    fn test_recipe_deserialize_nested() {
+        let json = r#"{"retrieve":{"bm25":{}}}"#;
+        let recipe: Recipe = serde_json::from_str(json).unwrap();
+        assert!(recipe.retrieve.is_some());
+        let bm25 = recipe.retrieve.unwrap().bm25.unwrap();
+        assert!(bm25.k1.is_none());
+        assert!(bm25.b.is_none());
+        assert!(bm25.k.is_none());
+    }
+
+    #[test]
+    fn test_recipe_merge_empty_overlay() {
+        let base = builtin_defaults();
+        let overlay = Recipe::default();
+        let merged = Recipe::merge(&base, &overlay);
+        assert_eq!(merged, base);
+    }
+
+    #[test]
+    fn test_recipe_merge_single_field_override() {
+        let base = builtin_defaults();
+        let overlay = Recipe {
+            retrieve: Some(RetrieveConfig {
+                bm25: Some(BM25Config {
+                    k1: Some(1.5),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let merged = Recipe::merge(&base, &overlay);
+
+        // k1 overridden
+        let bm25 = merged.retrieve.as_ref().unwrap().bm25.as_ref().unwrap();
+        assert_eq!(bm25.k1, Some(1.5));
+        // b still from base
+        assert_eq!(bm25.b, Some(0.4));
+        // k still from base
+        assert_eq!(bm25.k, Some(50));
+        // fusion still from base
+        assert_eq!(merged.fusion.as_ref().unwrap().method, Some("rrf".into()));
+    }
+
+    #[test]
+    fn test_recipe_resolve_three_levels() {
+        let builtin = builtin_defaults();
+
+        let branch = Recipe {
+            retrieve: Some(RetrieveConfig {
+                bm25: Some(BM25Config {
+                    k1: Some(1.2),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let per_call = Recipe {
+            transform: Some(TransformConfig {
+                limit: Some(5),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let resolved = Recipe::resolve(&builtin, &branch, Some(&per_call));
+
+        // k1 from branch level
+        assert_eq!(
+            resolved
+                .retrieve
+                .as_ref()
+                .unwrap()
+                .bm25
+                .as_ref()
+                .unwrap()
+                .k1,
+            Some(1.2)
+        );
+        // b from builtin (branch didn't override)
+        assert_eq!(
+            resolved.retrieve.as_ref().unwrap().bm25.as_ref().unwrap().b,
+            Some(0.4)
+        );
+        // limit from per_call
+        assert_eq!(resolved.transform.as_ref().unwrap().limit, Some(5));
+        // budget_ms from builtin (neither branch nor per_call overrode)
+        assert_eq!(resolved.control.as_ref().unwrap().budget_ms, Some(5000));
+    }
+
+    #[test]
+    fn test_builtin_defaults() {
+        let d = builtin_defaults();
+        assert_eq!(d.version, Some(1));
+        let bm25 = d.retrieve.as_ref().unwrap().bm25.as_ref().unwrap();
+        assert_eq!(bm25.k1, Some(0.9));
+        assert_eq!(bm25.b, Some(0.4));
+        assert_eq!(bm25.k, Some(50));
+        assert_eq!(bm25.stemmer, Some("porter".into()));
+        assert_eq!(bm25.stopwords, Some("lucene33".into()));
+        assert_eq!(d.fusion.as_ref().unwrap().method, Some("rrf".into()));
+        assert_eq!(d.fusion.as_ref().unwrap().k, Some(60));
+        assert_eq!(d.transform.as_ref().unwrap().limit, Some(10));
+        assert_eq!(d.control.as_ref().unwrap().budget_ms, Some(5000));
+    }
+
+    #[test]
+    fn test_recipe_roundtrip() {
+        let original = builtin_defaults();
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: Recipe = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, deserialized);
+    }
+}

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -1370,6 +1370,46 @@ pub enum Command {
     /// Returns: `Output::DurabilityCounters`
     DurabilityCounters,
 
+    /// Set a named recipe on a branch.
+    /// Returns: `Output::Unit`
+    RecipeSet {
+        /// Target branch (defaults to "default").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Recipe name (defaults to "default").
+        #[serde(default = "default_recipe_name")]
+        name: String,
+        /// Recipe JSON string.
+        recipe_json: String,
+    },
+
+    /// Get a named recipe from a branch.
+    /// Returns: `Output::Maybe`
+    RecipeGet {
+        /// Target branch (defaults to "default").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Recipe name (defaults to "default").
+        #[serde(default = "default_recipe_name")]
+        name: String,
+    },
+
+    /// Get the default recipe, auto-creating with built-in defaults if absent.
+    /// Returns: `Output::Maybe`
+    RecipeGetDefault {
+        /// Target branch (defaults to "default").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+    },
+
+    /// List all recipe names on a branch.
+    /// Returns: `Output::Keys`
+    RecipeList {
+        /// Target branch (defaults to "default").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+    },
+
     /// Delete a space (must be empty unless force=true).
     /// Returns: `Output::Unit`
     SpaceDelete {
@@ -1900,6 +1940,7 @@ impl Command {
                 | Command::GraphDeleteLinkType { .. }
                 | Command::GraphFreezeOntology { .. }
                 | Command::ReindexEmbeddings { .. }
+                | Command::RecipeSet { .. }
                 | Command::TagCreate { .. }
                 | Command::TagDelete { .. }
                 | Command::NoteAdd { .. }
@@ -2012,6 +2053,10 @@ impl Command {
             Command::ConfigSetAutoEmbed { .. } => "ConfigSetAutoEmbed",
             Command::AutoEmbedStatus => "AutoEmbedStatus",
             Command::DurabilityCounters => "DurabilityCounters",
+            Command::RecipeSet { .. } => "RecipeSet",
+            Command::RecipeGet { .. } => "RecipeGet",
+            Command::RecipeGetDefault { .. } => "RecipeGetDefault",
+            Command::RecipeList { .. } => "RecipeList",
             Command::Embed { .. } => "Embed",
             Command::EmbedBatch { .. } => "EmbedBatch",
             Command::ModelsList => "ModelsList",
@@ -2156,6 +2201,14 @@ impl Command {
             | Command::SpaceDelete { branch, .. }
             | Command::SpaceExists { branch, .. }
             | Command::ReindexEmbeddings { branch, .. } => {
+                resolve_branch!(branch);
+            }
+
+            // Recipe commands — only have branch
+            Command::RecipeSet { branch, .. }
+            | Command::RecipeGet { branch, .. }
+            | Command::RecipeGetDefault { branch, .. }
+            | Command::RecipeList { branch, .. } => {
                 resolve_branch!(branch);
             }
 
@@ -2359,8 +2412,19 @@ impl Command {
             | Command::GraphLcc { branch, .. }
             | Command::GraphSssp { branch, .. } => branch.as_ref(),
 
+            // Recipe commands
+            Command::RecipeSet { branch, .. }
+            | Command::RecipeGet { branch, .. }
+            | Command::RecipeGetDefault { branch, .. }
+            | Command::RecipeList { branch, .. } => branch.as_ref(),
+
             // Branch lifecycle, Transaction, Database — no data branch
             _ => None,
         }
     }
+}
+
+/// Default recipe name for serde deserialization.
+fn default_recipe_name() -> String {
+    "default".to_string()
 }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -298,6 +298,41 @@ impl Executor {
             Command::DurabilityCounters => {
                 crate::handlers::config::durability_counters(&self.primitives)
             }
+
+            // ==================== Recipe Commands ====================
+            Command::RecipeSet {
+                branch,
+                name,
+                recipe_json,
+            } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                    hint: None,
+                })?;
+                crate::handlers::recipe::recipe_set(&self.primitives, branch, name, recipe_json)
+            }
+            Command::RecipeGet { branch, name } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                    hint: None,
+                })?;
+                crate::handlers::recipe::recipe_get(&self.primitives, branch, name)
+            }
+            Command::RecipeGetDefault { branch } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                    hint: None,
+                })?;
+                crate::handlers::recipe::recipe_get_default(&self.primitives, branch)
+            }
+            Command::RecipeList { branch } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                    hint: None,
+                })?;
+                crate::handlers::recipe::recipe_list(&self.primitives, branch)
+            }
+
             Command::TimeRange { branch } => {
                 let branch = branch.ok_or(Error::InvalidInput {
                     reason: "Branch must be specified or resolved to default".into(),

--- a/crates/executor/src/handlers/mod.rs
+++ b/crates/executor/src/handlers/mod.rs
@@ -27,6 +27,7 @@ pub mod graph;
 pub mod json;
 pub mod kv;
 pub mod models;
+pub mod recipe;
 pub mod search;
 pub mod space;
 pub mod vector;

--- a/crates/executor/src/handlers/recipe.rs
+++ b/crates/executor/src/handlers/recipe.rs
@@ -1,0 +1,74 @@
+//! Recipe command handlers.
+
+use std::sync::Arc;
+
+use crate::bridge::{to_core_branch_id, Primitives};
+use crate::types::BranchId;
+use crate::{Error, Output, Result, Value};
+
+use strata_engine::recipe_store;
+use strata_engine::search::recipe::Recipe;
+
+/// Set a named recipe on a branch.
+pub fn recipe_set(
+    p: &Arc<Primitives>,
+    branch: BranchId,
+    name: String,
+    recipe_json: String,
+) -> Result<Output> {
+    let branch_id = to_core_branch_id(&branch)?;
+    let recipe: Recipe = serde_json::from_str(&recipe_json).map_err(|e| Error::InvalidInput {
+        reason: format!("Invalid recipe JSON: {e}"),
+        hint: None,
+    })?;
+    recipe_store::set_recipe(&p.db, branch_id, &name, &recipe).map_err(|e| Error::Internal {
+        reason: e.to_string(),
+        hint: None,
+    })?;
+    Ok(Output::Unit)
+}
+
+/// Get a named recipe from a branch.
+pub fn recipe_get(p: &Arc<Primitives>, branch: BranchId, name: String) -> Result<Output> {
+    let branch_id = to_core_branch_id(&branch)?;
+    let recipe =
+        recipe_store::get_recipe(&p.db, branch_id, &name).map_err(|e| Error::Internal {
+            reason: e.to_string(),
+            hint: None,
+        })?;
+    match recipe {
+        Some(r) => {
+            let json = serde_json::to_string(&r).map_err(|e| Error::Internal {
+                reason: e.to_string(),
+                hint: None,
+            })?;
+            Ok(Output::Maybe(Some(Value::String(json.into()))))
+        }
+        None => Ok(Output::Maybe(None)),
+    }
+}
+
+/// Get the default recipe, auto-creating with built-in defaults if absent.
+pub fn recipe_get_default(p: &Arc<Primitives>, branch: BranchId) -> Result<Output> {
+    let branch_id = to_core_branch_id(&branch)?;
+    let recipe =
+        recipe_store::get_default_recipe(&p.db, branch_id).map_err(|e| Error::Internal {
+            reason: e.to_string(),
+            hint: None,
+        })?;
+    let json = serde_json::to_string(&recipe).map_err(|e| Error::Internal {
+        reason: e.to_string(),
+        hint: None,
+    })?;
+    Ok(Output::Maybe(Some(Value::String(json.into()))))
+}
+
+/// List all recipe names on a branch.
+pub fn recipe_list(p: &Arc<Primitives>, branch: BranchId) -> Result<Output> {
+    let branch_id = to_core_branch_id(&branch)?;
+    let names = recipe_store::list_recipes(&p.db, branch_id).map_err(|e| Error::Internal {
+        reason: e.to_string(),
+        hint: None,
+    })?;
+    Ok(Output::Keys(names))
+}

--- a/crates/executor/src/tests/mod.rs
+++ b/crates/executor/src/tests/mod.rs
@@ -10,6 +10,7 @@ pub mod execute_many;
 pub mod export;
 pub mod ipc;
 pub mod parity;
+pub mod recipe;
 pub mod search;
 pub mod serialization;
 pub mod session;

--- a/crates/executor/src/tests/recipe.rs
+++ b/crates/executor/src/tests/recipe.rs
@@ -1,0 +1,104 @@
+//! Integration tests for Recipe commands.
+
+use crate::{Command, Executor, Output, Value};
+use strata_engine::Database;
+
+fn create_test_executor() -> Executor {
+    let db = Database::cache().unwrap();
+    Executor::new(db)
+}
+
+#[test]
+fn test_recipe_set_get_command() {
+    let executor = create_test_executor();
+
+    let recipe_json = r#"{"version":1,"retrieve":{"bm25":{"k1":1.5}}}"#;
+
+    // Set
+    let result = executor.execute(Command::RecipeSet {
+        branch: None,
+        name: "test".to_string(),
+        recipe_json: recipe_json.to_string(),
+    });
+    assert!(matches!(result, Ok(Output::Unit)));
+
+    // Get
+    let result = executor.execute(Command::RecipeGet {
+        branch: None,
+        name: "test".to_string(),
+    });
+    match result {
+        Ok(Output::Maybe(Some(Value::String(json)))) => {
+            assert!(json.contains("1.5"), "Should contain k1=1.5, got: {json}");
+        }
+        other => panic!("Expected Maybe(Some(String)), got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_recipe_get_default_command() {
+    let executor = create_test_executor();
+
+    let result = executor.execute(Command::RecipeGetDefault { branch: None });
+    match result {
+        Ok(Output::Maybe(Some(Value::String(json)))) => {
+            // Should contain builtin default values
+            assert!(json.contains("0.9"), "Should contain k1=0.9, got: {json}");
+            assert!(json.contains("0.4"), "Should contain b=0.4, got: {json}");
+        }
+        other => panic!("Expected Maybe(Some(String)), got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_recipe_list_command() {
+    let executor = create_test_executor();
+
+    // Set two recipes
+    executor
+        .execute(Command::RecipeSet {
+            branch: None,
+            name: "alpha".to_string(),
+            recipe_json: "{}".to_string(),
+        })
+        .unwrap();
+    executor
+        .execute(Command::RecipeSet {
+            branch: None,
+            name: "beta".to_string(),
+            recipe_json: "{}".to_string(),
+        })
+        .unwrap();
+
+    let result = executor.execute(Command::RecipeList { branch: None });
+    match result {
+        Ok(Output::Keys(names)) => {
+            assert!(names.contains(&"alpha".to_string()));
+            assert!(names.contains(&"beta".to_string()));
+        }
+        other => panic!("Expected Keys, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_recipe_set_invalid_json() {
+    let executor = create_test_executor();
+
+    let result = executor.execute(Command::RecipeSet {
+        branch: None,
+        name: "bad".to_string(),
+        recipe_json: "not valid json".to_string(),
+    });
+    assert!(result.is_err(), "Should reject invalid JSON");
+}
+
+#[test]
+fn test_recipe_get_nonexistent() {
+    let executor = create_test_executor();
+
+    let result = executor.execute(Command::RecipeGet {
+        branch: None,
+        name: "nonexistent".to_string(),
+    });
+    assert!(matches!(result, Ok(Output::Maybe(None))));
+}

--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -1103,11 +1103,7 @@ impl OwnedSegmentIter {
     /// Combines the seek capability of [`KVSegment::iter_seek`] with the
     /// `Arc` ownership of `OwnedSegmentIter`. Enables lazy iteration
     /// without borrowing the segment.
-    pub fn new_seek(
-        segment: Arc<KVSegment>,
-        start_key: &Key,
-        prefix_bytes: Vec<u8>,
-    ) -> Self {
+    pub fn new_seek(segment: Arc<KVSegment>, start_key: &Key, prefix_bytes: Vec<u8>) -> Self {
         let done = segment.index.is_empty();
         let (partition_idx, block_within_partition) = if done {
             (0, 0)


### PR DESCRIPTION
## Summary

- New `Recipe` schema with 13 top-level config sections (BM25, vector, fusion, rerank, etc.) — all fields `Option<T>` for partial override
- `Recipe::merge(base, overlay)` — field-by-field deep merge with recursive sub-config merge
- `Recipe::resolve(builtin, branch, per_call)` — three-level merge for runtime configuration
- `builtin_defaults()` — BEIR-tuned defaults (k1=0.9, b=0.4, RRF k=60, limit=10, budget=5s)
- Storage in `_system_` space via `system_kv_key("recipe:{name}")` — branch-isolated, COW-inherited on fork
- Executor commands: `RecipeSet`, `RecipeGet`, `RecipeGetDefault`, `RecipeList`

## Test plan

- [x] 7 unit tests for recipe types (deserialize, merge, resolve, roundtrip, defaults)
- [x] 5 integration tests for recipe storage (set/get, auto-create default, list, branch isolation)
- [x] 5 executor integration tests (set+get, get_default, list, invalid JSON, nonexistent)
- [x] Full engine suite passes (731 tests)
- [x] Full executor suite passes (563 tests)
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)