### PR TITLE
Remove debug instrumentation from compaction and block cache

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -601,11 +601,6 @@ impl Database {
         &self.scheduler
     }
 
-    /// Dump compaction chain profiling counters to stderr and reset.
-    pub fn dump_compaction_profile(&self) {
-        transaction::dump_compaction_profile();
-    }
-
     /// Seconds since the database was opened.
     pub fn uptime_secs(&self) -> u64 {
         self.opened_at.elapsed().as_secs()

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -44,23 +44,6 @@ fn release_freed_memory() {
 /// re-submitting through `schedule_background_compaction`.
 const MAX_IDLE_ROUNDS: u32 = 5;
 
-// Compaction chain profiling counters.
-static COMPACT_WORK_ROUNDS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-static COMPACT_IDLE_ROUNDS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-static COMPACT_CHAIN_STARTS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-static COMPACT_CHAIN_ENDS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
-/// Dump compaction chain profiling counters and reset.
-pub fn dump_compaction_profile() {
-    let work = COMPACT_WORK_ROUNDS.swap(0, Ordering::Relaxed);
-    let idle = COMPACT_IDLE_ROUNDS.swap(0, Ordering::Relaxed);
-    let starts = COMPACT_CHAIN_STARTS.swap(0, Ordering::Relaxed);
-    let ends = COMPACT_CHAIN_ENDS.swap(0, Ordering::Relaxed);
-    eprintln!(
-        "compaction_chain: {work} work rounds, {idle} idle rounds, {starts} chain starts, {ends} chain ends"
-    );
-}
-
 /// One round of the self-re-scheduling compaction chain.
 ///
 /// Each invocation picks the highest-scoring compaction across all branches,
@@ -85,10 +68,8 @@ fn compaction_round(
     let did_work = pick_and_run_one(&storage, &write_stall_cv);
 
     if did_work {
-        COMPACT_WORK_ROUNDS.fetch_add(1, Ordering::Relaxed);
         resubmit_chain(storage, write_stall_cv, flag, cancelled, scheduler, 0);
     } else if idle_count < MAX_IDLE_ROUNDS {
-        COMPACT_IDLE_ROUNDS.fetch_add(1, Ordering::Relaxed);
         if idle_count == 0 {
             if !cancelled.load(Ordering::Acquire) {
                 run_materialization(&storage);
@@ -98,7 +79,6 @@ fn compaction_round(
         resubmit_chain(storage, write_stall_cv, flag, cancelled, scheduler, idle_count + 1);
     } else {
         // Exceeded idle limit — release the flag.
-        COMPACT_CHAIN_ENDS.fetch_add(1, Ordering::Relaxed);
         flag.store(false, Ordering::Release);
     }
 }
@@ -265,8 +245,6 @@ impl Database {
         {
             return;
         }
-
-        COMPACT_CHAIN_STARTS.fetch_add(1, Ordering::Relaxed);
 
         let storage = Arc::clone(&self.storage);
         let write_stall_cv = Arc::clone(&self.write_stall_cv);

--- a/crates/storage/src/block_cache.rs
+++ b/crates/storage/src/block_cache.rs
@@ -163,6 +163,7 @@ pub enum Priority {
 }
 
 impl Priority {
+    #[allow(dead_code)]
     fn from_bits(bits: u64) -> Self {
         match bits {
             1 => Priority::High,

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -941,12 +941,10 @@ impl SegmentedStore {
             return Err(e);
         }
 
-        let _compact_t0 = std::time::Instant::now();
         let output_entries: u64 = outputs.iter().map(|(_, m)| m.entry_count).sum();
         let output_file_size: u64 = outputs.iter().map(|(_, m)| m.file_size).sum();
 
         // Open all output segments
-        let _compact_t2_open_start = std::time::Instant::now();
         let mut new_output_segments: Vec<Arc<KVSegment>> = Vec::new();
         for (path, _meta) in &outputs {
             match KVSegment::open(path) {
@@ -959,10 +957,8 @@ impl SegmentedStore {
                 }
             }
         }
-        let _compact_t2_seg_open = _compact_t2_open_start.elapsed();
 
         // ── 4. Atomic version swap ─────────────────────────────────────
-        let _compact_t2_swap_start = std::time::Instant::now();
         {
             let mut branch = self
                 .branches
@@ -992,39 +988,19 @@ impl SegmentedStore {
         }
 
         // ── 5. Cleanup ─────────────────────────────────────────────────
-        let _compact_t2_swap = _compact_t2_swap_start.elapsed();
 
         // Persist manifest BEFORE deleting old files (crash safety).
-        let _compact_t3_manifest_start = std::time::Instant::now();
         self.write_branch_manifest(branch_id);
-        let _compact_t3_manifest = _compact_t3_manifest_start.elapsed();
 
         // Delete old segment files (refcount-guarded).
-        let _compact_t4_delete_start = std::time::Instant::now();
         for seg in &input_segs {
             self.delete_segment_if_unreferenced(seg);
         }
         for seg in &overlap_segs {
             self.delete_segment_if_unreferenced(seg);
         }
-        let _compact_t4_delete = _compact_t4_delete_start.elapsed();
 
         let entries_pruned = total_input_entries.saturating_sub(output_entries);
-
-        // Log timing breakdown for rounds > 100ms
-        let total_ms = _compact_t0.elapsed().as_millis();
-        if total_ms > 100 {
-            eprintln!(
-                "    compact L{}→L{}: {}ms total (seg_open {}ms, version_swap {}ms, manifest {}ms, delete {}ms) — {} segs in, {} out, {:.1}MB",
-                level, level + 1, total_ms,
-                _compact_t2_seg_open.as_millis(),
-                _compact_t2_swap.as_millis(),
-                _compact_t3_manifest.as_millis(),
-                _compact_t4_delete.as_millis(),
-                segments_merged, outputs.len(),
-                output_file_size as f64 / (1024.0 * 1024.0),
-            );
-        }
 
         Ok(Some(CompactionResult {
             segments_merged,

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -2635,37 +2635,6 @@ impl SegmentedStore {
         })
     }
 
-    /// Print a compact summary of segment counts and bytes per level for all branches.
-    pub fn dump_level_stats(&self) {
-        for branch_ref in self.branches.iter() {
-            let branch_id = branch_ref.key();
-            let ver = branch_ref.version.load();
-            let mut parts = Vec::new();
-            for (level, segs) in ver.levels.iter().enumerate() {
-                if !segs.is_empty() {
-                    let bytes: u64 = segs.iter().map(|s| s.file_size()).sum();
-                    parts.push(format!(
-                        "L{}={} ({:.0}MB)",
-                        level,
-                        segs.len(),
-                        bytes as f64 / (1024.0 * 1024.0)
-                    ));
-                }
-            }
-            let frozen = branch_ref.frozen.len();
-            let active_bytes = branch_ref.active.approx_bytes();
-            if !parts.is_empty() || frozen > 0 || active_bytes > 0 {
-                let branch_hex = hex_encode_branch(branch_id);
-                let short = &branch_hex[..8];
-                eprintln!(
-                    "  branch {short}: active={:.0}MB frozen={frozen} {}",
-                    active_bytes as f64 / (1024.0 * 1024.0),
-                    parts.join(" "),
-                );
-            }
-        }
-    }
-
     /// Return the maximum commit_id across all flushed segments for a branch.
     ///
     /// Returns `None` if the branch has no segments.


### PR DESCRIPTION
## Summary

- Remove compaction chain profiling counters and `dump_compaction_profile()`
- Remove `dump_level_stats()` from SegmentedStore
- Remove compaction timing `eprintln!` from `compact_level()`
- Fix `Priority::from_bits` dead_code warning

Cleanup after the read performance investigation (#2228, #2229).

🤖 Generated with [Claude Code](https://claude.com/claude-code)