### PR TITLE
Fix #2185: Transaction-free direct read path for kv_get

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -457,6 +457,18 @@ impl Database {
         self.storage.get_value_direct(key)
     }
 
+    /// Direct single-key read returning full VersionedValue metadata.
+    ///
+    /// Bypasses the transaction layer (no coordinator mutex, no read-set
+    /// tracking). Provides per-key read consistency; for multi-key snapshot
+    /// isolation use `Database::transaction()`.
+    pub fn get_versioned_direct(
+        &self,
+        key: &Key,
+    ) -> strata_core::StrataResult<Option<strata_core::VersionedValue>> {
+        self.storage.get_versioned_direct(key)
+    }
+
     /// Get version history for a key directly from storage.
     ///
     /// History reads bypass the transaction layer because they are

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -115,6 +115,21 @@ impl KVStore {
         })
     }
 
+    /// Get a value with version metadata, bypassing the transaction layer.
+    ///
+    /// Provides per-key read consistency without coordinator mutex or
+    /// read-set tracking overhead. For multi-key snapshot isolation,
+    /// use `get_versioned()` which goes through `Database::transaction()`.
+    pub fn get_versioned_direct(
+        &self,
+        branch_id: &BranchId,
+        space: &str,
+        key: &str,
+    ) -> StrataResult<Option<strata_core::VersionedValue>> {
+        let storage_key = self.key_for(branch_id, space, key);
+        self.db.get_versioned_direct(&storage_key)
+    }
+
     /// Get full version history for a key.
     ///
     /// Returns `None` if the key doesn't exist. Index with `[0]` = latest,

--- a/crates/executor/src/handlers/kv.rs
+++ b/crates/executor/src/handlers/kv.rs
@@ -83,7 +83,7 @@ pub fn kv_put(
 pub fn kv_get(p: &Arc<Primitives>, branch: BranchId, space: String, key: String) -> Result<Output> {
     let branch_id = to_core_branch_id(&branch)?;
     convert_result(validate_key(&key))?;
-    let result = convert_result(p.kv.get_versioned(&branch_id, &space, &key))
+    let result = convert_result(p.kv.get_versioned_direct(&branch_id, &space, &key))
         .map_err(|e| enrich_kv_error(p, &branch_id, &space, e))?;
     Ok(Output::MaybeVersioned(result.map(to_versioned_value)))
 }

--- a/crates/storage/src/memtable.rs
+++ b/crates/storage/src/memtable.rs
@@ -77,6 +77,15 @@ impl MemtableEntry {
             timestamp: self.timestamp,
         }
     }
