### PR TITLE
v0.2 follow-up: recipe as single source of truth + CLI commands

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -104,6 +104,7 @@ pub fn build_cli() -> Command {
         .subcommand(build_detokenize())
         .subcommand(build_graph())
         .subcommand(build_config())
+        .subcommand(build_recipe())
         .subcommand(build_up())
         .subcommand(build_down())
         .subcommand(build_db_export())
@@ -140,6 +141,7 @@ pub fn build_repl_cmd() -> Command {
         .subcommand(build_detokenize())
         .subcommand(build_graph())
         .subcommand(build_config())
+        .subcommand(build_recipe())
         .subcommand(build_db_export())
         .subcommand(build_db_import())
 }
@@ -1347,6 +1349,33 @@ fn build_config() -> Command {
                 .arg(Arg::new("key").required(true).help("Configuration key")),
         )
         .subcommand(Command::new("list").about("Show all configuration values"))
+}
+
+fn build_recipe() -> Command {
+    Command::new("recipe")
+        .about("Search recipe operations")
+        .subcommand_required(true)
+        .subcommand(Command::new("show").about("Show the resolved default recipe"))
+        .subcommand(
+            Command::new("set")
+                .about("Set a named recipe (JSON)")
+                .arg(
+                    Arg::new("name")
+                        .long("name")
+                        .default_value("default")
+                        .help("Recipe name"),
+                )
+                .arg(Arg::new("recipe_json").required(true).help("Recipe JSON")),
+        )
+        .subcommand(
+            Command::new("get").about("Get a named recipe").arg(
+                Arg::new("name")
+                    .long("name")
+                    .default_value("default")
+                    .help("Recipe name"),
+            ),
+        )
+        .subcommand(Command::new("list").about("List all recipes"))
 }
 
 fn build_up() -> Command {

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -172,6 +172,7 @@ pub fn matches_to_action(matches: &ArgMatches, state: &SessionState) -> Result<C
         })),
         "search" => parse_search(sub_matches, state),
         "config" => parse_config(sub_matches),
+        "recipe" => parse_recipe(sub_matches, state),
         "configure-model" => parse_configure_model(sub_matches),
         "embed" => parse_embed(sub_matches),
         "models" => parse_models(sub_matches),
@@ -205,6 +206,7 @@ pub fn matches_to_action(matches: &ArgMatches, state: &SessionState) -> Result<C
                 "describe",
                 "search",
                 "config",
+                "recipe",
                 "configure-model",
                 "embed",
                 "models",
@@ -1333,6 +1335,39 @@ fn parse_config(matches: &ArgMatches) -> Result<CliAction, String> {
         }
         "list" => Ok(CliAction::Execute(Command::ConfigGet)),
         other => Err(unknown_subcommand("config", other, &["set", "get", "list"])),
+    }
+}
+
+fn parse_recipe(matches: &ArgMatches, state: &SessionState) -> Result<CliAction, String> {
+    let (sub, m) = matches.subcommand().ok_or("No recipe subcommand")?;
+    match sub {
+        "show" => Ok(CliAction::Execute(Command::RecipeGetDefault {
+            branch: branch(state),
+        })),
+        "set" => {
+            let name = m.get_one::<String>("name").unwrap().clone();
+            let json = m.get_one::<String>("recipe_json").unwrap().clone();
+            Ok(CliAction::Execute(Command::RecipeSet {
+                branch: branch(state),
+                name,
+                recipe_json: json,
+            }))
+        }
+        "get" => {
+            let name = m.get_one::<String>("name").unwrap().clone();
+            Ok(CliAction::Execute(Command::RecipeGet {
+                branch: branch(state),
+                name,
+            }))
+        }
+        "list" => Ok(CliAction::Execute(Command::RecipeList {
+            branch: branch(state),
+        })),
+        other => Err(unknown_subcommand(
+            "recipe",
+            other,
+            &["show", "set", "get", "list"],
+        )),
     }
 }
 

