### PR TITLE
Fix #2183: Bounded scan_range with seek + limit pushdown

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -495,6 +495,21 @@ impl Database {
         self.storage.count_prefix(prefix, max_version)
     }
 
+    /// Scan entries in a range directly from storage.
+    ///
+    /// Bypasses the transaction layer (read-only, no conflict tracking needed).
+    /// Uses the lazy merge pipeline with seek pushdown and optional limit.
+    pub(crate) fn scan_range(
+        &self,
+        prefix: &Key,
+        start_key: &Key,
+        max_version: u64,
+        limit: Option<usize>,
+    ) -> StrataResult<Vec<(Key, VersionedValue)>> {
+        self.storage
+            .scan_range(prefix, start_key, max_version, limit)
+    }
+
     /// Scan keys matching a prefix at or before the given timestamp.
     ///
     /// This is a non-transactional read for time-travel queries.

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -281,6 +281,10 @@ impl KVStore {
     /// Returns up to `limit` pairs where key >= start_key, sorted by key.
     /// If `start` is None, scans from the beginning. If `limit` is None,
     /// returns all matching pairs.
+    ///
+    /// Bypasses the transaction layer (read-only) and uses the lazy merge
+    /// pipeline with seek + limit pushdown. Uses `current_version()` for
+    /// snapshot isolation.
     pub fn scan(
         &self,
         branch_id: &BranchId,
@@ -288,29 +292,17 @@ impl KVStore {
         start: Option<&str>,
         limit: Option<usize>,
     ) -> StrataResult<Vec<(String, Value)>> {
-        self.db.transaction(*branch_id, |txn| {
-            let ns = self.namespace_for(branch_id, space);
-            let scan_prefix = Key::new_kv(ns, "");
-
-            let results = txn.scan_prefix(&scan_prefix)?;
-
-            let iter = results
-                .into_iter()
-                .filter_map(|(key, value)| key.user_key_string().map(|k| (k, value)));
-
-            let iter: Box<dyn Iterator<Item = (String, Value)>> = if let Some(s) = start {
-                let s_owned = s.to_string();
-                Box::new(iter.skip_while(move |(k, _)| k.as_str() < s_owned.as_str()))
-            } else {
-                Box::new(iter)
-            };
-
-            if let Some(lim) = limit {
-                Ok(iter.take(lim).collect())
-            } else {
-                Ok(iter.collect())
-            }
-        })
+        let ns = self.namespace_for(branch_id, space);
+        let scan_prefix = Key::new_kv(Arc::clone(&ns), "");
+        let start_key = Key::new_kv(ns, start.unwrap_or(""));
+        let snapshot = self.db.current_version();
+        let results = self
+            .db
+            .scan_range(&scan_prefix, &start_key, snapshot, limit)?;
+        Ok(results
+            .into_iter()
+            .filter_map(|(key, vv)| key.user_key_string().map(|k| (k, vv.value)))
+            .collect())
     }
 
     /// Count keys matching an optional prefix without materializing entries.

--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -1103,11 +1103,7 @@ impl OwnedSegmentIter {
     /// Combines the seek capability of [`KVSegment::iter_seek`] with the
     /// `Arc` ownership of `OwnedSegmentIter`. Enables lazy iteration
     /// without borrowing the segment.
-    pub fn new_seek(
-        segment: Arc<KVSegment>,
-        start_key: &Key,
-        prefix_bytes: Vec<u8>,
-    ) -> Self {
+    pub fn new_seek(segment: Arc<KVSegment>, start_key: &Key, prefix_bytes: Vec<u8>) -> Self {
         let done = segment.index.is_empty();
         let (partition_idx, block_within_partition) = if done {
             (0, 0)
@@ -1161,7 +1157,7 @@ impl OwnedSegmentIter {
     pub fn corruption_detected(&self) -> bool {
         self.corruption_detected
             .as_ref()
-            .map_or(false, |f| f.load(std::sync::atomic::Ordering::Relaxed))
+            .is_some_and(|f| f.load(std::sync::atomic::Ordering::Relaxed))
     }
 }
 

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -2861,6 +2861,7 @@ impl SegmentedStore {
     }
 
     /// Build a lazy `MergeIterator` over all sources in a branch.
+    #[allow(clippy::type_complexity)]
     ///
     /// Sources are added in read-path order (LSM-003): active memtable →
     /// frozen memtables (newest first) → L0-L6 segments → inherited COW layers.
@@ -2901,13 +2902,9 @@ impl SegmentedStore {
                 let flag = Arc::new(AtomicBool::new(false));
                 corruption_flags.push(Arc::clone(&flag));
                 sources.push(Box::new(
-                    OwnedSegmentIter::new_seek(
-                        Arc::clone(seg),
-                        start_key,
-                        prefix_bytes.clone(),
-                    )
-                    .with_corruption_flag(flag)
-                    .map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se))),
+                    OwnedSegmentIter::new_seek(Arc::clone(seg), start_key, prefix_bytes.clone())
+                        .with_corruption_flag(flag)
+                        .map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se))),
                 ));
             }
         }
