### PR TITLE
Epic 5: Persistent StorageIterator with Seek/Next API

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -38,7 +38,7 @@ use std::time::Instant;
 use strata_core::types::{BranchId, Key};
 use strata_core::{StrataError, StrataResult, VersionedValue};
 use strata_durability::wal::{DurabilityMode, WalWriter};
-use strata_storage::SegmentedStore;
+use strata_storage::{SegmentedStore, StorageIterator};
 
 // ============================================================================
 // Persistence Mode (Storage/Durability Split)
@@ -508,6 +508,20 @@ impl Database {
     ) -> StrataResult<Vec<(Key, VersionedValue)>> {
         self.storage
             .scan_range(prefix, start_key, max_version, limit)
+    }
+
+    /// Create a persistent [`StorageIterator`] for cursor-based pagination.
+    ///
+    /// Captures a branch snapshot and returns an iterator supporting
+    /// `seek()` + `next()` cycles.
+    pub(crate) fn storage_iterator(
+        &self,
+        branch_id: &BranchId,
+        prefix: Key,
+        snapshot_version: u64,
+    ) -> Option<StorageIterator> {
+        self.storage
+            .new_storage_iterator(branch_id, prefix, snapshot_version)
     }
 
     /// Scan keys matching a prefix at or before the given timestamp.

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -30,8 +30,9 @@ use std::sync::Arc;
 use strata_concurrency::TransactionContext;
 use strata_core::types::{BranchId, Key, Namespace};
 use strata_core::value::Value;
-use strata_core::StrataResult;
+use strata_core::{StrataError, StrataResult};
 use strata_core::{Version, VersionedHistory};
+use strata_storage::StorageIterator;
 
 /// Global cache of `Arc<Namespace>` per (branch, space) pair. One heap allocation
 /// per unique combination, ever — subsequent calls return `Arc::clone()`.
@@ -303,6 +304,20 @@ impl KVStore {
             .into_iter()
             .filter_map(|(key, vv)| key.user_key_string().map(|k| (k, vv.value)))
             .collect())
+    }
+
+    /// Create a persistent iterator for cursor-based pagination.
+    ///
+    /// Returns a [`StorageIterator`] positioned at the branch. Call `seek()`
+    /// to position, then `next()` to advance. The iterator holds a snapshot
+    /// of the branch — memtable rotation and compaction don't affect it.
+    pub fn scan_iter(&self, branch_id: &BranchId, space: &str) -> StrataResult<StorageIterator> {
+        let ns = self.namespace_for(branch_id, space);
+        let prefix = Key::new_kv(ns, "");
+        let snapshot_version = self.db.current_version();
+        self.db
+            .storage_iterator(branch_id, prefix, snapshot_version)
+            .ok_or_else(|| StrataError::branch_not_found(*branch_id))
     }
 
     /// Count keys matching an optional prefix without materializing entries.

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -39,6 +39,7 @@ pub use rate_limiter::RateLimiter;
 pub use segment::{KVSegment, OwnedSegmentIter};
 pub use segment_builder::{CompressionCodec, SegmentBuilder, SegmentMeta, SplittingSegmentBuilder};
 pub use segmented::{
-    CompactionResult, MaterializeResult, PickAndCompactResult, SegmentedStore, VersionedEntry,
+    CompactionResult, MaterializeResult, PickAndCompactResult, SegmentedStore, StorageIterator,
+    VersionedEntry,
 };
 pub use ttl::TTLIndex;

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -333,6 +333,73 @@ pub(crate) struct BranchSnapshot {
     pub(crate) inherited_layers: Vec<InheritedLayer>,
 }
 
