### PR TITLE
feat(durability): T3-E3 follower refresh convergence

### DIFF
--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -860,6 +860,16 @@ impl TransactionManager {
         self.visible_version.fetch_max(v, Ordering::AcqRel);
     }
 
+    /// Set the visible version exactly.
+    ///
+    /// Used when reopening a blocked follower: recovery restores the full WAL
+    /// state into storage, then the engine clamps visibility back below the
+    /// blocked record until an operator explicitly skips it.
+    pub fn set_visible_version(&self, version: CommitVersion) {
+        self.visible_version
+            .store(version.as_u64(), Ordering::Release);
+    }
+
     /// Advance the next_txn_id counter to at least `id + 1`.
     ///
     /// Used during multi-process refresh to ensure locally-allocated transaction

--- a/crates/durability/src/wal/mod.rs
+++ b/crates/durability/src/wal/mod.rs
@@ -15,7 +15,10 @@ pub use mode::DurabilityMode;
 
 // Segmented WAL types (primary API)
 pub use config::{WalConfig, WalConfigError};
-pub use reader::{ReadStopReason, TruncateInfo, WalReader, WalReaderError, WalRecordIterator};
+pub use reader::{
+    ReadStopReason, TruncateInfo, WalReader, WalReaderError, WalRecordIterator,
+    WatermarkBlockedRecord, WatermarkReadResult,
+};
 pub use writer::{WalCounters, WalDiskUsage, WalWriter};
 
 /// Parse a WAL segment number from a filename like `wal-NNNNNN.seg`.

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -6,6 +6,7 @@ use crate::format::segment_meta::SegmentMeta;
 use crate::format::{WalRecord, WalRecordError, WalSegment};
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use strata_core::id::TxnId;
 use tracing::warn;
 
 /// Maximum number of bytes to scan forward when searching for the next
@@ -298,6 +299,83 @@ impl WalReader {
         Ok(result)
     }
 
+    /// Read the longest contiguous WAL prefix after `watermark`.
+    ///
+    /// Unlike [`read_all_after_watermark`], this preserves valid records before the
+    /// first unreadable or missing transaction and reports the first blocked txn id.
+    pub fn read_all_after_watermark_contiguous(
+        &self,
+        wal_dir: &Path,
+        watermark: u64,
+    ) -> Result<WatermarkReadResult, WalReaderError> {
+        let mut segments = self.list_segments(wal_dir)?;
+        segments.sort();
+
+        if segments.is_empty() {
+            return Ok(WatermarkReadResult {
+                records: Vec::new(),
+                blocked: None,
+            });
+        }
+
+        let latest_segment = *segments.last().unwrap();
+        let mut records = Vec::new();
+        let mut next_expected = watermark.saturating_add(1);
+
+        for &segment_number in &segments {
+            if segment_number != latest_segment {
+                match SegmentMeta::read_from_file(wal_dir, segment_number) {
+                    Ok(Some(meta))
+                        if meta.segment_number == segment_number
+                            && meta.max_txn_id.as_u64() < next_expected =>
+                    {
+                        continue;
+                    }
+                    Ok(Some(meta)) if meta.segment_number != segment_number => {
+                        warn!(
+                            target: "strata::wal",
+                            segment = segment_number,
+                            meta_segment = meta.segment_number,
+                            "Segment meta has mismatched segment number, reading full segment"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            target: "strata::wal",
+                            segment = segment_number,
+                            error = %e,
+                            "Could not read .meta sidecar, reading full segment"
+                        );
+                    }
+                    _ => {}
+                }
+            }
+
+            let segment_result = self.read_segment_after_watermark_contiguous(
+                wal_dir,
+                segment_number,
+                next_expected,
+            )?;
+
+            if let Some(last) = segment_result.records.last() {
+                next_expected = last.txn_id.as_u64().saturating_add(1);
+            }
+            records.extend(segment_result.records);
+
+            if let Some(blocked) = segment_result.blocked {
+                return Ok(WatermarkReadResult {
+                    records,
+                    blocked: Some(blocked),
+                });
+            }
+        }
+
+        Ok(WatermarkReadResult {
+            records,
+            blocked: None,
+        })
+    }
+
     /// List all segment numbers in the WAL directory.
     pub fn list_segments(&self, wal_dir: &Path) -> Result<Vec<u64>, WalReaderError> {
         let mut segments = Vec::new();
@@ -316,6 +394,133 @@ impl WalReader {
 
         segments.sort();
         Ok(segments)
+    }
+
+    fn read_segment_after_watermark_contiguous(
+        &self,
+        wal_dir: &Path,
+        segment_number: u64,
+        next_expected: u64,
+    ) -> Result<WatermarkReadResult, WalReaderError> {
+        let mut segment = WalSegment::open_read(wal_dir, segment_number)
+            .map_err(|e: std::io::Error| WalReaderError::IoError(e.to_string()))?;
+        let mut buffer = Vec::new();
+        let hdr_size = segment.header_size() as u64;
+
+        segment
+            .seek_to(hdr_size)
+            .map_err(|e: std::io::Error| WalReaderError::IoError(e.to_string()))?;
+        segment
+            .file_mut()
+            .read_to_end(&mut buffer)
+            .map_err(|e: std::io::Error| WalReaderError::IoError(e.to_string()))?;
+
+        let mut records = Vec::new();
+        let mut offset = 0usize;
+        let mut next_expected = next_expected;
+
+        while offset < buffer.len() {
+            match WalRecord::from_bytes(&buffer[offset..]) {
+                Ok((record, consumed)) => {
+                    offset += consumed;
+                    let txn_id = record.txn_id.as_u64();
+                    if txn_id < next_expected {
+                        continue;
+                    }
+                    if txn_id == next_expected {
+                        next_expected = next_expected.saturating_add(1);
+                        records.push(record);
+                        continue;
+                    }
+
+                    return Ok(WatermarkReadResult {
+                        records,
+                        blocked: Some(WatermarkBlockedRecord {
+                            txn_id: TxnId(next_expected),
+                            detail: format!(
+                                "non-contiguous WAL: expected txn {}, found txn {}",
+                                next_expected, txn_id
+                            ),
+                            skip_allowed: true,
+                            stop_reason: ReadStopReason::Gap {
+                                expected_txn_id: TxnId(next_expected),
+                                observed_txn_id: record.txn_id,
+                            },
+                        }),
+                    });
+                }
+                Err(WalRecordError::InsufficientData) => break,
+                Err(err) => {
+                    if let Some((scan_offset, next_record)) =
+                        self.scan_forward_to_valid_record(&buffer, offset + 1)
+                    {
+                        let candidate_txn = next_record.txn_id.as_u64();
+                        if candidate_txn < next_expected {
+                            offset = scan_offset;
+                            continue;
+                        }
+                        if candidate_txn == next_expected {
+                            offset = scan_offset;
+                            continue;
+                        }
+
+                        return Ok(WatermarkReadResult {
+                            records,
+                            blocked: Some(WatermarkBlockedRecord {
+                                txn_id: TxnId(next_expected),
+                                detail: format!(
+                                    "{}; next readable txn is {}",
+                                    err, next_record.txn_id
+                                ),
+                                skip_allowed: true,
+                                stop_reason: Self::stop_reason_for_record_error(offset, &err),
+                            }),
+                        });
+                    }
+
+                    return Ok(WatermarkReadResult {
+                        records,
+                        blocked: Some(WatermarkBlockedRecord {
+                            txn_id: TxnId(next_expected),
+                            detail: err.to_string(),
+                            skip_allowed: false,
+                            stop_reason: Self::stop_reason_for_record_error(offset, &err),
+                        }),
+                    });
+                }
+            }
+        }
+
+        Ok(WatermarkReadResult {
+            records,
+            blocked: None,
+        })
+    }
+
+    fn scan_forward_to_valid_record(
+        &self,
+        buffer: &[u8],
+        scan_start: usize,
+    ) -> Option<(usize, WalRecord)> {
+        let scan_end = (scan_start + MAX_RECOVERY_SCAN_WINDOW).min(buffer.len());
+        for scan_offset in scan_start..scan_end {
+            if let Ok((record, _)) = WalRecord::from_bytes(&buffer[scan_offset..]) {
+                return Some((scan_offset, record));
+            }
+        }
+        None
+    }
+
+    fn stop_reason_for_record_error(offset: usize, err: &WalRecordError) -> ReadStopReason {
+        match err {
+            WalRecordError::ChecksumMismatch { .. } | WalRecordError::LengthChecksumMismatch => {
+                ReadStopReason::ChecksumMismatch { offset }
+            }
+            other => ReadStopReason::ParseError {
+                offset,
+                detail: other.to_string(),
+            },
+        }
     }
 
     /// Get the highest transaction ID in a segment.
@@ -540,6 +745,13 @@ pub enum ReadStopReason {
         /// Human-readable error description
         detail: String,
     },
+    /// A later valid record was found after one or more missing transaction IDs.
+    Gap {
+        /// First missing transaction ID in the contiguous sequence.
+        expected_txn_id: TxnId,
+        /// First later transaction ID that was still readable.
+        observed_txn_id: TxnId,
+    },
 }
 
 /// Result of reading all WAL segments.
@@ -576,6 +788,28 @@ impl TruncateInfo {
     pub fn bytes_to_truncate(&self) -> u64 {
         self.original_size - self.valid_end
     }
+}
+
+/// Block encountered while reading a contiguous replay prefix.
+#[derive(Debug, Clone)]
+pub struct WatermarkBlockedRecord {
+    /// First transaction ID in the contiguous sequence that could not be proven readable.
+    pub txn_id: TxnId,
+    /// Diagnostic detail describing the read failure or gap.
+    pub detail: String,
+    /// Whether an exact operator skip can safely advance past this transaction ID.
+    pub skip_allowed: bool,
+    /// Why segment reading stopped.
+    pub stop_reason: ReadStopReason,
+}
+
+/// Records read after a watermark until the first contiguous block, if any.
+#[derive(Debug, Clone)]
+pub struct WatermarkReadResult {
+    /// Contiguous readable records after the requested watermark.
+    pub records: Vec<WalRecord>,
+    /// First blocked txn, if contiguous replay could not continue.
+    pub blocked: Option<WatermarkBlockedRecord>,
 }
 
 /// WAL reader errors.
@@ -1773,6 +2007,102 @@ mod tests {
             matches!(result, Err(WalRecordError::LengthChecksumMismatch)),
             "Expected LengthChecksumMismatch for corrupted length, got: {:?}",
             result
+        );
+    }
+
+    #[test]
+    fn test_read_all_after_watermark_contiguous_preserves_prefix_and_exact_skip_resume() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+        let records: Vec<_> = (1..=3)
+            .map(|i| WalRecord::new(TxnId(i), [7u8; 16], i * 1000, vec![i as u8; 24]))
+            .collect();
+        write_records(&wal_dir, &records);
+
+        let segment_path = WalSegment::segment_path(&wal_dir, 1);
+        let segment = WalSegment::open_read(&wal_dir, 1).unwrap();
+        let hdr_size = segment.header_size() as usize;
+        let mut bytes = std::fs::read(&segment_path).unwrap();
+        let record_1_len = records[0].to_bytes().len();
+        let record_2_len = records[1].to_bytes().len();
+        let corrupt_offset = hdr_size + record_1_len + (record_2_len / 2);
+        bytes[corrupt_offset] ^= 0x5A;
+        std::fs::write(&segment_path, bytes).unwrap();
+
+        let reader = WalReader::new();
+        let first = reader
+            .read_all_after_watermark_contiguous(&wal_dir, 0)
+            .unwrap();
+        assert_eq!(
+            first
+                .records
+                .iter()
+                .map(|r| r.txn_id.as_u64())
+                .collect::<Vec<_>>(),
+            vec![1],
+            "reader must preserve the valid prefix before the corrupted record"
+        );
+        let blocked = first.blocked.expect("expected a blocked txn");
+        assert_eq!(blocked.txn_id, TxnId(2));
+        assert!(
+            blocked.skip_allowed,
+            "a later valid record should make an exact skip resumable"
+        );
+
+        let resumed = reader
+            .read_all_after_watermark_contiguous(&wal_dir, 2)
+            .unwrap();
+        assert_eq!(
+            resumed
+                .records
+                .iter()
+                .map(|r| r.txn_id.as_u64())
+                .collect::<Vec<_>>(),
+            vec![3],
+            "after an exact skip, reader should resume at the next readable txn"
+        );
+        assert!(
+            resumed.blocked.is_none(),
+            "skipping the blocked txn should clear the gap when a later anchor exists"
+        );
+    }
+
+    #[test]
+    fn test_read_all_after_watermark_contiguous_marks_unanchored_tail_corruption_not_skippable() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+        let records: Vec<_> = (1..=2)
+            .map(|i| WalRecord::new(TxnId(i), [9u8; 16], i * 1000, vec![i as u8; 24]))
+            .collect();
+        write_records(&wal_dir, &records);
+
+        let segment_path = WalSegment::segment_path(&wal_dir, 1);
+        let segment = WalSegment::open_read(&wal_dir, 1).unwrap();
+        let hdr_size = segment.header_size() as usize;
+        let mut bytes = std::fs::read(&segment_path).unwrap();
+        let record_1_len = records[0].to_bytes().len();
+        let record_2_len = records[1].to_bytes().len();
+        let corrupt_offset = hdr_size + record_1_len + (record_2_len / 2);
+        bytes[corrupt_offset] ^= 0x33;
+        std::fs::write(&segment_path, bytes).unwrap();
+
+        let reader = WalReader::new();
+        let result = reader
+            .read_all_after_watermark_contiguous(&wal_dir, 0)
+            .unwrap();
+        assert_eq!(
+            result
+                .records
+                .iter()
+                .map(|r| r.txn_id.as_u64())
+                .collect::<Vec<_>>(),
+            vec![1]
+        );
+        let blocked = result.blocked.expect("expected tail corruption to block");
+        assert_eq!(blocked.txn_id, TxnId(2));
+        assert!(
+            !blocked.skip_allowed,
+            "without a later valid anchor, exact skip must fail closed"
         );
     }
 }

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -465,6 +465,14 @@ impl TransactionCoordinator {
         self.manager.catch_up_txn_id(id);
     }
 
+    /// Restore the visible version exactly.
+    ///
+    /// Used by follower reopen to re-establish the last safe visibility point
+    /// when a blocked refresh was persisted across restart.
+    pub fn restore_visible_version(&self, version: CommitVersion) {
+        self.manager.set_visible_version(version);
+    }
+
     // ========================================================================
     // Coordinator-owned state
     // ========================================================================

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -8,9 +8,9 @@ use strata_core::StrataResult;
 use tracing::{info, warn};
 
 use super::refresh::{
-    clear_persisted_follower_state, persist_follower_state, BlockReason, BlockedTxn,
-    BlockedTxnState, FollowerStatus, PersistedFollowerState, PreparedRefresh, RefreshGuard,
-    RefreshOutcome, UnblockError,
+    clear_persisted_follower_state, persist_follower_state, sync_path_parent, BlockReason,
+    BlockedTxn, BlockedTxnState, FollowerStatus, PersistedFollowerState, PreparedRefresh,
+    RefreshGuard, RefreshOutcome, UnblockError,
 };
 use super::{Database, PersistenceMode};
 
