### PR TITLE
Compaction cache bypass: fill_cache=false for compaction reads

### DIFF
--- a/crates/storage/src/segment.rs
+++ b/crates/storage/src/segment.rs
@@ -32,11 +32,55 @@ use strata_core::error::StrataError;
 use strata_core::types::Key;
 use strata_core::value::Value;
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::io;
 use std::os::unix::fs::FileExt;
 use std::path::Path;
 use std::sync::Arc;
+
+// ── Compaction cache bypass (RocksDB fill_cache=false pattern) ──────────
+//
+// Compaction reads entire segments sequentially. Caching these reads
+// evicts hot user data — at 1M records, cache hit rate drops to 21-73%
+// despite a 15GB cache for 1GB of data (issue #2262).
+//
+// Thread-local flag: compaction threads set fill_cache=false before
+// iterating, so read_data_block skips cache insertion on miss.
+// User read threads keep the default fill_cache=true.
+
+thread_local! {
+    static FILL_CACHE: Cell<bool> = const { Cell::new(true) };
+}
+
+/// Set whether block reads on this thread should populate the cache.
+///
+/// Compaction sets this to `false` to avoid polluting the cache with
+/// sequential reads that will be immediately invalidated.
+pub fn set_fill_cache(fill: bool) {
+    FILL_CACHE.with(|c| c.set(fill));
+}
+
+fn should_fill_cache() -> bool {
+    FILL_CACHE.with(|c| c.get())
+}
+
+/// RAII guard that sets `fill_cache = false` on creation and restores
+/// `true` on drop. Ensures the flag is restored even on panic.
+pub struct NoCacheGuard;
+
+impl NoCacheGuard {
+    /// Create a guard that disables cache insertion for the current thread.
+    pub fn new() -> Self {
+        set_fill_cache(false);
+        NoCacheGuard
+    }
+}
+
+impl Drop for NoCacheGuard {
+    fn drop(&mut self) {
+        set_fill_cache(true);
+    }
+}
 
 // ── Segment block read profiling (STRATA_PROFILE_SEGMENT=1) ─────────────
 
@@ -996,7 +1040,7 @@ impl KVSegment {
             }
         }
 
-        // Cache the decompressed block
+        // Cache the decompressed block (unless compaction bypass is active)
         if profiling {
             let pread_ns = t_pread.map(|t| t.elapsed().as_nanos() as u64).unwrap_or(0);
             SEG_PROF.with(|p| {
@@ -1008,7 +1052,13 @@ impl KVSegment {
                 Self::maybe_print_seg_profile(&mut p);
             });
         }
-        Ok(cache.insert(self.file_id, block_offset, decompressed))
+        if should_fill_cache() {
+            Ok(cache.insert(self.file_id, block_offset, decompressed))
+        } else {
+            // Compaction bypass: return without caching to avoid evicting
+            // hot user data with sequential compaction reads.
+            Ok(Arc::new(decompressed))
+        }
     }
 
     /// Scan a single data block for the newest version of a typed key at or below snapshot.

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -247,6 +247,10 @@ impl SegmentedStore {
         std::fs::create_dir_all(&branch_dir)?;
         let seg_path = branch_dir.join(format!("{}.sst", seg_id));
 
+        // Compaction reads bypass the block cache to avoid evicting hot user
+        // data with sequential scans (RocksDB fill_cache=false pattern, #2262).
+        let _no_cache = crate::segment::NoCacheGuard::new();
+
         // Build streaming source iterators from each segment.
         let limiter = self.compaction_rate_limiter.load_full();
         let (sources, corruption_flags) = streaming_sources(&old_segments, &limiter);
@@ -406,6 +410,7 @@ impl SegmentedStore {
         std::fs::create_dir_all(&branch_dir)?;
         let seg_path = branch_dir.join(format!("{}.sst", seg_id));
 
+        let _no_cache = crate::segment::NoCacheGuard::new();
         let limiter = self.compaction_rate_limiter.load_full();
         let (sources, corruption_flags) = streaming_sources(&selected_segments, &limiter);
 
@@ -598,6 +603,7 @@ impl SegmentedStore {
         all_inputs.extend(l0_segs.iter().cloned());
         all_inputs.extend(overlapping_l1.iter().cloned());
 
+        let _no_cache = crate::segment::NoCacheGuard::new();
         let limiter = self.compaction_rate_limiter.load_full();
         let (sources, corruption_flags) = streaming_sources(&all_inputs, &limiter);
         let merge = MergeIterator::new(sources);
@@ -858,6 +864,7 @@ impl SegmentedStore {
         all_inputs.extend(input_segs.iter().cloned());
         all_inputs.extend(overlap_segs.iter().cloned());
 
+        let _no_cache = crate::segment::NoCacheGuard::new();
         let limiter = self.compaction_rate_limiter.load_full();
         let (sources, corruption_flags) = streaming_sources(&all_inputs, &limiter);
         let merge = MergeIterator::new(sources);


### PR DESCRIPTION
## Summary

Thread-local `fill_cache` flag prevents compaction from polluting the block cache with sequential reads. `NoCacheGuard` RAII guard sets `fill_cache=false` in all 4 compaction entry points.

Matches RocksDB's `compaction_job.cc:1417` pattern.

## Issue

#2262 — At 1M records, compaction reads fill the cache with blocks that are immediately invalidated, causing hit rate oscillation 21-73%.

## Design

- Thread-local `Cell<bool>` checked by `read_data_block` on cache miss
- Cache HITS still served normally (no bypass for existing hot data)
- `NoCacheGuard` restores flag on drop (panic-safe)
- Zero signature changes to iterators or read paths

## Note on benchmark impact

This alone doesn't significantly move YCSB Workload A at 1M because the write path overhead (26μs/update p50) dominates throughput, not read cache misses. The fix is correct for cache hygiene and will help when the write path is optimized further.

## Test plan

- [x] `cargo test -p strata-storage` — 650 pass
- [x] `cargo test -p strata-engine` — 796 pass
- [x] `cargo clippy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)