### PR TITLE
engine/executor/vector: close mixed-opener bypass (lifecycle audit Findings 2+3)

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -441,6 +441,23 @@ impl Database {
         *self.subsystems.write() = subsystems;
     }
 
+    /// Return the names of the subsystems currently installed on this
+    /// `Database`, in registration order.
+    ///
+    /// Used by `acquire_primary_db`'s fast-path mixed-opener detection
+    /// and by `Strata::from_database` to surface cases where a caller
+    /// wrapped a `Database` that was opened without the production
+    /// subsystem set (see audit follow-up to stratalab/strata-core#2354,
+    /// Finding 2). Also useful as a general diagnostic accessor.
+    ///
+    /// Returns an empty vec for cache databases or any `Database`
+    /// whose subsystems have not yet been installed (e.g. a partially-
+    /// opened instance inside `acquire_primary_db` after `open_finish`
+    /// but before the recovery loop completes).
+    pub fn installed_subsystem_names(&self) -> Vec<&'static str> {
+        self.subsystems.read().iter().map(|s| s.name()).collect()
+    }
+
     /// Run freeze hooks on all registered subsystems.
     ///
     /// Called during shutdown and drop. Attempts all hooks even if one fails,

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -266,6 +266,33 @@ impl Database {
 
         if let Some(weak) = registry.get(&canonical_path) {
             if let Some(db) = weak.upgrade() {
+                // Mixed-opener detection (audit follow-up to #2354
+                // Finding 2): compare the requested subsystem list to
+                // the list that is actually installed on the existing
+                // instance. If they differ, the second caller's
+                // subsystems are silently dropped — the single-
+                // instance-per-path contract requires us to return
+                // the existing Arc unchanged. Log a warning so the
+                // misuse surfaces at runtime. Order matters: reversed
+                // lists produce different freeze orders.
+                let installed = db.installed_subsystem_names();
+                let requested: Vec<&'static str> = subsystems.iter().map(|s| s.name()).collect();
+                if installed != requested {
+                    tracing::warn!(
+                        target: "strata::db",
+                        path = ?canonical_path,
+                        installed = ?installed,
+                        requested = ?requested,
+                        "Mixed-opener detected: an earlier caller opened this \
+                         database with a different subsystem list. Returning \
+                         the existing instance with the EARLIER subsystems; \
+                         the requested subsystems were silently dropped. Use \
+                         the same opener (e.g. `Strata::open` everywhere, or \
+                         `DatabaseBuilder` with the same list) across all \
+                         call sites for this path. See audit follow-up to \
+                         #2354 Finding 2."
+                    );
+                }
                 info!(target: "strata::db", path = ?canonical_path, "Returning existing database instance");
                 return Ok(db);
             }

--- a/crates/engine/tests/recovery_tests.rs
+++ b/crates/engine/tests/recovery_tests.rs
@@ -2214,3 +2214,97 @@ fn test_recovery_panic_does_not_deadlock() {
         ),
     }
 }
