### PR TITLE
Fix flaky test_issue_1702: drain scheduler before delete_branch

### DIFF
--- a/crates/engine/tests/branch_isolation_tests.rs
+++ b/crates/engine/tests/branch_isolation_tests.rs
@@ -342,6 +342,12 @@ fn test_issue_1702_delete_branch_cleans_up_segment_files() {
         branch_dir,
     );
 
+    // Drain background tasks (compaction may be running due to
+    // compaction-on-open and tiny write_buffer_size) before deleting.
+    // Without this, in-flight compaction may hold segment references or
+    // create output files that clear_branch misses.
+    db.scheduler().drain();
+
     // Delete the branch through the engine-level API.
     branch_index.delete_branch("doomed").unwrap();
 


### PR DESCRIPTION
The compaction-on-open change (#2228) starts background compaction immediately on DB open. With write_buffer_size=1, the test's writes trigger compaction that races with delete_branch. In-flight compaction holds segment references, preventing file cleanup.

Fix: `db.scheduler().drain()` before deleting. 10/10 passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)