### PR TITLE
feat(durability): T3-E2 WAL writer halt and resume

### DIFF
--- a/crates/concurrency/Cargo.toml
+++ b/crates/concurrency/Cargo.toml
@@ -14,11 +14,12 @@ workspace = true
 [features]
 default = []
 perf-trace = ["strata-core/perf-trace"]  # Enable per-operation timing in commit path
+fault-injection = []
 
 [dependencies]
 strata-core = { path = "../core" }
 strata-storage = { path = "../storage" }
-strata-durability = { path = "../durability" }
+strata-durability = { path = "../durability", features = ["engine-internal"] }
 chrono = { workspace = true }
 dashmap = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -18,6 +18,20 @@ pub mod recovery;
 pub mod transaction;
 pub mod validation;
 
+#[cfg(any(test, feature = "fault-injection"))]
+#[doc(hidden)]
+pub mod __internal {
+    /// Inject a single storage-apply failure after WAL commit.
+    pub fn inject_apply_failure_once(reason: impl Into<String>) {
+        crate::manager::inject_apply_failure_once(reason);
+    }
+
+    /// Clear any pending injected storage-apply failure.
+    pub fn clear_apply_failure_injection() {
+        crate::manager::clear_apply_failure_injection();
+    }
+}
+
 pub use manager::TransactionManager;
 pub use payload::TransactionPayload;
 pub use recovery::{RecoveryCoordinator, RecoveryResult, RecoveryStats};

--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -35,10 +35,13 @@ use std::cell::RefCell;
 use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+#[cfg(any(test, feature = "fault-injection"))]
+use std::sync::OnceLock;
 use strata_core::id::{CommitVersion, TxnId};
 use strata_core::perf_time;
 use strata_core::traits::Storage;
 use strata_core::types::BranchId;
+use strata_durability::__internal::WalWriterEngineExt;
 use strata_durability::now_micros;
 use strata_durability::wal::WalWriter;
 
@@ -59,6 +62,34 @@ use std::time::Instant;
 
 static COMMIT_PROFILE_ENABLED: AtomicBool = AtomicBool::new(false);
 static COMMIT_PROFILE_CHECKED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(any(test, feature = "fault-injection"))]
