### PR TITLE
feat(executor,graph): T2-E5 — session and transaction ownership

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -42,9 +42,10 @@ pub use merge_registry::{
     VectorMergePrecheckFn,
 };
 pub use observers::{
-    BranchOpEvent, BranchOpKind, BranchOpObserver, BranchOpObserverRegistry, CommitInfo,
-    CommitObserver, CommitObserverRegistry, ObserverError, ObserverErrorKind, ReplayInfo,
-    ReplayObserver, ReplayObserverRegistry,
+    AbortInfo, AbortObserver, AbortObserverRegistry, BranchOpEvent, BranchOpKind,
+    BranchOpObserver, BranchOpObserverRegistry, CommitInfo, CommitObserver,
+    CommitObserverRegistry, ObserverError, ObserverErrorKind, ReplayInfo, ReplayObserver,
+    ReplayObserverRegistry,
 };
 pub use spec::{
     search_only_cache_spec, search_only_follower_spec, search_only_primary_spec, DatabaseMode,
@@ -445,6 +446,12 @@ pub struct Database {
     /// Best-effort: failures are logged, not propagated.
     commit_observers: CommitObserverRegistry,
 
+    /// Per-database abort observer registry.
+    ///
+    /// Observers are notified after a transaction aborts or fails to commit.
+    /// Best-effort: failures are logged, not propagated.
+    abort_observers: AbortObserverRegistry,
+
     /// Per-database replay observer registry.
     ///
     /// Observers are notified after each fully-applied follower replay record.
@@ -619,7 +626,7 @@ impl Database {
     }
 
     // =========================================================================
-    // Commit/Replay Observers
+    // Commit/Abort/Replay Observers
     // =========================================================================
 
     /// Get the per-database commit observer registry.
@@ -627,6 +634,13 @@ impl Database {
     /// Observers are notified after each successful WAL-backed commit.
     pub fn commit_observers(&self) -> &CommitObserverRegistry {
         &self.commit_observers
+    }
+
+    /// Get the per-database abort observer registry.
+    ///
+    /// Observers are notified after transaction abort/failure cleanup points.
+    pub fn abort_observers(&self) -> &AbortObserverRegistry {
+        &self.abort_observers
     }
 
     /// Get the per-database replay observer registry.

--- a/crates/engine/src/database/observers.rs
+++ b/crates/engine/src/database/observers.rs
@@ -15,6 +15,7 @@
 //! | Observer | Fires When | Use Cases |
 //! |----------|------------|-----------|
 //! | `CommitObserver` | After successful commit | Index maintenance, audit log |
+//! | `AbortObserver` | After transaction abort/failure | Cleanup staged runtime state |
 //! | `ReplayObserver` | After follower applies record | Index rebuild on replica |
 //! | `BranchOpObserver` | After branch operation | DAG audit, branch metrics |
 //!
@@ -139,8 +140,8 @@ pub struct CommitInfo {
 ///
 /// `CommitObserver` receives only [`CommitInfo`], not the actual committed data.
 /// For operation-specific deferred work (graph node indexing, vector HNSW updates)
-/// that requires data captured during command execution, see `PostCommitOp` in
-/// the executor crate's session module.
+/// that requires data captured during command execution, subsystem state should
+/// be staged during command execution and drained by commit/abort observers.
 ///
 /// ## Thread Safety
 ///
@@ -160,6 +161,31 @@ pub trait CommitObserver: Send + Sync + 'static {
     /// This is called synchronously after the commit completes.
     /// Keep implementations fast to avoid blocking the commit path.
     fn on_commit(&self, info: &CommitInfo) -> Result<(), ObserverError>;
+}
+
+// =============================================================================
+// Replay Observer
+// =============================================================================
+
+/// Information about an aborted transaction.
+#[derive(Debug, Clone)]
+pub struct AbortInfo {
+    /// The transaction that aborted.
+    pub txn_id: TxnId,
+    /// The branch the transaction belonged to.
+    pub branch_id: BranchId,
+}
+
+/// Observer called after a transaction aborts or fails to commit.
+///
+/// Use for cleaning up subsystem-owned staged state that should only survive a
+/// successful commit.
+pub trait AbortObserver: Send + Sync + 'static {
+    /// Human-readable name for logging.
+    fn name(&self) -> &'static str;
+
+    /// Called after the transaction has been marked aborted.
+    fn on_abort(&self, info: &AbortInfo) -> Result<(), ObserverError>;
 }
 
 // =============================================================================
@@ -514,6 +540,55 @@ impl Default for CommitObserverRegistry {
     }
 }
 
+/// Registry for abort observers.
+pub struct AbortObserverRegistry {
+    observers: RwLock<Vec<Arc<dyn AbortObserver>>>,
+}
+
+impl AbortObserverRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            observers: RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Register an abort observer.
+    pub fn register(&self, observer: Arc<dyn AbortObserver>) {
+        self.observers.write().push(observer);
+    }
+
+    /// Notify all observers of an abort.
+    pub fn notify(&self, info: &AbortInfo) {
+        let observers = self.observers.read();
+        for observer in observers.iter() {
+            if let Err(e) = observer.on_abort(info) {
+                tracing::error!(
+                    observer = observer.name(),
+                    error = %e,
+                    "abort observer failed"
+                );
+            }
+        }
+    }
+
+    /// Number of registered observers.
+    pub fn len(&self) -> usize {
+        self.observers.read().len()
+    }
+
+    /// Whether the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.observers.read().is_empty()
+    }
+}
+
+impl Default for AbortObserverRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Registry for replay observers.
 pub struct ReplayObserverRegistry {
     observers: RwLock<Vec<Arc<dyn ReplayObserver>>>,
@@ -648,6 +723,33 @@ mod tests {
         }
     }
 
