### PR TITLE
fix(engine): prevent active_count underflow on commit failure

### DIFF
--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -756,7 +756,7 @@ fn test_gc_safe_point_with_active_txn() {
     }
 
     // Start a transaction but don't commit it yet — pins version
-    let txn = db.begin_transaction(branch_id).unwrap();
+    let mut txn = db.begin_transaction(branch_id).unwrap();
     let txn_start_version = txn.start_version;
 
     // Commit two more transactions to advance version further
@@ -780,7 +780,7 @@ fn test_gc_safe_point_with_active_txn() {
     );
 
     // Abort the active transaction
-    db.coordinator.record_abort(txn.txn_id);
+    txn.abort();
 
     // Now safe point should advance to current - 1 since no active txns
     let sp_after = db.gc_safe_point();
@@ -1381,7 +1381,7 @@ fn test_put_direct_gc_safety_with_concurrent_reader() {
     assert!(v2 > v1, "versions must be monotonically increasing");
 
     // Start a snapshot reader that pins the version at v2
-    let reader_txn = db.begin_transaction(branch_id).unwrap();
+    let mut reader_txn = db.begin_transaction(branch_id).unwrap();
     let pinned_version = reader_txn.start_version;
 
     // Write more versions while reader holds its snapshot
@@ -1412,7 +1412,7 @@ fn test_put_direct_gc_safety_with_concurrent_reader() {
     assert_eq!(reader_val.unwrap().value, Value::Int(10));
 
     // Release the reader — gc_safe_version should now be free to advance
-    db.coordinator.record_abort(reader_txn.txn_id);
+    reader_txn.abort();
 
     let safe_point_after = db.gc_safe_point();
     assert!(
@@ -1510,7 +1510,7 @@ fn test_issue_1697_compaction_preserves_snapshot_versions() {
     blind_write(&db, key.clone(), Value::Int(1));
 
     // Start a reader that pins the current snapshot
-    let reader = db.begin_read_only_transaction(branch_id).unwrap();
+    let mut reader = db.begin_read_only_transaction(branch_id).unwrap();
     let pinned_version = reader.start_version;
 
     // Write version 2 — now key has 2 versions, max_versions_per_key=1
@@ -1556,7 +1556,7 @@ fn test_issue_1697_compaction_preserves_snapshot_versions() {
     assert_eq!(latest.unwrap().value, Value::Int(2));
 
     // Clean up reader
-    db.coordinator.record_abort(reader.txn_id);
+    reader.abort();
 }
 
 #[test]

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -544,15 +544,19 @@ impl Database {
         }
     }
 
-    /// Mark a transaction aborted and run subsystem cleanup observers.
-    pub(crate) fn abort_transaction_in_place(
+    /// Mark a transaction aborted, optionally update coordinator state, and
+    /// run subsystem cleanup observers.
+    fn finalize_aborted_transaction_in_place(
         &self,
         txn: &mut TransactionContext,
         reason: impl Into<String>,
+        record_coordinator_abort: bool,
     ) {
         if txn.is_active() {
             let _ = txn.mark_aborted(reason.into());
-            self.coordinator.record_abort(txn.txn_id);
+            if record_coordinator_abort {
+                self.coordinator.record_abort(txn.txn_id);
+            }
         }
 
         let info = super::AbortInfo {
@@ -560,6 +564,15 @@ impl Database {
             branch_id: txn.branch_id,
         };
         self.abort_observers().notify(&info);
+    }
+
+    /// Mark a transaction aborted and run subsystem cleanup observers.
+    pub(crate) fn abort_transaction_in_place(
+        &self,
+        txn: &mut TransactionContext,
+        reason: impl Into<String>,
+    ) {
+        self.finalize_aborted_transaction_in_place(txn, reason, true);
     }
 
     /// Execute a transaction with the given closure
@@ -764,6 +777,14 @@ impl Database {
         &self,
         txn: &mut TransactionContext,
     ) -> StrataResult<u64> {
+        if self.follower {
+            let err = StrataError::internal(
+                "cannot commit: database opened in follower mode (read-only)",
+            );
+            self.abort_transaction_in_place(txn, format!("Commit failed: {}", err));
+            return Err(err);
+        }
+
         let had_writes = !txn.is_read_only();
         // Admission control: reject writes when L0 is saturated (#1924).
         // Must run BEFORE commit so the caller gets a clean error.
@@ -776,7 +797,14 @@ impl Database {
         let version = match self.commit_internal(txn, self.durability_mode) {
             Ok(version) => version,
             Err(e) => {
-                self.abort_transaction_in_place(txn, format!("Commit failed: {}", e));
+                // `TransactionCoordinator::commit*` already decremented
+                // active_count on commit failure. Only mirror the terminal
+                // state into the pooled TransactionContext here.
+                self.finalize_aborted_transaction_in_place(
+                    txn,
+                    format!("Commit failed: {}", e),
+                    false,
+                );
                 return Err(e);
             }
         };
@@ -810,12 +838,6 @@ impl Database {
         txn: &mut TransactionContext,
         durability: DurabilityMode,
     ) -> StrataResult<CommitVersion> {
-        if self.follower {
-            return Err(StrataError::internal(
-                "cannot commit: database opened in follower mode (read-only)",
-            ));
-        }
-
         // Capture info needed for observer notification before commit
         // (txn state may be modified during commit)
         let txn_id = txn.txn_id;


### PR DESCRIPTION
## Summary

- Fix double-decrement of `active_count` when transaction commit fails
- Update 3 tests to use `txn.abort()` instead of direct coordinator calls

## Root Cause

When `commit_internal` fails, `TransactionCoordinator::commit*` already decrements `active_count`. Then `abort_transaction_in_place` was called which decremented again via `record_abort`, causing underflow panic.

## Fix

- Add `finalize_aborted_transaction_in_place(txn, reason, record_coordinator_abort: bool)`
- On commit failure path, call with `record_coordinator_abort: false` to skip double-decrement
- Move follower check before `commit_internal` to ensure proper abort path

## Tests Fixed

All 5 were failing with "active_count underflow in finish_transaction":

- `test_gc_safe_point_with_active_txn`
- `test_put_direct_gc_safety_with_concurrent_reader`
- `test_issue_1697_compaction_preserves_snapshot_versions`
- `test_issue_1916_delete_branch_rejects_concurrent_commit`
- `test_issue_1916_delete_branch_concurrent_stress`

## Test plan

- [x] `cargo test -p strata-engine --lib` — all 874 tests pass
- [x] Specifically verified all 5 previously failing tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)