### PR TITLE
Fix #2213: LevelSegmentIter for O(log N) scan seek at L1+

### DIFF
--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -1145,6 +1145,14 @@ impl OwnedSegmentIter {
         self.corruption_detected = Some(flag);
         self
     }
+
+    /// Set a prefix filter without seeking. Used by `LevelSegmentIter` when
+    /// opening subsequent segments from the beginning (seek already done via
+    /// binary search on the segment list).
+    pub fn with_prefix_filter(mut self, prefix_bytes: Vec<u8>) -> Self {
+        self.prefix_bytes = Some(prefix_bytes);
+        self
+    }
 }
 
 impl OwnedSegmentIter {
@@ -1283,6 +1291,116 @@ impl Iterator for OwnedSegmentIter {
                     return None;
                 }
             }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LevelSegmentIter — lazy per-level iterator (RocksDB LevelIterator pattern)
+// ---------------------------------------------------------------------------
+
+/// Lazy iterator over a sorted, non-overlapping level of segments.
+///
+/// Analogous to RocksDB's `LevelIterator` (version_set.cc). Instead of
+/// opening iterators for ALL segments at creation time, this:
+/// 1. Binary-searches the segment list by `key_range()` to find the first
+///    relevant file (O(log N), no I/O)
+/// 2. Opens only that file's `OwnedSegmentIter` (1 block read)
+/// 3. When exhausted, lazily opens the next file
+///
+/// For a 10-entry scan at L2 with 1000 segments, this opens 1-2 files
+/// instead of 1000. See issue #2213.
+pub struct LevelSegmentIter {
+    segments: Vec<Arc<KVSegment>>,
+    current_idx: usize,
+    current_iter: Option<OwnedSegmentIter>,
+    prefix_bytes: Vec<u8>,
+    corruption_flag: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl LevelSegmentIter {
+    /// Create a new level iterator. No files are opened until iteration.
+    pub fn new(
+        segments: Vec<Arc<KVSegment>>,
+        prefix_bytes: Vec<u8>,
+        corruption_flag: Arc<std::sync::atomic::AtomicBool>,
+    ) -> Self {
+        Self {
+            segments,
+            current_idx: 0,
+            current_iter: None,
+            prefix_bytes,
+            corruption_flag,
+        }
+    }
+
+    /// Seek to the first segment whose key range includes `start_key`.
+    ///
+    /// Uses binary search on `key_range().max` (O(log N), no I/O).
+    /// Opens only the matching segment's iterator.
+    pub fn seek(&mut self, start_key: &Key) {
+        use crate::key_encoding::{encode_typed_key, COMMIT_ID_SUFFIX_LEN};
+
+        let start_bytes = encode_typed_key(start_key);
+
+        // Binary search: find first segment whose max_key >= start_bytes.
+        // Segments are sorted by key range (non-overlapping at L1+).
+        let idx = self.segments.partition_point(|seg| {
+            let (_, max_ik) = seg.key_range();
+            if max_ik.len() >= COMMIT_ID_SUFFIX_LEN {
+                let max_typed = &max_ik[..max_ik.len() - COMMIT_ID_SUFFIX_LEN];
+                max_typed < start_bytes.as_slice()
+            } else {
+                false
+            }
+        });
+
+        self.current_idx = idx;
+        if idx < self.segments.len() {
+            self.current_iter = Some(
+                OwnedSegmentIter::new_seek(
+                    Arc::clone(&self.segments[idx]),
+                    start_key,
+                    self.prefix_bytes.clone(),
+                )
+                .with_corruption_flag(Arc::clone(&self.corruption_flag)),
+            );
+        } else {
+            self.current_iter = None;
+        }
+    }
+
+    /// Open the next segment's iterator (lazy file opening).
+    fn advance_to_next_segment(&mut self) {
+        self.current_idx += 1;
+        if self.current_idx < self.segments.len() {
+            // Open from the beginning of the next segment (no seek needed —
+            // segments are sorted, so the next entry is at the start).
+            self.current_iter = Some(
+                OwnedSegmentIter::new(Arc::clone(&self.segments[self.current_idx]))
+                    .with_prefix_filter(self.prefix_bytes.clone())
+                    .with_corruption_flag(Arc::clone(&self.corruption_flag)),
+            );
+        } else {
+            self.current_iter = None;
+        }
+    }
+}
+
+impl Iterator for LevelSegmentIter {
+    type Item = (InternalKey, SegmentEntry);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(ref mut iter) = self.current_iter {
+                if let Some(item) = iter.next() {
+                    return Some(item);
+                }
+                // Current segment exhausted — try next
+            } else {
+                return None;
+            }
+            self.advance_to_next_segment();
         }
     }
 }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -17,7 +17,7 @@ use crate::memory_stats::{BranchMemoryStats, StorageMemoryStats};
 use crate::memtable::{Memtable, MemtableEntry};
 use crate::merge_iter::{MergeIterator, MvccIterator, RewritingIterator};
 use crate::pressure::{MemoryPressure, PressureLevel};
