### PR TITLE
Complete named recipes: delete three-level merge, add CLI support

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -747,6 +747,13 @@ fn build_search() -> Command {
                 .action(clap::ArgAction::SetTrue)
                 .help("Enable reranking"),
         )
+        .arg(
+            Arg::new("recipe")
+                .long("recipe")
+                .short('R')
+                .value_name("NAME_OR_JSON")
+                .help("Recipe name (e.g. 'keyword', 'hybrid') or inline JSON"),
+        )
 }
 
 // =========================================================================
@@ -1376,6 +1383,15 @@ fn build_recipe() -> Command {
             ),
         )
         .subcommand(Command::new("list").about("List all recipes"))
+        .subcommand(
+            Command::new("delete")
+                .about("Delete a recipe (built-ins cannot be deleted)")
+                .arg(
+                    Arg::new("name")
+                        .required(true)
+                        .help("Recipe name to delete"),
+                ),
+        )
 }
 
 fn build_up() -> Command {

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -1363,10 +1363,17 @@ fn parse_recipe(matches: &ArgMatches, state: &SessionState) -> Result<CliAction,
         "list" => Ok(CliAction::Execute(Command::RecipeList {
             branch: branch(state),
         })),
+        "delete" => {
+            let name = m.get_one::<String>("name").unwrap().clone();
+            Ok(CliAction::Execute(Command::RecipeDelete {
+                branch: branch(state),
+                name,
+            }))
+        }
         other => Err(unknown_subcommand(
             "recipe",
             other,
-            &["show", "set", "get", "list"],
+            &["show", "set", "get", "list", "delete"],
         )),
     }
 }
@@ -1468,12 +1475,20 @@ fn parse_search(matches: &ArgMatches, state: &SessionState) -> Result<CliAction,
     let query = matches.get_one::<String>("query").unwrap().clone();
     let k = matches.get_one::<u64>("top-k").copied();
 