@@ -217,7 +217,11 @@ impl Database {
                 .create(true)
                 .append(true)
                 .open(&audit_path)
-                .and_then(|mut f| std::io::Write::write_all(&mut f, entry.as_bytes()))
+                .and_then(|mut f| {
+                    std::io::Write::write_all(&mut f, entry.as_bytes())?;
+                    f.sync_all()?;
+                    sync_path_parent(&audit_path)
+                })
             {
                 warn!(
                     target: "strata::follower::audit",

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -1,12 +1,15 @@
 //! GC, maintenance, follower refresh, and shutdown.
 
 use std::sync::atomic::Ordering;
-use strata_core::id::CommitVersion;
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::traits::Storage;
 use strata_core::types::{BranchId, Key, TypeTag};
-use strata_core::{StrataError, StrataResult};
-use tracing::warn;
+use strata_core::StrataResult;
+use tracing::{info, warn};
 
+use super::refresh::{
+    BlockReason, BlockedTxn, FollowerStatus, RefreshGuard, RefreshOutcome, UnblockError,
+};
 use super::{Database, PersistenceMode};
 
 impl Database {
@@ -111,6 +114,87 @@ impl Database {
     // Follower Refresh
     // ========================================================================
 
+    /// Get the current status of this follower database.
+    ///
+    /// Returns information about watermarks, blocked state, and refresh progress.
+    /// For non-follower databases, returns a status with zero watermarks.
+    pub fn follower_status(&self) -> FollowerStatus {
+        FollowerStatus {
+            received_watermark: self.watermark.received(),
+            applied_watermark: self.watermark.applied(),
+            blocked_at: self.watermark.blocked(),
+            refresh_in_progress: self.refresh_gate.is_in_progress(),
+        }
+    }
+
+    /// Skip a blocked WAL record after manual intervention.
+    ///
+    /// This is an administrative operation for when a follower is stuck on a
+    /// problematic WAL record that cannot be processed. The operator must:
+    /// 1. Diagnose the issue using `follower_status().blocked_at`
+    /// 2. Manually remediate any downstream state if needed
+    /// 3. Call this method with the exact blocked transaction ID
+    ///
+    /// # Audit Trail
+    ///
+    /// This operation is logged to both:
+    /// - `tracing` target `strata::follower::audit`
+    /// - `{data_dir}/follower_audit.log` (durable, append-only)
+    ///
+    /// # Errors
+    ///
+    /// Returns `UnblockError::Mismatch` if `txn_id` doesn't match the blocked
+    /// transaction, `UnblockError::NotBlocked` if the follower isn't blocked,
+    /// or `UnblockError::NotFollower` if this isn't a follower database.
+    pub fn admin_skip_blocked_record(
+        &self,
+        txn_id: TxnId,
+        reason: &str,
+    ) -> Result<(), UnblockError> {
+        if !self.follower {
+            return Err(UnblockError::NotFollower);
+        }
+
+        // Attempt the skip
+        self.watermark.admin_skip(txn_id)?;
+
+        // Log to tracing
+        info!(
+            target: "strata::follower::audit",
+            txn_id = %txn_id,
+            reason = %reason,
+            "Admin skipped blocked WAL record"
+        );
+
+        // Write durable audit log
+        let data_dir = self.data_dir();
+        if !data_dir.as_os_str().is_empty() {
+            let audit_path = data_dir.join("follower_audit.log");
+            let timestamp = chrono::Utc::now().to_rfc3339();
+            let entry = format!(
+                "{}\tSKIP\ttxn_id={}\treason={}\n",
+                timestamp,
+                txn_id.as_u64(),
+                reason
+            );
+            if let Err(e) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&audit_path)
+                .and_then(|mut f| std::io::Write::write_all(&mut f, entry.as_bytes()))
+            {
+                warn!(
+                    target: "strata::follower::audit",
+                    path = ?audit_path,
+                    error = %e,
+                    "Failed to write follower audit log"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     /// Refresh local storage by tailing new WAL entries from the primary.
     ///
     /// In follower mode, the primary process may have appended new WAL records
@@ -118,45 +202,98 @@ impl Database {
     /// and applies them to local in-memory storage, bringing this instance
     /// up-to-date with all committed writes.
     ///
-    /// Returns the number of new records applied.
+    /// Returns a `RefreshOutcome` describing what happened:
+    /// - `CaughtUp`: All available records were applied
+    /// - `Stuck`: Some records applied, then hit a blocking error
+    /// - `NoProgress`: Already blocked, no records applied
     ///
-    /// For non-follower databases, this is a no-op returning 0.
+    /// For non-follower databases, returns `CaughtUp { applied: 0, applied_through: TxnId::ZERO }`.
     ///
-    /// # Error recovery
+    /// # Single-flight semantics
     ///
-    /// Refresh is a best-effort operation:
-    /// - **Storage mutations** (`apply_recovery_atomic`): a failure on a single
-    ///   WAL record logs a warning and skips that record. Subsequent records are
-    ///   still applied so the follower converges as closely as possible.
-    /// - **Search index updates**: silently skip entries that fail to parse.
-    /// - **Refresh hooks** (`apply_refresh`): infallible by trait contract.
-    pub fn refresh(&self) -> StrataResult<usize> {
+    /// Only one refresh can be in progress at a time per database. Concurrent
+    /// calls serialize via the internal `RefreshGate`.
+    ///
+    /// # Blocking behavior
+    ///
+    /// Unlike the legacy best-effort refresh, this implementation blocks on
+    /// any failure and does NOT advance the contiguous watermark past the
+    /// failed record. This ensures:
+    /// - `applied_watermark` is always truthful
+    /// - Secondary indexes never silently fall behind
+    /// - Operators can diagnose and skip blocked records explicitly
+    pub fn refresh(&self) -> RefreshOutcome {
         if !self.follower || self.persistence_mode == PersistenceMode::Ephemeral {
-            return Ok(0);
+            return RefreshOutcome::CaughtUp {
+                applied: 0,
+                applied_through: TxnId::ZERO,
+            };
         }
 
-        let watermark = self.wal_watermark.load(std::sync::atomic::Ordering::SeqCst);
+        // Acquire single-flight gate FIRST to prevent TOCTOU races on blocked state
+        let _guard = match RefreshGuard::try_new(&self.refresh_gate) {
+            Some(g) => g,
+            None => {
+                // Another refresh is in progress; return current state
+                return if let Some(blocked) = self.watermark.blocked() {
+                    RefreshOutcome::NoProgress {
+                        applied_through: self.watermark.applied(),
+                        blocked_at: blocked,
+                    }
+                } else {
+                    RefreshOutcome::CaughtUp {
+                        applied: 0,
+                        applied_through: self.watermark.applied(),
+                    }
+                };
+            }
+        };
+
+        // Now check if blocked (safe under gate protection)
+        if let Some(blocked) = self.watermark.blocked() {
+            return RefreshOutcome::NoProgress {
+                applied_through: self.watermark.applied(),
+                blocked_at: blocked,
+            };
+        }
+
+        let watermark = self.watermark.applied().as_u64();
 
         // Read all WAL records after our watermark
         let reader = strata_durability::wal::WalReader::new();
-        let records = reader
-            .read_all_after_watermark(&self.wal_dir, watermark)
-            .map_err(|e| StrataError::storage(format!("WAL refresh read failed: {}", e)))?;
+        let records = match reader.read_all_after_watermark(&self.wal_dir, watermark) {
+            Ok(r) => r,
+            Err(e) => {
+                let blocked = BlockedTxn {
+                    txn_id: TxnId(watermark + 1),
+                    reason: BlockReason::Decode {
+                        message: format!("WAL read failed: {}", e),
+                    },
+                };
+                self.watermark.set_blocked(blocked.clone());
+                return RefreshOutcome::Stuck {
+                    applied: 0,
+                    applied_through: TxnId(watermark),
+                    blocked_at: blocked,
+                };
+            }
+        };
 
         if records.is_empty() {
-            return Ok(0);
+            return RefreshOutcome::CaughtUp {
+                applied: 0,
+                applied_through: TxnId(watermark),
+            };
         }
 
         let mut applied = 0usize;
         let mut max_version = 0u64;
-        let mut max_txn_id = watermark;
 
         // Get search index (if available) for incremental updates
         let search_index = self.extension::<crate::search::InvertedIndex>().ok();
         let search_enabled = search_index.as_ref().is_some_and(|idx| idx.is_enabled());
 
-        // Get refresh hooks used for any subsystem that still relies on the
-        // legacy follower-refresh contract.
+        // Get refresh hooks
         let refresh_hooks = self
             .extension::<super::refresh::RefreshHooks>()
             .ok()
@@ -164,19 +301,28 @@ impl Database {
             .unwrap_or_default();
 
         for record in &records {
-            max_txn_id = max_txn_id.max(record.txn_id.as_u64());
+            let txn_id = record.txn_id;
 
+            // Update received watermark (telemetry)
+            self.watermark.set_received(txn_id);
+
+            // Decode the payload
             let payload = match strata_concurrency::TransactionPayload::from_bytes(&record.writeset)
             {
                 Ok(p) => p,
                 Err(e) => {
-                    warn!(
-                        target: "strata::db",
-                        txn_id = record.txn_id.as_u64(),
-                        error = %e,
-                        "Refresh: skipping WAL record with corrupt payload"
-                    );
-                    continue;
+                    let blocked = BlockedTxn {
+                        txn_id,
+                        reason: BlockReason::Decode {
+                            message: format!("corrupt payload: {}", e),
+                        },
+                    };
+                    self.watermark.set_blocked(blocked.clone());
+                    return RefreshOutcome::Stuck {
+                        applied,
+                        applied_through: self.watermark.applied(),
+                        blocked_at: blocked,
+                    };
                 }
             };
 
@@ -194,25 +340,12 @@ impl Database {
                     |key| match self.storage.get_versioned(key, CommitVersion::MAX) {
                         Ok(Some(vv)) => Some((key.clone(), vv.value)),
                         Ok(None) => None,
-                        Err(e) => {
-                            warn!(
-                                target: "strata::db",
-                                txn_id = record.txn_id.as_u64(),
-                                version = payload.version,
-                                error = %e,
-                                "Refresh: skipping pre-delete value capture for key"
-                            );
-                            None
-                        }
+                        Err(_) => None,
                     },
                 )
                 .collect();
 
-            // Apply puts and deletes atomically with original WAL timestamp
-            // and TTL. Combines #1699 (preserve commit timestamp for time-travel),
-            // #1707 (defer version bump until all entries installed),
-            // #1734 (defer version bump until secondary indexes are updated),
-            // and #1740 (preserve TTL through WAL replay).
+            // Apply puts and deletes atomically
             {
                 let writes: Vec<_> = payload
                     .puts
@@ -227,14 +360,18 @@ impl Database {
                     record.timestamp,
                     &payload.put_ttls,
                 ) {
-                    warn!(
-                        target: "strata::db",
-                        txn_id = record.txn_id.as_u64(),
-                        version = payload.version,
-                        error = %e,
-                        "Refresh: skipping WAL record due to storage error"
-                    );
-                    continue;
+                    let blocked = BlockedTxn {
+                        txn_id,
+                        reason: BlockReason::StorageApply {
+                            message: format!("{}", e),
+                        },
+                    };
+                    self.watermark.set_blocked(blocked.clone());
+                    return RefreshOutcome::Stuck {
+                        applied,
+                        applied_through: self.watermark.applied(),
+                        blocked_at: blocked,
+                    };
                 }
             }
 
@@ -357,16 +494,30 @@ impl Database {
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
             for (hook, pre_reads) in refresh_hooks.iter().zip(hook_pre_reads.iter()) {
-                hook.apply_refresh(&puts_slice, pre_reads);
+                if let Err(e) = hook.apply_refresh(&puts_slice, pre_reads) {
+                    let blocked = BlockedTxn {
+                        txn_id,
+                        reason: BlockReason::SecondaryIndex {
+                            hook_name: e.hook_name.clone(),
+                            message: e.message.clone(),
+                        },
+                    };
+                    self.watermark.set_blocked(blocked.clone());
+                    return RefreshOutcome::Stuck {
+                        applied,
+                        applied_through: self.watermark.applied(),
+                        blocked_at: blocked,
+                    };
+                }
             }
 
-            // Issue #1734: Advance visible version AFTER secondary indexes are
-            // updated, so readers never see KV data without corresponding
-            // BM25/HNSW entries.
+            // Advance visible version AFTER secondary indexes are updated
             self.storage.advance_version(CommitVersion(payload.version));
 
+            // Advance the contiguous watermark
+            self.watermark.advance_applied(txn_id);
+
             // Notify replay observers (best-effort, errors logged not propagated)
-            // Extract branch_id from the first put or delete key
             let branch_id = payload
                 .puts
                 .first()
@@ -387,14 +538,14 @@ impl Database {
         }
 
         // Advance local counters so new transactions get unique IDs/versions
+        let applied_through = self.watermark.applied();
         self.coordinator.catch_up_version(max_version);
-        self.coordinator.catch_up_txn_id(max_txn_id);
+        self.coordinator.catch_up_txn_id(applied_through.as_u64());
 
-        // Update watermark
-        self.wal_watermark
-            .store(max_txn_id, std::sync::atomic::Ordering::SeqCst);
-
-        Ok(applied)
+        RefreshOutcome::CaughtUp {
+            applied,
+            applied_through,
+        }
     }
 
     // Graceful Shutdown

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -3,12 +3,14 @@
 use std::sync::atomic::Ordering;
 use strata_core::id::{CommitVersion, TxnId};
 use strata_core::traits::Storage;
-use strata_core::types::{BranchId, Key, TypeTag};
+use strata_core::types::{BranchId, Key};
 use strata_core::StrataResult;
 use tracing::{info, warn};
 
 use super::refresh::{
-    BlockReason, BlockedTxn, FollowerStatus, RefreshGuard, RefreshOutcome, UnblockError,
+    clear_persisted_follower_state, persist_follower_state, BlockReason, BlockedTxn,
+    BlockedTxnState, FollowerStatus, PersistedFollowerState, PreparedRefresh, RefreshGuard,
+    RefreshOutcome, UnblockError,
 };
 use super::{Database, PersistenceMode};
 
@@ -127,6 +129,34 @@ impl Database {
         }
     }
 
+    fn persist_blocked_follower_state(&self, blocked: &BlockedTxnState) {
+        let state = PersistedFollowerState {
+            received_watermark: self.watermark.received(),
+            applied_watermark: self.watermark.applied(),
+            visible_version: CommitVersion(self.storage.version()),
+            blocked: blocked.clone(),
+        };
+        if let Err(e) = persist_follower_state(self.data_dir(), &state) {
+            warn!(
+                target: "strata::follower::audit",
+                path = ?self.data_dir().join(super::refresh::FOLLOWER_STATE_FILE),
+                error = %e,
+                "Failed to persist blocked follower state"
+            );
+        }
+    }
+
+    fn clear_blocked_follower_state_file(&self) {
+        if let Err(e) = clear_persisted_follower_state(self.data_dir()) {
+            warn!(
+                target: "strata::follower::audit",
+                path = ?self.data_dir().join(super::refresh::FOLLOWER_STATE_FILE),
+                error = %e,
+                "Failed to clear persisted follower state"
+            );
+        }
+    }
+
     /// Skip a blocked WAL record after manual intervention.
     ///
     /// This is an administrative operation for when a follower is stuck on a
@@ -155,8 +185,14 @@ impl Database {
             return Err(UnblockError::NotFollower);
         }
 
-        // Attempt the skip
-        self.watermark.admin_skip(txn_id)?;
+        let blocked = self.watermark.unblock_exact(txn_id)?;
+        if let Some(version) = blocked.visibility_version {
+            let _publish_guard = self.refresh_publish_guard();
+            self.storage.advance_version(version);
+            self.coordinator.catch_up_version(version.as_u64());
+        }
+        self.coordinator.catch_up_txn_id(txn_id.as_u64());
+        self.clear_blocked_follower_state_file();
 
         // Log to tracing
         info!(
@@ -230,24 +266,8 @@ impl Database {
             };
         }
 
-        // Acquire single-flight gate FIRST to prevent TOCTOU races on blocked state
-        let _guard = match RefreshGuard::try_new(&self.refresh_gate) {
-            Some(g) => g,
-            None => {
-                // Another refresh is in progress; return current state
-                return if let Some(blocked) = self.watermark.blocked() {
-                    RefreshOutcome::NoProgress {
-                        applied_through: self.watermark.applied(),
-                        blocked_at: blocked,
-                    }
-                } else {
-                    RefreshOutcome::CaughtUp {
-                        applied: 0,
-                        applied_through: self.watermark.applied(),
-                    }
-                };
-            }
-        };
+        // Acquire single-flight gate FIRST to prevent TOCTOU races on blocked state.
+        let _guard = RefreshGuard::new(&self.refresh_gate);
 
         // Now check if blocked (safe under gate protection)
         if let Some(blocked) = self.watermark.blocked() {
@@ -257,41 +277,51 @@ impl Database {
             };
         }
 
-        let watermark = self.watermark.applied().as_u64();
-
-        // Read all WAL records after our watermark
-        let reader = strata_durability::wal::WalReader::new();
-        let records = match reader.read_all_after_watermark(&self.wal_dir, watermark) {
-            Ok(r) => r,
-            Err(e) => {
-                let blocked = BlockedTxn {
-                    txn_id: TxnId(watermark + 1),
-                    reason: BlockReason::Decode {
-                        message: format!("WAL read failed: {}", e),
-                    },
-                };
-                self.watermark.set_blocked(blocked.clone());
-                return RefreshOutcome::Stuck {
-                    applied: 0,
-                    applied_through: TxnId(watermark),
-                    blocked_at: blocked,
-                };
+        let received_watermark = self.watermark.received().as_u64();
+        let make_blocked_state = |txn_id: TxnId,
+                                  reason: BlockReason,
+                                  visibility_version: Option<CommitVersion>,
+                                  skip_allowed: bool| {
+            BlockedTxnState {
+                blocked: BlockedTxn { txn_id, reason },
+                visibility_version,
+                skip_allowed,
             }
         };
 
-        if records.is_empty() {
+        // Read the longest contiguous WAL prefix after the received watermark.
+        let reader = strata_durability::wal::WalReader::new();
+        let read_result =
+            match reader.read_all_after_watermark_contiguous(&self.wal_dir, received_watermark) {
+                Ok(r) => r,
+                Err(e) => {
+                    let blocked = make_blocked_state(
+                        TxnId(received_watermark.saturating_add(1)),
+                        BlockReason::Decode {
+                            message: format!("WAL read failed: {}", e),
+                        },
+                        None,
+                        false,
+                    );
+                    self.watermark.block_at(blocked.clone());
+                    self.persist_blocked_follower_state(&blocked);
+                    return RefreshOutcome::Stuck {
+                        applied: 0,
+                        applied_through: self.watermark.applied(),
+                        blocked_at: blocked.blocked,
+                    };
+                }
+            };
+
+        if read_result.records.is_empty() && read_result.blocked.is_none() {
             return RefreshOutcome::CaughtUp {
                 applied: 0,
-                applied_through: TxnId(watermark),
+                applied_through: self.watermark.applied(),
             };
         }
 
         let mut applied = 0usize;
-        let mut max_version = 0u64;
-
-        // Get search index (if available) for incremental updates
-        let search_index = self.extension::<crate::search::InvertedIndex>().ok();
-        let search_enabled = search_index.as_ref().is_some_and(|idx| idx.is_enabled());
+        let mut pending_publications: Vec<Box<dyn PreparedRefresh>> = Vec::new();
 
         // Get refresh hooks
         let refresh_hooks = self
@@ -300,7 +330,7 @@ impl Database {
             .map(|h| h.hooks())
             .unwrap_or_default();
 
-        for record in &records {
+        for record in &read_result.records {
             let txn_id = record.txn_id;
 
             // Update received watermark (telemetry)
@@ -311,22 +341,23 @@ impl Database {
             {
                 Ok(p) => p,
                 Err(e) => {
-                    let blocked = BlockedTxn {
+                    let blocked = make_blocked_state(
                         txn_id,
-                        reason: BlockReason::Decode {
+                        BlockReason::Decode {
                             message: format!("corrupt payload: {}", e),
                         },
-                    };
-                    self.watermark.set_blocked(blocked.clone());
+                        None,
+                        true,
+                    );
+                    self.watermark.block_at(blocked.clone());
+                    self.persist_blocked_follower_state(&blocked);
                     return RefreshOutcome::Stuck {
                         applied,
                         applied_through: self.watermark.applied(),
-                        blocked_at: blocked,
+                        blocked_at: blocked.blocked,
                     };
                 }
             };
-
-            max_version = max_version.max(payload.version);
 
             // Pre-read state for delete hooks (must happen before storage mutations)
             let hook_pre_reads: Vec<Vec<(Key, Vec<u8>)>> = refresh_hooks
@@ -360,164 +391,85 @@ impl Database {
                     record.timestamp,
                     &payload.put_ttls,
                 ) {
-                    let blocked = BlockedTxn {
+                    let blocked = make_blocked_state(
                         txn_id,
-                        reason: BlockReason::StorageApply {
+                        BlockReason::StorageApply {
                             message: format!("{}", e),
                         },
-                    };
-                    self.watermark.set_blocked(blocked.clone());
+                        None,
+                        true,
+                    );
+                    self.watermark.block_at(blocked.clone());
+                    self.persist_blocked_follower_state(&blocked);
                     return RefreshOutcome::Stuck {
                         applied,
                         applied_through: self.watermark.applied(),
-                        blocked_at: blocked,
+                        blocked_at: blocked.blocked,
                     };
                 }
             }
 
-            // --- Update BM25 search index ---
-            if search_enabled {
-                let index = search_index.as_ref().unwrap();
-
-                for (key, value) in &payload.puts {
-                    let branch_id = key.namespace.branch_id;
-                    match key.type_tag {
-                        TypeTag::KV => {
-                            if let Some(text) = crate::search::extract_indexable_text(value) {
-                                if let Some(user_key) = key.user_key_string() {
-                                    let entity_ref = strata_core::EntityRef::Kv {
-                                        branch_id,
-                                        space: key.namespace.space.to_string(),
-                                        key: user_key,
-                                    };
-                                    index.index_document(&entity_ref, &text, None);
-                                }
-                            }
-                        }
-                        TypeTag::Event => {
-                            if *key.user_key == *b"__meta__"
-                                || key.user_key.starts_with(b"__tidx__")
-                            {
-                                continue;
-                            }
-                            if let Some(text) = crate::search::extract_indexable_text(value) {
-                                if key.user_key.len() == 8 {
-                                    let sequence = u64::from_be_bytes(
-                                        (*key.user_key).try_into().unwrap_or([0; 8]),
-                                    );
-                                    let entity_ref = strata_core::EntityRef::Event {
-                                        branch_id,
-                                        space: key.namespace.space.to_string(),
-                                        sequence,
-                                    };
-                                    index.index_document(&entity_ref, &text, None);
-                                }
-                            }
-                        }
-                        TypeTag::Graph => {
-                            if key.user_key.starts_with(b"__")
-                                || key.user_key.windows(3).any(|w| w == b"/__")
-                            {
-                                continue;
-                            }
-                            if let Some(text) = crate::search::extract_indexable_text(value) {
-                                if let Some(user_key) = key.user_key_string() {
-                                    let entity_ref = strata_core::EntityRef::Graph {
-                                        branch_id,
-                                        space: key.namespace.space.to_string(),
-                                        key: user_key,
-                                    };
-                                    index.index_document(&entity_ref, &text, None);
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-
-                for key in &payload.deletes {
-                    let branch_id = key.namespace.branch_id;
-                    match key.type_tag {
-                        TypeTag::KV => {
-                            if let Some(user_key) = key.user_key_string() {
-                                let entity_ref = strata_core::EntityRef::Kv {
-                                    branch_id,
-                                    space: key.namespace.space.to_string(),
-                                    key: user_key,
-                                };
-                                index.remove_document(&entity_ref);
-                            }
-                        }
-                        TypeTag::Event => {
-                            if *key.user_key == *b"__meta__"
-                                || key.user_key.starts_with(b"__tidx__")
-                            {
-                                continue;
-                            }
-                            if key.user_key.len() == 8 {
-                                let sequence = u64::from_be_bytes(
-                                    (*key.user_key).try_into().unwrap_or([0; 8]),
-                                );
-                                let branch_id = key.namespace.branch_id;
-                                let entity_ref = strata_core::EntityRef::Event {
-                                    branch_id,
-                                    space: key.namespace.space.to_string(),
-                                    sequence,
-                                };
-                                index.remove_document(&entity_ref);
-                            }
-                        }
-                        TypeTag::Graph => {
-                            if key.user_key.starts_with(b"__")
-                                || key.user_key.windows(3).any(|w| w == b"/__")
-                            {
-                                continue;
-                            }
-                            if let Some(user_key) = key.user_key_string() {
-                                let entity_ref = strata_core::EntityRef::Graph {
-                                    branch_id,
-                                    space: key.namespace.space.to_string(),
-                                    key: user_key,
-                                };
-                                index.remove_document(&entity_ref);
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-            }
-
-            // --- Update refresh hooks (vector backends, etc.) ---
+            // --- Update refresh hooks (vector backends, search index, etc.) ---
             let puts_slice: Vec<(Key, strata_core::value::Value)> = payload
                 .puts
                 .iter()
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
             for (hook, pre_reads) in refresh_hooks.iter().zip(hook_pre_reads.iter()) {
-                if let Err(e) = hook.apply_refresh(&puts_slice, pre_reads) {
-                    let blocked = BlockedTxn {
-                        txn_id,
-                        reason: BlockReason::SecondaryIndex {
-                            hook_name: e.hook_name.clone(),
-                            message: e.message.clone(),
-                        },
-                    };
-                    self.watermark.set_blocked(blocked.clone());
-                    return RefreshOutcome::Stuck {
-                        applied,
-                        applied_through: self.watermark.applied(),
-                        blocked_at: blocked,
-                    };
+                match hook.apply_refresh(&puts_slice, pre_reads) {
+                    Ok(pending) => pending_publications.push(pending),
+                    Err(e) => {
+                        let blocked = make_blocked_state(
+                            txn_id,
+                            BlockReason::SecondaryIndex {
+                                hook_name: e.hook_name.clone(),
+                                message: e.message.clone(),
+                            },
+                            Some(CommitVersion(payload.version)),
+                            true,
+                        );
+                        self.watermark.block_at(blocked.clone());
+                        self.persist_blocked_follower_state(&blocked);
+                        return RefreshOutcome::Stuck {
+                            applied,
+                            applied_through: self.watermark.applied(),
+                            blocked_at: blocked.blocked,
+                        };
+                    }
                 }
             }
 
-            // Advance visible version AFTER secondary indexes are updated
-            self.storage.advance_version(CommitVersion(payload.version));
+            if let Err(e) = self.watermark.try_advance(txn_id) {
+                let blocked = make_blocked_state(
+                    txn_id,
+                    BlockReason::Decode {
+                        message: format!("watermark advancement failed: {}", e),
+                    },
+                    Some(CommitVersion(payload.version)),
+                    false,
+                );
+                self.watermark.block_at(blocked.clone());
+                self.persist_blocked_follower_state(&blocked);
+                return RefreshOutcome::Stuck {
+                    applied,
+                    applied_through: self.watermark.applied(),
+                    blocked_at: blocked.blocked,
+                };
+            }
 
-            // Advance the contiguous watermark
-            self.watermark.advance_applied(txn_id);
+            // Publish staged derived-state changes and advance visibility as one
+            // synchronized handoff to readers.
+            {
+                let _publish_guard = self.refresh_publish_guard();
+                for pending in pending_publications.drain(..) {
+                    pending.publish();
+                }
+                self.storage.advance_version(CommitVersion(payload.version));
+                self.coordinator.catch_up_version(payload.version);
+                self.coordinator.catch_up_txn_id(txn_id.as_u64());
+            }
 
-            // Notify replay observers (best-effort, errors logged not propagated)
+            // Notify replay observers (best-effort, errors logged not propagated).
             let branch_id = payload
                 .puts
                 .first()
@@ -537,14 +489,43 @@ impl Database {
             applied += 1;
         }
 
-        // Advance local counters so new transactions get unique IDs/versions
-        let applied_through = self.watermark.applied();
-        self.coordinator.catch_up_version(max_version);
-        self.coordinator.catch_up_txn_id(applied_through.as_u64());
+        if let Some(blocked) = read_result.blocked {
+            let txn_id = blocked.txn_id;
+            let skip_allowed = blocked.skip_allowed;
+            let detail = blocked.detail;
+            let reason = match blocked.stop_reason {
+                strata_durability::wal::ReadStopReason::Gap {
+                    expected_txn_id,
+                    observed_txn_id,
+                } => BlockReason::Decode {
+                    message: format!(
+                        "missing WAL record at {}; next readable txn is {}",
+                        expected_txn_id, observed_txn_id
+                    ),
+                },
+                strata_durability::wal::ReadStopReason::ChecksumMismatch { .. }
+                | strata_durability::wal::ReadStopReason::ParseError { .. } => {
+                    BlockReason::Decode { message: detail }
+                }
+                strata_durability::wal::ReadStopReason::EndOfData
+                | strata_durability::wal::ReadStopReason::PartialRecord => {
+                    BlockReason::Decode { message: detail }
+                }
+            };
+            let blocked = make_blocked_state(txn_id, reason, None, skip_allowed);
+            self.watermark.block_at(blocked.clone());
+            self.persist_blocked_follower_state(&blocked);
+            return RefreshOutcome::Stuck {
+                applied,
+                applied_through: self.watermark.applied(),
+                blocked_at: blocked.blocked,
+            };
+        }
 
+        self.clear_blocked_follower_state_file();
         RefreshOutcome::CaughtUp {
             applied,
-            applied_through,
+            applied_through: self.watermark.applied(),
         }
     }
 

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -49,6 +49,10 @@ pub use observers::{
     BranchOpObserverRegistry, CommitInfo, CommitObserver, CommitObserverRegistry, ObserverError,
     ObserverErrorKind, ReplayInfo, ReplayObserver, ReplayObserverRegistry,
 };
+pub use refresh::{
+    AdvanceError, BlockReason, BlockedTxn, FollowerStatus, RefreshHookError, RefreshOutcome,
+    UnblockError,
+};
 pub use spec::{
     search_only_cache_spec, search_only_follower_spec, search_only_primary_spec, DatabaseMode,
     OpenSpec,
@@ -469,8 +473,16 @@ pub struct Database {
     /// WAL directory path (for follower refresh).
     wal_dir: PathBuf,
 
-    /// Max txn_id applied to local storage from WAL (follower watermark).
-    wal_watermark: AtomicU64,
+    /// Contiguous watermark tracking for follower refresh.
+    ///
+    /// Tracks both received and applied watermarks. The applied watermark
+    /// only advances after storage AND all refresh hooks succeed.
+    watermark: refresh::ContiguousWatermark,
+
+    /// Single-flight gate for follower refresh operations.
+    ///
+    /// Ensures only one refresh can be in progress at a time.
+    refresh_gate: refresh::RefreshGate,
 
     /// Whether this database is a read-only follower (no lock, no WAL writer).
     follower: bool,

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -484,6 +484,14 @@ pub struct Database {
     /// Ensures only one refresh can be in progress at a time.
     refresh_gate: refresh::RefreshGate,
 
+    /// Synchronizes follower refresh publication with search/vector/graph queries.
+    ///
+    /// Queries that read derived state take a shared guard. Follower refresh
+    /// takes an exclusive guard while publishing staged hook updates and
+    /// advancing visibility, preventing readers from observing either side of
+    /// the handoff in isolation.
+    refresh_publish_barrier: parking_lot::RwLock<()>,
+
     /// Whether this database is a read-only follower (no lock, no WAL writer).
     follower: bool,
 
@@ -611,6 +619,15 @@ impl Database {
     /// primitives (KVStore, EventLog, etc.) which go through transactions.
     pub fn storage(&self) -> &Arc<SegmentedStore> {
         &self.storage
+    }
+
+    #[doc(hidden)]
+    pub fn refresh_query_guard(&self) -> parking_lot::RwLockReadGuard<'_, ()> {
+        self.refresh_publish_barrier.read()
+    }
+
+    pub(crate) fn refresh_publish_guard(&self) -> parking_lot::RwLockWriteGuard<'_, ()> {
+        self.refresh_publish_barrier.write()
     }
 
     /// Clean up storage-layer segments for a deleted branch (#1702).

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -1,6 +1,7 @@
 //! Database opening and initialization.
 
 use super::config::StorageConfig;
+use super::refresh::load_persisted_follower_state;
 use crate::background::BackgroundScheduler;
 use crate::coordinator::TransactionCoordinator;
 use dashmap::DashMap;
@@ -453,7 +454,45 @@ impl Database {
             writes_applied = result.stats.writes_applied,
             "Follower recovery complete");
 
-        let watermark = super::refresh::ContiguousWatermark::new(result.stats.max_txn_id);
+        let persisted_follower_state = match load_persisted_follower_state(&canonical_path) {
+            Ok(Some(state))
+                if state.applied_watermark.as_u64() <= state.received_watermark.as_u64()
+                    && state.received_watermark.as_u64() <= result.stats.max_txn_id.as_u64()
+                    && state.visible_version.as_u64() <= result.stats.final_version.as_u64() =>
+            {
+                Some(state)
+            }
+            Ok(Some(state)) => {
+                warn!(
+                    target: "strata::db",
+                    received = state.received_watermark.as_u64(),
+                    applied = state.applied_watermark.as_u64(),
+                    visible_version = state.visible_version.as_u64(),
+                    recovered_txn = result.stats.max_txn_id.as_u64(),
+                    recovered_version = result.stats.final_version.as_u64(),
+                    "Ignoring inconsistent persisted follower state"
+                );
+                None
+            }
+            Ok(None) => None,
+            Err(e) => {
+                warn!(
+                    target: "strata::db",
+                    error = %e,
+                    "Failed to load persisted follower state"
+                );
+                None
+            }
+        };
+        let watermark = if let Some(state) = &persisted_follower_state {
+            super::refresh::ContiguousWatermark::from_state(
+                state.received_watermark,
+                state.applied_watermark,
+                Some(state.blocked.clone()),
+            )
+        } else {
+            super::refresh::ContiguousWatermark::new(result.stats.max_txn_id)
+        };
 
         let coordinator = TransactionCoordinator::from_recovery_with_limits(
             &result,
@@ -503,6 +542,7 @@ impl Database {
             wal_dir,
             watermark,
             refresh_gate: super::refresh::RefreshGate::new(),
+            refresh_publish_barrier: parking_lot::RwLock::new(()),
             follower: true,
             shutdown_started: AtomicBool::new(false),
             shutdown_complete: AtomicBool::new(false),
@@ -521,6 +561,12 @@ impl Database {
             runtime_signature: parking_lot::RwLock::new(None),
             merge_registry: super::MergeHandlerRegistry::new(),
         });
+
+        if let Some(state) = persisted_follower_state {
+            db.storage.set_version(state.visible_version);
+            db.coordinator
+                .restore_visible_version(state.visible_version);
+        }
 
         Ok(db)
     }
@@ -871,6 +917,7 @@ impl Database {
             wal_dir,
             watermark,
             refresh_gate: super::refresh::RefreshGate::new(),
+            refresh_publish_barrier: parking_lot::RwLock::new(()),
             follower: false,
             shutdown_started: AtomicBool::new(false),
             shutdown_complete: AtomicBool::new(false),
@@ -1018,6 +1065,7 @@ impl Database {
             wal_dir: PathBuf::new(),
             watermark: super::refresh::ContiguousWatermark::default(),
             refresh_gate: super::refresh::RefreshGate::new(),
+            refresh_publish_barrier: parking_lot::RwLock::new(()),
             follower: false,
             shutdown_started: AtomicBool::new(false),
             shutdown_complete: AtomicBool::new(false),

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -453,7 +453,7 @@ impl Database {
             writes_applied = result.stats.writes_applied,
             "Follower recovery complete");
 
-        let wal_watermark = AtomicU64::new(result.stats.max_txn_id.as_u64());
+        let watermark = super::refresh::ContiguousWatermark::new(result.stats.max_txn_id);
 
         let coordinator = TransactionCoordinator::from_recovery_with_limits(
             &result,
@@ -501,7 +501,8 @@ impl Database {
             backpressure_counter: AtomicU64::new(0),
             _lock_file: None, // No lock acquired
             wal_dir,
-            wal_watermark,
+            watermark,
+            refresh_gate: super::refresh::RefreshGate::new(),
             follower: true,
             shutdown_started: AtomicBool::new(false),
             shutdown_complete: AtomicBool::new(false),
@@ -801,7 +802,7 @@ impl Database {
             codec,
         )?;
 
-        let wal_watermark = AtomicU64::new(result.stats.max_txn_id.as_u64());
+        let watermark = super::refresh::ContiguousWatermark::new(result.stats.max_txn_id);
 
         let wal_arc = Arc::new(ParkingMutex::new(wal_writer));
         let flush_shutdown = Arc::new(AtomicBool::new(false));
@@ -868,7 +869,8 @@ impl Database {
             backpressure_counter: AtomicU64::new(0),
             _lock_file: lock_file,
             wal_dir,
-            wal_watermark,
+            watermark,
+            refresh_gate: super::refresh::RefreshGate::new(),
             follower: false,
             shutdown_started: AtomicBool::new(false),
             shutdown_complete: AtomicBool::new(false),
@@ -1014,7 +1016,8 @@ impl Database {
             backpressure_counter: AtomicU64::new(0),
             _lock_file: None, // No lock for ephemeral databases
             wal_dir: PathBuf::new(),
-            wal_watermark: AtomicU64::new(0),
+            watermark: super::refresh::ContiguousWatermark::default(),
+            refresh_gate: super::refresh::RefreshGate::new(),
             follower: false,
             shutdown_started: AtomicBool::new(false),
             shutdown_complete: AtomicBool::new(false),

--- a/crates/engine/src/database/refresh.rs
+++ b/crates/engine/src/database/refresh.rs
@@ -407,6 +407,13 @@ pub(crate) fn load_persisted_follower_state(
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
 }
 
+pub(crate) fn sync_path_parent(path: &Path) -> std::io::Result<()> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    std::fs::File::open(parent)?.sync_all()
+}
+
 pub(crate) fn persist_follower_state(
     data_dir: &Path,
     state: &PersistedFollowerState,
@@ -421,8 +428,16 @@ pub(crate) fn persist_follower_state(
     let tmp = path.with_extension("json.tmp");
     let bytes = serde_json::to_vec_pretty(state)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-    std::fs::write(&tmp, bytes)?;
-    std::fs::rename(tmp, path)?;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&tmp)?;
+    std::io::Write::write_all(&mut file, &bytes)?;
+    file.sync_all()?;
+    drop(file);
+    std::fs::rename(tmp, &path)?;
+    sync_path_parent(&path)?;
     Ok(())
 }
 
@@ -430,8 +445,8 @@ pub(crate) fn clear_persisted_follower_state(data_dir: &Path) -> std::io::Result
     let Some(path) = follower_state_path(data_dir) else {
         return Ok(());
     };
-    match std::fs::remove_file(path) {
-        Ok(()) => Ok(()),
+    match std::fs::remove_file(&path) {
+        Ok(()) => sync_path_parent(&path),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e),
     }

--- a/crates/engine/src/database/refresh.rs
+++ b/crates/engine/src/database/refresh.rs
@@ -1,8 +1,12 @@
-//! Refresh hook trait for follower refresh.
+//! Follower refresh types and traits.
 //!
-//! Secondary index subsystems (vector, search) implement this trait
-//! to participate in incremental follower refresh without the engine
-//! needing to know the concrete types.
+//! This module provides the follower refresh infrastructure:
+//!
+//! - `RefreshHook` trait: secondary index subsystems implement this to participate
+//!   in incremental follower refresh
+//! - `RefreshOutcome`: structured result from `Database::refresh()`
+//! - `FollowerStatus`: current follower state including watermarks
+//! - `ContiguousWatermark`: internal type enforcing contiguous advancement
 //!
 //! ## Usage
 //!
@@ -11,10 +15,460 @@
 //! 3. Register the hook with `db.register_refresh_hook()`
 //! 4. `Database::refresh()` will call your hook automatically
 
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use strata_core::id::TxnId;
 use strata_core::types::Key;
 use strata_core::value::Value;
 use strata_core::StrataResult;
+
+// =============================================================================
+// Error Types
+// =============================================================================
+
+/// Error returned by a fallible `RefreshHook::apply_refresh`.
+///
+/// Implementations should provide enough context for operators to diagnose
+/// why secondary index maintenance failed.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct RefreshHookError {
+    /// Hook name (e.g., "vector", "search").
+    pub hook_name: String,
+    /// Human-readable error message.
+    pub message: String,
+}
+
+impl RefreshHookError {
+    /// Create a new hook error.
+    pub fn new(hook_name: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            hook_name: hook_name.into(),
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RefreshHookError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} hook failed: {}", self.hook_name, self.message)
+    }
+}
+
+impl std::error::Error for RefreshHookError {}
+
+/// Reason why follower refresh is blocked at a specific transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum BlockReason {
+    /// WAL record could not be decoded (corrupt or incompatible format).
+    Decode { message: String },
+    /// Codec mismatch between WAL record and database.
+    Codec { expected: String, actual: String },
+    /// Storage layer rejected the mutation.
+    StorageApply { message: String },
+    /// A secondary index hook (vector, search, etc.) failed.
+    SecondaryIndex { hook_name: String, message: String },
+}
+
+impl fmt::Display for BlockReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BlockReason::Decode { message } => write!(f, "decode error: {}", message),
+            BlockReason::Codec { expected, actual } => {
+                write!(f, "codec mismatch: expected {}, got {}", expected, actual)
+            }
+            BlockReason::StorageApply { message } => write!(f, "storage apply error: {}", message),
+            BlockReason::SecondaryIndex { hook_name, message } => {
+                write!(f, "{} hook failed: {}", hook_name, message)
+            }
+        }
+    }
+}
+
+/// Information about a blocked transaction during follower refresh.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockedTxn {
+    /// Transaction ID that caused the block.
+    pub txn_id: TxnId,
+    /// Reason for the block.
+    pub reason: BlockReason,
+}
+
+impl fmt::Display for BlockedTxn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "blocked at {}: {}", self.txn_id, self.reason)
+    }
+}
+
+/// Outcome of a follower refresh operation.
+///
+/// This type is `#[must_use]` — callers must inspect the result to determine
+/// whether refresh succeeded, partially succeeded, or made no progress.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[must_use]
+#[non_exhaustive]
+pub enum RefreshOutcome {
+    /// Refresh caught up with all available records.
+    CaughtUp {
+        /// Number of records applied in this refresh call.
+        applied: usize,
+        /// Highest contiguously applied transaction ID.
+        applied_through: TxnId,
+    },
+    /// Refresh applied some records but is now stuck.
+    Stuck {
+        /// Number of records applied before hitting the block.
+        applied: usize,
+        /// Highest contiguously applied transaction ID.
+        applied_through: TxnId,
+        /// Information about the blocked transaction.
+        blocked_at: BlockedTxn,
+    },
+    /// Refresh was already blocked and made no progress.
+    NoProgress {
+        /// Highest contiguously applied transaction ID.
+        applied_through: TxnId,
+        /// Information about the blocked transaction.
+        blocked_at: BlockedTxn,
+    },
+}
+
+impl RefreshOutcome {
+    /// Returns `true` if refresh caught up with all available records.
+    pub fn is_caught_up(&self) -> bool {
+        matches!(self, RefreshOutcome::CaughtUp { .. })
+    }
+
+    /// Returns the number of records applied in this refresh call.
+    pub fn applied_count(&self) -> usize {
+        match self {
+            RefreshOutcome::CaughtUp { applied, .. } => *applied,
+            RefreshOutcome::Stuck { applied, .. } => *applied,
+            RefreshOutcome::NoProgress { .. } => 0,
+        }
+    }
+
+    /// Returns the highest contiguously applied transaction ID.
+    pub fn applied_through(&self) -> TxnId {
+        match self {
+            RefreshOutcome::CaughtUp { applied_through, .. } => *applied_through,
+            RefreshOutcome::Stuck { applied_through, .. } => *applied_through,
+            RefreshOutcome::NoProgress { applied_through, .. } => *applied_through,
+        }
+    }
+
+    /// Returns the blocked transaction info if refresh is stuck or made no progress.
+    pub fn blocked_at(&self) -> Option<&BlockedTxn> {
+        match self {
+            RefreshOutcome::CaughtUp { .. } => None,
+            RefreshOutcome::Stuck { blocked_at, .. } => Some(blocked_at),
+            RefreshOutcome::NoProgress { blocked_at, .. } => Some(blocked_at),
+        }
+    }
+}
+
+impl fmt::Display for RefreshOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RefreshOutcome::CaughtUp {
+                applied,
+                applied_through,
+            } => {
+                write!(
+                    f,
+                    "caught up: {} records applied through {}",
+                    applied, applied_through
+                )
+            }
+            RefreshOutcome::Stuck {
+                applied,
+                applied_through,
+                blocked_at,
+            } => {
+                write!(
+                    f,
+                    "stuck: {} records applied through {}, {}",
+                    applied, applied_through, blocked_at
+                )
+            }
+            RefreshOutcome::NoProgress {
+                applied_through,
+                blocked_at,
+            } => {
+                write!(
+                    f,
+                    "no progress: still at {}, {}",
+                    applied_through, blocked_at
+                )
+            }
+        }
+    }
+}
+
+/// Error returned when trying to unblock a follower.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum UnblockError {
+    /// The provided transaction ID doesn't match the blocked transaction.
+    Mismatch {
+        expected: TxnId,
+        provided: TxnId,
+    },
+    /// The follower is not currently blocked.
+    NotBlocked,
+    /// This database is not a follower.
+    NotFollower,
+}
+
+impl fmt::Display for UnblockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UnblockError::Mismatch { expected, provided } => {
+                write!(
+                    f,
+                    "unblock mismatch: blocked at {}, but {} was provided",
+                    expected, provided
+                )
+            }
+            UnblockError::NotBlocked => write!(f, "follower is not blocked"),
+            UnblockError::NotFollower => write!(f, "this database is not a follower"),
+        }
+    }
+}
+
+impl std::error::Error for UnblockError {}
+
+/// Error returned when watermark advancement fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AdvanceError {
+    /// Cannot advance: follower is blocked.
+    Blocked { blocked_at: TxnId },
+    /// Cannot advance: not a follower database.
+    NotFollower,
+}
+
+impl fmt::Display for AdvanceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AdvanceError::Blocked { blocked_at } => {
+                write!(f, "cannot advance: blocked at {}", blocked_at)
+            }
+            AdvanceError::NotFollower => write!(f, "cannot advance: not a follower"),
+        }
+    }
+}
+
+impl std::error::Error for AdvanceError {}
+
+// =============================================================================
+// Follower Status
+// =============================================================================
+
+/// Current status of a follower database.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FollowerStatus {
+    /// Highest transaction ID received from the WAL (may include unprocessed records).
+    pub received_watermark: TxnId,
+    /// Highest transaction ID contiguously applied to storage and secondary indexes.
+    pub applied_watermark: TxnId,
+    /// If blocked, information about the blocking transaction.
+    pub blocked_at: Option<BlockedTxn>,
+    /// Whether a refresh is currently in progress.
+    pub refresh_in_progress: bool,
+}
+
+impl FollowerStatus {
+    /// Returns `true` if the follower is blocked.
+    pub fn is_blocked(&self) -> bool {
+        self.blocked_at.is_some()
+    }
+
+    /// Returns `true` if there are pending records to apply.
+    pub fn has_pending(&self) -> bool {
+        self.received_watermark > self.applied_watermark
+    }
+}
+
+impl fmt::Display for FollowerStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "FollowerStatus {{ received: {}, applied: {}",
+            self.received_watermark, self.applied_watermark
+        )?;
+        if let Some(blocked) = &self.blocked_at {
+            write!(f, ", blocked: {}", blocked)?;
+        }
+        if self.refresh_in_progress {
+            write!(f, ", refresh_in_progress")?;
+        }
+        write!(f, " }}")
+    }
+}
+
+// =============================================================================
+// Internal Types
+// =============================================================================
+
+/// Internal state for contiguous watermark tracking.
+///
+/// This type ensures that the applied watermark can only advance contiguously
+/// — skipping is only possible through the explicit admin skip API.
+pub(crate) struct ContiguousWatermark {
+    /// Highest transaction ID received from WAL (telemetry only).
+    received: AtomicU64,
+    /// Highest contiguously applied transaction ID.
+    applied: AtomicU64,
+    /// If set, the transaction that is blocking progress.
+    blocked: parking_lot::RwLock<Option<BlockedTxn>>,
+}
+
+impl ContiguousWatermark {
+    /// Create a new watermark initialized to the given value.
+    pub fn new(initial: TxnId) -> Self {
+        Self {
+            received: AtomicU64::new(initial.as_u64()),
+            applied: AtomicU64::new(initial.as_u64()),
+            blocked: parking_lot::RwLock::new(None),
+        }
+    }
+
+    /// Get the received watermark.
+    pub fn received(&self) -> TxnId {
+        TxnId(self.received.load(Ordering::SeqCst))
+    }
+
+    /// Get the applied watermark.
+    pub fn applied(&self) -> TxnId {
+        TxnId(self.applied.load(Ordering::SeqCst))
+    }
+
+    /// Get the blocked transaction if any.
+    pub fn blocked(&self) -> Option<BlockedTxn> {
+        self.blocked.read().clone()
+    }
+
+    /// Check if currently blocked.
+    pub fn is_blocked(&self) -> bool {
+        self.blocked.read().is_some()
+    }
+
+    /// Update the received watermark (telemetry only, does not affect visibility).
+    pub fn set_received(&self, txn_id: TxnId) {
+        self.received.fetch_max(txn_id.as_u64(), Ordering::SeqCst);
+    }
+
+    /// Advance the applied watermark after successful processing.
+    ///
+    /// This should only be called after storage apply AND all hooks succeed.
+    pub fn advance_applied(&self, txn_id: TxnId) {
+        self.applied.fetch_max(txn_id.as_u64(), Ordering::SeqCst);
+    }
+
+    /// Mark the watermark as blocked at a specific transaction.
+    pub fn set_blocked(&self, blocked: BlockedTxn) {
+        *self.blocked.write() = Some(blocked);
+    }
+
+    /// Clear the blocked state (after admin skip).
+    pub fn clear_blocked(&self) {
+        *self.blocked.write() = None;
+    }
+
+    /// Admin skip: advance past the blocked transaction.
+    ///
+    /// Returns an error if the provided txn_id doesn't match the blocked transaction.
+    pub fn admin_skip(&self, txn_id: TxnId) -> Result<(), UnblockError> {
+        let mut blocked = self.blocked.write();
+        match &*blocked {
+            Some(b) if b.txn_id == txn_id => {
+                // Advance applied watermark past the skipped transaction
+                self.applied.fetch_max(txn_id.as_u64(), Ordering::SeqCst);
+                *blocked = None;
+                Ok(())
+            }
+            Some(b) => Err(UnblockError::Mismatch {
+                expected: b.txn_id,
+                provided: txn_id,
+            }),
+            None => Err(UnblockError::NotBlocked),
+        }
+    }
+}
+
+impl Default for ContiguousWatermark {
+    fn default() -> Self {
+        Self::new(TxnId::ZERO)
+    }
+}
+
+/// Single-flight gate for refresh operations.
+///
+/// Ensures only one refresh can be in progress at a time per follower database.
+pub(crate) struct RefreshGate {
+    in_progress: AtomicBool,
+}
+
+impl RefreshGate {
+    pub fn new() -> Self {
+        Self {
+            in_progress: AtomicBool::new(false),
+        }
+    }
+
+    /// Try to acquire the gate. Returns `true` if acquired, `false` if already held.
+    pub fn try_acquire(&self) -> bool {
+        self.in_progress
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+
+    /// Release the gate.
+    pub fn release(&self) {
+        self.in_progress.store(false, Ordering::SeqCst);
+    }
+
+    /// Check if refresh is in progress.
+    pub fn is_in_progress(&self) -> bool {
+        self.in_progress.load(Ordering::SeqCst)
+    }
+}
+
+impl Default for RefreshGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// RAII guard for the refresh gate.
+pub(crate) struct RefreshGuard<'a> {
+    gate: &'a RefreshGate,
+}
+
+impl<'a> RefreshGuard<'a> {
+    /// Try to acquire the gate.
+    pub fn try_new(gate: &'a RefreshGate) -> Option<Self> {
+        if gate.try_acquire() {
+            Some(Self { gate })
+        } else {
+            None
+        }
+    }
+}
+
+impl Drop for RefreshGuard<'_> {
+    fn drop(&mut self) {
+        self.gate.release();
+    }
+}
+
+// =============================================================================
+// Refresh Hook Trait
+// =============================================================================
 
 /// Trait for secondary index backends that participate in follower refresh.
 ///
@@ -23,7 +477,20 @@ use strata_core::StrataResult;
 ///
 /// 1. `pre_delete_read`: Before storage mutations, read state needed for deletes
 /// 2. `apply_refresh`: After storage mutations, apply puts and deletes
+///
+/// ## Fallibility
+///
+/// `apply_refresh` returns `Result<(), RefreshHookError>`. If any hook fails,
+/// refresh blocks at that transaction and returns `RefreshOutcome::Stuck`.
+/// The contiguous watermark does NOT advance past the failed transaction.
+///
+/// Operators can inspect `FollowerStatus::blocked_at` to diagnose the issue
+/// and use `Database::admin_skip_blocked_record()` to skip past the problematic
+/// transaction after manual intervention.
 pub trait RefreshHook: Send + Sync + 'static {
+    /// Return the hook's name for error reporting.
+    fn name(&self) -> &'static str;
+
     /// Pre-read any state needed for processing deletes.
     ///
     /// Called BEFORE storage mutations are applied. Returns opaque pre-read
@@ -33,8 +500,15 @@ pub trait RefreshHook: Send + Sync + 'static {
 
     /// Apply puts and deletes from a single WAL record.
     ///
-    /// Called AFTER storage mutations are applied.
-    fn apply_refresh(&self, puts: &[(Key, Value)], pre_read_deletes: &[(Key, Vec<u8>)]);
+    /// Called AFTER storage mutations are applied. Returns `Ok(())` on success,
+    /// or `Err(RefreshHookError)` if secondary index maintenance failed.
+    ///
+    /// On error, the contiguous watermark does NOT advance past this transaction.
+    fn apply_refresh(
+        &self,
+        puts: &[(Key, Value)],
+        pre_read_deletes: &[(Key, Vec<u8>)],
+    ) -> Result<(), RefreshHookError>;
 
     /// Freeze in-memory state to disk for fast recovery on next open.
     fn freeze_to_disk(&self, db: &super::Database) -> StrataResult<()>;

--- a/crates/engine/src/database/refresh.rs
+++ b/crates/engine/src/database/refresh.rs
@@ -17,9 +17,10 @@
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use strata_core::id::TxnId;
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::types::Key;
 use strata_core::value::Value;
 use strata_core::StrataResult;
@@ -64,13 +65,29 @@ impl std::error::Error for RefreshHookError {}
 #[non_exhaustive]
 pub enum BlockReason {
     /// WAL record could not be decoded (corrupt or incompatible format).
-    Decode { message: String },
+    Decode {
+        /// Human-readable decode failure detail.
+        message: String,
+    },
     /// Codec mismatch between WAL record and database.
-    Codec { expected: String, actual: String },
+    Codec {
+        /// Expected codec identifier.
+        expected: String,
+        /// Actual codec identifier observed while decoding.
+        actual: String,
+    },
     /// Storage layer rejected the mutation.
-    StorageApply { message: String },
+    StorageApply {
+        /// Human-readable storage failure detail.
+        message: String,
+    },
     /// A secondary index hook (vector, search, etc.) failed.
-    SecondaryIndex { hook_name: String, message: String },
+    SecondaryIndex {
+        /// Name of the failed refresh hook.
+        hook_name: String,
+        /// Human-readable hook failure detail.
+        message: String,
+    },
 }
 
 impl fmt::Display for BlockReason {
@@ -154,9 +171,15 @@ impl RefreshOutcome {
     /// Returns the highest contiguously applied transaction ID.
     pub fn applied_through(&self) -> TxnId {
         match self {
-            RefreshOutcome::CaughtUp { applied_through, .. } => *applied_through,
-            RefreshOutcome::Stuck { applied_through, .. } => *applied_through,
-            RefreshOutcome::NoProgress { applied_through, .. } => *applied_through,
+            RefreshOutcome::CaughtUp {
+                applied_through, ..
+            } => *applied_through,
+            RefreshOutcome::Stuck {
+                applied_through, ..
+            } => *applied_through,
+            RefreshOutcome::NoProgress {
+                applied_through, ..
+            } => *applied_through,
         }
     }
 
@@ -214,11 +237,18 @@ impl fmt::Display for RefreshOutcome {
 pub enum UnblockError {
     /// The provided transaction ID doesn't match the blocked transaction.
     Mismatch {
+        /// Transaction ID currently blocking refresh.
         expected: TxnId,
+        /// Transaction ID supplied by the operator.
         provided: TxnId,
     },
     /// The follower is not currently blocked.
     NotBlocked,
+    /// The current blocked record cannot be skipped safely.
+    NotSkippable {
+        /// Transaction ID that remains non-skippable.
+        txn_id: TxnId,
+    },
     /// This database is not a follower.
     NotFollower,
 }
@@ -234,6 +264,13 @@ impl fmt::Display for UnblockError {
                 )
             }
             UnblockError::NotBlocked => write!(f, "follower is not blocked"),
+            UnblockError::NotSkippable { txn_id } => {
+                write!(
+                    f,
+                    "blocked txn {} cannot be skipped safely; manual repair is required",
+                    txn_id
+                )
+            }
             UnblockError::NotFollower => write!(f, "this database is not a follower"),
         }
     }
@@ -246,7 +283,10 @@ impl std::error::Error for UnblockError {}
 #[non_exhaustive]
 pub enum AdvanceError {
     /// Cannot advance: follower is blocked.
-    Blocked { blocked_at: TxnId },
+    Blocked {
+        /// Transaction currently blocking contiguous advancement.
+        blocked_at: TxnId,
+    },
     /// Cannot advance: not a follower database.
     NotFollower,
 }
@@ -324,12 +364,82 @@ pub(crate) struct ContiguousWatermark {
     /// Highest contiguously applied transaction ID.
     applied: AtomicU64,
     /// If set, the transaction that is blocking progress.
-    blocked: parking_lot::RwLock<Option<BlockedTxn>>,
+    blocked: parking_lot::RwLock<Option<BlockedTxnState>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct BlockedTxnState {
+    pub blocked: BlockedTxn,
+    pub visibility_version: Option<CommitVersion>,
+    pub skip_allowed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct PersistedFollowerState {
+    pub received_watermark: TxnId,
+    pub applied_watermark: TxnId,
+    pub visible_version: CommitVersion,
+    pub blocked: BlockedTxnState,
+}
+
+pub(crate) const FOLLOWER_STATE_FILE: &str = "follower_state.json";
+
+pub(crate) fn follower_state_path(data_dir: &Path) -> Option<PathBuf> {
+    if data_dir.as_os_str().is_empty() {
+        None
+    } else {
+        Some(data_dir.join(FOLLOWER_STATE_FILE))
+    }
+}
+
+pub(crate) fn load_persisted_follower_state(
+    data_dir: &Path,
+) -> std::io::Result<Option<PersistedFollowerState>> {
+    let Some(path) = follower_state_path(data_dir) else {
+        return Ok(None);
+    };
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = std::fs::read(path)?;
+    serde_json::from_slice(&bytes)
+        .map(Some)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+pub(crate) fn persist_follower_state(
+    data_dir: &Path,
+    state: &PersistedFollowerState,
+) -> std::io::Result<()> {
+    let Some(path) = follower_state_path(data_dir) else {
+        return Ok(());
+    };
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    std::fs::create_dir_all(parent)?;
+    let tmp = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(state)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(&tmp, bytes)?;
+    std::fs::rename(tmp, path)?;
+    Ok(())
+}
+
+pub(crate) fn clear_persisted_follower_state(data_dir: &Path) -> std::io::Result<()> {
+    let Some(path) = follower_state_path(data_dir) else {
+        return Ok(());
+    };
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
 impl ContiguousWatermark {
     /// Create a new watermark initialized to the given value.
-    pub fn new(initial: TxnId) -> Self {
+    pub(crate) fn new(initial: TxnId) -> Self {
         Self {
             received: AtomicU64::new(initial.as_u64()),
             applied: AtomicU64::new(initial.as_u64()),
@@ -337,64 +447,83 @@ impl ContiguousWatermark {
         }
     }
 
+    /// Create watermark state from explicit values (used when restoring a blocked follower).
+    pub(crate) fn from_state(
+        received: TxnId,
+        applied: TxnId,
+        blocked: Option<BlockedTxnState>,
+    ) -> Self {
+        Self {
+            received: AtomicU64::new(received.as_u64()),
+            applied: AtomicU64::new(applied.as_u64()),
+            blocked: parking_lot::RwLock::new(blocked),
+        }
+    }
+
     /// Get the received watermark.
-    pub fn received(&self) -> TxnId {
+    pub(crate) fn received(&self) -> TxnId {
         TxnId(self.received.load(Ordering::SeqCst))
     }
 
     /// Get the applied watermark.
-    pub fn applied(&self) -> TxnId {
+    pub(crate) fn applied(&self) -> TxnId {
         TxnId(self.applied.load(Ordering::SeqCst))
     }
 
     /// Get the blocked transaction if any.
-    pub fn blocked(&self) -> Option<BlockedTxn> {
+    pub(crate) fn blocked(&self) -> Option<BlockedTxn> {
+        self.blocked
+            .read()
+            .as_ref()
+            .map(|state| state.blocked.clone())
+    }
+
+    /// Snapshot the full blocked state for persistence.
+    pub(crate) fn blocked_state(&self) -> Option<BlockedTxnState> {
         self.blocked.read().clone()
     }
 
-    /// Check if currently blocked.
-    pub fn is_blocked(&self) -> bool {
-        self.blocked.read().is_some()
-    }
-
     /// Update the received watermark (telemetry only, does not affect visibility).
-    pub fn set_received(&self, txn_id: TxnId) {
+    pub(crate) fn set_received(&self, txn_id: TxnId) {
         self.received.fetch_max(txn_id.as_u64(), Ordering::SeqCst);
     }
 
     /// Advance the applied watermark after successful processing.
     ///
     /// This should only be called after storage apply AND all hooks succeed.
-    pub fn advance_applied(&self, txn_id: TxnId) {
+    pub(crate) fn try_advance(&self, txn_id: TxnId) -> Result<(), AdvanceError> {
+        if let Some(blocked) = self.blocked.read().as_ref() {
+            return Err(AdvanceError::Blocked {
+                blocked_at: blocked.blocked.txn_id,
+            });
+        }
         self.applied.fetch_max(txn_id.as_u64(), Ordering::SeqCst);
+        Ok(())
     }
 
     /// Mark the watermark as blocked at a specific transaction.
-    pub fn set_blocked(&self, blocked: BlockedTxn) {
+    pub(crate) fn block_at(&self, blocked: BlockedTxnState) {
         *self.blocked.write() = Some(blocked);
-    }
-
-    /// Clear the blocked state (after admin skip).
-    pub fn clear_blocked(&self) {
-        *self.blocked.write() = None;
     }
 
     /// Admin skip: advance past the blocked transaction.
     ///
     /// Returns an error if the provided txn_id doesn't match the blocked transaction.
-    pub fn admin_skip(&self, txn_id: TxnId) -> Result<(), UnblockError> {
+    pub(crate) fn unblock_exact(&self, txn_id: TxnId) -> Result<BlockedTxnState, UnblockError> {
         let mut blocked = self.blocked.write();
         match &*blocked {
-            Some(b) if b.txn_id == txn_id => {
-                // Advance applied watermark past the skipped transaction
-                self.applied.fetch_max(txn_id.as_u64(), Ordering::SeqCst);
-                *blocked = None;
-                Ok(())
-            }
-            Some(b) => Err(UnblockError::Mismatch {
-                expected: b.txn_id,
+            Some(state) if state.blocked.txn_id != txn_id => Err(UnblockError::Mismatch {
+                expected: state.blocked.txn_id,
                 provided: txn_id,
             }),
+            Some(state) if !state.skip_allowed => Err(UnblockError::NotSkippable { txn_id }),
+            Some(state) => {
+                let state = state.clone();
+                self.received.fetch_max(txn_id.as_u64(), Ordering::SeqCst);
+                self.applied.fetch_max(txn_id.as_u64(), Ordering::SeqCst);
+                *blocked = None;
+                Ok(state)
+            }
             None => Err(UnblockError::NotBlocked),
         }
     }
@@ -410,30 +539,20 @@ impl Default for ContiguousWatermark {
 ///
 /// Ensures only one refresh can be in progress at a time per follower database.
 pub(crate) struct RefreshGate {
+    lock: parking_lot::Mutex<()>,
     in_progress: AtomicBool,
 }
 
 impl RefreshGate {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
+            lock: parking_lot::Mutex::new(()),
             in_progress: AtomicBool::new(false),
         }
     }
 
-    /// Try to acquire the gate. Returns `true` if acquired, `false` if already held.
-    pub fn try_acquire(&self) -> bool {
-        self.in_progress
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_ok()
-    }
-
-    /// Release the gate.
-    pub fn release(&self) {
-        self.in_progress.store(false, Ordering::SeqCst);
-    }
-
     /// Check if refresh is in progress.
-    pub fn is_in_progress(&self) -> bool {
+    pub(crate) fn is_in_progress(&self) -> bool {
         self.in_progress.load(Ordering::SeqCst)
     }
 }
@@ -447,22 +566,24 @@ impl Default for RefreshGate {
 /// RAII guard for the refresh gate.
 pub(crate) struct RefreshGuard<'a> {
     gate: &'a RefreshGate,
+    _guard: parking_lot::MutexGuard<'a, ()>,
 }
 
 impl<'a> RefreshGuard<'a> {
-    /// Try to acquire the gate.
-    pub fn try_new(gate: &'a RefreshGate) -> Option<Self> {
-        if gate.try_acquire() {
-            Some(Self { gate })
-        } else {
-            None
+    /// Acquire the gate, blocking until the active refresh completes.
+    pub(crate) fn new(gate: &'a RefreshGate) -> Self {
+        let guard = gate.lock.lock();
+        gate.in_progress.store(true, Ordering::SeqCst);
+        Self {
+            gate,
+            _guard: guard,
         }
     }
 }
 
 impl Drop for RefreshGuard<'_> {
     fn drop(&mut self) {
-        self.gate.release();
+        self.gate.in_progress.store(false, Ordering::SeqCst);
     }
 }
 
@@ -470,19 +591,39 @@ impl Drop for RefreshGuard<'_> {
 // Refresh Hook Trait
 // =============================================================================
 
+/// Pending refresh work prepared by a [`RefreshHook`].
+///
+/// Hooks validate and stage derived-state updates before the contiguous
+/// watermark advances. The engine publishes the prepared updates only after it
+/// has exclusive access to the follower's query/publish barrier, preventing
+/// search/vector/graph readers from observing pre-visibility state.
+pub trait PreparedRefresh: Send {
+    /// Publish the staged derived-state changes.
+    fn publish(self: Box<Self>);
+}
+
+/// No-op prepared refresh for hooks with nothing to publish.
+pub struct NoopPreparedRefresh;
+
+impl PreparedRefresh for NoopPreparedRefresh {
+    fn publish(self: Box<Self>) {}
+}
+
 /// Trait for secondary index backends that participate in follower refresh.
 ///
 /// Implementations handle incremental updates from WAL replay during
 /// `Database::refresh()`. The engine calls hooks in two phases:
 ///
 /// 1. `pre_delete_read`: Before storage mutations, read state needed for deletes
-/// 2. `apply_refresh`: After storage mutations, apply puts and deletes
+/// 2. `apply_refresh`: After storage mutations, validate and stage puts/deletes
 ///
 /// ## Fallibility
 ///
-/// `apply_refresh` returns `Result<(), RefreshHookError>`. If any hook fails,
-/// refresh blocks at that transaction and returns `RefreshOutcome::Stuck`.
-/// The contiguous watermark does NOT advance past the failed transaction.
+/// `apply_refresh` returns staged work as `Result<Box<dyn PreparedRefresh>,
+/// RefreshHookError>`. If any hook fails, refresh blocks at that transaction
+/// and returns `RefreshOutcome::Stuck`. The contiguous watermark does NOT
+/// advance past the failed transaction, and no staged derived-state updates are
+/// published.
 ///
 /// Operators can inspect `FollowerStatus::blocked_at` to diagnose the issue
 /// and use `Database::admin_skip_blocked_record()` to skip past the problematic
@@ -498,17 +639,18 @@ pub trait RefreshHook: Send + Sync + 'static {
     /// the old values at this point.
     fn pre_delete_read(&self, db: &super::Database, deletes: &[Key]) -> Vec<(Key, Vec<u8>)>;
 
-    /// Apply puts and deletes from a single WAL record.
+    /// Validate and stage puts and deletes from a single WAL record.
     ///
-    /// Called AFTER storage mutations are applied. Returns `Ok(())` on success,
-    /// or `Err(RefreshHookError)` if secondary index maintenance failed.
+    /// Called AFTER storage mutations are applied. Returns staged publication
+    /// work on success, or `Err(RefreshHookError)` if secondary index
+    /// maintenance failed.
     ///
     /// On error, the contiguous watermark does NOT advance past this transaction.
     fn apply_refresh(
         &self,
         puts: &[(Key, Value)],
         pre_read_deletes: &[(Key, Vec<u8>)],
-    ) -> Result<(), RefreshHookError>;
+    ) -> Result<Box<dyn PreparedRefresh>, RefreshHookError>;
 
     /// Freeze in-memory state to disk for fast recovery on next open.
     fn freeze_to_disk(&self, db: &super::Database) -> StrataResult<()>;

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -1761,7 +1761,10 @@ fn test_issue_1699_refresh_preserves_wal_timestamp() {
     // 6. Follower refresh — applies the new WAL records via Database::refresh
     let outcome = follower.refresh();
     assert!(outcome.is_caught_up(), "follower should catch up");
-    assert!(outcome.applied_count() > 0, "follower should apply the new transaction");
+    assert!(
+        outcome.applied_count() > 0,
+        "follower should apply the new transaction"
+    );
 
     // 7. Check: A's entry timestamp should come from the WAL record (near
     //    commit time), NOT from Timestamp::now() during refresh.

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -1759,8 +1759,9 @@ fn test_issue_1699_refresh_preserves_wal_timestamp() {
     std::thread::sleep(Duration::from_millis(100));
 
     // 6. Follower refresh — applies the new WAL records via Database::refresh
-    let applied = follower.refresh().unwrap();
-    assert!(applied > 0, "follower should apply the new transaction");
+    let outcome = follower.refresh();
+    assert!(outcome.is_caught_up(), "follower should catch up");
+    assert!(outcome.applied_count() > 0, "follower should apply the new transaction");
 
     // 7. Check: A's entry timestamp should come from the WAL record (near
     //    commit time), NOT from Timestamp::now() during refresh.

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -78,8 +78,8 @@ pub use primitives::extensions;
 
 // Re-export refresh types for secondary index subsystems and follower management
 pub use database::refresh::{
-    AdvanceError, BlockReason, BlockedTxn, FollowerStatus, RefreshHook, RefreshHookError,
-    RefreshHooks, RefreshOutcome, UnblockError,
+    AdvanceError, BlockReason, BlockedTxn, FollowerStatus, NoopPreparedRefresh, PreparedRefresh,
+    RefreshHook, RefreshHookError, RefreshHooks, RefreshOutcome, UnblockError,
 };
 
 // Re-export primitive types at crate root for convenience

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -76,8 +76,11 @@ pub use search::SearchSubsystem;
 // Re-export submodules for `strata_engine::extensions::*` access
 pub use primitives::extensions;
 
-// Re-export refresh hook trait for secondary index subsystems
-pub use database::refresh::{RefreshHook, RefreshHooks};
+// Re-export refresh types for secondary index subsystems and follower management
+pub use database::refresh::{
+    AdvanceError, BlockReason, BlockedTxn, FollowerStatus, RefreshHook, RefreshHookError,
+    RefreshHooks, RefreshOutcome, UnblockError,
+};
 
 // Re-export primitive types at crate root for convenience
 pub use primitives::{

--- a/crates/engine/src/primitives/event.rs
+++ b/crates/engine/src/primitives/event.rs
@@ -1071,6 +1071,7 @@ impl crate::search::Searchable for EventLog {
         use std::time::Instant;
 
         let start = Instant::now();
+        let _refresh_guard = self.db.refresh_query_guard();
         let index = self.db.extension::<InvertedIndex>()?;
 
         if !index.is_enabled() || index.total_docs() == 0 {

--- a/crates/engine/src/primitives/json/mod.rs
+++ b/crates/engine/src/primitives/json/mod.rs
@@ -1444,6 +1444,7 @@ impl JsonStore {
         use std::time::Instant;
 
         let start = Instant::now();
+        let _refresh_guard = self.db.refresh_query_guard();
         let index = self.db.extension::<InvertedIndex>()?;
 
         if !index.is_enabled() || index.total_docs() == 0 {

--- a/crates/engine/src/primitives/kv.rs
+++ b/crates/engine/src/primitives/kv.rs
@@ -613,6 +613,7 @@ impl crate::search::Searchable for KVStore {
         use std::time::Instant;
 
         let start = Instant::now();
+        let _refresh_guard = self.db.refresh_query_guard();
         let index = self.db.extension::<InvertedIndex>()?;
 
         // If the index is disabled or empty, return early

--- a/crates/engine/src/search/index.rs
+++ b/crates/engine/src/search/index.rs
@@ -39,6 +39,7 @@ use super::segment::{self, SealedSegment};
 use super::tokenizer::tokenize_with_positions;
 use super::types::EntityRef;
 use dashmap::DashMap;
+use sha2::{Digest, Sha256};
 use smallvec::SmallVec;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
@@ -452,6 +453,8 @@ pub struct InvertedIndex {
     doc_lengths: RwLock<Vec<Option<u32>>>,
     /// doc_id -> terms indexed for that document (forward index for O(terms) removal)
     doc_terms: RwLock<Vec<Option<Vec<String>>>>,
+    /// doc_id -> content fingerprint for fast reconcile.
+    doc_content_hashes: RwLock<Vec<Option<[u8; 32]>>>,
 
     // --- Sealed segments (immutable, mmap-backed) ---
     /// Sealed segments ordered by segment_id
@@ -503,6 +506,7 @@ impl InvertedIndex {
             total_doc_len: AtomicUsize::new(0),
             doc_lengths: RwLock::new(Vec::new()),
             doc_terms: RwLock::new(Vec::new()),
+            doc_content_hashes: RwLock::new(Vec::new()),
             doc_id_map: DocIdMap::new(),
             sealed: RwLock::new(Vec::new()),
             next_segment_id: AtomicU64::new(0),
@@ -541,6 +545,7 @@ impl InvertedIndex {
         self.doc_freqs.clear();
         self.doc_lengths.write().unwrap().clear();
         self.doc_terms.write().unwrap().clear();
+        self.doc_content_hashes.write().unwrap().clear();
         self.doc_id_map.clear();
         self.sealed.write().unwrap().clear();
         // Relaxed: clear() is called during logical reset — the subsequent
@@ -582,7 +587,30 @@ impl InvertedIndex {
 
     /// Check if a document is already present in the index.
     pub fn has_document(&self, doc_ref: &EntityRef) -> bool {
-        self.doc_id_map.get(doc_ref).is_some()
+        let Some(doc_id) = self.doc_id_map.get(doc_ref) else {
+            return false;
+        };
+        self.doc_lengths
+            .read()
+            .unwrap()
+            .get(doc_id as usize)
+            .copied()
+            .flatten()
+            .is_some()
+    }
+
+    /// Check whether the live indexed content matches `text`.
+    pub(crate) fn document_matches_text(&self, doc_ref: &EntityRef, text: &str) -> bool {
+        let Some(doc_id) = self.doc_id_map.get(doc_ref) else {
+            return false;
+        };
+        self.doc_content_hashes
+            .read()
+            .unwrap()
+            .get(doc_id as usize)
+            .copied()
+            .flatten()
+            .is_some_and(|existing| existing == Self::content_fingerprint(text))
     }
 
     /// Check if index is at least at given version
@@ -662,6 +690,23 @@ impl InvertedIndex {
     /// entries back to the original document references.
     pub fn resolve_doc_id(&self, doc_id: u32) -> Option<EntityRef> {
         self.doc_id_map.resolve(doc_id)
+    }
+
+    /// Snapshot all entity refs currently tracked by the index.
+    pub(crate) fn entity_refs_snapshot(&self) -> Vec<EntityRef> {
+        self.doc_id_map
+            .id_to_ref
+            .read()
+            .unwrap()
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    fn content_fingerprint(text: &str) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(text.as_bytes());
+        hasher.finalize().into()
     }
 
     // ========================================================================
@@ -1081,6 +1126,7 @@ impl InvertedIndex {
         }
 
         let tokens = tokenize_with_positions(text);
+        let content_hash = Self::content_fingerprint(text);
         // doc_len = max_position + 1 (includes stopword gaps for accurate BM25 length norm)
         let doc_len = tokens.last().map_or(0, |t| t.position + 1);
 
@@ -1131,6 +1177,15 @@ impl InvertedIndex {
                 lengths.resize(idx + 1, None);
             }
             lengths[idx] = Some(doc_len);
+        }
+
+        {
+            let mut hashes = self.doc_content_hashes.write().unwrap();
+            let idx = doc_id as usize;
+            if idx >= hashes.len() {
+                hashes.resize(idx + 1, None);
+            }
+            hashes[idx] = Some(content_hash);
         }
 
         // Relaxed: observational counters — the version bump below (Release)
@@ -1189,6 +1244,14 @@ impl InvertedIndex {
                 None
             }
         };
+
+        {
+            let mut hashes = self.doc_content_hashes.write().unwrap();
+            let idx = doc_id as usize;
+            if idx < hashes.len() {
+                hashes[idx] = None;
+            }
+        }
 
         // Remove from active segment using forward index — O(terms_in_doc) not O(vocabulary)
         let mut active_removed = false;
@@ -1408,6 +1471,7 @@ impl InvertedIndex {
         let doc_id_map_vec = self.doc_id_map.id_to_ref.read().unwrap().clone();
         let doc_lengths_vec = self.doc_lengths.read().unwrap().clone();
         let doc_terms_vec = self.doc_terms.read().unwrap().clone();
+        let doc_content_hashes_vec = self.doc_content_hashes.read().unwrap().clone();
 
         let manifest_data = ManifestData {
             version: 1,
@@ -1418,6 +1482,7 @@ impl InvertedIndex {
             doc_id_map: doc_id_map_vec,
             doc_lengths: doc_lengths_vec,
             doc_terms: doc_terms_vec,
+            doc_content_hashes: doc_content_hashes_vec,
         };
 
         let manifest_path = search_dir.join("search.manifest");
@@ -1497,6 +1562,7 @@ impl InvertedIndex {
 
         // Restore forward index (doc_id → terms) for O(terms) removal
         *self.doc_terms.write().unwrap() = data.doc_terms;
+        *self.doc_content_hashes.write().unwrap() = data.doc_content_hashes;
 
         // Rebuild branch_ids from restored DocIdMap
         {

--- a/crates/engine/src/search/manifest.rs
+++ b/crates/engine/src/search/manifest.rs
@@ -21,11 +21,12 @@ const MANIFEST_MAGIC: &[u8; 4] = b"SMNF";
 /// v2 was introduced when `EntityRef::{Kv,Event,Json,Vector}` gained a
 /// `space` field (Phase 0 of the space-correctness fix). v1 manifests
 /// stored space-blind `EntityRef` values that would silently collapse
-/// non-default-space identities; they are rejected by the version
-/// check in `load_manifest`. The recovery path
-/// (`crates/engine/src/search/recovery.rs`) catches the resulting
-/// error and rebuilds the index from KV with space-aware refs.
-const MANIFEST_VERSION: u32 = 2;
+/// non-default-space identities.
+///
+/// v3 adds per-document content fingerprints so fast-path reconcile can
+/// detect graph updates without rewriting every graph document on every
+/// startup. This also forces a one-time rebuild for pre-graph-hook caches.
+const MANIFEST_VERSION: u32 = 3;
 
 // ============================================================================
 // Manifest Data (serializable)
@@ -54,6 +55,9 @@ pub(crate) struct ManifestData {
     /// Enables O(terms_in_doc) removal instead of O(vocabulary).
     #[serde(default)]
     pub doc_terms: Vec<Option<Vec<String>>>,
+    /// Per-document content fingerprints used by fast-path reconcile.
+    #[serde(default)]
+    pub doc_content_hashes: Vec<Option<[u8; 32]>>,
 }
 
 /// Manifest entry for a single sealed segment.
@@ -179,6 +183,7 @@ mod tests {
                 Some(vec!["key1".to_string(), "value1".to_string()]),
                 Some(vec!["key2".to_string()]),
             ],
+            doc_content_hashes: vec![Some([1u8; 32]), Some([2u8; 32])],
         }
     }
 
@@ -205,6 +210,10 @@ mod tests {
             loaded.doc_terms[0],
             Some(vec!["key1".to_string(), "value1".to_string()])
         );
+        assert_eq!(
+            loaded.doc_content_hashes,
+            vec![Some([1u8; 32]), Some([2u8; 32])]
+        );
     }
 
     #[test]
@@ -221,6 +230,7 @@ mod tests {
             doc_id_map: vec![],
             doc_lengths: vec![],
             doc_terms: vec![],
+            doc_content_hashes: vec![],
         };
         write_manifest(&path, &data).unwrap();
 

--- a/crates/engine/src/search/recovery.rs
+++ b/crates/engine/src/search/recovery.rs
@@ -23,8 +23,11 @@
 use crate::database::Database;
 use crate::primitives::branch::resolve_branch_name;
 use crate::search::InvertedIndex;
+use std::collections::HashSet;
 use strata_core::branch_dag::SYSTEM_BRANCH;
-use strata_core::types::TypeTag;
+use strata_core::id::CommitVersion;
+use strata_core::traits::Storage;
+use strata_core::types::{Key, TypeTag};
 use strata_core::value::Value;
 use strata_core::StrataResult;
 use tracing::info;
@@ -49,6 +52,330 @@ pub fn extract_indexable_text(value: &Value) -> Option<String> {
 /// branch — these are not user documents and must not feed BM25.
 fn is_json_internal_space(space: &str) -> bool {
     space.starts_with("_idx/") || space.starts_with("_idx_meta/")
+}
+
+fn parse_graph_node_index_entry(
+    key: &Key,
+    value: &Value,
+) -> Option<(crate::search::EntityRef, String)> {
+    if key.type_tag != TypeTag::Graph {
+        return None;
+    }
+
+    if key.user_key.starts_with(b"__") || key.user_key.windows(3).any(|w| w == b"/__") {
+        return None;
+    }
+
+    let user_key = key.user_key_string()?;
+    let parts: Vec<&str> = user_key.splitn(3, '/').collect();
+    if parts.len() != 3 || parts[1] != "n" {
+        return None;
+    }
+
+    let node_id = parts[2];
+    let Value::String(json) = value else {
+        return None;
+    };
+    let data: GraphNodeData = serde_json::from_str(json).ok()?;
+
+    // Keep this in sync with strata-graph's GraphStore::build_node_search_text().
+    let mut text = String::new();
+    text.push_str(node_id);
+    if let Some(ref ot) = data.object_type {
+        text.push(' ');
+        text.push_str(ot);
+    }
+    if let Some(ref props) = data.properties {
+        text.push(' ');
+        text.push_str(&serde_json::to_string(props).unwrap_or_default());
+    }
+    if let Some(ref uri) = data.entity_ref {
+        text.push(' ');
+        text.push_str(uri);
+    }
+
+    Some((
+        crate::search::EntityRef::Graph {
+            branch_id: key.namespace.branch_id,
+            space: key.namespace.space.to_string(),
+            key: user_key,
+        },
+        text,
+    ))
+}
+
+#[derive(serde::Deserialize)]
+struct GraphNodeData {
+    #[serde(default)]
+    entity_ref: Option<String>,
+    #[serde(default)]
+    properties: Option<serde_json::Value>,
+    #[serde(default)]
+    object_type: Option<String>,
+}
+
+fn visible_entries_by_type(
+    db: &Database,
+    branch_id: strata_core::types::BranchId,
+    type_tag: TypeTag,
+) -> Vec<(Key, strata_core::VersionedValue)> {
+    let snapshot_version = CommitVersion(db.storage().version());
+    db.storage()
+        .list_by_type_at_version(&branch_id, type_tag, snapshot_version)
+        .into_iter()
+        .filter(|entry| !entry.is_tombstone)
+        .filter_map(|entry| {
+            db.storage()
+                .get_versioned(&entry.key, snapshot_version)
+                .ok()
+                .flatten()
+                .map(|vv| (entry.key, vv))
+        })
+        .collect()
+}
+
+fn visible_search_documents_for_branch(
+    db: &Database,
+    branch_id: strata_core::types::BranchId,
+) -> Vec<(crate::search::EntityRef, String)> {
+    let mut docs = Vec::new();
+
+    for (key, vv) in visible_entries_by_type(db, branch_id, TypeTag::KV) {
+        if let Some(op) = index_replayed_document(&key, &vv.value) {
+            if let SearchRefreshOp::Index { entity_ref, text } = op {
+                docs.push((entity_ref, text));
+            }
+        }
+    }
+
+    for (key, vv) in visible_entries_by_type(db, branch_id, TypeTag::Event) {
+        if let Some(op) = index_replayed_document(&key, &vv.value) {
+            if let SearchRefreshOp::Index { entity_ref, text } = op {
+                docs.push((entity_ref, text));
+            }
+        }
+    }
+
+    for (key, vv) in visible_entries_by_type(db, branch_id, TypeTag::Graph) {
+        if let Some(doc) = parse_graph_node_index_entry(&key, &vv.value) {
+            docs.push(doc);
+        }
+    }
+
+    for (key, vv) in visible_entries_by_type(db, branch_id, TypeTag::Json) {
+        if let Some(op) = index_replayed_document(&key, &vv.value) {
+            if let SearchRefreshOp::Index { entity_ref, text } = op {
+                docs.push((entity_ref, text));
+            }
+        }
+    }
+
+    docs
+}
+
+fn is_reconciled_search_entity_ref(
+    entity_ref: &crate::search::EntityRef,
+    branch_id: strata_core::types::BranchId,
+) -> bool {
+    match entity_ref {
+        crate::search::EntityRef::Kv {
+            branch_id: ref_bid, ..
+        }
+        | crate::search::EntityRef::Event {
+            branch_id: ref_bid, ..
+        }
+        | crate::search::EntityRef::Json {
+            branch_id: ref_bid, ..
+        }
+        | crate::search::EntityRef::Graph {
+            branch_id: ref_bid, ..
+        } => *ref_bid == branch_id,
+        crate::search::EntityRef::Vector { .. } | crate::search::EntityRef::Branch { .. } => false,
+    }
+}
+
+fn rebuild_search_entries_for_branch(
+    db: &Database,
+    index: &InvertedIndex,
+    branch_id: strata_core::types::BranchId,
+) -> u64 {
+    let current_docs = visible_search_documents_for_branch(db, branch_id);
+    for (entity_ref, text) in &current_docs {
+        index.index_document(entity_ref, text, None);
+    }
+    current_docs.len() as u64
+}
+
+fn reconcile_search_entries_for_branch(
+    db: &Database,
+    index: &InvertedIndex,
+    branch_id: strata_core::types::BranchId,
+) -> u64 {
+    let current_docs = visible_search_documents_for_branch(db, branch_id);
+    let current_refs: HashSet<_> = current_docs
+        .iter()
+        .map(|(entity_ref, _)| entity_ref.clone())
+        .collect();
+
+    let mut reconciled = 0u64;
+
+    for entity_ref in index.entity_refs_snapshot() {
+        if is_reconciled_search_entity_ref(&entity_ref, branch_id)
+            && index.has_document(&entity_ref)
+            && !current_refs.contains(&entity_ref)
+        {
+            index.remove_document(&entity_ref);
+            reconciled += 1;
+        }
+    }
+
+    for (entity_ref, text) in &current_docs {
+        if index.document_matches_text(entity_ref, text) {
+            continue;
+        }
+        index.index_document(entity_ref, text, None);
+        reconciled += 1;
+    }
+
+    reconciled
+}
+
+enum SearchRefreshOp {
+    Index {
+        entity_ref: crate::search::EntityRef,
+        text: String,
+    },
+    Remove {
+        entity_ref: crate::search::EntityRef,
+    },
+}
+
+fn index_replayed_document(key: &Key, value: &Value) -> Option<SearchRefreshOp> {
+    let branch_id = key.namespace.branch_id;
+    match key.type_tag {
+        TypeTag::KV => {
+            if let Some(text) = extract_indexable_text(value) {
+                if let Some(user_key) = key.user_key_string() {
+                    return Some(SearchRefreshOp::Index {
+                        entity_ref: crate::search::EntityRef::Kv {
+                            branch_id,
+                            space: key.namespace.space.to_string(),
+                            key: user_key,
+                        },
+                        text,
+                    });
+                }
+            }
+        }
+        TypeTag::Event => {
+            if *key.user_key == *b"__meta__" || key.user_key.starts_with(b"__tidx__") {
+                return None;
+            }
+            if let Some(text) = extract_indexable_text(value) {
+                if key.user_key.len() == 8 {
+                    let sequence = u64::from_be_bytes((*key.user_key).try_into().unwrap_or([0; 8]));
+                    return Some(SearchRefreshOp::Index {
+                        entity_ref: crate::search::EntityRef::Event {
+                            branch_id,
+                            space: key.namespace.space.to_string(),
+                            sequence,
+                        },
+                        text,
+                    });
+                }
+            }
+        }
+        TypeTag::Json => {
+            if is_json_internal_space(&key.namespace.space) {
+                return None;
+            }
+            let Some(doc_id) = key.user_key_string() else {
+                return None;
+            };
+            let Ok(doc) = crate::primitives::json::JsonStore::deserialize_doc(value) else {
+                return None;
+            };
+            let text = serde_json::to_string(doc.value.as_inner()).unwrap_or_default();
+            return Some(SearchRefreshOp::Index {
+                entity_ref: crate::search::EntityRef::Json {
+                    branch_id,
+                    space: key.namespace.space.to_string(),
+                    doc_id,
+                },
+                text,
+            });
+        }
+        _ => {}
+    }
+    None
+}
+
+fn remove_replayed_document(key: &Key) -> Option<SearchRefreshOp> {
+    let branch_id = key.namespace.branch_id;
+    match key.type_tag {
+        TypeTag::KV => {
+            if let Some(user_key) = key.user_key_string() {
+                return Some(SearchRefreshOp::Remove {
+                    entity_ref: crate::search::EntityRef::Kv {
+                        branch_id,
+                        space: key.namespace.space.to_string(),
+                        key: user_key,
+                    },
+                });
+            }
+        }
+        TypeTag::Event => {
+            if *key.user_key == *b"__meta__" || key.user_key.starts_with(b"__tidx__") {
+                return None;
+            }
+            if key.user_key.len() == 8 {
+                let sequence = u64::from_be_bytes((*key.user_key).try_into().unwrap_or([0; 8]));
+                return Some(SearchRefreshOp::Remove {
+                    entity_ref: crate::search::EntityRef::Event {
+                        branch_id,
+                        space: key.namespace.space.to_string(),
+                        sequence,
+                    },
+                });
+            }
+        }
+        TypeTag::Json => {
+            if is_json_internal_space(&key.namespace.space) {
+                return None;
+            }
+            if let Some(doc_id) = key.user_key_string() {
+                return Some(SearchRefreshOp::Remove {
+                    entity_ref: crate::search::EntityRef::Json {
+                        branch_id,
+                        space: key.namespace.space.to_string(),
+                        doc_id,
+                    },
+                });
+            }
+        }
+        _ => {}
+    }
+    None
+}
+
+struct PendingSearchRefresh {
+    index: std::sync::Arc<InvertedIndex>,
+    ops: Vec<SearchRefreshOp>,
+}
+
+impl crate::database::refresh::PreparedRefresh for PendingSearchRefresh {
+    fn publish(self: Box<Self>) {
+        for op in self.ops {
+            match op {
+                SearchRefreshOp::Index { entity_ref, text } => {
+                    self.index.index_document(&entity_ref, &text, None);
+                }
+                SearchRefreshOp::Remove { entity_ref } => {
+                    self.index.remove_document(&entity_ref);
+                }
+            }
+        }
+    }
 }
 
 /// Recovery function for the InvertedIndex.
@@ -78,7 +405,7 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
     // ---------------------------------------------------------------
     // Fast path: load from manifest + mmap'd sealed segments
     // ---------------------------------------------------------------
-    if use_disk {
+    if use_disk && !db.is_follower() {
         match index.load_from_disk() {
             Ok(true) => {
                 info!(
@@ -143,117 +470,7 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
         }
         branches_scanned += 1;
 
-        // --- KV entries ---
-        for (key, vv) in db.storage().list_by_type(&branch_id, TypeTag::KV) {
-            let text = match extract_indexable_text(&vv.value) {
-                Some(t) => t,
-                None => continue,
-            };
-
-            let user_key = match key.user_key_string() {
-                Some(k) => k,
-                None => continue,
-            };
-
-            let entity_ref = crate::search::EntityRef::Kv {
-                branch_id,
-                space: key.namespace.space.to_string(),
-                key: user_key,
-            };
-            index.index_document(&entity_ref, &text, None);
-            docs_indexed += 1;
-        }
-
-        // --- Event entries ---
-        for (key, vv) in db.storage().list_by_type(&branch_id, TypeTag::Event) {
-            // Skip metadata keys (same as checkpoint logic)
-            if *key.user_key == *b"__meta__" || key.user_key.starts_with(b"__tidx__") {
-                continue;
-            }
-
-            let text = match extract_indexable_text(&vv.value) {
-                Some(t) => t,
-                None => continue,
-            };
-
-            // Parse sequence from the key (8-byte big-endian u64)
-            let sequence = if key.user_key.len() == 8 {
-                u64::from_be_bytes((*key.user_key).try_into().unwrap_or([0; 8]))
-            } else {
-                continue; // Skip non-sequence keys
-            };
-
-            let entity_ref = crate::search::EntityRef::Event {
-                branch_id,
-                space: key.namespace.space.to_string(),
-                sequence,
-            };
-            index.index_document(&entity_ref, &text, None);
-            docs_indexed += 1;
-        }
-
-        // --- Graph entries (node data only) ---
-        for (key, vv) in db.storage().list_by_type(&branch_id, TypeTag::Graph) {
-            // Skip internal metadata keys (catalog, meta, type defs,
-            // edge counts, indexes). Covers both top-level (__catalog__)
-            // and graph-scoped ({graph}/__meta__, {graph}/__types__/, etc.)
-            if key.user_key.starts_with(b"__") || key.user_key.windows(3).any(|w| w == b"/__") {
-                continue;
-            }
-
-            let text = match extract_indexable_text(&vv.value) {
-                Some(t) => t,
-                None => continue,
-            };
-
-            let user_key = match key.user_key_string() {
-                Some(k) => k,
-                None => continue,
-            };
-
-            let entity_ref = crate::search::EntityRef::Graph {
-                branch_id,
-                space: key.namespace.space.to_string(),
-                key: user_key,
-            };
-            index.index_document(&entity_ref, &text, None);
-            docs_indexed += 1;
-        }
-
-        // --- JSON entries ---
-        // After Phase 0 bumped the BM25 manifest version, the slow path runs
-        // on every existing DB. Without this loop, JSON documents silently
-        // disappear from BM25 until the next user-triggered re-put.
-        //
-        // `list_by_type` returns JSON entries across ALL spaces in this
-        // branch, including secondary-index storage (`_idx/{space}/{name}`)
-        // and index metadata (`_idx_meta/{space}`). Skip those by space
-        // prefix — they are not user documents.
-        for (key, vv) in db.storage().list_by_type(&branch_id, TypeTag::Json) {
-            if is_json_internal_space(&key.namespace.space) {
-                continue;
-            }
-
-            let doc_id = match key.user_key_string() {
-                Some(k) => k,
-                None => continue,
-            };
-
-            let doc = match crate::primitives::json::JsonStore::deserialize_doc(&vv.value) {
-                Ok(d) => d,
-                Err(_) => continue,
-            };
-
-            let text = serde_json::to_string(doc.value.as_inner()).unwrap_or_default();
-
-            let entity_ref = crate::search::EntityRef::Json {
-                branch_id,
-                space: key.namespace.space.to_string(),
-                doc_id,
-            };
-            index.index_document(&entity_ref, &text, None);
-            docs_indexed += 1;
-        }
+        docs_indexed += rebuild_search_entries_for_branch(db, &index, branch_id);
     }
 
     // Freeze to disk for next startup (fast path).
@@ -295,126 +512,7 @@ fn reconcile_index(db: &Database, index: &InvertedIndex) -> StrataResult<u64> {
             continue;
         }
 
-        // --- KV entries ---
-        for (key, vv) in db.storage().list_by_type(&branch_id, TypeTag::KV) {
-            let user_key = match key.user_key_string() {
-                Some(k) => k,
-                None => continue,
-            };
-
-            let entity_ref = crate::search::EntityRef::Kv {
-                branch_id,
-                space: key.namespace.space.to_string(),
-                key: user_key,
-            };
-
-            if index.has_document(&entity_ref) {
-                continue;
-            }
-
-            let text = match extract_indexable_text(&vv.value) {
-                Some(t) => t,
-                None => continue,
-            };
-
-            index.index_document(&entity_ref, &text, None);
-            reconciled += 1;
-        }
-
-        // --- Event entries ---
-        for (key, vv) in db.storage().list_by_type(&branch_id, TypeTag::Event) {
-            if *key.user_key == *b"__meta__" || key.user_key.starts_with(b"__tidx__") {
-                continue;
-            }
-
-            let sequence = if key.user_key.len() == 8 {
-                u64::from_be_bytes((*key.user_key).try_into().unwrap_or([0; 8]))
-            } else {
-                continue;
-            };
-
-            let entity_ref = crate::search::EntityRef::Event {
-                branch_id,
-                space: key.namespace.space.to_string(),
-                sequence,
-            };
-
-            if index.has_document(&entity_ref) {
-                continue;
-            }
-
-            let text = match extract_indexable_text(&vv.value) {
-                Some(t) => t,
-                None => continue,
-            };
-
-            index.index_document(&entity_ref, &text, None);
-            reconciled += 1;
-        }
-
-        // --- Graph entries ---
-        for (key, vv) in db.storage().list_by_type(&branch_id, TypeTag::Graph) {
-            if key.user_key.starts_with(b"__") {
-                continue;
-            }
-
-            let user_key = match key.user_key_string() {
-                Some(k) => k,
-                None => continue,
-            };
-
-            let entity_ref = crate::search::EntityRef::Graph {
-                branch_id,
-                space: key.namespace.space.to_string(),
-                key: user_key,
-            };
-
-            if index.has_document(&entity_ref) {
-                continue;
-            }
-
-            let text = match extract_indexable_text(&vv.value) {
-                Some(t) => t,
-                None => continue,
-            };
-
-            index.index_document(&entity_ref, &text, None);
-            reconciled += 1;
-        }
-
-        // --- JSON entries ---
-        // Mirror the slow-path skip: never reconcile JSON-internal spaces
-        // (`_idx/...`, `_idx_meta/...`) — these are secondary-index storage,
-        // not user documents.
-        for (key, vv) in db.storage().list_by_type(&branch_id, TypeTag::Json) {
-            if is_json_internal_space(&key.namespace.space) {
-                continue;
-            }
-
-            let doc_id = match key.user_key_string() {
-                Some(k) => k,
-                None => continue,
-            };
-
-            let entity_ref = crate::search::EntityRef::Json {
-                branch_id,
-                space: key.namespace.space.to_string(),
-                doc_id,
-            };
-
-            if index.has_document(&entity_ref) {
-                continue;
-            }
-
-            let doc = match crate::primitives::json::JsonStore::deserialize_doc(&vv.value) {
-                Ok(d) => d,
-                Err(_) => continue,
-            };
-
-            let text = serde_json::to_string(doc.value.as_inner()).unwrap_or_default();
-            index.index_document(&entity_ref, &text, None);
-            reconciled += 1;
-        }
+        reconciled += reconcile_search_entries_for_branch(db, index, branch_id);
     }
 
     Ok(reconciled)
@@ -443,6 +541,13 @@ impl crate::recovery::Subsystem for SearchSubsystem {
     ) -> strata_core::StrataResult<()> {
         use std::sync::Arc;
 
+        if let Ok(index) = db.extension::<InvertedIndex>() {
+            let refresh_hook = Arc::new(SearchRefreshHook { index });
+            if let Ok(hooks) = db.extension::<crate::RefreshHooks>() {
+                hooks.register(refresh_hook);
+            }
+        }
+
         // Register commit observer for search index maintenance.
         // Index updates happen inline during primitive operations; this observer
         // handles periodic seal operations for durability.
@@ -450,14 +555,6 @@ impl crate::recovery::Subsystem for SearchSubsystem {
             _db: Arc::downgrade(db),
         });
         db.commit_observers().register(commit_observer);
-
-        // Register replay observer for follower index maintenance.
-        // Followers don't execute primitive operations (data arrives via WAL),
-        // so this observer ensures the index stays consistent after replays.
-        let replay_observer = Arc::new(SearchReplayObserver {
-            _db: Arc::downgrade(db),
-        });
-        db.replay_observers().register(replay_observer);
 
         Ok(())
     }
@@ -471,9 +568,7 @@ impl crate::recovery::Subsystem for SearchSubsystem {
 // Search Observers
 // =============================================================================
 
-use crate::database::observers::{
-    CommitInfo, CommitObserver, ObserverError, ReplayInfo, ReplayObserver,
-};
+use crate::database::observers::{CommitInfo, CommitObserver, ObserverError};
 use std::sync::Weak;
 
 /// Commit observer for search index maintenance.
@@ -515,36 +610,52 @@ impl CommitObserver for SearchCommitObserver {
     }
 }
 
-/// Replay observer for follower search index maintenance.
-///
-/// ## Architectural Note: Follower Search Reconciliation
-///
-/// Followers receive data via WAL replay, not primitive operations. Unlike
-/// vector (which uses RefreshHook to capture embeddings during WAL apply),
-/// search doesn't need real-time incremental updates because:
-///
-/// - **Recovery rebuilds**: Search index is rebuildable from committed data,
-///   so recovery can fully reconcile the index.
-/// - **Derived state**: Search tokens are derived from document content, not
-///   stored separately like embeddings.
-/// - **Cost tradeoff**: Real-time reconciliation would require re-parsing all
-///   replayed documents to extract tokens. Recovery-based reconciliation is
-///   more efficient for read replicas.
-///
-/// For workloads requiring real-time follower search, a RefreshHook-based
-/// approach (like vector) could be implemented as a future enhancement.
-struct SearchReplayObserver {
-    _db: Weak<Database>,
+struct SearchRefreshHook {
+    index: std::sync::Arc<InvertedIndex>,
 }
 
-impl ReplayObserver for SearchReplayObserver {
+impl crate::RefreshHook for SearchRefreshHook {
     fn name(&self) -> &'static str {
         "search"
     }
 
-    fn on_replay(&self, _info: &ReplayInfo) -> Result<(), ObserverError> {
-        // Follower search index reconciliation is deferred to recovery.
-        // See architectural note above for rationale.
+    fn pre_delete_read(&self, _db: &Database, deletes: &[Key]) -> Vec<(Key, Vec<u8>)> {
+        deletes
+            .iter()
+            .cloned()
+            .map(|key| (key, Vec::new()))
+            .collect()
+    }
+
+    fn apply_refresh(
+        &self,
+        puts: &[(Key, Value)],
+        pre_read_deletes: &[(Key, Vec<u8>)],
+    ) -> Result<Box<dyn crate::database::refresh::PreparedRefresh>, crate::database::RefreshHookError>
+    {
+        if !self.index.is_enabled() {
+            return Ok(Box::new(crate::database::refresh::NoopPreparedRefresh));
+        }
+
+        let mut ops = Vec::with_capacity(puts.len() + pre_read_deletes.len());
+        for (key, value) in puts {
+            if let Some(op) = index_replayed_document(key, value) {
+                ops.push(op);
+            }
+        }
+        for (key, _) in pre_read_deletes {
+            if let Some(op) = remove_replayed_document(key) {
+                ops.push(op);
+            }
+        }
+
+        Ok(Box::new(PendingSearchRefresh {
+            index: self.index.clone(),
+            ops,
+        }))
+    }
+
+    fn freeze_to_disk(&self, _db: &Database) -> StrataResult<()> {
         Ok(())
     }
 }

--- a/crates/engine/tests/follower_tests.rs
+++ b/crates/engine/tests/follower_tests.rs
@@ -1033,6 +1033,10 @@ fn test_admin_skip_after_hook_failure_makes_record_visible() {
         None,
         "storage apply must remain invisible until the blocked record is resolved"
     );
+    assert!(
+        dir.path().join("follower_state.json").exists(),
+        "blocked follower state must be persisted for restart recovery"
+    );
 
     follower
         .admin_skip_blocked_record(blocked_txn, "operator acknowledged hook failure")
@@ -1048,6 +1052,10 @@ fn test_admin_skip_after_hook_failure_makes_record_visible() {
     assert_eq!(
         recovered.applied_watermark, recovered.received_watermark,
         "skip should reconcile the watermarks for the skipped txn"
+    );
+    assert!(
+        !dir.path().join("follower_state.json").exists(),
+        "skip should clear the persisted blocked follower state"
     );
 
     let audit_log = std::fs::read_to_string(dir.path().join("follower_audit.log")).unwrap();

--- a/crates/engine/tests/follower_tests.rs
+++ b/crates/engine/tests/follower_tests.rs
@@ -8,9 +8,13 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use strata_core::types::{BranchId, Key, Namespace};
 use strata_core::value::Value;
+use strata_core::JsonValue;
 use strata_engine::database::OpenSpec;
-use strata_engine::Database;
-use strata_engine::SearchSubsystem;
+use strata_engine::search::Searchable;
+use strata_engine::{
+    Database, JsonStore, NoopPreparedRefresh, PreparedRefresh, RefreshHook, RefreshHookError,
+    RefreshHooks, SearchRequest, SearchSubsystem, Subsystem,
+};
 use tempfile::tempdir;
 
 fn ns(branch: BranchId) -> Arc<Namespace> {
@@ -48,6 +52,67 @@ fn read_kv(db: &Database, branch: BranchId, key: &str) -> Option<String> {
         Ok(Some(other)) => Some(format!("{:?}", other)),
         Ok(None) => None,
         Err(e) => panic!("read_kv failed unexpectedly: {}", e),
+    }
+}
+
+#[derive(Clone)]
+struct FailOnceRefreshSubsystem {
+    fail_once: Arc<AtomicBool>,
+}
+
+impl FailOnceRefreshSubsystem {
+    fn new(fail_once: Arc<AtomicBool>) -> Self {
+        Self { fail_once }
+    }
+}
+
+struct FailOnceRefreshHook {
+    fail_once: Arc<AtomicBool>,
+}
+
+impl RefreshHook for FailOnceRefreshHook {
+    fn name(&self) -> &'static str {
+        "test-fail-once"
+    }
+
+    fn pre_delete_read(&self, _db: &Database, _deletes: &[Key]) -> Vec<(Key, Vec<u8>)> {
+        Vec::new()
+    }
+
+    fn apply_refresh(
+        &self,
+        puts: &[(Key, Value)],
+        _pre_read_deletes: &[(Key, Vec<u8>)],
+    ) -> Result<Box<dyn PreparedRefresh>, RefreshHookError> {
+        if !puts.is_empty() && self.fail_once.swap(false, Ordering::SeqCst) {
+            return Err(RefreshHookError::new(
+                "test-fail-once",
+                "injected refresh hook failure",
+            ));
+        }
+        Ok(Box::new(NoopPreparedRefresh))
+    }
+
+    fn freeze_to_disk(&self, _db: &Database) -> strata_core::StrataResult<()> {
+        Ok(())
+    }
+}
+
+impl Subsystem for FailOnceRefreshSubsystem {
+    fn name(&self) -> &'static str {
+        "fail-once-refresh"
+    }
+
+    fn recover(&self, _db: &Arc<Database>) -> strata_core::StrataResult<()> {
+        Ok(())
+    }
+
+    fn initialize(&self, db: &Arc<Database>) -> strata_core::StrataResult<()> {
+        let hooks = db.extension::<RefreshHooks>()?;
+        hooks.register(Arc::new(FailOnceRefreshHook {
+            fail_once: self.fail_once.clone(),
+        }));
+        Ok(())
     }
 }
 
@@ -132,7 +197,10 @@ fn test_follower_refresh_sees_new_data() {
     // After refresh, follower sees the new data
     let outcome = follower.refresh();
     assert!(outcome.is_caught_up(), "refresh should catch up");
-    assert!(outcome.applied_count() > 0, "refresh should apply new records");
+    assert!(
+        outcome.applied_count() > 0,
+        "refresh should apply new records"
+    );
     assert_eq!(read_kv(&follower, branch, "k2").as_deref(), Some("v2"));
 
     // Original data still intact after refresh
@@ -145,6 +213,71 @@ fn test_follower_refresh_sees_new_data() {
         outcome2.applied_count(),
         0,
         "refresh with no new WAL records should return 0"
+    );
+}
+
+#[test]
+fn test_follower_refresh_updates_json_search_index() {
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+
+    let primary =
+        Database::open_runtime(OpenSpec::primary(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+    let follower =
+        Database::open_runtime(OpenSpec::follower(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+
+    let primary_json = JsonStore::new(primary.clone());
+    let follower_json = JsonStore::new(follower.clone());
+    let req = SearchRequest::new(branch, "supremacy").with_space("tenant_a");
+
+    primary_json
+        .create(
+            &branch,
+            "tenant_a",
+            "doc1",
+            JsonValue::from_value(serde_json::json!({
+                "title": "breakthrough quantum supremacy result"
+            })),
+        )
+        .unwrap();
+    primary.flush().unwrap();
+
+    let before = follower_json.search(&req).unwrap();
+    assert!(
+        before.hits.is_empty(),
+        "follower search should lag until refresh applies the WAL"
+    );
+
+    let first_refresh = follower.refresh();
+    assert!(first_refresh.is_caught_up(), "refresh should catch up");
+    assert!(
+        first_refresh.applied_count() > 0,
+        "refresh should replay the JSON create transaction"
+    );
+
+    let after_create = follower_json.search(&req).unwrap();
+    assert_eq!(
+        after_create.hits.len(),
+        1,
+        "follower refresh should index JSON docs via the search refresh hook"
+    );
+
+    primary_json.destroy(&branch, "tenant_a", "doc1").unwrap();
+    primary.flush().unwrap();
+
+    let second_refresh = follower.refresh();
+    assert!(second_refresh.is_caught_up(), "refresh should catch up");
+    assert!(
+        second_refresh.applied_count() > 0,
+        "refresh should replay the JSON delete transaction"
+    );
+
+    let after_delete = follower_json.search(&req).unwrap();
+    assert!(
+        after_delete.hits.is_empty(),
+        "follower refresh should remove deleted JSON docs from the search index"
     );
 }
 
@@ -235,7 +368,11 @@ fn test_follower_multiple_refreshes() {
 
         let outcome = follower.refresh();
         assert!(outcome.is_caught_up(), "round {} should catch up", i);
-        assert!(outcome.applied_count() > 0, "round {} should apply records", i);
+        assert!(
+            outcome.applied_count() > 0,
+            "round {} should apply records",
+            i
+        );
         assert_eq!(
             read_kv(&follower, branch, &key).as_deref(),
             Some(val.as_str()),
@@ -448,12 +585,20 @@ fn test_refresh_on_non_follower_returns_zero() {
             .unwrap();
     let outcome = primary.refresh();
     assert!(outcome.is_caught_up());
-    assert_eq!(outcome.applied_count(), 0, "refresh on non-follower should be a no-op");
+    assert_eq!(
+        outcome.applied_count(),
+        0,
+        "refresh on non-follower should be a no-op"
+    );
 
     let cache = Database::open_runtime(OpenSpec::cache().with_subsystem(SearchSubsystem)).unwrap();
     let outcome = cache.refresh();
     assert!(outcome.is_caught_up());
-    assert_eq!(outcome.applied_count(), 0, "refresh on cache should be a no-op");
+    assert_eq!(
+        outcome.applied_count(),
+        0,
+        "refresh on cache should be a no-op"
+    );
 }
 
 // ============================================================================
@@ -743,7 +888,10 @@ fn test_follower_status_basic() {
 
     // Initial status: caught up, not blocked
     let status = follower.follower_status();
-    assert!(!status.is_blocked(), "follower should not be blocked initially");
+    assert!(
+        !status.is_blocked(),
+        "follower should not be blocked initially"
+    );
     assert!(!status.refresh_in_progress, "no refresh in progress");
     // applied and received should be equal after recovery
     assert_eq!(
@@ -828,6 +976,274 @@ fn test_admin_skip_rejects_when_not_blocked() {
 }
 
 #[test]
+fn test_admin_skip_after_hook_failure_makes_record_visible() {
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+    let fail_once = Arc::new(AtomicBool::new(true));
+
+    let primary = Database::open_runtime(
+        OpenSpec::primary(dir.path())
+            .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+    )
+    .unwrap();
+    primary_put(&primary, branch, "base", "v1");
+    primary.flush().unwrap();
+
+    let follower = Database::open_runtime(
+        OpenSpec::follower(dir.path()).with_subsystem(FailOnceRefreshSubsystem::new(fail_once)),
+    )
+    .unwrap();
+
+    primary_put(&primary, branch, "blocked", "v2");
+    primary.flush().unwrap();
+
+    let outcome = follower.refresh();
+    let blocked_txn = match outcome {
+        strata_engine::RefreshOutcome::Stuck {
+            applied,
+            applied_through,
+            blocked_at,
+        } => {
+            assert_eq!(applied, 0, "hook failure should block before advancement");
+            assert_eq!(
+                blocked_at.reason.to_string(),
+                "test-fail-once hook failed: injected refresh hook failure"
+            );
+            assert_eq!(
+                applied_through,
+                follower.follower_status().applied_watermark,
+                "stuck outcome must report the last contiguously applied txn"
+            );
+            blocked_at.txn_id
+        }
+        other => panic!("expected refresh to get stuck, got {:?}", other),
+    };
+
+    let blocked_status = follower.follower_status();
+    assert!(
+        blocked_status.is_blocked(),
+        "follower should report blocked"
+    );
+    assert!(
+        blocked_status.received_watermark > blocked_status.applied_watermark,
+        "received watermark should move ahead of applied on hook failure"
+    );
+    assert_eq!(
+        read_kv(&follower, branch, "blocked"),
+        None,
+        "storage apply must remain invisible until the blocked record is resolved"
+    );
+
+    follower
+        .admin_skip_blocked_record(blocked_txn, "operator acknowledged hook failure")
+        .unwrap();
+
+    assert_eq!(
+        read_kv(&follower, branch, "blocked").as_deref(),
+        Some("v2"),
+        "admin skip must make a post-storage blocked record visible"
+    );
+    let recovered = follower.follower_status();
+    assert!(!recovered.is_blocked(), "skip should clear blocked state");
+    assert_eq!(
+        recovered.applied_watermark, recovered.received_watermark,
+        "skip should reconcile the watermarks for the skipped txn"
+    );
+
+    let audit_log = std::fs::read_to_string(dir.path().join("follower_audit.log")).unwrap();
+    assert!(
+        audit_log.contains(&format!("txn_id={}", blocked_txn.as_u64())),
+        "durable audit log must include the skipped txn id"
+    );
+}
+
+#[test]
+fn test_blocked_follower_state_survives_restart() {
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+    let fail_once = Arc::new(AtomicBool::new(true));
+
+    let primary = Database::open_runtime(
+        OpenSpec::primary(dir.path())
+            .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+    )
+    .unwrap();
+    primary_put(&primary, branch, "base", "v1");
+    primary.flush().unwrap();
+
+    let follower = Database::open_runtime(
+        OpenSpec::follower(dir.path())
+            .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+    )
+    .unwrap();
+
+    primary_put(&primary, branch, "blocked_after_restart", "v2");
+    primary.flush().unwrap();
+
+    let blocked_txn = match follower.refresh() {
+        strata_engine::RefreshOutcome::Stuck { blocked_at, .. } => blocked_at.txn_id,
+        other => panic!("expected blocked refresh before restart, got {:?}", other),
+    };
+    assert_eq!(
+        read_kv(&follower, branch, "blocked_after_restart"),
+        None,
+        "blocked record must remain invisible before restart"
+    );
+
+    drop(follower);
+
+    let reopened = Database::open_runtime(
+        OpenSpec::follower(dir.path()).with_subsystem(FailOnceRefreshSubsystem::new(fail_once)),
+    )
+    .unwrap();
+
+    let status = reopened.follower_status();
+    assert!(status.is_blocked(), "blocked follower state must persist");
+    assert_eq!(
+        status.blocked_at.as_ref().map(|blocked| blocked.txn_id),
+        Some(blocked_txn),
+        "reopened follower must report the same blocked txn"
+    );
+    assert_eq!(
+        read_kv(&reopened, branch, "blocked_after_restart"),
+        None,
+        "reopened blocked follower must keep the record invisible"
+    );
+    assert!(
+        matches!(
+            reopened.refresh(),
+            strata_engine::RefreshOutcome::NoProgress { .. }
+        ),
+        "blocked follower must stay blocked until operator action"
+    );
+
+    reopened
+        .admin_skip_blocked_record(blocked_txn, "verify blocked follower restart durability")
+        .unwrap();
+    assert_eq!(
+        read_kv(&reopened, branch, "blocked_after_restart").as_deref(),
+        Some("v2"),
+        "admin skip after restart must restore visibility"
+    );
+}
+
+#[test]
+fn test_blocked_follower_restart_keeps_search_state_clamped() {
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+    let fail_once = Arc::new(AtomicBool::new(true));
+
+    let primary = Database::open_runtime(
+        OpenSpec::primary(dir.path())
+            .with_subsystem(SearchSubsystem)
+            .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+    )
+    .unwrap();
+    let follower = Database::open_runtime(
+        OpenSpec::follower(dir.path())
+            .with_subsystem(SearchSubsystem)
+            .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+    )
+    .unwrap();
+
+    let primary_json = JsonStore::new(primary.clone());
+    let follower_json = JsonStore::new(follower.clone());
+    let req = SearchRequest::new(branch, "restartblocked").with_space("tenant_a");
+
+    primary_json
+        .create(
+            &branch,
+            "tenant_a",
+            "doc1",
+            JsonValue::from_value(serde_json::json!({
+                "title": "restartblocked must stay invisible across restart"
+            })),
+        )
+        .unwrap();
+    primary.flush().unwrap();
+
+    assert!(
+        matches!(
+            follower.refresh(),
+            strata_engine::RefreshOutcome::Stuck { .. }
+        ),
+        "refresh should block before making the document visible"
+    );
+    assert!(
+        follower_json.search(&req).unwrap().hits.is_empty(),
+        "blocked search updates must remain invisible before restart"
+    );
+
+    drop(follower);
+    primary.shutdown().unwrap();
+    drop(primary);
+
+    let reopened = Database::open_runtime(
+        OpenSpec::follower(dir.path())
+            .with_subsystem(SearchSubsystem)
+            .with_subsystem(FailOnceRefreshSubsystem::new(Arc::new(AtomicBool::new(
+                false,
+            )))),
+    )
+    .unwrap();
+    let reopened_json = JsonStore::new(reopened);
+
+    assert!(
+        reopened_json.search(&req).unwrap().hits.is_empty(),
+        "follower reopen must not rebuild blocked search docs from newer primary caches"
+    );
+}
+
+#[test]
+fn test_search_refresh_does_not_leak_before_visibility_advance() {
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+    let fail_once = Arc::new(AtomicBool::new(true));
+
+    let primary = Database::open_runtime(
+        OpenSpec::primary(dir.path())
+            .with_subsystem(SearchSubsystem)
+            .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+    )
+    .unwrap();
+    let follower = Database::open_runtime(
+        OpenSpec::follower(dir.path())
+            .with_subsystem(SearchSubsystem)
+            .with_subsystem(FailOnceRefreshSubsystem::new(fail_once)),
+    )
+    .unwrap();
+
+    let primary_json = JsonStore::new(primary.clone());
+    let follower_json = JsonStore::new(follower.clone());
+    let req = SearchRequest::new(branch, "blockedterm").with_space("tenant_a");
+
+    primary_json
+        .create(
+            &branch,
+            "tenant_a",
+            "doc1",
+            JsonValue::from_value(serde_json::json!({
+                "title": "blockedterm should stay invisible while refresh is stuck"
+            })),
+        )
+        .unwrap();
+    primary.flush().unwrap();
+
+    match follower.refresh() {
+        strata_engine::RefreshOutcome::Stuck { .. } => {}
+        other => panic!(
+            "expected refresh to get stuck after search staging, got {:?}",
+            other
+        ),
+    }
+
+    assert!(
+        follower_json.search(&req).unwrap().hits.is_empty(),
+        "staged BM25 updates must not leak before visibility advance"
+    );
+}
+
+#[test]
 fn test_concurrent_refresh_serialized() {
     use std::thread;
 
@@ -865,9 +1281,9 @@ fn test_concurrent_refresh_serialized() {
 
     let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
 
-    // At most one refresh should have applied records; others should return 0
-    // (either because they couldn't acquire the gate, or because records were
-    // already applied by the first refresher)
+    // Single-flight refresh means exactly one caller should apply the unseen
+    // WAL records. The rest should wait, then observe that the follower is
+    // already caught up.
     let total_applied: usize = results.iter().map(|r| r.applied_count()).sum();
     let non_zero_count = results.iter().filter(|r| r.applied_count() > 0).count();
 
@@ -877,13 +1293,14 @@ fn test_concurrent_refresh_serialized() {
         "all refreshes should report caught up"
     );
 
-    // The total records applied should be exactly the number of new records,
-    // not duplicated across threads
     assert!(
-        non_zero_count <= 1 || total_applied <= 100,
-        "concurrent refreshes should not duplicate work: {} threads applied records, total {}",
+        non_zero_count <= 1,
+        "single-flight refresh should have only one caller apply records, saw {}",
         non_zero_count,
-        total_applied
+    );
+    assert_eq!(
+        total_applied, 100,
+        "concurrent refreshes should apply each unseen record exactly once"
     );
 
     // Verify all data is visible

--- a/crates/engine/tests/follower_tests.rs
+++ b/crates/engine/tests/follower_tests.rs
@@ -130,17 +130,20 @@ fn test_follower_refresh_sees_new_data() {
     assert_eq!(read_kv(&follower, branch, "k2"), None);
 
     // After refresh, follower sees the new data
-    let applied = follower.refresh().unwrap();
-    assert!(applied > 0, "refresh should apply new records");
+    let outcome = follower.refresh();
+    assert!(outcome.is_caught_up(), "refresh should catch up");
+    assert!(outcome.applied_count() > 0, "refresh should apply new records");
     assert_eq!(read_kv(&follower, branch, "k2").as_deref(), Some("v2"));
 
     // Original data still intact after refresh
     assert_eq!(read_kv(&follower, branch, "k1").as_deref(), Some("v1"));
 
     // Second refresh with no new data returns 0
-    let applied2 = follower.refresh().unwrap();
+    let outcome2 = follower.refresh();
+    assert!(outcome2.is_caught_up());
     assert_eq!(
-        applied2, 0,
+        outcome2.applied_count(),
+        0,
         "refresh with no new WAL records should return 0"
     );
 }
@@ -168,7 +171,8 @@ fn test_follower_refresh_sees_updates_to_existing_keys() {
     primary_put(&primary, branch, "key", "updated");
     primary.flush().unwrap();
 
-    follower.refresh().unwrap();
+    let outcome = follower.refresh();
+    assert!(outcome.is_caught_up());
     assert_eq!(
         read_kv(&follower, branch, "key").as_deref(),
         Some("updated"),
@@ -199,7 +203,8 @@ fn test_follower_refresh_sees_deletes() {
     primary_del(&primary, branch, "ephemeral");
     primary.flush().unwrap();
 
-    follower.refresh().unwrap();
+    let outcome = follower.refresh();
+    assert!(outcome.is_caught_up());
     assert_eq!(
         read_kv(&follower, branch, "ephemeral"),
         None,
@@ -228,8 +233,9 @@ fn test_follower_multiple_refreshes() {
         primary_put(&primary, branch, &key, &val);
         primary.flush().unwrap();
 
-        let applied = follower.refresh().unwrap();
-        assert!(applied > 0, "round {} should apply records", i);
+        let outcome = follower.refresh();
+        assert!(outcome.is_caught_up(), "round {} should catch up", i);
+        assert!(outcome.applied_count() > 0, "round {} should apply records", i);
         assert_eq!(
             read_kv(&follower, branch, &key).as_deref(),
             Some(val.as_str()),
@@ -313,8 +319,9 @@ fn test_follower_with_empty_wal() {
     assert_eq!(read_kv(&follower, branch, "anything"), None);
 
     // Refresh on empty WAL is a no-op
-    let applied = follower.refresh().unwrap();
-    assert_eq!(applied, 0);
+    let outcome = follower.refresh();
+    assert!(outcome.is_caught_up());
+    assert_eq!(outcome.applied_count(), 0);
 }
 
 #[test]
@@ -362,7 +369,8 @@ fn test_follower_multiple_followers() {
     primary.flush().unwrap();
 
     // Only f1 refreshes
-    f1.refresh().unwrap();
+    let outcome = f1.refresh();
+    assert!(outcome.is_caught_up());
     assert_eq!(
         read_kv(&f1, branch, "new_key").as_deref(),
         Some("new_value")
@@ -372,7 +380,8 @@ fn test_follower_multiple_followers() {
     assert_eq!(read_kv(&f3, branch, "new_key"), None);
 
     // Now f2 refreshes
-    f2.refresh().unwrap();
+    let outcome = f2.refresh();
+    assert!(outcome.is_caught_up());
     assert_eq!(
         read_kv(&f2, branch, "new_key").as_deref(),
         Some("new_value")
@@ -437,12 +446,14 @@ fn test_refresh_on_non_follower_returns_zero() {
     let primary =
         Database::open_runtime(OpenSpec::primary(dir.path()).with_subsystem(SearchSubsystem))
             .unwrap();
-    let result = primary.refresh().unwrap();
-    assert_eq!(result, 0, "refresh on non-follower should be a no-op");
+    let outcome = primary.refresh();
+    assert!(outcome.is_caught_up());
+    assert_eq!(outcome.applied_count(), 0, "refresh on non-follower should be a no-op");
 
     let cache = Database::open_runtime(OpenSpec::cache().with_subsystem(SearchSubsystem)).unwrap();
-    let result = cache.refresh().unwrap();
-    assert_eq!(result, 0, "refresh on cache should be a no-op");
+    let outcome = cache.refresh();
+    assert!(outcome.is_caught_up());
+    assert_eq!(outcome.applied_count(), 0, "refresh on cache should be a no-op");
 }
 
 // ============================================================================
@@ -557,7 +568,8 @@ fn test_issue_1707_refresh_atomic_visibility() {
 
     // Give readers a moment to start, then refresh
     std::thread::sleep(std::time::Duration::from_millis(5));
-    follower.refresh().unwrap();
+    let outcome = follower.refresh();
+    assert!(outcome.is_caught_up());
 
     // Let readers run a bit after refresh to capture any lagging partial state
     std::thread::sleep(std::time::Duration::from_millis(10));
@@ -681,7 +693,8 @@ fn test_issue_1707_refresh_atomic_concurrent() {
         .collect();
 
     std::thread::sleep(std::time::Duration::from_millis(5));
-    follower.refresh().unwrap();
+    let outcome = follower.refresh();
+    assert!(outcome.is_caught_up());
 
     std::thread::sleep(std::time::Duration::from_millis(10));
     stop.store(true, Ordering::Relaxed);
@@ -705,4 +718,181 @@ fn test_issue_1707_refresh_atomic_concurrent() {
         "Concurrent reader observed mixed transaction state during refresh — \
          atomicity violation (ARCH-002)"
     );
+}
+
+// ============================================================================
+// Follower status and admin skip tests (T3-E3)
+// ============================================================================
+
+#[test]
+fn test_follower_status_basic() {
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+
+    // Primary writes initial data
+    let primary =
+        Database::open_runtime(OpenSpec::primary(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+    primary_put(&primary, branch, "k1", "v1");
+    primary.flush().unwrap();
+
+    // Open follower
+    let follower =
+        Database::open_runtime(OpenSpec::follower(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+
+    // Initial status: caught up, not blocked
+    let status = follower.follower_status();
+    assert!(!status.is_blocked(), "follower should not be blocked initially");
+    assert!(!status.refresh_in_progress, "no refresh in progress");
+    // applied and received should be equal after recovery
+    assert_eq!(
+        status.applied_watermark, status.received_watermark,
+        "watermarks should match after recovery"
+    );
+
+    // Primary writes more data
+    primary_put(&primary, branch, "k2", "v2");
+    primary.flush().unwrap();
+
+    // Before refresh: status reflects not caught up (once we check WAL)
+    let outcome = follower.refresh();
+    assert!(outcome.is_caught_up());
+
+    // After refresh: status shows new watermarks
+    let status2 = follower.follower_status();
+    assert!(!status2.is_blocked());
+    assert!(
+        status2.applied_watermark >= status.applied_watermark,
+        "applied watermark should advance after refresh"
+    );
+}
+
+#[test]
+fn test_follower_status_on_non_follower() {
+    let dir = tempdir().unwrap();
+
+    let primary =
+        Database::open_runtime(OpenSpec::primary(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+
+    // Primary should still be able to get follower_status (returns zero watermarks)
+    let status = primary.follower_status();
+    // We expect TxnId::ZERO or the recovered max_txn_id; either way, should not panic
+    assert!(!status.is_blocked());
+    assert!(!status.refresh_in_progress);
+}
+
+#[test]
+fn test_admin_skip_rejects_non_follower() {
+    let dir = tempdir().unwrap();
+
+    let primary =
+        Database::open_runtime(OpenSpec::primary(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+
+    // admin_skip should fail on non-follower
+    use strata_core::id::TxnId;
+    use strata_engine::UnblockError;
+
+    let result = primary.admin_skip_blocked_record(TxnId(1), "test skip");
+    assert!(matches!(result, Err(UnblockError::NotFollower)));
+}
+
+#[test]
+fn test_admin_skip_rejects_when_not_blocked() {
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+
+    // Primary writes data
+    let primary =
+        Database::open_runtime(OpenSpec::primary(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+    primary_put(&primary, branch, "k1", "v1");
+    primary.flush().unwrap();
+
+    // Open follower - should catch up without issues
+    let follower =
+        Database::open_runtime(OpenSpec::follower(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+
+    // Verify follower is not blocked
+    assert!(!follower.follower_status().is_blocked());
+
+    // admin_skip should fail when not blocked
+    use strata_core::id::TxnId;
+    use strata_engine::UnblockError;
+
+    let result = follower.admin_skip_blocked_record(TxnId(1), "test skip");
+    assert!(matches!(result, Err(UnblockError::NotBlocked)));
+}
+
+#[test]
+fn test_concurrent_refresh_serialized() {
+    use std::thread;
+
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+
+    // Primary writes data
+    let primary =
+        Database::open_runtime(OpenSpec::primary(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+    for i in 0..100 {
+        primary_put(&primary, branch, &format!("k{}", i), &format!("v{}", i));
+    }
+    primary.flush().unwrap();
+
+    // Open follower
+    let follower = Arc::new(
+        Database::open_runtime(OpenSpec::follower(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap(),
+    );
+
+    // Write more data that follower hasn't seen
+    for i in 100..200 {
+        primary_put(&primary, branch, &format!("k{}", i), &format!("v{}", i));
+    }
+    primary.flush().unwrap();
+
+    // Spawn multiple threads trying to refresh concurrently
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let f = follower.clone();
+            thread::spawn(move || f.refresh())
+        })
+        .collect();
+
+    let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    // At most one refresh should have applied records; others should return 0
+    // (either because they couldn't acquire the gate, or because records were
+    // already applied by the first refresher)
+    let total_applied: usize = results.iter().map(|r| r.applied_count()).sum();
+    let non_zero_count = results.iter().filter(|r| r.applied_count() > 0).count();
+
+    // All should report caught up
+    assert!(
+        results.iter().all(|r| r.is_caught_up()),
+        "all refreshes should report caught up"
+    );
+
+    // The total records applied should be exactly the number of new records,
+    // not duplicated across threads
+    assert!(
+        non_zero_count <= 1 || total_applied <= 100,
+        "concurrent refreshes should not duplicate work: {} threads applied records, total {}",
+        non_zero_count,
+        total_applied
+    );
+
+    // Verify all data is visible
+    for i in 0..200 {
+        assert_eq!(
+            read_kv(&follower, branch, &format!("k{}", i)).as_deref(),
+            Some(format!("v{}", i).as_str()),
+            "key k{} should be visible after refresh",
+            i
+        );
+    }
 }

--- a/crates/executor/src/tests/lifecycle_regression.rs
+++ b/crates/executor/src/tests/lifecycle_regression.rs
@@ -176,11 +176,15 @@ fn test_strata_follower_observes_primary_vector_writes_via_refresh() {
     // vector replay observer to be installed on the follower, which only
     // happens if `VectorSubsystem::initialize` ran during follower open —
     // which only happens if the production follower spec installed it.
-    let applied = follower.database().refresh().unwrap();
+    let outcome = follower.database().refresh();
     assert!(
-        applied > 0,
+        outcome.is_caught_up(),
+        "follower refresh should have caught up"
+    );
+    assert!(
+        outcome.applied_count() > 0,
         "follower refresh should have applied WAL records for the new vector, got {}",
-        applied
+        outcome.applied_count()
     );
 
     // Query for the "later" vector on the follower — must see it.

--- a/crates/graph/src/branch_dag.rs
+++ b/crates/graph/src/branch_dag.rs
@@ -904,8 +904,9 @@ impl strata_engine::Subsystem for GraphSubsystem {
         });
         db.branch_op_observers().register(audit_observer);
 
-        // Register commit and replay observers for graph index maintenance.
-        // T2-E5: moves graph index maintenance to subsystem-owned observers.
+        // Register commit/abort observers and the follower refresh hook for
+        // graph index maintenance. T2-E5/E3 move graph index maintenance into
+        // subsystem-owned lifecycle wiring.
         let state = db
             .extension::<crate::GraphBackendState>()
             .map_err(|e| StrataError::internal(format!("failed to get GraphBackendState: {e}")))?;

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -62,7 +62,8 @@ impl GraphStore {
     /// This returns the shared `GraphBackendState` stored in the Database.
     /// All GraphStore instances for the same Database share this state.
     ///
-    /// Also ensures runtime wiring (commit/replay observers) is registered.
+    /// Also ensures runtime wiring (commit/abort observers and follower refresh
+    /// hooks) is registered.
     pub fn state(&self) -> StrataResult<Arc<GraphBackendState>> {
         let state = self
             .db
@@ -200,6 +201,7 @@ impl strata_engine::search::Searchable for GraphStore {
         use strata_engine::search::{EntityRef, InvertedIndex, SearchHit, SearchStats};
 
         let start = Instant::now();
+        let _refresh_guard = self.db.refresh_query_guard();
         let index = self.db.extension::<InvertedIndex>()?;
 
         if !index.is_enabled() || index.total_docs() == 0 {

--- a/crates/graph/src/store.rs
+++ b/crates/graph/src/store.rs
@@ -9,7 +9,8 @@
 //! Graph index operations (BM25 search indexing) cannot participate in OCC
 //! because the inverted index is an in-memory structure that isn't rollback-safe.
 //! Operations are queued during transactions and applied after successful commit
-//! by `GraphCommitObserver`.
+//! by `GraphCommitObserver`. Followers apply the same graph-specific search
+//! maintenance through `GraphRefreshHook` during `Database::refresh()`.
 //!
 //! ## Thread Safety
 //!
@@ -151,19 +152,20 @@ fn apply_staged_graph_op(graph_store: &crate::GraphStore, op: StagedGraphOp) {
 }
 
 // =============================================================================
-// Commit and Replay Observers
+// Commit Observers and Refresh Hooks
 // =============================================================================
 
 use std::sync::Weak;
 use strata_engine::database::observers::{
     AbortInfo, AbortObserver, CommitInfo, CommitObserver, ObserverError,
 };
-use strata_engine::Database;
+use strata_engine::{Database, RefreshHook, RefreshHookError};
 
 /// Ensure runtime hooks are wired for this database instance.
 ///
-/// This is called from `GraphSubsystem::initialize()` to register commit and
-/// replay observers. Uses atomic flag to ensure idempotent registration.
+/// This is called from `GraphSubsystem::initialize()` to register commit/abort
+/// observers and the follower refresh hook. Uses atomic flag to ensure
+/// idempotent registration.
 pub fn ensure_runtime_wiring(db: &Arc<Database>, state: &Arc<GraphBackendState>) {
     use std::sync::atomic::Ordering;
 
@@ -181,10 +183,12 @@ pub fn ensure_runtime_wiring(db: &Arc<Database>, state: &Arc<GraphBackendState>)
     });
     db.abort_observers().register(abort_observer);
 
-    let replay_observer = Arc::new(GraphReplayObserver {
+    let refresh_hook = Arc::new(GraphRefreshHook {
         db: Arc::downgrade(db),
     });
-    db.replay_observers().register(replay_observer);
+    if let Ok(hooks) = db.extension::<strata_engine::RefreshHooks>() {
+        hooks.register(refresh_hook);
+    }
 }
 
 /// Observer that applies pending graph index operations after commit.
@@ -252,106 +256,163 @@ impl AbortObserver for GraphAbortObserver {
     }
 }
 
-/// Observer that updates graph search index during follower replay.
+fn parse_graph_node_key(key: &strata_core::types::Key) -> Result<Option<(String, String)>, String> {
+    use strata_core::types::TypeTag;
+
+    if key.type_tag != TypeTag::Graph {
+        return Ok(None);
+    }
+
+    let user_key = key
+        .user_key_string()
+        .ok_or_else(|| "graph key is not valid UTF-8".to_string())?;
+    let parts: Vec<&str> = user_key.splitn(3, '/').collect();
+    if parts.len() != 3 || parts[1] != "n" {
+        return Ok(None);
+    }
+
+    Ok(Some((parts[0].to_string(), parts[2].to_string())))
+}
+
+fn decode_graph_node_data(
+    value: &strata_core::value::Value,
+) -> Result<crate::types::NodeData, String> {
+    use strata_core::value::Value;
+
+    let Value::String(json) = value else {
+        return Err("graph node payload stored as non-string value".to_string());
+    };
+
+    serde_json::from_str(json).map_err(|e| format!("failed to decode graph node payload: {e}"))
+}
+
+/// Refresh hook that updates graph search index during follower replay.
 ///
-/// When a follower replays WAL records, it needs to update the BM25 index
-/// for any graph nodes that were added or removed.
-struct GraphReplayObserver {
+/// Graph node indexing semantics live in `GraphStore::index_node_for_search`.
+/// Followers must use the same path instead of the generic search hook so
+/// replay stays consistent with primary commit-time indexing.
+struct GraphRefreshHook {
     db: Weak<Database>,
 }
 
-use strata_engine::database::observers::{ReplayInfo, ReplayObserver};
+enum GraphRefreshOp {
+    Index {
+        branch_id: strata_core::types::BranchId,
+        space: String,
+        graph: String,
+        node_id: String,
+        data: crate::types::NodeData,
+    },
+    Remove {
+        branch_id: strata_core::types::BranchId,
+        space: String,
+        graph: String,
+        node_id: String,
+    },
+}
 
-impl ReplayObserver for GraphReplayObserver {
+struct PendingGraphRefresh {
+    graph_store: crate::GraphStore,
+    ops: Vec<GraphRefreshOp>,
+}
+
+impl strata_engine::PreparedRefresh for PendingGraphRefresh {
+    fn publish(self: Box<Self>) {
+        for op in self.ops {
+            match op {
+                GraphRefreshOp::Index {
+                    branch_id,
+                    space,
+                    graph,
+                    node_id,
+                    data,
+                } => {
+                    self.graph_store
+                        .index_node_for_search(branch_id, &space, &graph, &node_id, &data);
+                }
+                GraphRefreshOp::Remove {
+                    branch_id,
+                    space,
+                    graph,
+                    node_id,
+                } => {
+                    self.graph_store
+                        .deindex_node_for_search(branch_id, &space, &graph, &node_id);
+                }
+            }
+        }
+    }
+}
+
+impl RefreshHook for GraphRefreshHook {
     fn name(&self) -> &'static str {
         "graph"
     }
 
-    fn on_replay(&self, info: &ReplayInfo) -> Result<(), ObserverError> {
+    fn pre_delete_read(
+        &self,
+        _db: &Database,
+        deletes: &[strata_core::types::Key],
+    ) -> Vec<(strata_core::types::Key, Vec<u8>)> {
+        use strata_core::types::TypeTag;
+
+        deletes
+            .iter()
+            .filter(|key| key.type_tag == TypeTag::Graph)
+            .cloned()
+            .map(|key| (key, Vec::new()))
+            .collect()
+    }
+
+    fn apply_refresh(
+        &self,
+        puts: &[(strata_core::types::Key, strata_core::value::Value)],
+        pre_read_deletes: &[(strata_core::types::Key, Vec<u8>)],
+    ) -> Result<Box<dyn strata_engine::PreparedRefresh>, RefreshHookError> {
         let Some(db) = self.db.upgrade() else {
-            return Ok(());
+            return Ok(Box::new(strata_engine::NoopPreparedRefresh));
         };
+        let graph_store = crate::GraphStore::new(db);
+        let mut ops = Vec::with_capacity(puts.len() + pre_read_deletes.len());
 
-        // Apply graph index updates for replayed graph node changes.
-        apply_replayed_graph_changes(&db, &info.puts, &info.deleted_values);
+        for (key, value) in puts {
+            let Some((graph, node_id)) =
+                parse_graph_node_key(key).map_err(|e| RefreshHookError::new("graph", e))?
+            else {
+                continue;
+            };
 
+            let data =
+                decode_graph_node_data(value).map_err(|e| RefreshHookError::new("graph", e))?;
+            ops.push(GraphRefreshOp::Index {
+                branch_id: key.namespace.branch_id,
+                space: key.namespace.space.to_string(),
+                graph,
+                node_id,
+                data,
+            });
+        }
+
+        for (key, _) in pre_read_deletes {
+            let Some((graph, node_id)) =
+                parse_graph_node_key(key).map_err(|e| RefreshHookError::new("graph", e))?
+            else {
+                continue;
+            };
+
+            ops.push(GraphRefreshOp::Remove {
+                branch_id: key.namespace.branch_id,
+                space: key.namespace.space.to_string(),
+                graph,
+                node_id,
+            });
+        }
+
+        Ok(Box::new(PendingGraphRefresh { graph_store, ops }))
+    }
+
+    fn freeze_to_disk(&self, _db: &Database) -> strata_core::StrataResult<()> {
         Ok(())
-    }
-}
-
-/// Apply graph index updates from replayed WAL records.
-///
-/// Scans the puts and deletes for graph node keys and updates the BM25 index.
-/// Graph nodes are identified by their key format: `{graph}/n/{node_id}`.
-/// Nodes can be in ANY space (user-defined or system `_graph_`).
-fn apply_replayed_graph_changes(
-    db: &Arc<Database>,
-    puts: &[(strata_core::types::Key, strata_core::value::Value)],
-    deleted_values: &[(strata_core::types::Key, strata_core::value::Value)],
-) {
-    use strata_core::types::TypeTag;
-    use strata_core::value::Value;
-
-    let graph_store = crate::GraphStore::new(db.clone());
-
-    // Index new/updated graph nodes
-    for (key, value) in puts {
-        // Graph nodes are stored with TypeTag::Graph with key format: "{graph}/n/{node_id}"
-        if key.type_tag != TypeTag::Graph {
-            continue;
-        }
-
-        let user_key = match key.user_key_string() {
-            Some(s) => s,
-            None => continue,
-        };
-
-        // Parse key format: "{graph}/n/{node_id}"
-        // Only process keys that match the graph node pattern.
-        let parts: Vec<&str> = user_key.splitn(3, '/').collect();
-        if parts.len() != 3 || parts[1] != "n" {
-            continue;
-        }
-        let graph = parts[0];
-        let node_id = parts[2];
-
-        // Deserialize node data from JSON string
-        let json_str = match value {
-            Value::String(s) => s,
-            _ => continue,
-        };
-        let data: crate::types::NodeData = match serde_json::from_str(json_str) {
-            Ok(d) => d,
-            Err(_) => continue,
-        };
-
-        let branch_id = key.namespace.branch_id;
-        let space = key.namespace.space.as_str();
-        graph_store.index_node_for_search(branch_id, space, graph, node_id, &data);
-    }
-
-    // Deindex deleted graph nodes
-    for (key, _value) in deleted_values {
-        if key.type_tag != TypeTag::Graph {
-            continue;
-        }
-
-        let user_key = match key.user_key_string() {
-            Some(s) => s,
-            None => continue,
-        };
-
-        // Parse key format: "{graph}/n/{node_id}"
-        let parts: Vec<&str> = user_key.splitn(3, '/').collect();
-        if parts.len() != 3 || parts[1] != "n" {
-            continue;
-        }
-        let graph = parts[0];
-        let node_id = parts[2];
-
-        let branch_id = key.namespace.branch_id;
-        let space = key.namespace.space.as_str();
-        graph_store.deindex_node_for_search(branch_id, space, graph, node_id);
     }
 }
 
@@ -359,9 +420,89 @@ fn apply_replayed_graph_changes(
 mod tests {
     use super::*;
     use crate::ext::GraphStoreExt;
+    use crate::types::NodeData;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
     use strata_core::types::BranchId;
     use strata_engine::database::OpenSpec;
-    use strata_engine::SearchSubsystem;
+    use strata_engine::search::EntityRef;
+    use strata_engine::search::Searchable;
+    use strata_engine::RefreshOutcome;
+    use strata_engine::{
+        Database, NoopPreparedRefresh, PreparedRefresh, RefreshHook, RefreshHookError,
+        RefreshHooks, SearchRequest, SearchSubsystem, Subsystem,
+    };
+
+    #[derive(Clone)]
+    struct FailOnceRefreshSubsystem {
+        fail_once: Arc<AtomicBool>,
+    }
+
+    impl FailOnceRefreshSubsystem {
+        fn new(fail_once: Arc<AtomicBool>) -> Self {
+            Self { fail_once }
+        }
+    }
+
+    struct FailOnceRefreshHook {
+        fail_once: Arc<AtomicBool>,
+    }
+
+    impl RefreshHook for FailOnceRefreshHook {
+        fn name(&self) -> &'static str {
+            "graph-test-fail-once"
+        }
+
+        fn pre_delete_read(
+            &self,
+            _db: &Database,
+            _deletes: &[strata_core::types::Key],
+        ) -> Vec<(strata_core::types::Key, Vec<u8>)> {
+            Vec::new()
+        }
+
+        fn apply_refresh(
+            &self,
+            puts: &[(strata_core::types::Key, strata_core::value::Value)],
+            _pre_read_deletes: &[(strata_core::types::Key, Vec<u8>)],
+        ) -> Result<Box<dyn PreparedRefresh>, RefreshHookError> {
+            if !puts.is_empty() && self.fail_once.swap(false, Ordering::SeqCst) {
+                return Err(RefreshHookError::new(
+                    "graph-test-fail-once",
+                    "injected refresh hook failure",
+                ));
+            }
+            Ok(Box::new(NoopPreparedRefresh))
+        }
+
+        fn freeze_to_disk(&self, _db: &Database) -> strata_core::StrataResult<()> {
+            Ok(())
+        }
+    }
+
+    impl Subsystem for FailOnceRefreshSubsystem {
+        fn name(&self) -> &'static str {
+            "graph-test-fail-once"
+        }
+
+        fn recover(&self, _db: &Arc<Database>) -> strata_core::StrataResult<()> {
+            Ok(())
+        }
+
+        fn initialize(&self, db: &Arc<Database>) -> strata_core::StrataResult<()> {
+            let hooks = db.extension::<RefreshHooks>()?;
+            hooks.register(Arc::new(FailOnceRefreshHook {
+                fail_once: self.fail_once.clone(),
+            }));
+            Ok(())
+        }
+    }
+
+    fn unique_test_dir(prefix: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("{prefix}-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
 
     #[test]
     fn test_manual_abort_clears_pending_graph_ops() {
@@ -398,5 +539,436 @@ mod tests {
             !state.pending_ops.contains_key(&txn_id),
             "abort should clear staged graph work via engine observers"
         );
+    }
+
+    #[test]
+    fn graph_refresh_indexes_follower_nodes_by_graph_semantics() {
+        let path = unique_test_dir("strata-graph-follower-refresh");
+
+        {
+            let primary = Database::open_runtime(
+                OpenSpec::primary(&path)
+                    .with_subsystem(SearchSubsystem)
+                    .with_subsystem(crate::GraphSubsystem),
+            )
+            .unwrap();
+            let follower = Database::open_runtime(
+                OpenSpec::follower(&path)
+                    .with_subsystem(SearchSubsystem)
+                    .with_subsystem(crate::GraphSubsystem),
+            )
+            .unwrap();
+
+            let branch_id = BranchId::new();
+            let space = "tenant_a";
+            let graph = "papers";
+            let node_id = "quasar-node";
+
+            let primary_graph = crate::GraphStore::new(primary.clone());
+            let follower_graph = crate::GraphStore::new(follower.clone());
+
+            primary_graph
+                .create_graph(branch_id, space, graph, None)
+                .unwrap();
+            primary_graph
+                .add_node(
+                    branch_id,
+                    space,
+                    graph,
+                    node_id,
+                    NodeData {
+                        entity_ref: None,
+                        object_type: Some("paper".to_string()),
+                        properties: Some(serde_json::json!({
+                            "title": "baseline indexing"
+                        })),
+                    },
+                )
+                .unwrap();
+            primary.flush().unwrap();
+
+            let req = SearchRequest::new(branch_id, "quasar").with_space(space);
+            assert!(
+                follower_graph.search(&req).unwrap().hits.is_empty(),
+                "follower search should remain stale before refresh"
+            );
+
+            let create_outcome = follower.refresh();
+            assert!(
+                matches!(
+                    create_outcome,
+                    RefreshOutcome::CaughtUp { applied, .. } if applied >= 1
+                ),
+                "expected follower refresh to apply graph records, got {create_outcome:?}"
+            );
+
+            let after_create = follower_graph.search(&req).unwrap();
+            assert_eq!(after_create.hits.len(), 1);
+            assert!(matches!(
+                &after_create.hits[0].doc_ref,
+                EntityRef::Graph { key, .. } if key == "papers/n/quasar-node"
+            ));
+
+            primary_graph
+                .remove_node(branch_id, space, graph, node_id)
+                .unwrap();
+            primary.flush().unwrap();
+
+            let delete_outcome = follower.refresh();
+            assert!(
+                matches!(
+                    delete_outcome,
+                    RefreshOutcome::CaughtUp { applied, .. } if applied >= 1
+                ),
+                "expected follower refresh to deindex deleted graph node, got {delete_outcome:?}"
+            );
+            assert!(
+                follower_graph.search(&req).unwrap().hits.is_empty(),
+                "deleted graph node should be removed from follower search index"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn graph_refresh_does_not_leak_before_visibility_advance() {
+        let path = unique_test_dir("strata-graph-follower-blocked");
+        let branch_id = BranchId::new();
+        let space = "tenant_a";
+        let fail_once = Arc::new(AtomicBool::new(false));
+
+        let primary = Database::open_runtime(
+            OpenSpec::primary(&path)
+                .with_subsystem(SearchSubsystem)
+                .with_subsystem(crate::GraphSubsystem)
+                .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+        )
+        .unwrap();
+        let follower = Database::open_runtime(
+            OpenSpec::follower(&path)
+                .with_subsystem(SearchSubsystem)
+                .with_subsystem(crate::GraphSubsystem)
+                .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+        )
+        .unwrap();
+
+        let primary_graph = crate::GraphStore::new(primary.clone());
+        let follower_graph = crate::GraphStore::new(follower.clone());
+        primary_graph
+            .create_graph(branch_id, space, "papers", None)
+            .unwrap();
+        primary.flush().unwrap();
+
+        fail_once.store(true, Ordering::SeqCst);
+        primary_graph
+            .add_node(
+                branch_id,
+                space,
+                "papers",
+                "quasar-node",
+                NodeData {
+                    entity_ref: None,
+                    object_type: Some("paper".to_string()),
+                    properties: Some(serde_json::json!({
+                        "title": "blocked graph refresh"
+                    })),
+                },
+            )
+            .unwrap();
+        primary.flush().unwrap();
+
+        let outcome = follower.refresh();
+        assert!(
+            matches!(outcome, RefreshOutcome::Stuck { .. }),
+            "graph refresh should block after staging graph index work"
+        );
+
+        let req = SearchRequest::new(branch_id, "quasar").with_space(space);
+        assert!(
+            follower_graph.search(&req).unwrap().hits.is_empty(),
+            "graph search must not expose blocked staged index updates"
+        );
+
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn graph_restart_keeps_blocked_search_state_clamped() {
+        let path = unique_test_dir("strata-graph-follower-restart-blocked");
+        let branch_id = BranchId::new();
+        let space = "tenant_a";
+        let fail_once = Arc::new(AtomicBool::new(false));
+
+        let primary = Database::open_runtime(
+            OpenSpec::primary(&path)
+                .with_subsystem(SearchSubsystem)
+                .with_subsystem(crate::GraphSubsystem)
+                .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+        )
+        .unwrap();
+        let follower = Database::open_runtime(
+            OpenSpec::follower(&path)
+                .with_subsystem(SearchSubsystem)
+                .with_subsystem(crate::GraphSubsystem)
+                .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+        )
+        .unwrap();
+
+        let primary_graph = crate::GraphStore::new(primary.clone());
+        let follower_graph = crate::GraphStore::new(follower.clone());
+        primary_graph
+            .create_graph(branch_id, space, "papers", None)
+            .unwrap();
+        primary.flush().unwrap();
+        let _ = follower.refresh();
+
+        fail_once.store(true, Ordering::SeqCst);
+        primary_graph
+            .add_node(
+                branch_id,
+                space,
+                "papers",
+                "restart-quasar",
+                NodeData {
+                    entity_ref: None,
+                    object_type: Some("paper".to_string()),
+                    properties: Some(serde_json::json!({
+                        "title": "restart quasar"
+                    })),
+                },
+            )
+            .unwrap();
+        primary.flush().unwrap();
+
+        assert!(
+            matches!(follower.refresh(), RefreshOutcome::Stuck { .. }),
+            "graph refresh should block before publishing the node"
+        );
+
+        let req = SearchRequest::new(branch_id, "quasar").with_space(space);
+        assert!(
+            follower_graph.search(&req).unwrap().hits.is_empty(),
+            "blocked graph node must remain invisible before restart"
+        );
+
+        drop(follower);
+        primary.shutdown().unwrap();
+        drop(primary);
+
+        let reopened = Database::open_runtime(
+            OpenSpec::follower(&path)
+                .with_subsystem(SearchSubsystem)
+                .with_subsystem(crate::GraphSubsystem)
+                .with_subsystem(FailOnceRefreshSubsystem::new(Arc::new(AtomicBool::new(
+                    false,
+                )))),
+        )
+        .unwrap();
+        let reopened_graph = crate::GraphStore::new(reopened);
+        assert!(
+            reopened_graph.search(&req).unwrap().hits.is_empty(),
+            "follower reopen must not load blocked graph docs from primary caches"
+        );
+
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn graph_search_recovery_rebuilds_node_id_text_on_slow_path() {
+        let path = unique_test_dir("strata-graph-recovery-slow");
+        let branch_id = BranchId::new();
+        let space = "tenant_a";
+
+        {
+            let db = Database::open_runtime(
+                OpenSpec::primary(&path)
+                    .with_subsystem(crate::GraphSubsystem)
+                    .with_subsystem(SearchSubsystem),
+            )
+            .unwrap();
+            let graph = crate::GraphStore::new(db.clone());
+
+            graph
+                .create_graph(branch_id, space, "papers", None)
+                .unwrap();
+            graph
+                .add_node(
+                    branch_id,
+                    space,
+                    "papers",
+                    "quasar-node",
+                    NodeData {
+                        entity_ref: None,
+                        object_type: Some("paper".to_string()),
+                        properties: Some(serde_json::json!({
+                            "title": "baseline indexing"
+                        })),
+                    },
+                )
+                .unwrap();
+            db.flush().unwrap();
+        }
+
+        let _ = std::fs::remove_dir_all(path.join("search"));
+
+        {
+            let db = Database::open_runtime(
+                OpenSpec::primary(&path)
+                    .with_subsystem(crate::GraphSubsystem)
+                    .with_subsystem(SearchSubsystem),
+            )
+            .unwrap();
+            let graph = crate::GraphStore::new(db);
+            let req = SearchRequest::new(branch_id, "quasar").with_space(space);
+            let response = graph.search(&req).unwrap();
+            assert_eq!(response.hits.len(), 1);
+            assert!(matches!(
+                &response.hits[0].doc_ref,
+                EntityRef::Graph { key, .. } if key == "papers/n/quasar-node"
+            ));
+        }
+
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn graph_search_recovery_fast_path_prunes_stale_graph_docs() {
+        let path = unique_test_dir("strata-graph-recovery-fast");
+        let branch_id = BranchId::new();
+        let space = "tenant_a";
+
+        {
+            let db = Database::open_runtime(
+                OpenSpec::primary(&path)
+                    .with_subsystem(crate::GraphSubsystem)
+                    .with_subsystem(SearchSubsystem),
+            )
+            .unwrap();
+            let graph = crate::GraphStore::new(db.clone());
+            graph
+                .create_graph(branch_id, space, "papers", None)
+                .unwrap();
+            graph
+                .add_node(
+                    branch_id,
+                    space,
+                    "papers",
+                    "real-node",
+                    NodeData {
+                        entity_ref: None,
+                        object_type: Some("paper".to_string()),
+                        properties: Some(serde_json::json!({
+                            "title": "baseline indexing"
+                        })),
+                    },
+                )
+                .unwrap();
+
+            let index = db.extension::<strata_engine::InvertedIndex>().unwrap();
+            index.index_document(
+                &EntityRef::Graph {
+                    branch_id,
+                    space: space.to_string(),
+                    key: "papers/n/ghost-node".to_string(),
+                },
+                "ghostterm",
+                None,
+            );
+            db.flush().unwrap();
+
+            let stale_req = SearchRequest::new(branch_id, "ghostterm").with_space(space);
+            assert_eq!(graph.search(&stale_req).unwrap().hits.len(), 1);
+        }
+
+        {
+            let db = Database::open_runtime(
+                OpenSpec::primary(&path)
+                    .with_subsystem(crate::GraphSubsystem)
+                    .with_subsystem(SearchSubsystem),
+            )
+            .unwrap();
+            let graph = crate::GraphStore::new(db);
+
+            let stale_req = SearchRequest::new(branch_id, "ghostterm").with_space(space);
+            assert!(
+                graph.search(&stale_req).unwrap().hits.is_empty(),
+                "fast-path recovery should remove graph docs that are not present in storage"
+            );
+
+            let real_req = SearchRequest::new(branch_id, "real").with_space(space);
+            let real_response = graph.search(&real_req).unwrap();
+            assert_eq!(real_response.hits.len(), 1);
+            assert!(matches!(
+                &real_response.hits[0].doc_ref,
+                EntityRef::Graph { key, .. } if key == "papers/n/real-node"
+            ));
+        }
+
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn graph_search_recovery_fast_path_is_noop_when_storage_is_unchanged() {
+        let path = unique_test_dir("strata-graph-recovery-fast-noop");
+        let branch_id = BranchId::new();
+        let space = "tenant_a";
+        let manifest_path = path.join("search").join("search.manifest");
+
+        {
+            let db = Database::open_runtime(
+                OpenSpec::primary(&path)
+                    .with_subsystem(crate::GraphSubsystem)
+                    .with_subsystem(SearchSubsystem),
+            )
+            .unwrap();
+            let graph = crate::GraphStore::new(db.clone());
+            graph
+                .create_graph(branch_id, space, "papers", None)
+                .unwrap();
+            graph
+                .add_node(
+                    branch_id,
+                    space,
+                    "papers",
+                    "quasar-node",
+                    NodeData {
+                        entity_ref: None,
+                        object_type: Some("paper".to_string()),
+                        properties: Some(serde_json::json!({
+                            "title": "baseline indexing"
+                        })),
+                    },
+                )
+                .unwrap();
+            db.flush().unwrap();
+        }
+
+        let modified_before = std::fs::metadata(&manifest_path)
+            .unwrap()
+            .modified()
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+
+        let reopened = Database::open_runtime(
+            OpenSpec::primary(&path)
+                .with_subsystem(crate::GraphSubsystem)
+                .with_subsystem(SearchSubsystem),
+        )
+        .unwrap();
+        let graph = crate::GraphStore::new(reopened);
+        let modified_after = std::fs::metadata(&manifest_path)
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        let req = SearchRequest::new(branch_id, "quasar").with_space(space);
+        assert_eq!(graph.search(&req).unwrap().hits.len(), 1);
+        assert_eq!(
+            modified_after, modified_before,
+            "fast-path recovery should not rewrite the manifest when graph storage is unchanged"
+        );
+
+        let _ = std::fs::remove_dir_all(path);
     }
 }

--- a/crates/vector/src/recovery.rs
+++ b/crates/vector/src/recovery.rs
@@ -39,7 +39,7 @@ use tracing::info;
 /// Recovery function for VectorStore
 ///
 /// Called by Database during startup to restore vector state from KV store.
-fn recover_vector_state(db: &Database) -> StrataResult<()> {
+fn recover_vector_state(db: &std::sync::Arc<Database>) -> StrataResult<()> {
     recover_from_db(db)?;
 
     // Register the lifecycle hook used for freeze-to-disk and merge reloads.
@@ -160,9 +160,11 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
     let snapshot_version = CommitVersion(db.storage().version());
     let mut stats = super::RecoveryStats::default();
     let data_dir = db.data_dir();
-    let use_mmap = !data_dir.as_os_str().is_empty();
-    // Followers must never write to the primary's data directory.
-    let can_write_disk = use_mmap && !db.is_follower();
+    // Followers can intentionally lag the primary's visible version when a
+    // blocked record survives restart. Do not trust the primary's persisted
+    // vector caches in that case; rebuild from the follower-visible KV snapshot.
+    let use_mmap = !data_dir.as_os_str().is_empty() && !db.is_follower();
+    let can_write_disk = use_mmap;
 
     // Iterate all branch_ids in storage
     for branch_id in db.storage().branch_ids() {
@@ -542,9 +544,7 @@ impl strata_engine::recovery::Subsystem for VectorSubsystem {
 // Vector Commit Observer
 // =============================================================================
 
-use strata_engine::database::observers::{
-    CommitInfo, CommitObserver, ObserverError, ReplayInfo, ReplayObserver,
-};
+use strata_engine::database::observers::{CommitInfo, CommitObserver, ObserverError};
 
 pub(crate) fn ensure_runtime_wiring(
     db: &std::sync::Arc<strata_engine::Database>,
@@ -571,11 +571,6 @@ pub(crate) fn ensure_runtime_wiring(
         db: Arc::downgrade(db),
     });
     db.abort_observers().register(abort_observer);
-
-    let replay_observer = Arc::new(VectorReplayObserver {
-        db: Arc::downgrade(db),
-    });
-    db.replay_observers().register(replay_observer);
 }
 
 /// Observer that applies pending HNSW backend operations after commit.
@@ -642,137 +637,12 @@ impl AbortObserver for VectorAbortObserver {
     }
 }
 
-struct VectorReplayObserver {
-    db: std::sync::Weak<strata_engine::Database>,
-}
-
-impl ReplayObserver for VectorReplayObserver {
-    fn name(&self) -> &'static str {
-        "vector"
-    }
-
-    fn on_replay(&self, info: &ReplayInfo) -> Result<(), ObserverError> {
-        let Some(db) = self.db.upgrade() else {
-            return Ok(());
-        };
-
-        if let Ok(state) = db.extension::<super::VectorBackendState>() {
-            apply_replayed_vector_changes(&state, &info.puts, &info.deleted_values);
-        }
-
-        Ok(())
-    }
-}
-
 // =============================================================================
 // Lifecycle Hook Implementation
 // =============================================================================
 
-fn apply_replayed_vector_changes(
-    state: &super::VectorBackendState,
-    puts: &[(strata_core::types::Key, strata_core::value::Value)],
-    deleted_values: &[(strata_core::types::Key, strata_core::value::Value)],
-) {
-    use strata_core::primitives::vector::{CollectionId, VectorId};
-    use strata_core::types::TypeTag;
-
-    for (key, value) in puts {
-        if key.type_tag != TypeTag::Vector {
-            continue;
-        }
-        let bytes = match value {
-            strata_core::value::Value::Bytes(b) => b,
-            _ => continue,
-        };
-        let record = match super::VectorRecord::from_bytes(bytes) {
-            Ok(r) => r,
-            Err(_) => continue,
-        };
-        let user_key_str = match key.user_key_string() {
-            Some(s) => s,
-            None => continue,
-        };
-        let (collection, vector_key) = match user_key_str.split_once('/') {
-            Some(pair) => pair,
-            None => continue,
-        };
-        let branch_id = key.namespace.branch_id;
-        let cid = CollectionId::new(branch_id, key.namespace.space.as_str(), collection);
-        let vid = VectorId::new(record.vector_id);
-
-        if let Some(mut backend) = state.backends.get_mut(&cid) {
-            if let Err(e) = backend.insert_with_timestamp(vid, &record.embedding, record.created_at)
-            {
-                tracing::warn!(
-                    target: "strata::refresh",
-                    collection = collection,
-                    vector_key = vector_key,
-                    error = %e,
-                    "Vector insert failed during replay"
-                );
-            }
-            backend.set_inline_meta(
-                vid,
-                super::types::InlineMeta {
-                    key: vector_key.to_string(),
-                    source_ref: record.source_ref.clone(),
-                },
-            );
-        } else {
-            tracing::debug!(
-                target: "strata::refresh",
-                collection = collection,
-                "Skipping vector insert for unknown collection (will be picked up on restart)"
-            );
-        }
-    }
-
-    for (key, value) in deleted_values {
-        if key.type_tag != TypeTag::Vector {
-            continue;
-        }
-        let bytes = match value {
-            strata_core::value::Value::Bytes(b) => b,
-            _ => continue,
-        };
-        let record = match super::VectorRecord::from_bytes(bytes) {
-            Ok(r) => r,
-            Err(_) => continue,
-        };
-        let user_key_str = match key.user_key_string() {
-            Some(s) => s,
-            None => continue,
-        };
-        let collection = match user_key_str.split_once('/') {
-            Some((coll, _)) => coll,
-            None => continue,
-        };
-        let branch_id = key.namespace.branch_id;
-        let cid = CollectionId::new(branch_id, key.namespace.space.as_str(), collection);
-        let vid = VectorId::new(record.vector_id);
-
-        if let Some(mut backend) = state.backends.get_mut(&cid) {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_micros() as u64)
-                .unwrap_or(0);
-            if let Err(e) = backend.delete_with_timestamp(vid, now) {
-                tracing::warn!(
-                    target: "strata::refresh",
-                    collection = collection,
-                    error = %e,
-                    "Vector delete failed during replay"
-                );
-            }
-            backend.remove_inline_meta(vid);
-        }
-    }
-}
-
 /// Register the vector lifecycle hook with the database.
-///
-/// This hook only owns freeze-to-disk and post-merge reload behaviors.
-fn register_vector_lifecycle_hook(db: &Database) {
+fn register_vector_lifecycle_hook(db: &std::sync::Arc<Database>) {
     use std::sync::Arc;
 
     let state = match db.extension::<super::VectorBackendState>() {
@@ -780,7 +650,10 @@ fn register_vector_lifecycle_hook(db: &Database) {
         Err(_) => return,
     };
 
-    let hook = Arc::new(VectorLifecycleHook { state });
+    let hook = Arc::new(VectorLifecycleHook {
+        state,
+        db: Arc::downgrade(db),
+    });
 
     if let Ok(hooks) = db.extension::<strata_engine::RefreshHooks>() {
         hooks.register(hook);
@@ -790,6 +663,97 @@ fn register_vector_lifecycle_hook(db: &Database) {
 /// Lifecycle hook implementation for vector backends.
 struct VectorLifecycleHook {
     state: std::sync::Arc<super::VectorBackendState>,
+    db: std::sync::Weak<strata_engine::Database>,
+}
+
+enum PendingVectorOp {
+    CreateCollection {
+        collection_id: crate::CollectionId,
+        backend_type: crate::IndexBackendType,
+        config: crate::VectorConfig,
+    },
+    UpsertVector {
+        collection_id: crate::CollectionId,
+        vector_id: strata_core::primitives::vector::VectorId,
+        vector_key: String,
+        embedding: Vec<f32>,
+        created_at: u64,
+        source_ref: Option<strata_core::EntityRef>,
+    },
+    DeleteVector {
+        collection_id: crate::CollectionId,
+        vector_id: strata_core::primitives::vector::VectorId,
+        deleted_at: u64,
+    },
+    DropCollection {
+        collection_id: crate::CollectionId,
+    },
+}
+
+struct PendingVectorRefresh {
+    state: std::sync::Arc<super::VectorBackendState>,
+    ops: Vec<PendingVectorOp>,
+}
+
+impl strata_engine::PreparedRefresh for PendingVectorRefresh {
+    fn publish(self: Box<Self>) {
+        use dashmap::mapref::entry::Entry;
+
+        for op in self.ops {
+            match op {
+                PendingVectorOp::CreateCollection {
+                    collection_id,
+                    backend_type,
+                    config,
+                } => match self.state.backends.entry(collection_id) {
+                    Entry::Occupied(_) => {}
+                    Entry::Vacant(entry) => {
+                        entry.insert(
+                            crate::IndexBackendFactory::from_type(backend_type).create(&config),
+                        );
+                    }
+                },
+                PendingVectorOp::UpsertVector {
+                    collection_id,
+                    vector_id,
+                    vector_key,
+                    embedding,
+                    created_at,
+                    source_ref,
+                } => {
+                    let mut backend =
+                        self.state.backends.get_mut(&collection_id).expect(
+                            "staged vector refresh missing collection backend during publish",
+                        );
+                    backend
+                        .insert_with_timestamp(vector_id, &embedding, created_at)
+                        .expect("validated staged vector refresh insert failed during publish");
+                    backend.set_inline_meta(
+                        vector_id,
+                        crate::types::InlineMeta {
+                            key: vector_key,
+                            source_ref,
+                        },
+                    );
+                }
+                PendingVectorOp::DeleteVector {
+                    collection_id,
+                    vector_id,
+                    deleted_at,
+                } => {
+                    if let Some(mut backend) = self.state.backends.get_mut(&collection_id) {
+                        backend
+                            .delete_with_timestamp(vector_id, deleted_at)
+                            .expect("validated staged vector refresh delete failed during publish");
+                        backend.remove_inline_meta(vector_id);
+                    }
+                }
+                PendingVectorOp::DropCollection { collection_id } => {
+                    self.state.backends.remove(&collection_id);
+                }
+            }
+        }
+    }
 }
 
 // Safety: VectorBackendState uses DashMap which is Send + Sync
@@ -803,19 +767,297 @@ impl strata_engine::RefreshHook for VectorLifecycleHook {
 
     fn pre_delete_read(
         &self,
-        _db: &strata_engine::Database,
-        _deletes: &[strata_core::types::Key],
+        db: &strata_engine::Database,
+        deletes: &[strata_core::types::Key],
     ) -> Vec<(strata_core::types::Key, Vec<u8>)> {
-        Vec::new()
+        use strata_core::traits::Storage;
+
+        deletes
+            .iter()
+            .filter(|key| key.type_tag == strata_core::types::TypeTag::Vector)
+            .map(|key| {
+                let bytes = db
+                    .storage()
+                    .get_versioned(key, CommitVersion::MAX)
+                    .ok()
+                    .and_then(|value| value)
+                    .and_then(|versioned| match versioned.value {
+                        strata_core::value::Value::Bytes(bytes) => Some(bytes),
+                        _ => None,
+                    })
+                    .unwrap_or_default();
+                (key.clone(), bytes)
+            })
+            .collect()
     }
 
     fn apply_refresh(
         &self,
-        _puts: &[(strata_core::types::Key, strata_core::value::Value)],
-        _pre_read_deletes: &[(strata_core::types::Key, Vec<u8>)],
-    ) -> Result<(), strata_engine::RefreshHookError> {
-        // Follower-side vector maintenance now lives in VectorReplayObserver.
-        Ok(())
+        puts: &[(strata_core::types::Key, strata_core::value::Value)],
+        pre_read_deletes: &[(strata_core::types::Key, Vec<u8>)],
+    ) -> Result<Box<dyn strata_engine::PreparedRefresh>, strata_engine::RefreshHookError> {
+        use strata_core::primitives::vector::{CollectionId, VectorId};
+        use strata_core::types::TypeTag;
+
+        let Some(db) = self.db.upgrade() else {
+            return Ok(Box::new(strata_engine::NoopPreparedRefresh));
+        };
+        let store = crate::VectorStore::new(db.clone());
+        let mut ops = Vec::with_capacity(puts.len() + pre_read_deletes.len());
+
+        for (key, value) in puts
+            .iter()
+            .filter(|(key, _)| key.type_tag == TypeTag::Vector)
+        {
+            let Some(user_key) = key.user_key_string() else {
+                return Err(strata_engine::RefreshHookError::new(
+                    "vector",
+                    "vector key is not valid UTF-8",
+                ));
+            };
+
+            if let Some(collection_name) = user_key.strip_prefix("__config__/") {
+                let bytes = match value {
+                    strata_core::value::Value::Bytes(bytes) => bytes,
+                    _ => {
+                        return Err(strata_engine::RefreshHookError::new(
+                            "vector",
+                            format!(
+                                "collection config {} stored non-bytes payload during refresh",
+                                collection_name
+                            ),
+                        ))
+                    }
+                };
+                let record = crate::CollectionRecord::from_bytes(bytes).map_err(|e| {
+                    strata_engine::RefreshHookError::new(
+                        "vector",
+                        format!(
+                            "failed to decode collection config {}: {}",
+                            collection_name, e
+                        ),
+                    )
+                })?;
+                let config = crate::VectorConfig::try_from(record.config.clone()).map_err(|e| {
+                    strata_engine::RefreshHookError::new(
+                        "vector",
+                        format!("failed to decode config {}: {}", collection_name, e),
+                    )
+                })?;
+                let backend_type = record.backend_type();
+                let collection_id = CollectionId::new(
+                    key.namespace.branch_id,
+                    key.namespace.space.as_str(),
+                    collection_name,
+                );
+
+                ops.push(PendingVectorOp::CreateCollection {
+                    collection_id,
+                    backend_type,
+                    config,
+                });
+                continue;
+            }
+        }
+
+        for (key, value) in puts
+            .iter()
+            .filter(|(key, _)| key.type_tag == TypeTag::Vector)
+        {
+            let Some(user_key) = key.user_key_string() else {
+                return Err(strata_engine::RefreshHookError::new(
+                    "vector",
+                    "vector key is not valid UTF-8",
+                ));
+            };
+            if user_key.starts_with("__config__/") {
+                continue;
+            }
+
+            let (collection_name, vector_key) = user_key.split_once('/').ok_or_else(|| {
+                strata_engine::RefreshHookError::new(
+                    "vector",
+                    format!("invalid vector key format during refresh: {}", user_key),
+                )
+            })?;
+
+            store
+                .ensure_collection_loaded(
+                    key.namespace.branch_id,
+                    key.namespace.space.as_str(),
+                    collection_name,
+                )
+                .map_err(|e| {
+                    strata_engine::RefreshHookError::new(
+                        "vector",
+                        format!(
+                            "failed to load collection {} in space {}: {}",
+                            collection_name, key.namespace.space, e
+                        ),
+                    )
+                })?;
+
+            let bytes = match value {
+                strata_core::value::Value::Bytes(bytes) => bytes,
+                _ => {
+                    return Err(strata_engine::RefreshHookError::new(
+                        "vector",
+                        format!(
+                            "vector payload {} stored non-bytes value during refresh",
+                            user_key
+                        ),
+                    ))
+                }
+            };
+            let record = crate::VectorRecord::from_bytes(bytes).map_err(|e| {
+                strata_engine::RefreshHookError::new(
+                    "vector",
+                    format!("failed to decode vector {}: {}", user_key, e),
+                )
+            })?;
+
+            if record.embedding.is_empty() {
+                continue;
+            }
+
+            let collection_id = CollectionId::new(
+                key.namespace.branch_id,
+                key.namespace.space.as_str(),
+                collection_name,
+            );
+            let vid = VectorId::new(record.vector_id);
+            let backend = self.state.backends.get(&collection_id).ok_or_else(|| {
+                strata_engine::RefreshHookError::new(
+                    "vector",
+                    format!(
+                        "collection {} in space {} is not loaded during refresh",
+                        collection_name, key.namespace.space
+                    ),
+                )
+            })?;
+            let expected_dim = backend.config().dimension;
+            drop(backend);
+            if record.embedding.len() != expected_dim {
+                return Err(strata_engine::RefreshHookError::new(
+                    "vector",
+                    format!(
+                        "failed to insert vector {} into {}: dimension mismatch (expected {}, got {})",
+                        vector_key,
+                        collection_name,
+                        expected_dim,
+                        record.embedding.len()
+                    ),
+                ));
+            }
+            ops.push(PendingVectorOp::UpsertVector {
+                collection_id,
+                vector_id: vid,
+                vector_key: vector_key.to_string(),
+                embedding: record.embedding.clone(),
+                created_at: record.created_at,
+                source_ref: record.source_ref.clone(),
+            });
+        }
+
+        for (key, bytes) in pre_read_deletes
+            .iter()
+            .filter(|(key, _)| key.type_tag == TypeTag::Vector)
+        {
+            let Some(user_key) = key.user_key_string() else {
+                return Err(strata_engine::RefreshHookError::new(
+                    "vector",
+                    "deleted vector key is not valid UTF-8",
+                ));
+            };
+            if user_key.starts_with("__config__/") || bytes.is_empty() {
+                continue;
+            }
+
+            let (collection_name, _) = user_key.split_once('/').ok_or_else(|| {
+                strata_engine::RefreshHookError::new(
+                    "vector",
+                    format!(
+                        "invalid deleted vector key format during refresh: {}",
+                        user_key
+                    ),
+                )
+            })?;
+
+            store
+                .ensure_collection_loaded(
+                    key.namespace.branch_id,
+                    key.namespace.space.as_str(),
+                    collection_name,
+                )
+                .map_err(|e| {
+                    strata_engine::RefreshHookError::new(
+                        "vector",
+                        format!(
+                            "failed to load collection {} in space {}: {}",
+                            collection_name, key.namespace.space, e
+                        ),
+                    )
+                })?;
+
+            let record = crate::VectorRecord::from_bytes(bytes).map_err(|e| {
+                strata_engine::RefreshHookError::new(
+                    "vector",
+                    format!("failed to decode deleted vector {}: {}", user_key, e),
+                )
+            })?;
+            let collection_id = CollectionId::new(
+                key.namespace.branch_id,
+                key.namespace.space.as_str(),
+                collection_name,
+            );
+            let vid = VectorId::new(record.vector_id);
+            self.state.backends.get(&collection_id).ok_or_else(|| {
+                strata_engine::RefreshHookError::new(
+                    "vector",
+                    format!(
+                        "collection {} in space {} is not loaded during refresh delete",
+                        collection_name, key.namespace.space
+                    ),
+                )
+            })?;
+
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_micros() as u64)
+                .unwrap_or(0);
+            ops.push(PendingVectorOp::DeleteVector {
+                collection_id,
+                vector_id: vid,
+                deleted_at: now,
+            });
+        }
+
+        for (key, _) in pre_read_deletes
+            .iter()
+            .filter(|(key, _)| key.type_tag == TypeTag::Vector)
+        {
+            let Some(user_key) = key.user_key_string() else {
+                return Err(strata_engine::RefreshHookError::new(
+                    "vector",
+                    "deleted vector key is not valid UTF-8",
+                ));
+            };
+            let Some(collection_name) = user_key.strip_prefix("__config__/") else {
+                continue;
+            };
+
+            let collection_id = CollectionId::new(
+                key.namespace.branch_id,
+                key.namespace.space.as_str(),
+                collection_name,
+            );
+            ops.push(PendingVectorOp::DropCollection { collection_id });
+        }
+
+        Ok(Box::new(PendingVectorRefresh {
+            state: self.state.clone(),
+            ops,
+        }))
     }
 
     fn freeze_to_disk(&self, db: &strata_engine::Database) -> strata_core::StrataResult<()> {
@@ -851,16 +1093,87 @@ impl strata_engine::RefreshHook for VectorLifecycleHook {
     // spaces. The handler iterates affected (space, collection) pairs
     // explicitly and avoids both problems.
     //
-    // `freeze_to_disk` remains lifecycle-owned here. Follower replay moved
-    // to `VectorReplayObserver`.
+    // `freeze_to_disk` remains lifecycle-owned here. Follower replay now runs
+    // through the fallible refresh hook so refresh only advances after HNSW
+    // state is consistent.
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{DistanceMetric, VectorStore};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
     use strata_engine::database::OpenSpec;
-    use strata_engine::Database;
+    use strata_engine::{
+        Database, NoopPreparedRefresh, PreparedRefresh, RefreshHook, RefreshHookError,
+        RefreshHooks, Subsystem,
+    };
+
+    #[derive(Clone)]
+    struct FailOnceRefreshSubsystem {
+        fail_once: Arc<AtomicBool>,
+    }
+
+    impl FailOnceRefreshSubsystem {
+        fn new(fail_once: Arc<AtomicBool>) -> Self {
+            Self { fail_once }
+        }
+    }
+
+    struct FailOnceRefreshHook {
+        fail_once: Arc<AtomicBool>,
+    }
+
+    impl RefreshHook for FailOnceRefreshHook {
+        fn name(&self) -> &'static str {
+            "vector-test-fail-once"
+        }
+
+        fn pre_delete_read(
+            &self,
+            _db: &Database,
+            _deletes: &[strata_core::types::Key],
+        ) -> Vec<(strata_core::types::Key, Vec<u8>)> {
+            Vec::new()
+        }
+
+        fn apply_refresh(
+            &self,
+            puts: &[(strata_core::types::Key, strata_core::value::Value)],
+            _pre_read_deletes: &[(strata_core::types::Key, Vec<u8>)],
+        ) -> Result<Box<dyn PreparedRefresh>, RefreshHookError> {
+            if !puts.is_empty() && self.fail_once.swap(false, Ordering::SeqCst) {
+                return Err(RefreshHookError::new(
+                    "vector-test-fail-once",
+                    "injected refresh hook failure",
+                ));
+            }
+            Ok(Box::new(NoopPreparedRefresh))
+        }
+
+        fn freeze_to_disk(&self, _db: &Database) -> strata_core::StrataResult<()> {
+            Ok(())
+        }
+    }
+
+    impl Subsystem for FailOnceRefreshSubsystem {
+        fn name(&self) -> &'static str {
+            "vector-test-fail-once"
+        }
+
+        fn recover(&self, _db: &Arc<Database>) -> strata_core::StrataResult<()> {
+            Ok(())
+        }
+
+        fn initialize(&self, db: &Arc<Database>) -> strata_core::StrataResult<()> {
+            let hooks = db.extension::<RefreshHooks>()?;
+            hooks.register(Arc::new(FailOnceRefreshHook {
+                fail_once: self.fail_once.clone(),
+            }));
+            Ok(())
+        }
+    }
 
     /// Two collections with the same `(branch, name)` in different
     /// spaces must produce distinct on-disk paths. Without this, the
@@ -1013,5 +1326,286 @@ mod tests {
             !branch_dir.exists(),
             "branch delete must purge the entire branch cache tree, including orphan files"
         );
+    }
+
+    #[test]
+    fn test_follower_refresh_replays_collection_create_insert_and_delete() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let branch_id = strata_core::types::BranchId::default();
+
+        let primary =
+            Database::open_runtime(OpenSpec::primary(temp.path()).with_subsystem(VectorSubsystem))
+                .unwrap();
+        let primary_store = VectorStore::new(primary.clone());
+
+        let follower =
+            Database::open_runtime(OpenSpec::follower(temp.path()).with_subsystem(VectorSubsystem))
+                .unwrap();
+        let follower_store = VectorStore::new(follower.clone());
+
+        primary_store
+            .create_collection(
+                branch_id,
+                "default",
+                "embeddings",
+                crate::VectorConfig::new(3, DistanceMetric::Cosine).unwrap(),
+            )
+            .unwrap();
+        primary_store
+            .insert(
+                branch_id,
+                "default",
+                "embeddings",
+                "v1",
+                &[1.0, 0.0, 0.0],
+                None,
+            )
+            .unwrap();
+        primary.flush().unwrap();
+
+        let outcome = follower.refresh();
+        assert!(
+            outcome.is_caught_up(),
+            "follower refresh should apply collection creation and vector insert"
+        );
+
+        let matches = follower_store
+            .search(
+                branch_id,
+                "default",
+                "embeddings",
+                &[1.0, 0.0, 0.0],
+                5,
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            matches.len(),
+            1,
+            "inserted vector must be searchable after refresh"
+        );
+        assert_eq!(matches[0].key, "v1");
+        assert!(
+            follower_store
+                .get_collection(branch_id, "default", "embeddings")
+                .unwrap()
+                .is_some(),
+            "collection create must load a backend on the follower"
+        );
+
+        primary_store
+            .delete(branch_id, "default", "embeddings", "v1")
+            .unwrap();
+        primary.flush().unwrap();
+
+        let outcome = follower.refresh();
+        assert!(
+            outcome.is_caught_up(),
+            "follower refresh should apply vector delete"
+        );
+
+        let matches = follower_store
+            .search(
+                branch_id,
+                "default",
+                "embeddings",
+                &[1.0, 0.0, 0.0],
+                5,
+                None,
+            )
+            .unwrap();
+        assert!(
+            matches.is_empty(),
+            "deleted vector must be removed from follower search results"
+        );
+    }
+
+    #[test]
+    fn test_vector_refresh_does_not_perturb_visible_results_before_visibility_advance() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let branch_id = strata_core::types::BranchId::default();
+        let fail_once = Arc::new(AtomicBool::new(false));
+
+        let primary = Database::open_runtime(
+            OpenSpec::primary(temp.path())
+                .with_subsystem(VectorSubsystem)
+                .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+        )
+        .unwrap();
+        let primary_store = VectorStore::new(primary.clone());
+
+        primary_store
+            .create_collection(
+                branch_id,
+                "default",
+                "embeddings",
+                crate::VectorConfig::new(3, DistanceMetric::Cosine).unwrap(),
+            )
+            .unwrap();
+        primary_store
+            .insert(
+                branch_id,
+                "default",
+                "embeddings",
+                "visible-a",
+                &[1.0, 0.0, 0.0],
+                None,
+            )
+            .unwrap();
+        primary.flush().unwrap();
+
+        let follower = Database::open_runtime(
+            OpenSpec::follower(temp.path())
+                .with_subsystem(VectorSubsystem)
+                .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+        )
+        .unwrap();
+        let follower_store = VectorStore::new(follower.clone());
+
+        let baseline = follower_store
+            .search(
+                branch_id,
+                "default",
+                "embeddings",
+                &[0.0, 1.0, 0.0],
+                1,
+                None,
+            )
+            .unwrap();
+        assert_eq!(baseline.len(), 1);
+        assert_eq!(baseline[0].key, "visible-a");
+
+        fail_once.store(true, Ordering::SeqCst);
+        primary_store
+            .insert(
+                branch_id,
+                "default",
+                "embeddings",
+                "blocked-b",
+                &[0.0, 1.0, 0.0],
+                None,
+            )
+            .unwrap();
+        primary.flush().unwrap();
+
+        let outcome = follower.refresh();
+        assert!(
+            matches!(outcome, strata_engine::RefreshOutcome::Stuck { .. }),
+            "vector refresh should block after staging backend updates"
+        );
+
+        let after_block = follower_store
+            .search(
+                branch_id,
+                "default",
+                "embeddings",
+                &[0.0, 1.0, 0.0],
+                1,
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            after_block.len(),
+            1,
+            "blocked staged vectors must not displace visible results"
+        );
+        assert_eq!(
+            after_block[0].key, "visible-a",
+            "blocked staged vectors must remain invisible to readers"
+        );
+    }
+
+    #[test]
+    fn test_blocked_follower_restart_does_not_load_newer_vector_caches() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let branch_id = strata_core::types::BranchId::default();
+        let fail_once = Arc::new(AtomicBool::new(false));
+
+        let primary = Database::open_runtime(
+            OpenSpec::primary(temp.path())
+                .with_subsystem(VectorSubsystem)
+                .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+        )
+        .unwrap();
+        let primary_store = VectorStore::new(primary.clone());
+
+        primary_store
+            .create_collection(
+                branch_id,
+                "default",
+                "embeddings",
+                crate::VectorConfig::new(3, DistanceMetric::Cosine).unwrap(),
+            )
+            .unwrap();
+        primary_store
+            .insert(
+                branch_id,
+                "default",
+                "embeddings",
+                "visible-a",
+                &[1.0, 0.0, 0.0],
+                None,
+            )
+            .unwrap();
+        primary.flush().unwrap();
+
+        let follower = Database::open_runtime(
+            OpenSpec::follower(temp.path())
+                .with_subsystem(VectorSubsystem)
+                .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+        )
+        .unwrap();
+
+        fail_once.store(true, Ordering::SeqCst);
+        primary_store
+            .insert(
+                branch_id,
+                "default",
+                "embeddings",
+                "blocked-b",
+                &[0.0, 1.0, 0.0],
+                None,
+            )
+            .unwrap();
+        primary.flush().unwrap();
+
+        assert!(
+            matches!(
+                follower.refresh(),
+                strata_engine::RefreshOutcome::Stuck { .. }
+            ),
+            "refresh should block before making the new vector visible"
+        );
+
+        drop(follower);
+        primary.shutdown().unwrap();
+        drop(primary);
+
+        let reopened = Database::open_runtime(
+            OpenSpec::follower(temp.path())
+                .with_subsystem(VectorSubsystem)
+                .with_subsystem(FailOnceRefreshSubsystem::new(Arc::new(AtomicBool::new(
+                    false,
+                )))),
+        )
+        .unwrap();
+        let reopened_store = VectorStore::new(reopened);
+
+        let matches = reopened_store
+            .search(
+                branch_id,
+                "default",
+                "embeddings",
+                &[0.0, 1.0, 0.0],
+                1,
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            matches.len(),
+            1,
+            "follower reopen must not let blocked mmap-only vectors displace visible results"
+        );
+        assert_eq!(matches[0].key, "visible-a");
     }
 }

--- a/crates/vector/src/recovery.rs
+++ b/crates/vector/src/recovery.rs
@@ -797,6 +797,10 @@ unsafe impl Send for VectorLifecycleHook {}
 unsafe impl Sync for VectorLifecycleHook {}
 
 impl strata_engine::RefreshHook for VectorLifecycleHook {
+    fn name(&self) -> &'static str {
+        "vector"
+    }
+
     fn pre_delete_read(
         &self,
         _db: &strata_engine::Database,
@@ -809,8 +813,9 @@ impl strata_engine::RefreshHook for VectorLifecycleHook {
         &self,
         _puts: &[(strata_core::types::Key, strata_core::value::Value)],
         _pre_read_deletes: &[(strata_core::types::Key, Vec<u8>)],
-    ) {
+    ) -> Result<(), strata_engine::RefreshHookError> {
         // Follower-side vector maintenance now lives in VectorReplayObserver.
+        Ok(())
     }
 
     fn freeze_to_disk(&self, db: &strata_engine::Database) -> strata_core::StrataResult<()> {

--- a/crates/vector/src/recovery.rs
+++ b/crates/vector/src/recovery.rs
@@ -1608,4 +1608,107 @@ mod tests {
         );
         assert_eq!(matches[0].key, "visible-a");
     }
+
+    #[test]
+    fn test_blocked_follower_lazy_load_does_not_load_newer_vector_caches() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let branch_id = strata_core::types::BranchId::default();
+        let fail_once = Arc::new(AtomicBool::new(false));
+
+        let primary = Database::open_runtime(
+            OpenSpec::primary(temp.path())
+                .with_subsystem(VectorSubsystem)
+                .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+        )
+        .unwrap();
+        let primary_store = VectorStore::new(primary.clone());
+
+        primary_store
+            .create_collection(
+                branch_id,
+                "default",
+                "embeddings",
+                crate::VectorConfig::new(3, DistanceMetric::Cosine).unwrap(),
+            )
+            .unwrap();
+        primary_store
+            .insert(
+                branch_id,
+                "default",
+                "embeddings",
+                "visible-a",
+                &[1.0, 0.0, 0.0],
+                None,
+            )
+            .unwrap();
+        primary.flush().unwrap();
+
+        let follower = Database::open_runtime(
+            OpenSpec::follower(temp.path())
+                .with_subsystem(VectorSubsystem)
+                .with_subsystem(FailOnceRefreshSubsystem::new(fail_once.clone())),
+        )
+        .unwrap();
+
+        fail_once.store(true, Ordering::SeqCst);
+        primary_store
+            .insert(
+                branch_id,
+                "default",
+                "embeddings",
+                "blocked-b",
+                &[0.0, 1.0, 0.0],
+                None,
+            )
+            .unwrap();
+        primary.flush().unwrap();
+
+        assert!(
+            matches!(
+                follower.refresh(),
+                strata_engine::RefreshOutcome::Stuck { .. }
+            ),
+            "refresh should block before making the new vector visible"
+        );
+
+        drop(follower);
+        primary.shutdown().unwrap();
+        drop(primary);
+
+        let reopened = Database::open_runtime(
+            OpenSpec::follower(temp.path())
+                .with_subsystem(VectorSubsystem)
+                .with_subsystem(FailOnceRefreshSubsystem::new(Arc::new(AtomicBool::new(
+                    false,
+                )))),
+        )
+        .unwrap();
+        let reopened_store = VectorStore::new(reopened.clone());
+        let state = reopened.extension::<crate::VectorBackendState>().unwrap();
+        state.backends.clear();
+        assert!(
+            state.backends.is_empty(),
+            "test setup must force the lazy-load path instead of using recovered backends"
+        );
+
+        let matches = reopened_store
+            .search(
+                branch_id,
+                "default",
+                "embeddings",
+                &[0.0, 1.0, 0.0],
+                1,
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            matches.len(),
+            1,
+            "lazy-loaded follower collections must rebuild from visible KV state"
+        );
+        assert_eq!(
+            matches[0].key, "visible-a",
+            "lazy load must not pull blocked vectors from primary mmap caches"
+        );
+    }
 }

--- a/crates/vector/src/store/mod.rs
+++ b/crates/vector/src/store/mod.rs
@@ -4059,15 +4059,11 @@ mod tests {
             .create_collection(branch_id, "default", "emb", config)
             .unwrap();
 
-        // VectorStore registers commit+replay observers. SearchSubsystem also registers
-        // observers when present. Check that at least 1 observer exists (VectorStore's).
+        // VectorStore registers commit observers. Follower refresh is handled via
+        // RefreshHook (not ReplayObserver). Check that commit observer exists.
         assert!(
             !db.commit_observers().is_empty(),
             "VectorStore should register a commit observer"
-        );
-        assert!(
-            !db.replay_observers().is_empty(),
-            "VectorStore should register a replay observer"
         );
 
         let state = store.state().unwrap();
@@ -4096,7 +4092,6 @@ mod tests {
         let _ = store.state().unwrap();
         // Same as above: observers count includes SearchSubsystem observers
         assert!(!db.commit_observers().is_empty());
-        assert!(!db.replay_observers().is_empty());
     }
 
     #[test]

--- a/crates/vector/src/store/mod.rs
+++ b/crates/vector/src/store/mod.rs
@@ -308,7 +308,10 @@ impl VectorStore {
         let mut backend = self.create_backend_with_type(id, config, backend_type)?;
 
         let data_dir = self.db.data_dir();
-        let use_mmap = !data_dir.as_os_str().is_empty();
+        // Followers can reopen with storage intentionally clamped below the
+        // primary's latest durable caches. Keep lazy reload aligned with
+        // startup recovery and rebuild from the follower-visible KV snapshot.
+        let use_mmap = !data_dir.as_os_str().is_empty() && !self.db.is_follower();
 
         // Try mmap-accelerated reload (same logic as recover_from_db)
         let mut loaded_from_mmap = false;

--- a/crates/vector/src/store/search.rs
+++ b/crates/vector/src/store/search.rs
@@ -44,6 +44,7 @@ impl VectorStore {
         opts: SearchOptions,
     ) -> VectorResult<Vec<VectorMatch>> {
         let start = std::time::Instant::now();
+        let _refresh_guard = self.db.refresh_query_guard();
 
         // k=0 returns empty
         if k == 0 {
@@ -211,6 +212,7 @@ impl VectorStore {
         as_of_ts: u64,
     ) -> VectorResult<Vec<VectorMatch>> {
         let start = std::time::Instant::now();
+        let _refresh_guard = self.db.refresh_query_guard();
 
         // k=0 returns empty
         if k == 0 {
@@ -391,6 +393,7 @@ impl VectorStore {
         query: &[f32],
         k: usize,
     ) -> VectorResult<Vec<VectorMatchWithSource>> {
+        let _refresh_guard = self.db.refresh_query_guard();
         if k == 0 {
             return Ok(Vec::new());
         }
@@ -485,6 +488,7 @@ impl VectorStore {
         start_ts: u64,
         end_ts: u64,
     ) -> VectorResult<Vec<VectorMatchWithSource>> {
+        let _refresh_guard = self.db.refresh_query_guard();
         if k == 0 {
             return Ok(Vec::new());
         }
@@ -603,6 +607,7 @@ impl VectorStore {
         start_ts: u64,
         end_ts: u64,
     ) -> VectorResult<Vec<VectorMatchWithSource>> {
+        let _refresh_guard = self.db.refresh_query_guard();
         if k == 0 {
             return Ok(Vec::new());
         }
@@ -688,6 +693,7 @@ impl VectorStore {
         k: usize,
         as_of_ts: u64,
     ) -> VectorResult<Vec<VectorMatchWithSource>> {
+        let _refresh_guard = self.db.refresh_query_guard();
         if k == 0 {
             return Ok(Vec::new());
         }


### PR DESCRIPTION
## Summary

Make follower refresh contiguous, fallible, single-flight, and observable (T3-E3):

**Core refresh infrastructure:**
- Split watermark into received/applied with `ContiguousWatermark`
- Add `RefreshGate` (mutex-based) for single-flight refresh serialization
- Add `RefreshOutcome` enum (CaughtUp, Stuck, NoProgress)
- Add `FollowerStatus` and `admin_skip_blocked_record()` for observability

**Two-phase refresh pattern:**
- Add `PreparedRefresh` trait for staged publication
- Hooks validate/stage changes, engine publishes after watermark advances
- Prevents readers from observing pre-visibility derived state

**Contiguous WAL reading:**
- Add `read_all_after_watermark_contiguous` to report gaps and stop reasons
- `WatermarkBlockedRecord` captures txn_id, skip_allowed, stop_reason

**Blocked state persistence:**
- Add `follower_state.json` for crash recovery of blocked followers
- `BlockedTxnState` tracks visibility_version and skip_allowed flag
- `UnblockError::NotSkippable` for WAL gaps that cannot be skipped
- Proper fsync: write -> sync_all -> rename -> sync parent directory

**Subsystem refresh hooks:**
- `VectorLifecycleHook` returns `PreparedRefresh`, removes `VectorReplayObserver`
- `SearchRefreshHook` replaces inline BM25 updates in lifecycle.rs
- `GraphRefreshHook` replaces `GraphReplayObserver`
- Vector lazy-load on followers rebuilds from KV (not mmap cache)

## Test plan

- [x] 25 follower tests pass (5 new)
- [x] 331 vector tests pass (1 new)
- [x] 489 graph tests pass
- [x] New tests cover:
  - Blocked state persistence across restart
  - Search/vector visibility barriers
  - Admin skip after hook failure
  - JSON search index refresh
  - Lazy-load rebuilds from KV, not mmap

**Change class:** cutover
**Assurance class:** S4

Generated with [Claude Code](https://claude.com/claude-code)