### PR TITLE
fix(tests): T1-E7 — update integration tests for TxnId/CommitVersion types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [workspace]
 resolver = "2"
 default-members = ["crates/executor", "crates/cli", "crates/engine"]
+exclude = ["benchmarks"]
 members = [
     "crates/core",
     "crates/storage",

--- a/tests/concurrency/cas_operations.rs
+++ b/tests/concurrency/cas_operations.rs
@@ -9,6 +9,7 @@
 use std::sync::Arc;
 use strata_concurrency::transaction::{CASOperation, TransactionContext};
 use strata_concurrency::validation::{validate_cas_set, validate_transaction, ConflictType};
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{Key, Namespace};
 use strata_core::value::Value;
@@ -32,10 +33,10 @@ fn cas_succeeds_when_version_matches() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let version = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
@@ -86,15 +87,15 @@ fn cas_fails_when_version_stale() {
 
     // Create at version 1
     store
-        .put_with_version_mode(key.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // Update to version 2
     store
-        .put_with_version_mode(key.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
     let current_version = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
@@ -131,7 +132,7 @@ fn cas_create_fails_when_key_exists() {
 
     // Key exists
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // CAS with expected_version=0 (expects key doesn't exist)
@@ -153,15 +154,15 @@ fn cas_fails_when_key_deleted() {
 
     // Create and delete
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let version = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
-    store.delete_with_version(&key, 2).unwrap();
+    store.delete_with_version(&key, CommitVersion(2)).unwrap();
 
     // CAS with old version (before delete)
     let cas_set = vec![CASOperation {
@@ -183,7 +184,7 @@ fn cas_not_added_to_read_set() {
     let branch_id = BranchId::new();
     let key = create_test_key(branch_id, "cas_no_read");
 
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
 
     // Add CAS operation
     txn.cas_set.push(CASOperation {
@@ -206,26 +207,26 @@ fn cas_validated_separately_from_reads() {
 
     // Setup
     store
-        .put_with_version_mode(read_key.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(read_key.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let read_version = store
-        .get_versioned(&read_key, u64::MAX)
+        .get_versioned(&read_key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
     store
-        .put_with_version_mode(cas_key.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(cas_key.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
     let cas_version = store
-        .get_versioned(&cas_key, u64::MAX)
+        .get_versioned(&cas_key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     // Transaction reads one key, CAS on another
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     txn.read_set.insert(read_key.clone(), read_version);
     txn.cas_set.push(CASOperation {
         key: cas_key.clone(),
@@ -235,7 +236,7 @@ fn cas_validated_separately_from_reads() {
 
     // Modify read_key only
     store
-        .put_with_version_mode(read_key.clone(), Value::Int(10), 3, None, WriteMode::Append)
+        .put_with_version_mode(read_key.clone(), Value::Int(10), CommitVersion(3), None, WriteMode::Append)
         .unwrap();
 
     // Validation should fail on read_key (ReadWriteConflict), not on CAS
@@ -270,13 +271,13 @@ fn multiple_cas_all_succeed() {
                 .put_with_version_mode(
                     key.clone(),
                     Value::Int(i),
-                    (i + 1) as u64,
+                    CommitVersion((i + 1) as u64),
                     None,
                     WriteMode::Append,
                 )
                 .unwrap();
             let v = store
-                .get_versioned(&key, u64::MAX)
+                .get_versioned(&key, CommitVersion::MAX)
                 .unwrap()
                 .unwrap()
                 .version
@@ -311,28 +312,28 @@ fn multiple_cas_one_fails() {
     let key3 = create_test_key(branch_id, "cas_3");
 
     store
-        .put_with_version_mode(key1.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key1.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let v1 = store
-        .get_versioned(&key1, u64::MAX)
+        .get_versioned(&key1, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     store
-        .put_with_version_mode(key2.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key2.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
     // Update key2 to make its version stale
     store
-        .put_with_version_mode(key2.clone(), Value::Int(20), 3, None, WriteMode::Append)
+        .put_with_version_mode(key2.clone(), Value::Int(20), CommitVersion(3), None, WriteMode::Append)
         .unwrap();
 
     store
-        .put_with_version_mode(key3.clone(), Value::Int(3), 4, None, WriteMode::Append)
+        .put_with_version_mode(key3.clone(), Value::Int(3), CommitVersion(4), None, WriteMode::Append)
         .unwrap();
     let v3 = store
-        .get_versioned(&key3, u64::MAX)
+        .get_versioned(&key3, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
@@ -374,17 +375,17 @@ fn cas_in_full_transaction() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let version = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     // Transaction with CAS
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     txn.cas_set.push(CASOperation {
         key: key.clone(),
         expected_version: version,
@@ -404,17 +405,17 @@ fn cas_with_read_of_same_key() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let version = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     // Transaction reads and CAS same key
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     txn.read_set.insert(key.clone(), version);
     txn.cas_set.push(CASOperation {
         key: key.clone(),
@@ -463,10 +464,10 @@ fn cas_conflict_reports_correct_key() {
     let key = create_test_key(branch_id, "conflict_key");
 
     store
-        .put_with_version_mode(key.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     let cas_set = vec![CASOperation {

--- a/tests/concurrency/concurrent_transactions.rs
+++ b/tests/concurrency/concurrent_transactions.rs
@@ -11,6 +11,7 @@ use std::thread;
 use strata_concurrency::manager::TransactionManager;
 use strata_concurrency::transaction::TransactionContext;
 use strata_concurrency::validation::validate_transaction;
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{Key, Namespace};
 use strata_core::value::Value;
@@ -29,7 +30,7 @@ fn create_test_key(branch_id: BranchId, name: &str) -> Key {
 #[test]
 fn parallel_commits_different_runs_no_contention() {
     let store = Arc::new(SegmentedStore::new());
-    let manager = Arc::new(TransactionManager::new(1));
+    let manager = Arc::new(TransactionManager::new(CommitVersion(1)));
     let barrier = Arc::new(Barrier::new(4));
     let commits = Arc::new(AtomicU64::new(0));
 
@@ -46,7 +47,7 @@ fn parallel_commits_different_runs_no_contention() {
 
                 // Setup initial value
                 store
-                    .put_with_version_mode(key.clone(), Value::Int(0), 1, None, WriteMode::Append)
+                    .put_with_version_mode(key.clone(), Value::Int(0), CommitVersion(1), None, WriteMode::Append)
                     .unwrap();
 
                 barrier.wait();
@@ -62,7 +63,7 @@ fn parallel_commits_different_runs_no_contention() {
 
                     // Read and write
                     let v = store
-                        .get_versioned(&key, u64::MAX)
+                        .get_versioned(&key, CommitVersion::MAX)
                         .unwrap()
                         .unwrap()
                         .version
@@ -109,15 +110,15 @@ fn different_branches_have_independent_namespaces() {
 
     // Write different values to same logical name in different branches
     store
-        .put_with_version_mode(key1.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key1.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key2.clone(), Value::Int(200), 1, None, WriteMode::Append)
+        .put_with_version_mode(key2.clone(), Value::Int(200), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // They should be independent
-    let val1 = store.get_versioned(&key1, u64::MAX).unwrap().unwrap().value;
-    let val2 = store.get_versioned(&key2, u64::MAX).unwrap().unwrap().value;
+    let val1 = store.get_versioned(&key1, CommitVersion::MAX).unwrap().unwrap().value;
+    let val2 = store.get_versioned(&key2, CommitVersion::MAX).unwrap().unwrap().value;
 
     assert_eq!(val1, Value::Int(100));
     assert_eq!(val2, Value::Int(200));
@@ -130,13 +131,13 @@ fn different_branches_have_independent_namespaces() {
 #[test]
 fn high_contention_single_key() {
     let store = Arc::new(SegmentedStore::new());
-    let manager = Arc::new(TransactionManager::new(1));
+    let manager = Arc::new(TransactionManager::new(CommitVersion(1)));
     let branch_id = BranchId::new();
     let key = create_test_key(branch_id, "contested");
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(0), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(0), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     let barrier = Arc::new(Barrier::new(8));
@@ -158,12 +159,12 @@ fn high_contention_single_key() {
                 for i in 0..10 {
                     loop {
                         // Read current value
-                        let current = store.get_versioned(&key, u64::MAX).unwrap().unwrap();
+                        let current = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
                         let read_version = current.version.as_u64();
 
                         // Create transaction
                         let txn_id = manager.next_txn_id().unwrap();
-                        let mut txn = TransactionContext::new(txn_id, branch_id, read_version);
+                        let mut txn = TransactionContext::new(txn_id, branch_id, CommitVersion(read_version));
                         txn.read_set.insert(key.clone(), read_version);
                         txn.write_set
                             .insert(key.clone(), Value::Int((thread_id * 100 + i) as i64));
@@ -219,32 +220,32 @@ fn interleaved_disjoint_operations_both_commit() {
 
     // Initial values
     store
-        .put_with_version_mode(key_a.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key_a.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key_b.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key_b.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     let va = store
-        .get_versioned(&key_a, u64::MAX)
+        .get_versioned(&key_a, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
     let vb = store
-        .get_versioned(&key_b, u64::MAX)
+        .get_versioned(&key_b, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     // T1: reads A, writes B
-    let mut t1 = TransactionContext::new(1, branch_id, 1);
+    let mut t1 = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     t1.read_set.insert(key_a.clone(), va);
     t1.write_set.insert(key_b.clone(), Value::Int(20));
 
     // T2: reads B, writes A
-    let mut t2 = TransactionContext::new(2, branch_id, 1);
+    let mut t2 = TransactionContext::new(TxnId(2), branch_id, CommitVersion(1));
     t2.read_set.insert(key_b.clone(), vb);
     t2.write_set.insert(key_a.clone(), Value::Int(10));
 
@@ -268,7 +269,7 @@ fn interleaved_disjoint_operations_both_commit() {
 
 #[test]
 fn version_allocation_is_unique() {
-    let manager = Arc::new(TransactionManager::new(1));
+    let manager = Arc::new(TransactionManager::new(CommitVersion(1)));
     let barrier = Arc::new(Barrier::new(8));
 
     let handles: Vec<_> = (0..8)
@@ -287,7 +288,7 @@ fn version_allocation_is_unique() {
         })
         .collect();
 
-    let mut all_versions: Vec<u64> = handles
+    let mut all_versions: Vec<CommitVersion> = handles
         .into_iter()
         .flat_map(|h| h.join().unwrap())
         .collect();
@@ -307,7 +308,7 @@ fn version_allocation_is_unique() {
 
 #[test]
 fn txn_id_allocation_is_unique() {
-    let manager = Arc::new(TransactionManager::new(1));
+    let manager = Arc::new(TransactionManager::new(CommitVersion(1)));
     let barrier = Arc::new(Barrier::new(4));
 
     let handles: Vec<_> = (0..4)
@@ -326,7 +327,7 @@ fn txn_id_allocation_is_unique() {
         })
         .collect();
 
-    let mut all_ids: Vec<u64> = handles
+    let mut all_ids: Vec<TxnId> = handles
         .into_iter()
         .flat_map(|h| h.join().unwrap())
         .collect();
@@ -350,7 +351,7 @@ fn txn_id_allocation_is_unique() {
 
 #[test]
 fn manager_version_monotonically_increases() {
-    let manager = TransactionManager::new(100);
+    let manager = TransactionManager::new(CommitVersion(100));
 
     let v1 = manager.allocate_version().unwrap();
     let v2 = manager.allocate_version().unwrap();
@@ -362,19 +363,19 @@ fn manager_version_monotonically_increases() {
 
 #[test]
 fn manager_with_initial_version() {
-    let manager = TransactionManager::new(1000);
+    let manager = TransactionManager::new(CommitVersion(1000));
 
     let v1 = manager.allocate_version().unwrap();
-    assert!(v1 >= 1000, "First version should be >= initial");
+    assert!(v1 >= CommitVersion(1000), "First version should be >= initial");
 }
 
 #[test]
 fn manager_with_txn_id_recovery() {
     // Simulating recovery where we need to continue from a known max txn_id
-    let manager = TransactionManager::with_txn_id(100, 500);
+    let manager = TransactionManager::with_txn_id(CommitVersion(100), TxnId(500));
 
     let txn_id = manager.next_txn_id().unwrap();
-    assert!(txn_id > 500, "Txn ID should continue from max");
+    assert!(txn_id > TxnId(500), "Txn ID should continue from max");
 }
 
 // ============================================================================
@@ -396,7 +397,7 @@ fn concurrent_empty_transactions() {
                 barrier.wait();
 
                 // Empty transaction (read-only)
-                let txn = TransactionContext::new(i as u64, branch_id, 1);
+                let txn = TransactionContext::new(TxnId(i as u64), branch_id, CommitVersion(1));
                 let result = validate_transaction(&txn, &*store);
                 result.unwrap().is_valid()
             })
@@ -413,7 +414,7 @@ fn concurrent_empty_transactions() {
 
 #[test]
 fn rapid_transaction_creation() {
-    let manager = TransactionManager::new(1);
+    let manager = TransactionManager::new(CommitVersion(1));
     let branch_id = BranchId::new();
 
     // Create many transactions rapidly
@@ -426,7 +427,7 @@ fn rapid_transaction_creation() {
         .collect();
 
     // All should have unique IDs
-    let mut ids: Vec<u64> = txns.iter().map(|t| t.txn_id).collect();
+    let mut ids: Vec<TxnId> = txns.iter().map(|t| t.txn_id).collect();
     ids.sort();
     ids.dedup();
     assert_eq!(ids.len(), 1000);

--- a/tests/concurrency/conflict_detection.rs
+++ b/tests/concurrency/conflict_detection.rs
@@ -12,6 +12,7 @@ use strata_concurrency::transaction::{CASOperation, TransactionContext};
 use strata_concurrency::validation::{
     validate_cas_set, validate_read_set, validate_transaction, ConflictType,
 };
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{Key, Namespace};
 use strata_core::value::Value;
@@ -35,10 +36,10 @@ fn read_write_conflict_version_increased() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let v1 = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
@@ -50,7 +51,7 @@ fn read_write_conflict_version_increased() {
 
     // Update key
     store
-        .put_with_version_mode(key.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // Validate
@@ -70,10 +71,10 @@ fn read_write_conflict_key_deleted() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let v1 = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
@@ -84,7 +85,7 @@ fn read_write_conflict_key_deleted() {
     read_set.insert(key.clone(), v1);
 
     // Delete key
-    store.delete_with_version(&key, 2).unwrap();
+    store.delete_with_version(&key, CommitVersion(2)).unwrap();
 
     // Validate - should conflict (version changed to 0)
     let result = validate_read_set(&read_set, &*store).unwrap();
@@ -103,7 +104,7 @@ fn read_write_conflict_key_created() {
 
     // Create key
     store
-        .put_with_version_mode(key.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // Validate - should conflict (version changed from 0)
@@ -119,10 +120,10 @@ fn no_read_write_conflict_version_same() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let v1 = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
@@ -151,15 +152,15 @@ fn cas_conflict_version_mismatch() {
 
     // Initial value at version 1
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // Update to version 2
     store
-        .put_with_version_mode(key.clone(), Value::Int(200), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(200), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
     let v2 = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
@@ -195,7 +196,7 @@ fn cas_create_conflict_key_exists() {
 
     // Key already exists
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // CAS with expected_version=0 (key must not exist)
@@ -225,10 +226,10 @@ fn cas_success_version_matches() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let v1 = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
@@ -273,21 +274,21 @@ fn multiple_cas_operations() {
 
     // Setup
     store
-        .put_with_version_mode(key1.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key1.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let v1 = store
-        .get_versioned(&key1, u64::MAX)
+        .get_versioned(&key1, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
     store
-        .put_with_version_mode(key2.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key2.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // Update key2
     store
-        .put_with_version_mode(key2.clone(), Value::Int(20), 3, None, WriteMode::Append)
+        .put_with_version_mode(key2.clone(), Value::Int(20), CommitVersion(3), None, WriteMode::Append)
         .unwrap();
 
     // CAS on both - key1 should succeed, key2 should fail
@@ -322,20 +323,20 @@ fn transaction_validation_combines_all_checks() {
 
     // Setup
     store
-        .put_with_version_mode(key1.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key1.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let v1 = store
-        .get_versioned(&key1, u64::MAX)
+        .get_versioned(&key1, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
     store
-        .put_with_version_mode(key2.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key2.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // Transaction with read and CAS
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     txn.read_set.insert(key1.clone(), v1);
     txn.cas_set.push(CASOperation {
         key: key2.clone(),
@@ -345,10 +346,10 @@ fn transaction_validation_combines_all_checks() {
 
     // Modify both keys
     store
-        .put_with_version_mode(key1.clone(), Value::Int(10), 3, None, WriteMode::Append)
+        .put_with_version_mode(key1.clone(), Value::Int(10), CommitVersion(3), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key2.clone(), Value::Int(20), 4, None, WriteMode::Append)
+        .put_with_version_mode(key2.clone(), Value::Int(20), CommitVersion(4), None, WriteMode::Append)
         .unwrap();
 
     // Validate - should have both conflicts
@@ -409,13 +410,13 @@ fn large_read_set_validation() {
             .put_with_version_mode(
                 key.clone(),
                 Value::Int(i),
-                (i + 1) as u64,
+                CommitVersion((i + 1) as u64),
                 None,
                 WriteMode::Append,
             )
             .unwrap();
         let v = store
-            .get_versioned(&key, u64::MAX)
+            .get_versioned(&key, CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .version
@@ -441,13 +442,13 @@ fn large_read_set_with_one_conflict() {
             .put_with_version_mode(
                 key.clone(),
                 Value::Int(i),
-                (i + 1) as u64,
+                CommitVersion((i + 1) as u64),
                 None,
                 WriteMode::Append,
             )
             .unwrap();
         let v = store
-            .get_versioned(&key, u64::MAX)
+            .get_versioned(&key, CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .version
@@ -458,7 +459,7 @@ fn large_read_set_with_one_conflict() {
     // Modify one key
     let modified_key = create_test_key(branch_id, "key_50");
     store
-        .put_with_version_mode(modified_key, Value::Int(500), 101, None, WriteMode::Append)
+        .put_with_version_mode(modified_key, Value::Int(500), CommitVersion(101), None, WriteMode::Append)
         .unwrap();
 
     // Should have exactly one conflict

--- a/tests/concurrency/occ_invariants.rs
+++ b/tests/concurrency/occ_invariants.rs
@@ -9,6 +9,7 @@
 use std::sync::Arc;
 use strata_concurrency::transaction::TransactionContext;
 use strata_concurrency::validation::{validate_transaction, ConflictType, ValidationResult};
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{Key, Namespace};
 use strata_core::value::Value;
@@ -32,18 +33,18 @@ fn first_committer_wins_read_write_conflict() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // T1 reads the key
-    let mut t1 = TransactionContext::new(1, branch_id, 1);
-    let value = store.get_versioned(&key, u64::MAX).unwrap();
+    let mut t1 = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
+    let value = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     t1.read_set
         .insert(key.clone(), value.unwrap().version.as_u64());
 
     // T2 reads and commits first
-    let mut t2 = TransactionContext::new(2, branch_id, 1);
-    let value = store.get_versioned(&key, u64::MAX).unwrap();
+    let mut t2 = TransactionContext::new(TxnId(2), branch_id, CommitVersion(1));
+    let value = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     t2.read_set
         .insert(key.clone(), value.unwrap().version.as_u64());
     t2.write_set.insert(key.clone(), Value::Int(200));
@@ -54,7 +55,7 @@ fn first_committer_wins_read_write_conflict() {
 
     // Apply T2's write
     store
-        .put_with_version_mode(key.clone(), Value::Int(200), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(200), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // T1 tries to commit - should fail with read-write conflict
@@ -86,16 +87,16 @@ fn blind_writes_dont_conflict() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // T1 does a blind write (no read)
-    let mut t1 = TransactionContext::new(1, branch_id, 1);
+    let mut t1 = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     t1.write_set.insert(key.clone(), Value::Int(200));
 
     // T2 modifies the key
     store
-        .put_with_version_mode(key.clone(), Value::Int(300), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(300), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // T1 should still commit - blind writes don't conflict
@@ -114,18 +115,18 @@ fn read_only_transaction_always_commits() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // T1 only reads
-    let mut t1 = TransactionContext::new(1, branch_id, 1);
-    let value = store.get_versioned(&key, u64::MAX).unwrap();
+    let mut t1 = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
+    let value = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     t1.read_set
         .insert(key.clone(), value.unwrap().version.as_u64());
 
     // Another transaction modifies the key
     store
-        .put_with_version_mode(key.clone(), Value::Int(200), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(200), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // T1 should still commit - read-only transactions always succeed
@@ -153,22 +154,22 @@ fn write_skew_is_allowed() {
 
     // Initial balances
     store
-        .put_with_version_mode(key_a.clone(), Value::Int(50), 1, None, WriteMode::Append)
+        .put_with_version_mode(key_a.clone(), Value::Int(50), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key_b.clone(), Value::Int(50), 2, None, WriteMode::Append)
+        .put_with_version_mode(key_b.clone(), Value::Int(50), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // T1 reads A and B, writes A
-    let mut t1 = TransactionContext::new(1, branch_id, 1);
-    let val_a = store.get_versioned(&key_a, u64::MAX).unwrap().unwrap();
-    let val_b = store.get_versioned(&key_b, u64::MAX).unwrap().unwrap();
+    let mut t1 = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
+    let val_a = store.get_versioned(&key_a, CommitVersion::MAX).unwrap().unwrap();
+    let val_b = store.get_versioned(&key_b, CommitVersion::MAX).unwrap().unwrap();
     t1.read_set.insert(key_a.clone(), val_a.version.as_u64());
     t1.read_set.insert(key_b.clone(), val_b.version.as_u64());
     t1.write_set.insert(key_a.clone(), Value::Int(-10));
 
     // T2 reads A and B, writes B
-    let mut t2 = TransactionContext::new(2, branch_id, 1);
+    let mut t2 = TransactionContext::new(TxnId(2), branch_id, CommitVersion(1));
     t2.read_set.insert(key_a.clone(), val_a.version.as_u64());
     t2.read_set.insert(key_b.clone(), val_b.version.as_u64());
     t2.write_set.insert(key_b.clone(), Value::Int(-10));
@@ -199,25 +200,25 @@ fn conflict_reports_correct_versions() {
 
     // Initial value at version 1
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let v1 = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     // T1 reads at version 1
-    let mut t1 = TransactionContext::new(1, branch_id, 1);
+    let mut t1 = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     t1.read_set.insert(key.clone(), v1);
 
     // Update to version 2
     store
-        .put_with_version_mode(key.clone(), Value::Int(200), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(200), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
     let v2 = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
@@ -251,36 +252,36 @@ fn multiple_conflicts_all_reported() {
 
     // Initial values
     store
-        .put_with_version_mode(key1.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key1.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key2.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key2.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     let v1 = store
-        .get_versioned(&key1, u64::MAX)
+        .get_versioned(&key1, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
     let v2 = store
-        .get_versioned(&key2, u64::MAX)
+        .get_versioned(&key2, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     // T1 reads both
-    let mut t1 = TransactionContext::new(1, branch_id, 1);
+    let mut t1 = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     t1.read_set.insert(key1.clone(), v1);
     t1.read_set.insert(key2.clone(), v2);
 
     // Both keys modified
     store
-        .put_with_version_mode(key1.clone(), Value::Int(10), 3, None, WriteMode::Append)
+        .put_with_version_mode(key1.clone(), Value::Int(10), CommitVersion(3), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key2.clone(), Value::Int(20), 4, None, WriteMode::Append)
+        .put_with_version_mode(key2.clone(), Value::Int(20), CommitVersion(4), None, WriteMode::Append)
         .unwrap();
 
     // T1 writes
@@ -299,17 +300,17 @@ fn no_conflict_when_versions_match() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let version = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     // T1 reads and writes
-    let mut t1 = TransactionContext::new(1, branch_id, 1);
+    let mut t1 = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     t1.read_set.insert(key.clone(), version);
     t1.write_set.insert(key.clone(), Value::Int(200));
 
@@ -330,7 +331,7 @@ fn empty_transaction_validates() {
     let store = Arc::new(SegmentedStore::new());
     let branch_id = BranchId::new();
 
-    let t1 = TransactionContext::new(1, branch_id, 1);
+    let t1 = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     assert!(t1.is_read_only());
 
     let result = validate_transaction(&t1, &*store);
@@ -347,14 +348,14 @@ fn read_nonexistent_key_tracks_version_zero() {
     let key = create_test_key(branch_id, "ghost");
 
     // T1 reads nonexistent key (version 0)
-    let mut t1 = TransactionContext::new(1, branch_id, 1);
-    let result = store.get_versioned(&key, u64::MAX).unwrap();
+    let mut t1 = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
+    let result = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(result.is_none());
     t1.read_set.insert(key.clone(), 0); // Version 0 = doesn't exist
 
     // Key is created
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // T1 writes - should conflict (version changed from 0 to non-zero)
@@ -375,21 +376,21 @@ fn delete_after_read_causes_conflict() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let version = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     // T1 reads
-    let mut t1 = TransactionContext::new(1, branch_id, 1);
+    let mut t1 = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     t1.read_set.insert(key.clone(), version);
 
     // Key is deleted
-    store.delete_with_version(&key, 2).unwrap();
+    store.delete_with_version(&key, CommitVersion(2)).unwrap();
 
     // T1 writes
     t1.write_set.insert(key.clone(), Value::Int(200));

--- a/tests/concurrency/snapshot_isolation.rs
+++ b/tests/concurrency/snapshot_isolation.rs
@@ -7,6 +7,7 @@
 
 use std::sync::Arc;
 use strata_concurrency::transaction::TransactionContext;
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{Key, Namespace};
 use strata_core::value::Value;
@@ -29,10 +30,10 @@ fn snapshot_captures_state_at_creation() {
     let key = create_test_key(branch_id, "captured");
 
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
-    let result = store.get_versioned(&key, 1).unwrap();
+    let result = store.get_versioned(&key, CommitVersion(1)).unwrap();
     assert!(result.is_some());
     assert_eq!(result.unwrap().value, Value::Int(42));
 }
@@ -44,7 +45,7 @@ fn snapshot_is_immutable() {
     let key = create_test_key(branch_id, "immutable");
 
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // Capture current version as our "snapshot"
@@ -52,11 +53,11 @@ fn snapshot_is_immutable() {
 
     // Write a new version (simulating concurrent write)
     store
-        .put_with_version_mode(key.clone(), Value::Int(200), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(200), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // Reading at snapshot version should still see original value
-    let result = store.get_versioned(&key, snapshot_version).unwrap();
+    let result = store.get_versioned(&key, CommitVersion(snapshot_version)).unwrap();
     assert_eq!(result.unwrap().value, Value::Int(100));
 }
 
@@ -78,15 +79,15 @@ fn repeated_reads_return_same_value() {
     let key = create_test_key(branch_id, "repeat");
 
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     let version = store.version();
 
     // Read multiple times at the same version
-    let read1 = store.get_versioned(&key, version).unwrap();
-    let read2 = store.get_versioned(&key, version).unwrap();
-    let read3 = store.get_versioned(&key, version).unwrap();
+    let read1 = store.get_versioned(&key, CommitVersion(version)).unwrap();
+    let read2 = store.get_versioned(&key, CommitVersion(version)).unwrap();
+    let read3 = store.get_versioned(&key, CommitVersion(version)).unwrap();
 
     assert_eq!(read1, read2);
     assert_eq!(read2, read3);
@@ -98,8 +99,8 @@ fn missing_key_consistently_returns_none() {
     let branch_id = BranchId::new();
     let key = create_test_key(branch_id, "missing");
 
-    let read1 = store.get_versioned(&key, 1).unwrap();
-    let read2 = store.get_versioned(&key, 1).unwrap();
+    let read1 = store.get_versioned(&key, CommitVersion(1)).unwrap();
+    let read2 = store.get_versioned(&key, CommitVersion(1)).unwrap();
 
     assert!(read1.is_none());
     assert!(read2.is_none());
@@ -115,7 +116,7 @@ fn transaction_sees_own_uncommitted_writes() {
     let key = create_test_key(branch_id, "ryw");
 
     // Transaction without snapshot (for testing)
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
 
     // Write a value
     txn.write_set.insert(key.clone(), Value::Int(42));
@@ -133,7 +134,7 @@ fn transaction_sees_own_deletes() {
     let branch_id = BranchId::new();
     let key = create_test_key(branch_id, "deleted");
 
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
 
     // Delete a key
     txn.delete_set.insert(key.clone());
@@ -147,7 +148,7 @@ fn write_then_delete_sees_delete() {
     let branch_id = BranchId::new();
     let key = create_test_key(branch_id, "write_del");
 
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
 
     // Write then delete
     txn.write_set.insert(key.clone(), Value::Int(42));
@@ -170,17 +171,17 @@ fn snapshot_scan_prefix_returns_matching_keys() {
     for i in 0..10 {
         let key = Key::new_kv(ns.clone(), format!("prefix_{}", i));
         store
-            .put_with_version_mode(key, Value::Int(i), (i + 1) as u64, None, WriteMode::Append)
+            .put_with_version_mode(key, Value::Int(i), CommitVersion((i + 1) as u64), None, WriteMode::Append)
             .unwrap();
     }
 
     // Add some non-matching keys
     let other_key = Key::new_kv(ns.clone(), "other_key");
     store
-        .put_with_version_mode(other_key, Value::Int(999), 11, None, WriteMode::Append)
+        .put_with_version_mode(other_key, Value::Int(999), CommitVersion(11), None, WriteMode::Append)
         .unwrap();
 
-    let version = store.version();
+    let version = CommitVersion(store.version());
     let prefix = Key::new_kv(ns.clone(), "prefix_");
     let results = Storage::scan_prefix(&*store, &prefix, version).unwrap();
 
@@ -194,7 +195,7 @@ fn snapshot_scan_empty_prefix() {
     let ns = Arc::new(Namespace::for_branch(branch_id));
 
     let prefix = Key::new_kv(ns.clone(), "anything");
-    let results = Storage::scan_prefix(&*store, &prefix, 1).unwrap();
+    let results = Storage::scan_prefix(&*store, &prefix, CommitVersion(1)).unwrap();
 
     assert!(results.is_empty());
 }
@@ -210,14 +211,14 @@ fn store_can_be_shared_via_arc() {
     let key = create_test_key(branch_id, "shared");
 
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     let version = store.version();
 
     // Share via Arc clone
     let store2 = Arc::clone(&store);
-    let result = store2.get_versioned(&key, version).unwrap();
+    let result = store2.get_versioned(&key, CommitVersion(version)).unwrap();
     assert_eq!(result.unwrap().value, Value::Int(42));
 }
 
@@ -228,23 +229,23 @@ fn versioned_reads_are_independent() {
     let key = create_test_key(branch_id, "independent");
 
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let version1 = store.version();
 
     // Write a new version
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
     let version2 = store.version();
 
     // Both versions retain their values
     assert_eq!(
-        store.get_versioned(&key, version1).unwrap().unwrap().value,
+        store.get_versioned(&key, CommitVersion(version1)).unwrap().unwrap().value,
         Value::Int(42)
     );
     assert_eq!(
-        store.get_versioned(&key, version2).unwrap().unwrap().value,
+        store.get_versioned(&key, CommitVersion(version2)).unwrap().unwrap().value,
         Value::Int(100)
     );
 }
@@ -271,7 +272,7 @@ fn snapshot_concurrent_reads() {
     let key = create_test_key(branch_id, "concurrent");
 
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     let version = store.version();
@@ -282,7 +283,7 @@ fn snapshot_concurrent_reads() {
             let key = key.clone();
             thread::spawn(move || {
                 for _ in 0..1000 {
-                    let result = store.get_versioned(&key, version).unwrap();
+                    let result = store.get_versioned(&key, CommitVersion(version)).unwrap();
                     assert_eq!(result.unwrap().value, Value::Int(42));
                 }
             })
@@ -310,7 +311,7 @@ fn empty_store_get_returns_none() {
     let branch_id = BranchId::new();
     let key = create_test_key(branch_id, "any");
 
-    let result = store.get_versioned(&key, 0).unwrap();
+    let result = store.get_versioned(&key, CommitVersion(0)).unwrap();
     assert!(result.is_none());
 }
 
@@ -321,7 +322,7 @@ fn empty_store_scan_returns_empty() {
     let ns = Arc::new(Namespace::for_branch(branch_id));
     let prefix = Key::new_kv(ns, "any");
 
-    let results = Storage::scan_prefix(&store, &prefix, 0).unwrap();
+    let results = Storage::scan_prefix(&store, &prefix, CommitVersion(0)).unwrap();
     assert!(results.is_empty());
 }
 
@@ -340,12 +341,12 @@ fn transaction_context_ignores_concurrent_store_writes() {
 
     // Write initial value at version 1
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // Begin transaction — captures start_version
-    let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
-    assert_eq!(txn.start_version, 1);
+    let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
+    assert_eq!(txn.start_version, CommitVersion(1));
 
     // First read through transaction sees initial value
     let read1 = txn.get(&key).unwrap();
@@ -353,7 +354,7 @@ fn transaction_context_ignores_concurrent_store_writes() {
 
     // Concurrent write to the SAME key at a higher version
     store
-        .put_with_version_mode(key.clone(), Value::Int(999), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(999), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // Second read through transaction MUST still see the old value
@@ -377,19 +378,19 @@ fn transaction_context_scan_ignores_concurrent_writes() {
     let key_a = Key::new_kv(ns.clone(), "scan_a");
     let key_b = Key::new_kv(ns.clone(), "scan_b");
     store
-        .put_with_version_mode(key_a.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key_a.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key_b.clone(), Value::Int(2), 1, None, WriteMode::Append)
+        .put_with_version_mode(key_b.clone(), Value::Int(2), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // Begin transaction
-    let mut txn = TransactionContext::with_store(1, branch_id, Arc::clone(&store));
+    let mut txn = TransactionContext::with_store(TxnId(1), branch_id, Arc::clone(&store));
 
     // Concurrent write: add a third key at version 2
     let key_c = Key::new_kv(ns.clone(), "scan_c");
     store
-        .put_with_version_mode(key_c, Value::Int(3), 2, None, WriteMode::Append)
+        .put_with_version_mode(key_c, Value::Int(3), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // Scan through transaction should only see keys at version <= 1

--- a/tests/concurrency/stress.rs
+++ b/tests/concurrency/stress.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use strata_concurrency::manager::TransactionManager;
 use strata_concurrency::transaction::TransactionContext;
 use strata_concurrency::validation::validate_transaction;
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{Key, Namespace};
 use strata_core::value::Value;
@@ -26,14 +27,14 @@ fn create_test_key(branch_id: BranchId, name: &str) -> Key {
 #[ignore]
 fn stress_concurrent_read_write() {
     let store = Arc::new(SegmentedStore::new());
-    let manager = Arc::new(TransactionManager::new(1));
+    let manager = Arc::new(TransactionManager::new(CommitVersion(1)));
     let branch_id = BranchId::new();
 
     // Pre-populate
     for i in 0..100 {
         let key = create_test_key(branch_id, &format!("key_{}", i));
         store
-            .put_with_version_mode(key, Value::Int(i), (i + 1) as u64, None, WriteMode::Append)
+            .put_with_version_mode(key, Value::Int(i), CommitVersion((i + 1) as u64), None, WriteMode::Append)
             .unwrap();
     }
 
@@ -58,11 +59,11 @@ fn stress_concurrent_read_write() {
 
                     loop {
                         // Read-modify-write with retry
-                        let current = store.get_versioned(&key, u64::MAX).unwrap().unwrap();
+                        let current = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
                         let version = current.version.as_u64();
 
                         let txn_id = manager.next_txn_id().unwrap();
-                        let mut txn = TransactionContext::new(txn_id, branch_id, version);
+                        let mut txn = TransactionContext::new(txn_id, branch_id, CommitVersion(version));
                         txn.read_set.insert(key.clone(), version);
                         txn.write_set
                             .insert(key.clone(), Value::Int((thread_id * 1000 + iter) as i64));
@@ -112,12 +113,12 @@ fn stress_concurrent_read_write() {
 #[ignore]
 fn stress_transaction_throughput() {
     let store = Arc::new(SegmentedStore::new());
-    let manager = TransactionManager::new(1);
+    let manager = TransactionManager::new(CommitVersion(1));
     let branch_id = BranchId::new();
 
     let key = create_test_key(branch_id, "counter");
     store
-        .put_with_version_mode(key.clone(), Value::Int(0), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(0), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     let duration = Duration::from_secs(5);
@@ -127,11 +128,11 @@ fn stress_transaction_throughput() {
     let mut next_version = 2u64;
 
     while start.elapsed() < duration {
-        let current = store.get_versioned(&key, u64::MAX).unwrap().unwrap();
+        let current = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
         let version = current.version.as_u64();
 
         let txn_id = manager.next_txn_id().unwrap();
-        let mut txn = TransactionContext::new(txn_id, branch_id, version);
+        let mut txn = TransactionContext::new(txn_id, branch_id, CommitVersion(version));
         txn.read_set.insert(key.clone(), version);
 
         if let Value::Int(v) = current.value {
@@ -145,7 +146,7 @@ fn stress_transaction_throughput() {
                     .put_with_version_mode(
                         key.clone(),
                         Value::Int(v + 1),
-                        next_version,
+                        CommitVersion(next_version),
                         None,
                         WriteMode::Append,
                     )
@@ -181,7 +182,7 @@ fn stress_large_transaction() {
     let branch_id = BranchId::new();
 
     // Create transaction with 10K operations
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
 
     let start = Instant::now();
 
@@ -214,7 +215,7 @@ fn stress_large_transaction() {
 #[ignore]
 fn stress_many_branches() {
     let store = Arc::new(SegmentedStore::new());
-    let manager = Arc::new(TransactionManager::new(1));
+    let manager = Arc::new(TransactionManager::new(CommitVersion(1)));
     let barrier = Arc::new(Barrier::new(100));
     let commits = Arc::new(AtomicU64::new(0));
 
@@ -233,7 +234,7 @@ fn stress_many_branches() {
 
                 for i in 0..100 {
                     let txn_id = manager.next_txn_id().unwrap();
-                    let mut txn = TransactionContext::new(txn_id, branch_id, 1);
+                    let mut txn = TransactionContext::new(txn_id, branch_id, CommitVersion(1));
                     txn.write_set.insert(key.clone(), Value::Int(i));
 
                     let result = validate_transaction(&txn, &*store);
@@ -276,17 +277,17 @@ fn stress_long_running_transaction() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(0), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(0), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let initial_version = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     // Start a long-running transaction
-    let mut long_txn = TransactionContext::new(1, branch_id, initial_version);
+    let mut long_txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(initial_version));
     long_txn.read_set.insert(key.clone(), initial_version);
 
     // Spawn concurrent writers
@@ -298,7 +299,7 @@ fn stress_long_running_transaction() {
                 .put_with_version_mode(
                     key_clone.clone(),
                     Value::Int(i),
-                    (i + 1) as u64,
+                    CommitVersion((i + 1) as u64),
                     None,
                     WriteMode::Append,
                 )
@@ -328,14 +329,14 @@ fn stress_long_running_transaction() {
 #[ignore]
 fn stress_sustained_workload() {
     let store = Arc::new(SegmentedStore::new());
-    let manager = Arc::new(TransactionManager::new(1));
+    let manager = Arc::new(TransactionManager::new(CommitVersion(1)));
     let branch_id = BranchId::new();
 
     // Pre-populate
     for i in 0..50 {
         let key = create_test_key(branch_id, &format!("key_{}", i));
         store
-            .put_with_version_mode(key, Value::Int(i), (i + 1) as u64, None, WriteMode::Append)
+            .put_with_version_mode(key, Value::Int(i), CommitVersion((i + 1) as u64), None, WriteMode::Append)
             .unwrap();
     }
 
@@ -362,11 +363,11 @@ fn stress_sustained_workload() {
 
                     if ops.load(Ordering::Relaxed).is_multiple_of(3) {
                         // Write
-                        let current = store.get_versioned(&key, u64::MAX).unwrap().unwrap();
+                        let current = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
                         let version = current.version.as_u64();
 
                         let txn_id = manager.next_txn_id().unwrap();
-                        let mut txn = TransactionContext::new(txn_id, branch_id, version);
+                        let mut txn = TransactionContext::new(txn_id, branch_id, CommitVersion(version));
                         txn.read_set.insert(key.clone(), version);
                         txn.write_set
                             .insert(key.clone(), Value::Int(thread_id as i64));
@@ -386,7 +387,7 @@ fn stress_sustained_workload() {
                         }
                     } else {
                         // Read
-                        let _ = store.get_versioned(&key, u64::MAX);
+                        let _ = store.get_versioned(&key, CommitVersion::MAX);
                     }
 
                     ops.fetch_add(1, Ordering::Relaxed);

--- a/tests/concurrency/transaction_lifecycle.rs
+++ b/tests/concurrency/transaction_lifecycle.rs
@@ -8,6 +8,7 @@
 use std::sync::Arc;
 use strata_concurrency::transaction::TransactionContext;
 use strata_concurrency::validation::validate_transaction;
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{Key, Namespace};
 use strata_core::value::Value;
@@ -30,7 +31,7 @@ fn begin_commit_makes_writes_permanent() {
     let key = create_test_key(branch_id, "committed");
 
     // Begin transaction
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     assert!(txn.is_active());
 
     // Write
@@ -47,11 +48,11 @@ fn begin_commit_makes_writes_permanent() {
 
     // Apply write (simulating what manager does)
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // Value should be visible
-    let stored = store.get_versioned(&key, u64::MAX).unwrap();
+    let stored = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(stored.is_some());
     assert_eq!(stored.unwrap().value, Value::Int(42));
 }
@@ -59,7 +60,7 @@ fn begin_commit_makes_writes_permanent() {
 #[test]
 fn committed_status_is_committed() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
 
     txn.mark_validating().unwrap();
     txn.mark_committed().unwrap();
@@ -82,7 +83,7 @@ fn begin_abort_discards_writes() {
     let key = create_test_key(branch_id, "aborted");
 
     // Begin transaction
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
 
     // Write (not yet applied to store)
     txn.write_set.insert(key.clone(), Value::Int(42));
@@ -92,7 +93,7 @@ fn begin_abort_discards_writes() {
     assert!(txn.is_aborted());
 
     // Write should NOT be in store
-    let stored = store.get_versioned(&key, u64::MAX).unwrap();
+    let stored = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(
         stored.is_none(),
         "Aborted transaction writes should not be visible"
@@ -102,7 +103,7 @@ fn begin_abort_discards_writes() {
 #[test]
 fn abort_reason_recorded_in_status() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
 
     txn.mark_aborted("validation failed: conflict".to_string())
         .unwrap();
@@ -123,23 +124,23 @@ fn validation_failure_leads_to_abort() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let version = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     // Transaction reads key
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     txn.read_set.insert(key.clone(), version);
     txn.write_set.insert(key.clone(), Value::Int(10));
 
     // Concurrent modification
     store
-        .put_with_version_mode(key.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // Validate - should fail
@@ -162,7 +163,7 @@ fn reset_clears_all_sets() {
     let branch_id = BranchId::new();
     let key = create_test_key(branch_id, "reset");
 
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
 
     // Add some data
     txn.read_set.insert(key.clone(), 1);
@@ -174,7 +175,7 @@ fn reset_clears_all_sets() {
     assert!(!txn.delete_set.is_empty());
 
     // Reset
-    txn.reset(2, branch_id, None);
+    txn.reset(TxnId(2), branch_id, None);
 
     // All sets should be empty
     assert!(txn.read_set.is_empty());
@@ -183,15 +184,15 @@ fn reset_clears_all_sets() {
     assert!(txn.cas_set.is_empty());
 
     // New values
-    assert_eq!(txn.txn_id, 2);
-    assert_eq!(txn.start_version, 0); // 0 when no snapshot provided
+    assert_eq!(txn.txn_id, TxnId(2));
+    assert_eq!(txn.start_version, CommitVersion(0)); // 0 when no snapshot provided
     assert!(txn.is_active());
 }
 
 #[test]
 fn reset_preserves_capacity() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
 
     // Add many items to force allocation
     for i in 0..100 {
@@ -204,7 +205,7 @@ fn reset_preserves_capacity() {
     let write_capacity_before = txn.write_set.capacity();
 
     // Reset
-    txn.reset(2, branch_id, None);
+    txn.reset(TxnId(2), branch_id, None);
 
     // Capacity should be preserved (no reallocation needed for next use)
     assert!(txn.read_set.capacity() >= read_capacity_before);
@@ -214,14 +215,14 @@ fn reset_preserves_capacity() {
 #[test]
 fn reset_after_abort_allows_reuse() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
 
     // Abort
     txn.mark_aborted("test".to_string()).unwrap();
     assert!(txn.is_aborted());
 
     // Reset
-    txn.reset(2, branch_id, None);
+    txn.reset(TxnId(2), branch_id, None);
 
     // Should be active again
     assert!(txn.is_active());
@@ -230,7 +231,7 @@ fn reset_after_abort_allows_reuse() {
 #[test]
 fn reset_after_commit_allows_reuse() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
 
     // Commit
     txn.mark_validating().unwrap();
@@ -238,7 +239,7 @@ fn reset_after_commit_allows_reuse() {
     assert!(txn.is_committed());
 
     // Reset
-    txn.reset(2, branch_id, None);
+    txn.reset(TxnId(2), branch_id, None);
 
     // Should be active again
     assert!(txn.is_active());
@@ -256,20 +257,20 @@ fn read_modify_write_workflow() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let version = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     // Read-modify-write
-    let mut txn = TransactionContext::new(1, branch_id, version);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(version));
 
     // Read (track in read_set)
-    let current = store.get_versioned(&key, u64::MAX).unwrap().unwrap();
+    let current = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap();
     txn.read_set.insert(key.clone(), current.version.as_u64());
 
     // Modify
@@ -286,11 +287,11 @@ fn read_modify_write_workflow() {
 
     // Apply
     store
-        .put_with_version_mode(key.clone(), Value::Int(110), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(110), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // Verify
-    let final_value = store.get_versioned(&key, u64::MAX).unwrap().unwrap().value;
+    let final_value = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap().value;
     assert_eq!(final_value, Value::Int(110));
 }
 
@@ -305,28 +306,28 @@ fn multi_key_transaction_workflow() {
 
     // Initial values
     store
-        .put_with_version_mode(key1.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key1.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key2.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key2.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
     // key3 doesn't exist
 
     let v1 = store
-        .get_versioned(&key1, u64::MAX)
+        .get_versioned(&key1, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
     let v2 = store
-        .get_versioned(&key2, u64::MAX)
+        .get_versioned(&key2, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     // Transaction: read k1, write k2, create k3
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     txn.read_set.insert(key1.clone(), v1);
     txn.read_set.insert(key2.clone(), v2);
     txn.write_set.insert(key2.clone(), Value::Int(20));
@@ -341,19 +342,19 @@ fn multi_key_transaction_workflow() {
 
     // Apply all writes
     store
-        .put_with_version_mode(key2.clone(), Value::Int(20), 3, None, WriteMode::Append)
+        .put_with_version_mode(key2.clone(), Value::Int(20), CommitVersion(3), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key3.clone(), Value::Int(3), 4, None, WriteMode::Append)
+        .put_with_version_mode(key3.clone(), Value::Int(3), CommitVersion(4), None, WriteMode::Append)
         .unwrap();
 
     // Verify
     assert_eq!(
-        store.get_versioned(&key2, u64::MAX).unwrap().unwrap().value,
+        store.get_versioned(&key2, CommitVersion::MAX).unwrap().unwrap().value,
         Value::Int(20)
     );
     assert_eq!(
-        store.get_versioned(&key3, u64::MAX).unwrap().unwrap().value,
+        store.get_versioned(&key3, CommitVersion::MAX).unwrap().unwrap().value,
         Value::Int(3)
     );
 }
@@ -366,17 +367,17 @@ fn delete_workflow() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     let version = store
-        .get_versioned(&key, u64::MAX)
+        .get_versioned(&key, CommitVersion::MAX)
         .unwrap()
         .unwrap()
         .version
         .as_u64();
 
     // Transaction: read then delete
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
     txn.read_set.insert(key.clone(), version);
     txn.delete_set.insert(key.clone());
 
@@ -388,10 +389,10 @@ fn delete_workflow() {
     txn.mark_committed().unwrap();
 
     // Apply delete
-    store.delete_with_version(&key, 2).unwrap();
+    store.delete_with_version(&key, CommitVersion(2)).unwrap();
 
     // Verify deleted
-    assert!(store.get_versioned(&key, u64::MAX).unwrap().is_none());
+    assert!(store.get_versioned(&key, CommitVersion::MAX).unwrap().is_none());
 }
 
 // ============================================================================
@@ -403,7 +404,7 @@ fn empty_transaction_commits() {
     let store = Arc::new(SegmentedStore::new());
     let branch_id = BranchId::new();
 
-    let mut txn = TransactionContext::new(1, branch_id, 1);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(1));
 
     txn.mark_validating().unwrap();
     let result = validate_transaction(&txn, &*store);
@@ -420,18 +421,18 @@ fn many_sequential_transactions() {
     let key = create_test_key(branch_id, "sequential");
 
     store
-        .put_with_version_mode(key.clone(), Value::Int(0), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(0), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     for i in 1..=10 {
         let version = store
-            .get_versioned(&key, u64::MAX)
+            .get_versioned(&key, CommitVersion::MAX)
             .unwrap()
             .unwrap()
             .version
             .as_u64();
 
-        let mut txn = TransactionContext::new(i as u64, branch_id, version);
+        let mut txn = TransactionContext::new(TxnId(i as u64), branch_id, CommitVersion(version));
         txn.read_set.insert(key.clone(), version);
         txn.write_set.insert(key.clone(), Value::Int(i));
 
@@ -448,7 +449,7 @@ fn many_sequential_transactions() {
             .put_with_version_mode(
                 key.clone(),
                 Value::Int(i),
-                (i + 1) as u64,
+                CommitVersion((i + 1) as u64),
                 None,
                 WriteMode::Append,
             )
@@ -456,6 +457,6 @@ fn many_sequential_transactions() {
     }
 
     // Final value should be 10
-    let final_value = store.get_versioned(&key, u64::MAX).unwrap().unwrap().value;
+    let final_value = store.get_versioned(&key, CommitVersion::MAX).unwrap().unwrap().value;
     assert_eq!(final_value, Value::Int(10));
 }

--- a/tests/concurrency/transaction_states.rs
+++ b/tests/concurrency/transaction_states.rs
@@ -6,6 +6,7 @@
 //! - Active → Aborted (explicit)
 
 use strata_concurrency::transaction::{TransactionContext, TransactionStatus};
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::BranchId;
 
 // ============================================================================
@@ -15,7 +16,7 @@ use strata_core::BranchId;
 #[test]
 fn new_transaction_is_active() {
     let branch_id = BranchId::new();
-    let txn = TransactionContext::new(1, branch_id, 100);
+    let txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     assert!(txn.is_active());
     assert!(!txn.is_committed());
@@ -26,7 +27,7 @@ fn new_transaction_is_active() {
 #[test]
 fn transaction_status_active_variant() {
     let branch_id = BranchId::new();
-    let txn = TransactionContext::new(1, branch_id, 100);
+    let txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     match txn.status.clone() {
         TransactionStatus::Active => {}
@@ -41,7 +42,7 @@ fn transaction_status_active_variant() {
 #[test]
 fn active_to_validating_succeeds() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     assert!(txn.is_active());
     txn.mark_validating().unwrap();
@@ -51,7 +52,7 @@ fn active_to_validating_succeeds() {
 #[test]
 fn validating_to_committed_succeeds() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     txn.mark_validating().unwrap();
     txn.mark_committed().unwrap();
@@ -65,7 +66,7 @@ fn validating_to_committed_succeeds() {
 #[test]
 fn validating_to_aborted_succeeds() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     txn.mark_validating().unwrap();
     txn.mark_aborted("validation failed".to_string()).unwrap();
@@ -78,7 +79,7 @@ fn validating_to_aborted_succeeds() {
 #[test]
 fn active_to_aborted_succeeds() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     txn.mark_aborted("explicit abort".to_string()).unwrap();
 
@@ -89,7 +90,7 @@ fn active_to_aborted_succeeds() {
 #[test]
 fn aborted_status_contains_reason() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     txn.mark_aborted("conflict detected".to_string()).unwrap();
 
@@ -104,7 +105,7 @@ fn aborted_status_contains_reason() {
 #[test]
 fn committed_status_is_committed() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     txn.mark_validating().unwrap();
     txn.mark_committed().unwrap();
@@ -119,7 +120,7 @@ fn committed_status_is_committed() {
 #[test]
 fn double_mark_validating_fails() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     txn.mark_validating().unwrap();
     let result = txn.mark_validating();
@@ -135,7 +136,7 @@ fn double_mark_validating_fails() {
 #[test]
 fn commit_while_active_fails() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     // Skip validating state
     let result = txn.mark_committed();
@@ -151,7 +152,7 @@ fn commit_while_active_fails() {
 #[test]
 fn commit_while_aborted_fails() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     txn.mark_aborted("aborted".to_string()).unwrap();
     let result = txn.mark_committed();
@@ -167,7 +168,7 @@ fn commit_while_aborted_fails() {
 #[test]
 fn commit_while_already_committed_fails() {
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     txn.mark_validating().unwrap();
     txn.mark_committed().unwrap();
@@ -188,17 +189,17 @@ fn commit_while_already_committed_fails() {
 #[test]
 fn transaction_preserves_ids() {
     let branch_id = BranchId::new();
-    let txn = TransactionContext::new(42, branch_id, 100);
+    let txn = TransactionContext::new(TxnId(42), branch_id, CommitVersion(100));
 
-    assert_eq!(txn.txn_id, 42);
+    assert_eq!(txn.txn_id, TxnId(42));
     assert_eq!(txn.branch_id, branch_id);
-    assert_eq!(txn.start_version, 100);
+    assert_eq!(txn.start_version, CommitVersion(100));
 }
 
 #[test]
 fn transaction_tracks_elapsed_time() {
     let branch_id = BranchId::new();
-    let txn = TransactionContext::new(1, branch_id, 100);
+    let txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     let elapsed = txn.elapsed();
     assert!(elapsed.as_secs() < 1, "Elapsed should be very small");
@@ -209,7 +210,7 @@ fn transaction_expiration_check() {
     use std::time::Duration;
 
     let branch_id = BranchId::new();
-    let txn = TransactionContext::new(1, branch_id, 100);
+    let txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     // Should not be expired with 1 hour timeout
     assert!(!txn.is_expired(Duration::from_secs(3600)));
@@ -225,7 +226,7 @@ fn transaction_expiration_check() {
 #[test]
 fn empty_transaction_is_read_only() {
     let branch_id = BranchId::new();
-    let txn = TransactionContext::new(1, branch_id, 100);
+    let txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     assert!(txn.is_read_only());
 }
@@ -237,7 +238,7 @@ fn transaction_with_write_is_not_read_only() {
     use strata_core::value::Value;
 
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     let key = Key::new_kv(Arc::new(Namespace::for_branch(branch_id)), "test");
     txn.write_set.insert(key, Value::Int(42));
@@ -251,7 +252,7 @@ fn transaction_with_delete_is_not_read_only() {
     use strata_core::types::{Key, Namespace};
 
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     let key = Key::new_kv(Arc::new(Namespace::for_branch(branch_id)), "test");
     txn.delete_set.insert(key);
@@ -267,7 +268,7 @@ fn transaction_with_cas_is_not_read_only() {
     use strata_core::value::Value;
 
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     let key = Key::new_kv(Arc::new(Namespace::for_branch(branch_id)), "test");
     txn.cas_set.push(CASOperation {
@@ -285,7 +286,7 @@ fn transaction_with_only_reads_is_read_only() {
     use strata_core::types::{Key, Namespace};
 
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     let key = Key::new_kv(Arc::new(Namespace::for_branch(branch_id)), "test");
     txn.read_set.insert(key, 1);
@@ -304,7 +305,7 @@ fn pending_operations_count() {
     use strata_core::value::Value;
 
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     let ns = Arc::new(Namespace::for_branch(branch_id));
 
@@ -327,7 +328,7 @@ fn read_count_tracks_reads() {
     use strata_core::types::{Key, Namespace};
 
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     let ns = Arc::new(Namespace::for_branch(branch_id));
 
@@ -345,7 +346,7 @@ fn write_count_tracks_only_writes() {
     use strata_core::value::Value;
 
     let branch_id = BranchId::new();
-    let mut txn = TransactionContext::new(1, branch_id, 100);
+    let mut txn = TransactionContext::new(TxnId(1), branch_id, CommitVersion(100));
 
     let ns = Arc::new(Namespace::for_branch(branch_id));
 

--- a/tests/concurrency/version_counter.rs
+++ b/tests/concurrency/version_counter.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
 use strata_concurrency::manager::TransactionManager;
+use strata_core::id::{CommitVersion, TxnId};
 
 // ============================================================================
 // Monotonic Increment
@@ -17,9 +18,9 @@ use strata_concurrency::manager::TransactionManager;
 
 #[test]
 fn versions_monotonically_increase() {
-    let manager = TransactionManager::new(1);
+    let manager = TransactionManager::new(CommitVersion(1));
 
-    let mut prev = 0u64;
+    let mut prev = CommitVersion::ZERO;
     for _ in 0..100 {
         let v = manager.allocate_version().unwrap();
         assert!(v > prev, "Version should increase: {} -> {}", prev, v);
@@ -29,9 +30,9 @@ fn versions_monotonically_increase() {
 
 #[test]
 fn txn_ids_monotonically_increase() {
-    let manager = TransactionManager::new(1);
+    let manager = TransactionManager::new(CommitVersion(1));
 
-    let mut prev = 0u64;
+    let mut prev = TxnId::ZERO;
     for _ in 0..100 {
         let id = manager.next_txn_id().unwrap();
         assert!(id > prev, "Txn ID should increase: {} -> {}", prev, id);
@@ -41,11 +42,11 @@ fn txn_ids_monotonically_increase() {
 
 #[test]
 fn version_starts_from_initial() {
-    let manager = TransactionManager::new(1000);
+    let manager = TransactionManager::new(CommitVersion(1000));
 
     let v = manager.allocate_version().unwrap();
     assert!(
-        v >= 1000,
+        v >= CommitVersion(1000),
         "First version should be >= initial (1000), got {}",
         v
     );
@@ -57,7 +58,7 @@ fn version_starts_from_initial() {
 
 #[test]
 fn concurrent_version_allocation_unique() {
-    let manager = Arc::new(TransactionManager::new(1));
+    let manager = Arc::new(TransactionManager::new(CommitVersion(1)));
     let barrier = Arc::new(Barrier::new(8));
     let count_per_thread = 1000;
 
@@ -77,7 +78,7 @@ fn concurrent_version_allocation_unique() {
         })
         .collect();
 
-    let mut all_versions: Vec<u64> = handles
+    let mut all_versions: Vec<CommitVersion> = handles
         .into_iter()
         .flat_map(|h| h.join().unwrap())
         .collect();
@@ -97,7 +98,7 @@ fn concurrent_version_allocation_unique() {
 
 #[test]
 fn concurrent_txn_id_allocation_unique() {
-    let manager = Arc::new(TransactionManager::new(1));
+    let manager = Arc::new(TransactionManager::new(CommitVersion(1)));
     let barrier = Arc::new(Barrier::new(4));
 
     let handles: Vec<_> = (0..4)
@@ -116,7 +117,7 @@ fn concurrent_txn_id_allocation_unique() {
         })
         .collect();
 
-    let mut all_ids: Vec<u64> = handles
+    let mut all_ids: Vec<TxnId> = handles
         .into_iter()
         .flat_map(|h| h.join().unwrap())
         .collect();
@@ -130,7 +131,7 @@ fn concurrent_txn_id_allocation_unique() {
 
 #[test]
 fn high_contention_version_allocation() {
-    let manager = Arc::new(TransactionManager::new(1));
+    let manager = Arc::new(TransactionManager::new(CommitVersion(1)));
     let barrier = Arc::new(Barrier::new(16));
     let total_allocated = Arc::new(AtomicU64::new(0));
 
@@ -164,7 +165,7 @@ fn high_contention_version_allocation() {
 
 #[test]
 fn sequential_allocation_no_gaps() {
-    let manager = TransactionManager::new(100);
+    let manager = TransactionManager::new(CommitVersion(100));
 
     let mut versions = Vec::new();
     for _ in 0..100 {
@@ -175,7 +176,7 @@ fn sequential_allocation_no_gaps() {
     for i in 1..versions.len() {
         assert_eq!(
             versions[i],
-            versions[i - 1] + 1,
+            versions[i - 1].next(),
             "Gap between {} and {}",
             versions[i - 1],
             versions[i]
@@ -190,11 +191,11 @@ fn sequential_allocation_no_gaps() {
 #[test]
 fn manager_with_txn_id_continues_from_max() {
     // Simulating recovery where max txn_id was 1000
-    let manager = TransactionManager::with_txn_id(100, 1000);
+    let manager = TransactionManager::with_txn_id(CommitVersion(100), TxnId(1000));
 
     let id = manager.next_txn_id().unwrap();
     assert!(
-        id > 1000,
+        id > TxnId(1000),
         "After recovery, txn_id should be > max (1000), got {}",
         id
     );
@@ -202,23 +203,23 @@ fn manager_with_txn_id_continues_from_max() {
 
 #[test]
 fn manager_initial_version_respected() {
-    let manager = TransactionManager::new(5000);
+    let manager = TransactionManager::new(CommitVersion(5000));
 
     let v = manager.allocate_version().unwrap();
-    assert!(v >= 5000, "Initial version should be respected");
+    assert!(v >= CommitVersion(5000), "Initial version should be respected");
 }
 
 #[test]
 fn manager_recovery_scenario() {
     // Simulate: had transactions up to version 10000 and txn_id 500
-    let manager = TransactionManager::with_txn_id(10000, 500);
+    let manager = TransactionManager::with_txn_id(CommitVersion(10000), TxnId(500));
 
     // New allocations should continue from those points
     let v1 = manager.allocate_version().unwrap();
     let id1 = manager.next_txn_id().unwrap();
 
-    assert!(v1 >= 10000, "Version should continue from 10000");
-    assert!(id1 > 500, "Txn ID should continue from 500");
+    assert!(v1 >= CommitVersion(10000), "Version should continue from 10000");
+    assert!(id1 > TxnId(500), "Txn ID should continue from 500");
 
     // Subsequent allocations should still be monotonic
     let v2 = manager.allocate_version().unwrap();
@@ -235,7 +236,7 @@ fn manager_recovery_scenario() {
 #[test]
 fn version_allocation_thread_safe() {
     // This test verifies the AtomicU64 is working correctly
-    let manager = Arc::new(TransactionManager::new(0));
+    let manager = Arc::new(TransactionManager::new(CommitVersion(0)));
 
     let handles: Vec<_> = (0..4)
         .map(|_| {
@@ -244,7 +245,7 @@ fn version_allocation_thread_safe() {
                 for _ in 0..1000 {
                     let v = manager.allocate_version().unwrap();
                     // Each version should be valid (non-zero after first allocation)
-                    assert!(v > 0 || v == 1);
+                    assert!(v > CommitVersion::ZERO || v == CommitVersion(1));
                 }
             })
         })
@@ -257,7 +258,7 @@ fn version_allocation_thread_safe() {
 
 #[test]
 fn interleaved_version_and_txn_id_allocation() {
-    let manager = TransactionManager::new(100);
+    let manager = TransactionManager::new(CommitVersion(100));
 
     let mut versions = Vec::new();
     let mut txn_ids = Vec::new();
@@ -284,7 +285,7 @@ fn interleaved_version_and_txn_id_allocation() {
 
 #[test]
 fn rapid_allocation_performance() {
-    let manager = TransactionManager::new(1);
+    let manager = TransactionManager::new(CommitVersion(1));
 
     let start = std::time::Instant::now();
     for _ in 0..100_000 {
@@ -306,7 +307,7 @@ fn rapid_allocation_performance() {
 fn manager_creation_cost() {
     let start = std::time::Instant::now();
     for _ in 0..1000 {
-        let _ = TransactionManager::new(1);
+        let _ = TransactionManager::new(CommitVersion(1));
     }
     let elapsed = start.elapsed();
 

--- a/tests/integration/branching.rs
+++ b/tests/integration/branching.rs
@@ -6952,10 +6952,10 @@ fn dag_records_revert() {
 
     // Write a few versions so we have a non-trivial range to revert.
     kv.put(&branch_id, "default", "k1", Value::Int(1)).unwrap();
-    let v_before = test_db.db.current_version();
+    let v_before = test_db.db.current_version().as_u64();
     kv.put(&branch_id, "default", "k2", Value::Int(2)).unwrap();
     kv.put(&branch_id, "default", "k1", Value::Int(99)).unwrap();
-    let v_after = test_db.db.current_version();
+    let v_after = test_db.db.current_version().as_u64();
 
     let revert_info =
         branch_ops::revert_version_range(&test_db.db, "dag_revert_branch", v_before + 1, v_after)

--- a/tests/storage/branch_isolation.rs
+++ b/tests/storage/branch_isolation.rs
@@ -4,6 +4,7 @@
 
 use std::sync::Arc;
 use std::thread;
+use strata_core::id::CommitVersion;
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{Key, Namespace};
 use strata_core::value::Value;
@@ -30,14 +31,14 @@ fn different_branches_have_separate_namespaces() {
     let key2 = create_test_key(branch2, "shared_name");
 
     store
-        .put_with_version_mode(key1.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key1.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key2.clone(), Value::Int(200), 2, None, WriteMode::Append)
+        .put_with_version_mode(key2.clone(), Value::Int(200), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
-    let val1 = store.get_versioned(&key1, u64::MAX).unwrap().unwrap().value;
-    let val2 = store.get_versioned(&key2, u64::MAX).unwrap().unwrap().value;
+    let val1 = store.get_versioned(&key1, CommitVersion::MAX).unwrap().unwrap().value;
+    let val2 = store.get_versioned(&key2, CommitVersion::MAX).unwrap().unwrap().value;
 
     assert_eq!(val1, Value::Int(100));
     assert_eq!(val2, Value::Int(200));
@@ -55,11 +56,11 @@ fn clear_branch_only_affects_target_branch() {
         let key1 = create_test_key(branch1, &format!("key_{}", i));
         let key2 = create_test_key(branch2, &format!("key_{}", i));
         store
-            .put_with_version_mode(key1, Value::Int(i), version, None, WriteMode::Append)
+            .put_with_version_mode(key1, Value::Int(i), CommitVersion(version), None, WriteMode::Append)
             .unwrap();
         version += 1;
         store
-            .put_with_version_mode(key2, Value::Int(i + 100), version, None, WriteMode::Append)
+            .put_with_version_mode(key2, Value::Int(i + 100), CommitVersion(version), None, WriteMode::Append)
             .unwrap();
         version += 1;
     }
@@ -70,13 +71,13 @@ fn clear_branch_only_affects_target_branch() {
     // Branch1 should be empty
     for i in 0..5 {
         let key1 = create_test_key(branch1, &format!("key_{}", i));
-        assert!(store.get_versioned(&key1, u64::MAX).unwrap().is_none());
+        assert!(store.get_versioned(&key1, CommitVersion::MAX).unwrap().is_none());
     }
 
     // Branch2 should still have data
     for i in 0..5 {
         let key2 = create_test_key(branch2, &format!("key_{}", i));
-        let val = store.get_versioned(&key2, u64::MAX).unwrap();
+        let val = store.get_versioned(&key2, CommitVersion::MAX).unwrap();
         assert!(val.is_some());
         assert_eq!(val.unwrap().value, Value::Int(i + 100));
     }
@@ -92,21 +93,21 @@ fn delete_in_one_branch_doesnt_affect_other() {
     let key2 = create_test_key(branch2, "shared");
 
     store
-        .put_with_version_mode(key1.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key1.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key2.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key2.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // Delete in branch1
-    store.delete_with_version(&key1, 3).unwrap();
+    store.delete_with_version(&key1, CommitVersion(3)).unwrap();
 
     // Branch1 deleted
-    assert!(store.get_versioned(&key1, u64::MAX).unwrap().is_none());
+    assert!(store.get_versioned(&key1, CommitVersion::MAX).unwrap().is_none());
 
     // Branch2 unaffected
     assert_eq!(
-        store.get_versioned(&key2, u64::MAX).unwrap().unwrap().value,
+        store.get_versioned(&key2, CommitVersion::MAX).unwrap().unwrap().value,
         Value::Int(2)
     );
 }
@@ -128,7 +129,7 @@ fn concurrent_writes_to_different_branches() {
                 let branch_id = BranchId::new();
                 for i in 0..keys_per_branch {
                     let key = create_test_key(branch_id, &format!("key_{}", i));
-                    let version = store.next_version();
+                    let version = CommitVersion(store.next_version());
                     store
                         .put_with_version_mode(key, Value::Int(i), version, None, WriteMode::Append)
                         .unwrap();
@@ -144,7 +145,7 @@ fn concurrent_writes_to_different_branches() {
     for branch_id in branch_ids {
         for i in 0..keys_per_branch {
             let key = create_test_key(branch_id, &format!("key_{}", i));
-            let val = store.get_versioned(&key, u64::MAX).unwrap();
+            let val = store.get_versioned(&key, CommitVersion::MAX).unwrap();
             assert!(val.is_some(), "Branch {:?} key {} missing", branch_id, i);
             assert_eq!(val.unwrap().value, Value::Int(i));
         }
@@ -160,7 +161,7 @@ fn concurrent_reads_and_writes_different_branches() {
     // Pre-populate read branch
     for i in 0..100 {
         let key = create_test_key(read_branch, &format!("key_{}", i));
-        let version = store.next_version();
+        let version = CommitVersion(store.next_version());
         store
             .put_with_version_mode(key, Value::Int(i), version, None, WriteMode::Append)
             .unwrap();
@@ -175,7 +176,7 @@ fn concurrent_reads_and_writes_different_branches() {
         for _ in 0..1000 {
             for i in 0..100 {
                 let key = create_test_key(read_branch, &format!("key_{}", i));
-                let val = store_read.get_versioned(&key, u64::MAX).unwrap();
+                let val = store_read.get_versioned(&key, CommitVersion::MAX).unwrap();
                 assert!(val.is_some());
                 assert_eq!(val.unwrap().value, Value::Int(i));
                 reads += 1;
@@ -189,7 +190,7 @@ fn concurrent_reads_and_writes_different_branches() {
         for i in 0..1000 {
             for j in 0..10 {
                 let key = create_test_key(write_branch, &format!("key_{}", j));
-                let version = store_write.next_version();
+                let version = CommitVersion(store_write.next_version());
                 store_write
                     .put_with_version_mode(key, Value::Int(i), version, None, WriteMode::Append)
                     .unwrap();
@@ -220,13 +221,13 @@ fn branch_ids_lists_all_active_branches() {
     let key3 = create_test_key(branch3, "k");
 
     store
-        .put_with_version_mode(key1, Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key1, Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key2, Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key2, Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key3, Value::Int(3), 3, None, WriteMode::Append)
+        .put_with_version_mode(key3, Value::Int(3), CommitVersion(3), None, WriteMode::Append)
         .unwrap();
 
     let branches = store.branch_ids();
@@ -245,7 +246,7 @@ fn branch_entry_count() {
     for i in 0..10 {
         let key = create_test_key(branch_id, &format!("key_{}", i));
         store
-            .put_with_version_mode(key, Value::Int(i), (i + 1) as u64, None, WriteMode::Append)
+            .put_with_version_mode(key, Value::Int(i), CommitVersion((i + 1) as u64), None, WriteMode::Append)
             .unwrap();
     }
 
@@ -263,7 +264,7 @@ fn list_branch_keys() {
     for i in 0..5 {
         let key = Key::new_kv(ns.clone(), format!("key_{}", i));
         store
-            .put_with_version_mode(key, Value::Int(i), (i + 1) as u64, None, WriteMode::Append)
+            .put_with_version_mode(key, Value::Int(i), CommitVersion((i + 1) as u64), None, WriteMode::Append)
             .unwrap();
     }
 
@@ -281,7 +282,7 @@ fn get_from_nonexistent_branch_returns_none() {
     let branch_id = BranchId::new();
     let key = create_test_key(branch_id, "never_written");
 
-    let result = store.get_versioned(&key, u64::MAX).unwrap();
+    let result = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(result.is_none());
 }
 

--- a/tests/storage/mvcc_invariants.rs
+++ b/tests/storage/mvcc_invariants.rs
@@ -9,6 +9,7 @@
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
+use strata_core::id::CommitVersion;
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{Key, Namespace};
 use strata_core::value::Value;
@@ -32,13 +33,13 @@ fn version_chain_stores_newest_first() {
 
     // Put multiple versions
     store
-        .put_with_version_mode(key.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key.clone(), Value::Int(3), 3, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(3), CommitVersion(3), None, WriteMode::Append)
         .unwrap();
 
     // Get history - should be newest first
@@ -57,23 +58,23 @@ fn get_at_version_returns_value_lte_version() {
 
     // Put values at versions 1, 2, 3
     store
-        .put_with_version_mode(key.clone(), Value::Int(10), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(10), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key.clone(), Value::Int(20), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(20), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key.clone(), Value::Int(30), 3, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(30), CommitVersion(3), None, WriteMode::Append)
         .unwrap();
 
     // Get at version 2 - should return value 20
-    let result = Storage::get_versioned(&store, &key, 2).unwrap();
+    let result = Storage::get_versioned(&store, &key, CommitVersion(2)).unwrap();
     assert!(result.is_some());
     assert_eq!(result.unwrap().value, Value::Int(20));
 
     // Get at version 2.5 (between 2 and 3) - should return value at version 2
     // Since we can't have fractional versions, test with version 2
-    let result = Storage::get_versioned(&store, &key, 2).unwrap();
+    let result = Storage::get_versioned(&store, &key, CommitVersion(2)).unwrap();
     assert_eq!(result.unwrap().value, Value::Int(20));
 }
 
@@ -85,11 +86,11 @@ fn get_at_version_before_first_returns_none() {
 
     // Put value at version 5
     store
-        .put_with_version_mode(key.clone(), Value::Int(50), 5, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(50), CommitVersion(5), None, WriteMode::Append)
         .unwrap();
 
     // Get at version 1 (before first) - should return None
-    let result = Storage::get_versioned(&store, &key, 1).unwrap();
+    let result = Storage::get_versioned(&store, &key, CommitVersion(1)).unwrap();
     assert!(
         result.is_none(),
         "Should not find value before first version"
@@ -108,7 +109,7 @@ fn version_chain_preserves_all_versions() {
             .put_with_version_mode(
                 key.clone(),
                 Value::Int(i),
-                i as u64,
+                CommitVersion(i as u64),
                 None,
                 WriteMode::Append,
             )
@@ -121,7 +122,7 @@ fn version_chain_preserves_all_versions() {
 
     // Verify each version is accessible
     for i in 1..=10 {
-        let result = Storage::get_versioned(&store, &key, i as u64).unwrap();
+        let result = Storage::get_versioned(&store, &key, CommitVersion(i as u64)).unwrap();
         assert!(result.is_some(), "Version {} should exist", i);
         assert_eq!(result.unwrap().value, Value::Int(i));
     }
@@ -140,14 +141,14 @@ fn expired_values_filtered_at_read_time() {
     // Put value with very short TTL
     let ttl = Some(Duration::from_millis(1));
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, ttl, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), ttl, WriteMode::Append)
         .unwrap();
 
     // Wait for expiration
     thread::sleep(Duration::from_millis(10));
 
     // Should not be returned (expired)
-    let result = store.get_versioned(&key, u64::MAX).unwrap();
+    let result = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(result.is_none(), "Expired value should not be returned");
 }
 
@@ -160,11 +161,11 @@ fn non_expired_values_returned() {
     // Put value with long TTL
     let ttl = Some(Duration::from_secs(3600)); // 1 hour
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, ttl, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), ttl, WriteMode::Append)
         .unwrap();
 
     // Should be returned (not expired)
-    let result = store.get_versioned(&key, u64::MAX).unwrap();
+    let result = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(result.is_some(), "Non-expired value should be returned");
     assert_eq!(result.unwrap().value, Value::Int(42));
 }
@@ -177,11 +178,11 @@ fn no_ttl_never_expires() {
 
     // Put value without TTL
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // Should always be returned
-    let result = store.get_versioned(&key, u64::MAX).unwrap();
+    let result = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     assert_eq!(
         result.unwrap().value,
         Value::Int(42),
@@ -201,14 +202,14 @@ fn tombstone_preserves_snapshot_isolation() {
 
     // Put a value
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // Capture version BEFORE delete
-    let version = store.version();
+    let version = CommitVersion(store.version());
 
     // Delete the key (creates tombstone)
-    store.delete_with_version(&key, 2).unwrap();
+    store.delete_with_version(&key, CommitVersion(2)).unwrap();
 
     // Reading at captured version should still see the value
     let result = store.get_versioned(&key, version).unwrap();
@@ -219,7 +220,7 @@ fn tombstone_preserves_snapshot_isolation() {
     assert_eq!(result.unwrap().value, Value::Int(100));
 
     // Current store should not see the value
-    let current = store.get_versioned(&key, u64::MAX).unwrap();
+    let current = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(current.is_none(), "Current should not see deleted value");
 }
 
@@ -231,12 +232,12 @@ fn tombstone_not_returned_to_user() {
 
     // Put and delete
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
-    store.delete_with_version(&key, 2).unwrap();
+    store.delete_with_version(&key, CommitVersion(2)).unwrap();
 
     // Get should return None, not the tombstone
-    let result = store.get_versioned(&key, u64::MAX).unwrap();
+    let result = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(result.is_none(), "Tombstone should not be returned");
 }
 
@@ -247,7 +248,7 @@ fn delete_nonexistent_key_succeeds() {
     let key = create_test_key(branch_id, "never_existed");
 
     // Delete should succeed even for nonexistent key
-    let result = store.delete_with_version(&key, 1);
+    let result = store.delete_with_version(&key, CommitVersion(1));
     assert!(result.is_ok(), "Delete of nonexistent key should succeed");
 }
 
@@ -340,7 +341,7 @@ fn history_pagination_works() {
             .put_with_version_mode(
                 key.clone(),
                 Value::Int(i),
-                i as u64,
+                CommitVersion(i as u64),
                 None,
                 WriteMode::Append,
             )
@@ -354,13 +355,13 @@ fn history_pagination_works() {
     assert_eq!(page1[1].version.as_u64(), 4);
 
     // Page 2: next 2 (before version 4)
-    let page2 = Storage::get_history(&store, &key, Some(2), Some(4)).unwrap();
+    let page2 = Storage::get_history(&store, &key, Some(2), Some(CommitVersion(4))).unwrap();
     assert_eq!(page2.len(), 2);
     assert_eq!(page2[0].version.as_u64(), 3);
     assert_eq!(page2[1].version.as_u64(), 2);
 
     // Page 3: remaining
-    let page3 = Storage::get_history(&store, &key, Some(2), Some(2)).unwrap();
+    let page3 = Storage::get_history(&store, &key, Some(2), Some(CommitVersion(2))).unwrap();
     assert_eq!(page3.len(), 1);
     assert_eq!(page3[0].version.as_u64(), 1);
 }

--- a/tests/storage/snapshot_isolation.rs
+++ b/tests/storage/snapshot_isolation.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Instant;
+use strata_core::id::CommitVersion;
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{Key, Namespace};
 use strata_core::value::Value;
@@ -32,11 +33,11 @@ fn snapshot_captures_current_version() {
 
     // Put value
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // Capture version as our "snapshot"
-    let version = store.version();
+    let version = CommitVersion(store.version());
 
     // Should see the value at this version
     let result = store.get_versioned(&key, version).unwrap();
@@ -53,7 +54,7 @@ fn snapshot_acquisition_is_fast() {
     for i in 0..1000 {
         let key = create_test_key(branch_id, &format!("key_{}", i));
         store
-            .put_with_version_mode(key, Value::Int(i), (i + 1) as u64, None, WriteMode::Append)
+            .put_with_version_mode(key, Value::Int(i), CommitVersion((i + 1) as u64), None, WriteMode::Append)
             .unwrap();
     }
 
@@ -81,21 +82,21 @@ fn multiple_snapshots_independent() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(1), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(1), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
-    let v1 = store.version();
+    let v1 = CommitVersion(store.version());
 
     // Update value
     store
-        .put_with_version_mode(key.clone(), Value::Int(2), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(2), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
-    let v2 = store.version();
+    let v2 = CommitVersion(store.version());
 
     // Update again
     store
-        .put_with_version_mode(key.clone(), Value::Int(3), 3, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(3), CommitVersion(3), None, WriteMode::Append)
         .unwrap();
-    let v3 = store.version();
+    let v3 = CommitVersion(store.version());
 
     // Each version sees its value
     assert_eq!(
@@ -124,18 +125,18 @@ fn snapshot_ignores_concurrent_writes() {
 
     // Initial value
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // Capture version
-    let version = store.version();
+    let version = CommitVersion(store.version());
 
     // Modify after version capture
     store
-        .put_with_version_mode(key.clone(), Value::Int(200), 2, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(200), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key.clone(), Value::Int(300), 3, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(300), CommitVersion(3), None, WriteMode::Append)
         .unwrap();
 
     // Reading at captured version should still see original value
@@ -143,7 +144,7 @@ fn snapshot_ignores_concurrent_writes() {
     assert_eq!(result.unwrap().value, Value::Int(100));
 
     // Current store sees latest
-    let current = store.get_versioned(&key, u64::MAX).unwrap();
+    let current = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     assert_eq!(current.unwrap().value, Value::Int(300));
 }
 
@@ -155,14 +156,14 @@ fn snapshot_sees_pre_delete_value() {
 
     // Put value
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // Capture version
-    let version = store.version();
+    let version = CommitVersion(store.version());
 
     // Delete after version capture
-    store.delete_with_version(&key, 2).unwrap();
+    store.delete_with_version(&key, CommitVersion(2)).unwrap();
 
     // Reading at captured version should still see value
     let result = store.get_versioned(&key, version).unwrap();
@@ -173,7 +174,7 @@ fn snapshot_sees_pre_delete_value() {
     assert_eq!(result.unwrap().value, Value::Int(42));
 
     // Current should not see value
-    let current = store.get_versioned(&key, u64::MAX).unwrap();
+    let current = store.get_versioned(&key, CommitVersion::MAX).unwrap();
     assert!(current.is_none());
 }
 
@@ -184,10 +185,10 @@ fn repeated_reads_return_same_value() {
     let key = create_test_key(branch_id, "repeated");
 
     store
-        .put_with_version_mode(key.clone(), Value::Int(42), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(42), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
-    let version = store.version();
+    let version = CommitVersion(store.version());
 
     // Read multiple times at same version
     let read1 = store.get_versioned(&key, version).unwrap();
@@ -208,21 +209,21 @@ fn multi_key_consistency_within_snapshot() {
     let key_b = create_test_key(branch_id, "balance_b");
 
     store
-        .put_with_version_mode(key_a.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key_a.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key_b.clone(), Value::Int(200), 2, None, WriteMode::Append)
+        .put_with_version_mode(key_b.clone(), Value::Int(200), CommitVersion(2), None, WriteMode::Append)
         .unwrap();
 
     // Capture version
-    let version = store.version();
+    let version = CommitVersion(store.version());
 
     // Transfer in current store
     store
-        .put_with_version_mode(key_a.clone(), Value::Int(50), 3, None, WriteMode::Append)
+        .put_with_version_mode(key_a.clone(), Value::Int(50), CommitVersion(3), None, WriteMode::Append)
         .unwrap();
     store
-        .put_with_version_mode(key_b.clone(), Value::Int(250), 4, None, WriteMode::Append)
+        .put_with_version_mode(key_b.clone(), Value::Int(250), CommitVersion(4), None, WriteMode::Append)
         .unwrap();
 
     // Reading at captured version should see consistent pre-transfer state
@@ -250,11 +251,11 @@ fn concurrent_readers_dont_block() {
     for i in 0..100 {
         let key = create_test_key(branch_id, &format!("key_{}", i));
         store
-            .put_with_version_mode(key, Value::Int(i), (i + 1) as u64, None, WriteMode::Append)
+            .put_with_version_mode(key, Value::Int(i), CommitVersion((i + 1) as u64), None, WriteMode::Append)
             .unwrap();
     }
 
-    let version = store.version();
+    let version = CommitVersion(store.version());
     let barrier = Arc::new(Barrier::new(8));
 
     let handles: Vec<_> = (0..8)
@@ -289,11 +290,11 @@ fn snapshot_survives_store_modifications() {
     for i in 0..10 {
         let key = create_test_key(branch_id, &format!("key_{}", i));
         store
-            .put_with_version_mode(key, Value::Int(i), (i + 1) as u64, None, WriteMode::Append)
+            .put_with_version_mode(key, Value::Int(i), CommitVersion((i + 1) as u64), None, WriteMode::Append)
             .unwrap();
     }
 
-    let version = store.version();
+    let version = CommitVersion(store.version());
     let stop = Arc::new(AtomicBool::new(false));
 
     // Spawn writer
@@ -304,7 +305,7 @@ fn snapshot_survives_store_modifications() {
         while !stop_clone.load(Ordering::Relaxed) {
             for i in 0..10 {
                 let key = create_test_key(branch_id, &format!("key_{}", i));
-                let v = store_clone.next_version();
+                let v = CommitVersion(store_clone.next_version());
                 let _ = store_clone.put_with_version_mode(
                     key,
                     Value::Int(counter),
@@ -349,16 +350,16 @@ fn versioned_read_provides_isolation() {
 
     // Put value
     store
-        .put_with_version_mode(key.clone(), Value::Int(100), 1, None, WriteMode::Append)
+        .put_with_version_mode(key.clone(), Value::Int(100), CommitVersion(1), None, WriteMode::Append)
         .unwrap();
 
     // Capture version and read (verifies value exists)
-    let version = store.version();
+    let version = CommitVersion(store.version());
     let first_read = store.get_versioned(&key, version).unwrap();
     assert_eq!(first_read.unwrap().value, Value::Int(100));
 
     // Delete in store
-    store.delete_with_version(&key, 2).unwrap();
+    store.delete_with_version(&key, CommitVersion(2)).unwrap();
 
     // Reading at captured version should still see value
     let second_read = store.get_versioned(&key, version).unwrap();
@@ -383,11 +384,11 @@ fn snapshot_scan_sees_consistent_state() {
     for i in 0..10 {
         let key = Key::new_kv(ns.clone(), format!("prefix_{}", i));
         store
-            .put_with_version_mode(key, Value::Int(i), (i + 1) as u64, None, WriteMode::Append)
+            .put_with_version_mode(key, Value::Int(i), CommitVersion((i + 1) as u64), None, WriteMode::Append)
             .unwrap();
     }
 
-    let version = store.version();
+    let version = CommitVersion(store.version());
 
     // Modify after version capture
     for i in 0..10 {
@@ -396,7 +397,7 @@ fn snapshot_scan_sees_consistent_state() {
             .put_with_version_mode(
                 key,
                 Value::Int(i + 100),
-                (i + 11) as u64,
+                CommitVersion((i + 11) as u64),
                 None,
                 WriteMode::Append,
             )
@@ -425,16 +426,16 @@ fn snapshot_list_sees_all_keys() {
     for i in 0..5 {
         let key = Key::new_kv(ns.clone(), format!("list_key_{}", i));
         store
-            .put_with_version_mode(key, Value::Int(i), (i + 1) as u64, None, WriteMode::Append)
+            .put_with_version_mode(key, Value::Int(i), CommitVersion((i + 1) as u64), None, WriteMode::Append)
             .unwrap();
     }
 
-    let version = store.version();
+    let version = CommitVersion(store.version());
 
     // Delete some in store
     for i in 0..3 {
         let key = Key::new_kv(ns.clone(), format!("list_key_{}", i));
-        store.delete_with_version(&key, (i + 6) as u64).unwrap();
+        store.delete_with_version(&key, CommitVersion((i + 6) as u64)).unwrap();
     }
 
     // Scan at captured version should still see all 5

--- a/tests/storage/stress.rs
+++ b/tests/storage/stress.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
+use strata_core::id::CommitVersion;
 use strata_core::traits::{Storage, WriteMode};
 use strata_core::types::{Key, Namespace};
 use strata_core::value::Value;
@@ -31,7 +32,7 @@ fn stress_concurrent_writers_readers() {
     // Pre-populate
     for i in 0..100 {
         let key = create_test_key(branch_id, &format!("key_{}", i));
-        let version = store.next_version();
+        let version = CommitVersion(store.next_version());
         store
             .put_with_version_mode(key, Value::Int(i), version, None, WriteMode::Append)
             .unwrap();
@@ -48,7 +49,7 @@ fn stress_concurrent_writers_readers() {
                 while !stop.load(Ordering::Relaxed) {
                     for i in 0..100 {
                         let key = create_test_key(branch_id, &format!("key_{}", i));
-                        let version = store.next_version();
+                        let version = CommitVersion(store.next_version());
                         let _ = store.put_with_version_mode(
                             key,
                             Value::Int(t * 10000 + counter),
@@ -77,7 +78,7 @@ fn stress_concurrent_writers_readers() {
                 while !stop.load(Ordering::Relaxed) {
                     for i in 0..100 {
                         let key = create_test_key(branch_id, &format!("key_{}", i));
-                        let _ = store.get_versioned(&key, u64::MAX);
+                        let _ = store.get_versioned(&key, CommitVersion::MAX);
                         reads.fetch_add(1, Ordering::Relaxed);
                     }
                     if reads.load(Ordering::Relaxed) > 500_000 {
@@ -117,7 +118,7 @@ fn stress_rapid_snapshot_creation() {
     // Populate
     for i in 0..1000 {
         let key = create_test_key(branch_id, &format!("key_{}", i));
-        let version = store.next_version();
+        let version = CommitVersion(store.next_version());
         store
             .put_with_version_mode(key, Value::Int(i), version, None, WriteMode::Append)
             .unwrap();
@@ -140,7 +141,7 @@ fn stress_rapid_snapshot_creation() {
     // Verify versioned reads work
     for version in versions.iter().take(100) {
         let key = create_test_key(branch_id, "key_0");
-        let result = store.get_versioned(&key, *version).unwrap();
+        let result = store.get_versioned(&key, CommitVersion(*version)).unwrap();
         assert_eq!(result.unwrap().value, Value::Int(0));
     }
 }
@@ -161,7 +162,7 @@ fn stress_version_chain_growth() {
             .put_with_version_mode(
                 key.clone(),
                 Value::Int(i),
-                (i + 1) as u64,
+                CommitVersion((i + 1) as u64),
                 None,
                 WriteMode::Append,
             )
@@ -173,7 +174,7 @@ fn stress_version_chain_growth() {
     // Read latest
     let read_start = Instant::now();
     for _ in 0..10_000 {
-        let _ = store.get_versioned(&key, u64::MAX);
+        let _ = store.get_versioned(&key, CommitVersion::MAX);
     }
     let read_elapsed = read_start.elapsed();
 
@@ -199,7 +200,7 @@ fn stress_ttl_expiration_cleanup() {
     for i in 0..10_000 {
         let key = create_test_key(branch_id, &format!("ttl_key_{}", i));
         store
-            .put_with_version_mode(key, Value::Int(i), (i + 1) as u64, ttl, WriteMode::Append)
+            .put_with_version_mode(key, Value::Int(i), CommitVersion((i + 1) as u64), ttl, WriteMode::Append)
             .unwrap();
     }
 
@@ -210,7 +211,7 @@ fn stress_ttl_expiration_cleanup() {
     let mut expired_count = 0;
     for i in 0..10_000 {
         let key = create_test_key(branch_id, &format!("ttl_key_{}", i));
-        if store.get_versioned(&key, u64::MAX).unwrap().is_none() {
+        if store.get_versioned(&key, CommitVersion::MAX).unwrap().is_none() {
             expired_count += 1;
         }
     }
@@ -236,7 +237,7 @@ fn stress_many_branches_concurrent() {
                 let branch_id = BranchId::new();
                 for i in 0..keys_per_branch {
                     let key = create_test_key(branch_id, &format!("key_{}", i));
-                    let version = store.next_version();
+                    let version = CommitVersion(store.next_version());
                     store
                         .put_with_version_mode(key, Value::Int(i), version, None, WriteMode::Append)
                         .unwrap();
@@ -255,7 +256,7 @@ fn stress_many_branches_concurrent() {
     for branch_id in branch_ids {
         for i in 0..keys_per_branch {
             let key = create_test_key(branch_id, &format!("key_{}", i));
-            let val = store.get_versioned(&key, u64::MAX).unwrap();
+            let val = store.get_versioned(&key, CommitVersion::MAX).unwrap();
             assert_eq!(val.unwrap().value, Value::Int(i));
         }
     }
@@ -277,7 +278,7 @@ fn stress_sustained_throughput() {
     let duration = Duration::from_secs(5);
     let start = Instant::now();
     let mut ops = 0u64;
-    let mut version = 1u64;
+    let mut version = CommitVersion(1);
 
     while start.elapsed() < duration {
         let key = create_test_key(branch_id, &format!("key_{}", ops % 1000));
@@ -290,8 +291,8 @@ fn stress_sustained_throughput() {
                 WriteMode::Append,
             )
             .unwrap();
-        version += 1;
-        let _ = store.get_versioned(&key, u64::MAX);
+        version = CommitVersion(version.0 + 1);
+        let _ = store.get_versioned(&key, CommitVersion::MAX);
         ops += 2; // put + get
     }
 


### PR DESCRIPTION
## Summary
- Update 14 integration test files to use `TxnId` and `CommitVersion` newtypes
- Add `exclude = ["benchmarks"]` to workspace config

## Context
PR #2396 introduced the newtype wrappers but only included crate changes. This caused 290 compile errors in the integration tests on main.

## Test plan
- [x] `cargo test -p stratadb --test concurrency` compiles
- [x] `cargo test -p stratadb --test storage` compiles
- [x] `cargo test -p stratadb --test integration` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)