### PR TITLE
Fix block cache review: counter overflow, refresh_clock race, probe bounds

### DIFF
--- a/crates/storage/src/block_cache.rs
+++ b/crates/storage/src/block_cache.rs
@@ -58,6 +58,12 @@ const CLOCK_INITIAL: u64 = 1;
 /// Prevents O(N) scans when the table is nearly full.
 const MAX_PROBES: usize = 128;
 
+/// When both acquire and release counters exceed this threshold, they are
+/// reset by subtracting the same value from both (preserving refcount).
+/// This prevents counter overflow into adjacent bit fields.
+/// Must be well below COUNT_MASK (4194303) to leave headroom.
+const COUNTER_RESET_THRESHOLD: u64 = 1 << 20; // ~1M
+
 // ---------------------------------------------------------------------------
 // Meta word encoding
 // ---------------------------------------------------------------------------
@@ -352,22 +358,22 @@ impl BlockCache {
                     self.refresh_clock(slot, old_meta);
 
                     // Release our reference.
-                    slot.meta.fetch_add(RELEASE_ONE, Ordering::Release);
+                    self.release_ref(slot, Ordering::Release);
                     self.hits.fetch_add(1, Ordering::Relaxed);
                     return Some(arc);
                 }
 
                 // Key mismatch — release reference.
-                slot.meta.fetch_add(RELEASE_ONE, Ordering::Release);
+                self.release_ref(slot, Ordering::Release);
             } else if meta_is_empty(old_meta) {
                 // Empty slot means key is not in the table.
-                self.undo_acquire(slot);
+                self.release_ref(slot, Ordering::Relaxed);
                 self.misses.fetch_add(1, Ordering::Relaxed);
                 return None;
             } else {
                 // Slot is occupied but not visible (under construction or
                 // invisible). Undo acquire and keep probing.
-                self.undo_acquire(slot);
+                self.release_ref(slot, Ordering::Relaxed);
             }
 
             idx = (idx + inc) & self.len_mask;
@@ -378,10 +384,33 @@ impl BlockCache {
         None
     }
 
-    /// Undo an optimistic acquire by incrementing the release counter.
+    /// Release a reference by incrementing the release counter.
+    /// Also checks for counter overflow and resets both counters if needed.
     #[inline(always)]
-    fn undo_acquire(&self, slot: &Slot) {
-        slot.meta.fetch_add(RELEASE_ONE, Ordering::Relaxed);
+    fn release_ref(&self, slot: &Slot, ordering: Ordering) {
+        let old = slot.meta.fetch_add(RELEASE_ONE, ordering);
+        // Check if both counters are large (overflow risk). This is the
+        // rare path — only triggers after ~1M lookups on the same entry.
+        let acquire = meta_acquire_count(old);
+        let release = meta_release_count(old) + 1; // after our increment
+        if release > COUNTER_RESET_THRESHOLD && acquire > COUNTER_RESET_THRESHOLD {
+            // Reset both counters by subtracting the smaller value from both.
+            // This preserves the refcount (acquire - release) while freeing
+            // counter space. Best-effort CAS — if it fails, another release
+            // will try again.
+            let drain = release.min(acquire);
+            let sub = (drain << ACQUIRE_SHIFT) | (drain << RELEASE_SHIFT);
+            let current = slot.meta.load(Ordering::Relaxed);
+            // Only reset if counters are still high (another thread may have reset).
+            if meta_acquire_count(current) > COUNTER_RESET_THRESHOLD {
+                let _ = slot.meta.compare_exchange_weak(
+                    current,
+                    current.wrapping_sub(sub),
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                );
+            }
+        }
     }
 
     /// Refresh the clock countdown to CLOCK_MAX (best-effort CAS).
@@ -497,11 +526,11 @@ impl BlockCache {
                             let ptr = slot.data.load(Ordering::Acquire);
                             Arc::clone(&*ptr)
                         };
-                        slot.meta.fetch_add(RELEASE_ONE, Ordering::Release);
+                        self.release_ref(slot, Ordering::Release);
                         return existing;
                     } else {
                         // Slot changed state — undo and fall through.
-                        self.undo_acquire(slot);
+                        self.release_ref(slot, Ordering::Relaxed);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Post-implementation review of #2228 and #2229. Found and fixed:

**Critical: counter overflow → use-after-free (commit 1)**
- Acquire/release counters (22 bits) overflow after ~4M lookups on a hot entry
- Overflow corrupts adjacent bit fields, causing `meta_refcount()` to return garbage
- Eviction could free a referenced entry while a reader holds a pointer
- Fix: detect overflow in `release_ref()` and reset both counters via CAS (RocksDB's approach)

**refresh_clock meta word corruption (commit 2, from prior review)**
- `fetch_add(delta)` was a blind addition that could interact with concurrent modifications
- Fix: use `compare_exchange_weak` — if CAS fails, skip (clock refresh is advisory)

**promote_to_pinned unbounded probe (commit 2)**
- Used `table_len` loop bound (500K+ iterations). Fixed to `MAX_PROBES` (128)

## PR #2228 review: no issues found
Snapshot-then-release pattern is mechanically correct. All callers properly snapshot and release.

## Test plan
- [x] All 16 block_cache tests pass
- [x] 650 storage tests pass
- [x] 37 engine tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)