--- a/crates/engine/src/search/recipe.rs
+++ b/crates/engine/src/search/recipe.rs
@@ -435,7 +435,11 @@ impl ControlConfig {
 
 /// The built-in default recipe (level 0 of three-level merge).
 ///
-/// These values match Anserini/Pyserini BEIR-tuned defaults.
+/// Built-in default recipe with qmd-inspired search quality defaults.
+///
+/// BM25 tuned to Anserini/Pyserini BEIR values (k1=0.9, b=0.4).
+/// Expansion and reranking enabled — gracefully degrade when models
+/// are not available (search still works, just without the quality knobs).
 pub fn builtin_defaults() -> Recipe {
     Recipe {
         version: Some(1),
@@ -451,10 +455,25 @@ pub fn builtin_defaults() -> Recipe {
             vector: Some(VectorRetrieveConfig::default()),
             ..Default::default()
         }),
+        expansion: Some(ExpansionConfig {
+            strategy: Some("full".into()),
+            strong_signal_threshold: Some(0.85),
+            strong_signal_gap: Some(0.15),
+            min_shared_stems: Some(2),
+            original_weight: Some(2.0),
+        }),
         fusion: Some(FusionConfig {
             method: Some("rrf".into()),
             k: Some(60),
             ..Default::default()
+        }),
+        rerank: Some(RerankConfig {
+            top_n: Some(20),
+            blending: Some(BlendingConfig {
+                rank_1_3: Some(0.75),
+                rank_4_10: Some(0.60),
+                rank_11_plus: Some(0.40),
+            }),
         }),
         transform: Some(TransformConfig {
             limit: Some(10),

--- a/crates/executor/src/handlers/search.rs
+++ b/crates/executor/src/handlers/search.rs
@@ -221,7 +221,6 @@ fn try_expand_query(
 
     if let Ok(probe) = substrate::retrieve(&p.db, &probe_req) {
         if strata_intelligence::expand::has_strong_signal(&probe.hits, expansion_cfg) {
-            tracing::debug!(target: "strata::search", query = %query, "Strong signal, skipping expansion");
             return (
                 vec![ExpandedQuery {
                     query_type: QueryType::Lex,
@@ -230,6 +229,8 @@ fn try_expand_query(
                 false,
             );
         }
+    } else {
+        tracing::warn!(target: "strata::search", "BM25 probe for expansion failed");
     }
 
     // Generate expansions

--- a/crates/inference/src/registry/catalog.rs
+++ b/crates/inference/src/registry/catalog.rs
@@ -148,7 +148,7 @@ pub static CATALOG: &[CatalogEntry] = &[
         aliases: &["qwen3-1.7b"],
         task: ModelTask::Generate,
         hf_repo: "stratalab-org/Qwen3-1.7B-GGUF",
-        default_quant: "q4_k_m",
+        default_quant: "q8_0",
         variants: &[
             QuantVariant {
                 name: "q4_k_m",


### PR DESCRIPTION
## Summary

Follow-up to #2215. Makes the recipe the **sole** source of truth for search behavior.

- **Removed `mode: "hybrid"` hack** from SearchQuery — recipe controls what retrievers run
- **Builtin defaults updated**: BM25 + vector + expansion + reranking all enabled out of the box (graceful degradation when models unavailable)
- **SearchQuery simplified**: only `query`, `recipe` (per-call override), `k` (shorthand), `precomputed_embedding`
- **Recipe CLI commands**: `recipe show`, `recipe set`, `recipe get`, `recipe list`
- **qwen3:1.7b registry**: default quant changed to q8_0 (matches local model)
- **BEIR verified**: hybrid nDCG@10 = 0.3491 via pure recipe path (identical to v0.1 substrate)

## Expansion testing results

Expansion pipeline verified end-to-end (grammar output, hallucination guard, multi-pass retrieval, weighted RRF fusion). Quality tuning deferred to AutoResearch (v0.7) — current expansion adds latency without nDCG improvement on nfcorpus.

## Test plan

- [x] All workspace tests pass (excluding pre-existing test_kv_count)
- [x] Clippy clean
- [x] BEIR regression: recipe path = v0.1 substrate = 0.3491

🤖 Generated with [Claude Code](https://claude.com/claude-code)