@@ -2962,6 +2959,54 @@ impl SegmentedStore {
                 Some((key, entry.to_versioned(commit_id)))
             })
             .collect();
+        check_corruption(&flags)?;
+        Ok(results)
+    }
+
+    /// Scan entries starting from `start_key` within `prefix`, with optional limit.
+    ///
+    /// Uses the lazy merge pipeline with seek pushdown: sources start from
+    /// `start_key` (not the beginning of the prefix), and `.take(limit)` stops
+    /// iteration early. For `kv_scan(start, limit=10)` on 50K records, this
+    /// reduces work from O(N) to O(log N + limit).
+    pub fn scan_range(
+        &self,
+        prefix: &Key,
+        start_key: &Key,
+        max_version: u64,
+        limit: Option<usize>,
+    ) -> StrataResult<Vec<(Key, VersionedValue)>> {
+        let branch_id = prefix.namespace.branch_id;
+        let branch = match self.branches.get(&branch_id) {
+            Some(b) => b,
+            None => return Ok(Vec::new()),
+        };
+        Self::scan_range_from_branch(&branch, prefix, start_key, max_version, limit)
+    }
+
+    /// Bounded range scan with seek + limit pushdown.
+    fn scan_range_from_branch(
+        branch: &BranchState,
+        prefix: &Key,
+        start_key: &Key,
+        max_version: u64,
+        limit: Option<usize>,
+    ) -> StrataResult<Vec<(Key, VersionedValue)>> {
+        let (merge, flags) = Self::build_branch_merge_iter(branch, prefix, start_key)?;
+        let mvcc = MvccIterator::new(merge, max_version);
+        let filtered = mvcc
+            .filter_map(|(ik, entry)| {
+                if entry.is_tombstone || entry.is_expired() {
+                    return None;
+                }
+                let (key, commit_id) = ik.decode()?;
+                Some((key, entry.to_versioned(commit_id)))
+            })
+            .filter(|(key, _)| key >= start_key); // block seek imprecision
+        let results: Vec<_> = match limit {
+            Some(n) => filtered.take(n).collect(),
+            None => filtered.collect(),
+        };
         check_corruption(&flags)?;
         Ok(results)
     }


### PR DESCRIPTION
## Summary

- Add `scan_range` to storage → database → KV primitive with seek pushdown and limit enforcement
- Rewrite `KVStore::scan()` to bypass the transaction layer, use `current_version()` for snapshot isolation
- Fix clippy lint: `map_or` → `is_some_and` on `OwnedSegmentIter::corruption_detected()`

**This resolves #2183.** `kv_scan(start, limit=10)` on 50K records goes from O(N) ~20 ops/s to O(log N + limit).

Epic 3 of 5. Builds on Epic 1 (#2192) and Epic 2 (#2194).

## How it works

```
KVStore::scan(start, limit)
  → current_version() snapshot (no transaction overhead)
  → Database::scan_range(prefix, start_key, snapshot, limit)
    → SegmentedStore::scan_range_from_branch
      → build_branch_merge_iter(prefix, start_key)  ← seek pushdown
        → MvccIterator
          → .filter(key >= start_key)                ← block imprecision fix
          → .take(limit)                             ← limit pushdown
          → .collect()
```

Only `limit` entries are pulled through the entire merge/MVCC pipeline.

## Invariant check

| Invariant | Result |
|-----------|--------|
| LSM-003 (source ordering) | HOLDS — delegates to build_branch_merge_iter |
| MVCC-001 (version visibility) | HOLDS — MvccIterator gates on commit_id ≤ snapshot |
| MVCC-002 (tombstone semantics) | HOLDS — tombstone filter preserved |
| ARCH-002 (atomic publication) | HOLDS — same pattern as existing count() |

## Test plan

- [x] `cargo test -p strata-storage` — 640 passed
- [x] `cargo test -p strata-engine` — 724 passed
- [x] `cargo test -p strata-executor` — 558 passed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)