+/// Persistent, seekable iterator over a branch snapshot.
+///
+/// Analogous to RocksDB's `ArenaWrappedDBIter`. Supports multiple
+/// `seek()` + `next()` cycles without re-acquiring the DashMap guard.
+/// The [`BranchSnapshot`] pins memtables and segments for the iterator's
+/// lifetime.
+///
+/// Pipeline is rebuilt on each `seek()` — memtable entries collected
+/// (bounded by write_buffer_size from seek position), segments lazy
+/// via `OwnedSegmentIter`.
+pub struct StorageIterator {
+    snapshot: BranchSnapshot,
+    prefix: Key,
+    snapshot_version: u64,
+    pipeline: Option<Box<dyn Iterator<Item = (Key, VersionedValue)>>>,
+    corruption_flags: Vec<Arc<AtomicBool>>,
+}
+
+impl StorageIterator {
+    fn new(snapshot: BranchSnapshot, prefix: Key, snapshot_version: u64) -> Self {
+        Self {
+            snapshot,
+            prefix,
+            snapshot_version,
+            pipeline: None,
+            corruption_flags: Vec::new(),
+        }
+    }
+
+    /// Seek to first entry >= `target` within the prefix.
+    ///
+    /// Rebuilds the merge pipeline from the seek position. O(log N) per source.
+    /// Previous pipeline state is discarded.
+    pub fn seek(&mut self, target: &Key) -> StrataResult<()> {
+        let (merge, flags) =
+            SegmentedStore::build_snapshot_merge_iter(&self.snapshot, &self.prefix, target)?;
+        self.corruption_flags = flags;
+        let mvcc = MvccIterator::new(merge, self.snapshot_version);
+        let target_owned = target.clone();
+        self.pipeline = Some(Box::new(
+            mvcc.filter_map(|(ik, entry)| {
+                if entry.is_tombstone || entry.is_expired() {
+                    return None;
+                }
+                let (key, commit_id) = ik.decode()?;
+                Some((key, entry.to_versioned(commit_id)))
+            })
+            .filter(move |(key, _)| key >= &target_owned),
+        ));
+        Ok(())
+    }
+
+    /// Advance to the next live entry. O(log K) per call where K = source count.
+    ///
+    /// Returns `None` when exhausted. Call `check_corruption()` after iteration
+    /// to detect any segment data block corruption encountered during reads.
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> Option<(Key, VersionedValue)> {
+        self.pipeline.as_mut()?.next()
+    }
+
+    /// Check if any segment reported corruption during iteration.
+    pub fn check_corruption(&self) -> StrataResult<()> {
+        check_corruption(&self.corruption_flags)
+    }
+}
+
 /// Recompute cached level targets from the current segment version.
 fn refresh_level_targets(branch: &mut BranchState, max_base_bytes: u64) {
     let ver = branch.version.load();
@@ -3079,6 +3146,20 @@ impl SegmentedStore {
             segments: branch.version.load_full(),
             inherited_layers: branch.inherited_layers.clone(),
         })
+    }
+
+    /// Create a persistent [`StorageIterator`] for a branch.
+    ///
+    /// Captures a [`BranchSnapshot`] and returns an iterator that supports
+    /// `seek()` + `next()` cycles for cursor-based pagination.
+    pub fn new_storage_iterator(
+        &self,
+        branch_id: &BranchId,
+        prefix: Key,
+        snapshot_version: u64,
+    ) -> Option<StorageIterator> {
+        let snapshot = self.snapshot_branch(branch_id)?;
+        Some(StorageIterator::new(snapshot, prefix, snapshot_version))
     }
 
     /// Scan entries starting from `start_key` within `prefix`, with optional limit.

--- a/crates/storage/src/segmented/tests/basic.rs
+++ b/crates/storage/src/segmented/tests/basic.rs
@@ -765,3 +765,121 @@ fn snapshot_branch_returns_none_for_missing() {
     let missing = BranchId::from_bytes([99; 16]);
     assert!(store.snapshot_branch(&missing).is_none());
 }
