### PR TITLE
refactor(errors): T1-E6 — add #[non_exhaustive] to 29 public error enums

### DIFF
--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -60,6 +60,7 @@ pub fn format_error(err: &Error, mode: OutputMode) -> String {
                 ErrorSeverity::UserError => "user_error",
                 ErrorSeverity::SystemFailure => "system_error",
                 ErrorSeverity::InternalBug => "internal_bug",
+                _ => "unknown",
             };
             serde_json::to_string_pretty(&serde_json::json!({
                 "error": format!("{}", err),
@@ -73,6 +74,7 @@ pub fn format_error(err: &Error, mode: OutputMode) -> String {
                 ErrorSeverity::UserError => "(error)",
                 ErrorSeverity::SystemFailure => "(system error)",
                 ErrorSeverity::InternalBug => "(internal bug)",
+                _ => "(unknown)",
             };
             format!("{} {}", prefix, err)
         }

--- a/crates/concurrency/src/payload.rs
+++ b/crates/concurrency/src/payload.rs
@@ -145,6 +145,7 @@ pub fn serialize_wal_record_into(
 }
 
 /// Errors from payload serialization/deserialization.
+#[non_exhaustive]
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum PayloadError {
     /// Failed to deserialize payload bytes

--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -24,6 +24,7 @@ use strata_storage::SegmentedStore;
 /// Per spec Core Invariants:
 /// - All-or-nothing commit: transaction either commits or aborts entirely
 /// - First-committer-wins: conflicts are detected based on read-set
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum CommitError {
     /// Transaction aborted due to validation conflicts

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -22,5 +22,6 @@ serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 bincode = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/core/src/contract/branch_name.rs
+++ b/crates/core/src/contract/branch_name.rs
@@ -53,6 +53,7 @@ pub const MAX_BRANCH_NAME_LENGTH: usize = 256;
 pub struct BranchName(String);
 
 /// Error when validating a branch name
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BranchNameError {
     /// Name is empty

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -449,6 +449,7 @@ impl std::fmt::Display for ConstraintReason {
 ///     Ok(value) => { /* success */ }
 /// }
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum StrataError {
     // =========================================================================

--- a/crates/core/src/limits.rs
+++ b/crates/core/src/limits.rs
@@ -271,6 +271,7 @@ impl Limits {
 /// Limit validation errors
 ///
 /// These errors map to `ConstraintViolation` error codes in the wire protocol.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum LimitError {
     /// Key exceeds maximum length

--- a/crates/core/src/primitives/json.rs
+++ b/crates/core/src/primitives/json.rs
@@ -58,6 +58,7 @@ pub const MAX_ARRAY_SIZE: usize = 1_000_000;
 ///
 /// This error type is specific to JSON document constraints (size, nesting, paths).
 /// For general value limits, see [`crate::limits::LimitError`].
+#[non_exhaustive]
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum JsonLimitError {
     /// Document exceeds maximum size
@@ -407,6 +408,7 @@ impl<T: Into<JsonValue>> From<Option<T>> for JsonValue {
 // =============================================================================
 
 /// Error type for JSON path parsing
+#[non_exhaustive]
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum PathParseError {
     /// Empty key in path
@@ -986,6 +988,7 @@ impl fmt::Display for JsonPatch {
 // =============================================================================
 
 /// Error type for path operations
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum JsonPathError {
     /// Type mismatch during path traversal

--- a/crates/durability/src/branch_bundle/error.rs
+++ b/crates/durability/src/branch_bundle/error.rs
@@ -4,6 +4,7 @@ use std::io;
 use thiserror::Error;
 
 /// Errors that can occur during BranchBundle operations
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum BranchBundleError {
     /// Branch not found in BranchIndex

--- a/crates/durability/src/codec/traits.rs
+++ b/crates/durability/src/codec/traits.rs
@@ -50,6 +50,7 @@ pub trait StorageCodec: Send + Sync {
 }
 
 /// Codec errors.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum CodecError {
     /// Decoding failed (e.g., decryption failure, invalid format).

--- a/crates/durability/src/compaction/mod.rs
+++ b/crates/durability/src/compaction/mod.rs
@@ -113,6 +113,7 @@ impl Default for CompactInfo {
 }
 
 /// Compaction error types
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum CompactionError {
     /// No snapshot available for compaction

--- a/crates/durability/src/compaction/tombstone.rs
+++ b/crates/durability/src/compaction/tombstone.rs
@@ -434,6 +434,7 @@ impl TombstoneIndex {
 }
 
 /// Tombstone errors
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum TombstoneError {
     /// Not enough data to parse tombstone

--- a/crates/durability/src/disk_snapshot/checkpoint.rs
+++ b/crates/durability/src/disk_snapshot/checkpoint.rs
@@ -216,6 +216,7 @@ impl CheckpointData {
 }
 
 /// Errors that can occur during checkpoint creation
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum CheckpointError {
     /// IO error during checkpoint

--- a/crates/durability/src/disk_snapshot/reader.rs
+++ b/crates/durability/src/disk_snapshot/reader.rs
@@ -238,6 +238,7 @@ impl LoadedSection {
 }
 
 /// Errors that can occur when reading a snapshot
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum SnapshotReadError {
     /// File is too small to be a valid snapshot

--- a/crates/durability/src/format/manifest.rs
+++ b/crates/durability/src/format/manifest.rs
@@ -318,6 +318,7 @@ impl ManifestManager {
 }
 
 /// Errors that can occur with MANIFEST operations
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum ManifestError {
     /// MANIFEST file too short

--- a/crates/durability/src/format/primitives.rs
+++ b/crates/durability/src/format/primitives.rs
@@ -439,6 +439,7 @@ impl SnapshotSerializer {
 }
 
 /// Errors that can occur during primitive serialization
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum PrimitiveSerializeError {
     /// Unexpected end of data

--- a/crates/durability/src/format/segment_meta.rs
+++ b/crates/durability/src/format/segment_meta.rs
@@ -195,6 +195,7 @@ impl SegmentMeta {
 }
 
 /// Errors that can occur when reading or writing segment metadata.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum SegmentMetaError {
     /// Data too short to contain a valid metadata header.

--- a/crates/durability/src/format/snapshot.rs
+++ b/crates/durability/src/format/snapshot.rs
@@ -123,6 +123,7 @@ impl SnapshotHeader {
 }
 
 /// Errors that can occur when validating a snapshot header
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum SnapshotHeaderError {
     /// Invalid magic bytes

--- a/crates/durability/src/format/wal_record.rs
+++ b/crates/durability/src/format/wal_record.rs
@@ -803,6 +803,7 @@ impl WalRecord {
 }
 
 /// WAL record parsing errors.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum WalRecordError {
     /// Not enough data to parse record

--- a/crates/durability/src/format/watermark.rs
+++ b/crates/durability/src/format/watermark.rs
@@ -142,6 +142,7 @@ impl Default for SnapshotWatermark {
 }
 
 /// Errors that can occur with watermark operations
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum WatermarkError {
     /// Insufficient data for deserialization

--- a/crates/durability/src/format/writeset.rs
+++ b/crates/durability/src/format/writeset.rs
@@ -473,6 +473,7 @@ impl Writeset {
 }
 
 /// Writeset parsing errors.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum WritesetError {
     /// Not enough data to parse

--- a/crates/durability/src/wal/config.rs
+++ b/crates/durability/src/wal/config.rs
@@ -71,6 +71,7 @@ impl WalConfig {
 }
 
 /// WAL configuration errors.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum WalConfigError {
     /// Segment size is too small (minimum 1KB).

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -575,6 +575,7 @@ impl TruncateInfo {
 }
 
 /// WAL reader errors.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum WalReaderError {
     /// I/O error

--- a/crates/engine/src/primitives/event.rs
+++ b/crates/engine/src/primitives/event.rs
@@ -156,6 +156,7 @@ pub fn compute_event_hash(
 }
 
 /// Validation error for EventLog operations
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub enum EventLogValidationError {
     /// Payload must be an object, not a primitive or array

--- a/crates/executor/src/convert.rs
+++ b/crates/executor/src/convert.rs
@@ -167,6 +167,18 @@ impl From<StrataError> for Error {
                         .to_string(),
                 ),
             },
+
+            // Catch-all for future StrataError variants
+            _ => {
+                tracing::warn!(target: "strata::error::exhaustive", "unmapped StrataError variant in executor conversion");
+                Error::Internal {
+                    reason: format!("Unmapped error: {err}"),
+                    hint: Some(
+                        "A new error variant was added that the executor doesn't handle yet."
+                            .to_string(),
+                    ),
+                }
+            }
         }
     }
 }

--- a/crates/executor/src/error.rs
+++ b/crates/executor/src/error.rs
@@ -41,6 +41,7 @@ use serde::{Deserialize, Serialize};
 ///     }
 /// }
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, thiserror::Error)]
 pub enum Error {
     // ==================== Not Found ====================
@@ -322,6 +323,7 @@ pub enum Error {
 }
 
 /// Error severity classification for CLI output formatting.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorSeverity {
     /// User made a mistake (wrong input, missing entity, wrong type).

--- a/crates/inference/src/error.rs
+++ b/crates/inference/src/error.rs
@@ -1,4 +1,5 @@
 /// Errors that can occur during inference operations.
+#[non_exhaustive]
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum InferenceError {
     #[error("llama.cpp: {0}")]

--- a/crates/search/src/llm_client.rs
+++ b/crates/search/src/llm_client.rs
@@ -10,6 +10,7 @@ use std::fmt;
 // ============================================================================
 
 /// Errors that can occur when calling an external LLM endpoint
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum LlmClientError {
     /// HTTP request failed (network unreachable, connection refused, etc.)

--- a/crates/vector/src/error.rs
+++ b/crates/vector/src/error.rs
@@ -4,6 +4,7 @@ use strata_core::{BranchId, EntityRef, StrataError};
 use thiserror::Error;
 
 /// Errors specific to the Vector primitive
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum VectorError {
     /// Collection with given name was not found


### PR DESCRIPTION
## Summary

- Add `#[non_exhaustive]` attribute to 29 public error enums across 8 crates
- Add catch-all arms in external crates (executor, cli) for non-exhaustive matching
- Add `tracing` dependency to core crate for future catch-all logging
- Exclude `ErrorCode` and `ConstraintReason` (classification enums, not error enums)

This enables future architecture phases (T2–T6) to freely add error variants without coordinating catch-all migration across the codebase.

## Enums Updated

| Crate | Enums |
|-------|-------|
| core | `StrataError`, `LimitError`, `JsonLimitError`, `PathParseError`, `JsonPathError`, `BranchNameError` |
| executor | `Error`, `ErrorSeverity` |
| vector | `VectorError` |
| inference | `InferenceError` |
| concurrency | `CommitError`, `PayloadError` |
| durability | 15 enums (format, codec, wal, compaction, snapshot) |
| engine | `EventLogValidationError` |
| search | `LlmClientError` |

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets` — no errors
- [x] `cargo test --workspace` — all tests pass
- [x] Verified 29 `#[non_exhaustive]` attributes added
- [x] Verified `ErrorCode`/`ConstraintReason` excluded
- [x] No variant restructuring (attribute-only changes)

**Change-class:** refactor-only  
**Assurance-class:** S2 (benchmark exempted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)