### PR TITLE
refactor(core): T1-E7 — introduce TxnId and CommitVersion newtypes

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -35,6 +35,7 @@ use std::cell::RefCell;
 use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::perf_time;
 use strata_core::traits::Storage;
 use strata_core::types::BranchId;
@@ -191,8 +192,8 @@ impl TransactionManager {
     ///
     /// # Arguments
     /// * `initial_version` - Starting version (typically from recovery's final_version)
-    pub fn new(initial_version: u64) -> Self {
-        Self::with_txn_id(initial_version, 0)
+    pub fn new(initial_version: CommitVersion) -> Self {
+        Self::with_txn_id(initial_version, TxnId::ZERO)
     }
 
     /// Create a new transaction manager with specific starting txn_id
@@ -203,22 +204,22 @@ impl TransactionManager {
     /// # Arguments
     /// * `initial_version` - Starting version (from recovery's final_version)
     /// * `max_txn_id` - Maximum txn_id seen in WAL (new transactions start at max_txn_id + 1)
-    pub fn with_txn_id(initial_version: u64, max_txn_id: u64) -> Self {
+    pub fn with_txn_id(initial_version: CommitVersion, max_txn_id: TxnId) -> Self {
         TransactionManager {
-            version: AtomicU64::new(initial_version),
+            version: AtomicU64::new(initial_version.as_u64()),
             // Start next_txn_id at max_txn_id + 1 to avoid conflicts
-            next_txn_id: AtomicU64::new(max_txn_id + 1),
+            next_txn_id: AtomicU64::new(max_txn_id.as_u64() + 1),
             commit_locks: DashMap::new(),
             commit_quiesce: RwLock::new(()),
-            visible_version: AtomicU64::new(initial_version),
+            visible_version: AtomicU64::new(initial_version.as_u64()),
             pending_versions: Mutex::new(BTreeSet::new()),
             deleting_branches: DashSet::new(),
         }
     }
 
     /// Get current global version
-    pub fn current_version(&self) -> u64 {
-        self.version.load(Ordering::Acquire)
+    pub fn current_version(&self) -> CommitVersion {
+        CommitVersion(self.version.load(Ordering::Acquire))
     }
 
     /// Get the highest version where all data at versions ≤ V is fully applied.
@@ -232,8 +233,8 @@ impl TransactionManager {
     /// finish apply before A. A reader using `current_version()` (= N+1)
     /// would miss A's writes. `visible_version()` only advances to N+1
     /// once both A and B have completed their applies.
-    pub fn visible_version(&self) -> u64 {
-        self.visible_version.load(Ordering::Acquire)
+    pub fn visible_version(&self) -> CommitVersion {
+        CommitVersion(self.visible_version.load(Ordering::Acquire))
     }
 
     /// Mark a version as fully applied to storage.
@@ -242,9 +243,9 @@ impl TransactionManager {
     /// allocated but the commit fails, creating a version gap). Removes the
     /// version from the in-flight set and advances `visible_version` if the
     /// contiguous applied prefix has grown.
-    pub fn mark_version_applied(&self, version: u64) {
+    pub fn mark_version_applied(&self, version: CommitVersion) {
         let mut pending = self.pending_versions.lock();
-        pending.remove(&version);
+        pending.remove(&version.as_u64());
         let new_visible = match pending.iter().next() {
             // Some versions still in-flight: safe up to (lowest_pending - 1)
             Some(&min_pending) => min_pending.saturating_sub(1),
@@ -263,11 +264,11 @@ impl TransactionManager {
     /// has been fully compacted and contains no records.  Segments may hold
     /// data at versions higher than what the WAL reports; this method bumps
     /// the counter so that new transactions start above all existing data.
-    pub fn bump_version_floor(&self, floor: u64) {
-        self.version.fetch_max(floor, Ordering::AcqRel);
+    pub fn bump_version_floor(&self, floor: CommitVersion) {
+        self.version.fetch_max(floor.as_u64(), Ordering::AcqRel);
         // Recovery data at versions ≤ floor is already in storage,
         // so visible_version must reflect this (#1913).
-        self.visible_version.fetch_max(floor, Ordering::AcqRel);
+        self.visible_version.fetch_max(floor.as_u64(), Ordering::AcqRel);
     }
 
     /// Get the current version after draining all in-flight commits (#1710).
@@ -307,7 +308,7 @@ impl TransactionManager {
     /// Since reaching `u64::MAX` is physically impossible at any realistic
     /// throughput, we accept this theoretical race in exchange for
     /// contention-free allocation.
-    pub fn next_txn_id(&self) -> std::result::Result<u64, CommitError> {
+    pub fn next_txn_id(&self) -> std::result::Result<TxnId, CommitError> {
         let prev = self.next_txn_id.fetch_add(1, Ordering::AcqRel);
         if prev == u64::MAX {
             // Undo the wrapping increment: restore counter to u64::MAX
@@ -316,7 +317,7 @@ impl TransactionManager {
                 "transaction ID counter at u64::MAX".into(),
             ));
         }
-        Ok(prev)
+        Ok(TxnId(prev))
     }
 
     /// Allocate next commit version (increment global version)
@@ -338,7 +339,7 @@ impl TransactionManager {
     /// Overflow at `u64::MAX` is detected and repaired — practically unreachable
     /// (584 years at 1 billion txn/sec). See `next_txn_id` for the overflow
     /// race tradeoff rationale.
-    pub fn allocate_version(&self) -> std::result::Result<u64, CommitError> {
+    pub fn allocate_version(&self) -> std::result::Result<CommitVersion, CommitError> {
         let mut pending = self.pending_versions.lock();
         let prev = self.version.fetch_add(1, Ordering::AcqRel);
         if prev == u64::MAX {
@@ -350,7 +351,7 @@ impl TransactionManager {
         }
         let version = prev + 1;
         pending.insert(version);
-        Ok(version)
+        Ok(CommitVersion(version))
     }
 
     /// Core commit implementation shared by all public commit methods.
@@ -370,8 +371,8 @@ impl TransactionManager {
         txn: &mut TransactionContext,
         store: &S,
         wal_mode: WalMode<'_>,
-        external_version: Option<u64>,
-    ) -> std::result::Result<u64, CommitError> {
+        external_version: Option<CommitVersion>,
+    ) -> std::result::Result<CommitVersion, CommitError> {
         // Fast path: read-only transactions skip lock, validation, version alloc, WAL, apply
         if txn.is_read_only() && txn.json_writes().is_empty() {
             if !txn.is_active() {
@@ -381,7 +382,7 @@ impl TransactionManager {
                 )));
             }
             txn.status = TransactionStatus::Committed;
-            return Ok(external_version.unwrap_or_else(|| self.version.load(Ordering::Acquire)));
+            return Ok(external_version.unwrap_or_else(|| CommitVersion(self.version.load(Ordering::Acquire))));
         }
 
         let profiling = commit_profile_enabled();
@@ -434,7 +435,7 @@ impl TransactionManager {
             perf_time!(trace, read_set_validate_ns, {
                 txn.commit(store)?;
             });
-            tracing::debug!(target: "strata::txn", txn_id = txn.txn_id, "Validation passed");
+            tracing::debug!(target: "strata::txn", txn_id = txn.txn_id.as_u64(), "Validation passed");
         }
         let validation_ns = t0.elapsed().as_nanos() as u64;
 
@@ -448,8 +449,8 @@ impl TransactionManager {
                 // the higher counter with an empty pending set and advance
                 // visible_version to include this not-yet-applied version (#1913).
                 let mut pending = self.pending_versions.lock();
-                self.version.fetch_max(v, Ordering::AcqRel);
-                pending.insert(v);
+                self.version.fetch_max(v.as_u64(), Ordering::AcqRel);
+                pending.insert(v.as_u64());
                 v
             }
         };
@@ -488,8 +489,8 @@ impl TransactionManager {
                                     &mut rec_buf,
                                     &mut msg_buf,
                                     txn,
-                                    commit_version,
-                                    commit_version,
+                                    commit_version.as_u64(),
+                                    commit_version.as_u64(),
                                     *txn.branch_id.as_bytes(),
                                     timestamp,
                                 );
@@ -497,7 +498,7 @@ impl TransactionManager {
                                 // Direct mode: no separate mutex
                                 let tw = Instant::now();
                                 let r =
-                                    wal.append_pre_serialized(&rec_buf, commit_version, timestamp);
+                                    wal.append_pre_serialized(&rec_buf, commit_version.as_u64(), timestamp);
                                 wal_io_ns = tw.elapsed().as_nanos() as u64;
                                 r
                             })
@@ -509,7 +510,7 @@ impl TransactionManager {
                             self.mark_version_applied(commit_version);
                             return Err(CommitError::WALError(e.to_string()));
                         }
-                        tracing::debug!(target: "strata::txn", txn_id = txn.txn_id, commit_version, "WAL durable");
+                        tracing::debug!(target: "strata::txn", txn_id = txn.txn_id.as_u64(), commit_version = commit_version.as_u64(), "WAL durable");
                     }
                     WalMode::Shared(wal_arc) => {
                         let timestamp = now_micros();
@@ -522,8 +523,8 @@ impl TransactionManager {
                                     &mut rec_buf,
                                     &mut msg_buf,
                                     txn,
-                                    commit_version,
-                                    commit_version,
+                                    commit_version.as_u64(),
+                                    commit_version.as_u64(),
                                     *txn.branch_id.as_bytes(),
                                     timestamp,
                                 );
@@ -533,7 +534,7 @@ impl TransactionManager {
                                 wal_mutex_ns = tm.elapsed().as_nanos() as u64;
                                 let tw = Instant::now();
                                 let r =
-                                    wal.append_pre_serialized(&rec_buf, commit_version, timestamp);
+                                    wal.append_pre_serialized(&rec_buf, commit_version.as_u64(), timestamp);
                                 wal_io_ns = tw.elapsed().as_nanos() as u64;
                                 r
                             })
@@ -545,7 +546,7 @@ impl TransactionManager {
                             self.mark_version_applied(commit_version);
                             return Err(CommitError::WALError(e.to_string()));
                         }
-                        tracing::debug!(target: "strata::txn", txn_id = txn.txn_id, commit_version, "WAL durable");
+                        tracing::debug!(target: "strata::txn", txn_id = txn.txn_id.as_u64(), commit_version = commit_version.as_u64(), "WAL durable");
                     }
                     WalMode::None => {}
                 }
@@ -560,8 +561,8 @@ impl TransactionManager {
                 if has_wal {
                     tracing::error!(
                         target: "strata::txn",
-                        txn_id = txn.txn_id,
-                        commit_version = commit_version,
+                        txn_id = txn.txn_id.as_u64(),
+                        commit_version = commit_version.as_u64(),
                         error = %e,
                         "Storage application failed after WAL commit - will be recovered on restart"
                     );
@@ -644,8 +645,8 @@ impl TransactionManager {
             trace.keys_written = txn.write_set.len();
             tracing::info!(
                 target: "strata::perf",
-                txn_id = txn.txn_id,
-                commit_version,
+                txn_id = txn.txn_id.as_u64(),
+                commit_version = commit_version.as_u64(),
                 total_us = trace.commit_total_ns / 1000,
                 validate_us = trace.read_set_validate_ns / 1000,
                 wal_us = trace.wal_append_ns / 1000,
@@ -677,7 +678,7 @@ impl TransactionManager {
         txn: &mut TransactionContext,
         store: &S,
         wal: Option<&mut WalWriter>,
-    ) -> std::result::Result<u64, CommitError> {
+    ) -> std::result::Result<CommitVersion, CommitError> {
         let wal_mode = match wal {
             Some(w) => WalMode::Direct(w),
             None => WalMode::None,
@@ -707,7 +708,7 @@ impl TransactionManager {
         txn: &mut TransactionContext,
         store: &S,
         wal_arc: Option<&Arc<Mutex<WalWriter>>>,
-    ) -> std::result::Result<u64, CommitError> {
+    ) -> std::result::Result<CommitVersion, CommitError> {
         let wal_mode = match wal_arc {
             Some(arc) => WalMode::Shared(arc),
             None => WalMode::None,
@@ -798,8 +799,8 @@ impl TransactionManager {
         txn: &mut TransactionContext,
         store: &S,
         wal: Option<&mut WalWriter>,
-        version: u64,
-    ) -> std::result::Result<u64, CommitError> {
+        version: CommitVersion,
+    ) -> std::result::Result<CommitVersion, CommitError> {
         let wal_mode = match wal {
             Some(w) => WalMode::Direct(w),
             None => WalMode::None,
@@ -810,7 +811,7 @@ impl TransactionManager {
 
 impl Default for TransactionManager {
     fn default() -> Self {
-        Self::new(0)
+        Self::new(CommitVersion::ZERO)
     }
 }
 
@@ -821,6 +822,7 @@ mod tests {
     use crate::{JsonStoreExt, TransactionContext};
     use parking_lot::Mutex as ParkingMutex;
     use std::sync::Arc;
+    use strata_core::id::{CommitVersion, TxnId};
     use strata_core::types::{Key, Namespace};
     use strata_core::value::Value;
     use strata_durability::codec::IdentityCodec;
@@ -849,40 +851,40 @@ mod tests {
 
     #[test]
     fn test_new_manager_has_correct_initial_version() {
-        let manager = TransactionManager::new(100);
-        assert_eq!(manager.current_version(), 100);
+        let manager = TransactionManager::new(CommitVersion(100));
+        assert_eq!(manager.current_version(), CommitVersion(100));
     }
 
     #[test]
     fn test_allocate_version_increments() {
-        let manager = TransactionManager::new(0);
-        assert_eq!(manager.allocate_version().unwrap(), 1);
-        assert_eq!(manager.allocate_version().unwrap(), 2);
-        assert_eq!(manager.allocate_version().unwrap(), 3);
-        assert_eq!(manager.current_version(), 3);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
+        assert_eq!(manager.allocate_version().unwrap(), CommitVersion(1));
+        assert_eq!(manager.allocate_version().unwrap(), CommitVersion(2));
+        assert_eq!(manager.allocate_version().unwrap(), CommitVersion(3));
+        assert_eq!(manager.current_version(), CommitVersion(3));
     }
 
     #[test]
     fn test_next_txn_id_increments() {
-        // TransactionManager::new(0) calls with_txn_id(0, 0), which sets next_txn_id = 0 + 1 = 1
-        let manager = TransactionManager::new(0);
-        assert_eq!(manager.next_txn_id().unwrap(), 1);
-        assert_eq!(manager.next_txn_id().unwrap(), 2);
-        assert_eq!(manager.next_txn_id().unwrap(), 3);
+        // TransactionManager::new(CommitVersion::ZERO) calls with_txn_id(0, 0), which sets next_txn_id = 0 + 1 = 1
+        let manager = TransactionManager::new(CommitVersion::ZERO);
+        assert_eq!(manager.next_txn_id().unwrap(), TxnId(1));
+        assert_eq!(manager.next_txn_id().unwrap(), TxnId(2));
+        assert_eq!(manager.next_txn_id().unwrap(), TxnId(3));
     }
 
     #[test]
     fn test_with_txn_id_starts_from_max_plus_one() {
-        let manager = TransactionManager::with_txn_id(50, 100);
-        assert_eq!(manager.current_version(), 50);
-        assert_eq!(manager.next_txn_id().unwrap(), 101); // max_txn_id + 1
+        let manager = TransactionManager::with_txn_id(CommitVersion(50), TxnId(100));
+        assert_eq!(manager.current_version(), CommitVersion(50));
+        assert_eq!(manager.next_txn_id().unwrap(), TxnId(101)); // max_txn_id + 1
     }
 
     #[test]
     fn test_next_txn_id_overflow_returns_error() {
         // with_txn_id(0, max_txn_id) sets next_txn_id = max_txn_id + 1
         // So with_txn_id(0, u64::MAX - 2) → next_txn_id starts at u64::MAX - 1
-        let manager = TransactionManager::with_txn_id(0, u64::MAX - 2);
+        let manager = TransactionManager::with_txn_id(CommitVersion::ZERO, TxnId(u64::MAX - 2));
         // First call: returns u64::MAX - 1, counter advances to u64::MAX
         assert!(manager.next_txn_id().is_ok());
         // Second call fails: counter is at u64::MAX, cannot increment
@@ -892,7 +894,7 @@ mod tests {
     #[test]
     fn test_allocate_version_overflow_returns_error() {
         // Version starts at u64::MAX - 1
-        let manager = TransactionManager::with_txn_id(u64::MAX - 1, 0);
+        let manager = TransactionManager::with_txn_id(CommitVersion(u64::MAX - 1), TxnId::ZERO);
         // First call: version advances from MAX-1 to MAX, returns MAX
         assert!(manager.allocate_version().is_ok());
         // Second call fails: version is at u64::MAX, cannot increment
@@ -908,7 +910,7 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let wal = Arc::new(ParkingMutex::new(create_test_wal(&wal_dir)));
         let store = Arc::new(SegmentedStore::new());
-        let manager = Arc::new(TransactionManager::new(0));
+        let manager = Arc::new(TransactionManager::new(CommitVersion::ZERO));
 
         let branch_id1 = BranchId::new();
         let branch_id2 = BranchId::new();
@@ -918,10 +920,10 @@ mod tests {
         let key2 = create_test_key(&ns2, "key2");
 
         // Prepare transactions
-        let mut txn1 = TransactionContext::with_store(1, branch_id1, Arc::clone(&store));
+        let mut txn1 = TransactionContext::with_store(TxnId(1), branch_id1, Arc::clone(&store));
         txn1.put(key1.clone(), Value::Int(1)).unwrap();
 
-        let mut txn2 = TransactionContext::with_store(2, branch_id2, Arc::clone(&store));
+        let mut txn2 = TransactionContext::with_store(TxnId(2), branch_id2, Arc::clone(&store));
         txn2.put(key2.clone(), Value::Int(2)).unwrap();
 
         // Commit both in parallel threads
@@ -947,13 +949,13 @@ mod tests {
         let v2 = handle2.join().unwrap().unwrap();
 
         // Both commits should succeed with unique versions
-        assert!((1..=2).contains(&v1));
-        assert!((1..=2).contains(&v2));
+        assert!((CommitVersion(1)..=CommitVersion(2)).contains(&v1));
+        assert!((CommitVersion(1)..=CommitVersion(2)).contains(&v2));
         assert_ne!(v1, v2); // Versions must be unique
 
         // Both keys should be in storage
-        assert!(store.get_versioned(&key1, u64::MAX).unwrap().is_some());
-        assert!(store.get_versioned(&key2, u64::MAX).unwrap().is_some());
+        assert!(store.get_versioned(&key1, CommitVersion::MAX).unwrap().is_some());
+        assert!(store.get_versioned(&key2, CommitVersion::MAX).unwrap().is_some());
     }
 
     #[test]
@@ -964,7 +966,7 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let mut wal = create_test_wal(&wal_dir);
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
 
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
@@ -973,30 +975,30 @@ mod tests {
 
         // Commit first transaction
         {
-            let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+            let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
             txn.put(key1.clone(), Value::Int(100)).unwrap();
             let v = manager
                 .commit(&mut txn, store.as_ref(), Some(&mut wal))
                 .unwrap();
-            assert_eq!(v, 1);
+            assert_eq!(v, CommitVersion(1));
         }
 
         // Commit second transaction on same branch
         {
-            let mut txn = TransactionContext::with_store(2, branch_id, Arc::clone(&store));
+            let mut txn = TransactionContext::with_store(TxnId(2), branch_id, Arc::clone(&store));
             txn.put(key2.clone(), Value::Int(200)).unwrap();
             let v = manager
                 .commit(&mut txn, store.as_ref(), Some(&mut wal))
                 .unwrap();
-            assert_eq!(v, 2);
+            assert_eq!(v, CommitVersion(2));
         }
 
         // Both values should be present with correct versions
-        let v1 = store.get_versioned(&key1, u64::MAX).unwrap().unwrap();
+        let v1 = store.get_versioned(&key1, CommitVersion::MAX).unwrap().unwrap();
         assert_eq!(v1.value, Value::Int(100));
         assert_eq!(v1.version.as_u64(), 1);
 
-        let v2 = store.get_versioned(&key2, u64::MAX).unwrap().unwrap();
+        let v2 = store.get_versioned(&key2, CommitVersion::MAX).unwrap().unwrap();
         assert_eq!(v2.value, Value::Int(200));
         assert_eq!(v2.version.as_u64(), 2);
     }
@@ -1008,7 +1010,7 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let wal = Arc::new(ParkingMutex::new(create_test_wal(&wal_dir)));
         let store = Arc::new(SegmentedStore::new());
-        let manager = Arc::new(TransactionManager::new(0));
+        let manager = Arc::new(TransactionManager::new(CommitVersion::ZERO));
 
         let num_threads = 10;
         let mut handles = Vec::new();
@@ -1024,7 +1026,7 @@ mod tests {
                 let key = create_test_key(&ns, &format!("key_{}", i));
 
                 let mut txn = TransactionContext::with_store(
-                    i as u64 + 1,
+                    TxnId(i as u64 + 1),
                     branch_id,
                     Arc::clone(&store_clone),
                 );
@@ -1036,7 +1038,7 @@ mod tests {
         }
 
         // All commits should succeed
-        let versions: Vec<u64> = handles
+        let versions: Vec<CommitVersion> = handles
             .into_iter()
             .map(|h| h.join().unwrap().unwrap())
             .collect();
@@ -1046,8 +1048,8 @@ mod tests {
         sorted.sort();
         sorted.dedup();
         assert_eq!(sorted.len(), num_threads);
-        assert_eq!(sorted[0], 1);
-        assert_eq!(sorted[num_threads - 1], num_threads as u64);
+        assert_eq!(sorted[0], CommitVersion(1));
+        assert_eq!(sorted[num_threads - 1], CommitVersion(num_threads as u64));
     }
 
     /// Test that scan_prefix tracks deleted keys in read_set for conflict detection.
@@ -1057,7 +1059,7 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let mut wal = create_test_wal(&wal_dir);
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
 
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
@@ -1067,7 +1069,7 @@ mod tests {
 
         // Setup: Create initial data with alice and bob
         {
-            let mut setup_txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+            let mut setup_txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
             setup_txn.put(key_alice.clone(), Value::Int(100)).unwrap();
             setup_txn.put(key_bob.clone(), Value::Int(200)).unwrap();
             manager
@@ -1076,7 +1078,7 @@ mod tests {
         }
 
         // T1: Delete alice (blind), then scan
-        let mut txn1 = TransactionContext::with_store(2, branch_id, Arc::clone(&store));
+        let mut txn1 = TransactionContext::with_store(TxnId(2), branch_id, Arc::clone(&store));
         txn1.delete(key_alice.clone()).unwrap(); // Blind delete
         let scan_result = txn1.scan_prefix(&prefix).unwrap();
 
@@ -1086,7 +1088,7 @@ mod tests {
 
         // T2: Update alice and commit first
         {
-            let mut txn2 = TransactionContext::with_store(3, branch_id, Arc::clone(&store));
+            let mut txn2 = TransactionContext::with_store(TxnId(3), branch_id, Arc::clone(&store));
             // T2 reads alice first (creates read_set entry)
             let _ = txn2.get(&key_alice).unwrap();
             txn2.put(key_alice.clone(), Value::Int(999)).unwrap();
@@ -1105,7 +1107,7 @@ mod tests {
         );
 
         // T2's update should be preserved
-        let final_value = store.get_versioned(&key_alice, u64::MAX).unwrap().unwrap();
+        let final_value = store.get_versioned(&key_alice, CommitVersion::MAX).unwrap().unwrap();
         assert_eq!(
             final_value.value,
             Value::Int(999),
@@ -1120,7 +1122,7 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let mut wal = create_test_wal(&wal_dir);
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
 
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
@@ -1128,7 +1130,7 @@ mod tests {
 
         // Setup: Create alice
         {
-            let mut setup_txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+            let mut setup_txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
             setup_txn.put(key_alice.clone(), Value::Int(100)).unwrap();
             manager
                 .commit(&mut setup_txn, store.as_ref(), Some(&mut wal))
@@ -1136,12 +1138,12 @@ mod tests {
         }
 
         // T1: Blind delete alice (no read, no scan)
-        let mut txn1 = TransactionContext::with_store(2, branch_id, Arc::clone(&store));
+        let mut txn1 = TransactionContext::with_store(TxnId(2), branch_id, Arc::clone(&store));
         txn1.delete(key_alice.clone()).unwrap(); // Blind delete - no read_set entry
 
         // T2: Update alice and commit first
         {
-            let mut txn2 = TransactionContext::with_store(3, branch_id, Arc::clone(&store));
+            let mut txn2 = TransactionContext::with_store(TxnId(3), branch_id, Arc::clone(&store));
             let _ = txn2.get(&key_alice).unwrap();
             txn2.put(key_alice.clone(), Value::Int(999)).unwrap();
             manager
@@ -1157,7 +1159,7 @@ mod tests {
         );
 
         // T1's delete overwrites T2's update - this is expected for blind writes
-        let final_value = store.get_versioned(&key_alice, u64::MAX).unwrap();
+        let final_value = store.get_versioned(&key_alice, CommitVersion::MAX).unwrap();
         assert!(
             final_value.is_none(),
             "Blind delete should succeed, removing alice"
@@ -1171,13 +1173,13 @@ mod tests {
     #[test]
     fn test_read_only_no_version_increment() {
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
 
         let v_before = manager.current_version();
 
         // Read-only transaction (just reads, no writes)
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         // No operations — pure read-only
         let result = manager.commit(&mut txn, store.as_ref(), None);
         assert!(result.is_ok());
@@ -1190,7 +1192,7 @@ mod tests {
     fn test_read_only_no_lock_contention() {
         // Two concurrent read-only transactions on the same branch shouldn't block
         let store = Arc::new(SegmentedStore::new());
-        let manager = Arc::new(TransactionManager::new(0));
+        let manager = Arc::new(TransactionManager::new(CommitVersion::ZERO));
         let branch_id = BranchId::new();
 
         let manager1 = Arc::clone(&manager);
@@ -1199,11 +1201,11 @@ mod tests {
         let store2 = Arc::clone(&store);
 
         let h1 = std::thread::spawn(move || {
-            let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store1));
+            let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store1));
             manager1.commit(&mut txn, store1.as_ref(), None)
         });
         let h2 = std::thread::spawn(move || {
-            let mut txn = TransactionContext::with_store(2, branch_id, Arc::clone(&store2));
+            let mut txn = TransactionContext::with_store(TxnId(2), branch_id, Arc::clone(&store2));
             manager2.commit(&mut txn, store2.as_ref(), None)
         });
 
@@ -1217,12 +1219,12 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let mut wal = create_test_wal(&wal_dir);
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
 
         let v_before = manager.current_version();
 
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         // No KV writes, but has json_writes → not fast-pathed
         use strata_core::primitives::json::{JsonPatch, JsonPath};
         txn.record_json_write(
@@ -1241,10 +1243,10 @@ mod tests {
     #[test]
     fn test_read_only_rejects_non_active() {
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
 
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         txn.mark_aborted("test".to_string()).unwrap();
 
         let result = manager.commit(&mut txn, store.as_ref(), None);
@@ -1265,20 +1267,20 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let mut wal = create_test_wal(&wal_dir);
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "blind");
 
         // Blind write: put with no prior read
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         txn.put(key.clone(), Value::Int(42)).unwrap();
         assert!(txn.read_set.is_empty()); // Confirms it's a blind write
 
         let result = manager.commit(&mut txn, store.as_ref(), Some(&mut wal));
         assert!(result.is_ok());
 
-        let stored = store.get_versioned(&key, u64::MAX).unwrap().unwrap();
+        let stored = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
         assert_eq!(stored.value, Value::Int(42));
     }
 
@@ -1288,14 +1290,14 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let mut wal = create_test_wal(&wal_dir);
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "readwrite");
 
         // Setup: store initial value
         {
-            let mut setup = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+            let mut setup = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
             setup.put(key.clone(), Value::Int(1)).unwrap();
             manager
                 .commit(&mut setup, store.as_ref(), Some(&mut wal))
@@ -1303,14 +1305,14 @@ mod tests {
         }
 
         // T1: read then write (not a blind write)
-        let mut txn = TransactionContext::with_store(2, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(2), branch_id, Arc::clone(&store));
         let _ = txn.get(&key).unwrap();
         txn.put(key.clone(), Value::Int(2)).unwrap();
         assert!(!txn.read_set.is_empty()); // Has reads → goes through validation
 
         // Concurrent update
         {
-            let mut txn2 = TransactionContext::with_store(3, branch_id, Arc::clone(&store));
+            let mut txn2 = TransactionContext::with_store(TxnId(3), branch_id, Arc::clone(&store));
             txn2.put(key.clone(), Value::Int(99)).unwrap();
             manager
                 .commit(&mut txn2, store.as_ref(), Some(&mut wal))
@@ -1328,13 +1330,13 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let mut wal = create_test_wal(&wal_dir);
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "cas_key");
 
         // CAS operation → not a blind write, should validate
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         txn.cas(key.clone(), 0, Value::Int(1)).unwrap();
         assert!(!txn.cas_set.is_empty());
 
@@ -1348,21 +1350,21 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let mut wal = create_test_wal(&wal_dir);
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "json_doc");
 
         // Has json_snapshot_versions → should go through full validation path
         // Use version 0 (key doesn't exist) so validation passes
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         txn.put(key.clone(), Value::Int(1)).unwrap();
         txn.record_json_snapshot_version(key.clone(), 0);
 
         let result = manager.commit(&mut txn, store.as_ref(), Some(&mut wal));
         assert!(result.is_ok());
         // Verify it went through the normal path (version incremented)
-        assert!(manager.current_version() > 0);
+        assert!(manager.current_version() > CommitVersion::ZERO);
     }
 
     // ========================================================================
@@ -1377,21 +1379,21 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let wal = Arc::new(ParkingMutex::new(create_test_wal(&wal_dir)));
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "arc_basic");
 
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         txn.put(key.clone(), Value::Int(42)).unwrap();
 
         let v = manager
             .commit_with_wal_arc(&mut txn, store.as_ref(), Some(&wal))
             .unwrap();
-        assert_eq!(v, 1);
+        assert_eq!(v, CommitVersion(1));
 
         // Verify in-memory storage
-        let stored = store.get_versioned(&key, u64::MAX).unwrap().unwrap();
+        let stored = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
         assert_eq!(stored.value, Value::Int(42));
         assert_eq!(stored.version.as_u64(), 1);
 
@@ -1402,13 +1404,13 @@ mod tests {
 
         // Recovery should find exactly 1 transaction
         assert_eq!(result.stats.txns_replayed, 1);
-        assert_eq!(result.stats.final_version, 1);
+        assert_eq!(result.stats.final_version, CommitVersion(1));
         assert_eq!(result.stats.writes_applied, 1);
 
         // Recovered storage should contain the committed value
         let recovered = result
             .storage
-            .get_versioned(&key, u64::MAX)
+            .get_versioned(&key, CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(recovered.value, Value::Int(42));
@@ -1418,20 +1420,20 @@ mod tests {
     #[test]
     fn test_commit_with_wal_arc_no_wal() {
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "no_wal");
 
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         txn.put(key.clone(), Value::Int(7)).unwrap();
 
         let v = manager
             .commit_with_wal_arc(&mut txn, store.as_ref(), None)
             .unwrap();
-        assert_eq!(v, 1);
+        assert_eq!(v, CommitVersion(1));
 
-        let stored = store.get_versioned(&key, u64::MAX).unwrap().unwrap();
+        let stored = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
         assert_eq!(stored.value, Value::Int(7));
     }
 
@@ -1442,7 +1444,7 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let wal = Arc::new(ParkingMutex::new(create_test_wal(&wal_dir)));
         let store = Arc::new(SegmentedStore::new());
-        let manager = Arc::new(TransactionManager::new(0));
+        let manager = Arc::new(TransactionManager::new(CommitVersion::ZERO));
 
         let num_threads = 10;
         let mut handles = Vec::new();
@@ -1458,14 +1460,14 @@ mod tests {
                 let key = create_test_key(&ns, &format!("key_{}", i));
 
                 let mut txn =
-                    TransactionContext::with_store(i as u64 + 1, branch_id, Arc::clone(&s));
+                    TransactionContext::with_store(TxnId(i as u64 + 1), branch_id, Arc::clone(&s));
                 txn.put(key, Value::Int(i as i64)).unwrap();
 
                 m.commit_with_wal_arc(&mut txn, s.as_ref(), Some(&w))
             }));
         }
 
-        let versions: Vec<u64> = handles
+        let versions: Vec<CommitVersion> = handles
             .into_iter()
             .map(|h| h.join().unwrap().unwrap())
             .collect();
@@ -1475,15 +1477,15 @@ mod tests {
         sorted.sort();
         sorted.dedup();
         assert_eq!(sorted.len(), num_threads);
-        assert_eq!(sorted[0], 1);
-        assert_eq!(sorted[num_threads - 1], num_threads as u64);
+        assert_eq!(sorted[0], CommitVersion(1));
+        assert_eq!(sorted[num_threads - 1], CommitVersion(num_threads as u64));
 
         // Recover from WAL to verify all 10 records are well-formed
         drop(wal);
         let recovery = crate::RecoveryCoordinator::new(wal_dir);
         let result = recovery.recover().unwrap();
         assert_eq!(result.stats.txns_replayed, num_threads);
-        assert_eq!(result.stats.final_version, num_threads as u64);
+        assert_eq!(result.stats.final_version, CommitVersion(num_threads as u64));
     }
 
     #[test]
@@ -1494,14 +1496,14 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let wal = Arc::new(ParkingMutex::new(create_test_wal(&wal_dir)));
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "conflict");
 
         // Setup: store initial value (WAL record #1)
         {
-            let mut setup = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+            let mut setup = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
             setup.put(key.clone(), Value::Int(1)).unwrap();
             manager
                 .commit_with_wal_arc(&mut setup, store.as_ref(), Some(&wal))
@@ -1509,13 +1511,13 @@ mod tests {
         }
 
         // T1: read-modify-write (will conflict)
-        let mut txn1 = TransactionContext::with_store(2, branch_id, Arc::clone(&store));
+        let mut txn1 = TransactionContext::with_store(TxnId(2), branch_id, Arc::clone(&store));
         let _ = txn1.get(&key).unwrap(); // Creates read_set entry
         txn1.put(key.clone(), Value::Int(10)).unwrap();
 
         // T2: concurrent blind write, commits first (WAL record #2)
         {
-            let mut txn2 = TransactionContext::with_store(3, branch_id, Arc::clone(&store));
+            let mut txn2 = TransactionContext::with_store(TxnId(3), branch_id, Arc::clone(&store));
             txn2.put(key.clone(), Value::Int(99)).unwrap();
             manager
                 .commit_with_wal_arc(&mut txn2, store.as_ref(), Some(&wal))
@@ -1527,7 +1529,7 @@ mod tests {
         assert!(result.is_err(), "Should detect read-write conflict");
 
         // T2's value should be preserved in storage
-        let stored = store.get_versioned(&key, u64::MAX).unwrap().unwrap();
+        let stored = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
         assert_eq!(stored.value, Value::Int(99));
 
         // KEY ASSERTION: WAL should contain exactly 2 records (setup + T2).
@@ -1543,7 +1545,7 @@ mod tests {
         // Recovered value should be T2's write
         let recovered = result
             .storage
-            .get_versioned(&key, u64::MAX)
+            .get_versioned(&key, CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(recovered.value, Value::Int(99));
@@ -1555,13 +1557,13 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let wal = Arc::new(ParkingMutex::new(create_test_wal(&wal_dir)));
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
 
         let v_before = manager.current_version();
 
         // Read-only transaction: no writes
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         let result = manager.commit_with_wal_arc(&mut txn, store.as_ref(), Some(&wal));
         assert!(result.is_ok());
 
@@ -1583,13 +1585,13 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let wal = Arc::new(ParkingMutex::new(create_test_wal(&wal_dir)));
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
 
         let v_before = manager.current_version();
 
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         // No KV writes, but has json_writes → not fast-pathed
         use strata_core::primitives::json::{JsonPatch, JsonPath};
         txn.record_json_write(
@@ -1618,7 +1620,7 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let wal = Arc::new(ParkingMutex::new(create_test_wal(&wal_dir)));
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key_a = create_test_key(&ns, "multi_a");
@@ -1627,7 +1629,7 @@ mod tests {
 
         // Setup: write key_a and key_b
         {
-            let mut setup = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+            let mut setup = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
             setup.put(key_a.clone(), Value::Int(10)).unwrap();
             setup.put(key_b.clone(), Value::Int(20)).unwrap();
             manager
@@ -1637,7 +1639,7 @@ mod tests {
 
         // Transaction: delete key_a, update key_b, insert key_c
         {
-            let mut txn = TransactionContext::with_store(2, branch_id, Arc::clone(&store));
+            let mut txn = TransactionContext::with_store(TxnId(2), branch_id, Arc::clone(&store));
             txn.delete(key_a.clone()).unwrap();
             txn.put(key_b.clone(), Value::Int(200)).unwrap();
             txn.put(key_c.clone(), Value::Bytes(b"hello".to_vec()))
@@ -1648,10 +1650,10 @@ mod tests {
         }
 
         // Verify in-memory state
-        assert!(store.get_versioned(&key_a, u64::MAX).unwrap().is_none());
+        assert!(store.get_versioned(&key_a, CommitVersion::MAX).unwrap().is_none());
         assert_eq!(
             store
-                .get_versioned(&key_b, u64::MAX)
+                .get_versioned(&key_b, CommitVersion::MAX)
                 .unwrap()
                 .unwrap()
                 .value,
@@ -1659,7 +1661,7 @@ mod tests {
         );
         assert_eq!(
             store
-                .get_versioned(&key_c, u64::MAX)
+                .get_versioned(&key_c, CommitVersion::MAX)
                 .unwrap()
                 .unwrap()
                 .value,
@@ -1675,14 +1677,14 @@ mod tests {
         // key_a: was written in txn1 then deleted in txn2
         assert!(result
             .storage
-            .get_versioned(&key_a, u64::MAX)
+            .get_versioned(&key_a, CommitVersion::MAX)
             .unwrap()
             .is_none());
         // key_b: updated from 20 → 200
         assert_eq!(
             result
                 .storage
-                .get_versioned(&key_b, u64::MAX)
+                .get_versioned(&key_b, CommitVersion::MAX)
                 .unwrap()
                 .unwrap()
                 .value,
@@ -1692,7 +1694,7 @@ mod tests {
         assert_eq!(
             result
                 .storage
-                .get_versioned(&key_c, u64::MAX)
+                .get_versioned(&key_c, CommitVersion::MAX)
                 .unwrap()
                 .unwrap()
                 .value,
@@ -1708,36 +1710,36 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let wal = Arc::new(ParkingMutex::new(create_test_wal(&wal_dir)));
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key1 = create_test_key(&ns, "seq1");
         let key2 = create_test_key(&ns, "seq2");
 
         {
-            let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+            let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
             txn.put(key1.clone(), Value::Int(100)).unwrap();
             let v = manager
                 .commit_with_wal_arc(&mut txn, store.as_ref(), Some(&wal))
                 .unwrap();
-            assert_eq!(v, 1);
+            assert_eq!(v, CommitVersion(1));
         }
 
         {
-            let mut txn = TransactionContext::with_store(2, branch_id, Arc::clone(&store));
+            let mut txn = TransactionContext::with_store(TxnId(2), branch_id, Arc::clone(&store));
             txn.put(key2.clone(), Value::Int(200)).unwrap();
             let v = manager
                 .commit_with_wal_arc(&mut txn, store.as_ref(), Some(&wal))
                 .unwrap();
-            assert_eq!(v, 2);
+            assert_eq!(v, CommitVersion(2));
         }
 
         // Both values present with correct versions
-        let v1 = store.get_versioned(&key1, u64::MAX).unwrap().unwrap();
+        let v1 = store.get_versioned(&key1, CommitVersion::MAX).unwrap().unwrap();
         assert_eq!(v1.value, Value::Int(100));
         assert_eq!(v1.version.as_u64(), 1);
 
-        let v2 = store.get_versioned(&key2, u64::MAX).unwrap().unwrap();
+        let v2 = store.get_versioned(&key2, CommitVersion::MAX).unwrap().unwrap();
         assert_eq!(v2.value, Value::Int(200));
         assert_eq!(v2.version.as_u64(), 2);
     }
@@ -1748,7 +1750,7 @@ mod tests {
 
     #[test]
     fn test_remove_branch_lock_succeeds_when_not_held() {
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
 
         // Insert a lock entry by accessing it (simulates a prior commit)
@@ -1765,7 +1767,7 @@ mod tests {
 
     #[test]
     fn test_remove_branch_lock_nonexistent_succeeds() {
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
 
         // No lock entry exists — removal should return true
@@ -1776,7 +1778,7 @@ mod tests {
     fn test_remove_branch_lock_serializes_with_commit() {
         // Verify that remove_branch_lock removes the entry and that the
         // next commit recreates it via entry().or_insert_with().
-        let manager = Arc::new(TransactionManager::new(0));
+        let manager = Arc::new(TransactionManager::new(CommitVersion::ZERO));
         let branch_id = BranchId::new();
 
         // Insert a lock entry via the same path as commit()
@@ -1809,20 +1811,20 @@ mod tests {
 
     #[test]
     fn commit_no_wal_applies_writes() {
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let store = Arc::new(SegmentedStore::new());
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "bulk_key");
 
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         txn.put(key.clone(), Value::Int(42)).unwrap();
 
         let version = manager.commit(&mut txn, store.as_ref(), None).unwrap();
-        assert!(version > 0);
+        assert!(version > CommitVersion::ZERO);
 
         // Data should be readable
-        let result = store.get_versioned(&key, u64::MAX).unwrap();
+        let result = store.get_versioned(&key, CommitVersion::MAX).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap().value, Value::Int(42));
     }
@@ -1831,7 +1833,7 @@ mod tests {
     fn commit_no_wal_skips_wal_records() {
         let dir = TempDir::new().unwrap();
         let wal_dir = dir.path().join("wal");
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let store = Arc::new(SegmentedStore::new());
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
@@ -1841,13 +1843,13 @@ mod tests {
 
         // No-WAL commit — should NOT write to WAL
         let key = create_test_key(&ns, "no_wal");
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         txn.put(key.clone(), Value::Int(1)).unwrap();
         manager.commit(&mut txn, store.as_ref(), None).unwrap();
 
         // Normal commit — writes to WAL
         let key2 = create_test_key(&ns, "with_wal");
-        let mut txn2 = TransactionContext::with_store(2, branch_id, Arc::clone(&store));
+        let mut txn2 = TransactionContext::with_store(TxnId(2), branch_id, Arc::clone(&store));
         txn2.put(key2.clone(), Value::Int(2)).unwrap();
         manager
             .commit(&mut txn2, store.as_ref(), Some(&mut wal))
@@ -1867,7 +1869,7 @@ mod tests {
     fn commit_no_wal_then_normal_commits() {
         let dir = TempDir::new().unwrap();
         let wal_dir = dir.path().join("wal");
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let store = Arc::new(SegmentedStore::new());
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
@@ -1875,13 +1877,13 @@ mod tests {
 
         // No-WAL commit
         let key1 = create_test_key(&ns, "k1");
-        let mut txn1 = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn1 = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         txn1.put(key1.clone(), Value::Int(1)).unwrap();
         manager.commit(&mut txn1, store.as_ref(), None).unwrap();
 
         // Normal commit after no-WAL commit
         let key2 = create_test_key(&ns, "k2");
-        let mut txn2 = TransactionContext::with_store(2, branch_id, Arc::clone(&store));
+        let mut txn2 = TransactionContext::with_store(TxnId(2), branch_id, Arc::clone(&store));
         txn2.put(key2.clone(), Value::Int(2)).unwrap();
         manager
             .commit(&mut txn2, store.as_ref(), Some(&mut wal))
@@ -1889,11 +1891,11 @@ mod tests {
 
         // Both values readable
         assert_eq!(
-            store.get_versioned(&key1, u64::MAX).unwrap().unwrap().value,
+            store.get_versioned(&key1, CommitVersion::MAX).unwrap().unwrap().value,
             Value::Int(1)
         );
         assert_eq!(
-            store.get_versioned(&key2, u64::MAX).unwrap().unwrap().value,
+            store.get_versioned(&key2, CommitVersion::MAX).unwrap().unwrap().value,
             Value::Int(2)
         );
     }
@@ -1913,7 +1915,7 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let mut wal = create_test_wal(&wal_dir);
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
 
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
@@ -1925,7 +1927,7 @@ mod tests {
             Arc::clone(&store),
         );
         txn1.put(create_test_key(&ns, "k1"), Value::Int(1)).unwrap();
-        assert_eq!(txn1.txn_id, 1, "T1 should get txn_id=1");
+        assert_eq!(txn1.txn_id, TxnId(1), "T1 should get txn_id=1");
 
         // T2 starts → gets txn_id=2, and commits first → gets commit_version=1
         let mut txn2 = TransactionContext::with_store(
@@ -1937,13 +1939,13 @@ mod tests {
         let v2 = manager
             .commit(&mut txn2, store.as_ref(), Some(&mut wal))
             .unwrap();
-        assert_eq!(v2, 1, "T2 should get commit_version=1");
+        assert_eq!(v2, CommitVersion(1), "T2 should get commit_version=1");
 
         // T1 commits second → gets commit_version=2
         let v1 = manager
             .commit(&mut txn1, store.as_ref(), Some(&mut wal))
             .unwrap();
-        assert_eq!(v1, 2, "T1 should get commit_version=2");
+        assert_eq!(v1, CommitVersion(2), "T1 should get commit_version=2");
 
         // Read WAL records back and verify ordering keys
         wal.flush().unwrap();
@@ -1980,7 +1982,7 @@ mod tests {
         // This test verifies that commit_with_wal_arc() creates the commit_locks
         // entry for blind writes — proving the lock path is taken.
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "blind_key");
@@ -1989,7 +1991,7 @@ mod tests {
         assert!(!manager.commit_locks.contains_key(&branch_id));
 
         // Commit a blind write via commit_with_wal_arc
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         txn.put(key, Value::Int(42)).unwrap();
         assert!(txn.read_set.is_empty(), "Must be a blind write");
 
@@ -2014,14 +2016,14 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let mut wal = create_test_wal(&wal_dir);
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "blind_key");
 
         assert!(!manager.commit_locks.contains_key(&branch_id));
 
-        let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
         txn.put(key, Value::Int(42)).unwrap();
         assert!(txn.read_set.is_empty(), "Must be a blind write");
 
@@ -2050,7 +2052,7 @@ mod tests {
         fn get_versioned(
             &self,
             key: &Key,
-            max_version: u64,
+            max_version: CommitVersion,
         ) -> strata_core::error::StrataResult<Option<strata_core::contract::VersionedValue>>
         {
             self.inner.get_versioned(key, max_version)
@@ -2060,7 +2062,7 @@ mod tests {
             &self,
             key: &Key,
             limit: Option<usize>,
-            before_version: Option<u64>,
+            before_version: Option<CommitVersion>,
         ) -> strata_core::error::StrataResult<Vec<strata_core::contract::VersionedValue>> {
             self.inner.get_history(key, limit, before_version)
         }
@@ -2068,13 +2070,13 @@ mod tests {
         fn scan_prefix(
             &self,
             prefix: &Key,
-            max_version: u64,
+            max_version: CommitVersion,
         ) -> strata_core::error::StrataResult<Vec<(Key, strata_core::contract::VersionedValue)>>
         {
             self.inner.scan_prefix(prefix, max_version)
         }
 
-        fn current_version(&self) -> u64 {
+        fn current_version(&self) -> CommitVersion {
             self.inner.current_version()
         }
 
@@ -2082,7 +2084,7 @@ mod tests {
             &self,
             key: Key,
             value: Value,
-            version: u64,
+            version: CommitVersion,
             ttl: Option<std::time::Duration>,
             mode: strata_core::traits::WriteMode,
         ) -> strata_core::error::StrataResult<()> {
@@ -2093,7 +2095,7 @@ mod tests {
         fn delete_with_version(
             &self,
             key: &Key,
-            version: u64,
+            version: CommitVersion,
         ) -> strata_core::error::StrataResult<()> {
             self.inner.delete_with_version(key, version)
         }
@@ -2102,7 +2104,7 @@ mod tests {
             &self,
             writes: Vec<(Key, Value, strata_core::traits::WriteMode)>,
             deletes: Vec<Key>,
-            version: u64,
+            version: CommitVersion,
             put_ttls: &[u64],
         ) -> strata_core::error::StrataResult<()> {
             // Signal that apply has started (version already allocated)
@@ -2131,14 +2133,14 @@ mod tests {
             apply_started: Arc::clone(&apply_started),
             delay: std::time::Duration::from_millis(200),
         });
-        let manager = Arc::new(TransactionManager::new(0));
+        let manager = Arc::new(TransactionManager::new(CommitVersion::ZERO));
 
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "test_key");
 
         // Prepare a blind-write transaction (skips validation, no store reads)
-        let mut txn = TransactionContext::new(1, branch_id, 0);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion::ZERO);
         txn.put(key, Value::Int(42)).unwrap();
 
         let manager_clone = Arc::clone(&manager);
@@ -2157,7 +2159,8 @@ mod tests {
         // current_version() returns the in-flight version — unsafe for watermark
         let current = manager.current_version();
         assert_eq!(
-            current, 1,
+            current,
+            CommitVersion(1),
             "current_version() reflects allocated-but-unapplied version"
         );
 
@@ -2168,7 +2171,8 @@ mod tests {
 
         // The commit should have completed (200ms delay)
         assert_eq!(
-            quiesced, 1,
+            quiesced,
+            1,
             "quiesced_version returns version after commit completes"
         );
         assert!(
@@ -2179,7 +2183,7 @@ mod tests {
         );
 
         let committed_version = commit_handle.join().unwrap();
-        assert_eq!(committed_version, 1);
+        assert_eq!(committed_version, CommitVersion(1));
     }
 
     /// Issue #1710 stress variant: concurrent commits on multiple branches
@@ -2193,7 +2197,7 @@ mod tests {
             apply_started: Arc::clone(&apply_started),
             delay: std::time::Duration::from_millis(100),
         });
-        let manager = Arc::new(TransactionManager::new(0));
+        let manager = Arc::new(TransactionManager::new(CommitVersion::ZERO));
 
         let num_writers = 4;
         let mut handles = Vec::new();
@@ -2206,7 +2210,7 @@ mod tests {
             let key = create_test_key(&ns, &format!("key_{}", i));
 
             handles.push(std::thread::spawn(move || {
-                let mut txn = TransactionContext::new(i as u64 + 1, branch_id, 0);
+                let mut txn = TransactionContext::new(TxnId(i as u64 + 1), branch_id, CommitVersion::ZERO);
                 txn.put(key, Value::Int(i as i64)).unwrap();
                 manager_clone
                     .commit(&mut txn, store_clone.as_ref(), None)
@@ -2241,7 +2245,7 @@ mod tests {
         fn get_versioned(
             &self,
             key: &Key,
-            max_version: u64,
+            max_version: CommitVersion,
         ) -> strata_core::error::StrataResult<Option<strata_core::contract::VersionedValue>>
         {
             self.inner.get_versioned(key, max_version)
@@ -2251,7 +2255,7 @@ mod tests {
             &self,
             key: &Key,
             limit: Option<usize>,
-            before_version: Option<u64>,
+            before_version: Option<CommitVersion>,
         ) -> strata_core::error::StrataResult<Vec<strata_core::contract::VersionedValue>> {
             self.inner.get_history(key, limit, before_version)
         }
@@ -2259,13 +2263,13 @@ mod tests {
         fn scan_prefix(
             &self,
             prefix: &Key,
-            max_version: u64,
+            max_version: CommitVersion,
         ) -> strata_core::error::StrataResult<Vec<(Key, strata_core::contract::VersionedValue)>>
         {
             self.inner.scan_prefix(prefix, max_version)
         }
 
-        fn current_version(&self) -> u64 {
+        fn current_version(&self) -> CommitVersion {
             self.inner.current_version()
         }
 
@@ -2273,7 +2277,7 @@ mod tests {
             &self,
             key: Key,
             value: Value,
-            version: u64,
+            version: CommitVersion,
             ttl: Option<std::time::Duration>,
             mode: strata_core::traits::WriteMode,
         ) -> strata_core::error::StrataResult<()> {
@@ -2284,7 +2288,7 @@ mod tests {
         fn delete_with_version(
             &self,
             key: &Key,
-            version: u64,
+            version: CommitVersion,
         ) -> strata_core::error::StrataResult<()> {
             self.inner.delete_with_version(key, version)
         }
@@ -2293,7 +2297,7 @@ mod tests {
             &self,
             _writes: Vec<(Key, Value, strata_core::traits::WriteMode)>,
             _deletes: Vec<Key>,
-            _version: u64,
+            _version: CommitVersion,
             _put_ttls: &[u64],
         ) -> strata_core::error::StrataResult<()> {
             Err(strata_core::error::StrataError::storage(
@@ -2316,13 +2320,13 @@ mod tests {
         let failing_store = FailingApplyStorage {
             inner: SegmentedStore::new(),
         };
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "invisible_key");
 
         // Create a transaction with a write (blind write — skips validation)
-        let mut txn = TransactionContext::with_store(1, branch_id, real_store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, real_store);
         txn.put(key.clone(), Value::Int(42)).unwrap();
 
         // Commit should return an error because apply_writes fails,
@@ -2352,12 +2356,12 @@ mod tests {
         let failing_store = FailingApplyStorage {
             inner: SegmentedStore::new(),
         };
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "invisible_key");
 
-        let mut txn = TransactionContext::with_store(2, branch_id, real_store);
+        let mut txn = TransactionContext::with_store(TxnId(2), branch_id, real_store);
         txn.put(key.clone(), Value::Int(43)).unwrap();
 
         let result = manager.commit_with_wal_arc(&mut txn, &failing_store, Some(&wal));
@@ -2383,15 +2387,15 @@ mod tests {
         let failing_store = FailingApplyStorage {
             inner: SegmentedStore::new(),
         };
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "invisible_key");
 
-        let mut txn = TransactionContext::with_store(3, branch_id, real_store);
+        let mut txn = TransactionContext::with_store(TxnId(3), branch_id, real_store);
         txn.put(key.clone(), Value::Int(44)).unwrap();
 
-        let result = manager.commit_with_version(&mut txn, &failing_store, Some(&mut wal), 42);
+        let result = manager.commit_with_version(&mut txn, &failing_store, Some(&mut wal), CommitVersion(42));
         assert!(
             result.is_err(),
             "commit_with_version() must return Err when apply_writes fails after WAL write"
@@ -2415,7 +2419,7 @@ mod tests {
         use strata_core::primitives::json::JsonPath;
 
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let json_key = Key::new_json(ns.clone(), "doc1");
@@ -2475,7 +2479,7 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let mut wal = create_test_wal(&wal_dir);
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let json_key = Key::new_json(ns.clone(), "doc1");
@@ -2517,7 +2521,7 @@ mod tests {
         // Record[0] = base doc put, Record[1] = json_set commit
         assert!(records.len() >= 2, "Expected at least 2 WAL records");
         let payload = TransactionPayload::from_bytes(&records[1].writeset).unwrap();
-        assert_eq!(payload.version, commit_v);
+        assert_eq!(payload.version, commit_v.as_u64());
         assert!(
             !payload.puts.is_empty(),
             "WAL payload must contain the materialized JSON put"
@@ -2546,7 +2550,7 @@ mod tests {
     #[test]
     fn test_issue_1739_cas_rejects_key_already_in_write_set() {
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "k1");
@@ -2569,7 +2573,7 @@ mod tests {
     #[test]
     fn test_issue_1739_put_rejects_key_already_in_cas_set() {
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "k1");
@@ -2592,7 +2596,7 @@ mod tests {
     #[test]
     fn test_issue_1739_delete_rejects_key_already_in_cas_set() {
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "k1");
@@ -2615,7 +2619,7 @@ mod tests {
     #[test]
     fn test_issue_1739_cas_rejects_key_already_in_delete_set() {
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "k1");
@@ -2638,7 +2642,7 @@ mod tests {
     #[test]
     fn test_issue_1739_cas_with_read_rejects_key_already_in_write_set() {
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let key = create_test_key(&ns, "k1");
@@ -2667,7 +2671,7 @@ mod tests {
     #[test]
     fn test_issue_1913_cross_branch_snapshot_ordering() {
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
 
         let branch_a = BranchId::new();
         let branch_b = BranchId::new();
@@ -2677,19 +2681,19 @@ mod tests {
         let key_b = create_test_key(&ns_b, "key_b");
 
         // Prepare two transactions on different branches
-        let mut txn_a = TransactionContext::with_store(1, branch_a, Arc::clone(&store));
+        let mut txn_a = TransactionContext::with_store(TxnId(1), branch_a, Arc::clone(&store));
         txn_a.put(key_a.clone(), Value::Int(100)).unwrap();
         txn_a.status = TransactionStatus::Committed; // skip validation
 
-        let mut txn_b = TransactionContext::with_store(2, branch_b, Arc::clone(&store));
+        let mut txn_b = TransactionContext::with_store(TxnId(2), branch_b, Arc::clone(&store));
         txn_b.put(key_b.clone(), Value::Int(200)).unwrap();
         txn_b.status = TransactionStatus::Committed;
 
         // Step 1: Both branches allocate versions (simulates parallel allocation)
         let version_a = manager.allocate_version().unwrap(); // 1
         let version_b = manager.allocate_version().unwrap(); // 2
-        assert_eq!(version_a, 1);
-        assert_eq!(version_b, 2);
+        assert_eq!(version_a, CommitVersion(1));
+        assert_eq!(version_b, CommitVersion(2));
 
         // Step 2: Branch B applies FIRST (out-of-order, the faster branch)
         txn_b.apply_writes(store.as_ref(), version_b).unwrap();
@@ -2745,7 +2749,7 @@ mod tests {
         use std::sync::Barrier;
 
         let store = Arc::new(SegmentedStore::new());
-        let manager = Arc::new(TransactionManager::new(0));
+        let manager = Arc::new(TransactionManager::new(CommitVersion::ZERO));
         let num_threads = 8;
         let barrier = Arc::new(Barrier::new(num_threads));
 
@@ -2761,7 +2765,7 @@ mod tests {
                     let key = create_test_key(&ns, &format!("key_{}", i));
 
                     let mut txn =
-                        TransactionContext::with_store(i as u64 + 1, branch_id, Arc::clone(&store));
+                        TransactionContext::with_store(TxnId(i as u64 + 1), branch_id, Arc::clone(&store));
                     txn.put(key, Value::Int(i as i64)).unwrap();
                     txn.status = TransactionStatus::Committed;
 
@@ -2779,7 +2783,7 @@ mod tests {
             })
             .collect();
 
-        let versions: Vec<u64> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let versions: Vec<CommitVersion> = handles.into_iter().map(|h| h.join().unwrap()).collect();
 
         let max_version = *versions.iter().max().unwrap();
 
@@ -2787,7 +2791,7 @@ mod tests {
         let vis = manager.visible_version();
         assert!(
             vis >= max_version,
-            "After all {} commits applied, visible_version ({}) must be >= max_version ({})",
+            "After all {} commits applied, visible_version ({:?}) must be >= max_version ({:?})",
             num_threads,
             vis,
             max_version,
@@ -2806,7 +2810,7 @@ mod tests {
     #[test]
     fn test_issue_1913_version_gap_does_not_block_visible() {
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
 
         let branch = BranchId::new();
         let ns = create_test_namespace(branch);
@@ -2815,7 +2819,7 @@ mod tests {
         // Version 1: allocated and applied normally
         let v1 = manager.allocate_version().unwrap();
         {
-            let mut txn = TransactionContext::with_store(1, branch, Arc::clone(&store));
+            let mut txn = TransactionContext::with_store(TxnId(1), branch, Arc::clone(&store));
             txn.put(key.clone(), Value::Int(1)).unwrap();
             txn.status = TransactionStatus::Committed;
             txn.apply_writes(store.as_ref(), v1).unwrap();
@@ -2839,7 +2843,7 @@ mod tests {
         // Version 3: normal commit after the gap
         let v3 = manager.allocate_version().unwrap();
         {
-            let mut txn = TransactionContext::with_store(3, branch, Arc::clone(&store));
+            let mut txn = TransactionContext::with_store(TxnId(3), branch, Arc::clone(&store));
             txn.put(key.clone(), Value::Int(3)).unwrap();
             txn.status = TransactionStatus::Committed;
             txn.apply_writes(store.as_ref(), v3).unwrap();
@@ -2860,7 +2864,7 @@ mod tests {
         use strata_core::primitives::json::JsonPath;
 
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let json_key = Key::new_json(ns.clone(), "unique_doc");
@@ -2912,7 +2916,7 @@ mod tests {
         use strata_core::primitives::json::JsonPath;
 
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let json_key = Key::new_json(ns.clone(), "phantom_doc");
@@ -2963,7 +2967,7 @@ mod tests {
         use strata_core::primitives::json::JsonPath;
 
         let store = Arc::new(SegmentedStore::new());
-        let manager = TransactionManager::new(0);
+        let manager = TransactionManager::new(CommitVersion::ZERO);
         let branch_id = BranchId::new();
         let ns = create_test_namespace(branch_id);
         let json_key = Key::new_json(ns.clone(), "set_race_doc");
@@ -3020,7 +3024,7 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let wal = Arc::new(ParkingMutex::new(create_test_wal(&wal_dir)));
         let store = Arc::new(SegmentedStore::new());
-        let manager = Arc::new(TransactionManager::new(0));
+        let manager = Arc::new(TransactionManager::new(CommitVersion::ZERO));
 
         let num_committers = 8;
         let commits_per_thread = 50;
@@ -3058,7 +3062,7 @@ mod tests {
                 for j in 0..commits_per_thread {
                     let key = create_test_key(&ns, &format!("k_{}_{}", i, j));
                     let mut txn = TransactionContext::with_store(
-                        (i * commits_per_thread + j) as u64 + 1,
+                        TxnId((i * commits_per_thread + j) as u64 + 1),
                         branch_id,
                         Arc::clone(&st),
                     );
@@ -3085,7 +3089,7 @@ mod tests {
         let final_version = manager.current_version();
         assert_eq!(
             final_version,
-            (num_committers * commits_per_thread) as u64,
+            CommitVersion((num_committers * commits_per_thread) as u64),
             "All commits should have succeeded"
         );
         assert!(
@@ -3106,7 +3110,7 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let wal = Arc::new(ParkingMutex::new(create_test_wal(&wal_dir)));
         let store = Arc::new(SegmentedStore::new());
-        let manager = Arc::new(TransactionManager::new(0));
+        let manager = Arc::new(TransactionManager::new(CommitVersion::ZERO));
 
         let branch_id = BranchId::new();
         let num_committers = 4;
@@ -3140,7 +3144,7 @@ mod tests {
                 for j in 0..commits_per_thread {
                     let key = create_test_key(&ns, &format!("sb_{}_{}", i, j));
                     let mut txn = TransactionContext::with_store(
-                        (i * commits_per_thread + j) as u64 + 1,
+                        TxnId((i * commits_per_thread + j) as u64 + 1),
                         branch_id,
                         Arc::clone(&st),
                     );
@@ -3162,7 +3166,7 @@ mod tests {
         let final_version = manager.current_version();
         assert_eq!(
             final_version,
-            (num_committers * commits_per_thread) as u64,
+            CommitVersion((num_committers * commits_per_thread) as u64),
             "All same-branch commits should have succeeded"
         );
     }

--- a/crates/concurrency/src/payload.rs
+++ b/crates/concurrency/src/payload.rs
@@ -157,6 +157,7 @@ pub enum PayloadError {
 mod tests {
     use super::*;
     use std::sync::Arc;
+    use strata_core::id::{CommitVersion, TxnId};
     use strata_core::types::{BranchId, Key, Namespace};
     use strata_core::value::Value;
 
@@ -279,7 +280,7 @@ mod tests {
         let branch_id = ns.branch_id;
 
         // Build a transaction with writes, deletes, and TTLs
-        let mut txn = TransactionContext::new(1, branch_id, 0);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion::ZERO);
         txn.write_set.insert(
             Key::new_kv(ns.clone(), "key1"),
             Value::Bytes(vec![0x42u8; 1024]),

--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -17,6 +17,7 @@
 use crate::payload::TransactionPayload;
 use crate::TransactionManager;
 use std::path::PathBuf;
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::StrataResult;
 use strata_durability::format::WalSegment;
 use strata_durability::wal::WalReader;
@@ -162,7 +163,7 @@ impl RecoveryCoordinator {
         if !self.wal_dir.exists() {
             return Ok(RecoveryResult {
                 storage,
-                txn_manager: TransactionManager::new(0),
+                txn_manager: TransactionManager::new(CommitVersion::ZERO),
                 stats,
             });
         }
@@ -220,10 +221,10 @@ impl RecoveryCoordinator {
         // WalWriter::new() reopens at a clean record boundary (#1741).
         self.truncate_partial_tail(&reader);
 
-        stats.final_version = max_version;
-        stats.max_txn_id = max_txn_id;
+        stats.final_version = CommitVersion(max_version);
+        stats.max_txn_id = TxnId(max_txn_id);
 
-        let txn_manager = TransactionManager::with_txn_id(max_version, max_txn_id);
+        let txn_manager = TransactionManager::with_txn_id(CommitVersion(max_version), TxnId(max_txn_id));
 
         Ok(RecoveryResult {
             storage,
@@ -256,7 +257,7 @@ impl RecoveryResult {
     pub fn empty() -> Self {
         RecoveryResult {
             storage: SegmentedStore::new(),
-            txn_manager: TransactionManager::new(0),
+            txn_manager: TransactionManager::new(CommitVersion::ZERO),
             stats: RecoveryStats::default(),
         }
     }
@@ -296,14 +297,14 @@ pub struct RecoveryStats {
     ///
     /// This is the highest version seen in the WAL, used to initialize
     /// the TransactionManager's version counter.
-    pub final_version: u64,
+    pub final_version: CommitVersion,
 
     /// Maximum transaction ID seen in WAL
     ///
     /// This is used to initialize the TransactionManager's next_txn_id counter
     /// to ensure new transactions get unique IDs that don't conflict with
     /// transactions already in the WAL.
-    pub max_txn_id: u64,
+    pub max_txn_id: TxnId,
 
     /// Whether recovery was from checkpoint
     ///
@@ -328,6 +329,7 @@ mod tests {
     use super::*;
     use crate::payload::TransactionPayload;
     use std::sync::Arc;
+    use strata_core::id::{CommitVersion, TxnId};
     use strata_core::traits::Storage;
     use strata_core::types::{BranchId, Key, Namespace};
     use strata_core::value::Value;
@@ -390,8 +392,8 @@ mod tests {
         let result = coordinator.recover().unwrap();
 
         assert_eq!(result.stats.txns_replayed, 0);
-        assert_eq!(result.stats.final_version, 0);
-        assert_eq!(result.txn_manager.current_version(), 0);
+        assert_eq!(result.stats.final_version, CommitVersion(0));
+        assert_eq!(result.txn_manager.current_version(), CommitVersion(0));
     }
 
     #[test]
@@ -403,7 +405,7 @@ mod tests {
         let result = coordinator.recover().unwrap();
 
         assert_eq!(result.stats.txns_replayed, 0);
-        assert_eq!(result.stats.final_version, 0);
+        assert_eq!(result.stats.final_version, CommitVersion(0));
     }
 
     #[test]
@@ -432,12 +434,12 @@ mod tests {
 
         assert_eq!(result.stats.txns_replayed, 1);
         assert_eq!(result.stats.writes_applied, 1);
-        assert_eq!(result.stats.final_version, 100);
-        assert_eq!(result.txn_manager.current_version(), 100);
+        assert_eq!(result.stats.final_version, CommitVersion(100));
+        assert_eq!(result.txn_manager.current_version(), CommitVersion(100));
 
         let stored = result
             .storage
-            .get_versioned(&key, u64::MAX)
+            .get_versioned(&key, CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(stored.value, Value::Int(42));
@@ -482,14 +484,14 @@ mod tests {
         let coordinator = RecoveryCoordinator::new(wal_dir);
         let result = coordinator.recover().unwrap();
 
-        assert_eq!(result.stats.final_version, 200);
-        assert_eq!(result.txn_manager.current_version(), 200);
+        assert_eq!(result.stats.final_version, CommitVersion(200));
+        assert_eq!(result.txn_manager.current_version(), CommitVersion(200));
 
         let key1 = Key::new_kv(ns.clone(), "key1");
         assert_eq!(
             result
                 .storage
-                .get_versioned(&key1, u64::MAX)
+                .get_versioned(&key1, CommitVersion::MAX)
                 .unwrap()
                 .unwrap()
                 .version
@@ -501,7 +503,7 @@ mod tests {
         assert_eq!(
             result
                 .storage
-                .get_versioned(&key2, u64::MAX)
+                .get_versioned(&key2, CommitVersion::MAX)
                 .unwrap()
                 .unwrap()
                 .version
@@ -513,7 +515,7 @@ mod tests {
         assert_eq!(
             result
                 .storage
-                .get_versioned(&key3, u64::MAX)
+                .get_versioned(&key3, CommitVersion::MAX)
                 .unwrap()
                 .unwrap()
                 .version
@@ -561,12 +563,12 @@ mod tests {
             let key = Key::new_kv(ns.clone(), format!("key{}", i));
             let v1 = result1
                 .storage
-                .get_versioned(&key, u64::MAX)
+                .get_versioned(&key, CommitVersion::MAX)
                 .unwrap()
                 .unwrap();
             let v2 = result2
                 .storage
-                .get_versioned(&key, u64::MAX)
+                .get_versioned(&key, CommitVersion::MAX)
                 .unwrap()
                 .unwrap();
             assert_eq!(v1.value, v2.value);
@@ -607,7 +609,7 @@ mod tests {
         // Key should be deleted
         assert!(result
             .storage
-            .get_versioned(&key, u64::MAX)
+            .get_versioned(&key, CommitVersion::MAX)
             .unwrap()
             .is_none());
     }
@@ -620,8 +622,8 @@ mod tests {
             aborted_txns: 0,
             writes_applied: 10,
             deletes_applied: 3,
-            final_version: 100,
-            max_txn_id: 8,
+            final_version: CommitVersion(100),
+            max_txn_id: TxnId(8),
             from_checkpoint: false,
         };
 
@@ -665,9 +667,9 @@ mod tests {
         let result = coordinator.recover().unwrap();
 
         assert_eq!(result.stats.txns_replayed, 0);
-        assert_eq!(result.stats.final_version, 0);
+        assert_eq!(result.stats.final_version, CommitVersion(0));
         assert_eq!(result.stats.incomplete_txns, 0);
-        assert_eq!(result.txn_manager.current_version(), 0);
+        assert_eq!(result.txn_manager.current_version(), CommitVersion(0));
     }
 
     #[test]
@@ -702,7 +704,7 @@ mod tests {
 
         let stored = result
             .storage
-            .get_versioned(&Key::new_kv(ns, "durable_key"), u64::MAX)
+            .get_versioned(&Key::new_kv(ns, "durable_key"), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(stored.value, Value::String("must_exist".to_string()));
@@ -746,7 +748,7 @@ mod tests {
         assert_eq!(result.stats.txns_replayed, 1);
         let stored = result
             .storage
-            .get_versioned(&Key::new_kv(ns, "valid"), u64::MAX)
+            .get_versioned(&Key::new_kv(ns, "valid"), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(stored.value, Value::Int(42));
@@ -784,12 +786,12 @@ mod tests {
 
         let v1 = result1
             .storage
-            .get_versioned(&Key::new_kv(ns.clone(), "key"), u64::MAX)
+            .get_versioned(&Key::new_kv(ns.clone(), "key"), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         let v2 = result2
             .storage
-            .get_versioned(&Key::new_kv(ns, "key"), u64::MAX)
+            .get_versioned(&Key::new_kv(ns, "key"), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(v1.value, v2.value);
@@ -819,8 +821,8 @@ mod tests {
         let coordinator = RecoveryCoordinator::new(wal_dir);
         let result = coordinator.recover().unwrap();
 
-        assert_eq!(result.txn_manager.current_version(), 999);
-        assert_eq!(result.stats.final_version, 999);
+        assert_eq!(result.txn_manager.current_version(), CommitVersion(999));
+        assert_eq!(result.stats.final_version, CommitVersion(999));
     }
 
     #[test]
@@ -852,14 +854,14 @@ mod tests {
         let result = coordinator.recover().unwrap();
 
         assert_eq!(result.stats.txns_replayed, 10);
-        assert_eq!(result.stats.final_version, 10);
-        assert_eq!(result.txn_manager.current_version(), 10);
+        assert_eq!(result.stats.final_version, CommitVersion(10));
+        assert_eq!(result.txn_manager.current_version(), CommitVersion(10));
 
         for i in 1..=10u64 {
             let key = Key::new_kv(ns.clone(), format!("key{}", i));
             let stored = result
                 .storage
-                .get_versioned(&key, u64::MAX)
+                .get_versioned(&key, CommitVersion::MAX)
                 .unwrap()
                 .unwrap();
             assert_eq!(stored.value, Value::Int(i as i64 * 10));
@@ -934,12 +936,12 @@ mod tests {
         assert_eq!(result.stats.txns_replayed, 4);
         assert_eq!(result.stats.writes_applied, 4);
         assert_eq!(result.stats.deletes_applied, 1);
-        assert_eq!(result.stats.final_version, 5);
+        assert_eq!(result.stats.final_version, CommitVersion(5));
 
         // key1 should be "updated" at version 2
         let key1 = result
             .storage
-            .get_versioned(&Key::new_kv(ns.clone(), "key1"), u64::MAX)
+            .get_versioned(&Key::new_kv(ns.clone(), "key1"), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(key1.value, Value::String("updated".to_string()));
@@ -948,14 +950,14 @@ mod tests {
         // key2 should be deleted
         assert!(result
             .storage
-            .get_versioned(&Key::new_kv(ns.clone(), "key2"), u64::MAX)
+            .get_versioned(&Key::new_kv(ns.clone(), "key2"), CommitVersion::MAX)
             .unwrap()
             .is_none());
 
         // key3 should exist
         let key3 = result
             .storage
-            .get_versioned(&Key::new_kv(ns.clone(), "key3"), u64::MAX)
+            .get_versioned(&Key::new_kv(ns.clone(), "key3"), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(key3.value, Value::Int(42));
@@ -989,7 +991,7 @@ mod tests {
 
         let counter = result
             .storage
-            .get_versioned(&Key::new_kv(ns, "counter"), u64::MAX)
+            .get_versioned(&Key::new_kv(ns, "counter"), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(counter.value, Value::Int(300));
@@ -1019,9 +1021,9 @@ mod tests {
         let coordinator = RecoveryCoordinator::new(wal_dir);
         let result = coordinator.recover().unwrap();
 
-        assert_eq!(result.txn_manager.current_version(), 100);
+        assert_eq!(result.txn_manager.current_version(), CommitVersion(100));
         let new_txn_id = result.txn_manager.next_txn_id().unwrap();
-        assert!(new_txn_id > 0);
+        assert!(new_txn_id > TxnId::ZERO);
     }
 
     #[test]
@@ -1054,13 +1056,13 @@ mod tests {
         let result = coordinator.recover().unwrap();
 
         assert_eq!(result.stats.txns_replayed, num_txns as usize);
-        assert_eq!(result.stats.final_version, num_txns);
+        assert_eq!(result.stats.final_version, CommitVersion(num_txns));
 
         for i in [1, 50, 100] {
             let key = Key::new_kv(ns.clone(), format!("key_{}", i));
             let stored = result
                 .storage
-                .get_versioned(&key, u64::MAX)
+                .get_versioned(&key, CommitVersion::MAX)
                 .unwrap()
                 .unwrap();
             assert_eq!(stored.value, Value::Int(i as i64));
@@ -1100,9 +1102,9 @@ mod tests {
         let result = coordinator.recover().unwrap();
 
         assert_eq!(result.stats.txns_replayed, 20);
-        assert_eq!(result.stats.final_version, 20);
+        assert_eq!(result.stats.final_version, CommitVersion(20));
         assert_eq!(result.stats.writes_applied, 20);
-        assert_eq!(result.txn_manager.current_version(), 20);
+        assert_eq!(result.txn_manager.current_version(), CommitVersion(20));
 
         // Cross-check: read_all should yield the same records
         let reader = WalReader::new();
@@ -1114,7 +1116,7 @@ mod tests {
             let key = Key::new_kv(ns.clone(), format!("key{}", i));
             let stored = result
                 .storage
-                .get_versioned(&key, u64::MAX)
+                .get_versioned(&key, CommitVersion::MAX)
                 .unwrap()
                 .unwrap();
             assert_eq!(stored.value, Value::Int(i as i64 * 10));
@@ -1214,13 +1216,13 @@ mod tests {
                 result.stats.txns_replayed, 3,
                 "Second recovery must see the record written after crash recovery"
             );
-            assert_eq!(result.stats.final_version, 3);
+            assert_eq!(result.stats.final_version, CommitVersion(3));
 
             // Verify the post-crash record is accessible
             let key_after = Key::new_kv(ns.clone(), "key_after");
             let stored = result
                 .storage
-                .get_versioned(&key_after, u64::MAX)
+                .get_versioned(&key_after, CommitVersion::MAX)
                 .unwrap()
                 .expect("key_after must be visible after second recovery");
             assert_eq!(stored.value, Value::String("after_crash".into()));

--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -10,6 +10,7 @@ use crate::validation::{validate_transaction, ValidationResult};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::primitives::json::{get_at_path, JsonPatch, JsonPath, JsonValue};
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{BranchId, Key};
@@ -128,7 +129,7 @@ impl From<CommitError> for StrataError {
 #[derive(Debug, Clone)]
 pub struct ApplyResult {
     /// Version assigned to all writes in this transaction
-    pub commit_version: u64,
+    pub commit_version: CommitVersion,
     /// Number of puts applied
     pub puts_applied: usize,
     /// Number of deletes applied
@@ -403,7 +404,7 @@ pub trait JsonStoreExt {
 pub struct TransactionContext {
     // Identity
     /// Unique transaction ID
-    pub txn_id: u64,
+    pub txn_id: TxnId,
     /// Branch this transaction belongs to
     pub branch_id: BranchId,
 
@@ -411,7 +412,7 @@ pub struct TransactionContext {
     /// Version at transaction start (snapshot version)
     ///
     /// All reads see data as of this version. Used for conflict detection.
-    pub start_version: u64,
+    pub start_version: CommitVersion,
 
     /// Backing store for snapshot reads
     ///
@@ -529,12 +530,13 @@ impl TransactionContext {
     /// ```
     /// use strata_concurrency::TransactionContext;
     /// use strata_core::types::BranchId;
+    /// use strata_core::id::{TxnId, CommitVersion};
     ///
     /// let branch_id = BranchId::new();
-    /// let txn = TransactionContext::new(1, branch_id, 100);
+    /// let txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
     /// assert!(txn.is_active());
     /// ```
-    pub fn new(txn_id: u64, branch_id: BranchId, start_version: u64) -> Self {
+    pub fn new(txn_id: TxnId, branch_id: BranchId, start_version: CommitVersion) -> Self {
         TransactionContext {
             txn_id,
             branch_id,
@@ -574,16 +576,17 @@ impl TransactionContext {
     /// ```
     /// use strata_concurrency::TransactionContext;
     /// use strata_core::types::BranchId;
+    /// use strata_core::id::TxnId;
     /// use strata_storage::SegmentedStore;
     /// use std::sync::Arc;
     ///
     /// let branch_id = BranchId::new();
     /// let store = Arc::new(SegmentedStore::new());
-    /// let txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+    /// let txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
     /// assert!(txn.is_active());
     /// ```
-    pub fn with_store(txn_id: u64, branch_id: BranchId, store: Arc<SegmentedStore>) -> Self {
-        let start_version = store.version();
+    pub fn with_store(txn_id: TxnId, branch_id: BranchId, store: Arc<SegmentedStore>) -> Self {
+        let start_version = store.current_version();
         TransactionContext {
             txn_id,
             branch_id,
@@ -1316,11 +1319,12 @@ impl TransactionContext {
     /// # Example
     /// ```
     /// use strata_concurrency::TransactionContext;
+    /// use strata_core::id::{TxnId, CommitVersion};
     /// use strata_core::types::BranchId;
     /// use std::time::Duration;
     ///
     /// let branch_id = BranchId::new();
-    /// let txn = TransactionContext::new(1, branch_id, 100);
+    /// let txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
     ///
     /// // Should not be expired immediately
     /// assert!(!txn.is_expired(Duration::from_secs(1)));
@@ -1336,11 +1340,12 @@ impl TransactionContext {
     /// # Example
     /// ```
     /// use strata_concurrency::TransactionContext;
+    /// use strata_core::id::{TxnId, CommitVersion};
     /// use strata_core::types::BranchId;
     /// use std::time::Duration;
     ///
     /// let branch_id = BranchId::new();
-    /// let txn = TransactionContext::new(1, branch_id, 100);
+    /// let txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
     ///
     /// // Elapsed should be very small initially
     /// assert!(txn.elapsed() < Duration::from_secs(1));
@@ -1588,7 +1593,7 @@ impl TransactionContext {
     pub fn apply_writes<S: Storage>(
         &mut self,
         store: &S,
-        commit_version: u64,
+        commit_version: CommitVersion,
     ) -> StrataResult<ApplyResult> {
         if !self.is_committed() {
             return Err(StrataError::invalid_input(format!(
@@ -1781,24 +1786,25 @@ impl TransactionContext {
     /// ```no_run
     /// # use strata_concurrency::TransactionContext;
     /// # use strata_core::types::BranchId;
+    /// # use strata_core::id::{TxnId, CommitVersion};
     /// # use strata_storage::SegmentedStore;
     /// # use std::sync::Arc;
     /// let branch_id = BranchId::default();
-    /// let mut ctx = TransactionContext::new(1, branch_id, 100);
+    /// let mut ctx = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
     /// // ... use the context ...
     ///
     /// // Reset for reuse - capacity is preserved!
     /// let new_branch_id = BranchId::default();
     /// let store = Arc::new(SegmentedStore::new());
-    /// ctx.reset(2, new_branch_id, Some(store));
+    /// ctx.reset(TxnId(2), new_branch_id, Some(store));
     /// ```
-    pub fn reset(&mut self, txn_id: u64, branch_id: BranchId, store: Option<Arc<SegmentedStore>>) {
+    pub fn reset(&mut self, txn_id: TxnId, branch_id: BranchId, store: Option<Arc<SegmentedStore>>) {
         // Update identity
         self.txn_id = txn_id;
         self.branch_id = branch_id;
 
         // Update store and version
-        self.start_version = store.as_ref().map(|s| s.version()).unwrap_or(0);
+        self.start_version = store.as_ref().map(|s| s.current_version()).unwrap_or(CommitVersion::ZERO);
         self.store = store;
 
         // Clear collections but preserve capacity - this is the key optimization!
@@ -1857,9 +1863,10 @@ impl TransactionContext {
     ///
     /// ```no_run
     /// # use strata_concurrency::TransactionContext;
+    /// # use strata_core::id::{TxnId, CommitVersion};
     /// # use strata_core::types::BranchId;
     /// let branch_id = BranchId::default();
-    /// let ctx = TransactionContext::new(1, branch_id, 100);
+    /// let ctx = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
     /// let (read_cap, write_cap, delete_cap, cas_cap) = ctx.capacity();
     /// ```
     pub fn capacity(&self) -> (usize, usize, usize, usize) {
@@ -2028,6 +2035,7 @@ impl JsonStoreExt for TransactionContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use strata_core::id::{CommitVersion, TxnId};
     use strata_core::types::{BranchId, Namespace, TypeTag};
     use strata_core::value::Value;
 
@@ -2043,7 +2051,7 @@ mod tests {
     fn store_with_key(key: &Key, value: Value, version: u64) -> Arc<SegmentedStore> {
         let store = Arc::new(SegmentedStore::new());
         store
-            .put_with_version_mode(key.clone(), value, version, None, WriteMode::Append)
+            .put_with_version_mode(key.clone(), value, CommitVersion(version), None, WriteMode::Append)
             .unwrap();
         store
     }
@@ -2059,7 +2067,7 @@ mod tests {
         let ns = test_namespace_for(branch_id);
         let key = test_key(&ns, "k1");
         let store = store_with_key(&key, Value::Int(42), 5);
-        let mut txn = TransactionContext::with_store(1, branch_id, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store);
 
         let result = txn.get_versioned(&key).unwrap();
         let vv = result.unwrap();
@@ -2073,7 +2081,7 @@ mod tests {
         let ns = test_namespace_for(branch_id);
         let key = test_key(&ns, "k1");
         let store = empty_store();
-        let mut txn = TransactionContext::with_store(1, branch_id, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store);
 
         txn.put(key.clone(), Value::String("written".into()))
             .unwrap();
@@ -2090,7 +2098,7 @@ mod tests {
         let ns = test_namespace_for(branch_id);
         let key = test_key(&ns, "k1");
         let store = store_with_key(&key, Value::Int(42), 5);
-        let mut txn = TransactionContext::with_store(1, branch_id, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store);
 
         txn.delete(key.clone()).unwrap();
 
@@ -2104,7 +2112,7 @@ mod tests {
         let ns = test_namespace_for(branch_id);
         let key = test_key(&ns, "missing");
         let store = empty_store();
-        let mut txn = TransactionContext::with_store(1, branch_id, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store);
 
         let result = txn.get_versioned(&key).unwrap();
         assert!(result.is_none());
@@ -2118,7 +2126,7 @@ mod tests {
         let ns = test_namespace_for(branch_id);
         let key = test_key(&ns, "k1");
         let store = store_with_key(&key, Value::Int(7), 15);
-        let mut txn = TransactionContext::with_store(1, branch_id, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store);
 
         let _ = txn.get_versioned(&key).unwrap();
         // Verify version tracked for conflict detection
@@ -2133,7 +2141,7 @@ mod tests {
     fn test_write_buffer_limit_rejects_at_max() {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
-        let mut txn = TransactionContext::new(1, branch_id, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
         txn.set_max_write_entries(3);
 
         // Put 3 entries — should succeed
@@ -2156,7 +2164,7 @@ mod tests {
     fn test_write_buffer_limit_counts_deletes() {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
-        let mut txn = TransactionContext::new(1, branch_id, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
         txn.set_max_write_entries(2);
 
         txn.put(test_key(&ns, "k1"), Value::Int(1)).unwrap();
@@ -2170,7 +2178,7 @@ mod tests {
     fn test_write_buffer_limit_zero_unlimited() {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
-        let mut txn = TransactionContext::new(1, branch_id, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
         // max_write_entries = 0 (default, unlimited)
 
         for i in 0..1000 {
@@ -2188,7 +2196,7 @@ mod tests {
     fn test_reset_shrinks_large_capacity() {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
-        let mut txn = TransactionContext::new(1, branch_id, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
         // Inflate capacity well beyond the 4096 threshold
         for i in 0..5000 {
@@ -2197,7 +2205,7 @@ mod tests {
         }
         assert!(txn.write_set.capacity() >= 5000);
 
-        txn.reset(2, branch_id, Some(empty_store()));
+        txn.reset(TxnId(2), branch_id, Some(empty_store()));
 
         // After reset, capacity should be shrunk below threshold
         assert!(
@@ -2211,7 +2219,7 @@ mod tests {
     fn test_write_buffer_limit_counts_cas() {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
-        let mut txn = TransactionContext::new(1, branch_id, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
         txn.set_max_write_entries(2);
 
         // 1 put + 1 CAS = 2
@@ -2227,7 +2235,7 @@ mod tests {
     fn test_write_buffer_overwrite_at_limit() {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
-        let mut txn = TransactionContext::new(1, branch_id, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
         txn.set_max_write_entries(2);
 
         // Fill to limit
@@ -2247,7 +2255,7 @@ mod tests {
     fn test_write_buffer_delete_existing_at_limit() {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
-        let mut txn = TransactionContext::new(1, branch_id, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
         txn.set_max_write_entries(2);
 
         // Fill: 1 put + 1 delete = 2
@@ -2268,7 +2276,7 @@ mod tests {
     fn test_reset_preserves_normal_capacity() {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
-        let mut txn = TransactionContext::new(1, branch_id, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
         // Insert a modest number of entries (below threshold)
         for i in 0..100 {
@@ -2277,7 +2285,7 @@ mod tests {
         }
         let cap_before = txn.write_set.capacity();
 
-        txn.reset(2, branch_id, Some(empty_store()));
+        txn.reset(TxnId(2), branch_id, Some(empty_store()));
 
         // Capacity should be preserved (not shrunk)
         assert_eq!(txn.write_set.capacity(), cap_before);
@@ -2292,7 +2300,7 @@ mod tests {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
         let store = empty_store();
-        let mut txn = TransactionContext::new(1, branch_id, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
         // Mark some keys for replace
         txn.put_replace(test_key(&ns, "adj1"), Value::Int(1))
@@ -2302,7 +2310,7 @@ mod tests {
         assert_eq!(txn.key_write_modes.len(), 2);
 
         // Reset should clear key_write_modes
-        txn.reset(2, branch_id, Some(store.clone()));
+        txn.reset(TxnId(2), branch_id, Some(store.clone()));
         assert!(txn.key_write_modes.is_empty());
 
         // After reset, a normal put should NOT use KeepLast — verify no stale leak
@@ -2318,7 +2326,7 @@ mod tests {
     fn test_put_replace_uses_keep_last() {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
-        let mut txn = TransactionContext::new(1, branch_id, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
         let key = test_key(&ns, "graph_adj");
         txn.put_replace(key.clone(), Value::Int(42)).unwrap();
@@ -2332,7 +2340,7 @@ mod tests {
     fn test_delete_cleans_up_key_write_modes() {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
-        let mut txn = TransactionContext::new(1, branch_id, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
         let key = test_key(&ns, "adj_to_delete");
         txn.put_replace(key.clone(), Value::Int(1)).unwrap();
@@ -2363,7 +2371,7 @@ mod tests {
                 .put_with_version_mode(
                     key.clone(),
                     Value::Int(v as i64),
-                    v,
+                    CommitVersion(v),
                     None,
                     WriteMode::Append,
                 )
@@ -2376,17 +2384,17 @@ mod tests {
         assert_eq!(history.len(), 3);
 
         // Now create a transaction that uses put_replace
-        let mut txn = TransactionContext::with_store(1, branch_id, store.clone());
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store.clone());
         txn.put_replace(key.clone(), Value::Int(99)).unwrap();
 
         // Force status to Committed for apply_writes
         txn.status = TransactionStatus::Committed;
 
-        let result = txn.apply_writes(&*store, 4).unwrap();
+        let result = txn.apply_writes(&*store, CommitVersion(4)).unwrap();
         assert_eq!(result.puts_applied, 1);
 
         // KeepLast(1) is a retention hint — write still appends (issue #1700)
-        let latest = Storage::get_versioned(&*store, &key, u64::MAX)
+        let latest = Storage::get_versioned(&*store, &key, CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(latest.value, Value::Int(99));
@@ -2415,7 +2423,7 @@ mod tests {
         let ns = test_namespace_for(branch_id);
         let key = test_key(&ns, "k1");
         let store = store_with_key(&key, Value::Int(42), 1);
-        let mut txn = TransactionContext::with_store(1, branch_id, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store);
         txn.set_read_only(true);
 
         // Read should succeed
@@ -2433,7 +2441,7 @@ mod tests {
     fn test_read_only_rejects_put() {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
-        let mut txn = TransactionContext::new(1, branch_id, 0);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion::ZERO);
         txn.set_read_only(true);
 
         let key = test_key(&ns, "k1");
@@ -2445,7 +2453,7 @@ mod tests {
     fn test_read_only_rejects_delete() {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
-        let mut txn = TransactionContext::new(1, branch_id, 0);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion::ZERO);
         txn.set_read_only(true);
 
         let key = test_key(&ns, "k1");
@@ -2457,7 +2465,7 @@ mod tests {
     fn test_read_only_rejects_cas() {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
-        let mut txn = TransactionContext::new(1, branch_id, 0);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion::ZERO);
         txn.set_read_only(true);
 
         let key = test_key(&ns, "k1");
@@ -2468,11 +2476,11 @@ mod tests {
     #[test]
     fn test_read_only_reset_clears_flag() {
         let branch_id = BranchId::new();
-        let mut txn = TransactionContext::new(1, branch_id, 0);
+        let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion::ZERO);
         txn.set_read_only(true);
         assert!(txn.is_read_only_mode());
 
-        txn.reset(2, branch_id, Some(empty_store()));
+        txn.reset(TxnId(2), branch_id, Some(empty_store()));
         assert!(
             !txn.is_read_only_mode(),
             "read_only should be cleared after reset"
@@ -2489,7 +2497,7 @@ mod tests {
         let ns = test_namespace_for(branch_id);
         let key = test_key(&ns, "k1");
         let store = store_with_key(&key, Value::Int(10), 5);
-        let mut txn = TransactionContext::with_store(1, branch_id, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store);
 
         txn.cas_with_read(key.clone(), 5, Value::Int(20)).unwrap();
 
@@ -2506,7 +2514,7 @@ mod tests {
         let ns = test_namespace_for(branch_id);
         let key = test_key(&ns, "missing");
         let store = empty_store();
-        let mut txn = TransactionContext::with_store(1, branch_id, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store);
 
         txn.cas_with_read(key.clone(), 0, Value::Int(1)).unwrap();
 
@@ -2520,7 +2528,7 @@ mod tests {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
         let store = empty_store();
-        let mut txn = TransactionContext::with_store(1, branch_id, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store);
         txn.set_read_only(true);
 
         let key = test_key(&ns, "k1");
@@ -2538,7 +2546,7 @@ mod tests {
         let ns = test_namespace_for(branch_id);
         let key = test_key(&ns, "k1");
         let store = store_with_key(&key, Value::Int(42), 7);
-        let mut txn = TransactionContext::with_store(1, branch_id, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store);
         txn.set_read_only(true);
 
         // get_versioned should return the value
@@ -2558,7 +2566,7 @@ mod tests {
         let branch_id = BranchId::new();
         let ns = test_namespace_for(branch_id);
         let store = empty_store();
-        let mut txn = TransactionContext::with_store(1, branch_id, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store);
         txn.set_read_only(true);
 
         let key = test_key(&ns, "missing");
@@ -2580,10 +2588,10 @@ mod tests {
         for i in 0..3 {
             let key = test_key(&ns, &format!("pfx:{}", i));
             store
-                .put_with_version_mode(key, Value::Int(i as i64), 1, None, WriteMode::Append)
+                .put_with_version_mode(key, Value::Int(i as i64), CommitVersion(1), None, WriteMode::Append)
                 .unwrap();
         }
-        let mut txn = TransactionContext::with_store(1, branch_id, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store);
         txn.set_read_only(true);
 
         let prefix = test_key(&ns, "pfx:");
@@ -2609,7 +2617,7 @@ mod tests {
         let cross_key = Key::new(ns_b, TypeTag::KV, b"flag".to_vec());
 
         let store = Arc::new(SegmentedStore::new());
-        let mut txn = TransactionContext::with_store(1, branch_a, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_a, store);
 
         // Reading a key from branch B inside a branch A transaction must fail
         let err = txn.get(&cross_key).unwrap_err();
@@ -2627,7 +2635,7 @@ mod tests {
         let ns_b = Arc::new(Namespace::new(branch_b, "default".to_string()));
         let cross_key = Key::new(ns_b, TypeTag::KV, b"flag".to_vec());
 
-        let mut txn = TransactionContext::new(1, branch_a, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_a, CommitVersion(100));
 
         // Writing a key from branch B inside a branch A transaction must fail
         let err = txn.put(cross_key, Value::Int(1)).unwrap_err();
@@ -2645,7 +2653,7 @@ mod tests {
         let ns_b = Arc::new(Namespace::new(branch_b, "default".to_string()));
         let cross_key = Key::new(ns_b, TypeTag::KV, b"flag".to_vec());
 
-        let mut txn = TransactionContext::new(1, branch_a, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_a, CommitVersion(100));
 
         // Deleting a key from branch B inside a branch A transaction must fail
         let err = txn.delete(cross_key).unwrap_err();
@@ -2663,7 +2671,7 @@ mod tests {
         let ns_b = Arc::new(Namespace::new(branch_b, "default".to_string()));
         let cross_key = Key::new(ns_b, TypeTag::KV, b"flag".to_vec());
 
-        let mut txn = TransactionContext::new(1, branch_a, 100);
+        let mut txn = TransactionContext::new(TxnId(1), branch_a, CommitVersion(100));
 
         // CAS on a key from branch B inside a branch A transaction must fail
         let err = txn.cas(cross_key, 1, Value::Int(2)).unwrap_err();
@@ -2682,7 +2690,7 @@ mod tests {
         let cross_key = Key::new(ns_b, TypeTag::KV, b"flag".to_vec());
 
         let store = Arc::new(SegmentedStore::new());
-        let mut txn = TransactionContext::with_store(1, branch_a, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_a, store);
 
         // cas_with_read on a key from branch B must fail
         let err = txn.cas_with_read(cross_key, 0, Value::Int(2)).unwrap_err();
@@ -2701,7 +2709,7 @@ mod tests {
         let cross_prefix = Key::new(ns_b, TypeTag::KV, b"pfx:".to_vec());
 
         let store = Arc::new(SegmentedStore::new());
-        let mut txn = TransactionContext::with_store(1, branch_a, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_a, store);
 
         let err = txn.scan_prefix(&cross_prefix).unwrap_err();
         assert!(
@@ -2719,7 +2727,7 @@ mod tests {
         let cross_key = Key::new(ns_b, TypeTag::KV, b"flag".to_vec());
 
         let store = Arc::new(SegmentedStore::new());
-        let mut txn = TransactionContext::with_store(1, branch_a, store);
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_a, store);
         txn.set_allow_cross_branch(true);
 
         // With allow_cross_branch, cross-branch get should succeed (returns None, no data)
@@ -2740,14 +2748,14 @@ mod tests {
                 .put_with_version_mode(
                     test_key(&ns, name),
                     Value::Int(val),
-                    10,
+                    CommitVersion(10),
                     None,
                     WriteMode::Append,
                 )
                 .unwrap();
         }
 
-        let mut txn = TransactionContext::with_store(100, branch_id, store);
+        let mut txn = TransactionContext::with_store(TxnId(100), branch_id, store);
 
         // Buffer writes that interleave (b, d) and override (c, e)
         txn.put(test_key(&ns, "b"), Value::Int(20)).unwrap();

--- a/crates/core/src/id.rs
+++ b/crates/core/src/id.rs
@@ -1,0 +1,211 @@
+//! Strongly-typed identifiers for transaction and version tracking.
+//!
+//! These newtypes prevent accidental parameter swaps between
+//! transaction IDs, commit versions, and timestamps — all of which
+//! are `u64` at the wire level.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Unique identifier for a transaction.
+///
+/// Assigned by `TransactionManager` at transaction start. Monotonically
+/// increasing within a database instance. Used in WAL records, segment
+/// metadata, watermark tracking, and GC coordination.
+///
+/// Wire format: bare `u64` (via `#[repr(transparent)]` + `#[serde(transparent)]`).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[repr(transparent)]
+#[serde(transparent)]
+pub struct TxnId(pub u64);
+
+/// Monotonic commit version (MVCC sequence number).
+///
+/// Assigned at commit time. Used for snapshot isolation (`start_version`),
+/// version-bounded reads (`max_version`), fork points (`fork_version`),
+/// and garbage collection (`min_version`).
+///
+/// Wire format: bare `u64` (via `#[repr(transparent)]` + `#[serde(transparent)]`).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[repr(transparent)]
+#[serde(transparent)]
+pub struct CommitVersion(pub u64);
+
+impl TxnId {
+    /// The zero transaction ID (used as "no transaction" sentinel).
+    pub const ZERO: Self = Self(0);
+
+    /// Create the next sequential transaction ID.
+    #[inline]
+    pub fn next(self) -> Self {
+        Self(self.0 + 1)
+    }
+
+    /// Return the raw `u64` value.
+    #[inline]
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl CommitVersion {
+    /// The zero version (used as "no version" or "before any commit" sentinel).
+    pub const ZERO: Self = Self(0);
+
+    /// The maximum version (used for "latest" reads: `get_versioned(key, CommitVersion::MAX)`).
+    pub const MAX: Self = Self(u64::MAX);
+
+    /// Create the next sequential version.
+    #[inline]
+    pub fn next(self) -> Self {
+        Self(self.0 + 1)
+    }
+
+    /// Return the raw `u64` value.
+    #[inline]
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Debug for TxnId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TxnId({})", self.0)
+    }
+}
+
+impl fmt::Display for TxnId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "txn:{}", self.0)
+    }
+}
+
+impl fmt::Debug for CommitVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CommitVersion({})", self.0)
+    }
+}
+
+impl fmt::Display for CommitVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "v{}", self.0)
+    }
+}
+
+impl From<u64> for TxnId {
+    #[inline]
+    fn from(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl From<TxnId> for u64 {
+    #[inline]
+    fn from(id: TxnId) -> Self {
+        id.0
+    }
+}
+
+impl From<u64> for CommitVersion {
+    #[inline]
+    fn from(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl From<CommitVersion> for u64 {
+    #[inline]
+    fn from(v: CommitVersion) -> Self {
+        v.0
+    }
+}
+
+impl Default for TxnId {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl Default for CommitVersion {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_txn_id_serde_transparent() {
+        // Verify that TxnId serializes as bare u64, not {"TxnId": value}
+        let id = TxnId(42);
+        let serialized = serde_json::to_string(&id).unwrap();
+        assert_eq!(serialized, "42");
+
+        let deserialized: TxnId = serde_json::from_str("42").unwrap();
+        assert_eq!(deserialized, TxnId(42));
+    }
+
+    #[test]
+    fn test_commit_version_serde_transparent() {
+        // Verify that CommitVersion serializes as bare u64
+        let version = CommitVersion(100);
+        let serialized = serde_json::to_string(&version).unwrap();
+        assert_eq!(serialized, "100");
+
+        let deserialized: CommitVersion = serde_json::from_str("100").unwrap();
+        assert_eq!(deserialized, CommitVersion(100));
+    }
+
+    #[test]
+    fn test_txn_id_constants_and_methods() {
+        assert_eq!(TxnId::ZERO.as_u64(), 0);
+        assert_eq!(TxnId(5).next(), TxnId(6));
+    }
+
+    #[test]
+    fn test_commit_version_constants_and_methods() {
+        assert_eq!(CommitVersion::ZERO.as_u64(), 0);
+        assert_eq!(CommitVersion::MAX.as_u64(), u64::MAX);
+        assert_eq!(CommitVersion(10).next(), CommitVersion(11));
+    }
+
+    #[test]
+    fn test_from_conversions() {
+        let txn: TxnId = 42u64.into();
+        assert_eq!(txn, TxnId(42));
+
+        let raw: u64 = TxnId(42).into();
+        assert_eq!(raw, 42);
+
+        let ver: CommitVersion = 100u64.into();
+        assert_eq!(ver, CommitVersion(100));
+
+        let raw: u64 = CommitVersion(100).into();
+        assert_eq!(raw, 100);
+    }
+
+    #[test]
+    fn test_display_and_debug() {
+        assert_eq!(format!("{}", TxnId(5)), "txn:5");
+        assert_eq!(format!("{:?}", TxnId(5)), "TxnId(5)");
+        assert_eq!(format!("{}", CommitVersion(10)), "v10");
+        assert_eq!(format!("{:?}", CommitVersion(10)), "CommitVersion(10)");
+    }
+
+    #[test]
+    fn test_ordering() {
+        assert!(TxnId(1) < TxnId(2));
+        assert!(CommitVersion(10) > CommitVersion(5));
+    }
+
+    #[test]
+    fn test_repr_transparent_size() {
+        // Verify #[repr(transparent)] guarantees same size as u64
+        assert_eq!(std::mem::size_of::<TxnId>(), std::mem::size_of::<u64>());
+        assert_eq!(std::mem::size_of::<CommitVersion>(), std::mem::size_of::<u64>());
+        assert_eq!(std::mem::align_of::<TxnId>(), std::mem::align_of::<u64>());
+        assert_eq!(std::mem::align_of::<CommitVersion>(), std::mem::align_of::<u64>());
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod branch_dag; // Branch DAG types and constants
 pub mod branch_types; // Branch lifecycle types
 pub mod contract; // contract types
 pub mod error;
+pub mod id;
 pub mod instrumentation; // Performance tracing (feature-gated)
 pub mod limits; // Size limits for keys, values, and vectors
 pub mod primitives; // primitive types (Event, Vector, JSON types)
@@ -28,6 +29,7 @@ pub use branch_types::{BranchEventOffsets, BranchMetadata, BranchStatus};
 pub use error::{
     ConstraintReason, DetailValue, ErrorCode, ErrorDetails, StrataError, StrataResult,
 };
+pub use id::{CommitVersion, TxnId};
 pub use limits::{LimitError, Limits};
 pub use traits::{Storage, WriteMode};
 pub use types::{validate_space_name, BranchId, Key, Namespace, TypeTag};

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use crate::contract::VersionedValue;
 use crate::error::StrataResult;
+use crate::id::CommitVersion;
 use crate::types::Key;
 use crate::value::Value;
 
@@ -83,7 +84,7 @@ pub trait Storage: Send + Sync {
     /// # Errors
     ///
     /// Returns an error if the storage operation fails.
-    fn get_versioned(&self, key: &Key, max_version: u64) -> StrataResult<Option<VersionedValue>>;
+    fn get_versioned(&self, key: &Key, max_version: CommitVersion) -> StrataResult<Option<VersionedValue>>;
 
     /// Get version history for a key
     ///
@@ -106,7 +107,7 @@ pub trait Storage: Send + Sync {
         &self,
         key: &Key,
         limit: Option<usize>,
-        before_version: Option<u64>,
+        before_version: Option<CommitVersion>,
     ) -> StrataResult<Vec<VersionedValue>>;
 
     /// Scan keys with given prefix at or before max_version
@@ -120,14 +121,14 @@ pub trait Storage: Send + Sync {
     fn scan_prefix(
         &self,
         prefix: &Key,
-        max_version: u64,
+        max_version: CommitVersion,
     ) -> StrataResult<Vec<(Key, VersionedValue)>>;
 
     /// Get current global version
     ///
     /// Returns the highest version assigned so far.
     /// Used for creating snapshots at current version.
-    fn current_version(&self) -> u64;
+    fn current_version(&self) -> CommitVersion;
 
     /// Put a value with a specific version and write mode.
     ///
@@ -155,7 +156,7 @@ pub trait Storage: Send + Sync {
         &self,
         key: Key,
         value: Value,
-        version: u64,
+        version: CommitVersion,
         ttl: Option<Duration>,
         mode: WriteMode,
     ) -> StrataResult<()>;
@@ -172,7 +173,7 @@ pub trait Storage: Send + Sync {
     /// # Errors
     ///
     /// Returns an error if the storage operation fails.
-    fn delete_with_version(&self, key: &Key, version: u64) -> StrataResult<()>;
+    fn delete_with_version(&self, key: &Key, version: CommitVersion) -> StrataResult<()>;
 
     /// Apply a batch of writes in a single operation.
     ///
@@ -181,7 +182,7 @@ pub trait Storage: Send + Sync {
     /// branch guards once per branch instead of per entry).
     ///
     /// All writes share the same `version` (same transaction commit version).
-    fn apply_batch(&self, writes: Vec<(Key, Value, WriteMode)>, version: u64) -> StrataResult<()> {
+    fn apply_batch(&self, writes: Vec<(Key, Value, WriteMode)>, version: CommitVersion) -> StrataResult<()> {
         for (key, value, mode) in writes {
             self.put_with_version_mode(key, value, version, None, mode)?;
         }
@@ -191,7 +192,7 @@ pub trait Storage: Send + Sync {
     /// Apply a batch of deletes in a single operation.
     ///
     /// Default implementation iterates and calls `delete_with_version()` per entry.
-    fn delete_batch(&self, deletes: Vec<Key>, version: u64) -> StrataResult<()> {
+    fn delete_batch(&self, deletes: Vec<Key>, version: CommitVersion) -> StrataResult<()> {
         for key in &deletes {
             self.delete_with_version(key, version)?;
         }
@@ -211,7 +212,7 @@ pub trait Storage: Send + Sync {
         &self,
         writes: Vec<(Key, Value, WriteMode)>,
         deletes: Vec<Key>,
-        version: u64,
+        version: CommitVersion,
         put_ttls: &[u64],
     ) -> StrataResult<()> {
         // Default: ignore put_ttls — implementations that support TTL
@@ -238,7 +239,7 @@ pub trait Storage: Send + Sync {
     /// Returns an error if the storage operation fails.
     fn get_version_only(&self, key: &Key) -> StrataResult<Option<u64>> {
         Ok(self
-            .get_versioned(key, u64::MAX)?
+            .get_versioned(key, CommitVersion::MAX)?
             .map(|vv| vv.version.as_u64()))
     }
 }
@@ -279,14 +280,14 @@ mod tests {
         fn get_versioned(
             &self,
             key: &Key,
-            max_version: u64,
+            max_version: CommitVersion,
         ) -> StrataResult<Option<VersionedValue>> {
             let data = self.data.read().unwrap();
             Ok(data.get(key).and_then(|versions| {
                 versions
                     .iter()
                     .rev()
-                    .find(|v| v.version().as_u64() <= max_version)
+                    .find(|v| v.version().as_u64() <= max_version.as_u64())
                     .cloned()
             }))
         }
@@ -295,7 +296,7 @@ mod tests {
             &self,
             key: &Key,
             limit: Option<usize>,
-            before_version: Option<u64>,
+            before_version: Option<CommitVersion>,
         ) -> StrataResult<Vec<VersionedValue>> {
             let data = self.data.read().unwrap();
             let Some(versions) = data.get(key) else {
@@ -304,7 +305,7 @@ mod tests {
             let mut result: Vec<_> = versions
                 .iter()
                 .rev()
-                .filter(|v| before_version.map_or(true, |bv| v.version().as_u64() < bv))
+                .filter(|v| before_version.map_or(true, |bv| v.version().as_u64() < bv.as_u64()))
                 .cloned()
                 .collect();
             if let Some(limit) = limit {
@@ -316,7 +317,7 @@ mod tests {
         fn scan_prefix(
             &self,
             prefix: &Key,
-            max_version: u64,
+            max_version: CommitVersion,
         ) -> StrataResult<Vec<(Key, VersionedValue)>> {
             let data = self.data.read().unwrap();
             let mut result = vec![];
@@ -325,7 +326,7 @@ mod tests {
                     if let Some(v) = versions
                         .iter()
                         .rev()
-                        .find(|v| v.version().as_u64() <= max_version)
+                        .find(|v| v.version().as_u64() <= max_version.as_u64())
                     {
                         result.push((k.clone(), v.clone()));
                     }
@@ -334,27 +335,27 @@ mod tests {
             Ok(result)
         }
 
-        fn current_version(&self) -> u64 {
-            self.version.load(Ordering::SeqCst)
+        fn current_version(&self) -> CommitVersion {
+            CommitVersion(self.version.load(Ordering::SeqCst))
         }
 
         fn put_with_version_mode(
             &self,
             key: Key,
             value: Value,
-            version: u64,
+            version: CommitVersion,
             _ttl: Option<Duration>,
             _mode: WriteMode,
         ) -> StrataResult<()> {
             let versioned =
-                Versioned::with_timestamp(value, Version::txn(version), Timestamp::now());
+                Versioned::with_timestamp(value, Version::txn(version.as_u64()), Timestamp::now());
             let mut data = self.data.write().unwrap();
             data.entry(key).or_default().push(versioned);
-            self.version.fetch_max(version, Ordering::SeqCst);
+            self.version.fetch_max(version.as_u64(), Ordering::SeqCst);
             Ok(())
         }
 
-        fn delete_with_version(&self, key: &Key, _version: u64) -> StrataResult<()> {
+        fn delete_with_version(&self, key: &Key, _version: CommitVersion) -> StrataResult<()> {
             let mut data = self.data.write().unwrap();
             data.remove(key);
             Ok(())
@@ -390,7 +391,7 @@ mod tests {
     /// Helper: seed a value via put_with_version_mode (the only write method)
     fn seed(store: &MockStorage, key: Key, value: Value, version: u64) {
         store
-            .put_with_version_mode(key, value, version, None, WriteMode::Append)
+            .put_with_version_mode(key, value, CommitVersion(version), None, WriteMode::Append)
             .unwrap();
     }
 
@@ -399,7 +400,7 @@ mod tests {
         let store = MockStorage::new();
         let ns = test_ns();
         let key = test_key(&ns, "missing");
-        assert!(store.get_versioned(&key, u64::MAX).unwrap().is_none());
+        assert!(store.get_versioned(&key, CommitVersion::MAX).unwrap().is_none());
     }
 
     #[test]
@@ -409,7 +410,7 @@ mod tests {
         let key = test_key(&ns, "hello");
         seed(&store, key.clone(), Value::Int(42), 1);
 
-        let result = store.get_versioned(&key, u64::MAX).unwrap().unwrap();
+        let result = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
         assert_eq!(result.value, Value::Int(42));
     }
 
@@ -423,11 +424,11 @@ mod tests {
         seed(&store, key.clone(), Value::Int(2), 2);
 
         // Reading at v1 should see the first write
-        let result = store.get_versioned(&key, 1).unwrap().unwrap();
+        let result = store.get_versioned(&key, CommitVersion(1)).unwrap().unwrap();
         assert_eq!(result.value, Value::Int(1));
 
-        // Reading at u64::MAX should see the latest write
-        let result = store.get_versioned(&key, u64::MAX).unwrap().unwrap();
+        // Reading at CommitVersion::MAX should see the latest write
+        let result = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
         assert_eq!(result.value, Value::Int(2));
     }
 
@@ -439,7 +440,7 @@ mod tests {
         seed(&store, key.clone(), Value::Int(1), 1);
 
         // Version 0 is before any write
-        assert!(store.get_versioned(&key, 0).unwrap().is_none());
+        assert!(store.get_versioned(&key, CommitVersion::ZERO).unwrap().is_none());
     }
 
     #[test]
@@ -493,12 +494,12 @@ mod tests {
         seed(&store, key.clone(), Value::Int(3), 3);
 
         // Get history before v3 (should return v2 and v1)
-        let history = store.get_history(&key, None, Some(3)).unwrap();
+        let history = store.get_history(&key, None, Some(CommitVersion(3))).unwrap();
         assert_eq!(history.len(), 2);
         assert_eq!(history[0].value, Value::Int(2));
 
         // Get history before v2 (should return only v1)
-        let history = store.get_history(&key, None, Some(2)).unwrap();
+        let history = store.get_history(&key, None, Some(CommitVersion(2))).unwrap();
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].value, Value::Int(1));
     }
@@ -506,7 +507,7 @@ mod tests {
     #[test]
     fn storage_current_version_starts_at_zero() {
         let store = MockStorage::new();
-        assert_eq!(store.current_version(), 0);
+        assert_eq!(store.current_version(), CommitVersion::ZERO);
     }
 
     #[test]
@@ -514,7 +515,7 @@ mod tests {
         let store = MockStorage::new();
         let ns = test_ns();
         seed(&store, test_key(&ns, "a"), Value::Int(1), 5);
-        assert!(store.current_version() >= 5);
+        assert!(store.current_version() >= CommitVersion(5));
     }
 
     #[test]
@@ -524,7 +525,7 @@ mod tests {
         let key = test_key(&ns, "explicit");
         seed(&store, key.clone(), Value::Int(99), 42);
 
-        let result = store.get_versioned(&key, u64::MAX).unwrap().unwrap();
+        let result = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
         assert_eq!(result.value, Value::Int(99));
         assert_eq!(result.version().as_u64(), 42);
     }
@@ -553,7 +554,7 @@ mod tests {
             3,
         );
 
-        let results = store.scan_prefix(&prefix, u64::MAX).unwrap();
+        let results = store.scan_prefix(&prefix, CommitVersion::MAX).unwrap();
         assert_eq!(results.len(), 2);
     }
 
@@ -564,8 +565,8 @@ mod tests {
         let key = test_key(&ns, "deleteme");
         seed(&store, key.clone(), Value::Int(1), 1);
 
-        store.delete_with_version(&key, 2).unwrap();
-        assert!(store.get_versioned(&key, u64::MAX).unwrap().is_none());
+        store.delete_with_version(&key, CommitVersion(2)).unwrap();
+        assert!(store.get_versioned(&key, CommitVersion::MAX).unwrap().is_none());
     }
 
     // ====================================================================
@@ -576,34 +577,34 @@ mod tests {
     struct FailingStorage;
 
     impl Storage for FailingStorage {
-        fn get_versioned(&self, _: &Key, _: u64) -> StrataResult<Option<VersionedValue>> {
+        fn get_versioned(&self, _: &Key, _: CommitVersion) -> StrataResult<Option<VersionedValue>> {
             Err(StrataError::storage("disk read failed"))
         }
         fn get_history(
             &self,
             _: &Key,
             _: Option<usize>,
-            _: Option<u64>,
+            _: Option<CommitVersion>,
         ) -> StrataResult<Vec<VersionedValue>> {
             Err(StrataError::storage("disk read failed"))
         }
-        fn scan_prefix(&self, _: &Key, _: u64) -> StrataResult<Vec<(Key, VersionedValue)>> {
+        fn scan_prefix(&self, _: &Key, _: CommitVersion) -> StrataResult<Vec<(Key, VersionedValue)>> {
             Err(StrataError::storage("disk read failed"))
         }
-        fn current_version(&self) -> u64 {
-            0
+        fn current_version(&self) -> CommitVersion {
+            CommitVersion::ZERO
         }
         fn put_with_version_mode(
             &self,
             _: Key,
             _: Value,
-            _: u64,
+            _: CommitVersion,
             _: Option<Duration>,
             _: WriteMode,
         ) -> StrataResult<()> {
             Err(StrataError::storage("disk write failed"))
         }
-        fn delete_with_version(&self, _: &Key, _: u64) -> StrataResult<()> {
+        fn delete_with_version(&self, _: &Key, _: CommitVersion) -> StrataResult<()> {
             Err(StrataError::storage("disk write failed"))
         }
     }
@@ -614,13 +615,13 @@ mod tests {
         let ns = test_ns();
         let key = test_key(&ns, "k");
 
-        assert!(store.get_versioned(&key, u64::MAX).is_err());
+        assert!(store.get_versioned(&key, CommitVersion::MAX).is_err());
         assert!(store.get_history(&key, None, None).is_err());
-        assert!(store.scan_prefix(&key, 0).is_err());
+        assert!(store.scan_prefix(&key, CommitVersion::ZERO).is_err());
         assert!(store
-            .put_with_version_mode(key.clone(), Value::Null, 1, None, WriteMode::Append)
+            .put_with_version_mode(key.clone(), Value::Null, CommitVersion(1), None, WriteMode::Append)
             .is_err());
-        assert!(store.delete_with_version(&key, 1).is_err());
+        assert!(store.delete_with_version(&key, CommitVersion(1)).is_err());
     }
 
     #[test]
@@ -629,11 +630,11 @@ mod tests {
         let ns = test_ns();
         let key = test_key(&ns, "k");
 
-        let err = store.get_versioned(&key, u64::MAX).unwrap_err();
+        let err = store.get_versioned(&key, CommitVersion::MAX).unwrap_err();
         assert!(err.is_storage_error());
 
         let err = store
-            .put_with_version_mode(key, Value::Null, 1, None, WriteMode::Append)
+            .put_with_version_mode(key, Value::Null, CommitVersion(1), None, WriteMode::Append)
             .unwrap_err();
         assert!(err.is_storage_error());
     }

--- a/crates/engine/src/branch_ops/mod.rs
+++ b/crates/engine/src/branch_ops/mod.rs
@@ -39,6 +39,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
+use strata_core::id::CommitVersion;
 use strata_core::types::{BranchId, Key, Namespace, TypeTag};
 use strata_core::value::Value;
 use strata_core::StrataError;
@@ -863,7 +864,7 @@ pub fn fork_branch_with_metadata(
         target: "strata::branch_ops",
         source,
         destination,
-        fork_version,
+        fork_version = fork_version.as_u64(),
         "Branch forked (COW)"
     );
 
@@ -872,7 +873,7 @@ pub fn fork_branch_with_metadata(
         destination: destination.to_string(),
         keys_copied: 0,
         spaces_copied,
-        fork_version: Some(fork_version),
+        fork_version: Some(fork_version.as_u64()),
     };
 
     // Fire the branch DAG hook. Best-effort: the hook implementation
@@ -933,7 +934,7 @@ pub fn diff_branches_with_options(
     let storage = db.storage();
 
     // Capture snapshot version for consistent reads (#1920)
-    let snapshot_version = db.current_version();
+    let snapshot_version = db.current_version().as_u64();
 
     // COW fast path: if one branch is a direct child of the other and no
     // as_of timestamp, use O(W) diff instead of O(N) full scan.
@@ -1145,7 +1146,7 @@ fn cow_diff_branches(
             .clone();
         let key_a = Key::new(ns_a, *type_tag, user_key.clone());
         let val_a = storage
-            .get_versioned(&key_a, snapshot_version)?
+            .get_versioned(&key_a, CommitVersion(snapshot_version))?
             .map(|vv| vv.value);
 
         let ns_b = ns_cache
@@ -1154,7 +1155,7 @@ fn cow_diff_branches(
             .clone();
         let key_b = Key::new(ns_b, *type_tag, user_key.clone());
         let val_b = storage
-            .get_versioned(&key_b, snapshot_version)?
+            .get_versioned(&key_b, CommitVersion(snapshot_version))?
             .map(|vv| vv.value);
 
         let diff_entry = match (&val_a, &val_b) {
@@ -1919,7 +1920,7 @@ pub fn merge_branches_with_metadata(
     let all_spaces: Vec<String> = source_spaces.union(&target_spaces).cloned().collect();
 
     // Capture snapshot version for consistent reads during diff (#1917)
-    let snapshot_version = db.current_version();
+    let snapshot_version = db.current_version().as_u64();
 
     // Gather typed entries once, then route through the
     // PrimitiveMergeHandler registry. The registry's `precheck` step is
@@ -2439,7 +2440,7 @@ pub fn create_tag(
         )));
     }
 
-    let version = version.unwrap_or_else(|| db.current_version());
+    let version = version.unwrap_or_else(|| db.current_version().as_u64());
     let timestamp = strata_core::contract::Timestamp::now().as_micros();
 
     let tag_info = TagInfo {
@@ -2727,7 +2728,7 @@ pub fn revert_version_range_with_metadata(
             from_version, to_version
         )));
     }
-    let current_version = db.current_version();
+    let current_version = db.current_version().as_u64();
     if to_version > current_version {
         return Err(StrataError::invalid_input(format!(
             "to_version ({}) exceeds current database version ({})",
@@ -3075,7 +3076,7 @@ pub fn cherry_pick_from_diff(
     let all_spaces: Vec<String> = source_spaces.union(&target_spaces).cloned().collect();
 
     // Capture snapshot for consistent reads (#1917)
-    let snapshot_version = db.current_version();
+    let snapshot_version = db.current_version().as_u64();
 
     // Cherry-pick uses the same per-handler `precheck` + `plan` dispatch
     // as `merge_branches`, so it inherits the semantic graph merge and
@@ -5119,7 +5120,7 @@ mod tests {
         write_kv(&db, "main", "default", "b", Value::Int(10)); // v3
 
         // Get current version
-        let current = db.current_version();
+        let current = db.current_version().as_u64();
 
         // Revert the last write (v3 = b:10)
         let info = revert_version_range(&db, "main", current, current).unwrap();
@@ -5136,9 +5137,9 @@ mod tests {
         let (_temp, db) = setup_with_branch("main");
 
         write_kv(&db, "main", "default", "a", Value::Int(1)); // v_start
-        let v_start = db.current_version();
+        let v_start = db.current_version().as_u64();
         write_kv(&db, "main", "default", "a", Value::Int(2)); // v_change
-        let v_change = db.current_version();
+        let v_change = db.current_version().as_u64();
         write_kv(&db, "main", "default", "a", Value::Int(3)); // v_after (after range)
 
         // Revert [v_start+1, v_change] — but "a" was modified after the range
@@ -5169,11 +5170,11 @@ mod tests {
     fn test_revert_restores_deleted_key() {
         let (_temp, db) = setup_with_branch("main");
         write_kv(&db, "main", "default", "a", Value::Int(1));
-        let v_before = db.current_version();
+        let v_before = db.current_version().as_u64();
 
         // Delete "a" in the revert range
         delete_kv(&db, "main", "default", "a");
-        let v_delete = db.current_version();
+        let v_delete = db.current_version().as_u64();
 
         // Verify it's gone
         assert_eq!(read_kv(&db, "main", "default", "a"), None);

--- a/crates/engine/src/bundle.rs
+++ b/crates/engine/src/bundle.rs
@@ -148,7 +148,7 @@ fn scan_branch_data(
     let storage = db.storage();
 
     // Capture snapshot version for consistent reads (#1920)
-    let snapshot_version = db.current_version();
+    let snapshot_version = db.current_version().as_u64();
 
     // Discover all current keys across all type tags
     let type_tags = [

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -15,6 +15,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use strata_concurrency::{RecoveryResult, TransactionContext, TransactionManager};
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::traits::Storage;
 use strata_core::types::BranchId;
 use strata_core::StrataError;
@@ -78,7 +79,7 @@ impl TransactionCoordinator {
     ///
     /// # Arguments
     /// * `initial_version` - Starting version (typically from storage or recovery)
-    pub fn new(initial_version: u64) -> Self {
+    pub fn new(initial_version: CommitVersion) -> Self {
         Self {
             manager: TransactionManager::new(initial_version),
             active_count: AtomicU64::new(0),
@@ -176,7 +177,7 @@ impl TransactionCoordinator {
         // Track per-transaction snapshot for incremental GC advancement (#1923).
         self.active_snapshots
             .lock()
-            .insert(txn.txn_id, txn.start_version);
+            .insert(txn.txn_id.as_u64(), txn.start_version.as_u64());
 
         Ok(txn)
     }
@@ -207,7 +208,7 @@ impl TransactionCoordinator {
             }
             warn!(
                 target: "strata::txn",
-                txn_id = txn.txn_id,
+                txn_id = txn.txn_id.as_u64(),
                 elapsed_ms = elapsed.as_millis() as u64,
                 timeout_ms = self.transaction_timeout.as_millis() as u64,
                 "Transaction expired — rejecting commit"
@@ -244,7 +245,7 @@ impl TransactionCoordinator {
         txn: &mut TransactionContext,
         store: &S,
         wal: Option<&mut WalWriter>,
-    ) -> StrataResult<u64> {
+    ) -> StrataResult<CommitVersion> {
         self.enforce_timeout(txn)?;
         let txn_id = txn.txn_id;
         self.handle_commit_result(txn_id, self.manager.commit(txn, store, wal))
@@ -259,7 +260,7 @@ impl TransactionCoordinator {
         txn: &mut TransactionContext,
         store: &S,
         wal_arc: Option<&Arc<ParkingMutex<WalWriter>>>,
-    ) -> StrataResult<u64> {
+    ) -> StrataResult<CommitVersion> {
         self.enforce_timeout(txn)?;
         let txn_id = txn.txn_id;
         self.handle_commit_result(
@@ -271,13 +272,13 @@ impl TransactionCoordinator {
     /// Handle the result of a commit attempt: record metrics and convert errors.
     fn handle_commit_result(
         &self,
-        txn_id: u64,
-        result: Result<u64, strata_concurrency::CommitError>,
-    ) -> StrataResult<u64> {
+        txn_id: TxnId,
+        result: Result<CommitVersion, strata_concurrency::CommitError>,
+    ) -> StrataResult<CommitVersion> {
         match result {
             Ok(version) => {
                 self.record_commit(txn_id);
-                info!(target: "strata::txn", version, "Transaction committed");
+                info!(target: "strata::txn", version = version.as_u64(), "Transaction committed");
                 Ok(version)
             }
             Err(e) => {
@@ -296,11 +297,11 @@ impl TransactionCoordinator {
     /// # Arguments
     /// * `txn_id` - Unique transaction ID
     /// * `start_version` - Snapshot version at transaction start
-    pub fn record_start(&self, txn_id: u64, start_version: u64) {
+    pub fn record_start(&self, txn_id: TxnId, start_version: CommitVersion) {
         // Relaxed: observational counters only (see struct-level doc).
         self.active_count.fetch_add(1, Ordering::Relaxed);
         self.total_started.fetch_add(1, Ordering::Relaxed);
-        self.active_snapshots.lock().insert(txn_id, start_version);
+        self.active_snapshots.lock().insert(txn_id.as_u64(), start_version.as_u64());
     }
 
     /// Record transaction commit
@@ -314,7 +315,7 @@ impl TransactionCoordinator {
     ///
     /// # Arguments
     /// * `txn_id` - Transaction ID (used for snapshot tracking)
-    pub fn record_commit(&self, txn_id: u64) {
+    pub fn record_commit(&self, txn_id: TxnId) {
         self.total_committed.fetch_add(1, Ordering::Relaxed);
         self.finish_transaction(txn_id);
     }
@@ -330,7 +331,7 @@ impl TransactionCoordinator {
     ///
     /// # Arguments
     /// * `txn_id` - Transaction ID (used for snapshot tracking)
-    pub fn record_abort(&self, txn_id: u64) {
+    pub fn record_abort(&self, txn_id: TxnId) {
         self.total_aborted.fetch_add(1, Ordering::Relaxed);
         self.finish_transaction(txn_id);
     }
@@ -346,17 +347,17 @@ impl TransactionCoordinator {
     /// The Mutex on active_snapshots is held only for the brief
     /// insert/remove + min() computation. The lock is released before the
     /// atomic `fetch_max` to minimize contention.
-    fn finish_transaction(&self, txn_id: u64) {
+    fn finish_transaction(&self, txn_id: TxnId) {
         // Capture version BEFORE the decrement so gc_safe_version is always
         // ≤ the snapshot version of any concurrently-starting transaction.
-        let drain_version = self.manager.current_version();
+        let drain_version = self.manager.current_version().as_u64();
 
         let prev = self.active_count.fetch_sub(1, Ordering::AcqRel);
         debug_assert!(prev > 0, "active_count underflow in finish_transaction");
 
         let new_gc_safe = {
             let mut snapshots = self.active_snapshots.lock();
-            snapshots.remove(&txn_id);
+            snapshots.remove(&txn_id.as_u64());
 
             if snapshots.is_empty() {
                 // All transactions drained — advance to current version
@@ -388,17 +389,17 @@ impl TransactionCoordinator {
     // ========================================================================
 
     /// Get current global version.
-    pub fn current_version(&self) -> u64 {
+    pub fn current_version(&self) -> CommitVersion {
         self.manager.current_version()
     }
 
     /// Get the highest version where all data ≤ V is fully applied (#1913).
-    pub fn visible_version(&self) -> u64 {
+    pub fn visible_version(&self) -> CommitVersion {
         self.manager.visible_version()
     }
 
     /// Ensure the version counter is at least `floor` (#1726).
-    pub fn bump_version_floor(&self, floor: u64) {
+    pub fn bump_version_floor(&self, floor: CommitVersion) {
         self.manager.bump_version_floor(floor);
     }
 
@@ -417,7 +418,7 @@ impl TransactionCoordinator {
     }
 
     /// Get next transaction ID (for internal use).
-    pub fn next_txn_id(&self) -> StrataResult<u64> {
+    pub fn next_txn_id(&self) -> StrataResult<TxnId> {
         self.manager.next_txn_id().map_err(StrataError::from)
     }
 
@@ -485,8 +486,8 @@ impl TransactionCoordinator {
         txn: &mut TransactionContext,
         store: &S,
         wal: Option<&mut WalWriter>,
-        version: u64,
-    ) -> StrataResult<u64> {
+        version: CommitVersion,
+    ) -> StrataResult<CommitVersion> {
         self.enforce_timeout(txn)?;
         let txn_id = txn.txn_id;
         self.handle_commit_result(
@@ -609,7 +610,7 @@ impl TransactionMetrics {
 #[cfg(test)]
 impl TransactionCoordinator {
     /// Allocate commit version (test-only)
-    pub fn allocate_commit_version(&self) -> StrataResult<u64> {
+    pub fn allocate_commit_version(&self) -> StrataResult<CommitVersion> {
         self.manager.allocate_version().map_err(StrataError::from)
     }
 
@@ -629,8 +630,8 @@ mod tests {
 
     #[test]
     fn test_coordinator_new() {
-        let coordinator = TransactionCoordinator::new(0);
-        assert_eq!(coordinator.current_version(), 0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
+        assert_eq!(coordinator.current_version(), CommitVersion::ZERO);
 
         let metrics = coordinator.metrics();
         assert_eq!(metrics.active_count, 0);
@@ -649,24 +650,24 @@ mod tests {
             aborted_txns: 0,
             writes_applied: 10,
             deletes_applied: 2,
-            final_version: 100,
-            max_txn_id: 6,
+            final_version: CommitVersion(100),
+            max_txn_id: TxnId(6),
             from_checkpoint: false,
         };
 
         let result = RecoveryResult {
             storage: SegmentedStore::new(),
-            txn_manager: TransactionManager::new(100),
+            txn_manager: TransactionManager::new(CommitVersion(100)),
             stats,
         };
 
         let coordinator = TransactionCoordinator::from_recovery(&result);
-        assert_eq!(coordinator.current_version(), 100);
+        assert_eq!(coordinator.current_version(), CommitVersion(100));
     }
 
     #[test]
     fn test_start_transaction_updates_metrics() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
@@ -680,7 +681,7 @@ mod tests {
 
     #[test]
     fn test_record_commit_updates_metrics() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
@@ -696,7 +697,7 @@ mod tests {
 
     #[test]
     fn test_record_abort_updates_metrics() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
@@ -712,7 +713,7 @@ mod tests {
 
     #[test]
     fn test_version_monotonic() {
-        let coordinator = TransactionCoordinator::new(100);
+        let coordinator = TransactionCoordinator::new(CommitVersion(100));
 
         let v1 = coordinator.allocate_commit_version().unwrap();
         let v2 = coordinator.allocate_commit_version().unwrap();
@@ -720,14 +721,14 @@ mod tests {
 
         assert!(v1 < v2);
         assert!(v2 < v3);
-        assert_eq!(v1, 101);
-        assert_eq!(v2, 102);
-        assert_eq!(v3, 103);
+        assert_eq!(v1, CommitVersion(101));
+        assert_eq!(v2, CommitVersion(102));
+        assert_eq!(v3, CommitVersion(103));
     }
 
     #[test]
     fn test_metrics_helpers() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
@@ -752,7 +753,7 @@ mod tests {
 
     #[test]
     fn test_mixed_transactions() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
@@ -786,7 +787,7 @@ mod tests {
 
     #[test]
     fn test_wait_for_idle_no_active_transactions() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
 
         // No transactions active, should return immediately
         let result = coordinator.wait_for_idle(std::time::Duration::from_millis(100));
@@ -798,7 +799,7 @@ mod tests {
 
     #[test]
     fn test_wait_for_idle_timeout_with_active_transaction() {
-        let coordinator = Arc::new(TransactionCoordinator::new(0));
+        let coordinator = Arc::new(TransactionCoordinator::new(CommitVersion::ZERO));
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
@@ -828,7 +829,7 @@ mod tests {
     fn test_wait_for_idle_transaction_completes_before_timeout() {
         use std::thread;
 
-        let coordinator = Arc::new(TransactionCoordinator::new(0));
+        let coordinator = Arc::new(TransactionCoordinator::new(CommitVersion::ZERO));
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
@@ -866,7 +867,7 @@ mod tests {
         use std::sync::Barrier;
         use std::thread;
 
-        let coordinator = Arc::new(TransactionCoordinator::new(0));
+        let coordinator = Arc::new(TransactionCoordinator::new(CommitVersion::ZERO));
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
@@ -912,7 +913,7 @@ mod tests {
 
     #[test]
     fn test_wait_for_idle_zero_timeout() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
@@ -941,7 +942,7 @@ mod tests {
         use std::sync::atomic::{AtomicBool, Ordering};
         use std::thread;
 
-        let coordinator = Arc::new(TransactionCoordinator::new(0));
+        let coordinator = Arc::new(TransactionCoordinator::new(CommitVersion::ZERO));
         let storage = Arc::new(SegmentedStore::new());
         let branch_id = BranchId::new();
         let stop_flag = Arc::new(AtomicBool::new(false));
@@ -988,7 +989,7 @@ mod tests {
         use std::sync::Barrier;
         use std::thread;
 
-        let coordinator = Arc::new(TransactionCoordinator::new(0));
+        let coordinator = Arc::new(TransactionCoordinator::new(CommitVersion::ZERO));
         let storage = Arc::new(SegmentedStore::new());
         let branch_id = BranchId::new();
         let barrier = Arc::new(Barrier::new(10));
@@ -1053,27 +1054,27 @@ mod tests {
             aborted_txns: 1,
             writes_applied: 50,
             deletes_applied: 5,
-            final_version: 500,
-            max_txn_id: 15,
+            final_version: CommitVersion(500),
+            max_txn_id: TxnId(15),
             from_checkpoint: false,
         };
 
         let result = RecoveryResult {
             storage: SegmentedStore::new(),
-            txn_manager: TransactionManager::new(500),
+            txn_manager: TransactionManager::new(CommitVersion(500)),
             stats,
         };
 
         let coordinator = TransactionCoordinator::from_recovery(&result);
 
         // Version should be restored
-        assert_eq!(coordinator.current_version(), 500);
+        assert_eq!(coordinator.current_version(), CommitVersion(500));
 
         // Next txn_id should be > max_txn_id from recovery
         let next_id = coordinator.next_txn_id().unwrap();
         assert!(
-            next_id > 15,
-            "Next txn_id ({}) should be > max_txn_id from recovery (15)",
+            next_id > TxnId(15),
+            "Next txn_id ({:?}) should be > max_txn_id from recovery (15)",
             next_id
         );
     }
@@ -1086,32 +1087,32 @@ mod tests {
     /// cycles and that GC safe point advances on drain.
     #[test]
     fn test_active_count_balanced_start_commit() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
 
         // Start one transaction, commit it
-        coordinator.record_start(100, 0);
+        coordinator.record_start(TxnId(100), CommitVersion::ZERO);
         assert_eq!(coordinator.active_count(), 1);
-        coordinator.record_commit(100);
+        coordinator.record_commit(TxnId(100));
         assert_eq!(coordinator.active_count(), 0);
 
         // Start and abort
-        coordinator.record_start(101, 0);
+        coordinator.record_start(TxnId(101), CommitVersion::ZERO);
         assert_eq!(coordinator.active_count(), 1);
-        coordinator.record_abort(101);
+        coordinator.record_abort(TxnId(101));
         assert_eq!(coordinator.active_count(), 0);
 
         // Interleaved: 3 starts, then 2 commits + 1 abort
-        coordinator.record_start(200, 0);
-        coordinator.record_start(201, 0);
-        coordinator.record_start(202, 0);
+        coordinator.record_start(TxnId(200), CommitVersion::ZERO);
+        coordinator.record_start(TxnId(201), CommitVersion::ZERO);
+        coordinator.record_start(TxnId(202), CommitVersion::ZERO);
         assert_eq!(coordinator.active_count(), 3);
 
-        coordinator.record_commit(200);
+        coordinator.record_commit(TxnId(200));
         assert_eq!(coordinator.active_count(), 2);
-        coordinator.record_abort(201);
+        coordinator.record_abort(TxnId(201));
         assert_eq!(coordinator.active_count(), 1);
         // Last one drains — should be 0 after
-        coordinator.record_commit(202);
+        coordinator.record_commit(TxnId(202));
         assert_eq!(coordinator.active_count(), 0);
     }
 
@@ -1119,14 +1120,14 @@ mod tests {
     /// via fetch_sub (prev == 1 triggers drain detection).
     #[test]
     fn test_gc_safe_point_advances_after_fetch_sub_drain() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
 
         // Bump version so gc_safe_version can advance
         let _ = coordinator.allocate_commit_version().unwrap(); // version → 1
 
         // Start and commit a single transaction — drains active_count
-        coordinator.record_start(1, 0);
-        coordinator.record_commit(1);
+        coordinator.record_start(TxnId(1), CommitVersion::ZERO);
+        coordinator.record_commit(TxnId(1));
 
         // GC safe point should have advanced (drain_version = 1)
         assert!(
@@ -1137,14 +1138,14 @@ mod tests {
 
         // Now with multiple transactions: only the LAST drain advances
         let _ = coordinator.allocate_commit_version().unwrap(); // version → 2
-        coordinator.record_start(2, 0);
-        coordinator.record_start(3, 0);
+        coordinator.record_start(TxnId(2), CommitVersion::ZERO);
+        coordinator.record_start(TxnId(3), CommitVersion::ZERO);
         // Commit first — active_count goes from 2 → 1, prev=2, no drain
-        coordinator.record_commit(2);
+        coordinator.record_commit(TxnId(2));
         // GC safe point should still be at 1 (no drain yet)
         assert_eq!(coordinator.min_active_version().unwrap(), 1);
         // Commit second — active_count goes from 1 → 0, prev=1, drain!
-        coordinator.record_commit(3);
+        coordinator.record_commit(TxnId(3));
         assert_eq!(coordinator.min_active_version().unwrap(), 2);
     }
 
@@ -1155,7 +1156,7 @@ mod tests {
         use std::sync::Arc;
         use std::thread;
 
-        let coordinator = Arc::new(TransactionCoordinator::new(0));
+        let coordinator = Arc::new(TransactionCoordinator::new(CommitVersion::ZERO));
         let num_threads = 8;
         let iterations = 500;
 
@@ -1164,10 +1165,10 @@ mod tests {
                 let coord = Arc::clone(&coordinator);
                 thread::spawn(move || {
                     for i in 0..iterations {
-                        let id = (t * iterations + i) as u64;
-                        coord.record_start(id, 0);
+                        let id = TxnId((t * iterations + i) as u64);
+                        coord.record_start(id, CommitVersion::ZERO);
                         // Small amount of "work"
-                        std::hint::black_box(id);
+                        std::hint::black_box(id.as_u64());
                         if i % 3 == 0 {
                             coord.record_abort(id);
                         } else {
@@ -1194,18 +1195,18 @@ mod tests {
     #[cfg(debug_assertions)]
     #[should_panic(expected = "active_count underflow in finish_transaction")]
     fn test_active_count_underflow_panics_in_debug_commit() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
         // Commit without a preceding start — should panic in debug builds
-        coordinator.record_commit(999);
+        coordinator.record_commit(TxnId(999));
     }
 
     #[test]
     #[cfg(debug_assertions)]
     #[should_panic(expected = "active_count underflow in finish_transaction")]
     fn test_active_count_underflow_panics_in_debug_abort() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
         // Abort without a preceding start — should panic in debug builds
-        coordinator.record_abort(999);
+        coordinator.record_abort(TxnId(999));
     }
 
     /// Verify metrics reach consistent state after concurrent operations.
@@ -1217,7 +1218,7 @@ mod tests {
         use std::sync::atomic::AtomicUsize;
         use std::thread;
 
-        let coordinator = Arc::new(TransactionCoordinator::new(0));
+        let coordinator = Arc::new(TransactionCoordinator::new(CommitVersion::ZERO));
         let storage = Arc::new(SegmentedStore::new());
         let branch_id = BranchId::new();
 
@@ -1280,7 +1281,7 @@ mod tests {
         use std::collections::HashSet;
         use std::thread;
 
-        let coordinator = Arc::new(TransactionCoordinator::new(0));
+        let coordinator = Arc::new(TransactionCoordinator::new(CommitVersion::ZERO));
         let versions = Arc::new(Mutex::new(Vec::new()));
 
         let handles: Vec<_> = (0..8)
@@ -1316,7 +1317,7 @@ mod tests {
 
         // Verify all versions are > 0 (initial version)
         for v in all_versions.iter() {
-            assert!(*v > 0, "Version should be > initial version 0");
+            assert!(*v > CommitVersion::ZERO, "Version should be > initial version 0");
         }
     }
 
@@ -1329,7 +1330,7 @@ mod tests {
         use std::collections::HashSet;
         use std::thread;
 
-        let coordinator = Arc::new(TransactionCoordinator::new(0));
+        let coordinator = Arc::new(TransactionCoordinator::new(CommitVersion::ZERO));
         let txn_ids = Arc::new(Mutex::new(Vec::new()));
 
         let handles: Vec<_> = (0..8)
@@ -1370,7 +1371,7 @@ mod tests {
     /// Verify it handles zero gracefully.
     #[test]
     fn test_commit_rate_with_zero_started() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
 
         let metrics = coordinator.metrics();
 
@@ -1389,7 +1390,7 @@ mod tests {
         use std::sync::atomic::{AtomicBool, Ordering};
         use std::thread;
 
-        let coordinator = Arc::new(TransactionCoordinator::new(0));
+        let coordinator = Arc::new(TransactionCoordinator::new(CommitVersion::ZERO));
         let storage = Arc::new(SegmentedStore::new());
         let branch_id = BranchId::new();
         let should_stop = Arc::new(AtomicBool::new(false));
@@ -1442,7 +1443,7 @@ mod tests {
         use parking_lot::Mutex;
         use std::thread;
 
-        let coordinator = Arc::new(TransactionCoordinator::new(0));
+        let coordinator = Arc::new(TransactionCoordinator::new(CommitVersion::ZERO));
         let results = Arc::new(Mutex::new(Vec::new()));
 
         let handles: Vec<_> = (0..4)
@@ -1487,33 +1488,33 @@ mod tests {
 
     #[test]
     fn test_min_active_version_empty() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
         // No transactions ever started → gc_safe_version is 0 (sentinel) → returns None
         assert_eq!(coordinator.min_active_version(), None);
     }
 
     #[test]
     fn test_min_active_version_tracks_correctly() {
-        let coordinator = TransactionCoordinator::new(10);
+        let coordinator = TransactionCoordinator::new(CommitVersion(10));
 
         // Register 3 transactions at version 10
-        coordinator.record_start(1, 10);
-        coordinator.record_start(2, 10);
-        coordinator.record_start(3, 10);
+        coordinator.record_start(TxnId(1), CommitVersion(10));
+        coordinator.record_start(TxnId(2), CommitVersion(10));
+        coordinator.record_start(TxnId(3), CommitVersion(10));
 
         // While transactions are active but none have finished,
         // gc_safe_version is still 0 (initial)
         assert_eq!(coordinator.min_active_version(), None);
 
         // Partial commit: gc_safe advances to min(remaining) - 1 = 9 (#1923)
-        coordinator.record_commit(1);
+        coordinator.record_commit(TxnId(1));
         assert_eq!(
             coordinator.min_active_version(),
             Some(9),
             "partial drain should advance gc_safe to min(snapshots) - 1"
         );
 
-        coordinator.record_commit(2);
+        coordinator.record_commit(TxnId(2));
         assert_eq!(
             coordinator.min_active_version(),
             Some(9),
@@ -1521,7 +1522,7 @@ mod tests {
         );
 
         // Full drain → gc_safe_version advances to current_version (10)
-        coordinator.record_commit(3);
+        coordinator.record_commit(TxnId(3));
         assert_eq!(
             coordinator.min_active_version(),
             Some(10),
@@ -1531,11 +1532,11 @@ mod tests {
 
     #[test]
     fn test_min_active_version_after_commit() {
-        let coordinator = TransactionCoordinator::new(5);
+        let coordinator = TransactionCoordinator::new(CommitVersion(5));
 
         // Start and fully drain a transaction → gc_safe_version advances
-        coordinator.record_start(1, 5);
-        coordinator.record_commit(1);
+        coordinator.record_start(TxnId(1), CommitVersion(5));
+        coordinator.record_commit(TxnId(1));
 
         // gc_safe_version should be exactly 5 (current_version at drain time)
         assert_eq!(
@@ -1556,8 +1557,8 @@ mod tests {
         );
 
         // Start and drain again → gc_safe_version advances to 7
-        coordinator.record_start(2, 7);
-        coordinator.record_commit(2);
+        coordinator.record_start(TxnId(2), CommitVersion(7));
+        coordinator.record_commit(TxnId(2));
 
         assert_eq!(
             coordinator.min_active_version(),
@@ -1569,13 +1570,13 @@ mod tests {
     #[test]
     fn test_active_versions_cleaned_on_abort() {
         // Use non-zero initial version so drain produces a non-sentinel gc_safe_version
-        let coordinator = TransactionCoordinator::new(5);
+        let coordinator = TransactionCoordinator::new(CommitVersion(5));
 
         // Start a transaction then abort it — triggers drain
-        coordinator.record_start(1, 5);
+        coordinator.record_start(TxnId(1), CommitVersion(5));
         assert_eq!(coordinator.active_count(), 1);
 
-        coordinator.record_abort(1);
+        coordinator.record_abort(TxnId(1));
         assert_eq!(coordinator.active_count(), 0);
 
         // After abort with full drain, gc_safe_version should be exactly 5
@@ -1588,22 +1589,22 @@ mod tests {
 
     #[test]
     fn test_gc_safe_version_advances_incrementally() {
-        let coordinator = TransactionCoordinator::new(10);
+        let coordinator = TransactionCoordinator::new(CommitVersion(10));
 
         // Start 3 transactions at version 10
-        coordinator.record_start(1, 10);
-        coordinator.record_start(2, 10);
-        coordinator.record_start(3, 10);
+        coordinator.record_start(TxnId(1), CommitVersion(10));
+        coordinator.record_start(TxnId(2), CommitVersion(10));
+        coordinator.record_start(TxnId(3), CommitVersion(10));
 
         // Partial commit: gc_safe = min(10, 10) - 1 = 9 (#1923)
-        coordinator.record_commit(1);
+        coordinator.record_commit(TxnId(1));
         assert_eq!(
             coordinator.min_active_version(),
             Some(9),
             "gc_safe should be min(remaining_snapshots) - 1 = 9"
         );
 
-        coordinator.record_commit(2);
+        coordinator.record_commit(TxnId(2));
         assert_eq!(
             coordinator.min_active_version(),
             Some(9),
@@ -1611,7 +1612,7 @@ mod tests {
         );
 
         // Final commit → full drain → gc_safe_version = current_version = 10
-        coordinator.record_commit(3);
+        coordinator.record_commit(TxnId(3));
         assert_eq!(
             coordinator.min_active_version(),
             Some(10),
@@ -1621,18 +1622,18 @@ mod tests {
 
     #[test]
     fn test_gc_safe_version_conservative_while_active() {
-        let coordinator = TransactionCoordinator::new(5);
+        let coordinator = TransactionCoordinator::new(CommitVersion(5));
 
         // Drain once to establish a gc_safe_version
-        coordinator.record_start(1, 5);
-        coordinator.record_commit(1);
+        coordinator.record_start(TxnId(1), CommitVersion(5));
+        coordinator.record_commit(TxnId(1));
         assert_eq!(coordinator.min_active_version(), Some(5));
 
         // Advance version and start new transaction
         let _ = coordinator.allocate_commit_version(); // 6
         let _ = coordinator.allocate_commit_version(); // 7
 
-        coordinator.record_start(2, 7);
+        coordinator.record_start(TxnId(2), CommitVersion(7));
 
         // While txn 2 is active, gc_safe_version stays at the old value
         // (no new drain has occurred)
@@ -1643,7 +1644,7 @@ mod tests {
         );
 
         // Commit txn 2 → drain → gc_safe_version advances to 7
-        coordinator.record_commit(2);
+        coordinator.record_commit(TxnId(2));
         assert_eq!(
             coordinator.min_active_version(),
             Some(7),
@@ -1655,15 +1656,15 @@ mod tests {
     /// increasing versions should produce monotonically increasing safe points.
     #[test]
     fn test_gc_safe_version_monotonically_increases() {
-        let coordinator = TransactionCoordinator::new(1);
+        let coordinator = TransactionCoordinator::new(CommitVersion(1));
 
         let mut last_safe = 0u64;
 
         for round in 0..5 {
             // Start and drain a transaction
-            coordinator.record_start(round + 1, 0);
+            coordinator.record_start(TxnId(round + 1), CommitVersion::ZERO);
             let _ = coordinator.allocate_commit_version();
-            coordinator.record_commit(round + 1);
+            coordinator.record_commit(TxnId(round + 1));
 
             if let Some(v) = coordinator.min_active_version() {
                 assert!(
@@ -1687,7 +1688,7 @@ mod tests {
         use std::sync::Barrier;
         use std::thread;
 
-        let coordinator = Arc::new(TransactionCoordinator::new(100));
+        let coordinator = Arc::new(TransactionCoordinator::new(CommitVersion(100)));
         let storage = Arc::new(SegmentedStore::new());
         let branch_id = BranchId::new();
 
@@ -1737,10 +1738,10 @@ mod tests {
         // 3. gc_safe_version should be ≤ current_version (never overshoots)
         let current = coordinator.current_version();
         assert!(
-            v.unwrap() <= current,
+            v.unwrap() <= current.as_u64(),
             "gc_safe_version ({}) must not exceed current_version ({})",
             v.unwrap(),
-            current
+            current.as_u64()
         );
         // 4. Metrics should be consistent
         let metrics = coordinator.metrics();
@@ -1755,7 +1756,7 @@ mod tests {
     fn test_issue_1728_expired_transaction_rejected_at_commit() {
         use std::time::Duration;
 
-        let mut coordinator = TransactionCoordinator::new(0);
+        let mut coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
@@ -1789,7 +1790,7 @@ mod tests {
     /// Issue #1728: A non-expired transaction must still commit successfully.
     #[test]
     fn test_issue_1728_non_expired_transaction_commits() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
         let storage = create_test_storage();
         let branch_id = BranchId::new();
 
@@ -1809,7 +1810,7 @@ mod tests {
     /// that is always ≤ current_version.
     #[test]
     fn test_gc_safe_version_with_interleaved_version_bumps() {
-        let coordinator = Arc::new(TransactionCoordinator::new(1));
+        let coordinator = Arc::new(TransactionCoordinator::new(CommitVersion(1)));
         let storage = Arc::new(SegmentedStore::new());
         let branch_id = BranchId::new();
 
@@ -1836,10 +1837,10 @@ mod tests {
         let v = coordinator.min_active_version().unwrap();
         let current = coordinator.current_version();
         assert!(
-            v <= current,
+            v <= current.as_u64(),
             "gc_safe_version ({}) must be ≤ current_version ({})",
             v,
-            current
+            current.as_u64()
         );
         assert_eq!(
             v, 3,
@@ -1853,19 +1854,19 @@ mod tests {
 
     #[test]
     fn test_issue_1923_overlapping_txns_dont_pin_gc() {
-        let coordinator = TransactionCoordinator::new(100);
+        let coordinator = TransactionCoordinator::new(CommitVersion(100));
 
         // Simulate the scenario from #1923: overlapping transactions
         // where a new txn starts before the previous one completes.
         // Use record_start with explicit versions to control snapshot points.
-        coordinator.record_start(1, 100); // txn1 at v100
-        coordinator.record_start(2, 200); // txn2 at v200
-        coordinator.record_start(3, 300); // txn3 at v300
+        coordinator.record_start(TxnId(1), CommitVersion(100)); // txn1 at v100
+        coordinator.record_start(TxnId(2), CommitVersion(200)); // txn2 at v200
+        coordinator.record_start(TxnId(3), CommitVersion(300)); // txn3 at v300
         assert_eq!(coordinator.active_count(), 3);
 
         // Complete oldest (txn1). Before #1923, gc_safe would stay at 0
         // because active_count > 0. Now it advances to min(200,300)-1 = 199.
-        coordinator.record_commit(1);
+        coordinator.record_commit(TxnId(1));
         let v1 = coordinator.min_active_version();
         assert!(
             v1.is_some(),
@@ -1874,21 +1875,21 @@ mod tests {
         assert_eq!(v1, Some(199));
 
         // Start another txn — the overlapping pattern
-        coordinator.record_start(4, 400);
+        coordinator.record_start(TxnId(4), CommitVersion(400));
 
         // Complete txn2 — gc_safe should advance: min(300,400)-1 = 299
-        coordinator.record_commit(2);
+        coordinator.record_commit(TxnId(2));
         let v2 = coordinator.min_active_version().unwrap();
         assert_eq!(v2, 299);
         assert!(v2 > v1.unwrap(), "gc_safe must monotonically increase");
 
         // Complete txn3 — gc_safe = min(400)-1 = 399
-        coordinator.record_commit(3);
+        coordinator.record_commit(TxnId(3));
         let v3 = coordinator.min_active_version().unwrap();
         assert_eq!(v3, 399);
 
         // Complete final txn — full drain → gc_safe = current_version
-        coordinator.record_commit(4);
+        coordinator.record_commit(TxnId(4));
         let v4 = coordinator.min_active_version().unwrap();
         assert!(v4 >= v3, "full drain should advance gc_safe");
         assert_eq!(coordinator.active_count(), 0);
@@ -1896,27 +1897,27 @@ mod tests {
 
     #[test]
     fn test_issue_1923_gc_advances_to_min_snapshot_minus_one() {
-        let coordinator = TransactionCoordinator::new(0);
+        let coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
 
         // Use record_start with explicit, distinct versions
-        coordinator.record_start(1, 10); // txn1 at v10
-        coordinator.record_start(2, 20); // txn2 at v20
-        coordinator.record_start(3, 30); // txn3 at v30
+        coordinator.record_start(TxnId(1), CommitVersion(10)); // txn1 at v10
+        coordinator.record_start(TxnId(2), CommitVersion(20)); // txn2 at v20
+        coordinator.record_start(TxnId(3), CommitVersion(30)); // txn3 at v30
 
         // Complete txn1 (oldest). Remaining: txn2@20, txn3@30.
         // gc_safe = min(20, 30) - 1 = 19
-        coordinator.record_commit(1);
+        coordinator.record_commit(TxnId(1));
         let gc = coordinator.min_active_version().unwrap();
         assert_eq!(gc, 19, "gc_safe should be min(remaining) - 1 = 20 - 1");
 
         // Complete txn2. Remaining: txn3@30.
         // gc_safe = 30 - 1 = 29
-        coordinator.record_commit(2);
+        coordinator.record_commit(TxnId(2));
         let gc = coordinator.min_active_version().unwrap();
         assert_eq!(gc, 29, "gc_safe should be min(remaining) - 1 = 30 - 1");
 
         // Complete txn3 → full drain → gc_safe = current_version
-        coordinator.record_commit(3);
+        coordinator.record_commit(TxnId(3));
         let gc = coordinator.min_active_version().unwrap();
         assert!(
             gc > 0,
@@ -1930,7 +1931,7 @@ mod tests {
 
     #[test]
     fn test_issue_1922_expired_commit_no_double_decrement() {
-        let mut coordinator = TransactionCoordinator::new(0);
+        let mut coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
         coordinator.set_transaction_timeout(Duration::from_millis(1));
         let storage = create_test_storage();
         let branch_id = BranchId::new();
@@ -1957,7 +1958,7 @@ mod tests {
 
     #[test]
     fn test_issue_1922_timeout_marks_transaction_aborted() {
-        let mut coordinator = TransactionCoordinator::new(0);
+        let mut coordinator = TransactionCoordinator::new(CommitVersion::ZERO);
         coordinator.set_transaction_timeout(Duration::from_millis(1));
         let storage = create_test_storage();
         let branch_id = BranchId::new();

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -1,6 +1,7 @@
 //! GC, maintenance, follower refresh, and shutdown.
 
 use std::sync::atomic::Ordering;
+use strata_core::id::CommitVersion;
 use strata_core::types::{BranchId, Key, TypeTag};
 use strata_core::{StrataError, StrataResult};
 use tracing::warn;
@@ -23,7 +24,7 @@ impl Database {
     ///
     /// This is the highest version allocated so far and serves as
     /// a safe GC boundary when no active snapshots need older versions.
-    pub fn current_version(&self) -> u64 {
+    pub fn current_version(&self) -> CommitVersion {
         self.coordinator.current_version()
     }
 
@@ -34,7 +35,7 @@ impl Database {
     /// Versions strictly older than `safe_point` can be pruned from version
     /// chains. Returns 0 if no GC is safe (only one version or version 0).
     pub fn gc_safe_point(&self) -> u64 {
-        let current = self.current_version();
+        let current = self.current_version().as_u64();
         if current <= 1 {
             return 0;
         }

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -40,6 +40,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
+use strata_core::id::CommitVersion;
 use strata_core::types::{BranchId, Key};
 use strata_core::{StrataError, StrataResult, VersionedValue};
 use strata_durability::wal::{DurabilityMode, WalWriter};
@@ -520,8 +521,9 @@ impl Database {
         limit: Option<usize>,
         before_version: Option<u64>,
     ) -> StrataResult<Vec<VersionedValue>> {
+        use strata_core::id::CommitVersion;
         use strata_core::Storage;
-        self.storage.get_history(key, limit, before_version)
+        self.storage.get_history(key, limit, before_version.map(CommitVersion))
     }
 
     /// Get value at or before the given timestamp directly from storage.
@@ -541,7 +543,7 @@ impl Database {
     /// Bypasses the transaction layer (read-only, no conflict tracking needed).
     /// Uses the same MVCC pipeline as scan_prefix but counts instead of
     /// collecting, avoiding the O(N) Vec allocation.
-    pub(crate) fn count_prefix(&self, prefix: &Key, max_version: u64) -> StrataResult<u64> {
+    pub(crate) fn count_prefix(&self, prefix: &Key, max_version: CommitVersion) -> StrataResult<u64> {
         self.storage.count_prefix(prefix, max_version)
     }
 
@@ -569,7 +571,7 @@ impl Database {
         &self,
         branch_id: &BranchId,
         prefix: Key,
-        snapshot_version: u64,
+        snapshot_version: CommitVersion,
     ) -> Option<StorageIterator> {
         self.storage
             .new_storage_iterator(branch_id, prefix, snapshot_version)

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -32,6 +32,7 @@ fn apply_storage_config(storage: &SegmentedStore, cfg: &StorageConfig) {
     }
 }
 
+use strata_core::id::CommitVersion;
 use strata_core::{StrataError, StrataResult};
 
 /// Restrict a directory to owner-only access (rwx------).
@@ -533,7 +534,7 @@ impl Database {
             writes_applied = result.stats.writes_applied,
             "Follower recovery complete");
 
-        let wal_watermark = AtomicU64::new(result.stats.max_txn_id);
+        let wal_watermark = AtomicU64::new(result.stats.max_txn_id.as_u64());
 
         let coordinator = TransactionCoordinator::from_recovery_with_limits(
             &result,
@@ -728,7 +729,7 @@ impl Database {
                         "Recovered segments from disk");
                 }
                 if seg_info.max_commit_id > 0 {
-                    coordinator.bump_version_floor(seg_info.max_commit_id);
+                    coordinator.bump_version_floor(CommitVersion(seg_info.max_commit_id));
                 }
             }
             Err(e) => {
@@ -812,7 +813,7 @@ impl Database {
             txns_replayed = result.stats.txns_replayed,
             writes_applied = result.stats.writes_applied,
             deletes_applied = result.stats.deletes_applied,
-            final_version = result.stats.final_version,
+            final_version = result.stats.final_version.as_u64(),
             "Recovery complete"
         );
 
@@ -853,7 +854,7 @@ impl Database {
             codec,
         )?;
 
-        let wal_watermark = AtomicU64::new(result.stats.max_txn_id);
+        let wal_watermark = AtomicU64::new(result.stats.max_txn_id.as_u64());
 
         let wal_arc = Arc::new(ParkingMutex::new(wal_writer));
         let flush_shutdown = Arc::new(AtomicBool::new(false));
@@ -997,7 +998,7 @@ impl Database {
         let bg_threads = cfg.storage.background_threads.max(1);
 
         // Create coordinator starting at version 1 (no recovery needed), with write buffer limit
-        let coordinator = TransactionCoordinator::new(1);
+        let coordinator = TransactionCoordinator::new(CommitVersion(1));
         coordinator.set_max_write_buffer_entries(cfg.storage.max_write_buffer_entries);
 
         let db = Arc::new(Self {

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use std::sync::Arc;
 use std::time::Duration;
 use strata_concurrency::TransactionPayload;
+use strata_core::id::CommitVersion;
 use strata_core::types::{Key, Namespace, TypeTag};
 use strata_core::value::Value;
 use strata_core::{Storage, Timestamp};
@@ -115,7 +116,7 @@ fn test_wal_recovery() {
     let key1 = Key::new_kv(ns, "key1");
     let val = db
         .storage()
-        .get_versioned(&key1, u64::MAX)
+        .get_versioned(&key1, CommitVersion::MAX)
         .unwrap()
         .unwrap();
 
@@ -156,7 +157,7 @@ fn test_open_close_reopen() {
 
         // Data should be restored from WAL
         let key = Key::new_kv(ns, "persistent");
-        let val = db.storage().get_versioned(&key, u64::MAX).unwrap().unwrap();
+        let val = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
 
         if let Value::Bytes(bytes) = val.value {
             assert_eq!(bytes, b"data");
@@ -205,7 +206,7 @@ fn test_partial_record_discarded() {
 
     // Valid transaction should be present
     let key = Key::new_kv(ns.clone(), "valid");
-    let val = db.storage().get_versioned(&key, u64::MAX).unwrap().unwrap();
+    let val = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
     assert_eq!(val.value, Value::Int(42));
 }
 
@@ -227,7 +228,7 @@ fn test_corrupted_wal_handled_gracefully() {
     let db = result.unwrap();
     // Storage has only system branch init transactions (no user data recovered)
     // init_system_branch writes 3 transactions: branch, graph, node
-    assert!(db.storage().current_version() <= 3);
+    assert!(db.storage().current_version() <= CommitVersion(3));
 }
 
 #[test]
@@ -301,7 +302,7 @@ fn test_transaction_closure_api() {
     assert!(result.is_ok());
 
     // Verify data was committed
-    let stored = db.storage().get_versioned(&key, u64::MAX).unwrap().unwrap();
+    let stored = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
     assert_eq!(stored.value, Value::Int(42));
 }
 
@@ -375,7 +376,7 @@ fn test_transaction_aborts_on_closure_error() {
     // Data should NOT be committed
     assert!(db
         .storage()
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .is_none());
 }
@@ -397,7 +398,7 @@ fn test_begin_and_commit_manual() {
     db.commit_transaction(&mut txn).unwrap();
 
     // Verify committed
-    let stored = db.storage().get_versioned(&key, u64::MAX).unwrap().unwrap();
+    let stored = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
     assert_eq!(stored.value, Value::Int(123));
 }
 
@@ -710,10 +711,10 @@ fn test_gc_safe_point_with_active_txn() {
     // The active txn pins the safe point at its start version
     let sp = db.gc_safe_point();
     assert!(
-        sp <= txn_start_version,
+        sp <= txn_start_version.as_u64(),
         "safe point {} should be <= active txn start version {}",
         sp,
-        txn_start_version
+        txn_start_version.as_u64()
     );
 
     // Abort the active transaction
@@ -764,7 +765,7 @@ fn test_run_gc_prunes_old_versions() {
     assert!(safe_point > 0, "safe point should be non-zero");
 
     // Latest value should still be readable
-    let stored = db.storage().get_versioned(&key, u64::MAX).unwrap().unwrap();
+    let stored = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
     assert_eq!(stored.value, Value::Int(3));
 }
 
@@ -812,7 +813,7 @@ fn test_run_maintenance_end_to_end() {
     assert_eq!(expired, 0, "no TTL entries to expire");
 
     // Data should still be readable
-    let stored = db.storage().get_versioned(&key, u64::MAX).unwrap().unwrap();
+    let stored = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
     assert_eq!(stored.value, Value::Int(2));
 
     let _ = pruned; // suppress unused warning
@@ -885,7 +886,7 @@ fn test_open_corrupted_wal_succeeds_with_lossy_flag() {
     let db = result.unwrap();
     // Only system branch init transactions present (no user data recovered)
     assert!(
-        db.storage().current_version() <= 3,
+        db.storage().current_version() <= CommitVersion(3),
         "Should have at most system init transactions, got {}",
         db.storage().current_version()
     );
@@ -933,13 +934,13 @@ fn test_lossy_recovery_discards_valid_data_before_corruption() {
     let key = Key::new_kv(ns, "important_data");
     assert!(
         db.storage()
-            .get_versioned(&key, u64::MAX)
+            .get_versioned(&key, CommitVersion::MAX)
             .unwrap()
             .is_none(),
         "Valid data before corruption should be lost in lossy mode"
     );
     // Only system branch init transactions present (user data was discarded)
-    assert!(db.storage().current_version() <= 3);
+    assert!(db.storage().current_version() <= CommitVersion(3));
 }
 
 // ========================================================================
@@ -989,7 +990,7 @@ fn test_flush_thread_performs_final_sync() {
 
     // Re-open and verify data was persisted
     let db = Database::open(&db_path).unwrap();
-    let val = db.storage().get_versioned(&key, u64::MAX).unwrap();
+    let val = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(
         val.is_some(),
         "Data should be recoverable after shutdown (flush thread final sync + explicit flush)"
@@ -1063,7 +1064,7 @@ fn test_shutdown_blocks_until_in_flight_transactions_drain() {
     // Re-open and verify committed data was persisted
     drop(db);
     let db = Database::open(&db_path).unwrap();
-    let val = db.storage().get_versioned(&key, u64::MAX).unwrap();
+    let val = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(
         val.is_some(),
         "Transaction committed during shutdown drain should be persisted"
@@ -1111,7 +1112,7 @@ fn test_shutdown_proceeds_after_draining_with_no_transactions() {
     // Re-open and verify persistence
     drop(db);
     let db = Database::open(&db_path).unwrap();
-    let val = db.storage().get_versioned(&key, u64::MAX).unwrap();
+    let val = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(val.is_some(), "Data committed before shutdown must persist");
 }
 
@@ -1181,14 +1182,14 @@ fn test_shutdown_multiple_in_flight_transactions() {
     let db = Database::open(&db_path).unwrap();
     assert!(
         db.storage()
-            .get_versioned(&key1, u64::MAX)
+            .get_versioned(&key1, CommitVersion::MAX)
             .unwrap()
             .is_some(),
         "txn1 data lost"
     );
     assert!(
         db.storage()
-            .get_versioned(&key2, u64::MAX)
+            .get_versioned(&key2, CommitVersion::MAX)
             .unwrap()
             .is_some(),
         "txn2 data lost"
@@ -1266,7 +1267,7 @@ fn test_put_direct_contention_scaling() {
         // Spot-check first, middle, and last keys
         for &i in &[0, OPS_PER_THREAD / 2, OPS_PER_THREAD - 1] {
             let key = Key::new_kv(ns.clone(), format!("k{i}"));
-            let stored = db.storage().get_versioned(&key, u64::MAX).unwrap();
+            let stored = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap();
             assert!(
                 stored.is_some(),
                 "blind write data missing: thread={t}, key=k{i}"
@@ -1309,8 +1310,9 @@ fn test_put_direct_gc_safety_with_concurrent_reader() {
     // GC safe point must not advance past the reader's pinned version
     let safe_point = db.gc_safe_point();
     assert!(
-        safe_point <= pinned_version,
-        "gc_safe_point ({safe_point}) advanced past pinned reader version ({pinned_version})"
+        safe_point <= pinned_version.as_u64(),
+        "gc_safe_point ({safe_point}) advanced past pinned reader version ({})",
+        pinned_version.as_u64()
     );
 
     // GC should not prune versions the reader can still see
@@ -1319,7 +1321,7 @@ fn test_put_direct_gc_safety_with_concurrent_reader() {
     let _ = pruned;
 
     // Reader should still see the value at its snapshot version
-    let reader_val = db.storage().get_versioned(&key, u64::MAX).unwrap();
+    let reader_val = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(reader_val.is_some(), "key disappeared during concurrent GC");
     // Latest version should be 10
     assert_eq!(reader_val.unwrap().value, Value::Int(10));
@@ -1337,7 +1339,7 @@ fn test_put_direct_gc_safety_with_concurrent_reader() {
     let (_, _pruned_after) = db.run_gc();
 
     // Latest value must still be readable after GC
-    let final_val = db.storage().get_versioned(&key, u64::MAX).unwrap().unwrap();
+    let final_val = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
     assert_eq!(final_val.value, Value::Int(10));
 }
 
@@ -1386,7 +1388,7 @@ fn test_put_direct_concurrent_gc_no_data_loss() {
     for t in 0..NUM_WRITERS {
         for &i in &[0, WRITES_PER_THREAD / 2, WRITES_PER_THREAD - 1] {
             let key = Key::new_kv(ns.clone(), format!("w{t}_k{i}"));
-            let stored = db.storage().get_versioned(&key, u64::MAX).unwrap();
+            let stored = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap();
             assert!(
                 stored.is_some(),
                 "data lost after concurrent GC: thread={t}, key=w{t}_k{i}"
@@ -1451,7 +1453,7 @@ fn test_issue_1697_compaction_preserves_snapshot_versions() {
     );
 
     // Latest version must also be intact
-    let latest = db.storage().get_versioned(&key, u64::MAX).unwrap();
+    let latest = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(latest.is_some(), "latest version missing after compaction");
     assert_eq!(latest.unwrap().value, Value::Int(2));
 
@@ -1508,7 +1510,7 @@ fn test_issue_1730_checkpoint_compact_recovery_data_loss() {
         let key = Key::new_kv(ns, "critical_data");
 
         // Step 5: Data MUST still be present
-        let result = db.storage().get_versioned(&key, u64::MAX).unwrap();
+        let result = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap();
         assert!(
             result.is_some(),
             "CRITICAL: Data lost after checkpoint+compact+recovery! \
@@ -1565,7 +1567,7 @@ fn test_issue_1730_standard_durability() {
         let ns = create_test_namespace(branch_id);
         let key = Key::new_kv(ns, "standard_data");
 
-        let result = db.storage().get_versioned(&key, u64::MAX).unwrap();
+        let result = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap();
         assert!(
             result.is_some(),
             "Data must survive checkpoint+failed-compact+recovery under Standard durability"
@@ -1628,7 +1630,7 @@ fn test_issue_1699_refresh_preserves_wal_timestamp() {
     //    commit time), NOT from Timestamp::now() during refresh.
     let a_entry = follower
         .storage()
-        .get_versioned(&key_a, u64::MAX)
+        .get_versioned(&key_a, CommitVersion::MAX)
         .unwrap()
         .expect("key A should exist after refresh");
     let a_ts = a_entry.timestamp.as_micros();
@@ -1715,7 +1717,7 @@ fn test_issue_1736_compaction_runs_in_background() {
         let key = Key::new_kv(ns.clone(), format!("key_{:04}", i));
         let entry = db
             .storage
-            .get_versioned(&key, u64::MAX)
+            .get_versioned(&key, CommitVersion::MAX)
             .unwrap()
             .unwrap_or_else(|| panic!("key_{:04} should exist after compaction", i));
         assert_eq!(entry.value, Value::String(format!("value_{}", i)),);
@@ -1913,7 +1915,7 @@ fn test_issue_1733_history_no_duplicates_after_recovery() {
         assert_eq!(history[2].value, Value::Int(1));
 
         // Also verify point read returns the correct latest value (no regression)
-        let latest = db.storage().get_versioned(&key, u64::MAX).unwrap();
+        let latest = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap();
         assert!(latest.is_some(), "point read should find the key");
         assert_eq!(latest.unwrap().value, Value::Int(3));
     }
@@ -2007,7 +2009,7 @@ fn test_issue_1733_tombstone_no_duplicate_after_recovery() {
         );
 
         // Point read should return None (key is deleted)
-        let latest = db.storage().get_versioned(&key, u64::MAX).unwrap();
+        let latest = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap();
         assert!(
             latest.is_none(),
             "deleted key should not be found via point read"
@@ -2065,7 +2067,7 @@ fn test_shutdown_full_lifecycle() {
     // Re-open and verify data persisted through shutdown
     drop(db);
     let db = Database::open(&db_path).unwrap();
-    let val = db.storage().get_versioned(&key, u64::MAX).unwrap();
+    let val = db.storage().get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(
         val.is_some(),
         "Data committed before shutdown must survive re-open"

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use strata_concurrency::TransactionContext;
+use strata_core::id::CommitVersion;
 use strata_core::types::BranchId;
 use strata_core::{StrataError, StrataResult};
 use strata_durability::wal::DurabilityMode;
@@ -554,7 +555,7 @@ impl Database {
                 if had_writes {
                     self.schedule_flush_if_needed();
                 }
-                Ok((value, commit_version))
+                Ok((value, commit_version.as_u64()))
             }
             Err(e) => {
                 let _ = txn.mark_aborted(format!("Closure error: {}", e));
@@ -661,7 +662,7 @@ impl Database {
         // but wait for visible_version to catch up so all data at versions
         // ≤ snapshot is fully applied. This prevents the cross-branch snapshot
         // gap (#1913) without breaking same-thread sequential operations.
-        let snapshot_version = self.storage.version();
+        let snapshot_version = CommitVersion(self.storage.version());
         let mut spins = 0u32;
         while self.coordinator.visible_version() < snapshot_version {
             spins += 1;
@@ -772,7 +773,7 @@ impl Database {
         if had_writes {
             self.schedule_flush_if_needed();
         }
-        Ok(version)
+        Ok(version.as_u64())
     }
 
     /// Internal commit implementation shared by commit_transaction and transaction closures
@@ -792,7 +793,7 @@ impl Database {
         &self,
         txn: &mut TransactionContext,
         durability: DurabilityMode,
-    ) -> StrataResult<u64> {
+    ) -> StrataResult<CommitVersion> {
         if self.follower {
             return Err(StrataError::internal(
                 "cannot commit: database opened in follower mode (read-only)",

--- a/crates/engine/src/primitives/event.rs
+++ b/crates/engine/src/primitives/event.rs
@@ -42,6 +42,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use strata_concurrency::TransactionContext;
 use strata_core::contract::{Timestamp, Version, Versioned};
+use strata_core::id::CommitVersion;
 use strata_core::types::{BranchId, Key, Namespace};
 use strata_core::value::Value;
 use strata_core::StrataError;
@@ -747,7 +748,7 @@ impl EventLog {
         use strata_core::Storage;
         let ns = self.namespace_for(branch_id, space);
         let meta_key = Key::new_event_meta(ns.clone());
-        let meta: EventLogMeta = match self.db.storage().get_versioned(&meta_key, u64::MAX)? {
+        let meta: EventLogMeta = match self.db.storage().get_versioned(&meta_key, CommitVersion::MAX)? {
             Some(vv) => from_stored_value(&vv.value).map_err(|e| {
                 StrataError::serialization(format!("corrupt EventLog metadata: {}", e))
             })?,

--- a/crates/engine/src/primitives/json/mod.rs
+++ b/crates/engine/src/primitives/json/mod.rs
@@ -39,6 +39,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 use strata_concurrency::TransactionContext;
 use strata_core::contract::{Version, Versioned};
+use strata_core::id::CommitVersion;
 use strata_core::primitives::json::{
     delete_at_path, get_at_path, set_at_path, JsonLimitError, JsonPath, JsonValue,
 };
@@ -380,7 +381,7 @@ impl JsonStore {
 
         let key = self.key_for(branch_id, space, doc_id);
         use strata_core::Storage;
-        match self.db.storage().get_versioned(&key, u64::MAX)? {
+        match self.db.storage().get_versioned(&key, CommitVersion::MAX)? {
             Some(vv) => {
                 let doc = Self::deserialize_doc(&vv.value)?;
                 match get_at_path(&doc.value, path).cloned() {

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -28,6 +28,7 @@ use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use std::sync::Arc;
 use strata_concurrency::TransactionContext;
+use strata_core::id::CommitVersion;
 use strata_core::types::{BranchId, Key, Namespace};
 use strata_core::value::Value;
 use strata_core::{StrataError, StrataResult};
@@ -363,7 +364,7 @@ impl KVStore {
     ) -> StrataResult<u64> {
         let ns = self.namespace_for(branch_id, space);
         let scan_prefix = Key::new_kv(ns, prefix.unwrap_or(""));
-        self.db.count_prefix(&scan_prefix, u64::MAX)
+        self.db.count_prefix(&scan_prefix, CommitVersion::MAX)
     }
 
     /// Sample key-value pairs with evenly-spaced selection from a single scan.

--- a/crates/engine/src/recipe_store.rs
+++ b/crates/engine/src/recipe_store.rs
@@ -116,13 +116,14 @@ pub fn get_default_recipe(db: &Database, branch_id: BranchId) -> StrataResult<Re
 /// List all recipe names available to a branch (user + system, deduplicated).
 pub fn list_recipes(db: &Database, branch_id: BranchId) -> StrataResult<Vec<String>> {
     use std::collections::BTreeSet;
+    use strata_core::id::CommitVersion;
     use strata_core::traits::Storage;
 
     let mut names = BTreeSet::new();
 
     // User branch recipes
     let prefix = system_kv_key(branch_id, "recipe:");
-    let version = db.storage().version();
+    let version = CommitVersion(db.storage().version());
     for (k, _) in db.storage().scan_prefix(&prefix, version)? {
         if let Some(n) = k
             .user_key_string()

--- a/crates/engine/src/transaction/context.rs
+++ b/crates/engine/src/transaction/context.rs
@@ -144,7 +144,7 @@ impl<'a> TransactionOps for Transaction<'a> {
 
         // Delegate to ctx.get() which checks write_set → delete_set → snapshot
         let result = self.ctx.get(&full_key)?;
-        Ok(result.map(|v| Versioned::new(v, Version::txn(self.ctx.txn_id))))
+        Ok(result.map(|v| Versioned::new(v, Version::txn(self.ctx.txn_id.as_u64()))))
     }
 
     fn kv_put(&mut self, key: &str, value: Value) -> Result<Version, StrataError> {
@@ -165,7 +165,7 @@ impl<'a> TransactionOps for Transaction<'a> {
         // Use the ctx.put() method which handles all the bookkeeping
         self.ctx.put(full_key, value)?;
 
-        Ok(Version::txn(self.ctx.txn_id))
+        Ok(Version::txn(self.ctx.txn_id.as_u64()))
     }
 
     fn kv_delete(&mut self, key: &str) -> Result<bool, StrataError> {
@@ -392,7 +392,7 @@ impl<'a> TransactionOps for Transaction<'a> {
         // Create the document by setting at root path
         self.ctx.json_set(&full_key, &JsonPath::root(), value)?;
 
-        Ok(Version::txn(self.ctx.txn_id))
+        Ok(Version::txn(self.ctx.txn_id.as_u64()))
     }
 
     fn json_get(&mut self, doc_id: &str) -> Result<Option<Versioned<JsonValue>>, StrataError> {
@@ -400,7 +400,7 @@ impl<'a> TransactionOps for Transaction<'a> {
 
         // Delegate to ctx which checks json_writes buffer → snapshot
         match self.ctx.json_get_document(&full_key)? {
-            Some(jv) => Ok(Some(Versioned::new(jv, Version::txn(self.ctx.txn_id)))),
+            Some(jv) => Ok(Some(Versioned::new(jv, Version::txn(self.ctx.txn_id.as_u64())))),
             None => Ok(None),
         }
     }
@@ -433,7 +433,7 @@ impl<'a> TransactionOps for Transaction<'a> {
         // Call ctx.json_set (same pattern as kv_put calling ctx.put)
         self.ctx.json_set(&full_key, path, value)?;
 
-        Ok(Version::txn(self.ctx.txn_id))
+        Ok(Version::txn(self.ctx.txn_id.as_u64()))
     }
 
     fn json_delete(&mut self, doc_id: &str) -> Result<bool, StrataError> {
@@ -459,6 +459,7 @@ impl<'a> TransactionOps for Transaction<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use strata_core::id::{CommitVersion, TxnId};
     use strata_storage::SegmentedStore;
 
     fn create_test_namespace() -> Arc<Namespace> {
@@ -468,7 +469,7 @@ mod tests {
 
     fn create_test_context(ns: &Namespace) -> TransactionContext {
         let store = Arc::new(SegmentedStore::new());
-        TransactionContext::with_store(1, ns.branch_id, store)
+        TransactionContext::with_store(TxnId(1), ns.branch_id, store)
     }
 
     // =========================================================================
@@ -719,7 +720,7 @@ mod tests {
         };
         let meta_json = serde_json::to_string(&meta).unwrap();
         let meta_key = Key::new_event_meta(ns.clone());
-        let version = store.next_version();
+        let version = CommitVersion(store.next_version());
         store
             .put_with_version_mode(
                 meta_key,
@@ -730,7 +731,7 @@ mod tests {
             )
             .unwrap();
 
-        let mut ctx = TransactionContext::with_store(2, ns.branch_id, store);
+        let mut ctx = TransactionContext::with_store(TxnId(2), ns.branch_id, store);
         let mut txn = Transaction::with_base_sequence(&mut ctx, ns.clone(), 100, last_hash);
 
         // New events should continue from base
@@ -808,7 +809,7 @@ mod tests {
         };
         let meta_json = serde_json::to_string(&meta).unwrap();
         let meta_key = Key::new_event_meta(ns.clone());
-        let version = store.next_version();
+        let version = CommitVersion(store.next_version());
         store
             .put_with_version_mode(
                 meta_key,
@@ -819,7 +820,7 @@ mod tests {
             )
             .unwrap();
 
-        let mut ctx = TransactionContext::with_store(2, ns.branch_id, store);
+        let mut ctx = TransactionContext::with_store(TxnId(2), ns.branch_id, store);
         let mut txn = Transaction::new(&mut ctx, ns.clone());
 
         // Before any append, event_len should reflect committed count
@@ -843,7 +844,7 @@ mod tests {
         };
         let meta_json = serde_json::to_string(&meta).unwrap();
         let meta_key = Key::new_event_meta(ns.clone());
-        let version = store.next_version();
+        let version = CommitVersion(store.next_version());
         store
             .put_with_version_mode(
                 meta_key,
@@ -854,7 +855,7 @@ mod tests {
             )
             .unwrap();
 
-        let mut ctx = TransactionContext::with_store(2, ns.branch_id, store);
+        let mut ctx = TransactionContext::with_store(TxnId(2), ns.branch_id, store);
         let mut txn = Transaction::new(&mut ctx, ns.clone());
 
         // Before append: should read 10 from persisted meta
@@ -999,7 +1000,7 @@ mod tests {
         use strata_core::traits::Storage;
         use strata_core::WriteMode;
         let k = Key::new_kv(Arc::new(ns.clone()), key);
-        let version = store.next_version();
+        let version = CommitVersion(store.next_version());
         store
             .put_with_version_mode(k, value, version, None, WriteMode::Append)
             .unwrap();
@@ -1019,7 +1020,7 @@ mod tests {
         );
 
         // Create a new TransactionContext that sees the snapshot
-        let mut ctx = TransactionContext::with_store(2, ns.branch_id, store);
+        let mut ctx = TransactionContext::with_store(TxnId(2), ns.branch_id, store);
         let mut txn = Transaction::new(&mut ctx, ns.clone());
 
         // Read should see the committed data
@@ -1037,7 +1038,7 @@ mod tests {
         let store = Arc::new(SegmentedStore::new());
         commit_kv(&store, &ns, "exists_key", Value::Int(42));
 
-        let mut ctx = TransactionContext::with_store(2, ns.branch_id, store);
+        let mut ctx = TransactionContext::with_store(TxnId(2), ns.branch_id, store);
         let mut txn = Transaction::new(&mut ctx, ns.clone());
 
         assert!(txn.kv_exists("exists_key").unwrap());
@@ -1051,7 +1052,7 @@ mod tests {
         commit_kv(&store, &ns, "user:1", Value::Int(1));
         commit_kv(&store, &ns, "user:2", Value::Int(2));
 
-        let mut ctx = TransactionContext::with_store(2, ns.branch_id, store);
+        let mut ctx = TransactionContext::with_store(TxnId(2), ns.branch_id, store);
         let mut txn = Transaction::new(&mut ctx, ns.clone());
 
         let keys = txn.kv_list(Some("user:")).unwrap();
@@ -1066,7 +1067,7 @@ mod tests {
         let store = Arc::new(SegmentedStore::new());
         commit_kv(&store, &ns, "user:1", Value::Int(1));
 
-        let mut ctx = TransactionContext::with_store(2, ns.branch_id, store);
+        let mut ctx = TransactionContext::with_store(TxnId(2), ns.branch_id, store);
         let mut txn = Transaction::new(&mut ctx, ns.clone());
 
         // Add a new key in the transaction
@@ -1088,7 +1089,7 @@ mod tests {
         let store = Arc::new(SegmentedStore::new());
         commit_kv(&store, &ns, "to_delete", Value::Int(1));
 
-        let mut ctx = TransactionContext::with_store(2, ns.branch_id, store);
+        let mut ctx = TransactionContext::with_store(TxnId(2), ns.branch_id, store);
         let mut txn = Transaction::new(&mut ctx, ns.clone());
 
         // Verify it exists in snapshot
@@ -1109,7 +1110,7 @@ mod tests {
         let store = Arc::new(SegmentedStore::new());
         commit_kv(&store, &ns, "key", Value::String("old".into()));
 
-        let mut ctx = TransactionContext::with_store(2, ns.branch_id, store);
+        let mut ctx = TransactionContext::with_store(TxnId(2), ns.branch_id, store);
         let mut txn = Transaction::new(&mut ctx, ns.clone());
 
         // Override the snapshot value

--- a/crates/engine/src/transaction/pool.rs
+++ b/crates/engine/src/transaction/pool.rs
@@ -16,6 +16,7 @@
 use std::cell::RefCell;
 use std::sync::Arc;
 use strata_concurrency::TransactionContext;
+use strata_core::id::TxnId;
 use strata_core::types::BranchId;
 use strata_storage::SegmentedStore;
 
@@ -63,7 +64,7 @@ impl TransactionPool {
     /// # Returns
     /// * `TransactionContext` - Active transaction ready for operations
     pub fn acquire(
-        txn_id: u64,
+        txn_id: TxnId,
         branch_id: BranchId,
         store: Option<Arc<SegmentedStore>>,
     ) -> TransactionContext {
@@ -78,7 +79,7 @@ impl TransactionPool {
                     // Pool empty - allocate new
                     match store {
                         Some(s) => TransactionContext::with_store(txn_id, branch_id, s),
-                        None => TransactionContext::new(txn_id, branch_id, 0),
+                        None => TransactionContext::new(txn_id, branch_id, strata_core::id::CommitVersion::ZERO),
                     }
                 }
             }
@@ -132,7 +133,7 @@ impl TransactionPool {
             let current = pool.len();
             for _ in current..count {
                 // Create minimal context for pool
-                let ctx = TransactionContext::new(0, BranchId::new(), 0);
+                let ctx = TransactionContext::new(TxnId::ZERO, BranchId::new(), strata_core::id::CommitVersion::ZERO);
                 pool.push(ctx);
             }
         });
@@ -162,6 +163,7 @@ impl TransactionPool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use strata_core::id::{CommitVersion, TxnId};
     use strata_core::traits::{Storage, WriteMode};
     use strata_core::types::{Namespace, TypeTag};
     use strata_core::value::Value;
@@ -180,11 +182,11 @@ mod tests {
         assert_eq!(TransactionPool::pool_size(), 0);
 
         let branch_id = BranchId::new();
-        let ctx = TransactionPool::acquire(1, branch_id, None);
+        let ctx = TransactionPool::acquire(TxnId(1), branch_id, None);
 
         // Pool still empty (we acquired, not released)
         assert_eq!(TransactionPool::pool_size(), 0);
-        assert_eq!(ctx.txn_id, 1);
+        assert_eq!(ctx.txn_id, TxnId(1));
         assert_eq!(ctx.branch_id, branch_id);
     }
 
@@ -193,7 +195,7 @@ mod tests {
         TransactionPool::clear();
 
         let branch_id = BranchId::new();
-        let ctx = TransactionPool::acquire(1, branch_id, None);
+        let ctx = TransactionPool::acquire(TxnId(1), branch_id, None);
         TransactionPool::release(ctx);
 
         assert_eq!(TransactionPool::pool_size(), 1);
@@ -206,7 +208,7 @@ mod tests {
         let branch_id = ns.branch_id;
 
         // Create and release a context with capacity
-        let mut ctx = TransactionPool::acquire(1, branch_id, None);
+        let mut ctx = TransactionPool::acquire(TxnId(1), branch_id, None);
 
         // Fill with data to grow capacity
         for i in 0..100 {
@@ -224,7 +226,7 @@ mod tests {
 
         // Acquire again - should reuse with preserved capacity
         let new_branch_id = BranchId::new();
-        let ctx2 = TransactionPool::acquire(2, new_branch_id, None);
+        let ctx2 = TransactionPool::acquire(TxnId(2), new_branch_id, None);
 
         // Capacity preserved
         assert_eq!(ctx2.capacity(), original_cap);
@@ -232,7 +234,7 @@ mod tests {
         // But data cleared
         assert!(ctx2.read_set.is_empty());
         assert!(ctx2.write_set.is_empty());
-        assert_eq!(ctx2.txn_id, 2);
+        assert_eq!(ctx2.txn_id, TxnId(2));
         assert_eq!(ctx2.branch_id, new_branch_id);
     }
 
@@ -245,7 +247,7 @@ mod tests {
         // This tests that pool caps at MAX_POOL_SIZE
         let mut contexts = Vec::new();
         for i in 0..(MAX_POOL_SIZE + 5) {
-            contexts.push(TransactionPool::acquire(i as u64, branch_id, None));
+            contexts.push(TransactionPool::acquire(TxnId(i as u64), branch_id, None));
         }
 
         // Now release them all
@@ -265,7 +267,7 @@ mod tests {
         let branch_id = BranchId::new();
 
         // Add to this thread's pool
-        let ctx = TransactionPool::acquire(1, branch_id, None);
+        let ctx = TransactionPool::acquire(TxnId(1), branch_id, None);
         TransactionPool::release(ctx);
         assert_eq!(TransactionPool::pool_size(), 1);
 
@@ -274,7 +276,7 @@ mod tests {
             assert_eq!(TransactionPool::pool_size(), 0);
 
             // Add to other thread's pool
-            let ctx = TransactionPool::acquire(2, BranchId::new(), None);
+            let ctx = TransactionPool::acquire(TxnId(2), BranchId::new(), None);
             TransactionPool::release(ctx);
             assert_eq!(TransactionPool::pool_size(), 1);
         });
@@ -293,14 +295,14 @@ mod tests {
         let store = Arc::new(SegmentedStore::new());
         let ns = create_test_namespace();
         let key = create_test_key(&ns, b"test");
-        Storage::put_with_version_mode(&*store, key, Value::Int(1), 500, None, WriteMode::Append)
+        Storage::put_with_version_mode(&*store, key, Value::Int(1), CommitVersion(500), None, WriteMode::Append)
             .unwrap();
 
-        let ctx = TransactionPool::acquire(1, branch_id, Some(store));
+        let ctx = TransactionPool::acquire(TxnId(1), branch_id, Some(store));
 
-        assert_eq!(ctx.txn_id, 1);
+        assert_eq!(ctx.txn_id, TxnId(1));
         assert_eq!(ctx.branch_id, branch_id);
-        assert_eq!(ctx.start_version, 500);
+        assert_eq!(ctx.start_version, CommitVersion(500));
     }
 
     #[test]
@@ -339,8 +341,8 @@ mod tests {
 
         // Simulate typical usage pattern
         for cycle in 0..10 {
-            let ctx = TransactionPool::acquire(cycle as u64, branch_id, None);
-            assert_eq!(ctx.txn_id, cycle as u64);
+            let ctx = TransactionPool::acquire(TxnId(cycle as u64), branch_id, None);
+            assert_eq!(ctx.txn_id, TxnId(cycle as u64));
             TransactionPool::release(ctx);
         }
 
@@ -355,7 +357,7 @@ mod tests {
         let branch_id = ns.branch_id;
 
         // Create context with capacity and release
-        let mut ctx = TransactionPool::acquire(1, branch_id, None);
+        let mut ctx = TransactionPool::acquire(TxnId(1), branch_id, None);
         for i in 0..50 {
             let key = create_test_key(&ns, format!("key{}", i).as_bytes());
             ctx.read_set.insert(key.clone(), i as u64);

--- a/crates/engine/tests/flush_pipeline_tests.rs
+++ b/crates/engine/tests/flush_pipeline_tests.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use strata_engine::background::{BackgroundScheduler, TaskPriority};
 use strata_storage::segmented::SegmentedStore;
 
+use strata_core::id::CommitVersion;
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{BranchId, Key, Namespace, TypeTag};
 use strata_core::value::Value;
@@ -26,7 +27,7 @@ fn kv_key(name: &str) -> Key {
 
 fn seed(store: &SegmentedStore, key: Key, value: Value, version: u64) {
     store
-        .put_with_version_mode(key, value, version, None, WriteMode::Append)
+        .put_with_version_mode(key, value, CommitVersion(version), None, WriteMode::Append)
         .unwrap();
 }
 
@@ -40,7 +41,7 @@ fn scheduler_flushes_after_rotation() {
             .put_with_version_mode(
                 kv_key(&format!("k{:04}", i)),
                 Value::Int(i as i64),
-                i,
+                CommitVersion(i),
                 None,
                 WriteMode::Append,
             )
@@ -68,7 +69,7 @@ fn scheduler_flushes_after_rotation() {
 
     for i in 1..=50u64 {
         let result = store
-            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("k{:04}", i)), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(result.value, Value::Int(i as i64));
@@ -155,7 +156,7 @@ fn lifecycle_write_flush_recover_all_data_correct() {
 
     for i in 1..=100u64 {
         let result = store2
-            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("k{:04}", i)), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(result.value, Value::Int(i as i64));
@@ -210,7 +211,7 @@ fn lifecycle_crash_before_flush() {
 
     for i in 1..=50u64 {
         let result = store2
-            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("k{:04}", i)), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(result.value, Value::Int(i as i64));
@@ -270,7 +271,7 @@ fn lifecycle_crash_after_segment_before_manifest() {
     // Data readable via segment + memtable (MVCC dedup handles overlap)
     for i in 1..=50u64 {
         let result = store2
-            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("k{:04}", i)), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(result.value, Value::Int(i as i64));
@@ -326,7 +327,7 @@ fn lifecycle_multiple_flush_cycles() {
 
     for i in 1..=90u64 {
         let result = store2
-            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("k{:04}", i)), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(result.value, Value::Int(i as i64));
@@ -397,7 +398,7 @@ fn lifecycle_wal_truncation_after_flush() {
 
     for i in 1..=50u64 {
         let result = store2
-            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("k{:04}", i)), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(result.value, Value::Int(i as i64));
@@ -447,7 +448,7 @@ fn multi_level_compaction_cascades() {
     // All data still readable after cascading through levels
     for i in 1..=5u64 {
         let result = store
-            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("k{:04}", i)), CommitVersion::MAX)
             .unwrap()
             .unwrap_or_else(|| panic!("key k{:04} missing after cascade", i));
         assert_eq!(result.value, Value::Int(i as i64));
@@ -489,7 +490,8 @@ fn test_issue_1726_version_counter_from_segments() {
     let recovery = RecoveryCoordinator::new(wal_dir).with_segments(segments_dir, 0);
     let result = recovery.recover().unwrap();
     assert_eq!(
-        result.stats.final_version, 0,
+        result.stats.final_version,
+        CommitVersion::ZERO,
         "WAL is empty so WAL max_version must be 0"
     );
 
@@ -503,10 +505,10 @@ fn test_issue_1726_version_counter_from_segments() {
 
     // Phase 4: The version counter must be bumped to at least segment max.
     let coordinator = TransactionCoordinator::from_recovery_with_limits(&result, 0);
-    coordinator.bump_version_floor(seg_info.max_commit_id);
+    coordinator.bump_version_floor(CommitVersion(seg_info.max_commit_id));
     assert_eq!(
         coordinator.current_version(),
-        100,
+        CommitVersion(100),
         "version counter must equal segment max_commit_id after bump",
     );
 }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -1260,7 +1260,7 @@ impl Executor {
                 // Use the current version as the safe GC boundary:
                 // all versions older than the current version are prunable
                 // since they have been superseded by newer commits.
-                let current = self.primitives.db.current_version();
+                let current = self.primitives.db.current_version().as_u64();
                 let _pruned = self.primitives.db.gc_versions_before(branch_id, current);
                 Ok(Output::Unit)
             }

--- a/crates/executor/src/handlers/search.rs
+++ b/crates/executor/src/handlers/search.rs
@@ -284,7 +284,7 @@ pub fn search(
         },
         embedding_pending,
         embedding_total,
-        snapshot_version: Some(p.db.current_version()),
+        snapshot_version: Some(p.db.current_version().as_u64()),
         rag_used: rag_used_flag,
         rag_model: rag_model_field,
         rag_elapsed_ms: rag_elapsed,

--- a/crates/executor/src/tests/spaces.rs
+++ b/crates/executor/src/tests/spaces.rs
@@ -1063,9 +1063,10 @@ fn test_session_default_space_skipped() {
 
     // The default-space metadata key must remain absent after a write
     // to the default space — the helper short-circuits before the put.
+    use strata_core::id::CommitVersion;
     let bid = BranchId::from_bytes([0u8; 16]);
     let key = Key::new_space(bid, "default");
-    let version = db.storage().version();
+    let version = CommitVersion(db.storage().version());
     let entry = db.storage().get_versioned(&key, version).unwrap();
     assert!(
         entry.is_none(),

--- a/crates/search/src/substrate.rs
+++ b/crates/search/src/substrate.rs
@@ -128,7 +128,7 @@ pub fn retrieve(db: &Arc<Database>, request: &RetrievalRequest) -> StrataResult<
         .map(|ms| start + std::time::Duration::from_millis(ms));
 
     // INV-3: Snapshot isolation — all primitives see the same version.
-    let snapshot = db.current_version();
+    let snapshot = db.current_version().as_u64();
 
     let has_bm25 = recipe
         .retrieve

--- a/crates/storage/src/memtable.rs
+++ b/crates/storage/src/memtable.rs
@@ -12,6 +12,7 @@
 //! efficient ordered iteration.
 
 use crate::key_encoding::{encode_typed_key, encode_typed_key_prefix, InternalKey};
+use strata_core::id::CommitVersion;
 use strata_core::types::Key;
 use strata_core::value::Value;
 use strata_core::{Timestamp, Version, VersionedValue};
@@ -183,7 +184,7 @@ impl Memtable {
     /// Point read: get the newest visible version of a key at or before `snapshot_commit`.
     ///
     /// Returns `None` if the key doesn't exist or has no version ≤ `snapshot_commit`.
-    pub fn get_versioned(&self, key: &Key, snapshot_commit: u64) -> Option<MemtableEntry> {
+    pub fn get_versioned(&self, key: &Key, snapshot_commit: CommitVersion) -> Option<MemtableEntry> {
         // Seek to (key, u64::MAX) — the theoretical newest possible version
         let seek_key = InternalKey::encode(key, u64::MAX);
         let typed_prefix = encode_typed_key(key);
@@ -196,7 +197,7 @@ impl Memtable {
                 break;
             }
             // Check MVCC visibility
-            if ik.commit_id() <= snapshot_commit {
+            if ik.commit_id() <= snapshot_commit.as_u64() {
                 return Some(entry.value().clone());
             }
         }
@@ -459,14 +460,14 @@ mod tests {
     fn put_then_get_returns_value() {
         let mt = Memtable::new(0);
         mt.put(&key("k1"), 1, Value::Int(42), false);
-        let result = mt.get_versioned(&key("k1"), u64::MAX);
+        let result = mt.get_versioned(&key("k1"), CommitVersion::MAX);
         assert_eq!(result.unwrap().value, Value::Int(42));
     }
 
     #[test]
     fn get_nonexistent_returns_none() {
         let mt = Memtable::new(0);
-        assert!(mt.get_versioned(&key("k1"), u64::MAX).is_none());
+        assert!(mt.get_versioned(&key("k1"), CommitVersion::MAX).is_none());
     }
 
     #[test]
@@ -474,7 +475,7 @@ mod tests {
         let mt = Memtable::new(0);
         mt.put(&key("k1"), 1, Value::Null, false);
         mt.put(&key("k1"), 2, Value::Null, true);
-        let result = mt.get_versioned(&key("k1"), u64::MAX);
+        let result = mt.get_versioned(&key("k1"), CommitVersion::MAX);
         assert!(result.unwrap().is_tombstone);
     }
 
@@ -488,18 +489,18 @@ mod tests {
         mt.put(&key("k1"), 3, Value::Int(30), false);
 
         assert_eq!(
-            mt.get_versioned(&key("k1"), 3).unwrap().value,
+            mt.get_versioned(&key("k1"), CommitVersion(3)).unwrap().value,
             Value::Int(30)
         );
         assert_eq!(
-            mt.get_versioned(&key("k1"), 2).unwrap().value,
+            mt.get_versioned(&key("k1"), CommitVersion(2)).unwrap().value,
             Value::Int(20)
         );
         assert_eq!(
-            mt.get_versioned(&key("k1"), 1).unwrap().value,
+            mt.get_versioned(&key("k1"), CommitVersion(1)).unwrap().value,
             Value::Int(10)
         );
-        assert!(mt.get_versioned(&key("k1"), 0).is_none());
+        assert!(mt.get_versioned(&key("k1"), CommitVersion(0)).is_none());
     }
 
     #[test]
@@ -523,13 +524,13 @@ mod tests {
         mt.put(&key("k1"), 2, Value::Null, true);
         mt.put(&key("k1"), 3, Value::Int(30), false);
 
-        assert!(mt.get_versioned(&key("k1"), 2).unwrap().is_tombstone);
+        assert!(mt.get_versioned(&key("k1"), CommitVersion(2)).unwrap().is_tombstone);
         assert_eq!(
-            mt.get_versioned(&key("k1"), 3).unwrap().value,
+            mt.get_versioned(&key("k1"), CommitVersion(3)).unwrap().value,
             Value::Int(30)
         );
         assert_eq!(
-            mt.get_versioned(&key("k1"), 1).unwrap().value,
+            mt.get_versioned(&key("k1"), CommitVersion(1)).unwrap().value,
             Value::Int(10)
         );
     }
@@ -651,7 +652,7 @@ mod tests {
         mt.freeze();
         assert!(mt.is_frozen());
         assert_eq!(
-            mt.get_versioned(&key("k1"), u64::MAX).unwrap().value,
+            mt.get_versioned(&key("k1"), CommitVersion::MAX).unwrap().value,
             Value::Int(42)
         );
     }
@@ -847,7 +848,7 @@ mod tests {
                 let mt = Arc::clone(&mt);
                 std::thread::spawn(move || {
                     for i in 0..100u64 {
-                        let result = mt.get_versioned(&key(&format!("k{}", i)), u64::MAX);
+                        let result = mt.get_versioned(&key(&format!("k{}", i)), CommitVersion::MAX);
                         assert!(result.is_some());
                     }
                 })

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -78,6 +78,7 @@ thread_local! {
     }) };
 }
 
+use strata_core::id::CommitVersion;
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{BranchId, Key, TypeTag};
 use strata_core::value::Value;
@@ -1505,7 +1506,7 @@ impl SegmentedStore {
         &self,
         source_id: &BranchId,
         dest_id: &BranchId,
-    ) -> io::Result<(u64, usize)> {
+    ) -> io::Result<(CommitVersion, usize)> {
         if source_id == dest_id {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -1679,7 +1680,7 @@ impl SegmentedStore {
         // 7. Write manifest
         self.write_branch_manifest(dest_id);
 
-        Ok((fork_version, segments_shared))
+        Ok((CommitVersion(fork_version), segments_shared))
     }
 
     /// Count distinct live (non-tombstone, non-expired) logical keys in a branch.
@@ -3948,10 +3949,10 @@ impl SegmentedStore {
     fn count_prefix_from_snapshot(
         snapshot: &BranchSnapshot,
         prefix: &Key,
-        max_version: u64,
+        max_version: CommitVersion,
     ) -> StrataResult<u64> {
         let (merge, flags) = Self::build_snapshot_merge_iter(snapshot, prefix, prefix)?;
-        let mvcc = MvccIterator::new(merge, max_version);
+        let mvcc = MvccIterator::new(merge, max_version.as_u64());
         let count = mvcc
             .filter(|(_, entry)| !entry.is_tombstone && !entry.is_expired())
             .filter(|(ik, _)| ik.decode().is_some())
@@ -3983,10 +3984,10 @@ impl SegmentedStore {
         &self,
         branch_id: &BranchId,
         prefix: Key,
-        snapshot_version: u64,
+        snapshot_version: CommitVersion,
     ) -> Option<StorageIterator> {
         let snapshot = self.snapshot_branch(branch_id)?;
-        Some(StorageIterator::new(snapshot, prefix, snapshot_version))
+        Some(StorageIterator::new(snapshot, prefix, snapshot_version.as_u64()))
     }
 
     /// Scan entries starting from `start_key` within `prefix`, with optional limit.
@@ -4042,13 +4043,13 @@ impl SegmentedStore {
     /// Uses the same merge/MVCC pipeline as `scan_prefix` but only counts
     /// the live (non-tombstone, non-expired) entries, avoiding the O(N)
     /// `Vec<(Key, VersionedValue)>` allocation.
-    pub fn count_prefix(&self, prefix: &Key, max_version: u64) -> StrataResult<u64> {
+    pub fn count_prefix(&self, prefix: &Key, max_version: CommitVersion) -> StrataResult<u64> {
         let branch_id = prefix.namespace.branch_id;
 
         // O(1) fast path: unprefixed count at latest version uses
         // RocksDB-style EstimateNumKeys (entries - deletions).
         // This only needs a brief DashMap read for the atomic counters.
-        if prefix.user_key.is_empty() && max_version == u64::MAX {
+        if prefix.user_key.is_empty() && max_version == CommitVersion::MAX {
             if let Some(branch) = self.branches.get(&branch_id) {
                 return Ok(branch.estimate_live_keys());
             }
@@ -4067,10 +4068,10 @@ impl SegmentedStore {
     fn count_prefix_from_branch(
         branch: &BranchState,
         prefix: &Key,
-        max_version: u64,
+        max_version: CommitVersion,
     ) -> StrataResult<u64> {
         let (merge, flags) = Self::build_branch_merge_iter(branch, prefix, prefix)?;
-        let mvcc = MvccIterator::new(merge, max_version);
+        let mvcc = MvccIterator::new(merge, max_version.as_u64());
         let count = mvcc
             .filter(|(_, entry)| !entry.is_tombstone && !entry.is_expired())
             .filter(|(ik, _)| ik.decode().is_some())
@@ -4213,13 +4214,13 @@ impl std::fmt::Debug for SegmentedStore {
 // ============================================================================
 
 impl Storage for SegmentedStore {
-    fn get_versioned(&self, key: &Key, max_version: u64) -> StrataResult<Option<VersionedValue>> {
+    fn get_versioned(&self, key: &Key, max_version: CommitVersion) -> StrataResult<Option<VersionedValue>> {
         let snapshot = match self.snapshot_branch(&key.namespace.branch_id) {
             Some(s) => s,
             None => return Ok(None),
         };
 
-        match Self::get_versioned_from_snapshot(&snapshot, key, max_version)? {
+        match Self::get_versioned_from_snapshot(&snapshot, key, max_version.as_u64())? {
             Some((commit_id, entry)) => {
                 if entry.is_tombstone || entry.is_expired() {
                     Ok(None)
@@ -4235,7 +4236,7 @@ impl Storage for SegmentedStore {
         &self,
         key: &Key,
         limit: Option<usize>,
-        before_version: Option<u64>,
+        before_version: Option<CommitVersion>,
     ) -> StrataResult<Vec<VersionedValue>> {
         let snapshot = match self.snapshot_branch(&key.namespace.branch_id) {
             Some(s) => s,
@@ -4248,7 +4249,7 @@ impl Storage for SegmentedStore {
             .into_iter()
             .filter(|(commit_id, entry)| {
                 if let Some(bv) = before_version {
-                    if *commit_id >= bv {
+                    if *commit_id >= bv.as_u64() {
                         return false;
                     }
                 }
@@ -4266,25 +4267,25 @@ impl Storage for SegmentedStore {
     fn scan_prefix(
         &self,
         prefix: &Key,
-        max_version: u64,
+        max_version: CommitVersion,
     ) -> StrataResult<Vec<(Key, VersionedValue)>> {
         let snapshot = match self.snapshot_branch(&prefix.namespace.branch_id) {
             Some(s) => s,
             None => return Ok(Vec::new()),
         };
 
-        Self::scan_prefix_from_snapshot(&snapshot, prefix, max_version)
+        Self::scan_prefix_from_snapshot(&snapshot, prefix, max_version.as_u64())
     }
 
-    fn current_version(&self) -> u64 {
-        self.version.load(Ordering::Acquire)
+    fn current_version(&self) -> CommitVersion {
+        CommitVersion(self.version.load(Ordering::Acquire))
     }
 
     fn put_with_version_mode(
         &self,
         key: Key,
         value: Value,
-        version: u64,
+        version: CommitVersion,
         ttl: Option<Duration>,
         _mode: WriteMode,
     ) -> StrataResult<()> {
@@ -4309,21 +4310,21 @@ impl Storage for SegmentedStore {
             raw_value: None,
         };
         let ts = entry.timestamp.as_micros();
-        branch.active.put_entry(&key, version, entry);
+        branch.active.put_entry(&key, version.as_u64(), entry);
         // Track timestamp for O(1) time_range
         branch.track_timestamp(ts);
-        branch.track_version(version);
+        branch.track_version(version.as_u64());
 
         // Rotate if active memtable exceeds threshold
         self.maybe_rotate_branch(branch_id, &mut branch);
 
         // Update global version
-        self.version.fetch_max(version, Ordering::AcqRel);
+        self.version.fetch_max(version.as_u64(), Ordering::AcqRel);
 
         Ok(())
     }
 
-    fn delete_with_version(&self, key: &Key, version: u64) -> StrataResult<()> {
+    fn delete_with_version(&self, key: &Key, version: CommitVersion) -> StrataResult<()> {
         let branch_id = key.namespace.branch_id;
 
         let mut branch = self
@@ -4342,21 +4343,21 @@ impl Storage for SegmentedStore {
             raw_value: None,
         };
         let ts = entry.timestamp.as_micros();
-        branch.active.put_entry(key, version, entry);
+        branch.active.put_entry(key, version.as_u64(), entry);
         // Track timestamp for O(1) time_range
         branch.track_timestamp(ts);
-        branch.track_version(version);
+        branch.track_version(version.as_u64());
 
         // Rotate if active memtable exceeds threshold
         self.maybe_rotate_branch(branch_id, &mut branch);
 
         // Update global version
-        self.version.fetch_max(version, Ordering::AcqRel);
+        self.version.fetch_max(version.as_u64(), Ordering::AcqRel);
 
         Ok(())
     }
 
-    fn apply_batch(&self, writes: Vec<(Key, Value, WriteMode)>, version: u64) -> StrataResult<()> {
+    fn apply_batch(&self, writes: Vec<(Key, Value, WriteMode)>, version: CommitVersion) -> StrataResult<()> {
         if writes.is_empty() {
             return Ok(());
         }
@@ -4388,19 +4389,19 @@ impl Storage for SegmentedStore {
                     ttl_ms: 0,
                     raw_value: None,
                 };
-                branch.active.put_entry(&key, version, entry);
+                branch.active.put_entry(&key, version.as_u64(), entry);
             }
             // Track timestamp for O(1) time_range
             branch.track_timestamp(ts);
-            branch.track_version(version);
+            branch.track_version(version.as_u64());
             self.maybe_rotate_branch(branch_id, &mut branch);
         }
 
-        self.version.fetch_max(version, Ordering::AcqRel);
+        self.version.fetch_max(version.as_u64(), Ordering::AcqRel);
         Ok(())
     }
 
-    fn delete_batch(&self, deletes: Vec<Key>, version: u64) -> StrataResult<()> {
+    fn delete_batch(&self, deletes: Vec<Key>, version: CommitVersion) -> StrataResult<()> {
         if deletes.is_empty() {
             return Ok(());
         }
@@ -4429,15 +4430,15 @@ impl Storage for SegmentedStore {
                     ttl_ms: 0,
                     raw_value: None,
                 };
-                branch.active.put_entry(&key, version, entry);
+                branch.active.put_entry(&key, version.as_u64(), entry);
             }
             // Track timestamp for O(1) time_range
             branch.track_timestamp(ts);
-            branch.track_version(version);
+            branch.track_version(version.as_u64());
             self.maybe_rotate_branch(branch_id, &mut branch);
         }
 
-        self.version.fetch_max(version, Ordering::AcqRel);
+        self.version.fetch_max(version.as_u64(), Ordering::AcqRel);
         Ok(())
     }
 
@@ -4445,7 +4446,7 @@ impl Storage for SegmentedStore {
         &self,
         writes: Vec<(Key, Value, WriteMode)>,
         deletes: Vec<Key>,
-        version: u64,
+        version: CommitVersion,
         put_ttls: &[u64],
     ) -> StrataResult<()> {
         if writes.is_empty() && deletes.is_empty() {
@@ -4490,11 +4491,11 @@ impl Storage for SegmentedStore {
                     ttl_ms,
                     raw_value: None,
                 };
-                branch.active.put_entry(&key, version, entry);
+                branch.active.put_entry(&key, version.as_u64(), entry);
             }
             branch.num_entries.fetch_add(put_count, Ordering::Relaxed);
             branch.track_timestamp(ts);
-            branch.track_version(version);
+            branch.track_version(version.as_u64());
             self.maybe_rotate_branch(branch_id, &mut branch);
         }
 
@@ -4513,16 +4514,16 @@ impl Storage for SegmentedStore {
                     ttl_ms: 0,
                     raw_value: None,
                 };
-                branch.active.put_entry(&key, version, entry);
+                branch.active.put_entry(&key, version.as_u64(), entry);
             }
             branch.num_deletions.fetch_add(del_count, Ordering::Relaxed);
             branch.track_timestamp(ts);
-            branch.track_version(version);
+            branch.track_version(version.as_u64());
             self.maybe_rotate_branch(branch_id, &mut branch);
         }
 
         // Advance version only after ALL entries are installed.
-        self.version.fetch_max(version, Ordering::AcqRel);
+        self.version.fetch_max(version.as_u64(), Ordering::AcqRel);
         Ok(())
     }
 

--- a/crates/storage/src/segmented/tests/basic.rs
+++ b/crates/storage/src/segmented/tests/basic.rs
@@ -7,7 +7,7 @@ fn put_then_get() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("k"), Value::Int(42), 1);
     let result = store
-        .get_versioned(&kv_key("k"), u64::MAX)
+        .get_versioned(&kv_key("k"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(result.value, Value::Int(42));
@@ -18,7 +18,7 @@ fn put_then_get() {
 fn get_nonexistent_returns_none() {
     let store = SegmentedStore::new();
     assert!(store
-        .get_versioned(&kv_key("k"), u64::MAX)
+        .get_versioned(&kv_key("k"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 }
@@ -27,9 +27,9 @@ fn get_nonexistent_returns_none() {
 fn delete_creates_tombstone() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("k"), Value::Int(42), 1);
-    store.delete_with_version(&kv_key("k"), 2).unwrap();
+    store.delete_with_version(&kv_key("k"), CommitVersion(2)).unwrap();
     assert!(store
-        .get_versioned(&kv_key("k"), u64::MAX)
+        .get_versioned(&kv_key("k"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 }
@@ -42,37 +42,37 @@ fn versioned_read_respects_snapshot() {
     seed(&store, kv_key("k"), Value::Int(30), 3);
 
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 1).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(1)).unwrap().unwrap().value,
         Value::Int(10)
     );
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 2).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(2)).unwrap().unwrap().value,
         Value::Int(20)
     );
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 3).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(3)).unwrap().unwrap().value,
         Value::Int(30)
     );
-    assert!(store.get_versioned(&kv_key("k"), 0).unwrap().is_none());
+    assert!(store.get_versioned(&kv_key("k"), CommitVersion(0)).unwrap().is_none());
 }
 
 #[test]
 fn tombstone_snapshot_isolation() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("k"), Value::Int(10), 1);
-    store.delete_with_version(&kv_key("k"), 2).unwrap();
+    store.delete_with_version(&kv_key("k"), CommitVersion(2)).unwrap();
     seed(&store, kv_key("k"), Value::Int(30), 3);
 
     // Snapshot at 1: see original value
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 1).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(1)).unwrap().unwrap().value,
         Value::Int(10)
     );
     // Snapshot at 2: tombstone → None
-    assert!(store.get_versioned(&kv_key("k"), 2).unwrap().is_none());
+    assert!(store.get_versioned(&kv_key("k"), CommitVersion(2)).unwrap().is_none());
     // Snapshot at 3: see re-written value
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 3).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(3)).unwrap().unwrap().value,
         Value::Int(30)
     );
 }
@@ -112,7 +112,7 @@ fn get_history_with_before_version() {
     seed(&store, kv_key("k"), Value::Int(2), 2);
     seed(&store, kv_key("k"), Value::Int(3), 3);
 
-    let history = store.get_history(&kv_key("k"), None, Some(3)).unwrap();
+    let history = store.get_history(&kv_key("k"), None, Some(CommitVersion(3))).unwrap();
     assert_eq!(history.len(), 2);
     assert_eq!(history[0].value, Value::Int(2));
 }
@@ -121,7 +121,7 @@ fn get_history_with_before_version() {
 fn get_history_includes_tombstones() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("k"), Value::Int(1), 1);
-    store.delete_with_version(&kv_key("k"), 2).unwrap();
+    store.delete_with_version(&kv_key("k"), CommitVersion(2)).unwrap();
     seed(&store, kv_key("k"), Value::Int(3), 3);
 
     let history = store.get_history(&kv_key("k"), None, None).unwrap();
@@ -141,7 +141,7 @@ fn scan_prefix_returns_matching_keys() {
     seed(&store, kv_key("config/x"), Value::Int(3), 3);
 
     let prefix = Key::new(ns(), TypeTag::KV, "user/".as_bytes().to_vec());
-    let results = store.scan_prefix(&prefix, u64::MAX).unwrap();
+    let results = store.scan_prefix(&prefix, CommitVersion::MAX).unwrap();
     assert_eq!(results.len(), 2);
 }
 
@@ -150,10 +150,10 @@ fn scan_prefix_filters_tombstones() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("k1"), Value::Int(1), 1);
     seed(&store, kv_key("k2"), Value::Int(2), 2);
-    store.delete_with_version(&kv_key("k1"), 3).unwrap();
+    store.delete_with_version(&kv_key("k1"), CommitVersion(3)).unwrap();
 
     let prefix = Key::new(ns(), TypeTag::KV, "k".as_bytes().to_vec());
-    let results = store.scan_prefix(&prefix, u64::MAX).unwrap();
+    let results = store.scan_prefix(&prefix, CommitVersion::MAX).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].1.value, Value::Int(2));
 }
@@ -168,7 +168,7 @@ fn scan_prefix_mvcc_snapshot() {
     let prefix = Key::new(ns(), TypeTag::KV, "k".as_bytes().to_vec());
 
     // Snapshot at 2: k1@1 and k2@2
-    let results = store.scan_prefix(&prefix, 2).unwrap();
+    let results = store.scan_prefix(&prefix, CommitVersion(2)).unwrap();
     assert_eq!(results.len(), 2);
     assert_eq!(results[0].1.value, Value::Int(10)); // k1@1
     assert_eq!(results[1].1.value, Value::Int(30)); // k2@2
@@ -177,9 +177,9 @@ fn scan_prefix_mvcc_snapshot() {
 #[test]
 fn current_version_tracks_writes() {
     let store = SegmentedStore::new();
-    assert_eq!(store.current_version(), 0);
+    assert_eq!(store.current_version(), CommitVersion(0));
     seed(&store, kv_key("k"), Value::Int(1), 5);
-    assert!(store.current_version() >= 5);
+    assert!(store.current_version() >= CommitVersion(5));
 }
 
 #[test]
@@ -231,7 +231,7 @@ fn list_branch_returns_live_entries() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("a"), Value::Int(1), 1);
     seed(&store, kv_key("b"), Value::Int(2), 2);
-    store.delete_with_version(&kv_key("a"), 3).unwrap();
+    store.delete_with_version(&kv_key("a"), CommitVersion(3)).unwrap();
 
     let entries = store.list_branch(&branch());
     assert_eq!(entries.len(), 1);
@@ -249,18 +249,18 @@ fn multiple_branches_isolated() {
 
     let store = SegmentedStore::new();
     store
-        .put_with_version_mode(k1.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(k1.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(k2.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(k2.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     assert_eq!(
-        store.get_versioned(&k1, u64::MAX).unwrap().unwrap().value,
+        store.get_versioned(&k1, CommitVersion::MAX).unwrap().unwrap().value,
         Value::Int(1)
     );
     assert_eq!(
-        store.get_versioned(&k2, u64::MAX).unwrap().unwrap().value,
+        store.get_versioned(&k2, CommitVersion::MAX).unwrap().unwrap().value,
         Value::Int(2)
     );
     assert_eq!(store.branch_ids().len(), 2);
@@ -285,7 +285,7 @@ fn compaction_does_not_cross_branches() {
             .put_with_version_mode(
                 key_b1(&format!("k{:04}", i)),
                 Value::Int(i as i64),
-                i + 1,
+                CommitVersion(i + 1),
                 None,
                 WriteMode::Append,
             )
@@ -294,7 +294,7 @@ fn compaction_does_not_cross_branches() {
             .put_with_version_mode(
                 key_b2(&format!("k{:04}", i)),
                 Value::Int((i as i64) * 100),
-                i + 1,
+                CommitVersion(i + 1),
                 None,
                 WriteMode::Append,
             )
@@ -322,13 +322,13 @@ fn compaction_does_not_cross_branches() {
     // Verify data integrity on both branches
     for i in 0..20u64 {
         let e1 = store
-            .get_versioned(&key_b1(&format!("k{:04}", i)), u64::MAX)
+            .get_versioned(&key_b1(&format!("k{:04}", i)), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(e1.value, Value::Int(i as i64));
 
         let e2 = store
-            .get_versioned(&key_b2(&format!("k{:04}", i)), u64::MAX)
+            .get_versioned(&key_b2(&format!("k{:04}", i)), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(e2.value, Value::Int((i as i64) * 100));
@@ -337,12 +337,12 @@ fn compaction_does_not_cross_branches() {
     // Values are distinct: branch 1 stores i, branch 2 stores i*100
     // Verify a non-zero key to confirm no cross-contamination
     let e1 = store
-        .get_versioned(&key_b1("k0005"), u64::MAX)
+        .get_versioned(&key_b1("k0005"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(e1.value, Value::Int(5), "branch 1 must have its own value");
     let e2 = store
-        .get_versioned(&key_b2("k0005"), u64::MAX)
+        .get_versioned(&key_b2("k0005"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -375,7 +375,7 @@ fn ttl_expiration_at_read_time() {
     drop(branch);
 
     // Should be expired
-    assert!(store.get_versioned(&key, u64::MAX).unwrap().is_none());
+    assert!(store.get_versioned(&key, CommitVersion::MAX).unwrap().is_none());
 }
 
 #[test]
@@ -389,7 +389,7 @@ fn concurrent_readers_and_writer() {
             .put_with_version_mode(
                 kv_key(&format!("k{}", i)),
                 Value::Int(i as i64),
-                i + 1,
+                CommitVersion(i + 1),
                 None,
                 WriteMode::Append,
             )
@@ -402,7 +402,7 @@ fn concurrent_readers_and_writer() {
             let s = Arc::clone(&store);
             std::thread::spawn(move || {
                 for i in 0..100u64 {
-                    let result = s.get_versioned(&kv_key(&format!("k{}", i)), u64::MAX);
+                    let result = s.get_versioned(&kv_key(&format!("k{}", i)), CommitVersion::MAX);
                     assert!(result.unwrap().is_some());
                 }
             })
@@ -441,7 +441,7 @@ fn get_version_only_nonexistent() {
 fn get_version_only_tombstoned() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("k"), Value::Int(1), 1);
-    store.delete_with_version(&kv_key("k"), 2).unwrap();
+    store.delete_with_version(&kv_key("k"), CommitVersion(2)).unwrap();
     assert_eq!(store.get_version_only(&kv_key("k")).unwrap(), None);
 }
 
@@ -459,7 +459,7 @@ fn test_issue_1700_keep_last_does_not_prune_at_write_time() {
             .put_with_version_mode(
                 key.clone(),
                 Value::Int(v as i64),
-                v,
+                CommitVersion(v),
                 None,
                 WriteMode::Append,
             )
@@ -469,7 +469,7 @@ fn test_issue_1700_keep_last_does_not_prune_at_write_time() {
 
     // Write a 4th version with KeepLast(1) — memtable must still keep all 4.
     store
-        .put_with_version_mode(key.clone(), Value::Int(99), 4, None, WriteMode::KeepLast(1))
+        .put_with_version_mode(key.clone(), Value::Int(99), CommitVersion(4), None, WriteMode::KeepLast(1))
         .unwrap();
 
     let history = store.get_history(&key, None, None).unwrap();
@@ -497,7 +497,7 @@ fn test_issue_1700_apply_batch_keep_last_preserves_versions() {
     store
         .apply_batch(
             vec![(key.clone(), Value::Int(3), WriteMode::KeepLast(1))],
-            3,
+            CommitVersion(3),
         )
         .unwrap();
 
@@ -513,9 +513,9 @@ fn test_issue_1700_apply_batch_keep_last_preserves_versions() {
 fn delete_nonexistent_key() {
     let store = SegmentedStore::new();
     // Deleting a key that never existed should succeed (creates tombstone)
-    store.delete_with_version(&kv_key("ghost"), 1).unwrap();
+    store.delete_with_version(&kv_key("ghost"), CommitVersion(1)).unwrap();
     assert!(store
-        .get_versioned(&kv_key("ghost"), u64::MAX)
+        .get_versioned(&kv_key("ghost"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 }
@@ -529,7 +529,7 @@ fn scan_prefix_results_are_sorted() {
     seed(&store, kv_key("k2"), Value::Int(2), 2);
 
     let prefix = Key::new(ns(), TypeTag::KV, "k".as_bytes().to_vec());
-    let results = store.scan_prefix(&prefix, u64::MAX).unwrap();
+    let results = store.scan_prefix(&prefix, CommitVersion::MAX).unwrap();
     assert_eq!(results.len(), 3);
     // Must be sorted by key
     assert!(results[0].0 < results[1].0);
@@ -543,14 +543,14 @@ fn put_with_ttl_via_public_api() {
         .put_with_version_mode(
             kv_key("ttl"),
             Value::Int(1),
-            1,
+            CommitVersion(1),
             Some(Duration::from_secs(3600)), // 1 hour — should not expire
             WriteMode::Append,
         )
         .unwrap();
     // Should be readable (not expired yet)
     assert!(store
-        .get_versioned(&kv_key("ttl"), u64::MAX)
+        .get_versioned(&kv_key("ttl"), CommitVersion::MAX)
         .unwrap()
         .is_some());
 }
@@ -613,7 +613,7 @@ fn test_issue_1749_scan_prefix_returns_error_on_corruption() {
 
     // scan_prefix MUST return Err, not a silently truncated Vec.
     let prefix = Key::new(ns(), TypeTag::KV, "item_".as_bytes().to_vec());
-    let result = store2.scan_prefix(&prefix, u64::MAX);
+    let result = store2.scan_prefix(&prefix, CommitVersion::MAX);
     assert!(
         result.is_err(),
         "scan_prefix must return Err on corrupt segment, got {} entries",
@@ -675,8 +675,8 @@ fn count_prefix_matches_scan_prefix() {
     seed(&store, kv_key("c"), Value::Int(3), 3);
 
     let prefix = Key::new(ns(), TypeTag::KV, vec![]);
-    let scan_count = store.scan_prefix(&prefix, u64::MAX).unwrap().len() as u64;
-    let direct_count = store.count_prefix(&prefix, u64::MAX).unwrap();
+    let scan_count = store.scan_prefix(&prefix, CommitVersion::MAX).unwrap().len() as u64;
+    let direct_count = store.count_prefix(&prefix, CommitVersion::MAX).unwrap();
     assert_eq!(scan_count, direct_count);
     assert_eq!(direct_count, 3);
 }
@@ -687,10 +687,10 @@ fn count_prefix_excludes_tombstones() {
     seed(&store, kv_key("a"), Value::Int(1), 1);
     seed(&store, kv_key("b"), Value::Int(2), 2);
     seed(&store, kv_key("c"), Value::Int(3), 3);
-    store.delete_with_version(&kv_key("b"), 4).unwrap();
+    store.delete_with_version(&kv_key("b"), CommitVersion(4)).unwrap();
 
     let prefix = Key::new(ns(), TypeTag::KV, vec![]);
-    let count = store.count_prefix(&prefix, u64::MAX).unwrap();
+    let count = store.count_prefix(&prefix, CommitVersion::MAX).unwrap();
     assert_eq!(count, 2, "deleted key must not be counted");
 }
 
@@ -702,16 +702,16 @@ fn count_prefix_respects_version_snapshot() {
 
     // At version 2, only k1 exists
     let prefix = Key::new(ns(), TypeTag::KV, vec![]);
-    assert_eq!(store.count_prefix(&prefix, 2).unwrap(), 1);
+    assert_eq!(store.count_prefix(&prefix, CommitVersion(2)).unwrap(), 1);
     // At version 3, both exist
-    assert_eq!(store.count_prefix(&prefix, u64::MAX).unwrap(), 2);
+    assert_eq!(store.count_prefix(&prefix, CommitVersion::MAX).unwrap(), 2);
 }
 
 #[test]
 fn count_prefix_empty_store() {
     let store = SegmentedStore::new();
     let prefix = Key::new(ns(), TypeTag::KV, vec![]);
-    assert_eq!(store.count_prefix(&prefix, u64::MAX).unwrap(), 0);
+    assert_eq!(store.count_prefix(&prefix, CommitVersion::MAX).unwrap(), 0);
 }
 
 #[test]
@@ -722,10 +722,10 @@ fn count_prefix_with_key_filter() {
     seed(&store, kv_key("task:1"), Value::Int(3), 3);
 
     let user_prefix = Key::new(ns(), TypeTag::KV, "user:".as_bytes().to_vec());
-    assert_eq!(store.count_prefix(&user_prefix, u64::MAX).unwrap(), 2);
+    assert_eq!(store.count_prefix(&user_prefix, CommitVersion::MAX).unwrap(), 2);
 
     let task_prefix = Key::new(ns(), TypeTag::KV, "task:".as_bytes().to_vec());
-    assert_eq!(store.count_prefix(&task_prefix, u64::MAX).unwrap(), 1);
+    assert_eq!(store.count_prefix(&task_prefix, CommitVersion::MAX).unwrap(), 1);
 }
 
 // ===== BranchSnapshot tests =====
@@ -782,7 +782,7 @@ fn storage_iterator_seek_next() {
 
     let prefix = Key::new(ns(), TypeTag::KV, vec![]);
     let mut iter = store
-        .new_storage_iterator(&branch(), prefix, u64::MAX)
+        .new_storage_iterator(&branch(), prefix, CommitVersion::MAX)
         .unwrap();
 
     // Seek to key_05
@@ -805,7 +805,7 @@ fn storage_iterator_reseek() {
 
     let prefix = Key::new(ns(), TypeTag::KV, vec![]);
     let mut iter = store
-        .new_storage_iterator(&branch(), prefix, u64::MAX)
+        .new_storage_iterator(&branch(), prefix, CommitVersion::MAX)
         .unwrap();
 
     // First seek to "c", read 2
@@ -830,7 +830,7 @@ fn storage_iterator_seek_past_end() {
 
     let prefix = Key::new(ns(), TypeTag::KV, vec![]);
     let mut iter = store
-        .new_storage_iterator(&branch(), prefix, u64::MAX)
+        .new_storage_iterator(&branch(), prefix, CommitVersion::MAX)
         .unwrap();
 
     iter.seek(&kv_key("z")).unwrap();
@@ -853,7 +853,7 @@ fn storage_iterator_pagination() {
 
     let prefix = Key::new(ns(), TypeTag::KV, vec![]);
     let mut iter = store
-        .new_storage_iterator(&branch(), prefix, u64::MAX)
+        .new_storage_iterator(&branch(), prefix, CommitVersion::MAX)
         .unwrap();
 
     // Paginate: 5 pages of 3 entries

--- a/crates/storage/src/segmented/tests/batch.rs
+++ b/crates/storage/src/segmented/tests/batch.rs
@@ -19,13 +19,13 @@ fn apply_batch_equivalent_to_individual() {
         (kv_key("a"), Value::Int(1), WriteMode::Append),
         (kv_key("b"), Value::Int(2), WriteMode::Append),
     ];
-    store2.apply_batch(writes, 1).unwrap();
+    store2.apply_batch(writes, CommitVersion(1)).unwrap();
 
     // Both stores should produce the same results
     for key_name in &["a", "b"] {
         let k = kv_key(key_name);
-        let v1 = store.get_versioned(&k, u64::MAX).unwrap().unwrap().value;
-        let v2 = store2.get_versioned(&k, u64::MAX).unwrap().unwrap().value;
+        let v1 = store.get_versioned(&k, CommitVersion::MAX).unwrap().unwrap().value;
+        let v2 = store2.get_versioned(&k, CommitVersion::MAX).unwrap().unwrap().value;
         assert_eq!(v1, v2);
     }
 }
@@ -45,14 +45,14 @@ fn apply_batch_cross_branch() {
         (k1.clone(), Value::Int(10), WriteMode::Append),
         (k2.clone(), Value::Int(20), WriteMode::Append),
     ];
-    store.apply_batch(writes, 5).unwrap();
+    store.apply_batch(writes, CommitVersion(5)).unwrap();
 
     assert_eq!(
-        store.get_versioned(&k1, u64::MAX).unwrap().unwrap().value,
+        store.get_versioned(&k1, CommitVersion::MAX).unwrap().unwrap().value,
         Value::Int(10)
     );
     assert_eq!(
-        store.get_versioned(&k2, u64::MAX).unwrap().unwrap().value,
+        store.get_versioned(&k2, CommitVersion::MAX).unwrap().unwrap().value,
         Value::Int(20)
     );
 }
@@ -68,15 +68,15 @@ fn apply_batch_with_deletes() {
 
     // Delete via batch
     let deletes = vec![kv_key("a")];
-    store.delete_batch(deletes, 2).unwrap();
+    store.delete_batch(deletes, CommitVersion(2)).unwrap();
 
     assert!(store
-        .get_versioned(&kv_key("a"), u64::MAX)
+        .get_versioned(&kv_key("a"), CommitVersion::MAX)
         .unwrap()
         .is_none());
     assert_eq!(
         store
-            .get_versioned(&kv_key("b"), u64::MAX)
+            .get_versioned(&kv_key("b"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -87,9 +87,9 @@ fn apply_batch_with_deletes() {
 #[test]
 fn apply_batch_empty() {
     let store = SegmentedStore::new();
-    store.apply_batch(vec![], 1).unwrap();
-    store.delete_batch(vec![], 1).unwrap();
-    assert_eq!(store.current_version(), 0);
+    store.apply_batch(vec![], CommitVersion(1)).unwrap();
+    store.delete_batch(vec![], CommitVersion(1)).unwrap();
+    assert_eq!(store.current_version(), CommitVersion(0));
 }
 
 // ========================================================================
@@ -110,24 +110,24 @@ fn test_issue_1706_apply_writes_atomic_no_partial_visibility() {
     let deletes = vec![kv_key("K2")];
 
     // apply_writes_atomic should install everything BEFORE advancing version.
-    store.apply_writes_atomic(writes, deletes, 10, &[]).unwrap();
+    store.apply_writes_atomic(writes, deletes, CommitVersion(10), &[]).unwrap();
 
     // After the atomic call, version should be 10.
     assert_eq!(store.version(), 10);
 
     // A reader at version 10 must see BOTH the put AND the delete.
     // K1 should be "new" at version 10.
-    let k1 = store.get_versioned(&kv_key("K1"), 10).unwrap().unwrap();
+    let k1 = store.get_versioned(&kv_key("K1"), CommitVersion(10)).unwrap().unwrap();
     assert_eq!(k1.value, Value::from("new"));
 
     // K2 should be deleted (tombstone) at version 10 — returns None.
-    let k2 = store.get_versioned(&kv_key("K2"), 10).unwrap();
+    let k2 = store.get_versioned(&kv_key("K2"), CommitVersion(10)).unwrap();
     assert!(k2.is_none(), "K2 should be deleted at version 10");
 
     // A reader at version 9 (before the commit) must see old state.
-    let k1_old = store.get_versioned(&kv_key("K1"), 9).unwrap().unwrap();
+    let k1_old = store.get_versioned(&kv_key("K1"), CommitVersion(9)).unwrap().unwrap();
     assert_eq!(k1_old.value, Value::Int(1));
-    let k2_old = store.get_versioned(&kv_key("K2"), 9).unwrap().unwrap();
+    let k2_old = store.get_versioned(&kv_key("K2"), CommitVersion(9)).unwrap().unwrap();
     assert_eq!(k2_old.value, Value::Int(2));
 }
 
@@ -146,33 +146,33 @@ fn test_issue_1706_version_not_advanced_before_deletes_installed() {
     let writes = vec![(kv_key("B"), Value::Int(200), WriteMode::Append)];
     let deletes = vec![kv_key("A")];
 
-    store.apply_writes_atomic(writes, deletes, 5, &[]).unwrap();
+    store.apply_writes_atomic(writes, deletes, CommitVersion(5), &[]).unwrap();
 
     // Version advanced to 5 only after both writes and deletes are in.
     assert_eq!(store.version(), 5);
 
     // Reader at version 5: B exists, A is deleted.
-    assert!(store.get_versioned(&kv_key("B"), 5).unwrap().is_some());
-    assert!(store.get_versioned(&kv_key("A"), 5).unwrap().is_none());
+    assert!(store.get_versioned(&kv_key("B"), CommitVersion(5)).unwrap().is_some());
+    assert!(store.get_versioned(&kv_key("A"), CommitVersion(5)).unwrap().is_none());
 }
 
 #[test]
 fn test_issue_1706_apply_writes_atomic_empty() {
     let store = SegmentedStore::new();
     // Both empty — should not advance version.
-    store.apply_writes_atomic(vec![], vec![], 5, &[]).unwrap();
+    store.apply_writes_atomic(vec![], vec![], CommitVersion(5), &[]).unwrap();
     assert_eq!(store.version(), 0);
 
     // Only writes, no deletes.
     let writes = vec![(kv_key("X"), Value::Int(1), WriteMode::Append)];
-    store.apply_writes_atomic(writes, vec![], 3, &[]).unwrap();
+    store.apply_writes_atomic(writes, vec![], CommitVersion(3), &[]).unwrap();
     assert_eq!(store.version(), 3);
 
     // Only deletes, no writes.
     let deletes = vec![kv_key("X")];
-    store.apply_writes_atomic(vec![], deletes, 7, &[]).unwrap();
+    store.apply_writes_atomic(vec![], deletes, CommitVersion(7), &[]).unwrap();
     assert_eq!(store.version(), 7);
-    assert!(store.get_versioned(&kv_key("X"), 7).unwrap().is_none());
+    assert!(store.get_versioned(&kv_key("X"), CommitVersion(7)).unwrap().is_none());
 }
 
 // ========================================================================
@@ -191,7 +191,7 @@ fn bulk_load_data_readable() {
     // Data should be readable even during bulk load
     assert_eq!(
         store
-            .get_versioned(&kv_key("a"), u64::MAX)
+            .get_versioned(&kv_key("a"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -202,7 +202,7 @@ fn bulk_load_data_readable() {
 
     assert_eq!(
         store
-            .get_versioned(&kv_key("b"), u64::MAX)
+            .get_versioned(&kv_key("b"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -239,7 +239,7 @@ fn bulk_load_defers_rotation() {
     // After end_bulk_load, data is still readable
     for i in 0..100 {
         assert!(store
-            .get_versioned(&kv_key(&format!("k{}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("k{}", i)), CommitVersion::MAX)
             .unwrap()
             .is_some());
     }
@@ -259,7 +259,7 @@ fn bulk_load_normal_writes_after() {
 
     assert_eq!(
         store
-            .get_versioned(&kv_key("bulk"), u64::MAX)
+            .get_versioned(&kv_key("bulk"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -267,7 +267,7 @@ fn bulk_load_normal_writes_after() {
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("normal"), u64::MAX)
+            .get_versioned(&kv_key("normal"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -292,7 +292,7 @@ fn get_value_direct_returns_latest() {
 fn get_value_direct_skips_tombstone() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("k"), Value::Int(10), 1);
-    store.delete_with_version(&kv_key("k"), 2).unwrap();
+    store.delete_with_version(&kv_key("k"), CommitVersion(2)).unwrap();
     assert_eq!(store.get_value_direct(&kv_key("k")).unwrap(), None);
 }
 
@@ -316,7 +316,7 @@ fn get_versioned_direct_returns_latest() {
 fn get_versioned_direct_skips_tombstone() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("k"), Value::Int(10), 1);
-    store.delete_with_version(&kv_key("k"), 2).unwrap();
+    store.delete_with_version(&kv_key("k"), CommitVersion(2)).unwrap();
     assert!(store.get_versioned_direct(&kv_key("k")).unwrap().is_none());
 }
 
@@ -353,11 +353,11 @@ mod estimate_num_keys {
     #[test]
     fn tracks_inserts() {
         let store = SegmentedStore::new();
-        assert_eq!(store.count_prefix(&kv_key(""), u64::MAX).unwrap(), 0);
+        assert_eq!(store.count_prefix(&kv_key(""), CommitVersion::MAX).unwrap(), 0);
         seed(&store, kv_key("a"), Value::Int(1), 1);
         seed(&store, kv_key("b"), Value::Int(2), 2);
         seed(&store, kv_key("c"), Value::Int(3), 3);
-        assert_eq!(store.count_prefix(&kv_key(""), u64::MAX).unwrap(), 3);
+        assert_eq!(store.count_prefix(&kv_key(""), CommitVersion::MAX).unwrap(), 3);
     }
 
     #[test]
@@ -365,18 +365,18 @@ mod estimate_num_keys {
         let store = SegmentedStore::new();
         seed(&store, kv_key("a"), Value::Int(1), 1);
         seed(&store, kv_key("b"), Value::Int(2), 2);
-        assert_eq!(store.count_prefix(&kv_key(""), u64::MAX).unwrap(), 2);
-        store.delete_with_version(&kv_key("a"), 3).unwrap();
+        assert_eq!(store.count_prefix(&kv_key(""), CommitVersion::MAX).unwrap(), 2);
+        store.delete_with_version(&kv_key("a"), CommitVersion(3)).unwrap();
         // estimate = 2 entries - 1 deletion = 1
-        assert_eq!(store.count_prefix(&kv_key(""), u64::MAX).unwrap(), 1);
+        assert_eq!(store.count_prefix(&kv_key(""), CommitVersion::MAX).unwrap(), 1);
     }
 
     #[test]
     fn does_not_underflow() {
         let store = SegmentedStore::new();
         // Delete without any prior insert
-        store.delete_with_version(&kv_key("ghost"), 1).unwrap();
-        assert_eq!(store.count_prefix(&kv_key(""), u64::MAX).unwrap(), 0);
+        store.delete_with_version(&kv_key("ghost"), CommitVersion(1)).unwrap();
+        assert_eq!(store.count_prefix(&kv_key(""), CommitVersion::MAX).unwrap(), 0);
     }
 
     #[test]
@@ -386,11 +386,11 @@ mod estimate_num_keys {
         seed(&store, kv_key("apricot"), Value::Int(2), 2);
         seed(&store, kv_key("banana"), Value::Int(3), 3);
         // Unprefixed: uses O(1) estimate
-        assert_eq!(store.count_prefix(&kv_key(""), u64::MAX).unwrap(), 3);
+        assert_eq!(store.count_prefix(&kv_key(""), CommitVersion::MAX).unwrap(), 3);
         // Prefixed: uses exact O(N) iterator
-        assert_eq!(store.count_prefix(&kv_key("ap"), u64::MAX).unwrap(), 2);
-        assert_eq!(store.count_prefix(&kv_key("b"), u64::MAX).unwrap(), 1);
-        assert_eq!(store.count_prefix(&kv_key("z"), u64::MAX).unwrap(), 0);
+        assert_eq!(store.count_prefix(&kv_key("ap"), CommitVersion::MAX).unwrap(), 2);
+        assert_eq!(store.count_prefix(&kv_key("b"), CommitVersion::MAX).unwrap(), 1);
+        assert_eq!(store.count_prefix(&kv_key("z"), CommitVersion::MAX).unwrap(), 0);
     }
 }
 
@@ -448,7 +448,7 @@ fn get_at_timestamp_respects_tombstone() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("k"), Value::Int(10), 1);
     std::thread::sleep(std::time::Duration::from_millis(5));
-    store.delete_with_version(&kv_key("k"), 2).unwrap();
+    store.delete_with_version(&kv_key("k"), CommitVersion(2)).unwrap();
 
     // Query at current time should return None (tombstone)
     let result = store
@@ -579,7 +579,7 @@ fn write_stalling_skips_rotation_when_frozen_limit_reached() {
 
     // Data should still be readable
     assert!(store
-        .get_versioned(&kv_key("round0_0"), u64::MAX)
+        .get_versioned(&kv_key("round0_0"), CommitVersion::MAX)
         .unwrap()
         .is_some());
 }

--- a/crates/storage/src/segmented/tests/compact.rs
+++ b/crates/storage/src/segmented/tests/compact.rs
@@ -26,7 +26,7 @@ fn compact_merges_two_segments() {
 
     assert_eq!(
         store
-            .get_versioned(&kv_key("a"), u64::MAX)
+            .get_versioned(&kv_key("a"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -34,7 +34,7 @@ fn compact_merges_two_segments() {
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("b"), u64::MAX)
+            .get_versioned(&kv_key("b"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -62,14 +62,14 @@ fn compact_merges_overlapping_versions() {
 
     assert_eq!(
         store
-            .get_versioned(&kv_key("k"), u64::MAX)
+            .get_versioned(&kv_key("k"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
         Value::Int(2)
     );
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 1).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(1)).unwrap().unwrap().value,
         Value::Int(1)
     );
 }
@@ -96,18 +96,18 @@ fn compact_prunes_old_versions() {
     // Verify the correct versions survived
     assert_eq!(
         store
-            .get_versioned(&kv_key("k"), u64::MAX)
+            .get_versioned(&kv_key("k"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
         Value::Int(3)
     );
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 2).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(2)).unwrap().unwrap().value,
         Value::Int(2)
     );
     // Version 1 was pruned — reading at snapshot 1 should return nothing
-    assert!(store.get_versioned(&kv_key("k"), 1).unwrap().is_none());
+    assert!(store.get_versioned(&kv_key("k"), CommitVersion(1)).unwrap().is_none());
 }
 
 #[test]
@@ -120,7 +120,7 @@ fn compact_removes_dead_tombstones() {
     store.rotate_memtable(&b);
     store.flush_oldest_frozen(&b).unwrap();
 
-    store.delete_with_version(&kv_key("k"), 2).unwrap();
+    store.delete_with_version(&kv_key("k"), CommitVersion(2)).unwrap();
     store.rotate_memtable(&b);
     store.flush_oldest_frozen(&b).unwrap();
 
@@ -139,7 +139,7 @@ fn compact_preserves_tombstone_above_floor() {
     store.rotate_memtable(&b);
     store.flush_oldest_frozen(&b).unwrap();
 
-    store.delete_with_version(&kv_key("k"), 3).unwrap();
+    store.delete_with_version(&kv_key("k"), CommitVersion(3)).unwrap();
     store.rotate_memtable(&b);
     store.flush_oldest_frozen(&b).unwrap();
 
@@ -227,7 +227,7 @@ fn compact_reads_correct_after() {
 
     assert_eq!(
         store
-            .get_versioned(&kv_key("a"), u64::MAX)
+            .get_versioned(&kv_key("a"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -235,7 +235,7 @@ fn compact_reads_correct_after() {
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("b"), u64::MAX)
+            .get_versioned(&kv_key("b"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -243,7 +243,7 @@ fn compact_reads_correct_after() {
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("c"), u64::MAX)
+            .get_versioned(&kv_key("c"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -251,7 +251,7 @@ fn compact_reads_correct_after() {
     );
 
     let prefix_key = Key::new(ns(), TypeTag::KV, Vec::new());
-    let results = store.scan_prefix(&prefix_key, u64::MAX).unwrap();
+    let results = store.scan_prefix(&prefix_key, CommitVersion::MAX).unwrap();
     assert_eq!(results.len(), 3);
 
     let history = store.get_history(&kv_key("a"), None, None).unwrap();
@@ -288,19 +288,19 @@ fn compact_result_counts() {
     // Verify reads are correct
     assert_eq!(
         store
-            .get_versioned(&kv_key("a"), u64::MAX)
+            .get_versioned(&kv_key("a"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
         Value::Int(3)
     );
     assert_eq!(
-        store.get_versioned(&kv_key("a"), 2).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("a"), CommitVersion(2)).unwrap().unwrap().value,
         Value::Int(2)
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("b"), u64::MAX)
+            .get_versioned(&kv_key("b"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -573,7 +573,7 @@ fn compact_after_flush_integration() {
     for commit in 1..=3u64 {
         assert_eq!(
             store
-                .get_versioned(&kv_key(&format!("k{}", commit)), u64::MAX)
+                .get_versioned(&kv_key(&format!("k{}", commit)), CommitVersion::MAX)
                 .unwrap()
                 .unwrap()
                 .value,
@@ -610,7 +610,7 @@ fn compact_with_active_memtable_data() {
     // Memtable data visible
     assert_eq!(
         store
-            .get_versioned(&kv_key("c"), u64::MAX)
+            .get_versioned(&kv_key("c"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -619,7 +619,7 @@ fn compact_with_active_memtable_data() {
     // Memtable update shadows segment version
     assert_eq!(
         store
-            .get_versioned(&kv_key("a"), u64::MAX)
+            .get_versioned(&kv_key("a"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -627,13 +627,13 @@ fn compact_with_active_memtable_data() {
     );
     // Old segment version still readable at old snapshot
     assert_eq!(
-        store.get_versioned(&kv_key("a"), 1).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("a"), CommitVersion(1)).unwrap().unwrap().value,
         Value::Int(1)
     );
     // Segment-only data still readable
     assert_eq!(
         store
-            .get_versioned(&kv_key("b"), u64::MAX)
+            .get_versioned(&kv_key("b"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -681,7 +681,7 @@ fn compact_concurrent_flush_preserves_new_segment() {
     // All data still readable
     assert_eq!(
         store
-            .get_versioned(&kv_key("a"), u64::MAX)
+            .get_versioned(&kv_key("a"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -689,7 +689,7 @@ fn compact_concurrent_flush_preserves_new_segment() {
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("b"), u64::MAX)
+            .get_versioned(&kv_key("b"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -697,7 +697,7 @@ fn compact_concurrent_flush_preserves_new_segment() {
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("c"), u64::MAX)
+            .get_versioned(&kv_key("c"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -705,7 +705,7 @@ fn compact_concurrent_flush_preserves_new_segment() {
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("d"), u64::MAX)
+            .get_versioned(&kv_key("d"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,

--- a/crates/storage/src/segmented/tests/concurrency.rs
+++ b/crates/storage/src/segmented/tests/concurrency.rs
@@ -56,7 +56,7 @@ fn test_issue_1679_fork_concurrent_write_visibility() {
                     .put_with_version_mode(
                         parent_kv(&key_name),
                         Value::Int(v as i64),
-                        v,
+                        CommitVersion(v),
                         None,
                         WriteMode::Append,
                     )
@@ -110,7 +110,7 @@ fn test_issue_1679_fork_concurrent_write_visibility() {
                         TypeTag::KV,
                         key_name.as_bytes().to_vec(),
                     );
-                    match store.get_versioned(&child_key, u64::MAX) {
+                    match store.get_versioned(&child_key, CommitVersion::MAX) {
                         Ok(Some(child_entry)) => {
                             if child_entry.value != parent_entry.value {
                                 failures.push(format!(
@@ -215,13 +215,13 @@ fn test_issue_1680_corrupt_manifest_rejects_orphan_loading() {
         "corrupt manifest must be reported, not silently load as L0"
     );
     // The orphan SST must NOT be accessible (no L0 fallback).
-    let orphan_val = store2.get_versioned(&kv_key("orphan"), u64::MAX).unwrap();
+    let orphan_val = store2.get_versioned(&kv_key("orphan"), CommitVersion::MAX).unwrap();
     assert!(
         orphan_val.is_none(),
         "orphan segment must not be loaded when manifest is corrupt"
     );
     // The real segment must also not be accessible (branch skipped entirely).
-    let real_val = store2.get_versioned(&kv_key("real"), u64::MAX).unwrap();
+    let real_val = store2.get_versioned(&kv_key("real"), CommitVersion::MAX).unwrap();
     assert!(
         real_val.is_none(),
         "no segments should be loaded for corrupt-manifest branch"
@@ -331,7 +331,7 @@ fn test_issue_1682_segment_deletion_races_fork_refcount() {
             TypeTag::KV,
             format!("k{:04}", i).as_bytes().to_vec(),
         );
-        let result = store.get_versioned(&key, u64::MAX).unwrap();
+        let result = store.get_versioned(&key, CommitVersion::MAX).unwrap();
         assert!(
             result.is_some(),
             "child2 should see inherited key {:04} — segment file must not be deleted by race",
@@ -423,7 +423,7 @@ fn test_issue_1682_segment_deletion_races_fork_refcount_concurrent() {
                 TypeTag::KV,
                 format!("r{}k{:04}", round, i).as_bytes().to_vec(),
             );
-            let result = store.get_versioned(&key, u64::MAX).unwrap();
+            let result = store.get_versioned(&key, CommitVersion::MAX).unwrap();
             assert!(
                 result.is_some(),
                 "round {}: child2 missing key {:04} — segment file may have been deleted by race",
@@ -1032,12 +1032,12 @@ fn test_issue_1740_put_recovery_entry_preserves_ttl() {
         .unwrap();
 
     // Read the entry via store (filters expired) — should still be alive
-    let result = store.get_versioned(&key, u64::MAX).unwrap().unwrap();
+    let result = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
     assert_eq!(result.value, Value::Int(42));
 
     // Verify TTL was preserved by checking via the memtable directly
     let branch = store.branches.get(&branch()).unwrap();
-    let entry = branch.active.get_versioned(&key, u64::MAX).unwrap();
+    let entry = branch.active.get_versioned(&key, CommitVersion::MAX).unwrap();
     assert_eq!(
         entry.ttl_ms, ttl_ms,
         "put_recovery_entry must preserve TTL, got ttl_ms={}",
@@ -1064,7 +1064,7 @@ fn test_issue_1740_apply_recovery_atomic_preserves_ttl() {
 
     // Verify TTL was preserved
     let branch = store.branches.get(&branch()).unwrap();
-    let entry = branch.active.get_versioned(&key, u64::MAX).unwrap();
+    let entry = branch.active.get_versioned(&key, CommitVersion::MAX).unwrap();
     assert_eq!(
         entry.ttl_ms, ttl_ms,
         "apply_recovery_atomic must preserve TTL, got ttl_ms={}",
@@ -1152,7 +1152,7 @@ fn test_issue_1721_fork_resets_materializing_status() {
     // 7. Verify data is still readable through the child.
     let child_ns = Arc::new(Namespace::new(child, "default".to_string()));
     let child_key = Key::new(Arc::clone(&child_ns), TypeTag::KV, b"k0".to_vec());
-    let val = store.get_versioned(&child_key, u64::MAX).unwrap().unwrap();
+    let val = store.get_versioned(&child_key, CommitVersion::MAX).unwrap().unwrap();
     assert_eq!(val.value, Value::Int(0));
 }
 
@@ -1170,7 +1170,7 @@ fn test_issue_1718_concurrent_flush_no_duplicate_segments() {
             .put_with_version_mode(
                 kv_key(&format!("k{:04}", i)),
                 Value::Int(i as i64),
-                i + 1,
+                CommitVersion(i + 1),
                 None,
                 WriteMode::Append,
             )
@@ -1210,7 +1210,7 @@ fn test_issue_1718_concurrent_flush_no_duplicate_segments() {
     // All data is readable.
     for i in 0..10u64 {
         let result = store
-            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("k{:04}", i)), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(result.value, Value::Int(i as i64));
@@ -1232,7 +1232,7 @@ fn test_issue_1718_concurrent_flush_no_duplicate_segments_stress() {
                 .put_with_version_mode(
                     kv_key(&format!("k{:04}", key_idx)),
                     Value::Int(key_idx as i64),
-                    key_idx + 1,
+                    CommitVersion(key_idx + 1),
                     None,
                     WriteMode::Append,
                 )
@@ -1271,7 +1271,7 @@ fn test_issue_1718_concurrent_flush_no_duplicate_segments_stress() {
     // All data readable.
     for i in 0..15u64 {
         let result = store
-            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("k{:04}", i)), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(result.value, Value::Int(i as i64));
@@ -1317,13 +1317,13 @@ fn test_issue_1694_materialize_shadow_detection_ignores_memtable() {
 
     // Verify reads return the child's value for "a" and the materialized value for "b"
     let val_a = store
-        .get_versioned(&child_kv("a"), u64::MAX)
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val_a.value, Value::Int(999), "child's memtable write wins");
 
     let val_b = store
-        .get_versioned(&child_kv("b"), u64::MAX)
+        .get_versioned(&child_kv("b"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val_b.value, Value::Int(2), "inherited 'b' is materialized");
@@ -1357,7 +1357,7 @@ fn test_issue_1694_materialize_shadow_detection_ignores_frozen_memtable() {
     );
 
     let val_x = store
-        .get_versioned(&child_kv("x"), u64::MAX)
+        .get_versioned(&child_kv("x"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val_x.value, Value::Int(777), "child's frozen write wins");
@@ -1398,7 +1398,7 @@ fn test_issue_1734_apply_recovery_atomic_does_not_bump_version() {
 
     // The entry IS in the memtable but should be invisible at the current version (1)
     let invisible = store
-        .get_versioned(&kv_key("new_key"), store.version())
+        .get_versioned(&kv_key("new_key"), CommitVersion(store.version()))
         .unwrap();
     assert!(
         invisible.is_none(),
@@ -1410,7 +1410,7 @@ fn test_issue_1734_apply_recovery_atomic_does_not_bump_version() {
     assert_eq!(store.version(), 5);
 
     let visible = store
-        .get_versioned(&kv_key("new_key"), store.version())
+        .get_versioned(&kv_key("new_key"), CommitVersion(store.version()))
         .unwrap();
     assert!(
         visible.is_some(),
@@ -1480,7 +1480,7 @@ fn test_issue_2110_fork_version_gap_deterministic() {
             .put_with_version_mode(
                 parent_kv("gap_key"),
                 Value::Int(999),
-                v,
+                CommitVersion(v),
                 None,
                 WriteMode::Append,
             )
@@ -1517,16 +1517,16 @@ fn test_issue_2110_fork_version_gap_deterministic() {
     // The writer allocated a version via next_version() but hadn't applied
     // it yet, so fork_version correctly excludes it.
     assert!(
-        fork_version < allocated_version,
+        fork_version.as_u64() < allocated_version,
         "fork_version ({}) should be < allocated version ({}) — \
          fork_branch now uses per-branch max_version, not the global counter",
-        fork_version,
+        fork_version.as_u64(),
         allocated_version,
     );
 
     // Parent has the data (writer wrote it after fork)
     let parent_val = store
-        .get_versioned(&parent_kv("gap_key"), u64::MAX)
+        .get_versioned(&parent_kv("gap_key"), CommitVersion::MAX)
         .unwrap();
     assert_eq!(
         parent_val.map(|e| e.value),
@@ -1538,7 +1538,7 @@ fn test_issue_2110_fork_version_gap_deterministic() {
     // so the fork doesn't claim to include data it doesn't have.
     let child_ns = Arc::new(Namespace::new(fork_branch_id, "default".to_string()));
     let child_key = Key::new(child_ns, TypeTag::KV, b"gap_key".to_vec());
-    let child_val = store.get_versioned(&child_key, u64::MAX).unwrap();
+    let child_val = store.get_versioned(&child_key, CommitVersion::MAX).unwrap();
     assert!(
         child_val.is_none(),
         "child should not have gap_key (fork_version={} < allocated_version={})",

--- a/crates/storage/src/segmented/tests/flush.rs
+++ b/crates/storage/src/segmented/tests/flush.rs
@@ -27,7 +27,7 @@ fn flush_moves_data_to_segment() {
 
     for i in 1..=100u64 {
         let result = store
-            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("k{:04}", i)), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(result.value, Value::Int(i as i64));
@@ -101,7 +101,7 @@ fn rotation_creates_fresh_active() {
 
     assert_eq!(
         store
-            .get_versioned(&kv_key("old"), u64::MAX)
+            .get_versioned(&kv_key("old"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -109,7 +109,7 @@ fn rotation_creates_fresh_active() {
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("new"), u64::MAX)
+            .get_versioned(&kv_key("new"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -140,11 +140,11 @@ fn mvcc_correct_across_flush() {
     seed(&store, kv_key("k"), Value::Int(2), 2);
 
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 1).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(1)).unwrap().unwrap().value,
         Value::Int(1),
     );
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 2).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(2)).unwrap().unwrap().value,
         Value::Int(2),
     );
 }
@@ -163,7 +163,7 @@ fn prefix_scan_spans_memtable_and_segment() {
     seed(&store, kv_key("item/d"), Value::Int(4), 4);
 
     let prefix = Key::new(ns(), TypeTag::KV, "item/".as_bytes().to_vec());
-    let results = store.scan_prefix(&prefix, u64::MAX).unwrap();
+    let results = store.scan_prefix(&prefix, CommitVersion::MAX).unwrap();
     assert_eq!(results.len(), 4);
 }
 
@@ -211,7 +211,7 @@ fn multiple_flushes_produce_multiple_segments() {
         let base = cycle * 10 + 1;
         for i in 0..10u64 {
             let result = store
-                .get_versioned(&kv_key(&format!("c{}k{}", cycle, i)), u64::MAX)
+                .get_versioned(&kv_key(&format!("c{}k{}", cycle, i)), CommitVersion::MAX)
                 .unwrap()
                 .unwrap();
             assert_eq!(result.value, Value::Int((base + i) as i64));
@@ -235,7 +235,7 @@ fn newest_segment_wins_for_same_key() {
     assert_eq!(store.branch_segment_count(&branch()), 2);
 
     let result = store
-        .get_versioned(&kv_key("k"), u64::MAX)
+        .get_versioned(&kv_key("k"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(result.value, Value::Int(2));
@@ -251,7 +251,7 @@ fn reads_dont_block_during_flush() {
             .put_with_version_mode(
                 kv_key(&format!("k{:04}", i)),
                 Value::Int(i as i64),
-                i,
+                CommitVersion(i),
                 None,
                 WriteMode::Append,
             )
@@ -263,7 +263,7 @@ fn reads_dont_block_during_flush() {
     let reader = std::thread::spawn(move || {
         for i in 1..=50u64 {
             let result = store_reader
-                .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+                .get_versioned(&kv_key(&format!("k{:04}", i)), CommitVersion::MAX)
                 .unwrap();
             assert!(result.is_some(), "key k{:04} should be readable", i);
         }
@@ -296,11 +296,11 @@ fn delete_across_flush_boundary() {
     store.rotate_memtable(&branch());
     store.flush_oldest_frozen(&branch()).unwrap();
 
-    store.delete_with_version(&kv_key("k"), 2).unwrap();
+    store.delete_with_version(&kv_key("k"), CommitVersion(2)).unwrap();
 
-    assert!(store.get_versioned(&kv_key("k"), 2).unwrap().is_none());
+    assert!(store.get_versioned(&kv_key("k"), CommitVersion(2)).unwrap().is_none());
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 1).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(1)).unwrap().unwrap().value,
         Value::Int(1),
     );
 }
@@ -312,15 +312,15 @@ fn tombstone_survives_flush() {
 
     // Write value then delete, so the frozen memtable contains both
     seed(&store, kv_key("k"), Value::Int(1), 1);
-    store.delete_with_version(&kv_key("k"), 2).unwrap();
+    store.delete_with_version(&kv_key("k"), CommitVersion(2)).unwrap();
     store.rotate_memtable(&branch());
     store.flush_oldest_frozen(&branch()).unwrap();
 
     // Tombstone must survive the flush — key is deleted at snapshot 2
-    assert!(store.get_versioned(&kv_key("k"), 2).unwrap().is_none());
+    assert!(store.get_versioned(&kv_key("k"), CommitVersion(2)).unwrap().is_none());
     // Value is still visible at snapshot 1
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 1).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(1)).unwrap().unwrap().value,
         Value::Int(1),
     );
     // History shows both versions from the segment
@@ -356,7 +356,7 @@ fn recover_segments_loads_flushed_data() {
 
     for i in 1..=50u64 {
         let result = store2
-            .get_versioned(&kv_key(&format!("k{:04}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("k{:04}", i)), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(result.value, Value::Int(i as i64));
@@ -376,7 +376,7 @@ fn recover_segments_multiple_branches() {
     for i in 1..=10u64 {
         let key = Key::new(ns1.clone(), TypeTag::KV, format!("k{}", i).into_bytes());
         store
-            .put_with_version_mode(key, Value::Int(i as i64), i, None, WriteMode::Append)
+            .put_with_version_mode(key, Value::Int(i as i64), CommitVersion(i), None, WriteMode::Append)
             .unwrap();
     }
     store.rotate_memtable(&b1);
@@ -385,7 +385,7 @@ fn recover_segments_multiple_branches() {
     for i in 11..=20u64 {
         let key = Key::new(ns2.clone(), TypeTag::KV, format!("k{}", i).into_bytes());
         store
-            .put_with_version_mode(key, Value::Int(i as i64), i, None, WriteMode::Append)
+            .put_with_version_mode(key, Value::Int(i as i64), CommitVersion(i), None, WriteMode::Append)
             .unwrap();
     }
     store.rotate_memtable(&b2);
@@ -398,8 +398,8 @@ fn recover_segments_multiple_branches() {
 
     let k1 = Key::new(ns1, TypeTag::KV, "k1".as_bytes().to_vec());
     let k11 = Key::new(ns2, TypeTag::KV, "k11".as_bytes().to_vec());
-    assert!(store2.get_versioned(&k1, u64::MAX).unwrap().is_some());
-    assert!(store2.get_versioned(&k11, u64::MAX).unwrap().is_some());
+    assert!(store2.get_versioned(&k1, CommitVersion::MAX).unwrap().is_some());
+    assert!(store2.get_versioned(&k11, CommitVersion::MAX).unwrap().is_some());
 }
 
 #[test]
@@ -420,7 +420,7 @@ fn recover_segments_skips_corrupt_files() {
     assert_eq!(info.segments_loaded, 1);
     assert_eq!(info.errors_skipped, 1);
     assert!(store2
-        .get_versioned(&kv_key("k"), u64::MAX)
+        .get_versioned(&kv_key("k"), CommitVersion::MAX)
         .unwrap()
         .is_some());
 }
@@ -522,18 +522,18 @@ fn frozen_memtable_reads_correct_order() {
     assert_eq!(store.branch_frozen_count(&branch()), 2);
     assert_eq!(
         store
-            .get_versioned(&kv_key("k"), u64::MAX)
+            .get_versioned(&kv_key("k"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
         Value::Int(3),
     );
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 2).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(2)).unwrap().unwrap().value,
         Value::Int(2),
     );
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 1).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(1)).unwrap().unwrap().value,
         Value::Int(1),
     );
 }

--- a/crates/storage/src/segmented/tests/fork.rs
+++ b/crates/storage/src/segmented/tests/fork.rs
@@ -148,20 +148,20 @@ fn inherited_layer_point_lookup() {
 
     // Child should see parent's data
     let result = store
-        .get_versioned(&child_kv("a"), u64::MAX)
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(result.value, Value::Int(1));
 
     let result = store
-        .get_versioned(&child_kv("c"), u64::MAX)
+        .get_versioned(&child_kv("c"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(result.value, Value::Int(3));
 
     // Non-existent key still returns None
     assert!(store
-        .get_versioned(&child_kv("z"), u64::MAX)
+        .get_versioned(&child_kv("z"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 }
@@ -174,7 +174,7 @@ fn inherited_layer_version_filter() {
     attach_inherited_layer(&store, parent_branch(), child_branch(), 5);
 
     let result = store
-        .get_versioned(&child_kv("k"), u64::MAX)
+        .get_versioned(&child_kv("k"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -191,17 +191,17 @@ fn inherited_layer_write_shadows() {
 
     // Write to child — this should shadow the inherited value
     store
-        .put_with_version_mode(child_kv("k"), Value::Int(999), 11, None, WriteMode::Append)
+        .put_with_version_mode(child_kv("k"), Value::Int(999), CommitVersion(11), None, WriteMode::Append)
         .unwrap();
 
     let result = store
-        .get_versioned(&child_kv("k"), u64::MAX)
+        .get_versioned(&child_kv("k"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(result.value, Value::Int(999));
 
     // But at snapshot before the child write, we see the inherited value
-    let result = store.get_versioned(&child_kv("k"), 10).unwrap().unwrap();
+    let result = store.get_versioned(&child_kv("k"), CommitVersion(10)).unwrap().unwrap();
     assert_eq!(result.value, Value::Int(100));
 }
 
@@ -211,15 +211,15 @@ fn inherited_layer_delete_shadows() {
     attach_inherited_layer(&store, parent_branch(), child_branch(), 10);
 
     // Delete on child hides inherited entry
-    store.delete_with_version(&child_kv("k"), 11).unwrap();
+    store.delete_with_version(&child_kv("k"), CommitVersion(11)).unwrap();
 
     assert!(store
-        .get_versioned(&child_kv("k"), u64::MAX)
+        .get_versioned(&child_kv("k"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 
     // Snapshot before the delete still sees inherited data
-    let result = store.get_versioned(&child_kv("k"), 10).unwrap().unwrap();
+    let result = store.get_versioned(&child_kv("k"), CommitVersion(10)).unwrap().unwrap();
     assert_eq!(result.value, Value::Int(42));
 }
 
@@ -238,7 +238,7 @@ fn inherited_layer_range_scan() {
         .put_with_version_mode(
             child_kv("user:bob"),
             Value::Int(200),
-            11,
+            CommitVersion(11),
             None,
             WriteMode::Append,
         )
@@ -247,13 +247,13 @@ fn inherited_layer_range_scan() {
         .put_with_version_mode(
             child_kv("user:dave"),
             Value::Int(4),
-            12,
+            CommitVersion(12),
             None,
             WriteMode::Append,
         )
         .unwrap();
 
-    let results = store.scan_prefix(&child_kv("user:"), u64::MAX).unwrap();
+    let results = store.scan_prefix(&child_kv("user:"), CommitVersion::MAX).unwrap();
     assert_eq!(results.len(), 4); // alice, bob(200), carol, dave
 
     let values: Vec<i64> = results
@@ -273,7 +273,7 @@ fn inherited_layer_list_branch() {
 
     // Write one more on child
     store
-        .put_with_version_mode(child_kv("c"), Value::Int(3), 11, None, WriteMode::Append)
+        .put_with_version_mode(child_kv("c"), Value::Int(3), CommitVersion(11), None, WriteMode::Append)
         .unwrap();
 
     let entries = store.list_branch(&child_branch());
@@ -294,7 +294,7 @@ fn inherited_layer_bloom_correct() {
     attach_inherited_layer(&store, parent_branch(), child_branch(), 10);
 
     let result = store
-        .get_versioned(&child_kv("bloom_key"), u64::MAX)
+        .get_versioned(&child_kv("bloom_key"), CommitVersion::MAX)
         .unwrap();
     assert!(
         result.is_some(),
@@ -324,7 +324,7 @@ fn inherited_layer_two_levels() {
         .put_with_version_mode(
             Key::new(gp_ns.clone(), TypeTag::KV, b"from_gp".to_vec()),
             Value::Int(1),
-            1,
+            CommitVersion(1),
             None,
             WriteMode::Append,
         )
@@ -333,7 +333,7 @@ fn inherited_layer_two_levels() {
         .put_with_version_mode(
             Key::new(gp_ns.clone(), TypeTag::KV, b"shared".to_vec()),
             Value::Int(10),
-            2,
+            CommitVersion(2),
             None,
             WriteMode::Append,
         )
@@ -346,7 +346,7 @@ fn inherited_layer_two_levels() {
         .put_with_version_mode(
             Key::new(p_ns.clone(), TypeTag::KV, b"from_parent".to_vec()),
             Value::Int(2),
-            3,
+            CommitVersion(3),
             None,
             WriteMode::Append,
         )
@@ -355,7 +355,7 @@ fn inherited_layer_two_levels() {
         .put_with_version_mode(
             Key::new(p_ns.clone(), TypeTag::KV, b"shared".to_vec()),
             Value::Int(20),
-            4,
+            CommitVersion(4),
             None,
             WriteMode::Append,
         )
@@ -383,7 +383,7 @@ fn inherited_layer_two_levels() {
     let r = store
         .get_versioned(
             &Key::new(c_ns.clone(), TypeTag::KV, b"from_parent".to_vec()),
-            u64::MAX,
+            CommitVersion::MAX,
         )
         .unwrap()
         .unwrap();
@@ -393,7 +393,7 @@ fn inherited_layer_two_levels() {
     let r = store
         .get_versioned(
             &Key::new(c_ns.clone(), TypeTag::KV, b"shared".to_vec()),
-            u64::MAX,
+            CommitVersion::MAX,
         )
         .unwrap()
         .unwrap();
@@ -403,7 +403,7 @@ fn inherited_layer_two_levels() {
     let r = store
         .get_versioned(
             &Key::new(c_ns.clone(), TypeTag::KV, b"from_gp".to_vec()),
-            u64::MAX,
+            CommitVersion::MAX,
         )
         .unwrap()
         .unwrap();
@@ -418,11 +418,11 @@ fn inherited_layer_version_clamping() {
     attach_inherited_layer(&store, parent_branch(), child_branch(), 10);
 
     // Snapshot at version 3: should see version 1
-    let result = store.get_versioned(&child_kv("k"), 3).unwrap().unwrap();
+    let result = store.get_versioned(&child_kv("k"), CommitVersion(3)).unwrap().unwrap();
     assert_eq!(result.value, Value::Int(10));
 
     // Snapshot at version 7: should see version 5
-    let result = store.get_versioned(&child_kv("k"), 7).unwrap().unwrap();
+    let result = store.get_versioned(&child_kv("k"), CommitVersion(7)).unwrap().unwrap();
     assert_eq!(result.value, Value::Int(50));
 }
 
@@ -525,7 +525,7 @@ fn inherited_layer_materialized_skipped() {
 
     // Point lookup should return None — materialized layer is skipped
     assert!(store
-        .get_versioned(&child_kv("k"), u64::MAX)
+        .get_versioned(&child_kv("k"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 
@@ -534,7 +534,7 @@ fn inherited_layer_materialized_skipped() {
 
     // Scan should be empty
     assert!(store
-        .scan_prefix(&child_kv(""), u64::MAX)
+        .scan_prefix(&child_kv(""), CommitVersion::MAX)
         .unwrap()
         .is_empty());
 }
@@ -554,12 +554,12 @@ fn inherited_layer_empty_parent() {
     attach_inherited_layer(&store, parent_branch(), child_branch(), 10);
 
     assert!(store
-        .get_versioned(&child_kv("k"), u64::MAX)
+        .get_versioned(&child_kv("k"), CommitVersion::MAX)
         .unwrap()
         .is_none());
     assert!(store.list_branch(&child_branch()).is_empty());
     assert!(store
-        .scan_prefix(&child_kv(""), u64::MAX)
+        .scan_prefix(&child_kv(""), CommitVersion::MAX)
         .unwrap()
         .is_empty());
     assert!(store
@@ -576,7 +576,7 @@ fn inherited_layer_fork_version_zero() {
 
     // Point lookup: nothing visible
     assert!(store
-        .get_versioned(&child_kv("a"), u64::MAX)
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 
@@ -585,7 +585,7 @@ fn inherited_layer_fork_version_zero() {
 
     // Scan: empty
     assert!(store
-        .scan_prefix(&child_kv(""), u64::MAX)
+        .scan_prefix(&child_kv(""), CommitVersion::MAX)
         .unwrap()
         .is_empty());
 }
@@ -606,7 +606,7 @@ fn inherited_layer_custom_space() {
         .put_with_version_mode(
             Key::new(p_ns.clone(), TypeTag::KV, b"key1".to_vec()),
             Value::Int(42),
-            1,
+            CommitVersion(1),
             None,
             WriteMode::Append,
         )
@@ -620,7 +620,7 @@ fn inherited_layer_custom_space() {
     let result = store
         .get_versioned(
             &Key::new(c_ns.clone(), TypeTag::KV, b"key1".to_vec()),
-            u64::MAX,
+            CommitVersion::MAX,
         )
         .unwrap()
         .unwrap();
@@ -628,7 +628,7 @@ fn inherited_layer_custom_space() {
 
     // Query with child's namespace in the DEFAULT space should NOT find it
     assert!(store
-        .get_versioned(&child_kv("key1"), u64::MAX)
+        .get_versioned(&child_kv("key1"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 }
@@ -649,7 +649,7 @@ fn inherited_layer_non_kv_type_tags() {
         .put_with_version_mode(
             Key::new(p_ns.clone(), TypeTag::Json, b"doc1".to_vec()),
             Value::Int(100),
-            1,
+            CommitVersion(1),
             None,
             WriteMode::Append,
         )
@@ -658,7 +658,7 @@ fn inherited_layer_non_kv_type_tags() {
         .put_with_version_mode(
             Key::new(p_ns.clone(), TypeTag::Event, 42u64.to_be_bytes().to_vec()),
             Value::Int(200),
-            2,
+            CommitVersion(2),
             None,
             WriteMode::Append,
         )
@@ -672,7 +672,7 @@ fn inherited_layer_non_kv_type_tags() {
     let result = store
         .get_versioned(
             &Key::new(c_ns.clone(), TypeTag::Json, b"doc1".to_vec()),
-            u64::MAX,
+            CommitVersion::MAX,
         )
         .unwrap()
         .unwrap();
@@ -682,7 +682,7 @@ fn inherited_layer_non_kv_type_tags() {
     let result = store
         .get_versioned(
             &Key::new(c_ns.clone(), TypeTag::Event, 42u64.to_be_bytes().to_vec()),
-            u64::MAX,
+            CommitVersion::MAX,
         )
         .unwrap()
         .unwrap();
@@ -690,7 +690,7 @@ fn inherited_layer_non_kv_type_tags() {
 
     // KV lookup should NOT find Json/Event entries
     assert!(store
-        .get_versioned(&child_kv("doc1"), u64::MAX)
+        .get_versioned(&child_kv("doc1"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 }
@@ -736,7 +736,7 @@ fn fork_creates_inherited_layer() {
     let child = store.branches.get(&child_branch()).unwrap();
     assert_eq!(child.inherited_layers.len(), 1);
     assert_eq!(child.inherited_layers[0].source_branch_id, parent_branch());
-    assert_eq!(child.inherited_layers[0].fork_version, fork_version);
+    assert_eq!(child.inherited_layers[0].fork_version, fork_version.as_u64());
     assert_eq!(child.inherited_layers[0].status, LayerStatus::Active);
     assert!(segments_shared > 0);
 }
@@ -790,20 +790,20 @@ fn fork_read_through() {
 
     // Point lookups on child return parent's data
     let r = store
-        .get_versioned(&child_kv("x"), u64::MAX)
+        .get_versioned(&child_kv("x"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(r.value, Value::Int(42));
 
     let r = store
-        .get_versioned(&child_kv("y"), u64::MAX)
+        .get_versioned(&child_kv("y"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(r.value, Value::String("hello".into()));
 
     // Non-existent key
     assert!(store
-        .get_versioned(&child_kv("z"), u64::MAX)
+        .get_versioned(&child_kv("z"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 }
@@ -831,21 +831,21 @@ fn fork_write_shadows() {
         .put_with_version_mode(
             child_kv("k"),
             Value::Int(99),
-            child_version,
+            CommitVersion(child_version),
             None,
             WriteMode::Append,
         )
         .unwrap();
 
     let r = store
-        .get_versioned(&child_kv("k"), u64::MAX)
+        .get_versioned(&child_kv("k"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(r.value, Value::Int(99));
 
     // Parent is unchanged
     let r = store
-        .get_versioned(&parent_kv("k"), u64::MAX)
+        .get_versioned(&parent_kv("k"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(r.value, Value::Int(1));
@@ -874,7 +874,7 @@ fn fork_parent_write_invisible() {
         .put_with_version_mode(
             parent_kv("new_key"),
             Value::Int(999),
-            v,
+            CommitVersion(v),
             None,
             WriteMode::Append,
         )
@@ -884,14 +884,14 @@ fn fork_parent_write_invisible() {
 
     // Child should NOT see the new parent key
     assert!(store
-        .get_versioned(&child_kv("new_key"), u64::MAX)
+        .get_versioned(&child_kv("new_key"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 
     // But parent sees it
     assert_eq!(
         store
-            .get_versioned(&parent_kv("new_key"), u64::MAX)
+            .get_versioned(&parent_kv("new_key"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -920,7 +920,7 @@ fn fork_scan() {
 
     // Prefix scan on child finds inherited data
     let prefix = Key::new(child_ns(), TypeTag::KV, "user/".as_bytes().to_vec());
-    let results = store.scan_prefix(&prefix, u64::MAX).unwrap();
+    let results = store.scan_prefix(&prefix, CommitVersion::MAX).unwrap();
     assert_eq!(results.len(), 2);
 }
 
@@ -949,7 +949,7 @@ fn fork_chain_3_levels() {
         .put_with_version_mode(
             child_kv("child_key"),
             Value::Int(200),
-            v,
+            CommitVersion(v),
             None,
             WriteMode::Append,
         )
@@ -976,14 +976,14 @@ fn fork_chain_3_levels() {
 
     // Grandchild sees child's own data
     let r = store
-        .get_versioned(&grandchild_kv("child_key"), u64::MAX)
+        .get_versioned(&grandchild_kv("child_key"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(r.value, Value::Int(200));
 
     // Grandchild sees grandparent's data (through child's inherited layer)
     let r = store
-        .get_versioned(&grandchild_kv("gp_key"), u64::MAX)
+        .get_versioned(&grandchild_kv("gp_key"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(r.value, Value::Int(100));
@@ -1101,7 +1101,7 @@ fn fork_manifest_roundtrip() {
     {
         let child = store.branches.get(&child_branch()).unwrap();
         assert_eq!(child.inherited_layers.len(), 1);
-        assert_eq!(child.inherited_layers[0].fork_version, fork_version);
+        assert_eq!(child.inherited_layers[0].fork_version, fork_version.as_u64());
     }
 
     // Create a new store and recover from the same directory
@@ -1120,11 +1120,11 @@ fn fork_manifest_roundtrip() {
         1,
         "Inherited layers should survive recovery"
     );
-    assert_eq!(child2.inherited_layers[0].fork_version, fork_version);
+    assert_eq!(child2.inherited_layers[0].fork_version, fork_version.as_u64());
 
     // Verify data is readable through inherited layers after recovery
     let r = store2
-        .get_versioned(&child_kv("a"), u64::MAX)
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(r.value, Value::Int(1));
@@ -1170,7 +1170,7 @@ fn fork_ephemeral_succeeds_at_storage_level() {
     // layers (memtable data is not captured in the segment snapshot).
     // The engine layer prevents this by checking has_segments_dir() first.
     assert!(store
-        .get_versioned(&child_kv("a"), u64::MAX)
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 }
@@ -1201,7 +1201,7 @@ fn fork_empty_source_succeeds() {
     let child = store.branches.get(&child_branch()).unwrap();
     assert_eq!(child.inherited_layers.len(), 1);
     assert!(store
-        .get_versioned(&child_kv("anything"), u64::MAX)
+        .get_versioned(&child_kv("anything"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 }
@@ -1308,7 +1308,7 @@ fn list_own_entries_includes_tombstones() {
     attach_inherited_layer(&store, pid, cid, 1);
 
     // Child deletes "alpha" (writes tombstone)
-    store.delete_with_version(&child_kv("alpha"), 2).unwrap();
+    store.delete_with_version(&child_kv("alpha"), CommitVersion(2)).unwrap();
 
     // list_own_entries should include the tombstone
     let own = store.list_own_entries(&cid, None);

--- a/crates/storage/src/segmented/tests/leveled.rs
+++ b/crates/storage/src/segmented/tests/leveled.rs
@@ -64,7 +64,7 @@ fn compact_tier_merges_subset() {
     // All data still readable
     for commit in 1..=6u64 {
         let val = store
-            .get_versioned(&kv_key(&format!("k{}", commit)), u64::MAX)
+            .get_versioned(&kv_key(&format!("k{}", commit)), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(val.value, Value::Int(commit as i64));
@@ -127,7 +127,7 @@ fn compact_tier_prunes_versions() {
     // Latest version still readable
     assert_eq!(
         store
-            .get_versioned(&kv_key("k"), u64::MAX)
+            .get_versioned(&kv_key("k"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -168,7 +168,7 @@ fn time_range_o1_includes_deletes() {
 
     // Short sleep to ensure delete timestamp is strictly later
     std::thread::sleep(std::time::Duration::from_millis(1));
-    store.delete_with_version(&kv_key("a"), 2).unwrap();
+    store.delete_with_version(&kv_key("a"), CommitVersion(2)).unwrap();
 
     let range_after = store.time_range(branch()).unwrap().unwrap();
     // max should have advanced to include the delete timestamp
@@ -285,7 +285,7 @@ fn diagnostic_segment_layout_at_scale() {
     // Verify data is intact
     for i in [0u64, 500, 999] {
         assert!(store
-            .get_versioned(&kv_key(&format!("key_{:06}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("key_{:06}", i)), CommitVersion::MAX)
             .unwrap()
             .is_some());
     }
@@ -405,7 +405,7 @@ fn compact_l0_to_l1_merges_overlapping_l1() {
     // All data correct
     assert_eq!(
         store
-            .get_versioned(&kv_key("a"), u64::MAX)
+            .get_versioned(&kv_key("a"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -413,7 +413,7 @@ fn compact_l0_to_l1_merges_overlapping_l1() {
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("b"), u64::MAX)
+            .get_versioned(&kv_key("b"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -421,7 +421,7 @@ fn compact_l0_to_l1_merges_overlapping_l1() {
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("c"), u64::MAX)
+            .get_versioned(&kv_key("c"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -457,7 +457,7 @@ fn compact_l0_to_l1_preserves_non_overlapping_l1() {
     for (key, val) in [("a", 10), ("b", 20), ("x", 1), ("y", 2), ("z", 3)] {
         assert_eq!(
             store
-                .get_versioned(&kv_key(key), u64::MAX)
+                .get_versioned(&kv_key(key), CommitVersion::MAX)
                 .unwrap()
                 .unwrap()
                 .value,
@@ -484,17 +484,17 @@ fn compact_l0_to_l1_prunes_versions() {
 
     assert_eq!(
         store
-            .get_versioned(&kv_key("k"), u64::MAX)
+            .get_versioned(&kv_key("k"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
         Value::Int(3)
     );
     assert_eq!(
-        store.get_versioned(&kv_key("k"), 2).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("k"), CommitVersion(2)).unwrap().unwrap().value,
         Value::Int(2)
     );
-    assert!(store.get_versioned(&kv_key("k"), 1).unwrap().is_none());
+    assert!(store.get_versioned(&kv_key("k"), CommitVersion(1)).unwrap().is_none());
 }
 
 #[test]
@@ -558,15 +558,15 @@ fn compact_l0_to_l1_concurrent_flush_preserves_new_l0() {
 
     // All data still readable
     assert!(store
-        .get_versioned(&kv_key("a"), u64::MAX)
+        .get_versioned(&kv_key("a"), CommitVersion::MAX)
         .unwrap()
         .is_some());
     assert!(store
-        .get_versioned(&kv_key("b"), u64::MAX)
+        .get_versioned(&kv_key("b"), CommitVersion::MAX)
         .unwrap()
         .is_some());
     assert!(store
-        .get_versioned(&kv_key("c"), u64::MAX)
+        .get_versioned(&kv_key("c"), CommitVersion::MAX)
         .unwrap()
         .is_some());
 }
@@ -585,19 +585,19 @@ fn compact_l0_to_l1_data_correct_after() {
     // Point lookups
     assert_eq!(
         store
-            .get_versioned(&kv_key("a"), u64::MAX)
+            .get_versioned(&kv_key("a"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
         Value::Int(2)
     );
     assert_eq!(
-        store.get_versioned(&kv_key("a"), 1).unwrap().unwrap().value,
+        store.get_versioned(&kv_key("a"), CommitVersion(1)).unwrap().unwrap().value,
         Value::Int(1)
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("b"), u64::MAX)
+            .get_versioned(&kv_key("b"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -605,7 +605,7 @@ fn compact_l0_to_l1_data_correct_after() {
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("c"), u64::MAX)
+            .get_versioned(&kv_key("c"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -614,7 +614,7 @@ fn compact_l0_to_l1_data_correct_after() {
 
     // Prefix scan
     let prefix_key = Key::new(ns(), TypeTag::KV, Vec::new());
-    let results = store.scan_prefix(&prefix_key, u64::MAX).unwrap();
+    let results = store.scan_prefix(&prefix_key, CommitVersion::MAX).unwrap();
     assert_eq!(results.len(), 3);
 
     // History
@@ -676,7 +676,7 @@ fn compact_l0_to_l1_repeated() {
     // All data correct
     assert_eq!(
         store
-            .get_versioned(&kv_key("a"), u64::MAX)
+            .get_versioned(&kv_key("a"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -684,7 +684,7 @@ fn compact_l0_to_l1_repeated() {
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("z"), u64::MAX)
+            .get_versioned(&kv_key("z"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -732,7 +732,7 @@ fn point_lookup_reads_l1_segments() {
     // Data in L1 only
     assert_eq!(
         store
-            .get_versioned(&kv_key("k1"), u64::MAX)
+            .get_versioned(&kv_key("k1"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
@@ -740,14 +740,14 @@ fn point_lookup_reads_l1_segments() {
     );
     assert_eq!(
         store
-            .get_versioned(&kv_key("k2"), u64::MAX)
+            .get_versioned(&kv_key("k2"), CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .value,
         Value::Int(2)
     );
     assert!(store
-        .get_versioned(&kv_key("nonexistent"), u64::MAX)
+        .get_versioned(&kv_key("nonexistent"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 }
@@ -765,7 +765,7 @@ fn scan_prefix_includes_l1() {
     seed(&store, kv_key("item/c"), Value::Int(3), 2);
 
     let prefix = Key::new(ns(), TypeTag::KV, "item/".as_bytes().to_vec());
-    let results = store.scan_prefix(&prefix, u64::MAX).unwrap();
+    let results = store.scan_prefix(&prefix, CommitVersion::MAX).unwrap();
     assert_eq!(results.len(), 3); // 2 from L1 + 1 from memtable
 }
 
@@ -804,7 +804,7 @@ fn l1_binary_search_correct_segment() {
     for (key, val) in [("a", 1), ("b", 2), ("m", 3), ("n", 4), ("x", 5), ("y", 6)] {
         assert_eq!(
             store
-                .get_versioned(&kv_key(key), u64::MAX)
+                .get_versioned(&kv_key(key), CommitVersion::MAX)
                 .unwrap()
                 .unwrap()
                 .value,
@@ -815,15 +815,15 @@ fn l1_binary_search_correct_segment() {
 
     // Keys not in any segment
     assert!(store
-        .get_versioned(&kv_key("c"), u64::MAX)
+        .get_versioned(&kv_key("c"), CommitVersion::MAX)
         .unwrap()
         .is_none());
     assert!(store
-        .get_versioned(&kv_key("p"), u64::MAX)
+        .get_versioned(&kv_key("p"), CommitVersion::MAX)
         .unwrap()
         .is_none());
     assert!(store
-        .get_versioned(&kv_key("zzz"), u64::MAX)
+        .get_versioned(&kv_key("zzz"), CommitVersion::MAX)
         .unwrap()
         .is_none());
 }
@@ -890,7 +890,7 @@ fn recover_with_manifest_restores_levels() {
     for (key, val) in [("a", 1), ("b", 2), ("c", 3), ("d", 4)] {
         assert_eq!(
             store2
-                .get_versioned(&kv_key(key), u64::MAX)
+                .get_versioned(&kv_key(key), CommitVersion::MAX)
                 .unwrap()
                 .unwrap()
                 .value,
@@ -925,11 +925,11 @@ fn recover_without_manifest_all_l0() {
 
     // Data still correct
     assert!(store2
-        .get_versioned(&kv_key("a"), u64::MAX)
+        .get_versioned(&kv_key("a"), CommitVersion::MAX)
         .unwrap()
         .is_some());
     assert!(store2
-        .get_versioned(&kv_key("b"), u64::MAX)
+        .get_versioned(&kv_key("b"), CommitVersion::MAX)
         .unwrap()
         .is_some());
 }
@@ -960,7 +960,7 @@ fn recover_manifest_corrupt_returns_error() {
     // The corrupt branch's data must NOT be accessible.
     assert!(
         store2
-            .get_versioned(&kv_key("a"), u64::MAX)
+            .get_versioned(&kv_key("a"), CommitVersion::MAX)
             .unwrap()
             .is_none(),
         "corrupt-manifest branch must not have segments loaded"
@@ -1001,14 +1001,14 @@ fn compact_l0_to_l1_streaming_correctness() {
     // All 250 entries should be readable
     for i in 0..250u64 {
         let result = store
-            .get_versioned(&kv_key(&format!("key_{:06}", i)), u64::MAX)
+            .get_versioned(&kv_key(&format!("key_{:06}", i)), CommitVersion::MAX)
             .unwrap();
         assert!(result.is_some(), "key_{:06} should be readable", i);
     }
 
     // Prefix scan should find all entries
     let prefix = Key::new(ns(), TypeTag::KV, "key_".as_bytes().to_vec());
-    let results = store.scan_prefix(&prefix, u64::MAX).unwrap();
+    let results = store.scan_prefix(&prefix, CommitVersion::MAX).unwrap();
     assert_eq!(results.len(), 250);
 }
 
@@ -1047,7 +1047,7 @@ fn compact_l0_to_l1_with_splitting_builder() {
     for i in 0..400u64 {
         assert!(
             store
-                .get_versioned(&kv_key(&format!("k{:06}", i)), u64::MAX)
+                .get_versioned(&kv_key(&format!("k{:06}", i)), CommitVersion::MAX)
                 .unwrap()
                 .is_some(),
             "k{:06} missing",
@@ -1084,7 +1084,7 @@ fn compact_level_0_equivalent_to_compact_l0_to_l1() {
     let expected = [("a", 1i64), ("b", 2), ("c", 3), ("d", 4), ("e", 5)];
     for (key_name, expected_val) in &expected {
         let val = store
-            .get_versioned(&kv_key(key_name), u64::MAX)
+            .get_versioned(&kv_key(key_name), CommitVersion::MAX)
             .unwrap()
             .unwrap_or_else(|| panic!("key {} missing after compact_level(0)", key_name));
         assert_eq!(val.value, Value::Int(*expected_val));
@@ -1116,7 +1116,7 @@ fn compact_level_1_moves_to_l2() {
     let expected = [("a", 1i64), ("b", 2), ("c", 3), ("d", 4)];
     for (key_name, expected_val) in &expected {
         let val = store
-            .get_versioned(&kv_key(key_name), u64::MAX)
+            .get_versioned(&kv_key(key_name), CommitVersion::MAX)
             .unwrap()
             .unwrap_or_else(|| panic!("key {} missing after compact_level(1)", key_name));
         assert_eq!(val.value, Value::Int(*expected_val));
@@ -1165,7 +1165,7 @@ fn compact_level_picks_round_robin() {
     for key_name in &["aaa", "mmm", "zzz"] {
         assert!(
             store
-                .get_versioned(&kv_key(key_name), u64::MAX)
+                .get_versioned(&kv_key(key_name), CommitVersion::MAX)
                 .unwrap()
                 .is_some(),
             "key {} missing after round-robin compact",
@@ -1205,7 +1205,7 @@ fn compact_level_trivial_move() {
 
     // Data still findable with correct value
     let val = store
-        .get_versioned(&kv_key("x"), u64::MAX)
+        .get_versioned(&kv_key("x"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val.value, Value::Int(1));
@@ -1254,7 +1254,7 @@ fn compact_level_finds_overlapping_next() {
 
     // Verify updated value for "b"
     let val = store
-        .get_versioned(&kv_key("b"), u64::MAX)
+        .get_versioned(&kv_key("b"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val.value, Value::Int(20));
@@ -1263,7 +1263,7 @@ fn compact_level_finds_overlapping_next() {
     let expected = [("a", 1i64), ("c", 3), ("d", 4)];
     for (key_name, expected_val) in &expected {
         let val = store
-            .get_versioned(&kv_key(key_name), u64::MAX)
+            .get_versioned(&kv_key(key_name), CommitVersion::MAX)
             .unwrap()
             .unwrap_or_else(|| panic!("key {} missing after overlap merge", key_name));
         assert_eq!(val.value, Value::Int(*expected_val));
@@ -1289,7 +1289,7 @@ fn point_lookup_finds_data_in_l3() {
 
     // Point lookup must find data at L3
     let val = store
-        .get_versioned(&kv_key("deep"), u64::MAX)
+        .get_versioned(&kv_key("deep"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val.value, Value::Int(42));
@@ -1321,7 +1321,7 @@ fn scan_includes_all_levels() {
     seed(&store, kv_key("p/d"), Value::Int(4), 4);
 
     // Prefix scan should find all four
-    let results = store.scan_prefix(&kv_key("p/"), u64::MAX).unwrap();
+    let results = store.scan_prefix(&kv_key("p/"), CommitVersion::MAX).unwrap();
     assert_eq!(results.len(), 4, "scan should merge data across all levels");
 }
 
@@ -1359,7 +1359,7 @@ fn recover_restores_multi_level() {
     let expected = [("a", 1i64), ("b", 2), ("c", 3)];
     for (key_name, expected_val) in &expected {
         let val = store2
-            .get_versioned(&kv_key(key_name), u64::MAX)
+            .get_versioned(&kv_key(key_name), CommitVersion::MAX)
             .unwrap()
             .unwrap_or_else(|| panic!("key {} missing after recovery", key_name));
         assert_eq!(val.value, Value::Int(*expected_val));
@@ -1434,7 +1434,7 @@ fn compact_level_prunes_old_versions() {
 
     // Latest version should be visible
     let val = store
-        .get_versioned(&kv_key("k"), u64::MAX)
+        .get_versioned(&kv_key("k"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val.value, Value::Int(4));
@@ -1985,19 +1985,19 @@ fn compaction_with_rate_limiter_multi_block() {
 
     // Verify data integrity: spot-check first, last, and middle keys
     assert!(store
-        .get_versioned(&kv_key("a000000"), u64::MAX)
+        .get_versioned(&kv_key("a000000"), CommitVersion::MAX)
         .unwrap()
         .is_some());
     assert!(store
-        .get_versioned(&kv_key("a000199"), u64::MAX)
+        .get_versioned(&kv_key("a000199"), CommitVersion::MAX)
         .unwrap()
         .is_some());
     assert!(store
-        .get_versioned(&kv_key("b000100"), u64::MAX)
+        .get_versioned(&kv_key("b000100"), CommitVersion::MAX)
         .unwrap()
         .is_some());
     assert!(store
-        .get_versioned(&kv_key("b000199"), u64::MAX)
+        .get_versioned(&kv_key("b000199"), CommitVersion::MAX)
         .unwrap()
         .is_some());
 }
@@ -2022,11 +2022,11 @@ fn rate_limiter_disabled_by_default() {
     assert_eq!(result.output_entries, 200);
 
     assert!(store
-        .get_versioned(&kv_key("x000000"), u64::MAX)
+        .get_versioned(&kv_key("x000000"), CommitVersion::MAX)
         .unwrap()
         .is_some());
     assert!(store
-        .get_versioned(&kv_key("y000099"), u64::MAX)
+        .get_versioned(&kv_key("y000099"), CommitVersion::MAX)
         .unwrap()
         .is_some());
 }
@@ -2076,11 +2076,11 @@ fn rate_limiter_l0_to_l1_compaction() {
 
     // Spot-check data after L0→L1 compaction
     assert!(store
-        .get_versioned(&kv_key("l0seg0000000"), u64::MAX)
+        .get_versioned(&kv_key("l0seg0000000"), CommitVersion::MAX)
         .unwrap()
         .is_some());
     assert!(store
-        .get_versioned(&kv_key("l0seg3000049"), u64::MAX)
+        .get_versioned(&kv_key("l0seg3000049"), CommitVersion::MAX)
         .unwrap()
         .is_some());
 }
@@ -2112,14 +2112,14 @@ fn rate_limited_compaction_preserves_prune_semantics() {
 
     // Version 5 still readable
     let val = store
-        .get_versioned(&kv_key("k000050"), u64::MAX)
+        .get_versioned(&kv_key("k000050"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val.version.as_u64(), 5);
 
     // Version 1 was pruned
     assert!(store
-        .get_versioned(&kv_key("k000050"), 1)
+        .get_versioned(&kv_key("k000050"), CommitVersion(1))
         .unwrap()
         .is_none());
 }

--- a/crates/storage/src/segmented/tests/lifecycle.rs
+++ b/crates/storage/src/segmented/tests/lifecycle.rs
@@ -143,7 +143,7 @@ fn clear_branch_cleans_up_inherited_and_own_segments() {
 
     // Parent can still read its data
     let result = store
-        .get_versioned(&parent_kv("a"), u64::MAX)
+        .get_versioned(&parent_kv("a"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(result.value, Value::Int(1));
@@ -218,7 +218,7 @@ fn concurrent_fork_and_compaction_no_data_loss() {
     // without ENOENT errors on deleted segment files.
     for i in 0..100 {
         let key = child_kv(&format!("key{:04}", i));
-        let result = store.get_versioned(&key, u64::MAX).unwrap();
+        let result = store.get_versioned(&key, CommitVersion::MAX).unwrap();
         assert!(
             result.is_some(),
             "child should see inherited key {:04} — segment file must not be deleted",
@@ -290,7 +290,7 @@ fn concurrent_fork_and_compaction_stress() {
         // Verify all data readable from child
         for i in 0..40 {
             let key = child_kv(&format!("r{}k{:04}", round, i));
-            let result = store.get_versioned(&key, u64::MAX).unwrap();
+            let result = store.get_versioned(&key, CommitVersion::MAX).unwrap();
             assert!(
                 result.is_some(),
                 "round {}: child missing key {:04}",
@@ -431,7 +431,7 @@ fn bench_100_branch_fanout() {
                 strata_core::types::TypeTag::KV,
                 format!("k{:06}", i).into_bytes(),
             );
-            let val = store.get_versioned(&key, u64::MAX).unwrap();
+            let val = store.get_versioned(&key, CommitVersion::MAX).unwrap();
             assert!(val.is_some(), "child {} missing key {}", c, i);
         }
     }
@@ -501,7 +501,7 @@ fn bench_fork_chain_depth() {
             strata_core::types::TypeTag::KV,
             format!("k{:04}", i).into_bytes(),
         );
-        let val = store.get_versioned(&key, u64::MAX).unwrap();
+        let val = store.get_versioned(&key, CommitVersion::MAX).unwrap();
         assert!(val.is_some(), "E missing key {}", i);
     }
 
@@ -582,7 +582,7 @@ fn recovery_skips_orphan_sst_not_in_manifest() {
     // Data from the real segment should be readable
     drop(parent_state);
     let result = store2
-        .get_versioned(&parent_kv("a"), u64::MAX)
+        .get_versioned(&parent_kv("a"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(result.value, Value::Int(1));
@@ -618,7 +618,7 @@ fn test_issue_1701_recovery_inherited_layer_finds_orphan_segments() {
 
     // Verify child can read inherited data before compaction
     let val_a = store
-        .get_versioned(&child_kv("a"), u64::MAX)
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val_a.value, Value::Int(1));
@@ -640,7 +640,7 @@ fn test_issue_1701_recovery_inherited_layer_finds_orphan_segments() {
 
     // Verify child still reads correctly (in-memory Arcs are alive)
     let val_b = store
-        .get_versioned(&child_kv("b"), u64::MAX)
+        .get_versioned(&child_kv("b"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val_b.value, Value::Int(2));
@@ -654,14 +654,14 @@ fn test_issue_1701_recovery_inherited_layer_finds_orphan_segments() {
     // 5. Child must still see inherited data after recovery
     //    This is the bug: without the fix, inherited layer resolution can't
     //    find the orphan segments because they're not in the parent's version.
-    let val_a_recovered = store2.get_versioned(&child_kv("a"), u64::MAX).unwrap();
+    let val_a_recovered = store2.get_versioned(&child_kv("a"), CommitVersion::MAX).unwrap();
     assert!(
         val_a_recovered.is_some(),
         "child should see inherited key 'a' after recovery (orphan segment)"
     );
     assert_eq!(val_a_recovered.unwrap().value, Value::Int(1));
 
-    let val_b_recovered = store2.get_versioned(&child_kv("b"), u64::MAX).unwrap();
+    let val_b_recovered = store2.get_versioned(&child_kv("b"), CommitVersion::MAX).unwrap();
     assert!(
         val_b_recovered.is_some(),
         "child should see inherited key 'b' after recovery (orphan segment)"
@@ -670,7 +670,7 @@ fn test_issue_1701_recovery_inherited_layer_finds_orphan_segments() {
 
     // Parent should still read the compacted data
     let parent_a = store2
-        .get_versioned(&parent_kv("a"), u64::MAX)
+        .get_versioned(&parent_kv("a"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(parent_a.value, Value::Int(1));
@@ -710,7 +710,7 @@ fn test_issue_1691_inherited_layer_recovery_independent_of_source() {
 
     // Verify child can read inherited data before crash
     let val_a = store
-        .get_versioned(&child_kv("a"), u64::MAX)
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val_a.value, Value::Int(1));
@@ -736,14 +736,14 @@ fn test_issue_1691_inherited_layer_recovery_independent_of_source() {
     let info = store2.recover_segments().unwrap();
 
     // 6. Child must still see inherited data after recovery.
-    let val_a_recovered = store2.get_versioned(&child_kv("a"), u64::MAX).unwrap();
+    let val_a_recovered = store2.get_versioned(&child_kv("a"), CommitVersion::MAX).unwrap();
     assert!(
         val_a_recovered.is_some(),
         "child should see inherited key 'a' after recovery"
     );
     assert_eq!(val_a_recovered.unwrap().value, Value::Int(1));
 
-    let val_b_recovered = store2.get_versioned(&child_kv("b"), u64::MAX).unwrap();
+    let val_b_recovered = store2.get_versioned(&child_kv("b"), CommitVersion::MAX).unwrap();
     assert!(
         val_b_recovered.is_some(),
         "child should see inherited key 'b' after recovery"
@@ -760,7 +760,7 @@ fn test_issue_1691_inherited_layer_recovery_independent_of_source() {
     // Parent branch must not have its own segments loaded.
     assert!(
         store2
-            .get_versioned(&parent_kv("a"), u64::MAX)
+            .get_versioned(&parent_kv("a"), CommitVersion::MAX)
             .unwrap()
             .is_none(),
         "parent branch own segments must not be loaded (corrupt manifest)"
@@ -839,7 +839,7 @@ fn concurrent_materialize_serialized() {
 
     // Data should be accessible
     let result = store
-        .get_versioned(&child_kv("k0050"), u64::MAX)
+        .get_versioned(&child_kv("k0050"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(result.value, Value::Int(50));
@@ -896,7 +896,7 @@ fn clear_branch_preserves_referenced_own_segments() {
 
     // Child should still be able to read inherited data
     let result = store
-        .get_versioned(&child_kv("a"), u64::MAX)
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(result.value, Value::Int(1));
@@ -1079,7 +1079,7 @@ fn test_issue_1705_materialize_layer_gc_orphan_segments() {
 
     // Child should still read materialized data from its own segments
     let val = store
-        .get_versioned(&child_kv("k0000"), u64::MAX)
+        .get_versioned(&child_kv("k0000"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val.value, Value::Int(0));
@@ -1137,7 +1137,7 @@ fn test_issue_1677_corruption_does_not_resurrect_stale_data() {
     // 5. Read must return a corruption error, NEVER the stale value (100).
     //    Before this fix, corruption returned None which fell through to the
     //    older segment and returned Value::Int(100) — a data-correctness violation.
-    let result = store.get_versioned(&kv_key("k"), u64::MAX);
+    let result = store.get_versioned(&kv_key("k"), CommitVersion::MAX);
     match result {
         Err(e) => {
             assert!(

--- a/crates/storage/src/segmented/tests/materialize.rs
+++ b/crates/storage/src/segmented/tests/materialize.rs
@@ -53,7 +53,7 @@ fn compaction_preserves_shared_segments() {
 
     // Child can still read inherited data
     let result = store
-        .get_versioned(&child_kv("a"), u64::MAX)
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(result.value, Value::Int(1));
@@ -82,13 +82,13 @@ fn materialize_collapses_layer() {
 
     // Data still accessible in own segments
     let val = store
-        .get_versioned(&child_kv("a"), u64::MAX)
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val.value, Value::Int(1));
 
     let val = store
-        .get_versioned(&child_kv("b"), u64::MAX)
+        .get_versioned(&child_kv("b"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val.value, Value::Int(2));
@@ -109,7 +109,7 @@ fn materialize_preserves_commit_ids() {
     store.materialize_layer(&child_branch(), 0).unwrap();
 
     let val = store
-        .get_versioned(&child_kv("k"), u64::MAX)
+        .get_versioned(&child_kv("k"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val.value, Value::Int(42));
@@ -151,7 +151,7 @@ fn materialize_skips_post_fork_entries() {
 
     // "early" (version 1 <= 50) should be materialized
     let val = store
-        .get_versioned(&child_kv("early"), u64::MAX)
+        .get_versioned(&child_kv("early"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val.value, Value::Int(1));
@@ -159,7 +159,7 @@ fn materialize_skips_post_fork_entries() {
     // "late" (version 100 > 50) should NOT be materialized
     assert!(
         store
-            .get_versioned(&child_kv("late"), u64::MAX)
+            .get_versioned(&child_kv("late"), CommitVersion::MAX)
             .unwrap()
             .is_none(),
         "post-fork entry should not be materialized"
@@ -191,7 +191,7 @@ fn materialize_skips_shadowed_by_own() {
 
     // Value should be child's own
     let val = store
-        .get_versioned(&child_kv("k"), u64::MAX)
+        .get_versioned(&child_kv("k"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val.value, Value::Int(999));
@@ -308,13 +308,13 @@ fn materialize_deepest_first() {
 
     // All data accessible
     let val = store
-        .get_versioned(&child_kv("a_key"), u64::MAX)
+        .get_versioned(&child_kv("a_key"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val.value, Value::Int(1));
 
     let val = store
-        .get_versioned(&child_kv("b_key"), u64::MAX)
+        .get_versioned(&child_kv("b_key"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(val.value, Value::Int(2));
@@ -405,7 +405,7 @@ fn materialize_preserves_read_path() {
         .iter()
         .filter_map(|k| {
             store
-                .get_versioned(&child_kv(k), u64::MAX)
+                .get_versioned(&child_kv(k), CommitVersion::MAX)
                 .unwrap()
                 .map(|v| (k.to_string(), v.value))
         })
@@ -418,7 +418,7 @@ fn materialize_preserves_read_path() {
         .iter()
         .filter_map(|k| {
             store
-                .get_versioned(&child_kv(k), u64::MAX)
+                .get_versioned(&child_kv(k), CommitVersion::MAX)
                 .unwrap()
                 .map(|v| (k.to_string(), v.value))
         })
@@ -551,20 +551,20 @@ fn materialize_crash_recovery_with_partial_segment() {
 
         // Data should be readable through inherited layers
         let a = store
-            .get_versioned(&child_kv("a"), u64::MAX)
+            .get_versioned(&child_kv("a"), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(a.value, Value::Int(1));
 
         let b = store
-            .get_versioned(&child_kv("b"), u64::MAX)
+            .get_versioned(&child_kv("b"), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(b.value, Value::Int(2));
 
         // Parent data should also be intact
         let pa = store
-            .get_versioned(&parent_kv("a"), u64::MAX)
+            .get_versioned(&parent_kv("a"), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(pa.value, Value::Int(1));
@@ -621,14 +621,14 @@ fn materialize_crash_recovery_with_valid_orphan_segment() {
 
         // Child's own data (from the valid segment) should be readable
         let y = store
-            .get_versioned(&child_kv("y"), u64::MAX)
+            .get_versioned(&child_kv("y"), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(y.value, Value::Int(20));
 
         // Inherited data from parent should also be readable
         let x = store
-            .get_versioned(&child_kv("x"), u64::MAX)
+            .get_versioned(&child_kv("x"), CommitVersion::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(x.value, Value::Int(10));
@@ -836,19 +836,19 @@ fn materialize_multi_segment_inherited_layer() {
 
     // Verify ALL keys are readable via point lookup (would fail on corrupt segment)
     let a = store
-        .get_versioned(&child_kv("a"), u64::MAX)
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(a.value, Value::Int(1));
 
     let b = store
-        .get_versioned(&child_kv("b"), u64::MAX)
+        .get_versioned(&child_kv("b"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(b.value, Value::Int(2));
 
     let c = store
-        .get_versioned(&child_kv("c"), u64::MAX)
+        .get_versioned(&child_kv("c"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(c.value, Value::Int(3));
@@ -901,19 +901,19 @@ fn materialize_multi_level_inherited_layer() {
 
     // All keys must be readable (verifies correct sort order in output segment)
     let a = store
-        .get_versioned(&child_kv("a"), u64::MAX)
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(a.value, Value::Int(1));
 
     let b = store
-        .get_versioned(&child_kv("b"), u64::MAX)
+        .get_versioned(&child_kv("b"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(b.value, Value::Int(2));
 
     let c = store
-        .get_versioned(&child_kv("c"), u64::MAX)
+        .get_versioned(&child_kv("c"), CommitVersion::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(c.value, Value::Int(3));

--- a/crates/storage/src/segmented/tests/mod.rs
+++ b/crates/storage/src/segmented/tests/mod.rs
@@ -2,6 +2,7 @@
 
 pub(in crate::segmented) use super::compaction::*;
 pub(crate) use super::*;
+pub(crate) use strata_core::id::CommitVersion;
 pub(crate) use strata_core::types::{Namespace, TypeTag};
 
 pub fn branch() -> BranchId {
@@ -18,7 +19,7 @@ pub fn kv_key(name: &str) -> Key {
 
 pub fn seed(store: &SegmentedStore, key: Key, value: Value, version: u64) {
     store
-        .put_with_version_mode(key, value, version, None, WriteMode::Append)
+        .put_with_version_mode(key, value, CommitVersion(version), None, WriteMode::Append)
         .unwrap();
 }
 
@@ -83,7 +84,7 @@ pub fn setup_parent_with_segments(
             .put_with_version_mode(
                 parent_kv(key),
                 Value::Int(val),
-                ver,
+                CommitVersion(ver),
                 None,
                 WriteMode::Append,
             )

--- a/crates/vector/src/merge_handler.rs
+++ b/crates/vector/src/merge_handler.rs
@@ -44,6 +44,7 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
+use strata_core::id::CommitVersion;
 use strata_core::traits::Storage;
 use strata_core::types::{BranchId, Key, Namespace};
 use strata_core::value::Value;
@@ -87,7 +88,7 @@ fn vector_precheck_fn(db: &Arc<Database>, source: BranchId, target: BranchId) ->
         .collect();
 
     let storage = db.storage();
-    let version = storage.version();
+    let version = CommitVersion(storage.version());
 
     for space in shared_spaces {
         let source_ns = Arc::new(Namespace::for_branch_space(source, space));
@@ -155,7 +156,7 @@ fn vector_precheck_fn(db: &Arc<Database>, source: BranchId, target: BranchId) ->
 fn decode_configs_for_space(
     db: &Arc<Database>,
     prefix: &Key,
-    version: u64,
+    version: CommitVersion,
 ) -> std::collections::BTreeMap<String, CollectionRecord> {
     let mut out = std::collections::BTreeMap::new();
     let entries = match db.storage().scan_prefix(prefix, version) {

--- a/crates/vector/src/recovery.rs
+++ b/crates/vector/src/recovery.rs
@@ -30,6 +30,7 @@
 //! mismatch, recovery falls back transparently to full KV-based rebuild
 //! with no data loss.
 
+use strata_core::id::CommitVersion;
 use strata_core::StrataResult;
 use strata_engine::Database;
 use tracing::info;
@@ -122,7 +123,7 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
     // Get access to the shared backend state
     let state = db.extension::<VectorBackendState>()?;
 
-    let snapshot_version = db.storage().version();
+    let snapshot_version = CommitVersion(db.storage().version());
     let mut stats = super::RecoveryStats::default();
     let data_dir = db.data_dir();
     let use_mmap = !data_dir.as_os_str().is_empty();
@@ -524,7 +525,7 @@ impl strata_engine::RefreshHook for VectorRefreshHook {
         let mut pre_reads = Vec::new();
         for key in deletes {
             if key.type_tag == TypeTag::Vector {
-                if let Ok(Some(vv)) = db.storage().get_versioned(key, u64::MAX) {
+                if let Ok(Some(vv)) = db.storage().get_versioned(key, CommitVersion::MAX) {
                     if let strata_core::value::Value::Bytes(ref bytes) = vv.value {
                         pre_reads.push((key.clone(), bytes.clone()));
                     }

--- a/crates/vector/src/store/collections.rs
+++ b/crates/vector/src/store/collections.rs
@@ -267,7 +267,7 @@ impl VectorStore {
         let prefix = Key::new_vector_config_prefix(namespace);
 
         // Read at current version for consistency
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
         let entries = self
             .db
             .storage()
@@ -322,7 +322,7 @@ impl VectorStore {
         use strata_core::traits::Storage;
 
         let config_key = Key::new_vector_config(self.namespace_for(branch_id, space), name);
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
 
         Ok(self
             .db
@@ -342,7 +342,7 @@ impl VectorStore {
         let config_key = Key::new_vector_config(self.namespace_for(branch_id, space), name);
 
         use strata_core::traits::Storage;
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
 
         let Some(versioned_value) = self
             .db

--- a/crates/vector/src/store/crud.rs
+++ b/crates/vector/src/store/crud.rs
@@ -114,7 +114,7 @@ impl VectorStore {
 
         // Get record from KV with version info
         use strata_core::traits::Storage;
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
         let Some(versioned_value) = self
             .db
             .storage()
@@ -475,7 +475,7 @@ impl VectorStore {
         let collection_id = CollectionId::new(branch_id, space, collection);
 
         use strata_core::traits::Storage;
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
 
         let state = self.state()?;
         let backend =
@@ -632,7 +632,7 @@ impl VectorStore {
         let namespace = self.namespace_for(branch_id, space);
         let prefix = Key::vector_collection_prefix(namespace, collection);
 
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
         let entries = self
             .db
             .storage()

--- a/crates/vector/src/store/mod.rs
+++ b/crates/vector/src/store/mod.rs
@@ -35,6 +35,7 @@ use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use strata_core::contract::{Timestamp, Version, Versioned};
+use strata_core::id::CommitVersion;
 use strata_core::types::{BranchId, Key, Namespace};
 use strata_core::value::Value;
 use strata_core::EntityRef;
@@ -276,7 +277,7 @@ impl VectorStore {
 
         // Scan KV for vector entries
         let ns = self.namespace_for(id.branch_id, space);
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
         let vector_prefix = Key::new_vector(ns, &id.name, "");
         let vector_entries = self
             .db
@@ -372,7 +373,7 @@ impl VectorStore {
     fn get_vector_record_by_key(&self, key: &Key) -> VectorResult<Option<VectorRecord>> {
         use strata_core::traits::Storage;
 
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
         let Some(versioned) = self
             .db
             .storage()
@@ -408,7 +409,7 @@ impl VectorStore {
         let namespace = self.namespace_for(branch_id, space);
         let prefix = Key::vector_collection_prefix(namespace, collection);
 
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
         let entries = self
             .db
             .storage()
@@ -467,7 +468,7 @@ impl VectorStore {
         let namespace = self.namespace_for(branch_id, space);
         let prefix = Key::vector_collection_prefix(namespace, name);
 
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
         let entries = self
             .db
             .storage()
@@ -488,7 +489,7 @@ impl VectorStore {
         let prefix = Key::vector_collection_prefix(namespace, name);
 
         // Scan all vector keys in this collection
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
         let entries = self
             .db
             .storage()
@@ -533,7 +534,7 @@ impl VectorStore {
         use strata_core::traits::Storage;
 
         let config_key = Key::new_vector_config(self.namespace_for(branch_id, space), name);
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
 
         let Some(versioned_value) = self
             .db

--- a/crates/vector/src/store/recovery.rs
+++ b/crates/vector/src/store/recovery.rs
@@ -49,7 +49,7 @@ impl VectorStore {
     ) -> VectorResult<()> {
         use strata_core::traits::Storage;
 
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
 
         // Get all spaces for this branch (SpaceIndex.list always includes "default")
         let space_index = strata_engine::SpaceIndex::new(self.db.clone());
@@ -154,7 +154,7 @@ impl VectorStore {
         use strata_core::traits::Storage;
 
         let state = self.state()?;
-        let version = self.db.storage().version();
+        let version = CommitVersion(self.db.storage().version());
         let ns = self.namespace_for(branch_id, space);
 
         // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `TxnId(u64)` and `CommitVersion(u64)` newtypes in `strata_core::id` to prevent accidental parameter swaps
- Both types use `#[repr(transparent)]` for zero-cost abstraction and `#[serde(transparent)]` for wire compatibility
- Migrate Storage trait, TransactionManager, and all primitives to use typed versions throughout

## Change Class
- **Refactor-only** (S2 quality enabler): No behavior changes, no public API surface changes beyond the new types

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets` passes (0 errors)
- [x] `cargo test --workspace` passes (730+ tests)
- [x] `cargo hack --feature-powerset --depth 2` passes on core crates
- [x] Feature-gated `perf-trace` code compiles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)