+
+// ============================================================================
+// Audit-follow-up regression for stratalab/strata-core#2354 Finding 2:
+// mixed-opener bypass must preserve the earlier subsystem list. See the
+// fast-path mismatch warning in `acquire_primary_db`.
+// ============================================================================
+
+/// Trivial test-only `Subsystem` whose `recover()` is a no-op. Used by
+/// `test_mixed_opener_returns_earlier_subsystems` to construct a second
+/// caller's subsystem list that is intentionally distinct from
+/// `Database::open`'s hardcoded `[SearchSubsystem]`.
+struct NoopRegressionSubsystem;
+
+impl strata_engine::Subsystem for NoopRegressionSubsystem {
+    fn name(&self) -> &'static str {
+        "noop-mixed-opener-regression"
+    }
+
+    fn recover(&self, _db: &Arc<Database>) -> strata_core::StrataResult<()> {
+        Ok(())
+    }
+}
+
+/// Audit follow-up to stratalab/strata-core#2354 Finding 2.
+///
+/// When two callers open the same canonical path through
+/// `acquire_primary_db` with different subsystem lists, the fast-path
+/// single-instance-per-path contract returns the **earlier** instance
+/// unchanged — the second caller's requested subsystems are silently
+/// dropped. This is the behavior we are locking in, not the behavior
+/// we wish we had: `Strata` / `DatabaseBuilder` callers must notice
+/// the mismatch via the `tracing::warn!` that `acquire_primary_db`'s
+/// fast path emits. "Upgrading" the subsystem list instead would
+/// break the singleton-per-path contract and surprise callers who
+/// mix `Database::open` and `Strata::open` in the same process.
+///
+/// The test asserts two invariants:
+///   1. Singleton-per-path: `Arc::ptr_eq(&db_a, &db_b)`.
+///   2. The installed subsystem list on the returned Arc is what the
+///      FIRST caller requested — the second caller's distinct
+///      subsystems are not present.
+///
+/// Lives in the integration test binary (not `crates/engine/src/database/tests.rs`)
+/// because several lib tests call `OPEN_DATABASES.lock().clear()` for
+/// their own isolation; in parallel test runs they would wipe this
+/// test's fresh registry entry out from under it, causing the second
+/// `open()` to fall through to a file-lock collision. Integration
+/// tests run in a separate process so the race cannot fire.
+#[test]
+fn test_mixed_opener_returns_earlier_subsystems() {
+    use strata_engine::DatabaseBuilder;
+
+    let temp = TempDir::new().unwrap();
+
+    // Caller A: bare `Database::open` → `[SearchSubsystem]`.
+    let db_a = Database::open(temp.path()).unwrap();
+    assert_eq!(
+        db_a.installed_subsystem_names(),
+        vec!["search"],
+        "Database::open should install only SearchSubsystem"
+    );
+
+    // Caller B: `DatabaseBuilder` with an intentionally different
+    // subsystem list (`SearchSubsystem` + `NoopRegressionSubsystem`).
+    // This enters `acquire_primary_db`, hits the registry fast path,
+    // and must return the SAME Arc as caller A — with caller A's
+    // subsystem list, not caller B's.
+    let db_b = DatabaseBuilder::new()
+        .with_subsystem(strata_engine::SearchSubsystem)
+        .with_subsystem(NoopRegressionSubsystem)
+        .open(temp.path())
+        .unwrap();
+
+    // Singleton-per-path invariant.
+    assert!(
+        Arc::ptr_eq(&db_a, &db_b),
+        "same-path opens must return the same Arc<Database> \
+         (single-instance-per-path contract)"
+    );
+
+    // Key assertion: the installed list is A's, not B's. Caller B's
+    // `NoopRegressionSubsystem` was silently dropped. If a future
+    // refactor ever makes the second caller's list win, this
+    // assertion fires.
+    assert_eq!(
+        db_b.installed_subsystem_names(),
+        vec!["search"],
+        "mixed-opener bypass must preserve the EARLIER subsystem list; \
+         caller B's requested `noop-mixed-opener-regression` subsystem \
+         was silently dropped (see tracing::warn! in \
+         acquire_primary_db's fast path, audit follow-up to #2354 \
+         Finding 2)"
+    );
+}

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -401,6 +401,29 @@ impl Strata {
     ///
     /// Use this when you need more control over database configuration.
     /// For most cases, prefer [`Strata::open()`].
+    ///
+    /// # Subsystem contract
+    ///
+    /// The supplied `Arc<Database>` **must** have been opened through a
+    /// builder that installed the production subsystem set
+    /// (`VectorSubsystem` + `SearchSubsystem`). The recommended path is:
+    ///
+    /// ```text
+    /// use strata_engine::{DatabaseBuilder, SearchSubsystem};
+    /// use strata_vector::VectorSubsystem;
+    ///
+    /// let db = DatabaseBuilder::new()
+    ///     .with_subsystem(VectorSubsystem)
+    ///     .with_subsystem(SearchSubsystem)
+    ///     .open("/path/to/data")?;
+    /// let strata = Strata::from_database(db)?;
+    /// ```
+    ///
+    /// If you hand in a `Database` opened via `Database::open` or a
+    /// plain `DatabaseBuilder::new().open(...)` without
+    /// `VectorSubsystem`, vector recovery and drop-time freeze will
+    /// silently not run for this handle. A `tracing::warn!` is
+    /// emitted in that case so the misuse surfaces at runtime.
     pub fn from_database(db: Arc<Database>) -> Result<Self> {
         Self::from_database_with_mode(db, AccessMode::ReadWrite)
     }
@@ -409,6 +432,35 @@ impl Strata {
     /// specific access mode.
     fn from_database_with_mode(db: Arc<Database>, access_mode: AccessMode) -> Result<Self> {
         ensure_merge_handlers_registered();
+
+        // Mixed-opener detection (audit follow-up to #2354 Finding 2).
+        // A caller wrapping a bare `Database::open` / plain-builder
+        // result loses vector recovery + drop-freeze guarantees
+        // silently. We can't reject this — `new_handle` and test
+        // fixtures both route through here with already-valid dbs —
+        // but we can surface the mismatch. Skip for cache databases:
+        // they have no persistent vector state and their subsystems
+        // are no-ops by design, so test fixtures using
+        // `Database::cache()` should not trip the warning.
+        if !db.is_cache() {
+            let installed = db.installed_subsystem_names();
+            if !installed.contains(&"vector") {
+                tracing::warn!(
+                    target: "strata::executor",
+                    installed = ?installed,
+                    "Strata::from_database was handed a disk-backed Database \
+                     without VectorSubsystem installed. Vector recovery and \
+                     drop-time freeze will not run for this handle. If you \
+                     opened the Database via `Database::open` or plain \
+                     `DatabaseBuilder::new().open(...)` without explicitly \
+                     adding `VectorSubsystem`, vector state will not survive \
+                     drop+reopen. Prefer `Strata::open` / `Strata::open_with` \
+                     for the full production subsystem set. See audit \
+                     follow-up to #2354 Finding 2."
+                );
+            }
+        }
+
         let executor = Executor::new_with_mode(db, access_mode);
 
         match access_mode {

--- a/crates/vector/src/store/mod.rs
+++ b/crates/vector/src/store/mod.rs
@@ -104,11 +104,20 @@ fn validate_query_values(values: &[f32]) -> VectorResult<()> {
 /// # Example
 ///
 /// ```text
-/// use strata_primitives::VectorStore;
-/// use strata_engine::Database;
+/// use strata_engine::DatabaseBuilder;
+/// use strata_vector::{VectorConfig, VectorStore, VectorSubsystem};
 /// use strata_core::types::BranchId;
 ///
-/// let db = Database::open("/path/to/data")?;
+/// // Open via DatabaseBuilder with VectorSubsystem so vector recovery
+/// // and drop-time freeze are installed. `Database::open` alone does
+/// // NOT install VectorSubsystem — always use the builder (or
+/// // `strata_executor::Strata::open`, which wraps this pattern) for
+/// // disk-backed vector stores, otherwise vector state will not
+/// // survive drop+reopen.
+/// let db = DatabaseBuilder::new()
+///     .with_subsystem(VectorSubsystem)
+///     .open("/path/to/data")?;
+///
 /// let store = VectorStore::new(db.clone());
 /// let branch_id = BranchId::new();
 ///
@@ -116,7 +125,8 @@ fn validate_query_values(values: &[f32]) -> VectorResult<()> {
 /// let config = VectorConfig::for_minilm();
 /// store.create_collection(branch_id, "embeddings", config)?;
 ///
-/// // Multiple stores share the same backend state
+/// // Multiple stores share the same backend state (VectorBackendState
+/// // is a Database extension)
 /// let store2 = VectorStore::new(db.clone());
 /// // store2 sees the same collections as store
 /// ```


### PR DESCRIPTION
## Summary

Close the two remaining observability/documentation gaps from the post-merge audit of the lifecycle unification refactor (stratalab/strata-core#2354). Finding 1 already shipped as stratalab/strata-core#2378. These are non-behavioral — runtime warnings + doc corrections so the footgun surfaces instead of silently stripping vector guarantees.

## Finding 2 — mixed-opener bypass

\`Database::open\` hardcodes \`[SearchSubsystem]\`. \`Strata::open\` uses \`[VectorSubsystem, SearchSubsystem]\`. If caller A opens a path via \`Database::open\` first, the OPEN_DATABASES entry is tagged with \`[search]\`. A subsequent \`DatabaseBuilder::new().with_subsystem(VectorSubsystem)...open()\` (or \`Strata::open()\`) enters \`acquire_primary_db\`, hits the registry fast path, and returns the existing Arc **with caller A's earlier subsystem list**. Caller B's requested \`VectorSubsystem\` is silently dropped. Similarly, \`Strata::from_database(db: Arc<Database>)\` wraps any Arc without validating the subsystem contract.

### Fix

- **\`Database::installed_subsystem_names()\`** — new \`pub\` accessor returning \`Vec<&'static str>\`.
- **\`acquire_primary_db\` fast path** — \`tracing::warn!\` on installed-vs-requested mismatch. Still returns the existing instance (the singleton-per-path contract is load-bearing; "upgrading" would surprise callers). Order-sensitive because \`[Vector, Search]\` vs \`[Search, Vector]\` produce different freeze orders.
- **\`Strata::from_database_with_mode\`** — \`tracing::warn!\` when the supplied disk-backed \`Arc<Database>\` lacks a subsystem named \`\"vector\"\`. Gated on \`!db.is_cache()\` so the existing test fixtures using \`Database::cache()\` don't trip it. Verified both \`session_from_strata\` and \`strata_api_thread_safe\` still pass.

## Finding 3 — rustdoc footguns

- **\`crates/vector/src/store/mod.rs\` VectorStore example** — pointed at \`Database::open(\"/path/to/data\")?\`, the exact bypass path Finding 2 is about. Also imported from the non-existent \`strata_primitives\` crate (stale from an earlier reorg). Rewritten to use \`DatabaseBuilder::new().with_subsystem(VectorSubsystem).open(...)\` with an inline comment explaining why \`Database::open\` alone is wrong for disk-backed vector stores.
- **\`Strata::from_database\` rustdoc** — added a \`# Subsystem contract\` section with the recommended \`DatabaseBuilder\` pattern and an explicit warning that passing a \`Database::open\`-produced handle silently loses vector guarantees.

## Regression test

\`crates/engine/tests/recovery_tests.rs::test_mixed_opener_returns_earlier_subsystems\` — opens a tempdir path via \`Database::open\`, then via \`DatabaseBuilder\` with a distinct subsystem list, asserts:

1. Singleton-per-path: \`Arc::ptr_eq(&db_a, &db_b)\`
2. Installed list is what caller A requested — caller B's distinct \`NoopRegressionSubsystem\` was dropped

Lives in the integration test binary (not \`crates/engine/src/database/tests.rs\`) because several lib tests call \`OPEN_DATABASES.lock().clear()\` for their own isolation; in parallel test runs they would wipe my fresh registry entry out from under me. Integration tests run in a separate process so the race cannot fire. I discovered this by moving the test into tests.rs first and hitting the failure mode empirically.

## What is NOT in this PR

- No change to the fast-path return value — still silently returns the earlier instance. "Upgrading" would break the singleton contract.
- No change to \`Database::open\` — still installs \`[SearchSubsystem]\`. Deleting it is a bigger API change out of scope.
- 7 pre-existing \`cargo doc -p strata-vector\` warnings (unresolved \`[d]\` link, unclosed \`<f32>\` tags) unchanged — verified against origin/main, not introduced here.

## Epic tracker

- Closes audit follow-up to stratalab/strata-core#2354 (Findings 2 + 3). Finding 1 is stratalab/strata-core#2378 (merged).

## Test plan

- [x] \`cargo check -p strata-engine -p strata-vector -p strata-executor\` — clean
- [x] \`cargo test -p strata-engine --test recovery_tests\` — 37 tests (was 36; +1 mixed-opener) all green
- [x] \`cargo test -p strata-executor lifecycle_regression\` — Epic 5 regressions still green
- [x] \`cargo test -p strata-engine --lib\` — 835 tests green
- [x] \`cargo test -p strata-engine -p strata-executor\` — full suites all green
- [x] \`cargo test --test executor strata_api::session_from_strata\` — cache db, no warning, green
- [x] \`cargo test --test executor adversarial::strata_api_thread_safe\` — cache db, no warning, green
- [x] \`cargo clippy --workspace --all-targets --exclude strata-inference -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo doc -p strata-vector --no-deps\` — 7 pre-existing warnings, zero new

🤖 Generated with [Claude Code](https://claude.com/claude-code)