### PR TITLE
chore(workspace): centralize lints, deps, and metadata (T1-E2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,12 @@ edition = "2021"
 license = "Apache-2.0"
 description = "Production-grade embedded database for AI agents"
 
+[lints]
+workspace = true
+
 [workspace]
 resolver = "2"
+default-members = ["crates/executor", "crates/cli", "crates/engine"]
 members = [
     "crates/core",
     "crates/storage",
@@ -30,6 +34,29 @@ rust-version = "1.88"
 authors = ["Strata contributors"]
 license = "Apache-2.0"
 repository = "https://github.com/anibjoshi/strata"
+
+[workspace.lints.rust]
+unused_must_use = "deny"
+unsafe_op_in_unsafe_fn = "warn"
+missing_docs = "warn"
+unreachable_pub = "warn"
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+# Relaxations for existing code patterns
+module_name_repetitions = "allow"
+too_many_arguments = "allow"
+must_use_candidate = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+# Existing code uses these patterns - fix in later cleanup
+map_err_ignore = "allow"
+manual_div_ceil = "allow"
+manual_is_multiple_of = "allow"
+io_other_error = "allow"
+option_map_or_none = "allow"
+unnecessary_map_or = "allow"
 
 [workspace.dependencies]
 # Core dependencies shared across crates
@@ -70,6 +97,22 @@ base64 = "0.21"
 rand = "0.8"
 tempfile = "3.8"
 serde_json = "1.0"
+proptest = "1.7"
+criterion = "0.5"
+
+# Cryptography
+sha2 = "0.10"
+aes-gcm = "0.10"
+
+# System
+fs2 = "0.4"
+libc = "0.2"
+crc32fast = "1.3"
+
+# Data structures
+arc-swap = "1"
+crossbeam-skiplist = "0.1"
+static_assertions = "1.1"
 
 # String similarity
 strsim = "0.11"
@@ -135,7 +178,7 @@ rusqlite = { version = "0.32", features = ["bundled", "serde_json"], optional = 
 usearch = { version = "2.0", optional = true }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = { workspace = true }
 tempfile = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
@@ -152,5 +195,5 @@ strata-vector = { path = "crates/vector" }
 strata-intelligence = { path = "crates/intelligence" }
 strata-search = { path = "crates/search" }
 uuid = { workspace = true }
-crc32fast = "1.3"
-base64 = "0.21"
+crc32fast = { workspace = true }
+base64 = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "strata-cli"
-version = "0.6.1"
-edition = "2021"
-description = "Redis-inspired CLI for the Strata database"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
 license.workspace = true
+repository.workspace = true
+description = "Redis-inspired CLI for the Strata database"
 publish = false
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "strata"
@@ -25,7 +31,7 @@ strata-executor = { path = "../executor" }
 strata-intelligence = { path = "../intelligence", features = ["embed"], optional = true }
 clap = { version = "4", features = ["string"] }
 daemonize = "0.5"
-libc = "0.2"
+libc = { workspace = true }
 rustyline = { version = "15", features = ["with-file-history"] }
 shlex = "1"
 serde_json = { workspace = true }

--- a/crates/concurrency/Cargo.toml
+++ b/crates/concurrency/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [features]
 default = []
 perf-trace = ["strata-core/perf-trace"]  # Enable per-operation timing in commit path
@@ -26,5 +29,5 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
-static_assertions = "1.1"
+static_assertions = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -10,9 +10,6 @@
 //! - WAL integration for durability
 //! - JSON region-based conflict detection
 
-#![warn(missing_docs)]
-#![warn(clippy::all)]
-
 pub(crate) mod conflict;
 pub mod lock_ordering;
 pub mod manager;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [features]
 default = []
 perf-trace = []  # Enable per-operation timing instrumentation

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,9 +11,6 @@
 //! - Primitive types: Event, JSON, Vector types (in `primitives` module)
 //! - Contract types: EntityRef, Versioned<T>, Version, Timestamp, PrimitiveType, BranchName
 
-#![warn(missing_docs)]
-#![warn(clippy::all)]
-
 // Module declarations
 pub mod branch_dag; // Branch DAG types and constants
 pub mod branch_types; // Branch lifecycle types

--- a/crates/durability/Cargo.toml
+++ b/crates/durability/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [features]
 default = []
 
@@ -20,9 +23,9 @@ rmp-serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
-crc32fast = "1.3"
-fs2 = "0.4"
-aes-gcm = "0.10"
+crc32fast = { workspace = true }
+fs2 = { workspace = true }
+aes-gcm = { workspace = true }
 rand = { workspace = true }
 
 # RunBundle support
@@ -31,7 +34,7 @@ zstd = { workspace = true }
 xxhash-rust = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -13,9 +13,6 @@
 //! Recovery planning lives in `strata_concurrency::RecoveryCoordinator`,
 //! which consumes the building blocks above.
 
-#![warn(missing_docs)]
-#![warn(clippy::all)]
-
 // === Modules ===
 pub mod branch_bundle; // Portable execution artifacts (BranchBundle)
 pub mod codec; // Storage codec abstraction (identity, future encryption/compression)

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [features]
 default = []
 perf-trace = ["strata-concurrency/perf-trace"]  # Enable per-operation timing instrumentation
@@ -27,8 +30,8 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
-fs2 = "0.4"
-sha2 = "0.10.9"
+fs2 = { workspace = true }
+sha2 = { workspace = true }
 base64 = { workspace = true }
 byteorder = { workspace = true }
 rmp-serde = { workspace = true }
@@ -38,11 +41,11 @@ rayon = { workspace = true }
 smallvec = { workspace = true }
 unicode-segmentation = "1.12"
 chrono = { workspace = true }
-libc = "0.2"
+libc = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-criterion = "0.5"
+criterion = { workspace = true }
 serde_json = { workspace = true }
 tracing-subscriber = { workspace = true }
 strata-vector = { path = "../vector" }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -20,9 +20,6 @@
 //! cargo build --features perf-trace
 //! ```
 
-#![warn(missing_docs)]
-#![warn(clippy::all)]
-
 pub mod background;
 pub mod coordinator;
 pub mod database;

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 publish = false
 description = "Command execution layer for Strata database"
 
+[lints]
+workspace = true
+
 [features]
 default = []
 embed = ["strata-intelligence/embed", "strata-engine/embed"]
@@ -55,7 +58,7 @@ strsim = { workspace = true }
 tracing = { workspace = true }
 
 # Unix signals for IPC server
-libc = "0.2"
+libc = { workspace = true }
 
 # Arrow interoperability (optional)
 arrow = { workspace = true, optional = true }

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -45,8 +45,6 @@
 //! // Data from experiment-1 is not visible here
 //! ```
 
-#![warn(missing_docs)]
-
 mod api;
 pub(crate) mod bridge;
 mod command;

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -1,9 +1,15 @@
 [package]
 name = "strata-graph"
-version = "0.6.1"
-edition = "2021"
-description = "Graph engine for StrataDB"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
 license.workspace = true
+repository.workspace = true
+description = "Graph engine for StrataDB"
+
+[lints]
+workspace = true
 
 [dependencies]
 strata-core = { path = "../core" }

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 publish = false
 description = "Inference engine for Strata — local (llama.cpp) and cloud providers"
 
+[lints]
+workspace = true
+
 [features]
 default = ["local"]
 local = ["dep:cmake"]   # Compile llama.cpp from vendored source (GPU auto-detected)
@@ -24,7 +27,7 @@ cmake = { version = "0.1", optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 ureq = { workspace = true, optional = true }
-sha2 = { version = "0.10", optional = true }
+sha2 = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 

--- a/crates/intelligence/Cargo.toml
+++ b/crates/intelligence/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 publish = false
 description = "Embedding and inference infrastructure for Strata"
 
+[lints]
+workspace = true
+
 [features]
 default = []
 embed = ["dep:strata-inference"]
@@ -25,7 +28,7 @@ strata-search = { path = "../search" }
 tracing = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sha2 = "0.10"
+sha2 = { workspace = true }
 strata-inference = { path = "../inference", optional = true, features = ["local", "download"] }
 
 [dev-dependencies]

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 publish = false
 description = "Pluggable search orchestration for Strata"
 
+[lints]
+workspace = true
+
 [features]
 default = []
 expand = ["dep:ureq"]

--- a/crates/security/Cargo.toml
+++ b/crates/security/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 publish = false
 description = "Access control and configuration for Strata database"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { workspace = true }
 zeroize = "1"

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -3,8 +3,6 @@
 //! This crate provides the [`AccessMode`] and [`OpenOptions`] types used to
 //! control how a database is opened and what operations are permitted.
 
-#![warn(missing_docs)]
-
 mod sensitive;
 
 pub use sensitive::SensitiveString;

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -8,21 +8,24 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 strata-core = { path = "../core" }
 dashmap = { workspace = true }
 rustc-hash = { workspace = true }
 thiserror = { workspace = true }
-crossbeam-skiplist = "0.1.3"
-crc32fast = "1.3"
+crossbeam-skiplist = { workspace = true }
+crc32fast = { workspace = true }
 bincode = { workspace = true }
-zstd = "0.13"
+zstd = { workspace = true }
 parking_lot = { workspace = true }
-arc-swap = "1"
+arc-swap = { workspace = true }
 tracing = { workspace = true }
 xxhash-rust = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.7.0"
+proptest = { workspace = true }
 rand = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -10,9 +10,6 @@
 //!
 //! Persistence and durability are handled by the `strata-durability` crate.
 
-#![warn(missing_docs)]
-#![warn(clippy::all)]
-
 pub mod block_cache;
 pub mod bloom;
 pub mod compaction;

--- a/crates/vector/Cargo.toml
+++ b/crates/vector/Cargo.toml
@@ -1,9 +1,15 @@
 [package]
 name = "strata-vector"
-version = "0.6.1"
-edition = "2021"
-description = "Vector similarity search engine for StrataDB"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
 license.workspace = true
+repository.workspace = true
+description = "Vector similarity search engine for StrataDB"
+
+[lints]
+workspace = true
 
 [dependencies]
 strata-core = { path = "../core" }
@@ -24,7 +30,7 @@ parking_lot = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 rand = { workspace = true }
-fs2 = "0.4"
+fs2 = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }


### PR DESCRIPTION
## Summary

- Add `[workspace.lints]` with `clippy::all = "deny"`, `clippy::pedantic = "warn"`
- Add `[lints] workspace = true` to all 14 crates
- Add `default-members = ["crates/executor", "crates/cli", "crates/engine"]`
- Centralize 10 dependencies in `[workspace.dependencies]`
- Normalize metadata in cli, graph, vector (full workspace inheritance)
- Delete 12 `#![warn()]` attributes from lib.rs files

## Centralized Dependencies

| Dependency | Crates Using |
|------------|--------------|
| fs2 | durability, engine, vector |
| libc | cli, durability, engine, executor |
| sha2 | engine, inference, intelligence |
| aes-gcm | durability |
| crc32fast | durability, storage |
| arc-swap | storage |
| crossbeam-skiplist | storage |
| proptest | storage |
| static_assertions | concurrency |
| criterion | engine, root |

## Clippy Relaxations

Added for existing code patterns (to fix post-cleanup):
- `map_err_ignore`, `manual_div_ceil`, `manual_is_multiple_of`
- `io_other_error`, `option_map_or_none`, `unnecessary_map_or`

~6k pedantic warnings tracked in #2389.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets` passes (warnings only)
- [x] `cargo test --workspace --lib` passes (323 tests)
- [x] All 14 crates have `[lints] workspace = true`
- [x] Zero `#![warn(` attributes in lib.rs files

## Tranche

```
tranche: 1
epic: T1-E2
change_class: refactor-only
assurance_class: S2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)