### PR TITLE
Fix compaction I/O starvation: enable rate limiter and write backpressure defaults

### DIFF
--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -119,9 +119,10 @@ pub struct StorageConfig {
     /// Default: 10.
     #[serde(default = "default_bloom_bits_per_key")]
     pub bloom_bits_per_key: usize,
-    /// Compaction I/O rate limit in bytes per second. 0 = unlimited (default).
-    /// On slow storage (SD cards), set to e.g. 5–10 MB/s to avoid starving user I/O.
-    #[serde(default)]
+    /// Compaction I/O rate limit in bytes per second.
+    /// Default: 50 MB/s. Set to 0 for unlimited (not recommended — can starve foreground reads).
+    /// On slow storage (SD cards), set to 5–10 MB/s.
+    #[serde(default = "default_compaction_rate_limit")]
     pub compaction_rate_limit: u64,
     /// Maximum time (milliseconds) a write can be stalled waiting for L0 compaction.
     /// If exceeded, the write returns an error instead of blocking indefinitely.
@@ -156,11 +157,15 @@ fn default_max_immutable_memtables() -> usize {
 }
 
 fn default_l0_slowdown_writes_trigger() -> usize {
-    0 // disabled by default until compaction throughput improves
+    20 // RocksDB default: 1ms yield per write when L0 count >= 20
 }
 
 fn default_l0_stop_writes_trigger() -> usize {
-    0 // disabled by default until compaction throughput improves
+    36 // RocksDB default: complete stall when L0 count >= 36
+}
+
+fn default_compaction_rate_limit() -> u64 {
+    50 * 1024 * 1024 // 50 MB/s — leaves majority of bandwidth for foreground reads
 }
 
 fn default_background_threads() -> usize {
@@ -239,7 +244,7 @@ impl Default for StorageConfig {
             level_base_bytes: default_level_base_bytes(),
             data_block_size: default_data_block_size(),
             bloom_bits_per_key: default_bloom_bits_per_key(),
-            compaction_rate_limit: 0,
+            compaction_rate_limit: default_compaction_rate_limit(),
             write_stall_timeout_ms: default_write_stall_timeout_ms(),
             codec: default_codec(),
         }
@@ -497,7 +502,7 @@ auto_embed = false
 # level_base_bytes = 268435456  # 256 MiB; L1 target size (Pi: 32 MiB)
 # data_block_size = 4096        # 4 KiB; segment data block size
 # bloom_bits_per_key = 10       # bloom filter bits per key
-# compaction_rate_limit = 0     # 0 = unlimited; bytes/sec cap for compaction I/O
+# compaction_rate_limit = 52428800  # 50 MB/s default; 0 = unlimited
 "#
     }
 
@@ -1148,7 +1153,11 @@ auto_embed = false
     fn test_issue_1737_compaction_rate_limit_in_config() {
         // S-M7: compaction_rate_limit must be configurable via strata.toml
         let config = StorageConfig::default();
-        assert_eq!(config.compaction_rate_limit, 0, "default 0 = unlimited");
+        assert_eq!(
+            config.compaction_rate_limit,
+            50 * 1024 * 1024,
+            "default 50 MB/s"
+        );
     }
 
     #[test]
@@ -1200,7 +1209,7 @@ max_branches = 512
         assert_eq!(config.storage.level_base_bytes, 256 * 1024 * 1024);
         assert_eq!(config.storage.data_block_size, 4096);
         assert_eq!(config.storage.bloom_bits_per_key, 10);
-        assert_eq!(config.storage.compaction_rate_limit, 0);
+        assert_eq!(config.storage.compaction_rate_limit, 50 * 1024 * 1024);
     }
 
     #[cfg(unix)]

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -311,6 +311,11 @@ pub struct Database {
     /// Set to `true` when a compaction task is in flight; cleared when it completes.
     compaction_in_flight: Arc<AtomicBool>,
 
+    /// Cancellation flag for background compaction. Set during shutdown/drop to
+    /// stop the compaction loop promptly instead of waiting for it to exhaust
+    /// all branches and levels.
+    compaction_cancelled: Arc<AtomicBool>,
+
     /// Condition variable signalled by compaction when L0 count drops.
     /// Writers wait on this when L0 exceeds `l0_stop_writes_trigger`.
     write_stall_cv: Arc<parking_lot::Condvar>,
@@ -1069,6 +1074,8 @@ impl Database {
 
 impl Drop for Database {
     fn drop(&mut self) {
+        // Signal background compaction to stop promptly
+        self.compaction_cancelled.store(true, Ordering::Release);
         // Shut down the background task scheduler
         self.scheduler.shutdown();
 

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -27,6 +27,9 @@ fn apply_storage_config(storage: &SegmentedStore, cfg: &StorageConfig) {
     storage.set_level_base_bytes(cfg.level_base_bytes);
     storage.set_data_block_size(cfg.data_block_size);
     storage.set_bloom_bits_per_key(cfg.bloom_bits_per_key);
+    if cfg.compaction_rate_limit > 0 {
+        storage.set_compaction_rate_limit(cfg.compaction_rate_limit);
+    }
 }
 
 use strata_core::{StrataError, StrataResult};
@@ -321,6 +324,7 @@ impl Database {
             flush_handle: ParkingMutex::new(None), // No flush thread
             scheduler: Arc::new(BackgroundScheduler::new(bg_threads, 4096)),
             compaction_in_flight: Arc::new(AtomicBool::new(false)),
+            compaction_cancelled: Arc::new(AtomicBool::new(false)),
             write_stall_cv: Arc::new(parking_lot::Condvar::new()),
             write_stall_mu: parking_lot::Mutex::new(()),
             _lock_file: None, // No lock acquired
@@ -564,9 +568,6 @@ impl Database {
         // Apply storage resource limits from config
         let storage = Arc::new(result.storage);
         apply_storage_config(&storage, &cfg.storage);
-        if cfg.storage.compaction_rate_limit > 0 {
-            storage.set_compaction_rate_limit(cfg.storage.compaction_rate_limit);
-        }
 
         let bg_threads = cfg.storage.background_threads.max(1);
 
@@ -587,6 +588,7 @@ impl Database {
             flush_handle: ParkingMutex::new(flush_handle),
             scheduler: Arc::new(BackgroundScheduler::new(bg_threads, 4096)),
             compaction_in_flight: Arc::new(AtomicBool::new(false)),
+            compaction_cancelled: Arc::new(AtomicBool::new(false)),
             write_stall_cv: Arc::new(parking_lot::Condvar::new()),
             write_stall_mu: parking_lot::Mutex::new(()),
             _lock_file: lock_file,
@@ -668,6 +670,7 @@ impl Database {
             flush_handle: ParkingMutex::new(None),
             scheduler: Arc::new(BackgroundScheduler::new(bg_threads, 4096)),
             compaction_in_flight: Arc::new(AtomicBool::new(false)),
+            compaction_cancelled: Arc::new(AtomicBool::new(false)),
             write_stall_cv: Arc::new(parking_lot::Condvar::new()),
             write_stall_mu: parking_lot::Mutex::new(()),
             _lock_file: None, // No lock for ephemeral databases

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -111,6 +111,7 @@ impl Database {
         let storage = Arc::clone(&self.storage);
         let write_stall_cv = Arc::clone(&self.write_stall_cv);
         let flag = Arc::clone(&self.compaction_in_flight);
+        let cancelled = Arc::clone(&self.compaction_cancelled);
 
         if self
             .scheduler
@@ -118,7 +119,13 @@ impl Database {
                 // Compact all branches that are over target.
                 let branch_ids = storage.branch_ids();
                 for branch_id in &branch_ids {
+                    if cancelled.load(Ordering::Acquire) {
+                        break;
+                    }
                     loop {
+                        if cancelled.load(Ordering::Acquire) {
+                            break;
+                        }
                         match storage.pick_and_compact(branch_id, 0) {
                             Ok(Some(_)) => {
                                 write_stall_cv.notify_all();
@@ -138,27 +145,29 @@ impl Database {
                 }
 
                 // Materialize inherited layers that exceed depth limit (#1704).
-                for branch_id in storage.branches_needing_materialization() {
-                    let layer_count = storage.inherited_layer_count(&branch_id);
-                    if layer_count > 0 {
-                        let deepest = layer_count - 1;
-                        match storage.materialize_layer(&branch_id, deepest) {
-                            Ok(result) => {
-                                tracing::info!(
-                                    target: "strata::materialize",
-                                    ?branch_id,
-                                    entries = result.entries_materialized,
-                                    segments = result.segments_created,
-                                    "materialized inherited layer"
-                                );
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    target: "strata::materialize",
-                                    ?branch_id,
-                                    error = %e,
-                                    "materialization failed"
-                                );
+                if !cancelled.load(Ordering::Acquire) {
+                    for branch_id in storage.branches_needing_materialization() {
+                        let layer_count = storage.inherited_layer_count(&branch_id);
+                        if layer_count > 0 {
+                            let deepest = layer_count - 1;
+                            match storage.materialize_layer(&branch_id, deepest) {
+                                Ok(result) => {
+                                    tracing::info!(
+                                        target: "strata::materialize",
+                                        ?branch_id,
+                                        entries = result.entries_materialized,
+                                        segments = result.segments_created,
+                                        "materialized inherited layer"
+                                    );
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        target: "strata::materialize",
+                                        ?branch_id,
+                                        error = %e,
+                                        "materialization failed"
+                                    );
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

- Enable the existing compaction rate limiter by default (50 MB/s) — was 0 (unlimited)
- Enable L0 write backpressure defaults (slowdown at 20, stop at 36) — were disabled
- Move `set_compaction_rate_limit` into `apply_storage_config` so all open paths apply it consistently
- Add cooperative cancellation flag for prompt compaction shutdown

## Problem

At 100M records, concurrent point reads hang for 60+ minutes (RocksDB: 174s). Background compaction writes 155+ GB at full disk speed with no throttling, starving reads of disk bandwidth. All throttling infrastructure already existed (`RateLimiter`, `ThrottledSegmentIter`, `SplittingSegmentBuilder` limiter charging, L0 backpressure) but was disabled by default.

## Test plan

- [x] `cargo test -p strata-engine` — all 37 tests pass (including updated config default tests)
- [x] `cargo clippy -p strata-engine` — clean
- [x] Invariant check against ENGINE_INVARIANTS.md — 6 affected invariants, all HOLDS
- [ ] 100M benchmark: `redb_benchmark --records 100000000 --only strata` — concurrent reads should complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)