### PR TITLE
feat(durability): T3-E5 Recovery Coordinator Extension (snapshot load + delta-WAL + sidecar rebuild)

### DIFF
--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -34,5 +34,8 @@ pub mod __internal {
 
 pub use manager::TransactionManager;
 pub use payload::TransactionPayload;
-pub use recovery::{RecoveryCoordinator, RecoveryPlan, RecoveryResult, RecoveryStats};
+pub use recovery::{
+    apply_wal_record_to_memory_storage, RecoveryCoordinator, RecoveryPlan, RecoveryResult,
+    RecoveryStats,
+};
 pub use transaction::{CommitError, JsonStoreExt, TransactionContext, TransactionStatus};

--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -34,5 +34,5 @@ pub mod __internal {
 
 pub use manager::TransactionManager;
 pub use payload::TransactionPayload;
-pub use recovery::{RecoveryCoordinator, RecoveryResult, RecoveryStats};
+pub use recovery::{RecoveryCoordinator, RecoveryPlan, RecoveryResult, RecoveryStats};
 pub use transaction::{CommitError, JsonStoreExt, TransactionContext, TransactionStatus};

--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -1523,7 +1523,7 @@ mod tests {
         // Drop WAL to flush buffers, then recover from disk
         drop(wal);
         let recovery = test_recovery(temp_dir.path());
-        let result = recovery.recover().unwrap();
+        let result = recovery.recover_into_memory_storage().unwrap();
 
         // Recovery should find exactly 1 transaction
         assert_eq!(result.stats.txns_replayed, 1);
@@ -1609,7 +1609,7 @@ mod tests {
         // Recover from WAL to verify all 10 records are well-formed
         drop(wal);
         let recovery = test_recovery(temp_dir.path());
-        let result = recovery.recover().unwrap();
+        let result = recovery.recover_into_memory_storage().unwrap();
         assert_eq!(result.stats.txns_replayed, num_threads);
         assert_eq!(
             result.stats.final_version,
@@ -1668,7 +1668,7 @@ mod tests {
         // T1 was aborted before WAL write, so its record must NOT be in WAL.
         drop(wal);
         let recovery = test_recovery(temp_dir.path());
-        let result = recovery.recover().unwrap();
+        let result = recovery.recover_into_memory_storage().unwrap();
         assert_eq!(
             result.stats.txns_replayed, 2,
             "Aborted txn must not appear in WAL"
@@ -1705,7 +1705,7 @@ mod tests {
         // WAL should be empty — no records written for read-only txn
         drop(wal);
         let recovery = test_recovery(temp_dir.path());
-        let result = recovery.recover().unwrap();
+        let result = recovery.recover_into_memory_storage().unwrap();
         assert_eq!(result.stats.txns_replayed, 0);
     }
 
@@ -1741,7 +1741,7 @@ mod tests {
         // WAL should have a record
         drop(wal);
         let recovery = test_recovery(temp_dir.path());
-        let rec_result = recovery.recover().unwrap();
+        let rec_result = recovery.recover_into_memory_storage().unwrap();
         assert_eq!(rec_result.stats.txns_replayed, 1);
     }
 
@@ -1806,7 +1806,7 @@ mod tests {
         // Recover from WAL and verify all operations replayed correctly
         drop(wal);
         let recovery = test_recovery(temp_dir.path());
-        let result = recovery.recover().unwrap();
+        let result = recovery.recover_into_memory_storage().unwrap();
         assert_eq!(result.stats.txns_replayed, 2);
 
         // key_a: was written in txn1 then deleted in txn2

--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -19,10 +19,11 @@ use crate::payload::TransactionPayload;
 use crate::TransactionManager;
 use strata_core::id::{CommitVersion, TxnId};
 use strata_core::{StrataError, StrataResult};
-use strata_durability::format::{WalRecord, WalSegment};
+use strata_durability::codec::{clone_codec, StorageCodec};
+use strata_durability::format::{snapshot_path, WalRecord, WalSegment};
 use strata_durability::layout::DatabaseLayout;
 use strata_durability::wal::WalReader;
-use strata_durability::{LoadedSnapshot, ManifestManager};
+use strata_durability::{LoadedSnapshot, ManifestManager, SnapshotReader};
 use strata_storage::SegmentedStore;
 use tracing::{info, warn};
 
@@ -101,6 +102,11 @@ pub struct RecoveryCoordinator {
     write_buffer_size: usize,
     /// When true, WAL reader scans past corrupted regions instead of erroring.
     allow_lossy_recovery: bool,
+    /// Storage codec used to decode snapshot payloads. When unset, the
+    /// coordinator skips snapshot loading — callers that stay on the legacy
+    /// `recover_into_memory_storage` wrapper preserve WAL-only behavior until
+    /// they migrate to the direct callback API with a codec wired in.
+    codec: Option<Box<dyn StorageCodec>>,
 }
 
 impl RecoveryCoordinator {
@@ -114,6 +120,7 @@ impl RecoveryCoordinator {
             layout,
             write_buffer_size,
             allow_lossy_recovery: false,
+            codec: None,
         }
     }
 
@@ -125,6 +132,14 @@ impl RecoveryCoordinator {
     /// Enable lossy WAL recovery (scan past corrupted regions).
     pub fn with_lossy_recovery(mut self, allow: bool) -> Self {
         self.allow_lossy_recovery = allow;
+        self
+    }
+
+    /// Install the storage codec used to load and validate snapshots during
+    /// recovery. When unset, `recover()` does not attempt to load snapshots
+    /// and `on_snapshot` never fires.
+    pub fn with_codec(mut self, codec: Box<dyn StorageCodec>) -> Self {
+        self.codec = Some(codec);
         self
     }
 
@@ -219,6 +234,53 @@ impl RecoveryCoordinator {
         })
     }
 
+    /// Read the MANIFEST and, if a snapshot is recorded, load and return it
+    /// after validating magic/CRC/codec via [`SnapshotReader`]. Returns
+    /// `Ok(None)` when the MANIFEST has no snapshot recorded or is absent.
+    ///
+    /// Codec validation runs at two layers:
+    /// 1. MANIFEST-level: `plan_recovery` rejects pre-WAL-read if the MANIFEST
+    ///    codec doesn't match the caller-installed codec.
+    /// 2. Snapshot-level: `SnapshotReader::load` rejects if the snapshot file's
+    ///    embedded codec id doesn't match. These should align when the
+    ///    MANIFEST and snapshot were written by the same process; snapshot
+    ///    codec mismatch is elevated to `StrataError::corruption` here.
+    fn load_snapshot_if_present(
+        &self,
+        codec: &dyn StorageCodec,
+    ) -> StrataResult<Option<LoadedSnapshot>> {
+        let plan = self.plan_recovery(codec.codec_id())?;
+        let snapshot_id = match plan.snapshot_id {
+            Some(id) => id,
+            None => return Ok(None),
+        };
+        let path = snapshot_path(self.layout.snapshots_dir(), snapshot_id);
+        if !path.exists() {
+            return Err(StrataError::corruption(format!(
+                "MANIFEST references snapshot {} but {} is missing",
+                snapshot_id,
+                path.display()
+            )));
+        }
+        let reader = SnapshotReader::new(clone_codec(codec));
+        let snapshot = reader.load(&path).map_err(|e| {
+            StrataError::corruption(format!(
+                "failed to load snapshot {} at {}: {}",
+                snapshot_id,
+                path.display(),
+                e
+            ))
+        })?;
+        info!(
+            target: "strata::recovery",
+            snapshot_id,
+            watermark = snapshot.watermark_txn(),
+            sections = snapshot.sections.len(),
+            "Loaded snapshot"
+        );
+        Ok(Some(snapshot))
+    }
+
     /// Drive recovery through caller-supplied callbacks.
     ///
     /// The engine owns storage construction; the coordinator only:
@@ -243,7 +305,7 @@ impl RecoveryCoordinator {
     /// is expected to surface it.
     pub fn recover<FS, FR>(
         self,
-        _on_snapshot: FS,
+        on_snapshot: FS,
         mut on_record: FR,
     ) -> StrataResult<RecoveryStats>
     where
@@ -254,8 +316,28 @@ impl RecoveryCoordinator {
         let mut max_version = 0u64;
         let mut max_txn_id = 0u64;
 
-        // Snapshot loading is wired in Epic 5 Chunk 2; until then the
-        // coordinator never fires `on_snapshot`.
+        // Snapshot loading: when the caller installed a codec via
+        // `with_codec()`, the coordinator consults the MANIFEST for a
+        // recorded snapshot and invokes `on_snapshot` with the decoded
+        // `LoadedSnapshot`. When no codec is installed, snapshot loading
+        // is skipped to preserve the pre-Epic-5 WAL-only behavior that the
+        // compat wrapper depends on.
+        //
+        // The snapshot's `watermark_txn` is the max TxnId covered by the
+        // snapshot and is folded into `max_txn_id` so the txn-id counter
+        // bootstraps above it. The snapshot's max *commit version* is not
+        // observable here — it lives inside the per-entry `version` fields
+        // the callback installs — so callers who need `stats.final_version`
+        // to include the snapshot must fold in their storage's post-install
+        // `current_version()` themselves. Doing that here would require
+        // the coordinator to reach into caller-owned state.
+        if let Some(codec) = self.codec.as_deref() {
+            if let Some(snapshot) = self.load_snapshot_if_present(codec)? {
+                stats.from_checkpoint = true;
+                max_txn_id = max_txn_id.max(snapshot.watermark_txn());
+                on_snapshot(snapshot)?;
+            }
+        }
 
         // If WAL dir doesn't exist, return an empty-replay plan.
         if !self.layout.wal_dir().exists() {
@@ -341,10 +423,16 @@ impl RecoveryCoordinator {
     }
 }
 
-/// Default WAL-record apply used by the legacy `recover_into_memory_storage`
-/// wrapper. Preserves `#1619` / `#1740` invariants: recovery uses the WAL
-/// record's commit timestamp and the payload's TTL, not now-based values.
-fn apply_wal_record_to_memory_storage(
+/// Apply a WAL record to `SegmentedStore` using recovery-specific write paths
+/// that preserve the original commit timestamp and the payload's TTL
+/// (`#1619` / `#1740`).
+///
+/// This is the default apply used by
+/// [`RecoveryCoordinator::recover_into_memory_storage`] and is exposed so
+/// engine open paths that drive the callback-driven [`RecoveryCoordinator::recover`]
+/// directly can reuse the exact same apply semantics in their `on_record`
+/// closure without duplicating the decode/apply ladder.
+pub fn apply_wal_record_to_memory_storage(
     storage: &SegmentedStore,
     record: &WalRecord,
 ) -> StrataResult<()> {
@@ -1499,7 +1587,10 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(snapshot_fired, 0, "on_snapshot must not fire in Chunk 1");
+        assert_eq!(
+            snapshot_fired, 0,
+            "on_snapshot must not fire without codec and snapshot"
+        );
         assert_eq!(record_txns, vec![1, 2, 3, 4, 5]);
         assert_eq!(stats.txns_replayed, 5);
         assert_eq!(stats.writes_applied, 5);
@@ -1710,5 +1801,123 @@ mod tests {
         assert_eq!(result.stats.deletes_applied, stats_b.deletes_applied);
         assert_eq!(result.stats.final_version, stats_b.final_version);
         assert_eq!(result.stats.max_txn_id, stats_b.max_txn_id);
+    }
+
+    // ========================================
+    // Epic 5 Chunk 2: coordinator snapshot loading
+    // ========================================
+
+    use strata_durability::disk_snapshot::{SnapshotSection, SnapshotWriter};
+    use strata_durability::format::primitive_tags;
+
+    /// Helper: seed a snapshot file and matching MANIFEST entry so the
+    /// coordinator's snapshot-loading path can find them.
+    fn seed_snapshot(layout: &DatabaseLayout, snapshot_id: u64, watermark: u64) {
+        std::fs::create_dir_all(layout.snapshots_dir()).unwrap();
+        let writer = SnapshotWriter::new(
+            layout.snapshots_dir().to_path_buf(),
+            Box::new(IdentityCodec),
+            [4u8; 16],
+        )
+        .unwrap();
+        // Minimal valid KV section (entry count = 0); coordinator only
+        // cares that the file loads cleanly.
+        let sections = vec![SnapshotSection::new(primitive_tags::KV, vec![0, 0, 0, 0])];
+        writer
+            .create_snapshot(snapshot_id, watermark, sections)
+            .unwrap();
+
+        let mut mgr = ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            [4u8; 16],
+            "identity".to_string(),
+        )
+        .unwrap();
+        mgr.set_snapshot_watermark(snapshot_id, TxnId(watermark))
+            .unwrap();
+    }
+
+    /// With a codec installed and a snapshot recorded in the MANIFEST, the
+    /// coordinator loads the snapshot, fires `on_snapshot` once with the
+    /// correct watermark, and reports `from_checkpoint = true`.
+    #[test]
+    fn test_recover_invokes_on_snapshot_when_codec_and_manifest_agree() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = test_layout(temp_dir.path());
+        seed_snapshot(&layout, 7, 42);
+
+        let coord = RecoveryCoordinator::new(layout, 0).with_codec(Box::new(IdentityCodec));
+
+        let mut snapshot_seen = Vec::<u64>::new();
+        let stats = coord
+            .recover(
+                |snapshot| {
+                    snapshot_seen.push(snapshot.watermark_txn());
+                    Ok(())
+                },
+                |_| Ok(()),
+            )
+            .unwrap();
+
+        assert_eq!(snapshot_seen, vec![42]);
+        assert!(stats.from_checkpoint);
+        assert_eq!(stats.max_txn_id, TxnId(42));
+        // The coordinator does not bump final_version from snapshot load —
+        // it stays at the max payload version seen in WAL replay (zero here).
+        assert_eq!(stats.final_version, CommitVersion::ZERO);
+    }
+
+    /// With a codec installed but no MANIFEST on disk, snapshot loading is
+    /// skipped silently and `on_snapshot` never fires.
+    #[test]
+    fn test_recover_skips_snapshot_when_manifest_absent() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = test_layout(temp_dir.path());
+
+        let coord = RecoveryCoordinator::new(layout, 0).with_codec(Box::new(IdentityCodec));
+
+        let mut fired = 0usize;
+        let stats = coord
+            .recover(
+                |_| {
+                    fired += 1;
+                    Ok(())
+                },
+                |_| Ok(()),
+            )
+            .unwrap();
+        assert_eq!(fired, 0);
+        assert!(!stats.from_checkpoint);
+    }
+
+    /// MANIFEST references a snapshot id but the corresponding .chk file was
+    /// deleted from disk. Recovery must fail loud with `StrataError::corruption`,
+    /// not silently fall back to WAL-only or produce an empty plan.
+    #[test]
+    fn test_recover_rejects_missing_snapshot_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = test_layout(temp_dir.path());
+        seed_snapshot(&layout, 3, 100);
+
+        // Remove the snapshot file the MANIFEST still points at.
+        let snap = strata_durability::format::snapshot_path(layout.snapshots_dir(), 3);
+        std::fs::remove_file(&snap).unwrap();
+
+        let coord = RecoveryCoordinator::new(layout, 0).with_codec(Box::new(IdentityCodec));
+
+        let err = coord
+            .recover(|_| Ok(()), |_| Ok(()))
+            .expect_err("missing snapshot file must surface as corruption");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("MANIFEST references snapshot"),
+            "error should mention MANIFEST ref, got: {}",
+            msg
+        );
+        assert!(
+            msg.contains("missing"),
+            "error should state the file is missing, got: {}",
+            msg
+        );
     }
 }

--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -213,9 +213,8 @@ impl RecoveryCoordinator {
         if !ManifestManager::exists(manifest_path) {
             return Ok(RecoveryPlan::fresh());
         }
-        let mgr = ManifestManager::load(manifest_path.to_path_buf()).map_err(|e| {
-            StrataError::corruption(format!("failed to load MANIFEST: {}", e))
-        })?;
+        let mgr = ManifestManager::load(manifest_path.to_path_buf())
+            .map_err(|e| StrataError::corruption(format!("failed to load MANIFEST: {}", e)))?;
         let m = mgr.manifest();
         if m.codec_id != expected_codec_id {
             return Err(StrataError::corruption(format!(
@@ -303,11 +302,7 @@ impl RecoveryCoordinator {
     /// Propagates errors from `on_snapshot`, `on_record`, and WAL reading.
     /// A hard error from `on_record` halts replay immediately — the caller
     /// is expected to surface it.
-    pub fn recover<FS, FR>(
-        self,
-        on_snapshot: FS,
-        mut on_record: FR,
-    ) -> StrataResult<RecoveryStats>
+    pub fn recover<FS, FR>(self, on_snapshot: FS, mut on_record: FR) -> StrataResult<RecoveryStats>
     where
         FS: FnOnce(LoadedSnapshot) -> StrataResult<()>,
         FR: FnMut(&WalRecord) -> StrataResult<()>,
@@ -527,8 +522,7 @@ impl RecoveryCoordinator {
                 |record| apply_wal_record_to_memory_storage(storage_ref, record),
             )?
         };
-        let txn_manager =
-            TransactionManager::with_txn_id(stats.final_version, stats.max_txn_id);
+        let txn_manager = TransactionManager::with_txn_id(stats.final_version, stats.max_txn_id);
         Ok(RecoveryResult {
             storage,
             txn_manager,
@@ -559,7 +553,13 @@ pub fn apply_wal_record_to_memory_storage(
     let version = CommitVersion(payload.version);
     for (i, (key, value)) in payload.puts.iter().enumerate() {
         let ttl_ms = payload.put_ttls.get(i).copied().unwrap_or(0);
-        storage.put_recovery_entry(key.clone(), value.clone(), version, record.timestamp, ttl_ms)?;
+        storage.put_recovery_entry(
+            key.clone(),
+            value.clone(),
+            version,
+            record.timestamp,
+            ttl_ms,
+        )?;
     }
     for key in &payload.deletes {
         storage.delete_recovery_entry(key, version, record.timestamp)?;
@@ -1685,7 +1685,10 @@ mod tests {
                     &mut wal,
                     i,
                     branch_id,
-                    vec![(Key::new_kv(ns.clone(), format!("k{}", i)), Value::Int(i as i64))],
+                    vec![(
+                        Key::new_kv(ns.clone(), format!("k{}", i)),
+                        Value::Int(i as i64),
+                    )],
                     vec![],
                     i * 10,
                 );
@@ -1735,7 +1738,10 @@ mod tests {
                     &mut wal,
                     i,
                     branch_id,
-                    vec![(Key::new_kv(ns.clone(), format!("k{}", i)), Value::Int(i as i64))],
+                    vec![(
+                        Key::new_kv(ns.clone(), format!("k{}", i)),
+                        Value::Int(i as i64),
+                    )],
                     vec![],
                     i,
                 );
@@ -2033,7 +2039,10 @@ mod tests {
                     &mut wal,
                     i,
                     branch_id,
-                    vec![(Key::new_kv(ns.clone(), format!("k{}", i)), Value::Int(i as i64))],
+                    vec![(
+                        Key::new_kv(ns.clone(), format!("k{}", i)),
+                        Value::Int(i as i64),
+                    )],
                     vec![],
                     i,
                 );
@@ -2080,7 +2089,10 @@ mod tests {
                     &mut wal,
                     i,
                     branch_id,
-                    vec![(Key::new_kv(ns.clone(), format!("k{}", i)), Value::Int(i as i64))],
+                    vec![(
+                        Key::new_kv(ns.clone(), format!("k{}", i)),
+                        Value::Int(i as i64),
+                    )],
                     vec![],
                     i,
                 );
@@ -2090,10 +2102,13 @@ mod tests {
         let coord = test_recovery(temp_dir.path());
         let mut replayed = 0usize;
         let stats = coord
-            .recover(|_| Ok(()), |_| {
-                replayed += 1;
-                Ok(())
-            })
+            .recover(
+                |_| Ok(()),
+                |_| {
+                    replayed += 1;
+                    Ok(())
+                },
+            )
             .unwrap();
         assert_eq!(replayed, 4);
         assert_eq!(stats.txns_replayed, 4);
@@ -2120,7 +2135,10 @@ mod tests {
                     &mut wal,
                     i,
                     branch_id,
-                    vec![(Key::new_kv(ns.clone(), format!("k{}", i)), Value::Int(i as i64))],
+                    vec![(
+                        Key::new_kv(ns.clone(), format!("k{}", i)),
+                        Value::Int(i as i64),
+                    )],
                     vec![],
                     i,
                 );
@@ -2130,10 +2148,13 @@ mod tests {
         let coord = RecoveryCoordinator::new(layout, 0).with_codec(Box::new(IdentityCodec));
         let mut replayed = 0usize;
         let stats = coord
-            .recover(|_| Ok(()), |_| {
-                replayed += 1;
-                Ok(())
-            })
+            .recover(
+                |_| Ok(()),
+                |_| {
+                    replayed += 1;
+                    Ok(())
+                },
+            )
             .unwrap();
         assert_eq!(replayed, 0);
         assert_eq!(stats.txns_replayed, 0);
@@ -2187,8 +2208,7 @@ mod tests {
 
         // Delete the sidecar for the closed segment (segment 1) so recovery
         // has something to rebuild.
-        let closed_sidecar =
-            strata_durability::format::SegmentMeta::meta_path(&wal_dir, 1);
+        let closed_sidecar = strata_durability::format::SegmentMeta::meta_path(&wal_dir, 1);
         if closed_sidecar.exists() {
             std::fs::remove_file(&closed_sidecar).unwrap();
         }
@@ -2245,8 +2265,7 @@ mod tests {
 
         // Overwrite the closed sidecar with bytes that will fail magic/CRC
         // validation in `SegmentMeta::from_bytes`.
-        let closed_sidecar =
-            strata_durability::format::SegmentMeta::meta_path(&wal_dir, 1);
+        let closed_sidecar = strata_durability::format::SegmentMeta::meta_path(&wal_dir, 1);
         std::fs::write(&closed_sidecar, b"CORRUPT_GARBAGE_NOT_A_VALID_META").unwrap();
 
         let coord = test_recovery(temp_dir.path());
@@ -2292,8 +2311,7 @@ mod tests {
         }
 
         // Delete the active-segment sidecar (segment 2 is the tail here).
-        let active_sidecar =
-            strata_durability::format::SegmentMeta::meta_path(&wal_dir, 2);
+        let active_sidecar = strata_durability::format::SegmentMeta::meta_path(&wal_dir, 2);
         if active_sidecar.exists() {
             std::fs::remove_file(&active_sidecar).unwrap();
         }

--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -8,30 +8,92 @@
 //!
 //! ## Recovery Procedure
 //!
-//! 1. Load snapshot (if exists) - not implemented in M2
-//! 2. Scan segmented WAL directory for records
-//! 3. Each WalRecord = one committed transaction (TransactionPayload)
-//! 4. Apply all records in order
-//! 5. Initialize TransactionManager with final version
+//! 1. Plan recovery: read MANIFEST and validate codec identity (`plan_recovery`).
+//! 2. Load snapshot (if present) and install decoded entries via `on_snapshot`.
+//! 3. Scan segmented WAL directory for records.
+//! 4. Each WalRecord = one committed transaction (TransactionPayload).
+//! 5. Apply records via `on_record`; truncate partial WAL tail on the active segment.
+//! 6. Return `RecoveryStats`; caller owns storage and txn-manager construction.
 
 use crate::payload::TransactionPayload;
 use crate::TransactionManager;
 use strata_core::id::{CommitVersion, TxnId};
-use strata_core::StrataResult;
-use strata_durability::format::WalSegment;
+use strata_core::{StrataError, StrataResult};
+use strata_durability::format::{WalRecord, WalSegment};
 use strata_durability::layout::DatabaseLayout;
 use strata_durability::wal::WalReader;
+use strata_durability::{LoadedSnapshot, ManifestManager};
 use strata_storage::SegmentedStore;
 use tracing::{info, warn};
 
-/// Coordinates database recovery after crash or restart
+/// Recovery plan summarizing MANIFEST state before WAL bytes are read.
 ///
-/// Per spec Section 5.4:
-/// 1. Loads checkpoint (if exists) - not implemented in M2
-/// 2. Reads all WAL records from the segmented WAL directory
-/// 3. Each record is a committed transaction (one WalRecord per txn)
-/// 4. Applies all writes/deletes with version preservation
-/// 5. Initializes TransactionManager with final version
+/// Produced by [`RecoveryCoordinator::plan_recovery`]. Callers use this to:
+///
+/// - Detect fresh databases (no MANIFEST).
+/// - Decide whether a snapshot load is needed (`snapshot_id.is_some()`).
+/// - Compute the delta-WAL replay watermark (`snapshot_watermark`).
+///
+/// Codec validation happens inside `plan_recovery` and short-circuits with a
+/// clear error before any WAL bytes are touched, so callers never observe a
+/// plan with a mismatched codec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RecoveryPlan {
+    /// Whether the MANIFEST file existed when the plan was built.
+    pub manifest_present: bool,
+    /// Codec identifier recorded in the MANIFEST, if present.
+    pub codec_id: Option<String>,
+    /// Snapshot identifier recorded in the MANIFEST, if any.
+    pub snapshot_id: Option<u64>,
+    /// Snapshot watermark (highest txn id covered by snapshot), if any.
+    pub snapshot_watermark: Option<u64>,
+    /// Highest commit id flushed to on-disk segments, if recorded.
+    pub flushed_through_commit_id: Option<u64>,
+    /// Database UUID recorded in the MANIFEST, if present.
+    pub database_uuid: Option<[u8; 16]>,
+}
+
+impl RecoveryPlan {
+    /// Returns a fresh-database plan (no MANIFEST, no snapshot).
+    fn fresh() -> Self {
+        RecoveryPlan {
+            manifest_present: false,
+            codec_id: None,
+            snapshot_id: None,
+            snapshot_watermark: None,
+            flushed_through_commit_id: None,
+            database_uuid: None,
+        }
+    }
+
+    /// Returns the snapshot watermark as a typed `TxnId`, if a snapshot is
+    /// recorded in the MANIFEST.
+    ///
+    /// Delta-WAL replay semantics: after the snapshot is installed, records
+    /// with `txn_id > snapshot_watermark` must be replayed. Records with
+    /// `txn_id <= snapshot_watermark` are already reflected in the snapshot
+    /// and can be skipped.
+    ///
+    /// Returns `None` when no snapshot is recorded (fresh database or
+    /// snapshot-less reopen).
+    pub fn snapshot_watermark(&self) -> Option<TxnId> {
+        self.snapshot_watermark.map(TxnId)
+    }
+}
+
+/// Coordinates database recovery after crash or restart.
+///
+/// Epic 5 reshapes the coordinator into a callback-driven driver:
+///
+/// 1. `plan_recovery` validates MANIFEST codec identity before any WAL read.
+/// 2. `recover(on_snapshot, on_record)` streams snapshot install and WAL
+///    replay through caller-supplied closures. The coordinator owns the
+///    directory layout and record streaming; the engine owns storage
+///    construction and application.
+///
+/// The legacy `recover_into_memory_storage` wrapper preserves the pre-Epic-5
+/// engine open surface until the callback-driven open path lands.
 pub struct RecoveryCoordinator {
     /// Canonical database layout.
     layout: DatabaseLayout,
@@ -117,34 +179,89 @@ impl RecoveryCoordinator {
         }
     }
 
-    /// Perform recovery and return initialized components
+    /// Read the MANIFEST (if any) and validate that its codec identity
+    /// matches `expected_codec_id` before any WAL bytes are touched.
     ///
-    /// Each WalRecord in the segmented WAL represents a single committed
-    /// transaction. The writeset field contains a serialized TransactionPayload
-    /// with the version, puts, and deletes.
-    ///
-    /// # Returns
-    /// - `RecoveryResult` containing storage, transaction manager, and stats
+    /// Returns a [`RecoveryPlan`] that summarizes what recovery will consume:
+    /// snapshot identity, snapshot watermark, and the last flushed commit id.
+    /// If the MANIFEST is absent the returned plan is the fresh-database plan.
     ///
     /// # Errors
-    /// - If WAL directory cannot be read
-    /// - If record deserialization fails
-    pub fn recover(&self) -> StrataResult<RecoveryResult> {
-        let storage = SegmentedStore::with_dir(
-            self.layout.segments_dir().to_path_buf(),
-            self.write_buffer_size,
-        );
+    ///
+    /// - `StrataError::corruption` if the MANIFEST cannot be parsed.
+    /// - `StrataError::corruption` if the MANIFEST codec does not match
+    ///   `expected_codec_id`. Returning the corruption variant keeps the
+    ///   error visible to operators without widening `StrataError` in this
+    ///   change class; the error text is structured for the taxonomy pass.
+    pub fn plan_recovery(&self, expected_codec_id: &str) -> StrataResult<RecoveryPlan> {
+        let manifest_path = self.layout.manifest_path();
+        if !ManifestManager::exists(manifest_path) {
+            return Ok(RecoveryPlan::fresh());
+        }
+        let mgr = ManifestManager::load(manifest_path.to_path_buf()).map_err(|e| {
+            StrataError::corruption(format!("failed to load MANIFEST: {}", e))
+        })?;
+        let m = mgr.manifest();
+        if m.codec_id != expected_codec_id {
+            return Err(StrataError::corruption(format!(
+                "codec mismatch: database was created with '{}' but config specifies '{}'. \
+                 A database cannot be reopened with a different codec.",
+                m.codec_id, expected_codec_id
+            )));
+        }
+        Ok(RecoveryPlan {
+            manifest_present: true,
+            codec_id: Some(m.codec_id.clone()),
+            snapshot_id: m.snapshot_id,
+            snapshot_watermark: m.snapshot_watermark,
+            flushed_through_commit_id: m.flushed_through_commit_id,
+            database_uuid: Some(m.database_uuid),
+        })
+    }
+
+    /// Drive recovery through caller-supplied callbacks.
+    ///
+    /// The engine owns storage construction; the coordinator only:
+    ///
+    /// 1. (future) Loads the snapshot declared in the MANIFEST and invokes
+    ///    `on_snapshot` with the decoded `LoadedSnapshot`. Snapshot loading
+    ///    is wired in Epic 5 Chunk 2 — until then `on_snapshot` never fires.
+    /// 2. Streams committed WAL records and invokes `on_record` for each,
+    ///    preserving arrival order. Partial tails on the active segment
+    ///    are truncated before return so reopens land on clean boundaries.
+    /// 3. Returns `RecoveryStats` summarizing the replay.
+    ///
+    /// The coordinator decodes each WAL record once internally to populate
+    /// `RecoveryStats::writes_applied`/`deletes_applied`/`final_version`;
+    /// callers that need the decoded payload perform their own decode
+    /// inside `on_record` to preserve the inline-decode invariant.
+    ///
+    /// # Errors
+    ///
+    /// Propagates errors from `on_snapshot`, `on_record`, and WAL reading.
+    /// A hard error from `on_record` halts replay immediately — the caller
+    /// is expected to surface it.
+    pub fn recover<FS, FR>(
+        self,
+        _on_snapshot: FS,
+        mut on_record: FR,
+    ) -> StrataResult<RecoveryStats>
+    where
+        FS: FnOnce(LoadedSnapshot) -> StrataResult<()>,
+        FR: FnMut(&WalRecord) -> StrataResult<()>,
+    {
+        let mut stats = RecoveryStats::default();
         let mut max_version = 0u64;
         let mut max_txn_id = 0u64;
-        let mut stats = RecoveryStats::default();
 
-        // If WAL dir doesn't exist, return empty result
+        // Snapshot loading is wired in Epic 5 Chunk 2; until then the
+        // coordinator never fires `on_snapshot`.
+
+        // If WAL dir doesn't exist, return an empty-replay plan.
         if !self.layout.wal_dir().exists() {
-            return Ok(RecoveryResult {
-                storage,
-                txn_manager: TransactionManager::new(CommitVersion::ZERO),
-                stats,
-            });
+            stats.final_version = CommitVersion(max_version);
+            stats.max_txn_id = TxnId(max_txn_id);
+            return Ok(stats);
         }
 
         // Stream records from segmented WAL one segment at a time.
@@ -156,47 +273,28 @@ impl RecoveryCoordinator {
         }
         let records_iter = reader
             .iter_all(self.layout.wal_dir())
-            .map_err(|e| strata_core::StrataError::storage(format!("WAL read failed: {}", e)))?;
+            .map_err(|e| StrataError::storage(format!("WAL read failed: {}", e)))?;
 
         for record_result in records_iter {
-            let record = record_result.map_err(|e| {
-                strata_core::StrataError::storage(format!("WAL segment read failed: {}", e))
-            })?;
-            max_txn_id = max_txn_id.max(record.txn_id.as_u64());
+            let record = record_result
+                .map_err(|e| StrataError::storage(format!("WAL segment read failed: {}", e)))?;
 
             let payload = TransactionPayload::from_bytes(&record.writeset).map_err(|e| {
-                strata_core::StrataError::storage(format!(
+                StrataError::storage(format!(
                     "Failed to decode transaction payload for txn {}: {}",
                     record.txn_id, e
                 ))
             })?;
 
+            // Invoke the caller before bumping stats so a failing callback
+            // never leaves behind inflated counts claiming work that was
+            // never applied.
+            on_record(&record)?;
+
+            max_txn_id = max_txn_id.max(record.txn_id.as_u64());
             max_version = max_version.max(payload.version);
-
-            // Apply puts — use recovery-specific method to preserve original
-            // commit timestamp and TTL (#1619, #1740).
-            for (i, (key, value)) in payload.puts.iter().enumerate() {
-                let ttl_ms = payload.put_ttls.get(i).copied().unwrap_or(0);
-                storage.put_recovery_entry(
-                    key.clone(),
-                    value.clone(),
-                    CommitVersion(payload.version),
-                    record.timestamp,
-                    ttl_ms,
-                )?;
-                stats.writes_applied += 1;
-            }
-
-            // Apply deletes with original timestamp (#1619)
-            for key in &payload.deletes {
-                storage.delete_recovery_entry(
-                    key,
-                    CommitVersion(payload.version),
-                    record.timestamp,
-                )?;
-                stats.deletes_applied += 1;
-            }
-
+            stats.writes_applied += payload.puts.len();
+            stats.deletes_applied += payload.deletes.len();
             stats.txns_replayed += 1;
         }
 
@@ -207,15 +305,64 @@ impl RecoveryCoordinator {
         stats.final_version = CommitVersion(max_version);
         stats.max_txn_id = TxnId(max_txn_id);
 
-        let txn_manager =
-            TransactionManager::with_txn_id(CommitVersion(max_version), TxnId(max_txn_id));
+        Ok(stats)
+    }
 
+    /// Legacy convenience wrapper that constructs a fresh `SegmentedStore`
+    /// rooted at the layout's segments directory and applies all WAL records
+    /// into it, returning the fully-materialized `RecoveryResult`.
+    ///
+    /// This preserves the pre-Epic-5 surface so the engine open paths and
+    /// existing tests keep working while callback-driven recovery is staged.
+    /// Snapshot loading is not performed here; that arrives in later Epic 5
+    /// chunks alongside the engine-side decoder.
+    ///
+    /// Epic 5 Chunk 3 removes this wrapper once `Database::open` drives
+    /// `recover` directly with its own snapshot and WAL apply closures.
+    pub fn recover_into_memory_storage(self) -> StrataResult<RecoveryResult> {
+        let storage = SegmentedStore::with_dir(
+            self.layout.segments_dir().to_path_buf(),
+            self.write_buffer_size,
+        );
+        let stats = {
+            let storage_ref = &storage;
+            self.recover(
+                |_snapshot| Ok(()),
+                |record| apply_wal_record_to_memory_storage(storage_ref, record),
+            )?
+        };
+        let txn_manager =
+            TransactionManager::with_txn_id(stats.final_version, stats.max_txn_id);
         Ok(RecoveryResult {
             storage,
             txn_manager,
             stats,
         })
     }
+}
+
+/// Default WAL-record apply used by the legacy `recover_into_memory_storage`
+/// wrapper. Preserves `#1619` / `#1740` invariants: recovery uses the WAL
+/// record's commit timestamp and the payload's TTL, not now-based values.
+fn apply_wal_record_to_memory_storage(
+    storage: &SegmentedStore,
+    record: &WalRecord,
+) -> StrataResult<()> {
+    let payload = TransactionPayload::from_bytes(&record.writeset).map_err(|e| {
+        StrataError::storage(format!(
+            "Failed to decode transaction payload for txn {}: {}",
+            record.txn_id, e
+        ))
+    })?;
+    let version = CommitVersion(payload.version);
+    for (i, (key, value)) in payload.puts.iter().enumerate() {
+        let ttl_ms = payload.put_ttls.get(i).copied().unwrap_or(0);
+        storage.put_recovery_entry(key.clone(), value.clone(), version, record.timestamp, ttl_ms)?;
+    }
+    for key in &payload.deletes {
+        storage.delete_recovery_entry(key, version, record.timestamp)?;
+    }
+    Ok(())
 }
 
 /// Result of recovery operation
@@ -382,7 +529,7 @@ mod tests {
         let _wal = create_test_wal(&wal_dir);
 
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result.stats.txns_replayed, 0);
         assert_eq!(result.stats.final_version, CommitVersion(0));
@@ -393,7 +540,7 @@ mod tests {
     fn test_recovery_nonexistent_dir() {
         let temp_dir = TempDir::new().unwrap();
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result.stats.txns_replayed, 0);
         assert_eq!(result.stats.final_version, CommitVersion(0));
@@ -421,7 +568,7 @@ mod tests {
         }
 
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result.stats.txns_replayed, 1);
         assert_eq!(result.stats.writes_applied, 1);
@@ -473,7 +620,7 @@ mod tests {
         }
 
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result.stats.final_version, CommitVersion(200));
         assert_eq!(result.txn_manager.current_version(), CommitVersion(200));
@@ -541,10 +688,10 @@ mod tests {
         }
 
         let coordinator = test_recovery(temp_dir.path());
-        let result1 = coordinator.recover().unwrap();
+        let result1 = coordinator.recover_into_memory_storage().unwrap();
 
         let coordinator = test_recovery(temp_dir.path());
-        let result2 = coordinator.recover().unwrap();
+        let result2 = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result1.stats.final_version, result2.stats.final_version);
         assert_eq!(result1.stats.txns_replayed, result2.stats.txns_replayed);
@@ -592,7 +739,7 @@ mod tests {
         }
 
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result.stats.writes_applied, 1);
         assert_eq!(result.stats.deletes_applied, 1);
@@ -632,10 +779,10 @@ mod tests {
 
         let layout = test_layout(temp_dir.path());
         let coordinator = RecoveryCoordinator::new(layout.clone(), 0);
-
-        let result = coordinator.recover().unwrap();
-        assert!(!result.stats.from_checkpoint);
         assert_eq!(coordinator.layout(), &layout);
+
+        let result = coordinator.recover_into_memory_storage().unwrap();
+        assert!(!result.stats.from_checkpoint);
     }
 
     // ========================================
@@ -656,7 +803,7 @@ mod tests {
         let _wal = create_test_wal(&wal_dir);
 
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result.stats.txns_replayed, 0);
         assert_eq!(result.stats.final_version, CommitVersion(0));
@@ -689,7 +836,7 @@ mod tests {
         }
 
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result.stats.txns_replayed, 1);
         assert_eq!(result.stats.incomplete_txns, 0);
@@ -734,7 +881,7 @@ mod tests {
         file.write_all(&[0xFF; 20]).unwrap();
 
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         // Valid record should be recovered, garbage skipped
         assert_eq!(result.stats.txns_replayed, 1);
@@ -767,10 +914,10 @@ mod tests {
         }
 
         let coordinator = test_recovery(temp_dir.path());
-        let result1 = coordinator.recover().unwrap();
+        let result1 = coordinator.recover_into_memory_storage().unwrap();
 
         let coordinator = test_recovery(temp_dir.path());
-        let result2 = coordinator.recover().unwrap();
+        let result2 = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result1.stats.txns_replayed, result2.stats.txns_replayed);
         assert_eq!(result1.stats.final_version, result2.stats.final_version);
@@ -811,7 +958,7 @@ mod tests {
         }
 
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result.txn_manager.current_version(), CommitVersion(999));
         assert_eq!(result.stats.final_version, CommitVersion(999));
@@ -843,7 +990,7 @@ mod tests {
         }
 
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result.stats.txns_replayed, 10);
         assert_eq!(result.stats.final_version, CommitVersion(10));
@@ -923,7 +1070,7 @@ mod tests {
         }
 
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result.stats.txns_replayed, 4);
         assert_eq!(result.stats.writes_applied, 4);
@@ -979,7 +1126,7 @@ mod tests {
         }
 
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         let counter = result
             .storage
@@ -1011,7 +1158,7 @@ mod tests {
         }
 
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result.txn_manager.current_version(), CommitVersion(100));
         let new_txn_id = result.txn_manager.next_txn_id().unwrap();
@@ -1045,7 +1192,7 @@ mod tests {
         }
 
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result.stats.txns_replayed, num_txns as usize);
         assert_eq!(result.stats.final_version, CommitVersion(num_txns));
@@ -1091,7 +1238,7 @@ mod tests {
 
         // Verify recovery (which uses iter_all) returns correct results
         let coordinator = test_recovery(temp_dir.path());
-        let result = coordinator.recover().unwrap();
+        let result = coordinator.recover_into_memory_storage().unwrap();
 
         assert_eq!(result.stats.txns_replayed, 20);
         assert_eq!(result.stats.final_version, CommitVersion(20));
@@ -1176,7 +1323,7 @@ mod tests {
         // and truncate the partial tail
         {
             let coordinator = test_recovery(temp_dir.path());
-            let result = coordinator.recover().unwrap();
+            let result = coordinator.recover_into_memory_storage().unwrap();
             assert_eq!(result.stats.txns_replayed, 2);
         }
 
@@ -1202,7 +1349,7 @@ mod tests {
         // and never reaches record 3.
         {
             let coordinator = test_recovery(temp_dir.path());
-            let result = coordinator.recover().unwrap();
+            let result = coordinator.recover_into_memory_storage().unwrap();
 
             assert_eq!(
                 result.stats.txns_replayed, 3,
@@ -1219,5 +1366,349 @@ mod tests {
                 .expect("key_after must be visible after second recovery");
             assert_eq!(stored.value, Value::String("after_crash".into()));
         }
+    }
+
+    // ========================================
+    // Epic 5 Chunk 1: plan_recovery + callback API
+    // ========================================
+
+    use strata_durability::ManifestManager;
+
+    /// A fresh database (no MANIFEST) yields the zero-valued plan.
+    #[test]
+    fn test_plan_recovery_fresh_database() {
+        let temp_dir = TempDir::new().unwrap();
+        let coordinator = test_recovery(temp_dir.path());
+
+        let plan = coordinator.plan_recovery("identity").unwrap();
+
+        assert!(!plan.manifest_present);
+        assert_eq!(plan.codec_id, None);
+        assert_eq!(plan.snapshot_id, None);
+        assert_eq!(plan.snapshot_watermark(), None);
+        assert_eq!(plan.flushed_through_commit_id, None);
+        assert_eq!(plan.database_uuid, None);
+    }
+
+    /// An existing MANIFEST with a matching codec produces a populated plan.
+    #[test]
+    fn test_plan_recovery_accepts_matching_codec() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = test_layout(temp_dir.path());
+        let uuid = [7u8; 16];
+        ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            uuid,
+            "identity".to_string(),
+        )
+        .unwrap();
+
+        let coordinator = RecoveryCoordinator::new(layout, 0);
+        let plan = coordinator.plan_recovery("identity").unwrap();
+
+        assert!(plan.manifest_present);
+        assert_eq!(plan.codec_id.as_deref(), Some("identity"));
+        assert_eq!(plan.database_uuid, Some(uuid));
+    }
+
+    /// plan_recovery rejects codec mismatch before any WAL bytes are read.
+    #[test]
+    fn test_plan_recovery_rejects_codec_mismatch() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = test_layout(temp_dir.path());
+        ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            [0u8; 16],
+            "identity".to_string(),
+        )
+        .unwrap();
+
+        let coordinator = RecoveryCoordinator::new(layout, 0);
+        let err = coordinator
+            .plan_recovery("aes-gcm-256")
+            .expect_err("codec mismatch must be rejected");
+        let message = err.to_string();
+        assert!(
+            message.contains("codec mismatch"),
+            "expected codec mismatch error, got: {}",
+            message
+        );
+        assert!(message.contains("identity"));
+        assert!(message.contains("aes-gcm-256"));
+    }
+
+    /// plan_recovery reports snapshot identity and watermark so Epic 5
+    /// Chunk 2 can drive snapshot-install from the plan.
+    #[test]
+    fn test_plan_recovery_reports_snapshot_identity_and_watermark() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = test_layout(temp_dir.path());
+        let mut mgr = ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            [1u8; 16],
+            "identity".to_string(),
+        )
+        .unwrap();
+        mgr.set_snapshot_watermark(42, TxnId(7_000)).unwrap();
+
+        let coordinator = RecoveryCoordinator::new(layout, 0);
+        let plan = coordinator.plan_recovery("identity").unwrap();
+
+        assert_eq!(plan.snapshot_id, Some(42));
+        assert_eq!(plan.snapshot_watermark(), Some(TxnId(7_000)));
+    }
+
+    /// The callback-driven `recover()` fires `on_record` once per WAL record
+    /// in ascending txn-id order, never fires `on_snapshot` (Chunk 1 stub),
+    /// and returns aggregated stats matching the pre-Epic-5 surface.
+    #[test]
+    fn test_recover_callback_fires_on_record_in_order() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+
+        {
+            let mut wal = create_test_wal(&wal_dir);
+            for i in 1u64..=5 {
+                write_txn(
+                    &mut wal,
+                    i,
+                    branch_id,
+                    vec![(Key::new_kv(ns.clone(), format!("k{}", i)), Value::Int(i as i64))],
+                    vec![],
+                    i * 10,
+                );
+            }
+        }
+
+        let coordinator = test_recovery(temp_dir.path());
+        let mut snapshot_fired = 0usize;
+        let mut record_txns: Vec<u64> = Vec::new();
+        let stats = coordinator
+            .recover(
+                |_snapshot| {
+                    snapshot_fired += 1;
+                    Ok(())
+                },
+                |record| {
+                    record_txns.push(record.txn_id.as_u64());
+                    Ok(())
+                },
+            )
+            .unwrap();
+
+        assert_eq!(snapshot_fired, 0, "on_snapshot must not fire in Chunk 1");
+        assert_eq!(record_txns, vec![1, 2, 3, 4, 5]);
+        assert_eq!(stats.txns_replayed, 5);
+        assert_eq!(stats.writes_applied, 5);
+        assert_eq!(stats.deletes_applied, 0);
+        assert_eq!(stats.final_version, CommitVersion(50));
+        assert_eq!(stats.max_txn_id, TxnId(5));
+    }
+
+    /// An error from `on_record` halts replay immediately and propagates out.
+    #[test]
+    fn test_recover_callback_propagates_on_record_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+
+        {
+            let mut wal = create_test_wal(&wal_dir);
+            for i in 1u64..=3 {
+                write_txn(
+                    &mut wal,
+                    i,
+                    branch_id,
+                    vec![(Key::new_kv(ns.clone(), format!("k{}", i)), Value::Int(i as i64))],
+                    vec![],
+                    i,
+                );
+            }
+        }
+
+        let coordinator = test_recovery(temp_dir.path());
+        let mut seen = 0usize;
+        let result = coordinator.recover(
+            |_| Ok(()),
+            |_record| {
+                seen += 1;
+                if seen == 2 {
+                    Err(strata_core::StrataError::internal("injected apply failure"))
+                } else {
+                    Ok(())
+                }
+            },
+        );
+        assert!(result.is_err(), "injected error must propagate");
+        assert_eq!(seen, 2, "replay must stop at the failing record");
+    }
+
+    /// Stats must reflect only fully-applied records: if `on_record` errors
+    /// at record N, the first N-1 records count and no partial work for
+    /// record N leaks into `writes_applied`/`deletes_applied`/`txns_replayed`.
+    ///
+    /// Exercises the invariant by collecting stats through a wrapper that
+    /// re-runs the callback sequence and inspects cumulative state at the
+    /// moment the injected failure fires.
+    #[test]
+    fn test_recover_callback_stats_reflect_only_applied_records() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+
+        // Three records with distinct put/delete mixes so the test can
+        // tell from stats how far replay got.
+        {
+            let mut wal = create_test_wal(&wal_dir);
+            write_txn(
+                &mut wal,
+                1,
+                branch_id,
+                vec![(Key::new_kv(ns.clone(), "a"), Value::Int(1))],
+                vec![],
+                10,
+            );
+            write_txn(
+                &mut wal,
+                2,
+                branch_id,
+                vec![(Key::new_kv(ns.clone(), "b"), Value::Int(2))],
+                vec![Key::new_kv(ns.clone(), "a")],
+                20,
+            );
+            write_txn(
+                &mut wal,
+                3,
+                branch_id,
+                vec![(Key::new_kv(ns.clone(), "c"), Value::Int(3))],
+                vec![],
+                30,
+            );
+        }
+
+        // First pass: succeed for record 1, fail on record 2. The first
+        // record must count in stats; the failing record must not.
+        let coord = test_recovery(temp_dir.path());
+        let mut seen = 0usize;
+        let fail_on_second = coord.recover(
+            |_| Ok(()),
+            |_record| {
+                seen += 1;
+                if seen == 2 {
+                    Err(strata_core::StrataError::internal("injected"))
+                } else {
+                    Ok(())
+                }
+            },
+        );
+        assert!(fail_on_second.is_err());
+
+        // Second pass: succeed for all three. Stats must reflect the full
+        // replay: 3 txns, 3 puts, 1 delete, final_version = 30, max_txn_id = 3.
+        let coord = test_recovery(temp_dir.path());
+        let stats = coord
+            .recover(|_| Ok(()), |_record| Ok(()))
+            .expect("clean replay");
+        assert_eq!(stats.txns_replayed, 3);
+        assert_eq!(stats.writes_applied, 3);
+        assert_eq!(stats.deletes_applied, 1);
+        assert_eq!(stats.final_version, CommitVersion(30));
+        assert_eq!(stats.max_txn_id, TxnId(3));
+    }
+
+    /// A corrupt MANIFEST file surfaces as `StrataError::corruption`, not a
+    /// silent empty plan or a generic storage error.
+    #[test]
+    fn test_plan_recovery_reports_corrupt_manifest() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = test_layout(temp_dir.path());
+        // Write garbage at the MANIFEST path so ManifestManager::load fails.
+        std::fs::write(layout.manifest_path(), b"not-a-manifest").unwrap();
+
+        let coordinator = RecoveryCoordinator::new(layout, 0);
+        let err = coordinator
+            .plan_recovery("identity")
+            .expect_err("corrupt MANIFEST must fail plan_recovery");
+        // StrataError::corruption carries the "corruption" category; the
+        // underlying ManifestError message is preserved in the text.
+        let message = err.to_string();
+        assert!(
+            message.to_lowercase().contains("manifest"),
+            "error should mention MANIFEST, got: {}",
+            message
+        );
+    }
+
+    /// Empty WAL produces zero stats and never fires either callback.
+    #[test]
+    fn test_recover_callback_empty_wal() {
+        let temp_dir = TempDir::new().unwrap();
+        let coordinator = test_recovery(temp_dir.path());
+        let mut snapshot_fired = 0usize;
+        let mut record_fired = 0usize;
+        let stats = coordinator
+            .recover(
+                |_| {
+                    snapshot_fired += 1;
+                    Ok(())
+                },
+                |_| {
+                    record_fired += 1;
+                    Ok(())
+                },
+            )
+            .unwrap();
+        assert_eq!(snapshot_fired, 0);
+        assert_eq!(record_fired, 0);
+        assert_eq!(stats.txns_replayed, 0);
+        assert_eq!(stats.final_version, CommitVersion::ZERO);
+        assert_eq!(stats.max_txn_id, TxnId::ZERO);
+    }
+
+    /// The legacy compat wrapper must produce identical stats to the
+    /// callback API's default-apply path.
+    #[test]
+    fn test_recover_into_memory_storage_matches_callback_apply() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+
+        {
+            let mut wal = create_test_wal(&wal_dir);
+            write_txn(
+                &mut wal,
+                1,
+                branch_id,
+                vec![(Key::new_kv(ns.clone(), "k"), Value::Int(10))],
+                vec![],
+                100,
+            );
+            write_txn(
+                &mut wal,
+                2,
+                branch_id,
+                vec![],
+                vec![Key::new_kv(ns.clone(), "k")],
+                101,
+            );
+        }
+
+        let coord_a = test_recovery(temp_dir.path());
+        let result = coord_a.recover_into_memory_storage().unwrap();
+
+        let coord_b = test_recovery(temp_dir.path());
+        let stats_b = coord_b.recover(|_| Ok(()), |_| Ok(())).unwrap();
+
+        assert_eq!(result.stats.txns_replayed, stats_b.txns_replayed);
+        assert_eq!(result.stats.writes_applied, stats_b.writes_applied);
+        assert_eq!(result.stats.deletes_applied, stats_b.deletes_applied);
+        assert_eq!(result.stats.final_version, stats_b.final_version);
+        assert_eq!(result.stats.max_txn_id, stats_b.max_txn_id);
     }
 }

--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -20,7 +20,7 @@ use crate::TransactionManager;
 use strata_core::id::{CommitVersion, TxnId};
 use strata_core::{StrataError, StrataResult};
 use strata_durability::codec::{clone_codec, StorageCodec};
-use strata_durability::format::{snapshot_path, WalRecord, WalSegment};
+use strata_durability::format::{snapshot_path, SegmentMeta, WalRecord, WalSegment};
 use strata_durability::layout::DatabaseLayout;
 use strata_durability::wal::WalReader;
 use strata_durability::{LoadedSnapshot, ManifestManager, SnapshotReader};
@@ -331,10 +331,16 @@ impl RecoveryCoordinator {
         // to include the snapshot must fold in their storage's post-install
         // `current_version()` themselves. Doing that here would require
         // the coordinator to reach into caller-owned state.
+        //
+        // `snapshot_watermark_txn` also drives delta-WAL replay below:
+        // records with `txn_id <= snapshot_watermark_txn` are already
+        // covered by the snapshot and must be skipped to avoid double-apply.
+        let mut snapshot_watermark_txn: u64 = 0;
         if let Some(codec) = self.codec.as_deref() {
             if let Some(snapshot) = self.load_snapshot_if_present(codec)? {
                 stats.from_checkpoint = true;
-                max_txn_id = max_txn_id.max(snapshot.watermark_txn());
+                snapshot_watermark_txn = snapshot.watermark_txn();
+                max_txn_id = max_txn_id.max(snapshot_watermark_txn);
                 on_snapshot(snapshot)?;
             }
         }
@@ -361,6 +367,21 @@ impl RecoveryCoordinator {
             let record = record_result
                 .map_err(|e| StrataError::storage(format!("WAL segment read failed: {}", e)))?;
 
+            // Delta-WAL replay: records at or below the snapshot watermark
+            // are already reflected in the installed snapshot. Skip them to
+            // avoid double-apply of puts/deletes. `snapshot_watermark_txn`
+            // is zero when no snapshot was loaded, which degenerates to
+            // full WAL replay (the pre-Epic-5 behavior).
+            //
+            // We still account for the txn id in `max_txn_id` so the
+            // downstream coordinator sees the true max id across both
+            // sources.
+            if snapshot_watermark_txn > 0 && record.txn_id.as_u64() <= snapshot_watermark_txn {
+                max_txn_id = max_txn_id.max(record.txn_id.as_u64());
+                stats.txns_skipped_below_watermark += 1;
+                continue;
+            }
+
             let payload = TransactionPayload::from_bytes(&record.writeset).map_err(|e| {
                 StrataError::storage(format!(
                     "Failed to decode transaction payload for txn {}: {}",
@@ -384,10 +405,103 @@ impl RecoveryCoordinator {
         // WalWriter::new() reopens at a clean record boundary (#1741).
         self.truncate_partial_tail(&reader);
 
+        // Rebuild missing or corrupt `.meta` sidecars from segment records
+        // so subsequent compaction/read paths hit the O(1) fast path rather
+        // than falling back to a full scan per segment. Best-effort: errors
+        // are logged but never fail recovery.
+        self.rebuild_missing_sidecars(&reader);
+
         stats.final_version = CommitVersion(max_version);
         stats.max_txn_id = TxnId(max_txn_id);
 
         Ok(stats)
+    }
+
+    /// Best-effort sidecar rebuild for closed WAL segments whose `.meta`
+    /// file is missing or fails the header/CRC check.
+    ///
+    /// For each segment whose `.meta` cannot be read cleanly, this scans
+    /// the segment records via [`WalReader::read_segment`] and writes a
+    /// freshly-computed [`SegmentMeta`]. Existing valid sidecars are left
+    /// untouched so re-running recovery is cheap.
+    ///
+    /// The active (last) segment is skipped because the WAL writer owns
+    /// and lazily rebuilds the active sidecar on reopen; touching it here
+    /// would race with writer state.
+    ///
+    /// Failures during scan or write are logged at `warn` and do not
+    /// escalate — readers and compaction already fall back to full-segment
+    /// scans when a sidecar is absent, so a failed rebuild only costs
+    /// performance, not correctness.
+    fn rebuild_missing_sidecars(&self, reader: &WalReader) {
+        let wal_dir = self.layout.wal_dir();
+        let segments = match reader.list_segments(wal_dir) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        if segments.is_empty() {
+            return;
+        }
+        // Skip the active (last) segment — the writer owns its sidecar.
+        let closed = &segments[..segments.len().saturating_sub(1)];
+        for &segment_number in closed {
+            match SegmentMeta::read_from_file(wal_dir, segment_number) {
+                Ok(Some(meta)) if meta.segment_number == segment_number => {
+                    // Existing sidecar is structurally valid; leave it alone.
+                    continue;
+                }
+                Ok(Some(_)) => {
+                    warn!(
+                        target: "strata::recovery",
+                        segment = segment_number,
+                        "Sidecar segment_number mismatch; rebuilding"
+                    );
+                }
+                Ok(None) => {
+                    // Missing — rebuild silently.
+                }
+                Err(e) => {
+                    warn!(
+                        target: "strata::recovery",
+                        segment = segment_number,
+                        error = %e,
+                        "Sidecar corrupt; rebuilding"
+                    );
+                }
+            }
+
+            let (records, _, _, _) = match reader.read_segment(wal_dir, segment_number) {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(
+                        target: "strata::recovery",
+                        segment = segment_number,
+                        error = %e,
+                        "Failed to scan segment for sidecar rebuild; readers will fall back to full scan"
+                    );
+                    continue;
+                }
+            };
+            let mut meta = SegmentMeta::new_empty(segment_number);
+            for record in &records {
+                meta.track_record(record.txn_id, record.timestamp);
+            }
+            if let Err(e) = meta.write_to_file(wal_dir) {
+                warn!(
+                    target: "strata::recovery",
+                    segment = segment_number,
+                    error = %e,
+                    "Failed to persist rebuilt sidecar; readers will fall back to full scan"
+                );
+            } else {
+                info!(
+                    target: "strata::recovery",
+                    segment = segment_number,
+                    records = records.len(),
+                    "Rebuilt missing WAL segment sidecar"
+                );
+            }
+        }
     }
 
     /// Legacy convenience wrapper that constructs a fresh `SegmentedStore`
@@ -525,10 +639,16 @@ pub struct RecoveryStats {
     /// transactions already in the WAL.
     pub max_txn_id: TxnId,
 
-    /// Whether recovery was from checkpoint
-    ///
-    /// In M2, this is always false as checkpoint-based recovery is not implemented.
+    /// Whether a snapshot was loaded during recovery. Set to `true` when
+    /// `recover()` consulted the MANIFEST, found a snapshot reference, and
+    /// handed the decoded payload to `on_snapshot`. Snapshot loading
+    /// requires a codec to be installed via `with_codec()`.
     pub from_checkpoint: bool,
+
+    /// Number of WAL records skipped during delta replay because their
+    /// `txn_id` was at or below the snapshot watermark (already reflected
+    /// in the installed snapshot). Always zero for WAL-only recovery.
+    pub txns_skipped_below_watermark: usize,
 }
 
 impl RecoveryStats {
@@ -851,6 +971,7 @@ mod tests {
             final_version: CommitVersion(100),
             max_txn_id: TxnId(8),
             from_checkpoint: false,
+            txns_skipped_below_watermark: 0,
         };
 
         assert_eq!(stats.total_operations(), 13);
@@ -1888,6 +2009,304 @@ mod tests {
             .unwrap();
         assert_eq!(fired, 0);
         assert!(!stats.from_checkpoint);
+    }
+
+    /// Delta-WAL replay: when a snapshot with watermark=N is loaded, records
+    /// with `txn_id <= N` are skipped (already in the snapshot), and only
+    /// records with `txn_id > N` fire `on_record`. The skipped count surfaces
+    /// in `RecoveryStats::txns_skipped_below_watermark` for observability.
+    #[test]
+    fn test_recover_delta_wal_skips_records_at_or_below_watermark() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+
+        // Seed a snapshot whose watermark sits in the middle of the WAL.
+        let layout = test_layout(temp_dir.path());
+        seed_snapshot(&layout, 1, 5);
+
+        {
+            let mut wal = create_test_wal(&wal_dir);
+            for i in 1u64..=10 {
+                write_txn(
+                    &mut wal,
+                    i,
+                    branch_id,
+                    vec![(Key::new_kv(ns.clone(), format!("k{}", i)), Value::Int(i as i64))],
+                    vec![],
+                    i,
+                );
+            }
+        }
+
+        let coord = RecoveryCoordinator::new(layout, 0).with_codec(Box::new(IdentityCodec));
+        let mut replayed_txns: Vec<u64> = Vec::new();
+        let stats = coord
+            .recover(
+                |_snapshot| Ok(()),
+                |record| {
+                    replayed_txns.push(record.txn_id.as_u64());
+                    Ok(())
+                },
+            )
+            .unwrap();
+
+        assert_eq!(
+            replayed_txns,
+            vec![6, 7, 8, 9, 10],
+            "only records strictly above the watermark must replay"
+        );
+        assert_eq!(stats.txns_replayed, 5);
+        assert_eq!(stats.txns_skipped_below_watermark, 5);
+        assert!(stats.from_checkpoint);
+        assert_eq!(stats.max_txn_id, TxnId(10));
+        assert_eq!(stats.writes_applied, 5);
+    }
+
+    /// When no snapshot is loaded (no codec), every WAL record replays
+    /// regardless of txn id — the delta filter degenerates to full replay.
+    #[test]
+    fn test_recover_without_snapshot_replays_all_records() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+
+        {
+            let mut wal = create_test_wal(&wal_dir);
+            for i in 1u64..=4 {
+                write_txn(
+                    &mut wal,
+                    i,
+                    branch_id,
+                    vec![(Key::new_kv(ns.clone(), format!("k{}", i)), Value::Int(i as i64))],
+                    vec![],
+                    i,
+                );
+            }
+        }
+
+        let coord = test_recovery(temp_dir.path());
+        let mut replayed = 0usize;
+        let stats = coord
+            .recover(|_| Ok(()), |_| {
+                replayed += 1;
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(replayed, 4);
+        assert_eq!(stats.txns_replayed, 4);
+        assert_eq!(stats.txns_skipped_below_watermark, 0);
+        assert!(!stats.from_checkpoint);
+    }
+
+    /// Snapshot watermark sits past every WAL record: every record is
+    /// skipped, `on_record` never fires, replay reports zero applied.
+    #[test]
+    fn test_recover_delta_wal_all_records_covered_by_snapshot() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+
+        let layout = test_layout(temp_dir.path());
+        seed_snapshot(&layout, 9, 100);
+
+        {
+            let mut wal = create_test_wal(&wal_dir);
+            for i in 1u64..=3 {
+                write_txn(
+                    &mut wal,
+                    i,
+                    branch_id,
+                    vec![(Key::new_kv(ns.clone(), format!("k{}", i)), Value::Int(i as i64))],
+                    vec![],
+                    i,
+                );
+            }
+        }
+
+        let coord = RecoveryCoordinator::new(layout, 0).with_codec(Box::new(IdentityCodec));
+        let mut replayed = 0usize;
+        let stats = coord
+            .recover(|_| Ok(()), |_| {
+                replayed += 1;
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(replayed, 0);
+        assert_eq!(stats.txns_replayed, 0);
+        assert_eq!(stats.txns_skipped_below_watermark, 3);
+        // `max_txn_id` still reflects snapshot watermark and any skipped
+        // records so the downstream counter seeds safely above all sources.
+        assert_eq!(stats.max_txn_id, TxnId(100));
+    }
+
+    /// Missing `.meta` sidecars on closed WAL segments are rebuilt during
+    /// recovery so subsequent compaction/read paths hit the O(1) fast path.
+    /// The active segment is deliberately left alone (writer owns it); corrupt
+    /// sidecars on closed segments are replaced with a freshly-computed one.
+    #[test]
+    fn test_recover_rebuilds_missing_sidecar_on_closed_segment() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+
+        // Force segment rotation by writing records whose combined size
+        // exceeds the test config's 64KB segment_size. Each record carries
+        // a ~40KB Value::Bytes payload, so record 2 rotates the writer and
+        // lands in segment 2 while segment 1 closes with record 1.
+        let big_value = || Value::Bytes(vec![0u8; 40 * 1024]);
+        {
+            let mut wal = create_test_wal(&wal_dir);
+            write_txn(
+                &mut wal,
+                1,
+                branch_id,
+                vec![(Key::new_kv(ns.clone(), "a"), big_value())],
+                vec![],
+                1,
+            );
+            write_txn(
+                &mut wal,
+                2,
+                branch_id,
+                vec![(Key::new_kv(ns.clone(), "b"), big_value())],
+                vec![],
+                2,
+            );
+        }
+
+        // Confirm we actually produced two segments before touching sidecars.
+        let seg1 = WalSegment::segment_path(&wal_dir, 1);
+        let seg2 = WalSegment::segment_path(&wal_dir, 2);
+        assert!(seg1.exists(), "segment 1 must exist");
+        assert!(seg2.exists(), "segment 2 must exist (rotation required)");
+
+        // Delete the sidecar for the closed segment (segment 1) so recovery
+        // has something to rebuild.
+        let closed_sidecar =
+            strata_durability::format::SegmentMeta::meta_path(&wal_dir, 1);
+        if closed_sidecar.exists() {
+            std::fs::remove_file(&closed_sidecar).unwrap();
+        }
+        assert!(!closed_sidecar.exists(), "precondition: sidecar removed");
+
+        // Recovery should rebuild the closed-segment sidecar as a side effect.
+        let coord = test_recovery(temp_dir.path());
+        let _ = coord.recover(|_| Ok(()), |_| Ok(())).unwrap();
+
+        assert!(
+            closed_sidecar.exists(),
+            "closed-segment sidecar must be rebuilt by recovery"
+        );
+        let rebuilt = strata_durability::format::SegmentMeta::read_from_file(&wal_dir, 1)
+            .expect("rebuilt sidecar must be readable")
+            .expect("rebuilt sidecar must exist");
+        assert_eq!(rebuilt.segment_number, 1);
+        assert_eq!(rebuilt.record_count, 1);
+        assert_eq!(rebuilt.max_txn_id, TxnId(1));
+    }
+
+    /// Corrupt sidecars on closed segments (fails header/CRC check) are
+    /// replaced with a freshly-computed one. A rebuild must restore the
+    /// correct metadata so the fast path can trust the sidecar again.
+    #[test]
+    fn test_recover_rebuilds_corrupt_sidecar_on_closed_segment() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+
+        // Force two segments so the first is a closed segment the rebuild
+        // path targets.
+        let big_value = || Value::Bytes(vec![0u8; 40 * 1024]);
+        {
+            let mut wal = create_test_wal(&wal_dir);
+            write_txn(
+                &mut wal,
+                1,
+                branch_id,
+                vec![(Key::new_kv(ns.clone(), "a"), big_value())],
+                vec![],
+                1,
+            );
+            write_txn(
+                &mut wal,
+                2,
+                branch_id,
+                vec![(Key::new_kv(ns.clone(), "b"), big_value())],
+                vec![],
+                2,
+            );
+        }
+
+        // Overwrite the closed sidecar with bytes that will fail magic/CRC
+        // validation in `SegmentMeta::from_bytes`.
+        let closed_sidecar =
+            strata_durability::format::SegmentMeta::meta_path(&wal_dir, 1);
+        std::fs::write(&closed_sidecar, b"CORRUPT_GARBAGE_NOT_A_VALID_META").unwrap();
+
+        let coord = test_recovery(temp_dir.path());
+        let _ = coord.recover(|_| Ok(()), |_| Ok(())).unwrap();
+
+        let rebuilt = strata_durability::format::SegmentMeta::read_from_file(&wal_dir, 1)
+            .expect("rebuilt sidecar must be readable after corruption")
+            .expect("rebuilt sidecar must exist");
+        assert_eq!(rebuilt.segment_number, 1);
+        assert_eq!(rebuilt.record_count, 1);
+        assert_eq!(rebuilt.max_txn_id, TxnId(1));
+    }
+
+    /// The active (last) segment's sidecar is deliberately left alone by
+    /// rebuild — the WAL writer owns it. Verify by deleting the active
+    /// sidecar and checking it is NOT rebuilt by recovery.
+    #[test]
+    fn test_recover_does_not_rebuild_active_segment_sidecar() {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let branch_id = BranchId::new();
+        let ns = create_test_namespace(branch_id);
+
+        let big_value = || Value::Bytes(vec![0u8; 40 * 1024]);
+        {
+            let mut wal = create_test_wal(&wal_dir);
+            write_txn(
+                &mut wal,
+                1,
+                branch_id,
+                vec![(Key::new_kv(ns.clone(), "a"), big_value())],
+                vec![],
+                1,
+            );
+            write_txn(
+                &mut wal,
+                2,
+                branch_id,
+                vec![(Key::new_kv(ns.clone(), "b"), big_value())],
+                vec![],
+                2,
+            );
+        }
+
+        // Delete the active-segment sidecar (segment 2 is the tail here).
+        let active_sidecar =
+            strata_durability::format::SegmentMeta::meta_path(&wal_dir, 2);
+        if active_sidecar.exists() {
+            std::fs::remove_file(&active_sidecar).unwrap();
+        }
+
+        let coord = test_recovery(temp_dir.path());
+        let _ = coord.recover(|_| Ok(()), |_| Ok(())).unwrap();
+
+        // Recovery must not have rebuilt the active sidecar — that is the
+        // writer's responsibility at reopen time.
+        assert!(
+            !active_sidecar.exists(),
+            "active segment sidecar must remain untouched by the recovery rebuild"
+        );
     }
 
     /// MANIFEST references a snapshot id but the corresponding .chk file was

--- a/crates/durability/src/compaction/wal_only.rs
+++ b/crates/durability/src/compaction/wal_only.rs
@@ -77,7 +77,12 @@ impl WalOnlyCompactor {
         let start_time = std::time::Instant::now();
         let mut info = CompactInfo::new(CompactMode::WALOnly);
 
-        // Get effective watermark from MANIFEST (flush watermark only; see #1730)
+        // Get effective watermark from MANIFEST — max of flush watermark
+        // and snapshot watermark. Both sources produce recovery-complete
+        // state at or below their respective txn id, so WAL segments
+        // covered by either are safe to delete. Snapshot coverage became
+        // trustworthy in T3-E5 when `RecoveryCoordinator::recover` started
+        // consuming snapshots; see `effective_watermark` for details.
         let (watermark, manifest_active) = {
             let manifest = self.manifest.lock();
             let m = manifest.manifest();
@@ -309,12 +314,29 @@ impl WalOnlyCompactor {
 
 /// Compute the effective watermark for WAL truncation.
 ///
-/// Returns the flush watermark from the MANIFEST, ignoring the snapshot
-/// watermark. Snapshot-aware recovery is not yet implemented (#1730), so
-/// WAL segments must only be deleted when their data is persisted in
-/// on-disk SST segments (tracked by `flushed_through_commit_id`).
+/// Returns the highest txn id whose data recovery can reconstruct without
+/// the WAL: either by replaying flushed SST segments (tracked via
+/// `flushed_through_commit_id`), by installing the latest snapshot
+/// (tracked via `snapshot_watermark`), or both. A WAL segment covered by
+/// this watermark is safe to delete because its records are reconstructible
+/// from one of those two sources during recovery.
+///
+/// T3-E5 restored snapshot coverage here. Before Epic 5, recovery was
+/// WAL-only — the snapshot was written but never loaded — so deleting WAL
+/// segments on snapshot coverage alone (`#1730`) caused data loss. Now
+/// that `RecoveryCoordinator::recover` consumes the snapshot via the
+/// engine's `snapshot_install` decoder, WAL retention can trust the
+/// composite coverage again.
 fn effective_watermark(manifest: &crate::format::Manifest) -> Option<u64> {
-    manifest.flushed_through_commit_id
+    match (
+        manifest.flushed_through_commit_id,
+        manifest.snapshot_watermark,
+    ) {
+        (Some(flushed), Some(snap)) => Some(flushed.max(snap)),
+        (Some(flushed), None) => Some(flushed),
+        (None, Some(snap)) => Some(snap),
+        (None, None) => None,
+    }
 }
 
 /// Generate segment file path
@@ -783,15 +805,23 @@ mod tests {
     }
 
     #[test]
-    fn test_wal_truncation_ignores_snapshot_watermark() {
-        // Issue #1730: snapshot watermark must NOT drive WAL deletion because
-        // recovery is WAL-only and cannot load snapshots.
+    fn test_wal_truncation_accepts_snapshot_watermark_alone() {
+        // Inverted from the pre-T3-E5 `test_wal_truncation_ignores_snapshot_watermark`.
+        //
+        // Before T3-E5, recovery was WAL-only — snapshots were written but
+        // never consumed — so WAL deletion could not trust snapshot coverage
+        // (`#1730`). After T3-E5, `RecoveryCoordinator::recover` installs
+        // snapshots through the engine's `snapshot_install` decoder, which
+        // makes snapshot watermark a valid input to `effective_watermark`.
+        // WAL segments whose records are covered by the snapshot are now
+        // safe to delete even when no flush watermark has been recorded.
         let (_dir, wal_dir, manifest) = setup_test_env();
 
         create_segment_with_records(&wal_dir, 1, &[1, 2, 3]).unwrap();
         create_segment_with_records(&wal_dir, 2, &[4, 5, 6]).unwrap();
 
-        // Set only snapshot watermark (no flush watermark)
+        // Set only snapshot watermark (no flush watermark). Watermark=100
+        // covers every record written to segments 1 and 2.
         {
             let mut m = manifest.lock();
             m.set_snapshot_watermark(1, TxnId(100)).unwrap();
@@ -800,13 +830,17 @@ mod tests {
         }
 
         let compactor = WalOnlyCompactor::new(wal_dir.clone(), manifest);
-        let result = compactor.compact();
+        let info = compactor
+            .compact()
+            .expect("snapshot watermark alone must drive successful compaction after T3-E5");
 
-        // Must return NoSnapshot because snapshot watermark alone is not safe
-        assert!(matches!(result, Err(CompactionError::NoSnapshot)));
-        // WAL segments must NOT be deleted
-        assert!(segment_path(&wal_dir, 1).exists());
-        assert!(segment_path(&wal_dir, 2).exists());
+        // Both closed segments are covered by the snapshot watermark and
+        // must be removed; the active boundary is manifest.active=10 so
+        // nothing there to protect.
+        assert_eq!(info.wal_segments_removed, 2);
+        assert!(!segment_path(&wal_dir, 1).exists());
+        assert!(!segment_path(&wal_dir, 2).exists());
+        assert_eq!(info.snapshot_watermark, Some(100));
     }
 
     #[test]

--- a/crates/durability/src/compaction/wal_only.rs
+++ b/crates/durability/src/compaction/wal_only.rs
@@ -77,12 +77,7 @@ impl WalOnlyCompactor {
         let start_time = std::time::Instant::now();
         let mut info = CompactInfo::new(CompactMode::WALOnly);
 
-        // Get effective watermark from MANIFEST — max of flush watermark
-        // and snapshot watermark. Both sources produce recovery-complete
-        // state at or below their respective txn id, so WAL segments
-        // covered by either are safe to delete. Snapshot coverage became
-        // trustworthy in T3-E5 when `RecoveryCoordinator::recover` started
-        // consuming snapshots; see `effective_watermark` for details.
+        // Get effective watermark from MANIFEST (flush watermark only; see #1730)
         let (watermark, manifest_active) = {
             let manifest = self.manifest.lock();
             let m = manifest.manifest();
@@ -314,29 +309,12 @@ impl WalOnlyCompactor {
 
 /// Compute the effective watermark for WAL truncation.
 ///
-/// Returns the highest txn id whose data recovery can reconstruct without
-/// the WAL: either by replaying flushed SST segments (tracked via
-/// `flushed_through_commit_id`), by installing the latest snapshot
-/// (tracked via `snapshot_watermark`), or both. A WAL segment covered by
-/// this watermark is safe to delete because its records are reconstructible
-/// from one of those two sources during recovery.
-///
-/// T3-E5 restored snapshot coverage here. Before Epic 5, recovery was
-/// WAL-only — the snapshot was written but never loaded — so deleting WAL
-/// segments on snapshot coverage alone (`#1730`) caused data loss. Now
-/// that `RecoveryCoordinator::recover` consumes the snapshot via the
-/// engine's `snapshot_install` decoder, WAL retention can trust the
-/// composite coverage again.
+/// Returns the flush watermark from the MANIFEST, ignoring the snapshot
+/// watermark. Snapshot-aware recovery is not yet implemented (#1730), so
+/// WAL segments must only be deleted when their data is persisted in
+/// on-disk SST segments (tracked by `flushed_through_commit_id`).
 fn effective_watermark(manifest: &crate::format::Manifest) -> Option<u64> {
-    match (
-        manifest.flushed_through_commit_id,
-        manifest.snapshot_watermark,
-    ) {
-        (Some(flushed), Some(snap)) => Some(flushed.max(snap)),
-        (Some(flushed), None) => Some(flushed),
-        (None, Some(snap)) => Some(snap),
-        (None, None) => None,
-    }
+    manifest.flushed_through_commit_id
 }
 
 /// Generate segment file path
@@ -805,23 +783,15 @@ mod tests {
     }
 
     #[test]
-    fn test_wal_truncation_accepts_snapshot_watermark_alone() {
-        // Inverted from the pre-T3-E5 `test_wal_truncation_ignores_snapshot_watermark`.
-        //
-        // Before T3-E5, recovery was WAL-only — snapshots were written but
-        // never consumed — so WAL deletion could not trust snapshot coverage
-        // (`#1730`). After T3-E5, `RecoveryCoordinator::recover` installs
-        // snapshots through the engine's `snapshot_install` decoder, which
-        // makes snapshot watermark a valid input to `effective_watermark`.
-        // WAL segments whose records are covered by the snapshot are now
-        // safe to delete even when no flush watermark has been recorded.
+    fn test_wal_truncation_ignores_snapshot_watermark() {
+        // Issue #1730: snapshot watermark must NOT drive WAL deletion because
+        // recovery is WAL-only and cannot load snapshots.
         let (_dir, wal_dir, manifest) = setup_test_env();
 
         create_segment_with_records(&wal_dir, 1, &[1, 2, 3]).unwrap();
         create_segment_with_records(&wal_dir, 2, &[4, 5, 6]).unwrap();
 
-        // Set only snapshot watermark (no flush watermark). Watermark=100
-        // covers every record written to segments 1 and 2.
+        // Set only snapshot watermark (no flush watermark)
         {
             let mut m = manifest.lock();
             m.set_snapshot_watermark(1, TxnId(100)).unwrap();
@@ -830,17 +800,13 @@ mod tests {
         }
 
         let compactor = WalOnlyCompactor::new(wal_dir.clone(), manifest);
-        let info = compactor
-            .compact()
-            .expect("snapshot watermark alone must drive successful compaction after T3-E5");
+        let result = compactor.compact();
 
-        // Both closed segments are covered by the snapshot watermark and
-        // must be removed; the active boundary is manifest.active=10 so
-        // nothing there to protect.
-        assert_eq!(info.wal_segments_removed, 2);
-        assert!(!segment_path(&wal_dir, 1).exists());
-        assert!(!segment_path(&wal_dir, 2).exists());
-        assert_eq!(info.snapshot_watermark, Some(100));
+        // Must return NoSnapshot because snapshot watermark alone is not safe
+        assert!(matches!(result, Err(CompactionError::NoSnapshot)));
+        // WAL segments must NOT be deleted
+        assert!(segment_path(&wal_dir, 1).exists());
+        assert!(segment_path(&wal_dir, 2).exists());
     }
 
     #[test]

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -663,6 +663,7 @@ mod tests {
             final_version: CommitVersion(100),
             max_txn_id: TxnId(6),
             from_checkpoint: false,
+            txns_skipped_below_watermark: 0,
         };
 
         let result = RecoveryResult {
@@ -1126,6 +1127,7 @@ mod tests {
             final_version: CommitVersion(500),
             max_txn_id: TxnId(15),
             from_checkpoint: false,
+            txns_skipped_below_watermark: 0,
         };
 
         let result = RecoveryResult {

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -722,7 +722,7 @@ mod tests {
         drop(store);
 
         let recovery = RecoveryCoordinator::new(layout, 0);
-        let result = recovery.recover().unwrap();
+        let result = recovery.recover_into_memory_storage().unwrap();
         assert_eq!(result.stats.final_version, CommitVersion::ZERO);
 
         let seg_info = result.storage.recover_segments().unwrap();

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -566,6 +566,7 @@ mod compaction;
 mod lifecycle;
 mod open;
 pub mod refresh;
+mod snapshot_install;
 mod transaction;
 
 #[cfg(test)]

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -466,11 +466,9 @@ impl Database {
             layout.segments_dir().to_path_buf(),
             cfg.storage.effective_write_buffer_size(),
         );
-        let mut recovery = RecoveryCoordinator::new(
-            layout.clone(),
-            cfg.storage.effective_write_buffer_size(),
-        )
-        .with_lossy_recovery(cfg.allow_lossy_recovery);
+        let mut recovery =
+            RecoveryCoordinator::new(layout.clone(), cfg.storage.effective_write_buffer_size())
+                .with_lossy_recovery(cfg.allow_lossy_recovery);
         if let Some(ref c) = follower_codec {
             recovery = recovery.with_codec(clone_codec(c.as_ref()));
         }
@@ -907,12 +905,10 @@ impl Database {
             cfg.storage.effective_write_buffer_size(),
         );
         let recovery_codec_for_install = clone_codec(codec.as_ref());
-        let recovery = RecoveryCoordinator::new(
-            layout.clone(),
-            cfg.storage.effective_write_buffer_size(),
-        )
-        .with_lossy_recovery(cfg.allow_lossy_recovery)
-        .with_codec(clone_codec(codec.as_ref()));
+        let recovery =
+            RecoveryCoordinator::new(layout.clone(), cfg.storage.effective_write_buffer_size())
+                .with_lossy_recovery(cfg.allow_lossy_recovery)
+                .with_codec(clone_codec(codec.as_ref()));
 
         let recover_result = {
             let storage_ref = &storage;

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -10,8 +10,9 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
-use strata_concurrency::RecoveryCoordinator;
+use strata_concurrency::{apply_wal_record_to_memory_storage, RecoveryCoordinator, RecoveryStats};
 use strata_durability::__internal::WalWriterEngineExt;
+use strata_durability::codec::clone_codec;
 use strata_durability::layout::DatabaseLayout;
 use strata_durability::wal::{DurabilityMode, WalConfig, WalWriter};
 use strata_durability::ManifestManager;
@@ -779,43 +780,16 @@ impl Database {
         let wal_dir = layout.wal_dir().to_path_buf();
         let manifest_path = layout.manifest_path().to_path_buf();
 
-        // Use RecoveryCoordinator for proper transaction-aware recovery
-        // This reads all WalRecords from the segmented WAL directory
-        let recovery = RecoveryCoordinator::new(layout, cfg.storage.effective_write_buffer_size())
-            .with_lossy_recovery(cfg.allow_lossy_recovery);
-        let result = match recovery.recover_into_memory_storage() {
-            Ok(result) => result,
-            Err(e) => {
-                if cfg.allow_lossy_recovery {
-                    warn!(
-                        target: "strata::db",
-                        error = %e,
-                        "Recovery failed — starting with empty state (allow_lossy_recovery=true)"
-                    );
-                    strata_concurrency::RecoveryResult::empty()
-                } else {
-                    return Err(StrataError::corruption(format!(
-                        "WAL recovery failed: {}. Set allow_lossy_recovery=true to force open with data loss.",
-                        e
-                    )));
-                }
-            }
-        };
-
-        info!(
-            target: "strata::db",
-            txns_replayed = result.stats.txns_replayed,
-            writes_applied = result.stats.writes_applied,
-            deletes_applied = result.stats.deletes_applied,
-            final_version = result.stats.final_version.as_u64(),
-            "Recovery complete"
-        );
-
-        // Load or create MANIFEST to get the database UUID.
-        // On first open: generate a new UUID and persist it with the configured codec.
+        // Load or create MANIFEST before recovery runs so the coordinator can
+        // consult it for snapshot identity and codec validation. On first
+        // open: generate a new UUID and persist it with the configured codec.
         // On subsequent opens: load the existing UUID and validate codec matches.
+        //
+        // The coordinator re-validates codec inside `plan_recovery` before any
+        // WAL bytes are read; the check here is kept as fail-fast defense in
+        // depth and can be removed in Chunk 3 once the rewire is complete.
         let database_uuid = if ManifestManager::exists(&manifest_path) {
-            let m = ManifestManager::load(manifest_path)
+            let m = ManifestManager::load(manifest_path.clone())
                 .map_err(|e| StrataError::internal(format!("failed to load MANIFEST: {}", e)))?;
             let stored_codec = &m.manifest().codec_id;
             if stored_codec != &cfg.storage.codec {
@@ -833,10 +807,95 @@ impl Database {
             uuid
         };
 
-        // Instantiate the configured storage codec (identity or aes-gcm-256)
+        // Instantiate the configured storage codec (identity or aes-gcm-256).
+        // One instance is owned here for the WAL writer; a clone is handed to
+        // the coordinator for snapshot decode.
         let codec = strata_durability::get_codec(&cfg.storage.codec).map_err(|e| {
             StrataError::internal(format!("failed to initialize storage codec: {}", e))
         })?;
+
+        // Drive recovery via the callback-driven API so the engine owns
+        // storage construction and snapshot install decoding.
+        let mut storage = SegmentedStore::with_dir(
+            layout.segments_dir().to_path_buf(),
+            cfg.storage.effective_write_buffer_size(),
+        );
+        let recovery_codec_for_install = clone_codec(codec.as_ref());
+        let recovery = RecoveryCoordinator::new(
+            layout.clone(),
+            cfg.storage.effective_write_buffer_size(),
+        )
+        .with_lossy_recovery(cfg.allow_lossy_recovery)
+        .with_codec(clone_codec(codec.as_ref()));
+
+        let recover_result = {
+            let storage_ref = &storage;
+            let install_codec = recovery_codec_for_install.as_ref();
+            recovery.recover(
+                |snapshot| {
+                    let installed = super::snapshot_install::install_snapshot(
+                        &snapshot,
+                        install_codec,
+                        storage_ref,
+                    )?;
+                    info!(
+                        target: "strata::recovery",
+                        snapshot_id = snapshot.snapshot_id(),
+                        watermark = snapshot.watermark_txn(),
+                        entries = installed.total_installed(),
+                        "Installed snapshot into SegmentedStore"
+                    );
+                    Ok(())
+                },
+                |record| apply_wal_record_to_memory_storage(storage_ref, record),
+            )
+        };
+
+        let mut stats = match recover_result {
+            Ok(stats) => stats,
+            Err(e) => {
+                if cfg.allow_lossy_recovery {
+                    warn!(
+                        target: "strata::db",
+                        error = %e,
+                        "Recovery failed — starting with empty state (allow_lossy_recovery=true)"
+                    );
+                    // Discard any partial writes accumulated before the
+                    // failure so lossy-mode semantics match the pre-Epic-5
+                    // `RecoveryResult::empty()` fallback: no user data
+                    // surfaces from a failed recovery pass.
+                    storage = SegmentedStore::with_dir(
+                        layout.segments_dir().to_path_buf(),
+                        cfg.storage.effective_write_buffer_size(),
+                    );
+                    RecoveryStats::default()
+                } else {
+                    return Err(StrataError::corruption(format!(
+                        "WAL recovery failed: {}. Set allow_lossy_recovery=true to force open with data loss.",
+                        e
+                    )));
+                }
+            }
+        };
+
+        // Snapshot install advances `storage.version` beyond the per-record
+        // WAL versions the coordinator tracks in `stats.final_version`.
+        // Fold the storage-side counter back into stats so the downstream
+        // `TransactionCoordinator::from_recovery_with_limits` bootstraps
+        // above the snapshot's max commit version. Missing this leaves the
+        // commit version counter below installed data, producing monotonicity
+        // violations on the first post-reopen commit.
+        stats.final_version = stats.final_version.max(CommitVersion(storage.version()));
+
+        info!(
+            target: "strata::db",
+            txns_replayed = stats.txns_replayed,
+            writes_applied = stats.writes_applied,
+            deletes_applied = stats.deletes_applied,
+            final_version = stats.final_version.as_u64(),
+            from_checkpoint = stats.from_checkpoint,
+            "Recovery complete"
+        );
 
         // Open segmented WAL writer for appending
         let wal_writer = WalWriter::new(
@@ -846,6 +905,18 @@ impl Database {
             WalConfig::default(),
             codec,
         )?;
+
+        // Re-assemble the legacy `RecoveryResult` shape for downstream code
+        // paths (coordinator bootstrap, segment recovery bump). Chunk 3
+        // collapses this by introducing a stats-only coordinator constructor.
+        let result = strata_concurrency::RecoveryResult {
+            storage,
+            txn_manager: strata_concurrency::TransactionManager::with_txn_id(
+                stats.final_version,
+                stats.max_txn_id,
+            ),
+            stats,
+        };
 
         let watermark = super::refresh::ContiguousWatermark::new(result.stats.max_txn_id);
 

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -429,17 +429,92 @@ impl Database {
         let wal_dir = layout.wal_dir().to_path_buf();
         let manifest_path = layout.manifest_path().to_path_buf();
 
-        // Recovery — purely read-only (no truncation, no file writes)
-        let recovery = RecoveryCoordinator::new(layout, cfg.storage.effective_write_buffer_size())
-            .with_lossy_recovery(cfg.allow_lossy_recovery);
-        let result = match recovery.recover_into_memory_storage() {
-            Ok(result) => result,
+        // Read-only MANIFEST inspection: the follower derives its codec
+        // from whatever the database was created with. When the MANIFEST is
+        // absent (fresh database) or the codec is unsupported on this build,
+        // snapshot loading is skipped and recovery stays WAL-only.
+        let (database_uuid, follower_codec) = if ManifestManager::exists(&manifest_path) {
+            match ManifestManager::load(manifest_path.clone()) {
+                Ok(m) => {
+                    let manifest = m.manifest();
+                    let codec = strata_durability::get_codec(&manifest.codec_id).ok();
+                    if codec.is_none() {
+                        warn!(
+                            target: "strata::db",
+                            codec_id = %manifest.codec_id,
+                            "Follower could not initialize MANIFEST codec; snapshot loading will be skipped"
+                        );
+                    }
+                    (manifest.database_uuid, codec)
+                }
+                Err(e) => {
+                    warn!(
+                        target: "strata::db",
+                        error = %e,
+                        "Follower could not load MANIFEST; continuing with WAL-only recovery"
+                    );
+                    ([0u8; 16], None)
+                }
+            }
+        } else {
+            ([0u8; 16], None)
+        };
+
+        // Drive recovery via the callback-driven API. Snapshot install is
+        // wired only when a codec was resolved above; otherwise the
+        // coordinator falls back to WAL-only, matching the pre-Chunk-3
+        // follower behavior.
+        let mut storage = SegmentedStore::with_dir(
+            layout.segments_dir().to_path_buf(),
+            cfg.storage.effective_write_buffer_size(),
+        );
+        let mut recovery = RecoveryCoordinator::new(
+            layout.clone(),
+            cfg.storage.effective_write_buffer_size(),
+        )
+        .with_lossy_recovery(cfg.allow_lossy_recovery);
+        if let Some(ref c) = follower_codec {
+            recovery = recovery.with_codec(clone_codec(c.as_ref()));
+        }
+        let install_codec_for_follower = follower_codec.as_ref().map(|c| clone_codec(c.as_ref()));
+
+        let recover_result = {
+            let storage_ref = &storage;
+            let install_codec_ref = install_codec_for_follower.as_deref();
+            recovery.recover(
+                |snapshot| {
+                    if let Some(install_codec) = install_codec_ref {
+                        let installed = super::snapshot_install::install_snapshot(
+                            &snapshot,
+                            install_codec,
+                            storage_ref,
+                        )?;
+                        info!(
+                            target: "strata::recovery",
+                            snapshot_id = snapshot.snapshot_id(),
+                            watermark = snapshot.watermark_txn(),
+                            entries = installed.total_installed(),
+                            "Follower installed snapshot into SegmentedStore"
+                        );
+                    }
+                    Ok(())
+                },
+                |record| apply_wal_record_to_memory_storage(storage_ref, record),
+            )
+        };
+
+        let mut stats = match recover_result {
+            Ok(stats) => stats,
             Err(e) => {
                 if cfg.allow_lossy_recovery {
                     warn!(target: "strata::db",
                         error = %e,
                         "Follower recovery failed — starting with empty state");
-                    strata_concurrency::RecoveryResult::empty()
+                    storage = SegmentedStore::with_dir(
+                        layout.segments_dir().to_path_buf(),
+                        cfg.storage.effective_write_buffer_size(),
+                    );
+                    RecoveryStats::default()
                 } else {
                     return Err(StrataError::corruption(format!(
                         "WAL recovery failed in follower mode: {}. \
@@ -450,10 +525,24 @@ impl Database {
             }
         };
 
+        // Fold snapshot-installed storage version into stats so the follower's
+        // TransactionCoordinator bootstraps above snapshot entries.
+        stats.final_version = stats.final_version.max(CommitVersion(storage.version()));
+
         info!(target: "strata::db",
-            txns_replayed = result.stats.txns_replayed,
-            writes_applied = result.stats.writes_applied,
+            txns_replayed = stats.txns_replayed,
+            writes_applied = stats.writes_applied,
+            from_checkpoint = stats.from_checkpoint,
             "Follower recovery complete");
+
+        let result = strata_concurrency::RecoveryResult {
+            storage,
+            txn_manager: strata_concurrency::TransactionManager::with_txn_id(
+                stats.final_version,
+                stats.max_txn_id,
+            ),
+            stats,
+        };
 
         let persisted_follower_state = match load_persisted_follower_state(&canonical_path) {
             Ok(Some(state))
@@ -507,14 +596,9 @@ impl Database {
 
         Self::recover_segments_and_bump(&storage, &coordinator, cfg.allow_lossy_recovery)?;
 
-        // Load database UUID from MANIFEST if it exists (read-only, no create)
-        let database_uuid = if ManifestManager::exists(&manifest_path) {
-            ManifestManager::load(manifest_path)
-                .map(|m| m.manifest().database_uuid)
-                .unwrap_or([0u8; 16])
-        } else {
-            [0u8; 16]
-        };
+        // `database_uuid` was already resolved from the MANIFEST above (or
+        // defaulted when absent) before recovery ran, so the snapshot-install
+        // codec and the instance UUID come from the same read.
 
         let db = Arc::new(Self {
             data_dir: canonical_path,
@@ -783,11 +867,15 @@ impl Database {
         // Load or create MANIFEST before recovery runs so the coordinator can
         // consult it for snapshot identity and codec validation. On first
         // open: generate a new UUID and persist it with the configured codec.
-        // On subsequent opens: load the existing UUID and validate codec matches.
+        // On subsequent opens: load the existing UUID and reject codec drift.
         //
-        // The coordinator re-validates codec inside `plan_recovery` before any
-        // WAL bytes are read; the check here is kept as fail-fast defense in
-        // depth and can be removed in Chunk 3 once the rewire is complete.
+        // The coordinator's `plan_recovery` also validates codec, but only
+        // while inside `recover()`, whose error path is subject to the
+        // lossy-recovery fallback. Codec mismatch is a configuration error,
+        // not data corruption, and must NOT be swallowed by lossy mode —
+        // otherwise a misconfigured reopen would silently discard the
+        // database instead of alerting the operator. Keeping the check here
+        // keeps it ahead of the lossy branch.
         let database_uuid = if ManifestManager::exists(&manifest_path) {
             let m = ManifestManager::load(manifest_path.clone())
                 .map_err(|e| StrataError::internal(format!("failed to load MANIFEST: {}", e)))?;

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -429,33 +429,31 @@ impl Database {
         let wal_dir = layout.wal_dir().to_path_buf();
         let manifest_path = layout.manifest_path().to_path_buf();
 
-        // Read-only MANIFEST inspection: the follower derives its codec
-        // from whatever the database was created with. When the MANIFEST is
-        // absent (fresh database) or the codec is unsupported on this build,
-        // snapshot loading is skipped and recovery stays WAL-only.
+        // Read-only MANIFEST inspection: the follower derives its codec from
+        // whatever the database was created with. Failures here match the
+        // primary's error handling — a MANIFEST that exists but cannot be
+        // parsed is corruption, and a codec id the local build cannot
+        // initialize is a configuration mismatch. Both produce hard errors
+        // so a snapshot-aware compact on the primary does not cause the
+        // follower to silently serve stale / empty state once pre-snapshot
+        // WAL has been reclaimed. Only a genuinely absent MANIFEST (fresh
+        // database) degrades to WAL-only recovery.
         let (database_uuid, follower_codec) = if ManifestManager::exists(&manifest_path) {
-            match ManifestManager::load(manifest_path.clone()) {
-                Ok(m) => {
-                    let manifest = m.manifest();
-                    let codec = strata_durability::get_codec(&manifest.codec_id).ok();
-                    if codec.is_none() {
-                        warn!(
-                            target: "strata::db",
-                            codec_id = %manifest.codec_id,
-                            "Follower could not initialize MANIFEST codec; snapshot loading will be skipped"
-                        );
-                    }
-                    (manifest.database_uuid, codec)
-                }
-                Err(e) => {
-                    warn!(
-                        target: "strata::db",
-                        error = %e,
-                        "Follower could not load MANIFEST; continuing with WAL-only recovery"
-                    );
-                    ([0u8; 16], None)
-                }
-            }
+            let m = ManifestManager::load(manifest_path.clone()).map_err(|e| {
+                StrataError::corruption(format!(
+                    "follower could not load MANIFEST at {}: {}",
+                    manifest_path.display(),
+                    e
+                ))
+            })?;
+            let manifest = m.manifest();
+            let codec = strata_durability::get_codec(&manifest.codec_id).map_err(|e| {
+                StrataError::internal(format!(
+                    "follower could not initialize MANIFEST codec '{}': {}",
+                    manifest.codec_id, e
+                ))
+            })?;
+            (manifest.database_uuid, Some(codec))
         } else {
             ([0u8; 16], None)
         };

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -431,7 +431,7 @@ impl Database {
         // Recovery — purely read-only (no truncation, no file writes)
         let recovery = RecoveryCoordinator::new(layout, cfg.storage.effective_write_buffer_size())
             .with_lossy_recovery(cfg.allow_lossy_recovery);
-        let result = match recovery.recover() {
+        let result = match recovery.recover_into_memory_storage() {
             Ok(result) => result,
             Err(e) => {
                 if cfg.allow_lossy_recovery {
@@ -783,7 +783,7 @@ impl Database {
         // This reads all WalRecords from the segmented WAL directory
         let recovery = RecoveryCoordinator::new(layout, cfg.storage.effective_write_buffer_size())
             .with_lossy_recovery(cfg.allow_lossy_recovery);
-        let result = match recovery.recover() {
+        let result = match recovery.recover_into_memory_storage() {
             Ok(result) => result,
             Err(e) => {
                 if cfg.allow_lossy_recovery {

--- a/crates/engine/src/database/snapshot_install.rs
+++ b/crates/engine/src/database/snapshot_install.rs
@@ -1,0 +1,706 @@
+//! Decode `LoadedSnapshot` sections and install them into `SegmentedStore`.
+//!
+//! This is the engine-side inverse of `compaction::collect_checkpoint_data`.
+//! It walks the per-primitive sections of a `LoadedSnapshot`, deserializes
+//! each section via [`SnapshotSerializer`], and routes decoded entries into
+//! [`SegmentedStore::install_snapshot_entries`] grouped by
+//! `(branch_id, type_tag)`.
+//!
+//! Recovery calls this from the `on_snapshot` callback passed to
+//! `RecoveryCoordinator::recover` so checkpoint-only restart (no WAL covering
+//! some pre-snapshot range) produces the same observable state as the
+//! original commits.
+//!
+//! Branch-primitive sections are currently skipped with a warning: their
+//! snapshot DTO does not carry `branch_id` so install cannot know which
+//! branch to target. Branch metadata remains recoverable through WAL replay;
+//! a DTO fix for Branch is tracked separately from T3-E5.
+//!
+//! Graph-primitive standalone sections are also skipped: today
+//! `collect_checkpoint_data` emits Graph entries inside the KV section with
+//! `type_tag = TypeTag::Graph`, and the KV decoder below routes them to the
+//! correct storage type. A future standalone Graph section would need its
+//! own decoder.
+
+use std::collections::HashMap;
+
+use strata_core::id::CommitVersion;
+use strata_core::value::Value;
+use strata_core::{BranchId, StrataError, StrataResult, TypeTag};
+use strata_durability::codec::{clone_codec, StorageCodec};
+use strata_durability::format::primitive_tags;
+use strata_durability::{LoadedSnapshot, SnapshotSerializer};
+use strata_storage::{DecodedSnapshotEntry, DecodedSnapshotValue, SegmentedStore};
+use tracing::warn;
+
+/// Counts of entries installed per primitive during a snapshot install.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct InstallStats {
+    /// KV entries installed (TypeTag::KV).
+    pub kv: usize,
+    /// Graph entries installed (TypeTag::Graph) — routed through the KV section.
+    pub graph: usize,
+    /// Event entries installed.
+    pub events: usize,
+    /// JSON entries installed.
+    pub json: usize,
+    /// Vector collection configs installed (the `__config__/{name}` rows).
+    pub vector_configs: usize,
+    /// Individual vector records installed.
+    pub vectors: usize,
+    /// Sections that were present in the snapshot but intentionally skipped
+    /// (Branch section today; Graph standalone section if ever non-empty).
+    pub sections_skipped: usize,
+}
+
+impl InstallStats {
+    /// Total number of logical entries written into storage.
+    pub(crate) fn total_installed(&self) -> usize {
+        self.kv + self.graph + self.events + self.json + self.vector_configs + self.vectors
+    }
+}
+
+/// Install every section of `snapshot` into `storage`, preserving the original
+/// commit version, timestamp, and tombstone state recorded in the checkpoint.
+///
+/// Returns `InstallStats` describing what was installed. Sections with
+/// unknown primitive tags are treated as corruption and returned as error —
+/// an unrecognized tag means we are reading a newer snapshot format than
+/// this binary supports, which is unsafe to ignore.
+pub(crate) fn install_snapshot(
+    snapshot: &LoadedSnapshot,
+    codec: &dyn StorageCodec,
+    storage: &SegmentedStore,
+) -> StrataResult<InstallStats> {
+    let serializer = SnapshotSerializer::new(clone_codec(codec));
+    let mut stats = InstallStats::default();
+    for section in &snapshot.sections {
+        match section.primitive_type {
+            primitive_tags::KV => install_kv_section(&serializer, &section.data, storage, &mut stats)?,
+            primitive_tags::EVENT => install_event_section(&serializer, &section.data, storage, &mut stats)?,
+            primitive_tags::JSON => install_json_section(&serializer, &section.data, storage, &mut stats)?,
+            primitive_tags::VECTOR => install_vector_section(&serializer, &section.data, storage, &mut stats)?,
+            primitive_tags::BRANCH => {
+                // BranchSnapshotEntry does not carry a `branch_id` field today,
+                // so install cannot dispatch per-branch correctly. Branch
+                // metadata is also recorded in the WAL, so delta-replay
+                // reconstitutes it. Log and skip.
+                warn!(
+                    target: "strata::recovery",
+                    section = "Branch",
+                    bytes = section.data.len(),
+                    "Skipping Branch snapshot section: DTO lacks branch_id; \
+                     Branch metadata will be reconstituted from WAL"
+                );
+                stats.sections_skipped += 1;
+            }
+            primitive_tags::GRAPH => {
+                // Graph entries are written inside the KV section today; a
+                // standalone Graph section is not emitted by
+                // collect_checkpoint_data. Tolerate an empty section for
+                // forward-compat but warn if one ever shows up with data.
+                if !section.data.is_empty() {
+                    warn!(
+                        target: "strata::recovery",
+                        section = "Graph",
+                        bytes = section.data.len(),
+                        "Skipping standalone Graph snapshot section: no decoder wired; \
+                         Graph entries are expected in the KV section"
+                    );
+                    stats.sections_skipped += 1;
+                }
+            }
+            other => {
+                return Err(StrataError::corruption(format!(
+                    "Unknown snapshot primitive tag 0x{:02x} at section boundary",
+                    other
+                )));
+            }
+        }
+    }
+    Ok(stats)
+}
+
+/// Decode one KV section and install entries grouped by `(branch_id, type_tag)`.
+///
+/// The KV section carries both KV and Graph entries (`type_tag` discriminates);
+/// install routes them to the appropriate storage type.
+fn install_kv_section(
+    serializer: &SnapshotSerializer,
+    data: &[u8],
+    storage: &SegmentedStore,
+    stats: &mut InstallStats,
+) -> StrataResult<()> {
+    let entries = serializer
+        .deserialize_kv(data)
+        .map_err(|e| StrataError::corruption(format!("KV section decode failed: {}", e)))?;
+
+    let mut groups: HashMap<([u8; 16], u8), Vec<DecodedSnapshotEntry>> = HashMap::new();
+    for entry in entries {
+        let value = decode_value_json(&entry.value, "KV")?;
+        let decoded = DecodedSnapshotEntry {
+            space: entry.space,
+            user_key: entry.user_key,
+            payload: DecodedSnapshotValue::Value(value),
+            version: CommitVersion(entry.version),
+            timestamp_micros: entry.timestamp,
+            // KV snapshot DTO does not carry TTL today; T3-E4 flagged this
+            // as a retention-completeness follow-up. 0 = no expiry, matching
+            // pre-snapshot-install behavior.
+            ttl_ms: 0,
+        };
+        groups
+            .entry((entry.branch_id, entry.type_tag))
+            .or_default()
+            .push(decoded);
+    }
+    for ((branch_bytes, tag_byte), group_entries) in groups {
+        let branch_id = BranchId::from_bytes(branch_bytes);
+        let type_tag = TypeTag::from_byte(tag_byte).ok_or_else(|| {
+            StrataError::corruption(format!(
+                "Invalid TypeTag 0x{:02x} in KV snapshot entry",
+                tag_byte
+            ))
+        })?;
+        let count = storage.install_snapshot_entries(branch_id, type_tag, &group_entries)?;
+        match type_tag {
+            TypeTag::Graph => stats.graph += count,
+            _ => stats.kv += count,
+        }
+    }
+    Ok(())
+}
+
+/// Decode an Event section and install entries per-branch.
+///
+/// Event keys are reconstructed from the 8-byte big-endian sequence number,
+/// matching the invariant in `Key::new_event`.
+fn install_event_section(
+    serializer: &SnapshotSerializer,
+    data: &[u8],
+    storage: &SegmentedStore,
+    stats: &mut InstallStats,
+) -> StrataResult<()> {
+    let entries = serializer
+        .deserialize_events(data)
+        .map_err(|e| StrataError::corruption(format!("Event section decode failed: {}", e)))?;
+
+    let mut groups: HashMap<[u8; 16], Vec<DecodedSnapshotEntry>> = HashMap::new();
+    for entry in entries {
+        let value = decode_value_json(&entry.payload, "Event")?;
+        let decoded = DecodedSnapshotEntry {
+            space: entry.space,
+            user_key: entry.sequence.to_be_bytes().to_vec(),
+            payload: DecodedSnapshotValue::Value(value),
+            version: CommitVersion(entry.version),
+            timestamp_micros: entry.timestamp,
+            ttl_ms: 0,
+        };
+        groups.entry(entry.branch_id).or_default().push(decoded);
+    }
+    for (branch_bytes, group_entries) in groups {
+        let branch_id = BranchId::from_bytes(branch_bytes);
+        let count =
+            storage.install_snapshot_entries(branch_id, TypeTag::Event, &group_entries)?;
+        stats.events += count;
+    }
+    Ok(())
+}
+
+/// Decode a JSON section and install entries per-branch with doc-id as the
+/// user key (matching the Json primitive's key encoding).
+fn install_json_section(
+    serializer: &SnapshotSerializer,
+    data: &[u8],
+    storage: &SegmentedStore,
+    stats: &mut InstallStats,
+) -> StrataResult<()> {
+    let entries = serializer
+        .deserialize_json(data)
+        .map_err(|e| StrataError::corruption(format!("JSON section decode failed: {}", e)))?;
+
+    let mut groups: HashMap<[u8; 16], Vec<DecodedSnapshotEntry>> = HashMap::new();
+    for entry in entries {
+        let value = decode_value_json(&entry.content, "Json")?;
+        let decoded = DecodedSnapshotEntry {
+            space: entry.space,
+            user_key: entry.doc_id.into_bytes(),
+            payload: DecodedSnapshotValue::Value(value),
+            version: CommitVersion(entry.version),
+            timestamp_micros: entry.timestamp,
+            ttl_ms: 0,
+        };
+        groups.entry(entry.branch_id).or_default().push(decoded);
+    }
+    for (branch_bytes, group_entries) in groups {
+        let branch_id = BranchId::from_bytes(branch_bytes);
+        let count =
+            storage.install_snapshot_entries(branch_id, TypeTag::Json, &group_entries)?;
+        stats.json += count;
+    }
+    Ok(())
+}
+
+/// Decode a Vector section and install two classes of entries per collection:
+///
+/// 1. The collection-config row keyed `__config__/{name}`.
+/// 2. One row per vector keyed `{name}/{vector_key}`, carrying the raw
+///    `VectorRecord` bytes so subsystem recovery can reconstruct the index.
+fn install_vector_section(
+    serializer: &SnapshotSerializer,
+    data: &[u8],
+    storage: &SegmentedStore,
+    stats: &mut InstallStats,
+) -> StrataResult<()> {
+    let collections = serializer
+        .deserialize_vectors(data)
+        .map_err(|e| StrataError::corruption(format!("Vector section decode failed: {}", e)))?;
+
+    let mut groups: HashMap<[u8; 16], Vec<DecodedSnapshotEntry>> = HashMap::new();
+    for collection in collections {
+        let branch_bytes = collection.branch_id;
+        let space = collection.space.clone();
+        let name = collection.name.clone();
+
+        // Collection config: `__config__/{name}` key carrying the raw
+        // serialized config bytes as Value::Bytes (matches the compaction
+        // collect path which also treats config as Value::Bytes).
+        let config_key = format!("__config__/{}", name).into_bytes();
+        groups
+            .entry(branch_bytes)
+            .or_default()
+            .push(DecodedSnapshotEntry {
+                space: space.clone(),
+                user_key: config_key,
+                payload: DecodedSnapshotValue::Value(Value::Bytes(collection.config.clone())),
+                version: CommitVersion(collection.config_version),
+                timestamp_micros: collection.config_timestamp,
+                ttl_ms: 0,
+            });
+        stats.vector_configs += 1;
+
+        for vector in collection.vectors {
+            let vec_key = format!("{}/{}", name, vector.key).into_bytes();
+            groups
+                .entry(branch_bytes)
+                .or_default()
+                .push(DecodedSnapshotEntry {
+                    space: space.clone(),
+                    user_key: vec_key,
+                    // `raw_value` is the original serialized `VectorRecord`
+                    // bytes; reinstalling as `Value::Bytes` preserves the
+                    // exact payload that subsystem recovery expects to decode.
+                    payload: DecodedSnapshotValue::Value(Value::Bytes(vector.raw_value)),
+                    version: CommitVersion(vector.version),
+                    timestamp_micros: vector.timestamp,
+                    ttl_ms: 0,
+                });
+            stats.vectors += 1;
+        }
+    }
+
+    for (branch_bytes, group_entries) in groups {
+        let branch_id = BranchId::from_bytes(branch_bytes);
+        storage.install_snapshot_entries(branch_id, TypeTag::Vector, &group_entries)?;
+    }
+    Ok(())
+}
+
+/// Decode a JSON-encoded `Value` blob with a section-scoped error message.
+fn decode_value_json(bytes: &[u8], section: &str) -> StrataResult<Value> {
+    serde_json::from_slice(bytes).map_err(|e| {
+        StrataError::corruption(format!(
+            "{} snapshot Value JSON decode failed: {}",
+            section, e
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use strata_core::contract::Version;
+    use strata_core::id::CommitVersion;
+    use strata_core::traits::Storage;
+    use strata_core::value::Value;
+    use strata_core::{BranchId, Key, Namespace};
+    use strata_durability::codec::IdentityCodec;
+    use strata_durability::format::{
+        EventSnapshotEntry, JsonSnapshotEntry, KvSnapshotEntry, VectorCollectionSnapshotEntry,
+        VectorSnapshotEntry,
+    };
+    use strata_durability::{
+        disk_snapshot::{SnapshotSection, SnapshotWriter},
+        SnapshotReader,
+    };
+    use std::sync::Arc;
+
+    fn writer_for(dir: &std::path::Path) -> SnapshotWriter {
+        SnapshotWriter::new(dir.to_path_buf(), Box::new(IdentityCodec), [9u8; 16]).unwrap()
+    }
+
+    fn load_snapshot(path: &std::path::Path) -> LoadedSnapshot {
+        SnapshotReader::new(Box::new(IdentityCodec))
+            .load(path)
+            .unwrap()
+    }
+
+    fn serializer() -> SnapshotSerializer {
+        SnapshotSerializer::new(Box::new(IdentityCodec))
+    }
+
+    fn ns(branch_id: BranchId, space: &str) -> Arc<Namespace> {
+        Arc::new(Namespace::for_branch_space(branch_id, space))
+    }
+
+    #[test]
+    fn install_round_trips_kv_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let kv_bytes = serializer().serialize_kv(&[
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: TypeTag::KV.as_byte(),
+                user_key: b"alpha".to_vec(),
+                value: serde_json::to_vec(&Value::Int(1)).unwrap(),
+                version: 5,
+                timestamp: 1_000,
+            },
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: TypeTag::KV.as_byte(),
+                user_key: b"beta".to_vec(),
+                value: serde_json::to_vec(&Value::String("two".into())).unwrap(),
+                version: 6,
+                timestamp: 2_000,
+            },
+        ]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                1,
+                6,
+                vec![SnapshotSection::new(primitive_tags::KV, kv_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let stats = install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
+        assert_eq!(stats.kv, 2);
+        assert_eq!(stats.total_installed(), 2);
+
+        let alpha = storage
+            .get_versioned(&Key::new_kv(ns(branch_id, "default"), "alpha"), CommitVersion::MAX)
+            .unwrap()
+            .expect("alpha must be installed");
+        assert_eq!(alpha.value, Value::Int(1));
+        assert_eq!(alpha.version, Version::Txn(5));
+
+        let beta = storage
+            .get_versioned(&Key::new_kv(ns(branch_id, "default"), "beta"), CommitVersion::MAX)
+            .unwrap()
+            .expect("beta must be installed");
+        assert_eq!(beta.value, Value::String("two".into()));
+        assert_eq!(beta.version, Version::Txn(6));
+    }
+
+    #[test]
+    fn install_routes_graph_tag_into_graph_storage() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let kv_bytes = serializer().serialize_kv(&[
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "_graph_".to_string(),
+                type_tag: TypeTag::Graph.as_byte(),
+                user_key: b"node:1".to_vec(),
+                value: serde_json::to_vec(&Value::String("node-one".into())).unwrap(),
+                version: 10,
+                timestamp: 100,
+            },
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: TypeTag::KV.as_byte(),
+                user_key: b"k".to_vec(),
+                value: serde_json::to_vec(&Value::Int(42)).unwrap(),
+                version: 11,
+                timestamp: 200,
+            },
+        ]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                2,
+                11,
+                vec![SnapshotSection::new(primitive_tags::KV, kv_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let stats = install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
+        assert_eq!(stats.graph, 1);
+        assert_eq!(stats.kv, 1);
+
+        let node_key = Key::new(ns(branch_id, "_graph_"), TypeTag::Graph, b"node:1".to_vec());
+        let node = storage
+            .get_versioned(&node_key, CommitVersion::MAX)
+            .unwrap()
+            .expect("graph node must be installed via Graph tag routing");
+        assert_eq!(node.value, Value::String("node-one".into()));
+    }
+
+    #[test]
+    fn install_preserves_commit_version_and_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let kv_bytes = serializer().serialize_kv(&[KvSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "default".to_string(),
+            type_tag: TypeTag::KV.as_byte(),
+            user_key: b"k".to_vec(),
+            value: serde_json::to_vec(&Value::Int(7)).unwrap(),
+            version: 999,
+            timestamp: 1_234_567,
+        }]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                3,
+                999,
+                vec![SnapshotSection::new(primitive_tags::KV, kv_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
+
+        let entry = storage
+            .get_versioned(&Key::new_kv(ns(branch_id, "default"), "k"), CommitVersion::MAX)
+            .unwrap()
+            .unwrap();
+        assert_eq!(entry.version, Version::Txn(999));
+        assert_eq!(entry.timestamp.as_micros(), 1_234_567);
+    }
+
+    #[test]
+    fn install_events_uses_big_endian_sequence_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let event_bytes = serializer().serialize_events(&[EventSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "stream".to_string(),
+            sequence: 0x01020304,
+            payload: serde_json::to_vec(&Value::String("payload".into())).unwrap(),
+            version: 50,
+            timestamp: 9_000,
+        }]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                4,
+                50,
+                vec![SnapshotSection::new(primitive_tags::EVENT, event_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let stats = install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
+        assert_eq!(stats.events, 1);
+
+        let key = Key::new_event(ns(branch_id, "stream"), 0x01020304);
+        let entry = storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("event must be installed under its big-endian sequence key");
+        assert_eq!(entry.value, Value::String("payload".into()));
+    }
+
+    #[test]
+    fn install_json_uses_doc_id_as_user_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let json_bytes = serializer().serialize_json(&[JsonSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "docs".to_string(),
+            doc_id: "doc-42".to_string(),
+            content: serde_json::to_vec(&Value::String("content".into())).unwrap(),
+            version: 100,
+            timestamp: 77,
+        }]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                5,
+                100,
+                vec![SnapshotSection::new(primitive_tags::JSON, json_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let stats = install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
+        assert_eq!(stats.json, 1);
+
+        let key = Key::new(ns(branch_id, "docs"), TypeTag::Json, b"doc-42".to_vec());
+        let entry = storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("json doc must be installed under its doc-id user_key");
+        assert_eq!(entry.value, Value::String("content".into()));
+    }
+
+    #[test]
+    fn install_vectors_installs_config_and_per_vector_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let vec_bytes = serializer().serialize_vectors(&[VectorCollectionSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "default".to_string(),
+            name: "col".to_string(),
+            config: b"collection-config".to_vec(),
+            config_version: 12,
+            config_timestamp: 1_500,
+            vectors: vec![VectorSnapshotEntry {
+                key: "vec1".to_string(),
+                vector_id: 1,
+                embedding: vec![0.1, 0.2],
+                metadata: vec![],
+                raw_value: b"raw-record-bytes".to_vec(),
+                version: 13,
+                timestamp: 1_600,
+            }],
+        }]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                6,
+                13,
+                vec![SnapshotSection::new(primitive_tags::VECTOR, vec_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let stats = install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
+        assert_eq!(stats.vector_configs, 1);
+        assert_eq!(stats.vectors, 1);
+
+        let config_key = Key::new(
+            ns(branch_id, "default"),
+            TypeTag::Vector,
+            b"__config__/col".to_vec(),
+        );
+        let config = storage
+            .get_versioned(&config_key, CommitVersion::MAX)
+            .unwrap()
+            .expect("collection config row must be installed");
+        match config.value {
+            Value::Bytes(b) => assert_eq!(b, b"collection-config".to_vec()),
+            other => panic!("expected Value::Bytes, got {:?}", other),
+        }
+
+        let vec_key = Key::new(
+            ns(branch_id, "default"),
+            TypeTag::Vector,
+            b"col/vec1".to_vec(),
+        );
+        let vec_entry = storage
+            .get_versioned(&vec_key, CommitVersion::MAX)
+            .unwrap()
+            .expect("vector row must be installed");
+        match vec_entry.value {
+            Value::Bytes(b) => assert_eq!(b, b"raw-record-bytes".to_vec()),
+            other => panic!("expected Value::Bytes, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn install_branch_section_is_skipped_with_warning() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Empty Branch section is accepted; non-empty is skipped with a warning.
+        // We use an empty payload here so the test does not rely on the Branch
+        // deserializer's internal format.
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                7,
+                0,
+                vec![SnapshotSection::new(
+                    primitive_tags::BRANCH,
+                    vec![0, 0, 0, 0], // entry count = 0
+                )],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let stats = install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
+        assert_eq!(stats.sections_skipped, 1);
+        assert_eq!(stats.total_installed(), 0);
+    }
+
+    #[test]
+    fn install_graph_standalone_nonempty_section_is_skipped() {
+        // Graph standalone sections are not emitted by today's
+        // collect_checkpoint_data; if a future writer (or a corrupt file)
+        // produces one with payload bytes, install must skip it with a
+        // warning rather than silently drop entries or error out.
+        let dir = tempfile::tempdir().unwrap();
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                9,
+                0,
+                vec![SnapshotSection::new(
+                    primitive_tags::GRAPH,
+                    b"opaque-graph-payload".to_vec(),
+                )],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let stats = install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
+        assert_eq!(stats.sections_skipped, 1);
+        assert_eq!(stats.total_installed(), 0);
+    }
+
+    #[test]
+    fn install_rejects_unknown_primitive_tag() {
+        let dir = tempfile::tempdir().unwrap();
+        // Writer validates tag at create_snapshot, so we must build a
+        // snapshot with a known tag first and test the decoder by injecting
+        // a synthetic LoadedSnapshot with an unknown tag.
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                8,
+                0,
+                vec![SnapshotSection::new(primitive_tags::KV, vec![0, 0, 0, 0])],
+            )
+            .unwrap();
+        let mut snapshot = load_snapshot(&info.path);
+        // Replace the real section with a bogus primitive type.
+        snapshot.sections[0].primitive_type = 0xFE;
+
+        let storage = SegmentedStore::new();
+        let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+            .expect_err("unknown primitive tag must be rejected");
+        assert!(
+            err.to_string().contains("0xfe"),
+            "error should mention the unknown tag, got: {}",
+            err
+        );
+    }
+}

--- a/crates/engine/src/database/snapshot_install.rs
+++ b/crates/engine/src/database/snapshot_install.rs
@@ -76,10 +76,18 @@ pub(crate) fn install_snapshot(
     let mut stats = InstallStats::default();
     for section in &snapshot.sections {
         match section.primitive_type {
-            primitive_tags::KV => install_kv_section(&serializer, &section.data, storage, &mut stats)?,
-            primitive_tags::EVENT => install_event_section(&serializer, &section.data, storage, &mut stats)?,
-            primitive_tags::JSON => install_json_section(&serializer, &section.data, storage, &mut stats)?,
-            primitive_tags::VECTOR => install_vector_section(&serializer, &section.data, storage, &mut stats)?,
+            primitive_tags::KV => {
+                install_kv_section(&serializer, &section.data, storage, &mut stats)?
+            }
+            primitive_tags::EVENT => {
+                install_event_section(&serializer, &section.data, storage, &mut stats)?
+            }
+            primitive_tags::JSON => {
+                install_json_section(&serializer, &section.data, storage, &mut stats)?
+            }
+            primitive_tags::VECTOR => {
+                install_vector_section(&serializer, &section.data, storage, &mut stats)?
+            }
             primitive_tags::BRANCH => {
                 // BranchSnapshotEntry does not carry a `branch_id` field today,
                 // so install cannot dispatch per-branch correctly. Branch
@@ -200,8 +208,7 @@ fn install_event_section(
     }
     for (branch_bytes, group_entries) in groups {
         let branch_id = BranchId::from_bytes(branch_bytes);
-        let count =
-            storage.install_snapshot_entries(branch_id, TypeTag::Event, &group_entries)?;
+        let count = storage.install_snapshot_entries(branch_id, TypeTag::Event, &group_entries)?;
         stats.events += count;
     }
     Ok(())
@@ -234,8 +241,7 @@ fn install_json_section(
     }
     for (branch_bytes, group_entries) in groups {
         let branch_id = BranchId::from_bytes(branch_bytes);
-        let count =
-            storage.install_snapshot_entries(branch_id, TypeTag::Json, &group_entries)?;
+        let count = storage.install_snapshot_entries(branch_id, TypeTag::Json, &group_entries)?;
         stats.json += count;
     }
     Ok(())
@@ -319,6 +325,7 @@ fn decode_value_json(bytes: &[u8], section: &str) -> StrataResult<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use strata_core::contract::Version;
     use strata_core::id::CommitVersion;
     use strata_core::traits::Storage;
@@ -333,7 +340,6 @@ mod tests {
         disk_snapshot::{SnapshotSection, SnapshotWriter},
         SnapshotReader,
     };
-    use std::sync::Arc;
 
     fn writer_for(dir: &std::path::Path) -> SnapshotWriter {
         SnapshotWriter::new(dir.to_path_buf(), Box::new(IdentityCodec), [9u8; 16]).unwrap()
@@ -394,14 +400,20 @@ mod tests {
         assert_eq!(stats.total_installed(), 2);
 
         let alpha = storage
-            .get_versioned(&Key::new_kv(ns(branch_id, "default"), "alpha"), CommitVersion::MAX)
+            .get_versioned(
+                &Key::new_kv(ns(branch_id, "default"), "alpha"),
+                CommitVersion::MAX,
+            )
             .unwrap()
             .expect("alpha must be installed");
         assert_eq!(alpha.value, Value::Int(1));
         assert_eq!(alpha.version, Version::Txn(5));
 
         let beta = storage
-            .get_versioned(&Key::new_kv(ns(branch_id, "default"), "beta"), CommitVersion::MAX)
+            .get_versioned(
+                &Key::new_kv(ns(branch_id, "default"), "beta"),
+                CommitVersion::MAX,
+            )
             .unwrap()
             .expect("beta must be installed");
         assert_eq!(beta.value, Value::String("two".into()));
@@ -484,7 +496,10 @@ mod tests {
         install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
 
         let entry = storage
-            .get_versioned(&Key::new_kv(ns(branch_id, "default"), "k"), CommitVersion::MAX)
+            .get_versioned(
+                &Key::new_kv(ns(branch_id, "default"), "k"),
+                CommitVersion::MAX,
+            )
             .unwrap()
             .unwrap();
         assert_eq!(entry.version, Version::Txn(999));

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -707,10 +707,13 @@ fn test_checkpoint_creates_snapshot() {
 }
 
 #[test]
-fn test_checkpoint_then_compact_without_flush_fails() {
-    // Issue #1730: compact() after checkpoint-only must fail because
-    // recovery cannot load snapshots. WAL compaction is only safe
-    // when driven by the flush watermark (data in SST segments).
+fn test_checkpoint_then_compact_without_flush_succeeds() {
+    // Inverted in T3-E5 Chunk 4.
+    //
+    // Pre-Epic-5, compact() had to refuse on snapshot-only coverage because
+    // recovery was WAL-only. Now the recovery coordinator installs
+    // snapshots, so the snapshot watermark is a valid WAL-retention input
+    // and compact() succeeds without a flush watermark.
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("db");
     let db = Database::open(&db_path).unwrap();
@@ -719,19 +722,18 @@ fn test_checkpoint_then_compact_without_flush_fails() {
     let ns = create_test_namespace(branch_id);
     let key = Key::new_kv(ns, "compact_test");
 
-    // Write data
     db.transaction(branch_id, |txn| {
         txn.put(key.clone(), Value::Int(42))?;
         Ok(())
     })
     .unwrap();
 
-    // Checkpoint creates snapshot but no flush watermark
-    assert!(db.checkpoint().is_ok());
+    db.checkpoint()
+        .expect("checkpoint must succeed to populate the snapshot watermark");
 
-    // Compact must fail — snapshot watermark alone is not safe
-    let result = db.compact();
-    assert!(result.is_err());
+    // Compact now succeeds on snapshot-only coverage.
+    db.compact()
+        .expect("compact() must succeed once recovery consumes snapshots");
 }
 
 #[test]
@@ -1592,17 +1594,20 @@ fn test_issue_1697_compaction_preserves_snapshot_versions() {
 #[test]
 #[serial(open_databases)]
 fn test_issue_1730_checkpoint_compact_recovery_data_loss() {
-    // Issue #1730: checkpoint+compact deletes WAL segments, but recovery
-    // is WAL-only and never loads snapshots. This causes data loss.
+    // Inverted in T3-E5 Chunk 4.
     //
-    // After the fix, compact() must refuse to delete WAL segments based
-    // on the snapshot watermark alone, since recovery cannot load snapshots.
+    // Pre-Epic-5, recovery was WAL-only and checkpoints were never loaded,
+    // so `compact()` had to refuse to delete WAL segments covered only by
+    // a snapshot watermark — otherwise those records would vanish on the
+    // next reopen. That hardening is now removed: the recovery coordinator
+    // installs snapshots through the engine decoder, so `compact()`
+    // succeeds, the WAL shrinks, and the committed data survives reopen
+    // via snapshot install.
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("db");
 
     let branch_id = BranchId::new();
 
-    // Step 1: Write data
     {
         let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
         let ns = create_test_namespace(branch_id);
@@ -1614,51 +1619,40 @@ fn test_issue_1730_checkpoint_compact_recovery_data_loss() {
         })
         .unwrap();
 
-        // Step 2: Checkpoint (creates snapshot, sets watermark in MANIFEST)
+        // Checkpoint populates the snapshot and sets the MANIFEST watermark.
         db.checkpoint().unwrap();
 
-        // Step 3: Compact — should NOT delete WAL segments since recovery
-        // cannot load snapshots. With the fix, this returns an error.
-        let compact_result = db.compact();
-        assert!(
-            compact_result.is_err(),
-            "compact() must fail when only snapshot watermark exists \
-             (no flush watermark) because recovery cannot load snapshots"
-        );
+        // Compact now succeeds on snapshot watermark alone: the snapshot
+        // is a valid recovery source, so WAL segments covered by it can be
+        // deleted without risking data loss.
+        db.compact()
+            .expect("compact() must succeed once snapshot coverage is trusted");
     }
-    // Database dropped (simulates clean shutdown)
 
-    // Clear the registry so reopen doesn't return the cached instance
     OPEN_DATABASES.lock().clear();
 
-    // Step 4: Reopen — recovery replays WAL
     {
         let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
 
         let ns = create_test_namespace(branch_id);
         let key = Key::new_kv(ns, "critical_data");
 
-        // Step 5: Data MUST still be present
         let result = db
             .storage()
             .get_versioned(&key, CommitVersion::MAX)
-            .unwrap();
-        assert!(
-            result.is_some(),
-            "CRITICAL: Data lost after checkpoint+compact+recovery! \
-             WAL segments were deleted but recovery never loaded the snapshot."
-        );
-        assert_eq!(
-            result.unwrap().value,
-            Value::String("must_survive".to_string())
-        );
+            .unwrap()
+            .expect("data must survive checkpoint+compact+recovery via snapshot install");
+        assert_eq!(result.value, Value::String("must_survive".to_string()));
     }
 }
 
 #[test]
 #[serial(open_databases)]
 fn test_issue_1730_standard_durability() {
-    // Same as above but with Standard durability mode (disk-based, batched fsync).
+    // Inverted twin of `test_issue_1730_checkpoint_compact_recovery_data_loss`
+    // for the Standard durability mode. Same contract: after T3-E5, compact
+    // succeeds on snapshot coverage alone and reopen sees the data via
+    // snapshot install.
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("db");
 
@@ -1679,22 +1673,18 @@ fn test_issue_1730_standard_durability() {
         })
         .unwrap();
 
-        // Ensure WAL is flushed to disk
+        // Flush ensures the record is on disk before checkpoint so the
+        // snapshot + MANIFEST watermark reflect the transaction.
         db.flush().unwrap();
-
         db.checkpoint().unwrap();
 
-        // compact() must fail — only snapshot watermark, no flush watermark
-        let compact_result = db.compact();
-        assert!(
-            compact_result.is_err(),
-            "compact() after checkpoint-only must fail under Standard durability"
-        );
+        // compact() succeeds on snapshot watermark alone after T3-E5.
+        db.compact()
+            .expect("compact() must succeed on snapshot-only watermark under Standard durability");
     }
 
     OPEN_DATABASES.lock().clear();
 
-    // Reopen and verify data survived
     {
         let db = Database::open_with_durability(&db_path, durability).unwrap();
         let ns = create_test_namespace(branch_id);
@@ -1703,12 +1693,9 @@ fn test_issue_1730_standard_durability() {
         let result = db
             .storage()
             .get_versioned(&key, CommitVersion::MAX)
-            .unwrap();
-        assert!(
-            result.is_some(),
-            "Data must survive checkpoint+failed-compact+recovery under Standard durability"
-        );
-        assert_eq!(result.unwrap().value, Value::String("durable".to_string()));
+            .unwrap()
+            .expect("data must survive checkpoint+compact+recovery under Standard durability");
+        assert_eq!(result.value, Value::String("durable".to_string()));
     }
 }
 

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -707,13 +707,10 @@ fn test_checkpoint_creates_snapshot() {
 }
 
 #[test]
-fn test_checkpoint_then_compact_without_flush_succeeds() {
-    // Inverted in T3-E5 Chunk 4.
-    //
-    // Pre-Epic-5, compact() had to refuse on snapshot-only coverage because
-    // recovery was WAL-only. Now the recovery coordinator installs
-    // snapshots, so the snapshot watermark is a valid WAL-retention input
-    // and compact() succeeds without a flush watermark.
+fn test_checkpoint_then_compact_without_flush_fails() {
+    // Issue #1730: compact() after checkpoint-only must fail because
+    // recovery cannot load snapshots. WAL compaction is only safe
+    // when driven by the flush watermark (data in SST segments).
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("db");
     let db = Database::open(&db_path).unwrap();
@@ -722,18 +719,19 @@ fn test_checkpoint_then_compact_without_flush_succeeds() {
     let ns = create_test_namespace(branch_id);
     let key = Key::new_kv(ns, "compact_test");
 
+    // Write data
     db.transaction(branch_id, |txn| {
         txn.put(key.clone(), Value::Int(42))?;
         Ok(())
     })
     .unwrap();
 
-    db.checkpoint()
-        .expect("checkpoint must succeed to populate the snapshot watermark");
+    // Checkpoint creates snapshot but no flush watermark
+    assert!(db.checkpoint().is_ok());
 
-    // Compact now succeeds on snapshot-only coverage.
-    db.compact()
-        .expect("compact() must succeed once recovery consumes snapshots");
+    // Compact must fail — snapshot watermark alone is not safe
+    let result = db.compact();
+    assert!(result.is_err());
 }
 
 #[test]
@@ -1594,20 +1592,17 @@ fn test_issue_1697_compaction_preserves_snapshot_versions() {
 #[test]
 #[serial(open_databases)]
 fn test_issue_1730_checkpoint_compact_recovery_data_loss() {
-    // Inverted in T3-E5 Chunk 4.
+    // Issue #1730: checkpoint+compact deletes WAL segments, but recovery
+    // is WAL-only and never loads snapshots. This causes data loss.
     //
-    // Pre-Epic-5, recovery was WAL-only and checkpoints were never loaded,
-    // so `compact()` had to refuse to delete WAL segments covered only by
-    // a snapshot watermark — otherwise those records would vanish on the
-    // next reopen. That hardening is now removed: the recovery coordinator
-    // installs snapshots through the engine decoder, so `compact()`
-    // succeeds, the WAL shrinks, and the committed data survives reopen
-    // via snapshot install.
+    // After the fix, compact() must refuse to delete WAL segments based
+    // on the snapshot watermark alone, since recovery cannot load snapshots.
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("db");
 
     let branch_id = BranchId::new();
 
+    // Step 1: Write data
     {
         let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
         let ns = create_test_namespace(branch_id);
@@ -1619,40 +1614,51 @@ fn test_issue_1730_checkpoint_compact_recovery_data_loss() {
         })
         .unwrap();
 
-        // Checkpoint populates the snapshot and sets the MANIFEST watermark.
+        // Step 2: Checkpoint (creates snapshot, sets watermark in MANIFEST)
         db.checkpoint().unwrap();
 
-        // Compact now succeeds on snapshot watermark alone: the snapshot
-        // is a valid recovery source, so WAL segments covered by it can be
-        // deleted without risking data loss.
-        db.compact()
-            .expect("compact() must succeed once snapshot coverage is trusted");
+        // Step 3: Compact — should NOT delete WAL segments since recovery
+        // cannot load snapshots. With the fix, this returns an error.
+        let compact_result = db.compact();
+        assert!(
+            compact_result.is_err(),
+            "compact() must fail when only snapshot watermark exists \
+             (no flush watermark) because recovery cannot load snapshots"
+        );
     }
+    // Database dropped (simulates clean shutdown)
 
+    // Clear the registry so reopen doesn't return the cached instance
     OPEN_DATABASES.lock().clear();
 
+    // Step 4: Reopen — recovery replays WAL
     {
         let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
 
         let ns = create_test_namespace(branch_id);
         let key = Key::new_kv(ns, "critical_data");
 
+        // Step 5: Data MUST still be present
         let result = db
             .storage()
             .get_versioned(&key, CommitVersion::MAX)
-            .unwrap()
-            .expect("data must survive checkpoint+compact+recovery via snapshot install");
-        assert_eq!(result.value, Value::String("must_survive".to_string()));
+            .unwrap();
+        assert!(
+            result.is_some(),
+            "CRITICAL: Data lost after checkpoint+compact+recovery! \
+             WAL segments were deleted but recovery never loaded the snapshot."
+        );
+        assert_eq!(
+            result.unwrap().value,
+            Value::String("must_survive".to_string())
+        );
     }
 }
 
 #[test]
 #[serial(open_databases)]
 fn test_issue_1730_standard_durability() {
-    // Inverted twin of `test_issue_1730_checkpoint_compact_recovery_data_loss`
-    // for the Standard durability mode. Same contract: after T3-E5, compact
-    // succeeds on snapshot coverage alone and reopen sees the data via
-    // snapshot install.
+    // Same as above but with Standard durability mode (disk-based, batched fsync).
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("db");
 
@@ -1673,18 +1679,22 @@ fn test_issue_1730_standard_durability() {
         })
         .unwrap();
 
-        // Flush ensures the record is on disk before checkpoint so the
-        // snapshot + MANIFEST watermark reflect the transaction.
+        // Ensure WAL is flushed to disk
         db.flush().unwrap();
+
         db.checkpoint().unwrap();
 
-        // compact() succeeds on snapshot watermark alone after T3-E5.
-        db.compact()
-            .expect("compact() must succeed on snapshot-only watermark under Standard durability");
+        // compact() must fail — only snapshot watermark, no flush watermark
+        let compact_result = db.compact();
+        assert!(
+            compact_result.is_err(),
+            "compact() after checkpoint-only must fail under Standard durability"
+        );
     }
 
     OPEN_DATABASES.lock().clear();
 
+    // Reopen and verify data survived
     {
         let db = Database::open_with_durability(&db_path, durability).unwrap();
         let ns = create_test_namespace(branch_id);
@@ -1693,9 +1703,12 @@ fn test_issue_1730_standard_durability() {
         let result = db
             .storage()
             .get_versioned(&key, CommitVersion::MAX)
-            .unwrap()
-            .expect("data must survive checkpoint+compact+recovery under Standard durability");
-        assert_eq!(result.value, Value::String("durable".to_string()));
+            .unwrap();
+        assert!(
+            result.is_some(),
+            "Data must survive checkpoint+failed-compact+recovery under Standard durability"
+        );
+        assert_eq!(result.unwrap().value, Value::String("durable".to_string()));
     }
 }
 

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -4053,6 +4053,44 @@ fn test_codec_mismatch_on_reopen_fails_even_with_lossy_flag() {
     }
 }
 
+/// Follower open must fail loud when the MANIFEST cannot be parsed.
+/// Pre-fix, this case silently degraded to WAL-only recovery, which is
+/// unsafe once snapshot-aware compaction reclaims pre-snapshot WAL: the
+/// follower would serve stale/empty state without operator visibility.
+#[test]
+#[serial(open_databases)]
+fn test_follower_open_fails_hard_on_corrupt_manifest() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    {
+        let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+        db.transaction(branch_id, |txn| {
+            txn.put(Key::new_kv(ns.clone(), "k"), Value::Int(1))?;
+            Ok(())
+        })
+        .unwrap();
+    }
+    OPEN_DATABASES.lock().clear();
+
+    // Corrupt the MANIFEST on disk so ManifestManager::load fails.
+    let manifest_path = db_path.join("MANIFEST");
+    std::fs::write(&manifest_path, b"NOT-A-VALID-MANIFEST").unwrap();
+
+    let err = match Database::open_follower(&db_path) {
+        Ok(_) => panic!("follower must fail on corrupt MANIFEST"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.to_lowercase().contains("manifest"),
+        "error should mention MANIFEST, got: {}",
+        msg
+    );
+}
+
 /// Follower open: after the primary checkpoints, a fresh follower must see
 /// every committed value — including the ones that now live only in the
 /// snapshot on disk — without going through the primary's in-process state.

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -3898,7 +3898,10 @@ fn test_checkpoint_only_restart_recovers_kv_from_snapshot() {
         .flatten()
         .filter(|e| e.path().is_file())
         .collect();
-    assert!(remaining.is_empty(), "WAL dir should be empty before reopen");
+    assert!(
+        remaining.is_empty(),
+        "WAL dir should be empty before reopen"
+    );
 
     // Step 5: reopen. Recovery must install the snapshot.
     let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -3914,3 +3914,193 @@ fn test_checkpoint_only_restart_recovers_kv_from_snapshot() {
         assert_eq!(stored.value, Value::String(format!("payload-{}", i)));
     }
 }
+
+/// Checkpoint + delta-WAL replay: keys written before the checkpoint arrive
+/// through snapshot install; keys written after the checkpoint arrive through
+/// WAL replay filtered by the snapshot watermark. Both groups must be visible
+/// after reopen, and the snapshot-covered records must not be double-applied.
+#[test]
+#[serial(open_databases)]
+fn test_checkpoint_plus_delta_wal_replay_merges_sources() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    // Phase 1: write 5 "pre-checkpoint" keys, checkpoint, then write 5
+    // "post-checkpoint" keys that only live in the WAL tail.
+    {
+        let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+        for i in 0u64..5 {
+            let key = Key::new_kv(ns.clone(), format!("pre-{}", i));
+            db.transaction(branch_id, |txn| {
+                txn.put(key, Value::String(format!("v{}", i)))?;
+                Ok(())
+            })
+            .unwrap();
+        }
+        db.checkpoint().unwrap();
+
+        for i in 0u64..5 {
+            let key = Key::new_kv(ns.clone(), format!("post-{}", i));
+            db.transaction(branch_id, |txn| {
+                txn.put(key, Value::String(format!("w{}", i)))?;
+                Ok(())
+            })
+            .unwrap();
+        }
+    }
+    OPEN_DATABASES.lock().clear();
+
+    // Phase 2: reopen. Both the snapshot-installed pre-* keys and the
+    // delta-replayed post-* keys must be visible.
+    let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+
+    for i in 0u64..5 {
+        let pre_key = Key::new_kv(ns.clone(), format!("pre-{}", i));
+        let pre = db
+            .storage()
+            .get_versioned(&pre_key, CommitVersion::MAX)
+            .unwrap()
+            .unwrap_or_else(|| panic!("pre-{} must survive via snapshot install", i));
+        assert_eq!(pre.value, Value::String(format!("v{}", i)));
+
+        let post_key = Key::new_kv(ns.clone(), format!("post-{}", i));
+        let post = db
+            .storage()
+            .get_versioned(&post_key, CommitVersion::MAX)
+            .unwrap()
+            .unwrap_or_else(|| panic!("post-{} must survive via delta-WAL replay", i));
+        assert_eq!(post.value, Value::String(format!("w{}", i)));
+    }
+
+    // The post-reopen database must be writable at a commit version above
+    // both sources — exercise it to surface monotonicity regressions.
+    let followup_key = Key::new_kv(ns.clone(), "after-reopen");
+    db.transaction(branch_id, |txn| {
+        txn.put(followup_key.clone(), Value::Int(1))?;
+        Ok(())
+    })
+    .unwrap();
+    let followup = db
+        .storage()
+        .get_versioned(&followup_key, CommitVersion::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(followup.value, Value::Int(1));
+}
+
+/// Codec mismatch at reopen must fail loud regardless of the
+/// `allow_lossy_recovery` flag. Lossy recovery is for tolerating WAL
+/// corruption, not for silently rewriting the database under a different
+/// codec id. The check belongs ahead of the lossy fallback so an operator
+/// cannot accidentally discard a database by misconfiguring the codec.
+///
+/// Because there is only one WAL-compatible codec in the workspace today
+/// (`identity`), the test simulates codec drift by rewriting the MANIFEST
+/// directly with a foreign codec id, then reopens with `identity`.
+#[test]
+#[serial(open_databases)]
+fn test_codec_mismatch_on_reopen_fails_even_with_lossy_flag() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    // Create the DB with the default identity codec and write a key so there
+    // is real state for lossy mode to potentially discard.
+    let database_uuid;
+    {
+        let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+        db.transaction(branch_id, |txn| {
+            txn.put(Key::new_kv(ns.clone(), "k"), Value::Int(1))?;
+            Ok(())
+        })
+        .unwrap();
+        database_uuid = db.database_uuid();
+    }
+    OPEN_DATABASES.lock().clear();
+
+    // Rewrite the MANIFEST to claim a different codec id without changing
+    // any other on-disk state. This is the smallest faithful simulation of
+    // codec drift we can produce with the currently-shipping codec set.
+    let manifest_path = db_path.join("MANIFEST");
+    std::fs::remove_file(&manifest_path).unwrap();
+    strata_durability::ManifestManager::create(
+        manifest_path,
+        database_uuid,
+        "some-other-codec".to_string(),
+    )
+    .unwrap();
+
+    // Reopen with the default (identity) codec AND allow_lossy_recovery.
+    // The lossy flag must not suppress the codec-mismatch error.
+    let cfg = StrataConfig {
+        allow_lossy_recovery: true,
+        ..Default::default()
+    };
+    let result = Database::open_with_config(&db_path, cfg);
+    match result {
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("codec mismatch"),
+                "reopen with different codec must fail with codec mismatch, got: {}",
+                msg
+            );
+        }
+        Ok(_) => panic!("reopen with wrong codec + lossy flag must still fail"),
+    }
+}
+
+/// Follower open: after the primary checkpoints, a fresh follower must see
+/// every committed value — including the ones that now live only in the
+/// snapshot on disk — without going through the primary's in-process state.
+/// This exercises the Chunk 3 follower migration to the direct callback API
+/// plus snapshot install.
+#[test]
+fn test_follower_open_installs_checkpoint_snapshot() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    // Primary writes then checkpoints then exits. The data that is now
+    // covered by the snapshot is the follower's only path to see those
+    // values after the WAL is manually truncated.
+    {
+        let primary = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+        for i in 0u64..6 {
+            let key = Key::new_kv(ns.clone(), format!("k{}", i));
+            primary
+                .transaction(branch_id, |txn| {
+                    txn.put(key, Value::String(format!("v{}", i)))?;
+                    Ok(())
+                })
+                .unwrap();
+        }
+        primary.checkpoint().unwrap();
+    }
+    OPEN_DATABASES.lock().clear();
+
+    // Delete WAL so the follower can only see data through the snapshot.
+    let wal_dir = db_path.join("wal");
+    for entry in std::fs::read_dir(&wal_dir).unwrap().flatten() {
+        let p = entry.path();
+        if p.is_file() {
+            std::fs::remove_file(&p).unwrap();
+        }
+    }
+
+    // Open as follower and verify all pre-checkpoint data is visible.
+    let follower = Database::open_follower(&db_path).unwrap();
+    for i in 0u64..6 {
+        let key = Key::new_kv(ns.clone(), format!("k{}", i));
+        let stored = follower
+            .storage()
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .unwrap_or_else(|| panic!("follower must see k{} via snapshot install", i));
+        assert_eq!(stored.value, Value::String(format!("v{}", i)));
+    }
+}

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -3835,3 +3835,82 @@ fn test_issue_1380_encryption_rejected_with_wal() {
         Ok(_) => panic!("should reject encryption with WAL-based durability"),
     }
 }
+
+// ============================================================================
+// T3-E5 Chunk 2: checkpoint-only restart via snapshot load + install
+// ============================================================================
+
+/// Write KV entries, checkpoint, drop the database, manually delete the WAL
+/// segments (simulating what post-Chunk-4 `compact()` will do), reopen, and
+/// verify all data is recovered from the snapshot alone.
+///
+/// This is the core Epic 5 correctness gate: checkpoints must be a complete
+/// recovery artifact, not just a future optimization. Until Chunk 2 wired
+/// snapshot loading into the coordinator and engine install decoder, this
+/// scenario was impossible — checkpoints were written but never consumed.
+///
+/// Tranche 4 branch-aware retention will depend on this path being correct
+/// for tombstone and TTL state as well; those cases are validated in
+/// Chunk 3 once the checkpoint payload carries that metadata.
+#[test]
+#[serial(open_databases)]
+fn test_checkpoint_only_restart_recovers_kv_from_snapshot() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    // Step 1: write several KV entries on the user branch.
+    {
+        let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+        for i in 0u64..10 {
+            let key = Key::new_kv(ns.clone(), format!("kv-{}", i));
+            let value = Value::String(format!("payload-{}", i));
+            db.transaction(branch_id, |txn| {
+                txn.put(key, value.clone())?;
+                Ok(())
+            })
+            .unwrap();
+        }
+
+        // Step 2: checkpoint. This flushes the WAL, serializes the KV
+        // section to a `snap-NNNNNN.chk` file, and updates the MANIFEST
+        // with the new snapshot id and watermark.
+        db.checkpoint().unwrap();
+    }
+    // Step 3: drop DB. Clear registry so reopen produces a fresh instance.
+    OPEN_DATABASES.lock().clear();
+
+    // Step 4: simulate post-Chunk-4 compact() by manually deleting every WAL
+    // segment. The MANIFEST still points at the snapshot; recovery must fall
+    // back to snapshot load and surface all 10 entries without WAL replay.
+    let wal_dir = db_path.join("wal");
+    for entry in std::fs::read_dir(&wal_dir).unwrap().flatten() {
+        let p = entry.path();
+        if p.is_file() {
+            std::fs::remove_file(&p).unwrap();
+        }
+    }
+    // Confirm the WAL dir is now empty so the test is actually exercising
+    // snapshot-only recovery rather than accidentally still hitting WAL.
+    let remaining: Vec<_> = std::fs::read_dir(&wal_dir)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.path().is_file())
+        .collect();
+    assert!(remaining.is_empty(), "WAL dir should be empty before reopen");
+
+    // Step 5: reopen. Recovery must install the snapshot.
+    let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+
+    // Step 6: every committed key must be visible with its original value.
+    for i in 0u64..10 {
+        let key = Key::new_kv(ns.clone(), format!("kv-{}", i));
+        let stored = db
+            .storage()
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .unwrap_or_else(|| panic!("kv-{} must survive snapshot-only restart", i));
+        assert_eq!(stored.value, Value::String(format!("payload-{}", i)));
+    }
+}

--- a/docs/design/execution/tranche-3-durability.md
+++ b/docs/design/execution/tranche-3-durability.md
@@ -4,14 +4,16 @@
 
 | Field | Value |
 |-------|-------|
-| Goal | Unified recovery, WAL correctness, follower convergence, authoritative shutdown |
+| Goal | Unified recovery, WAL correctness, follower convergence, authoritative shutdown, retention-complete checkpoint fidelity |
 | Owning scopes | durability-recovery |
 | Contributing phases | DR-0 through DR-10 |
 | Prerequisite tranches | T1 (CI); T2 (RC-1 observer traits, RC-6 session shape for DR-8) |
 | Change class | cutover (DR-1, DR-5) + intentional (DR-2 new errors, DR-3 new types) |
 | Assurance class | S4 (WAL correctness, recovery, commit ordering) |
 | Benchmark required | Yes — after every epic |
-| Exit gate | SyncHandle in WAL, RecoveryCoordinator snapshot-aware, follower contiguous, shutdown authoritative, codec uniform |
+| Exit gate | SyncHandle in WAL, RecoveryCoordinator snapshot-aware, follower contiguous, shutdown authoritative, codec uniform, checkpoint/recovery preserve tombstone and TTL barrier state |
+
+**Preparation note:** T3-E4 and T3-E5 now explicitly prepare the branch-aware storage retention work planned in Tranche 4 by making checkpoint/install/recovery fidelity complete for tombstones and TTL, not just branch/space/type identity.
 
 ---
 
@@ -128,7 +130,7 @@ Implementation note:
 
 - Land this epic as two PRs.
 - PR 1 is layout and coordinator cleanup only: `DatabaseLayout`, open-path adoption, `RecoveryCoordinator::new(layout, write_buffer_size)`, and harness migration.
-- PR 2 adds the storage-side snapshot install contract, fixes the checkpoint payload so it preserves branch/space/type identity plus raw KV/Graph key bytes and per-entry MVCC metadata, and adds tests that pin the remaining known omissions honestly.
+- PR 2 adds the storage-side snapshot install contract and fixes the checkpoint payload so it preserves branch/space/type identity, raw KV/Graph key bytes, per-entry MVCC metadata, tombstones, and TTL.
 - Neither PR changes production recovery behavior or callback shape. Snapshot loading, codec validation, and delta-WAL replay remain Epic T3-E5.
 
 ### Tasks
@@ -140,10 +142,11 @@ Implementation note:
   - Delete the production `with_segments` builder path once all call sites move; delete `with_snapshot_path()` if no longer needed
   - Update test harnesses to use `DatabaseLayout`
 - [ ] **PR 2: snapshot-install groundwork**
-  - Add tests that pin the remaining known checkpoint omissions so Epic T3-E5 consumes the payload honestly
-  - Add `SegmentedStore::install_snapshot_entries(branch_id, type_tag, entries)` with unit tests
+  - Add `SegmentedStore::install_snapshot_entries(branch_id, type_tag, entries)` with unit tests covering tombstones and TTL
   - Entry shape must preserve namespace space, raw user key bytes, timestamp, commit version, TTL, and tombstone state; it must not assume snapshot sections already contain fully reconstructed `Key` values
-  - Checkpoint DTOs must preserve branch, space, and type identity explicitly so recovery does not infer them from flattened section ordering
+  - Checkpoint DTOs and collection paths must preserve branch, space, type, tombstone, and TTL identity explicitly so restart correctness does not depend on live-only collection behavior
+  - Recovery artifacts taken together must not regress fork-frontier, inherited-layer, or reachability state that remains persisted outside checkpoint payloads
+  - Add characterization and regression tests proving checkpoint payload/install semantics are retention-complete for the T4 branch-aware storage retention work
 
 ### Acceptance Criteria
 
@@ -152,7 +155,10 @@ Implementation note:
 - [ ] No `new(wal_dir).with_segments(...)` construction remains on the active production path
 - [ ] PR 1 has no regression in WAL-only recovery
 - [ ] `install_snapshot_entries` unit tests pass
-- [ ] Characterization tests pin the current checkpoint payload shape before Epic T3-E5 consumes it
+- [ ] Checkpoint payload preserves tombstone state needed for restart correctness
+- [ ] Checkpoint payload preserves TTL state needed for restart correctness
+- [ ] Checkpoint/recovery preparation does not regress inherited-layer or reachability metadata needed for safe reopen semantics
+- [ ] Characterization and regression tests prove delete/TTL fidelity before Epic T3-E5 consumes checkpoints
 - [ ] `/regression-check` passes
 
 ---
@@ -171,6 +177,7 @@ Implementation note:
   - Add snapshot loading: read MANIFEST's snapshot_id/watermark, load via `SnapshotReader`, validate magic/CRC/codec
   - Add codec validation in `plan_recovery()`: reject mismatch BEFORE any WAL bytes read
   - Add delta-WAL replay: after snapshot install, replay only `txn_id > snapshot_watermark`
+  - Preserve inherited-layer and reachability metadata from `MANIFEST` / segment recovery so fork-frontier visibility and safe shared-segment deletion remain restart-correct
   - Add `.meta` sidecar rebuild when missing or stale
   - Change API to callback-driven: `recover(on_snapshot, on_record) -> RecoveryStats`
 - [ ] **Engine changes** (`crates/engine/src/database/`):
@@ -182,6 +189,10 @@ Implementation note:
 - [ ] **Test matrix** (`engine/tests/checkpoint_recovery_tests.rs`):
   - WAL-only restart (regression guard)
   - Checkpoint-only restart
+  - Checkpoint-only restart with tombstones preserved
+  - Checkpoint-only restart with TTL preserved
+  - Restart preserves inherited-layer visibility/fork-frontier behavior
+  - Restart preserves safe shared-segment deletion behavior
   - Checkpoint + delta-WAL replay
   - Partial WAL tail truncation (regression guard)
   - `.meta` sidecar rebuild
@@ -192,11 +203,15 @@ Implementation note:
 
 ### Acceptance Criteria
 
-- [ ] All 9 checkpoint recovery test scenarios pass
+- [ ] All 13 checkpoint recovery test scenarios pass
 - [ ] Pre-DR-5 `.chk` fixtures remain consumable
 - [ ] `test_issue_1730` inverted (compact succeeds)
 - [ ] Codec mismatch rejected with clear error at open
 - [ ] Non-identity codec survives write→crash→reopen→read
+- [ ] Checkpoint/reopen preserves delete state
+- [ ] Checkpoint/reopen preserves TTL behavior
+- [ ] Restart preserves inherited-layer visibility across reopen
+- [ ] Restart preserves safe shared-segment deletion behavior
 - [ ] `/regression-check` passes
 
 ---
@@ -316,7 +331,7 @@ T3-E8 (cleanup + docs)
 
 - **E1 → E2:** halt/resume consumes `bg_error` field from E1
 - **E3 parallel with E1/E2:** independent code area (follower refresh vs WAL write path)
-- **E4 → E5:** snapshot install needed before recovery extension
+- **E4 → E5:** snapshot install and retention-complete payload fidelity needed before recovery extension
 - **E5 depends on E3:** ReplayObserver insertion point wired in E3
 - **E6 depends on T2-E5:** session shape must be fixed for shutdown integration
 - **E7 after E5:** codec validation moved into coordinator in E5
@@ -339,6 +354,7 @@ T3-E8 (cleanup + docs)
 - **T2 (runtime):** E6 (shutdown) depends on T2-E5 (RC-6 session shape fix)
 - **T2 (runtime):** E3 (follower refresh) needs RC Phase 2 `ReplayObserver` trait from T2-E2
 - **T2 (runtime):** E5 (recovery) coordinates with RC `open_runtime` step 3 sequence
+- **T4 (branch):** branch-aware storage retention depends on E4/E5 carrying tombstones and TTL faithfully through checkpoint/install/recovery
 - **T4 (branch):** BP-5 adds `Subsystem::lifecycle_contracts()` which does NOT block T3, but T3's subsystem freeze hooks must be forward-compatible
 - **T5 (product):** PCS-2 (ControlRegistry) consumes DR-9 config matrix — T5-E2 depends on T3-E7
 

--- a/docs/design/implementation/tranche-3-durability.md
+++ b/docs/design/implementation/tranche-3-durability.md
@@ -349,16 +349,16 @@ Every in-tree `refresh()` caller must pattern-match `RefreshOutcome`. `#[must_us
 
 ## Epic 4: DatabaseLayout and Snapshot Install
 
-**Goal:** Introduce one canonical directory layout type and a snapshot install path that the recovery coordinator can call.
+**Goal:** Introduce one canonical directory layout type and a snapshot install path that the recovery coordinator can call, with retention-complete payload fidelity for tombstones and TTL.
 
-**Why:** Epic 5 needs a layout object shared by engine, coordinator, and tests. It also needs a way to install decoded checkpoint entries into `SegmentedStore`.
+**Why:** Epic 5 needs a layout object shared by engine, coordinator, and tests. It also needs a way to install decoded checkpoint entries into `SegmentedStore`. Tranche 4 now depends on Tranche 3 to preserve tombstone and TTL state faithfully through checkpoints and restart recovery, not just branch/space/type identity.
 
 **Implementation split:**
 
 - **PR 1:** layout and coordinator cleanup only. Land `DatabaseLayout`, move open/recovery call sites to it, and collapse `RecoveryCoordinator` construction onto one layout-based shape.
-- **PR 2:** storage-side snapshot install contract plus checkpoint payload fixes/tests so branch, space, type, raw key bytes, and per-entry MVCC metadata are explicit instead of inferred.
+- **PR 2:** storage-side snapshot install contract plus checkpoint payload fixes/tests so branch, space, type, raw key bytes, per-entry MVCC metadata, tombstones, and TTL are explicit instead of inferred or dropped.
 - **Non-goal for Epic 4:** do not change production recovery behavior, callback shape, or codec validation flow. Snapshot loading and delta-WAL replay remain Epic 5.
-- **Compatibility constraint:** snapshot payload and storage install semantics must be lossless for branch/space/type identity, raw user keys where applicable, and the MVCC version/timestamp needed to reinstall each logical entry. Epic 4 still does not solve tombstone or TTL serialization unless explicitly added.
+- **Compatibility constraint:** snapshot payload and storage install semantics must be lossless for branch/space/type identity, raw user keys where applicable, tombstone state, TTL state, and the MVCC version/timestamp needed to reinstall each logical entry. Recovery artifacts taken together must also preserve fork-frontier, inherited-layer, and reachability state needed for restart-correct branch retention semantics.
 
 ### Changes
 
@@ -396,18 +396,18 @@ RecoveryCoordinator::new(layout: DatabaseLayout, write_buffer_size: usize)
 - Delete `with_snapshot_path()` once tests and stubs no longer need it.
 - Epic 4 does not thread codec identity through the coordinator constructor yet. That validation moves in Epic 5 when recovery planning reads `MANIFEST`.
 
-**4. Fix and characterize the checkpoint payload** (~120-180 lines)
+**4. Fix and characterize the checkpoint payload** (~140-220 lines)
 
-- Update checkpoint DTOs so branch ID, namespace space, KV-vs-Graph type identity, raw KV/Graph user-key bytes, and per-entry MVCC metadata are serialized explicitly.
-- Add tests that pin the remaining omissions the payload still has.
+- Update checkpoint DTOs so branch ID, namespace space, KV-vs-Graph type identity, raw KV/Graph user-key bytes, per-entry MVCC metadata, tombstone state, and TTL state are serialized explicitly.
+- Add tests that prove checkpoint payload/install semantics are retention-complete for the branch-aware storage retention work in Tranche 4.
 - Cover at least:
   - branch/space/type identity is preserved explicitly in checkpoint DTOs
   - raw KV/Graph user-key bytes survive checkpoint serialization
   - event/branch/vector entries carry the MVCC version/timestamp Epic 5 will need to reinstall them
   - vector snapshot entries preserve the raw serialized `VectorRecord` bytes instead of a lossy projection
-  - checkpoint collection is live-only, so tombstones are not currently serialized
-  - TTL is not currently serialized in snapshot DTOs
-- These tests are groundwork for Epic 5. They prevent the storage install API from being defined around assumptions the remaining snapshot wire format still does not satisfy.
+  - tombstone state is serialized and re-installable instead of being dropped by live-only collection
+  - TTL state is serialized and re-installable instead of being omitted from snapshot DTOs
+- These tests are groundwork for Epic 5 and Tranche 4. They prevent the storage install API and later branch-retention work from being defined around a lossy snapshot wire format. They do not replace the need to preserve fork-frontier, inherited-layer, and reachability state through the non-checkpoint portions of the recovery chain.
 
 **5. `SegmentedStore::install_snapshot_entries` contract** (~150 lines)
 
@@ -430,7 +430,7 @@ where `DecodedSnapshotEntry` preserves:
 - value or tombstone state
 - commit version
 - timestamp
-- TTL, when the caller has it
+- TTL state
 
 The storage layer constructs `Key` values from `(branch_id, space, type_tag, user_key)`; it does not require snapshot sections to arrive with fully materialized `Key` objects.
 
@@ -445,8 +445,10 @@ Rules:
 
 - Test: `DatabaseLayout::from_root` produces expected paths.
 - Test: coordinator accepts `DatabaseLayout`; no `wal_dir` plus `with_segments` construction remains on the active production path.
-- Test: checkpoint characterization tests pin the current payload shape before Epic 5 consumes it.
+- Test: checkpoint characterization and regression tests prove tombstone and TTL fidelity before Epic 5 consumes checkpoints.
 - Test: `install_snapshot_entries` round-trips entries.
+- Test: checkpoint/install preserves tombstone state needed for restart correctness.
+- Test: checkpoint/install preserves TTL behavior needed for restart correctness.
 - Test: WAL-only recovery still passes unchanged.
 - Benchmark: YCSB, redb, open latency smoke.
 
@@ -458,7 +460,7 @@ Rules:
 
 **Goal:** Extend the existing `strata_concurrency::RecoveryCoordinator` with snapshot loading, codec validation, delta-WAL replay, and `.meta` sidecar rebuild.
 
-**Why:** This is the main recovery correctness fix. Checkpoints are written but not consumed. Recovery currently replays WAL only, so checkpoint coverage and WAL retention cannot become truthful.
+**Why:** This is the main recovery correctness fix. Checkpoints are written but not consumed. Recovery currently replays WAL only, so checkpoint coverage and WAL retention cannot become truthful. Tranche 4 branch-retention semantics also depend on restart preserving tombstone and TTL barriers exactly.
 
 ### Changes
 
@@ -468,6 +470,7 @@ Rules:
 - Load snapshot via durability snapshot reader.
 - Validate magic, CRC, and codec.
 - Pass a `LoadedSnapshot` to the engine callback.
+- Preserve the branch/inherited-layer/reachability state already carried by `MANIFEST` and segment recovery so fork-frontier visibility and safe shared-segment deletion remain restart-correct.
 
 No new recovery coordinator type. Extend the existing coordinator in place.
 
@@ -549,6 +552,10 @@ The old test asserted that checkpoint compact recovery must fail. It now asserts
 
 - Test: WAL-only restart still works.
 - Test: checkpoint-only restart works.
+- Test: checkpoint-only restart preserves tombstones.
+- Test: checkpoint-only restart preserves TTL behavior.
+- Test: restart preserves inherited-layer/fork-frontier visibility across reopen.
+- Test: restart preserves safe shared-segment deletion behavior.
 - Test: checkpoint plus delta-WAL replay works.
 - Test: partial WAL tail truncation still works.
 - Test: missing/stale `.meta` sidecar rebuild works.
@@ -746,7 +753,7 @@ Epic 1 + T2-E5 (session shape)
 
 **Sprint 2:** Epic 2 and Epic 4 PR 1 in parallel. Epic 2 consumes `bg_error`; Epic 4 PR 1 prepares the layout/coordinator structure.
 
-**Sprint 3:** Epic 4 PR 2, then Epic 5. PR 2 pins the storage install contract against the shipped snapshot payload; Epic 5 is the main load-bearing recovery PR and gets the heaviest review.
+**Sprint 3:** Epic 4 PR 2, then Epic 5. PR 2 makes the storage install contract and checkpoint payload retention-complete for tombstones/TTL; Epic 5 is the main load-bearing recovery PR and gets the heaviest review.
 
 **Sprint 4:** Epic 6 and Epic 7. Shutdown depends on T2-E5 and Epic 1; codec matrix depends on Epic 5.
 
@@ -768,12 +775,12 @@ Epic 1 + T2-E5 (session shape)
 | E2 | Yes | New error variants and health API are additive |
 | E3 | Partially | `RefreshHook` signature change breaks vector/search implementations on revert |
 | E4 | Yes | New types only |
-| E5 | Partially | Pre-DR-5 databases remain compatible; post-DR-5 snapshots would be unused on revert |
+| E5 | Partially | Recovery fidelity now carries tombstone/TTL state as well as snapshot coverage; reverting would reintroduce lossy reopen semantics |
 | E6 | Mostly | Reverting re-introduces unordered close |
 | E7 | Yes | Validation-only, additive |
 | E8 | Yes | Doc-only |
 
-No storage format changes in T3. Recovery consumes existing snapshot files that were already being written but never loaded.
+Storage format note: T3 now tightens checkpoint payload fidelity for tombstones and TTL in addition to the branch/space/type and MVCC metadata already needed for recovery. This is an intentional durability-format change in service of restart correctness and the later T4 branch-retention contract.
 
 ### Expected Results
 
@@ -788,6 +795,7 @@ No storage format changes in T3. Recovery consumes existing snapshot files that 
 | Concurrent refresh | Unspecified | Single-flight refresh gate |
 | Recovery | WAL-only | Snapshot load plus delta-WAL replay |
 | Directory layout | Ad-hoc paths | Shared `DatabaseLayout` |
+| Checkpoint payload | Lossy for delete/expiry barriers | Retention-complete for tombstones and TTL |
 | WAL retention | Snapshot coverage distrusted | Real recovery coverage reflected |
 | Shutdown | Warn-and-proceed on timeout | Error without freeze; retryable |
 | MANIFEST close path | No explicit fsync | MANIFEST fsynced on shutdown |
@@ -827,6 +835,8 @@ Required recovery correctness tests:
 
 - WAL-only restart still works.
 - Checkpoint-only restart works.
+- Checkpoint-only restart preserves tombstones.
+- Checkpoint-only restart preserves TTL behavior.
 - Checkpoint plus delta-WAL replay works.
 - Partial tail truncation still works.
 - Pre-DR-5 `.chk` fixtures remain consumable.
@@ -841,9 +851,9 @@ Performance regressions are not waived. Durability correctness that materially r
 From sibling scopes and post-cleanup backlog:
 
 - Runtime consolidation follow-through if any T2 session/open integration remains.
-- Branch primitives: `BranchRef`, lifecycle generations, primitive lifecycle contracts, and branch mutation control surfaces.
+- Branch primitives: `BranchRef`, lifecycle generations, primitive lifecycle contracts, branch mutation control surfaces, and branch-aware storage retention semantics above the recovery fidelity delivered here.
 - Product control surface: `ControlRegistry`, product open plans, config overlays, and doc gates.
 - Search/intelligence/inference: auto-embedding, HNSW and BM25 index creation, native inference providers, built-in and custom recipes.
 - Quality cleanup: full error taxonomy, visibility tightening, unsafe documentation, file decomposition, and catalog-to-test mapping.
 - Forced transaction abort on shutdown timeout. T3 deliberately returns `ShutdownTimeout` and leaves retry/abort decisions to callers.
-- New snapshot file formats. T3 consumes existing checkpoint files; it does not introduce a storage-format migration.
+- Further checkpoint-format optimization beyond the retention-complete fidelity introduced here. T3's concern is restart correctness, not later throughput or storage-efficiency tuning.


### PR DESCRIPTION
## Summary
T3-E5 (Epic 5 — Recovery Coordinator Extension). Checkpoints become a real recovery artifact: the coordinator loads snapshots before WAL replay, the engine decodes per-primitive sections into `SegmentedStore::install_snapshot_entries`, WAL records covered by the snapshot watermark are skipped, and WAL retention once again trusts composite coverage now that recovery consumes snapshots.

Landed as four sequential chunks on a shared branch (single PR):

1. **Chunk 1** (`19ddd3c0`) — Reshape `RecoveryCoordinator::recover` to a callback-driven `(self, on_snapshot, on_record) → RecoveryStats`. Add `RecoveryPlan` + `plan_recovery(expected_codec_id)` for pre-WAL codec validation. Add `recover_into_memory_storage()` compat wrapper for non-production call sites.
2. **Chunk 2** (`3de53663`) — `with_codec(codec)` builder + snapshot loading via `SnapshotReader`. New `crates/engine/src/database/snapshot_install.rs` with decoders for KV/Graph/Event/JSON/Vector sections (Branch section skipped with warning pending DTO fix; unknown tags hard-rejected). Primary open path migrated to the direct callback API; lossy fallback replaces storage with a fresh empty store. Fold `storage.version()` into `stats.final_version` so the txn coordinator bootstraps above installed snapshot entries.
3. **Chunk 3** (`8ba822f8`) — Delta-WAL replay: skip records with `txn_id ≤ snapshot_watermark` (avoids double-apply). Follower open path migrated to the direct callback API with snapshot install. Closed-segment `.meta` sidecar rebuild on missing/corrupt files (active segment left alone; best-effort). Codec-mismatch check kept in open path to avoid lossy-mode swallowing the error.
4. **Chunk 4** (`45ea3945`) — Revert the `#1730` defensive hardening in `effective_watermark`: WAL retention now trusts snapshot coverage alongside flush coverage. Invert `test_issue_1730_*` and `test_checkpoint_then_compact_without_flush_*` + the durability-layer twin. Commit scope-refinement docs for the retention-complete tombstone/TTL exit gate.

## Change class
- Mix of **cutover** (callback-driven recovery API, `effective_watermark` semantics restored) and **intentional semantic change** (snapshot loading is now the shipped path).
- Observable behavior for end-users: `checkpoint()` + `compact()` no longer errors when no flush watermark exists; reopen recovers snapshot-covered data through the engine install decoder.

## Assurance class
- **S4** — recovery/replay + WAL retention + commit ordering. All new paths have characterization tests covering happy path, failure propagation, and specific edge cases (missing snapshot file, corrupt sidecar, codec mismatch + lossy fallback, delta watermark exactly at/above/below WAL tail, active segment untouched by rebuild).

## What's explicitly not in this PR
- Branch section snapshot install (DTO lacks `branch_id` today — tracked separately; Branch metadata is still reconstituted via WAL replay).
- Tombstone/TTL retention-complete round-trip through install (the DTOs now carry it per T3-E4; collection-side rewrite is a follow-up).
- `recover_into_memory_storage` compat wrapper deletion — still referenced by `strata_concurrency::manager` tests and the engine coordinator unit test. Production primary/follower paths no longer use it.
- Forced transaction abort on shutdown timeout (T3-E6 concern).
- `CompatibilitySignature` codec field threading through coordinator construction (T3-E7).

## Benchmarks
`cargo run --release -p strata-benchmarks --bin regression -- --quick` reports a FAIL verdict but the specific failing metrics differ between runs (YCSB `load_ops_sec` / `p50_us` variance on the 1-second quick workload). No hot-path code is touched by this PR — all changes live in open, recovery, and compact paths. Recommend running the full `regression` binary with a fresh baseline before merge to confirm no real hot-path regression.

## Test plan
- [x] `cargo test --workspace --lib` — all green
  - `strata_concurrency` recovery: 41/41
  - `strata_engine` lib: 911/911 (includes inverted `test_issue_1730_*`, `test_checkpoint_plus_delta_wal_replay_merges_sources`, `test_checkpoint_only_restart_recovers_kv_from_snapshot`, `test_follower_open_installs_checkpoint_snapshot`, `test_codec_mismatch_on_reopen_fails_even_with_lossy_flag`)
  - `strata_durability` compaction: 3/3 (incl. inverted `test_wal_truncation_accepts_snapshot_watermark_alone`)
- [ ] Full `cargo run --release -p strata-benchmarks --bin regression` against a fresh baseline
- [ ] Second reviewer per S4 gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)