-use crate::segment::{KVSegment, OwnedSegmentIter, SegmentEntry};
+use crate::segment::{KVSegment, LevelSegmentIter, OwnedSegmentIter, SegmentEntry};
 use crate::segment_builder::{SegmentBuilder, SplittingSegmentBuilder};
 
 use arc_swap::ArcSwap;
@@ -3028,20 +3028,48 @@ impl SegmentedStore {
             sources.push(Box::new(frozen.iter_range(start_key, prefix)));
         }
 
-        // On-disk segments — lazy via OwnedSegmentIter::new_seek
+        // On-disk segments — lazy iterators
         let prefix_bytes = encode_typed_key_prefix(prefix);
         let ver = branch.version.load();
-        for level in &ver.levels {
-            for seg in level {
-                if !segment_overlaps_prefix(seg, &prefix_bytes) {
+        for (level_idx, level) in ver.levels.iter().enumerate() {
+            if level.is_empty() {
+                continue;
+            }
+            if level_idx == 0 {
+                // L0: overlapping files — individual iterators (unavoidable)
+                for seg in level {
+                    if !segment_overlaps_prefix(seg, &prefix_bytes) {
+                        continue;
+                    }
+                    let flag = Arc::new(AtomicBool::new(false));
+                    corruption_flags.push(Arc::clone(&flag));
+                    sources.push(Box::new(
+                        OwnedSegmentIter::new_seek(
+                            Arc::clone(seg),
+                            start_key,
+                            prefix_bytes.clone(),
+                        )
+                        .with_corruption_flag(flag)
+                        .map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se))),
+                    ));
+                }
+            } else {
+                // L1+: non-overlapping, sorted — one LevelSegmentIter per level.
+                // Binary-searches to the relevant file, opens lazily (#2213).
+                let level_segs: Vec<Arc<KVSegment>> = level
+                    .iter()
+                    .filter(|s| segment_overlaps_prefix(s, &prefix_bytes))
+                    .cloned()
+                    .collect();
+                if level_segs.is_empty() {
                     continue;
                 }
                 let flag = Arc::new(AtomicBool::new(false));
                 corruption_flags.push(Arc::clone(&flag));
+                let mut level_iter = LevelSegmentIter::new(level_segs, prefix_bytes.clone(), flag);
+                level_iter.seek(start_key);
                 sources.push(Box::new(
-                    OwnedSegmentIter::new_seek(Arc::clone(seg), start_key, prefix_bytes.clone())
-                        .with_corruption_flag(flag)
-                        .map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se))),
+                    level_iter.map(|(ik, se)| (ik, segment_entry_to_memtable_entry(se))),
                 ));
             }
         }


### PR DESCRIPTION
## Summary

Add `LevelSegmentIter` — a lazy per-level iterator modeled after RocksDB's `LevelIterator` (version_set.cc:969-1814). For L1+ levels (non-overlapping, sorted), instead of creating an `OwnedSegmentIter` for every segment, create ONE `LevelSegmentIter` that:

1. Binary-searches the file list by `key_range()` to find the relevant file (O(log N), no I/O)
2. Opens only that file's iterator (1 block read)
3. When exhausted, lazily opens the next file

L0 (overlapping) is unchanged — individual iterators per file.

## Root Cause

`build_branch_merge_iter` created iterators for ALL segments in ALL levels. At 5M records with ~100 segments across L0-L6, each scan did ~100 index binary searches + ~100 block reads (mostly cache misses). The `segment_overlaps_prefix` filter only checked namespace overlap, not start_key overlap.

## Expected Impact

At 5M records with 100 segments (4 L0 + ~16 L1 + ~80 L2):
- Before: 100 iterators, 100 seeks, 100 block reads per scan
- After: 4 L0 iters + 1 L1 LevelIter + 1 L2 LevelIter = 6 sources, ~6 block reads
- **~17x fewer I/O operations per scan**

## Test plan

- [x] 655 storage tests pass
- [x] 745 engine tests pass
- [x] clippy + fmt clean
- [ ] Run `redb_benchmark --records 100000` — range reads should improve
- [ ] Run `redb_benchmark --records 5000000` — verify scaling fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)