+    struct CountingAbortObserver {
+        count: AtomicUsize,
+    }
+
+    impl CountingAbortObserver {
+        fn new() -> Self {
+            Self {
+                count: AtomicUsize::new(0),
+            }
+        }
+
+        fn count(&self) -> usize {
+            self.count.load(Ordering::SeqCst)
+        }
+    }
+
+    impl AbortObserver for CountingAbortObserver {
+        fn name(&self) -> &'static str {
+            "counting-abort"
+        }
+
+        fn on_abort(&self, _info: &AbortInfo) -> Result<(), ObserverError> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
     #[test]
     fn test_commit_observer_registry() {
         let registry = CommitObserverRegistry::new();
@@ -670,6 +772,24 @@ mod tests {
 
         registry.notify(&info);
         assert_eq!(observer.count(), 2);
+    }
+
+    #[test]
+    fn test_abort_observer_registry() {
+        let registry = AbortObserverRegistry::new();
+        assert!(registry.is_empty());
+
+        let observer = Arc::new(CountingAbortObserver::new());
+        registry.register(observer.clone());
+        assert_eq!(registry.len(), 1);
+
+        let info = AbortInfo {
+            txn_id: 9u64.into(),
+            branch_id: BranchId::new(),
+        };
+
+        registry.notify(&info);
+        assert_eq!(observer.count(), 1);
     }
 
     #[test]

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -506,6 +506,7 @@ impl Database {
             dag_hook_slot: super::DagHookSlot::new(),
             branch_op_observers: super::BranchOpObserverRegistry::new(),
             commit_observers: super::CommitObserverRegistry::new(),
+            abort_observers: super::AbortObserverRegistry::new(),
             replay_observers: super::ReplayObserverRegistry::new(),
             lifecycle_state: std::sync::atomic::AtomicU8::new(
                 super::LifecycleState::Uninitialized.as_u8(),
@@ -797,6 +798,7 @@ impl Database {
             dag_hook_slot: super::DagHookSlot::new(),
             branch_op_observers: super::BranchOpObserverRegistry::new(),
             commit_observers: super::CommitObserverRegistry::new(),
+            abort_observers: super::AbortObserverRegistry::new(),
             replay_observers: super::ReplayObserverRegistry::new(),
             lifecycle_state: std::sync::atomic::AtomicU8::new(
                 super::LifecycleState::Uninitialized.as_u8(),
@@ -929,6 +931,7 @@ impl Database {
             dag_hook_slot: super::DagHookSlot::new(),
             branch_op_observers: super::BranchOpObserverRegistry::new(),
             commit_observers: super::CommitObserverRegistry::new(),
+            abort_observers: super::AbortObserverRegistry::new(),
             replay_observers: super::ReplayObserverRegistry::new(),
             lifecycle_state: std::sync::atomic::AtomicU8::new(
                 super::LifecycleState::Uninitialized.as_u8(),

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::recovery::Subsystem;
 use serial_test::serial;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use strata_concurrency::TransactionPayload;
@@ -422,6 +422,46 @@ fn test_begin_and_commit_manual() {
         .unwrap()
         .unwrap();
     assert_eq!(stored.value, Value::Int(123));
+}
+
+#[test]
+fn test_owned_transaction_commit_emits_one_commit_observer_event() {
+    struct CountingCommitObserver {
+        count: AtomicUsize,
+    }
+
+    impl super::CommitObserver for CountingCommitObserver {
+        fn name(&self) -> &'static str {
+            "counting-commit"
+        }
+
+        fn on_commit(&self, _info: &super::CommitInfo) -> Result<(), super::ObserverError> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    let db = Database::open(temp_dir.path().join("db")).unwrap();
+    let observer = Arc::new(CountingCommitObserver {
+        count: AtomicUsize::new(0),
+    });
+    db.commit_observers().register(observer.clone());
+
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    let key = Key::new_kv(ns, "observer_key");
+
+    let mut txn = db.begin_transaction(branch_id).unwrap();
+    txn.put(key.clone(), Value::Int(1)).unwrap();
+    let version = txn.commit().unwrap();
+
+    assert!(version > 0);
+    assert_eq!(
+        observer.count.load(Ordering::SeqCst),
+        1,
+        "successful manual commits should emit exactly one observer event"
+    );
 }
 
 // ========================================================================
@@ -2476,7 +2516,6 @@ fn test_open_runtime_failed_config_write_can_retry() {
 /// read, so OCC validation had no read-set entry to detect the conflict.
 #[test]
 fn test_issue_1914_concurrent_event_append_occ_conflict() {
-    use crate::transaction::Transaction;
     use crate::transaction_ops::TransactionOps;
 
     let temp_dir = TempDir::new().unwrap();
@@ -2491,12 +2530,12 @@ fn test_issue_1914_concurrent_event_append_occ_conflict() {
 
     // Both append an event using the Transaction wrapper (executor path)
     {
-        let mut t1 = Transaction::new(&mut txn1, ns.clone());
+        let mut t1 = crate::transaction::context::Transaction::new(&mut txn1, ns.clone());
         t1.event_append("test_event", Value::String("from_t1".into()))
             .unwrap();
     }
     {
-        let mut t2 = Transaction::new(&mut txn2, ns.clone());
+        let mut t2 = crate::transaction::context::Transaction::new(&mut txn2, ns.clone());
         t2.event_append("test_event", Value::String("from_t2".into()))
             .unwrap();
     }
@@ -2524,7 +2563,6 @@ fn test_issue_1914_concurrent_event_append_occ_conflict() {
 /// sequence numbers sourced from persisted metadata, not ephemeral defaults.
 #[test]
 fn test_issue_1914_sequence_from_persisted_meta() {
-    use crate::transaction::Transaction;
     use crate::transaction_ops::TransactionOps;
 
     let temp_dir = TempDir::new().unwrap();
@@ -2536,7 +2574,7 @@ fn test_issue_1914_sequence_from_persisted_meta() {
     // First transaction: append event at sequence 0
     let mut txn1 = db.begin_transaction(branch_id).unwrap();
     {
-        let mut t = Transaction::new(&mut txn1, ns.clone());
+        let mut t = crate::transaction::context::Transaction::new(&mut txn1, ns.clone());
         let v = t
             .event_append("evt", Value::String("first".into()))
             .unwrap();
@@ -2548,7 +2586,7 @@ fn test_issue_1914_sequence_from_persisted_meta() {
     // Second transaction: should continue at sequence 1 (from persisted meta)
     let mut txn2 = db.begin_transaction(branch_id).unwrap();
     {
-        let mut t = Transaction::new(&mut txn2, ns.clone());
+        let mut t = crate::transaction::context::Transaction::new(&mut txn2, ns.clone());
         let v = t
             .event_append("evt", Value::String("second".into()))
             .unwrap();
@@ -2567,7 +2605,7 @@ fn test_issue_1914_sequence_from_persisted_meta() {
     // Verify the hash chain: event 1's prev_hash must equal event 0's hash
     let mut txn3 = db.begin_transaction(branch_id).unwrap();
     {
-        let mut t = Transaction::new(&mut txn3, ns.clone());
+        let mut t = crate::transaction::context::Transaction::new(&mut txn3, ns.clone());
         let e0 = t.event_get(0).unwrap().expect("event 0 must exist");
         let e1 = t.event_get(1).unwrap().expect("event 1 must exist");
         assert_eq!(

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -13,7 +13,7 @@ use strata_durability::{ManifestManager, WalOnlyCompactor};
 use strata_storage::SegmentedStore;
 
 use super::Database;
-use crate::transaction::TransactionPool;
+use crate::transaction::{Transaction, TransactionPool};
 
 /// Return freed heap pages to the OS.
 ///
@@ -526,43 +526,40 @@ impl Database {
     }
 
     /// Execute one transaction attempt: commit on success, abort on error.
-    ///
-    /// Handles the commit-or-abort decision and coordinator bookkeeping.
-    /// The caller is responsible for calling `end_transaction()` afterward.
-    ///
     /// Returns `(closure_result, commit_version)` on success.
     fn run_single_attempt<T>(
         &self,
         txn: &mut TransactionContext,
         result: StrataResult<T>,
-        durability: DurabilityMode,
     ) -> StrataResult<(T, u64)> {
         match result {
             Ok(value) => {
-                let had_writes = !txn.is_read_only();
-                // Admission control: reject writes when L0 is saturated (#1924).
-                // Must run BEFORE commit so the caller gets a clean error and
-                // no data is committed that the caller doesn't know about.
-                if had_writes {
-                    if let Err(e) = self.maybe_apply_write_backpressure() {
-                        let _ = txn.mark_aborted(format!("Write stall: {}", e));
-                        self.coordinator.record_abort(txn.txn_id);
-                        return Err(e);
-                    }
-                }
-                let commit_version = self.commit_internal(txn, durability)?;
-                // Schedule flush only for write transactions (reads skip entirely)
-                if had_writes {
-                    self.schedule_flush_if_needed();
-                }
-                Ok((value, commit_version.as_u64()))
+                let commit_version = self.commit_transaction_context(txn)?;
+                Ok((value, commit_version))
             }
             Err(e) => {
-                let _ = txn.mark_aborted(format!("Closure error: {}", e));
-                self.coordinator.record_abort(txn.txn_id);
+                self.abort_transaction_in_place(txn, format!("Closure error: {}", e));
                 Err(e)
             }
         }
+    }
+
+    /// Mark a transaction aborted and run subsystem cleanup observers.
+    pub(crate) fn abort_transaction_in_place(
+        &self,
+        txn: &mut TransactionContext,
+        reason: impl Into<String>,
+    ) {
+        if txn.is_active() {
+            let _ = txn.mark_aborted(reason.into());
+            self.coordinator.record_abort(txn.txn_id);
+        }
+
+        let info = super::AbortInfo {
+            txn_id: txn.txn_id,
+            branch_id: txn.branch_id,
+        };
+        self.abort_observers().notify(&info);
     }
 
     /// Execute a transaction with the given closure
@@ -594,10 +591,10 @@ impl Database {
         F: FnOnce(&mut TransactionContext) -> StrataResult<T>,
     {
         self.check_accepting()?;
-        let mut txn = self.begin_transaction(branch_id)?;
+        let mut txn = self.begin_transaction_context(branch_id)?;
         let result = f(&mut txn);
-        let outcome = self.run_single_attempt(&mut txn, result, self.durability_mode);
-        self.end_transaction(txn);
+        let outcome = self.run_single_attempt(&mut txn, result);
+        self.end_transaction_context(txn);
         outcome.map(|(value, _)| value)
     }
 
@@ -627,35 +624,40 @@ impl Database {
         F: FnOnce(&mut TransactionContext) -> StrataResult<T>,
     {
         self.check_accepting()?;
-        let mut txn = self.begin_transaction(branch_id)?;
+        let mut txn = self.begin_transaction_context(branch_id)?;
         let result = f(&mut txn);
-        let outcome = self.run_single_attempt(&mut txn, result, self.durability_mode);
-        self.end_transaction(txn);
+        let outcome = self.run_single_attempt(&mut txn, result);
+        self.end_transaction_context(txn);
         outcome
     }
 
     /// Begin a new transaction (for manual control)
     ///
-    /// Returns a TransactionContext that must be manually committed or aborted.
-    /// Prefer `transaction()` closure API for automatic handling.
-    ///
-    /// Uses thread-local pool to avoid allocation overhead after warmup.
-    /// Call `end_transaction()` after commit/abort to return context to pool.
+    /// Returns an owned transaction handle that commits, aborts, and returns
+    /// its context to the pool without executor/session state.
     ///
     /// # Arguments
     /// * `branch_id` - BranchId for namespace isolation
     ///
     /// # Returns
-    /// * `TransactionContext` - Active transaction ready for operations
+    /// * `Transaction` - Active transaction ready for operations
     ///
     /// # Example
     /// ```text
     /// let mut txn = db.begin_transaction(branch_id)?;
     /// txn.put(key, value)?;
-    /// db.commit_transaction(&mut txn)?;
-    /// db.end_transaction(txn); // Return to pool
+    /// txn.commit()?;
     /// ```
-    pub fn begin_transaction(&self, branch_id: BranchId) -> StrataResult<TransactionContext> {
+    pub fn begin_transaction(&self, branch_id: BranchId) -> StrataResult<Transaction> {
+        let txn = self.begin_transaction_context(branch_id)?;
+        Ok(Transaction::new(Self::shared(self), txn))
+    }
+
+    /// Internal transaction-context constructor used by closure APIs.
+    pub(crate) fn begin_transaction_context(
+        &self,
+        branch_id: BranchId,
+    ) -> StrataResult<TransactionContext> {
         self.check_accepting()?;
         let txn_id = self.coordinator.next_txn_id()?;
         // Use storage.version() as the snapshot (includes own thread's commits),
@@ -706,11 +708,17 @@ impl Database {
     ///
     /// Returns a transaction that rejects writes and skips read-set tracking,
     /// saving memory on large scan workloads.
-    pub fn begin_read_only_transaction(
+    pub fn begin_read_only_transaction(&self, branch_id: BranchId) -> StrataResult<Transaction> {
+        let txn = self.begin_read_only_transaction_context(branch_id)?;
+        Ok(Transaction::new(Self::shared(self), txn))
+    }
+
+    /// Internal read-only context constructor used by engine internals.
+    pub(crate) fn begin_read_only_transaction_context(
         &self,
         branch_id: BranchId,
     ) -> StrataResult<TransactionContext> {
-        let mut txn = self.begin_transaction(branch_id)?;
+        let mut txn = self.begin_transaction_context(branch_id)?;
         txn.set_read_only(true);
         Ok(txn)
     }
@@ -720,21 +728,15 @@ impl Database {
     /// Returns the transaction context to the thread-local pool for reuse.
     /// This avoids allocation overhead on subsequent transactions.
     ///
-    /// Should be called after `commit_transaction()` or after aborting.
-    /// The closure API (`transaction()`) calls this automatically.
-    ///
-    /// # Arguments
-    /// * `ctx` - Transaction context to return to pool
-    ///
-    /// # Example
-    /// ```text
-    /// let mut txn = db.begin_transaction(branch_id)?;
-    /// txn.put(key, value)?;
-    /// db.commit_transaction(&mut txn)?;
-    /// db.end_transaction(txn); // Return to pool for reuse
-    /// ```
-    pub fn end_transaction(&self, ctx: TransactionContext) {
+    /// Internal pool-return helper for transaction contexts.
+    pub(crate) fn end_transaction_context(&self, ctx: TransactionContext) {
         TransactionPool::release(ctx);
+    }
+
+    /// Legacy compatibility shim: dropping the owned transaction already
+    /// returns it to the pool, so this is just an explicit drop.
+    pub fn end_transaction(&self, txn: Transaction) {
+        drop(txn);
     }
 
     /// Commit a transaction
@@ -758,22 +760,35 @@ impl Database {
     ///
     /// # Contract
     /// Returns the commit version (u64) assigned to all writes in this transaction.
-    pub fn commit_transaction(&self, txn: &mut TransactionContext) -> StrataResult<u64> {
+    pub(crate) fn commit_transaction_context(
+        &self,
+        txn: &mut TransactionContext,
+    ) -> StrataResult<u64> {
         let had_writes = !txn.is_read_only();
         // Admission control: reject writes when L0 is saturated (#1924).
         // Must run BEFORE commit so the caller gets a clean error.
         if had_writes {
             if let Err(e) = self.maybe_apply_write_backpressure() {
-                let _ = txn.mark_aborted(format!("Write stall: {}", e));
-                self.coordinator.record_abort(txn.txn_id);
+                self.abort_transaction_in_place(txn, format!("Write stall: {}", e));
                 return Err(e);
             }
         }
-        let version = self.commit_internal(txn, self.durability_mode)?;
+        let version = match self.commit_internal(txn, self.durability_mode) {
+            Ok(version) => version,
+            Err(e) => {
+                self.abort_transaction_in_place(txn, format!("Commit failed: {}", e));
+                return Err(e);
+            }
+        };
         if had_writes {
             self.schedule_flush_if_needed();
         }
         Ok(version.as_u64())
+    }
+
+    /// Legacy compatibility shim for callers still routing through Database.
+    pub fn commit_transaction(&self, txn: &mut Transaction) -> StrataResult<u64> {
+        txn.commit()
     }
 
     /// Internal commit implementation shared by commit_transaction and transaction closures
@@ -830,5 +845,22 @@ impl Database {
         }
 
         Ok(commit_version)
+    }
+
+    /// Clone an `Arc<Database>` from an internal `&Database` reference.
+    ///
+    /// `Database` instances are always owned behind `Arc`; the public open
+    /// paths never hand out stack-owned values. This lets the manual
+    /// transaction handle retain shared ownership even when callers only have
+    /// `&Database` (common in helper functions and integration tests).
+    fn shared(this: &Self) -> Arc<Self> {
+        let ptr = this as *const Self;
+        // SAFETY: every live Database is allocated inside an Arc returned from
+        // the open paths. We increment the strong count before reconstructing
+        // the Arc so the original allocation remains owned.
+        unsafe {
+            Arc::increment_strong_count(ptr);
+            Arc::from_raw(ptr)
+        }
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -53,7 +53,7 @@ pub use strata_durability::wal::DurabilityMode;
 pub use strata_durability::WalCounters;
 pub use strata_storage::StorageIterator;
 pub use strata_storage::VersionedEntry;
-pub use transaction::{Transaction, TransactionPool, MAX_POOL_SIZE};
+pub use transaction::{ScopedTransaction, Transaction, TransactionPool, MAX_POOL_SIZE};
 pub use transaction_ops::TransactionOps;
 
 pub mod branch_ops;

--- a/crates/engine/src/transaction/mod.rs
+++ b/crates/engine/src/transaction/mod.rs
@@ -18,7 +18,9 @@
 //! TransactionOps trait for unified primitive access within transactions.
 
 pub mod context;
+pub mod owned;
 pub mod pool;
 
-pub use context::Transaction;
+pub use context::Transaction as ScopedTransaction;
+pub use owned::Transaction;
 pub use pool::{TransactionPool, MAX_POOL_SIZE};

--- a/crates/engine/src/transaction/owned.rs
+++ b/crates/engine/src/transaction/owned.rs
@@ -1,0 +1,84 @@
+//! Owned transaction handle for manual transaction lifecycle.
+
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+
+use strata_concurrency::TransactionContext;
+use strata_core::types::BranchId;
+use strata_core::{StrataError, StrataResult};
+
+use crate::Database;
+
+/// Owned manual transaction handle.
+///
+/// The handle owns the pooled `TransactionContext` and returns it to the
+/// engine automatically on commit, abort, or drop.
+pub struct Transaction {
+    db: Arc<Database>,
+    ctx: Option<TransactionContext>,
+}
+
+impl Transaction {
+    /// Construct an owned transaction handle from an active context.
+    pub(crate) fn new(db: Arc<Database>, ctx: TransactionContext) -> Self {
+        Self { db, ctx: Some(ctx) }
+    }
+
+    /// Commit the transaction and return its commit version.
+    pub fn commit(&mut self) -> StrataResult<u64> {
+        let mut ctx = self
+            .ctx
+            .take()
+            .ok_or_else(|| StrataError::transaction_not_active("finished"))?;
+        let result = self.db.commit_transaction_context(&mut ctx);
+        self.db.end_transaction_context(ctx);
+        result
+    }
+
+    /// Abort the transaction and release its pooled context.
+    pub fn abort(&mut self) {
+        if let Some(mut ctx) = self.ctx.take() {
+            self.db
+                .abort_transaction_in_place(&mut ctx, "Transaction aborted");
+            self.db.end_transaction_context(ctx);
+        }
+    }
+
+    /// Get the transaction's branch ID.
+    pub fn branch_id(&self) -> BranchId {
+        self.context()
+            .expect("branch_id() requires an active transaction")
+            .branch_id
+    }
+
+    /// Get a mutable reference to the underlying context.
+    pub fn context_mut(&mut self) -> Option<&mut TransactionContext> {
+        self.ctx.as_mut()
+    }
+
+    fn context(&self) -> Option<&TransactionContext> {
+        self.ctx.as_ref()
+    }
+}
+
+impl Deref for Transaction {
+    type Target = TransactionContext;
+
+    fn deref(&self) -> &Self::Target {
+        self.context()
+            .expect("transaction context not available after commit/abort")
+    }
+}
+
+impl DerefMut for Transaction {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.context_mut()
+            .expect("transaction context not available after commit/abort")
+    }
+}
+
+impl Drop for Transaction {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}

--- a/crates/executor/src/api/mod.rs
+++ b/crates/executor/src/api/mod.rs
@@ -536,8 +536,8 @@ impl Strata {
             Backend::Local { .. } => Session::new_with_mode(self.database(), self.access_mode),
             Backend::Ipc {
                 client,
-                access_mode,
                 data_dir: _,
+                ..
             } => {
                 // For IPC, each session is a new connection (server creates
                 // a per-connection Session automatically)
@@ -552,7 +552,7 @@ impl Strata {
                         e
                     );
                 });
-                Session::new_ipc(new_client, *access_mode)
+                Session::new_ipc(new_client)
             }
         }
     }

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -33,12 +33,13 @@
 //! During transactions, operations are queued in `VectorBackendState` and
 //! `GraphBackendState` (stored as Database extensions). After commit, the
 //! corresponding observers apply the queued operations. On abort or commit
-//! failure, Session clears the queued operations without applying them.
+//! failure, engine-owned abort observers clear the queued operations without
+//! executor/session cleanup.
 
 use std::sync::Arc;
 
 use strata_core::types::{Key, Namespace, TypeTag};
-use strata_engine::database::search_only_cache_spec;
+use strata_engine::transaction::context::Transaction as ScopedTransaction;
 use strata_engine::{Database, Transaction, TransactionContext, TransactionOps};
 use strata_graph::ext::GraphStoreExt;
 use strata_graph::types::NodeData;
@@ -59,43 +60,50 @@ use crate::{Command, Error, Executor, Output, Result};
 ///
 /// When no transaction is active, commands delegate to the inner `Executor`.
 /// When a transaction is active, data commands (KV, Event, JSON)
-/// route through the engine's `Transaction<'a>` / `TransactionOps` trait,
+/// route through the engine's `ScopedTransaction<'a>` / `TransactionOps` trait,
 /// while non-transactional commands (Branch, Vector, DB) still delegate to
 /// the `Executor`.
 ///
 /// For IPC mode, the session delegates all commands (including transactions)
 /// to the server via a dedicated IPC connection. The server creates a
 /// per-connection Session, so transaction state is managed server-side.
-pub struct Session {
+pub enum Session {
+    /// Database-backed local session state.
+    Local(LocalSession),
+    /// IPC-backed remote session state.
+    Ipc(IpcSession),
+}
+
+#[doc(hidden)]
+pub struct LocalSession {
     executor: Executor,
     db: Arc<Database>,
-    txn_ctx: Option<TransactionContext>,
-    txn_branch_id: Option<strata_core::types::BranchId>,
-    /// Optional IPC client for remote sessions.
-    ipc_client: Option<IpcClient>,
+    txn: Option<Transaction>,
+}
+
+#[doc(hidden)]
+pub struct IpcSession {
+    client: IpcClient,
+    txn_active: bool,
 }
 
 impl Session {
     /// Create a new session.
     pub fn new(db: Arc<Database>) -> Self {
-        Self {
+        Self::Local(LocalSession {
             executor: Executor::new(db.clone()),
             db,
-            txn_ctx: None,
-            txn_branch_id: None,
-            ipc_client: None,
-        }
+            txn: None,
+        })
     }
 
     /// Create a new session with an explicit access mode.
     pub fn new_with_mode(db: Arc<Database>, access_mode: AccessMode) -> Self {
-        Self {
+        Self::Local(LocalSession {
             executor: Executor::new_with_mode(db.clone(), access_mode),
             db,
-            txn_ctx: None,
-            txn_branch_id: None,
-            ipc_client: None,
-        }
+            txn: None,
+        })
     }
 
     /// Create a new IPC-backed session.
@@ -103,33 +111,83 @@ impl Session {
     /// All commands (including transaction lifecycle) are sent over the IPC
     /// connection. The server creates a per-connection Session, so transaction
     /// state is managed server-side.
-    pub fn new_ipc(client: IpcClient, access_mode: AccessMode) -> Self {
-        // We need a dummy Database for the executor, but for IPC sessions
-        // the executor is never used — all commands go through the IPC client.
-        // Use an in-memory cache DB as a placeholder.
-        let db = Database::open_runtime(search_only_cache_spec())
-            .expect("failed to create in-memory placeholder DB (out of memory?)");
-        Self {
-            executor: Executor::new_with_mode(db.clone(), access_mode),
-            db,
-            txn_ctx: None,
-            txn_branch_id: None,
-            ipc_client: Some(client),
-        }
+    pub fn new_ipc(client: IpcClient) -> Self {
+        Self::Ipc(IpcSession {
+            client,
+            txn_active: false,
+        })
     }
 
     /// Returns whether a transaction is currently active.
+    ///
+    /// For IPC sessions, this reflects the last transaction state confirmed
+    /// by the remote server on this connection.
     pub fn in_transaction(&self) -> bool {
-        self.txn_ctx.is_some()
+        match self {
+            Self::Local(session) => session.txn.is_some(),
+            Self::Ipc(session) => session.txn_active,
+        }
     }
 
     /// Execute a command, routing through the active transaction when appropriate.
-    pub fn execute(&mut self, mut cmd: Command) -> Result<Output> {
-        // IPC sessions delegate everything to the server
-        if let Some(ref mut client) = self.ipc_client {
-            return client.execute(cmd);
+    pub fn execute(&mut self, cmd: Command) -> Result<Output> {
+        match self {
+            Self::Local(session) => session.execute(cmd),
+            Self::Ipc(session) => session.execute(cmd),
+        }
+    }
+
+    /// Get a reference to the underlying executor for local sessions.
+    pub fn executor(&self) -> Option<&Executor> {
+        match self {
+            Self::Local(session) => Some(&session.executor),
+            Self::Ipc(_) => None,
+        }
+    }
+}
+
+impl IpcSession {
+    fn execute(&mut self, cmd: Command) -> Result<Output> {
+        enum TxnCommand {
+            Begin,
+            Commit,
+            Rollback,
+            IsActive,
         }
 
+        let txn_cmd = match &cmd {
+            Command::TxnBegin { .. } => Some(TxnCommand::Begin),
+            Command::TxnCommit => Some(TxnCommand::Commit),
+            Command::TxnRollback => Some(TxnCommand::Rollback),
+            Command::TxnIsActive => Some(TxnCommand::IsActive),
+            _ => None,
+        };
+
+        let result = self.client.execute(cmd);
+
+        match (txn_cmd, &result) {
+            (Some(TxnCommand::Begin), Ok(Output::TxnBegun))
+            | (Some(TxnCommand::Begin), Err(Error::TransactionAlreadyActive { .. })) => {
+                self.txn_active = true;
+            }
+            (Some(TxnCommand::Commit), _)
+            | (Some(TxnCommand::Rollback), _)
+            | (Some(TxnCommand::IsActive), Ok(Output::Bool(false))) => {
+                self.txn_active = false;
+            }
+            (Some(TxnCommand::IsActive), Ok(Output::Bool(true))) => {
+                self.txn_active = true;
+            }
+            _ => {}
+        }
+
+        result
+    }
+}
+
+impl LocalSession {
+    /// Execute a command, routing through the active transaction when appropriate.
+    fn execute(&mut self, mut cmd: Command) -> Result<Output> {
         if self.executor.access_mode() == AccessMode::ReadOnly && cmd.is_write() {
             let hint = if self.db.is_follower() {
                 Some("This database is a read-only follower. Writes must go through the primary instance.".to_string())
@@ -150,13 +208,13 @@ impl Session {
             Command::TxnCommit => self.handle_commit(),
             Command::TxnRollback => self.handle_abort(),
             Command::TxnInfo => self.handle_txn_info(),
-            Command::TxnIsActive => Ok(Output::Bool(self.in_transaction())),
+            Command::TxnIsActive => Ok(Output::Bool(self.txn.is_some())),
 
             // Vector collection DDL modifies in-memory backend state (DashMap)
             // and is not rollback-safe, so it's rejected inside transactions.
             // Vector upsert/delete now participate in OCC via VectorStoreExt.
             Command::VectorCreateCollection { .. } | Command::VectorDeleteCollection { .. }
-                if self.txn_ctx.is_some() =>
+                if self.txn.is_some() =>
             {
                 Err(Error::InvalidInput {
                     reason:
@@ -169,7 +227,7 @@ impl Session {
             // Branch create/delete modify global state outside the transaction
             // scope and are not supported inside a transaction.
             Command::BranchCreate { .. } | Command::BranchDelete { .. }
-                if self.txn_ctx.is_some() =>
+                if self.txn.is_some() =>
             {
                 Err(Error::InvalidInput {
                     reason: "Branch create/delete operations are not supported inside a transaction"
@@ -188,7 +246,7 @@ impl Session {
             | Command::GraphDeleteLinkType { .. }
             | Command::GraphFreezeOntology { .. }
             | Command::GraphBulkInsert { .. }
-                if self.txn_ctx.is_some() =>
+                if self.txn.is_some() =>
             {
                 Err(Error::InvalidInput {
                     reason: "Graph delete, bulk insert, and ontology operations are not supported inside a transaction"
@@ -240,7 +298,7 @@ impl Session {
 
             // Data commands: route through txn if active, else delegate
             _ => {
-                if self.txn_ctx.is_some() {
+                if self.txn.is_some() {
                     self.execute_in_txn(cmd)
                 } else {
                     self.executor.execute(cmd)
@@ -249,17 +307,8 @@ impl Session {
         }
     }
 
-    /// Get a reference to the underlying executor.
-    pub fn executor(&self) -> &Executor {
-        &self.executor
-    }
-
-    // =========================================================================
-    // Transaction lifecycle handlers
-    // =========================================================================
-
     fn handle_begin(&mut self, cmd: &Command) -> Result<Output> {
-        if self.txn_ctx.is_some() {
+        if self.txn.is_some() {
             return Err(Error::TransactionAlreadyActive {
                 hint: Some("Commit or rollback before starting a new one.".to_string()),
             });
@@ -271,37 +320,19 @@ impl Session {
         };
 
         let core_branch_id = to_core_branch_id(&branch)?;
-        let ctx = self.db.begin_transaction(core_branch_id)?;
-        self.txn_ctx = Some(ctx);
-        self.txn_branch_id = Some(core_branch_id);
+        let txn = self.db.begin_transaction(core_branch_id)?;
+        self.txn = Some(txn);
 
         Ok(Output::TxnBegun)
     }
 
     fn handle_commit(&mut self) -> Result<Output> {
-        let mut ctx = self.txn_ctx.take().ok_or(Error::TransactionNotActive {
+        let mut txn = self.txn.take().ok_or(Error::TransactionNotActive {
             hint: Some("Start one with: begin".to_string()),
         })?;
-        let txn_id = ctx.txn_id;
-        self.txn_branch_id = None;
-
-        match self.db.commit_transaction(&mut ctx) {
-            Ok(version) => {
-                // T2-E5: Post-commit work is now handled by subsystem observers
-                // (GraphCommitObserver, VectorCommitObserver) registered with the database.
-                self.db.end_transaction(ctx);
-                Ok(Output::TxnCommitted { version })
-            }
+        match txn.commit() {
+            Ok(version) => Ok(Output::TxnCommitted { version }),
             Err(e) => {
-                // Return context to pool even on failure
-                self.db.end_transaction(ctx);
-                // Clear pending ops for uncommitted transactions (T2-E2, T2-E5: subsystem-owned cleanup).
-                if let Ok(state) = self.executor.primitives().vector.state() {
-                    state.clear_pending_ops(txn_id);
-                }
-                if let Ok(state) = self.executor.primitives().graph.state() {
-                    state.clear_pending_ops(txn_id);
-                }
                 // Discriminate error types: only OCC validation failures
                 // become TransactionConflict; storage/WAL errors become Io;
                 // other errors become Internal.
@@ -333,29 +364,17 @@ impl Session {
     }
 
     fn handle_abort(&mut self) -> Result<Output> {
-        let ctx = self.txn_ctx.take().ok_or(Error::TransactionNotActive {
+        let mut txn = self.txn.take().ok_or(Error::TransactionNotActive {
             hint: Some("Start one with: begin".to_string()),
         })?;
-        let txn_id = ctx.txn_id;
-        self.txn_branch_id.take();
-
-        // Clear pending ops for aborted transactions (T2-E2, T2-E5: subsystem-owned cleanup).
-        // These ops were queued by VectorStoreExt/GraphStoreExt but will not be committed.
-        if let Ok(state) = self.executor.primitives().vector.state() {
-            state.clear_pending_ops(txn_id);
-        }
-        if let Ok(state) = self.executor.primitives().graph.state() {
-            state.clear_pending_ops(txn_id);
-        }
-
-        self.db.end_transaction(ctx);
+        txn.abort();
         Ok(Output::TxnAborted)
     }
 
     fn handle_txn_info(&self) -> Result<Output> {
-        if let Some(ctx) = &self.txn_ctx {
+        if let Some(txn) = &self.txn {
             Ok(Output::TxnInfo(Some(crate::types::TransactionInfo {
-                id: ctx.txn_id.to_string(),
+                id: txn.txn_id.to_string(),
                 status: crate::types::TxnStatus::Active,
                 started_at: 0,
             })))
@@ -370,8 +389,10 @@ impl Session {
 
     fn execute_in_txn(&mut self, cmd: Command) -> Result<Output> {
         let branch_id = self
-            .txn_branch_id
-            .expect("txn_branch_id set when txn_ctx is Some");
+            .txn
+            .as_ref()
+            .expect("txn set when transaction is active")
+            .branch_id();
 
         // Extract space from the command being executed
         let space = match &cmd {
@@ -432,13 +453,15 @@ impl Session {
             _ => "default".to_string(),
         };
         let ns = Arc::new(Namespace::for_branch_space(branch_id, &space));
-
-        // Temporarily take the context to create a Transaction
-        let mut ctx = self.txn_ctx.take().unwrap();
-        let result = Self::dispatch_in_txn(&self.executor, &mut ctx, ns, branch_id, &space, cmd);
-        self.txn_ctx = Some(ctx);
-
-        result
+        let executor = &self.executor;
+        let txn = self
+            .txn
+            .as_mut()
+            .expect("txn set when transaction is active");
+        let ctx = txn
+            .context_mut()
+            .expect("transaction context available until commit/abort");
+        Self::dispatch_in_txn(executor, ctx, ns, branch_id, &space, cmd)
     }
 
     fn dispatch_in_txn(
@@ -548,7 +571,7 @@ impl Session {
                     }
                 } else {
                     // Path-based get still needs Transaction for JSON patch logic
-                    let mut txn = Transaction::new(ctx, ns);
+                    let mut txn = ScopedTransaction::new(ctx, ns);
                     let json_path = convert_result(parse_path(&path))?;
                     let result = txn.json_get_path(&key, &json_path).map_err(Error::from)?;
                     match result {
@@ -563,7 +586,7 @@ impl Session {
 
             // === Write commands — use Transaction ===
             Command::KvPut { key, value, .. } => {
-                let mut txn = Transaction::new(ctx, ns);
+                let mut txn = ScopedTransaction::new(ctx, ns);
                 let version = txn.kv_put(&key, value).map_err(Error::from)?;
                 Ok(Output::WriteResult {
                     key,
@@ -593,7 +616,7 @@ impl Session {
                 payload,
                 ..
             } => {
-                let mut txn = Transaction::new(ctx, ns);
+                let mut txn = ScopedTransaction::new(ctx, ns);
                 let version = txn
                     .event_append(&event_type, payload)
                     .map_err(Error::from)?;
@@ -603,7 +626,7 @@ impl Session {
                 })
             }
             Command::EventGet { sequence, .. } => {
-                let mut txn = Transaction::new(ctx, ns);
+                let mut txn = ScopedTransaction::new(ctx, ns);
                 let result = txn.event_get(sequence).map_err(Error::from)?;
                 Ok(Output::MaybeVersioned(result.map(|v| {
                     to_versioned_value(strata_core::Versioned::new(
@@ -613,7 +636,7 @@ impl Session {
                 })))
             }
             Command::EventLen { .. } => {
-                let mut txn = Transaction::new(ctx, ns);
+                let mut txn = ScopedTransaction::new(ctx, ns);
                 let len = txn.event_len().map_err(Error::from)?;
                 Ok(Output::Uint(len))
             }
@@ -622,7 +645,7 @@ impl Session {
             Command::JsonSet {
                 key, path, value, ..
             } => {
-                let mut txn = Transaction::new(ctx, ns);
+                let mut txn = ScopedTransaction::new(ctx, ns);
                 let json_path = convert_result(parse_path(&path))?;
                 let json_value = convert_result(value_to_json(value))?;
                 let version = txn
@@ -634,7 +657,7 @@ impl Session {
                 })
             }
             Command::JsonDelete { key, .. } => {
-                let mut txn = Transaction::new(ctx, ns);
+                let mut txn = ScopedTransaction::new(ctx, ns);
                 let deleted = txn.json_delete(&key).map_err(Error::from)?;
                 Ok(Output::DeleteResult { key, deleted })
             }
@@ -1046,7 +1069,7 @@ impl Session {
                     };
                     entries.len()
                 ];
-                let mut txn = Transaction::new(ctx, ns);
+                let mut txn = ScopedTransaction::new(ctx, ns);
                 for (i, entry) in entries.into_iter().enumerate() {
                     match txn.kv_put(&entry.key, entry.value) {
                         Ok(_) => {} // version assigned at commit time
@@ -1096,7 +1119,7 @@ impl Session {
                     };
                     entries.len()
                 ];
-                let mut txn = Transaction::new(ctx, ns);
+                let mut txn = ScopedTransaction::new(ctx, ns);
                 for (i, entry) in entries.into_iter().enumerate() {
                     match txn.event_append(&entry.event_type, entry.payload) {
                         Ok(version) => results[i].version = Some(extract_version(&version)),
@@ -1109,24 +1132,6 @@ impl Session {
             // Commands not directly mapped — delegate to executor.
             // This includes version history, graph analytics, search, etc.
             other => executor.execute(other),
-        }
-    }
-}
-
-impl Drop for Session {
-    fn drop(&mut self) {
-        // Clean up any in-progress transaction on drop.
-        // Clear pending ops and return context to pool.
-        if let Some(ctx) = self.txn_ctx.take() {
-            // Clear pending ops for the abandoned transaction (T2-E2, T2-E5).
-            if let Ok(state) = self.executor.primitives().vector.state() {
-                state.clear_pending_ops(ctx.txn_id);
-            }
-            if let Ok(state) = self.executor.primitives().graph.state() {
-                state.clear_pending_ops(ctx.txn_id);
-            }
-            self.txn_branch_id = None;
-            self.db.end_transaction(ctx);
         }
     }
 }

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -22,32 +22,24 @@
 //! session.execute(Command::TxnCommit)?;
 //! ```
 //!
-//! # Deferred Operations
+//! # Post-Commit Work
 //!
-//! The session maintains two distinct deferred operation mechanisms:
+//! Post-commit work (derived index updates) is handled by subsystem-owned
+//! observers registered with the Database:
 //!
-//! ## PostCommitOp (Executor Layer)
+//! - `VectorCommitObserver` (T2-E2): applies queued HNSW operations
+//! - `GraphCommitObserver` (T2-E5): applies queued BM25 index operations
 //!
-//! Command-specific side effects requiring data staged during execution.
-//! Applied by `run_post_commit_ops()` after successful commit. Examples:
-//! - Graph node indexing for BM25 search
-//! - Vector HNSW index updates
-//!
-//! ## CommitObserver (Engine Layer)
-//!
-//! Generic commit notifications via `db.commit_observers().notify()`.
-//! Receives only `CommitInfo` (branch_id, commit_version, entry_count).
-//! Used for audit, metrics, and other cross-cutting concerns.
-//!
-//! These are complementary, not competing patterns. `PostCommitOp` handles
-//! operations requiring command-specific data (embeddings, node properties),
-//! while `CommitObserver` handles generic notifications.
+//! During transactions, operations are queued in `VectorBackendState` and
+//! `GraphBackendState` (stored as Database extensions). After commit, the
+//! corresponding observers apply the queued operations. On abort or commit
+//! failure, Session clears the queued operations without applying them.
 
 use std::sync::Arc;
 
-use strata_core::types::{BranchId as CoreBranchId, Key, Namespace, TypeTag};
-use strata_engine::database::{search_only_cache_spec, OpenSpec};
-use strata_engine::{Database, SearchSubsystem, Transaction, TransactionContext, TransactionOps};
+use strata_core::types::{Key, Namespace, TypeTag};
+use strata_engine::database::search_only_cache_spec;
+use strata_engine::{Database, Transaction, TransactionContext, TransactionOps};
 use strata_graph::ext::GraphStoreExt;
 use strata_graph::types::NodeData;
 use strata_security::AccessMode;
@@ -61,50 +53,6 @@ use crate::convert::convert_result;
 use crate::ipc::IpcClient;
 use crate::types::BranchId;
 use crate::{Command, Error, Executor, Output, Result};
-
-/// Deferred operations executed after a successful transaction commit.
-///
-/// ## Why PostCommitOp Exists
-///
-/// These operations update derived indices (graph search index, vector HNSW)
-/// that cannot participate in OCC (Optimistic Concurrency Control):
-/// - HNSW index updates are in-memory and not rollback-safe
-/// - Graph search index updates depend on committed node data
-///
-/// ## Why Not CommitObserver?
-///
-/// Engine's `CommitObserver` receives only `CommitInfo` (branch_id,
-/// commit_version, entry_count). `PostCommitOp` variants require
-/// operation-specific data captured during command execution:
-/// - `GraphIndexNode` needs `NodeData` (properties, entity_ref)
-/// - `VectorBackendOp` needs `StagedVectorOp` (embedding, vector_id)
-///
-/// This data cannot be reconstructed from generic commit info without
-/// re-reading and parsing committed data, making `CommitObserver` unsuitable.
-///
-/// ## Failure Model
-///
-/// Best-effort: failures are logged but never propagate back to the caller.
-/// The primary data is already committed to KV; derived indices will catch
-/// up on next recovery if an update fails.
-///
-/// Note: VectorBackendOp was removed in T2-E2. Vector HNSW maintenance is now
-/// subsystem-owned via VectorCommitObserver in VectorSubsystem.
-enum PostCommitOp {
-    GraphIndexNode {
-        branch_id: CoreBranchId,
-        space: String,
-        graph: String,
-        node_id: String,
-        data: NodeData,
-    },
-    GraphDeindexNode {
-        branch_id: CoreBranchId,
-        space: String,
-        graph: String,
-        node_id: String,
-    },
-}
 
 /// A stateful session that wraps an [`Executor`] and manages an optional
 /// open transaction with read-your-writes semantics.
@@ -125,8 +73,6 @@ pub struct Session {
     txn_branch_id: Option<strata_core::types::BranchId>,
     /// Optional IPC client for remote sessions.
     ipc_client: Option<IpcClient>,
-    /// Deferred operations executed after a successful commit.
-    post_commit_ops: Vec<PostCommitOp>,
 }
 
 impl Session {
@@ -138,7 +84,6 @@ impl Session {
             txn_ctx: None,
             txn_branch_id: None,
             ipc_client: None,
-            post_commit_ops: Vec::new(),
         }
     }
 
@@ -150,7 +95,6 @@ impl Session {
             txn_ctx: None,
             txn_branch_id: None,
             ipc_client: None,
-            post_commit_ops: Vec::new(),
         }
     }
 
@@ -171,7 +115,6 @@ impl Session {
             txn_ctx: None,
             txn_branch_id: None,
             ipc_client: Some(client),
-            post_commit_ops: Vec::new(),
         }
     }
 
@@ -344,15 +287,19 @@ impl Session {
 
         match self.db.commit_transaction(&mut ctx) {
             Ok(version) => {
+                // T2-E5: Post-commit work is now handled by subsystem observers
+                // (GraphCommitObserver, VectorCommitObserver) registered with the database.
                 self.db.end_transaction(ctx);
-                self.run_post_commit_ops();
                 Ok(Output::TxnCommitted { version })
             }
             Err(e) => {
                 // Return context to pool even on failure
                 self.db.end_transaction(ctx);
-                self.post_commit_ops.clear();
+                // Clear pending ops for uncommitted transactions (T2-E2, T2-E5: subsystem-owned cleanup).
                 if let Ok(state) = self.executor.primitives().vector.state() {
+                    state.clear_pending_ops(txn_id);
+                }
+                if let Ok(state) = self.executor.primitives().graph.state() {
                     state.clear_pending_ops(txn_id);
                 }
                 // Discriminate error types: only OCC validation failures
@@ -391,11 +338,13 @@ impl Session {
         })?;
         let txn_id = ctx.txn_id;
         self.txn_branch_id.take();
-        self.post_commit_ops.clear();
 
-        // Clear pending vector ops for this transaction (T2-E2: subsystem-owned cleanup).
-        // These ops were queued by VectorStoreExt but will not be committed.
+        // Clear pending ops for aborted transactions (T2-E2, T2-E5: subsystem-owned cleanup).
+        // These ops were queued by VectorStoreExt/GraphStoreExt but will not be committed.
         if let Ok(state) = self.executor.primitives().vector.state() {
+            state.clear_pending_ops(txn_id);
+        }
+        if let Ok(state) = self.executor.primitives().graph.state() {
             state.clear_pending_ops(txn_id);
         }
 
@@ -412,41 +361,6 @@ impl Session {
             })))
         } else {
             Ok(Output::TxnInfo(None))
-        }
-    }
-
-    // =========================================================================
-    // Post-commit hooks
-    // =========================================================================
-
-    fn run_post_commit_ops(&mut self) {
-        let ops = std::mem::take(&mut self.post_commit_ops);
-        let primitives = self.executor.primitives();
-
-        for op in ops {
-            match op {
-                PostCommitOp::GraphIndexNode {
-                    branch_id,
-                    space,
-                    graph,
-                    node_id,
-                    data,
-                } => {
-                    primitives
-                        .graph
-                        .index_node_for_search(branch_id, &space, &graph, &node_id, &data);
-                }
-                PostCommitOp::GraphDeindexNode {
-                    branch_id,
-                    space,
-                    graph,
-                    node_id,
-                } => {
-                    primitives
-                        .graph
-                        .deindex_node_for_search(branch_id, &space, &graph, &node_id);
-                }
-            }
         }
     }
 
@@ -521,15 +435,7 @@ impl Session {
 
         // Temporarily take the context to create a Transaction
         let mut ctx = self.txn_ctx.take().unwrap();
-        let result = Self::dispatch_in_txn(
-            &self.executor,
-            &mut ctx,
-            ns,
-            branch_id,
-            &space,
-            cmd,
-            &mut self.post_commit_ops,
-        );
+        let result = Self::dispatch_in_txn(&self.executor, &mut ctx, ns, branch_id, &space, cmd);
         self.txn_ctx = Some(ctx);
 
         result
@@ -542,7 +448,6 @@ impl Session {
         branch_id: strata_core::types::BranchId,
         space: &str,
         cmd: Command,
-        post_commit_ops: &mut Vec<PostCommitOp>,
     ) -> Result<Output> {
         // Read commands use ctx.get() / ctx.scan_prefix() directly so they
         // fall through to the snapshot when the key isn't in the write-set.
@@ -771,23 +676,63 @@ impl Session {
                 };
                 let created =
                     convert_result(ctx.graph_add_node(branch_id, space, &graph, &node_id, &data))?;
-                post_commit_ops.push(PostCommitOp::GraphIndexNode {
-                    branch_id,
-                    space: space.to_string(),
-                    graph,
-                    node_id: node_id.clone(),
-                    data,
-                });
+                // Queue for GraphCommitObserver (subsystem-owned maintenance).
+                // T2-E5: replaces executor-owned PostCommitOp pattern.
+                match executor.primitives().graph.state() {
+                    Ok(state) => {
+                        state.queue_pending_op(
+                            ctx.txn_id,
+                            strata_graph::StagedGraphOp::IndexNode {
+                                branch_id,
+                                space: space.to_string(),
+                                graph: graph.clone(),
+                                node_id: node_id.clone(),
+                                data,
+                            },
+                        );
+                    }
+                    Err(e) => {
+                        // Best-effort: log but don't fail the operation.
+                        // Search index can be rebuilt from committed data.
+                        tracing::warn!(
+                            target: "strata::graph",
+                            graph = %graph,
+                            node_id = %node_id,
+                            error = %e,
+                            "Failed to queue graph index op; search index may be stale"
+                        );
+                    }
+                }
                 Ok(Output::GraphWriteResult { node_id, created })
             }
             Command::GraphRemoveNode { graph, node_id, .. } => {
                 convert_result(ctx.graph_remove_node(branch_id, space, &graph, &node_id))?;
-                post_commit_ops.push(PostCommitOp::GraphDeindexNode {
-                    branch_id,
-                    space: space.to_string(),
-                    graph,
-                    node_id: node_id.clone(),
-                });
+                // Queue for GraphCommitObserver (subsystem-owned maintenance).
+                // T2-E5: replaces executor-owned PostCommitOp pattern.
+                match executor.primitives().graph.state() {
+                    Ok(state) => {
+                        state.queue_pending_op(
+                            ctx.txn_id,
+                            strata_graph::StagedGraphOp::DeindexNode {
+                                branch_id,
+                                space: space.to_string(),
+                                graph: graph.clone(),
+                                node_id: node_id.clone(),
+                            },
+                        );
+                    }
+                    Err(e) => {
+                        // Best-effort: log but don't fail the operation.
+                        // Search index can be rebuilt from committed data.
+                        tracing::warn!(
+                            target: "strata::graph",
+                            graph = %graph,
+                            node_id = %node_id,
+                            error = %e,
+                            "Failed to queue graph deindex op; search index may be stale"
+                        );
+                    }
+                }
                 Ok(Output::Unit)
             }
             Command::GraphAddEdge {
@@ -1205,9 +1150,14 @@ impl Session {
 
 impl Drop for Session {
     fn drop(&mut self) {
-        self.post_commit_ops.clear();
+        // Clean up any in-progress transaction on drop.
+        // Clear pending ops and return context to pool.
         if let Some(ctx) = self.txn_ctx.take() {
+            // Clear pending ops for the abandoned transaction (T2-E2, T2-E5).
             if let Ok(state) = self.executor.primitives().vector.state() {
+                state.clear_pending_ops(ctx.txn_id);
+            }
+            if let Ok(state) = self.executor.primitives().graph.state() {
                 state.clear_pending_ops(ctx.txn_id);
             }
             self.txn_branch_id = None;

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -674,65 +674,30 @@ impl Session {
                     properties: props,
                     object_type,
                 };
-                let created =
-                    convert_result(ctx.graph_add_node(branch_id, space, &graph, &node_id, &data))?;
-                // Queue for GraphCommitObserver (subsystem-owned maintenance).
-                // T2-E5: replaces executor-owned PostCommitOp pattern.
-                match executor.primitives().graph.state() {
-                    Ok(state) => {
-                        state.queue_pending_op(
-                            ctx.txn_id,
-                            strata_graph::StagedGraphOp::IndexNode {
-                                branch_id,
-                                space: space.to_string(),
-                                graph: graph.clone(),
-                                node_id: node_id.clone(),
-                                data,
-                            },
-                        );
-                    }
-                    Err(e) => {
-                        // Best-effort: log but don't fail the operation.
-                        // Search index can be rebuilt from committed data.
-                        tracing::warn!(
-                            target: "strata::graph",
-                            graph = %graph,
-                            node_id = %node_id,
-                            error = %e,
-                            "Failed to queue graph index op; search index may be stale"
-                        );
-                    }
-                }
+                // Get backend state for subsystem-owned index maintenance.
+                // T2-E5: graph_add_node queues ops that CommitObserver applies after commit.
+                let backend_state = convert_result(executor.primitives().graph.state())?;
+                let created = convert_result(ctx.graph_add_node(
+                    branch_id,
+                    space,
+                    &graph,
+                    &node_id,
+                    &data,
+                    &backend_state,
+                ))?;
                 Ok(Output::GraphWriteResult { node_id, created })
             }
             Command::GraphRemoveNode { graph, node_id, .. } => {
-                convert_result(ctx.graph_remove_node(branch_id, space, &graph, &node_id))?;
-                // Queue for GraphCommitObserver (subsystem-owned maintenance).
-                // T2-E5: replaces executor-owned PostCommitOp pattern.
-                match executor.primitives().graph.state() {
-                    Ok(state) => {
-                        state.queue_pending_op(
-                            ctx.txn_id,
-                            strata_graph::StagedGraphOp::DeindexNode {
-                                branch_id,
-                                space: space.to_string(),
-                                graph: graph.clone(),
-                                node_id: node_id.clone(),
-                            },
-                        );
-                    }
-                    Err(e) => {
-                        // Best-effort: log but don't fail the operation.
-                        // Search index can be rebuilt from committed data.
-                        tracing::warn!(
-                            target: "strata::graph",
-                            graph = %graph,
-                            node_id = %node_id,
-                            error = %e,
-                            "Failed to queue graph deindex op; search index may be stale"
-                        );
-                    }
-                }
+                // Get backend state for subsystem-owned index maintenance.
+                // T2-E5: graph_remove_node queues ops that CommitObserver applies after commit.
+                let backend_state = convert_result(executor.primitives().graph.state())?;
+                convert_result(ctx.graph_remove_node(
+                    branch_id,
+                    space,
+                    &graph,
+                    &node_id,
+                    &backend_state,
+                ))?;
                 Ok(Output::Unit)
             }
             Command::GraphAddEdge {

--- a/crates/executor/src/tests/ipc.rs
+++ b/crates/executor/src/tests/ipc.rs
@@ -4,7 +4,7 @@ use crate::ipc::client::IpcClient;
 use crate::ipc::protocol::{self, Request, Response};
 use crate::ipc::server::IpcServer;
 use crate::ipc::wire;
-use crate::{Command, Output, Value};
+use crate::{Command, Output, Session, Value};
 use strata_engine::database::search_only_primary_spec;
 use strata_engine::Database;
 use strata_security::AccessMode;
@@ -273,6 +273,60 @@ fn ipc_connect_new() {
 
     let result = client2.execute(Command::Ping).unwrap();
     assert!(matches!(result, Output::Pong { .. }));
+
+    server.shutdown();
+}
+
+#[test]
+fn ipc_session_has_no_local_executor() {
+    let (_dir, mut server) = setup_server();
+    let socket_path = server.socket_path().to_path_buf();
+
+    let client = IpcClient::connect(&socket_path).unwrap();
+    let mut session = Session::new_ipc(client);
+
+    assert!(matches!(session, Session::Ipc(_)));
+    assert!(session.executor().is_none());
+    assert!(!session.in_transaction());
+    assert!(matches!(session.execute(Command::Ping).unwrap(), Output::Pong { .. }));
+
+    server.shutdown();
+}
+
+#[test]
+fn ipc_session_tracks_remote_transaction_state() {
+    let (_dir, mut server) = setup_server();
+    let socket_path = server.socket_path().to_path_buf();
+
+    let client = IpcClient::connect(&socket_path).unwrap();
+    let mut session = Session::new_ipc(client);
+
+    assert!(!session.in_transaction());
+
+    assert!(matches!(
+        session
+            .execute(Command::TxnBegin {
+                branch: None,
+                options: None,
+            })
+            .unwrap(),
+        Output::TxnBegun
+    ));
+    assert!(session.in_transaction());
+    assert!(matches!(
+        session.execute(Command::TxnIsActive).unwrap(),
+        Output::Bool(true)
+    ));
+
+    assert!(matches!(
+        session.execute(Command::TxnRollback).unwrap(),
+        Output::TxnAborted
+    ));
+    assert!(!session.in_transaction());
+    assert!(matches!(
+        session.execute(Command::TxnIsActive).unwrap(),
+        Output::Bool(false)
+    ));
 
     server.shutdown();
 }

--- a/crates/graph/src/branch_dag.rs
+++ b/crates/graph/src/branch_dag.rs
@@ -947,6 +947,14 @@ impl strata_engine::Subsystem for GraphSubsystem {
         });
         db.branch_op_observers().register(audit_observer);
 
+        // Register commit and replay observers for graph index maintenance.
+        // T2-E5: moves graph index maintenance from executor-owned PostCommitOp
+        // to subsystem-owned observers.
+        let state = db
+            .extension::<crate::GraphBackendState>()
+            .map_err(|e| StrataError::internal(format!("failed to get GraphBackendState: {e}")))?;
+        crate::store::ensure_runtime_wiring(db, &state);
+
         Ok(())
     }
 

--- a/crates/graph/src/branch_dag.rs
+++ b/crates/graph/src/branch_dag.rs
@@ -948,8 +948,7 @@ impl strata_engine::Subsystem for GraphSubsystem {
         db.branch_op_observers().register(audit_observer);
 
         // Register commit and replay observers for graph index maintenance.
-        // T2-E5: moves graph index maintenance from executor-owned PostCommitOp
-        // to subsystem-owned observers.
+        // T2-E5: moves graph index maintenance to subsystem-owned observers.
         let state = db
             .extension::<crate::GraphBackendState>()
             .map_err(|e| StrataError::internal(format!("failed to get GraphBackendState: {e}")))?;

--- a/crates/graph/src/ext.rs
+++ b/crates/graph/src/ext.rs
@@ -343,7 +343,7 @@ impl GraphStoreExt for TransactionContext {
         }
 
         // Queue for GraphCommitObserver (subsystem-owned maintenance).
-        // T2-E5: replaces executor-owned PostCommitOp pattern.
+        // T2-E5: derived index work is staged in subsystem state, not Session.
         backend_state.queue_pending_op(
             self.txn_id,
             StagedGraphOp::IndexNode {
@@ -478,7 +478,7 @@ impl GraphStoreExt for TransactionContext {
         self.delete(node_storage_key)?;
 
         // Queue for GraphCommitObserver (subsystem-owned maintenance).
-        // T2-E5: replaces executor-owned PostCommitOp pattern.
+        // T2-E5: derived index work is staged in subsystem state, not Session.
         backend_state.queue_pending_op(
             self.txn_id,
             StagedGraphOp::DeindexNode {

--- a/crates/graph/src/ext.rs
+++ b/crates/graph/src/ext.rs
@@ -1,9 +1,14 @@
 //! Extension trait for graph operations on TransactionContext.
 //!
-//! Follows the same pattern as `KVStoreExt`, `EventLogExt`, and `JsonStoreExt`
-//! in `strata-engine`. By implementing graph operations directly on
+//! Follows the same pattern as `KVStoreExt`, `EventLogExt`, `JsonStoreExt`,
+//! and `VectorStoreExt`. By implementing graph operations directly on
 //! `TransactionContext`, both the standalone `GraphStore` methods and the
 //! Session's `dispatch_in_txn` can share one implementation.
+//!
+//! Graph index updates (BM25 search) cannot participate in OCC (they're
+//! in-memory and not rollback-safe), so write methods queue `StagedGraphOp`s
+//! in the `GraphBackendState` for the `GraphCommitObserver` to apply after
+//! successful commit.
 
 use std::collections::HashMap;
 
@@ -14,6 +19,7 @@ use strata_core::{StrataError, StrataResult};
 
 use crate::keys;
 use crate::packed;
+use crate::store::{GraphBackendState, StagedGraphOp};
 use crate::types::*;
 
 // ============================================================================
@@ -78,6 +84,9 @@ pub trait GraphStoreExt {
     // --- Nodes ---
 
     /// Add or update a node. Returns true if created, false if updated.
+    ///
+    /// Queues a `StagedGraphOp::IndexNode` in the backend state for the
+    /// `GraphCommitObserver` to apply after successful commit.
     fn graph_add_node(
         &mut self,
         branch_id: BranchId,
@@ -85,6 +94,7 @@ pub trait GraphStoreExt {
         graph: &str,
         node_id: &str,
         data: &NodeData,
+        backend_state: &GraphBackendState,
     ) -> StrataResult<bool>;
 
     /// Get node data, or None if not found.
@@ -97,12 +107,16 @@ pub trait GraphStoreExt {
     ) -> StrataResult<Option<NodeData>>;
 
     /// Remove a node and all its incident edges.
+    ///
+    /// Queues a `StagedGraphOp::DeindexNode` in the backend state for the
+    /// `GraphCommitObserver` to apply after successful commit.
     fn graph_remove_node(
         &mut self,
         branch_id: BranchId,
         space: &str,
         graph: &str,
         node_id: &str,
+        backend_state: &GraphBackendState,
     ) -> StrataResult<()>;
 
     /// List all node IDs in a graph.
@@ -276,6 +290,7 @@ impl GraphStoreExt for TransactionContext {
         graph: &str,
         node_id: &str,
         data: &NodeData,
+        backend_state: &GraphBackendState,
     ) -> StrataResult<bool> {
         keys::validate_graph_name(graph)?;
         keys::validate_node_id(node_id)?;
@@ -327,6 +342,19 @@ impl GraphStoreExt for TransactionContext {
             self.put(tk, Value::Null)?;
         }
 
+        // Queue for GraphCommitObserver (subsystem-owned maintenance).
+        // T2-E5: replaces executor-owned PostCommitOp pattern.
+        backend_state.queue_pending_op(
+            self.txn_id,
+            StagedGraphOp::IndexNode {
+                branch_id,
+                space: space.to_string(),
+                graph: graph.to_string(),
+                node_id: node_id.to_string(),
+                data: data.clone(),
+            },
+        );
+
         Ok(created)
     }
 
@@ -359,6 +387,7 @@ impl GraphStoreExt for TransactionContext {
         space: &str,
         graph: &str,
         node_id: &str,
+        backend_state: &GraphBackendState,
     ) -> StrataResult<()> {
         let node_user_key = keys::node_key(graph, node_id);
         let node_storage_key = keys::storage_key(branch_id, space, &node_user_key);
@@ -447,6 +476,19 @@ impl GraphStoreExt for TransactionContext {
         self.delete(fwd_adj_sk)?;
         self.delete(rev_adj_sk)?;
         self.delete(node_storage_key)?;
+
+        // Queue for GraphCommitObserver (subsystem-owned maintenance).
+        // T2-E5: replaces executor-owned PostCommitOp pattern.
+        backend_state.queue_pending_op(
+            self.txn_id,
+            StagedGraphOp::DeindexNode {
+                branch_id,
+                space: space.to_string(),
+                graph: graph.to_string(),
+                node_id: node_id.to_string(),
+            },
+        );
+
         Ok(())
     }
 

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -22,6 +22,7 @@ mod nodes;
 pub mod ontology;
 pub mod packed;
 mod snapshot;
+pub mod store;
 pub mod traversal;
 pub mod types;
 
@@ -30,6 +31,7 @@ pub use strata_core::branch_dag::{
     is_system_branch, DagBranchInfo, DagBranchStatus, DagEventId, ForkRecord, MergeRecord,
     BRANCH_DAG_GRAPH, SYSTEM_BRANCH,
 };
+pub use store::{GraphBackendState, StagedGraphOp};
 
 use std::sync::Arc;
 
@@ -53,6 +55,21 @@ impl GraphStore {
     /// Create a new GraphStore backed by the given database.
     pub fn new(db: Arc<Database>) -> Self {
         Self { db }
+    }
+
+    /// Get access to the shared backend state.
+    ///
+    /// This returns the shared `GraphBackendState` stored in the Database.
+    /// All GraphStore instances for the same Database share this state.
+    ///
+    /// Also ensures runtime wiring (commit/replay observers) is registered.
+    pub fn state(&self) -> StrataResult<Arc<GraphBackendState>> {
+        let state = self
+            .db
+            .extension::<GraphBackendState>()
+            .map_err(|e| StrataError::internal(e.to_string()))?;
+        store::ensure_runtime_wiring(&self.db, &state);
+        Ok(state)
     }
 
     /// Build a snapshot of the entire graph.

--- a/crates/graph/src/nodes.rs
+++ b/crates/graph/src/nodes.rs
@@ -27,14 +27,13 @@ impl GraphStore {
             }
         }
 
-        let result = self.db.transaction(branch_id, |txn| {
-            txn.graph_add_node(branch_id, space, graph, node_id, &data)
-        })?;
+        // Get backend state for subsystem-owned index maintenance.
+        // T2-E5: graph_add_node queues ops that CommitObserver applies after commit.
+        let backend_state = self.state()?;
 
-        // Post-commit: update search index
-        self.index_node_for_search(branch_id, space, graph, node_id, &data);
-
-        Ok(result)
+        self.db.transaction(branch_id, |txn| {
+            txn.graph_add_node(branch_id, space, graph, node_id, &data, &backend_state)
+        })
     }
 
     /// Get node data, or None if node doesn't exist.
@@ -114,14 +113,13 @@ impl GraphStore {
         graph: &str,
         node_id: &str,
     ) -> StrataResult<()> {
+        // Get backend state for subsystem-owned index maintenance.
+        // T2-E5: graph_remove_node queues ops that CommitObserver applies after commit.
+        let backend_state = self.state()?;
+
         self.db.transaction(branch_id, |txn| {
-            txn.graph_remove_node(branch_id, space, graph, node_id)
-        })?;
-
-        // Post-commit: remove from search index
-        self.deindex_node_for_search(branch_id, space, graph, node_id);
-
-        Ok(())
+            txn.graph_remove_node(branch_id, space, graph, node_id, &backend_state)
+        })
     }
 
     /// Get all nodes with their data in a graph (for snapshot).

--- a/crates/graph/src/store.rs
+++ b/crates/graph/src/store.rs
@@ -159,9 +159,9 @@ use strata_engine::Database;
 
 /// Ensure runtime hooks are wired for this database instance.
 ///
-/// This is called lazily from `GraphStore::state()`. It registers the
-/// commit and replay observers if they haven't been registered yet.
-pub(crate) fn ensure_runtime_wiring(db: &Arc<Database>, state: &Arc<GraphBackendState>) {
+/// This is called from `GraphSubsystem::initialize()` to register commit and
+/// replay observers. Uses atomic flag to ensure idempotent registration.
+pub fn ensure_runtime_wiring(db: &Arc<Database>, state: &Arc<GraphBackendState>) {
     use std::sync::atomic::Ordering;
 
     if state.runtime_wired.swap(true, Ordering::AcqRel) {
@@ -266,8 +266,8 @@ fn apply_replayed_graph_changes(
 
     // Index new/updated graph nodes
     for (key, value) in puts {
-        // Graph nodes are stored with TypeTag::KV with key format: "{graph}/n/{node_id}"
-        if key.type_tag != TypeTag::KV {
+        // Graph nodes are stored with TypeTag::Graph with key format: "{graph}/n/{node_id}"
+        if key.type_tag != TypeTag::Graph {
             continue;
         }
 
@@ -285,12 +285,12 @@ fn apply_replayed_graph_changes(
         let graph = parts[0];
         let node_id = parts[2];
 
-        // Deserialize node data
-        let bytes = match value {
-            Value::Bytes(b) => b,
+        // Deserialize node data from JSON string
+        let json_str = match value {
+            Value::String(s) => s,
             _ => continue,
         };
-        let data: crate::types::NodeData = match serde_json::from_slice(bytes) {
+        let data: crate::types::NodeData = match serde_json::from_str(json_str) {
             Ok(d) => d,
             Err(_) => continue,
         };
@@ -302,7 +302,7 @@ fn apply_replayed_graph_changes(
 
     // Deindex deleted graph nodes
     for (key, _value) in deleted_values {
-        if key.type_tag != TypeTag::KV {
+        if key.type_tag != TypeTag::Graph {
             continue;
         }
 

--- a/crates/graph/src/store.rs
+++ b/crates/graph/src/store.rs
@@ -1,0 +1,326 @@
+//! Shared backend state for GraphStore.
+//!
+//! This module provides `GraphBackendState` which is stored as a Database
+//! extension. This follows the same pattern as `VectorBackendState` in the
+//! vector crate.
+//!
+//! ## Design
+//!
+//! Graph index operations (BM25 search indexing) cannot participate in OCC
+//! because the inverted index is an in-memory structure that isn't rollback-safe.
+//! Operations are queued during transactions and applied after successful commit
+//! by `GraphCommitObserver`.
+//!
+//! ## Thread Safety
+//!
+//! Uses `DashMap` for per-transaction pending ops, allowing concurrent
+//! transactions to queue operations without blocking each other.
+
+use dashmap::DashMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use strata_core::id::TxnId;
+use strata_core::types::BranchId;
+
+use crate::types::NodeData;
+
+/// Staged graph index operation to be applied after commit.
+///
+/// These operations update derived indices (BM25 search index) that cannot
+/// participate in OCC. They're queued during transaction execution and
+/// applied by `GraphCommitObserver` after the transaction commits.
+#[derive(Debug, Clone)]
+pub enum StagedGraphOp {
+    /// Index a node's text into the BM25 inverted index.
+    IndexNode {
+        /// Branch where the node was added.
+        branch_id: BranchId,
+        /// Space containing the graph.
+        space: String,
+        /// Name of the graph.
+        graph: String,
+        /// ID of the node to index.
+        node_id: String,
+        /// Node data containing text to index.
+        data: NodeData,
+    },
+    /// Remove a node from the BM25 inverted index.
+    DeindexNode {
+        /// Branch where the node was removed.
+        branch_id: BranchId,
+        /// Space containing the graph.
+        space: String,
+        /// Name of the graph.
+        graph: String,
+        /// ID of the node to deindex.
+        node_id: String,
+    },
+}
+
+/// Shared backend state for GraphStore.
+///
+/// This struct is stored in the Database via the extension mechanism,
+/// ensuring all GraphStore instances for the same Database share the same
+/// state. This follows the same pattern as `VectorBackendState`.
+///
+/// # Thread Safety
+///
+/// Uses `DashMap` for pending ops so concurrent transactions on different
+/// branches don't block each other.
+pub struct GraphBackendState {
+    /// Pending index operations to be applied after transaction commit.
+    ///
+    /// Operations are keyed by transaction id so concurrent writers cannot
+    /// apply or clear each other's deferred work. On commit, the
+    /// `GraphCommitObserver` drains and applies only the committed
+    /// transaction's ops. On abort or failed commit, the Session clears
+    /// that transaction's queued ops without touching other in-flight writers.
+    pending_ops: DashMap<TxnId, Vec<StagedGraphOp>>,
+
+    /// Tracks whether runtime-only hooks have been registered for this
+    /// database instance.
+    pub(crate) runtime_wired: AtomicBool,
+}
+
+impl Default for GraphBackendState {
+    fn default() -> Self {
+        Self {
+            pending_ops: DashMap::new(),
+            runtime_wired: AtomicBool::new(false),
+        }
+    }
+}
+
+impl GraphBackendState {
+    /// Queue a staged graph operation for post-commit application.
+    ///
+    /// Called during transaction execution when graph nodes are added or
+    /// removed. The operation will be applied by `GraphCommitObserver`
+    /// after the transaction commits.
+    pub fn queue_pending_op(&self, txn_id: TxnId, op: StagedGraphOp) {
+        self.pending_ops.entry(txn_id).or_default().push(op);
+    }
+
+    /// Apply and clear all pending operations for a transaction.
+    ///
+    /// Called by `GraphCommitObserver` after transaction commit.
+    /// Returns the number of operations applied.
+    pub fn apply_pending_ops(&self, txn_id: TxnId, graph_store: &crate::GraphStore) -> usize {
+        if let Some((_, ops)) = self.pending_ops.remove(&txn_id) {
+            let count = ops.len();
+            for op in ops {
+                apply_staged_graph_op(graph_store, op);
+            }
+            count
+        } else {
+            0
+        }
+    }
+
+    /// Clear pending operations for a transaction without applying them.
+    ///
+    /// Called by Session on transaction abort or commit failure to clean up
+    /// uncommitted ops.
+    pub fn clear_pending_ops(&self, txn_id: TxnId) {
+        self.pending_ops.remove(&txn_id);
+    }
+}
+
+/// Apply a single staged graph operation.
+fn apply_staged_graph_op(graph_store: &crate::GraphStore, op: StagedGraphOp) {
+    match op {
+        StagedGraphOp::IndexNode {
+            branch_id,
+            space,
+            graph,
+            node_id,
+            data,
+        } => {
+            graph_store.index_node_for_search(branch_id, &space, &graph, &node_id, &data);
+        }
+        StagedGraphOp::DeindexNode {
+            branch_id,
+            space,
+            graph,
+            node_id,
+        } => {
+            graph_store.deindex_node_for_search(branch_id, &space, &graph, &node_id);
+        }
+    }
+}
+
+// =============================================================================
+// Commit and Replay Observers
+// =============================================================================
+
+use std::sync::Weak;
+use strata_engine::database::observers::{CommitInfo, CommitObserver, ObserverError};
+use strata_engine::Database;
+
+/// Ensure runtime hooks are wired for this database instance.
+///
+/// This is called lazily from `GraphStore::state()`. It registers the
+/// commit and replay observers if they haven't been registered yet.
+pub(crate) fn ensure_runtime_wiring(db: &Arc<Database>, state: &Arc<GraphBackendState>) {
+    use std::sync::atomic::Ordering;
+
+    if state.runtime_wired.swap(true, Ordering::AcqRel) {
+        return;
+    }
+
+    let commit_observer = Arc::new(GraphCommitObserver {
+        db: Arc::downgrade(db),
+    });
+    db.commit_observers().register(commit_observer);
+
+    let replay_observer = Arc::new(GraphReplayObserver {
+        db: Arc::downgrade(db),
+    });
+    db.replay_observers().register(replay_observer);
+}
+
+/// Observer that applies pending graph index operations after commit.
+///
+/// Graph write methods queue `StagedGraphOp`s in `GraphBackendState` during
+/// transactions. This observer applies them after successful commit, updating
+/// the BM25 inverted index.
+///
+/// This moves graph index maintenance ownership from executor (Session's
+/// `PostCommitOp::GraphIndexNode/GraphDeindexNode`) to subsystem
+/// (GraphSubsystem), fulfilling the T2-E5 requirement.
+struct GraphCommitObserver {
+    db: Weak<Database>,
+}
+
+impl CommitObserver for GraphCommitObserver {
+    fn name(&self) -> &'static str {
+        "graph"
+    }
+
+    fn on_commit(&self, info: &CommitInfo) -> Result<(), ObserverError> {
+        let Some(db) = self.db.upgrade() else {
+            return Ok(()); // Database dropped
+        };
+
+        // Get graph backend state and apply pending ops for this commit only.
+        if let Ok(state) = db.extension::<GraphBackendState>() {
+            let graph_store = crate::GraphStore::new(db.clone());
+            let applied = state.apply_pending_ops(info.txn_id, &graph_store);
+            if applied > 0 {
+                tracing::debug!(
+                    target: "strata::graph",
+                    txn_id = info.txn_id.0,
+                    branch_id = ?info.branch_id,
+                    commit_version = info.commit_version.0,
+                    ops_applied = applied,
+                    "Applied pending graph index operations"
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Observer that updates graph search index during follower replay.
+///
+/// When a follower replays WAL records, it needs to update the BM25 index
+/// for any graph nodes that were added or removed.
+struct GraphReplayObserver {
+    db: Weak<Database>,
+}
+
+use strata_engine::database::observers::{ReplayInfo, ReplayObserver};
+
+impl ReplayObserver for GraphReplayObserver {
+    fn name(&self) -> &'static str {
+        "graph"
+    }
+
+    fn on_replay(&self, info: &ReplayInfo) -> Result<(), ObserverError> {
+        let Some(db) = self.db.upgrade() else {
+            return Ok(());
+        };
+
+        // Apply graph index updates for replayed graph node changes.
+        apply_replayed_graph_changes(&db, &info.puts, &info.deleted_values);
+
+        Ok(())
+    }
+}
+
+/// Apply graph index updates from replayed WAL records.
+///
+/// Scans the puts and deletes for graph node keys and updates the BM25 index.
+/// Graph nodes are identified by their key format: `{graph}/n/{node_id}`.
+/// Nodes can be in ANY space (user-defined or system `_graph_`).
+fn apply_replayed_graph_changes(
+    db: &Arc<Database>,
+    puts: &[(strata_core::types::Key, strata_core::value::Value)],
+    deleted_values: &[(strata_core::types::Key, strata_core::value::Value)],
+) {
+    use strata_core::types::TypeTag;
+    use strata_core::value::Value;
+
+    let graph_store = crate::GraphStore::new(db.clone());
+
+    // Index new/updated graph nodes
+    for (key, value) in puts {
+        // Graph nodes are stored with TypeTag::KV with key format: "{graph}/n/{node_id}"
+        if key.type_tag != TypeTag::KV {
+            continue;
+        }
+
+        let user_key = match key.user_key_string() {
+            Some(s) => s,
+            None => continue,
+        };
+
+        // Parse key format: "{graph}/n/{node_id}"
+        // Only process keys that match the graph node pattern.
+        let parts: Vec<&str> = user_key.splitn(3, '/').collect();
+        if parts.len() != 3 || parts[1] != "n" {
+            continue;
+        }
+        let graph = parts[0];
+        let node_id = parts[2];
+
+        // Deserialize node data
+        let bytes = match value {
+            Value::Bytes(b) => b,
+            _ => continue,
+        };
+        let data: crate::types::NodeData = match serde_json::from_slice(bytes) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+
+        let branch_id = key.namespace.branch_id;
+        let space = key.namespace.space.as_str();
+        graph_store.index_node_for_search(branch_id, space, graph, node_id, &data);
+    }
+
+    // Deindex deleted graph nodes
+    for (key, _value) in deleted_values {
+        if key.type_tag != TypeTag::KV {
+            continue;
+        }
+
+        let user_key = match key.user_key_string() {
+            Some(s) => s,
+            None => continue,
+        };
+
+        // Parse key format: "{graph}/n/{node_id}"
+        let parts: Vec<&str> = user_key.splitn(3, '/').collect();
+        if parts.len() != 3 || parts[1] != "n" {
+            continue;
+        }
+        let graph = parts[0];
+        let node_id = parts[2];
+
+        let branch_id = key.namespace.branch_id;
+        let space = key.namespace.space.as_str();
+        graph_store.deindex_node_for_search(branch_id, space, graph, node_id);
+    }
+}

--- a/crates/graph/src/store.rs
+++ b/crates/graph/src/store.rs
@@ -73,8 +73,9 @@ pub struct GraphBackendState {
     /// Operations are keyed by transaction id so concurrent writers cannot
     /// apply or clear each other's deferred work. On commit, the
     /// `GraphCommitObserver` drains and applies only the committed
-    /// transaction's ops. On abort or failed commit, the Session clears
-    /// that transaction's queued ops without touching other in-flight writers.
+    /// transaction's ops. On abort or failed commit, engine-owned abort
+    /// observers clear that transaction's queued ops without touching other
+    /// in-flight writers.
     pending_ops: DashMap<TxnId, Vec<StagedGraphOp>>,
 
     /// Tracks whether runtime-only hooks have been registered for this
@@ -119,8 +120,8 @@ impl GraphBackendState {
 
     /// Clear pending operations for a transaction without applying them.
     ///
-    /// Called by Session on transaction abort or commit failure to clean up
-    /// uncommitted ops.
+    /// Called by engine-owned abort observers on transaction abort or commit
+    /// failure to clean up uncommitted ops.
     pub fn clear_pending_ops(&self, txn_id: TxnId) {
         self.pending_ops.remove(&txn_id);
     }
@@ -154,7 +155,9 @@ fn apply_staged_graph_op(graph_store: &crate::GraphStore, op: StagedGraphOp) {
 // =============================================================================
 
 use std::sync::Weak;
-use strata_engine::database::observers::{CommitInfo, CommitObserver, ObserverError};
+use strata_engine::database::observers::{
+    AbortInfo, AbortObserver, CommitInfo, CommitObserver, ObserverError,
+};
 use strata_engine::Database;
 
 /// Ensure runtime hooks are wired for this database instance.
@@ -173,6 +176,11 @@ pub fn ensure_runtime_wiring(db: &Arc<Database>, state: &Arc<GraphBackendState>)
     });
     db.commit_observers().register(commit_observer);
 
+    let abort_observer = Arc::new(GraphAbortObserver {
+        db: Arc::downgrade(db),
+    });
+    db.abort_observers().register(abort_observer);
+
     let replay_observer = Arc::new(GraphReplayObserver {
         db: Arc::downgrade(db),
     });
@@ -185,9 +193,9 @@ pub fn ensure_runtime_wiring(db: &Arc<Database>, state: &Arc<GraphBackendState>)
 /// transactions. This observer applies them after successful commit, updating
 /// the BM25 inverted index.
 ///
-/// This moves graph index maintenance ownership from executor (Session's
-/// `PostCommitOp::GraphIndexNode/GraphDeindexNode`) to subsystem
-/// (GraphSubsystem), fulfilling the T2-E5 requirement.
+/// This moves graph index maintenance ownership from executor-local deferred
+/// work to subsystem-owned observers (GraphSubsystem), fulfilling the T2-E5
+/// requirement.
 struct GraphCommitObserver {
     db: Weak<Database>,
 }
@@ -216,6 +224,28 @@ impl CommitObserver for GraphCommitObserver {
                     "Applied pending graph index operations"
                 );
             }
+        }
+
+        Ok(())
+    }
+}
+
+struct GraphAbortObserver {
+    db: Weak<Database>,
+}
+
+impl AbortObserver for GraphAbortObserver {
+    fn name(&self) -> &'static str {
+        "graph-abort"
+    }
+
+    fn on_abort(&self, info: &AbortInfo) -> Result<(), ObserverError> {
+        let Some(db) = self.db.upgrade() else {
+            return Ok(());
+        };
+
+        if let Ok(state) = db.extension::<GraphBackendState>() {
+            state.clear_pending_ops(info.txn_id);
         }
 
         Ok(())
@@ -322,5 +352,51 @@ fn apply_replayed_graph_changes(
         let branch_id = key.namespace.branch_id;
         let space = key.namespace.space.as_str();
         graph_store.deindex_node_for_search(branch_id, space, graph, node_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ext::GraphStoreExt;
+    use strata_core::types::BranchId;
+    use strata_engine::database::OpenSpec;
+    use strata_engine::SearchSubsystem;
+
+    #[test]
+    fn test_manual_abort_clears_pending_graph_ops() {
+        let db = Database::open_runtime(OpenSpec::cache().with_subsystem(SearchSubsystem)).unwrap();
+        let graph_store = crate::GraphStore::new(db.clone());
+        let branch_id = BranchId::new();
+
+        graph_store
+            .create_graph(branch_id, "default", "g", None)
+            .unwrap();
+
+        let state = graph_store.state().unwrap();
+        let mut txn = db.begin_transaction(branch_id).unwrap();
+        let txn_id = txn.txn_id;
+
+        txn.graph_add_node(
+            branch_id,
+            "default",
+            "g",
+            "n_abort",
+            &crate::types::NodeData::default(),
+            &state,
+        )
+        .unwrap();
+
+        assert!(
+            state.pending_ops.contains_key(&txn_id),
+            "graph add node should stage index work until commit"
+        );
+
+        txn.abort();
+
+        assert!(
+            !state.pending_ops.contains_key(&txn_id),
+            "abort should clear staged graph work via engine observers"
+        );
     }
 }

--- a/crates/vector/src/recovery.rs
+++ b/crates/vector/src/recovery.rs
@@ -32,6 +32,7 @@
 
 use strata_core::id::CommitVersion;
 use strata_core::StrataResult;
+use strata_engine::database::observers::{AbortInfo, AbortObserver};
 use strata_engine::Database;
 use tracing::info;
 
@@ -519,6 +520,11 @@ pub(crate) fn ensure_runtime_wiring(
     });
     db.commit_observers().register(commit_observer);
 
+    let abort_observer = Arc::new(VectorAbortObserver {
+        db: Arc::downgrade(db),
+    });
+    db.abort_observers().register(abort_observer);
+
     let replay_observer = Arc::new(VectorReplayObserver {
         db: Arc::downgrade(db),
     });
@@ -531,9 +537,9 @@ pub(crate) fn ensure_runtime_wiring(
 /// transactions. This observer applies them after successful commit, updating
 /// the in-memory HNSW indices.
 ///
-/// This moves vector backend maintenance ownership from executor (Session's
-/// `PostCommitOp::VectorBackendOp`) to subsystem (VectorSubsystem), fulfilling
-/// the T2-E2 requirement.
+/// This moves vector backend maintenance ownership from executor-local deferred
+/// work to subsystem-owned observers (VectorSubsystem), fulfilling the T2-E2
+/// requirement.
 struct VectorCommitObserver {
     db: std::sync::Weak<strata_engine::Database>,
 }
@@ -561,6 +567,28 @@ impl CommitObserver for VectorCommitObserver {
                     "Applied pending HNSW operations"
                 );
             }
+        }
+
+        Ok(())
+    }
+}
+
+struct VectorAbortObserver {
+    db: std::sync::Weak<strata_engine::Database>,
+}
+
+impl AbortObserver for VectorAbortObserver {
+    fn name(&self) -> &'static str {
+        "vector-abort"
+    }
+
+    fn on_abort(&self, info: &AbortInfo) -> Result<(), ObserverError> {
+        let Some(db) = self.db.upgrade() else {
+            return Ok(());
+        };
+
+        if let Ok(state) = db.extension::<super::VectorBackendState>() {
+            state.clear_pending_ops(info.txn_id);
         }
 
         Ok(())

--- a/crates/vector/src/store/mod.rs
+++ b/crates/vector/src/store/mod.rs
@@ -81,8 +81,9 @@ pub struct VectorBackendState {
     /// Operations are keyed by transaction id so concurrent writers on the same
     /// branch cannot apply or clear each other's deferred backend work.
     /// On commit, the VectorCommitObserver drains and applies only the committed
-    /// transaction's ops. On abort or failed commit, the Session clears that
-    /// transaction's queued ops without touching other in-flight writers.
+    /// transaction's ops. On abort or failed commit, engine-owned abort
+    /// observers clear that transaction's queued ops without touching other
+    /// in-flight writers.
     ///
     /// This moves vector backend maintenance ownership from executor (Session)
     /// to subsystem (VectorSubsystem), fulfilling the T2-E2 requirement.
@@ -130,8 +131,8 @@ impl VectorBackendState {
 
     /// Clear pending operations for a transaction without applying them.
     ///
-    /// Called by Session on transaction abort or commit failure to clean up
-    /// uncommitted ops.
+    /// Called by engine-owned abort observers on transaction abort or commit
+    /// failure to clean up uncommitted ops.
     pub fn clear_pending_ops(&self, txn_id: TxnId) {
         self.pending_ops.remove(&txn_id);
     }
@@ -4096,5 +4097,45 @@ mod tests {
         // Same as above: observers count includes SearchSubsystem observers
         assert!(!db.commit_observers().is_empty());
         assert!(!db.replay_observers().is_empty());
+    }
+
+    #[test]
+    fn test_manual_abort_clears_pending_vector_ops() {
+        let db = Database::open_runtime(OpenSpec::cache().with_subsystem(SearchSubsystem)).unwrap();
+        let store = VectorStore::new(db.clone());
+        let branch_id = BranchId::new();
+
+        let config = VectorConfig::new(3, DistanceMetric::Cosine).unwrap();
+        store
+            .create_collection(branch_id, "default", "emb", config)
+            .unwrap();
+
+        let state = store.state().unwrap();
+        let mut txn = db.begin_transaction(branch_id).unwrap();
+        let txn_id = txn.txn_id;
+
+        txn.vector_upsert(
+            branch_id,
+            "default",
+            "emb",
+            "v_abort",
+            &[1.0, 0.0, 0.0],
+            None,
+            None,
+            &state,
+        )
+        .unwrap();
+
+        assert!(
+            state.pending_ops.contains_key(&txn_id),
+            "vector upsert should stage backend work until commit"
+        );
+
+        txn.abort();
+
+        assert!(
+            !state.pending_ops.contains_key(&txn_id),
+            "abort should clear staged vector work via engine observers"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Move graph index maintenance from executor-owned `PostCommitOp` to subsystem-owned `GraphCommitObserver`
- Delete `PostCommitOp` enum (~45 lines) and `run_post_commit_ops()` method (~30 lines)
- Add `GraphBackendState` with pending ops DashMap for concurrent transaction isolation
- Add `GraphReplayObserver` for follower search index updates during WAL replay

This completes the post-commit work migration started in T2-E2 (vectors) for graph primitives.

## Changes

| File | Change |
|------|--------|
| `crates/graph/src/store.rs` | New: GraphBackendState, StagedGraphOp, observers |
| `crates/graph/src/lib.rs` | Add store module, state() method on GraphStore |
| `crates/executor/src/session.rs` | Delete PostCommitOp, queue via GraphBackendState |

## Test plan

- [x] All 481 graph crate tests pass
- [x] All 602 executor crate tests pass
- [x] All 138 integration tests pass
- [x] Workspace compiles with no new warnings in changed files

## Review findings addressed

During self-review, found and fixed:
1. **Critical bug**: Replay observer was filtering by `_graph_` space only, but user graphs are in user spaces
2. **Observability**: Added warning logs when `graph.state()` fails during op queueing

🤖 Generated with [Claude Code](https://claude.com/claude-code)