+    // --recipe: try to parse as JSON object, otherwise treat as recipe name
+    let recipe = matches.get_one::<String>("recipe").map(|s| {
+        match serde_json::from_str::<serde_json::Value>(s) {
+            Ok(v) if v.is_object() => v,
+            _ => serde_json::Value::String(s.clone()),
+        }
+    });
+
     Ok(CliAction::Execute(Command::Search {
         branch: branch(state),
         space: space(state),
         search: SearchQuery {
             query,
-            recipe: None,
+            recipe,
             precomputed_embedding: None,
             k,
             as_of: None,

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -91,10 +91,7 @@ fn compaction_round(
 /// Pick the single highest-scoring compaction across all branches and execute it.
 ///
 /// Returns `true` if a compaction was performed.
-fn pick_and_run_one(
-    storage: &SegmentedStore,
-    write_stall_cv: &parking_lot::Condvar,
-) -> bool {
+fn pick_and_run_one(storage: &SegmentedStore, write_stall_cv: &parking_lot::Condvar) -> bool {
     let mut best_score = 0.0f64;
     let mut best_branch = None;
 

--- a/crates/engine/src/recipe_store.rs
+++ b/crates/engine/src/recipe_store.rs
@@ -20,11 +20,18 @@ fn system_branch_id() -> BranchId {
 
 /// Seed all built-in recipes onto the `_system_` branch.
 ///
-/// Called once at database creation time. Safe to call multiple times
-/// (overwrites existing built-ins with the latest definitions).
+/// Only writes recipes that don't already exist on `_system_`.
+/// Safe to call on every open — skips seeding if recipes are present.
 pub fn seed_builtin_recipes(db: &Database) -> StrataResult<()> {
     use crate::search::recipe::builtin_recipes;
     let sys_branch = system_branch_id();
+
+    // Quick check: if "default" exists on _system_, assume all built-ins are seeded.
+    let check_key = system_kv_key(sys_branch, "recipe:default");
+    if db.get_value_direct(&check_key)?.is_some() {
+        return Ok(());
+    }
+
     for (name, recipe) in builtin_recipes() {
         let key = system_kv_key(sys_branch, &format!("recipe:{name}"));
         let json = serde_json::to_string(&recipe)?;

--- a/crates/engine/src/search/mod.rs
+++ b/crates/engine/src/search/mod.rs
@@ -20,7 +20,7 @@ pub mod tokenizer;
 mod types;
 
 pub use index::{InvertedIndex, PostingEntry, PostingList, ScoredDocId};
-pub use recipe::{builtin_defaults, Recipe};
+pub use recipe::Recipe;
 pub use recovery::{extract_indexable_text, register_search_recovery, SearchSubsystem};
 pub use searchable::{
     build_search_response, build_search_response_with_index, build_search_response_with_scorer,

--- a/crates/engine/src/search/recipe.rs
+++ b/crates/engine/src/search/recipe.rs
@@ -1,8 +1,8 @@
 //! Recipe schema for search retrieval configuration.
 //!
 //! Recipes control all aspects of search behavior: BM25 tuning, vector search,
-//! fusion strategy, expansion, reranking, and more. Every field is `Option<T>`
-//! to support three-level merge: built-in defaults → branch recipe → per-call override.
+//! fusion strategy, expansion, reranking, and more. Each recipe is fully
+//! self-contained — what you see is what runs. No inheritance, no merge.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -13,7 +13,8 @@ use std::collections::HashMap;
 
 /// Search recipe — controls all retrieval behavior.
 ///
-/// All fields are `Option<T>` to support partial overrides via [`Recipe::merge`].
+/// Each recipe is fully self-contained. Presence of a section = enabled,
+/// absence = disabled. Named recipes are stored on the `_system_` branch.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct Recipe {
     /// Schema version (currently 1).
@@ -293,175 +294,18 @@ pub struct ControlConfig {
 // ============================================================================
 // Merge
 // ============================================================================
-
-/// Merge two optional sub-configs using a merge function.
-fn merge_option<T, F>(base: &Option<T>, overlay: &Option<T>, merge_fn: F) -> Option<T>
-where
-    T: Clone,
-    F: FnOnce(&T, &T) -> T,
-{
-    match (base, overlay) {
-        (Some(b), Some(o)) => Some(merge_fn(b, o)),
-        (None, Some(o)) => Some(o.clone()),
-        (Some(b), None) => Some(b.clone()),
-        (None, None) => None,
-    }
-}
-
-impl Recipe {
-    /// Merge two recipes. Overlay fields win when `Some`; base fills gaps.
-    pub fn merge(base: &Recipe, overlay: &Recipe) -> Recipe {
-        Recipe {
-            version: overlay.version.or(base.version),
-            retrieve: merge_option(&base.retrieve, &overlay.retrieve, RetrieveConfig::merge),
-            expansion: overlay
-                .expansion
-                .as_ref()
-                .or(base.expansion.as_ref())
-                .cloned(),
-            filter: overlay.filter.as_ref().or(base.filter.as_ref()).cloned(),
-            fusion: merge_option(&base.fusion, &overlay.fusion, FusionConfig::merge),
-            rerank: overlay.rerank.as_ref().or(base.rerank.as_ref()).cloned(),
-            transform: merge_option(&base.transform, &overlay.transform, TransformConfig::merge),
-            prompt: overlay.prompt.as_ref().or(base.prompt.as_ref()).cloned(),
-            rag_context_hits: overlay.rag_context_hits.or(base.rag_context_hits),
-            rag_max_tokens: overlay.rag_max_tokens.or(base.rag_max_tokens),
-            models: merge_option(&base.models, &overlay.models, ModelsConfig::merge),
-            version_output: merge_option(
-                &base.version_output,
-                &overlay.version_output,
-                VersionOutputConfig::merge,
-            ),
-            control: merge_option(&base.control, &overlay.control, ControlConfig::merge),
-        }
-    }
-
-    /// Three-level resolution: built-in defaults → branch recipe → per-call override.
-    pub fn resolve(builtin: &Recipe, branch: &Recipe, per_call: Option<&Recipe>) -> Recipe {
-        let merged = Recipe::merge(builtin, branch);
-        match per_call {
-            Some(o) => Recipe::merge(&merged, o),
-            None => merged,
-        }
-    }
-}
-
-impl RetrieveConfig {
-    fn merge(base: &Self, overlay: &Self) -> Self {
-        RetrieveConfig {
-            bm25: merge_option(&base.bm25, &overlay.bm25, BM25Config::merge),
-            vector: merge_option(&base.vector, &overlay.vector, VectorRetrieveConfig::merge),
-            graph: overlay.graph.as_ref().or(base.graph.as_ref()).cloned(),
-        }
-    }
-}
-
-impl BM25Config {
-    fn merge(base: &Self, overlay: &Self) -> Self {
-        BM25Config {
-            sources: overlay.sources.as_ref().or(base.sources.as_ref()).cloned(),
-            spaces: overlay.spaces.as_ref().or(base.spaces.as_ref()).cloned(),
-            k: overlay.k.or(base.k),
-            k1: overlay.k1.or(base.k1),
-            b: overlay.b.or(base.b),
-            field_weights: overlay
-                .field_weights
-                .as_ref()
-                .or(base.field_weights.as_ref())
-                .cloned(),
-            stemmer: overlay.stemmer.as_ref().or(base.stemmer.as_ref()).cloned(),
-            stopwords: overlay
-                .stopwords
-                .as_ref()
-                .or(base.stopwords.as_ref())
-                .cloned(),
-            phrase_boost: overlay.phrase_boost.or(base.phrase_boost),
-            proximity_boost: overlay.proximity_boost.or(base.proximity_boost),
-        }
-    }
-}
-
-impl VectorRetrieveConfig {
-    fn merge(base: &Self, overlay: &Self) -> Self {
-        VectorRetrieveConfig {
-            collections: overlay
-                .collections
-                .as_ref()
-                .or(base.collections.as_ref())
-                .cloned(),
-            k: overlay.k.or(base.k),
-            metric: overlay.metric.as_ref().or(base.metric.as_ref()).cloned(),
-        }
-    }
-}
-
-impl FusionConfig {
-    fn merge(base: &Self, overlay: &Self) -> Self {
-        FusionConfig {
-            method: overlay.method.as_ref().or(base.method.as_ref()).cloned(),
-            k: overlay.k.or(base.k),
-            weights: overlay.weights.as_ref().or(base.weights.as_ref()).cloned(),
-        }
-    }
-}
-
-impl TransformConfig {
-    fn merge(base: &Self, overlay: &Self) -> Self {
-        TransformConfig {
-            limit: overlay.limit.or(base.limit),
-            dedup: overlay.dedup.as_ref().or(base.dedup.as_ref()).cloned(),
-        }
-    }
-}
-
-impl ModelsConfig {
-    fn merge(base: &Self, overlay: &Self) -> Self {
-        ModelsConfig {
-            embed: overlay.embed.as_ref().or(base.embed.as_ref()).cloned(),
-            rerank: overlay.rerank.as_ref().or(base.rerank.as_ref()).cloned(),
-            generate: overlay
-                .generate
-                .as_ref()
-                .or(base.generate.as_ref())
-                .cloned(),
-            expand: overlay.expand.as_ref().or(base.expand.as_ref()).cloned(),
-        }
-    }
-}
-
-impl ControlConfig {
-    fn merge(base: &Self, overlay: &Self) -> Self {
-        ControlConfig {
-            budget_ms: overlay.budget_ms.or(base.budget_ms),
-            max_candidates: overlay.max_candidates.or(base.max_candidates),
-            snapshot_version: overlay.snapshot_version.or(base.snapshot_version),
-        }
-    }
-}
-
-impl VersionOutputConfig {
-    fn merge(base: &Self, overlay: &Self) -> Self {
-        VersionOutputConfig {
-            include_version: overlay.include_version.or(base.include_version),
-            include_timestamp: overlay.include_timestamp.or(base.include_timestamp),
-            include_history: overlay.include_history.or(base.include_history),
-            depth: overlay.depth.or(base.depth),
-        }
-    }
-}
-
-// ============================================================================
 // Built-in Defaults
 // ============================================================================
 
-/// The built-in default recipe (level 0 of three-level merge).
-///
-/// Built-in default recipe with qmd-inspired search quality defaults.
+/// The full-featured default recipe.
 ///
 /// BM25 tuned to Anserini/Pyserini BEIR values (k1=0.9, b=0.4).
 /// Expansion and reranking enabled — gracefully degrade when models
 /// are not available (search still works, just without the quality knobs).
-pub fn builtin_defaults() -> Recipe {
+///
+/// Used internally by `builtin_recipes()` to define the "default" named recipe
+/// and as a fallback in `get_default_recipe()` for legacy/unseeded databases.
+pub(crate) fn builtin_defaults() -> Recipe {
     Recipe {
         version: Some(1),
         retrieve: Some(RetrieveConfig {
@@ -742,101 +586,39 @@ mod tests {
     }
 
     #[test]
-    fn test_recipe_merge_empty_overlay() {
-        let base = builtin_defaults();
-        let overlay = Recipe::default();
-        let merged = Recipe::merge(&base, &overlay);
-        assert_eq!(merged, base);
+    fn test_builtin_recipes_count() {
+        assert_eq!(BUILTIN_RECIPE_NAMES.len(), 6);
+        assert_eq!(builtin_recipes().len(), 6);
     }
 
     #[test]
-    fn test_recipe_merge_single_field_override() {
-        let base = builtin_defaults();
-        let overlay = Recipe {
-            retrieve: Some(RetrieveConfig {
-                bm25: Some(BM25Config {
-                    k1: Some(1.5),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let merged = Recipe::merge(&base, &overlay);
-
-        // k1 overridden
-        let bm25 = merged.retrieve.as_ref().unwrap().bm25.as_ref().unwrap();
-        assert_eq!(bm25.k1, Some(1.5));
-        // b still from base
-        assert_eq!(bm25.b, Some(0.4));
-        // k still from base
-        assert_eq!(bm25.k, Some(50));
-        // fusion still from base
-        assert_eq!(merged.fusion.as_ref().unwrap().method, Some("rrf".into()));
+    fn test_builtin_keyword_no_expansion() {
+        let r = get_builtin_recipe("keyword").unwrap();
+        assert!(r.retrieve.as_ref().unwrap().bm25.is_some());
+        assert!(r.retrieve.as_ref().unwrap().vector.is_none());
+        assert!(r.expansion.is_none());
+        assert!(r.rerank.is_none());
     }
 
     #[test]
-    fn test_recipe_resolve_three_levels() {
-        let builtin = builtin_defaults();
-
-        let branch = Recipe {
-            retrieve: Some(RetrieveConfig {
-                bm25: Some(BM25Config {
-                    k1: Some(1.2),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-
-        let per_call = Recipe {
-            transform: Some(TransformConfig {
-                limit: Some(5),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-
-        let resolved = Recipe::resolve(&builtin, &branch, Some(&per_call));
-
-        // k1 from branch level
-        assert_eq!(
-            resolved
-                .retrieve
-                .as_ref()
-                .unwrap()
-                .bm25
-                .as_ref()
-                .unwrap()
-                .k1,
-            Some(1.2)
-        );
-        // b from builtin (branch didn't override)
-        assert_eq!(
-            resolved.retrieve.as_ref().unwrap().bm25.as_ref().unwrap().b,
-            Some(0.4)
-        );
-        // limit from per_call
-        assert_eq!(resolved.transform.as_ref().unwrap().limit, Some(5));
-        // budget_ms from builtin (neither branch nor per_call overrode)
-        assert_eq!(resolved.control.as_ref().unwrap().budget_ms, Some(5000));
+    fn test_builtin_default_has_expansion() {
+        let r = get_builtin_recipe("default").unwrap();
+        assert!(r.expansion.is_some());
+        assert!(r.rerank.is_some());
+        assert!(r.retrieve.as_ref().unwrap().bm25.is_some());
+        assert!(r.retrieve.as_ref().unwrap().vector.is_some());
     }
 
     #[test]
-    fn test_builtin_defaults() {
-        let d = builtin_defaults();
-        assert_eq!(d.version, Some(1));
-        let bm25 = d.retrieve.as_ref().unwrap().bm25.as_ref().unwrap();
-        assert_eq!(bm25.k1, Some(0.9));
-        assert_eq!(bm25.b, Some(0.4));
-        assert_eq!(bm25.k, Some(50));
-        assert_eq!(bm25.stemmer, Some("porter".into()));
-        assert_eq!(bm25.stopwords, Some("lucene33".into()));
-        assert_eq!(d.fusion.as_ref().unwrap().method, Some("rrf".into()));
-        assert_eq!(d.fusion.as_ref().unwrap().k, Some(60));
-        assert_eq!(d.transform.as_ref().unwrap().limit, Some(10));
-        assert_eq!(d.control.as_ref().unwrap().budget_ms, Some(5000));
+    fn test_builtin_semantic_vector_only() {
+        let r = get_builtin_recipe("semantic").unwrap();
+        assert!(r.retrieve.as_ref().unwrap().bm25.is_none());
+        assert!(r.retrieve.as_ref().unwrap().vector.is_some());
+    }
+
+    #[test]
+    fn test_builtin_unknown_returns_none() {
+        assert!(get_builtin_recipe("nonexistent").is_none());
     }
 
     #[test]
@@ -845,55 +627,5 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
         let deserialized: Recipe = serde_json::from_str(&json).unwrap();
         assert_eq!(original, deserialized);
-    }
-
-    #[test]
-    fn test_version_output_config_merge() {
-        let base = Recipe {
-            version_output: Some(VersionOutputConfig {
-                include_version: Some(true),
-                include_timestamp: Some(true),
-                include_history: None,
-                depth: None,
-            }),
-            ..Default::default()
-        };
-        let overlay = Recipe {
-            version_output: Some(VersionOutputConfig {
-                include_history: Some(true),
-                depth: Some(5),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let merged = Recipe::merge(&base, &overlay);
-        let vo = merged.version_output.unwrap();
-        assert_eq!(vo.include_version, Some(true)); // from base
-        assert_eq!(vo.include_timestamp, Some(true)); // from base
-        assert_eq!(vo.include_history, Some(true)); // from overlay
-        assert_eq!(vo.depth, Some(5)); // from overlay
-    }
-
-    #[test]
-    fn test_control_config_snapshot_version_merge() {
-        let base = Recipe {
-            control: Some(ControlConfig {
-                budget_ms: Some(5000),
-                max_candidates: None,
-                snapshot_version: None,
-            }),
-            ..Default::default()
-        };
-        let overlay = Recipe {
-            control: Some(ControlConfig {
-                snapshot_version: Some(42),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let merged = Recipe::merge(&base, &overlay);
-        let ctrl = merged.control.unwrap();
-        assert_eq!(ctrl.budget_ms, Some(5000)); // from base
-        assert_eq!(ctrl.snapshot_version, Some(42)); // from overlay
     }
 }

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -174,6 +174,10 @@ impl Strata {
         match Database::open_with_config(&data_dir, cfg) {
             Ok(db) => {
                 strata_graph::branch_dag::init_system_branch(&db);
+                // Seed built-in recipes if not already present
+                if let Err(e) = strata_engine::recipe_store::seed_builtin_recipes(&db) {
+                    tracing::warn!(error = %e, "Failed to seed built-in recipes");
+                }
                 let executor = Executor::new_with_mode(db, access_mode);
                 match access_mode {
                     AccessMode::ReadWrite => Self::ensure_default_branch(&executor)?,

--- a/crates/executor/src/command.rs
+++ b/crates/executor/src/command.rs
@@ -1410,6 +1410,19 @@ pub enum Command {
         branch: Option<BranchId>,
     },
 
+    /// Delete a recipe from a branch.
+    /// Built-in recipes on `_system_` branch cannot be deleted.
+    /// Deleting a user shadow restores the built-in fallback.
+    /// Returns: `Output::Unit`
+    RecipeDelete {
+        /// Target branch (defaults to "default").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<BranchId>,
+        /// Recipe name to delete.
+        #[serde(default = "default_recipe_name")]
+        name: String,
+    },
+
     /// Delete a space (must be empty unless force=true).
     /// Returns: `Output::Unit`
     SpaceDelete {
@@ -1941,6 +1954,7 @@ impl Command {
                 | Command::GraphFreezeOntology { .. }
                 | Command::ReindexEmbeddings { .. }
                 | Command::RecipeSet { .. }
+                | Command::RecipeDelete { .. }
                 | Command::TagCreate { .. }
                 | Command::TagDelete { .. }
                 | Command::NoteAdd { .. }
@@ -2057,6 +2071,7 @@ impl Command {
             Command::RecipeGet { .. } => "RecipeGet",
             Command::RecipeGetDefault { .. } => "RecipeGetDefault",
             Command::RecipeList { .. } => "RecipeList",
+            Command::RecipeDelete { .. } => "RecipeDelete",
             Command::Embed { .. } => "Embed",
             Command::EmbedBatch { .. } => "EmbedBatch",
             Command::ModelsList => "ModelsList",
@@ -2208,7 +2223,8 @@ impl Command {
             Command::RecipeSet { branch, .. }
             | Command::RecipeGet { branch, .. }
             | Command::RecipeGetDefault { branch, .. }
-            | Command::RecipeList { branch, .. } => {
+            | Command::RecipeList { branch, .. }
+            | Command::RecipeDelete { branch, .. } => {
                 resolve_branch!(branch);
             }
 
@@ -2416,7 +2432,8 @@ impl Command {
             Command::RecipeSet { branch, .. }
             | Command::RecipeGet { branch, .. }
             | Command::RecipeGetDefault { branch, .. }
-            | Command::RecipeList { branch, .. } => branch.as_ref(),
+            | Command::RecipeList { branch, .. }
+            | Command::RecipeDelete { branch, .. } => branch.as_ref(),
 
             // Branch lifecycle, Transaction, Database — no data branch
             _ => None,

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -332,6 +332,13 @@ impl Executor {
                 })?;
                 crate::handlers::recipe::recipe_list(&self.primitives, branch)
             }
+            Command::RecipeDelete { branch, name } => {
+                let branch = branch.ok_or(Error::InvalidInput {
+                    reason: "Branch must be specified or resolved to default".into(),
+                    hint: None,
+                })?;
+                crate::handlers::recipe::recipe_delete(&self.primitives, branch, name)
+            }
 
             Command::TimeRange { branch } => {
                 let branch = branch.ok_or(Error::InvalidInput {

--- a/crates/executor/src/handlers/recipe.rs
+++ b/crates/executor/src/handlers/recipe.rs
@@ -21,9 +21,18 @@ pub fn recipe_set(
         reason: format!("Invalid recipe JSON: {e}"),
         hint: None,
     })?;
-    recipe_store::set_recipe(&p.db, branch_id, &name, &recipe).map_err(|e| Error::Internal {
-        reason: e.to_string(),
-        hint: None,
+    recipe_store::set_recipe(&p.db, branch_id, &name, &recipe).map_err(|e| {
+        if e.to_string().contains("Cannot overwrite built-in") {
+            Error::InvalidInput {
+                reason: e.to_string(),
+                hint: Some("Built-in recipes on _system_ branch are read-only".into()),
+            }
+        } else {
+            Error::Internal {
+                reason: e.to_string(),
+                hint: None,
+            }
+        }
     })?;
     Ok(Output::Unit)
 }
@@ -61,6 +70,26 @@ pub fn recipe_get_default(p: &Arc<Primitives>, branch: BranchId) -> Result<Outpu
         hint: None,
     })?;
     Ok(Output::Maybe(Some(Value::String(json))))
+}
+
+/// Delete a named recipe from a branch.
+pub fn recipe_delete(p: &Arc<Primitives>, branch: BranchId, name: String) -> Result<Output> {
+    let branch_id = to_core_branch_id(&branch)?;
+    recipe_store::delete_recipe(&p.db, branch_id, &name).map_err(|e| {
+        // InvalidInput from recipe_store means built-in protection
+        if e.to_string().contains("Cannot delete built-in") {
+            Error::InvalidInput {
+                reason: e.to_string(),
+                hint: Some("Built-in recipes on _system_ branch are read-only".into()),
+            }
+        } else {
+            Error::Internal {
+                reason: e.to_string(),
+                hint: None,
+            }
+        }
+    })?;
+    Ok(Output::Unit)
 }
 
 /// List all recipe names on a branch.

--- a/crates/search/src/substrate.rs
+++ b/crates/search/src/substrate.rs
@@ -423,8 +423,38 @@ fn hash_entity(e: &EntityRef) -> u64 {
 mod tests {
     use super::*;
     use strata_core::Value;
-    use strata_engine::search::recipe::{TransformConfig, VectorRetrieveConfig};
-    use strata_engine::search::{builtin_defaults, Recipe};
+    use strata_engine::search::recipe::{
+        BM25Config, FusionConfig, RetrieveConfig, TransformConfig, VectorRetrieveConfig,
+    };
+    use strata_engine::search::Recipe;
+
+    /// Simple keyword recipe for tests (BM25 + RRF + limit 10).
+    fn test_recipe() -> Recipe {
+        Recipe {
+            version: Some(1),
+            retrieve: Some(RetrieveConfig {
+                bm25: Some(BM25Config {
+                    k: Some(50),
+                    k1: Some(0.9),
+                    b: Some(0.4),
+                    stemmer: Some("porter".into()),
+                    stopwords: Some("lucene33".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            fusion: Some(FusionConfig {
+                method: Some("rrf".into()),
+                k: Some(60),
+                ..Default::default()
+            }),
+            transform: Some(TransformConfig {
+                limit: Some(10),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
 
     /// Helper: create a test database and insert KV data.
     /// Returns (db, branch_id) so tests can use the same branch for search.
@@ -448,7 +478,7 @@ mod tests {
             ("doc2", "lazy brown dog"),
             ("doc3", "something completely different"),
         ]);
-        let recipe = builtin_defaults(); // BM25 only, no vector
+        let recipe = test_recipe(); // BM25 only, no vector
         let request = RetrievalRequest {
             query: "brown fox".into(),
             branch_id,
@@ -487,7 +517,7 @@ mod tests {
             ("e", "test data five"),
         ]);
 
-        let mut recipe = builtin_defaults();
+        let mut recipe = test_recipe();
         recipe.transform = Some(TransformConfig {
             limit: Some(2),
             ..Default::default()
@@ -511,7 +541,7 @@ mod tests {
     #[test]
     fn test_retrieve_empty_db() {
         let db = Database::cache().expect("Failed to create test database");
-        let recipe = builtin_defaults();
+        let recipe = test_recipe();
         let request = RetrievalRequest {
             query: "anything".into(),
             branch_id: BranchId::default(),
@@ -535,7 +565,7 @@ mod tests {
             ("y", "beta gamma delta"),
             ("z", "gamma delta epsilon"),
         ]);
-        let recipe = builtin_defaults();
+        let recipe = test_recipe();
 
         let req = RetrievalRequest {
             query: "gamma".into(),
@@ -722,7 +752,7 @@ mod tests {
         .expect("put");
         db.flush().expect("flush");
 
-        let recipe = builtin_defaults();
+        let recipe = test_recipe();
         let request = RetrievalRequest {
             query: "rust".into(),
             branch_id,
@@ -759,7 +789,7 @@ mod tests {
     fn test_retrieve_as_of_before_data() {
         // as_of before any data → empty results
         let (db, branch_id) = setup_db_with_kv(&[("doc", "some text about testing")]);
-        let recipe = builtin_defaults();
+        let recipe = test_recipe();
         let request = RetrievalRequest {
             query: "testing".into(),
             branch_id,
@@ -783,7 +813,7 @@ mod tests {
         // as_of=None should return all docs (regression test)
         let (db, branch_id) =
             setup_db_with_kv(&[("a", "alpha test data"), ("b", "beta test data")]);
-        let recipe = builtin_defaults();
+        let recipe = test_recipe();
         let request = RetrievalRequest {
             query: "test data".into(),
             branch_id,


### PR DESCRIPTION
## Summary
Completes the named recipes system from #2225.

- **Delete three-level merge**: `Recipe::merge()`, `Recipe::resolve()`, `merge_option()`, and all 10 per-struct merge impls removed (~160 lines). The three-level merge is gone.
- **Seed at Strata::open()**: Built-in recipes seeded at executor layer (not engine layer) to avoid disrupting low-level engine tests.
- **RecipeDelete**: New command + handler + CLI `recipe delete <name>`. Built-ins on `_system_` branch protected.
- **CLI --recipe flag**: `strata search --recipe keyword "query"` or `--recipe '{"retrieve":{"bm25":{}}}'`
- **builtin_defaults() made private**: No longer public API. Replaced by named recipe lookup.
- **Substrate tests**: Use local `test_recipe()` helper instead of deleted `builtin_defaults()`

## Test plan
- [x] 562 tests pass (1 pre-existing `test_kv_count` failure)
- [x] Clippy clean, fmt clean
- [x] Built-in recipe validation tests (count, keyword/default/semantic structure)
- [x] No engine test regressions (seeding moved to executor layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)