+
+// ===== StorageIterator tests =====
+
+#[test]
+fn storage_iterator_seek_next() {
+    let store = SegmentedStore::new();
+    for i in 0..10u64 {
+        seed(
+            &store,
+            kv_key(&format!("key_{:02}", i)),
+            Value::Int(i as i64),
+            i + 1,
+        );
+    }
+
+    let prefix = Key::new(ns(), TypeTag::KV, vec![]);
+    let mut iter = store
+        .new_storage_iterator(&branch(), prefix, u64::MAX)
+        .unwrap();
+
+    // Seek to key_05
+    iter.seek(&kv_key("key_05")).unwrap();
+    let mut keys = Vec::new();
+    while let Some((key, _)) = iter.next() {
+        keys.push(key.user_key_string().unwrap());
+    }
+    iter.check_corruption().unwrap();
+    assert_eq!(keys, vec!["key_05", "key_06", "key_07", "key_08", "key_09"]);
+}
+
+#[test]
+fn storage_iterator_reseek() {
+    let store = SegmentedStore::new();
+    for c in ['a', 'b', 'c', 'd', 'e'] {
+        let v = c as i64;
+        seed(&store, kv_key(&c.to_string()), Value::Int(v), v as u64);
+    }
+
+    let prefix = Key::new(ns(), TypeTag::KV, vec![]);
+    let mut iter = store
+        .new_storage_iterator(&branch(), prefix, u64::MAX)
+        .unwrap();
+
+    // First seek to "c", read 2
+    iter.seek(&kv_key("c")).unwrap();
+    let k1 = iter.next().unwrap().0.user_key_string().unwrap();
+    let k2 = iter.next().unwrap().0.user_key_string().unwrap();
+    assert_eq!(k1, "c");
+    assert_eq!(k2, "d");
+
+    // Re-seek to "a", should restart from beginning
+    iter.seek(&kv_key("a")).unwrap();
+    let k3 = iter.next().unwrap().0.user_key_string().unwrap();
+    assert_eq!(k3, "a");
+    iter.check_corruption().unwrap();
+}
+
+#[test]
+fn storage_iterator_seek_past_end() {
+    let store = SegmentedStore::new();
+    seed(&store, kv_key("a"), Value::Int(1), 1);
+    seed(&store, kv_key("b"), Value::Int(2), 2);
+
+    let prefix = Key::new(ns(), TypeTag::KV, vec![]);
+    let mut iter = store
+        .new_storage_iterator(&branch(), prefix, u64::MAX)
+        .unwrap();
+
+    iter.seek(&kv_key("z")).unwrap();
+    assert!(iter.next().is_none(), "seek past end should yield nothing");
+    iter.check_corruption().unwrap();
+}
+
+#[test]
+fn storage_iterator_pagination() {
+    let store = SegmentedStore::new();
+    // 15 keys: key_00 through key_14
+    for i in 0..15u64 {
+        seed(
+            &store,
+            kv_key(&format!("key_{:02}", i)),
+            Value::Int(i as i64),
+            i + 1,
+        );
+    }
+
+    let prefix = Key::new(ns(), TypeTag::KV, vec![]);
+    let mut iter = store
+        .new_storage_iterator(&branch(), prefix, u64::MAX)
+        .unwrap();
+
+    // Paginate: 5 pages of 3 entries
+    let mut all_keys = Vec::new();
+    let mut cursor = kv_key("");
+    for _ in 0..5 {
+        iter.seek(&cursor).unwrap();
+        let mut page = Vec::new();
+        for _ in 0..3 {
+            if let Some((key, _)) = iter.next() {
+                page.push(key);
+            }
+        }
+        if page.is_empty() {
+            break;
+        }
+        // Next cursor is one past the last key in this page.
+        // For simplicity, use the last key's user_key + "\0" as next cursor.
+        let last = page.last().unwrap();
+        let mut next_user_key = last.user_key.to_vec();
+        next_user_key.push(0);
+        cursor = Key::new_kv(ns(), next_user_key);
+        all_keys.extend(page.iter().filter_map(|k| k.user_key_string()));
+    }
+    iter.check_corruption().unwrap();
+    assert_eq!(all_keys.len(), 15, "should paginate through all 15 keys");
+    assert_eq!(all_keys[0], "key_00");
+    assert_eq!(all_keys[14], "key_14");
+}


### PR DESCRIPTION
## Summary

- Add `StorageIterator` — persistent, seekable iterator over a branch snapshot (analogous to RocksDB's `ArenaWrappedDBIter`)
- Add `SegmentedStore::new_storage_iterator()` factory method
- Add `Database::storage_iterator()` pass-through
- Add `KVStore::scan_iter(branch, space)` public API
- Export `StorageIterator` from `strata-storage` crate

Final epic (5 of 5) for #2183. Completes the RocksDB-aligned scan pipeline redesign.

## API

```rust
// Create iterator (captures branch snapshot)
let mut iter = kv.scan_iter(&branch_id, "default")?;

// Seek + iterate
iter.seek(&Key::new_kv(ns, "user:500"))?;
while let Some((key, value)) = iter.next() {
    // process entry
}
iter.check_corruption()?;

// Re-seek (pipeline rebuilt, snapshot unchanged)
iter.seek(&Key::new_kv(ns, "user:100"))?;
```

## Design

- `BranchSnapshot` pins memtables (`Arc<Memtable>`) and segments (`Arc<SegmentVersion>`) for the iterator's lifetime
- `seek()` rebuilds the merge pipeline: memtable entries collected (bounded by write_buffer_size from seek position), segments lazy via `OwnedSegmentIter`
- Pipeline is fully `'static` — no self-referential struct, no lifetime ties to DashMap guard
- `next()` advances the pipeline: O(log K) per call where K = source count

## Test plan

- [x] `cargo test -p strata-storage` — 646 passed (4 new StorageIterator tests)
- [x] `cargo test -p strata-engine` — 737 passed
- [x] `cargo test -p strata-executor` — 563 passed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (storage crate)
- [x] New: `storage_iterator_seek_next` — seek to middle, verify exact key sequence
- [x] New: `storage_iterator_reseek` — re-seek to earlier position, verify pipeline rebuilt
- [x] New: `storage_iterator_seek_past_end` — seek past all keys, next() returns None
- [x] New: `storage_iterator_pagination` — 5 pages of 3 over 15 keys, cursor-based advance

## Complete epic summary

| Epic | PR | What |
|---|---|---|
| 1 | #2192 | `iter_range` + `OwnedSegmentIter::new_seek` |
| 2 | #2194 | `build_branch_merge_iter` — lazy merge builder |
| 3 | #2196 | `scan_range` + `KVStore::scan()` rewrite (**fixes #2183**) |
| 4 | #2198 | `Arc<Memtable>` + `BranchSnapshot` |
| 5 | this | `StorageIterator` with Seek/Next API |

🤖 Generated with [Claude Code](https://claude.com/claude-code)