+fn apply_failure_injection_slot() -> &'static Mutex<Option<String>> {
+    static APPLY_FAILURE_INJECTION: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+    APPLY_FAILURE_INJECTION.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(any(test, feature = "fault-injection"))]
+pub(crate) fn inject_apply_failure_once(reason: impl Into<String>) {
+    *apply_failure_injection_slot().lock() = Some(reason.into());
+}
+
+#[cfg(any(test, feature = "fault-injection"))]
+pub(crate) fn clear_apply_failure_injection() {
+    *apply_failure_injection_slot().lock() = None;
+}
+
+#[cfg(any(test, feature = "fault-injection"))]
+fn maybe_take_apply_failure_injection() -> Option<String> {
+    apply_failure_injection_slot().lock().take()
+}
+
+fn writer_halted_commit_error(wal: &WalWriter) -> Option<CommitError> {
+    wal.bg_error().map(|bg_error| CommitError::WriterHalted {
+        reason: bg_error.message().to_string(),
+        first_observed_at: bg_error.first_observed_at(),
+    })
+}
 
 fn commit_profile_enabled() -> bool {
     if !COMMIT_PROFILE_CHECKED.load(Ordering::Relaxed) {
@@ -482,13 +513,13 @@ impl TransactionManager {
                 match wal_mode {
                     WalMode::Direct(wal) => {
                         let timestamp = now_micros();
+                        let wal_txn_id = TxnId(commit_version.as_u64());
                         let result = WAL_RECORD_BUF.with(|rec_cell| {
                             MSGPACK_BUF.with(|msg_cell| {
                                 let mut rec_buf = rec_cell.borrow_mut();
                                 let mut msg_buf = msg_cell.borrow_mut();
                                 let ts = Instant::now();
                                 // Issue #1696: Use commit_version as WAL record ordering key
-                                let wal_txn_id = TxnId(commit_version.as_u64());
                                 payload::serialize_wal_record_into(
                                     &mut rec_buf,
                                     &mut msg_buf,
@@ -499,30 +530,41 @@ impl TransactionManager {
                                     timestamp,
                                 );
                                 wal_serialize_ns = ts.elapsed().as_nanos() as u64;
+                                if let Some(err) = writer_halted_commit_error(wal) {
+                                    return Err(err);
+                                }
                                 // Direct mode: no separate mutex
                                 let tw = Instant::now();
-                                let r = wal.append_pre_serialized(&rec_buf, wal_txn_id, timestamp);
+                                wal.append_pre_serialized(&rec_buf, wal_txn_id, timestamp)
+                                    .map_err(|e| CommitError::WALError(e.to_string()))?;
                                 wal_io_ns = tw.elapsed().as_nanos() as u64;
-                                r
+                                Ok(())
                             })
                         });
                         if let Err(e) = result {
+                            let abort_reason = match &e {
+                                CommitError::WriterHalted { reason, .. } => {
+                                    format!("WAL writer halted: {}", reason)
+                                }
+                                CommitError::WALError(msg) => format!("WAL write failed: {}", msg),
+                                other => format!("WAL write failed: {}", other),
+                            };
                             txn.status = TransactionStatus::Aborted {
-                                reason: format!("WAL write failed: {}", e),
+                                reason: abort_reason,
                             };
                             self.mark_version_applied(commit_version);
-                            return Err(CommitError::WALError(e.to_string()));
+                            return Err(e);
                         }
                         tracing::debug!(target: "strata::txn", txn_id = txn.txn_id.as_u64(), commit_version = commit_version.as_u64(), "WAL durable");
                     }
                     WalMode::Shared(wal_arc) => {
                         let timestamp = now_micros();
+                        let wal_txn_id = TxnId(commit_version.as_u64());
                         let result = WAL_RECORD_BUF.with(|rec_cell| {
                             MSGPACK_BUF.with(|msg_cell| {
                                 let mut rec_buf = rec_cell.borrow_mut();
                                 let mut msg_buf = msg_cell.borrow_mut();
                                 // Issue #1696: Use commit_version as WAL record ordering key
-                                let wal_txn_id = TxnId(commit_version.as_u64());
                                 let ts = Instant::now();
                                 payload::serialize_wal_record_into(
                                     &mut rec_buf,
@@ -537,18 +579,29 @@ impl TransactionManager {
                                 let tm = Instant::now();
                                 let mut wal = wal_arc.lock(); // Lock Level 4: WAL append
                                 wal_mutex_ns = tm.elapsed().as_nanos() as u64;
+                                if let Some(err) = writer_halted_commit_error(&wal) {
+                                    return Err(err);
+                                }
                                 let tw = Instant::now();
-                                let r = wal.append_pre_serialized(&rec_buf, wal_txn_id, timestamp);
+                                wal.append_pre_serialized(&rec_buf, wal_txn_id, timestamp)
+                                    .map_err(|e| CommitError::WALError(e.to_string()))?;
                                 wal_io_ns = tw.elapsed().as_nanos() as u64;
-                                r
+                                Ok(())
                             })
                         });
                         if let Err(e) = result {
+                            let abort_reason = match &e {
+                                CommitError::WriterHalted { reason, .. } => {
+                                    format!("WAL writer halted: {}", reason)
+                                }
+                                CommitError::WALError(msg) => format!("WAL write failed: {}", msg),
+                                other => format!("WAL write failed: {}", other),
+                            };
                             txn.status = TransactionStatus::Aborted {
-                                reason: format!("WAL write failed: {}", e),
+                                reason: abort_reason,
                             };
                             self.mark_version_applied(commit_version);
-                            return Err(CommitError::WALError(e.to_string()));
+                            return Err(e);
                         }
                         tracing::debug!(target: "strata::txn", txn_id = txn.txn_id.as_u64(), commit_version = commit_version.as_u64(), "WAL durable");
                     }
@@ -560,6 +613,30 @@ impl TransactionManager {
         // Apply to storage
         let t0 = Instant::now();
         perf_time!(trace, write_set_apply_ns, {
+            #[cfg(any(test, feature = "fault-injection"))]
+            if let Some(reason) = maybe_take_apply_failure_injection() {
+                self.mark_version_applied(commit_version);
+                if has_wal {
+                    tracing::error!(
+                        target: "strata::txn",
+                        txn_id = txn.txn_id.as_u64(),
+                        commit_version = commit_version.as_u64(),
+                        reason,
+                        "Injected storage-apply failure after WAL commit"
+                    );
+                    return Err(CommitError::DurableButNotVisible {
+                        txn_id: txn.txn_id.as_u64(),
+                        commit_version: commit_version.as_u64(),
+                        reason,
+                    });
+                } else {
+                    txn.status = TransactionStatus::Aborted {
+                        reason: reason.clone(),
+                    };
+                    return Err(CommitError::WALError(reason));
+                }
+            }
+
             if let Err(e) = txn.apply_writes(store, commit_version) {
                 self.mark_version_applied(commit_version);
                 if has_wal {
@@ -830,6 +907,7 @@ mod tests {
     use strata_core::id::{CommitVersion, TxnId};
     use strata_core::types::{Key, Namespace};
     use strata_core::value::Value;
+    use strata_durability::__internal::WalWriterEngineExt;
     use strata_durability::codec::IdentityCodec;
     use strata_durability::wal::{DurabilityMode, WalConfig, WalReader};
     use strata_storage::SegmentedStore;
@@ -2433,6 +2511,40 @@ mod tests {
             "Expected DurableButNotVisible error, got: {:?}",
             err
         );
+    }
+
+    #[test]
+    fn test_commit_with_wal_arc_rejects_when_writer_is_halted() {
+        let dir = TempDir::new().unwrap();
+        let wal = Arc::new(ParkingMutex::new(create_test_wal(dir.path())));
+        let store = Arc::new(SegmentedStore::new());
+        let manager = TransactionManager::new(CommitVersion::ZERO);
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+        let key = create_test_key(&ns, "halted_writer");
+
+        {
+            let mut writer = wal.lock();
+            writer.record_sync_failure(std::io::Error::other("disk full"));
+        }
+
+        let mut txn = TransactionContext::with_store(TxnId(9), branch_id, Arc::clone(&store));
+        txn.put(key, Value::Int(99)).unwrap();
+
+        let err = manager
+            .commit_with_wal_arc(&mut txn, store.as_ref(), Some(&wal))
+            .expect_err("halted WAL writer must reject commit");
+
+        match err {
+            CommitError::WriterHalted { reason, .. } => {
+                assert!(
+                    reason.contains("disk full"),
+                    "unexpected halt reason: {}",
+                    reason
+                );
+            }
+            other => panic!("expected WriterHalted, got {:?}", other),
+        }
     }
 
     /// Issue #1725: Same test for the commit_with_version path.

--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -570,10 +570,11 @@ impl TransactionManager {
                         error = %e,
                         "Storage application failed after WAL commit - will be recovered on restart"
                     );
-                    return Err(CommitError::DurableButNotVisible(format!(
-                        "Storage application failed after WAL commit: {}",
-                        e
-                    )));
+                    return Err(CommitError::DurableButNotVisible {
+                        txn_id: txn.txn_id.as_u64(),
+                        commit_version: commit_version.as_u64(),
+                        reason: format!("Storage application failed: {}", e),
+                    });
                 } else {
                     txn.status = TransactionStatus::Aborted {
                         reason: format!("Storage application failed: {}", e),
@@ -2397,7 +2398,7 @@ mod tests {
         // Verify it's the right error variant
         let err = result.unwrap_err();
         assert!(
-            matches!(err, CommitError::DurableButNotVisible(_)),
+            matches!(err, CommitError::DurableButNotVisible { .. }),
             "Expected DurableButNotVisible error, got: {:?}",
             err
         );
@@ -2428,7 +2429,7 @@ mod tests {
 
         let err = result.unwrap_err();
         assert!(
-            matches!(err, CommitError::DurableButNotVisible(_)),
+            matches!(err, CommitError::DurableButNotVisible { .. }),
             "Expected DurableButNotVisible error, got: {:?}",
             err
         );
@@ -2464,7 +2465,7 @@ mod tests {
 
         let err = result.unwrap_err();
         assert!(
-            matches!(err, CommitError::DurableButNotVisible(_)),
+            matches!(err, CommitError::DurableButNotVisible { .. }),
             "Expected DurableButNotVisible error, got: {:?}",
             err
         );

--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -44,6 +44,17 @@ pub enum CommitError {
     /// If WAL write fails, the transaction cannot be durably committed.
     WALError(String),
 
+    /// WAL writer halted due to a failed sync.
+    ///
+    /// The transaction was not durably committed. Callers should resolve the
+    /// underlying storage issue and retry only after the writer is resumed.
+    WriterHalted {
+        /// Human-readable reason for the halt
+        reason: String,
+        /// When the halt-causing failure streak was first observed
+        first_observed_at: std::time::SystemTime,
+    },
+
     /// Storage error during validation
     ///
     /// A storage I/O error occurred while reading current versions for
@@ -82,6 +93,16 @@ impl std::fmt::Display for CommitError {
             }
             CommitError::InvalidState(msg) => write!(f, "Invalid state: {}", msg),
             CommitError::WALError(msg) => write!(f, "WAL error: {}", msg),
+            CommitError::WriterHalted {
+                reason,
+                first_observed_at,
+            } => {
+                write!(
+                    f,
+                    "WAL writer halted: {} (first observed: {:?})",
+                    reason, first_observed_at
+                )
+            }
             CommitError::StorageError(msg) => write!(f, "Storage error during validation: {}", msg),
             CommitError::CounterOverflow(msg) => write!(f, "Counter overflow: {}", msg),
             CommitError::DurableButNotVisible {
@@ -116,6 +137,13 @@ impl From<CommitError> for StrataError {
                 message: format!("WAL error: {}", msg),
                 source: None,
             },
+            CommitError::WriterHalted {
+                reason,
+                first_observed_at,
+            } => StrataError::WriterHalted {
+                reason,
+                first_observed_at,
+            },
             CommitError::StorageError(msg) => StrataError::Storage {
                 message: format!("Storage error during validation: {}", msg),
                 source: None,
@@ -126,11 +154,10 @@ impl From<CommitError> for StrataError {
             CommitError::DurableButNotVisible {
                 txn_id,
                 commit_version,
-                reason,
+                ..
             } => StrataError::DurableButNotVisible {
                 txn_id,
                 commit_version,
-                reason,
             },
             CommitError::BranchDeleting(branch_id) => StrataError::TransactionAborted {
                 reason: format!("Branch {} is being deleted", branch_id),

--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -58,7 +58,14 @@ pub enum CommitError {
     /// The transaction IS durable (WAL record written) and will be recovered
     /// on restart, but it is NOT visible to reads in the current process.
     /// The caller must not assume the data is immediately readable.
-    DurableButNotVisible(String),
+    DurableButNotVisible {
+        /// Transaction ID that committed durably
+        txn_id: u64,
+        /// Commit version assigned to the transaction
+        commit_version: u64,
+        /// Reason the storage apply failed
+        reason: String,
+    },
 
     /// Branch is being deleted (#1916)
     ///
@@ -77,11 +84,15 @@ impl std::fmt::Display for CommitError {
             CommitError::WALError(msg) => write!(f, "WAL error: {}", msg),
             CommitError::StorageError(msg) => write!(f, "Storage error during validation: {}", msg),
             CommitError::CounterOverflow(msg) => write!(f, "Counter overflow: {}", msg),
-            CommitError::DurableButNotVisible(msg) => {
+            CommitError::DurableButNotVisible {
+                txn_id,
+                commit_version,
+                reason,
+            } => {
                 write!(
                     f,
-                    "Durable but not visible (will recover on restart): {}",
-                    msg
+                    "Durable but not visible (will recover on restart): txn {} at version {} - {}",
+                    txn_id, commit_version, reason
                 )
             }
             CommitError::BranchDeleting(branch_id) => {
@@ -112,9 +123,14 @@ impl From<CommitError> for StrataError {
             CommitError::CounterOverflow(msg) => {
                 StrataError::capacity_exceeded(msg, usize::MAX, usize::MAX)
             }
-            CommitError::DurableButNotVisible(msg) => StrataError::Storage {
-                message: format!("Durable but not visible (will recover on restart): {}", msg),
-                source: None,
+            CommitError::DurableButNotVisible {
+                txn_id,
+                commit_version,
+                reason,
+            } => StrataError::DurableButNotVisible {
+                txn_id,
+                commit_version,
+                reason,
             },
             CommitError::BranchDeleting(branch_id) => StrataError::TransactionAborted {
                 reason: format!("Branch {} is being deleted", branch_id),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -871,6 +871,82 @@ pub enum StrataError {
     },
 
     // =========================================================================
+    // Durability Errors
+    // =========================================================================
+    /// WAL writer is halted
+    ///
+    /// The WAL writer has halted due to a background sync failure (fsync error).
+    /// The database cannot accept new commits until the underlying issue is
+    /// resolved and `resume_wal_writer()` is called.
+    ///
+    /// ## Example
+    /// ```no_run
+    /// # use strata_core::StrataError;
+    /// # use std::time::SystemTime;
+    /// StrataError::WriterHalted {
+    ///     reason: "disk full".to_string(),
+    ///     first_observed_at: SystemTime::now(),
+    ///     failed_sync_count: 3,
+    /// };
+    /// ```
+    #[error("WAL writer halted: {reason} (first observed: {first_observed_at:?}, failed syncs: {failed_sync_count})")]
+    WriterHalted {
+        /// Human-readable reason for the halt
+        reason: String,
+        /// When the first sync failure was observed
+        first_observed_at: std::time::SystemTime,
+        /// Number of consecutive failed sync attempts
+        failed_sync_count: u64,
+    },
+
+    /// Durable but not visible
+    ///
+    /// The transaction was successfully written to the WAL (durable) but failed
+    /// to apply to in-memory storage (not visible). The data **will be recovered**
+    /// on restart.
+    ///
+    /// Callers should:
+    /// 1. **Not retry** - the data is already durable
+    /// 2. **Not assume visibility** - reads may not see the committed data
+    /// 3. **Consider graceful shutdown** - to trigger recovery
+    ///
+    /// ## Example
+    /// ```no_run
+    /// # use strata_core::StrataError;
+    /// StrataError::DurableButNotVisible {
+    ///     txn_id: 12345,
+    ///     commit_version: 67890,
+    ///     reason: "storage apply failed".to_string(),
+    /// };
+    /// ```
+    #[error("durable but not visible: txn {txn_id} at version {commit_version} ({reason})")]
+    DurableButNotVisible {
+        /// Transaction ID that committed durably
+        txn_id: u64,
+        /// Commit version assigned to the transaction
+        commit_version: u64,
+        /// Reason the storage apply failed
+        reason: String,
+    },
+
+    /// Shutdown timeout
+    ///
+    /// The database shutdown timed out waiting for active transactions to complete.
+    /// Freeze hooks were **not** run. The database is still usable; callers can
+    /// either complete their transactions and retry shutdown, or abandon them.
+    ///
+    /// ## Example
+    /// ```no_run
+    /// # use strata_core::StrataError;
+    /// StrataError::ShutdownTimeout { active_txn_count: 3 };
+    /// ```
+    #[error("shutdown timeout: {active_txn_count} transaction(s) still active")]
+    ShutdownTimeout {
+        /// Number of transactions that were still active when timeout occurred
+        active_txn_count: u64,
+    },
+
+    // =========================================================================
     // Internal Errors
     // =========================================================================
     /// Internal error

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -886,17 +886,14 @@ pub enum StrataError {
     /// StrataError::WriterHalted {
     ///     reason: "disk full".to_string(),
     ///     first_observed_at: SystemTime::now(),
-    ///     failed_sync_count: 3,
     /// };
     /// ```
-    #[error("WAL writer halted: {reason} (first observed: {first_observed_at:?}, failed syncs: {failed_sync_count})")]
+    #[error("WAL writer halted: {reason} (first observed: {first_observed_at:?})")]
     WriterHalted {
         /// Human-readable reason for the halt
         reason: String,
         /// When the first sync failure was observed
         first_observed_at: std::time::SystemTime,
-        /// Number of consecutive failed sync attempts
-        failed_sync_count: u64,
     },
 
     /// Durable but not visible
@@ -916,17 +913,14 @@ pub enum StrataError {
     /// StrataError::DurableButNotVisible {
     ///     txn_id: 12345,
     ///     commit_version: 67890,
-    ///     reason: "storage apply failed".to_string(),
     /// };
     /// ```
-    #[error("durable but not visible: txn {txn_id} at version {commit_version} ({reason})")]
+    #[error("durable but not visible: txn {txn_id} at version {commit_version}")]
     DurableButNotVisible {
         /// Transaction ID that committed durably
         txn_id: u64,
         /// Commit version assigned to the transaction
         commit_version: u64,
-        /// Reason the storage apply failed
-        reason: String,
     },
 
     /// Shutdown timeout

--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -179,6 +179,8 @@ pub mod __internal {
         fn abort_background_sync(&mut self, handle: BackgroundSyncHandle, error: io::Error);
         /// Returns the last background sync error, if any.
         fn bg_error(&self) -> Option<BackgroundSyncError>;
+        /// Clears the last background sync error.
+        fn clear_bg_error(&mut self);
         /// Returns whether a background sync is currently in flight.
         fn sync_in_flight(&self) -> bool;
     }
@@ -221,6 +223,10 @@ pub mod __internal {
 
         fn bg_error(&self) -> Option<BackgroundSyncError> {
             crate::wal::writer::WalWriter::bg_error(self).map(BackgroundSyncError::from)
+        }
+
+        fn clear_bg_error(&mut self) {
+            crate::wal::writer::WalWriter::clear_bg_error(self)
         }
 
         fn sync_in_flight(&self) -> bool {

--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -179,6 +179,8 @@ pub mod __internal {
         fn abort_background_sync(&mut self, handle: BackgroundSyncHandle, error: io::Error);
         /// Returns the last background sync error, if any.
         fn bg_error(&self) -> Option<BackgroundSyncError>;
+        /// Records a failed sync attempt without a background handle.
+        fn record_sync_failure(&mut self, error: io::Error);
         /// Clears the last background sync error.
         fn clear_bg_error(&mut self);
         /// Returns whether a background sync is currently in flight.
@@ -223,6 +225,10 @@ pub mod __internal {
 
         fn bg_error(&self) -> Option<BackgroundSyncError> {
             crate::wal::writer::WalWriter::bg_error(self).map(BackgroundSyncError::from)
+        }
+
+        fn record_sync_failure(&mut self, error: io::Error) {
+            crate::wal::writer::WalWriter::record_sync_failure(self, error)
         }
 
         fn clear_bg_error(&mut self) {

--- a/crates/durability/src/wal/writer.rs
+++ b/crates/durability/src/wal/writer.rs
@@ -604,6 +604,11 @@ impl WalWriter {
         let _snapshot = handle.take_snapshot();
         self.sync_in_flight = false;
 
+        self.record_sync_failure(error);
+    }
+
+    /// Records a sync failure while preserving dirty counters.
+    pub(crate) fn record_sync_failure(&mut self, error: io::Error) {
         let failed_sync_count = self
             .bg_error
             .as_ref()
@@ -2098,6 +2103,7 @@ mod tests {
             ["pub", " fn commit_background_sync("].concat(),
             ["pub", " fn abort_background_sync("].concat(),
             ["pub", " fn bg_error("].concat(),
+            ["pub", " fn record_sync_failure("].concat(),
             ["pub", " fn clear_bg_error("].concat(),
             ["pub", " fn sync_in_flight("].concat(),
         ] {

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -45,6 +45,7 @@ chrono = { workspace = true }
 libc = { workspace = true }
 
 [dev-dependencies]
+strata-concurrency = { path = "../concurrency", features = ["fault-injection"] }
 tempfile = { workspace = true }
 criterion = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -442,6 +442,8 @@ impl Database {
     /// assert!(!db.is_open());
     /// ```
     pub fn shutdown(&self) -> StrataResult<()> {
+        self.shutdown_started.store(true, Ordering::Release);
+
         // 1. Stop accepting new transactions
         self.accepting_transactions.store(false, Ordering::Release);
 

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -74,6 +74,7 @@ use std::time::Instant;
 use strata_core::id::CommitVersion;
 use strata_core::types::{BranchId, Key};
 use strata_core::{StrataError, StrataResult, VersionedValue};
+use strata_durability::__internal::WalWriterEngineExt;
 use strata_durability::wal::{DurabilityMode, WalWriter};
 use strata_storage::{SegmentedStore, StorageIterator};
 
@@ -165,6 +166,55 @@ impl std::fmt::Display for SubsystemStatus {
             SubsystemStatus::Healthy => write!(f, "healthy"),
             SubsystemStatus::Degraded => write!(f, "degraded"),
             SubsystemStatus::Unhealthy => write!(f, "unhealthy"),
+        }
+    }
+}
+
+/// WAL writer health status.
+///
+/// The WAL writer can halt on background sync (fsync) failure to prevent
+/// data loss. This enum reports the current health state and, when halted,
+/// provides diagnostic information for recovery.
+///
+/// # Recovery
+///
+/// When halted, the writer refuses new commits until the underlying issue
+/// is resolved and [`Database::resume_wal_writer`] is called. A successful
+/// resume requires that a sync operation succeed, proving the underlying
+/// storage is healthy again.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum WalWriterHealth {
+    /// Writer is accepting transactions normally.
+    Healthy,
+    /// Writer has halted due to a background sync failure.
+    ///
+    /// No new commits will be accepted until [`Database::resume_wal_writer`]
+    /// is called and succeeds.
+    Halted {
+        /// Human-readable reason for the halt.
+        reason: String,
+        /// Timestamp of the first observed failure in the current streak.
+        first_observed_at: std::time::SystemTime,
+        /// Number of consecutive failed sync attempts.
+        failed_sync_count: u64,
+    },
+}
+
+impl Default for WalWriterHealth {
+    fn default() -> Self {
+        WalWriterHealth::Healthy
+    }
+}
+
+impl std::fmt::Display for WalWriterHealth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WalWriterHealth::Healthy => write!(f, "healthy"),
+            WalWriterHealth::Halted {
+                reason,
+                failed_sync_count,
+                ..
+            } => write!(f, "halted: {} ({} failed syncs)", reason, failed_sync_count),
         }
     }
 }
@@ -351,7 +401,15 @@ pub struct Database {
     /// Flag to track if database is accepting new transactions
     ///
     /// Set to false during shutdown to reject new transactions.
-    accepting_transactions: AtomicBool,
+    /// Arc-wrapped to share with the flush thread (for halt behavior).
+    accepting_transactions: Arc<AtomicBool>,
+
+    /// WAL writer health state.
+    ///
+    /// Set to `Halted` when background sync fails; prevents new commits until
+    /// `resume_wal_writer()` succeeds. Per-database, not process-global.
+    /// Arc-wrapped to share with the flush thread (for halt behavior).
+    wal_writer_health: Arc<ParkingMutex<WalWriterHealth>>,
 
     /// Type-erased extension storage for primitive state
     ///
@@ -506,7 +564,13 @@ impl Database {
     ) -> StrataResult<()> {
         debug_assert!(matches!(mode, DurabilityMode::Standard { .. }));
         self.flush_shutdown.store(false, Ordering::SeqCst);
-        if let Some(handle) = Self::spawn_wal_flush_thread(mode, wal, &self.flush_shutdown)? {
+        if let Some(handle) = Self::spawn_wal_flush_thread(
+            mode,
+            wal,
+            &self.flush_shutdown,
+            &self.accepting_transactions,
+            &self.wal_writer_health,
+        )? {
             *self.flush_handle.lock() = Some(handle);
         }
         Ok(())
@@ -997,6 +1061,101 @@ impl Database {
     /// Check if the database is currently open and accepting transactions
     pub fn is_open(&self) -> bool {
         self.accepting_transactions.load(Ordering::Acquire)
+    }
+
+    // ========================================================================
+    // WAL Writer Health
+    // ========================================================================
+
+    /// Returns the current WAL writer health status.
+    ///
+    /// The WAL writer halts on background sync (fsync) failure to prevent
+    /// data loss. When halted, no new commits will be accepted until the
+    /// underlying issue is resolved and [`resume_wal_writer`](Self::resume_wal_writer)
+    /// is called.
+    ///
+    /// For ephemeral databases (no WAL), this always returns `Healthy`.
+    ///
+    /// # Example
+    /// ```text
+    /// match db.wal_writer_health() {
+    ///     WalWriterHealth::Healthy => println!("Writer healthy"),
+    ///     WalWriterHealth::Halted { reason, failed_sync_count, .. } => {
+    ///         eprintln!("Writer halted: {} ({} failed syncs)", reason, failed_sync_count);
+    ///     }
+    /// }
+    /// ```
+    pub fn wal_writer_health(&self) -> WalWriterHealth {
+        self.wal_writer_health.lock().clone()
+    }
+
+    /// Attempt to resume a halted WAL writer.
+    ///
+    /// When the WAL writer halts due to background sync failure, this method
+    /// attempts to resume normal operation. A successful resume requires that
+    /// a sync operation succeed, proving the underlying storage is healthy.
+    ///
+    /// # Arguments
+    ///
+    /// * `confirm_reason` - A brief description of what action was taken to
+    ///   resolve the underlying issue. This is logged for audit purposes.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - Writer resumed successfully and is accepting commits
+    /// * `Err(WriterHalted)` - Sync still failing; writer remains halted
+    /// * `Err(Internal)` - No WAL writer (ephemeral database) or other error
+    ///
+    /// # Example
+    /// ```text
+    /// // After fixing disk space issue:
+    /// db.resume_wal_writer("freed 10GB disk space")?;
+    /// ```
+    pub fn resume_wal_writer(&self, confirm_reason: &str) -> StrataResult<()> {
+        let wal = self.wal_writer.as_ref().ok_or_else(|| {
+            StrataError::internal("cannot resume WAL writer on ephemeral database".to_string())
+        })?;
+
+        // Attempt a sync to prove storage is healthy
+        {
+            let mut writer = wal.lock();
+            if let Err(e) = writer.flush() {
+                // Sync still failing — update failed_sync_count but stay halted
+                let mut health = self.wal_writer_health.lock();
+                if let WalWriterHealth::Halted {
+                    failed_sync_count, ..
+                } = &mut *health
+                {
+                    *failed_sync_count += 1;
+                }
+                return Err(StrataError::storage(format!(
+                    "resume failed: sync still failing: {}",
+                    e
+                )));
+            }
+
+            // Clear any recorded background error in the writer
+            writer.clear_bg_error();
+        }
+
+        // Sync succeeded — restore healthy state
+        let mut health = self.wal_writer_health.lock();
+        let was_halted = matches!(&*health, WalWriterHealth::Halted { .. });
+        *health = WalWriterHealth::Healthy;
+        drop(health);
+
+        // Re-enable transactions
+        self.accepting_transactions.store(true, Ordering::Release);
+
+        if was_halted {
+            tracing::info!(
+                target: "strata::wal",
+                confirm_reason = confirm_reason,
+                "WAL writer resumed"
+            );
+        }
+
+        Ok(())
     }
 
     /// Returns a reference to the background task scheduler.

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -74,7 +74,7 @@ use std::time::Instant;
 use strata_core::id::CommitVersion;
 use strata_core::types::{BranchId, Key};
 use strata_core::{StrataError, StrataResult, VersionedValue};
-use strata_durability::__internal::WalWriterEngineExt;
+use strata_durability::__internal::{BackgroundSyncError, WalWriterEngineExt};
 use strata_durability::wal::{DurabilityMode, WalWriter};
 use strata_storage::{SegmentedStore, StorageIterator};
 
@@ -474,6 +474,9 @@ pub struct Database {
 
     /// Whether this database is a read-only follower (no lock, no WAL writer).
     follower: bool,
+
+    /// Whether shutdown() has started (prevents halt-resume from reopening it).
+    shutdown_started: AtomicBool,
 
     /// Whether shutdown() has already completed (prevents double freeze in Drop).
     shutdown_complete: AtomicBool,
@@ -1063,6 +1066,35 @@ impl Database {
         self.accepting_transactions.load(Ordering::Acquire)
     }
 
+    pub(crate) fn writer_halted_error(&self) -> Option<StrataError> {
+        match &*self.wal_writer_health.lock() {
+            WalWriterHealth::Healthy => None,
+            WalWriterHealth::Halted {
+                reason,
+                first_observed_at,
+                ..
+            } => Some(StrataError::WriterHalted {
+                reason: reason.clone(),
+                first_observed_at: *first_observed_at,
+            }),
+        }
+    }
+
+    pub(crate) fn ensure_writer_healthy(&self) -> StrataResult<()> {
+        if let Some(err) = self.writer_halted_error() {
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn halted_health_from_bg_error(bg_error: BackgroundSyncError) -> WalWriterHealth {
+        WalWriterHealth::Halted {
+            reason: bg_error.message().to_string(),
+            first_observed_at: bg_error.first_observed_at(),
+            failed_sync_count: bg_error.failed_sync_count(),
+        }
+    }
+
     // ========================================================================
     // WAL Writer Health
     // ========================================================================
@@ -1104,7 +1136,8 @@ impl Database {
     ///
     /// * `Ok(())` - Writer resumed successfully and is accepting commits
     /// * `Err(WriterHalted)` - Sync still failing; writer remains halted
-    /// * `Err(Internal)` - No WAL writer (ephemeral database) or other error
+    /// * `Err(InvalidInput)` - Shutdown has started or the database is closed
+    /// * `Err(Internal)` - No WAL writer (ephemeral database)
     ///
     /// # Example
     /// ```text
@@ -1116,22 +1149,47 @@ impl Database {
             StrataError::internal("cannot resume WAL writer on ephemeral database".to_string())
         })?;
 
+        if self.shutdown_started.load(Ordering::Acquire)
+            || self.shutdown_complete.load(Ordering::Acquire)
+        {
+            return Err(StrataError::invalid_input(
+                "cannot resume WAL writer after shutdown has started".to_string(),
+            ));
+        }
+
+        let was_halted = matches!(self.wal_writer_health(), WalWriterHealth::Halted { .. });
+        if !was_halted {
+            if self.accepting_transactions.load(Ordering::Acquire) {
+                return Ok(());
+            }
+            return Err(StrataError::invalid_input(
+                "database is not accepting transactions".to_string(),
+            ));
+        }
+
         // Attempt a sync to prove storage is healthy
         {
             let mut writer = wal.lock();
-            if let Err(e) = writer.flush() {
-                // Sync still failing — update failed_sync_count but stay halted
+            #[cfg(test)]
+            let flush_result = crate::database::test_hooks::maybe_inject_sync_failure()
+                .map_or_else(|| writer.flush(), Err);
+
+            #[cfg(not(test))]
+            let flush_result = writer.flush();
+
+            if let Err(e) = flush_result {
+                writer.record_sync_failure(e);
+                let bg_error = writer.bg_error().expect(
+                    "record_sync_failure must preserve a background error for halted writer",
+                );
+                let reason = bg_error.message().to_string();
+                let first_observed_at = bg_error.first_observed_at();
                 let mut health = self.wal_writer_health.lock();
-                if let WalWriterHealth::Halted {
-                    failed_sync_count, ..
-                } = &mut *health
-                {
-                    *failed_sync_count += 1;
-                }
-                return Err(StrataError::storage(format!(
-                    "resume failed: sync still failing: {}",
-                    e
-                )));
+                *health = Self::halted_health_from_bg_error(bg_error);
+                return Err(StrataError::WriterHalted {
+                    reason,
+                    first_observed_at,
+                });
             }
 
             // Clear any recorded background error in the writer
@@ -1140,7 +1198,6 @@ impl Database {
 
         // Sync succeeded — restore healthy state
         let mut health = self.wal_writer_health.lock();
-        let was_halted = matches!(&*health, WalWriterHealth::Halted { .. });
         *health = WalWriterHealth::Healthy;
         drop(health);
 

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -81,7 +81,7 @@ fn restrict_file(_path: &Path) {}
 
 use super::config::{self, StrataConfig};
 use super::registry::OPEN_DATABASES;
-use super::{Database, PersistenceMode};
+use super::{Database, PersistenceMode, WalWriterHealth};
 
 enum AcquiredDatabase {
     Existing(Arc<Database>),
@@ -486,7 +486,8 @@ impl Database {
             persistence_mode: PersistenceMode::Disk,
             coordinator,
             durability_mode: parking_lot::RwLock::new(DurabilityMode::Cache), // Irrelevant for follower
-            accepting_transactions: AtomicBool::new(true),
+            accepting_transactions: Arc::new(AtomicBool::new(true)),
+            wal_writer_health: Arc::new(ParkingMutex::new(WalWriterHealth::Healthy)),
             extensions: DashMap::new(),
             config: parking_lot::RwLock::new(cfg),
             flush_shutdown: Arc::new(AtomicBool::new(false)),
@@ -524,14 +525,25 @@ impl Database {
     /// Spawn the background WAL flush thread for Standard durability mode.
     ///
     /// Returns `None` for non-Standard modes (Cache, Always).
+    ///
+    /// # Arguments
+    /// * `durability_mode` - The durability mode (only Standard spawns a thread)
+    /// * `wal` - The WAL writer mutex
+    /// * `shutdown` - Signal to stop the flush thread
+    /// * `accepting_transactions` - Flag to disable when writer halts
+    /// * `wal_writer_health` - Health state to update on sync failure
     pub(crate) fn spawn_wal_flush_thread(
         durability_mode: DurabilityMode,
         wal: &Arc<ParkingMutex<WalWriter>>,
         shutdown: &Arc<AtomicBool>,
+        accepting_transactions: &Arc<AtomicBool>,
+        wal_writer_health: &Arc<ParkingMutex<WalWriterHealth>>,
     ) -> StrataResult<Option<std::thread::JoinHandle<()>>> {
         if let DurabilityMode::Standard { interval_ms, .. } = durability_mode {
             let wal = Arc::clone(wal);
             let shutdown = Arc::clone(shutdown);
+            let accepting = Arc::clone(accepting_transactions);
+            let health = Arc::clone(wal_writer_health);
             let interval = std::time::Duration::from_millis(interval_ms);
 
             #[cfg(test)]
@@ -582,6 +594,39 @@ impl Database {
                                     Err(e) => {
                                         tracing::error!(target: "strata::wal", error = %e, "Background WAL sync failed");
                                         w.abort_background_sync(handle, e);
+
+                                        // Halt the writer: stop accepting transactions
+                                        accepting.store(false, Ordering::Release);
+
+                                        // Update health state with error details from WAL writer
+                                        let mut h = health.lock();
+                                        if let Some(bg_error) = w.bg_error() {
+                                            *h = WalWriterHealth::Halted {
+                                                reason: bg_error.message().to_string(),
+                                                first_observed_at: bg_error.first_observed_at(),
+                                                failed_sync_count: bg_error.failed_sync_count(),
+                                            };
+                                            tracing::error!(
+                                                target: "strata::wal",
+                                                reason = %bg_error.message(),
+                                                failed_sync_count = bg_error.failed_sync_count(),
+                                                "WAL writer halted due to sync failure"
+                                            );
+                                        } else {
+                                            // Defensive: bg_error should always be Some after
+                                            // abort_background_sync, but ensure consistent state
+                                            *h = WalWriterHealth::Halted {
+                                                reason: "sync failure (details unavailable)".to_string(),
+                                                first_observed_at: std::time::SystemTime::now(),
+                                                failed_sync_count: 1,
+                                            };
+                                            tracing::error!(
+                                                target: "strata::wal",
+                                                "WAL writer halted due to sync failure (bg_error unexpectedly None)"
+                                            );
+                                        }
+                                        drop(h);
+
                                         false
                                     }
                                 }
@@ -756,8 +801,9 @@ impl Database {
 
         let wal_arc = Arc::new(ParkingMutex::new(wal_writer));
         let flush_shutdown = Arc::new(AtomicBool::new(false));
-        let flush_handle =
-            Self::spawn_wal_flush_thread(durability_mode, &wal_arc, &flush_shutdown)?;
+        // Pre-create Arc-wrapped fields that need to be shared with flush thread
+        let accepting_transactions = Arc::new(AtomicBool::new(true));
+        let wal_writer_health = Arc::new(ParkingMutex::new(WalWriterHealth::Healthy));
 
         // Create coordinator with write buffer limit from config (before moving result.storage)
         let coordinator = TransactionCoordinator::from_recovery_with_limits(
@@ -799,15 +845,16 @@ impl Database {
             data_dir: canonical_path.clone(),
             database_uuid,
             storage,
-            wal_writer: Some(wal_arc),
+            wal_writer: Some(Arc::clone(&wal_arc)),
             persistence_mode: PersistenceMode::Disk,
             coordinator,
             durability_mode: parking_lot::RwLock::new(durability_mode),
-            accepting_transactions: AtomicBool::new(true),
+            accepting_transactions: Arc::clone(&accepting_transactions),
+            wal_writer_health: Arc::clone(&wal_writer_health),
             extensions: DashMap::new(),
             config: parking_lot::RwLock::new(cfg),
-            flush_shutdown,
-            flush_handle: ParkingMutex::new(flush_handle),
+            flush_shutdown: Arc::clone(&flush_shutdown),
+            flush_handle: ParkingMutex::new(None), // Spawned after construction
             scheduler: Arc::new(BackgroundScheduler::new(bg_threads, 4096)),
             flush_in_flight: Arc::new(AtomicBool::new(false)),
             compaction_in_flight: Arc::new(AtomicBool::new(false)),
@@ -835,6 +882,17 @@ impl Database {
             runtime_signature: parking_lot::RwLock::new(None),
             merge_registry: super::MergeHandlerRegistry::new(),
         });
+
+        // Spawn flush thread now that Database is constructed (shares Arc fields)
+        if let Some(handle) = Self::spawn_wal_flush_thread(
+            durability_mode,
+            &wal_arc,
+            &flush_shutdown,
+            &accepting_transactions,
+            &wal_writer_health,
+        )? {
+            *db.flush_handle.lock() = Some(handle);
+        }
 
         // Trigger compaction if any levels have accumulated segments from
         // recovery. Without this, compaction only runs after the next write
@@ -936,7 +994,8 @@ impl Database {
             persistence_mode: PersistenceMode::Ephemeral,
             coordinator,
             durability_mode: parking_lot::RwLock::new(DurabilityMode::Cache), // Irrelevant but set for consistency
-            accepting_transactions: AtomicBool::new(true),
+            accepting_transactions: Arc::new(AtomicBool::new(true)),
+            wal_writer_health: Arc::new(ParkingMutex::new(WalWriterHealth::Healthy)),
             extensions: DashMap::new(),
             config: parking_lot::RwLock::new(cfg),
             flush_shutdown: Arc::new(AtomicBool::new(false)),

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -503,6 +503,7 @@ impl Database {
             wal_dir,
             wal_watermark,
             follower: true,
+            shutdown_started: AtomicBool::new(false),
             shutdown_complete: AtomicBool::new(false),
             opened_at: Instant::now(),
             subsystems: parking_lot::RwLock::new(Vec::new()),
@@ -561,6 +562,9 @@ impl Database {
                         if shutdown.load(Ordering::Relaxed) {
                             break;
                         }
+                        if matches!(&*health.lock(), WalWriterHealth::Halted { .. }) {
+                            continue;
+                        }
                         let sync_plan = {
                             let mut w = wal.lock();
                             match w.begin_background_sync() {
@@ -595,21 +599,16 @@ impl Database {
                                         tracing::error!(target: "strata::wal", error = %e, "Background WAL sync failed");
                                         w.abort_background_sync(handle, e);
 
-                                        // Halt the writer: stop accepting transactions
-                                        accepting.store(false, Ordering::Release);
-
                                         // Update health state with error details from WAL writer
                                         let mut h = health.lock();
                                         if let Some(bg_error) = w.bg_error() {
-                                            *h = WalWriterHealth::Halted {
-                                                reason: bg_error.message().to_string(),
-                                                first_observed_at: bg_error.first_observed_at(),
-                                                failed_sync_count: bg_error.failed_sync_count(),
-                                            };
+                                            let reason = bg_error.message().to_string();
+                                            let failed_sync_count = bg_error.failed_sync_count();
+                                            *h = Self::halted_health_from_bg_error(bg_error);
                                             tracing::error!(
                                                 target: "strata::wal",
-                                                reason = %bg_error.message(),
-                                                failed_sync_count = bg_error.failed_sync_count(),
+                                                reason = %reason,
+                                                failed_sync_count,
                                                 "WAL writer halted due to sync failure"
                                             );
                                         } else {
@@ -626,6 +625,11 @@ impl Database {
                                             );
                                         }
                                         drop(h);
+
+                                        // Publish the halt after health is updated so
+                                        // new callers observe WriterHalted, not a
+                                        // generic shutdown-style rejection.
+                                        accepting.store(false, Ordering::Release);
 
                                         false
                                     }
@@ -866,6 +870,7 @@ impl Database {
             wal_dir,
             wal_watermark,
             follower: false,
+            shutdown_started: AtomicBool::new(false),
             shutdown_complete: AtomicBool::new(false),
             opened_at: Instant::now(),
             subsystems: parking_lot::RwLock::new(Vec::new()),
@@ -1011,6 +1016,7 @@ impl Database {
             wal_dir: PathBuf::new(),
             wal_watermark: AtomicU64::new(0),
             follower: false,
+            shutdown_started: AtomicBool::new(false),
             shutdown_complete: AtomicBool::new(false),
             opened_at: Instant::now(),
             subsystems: parking_lot::RwLock::new(Vec::new()),

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use strata_concurrency::TransactionPayload;
+use strata_concurrency::__internal as concurrency_test_hooks;
 use strata_core::id::{CommitVersion, TxnId};
 use strata_core::types::{Key, Namespace, TypeTag};
 use strata_core::value::Value;
@@ -2463,10 +2464,11 @@ fn test_set_durability_mode_spawn_failure_rolls_back_state() {
     db.shutdown().unwrap();
 }
 
-/// T3-E2: Background sync failure halts the writer and rejects new transactions.
+/// T3-E2: Background sync failure halts the writer and rejects both new and
+/// already-open manual commits until explicit resume succeeds.
 #[test]
 #[serial]
-fn test_background_sync_failure_halts_writer() {
+fn test_background_sync_failure_halts_writer_and_rejects_manual_commit() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("bg_sync_halt_db");
     let db = Database::open_with_durability(&db_path, DurabilityMode::standard_default()).unwrap();
@@ -2477,18 +2479,20 @@ fn test_background_sync_failure_halts_writer() {
     .unwrap();
 
     let branch_id = BranchId::new();
-    let key = Key::new_kv(create_test_namespace(branch_id), "bg_sync_key");
+    let trigger_key = Key::new_kv(create_test_namespace(branch_id), "bg_sync_key");
+    let pending_key = Key::new_kv(create_test_namespace(branch_id), "pending_key");
 
-    // First transaction succeeds (before sync failure)
     super::test_hooks::clear_sync_failure();
+    let mut manual_txn = db.begin_transaction(branch_id).unwrap();
+    manual_txn.put(pending_key.clone(), Value::Int(6)).unwrap();
+
+    // Commit a separate transaction to create unsynced WAL data.
+    super::test_hooks::inject_sync_failure(std::io::ErrorKind::Other);
     db.transaction(branch_id, |txn| {
-        txn.put(key.clone(), Value::Int(7))?;
+        txn.put(trigger_key.clone(), Value::Int(7))?;
         Ok(())
     })
     .unwrap();
-
-    // Inject sync failure for the background flush
-    super::test_hooks::inject_sync_failure(std::io::ErrorKind::Other);
 
     // Wait for background sync to fail and halt the writer
     wait_until(Duration::from_secs(2), || {
@@ -2511,10 +2515,19 @@ fn test_background_sync_failure_halts_writer() {
         }
     }
 
+    let err = manual_txn
+        .commit()
+        .expect_err("manual transaction should be rejected once the writer halts");
+    assert!(
+        matches!(err, StrataError::WriterHalted { .. }),
+        "expected WriterHalted from manual commit, got: {:?}",
+        err
+    );
+
     // Verify new transactions are rejected with WriterHalted error
     let err = db
         .transaction(branch_id, |txn| {
-            txn.put(key.clone(), Value::Int(8))?;
+            txn.put(trigger_key.clone(), Value::Int(8))?;
             Ok(())
         })
         .expect_err("transaction should be rejected when writer is halted");
@@ -2525,8 +2538,18 @@ fn test_background_sync_failure_halts_writer() {
         err
     );
 
-    // Clear the injected failure and resume
+    // Clearing the fault should NOT auto-resume; the flush thread stays alive
+    // but passive until explicit operator resume.
     super::test_hooks::clear_sync_failure();
+    std::thread::sleep(Duration::from_millis(50));
+    assert!(
+        matches!(
+            db.wal_writer_health(),
+            super::WalWriterHealth::Halted { .. }
+        ),
+        "writer must remain halted until explicit resume"
+    );
+
     db.resume_wal_writer("test cleared injected failure")
         .unwrap();
 
@@ -2538,7 +2561,7 @@ fn test_background_sync_failure_halts_writer() {
 
     // Verify transactions work again
     db.transaction(branch_id, |txn| {
-        txn.put(key.clone(), Value::Int(9))?;
+        txn.put(trigger_key.clone(), Value::Int(9))?;
         Ok(())
     })
     .unwrap();
@@ -2546,10 +2569,10 @@ fn test_background_sync_failure_halts_writer() {
     db.shutdown().unwrap();
 }
 
-/// T3-E2: Sync failure sets initial failed_sync_count and can be resumed.
+/// T3-E2: Failed explicit resumes preserve the halt and increment the failure streak.
 #[test]
 #[serial]
-fn test_sync_failure_halt_and_resume() {
+fn test_resume_while_still_failing_increments_failed_sync_count() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("repeated_sync_fail_db");
     let db = Database::open_with_durability(&db_path, DurabilityMode::standard_default()).unwrap();
@@ -2562,7 +2585,6 @@ fn test_sync_failure_halt_and_resume() {
     let branch_id = BranchId::new();
     let key = Key::new_kv(create_test_namespace(branch_id), "repeat_fail_key");
 
-    // First transaction
     super::test_hooks::clear_sync_failure();
     db.transaction(branch_id, |txn| {
         txn.put(key.clone(), Value::Int(1))?;
@@ -2581,32 +2603,49 @@ fn test_sync_failure_halt_and_resume() {
         )
     });
 
-    // Verify health state shows halted with at least 1 failed sync
-    match db.wal_writer_health() {
+    let (first_reason, first_seen, first_count) = match db.wal_writer_health() {
         super::WalWriterHealth::Halted {
-            failed_sync_count, ..
-        } => {
-            assert!(
-                failed_sync_count >= 1,
-                "expected at least 1 failed sync, got {}",
-                failed_sync_count
-            );
-        }
+            reason,
+            first_observed_at,
+            failed_sync_count,
+        } => (reason, first_observed_at, failed_sync_count),
         super::WalWriterHealth::Healthy => {
             panic!("expected writer to be halted");
         }
-    }
+    };
+    assert!(first_count >= 1, "expected at least 1 failed sync");
 
-    // Clean up and resume
-    super::test_hooks::clear_sync_failure();
-    db.resume_wal_writer("cleanup").unwrap();
-
-    // Verify health is restored
+    super::test_hooks::inject_sync_failure(std::io::ErrorKind::Other);
+    let err = db
+        .resume_wal_writer("fault still present")
+        .expect_err("resume should fail while sync is still failing");
     assert!(
-        matches!(db.wal_writer_health(), super::WalWriterHealth::Healthy),
-        "expected writer to be healthy after resume"
+        matches!(err, StrataError::WriterHalted { .. }),
+        "expected WriterHalted, got: {:?}",
+        err
     );
 
+    match db.wal_writer_health() {
+        super::WalWriterHealth::Halted {
+            reason,
+            first_observed_at,
+            failed_sync_count,
+        } => {
+            assert_eq!(reason, first_reason, "halt reason should stay stable");
+            assert_eq!(
+                first_observed_at, first_seen,
+                "first_observed_at should not reset across failed resumes"
+            );
+            assert_eq!(
+                failed_sync_count,
+                first_count + 1,
+                "failed resume must increment failed_sync_count"
+            );
+        }
+        super::WalWriterHealth::Healthy => panic!("writer must remain halted"),
+    }
+
+    super::test_hooks::clear_sync_failure();
     db.shutdown().unwrap();
 }
 
@@ -2659,6 +2698,90 @@ fn test_resume_when_already_healthy_is_noop() {
     .unwrap();
 
     db.shutdown().unwrap();
+}
+
+/// T3-E2: Resume must not reopen a database after shutdown has started.
+#[test]
+fn test_resume_after_shutdown_returns_error_and_does_not_reopen() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("resume_after_shutdown_db");
+    let db = Database::open_with_durability(&db_path, DurabilityMode::standard_default()).unwrap();
+
+    db.shutdown().unwrap();
+    assert!(!db.is_open(), "shutdown must close the database");
+
+    let err = db
+        .resume_wal_writer("should not reopen closed database")
+        .expect_err("resume after shutdown must fail");
+    assert!(
+        matches!(err, StrataError::InvalidInput { .. }),
+        "expected InvalidInput after shutdown, got: {:?}",
+        err
+    );
+    assert!(!db.is_open(), "resume must not reopen a shut-down database");
+}
+
+/// T3-E2: Engine callers see DurableButNotVisible and the durable write becomes
+/// visible after reopen recovery.
+#[test]
+#[serial]
+fn test_durable_but_not_visible_is_surfaced_and_recovers_on_reopen() {
+    concurrency_test_hooks::clear_apply_failure_injection();
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("durable_not_visible_db");
+    let branch_id = BranchId::new();
+    let key = Key::new_kv(create_test_namespace(branch_id), "durable_not_visible_key");
+
+    {
+        let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+
+        concurrency_test_hooks::inject_apply_failure_once(
+            "injected apply_writes failure after WAL commit",
+        );
+        let err = db
+            .transaction(branch_id, |txn| {
+                txn.put(key.clone(), Value::Int(77))?;
+                Ok(())
+            })
+            .expect_err("commit should surface durable-but-not-visible");
+
+        match err {
+            StrataError::DurableButNotVisible {
+                txn_id,
+                commit_version,
+            } => {
+                assert!(txn_id > 0, "txn_id must be preserved");
+                assert!(commit_version > 0, "commit_version must be preserved");
+            }
+            other => panic!(
+                "expected DurableButNotVisible from engine commit path, got {:?}",
+                other
+            ),
+        }
+
+        let visible_now: Option<Value> =
+            db.transaction(branch_id, |txn| Ok(txn.get(&key)?)).unwrap();
+        assert!(
+            visible_now.is_none(),
+            "write must remain invisible in the current process"
+        );
+    }
+
+    concurrency_test_hooks::clear_apply_failure_injection();
+    OPEN_DATABASES.lock().clear();
+
+    let reopened = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+    let recovered: Option<Value> = reopened
+        .transaction(branch_id, |txn| Ok(txn.get(&key)?))
+        .unwrap();
+    assert_eq!(
+        recovered,
+        Some(Value::Int(77)),
+        "reopen recovery must make the durable write visible"
+    );
+
+    reopened.shutdown().unwrap();
 }
 
 #[test]

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -2463,11 +2463,12 @@ fn test_set_durability_mode_spawn_failure_rolls_back_state() {
     db.shutdown().unwrap();
 }
 
+/// T3-E2: Background sync failure halts the writer and rejects new transactions.
 #[test]
 #[serial]
-fn test_background_sync_failure_sets_bg_error_and_retries() {
+fn test_background_sync_failure_halts_writer() {
     let temp_dir = TempDir::new().unwrap();
-    let db_path = temp_dir.path().join("bg_sync_retry_db");
+    let db_path = temp_dir.path().join("bg_sync_halt_db");
     let db = Database::open_with_durability(&db_path, DurabilityMode::standard_default()).unwrap();
     db.set_durability_mode(DurabilityMode::Standard {
         interval_ms: 10,
@@ -2478,32 +2479,184 @@ fn test_background_sync_failure_sets_bg_error_and_retries() {
     let branch_id = BranchId::new();
     let key = Key::new_kv(create_test_namespace(branch_id), "bg_sync_key");
 
+    // First transaction succeeds (before sync failure)
     super::test_hooks::clear_sync_failure();
-    super::test_hooks::inject_sync_failure(std::io::ErrorKind::Other);
-
     db.transaction(branch_id, |txn| {
         txn.put(key.clone(), Value::Int(7))?;
         Ok(())
     })
     .unwrap();
 
+    // Inject sync failure for the background flush
+    super::test_hooks::inject_sync_failure(std::io::ErrorKind::Other);
+
+    // Wait for background sync to fail and halt the writer
     wait_until(Duration::from_secs(2), || {
-        db.wal_writer.as_ref().unwrap().lock().bg_error().is_some()
+        matches!(
+            db.wal_writer_health(),
+            super::WalWriterHealth::Halted { .. }
+        )
     });
 
-    let failure = db
-        .wal_writer
-        .as_ref()
-        .unwrap()
-        .lock()
-        .bg_error()
-        .expect("expected background sync failure");
-    assert_eq!(failure.kind(), std::io::ErrorKind::Other);
-    assert_eq!(failure.failed_sync_count(), 1);
+    // Verify health state shows halted
+    let health = db.wal_writer_health();
+    match health {
+        super::WalWriterHealth::Halted {
+            failed_sync_count, ..
+        } => {
+            assert!(failed_sync_count >= 1, "expected at least one failed sync");
+        }
+        super::WalWriterHealth::Healthy => {
+            panic!("expected writer to be halted after sync failure");
+        }
+    }
 
+    // Verify new transactions are rejected with WriterHalted error
+    let err = db
+        .transaction(branch_id, |txn| {
+            txn.put(key.clone(), Value::Int(8))?;
+            Ok(())
+        })
+        .expect_err("transaction should be rejected when writer is halted");
+
+    assert!(
+        matches!(err, StrataError::WriterHalted { .. }),
+        "expected WriterHalted error, got: {:?}",
+        err
+    );
+
+    // Clear the injected failure and resume
+    super::test_hooks::clear_sync_failure();
+    db.resume_wal_writer("test cleared injected failure")
+        .unwrap();
+
+    // Verify health is restored
+    assert!(
+        matches!(db.wal_writer_health(), super::WalWriterHealth::Healthy),
+        "expected writer to be healthy after resume"
+    );
+
+    // Verify transactions work again
+    db.transaction(branch_id, |txn| {
+        txn.put(key.clone(), Value::Int(9))?;
+        Ok(())
+    })
+    .unwrap();
+
+    db.shutdown().unwrap();
+}
+
+/// T3-E2: Sync failure sets initial failed_sync_count and can be resumed.
+#[test]
+#[serial]
+fn test_sync_failure_halt_and_resume() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("repeated_sync_fail_db");
+    let db = Database::open_with_durability(&db_path, DurabilityMode::standard_default()).unwrap();
+    db.set_durability_mode(DurabilityMode::Standard {
+        interval_ms: 10,
+        batch_size: 64,
+    })
+    .unwrap();
+
+    let branch_id = BranchId::new();
+    let key = Key::new_kv(create_test_namespace(branch_id), "repeat_fail_key");
+
+    // First transaction
+    super::test_hooks::clear_sync_failure();
+    db.transaction(branch_id, |txn| {
+        txn.put(key.clone(), Value::Int(1))?;
+        Ok(())
+    })
+    .unwrap();
+
+    // Inject sync failure
+    super::test_hooks::inject_sync_failure(std::io::ErrorKind::Other);
+
+    // Wait for writer to halt
     wait_until(Duration::from_secs(2), || {
-        db.wal_writer.as_ref().unwrap().lock().bg_error().is_none()
+        matches!(
+            db.wal_writer_health(),
+            super::WalWriterHealth::Halted { .. }
+        )
     });
+
+    // Verify health state shows halted with at least 1 failed sync
+    match db.wal_writer_health() {
+        super::WalWriterHealth::Halted {
+            failed_sync_count, ..
+        } => {
+            assert!(
+                failed_sync_count >= 1,
+                "expected at least 1 failed sync, got {}",
+                failed_sync_count
+            );
+        }
+        super::WalWriterHealth::Healthy => {
+            panic!("expected writer to be halted");
+        }
+    }
+
+    // Clean up and resume
+    super::test_hooks::clear_sync_failure();
+    db.resume_wal_writer("cleanup").unwrap();
+
+    // Verify health is restored
+    assert!(
+        matches!(db.wal_writer_health(), super::WalWriterHealth::Healthy),
+        "expected writer to be healthy after resume"
+    );
+
+    db.shutdown().unwrap();
+}
+
+/// T3-E2: Resume on ephemeral database returns error.
+#[test]
+fn test_resume_ephemeral_database_returns_error() {
+    let db = Database::cache().unwrap();
+
+    // Ephemeral databases have no WAL writer, so resume should fail
+    let err = db
+        .resume_wal_writer("test")
+        .expect_err("resume on ephemeral should fail");
+
+    assert!(
+        matches!(err, StrataError::Internal { .. }),
+        "expected Internal error for ephemeral resume, got: {:?}",
+        err
+    );
+}
+
+/// T3-E2: Resume when already healthy is a no-op.
+#[test]
+fn test_resume_when_already_healthy_is_noop() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("resume_healthy_db");
+    let db = Database::open_with_durability(&db_path, DurabilityMode::standard_default()).unwrap();
+
+    // Verify initially healthy
+    assert!(
+        matches!(db.wal_writer_health(), super::WalWriterHealth::Healthy),
+        "expected writer to be healthy initially"
+    );
+
+    // Resume when already healthy should succeed (no-op)
+    db.resume_wal_writer("no-op test").unwrap();
+
+    // Still healthy
+    assert!(
+        matches!(db.wal_writer_health(), super::WalWriterHealth::Healthy),
+        "expected writer to remain healthy"
+    );
+
+    // Transactions should still work
+    let branch_id = BranchId::new();
+    let key = Key::new_kv(create_test_namespace(branch_id), "noop_key");
+    db.transaction(branch_id, |txn| {
+        txn.put(key, Value::Int(42))?;
+        Ok(())
+    })
+    .unwrap();
 
     db.shutdown().unwrap();
 }

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -188,8 +188,29 @@ impl Database {
     // ========================================================================
 
     /// Check if the database is accepting transactions.
+    ///
+    /// Returns an error if:
+    /// - The database is shutting down (`InvalidInput`)
+    /// - The WAL writer is halted due to sync failure (`WriterHalted`)
     fn check_accepting(&self) -> StrataResult<()> {
         if !self.accepting_transactions.load(Ordering::Acquire) {
+            // Check if writer is halted (more specific error)
+            let health = self.wal_writer_health.lock();
+            if let super::WalWriterHealth::Halted {
+                reason,
+                first_observed_at,
+                failed_sync_count,
+            } = &*health
+            {
+                return Err(StrataError::WriterHalted {
+                    reason: reason.clone(),
+                    first_observed_at: *first_observed_at,
+                    failed_sync_count: *failed_sync_count,
+                });
+            }
+            drop(health);
+
+            // Not halted, must be shutting down
             return Err(StrataError::invalid_input(
                 "Database is shutting down".to_string(),
             ));

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -195,20 +195,9 @@ impl Database {
     fn check_accepting(&self) -> StrataResult<()> {
         if !self.accepting_transactions.load(Ordering::Acquire) {
             // Check if writer is halted (more specific error)
-            let health = self.wal_writer_health.lock();
-            if let super::WalWriterHealth::Halted {
-                reason,
-                first_observed_at,
-                failed_sync_count,
-            } = &*health
-            {
-                return Err(StrataError::WriterHalted {
-                    reason: reason.clone(),
-                    first_observed_at: *first_observed_at,
-                    failed_sync_count: *failed_sync_count,
-                });
+            if let Some(err) = self.writer_halted_error() {
+                return Err(err);
             }
-            drop(health);
 
             // Not halted, must be shutting down
             return Err(StrataError::invalid_input(
@@ -798,6 +787,11 @@ impl Database {
         &self,
         txn: &mut TransactionContext,
     ) -> StrataResult<u64> {
+        if let Err(e) = self.ensure_writer_healthy() {
+            self.abort_transaction_in_place(txn, format!("Commit failed: {}", e));
+            return Err(e);
+        }
+
         if self.follower {
             let err = StrataError::internal(
                 "cannot commit: database opened in follower mode (read-only)",
@@ -818,13 +812,15 @@ impl Database {
         let version = match self.commit_internal(txn, self.current_durability_mode()) {
             Ok(version) => version,
             Err(e) => {
+                let should_record_coordinator_abort =
+                    txn.is_active() && matches!(&e, StrataError::WriterHalted { .. });
                 // `TransactionCoordinator::commit*` already decremented
                 // active_count on commit failure. Only mirror the terminal
                 // state into the pooled TransactionContext here.
                 self.finalize_aborted_transaction_in_place(
                     txn,
                     format!("Commit failed: {}", e),
-                    false,
+                    should_record_coordinator_abort,
                 );
                 return Err(e);
             }
@@ -859,6 +855,8 @@ impl Database {
         txn: &mut TransactionContext,
         durability: DurabilityMode,
     ) -> StrataResult<CommitVersion> {
+        self.ensure_writer_healthy()?;
+
         // Capture info needed for observer notification before commit
         // (txn state may be modified during commit)
         let txn_id = txn.txn_id;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -45,6 +45,7 @@ pub use database::profile::{
 pub use database::{
     CacheMetrics, Database, DatabaseDiskUsage, HealthReport, ModelConfig, StorageConfig,
     StorageMetricsSummary, StrataConfig, SubsystemHealth, SubsystemStatus, SystemMetrics,
+    WalWriterHealth,
 };
 pub use instrumentation::PerfTrace;
 pub use recovery::Subsystem;


### PR DESCRIPTION
## Summary

- Add `WalWriterHealth` enum (`Healthy`/`Halted`) with public accessor `db.wal_writer_health()`
- Halt writer and reject new transactions on background sync (fsync) failure
- Add `db.resume_wal_writer()` API to recover after underlying issue is resolved
- Surface `DurableButNotVisible` as first-class `StrataError` variant with structured fields
- Add `WriterHalted` and `ShutdownTimeout` error variants to `StrataError`
- Add storage-apply failure injection hook for testing `DurableButNotVisible` end-to-end
- Reject manual commits when writer is halted (ensure_writer_healthy check before commit)
- Flush thread stays passive when halted until explicit resume
- Prevent `resume_wal_writer()` from reopening database after shutdown

This implements fail-closed semantics: on fsync failure the writer halts immediately, preventing data loss from accepting commits that cannot be durably persisted.

**Change class:** cutover  
**Assurance class:** S4 (durability path)  
**D4 surface:** `WalWriterHealth` authorized under Durability section

## Test plan

- [x] `test_background_sync_failure_halts_writer_and_rejects_manual_commit` — verifies writer halts and both new and pending transactions are rejected
- [x] `test_resume_while_still_failing_increments_failed_sync_count` — verifies failed resume attempts are tracked
- [x] `test_resume_ephemeral_database_returns_error` — verifies resume on ephemeral (no WAL) database returns error
- [x] `test_resume_when_already_healthy_is_noop` — verifies resume on healthy writer is a no-op
- [x] `test_resume_after_shutdown_returns_error_and_does_not_reopen` — verifies resume cannot reopen after shutdown
- [x] `test_durable_but_not_visible_is_surfaced_and_recovers_on_reopen` — verifies DurableButNotVisible error surfaces and data recovers on reopen

```bash
cargo test -p strata-engine test_background_sync
cargo test -p strata-engine test_resume
cargo test -p strata-engine test_durable_but_not_visible
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)