### PR TITLE
Revert L0 write backpressure defaults to 0 (disabled)

### DIFF
--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -157,11 +157,14 @@ fn default_max_immutable_memtables() -> usize {
 }
 
 fn default_l0_slowdown_writes_trigger() -> usize {
-    20 // RocksDB default: 1ms yield per write when L0 count >= 20
+    0 // disabled — enabling with a rate-limited compaction creates a deadlock:
+      // writes stall waiting for L0 to drain, but compaction is throttled.
+      // Revisit when adaptive rate limiting is implemented (throttle only under
+      // read pressure, run at full speed during write-only phases).
 }
 
 fn default_l0_stop_writes_trigger() -> usize {
-    36 // RocksDB default: complete stall when L0 count >= 36
+    0 // disabled — see l0_slowdown rationale above
 }
 
 fn default_compaction_rate_limit() -> u64 {


### PR DESCRIPTION
## Summary

- Revert `l0_slowdown_writes_trigger` and `l0_stop_writes_trigger` defaults back to 0 (disabled)
- Keeps the 50 MB/s compaction rate limiter from #2222

## Problem

#2222 enabled both rate limiting (50 MB/s) and L0 write backpressure (slowdown=20, stop=36). Together these create a deadlock during bulk loads: writes stall waiting for L0 to drain, but compaction is throttled to 50 MB/s and can't drain fast enough → 30s timeout → commit error.

The rate limiter alone fixes the concurrent read starvation. L0 backpressure should be re-enabled when adaptive rate limiting is implemented (throttle only under read pressure, full speed during write-only phases).

## Test plan

- [x] `cargo test -p strata-engine` — all tests pass
- [ ] 100M benchmark completes without write stall timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)