+
+    /// Convert to a `VersionedValue` by moving the value (avoids clone).
+    pub fn into_versioned(self, commit_id: u64) -> VersionedValue {
+        VersionedValue {
+            value: self.value,
+            version: Version::txn(commit_id),
+            timestamp: self.timestamp,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -1550,10 +1550,7 @@ impl SegmentedStore {
     /// This provides per-key read consistency without the overhead of
     /// transaction allocation, coordinator mutex, or read-set tracking.
     /// For multi-key snapshot isolation, use `Database::transaction()`.
-    pub fn get_versioned_direct(
-        &self,
-        key: &Key,
-    ) -> StrataResult<Option<VersionedValue>> {
+    pub fn get_versioned_direct(&self, key: &Key) -> StrataResult<Option<VersionedValue>> {
         let branch_id = key.namespace.branch_id;
         let branch = match self.branches.get(&branch_id) {
             Some(b) => b,

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -1542,6 +1542,35 @@ impl SegmentedStore {
         }
     }
 
+    /// Get a versioned value directly from storage, bypassing the transaction layer.
+    ///
+    /// Like `get_value_direct` but preserves version and timestamp metadata.
+    /// Uses `u64::MAX` as the snapshot version to see all committed data.
+    ///
+    /// This provides per-key read consistency without the overhead of
+    /// transaction allocation, coordinator mutex, or read-set tracking.
+    /// For multi-key snapshot isolation, use `Database::transaction()`.
+    pub fn get_versioned_direct(
+        &self,
+        key: &Key,
+    ) -> StrataResult<Option<VersionedValue>> {
+        let branch_id = key.namespace.branch_id;
+        let branch = match self.branches.get(&branch_id) {
+            Some(b) => b,
+            None => return Ok(None),
+        };
+        match Self::get_versioned_from_branch(&branch, key, u64::MAX)? {
+            Some((commit_id, entry)) => {
+                if entry.is_tombstone || entry.is_expired() {
+                    Ok(None)
+                } else {
+                    Ok(Some(entry.into_versioned(commit_id)))
+                }
+            }
+            None => Ok(None),
+        }
+    }
+
     /// List all live entries for a branch filtered by type tag.
     pub fn list_by_type(
         &self,

--- a/crates/storage/src/segmented/tests/batch.rs
+++ b/crates/storage/src/segmented/tests/batch.rs
@@ -303,6 +303,54 @@ fn get_value_direct_nonexistent() {
 }
 
 #[test]
+fn get_versioned_direct_returns_latest() {
+    let store = SegmentedStore::new();
+    seed(&store, kv_key("k"), Value::Int(10), 1);
+    seed(&store, kv_key("k"), Value::Int(20), 2);
+    let vv = store.get_versioned_direct(&kv_key("k")).unwrap().unwrap();
+    assert_eq!(vv.value, Value::Int(20));
+    assert_eq!(vv.version, strata_core::Version::txn(2));
+}
+
+#[test]
+fn get_versioned_direct_skips_tombstone() {
+    let store = SegmentedStore::new();
+    seed(&store, kv_key("k"), Value::Int(10), 1);
+    store.delete_with_version(&kv_key("k"), 2).unwrap();
+    assert!(store.get_versioned_direct(&kv_key("k")).unwrap().is_none());
+}
+
+#[test]
+fn get_versioned_direct_nonexistent() {
+    let store = SegmentedStore::new();
+    assert!(store.get_versioned_direct(&kv_key("k")).unwrap().is_none());
+}
+
+#[test]
+fn get_versioned_direct_preserves_timestamp() {
+    let store = SegmentedStore::new();
+    seed(&store, kv_key("k"), Value::String("hello".into()), 5);
+    let vv = store.get_versioned_direct(&kv_key("k")).unwrap().unwrap();
+    assert_eq!(vv.value, Value::String("hello".into()));
+    assert_eq!(vv.version, strata_core::Version::txn(5));
+    // Timestamp should be non-zero (set by Memtable::put)
+    assert!(vv.timestamp > 0.into());
+}
+
+#[test]
+fn get_versioned_direct_moves_bytes_value() {
+    let store = SegmentedStore::new();
+    let data = vec![0xDE, 0xAD, 0xBE, 0xEF];
+    seed(&store, kv_key("bin"), Value::Bytes(data.clone()), 3);
+    let vv = store
+        .get_versioned_direct(&kv_key("bin"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(vv.value, Value::Bytes(data));
+    assert_eq!(vv.version, strata_core::Version::txn(3));
+}
+
+#[test]
 fn list_by_type_filters_correctly() {
     let store = SegmentedStore::new();
     let b = branch();

--- a/crates/storage/src/segmented/tests/batch.rs
+++ b/crates/storage/src/segmented/tests/batch.rs
@@ -342,10 +342,7 @@ fn get_versioned_direct_moves_bytes_value() {
     let store = SegmentedStore::new();
     let data = vec![0xDE, 0xAD, 0xBE, 0xEF];
     seed(&store, kv_key("bin"), Value::Bytes(data.clone()), 3);
-    let vv = store
-        .get_versioned_direct(&kv_key("bin"))
-        .unwrap()
-        .unwrap();
+    let vv = store.get_versioned_direct(&kv_key("bin")).unwrap().unwrap();
     assert_eq!(vv.value, Value::Bytes(data));
     assert_eq!(vv.version, strata_core::Version::txn(3));
 }


### PR DESCRIPTION
## Summary

- Add `get_versioned_direct()` at storage, engine, and KVStore layers — bypasses the full transaction layer for single-key reads
- Add `MemtableEntry::into_versioned(self)` — moves value instead of cloning (saves one heap alloc per read)
- Wire `kv_get` handler to use the direct path (one-line change)

## Root Cause

Every `kv_get()` was creating a full MVCC transaction, which acquires a **global Mutex twice** (`active_snapshots.lock()` in `coordinator.rs` — once on start, once on end). At 32 threads, this serializes all concurrent reads, causing throughput to **regress** from 8→16→32 threads (65ms→116ms→134ms) — a 29x gap vs lmdb.

## Per-read overhead eliminated

| Before | After |
|--------|-------|
| `coordinator.next_txn_id()` (atomic increment) | gone |
| `active_snapshots.lock().insert()` (**Mutex #1**) | gone |
| `TransactionPool::acquire()` (context alloc) | gone |
| `TransactionContext` read_set tracking | gone |
| `active_snapshots.lock().remove()` (**Mutex #2**) | gone |
| `Value::clone()` in `to_versioned()` | `into_versioned()` moves |

## ACID compliance

Single-key reads are inherently atomic (SkipMap inserts are atomic per entry). Multi-key snapshot isolation remains available via `Database::transaction()`. This mirrors RocksDB's `DB::Get()` (fast, no snapshot) vs `TransactionDB::GetForUpdate()` (snapshot isolation) design.

## Test plan

- [x] 4 new storage tests (returns_latest, skips_tombstone, nonexistent, preserves_timestamp)
- [x] 650 storage tests pass
- [x] 745 engine tests pass
- [x] `cargo clippy` clean
- [ ] Run `redb_benchmark` concurrent reads — verify the 8→16→32 regression is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)