### PR TITLE
Fix embed feature build errors

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -256,7 +256,7 @@ fn pull_with_bar(
     registry: &strata_intelligence::ModelRegistry,
     name: &str,
     display_name: &str,
-) -> Result<std::path::PathBuf, strata_inference::InferenceError> {
+) -> Result<std::path::PathBuf, strata_intelligence::InferenceError> {
     use std::time::Instant;
 
     let start = Instant::now();
@@ -308,7 +308,7 @@ fn pull_with_retry(
     registry: &strata_intelligence::ModelRegistry,
     name: &str,
     display_name: &str,
-) -> Result<std::path::PathBuf, strata_inference::InferenceError> {
+) -> Result<std::path::PathBuf, strata_intelligence::InferenceError> {
     match pull_with_bar(registry, name, display_name) {
         Ok(path) => Ok(path),
         Err(first_err) => {
@@ -370,7 +370,7 @@ fn offer_model_downloads(config_path: &Path, hw: &HardwareInfo, non_interactive:
         .list_available()
         .into_iter()
         .filter(|m| {
-            m.task == strata_inference::ModelTask::Generate
+            m.task == strata_intelligence::ModelTask::Generate
                 && m.size_bytes <= budget
                 && m.name != "gpt2" // skip gpt2 — too small to be useful
         })

--- a/crates/executor/src/handlers/generate.rs
+++ b/crates/executor/src/handlers/generate.rs
@@ -110,6 +110,7 @@ pub fn generate(
         seed,
         stop_sequences: stop_sequences.unwrap_or_default(),
         stop_tokens: stop_tokens.unwrap_or_default(),
+        grammar: None,
     };
 
     // Use the resolved model name in the output (may differ from input for cloud)

--- a/crates/intelligence/src/lib.rs
+++ b/crates/intelligence/src/lib.rs
@@ -21,6 +21,8 @@ pub use strata_inference::InferenceError;
 #[cfg(feature = "embed")]
 pub use strata_inference::ModelRegistry;
 #[cfg(feature = "embed")]
+pub use strata_inference::ModelTask;
+#[cfg(feature = "embed")]
 pub use strata_inference::ProviderKind;
 #[cfg(feature = "embed")]
 pub use strata_inference::{GenerateRequest, GenerateResponse, StopReason};


### PR DESCRIPTION
## Summary

- Add missing `grammar: None` field to `GenerateRequest` construction in executor (field added in #2169 but handler not updated)
- Fix `strata_inference::` → `strata_intelligence::` typo in `cli/src/init.rs` (CLI depends on strata-intelligence, not strata-inference)
- Add `ModelTask` re-export from strata-intelligence

Without these fixes, `cargo build --features embed` fails to compile.

## Test plan

- [x] `cargo check -p strata-executor -p strata-engine` passes
- [x] Verified full `--features embed` build succeeds on main repo (worktree lacks llama.cpp submodule for CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)