### PR TITLE
Fix missing as_of field in expansion probe request

### DIFF
--- a/crates/executor/src/handlers/search.rs
+++ b/crates/executor/src/handlers/search.rs
@@ -283,6 +283,7 @@ fn try_expand_query(
         embedding: None,
         time_range: None,
         primitive_filter: None,
+        as_of: None,
     };
 
     if let Ok(probe) = substrate::retrieve(&p.db, &probe_req) {


### PR DESCRIPTION
## Summary
- Adds missing `as_of: None` to the `RetrievalRequest` in `try_expand_query()` — the BM25 probe for strong signal detection.
- This was missed during the squash merge of #2218 (v0.3 temporal search).

## Test plan
- [x] Compilation fix — was blocking `cargo build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)