### PR TITLE
feat(durability): T3-E5 follow-up — retention-complete checkpoint DTOs

### DIFF
--- a/crates/durability/src/compaction/wal_only.rs
+++ b/crates/durability/src/compaction/wal_only.rs
@@ -77,7 +77,13 @@ impl WalOnlyCompactor {
         let start_time = std::time::Instant::now();
         let mut info = CompactInfo::new(CompactMode::WALOnly);
 
-        // Get effective watermark from MANIFEST (flush watermark only; see #1730)
+        // Get effective watermark from MANIFEST — max of flush watermark and
+        // snapshot watermark. Both sources produce retention-complete state
+        // on reopen: segment flush persists records into on-disk SSTs, and
+        // snapshot install (T3-E5 + follow-up) reinstalls every logical
+        // entry including tombstones, TTL, and branch metadata. WAL segments
+        // covered by either source are safe to delete. See
+        // `effective_watermark` for the retention contract.
         let (watermark, manifest_active) = {
             let manifest = self.manifest.lock();
             let m = manifest.manifest();
@@ -309,12 +315,26 @@ impl WalOnlyCompactor {
 
 /// Compute the effective watermark for WAL truncation.
 ///
-/// Returns the flush watermark from the MANIFEST, ignoring the snapshot
-/// watermark. Snapshot-aware recovery is not yet implemented (#1730), so
-/// WAL segments must only be deleted when their data is persisted in
-/// on-disk SST segments (tracked by `flushed_through_commit_id`).
+/// Returns the highest txn id whose data is fully reconstructible on reopen
+/// without the WAL: either flushed to on-disk SSTs (`flushed_through_commit_id`)
+/// or captured in a retention-complete snapshot (`snapshot_watermark`).
+/// A WAL segment covered by the max of these is safe to delete.
+///
+/// The T3-E5 follow-up made snapshot coverage trustworthy by wiring
+/// tombstones, TTL, and Branch metadata through the checkpoint DTOs and
+/// install decoder. Before that work, WAL retention could only trust the
+/// flush watermark (the original `#1730` defensive hardening); after it,
+/// either source is sufficient.
 fn effective_watermark(manifest: &crate::format::Manifest) -> Option<u64> {
-    manifest.flushed_through_commit_id
+    match (
+        manifest.flushed_through_commit_id,
+        manifest.snapshot_watermark,
+    ) {
+        (Some(flushed), Some(snap)) => Some(flushed.max(snap)),
+        (Some(flushed), None) => Some(flushed),
+        (None, Some(snap)) => Some(snap),
+        (None, None) => None,
+    }
 }
 
 /// Generate segment file path
@@ -783,15 +803,20 @@ mod tests {
     }
 
     #[test]
-    fn test_wal_truncation_ignores_snapshot_watermark() {
-        // Issue #1730: snapshot watermark must NOT drive WAL deletion because
-        // recovery is WAL-only and cannot load snapshots.
+    fn test_wal_truncation_accepts_snapshot_watermark_alone() {
+        // Inverted from the pre-retention `test_wal_truncation_ignores_
+        // snapshot_watermark`. Once snapshot install became retention-
+        // complete (tombstones, TTL, branch metadata all round-trip), WAL
+        // segments covered by the snapshot watermark are safe to delete
+        // even without a flush watermark — the snapshot is an authoritative
+        // recovery source on reopen.
         let (_dir, wal_dir, manifest) = setup_test_env();
 
         create_segment_with_records(&wal_dir, 1, &[1, 2, 3]).unwrap();
         create_segment_with_records(&wal_dir, 2, &[4, 5, 6]).unwrap();
 
-        // Set only snapshot watermark (no flush watermark)
+        // Set only snapshot watermark (no flush watermark). watermark=100
+        // covers every record in segments 1 and 2.
         {
             let mut m = manifest.lock();
             m.set_snapshot_watermark(1, TxnId(100)).unwrap();
@@ -800,13 +825,14 @@ mod tests {
         }
 
         let compactor = WalOnlyCompactor::new(wal_dir.clone(), manifest);
-        let result = compactor.compact();
+        let info = compactor
+            .compact()
+            .expect("snapshot watermark alone must drive successful compaction post-retention");
 
-        // Must return NoSnapshot because snapshot watermark alone is not safe
-        assert!(matches!(result, Err(CompactionError::NoSnapshot)));
-        // WAL segments must NOT be deleted
-        assert!(segment_path(&wal_dir, 1).exists());
-        assert!(segment_path(&wal_dir, 2).exists());
+        assert_eq!(info.wal_segments_removed, 2);
+        assert!(!segment_path(&wal_dir, 1).exists());
+        assert!(!segment_path(&wal_dir, 2).exists());
+        assert_eq!(info.snapshot_watermark, Some(100));
     }
 
     #[test]

--- a/crates/durability/src/disk_snapshot/checkpoint.rs
+++ b/crates/durability/src/disk_snapshot/checkpoint.rs
@@ -278,6 +278,8 @@ mod tests {
                 value: b"value1".to_vec(),
                 version: 1,
                 timestamp: 1000,
+                ttl_ms: 0,
+                is_tombstone: false,
             },
             KvSnapshotEntry {
                 branch_id: [2; 16],
@@ -287,6 +289,8 @@ mod tests {
                 value: b"value2".to_vec(),
                 version: 2,
                 timestamp: 2000,
+                ttl_ms: 0,
+                is_tombstone: false,
             },
         ];
 
@@ -351,6 +355,8 @@ mod tests {
                 value: vec![],
                 version: 1,
                 timestamp: 0,
+                ttl_ms: 0,
+                is_tombstone: false,
             }])
             .with_events(vec![EventSnapshotEntry {
                 branch_id: test_uuid(),

--- a/crates/durability/src/format/primitives.rs
+++ b/crates/durability/src/format/primitives.rs
@@ -81,11 +81,17 @@ impl<'a> CursorReader<'a> {
     }
 }
 
-/// Snapshot entry for KV primitive
+/// Snapshot entry for KV primitive (v2 format)
 ///
 /// Format:
 /// branch_id(16) + space_len(4) + space + type_tag(1) + user_key_len(4) + user_key
-/// + value_len(4) + value + version(8) + timestamp(8)
+/// + value_len(4) + value + version(8) + timestamp(8) + ttl_ms(8) + is_tombstone(1)
+///
+/// Retention metadata (`ttl_ms`, `is_tombstone`) was added in the T3-E5
+/// follow-up so snapshots are retention-complete — compact() can delete WAL
+/// segments covered by a snapshot without losing TTL or tombstone state.
+/// When `is_tombstone` is true, `value` is conventionally empty but
+/// serialized identically so the format layout stays fixed.
 #[derive(Debug, Clone, PartialEq)]
 pub struct KvSnapshotEntry {
     /// Branch identifier (UUID bytes)
@@ -96,12 +102,16 @@ pub struct KvSnapshotEntry {
     pub type_tag: u8,
     /// Raw user-key bytes
     pub user_key: Vec<u8>,
-    /// Value bytes (pre-codec)
+    /// Value bytes (pre-codec). Empty when `is_tombstone` is true.
     pub value: Vec<u8>,
     /// Version counter
     pub version: u64,
     /// Timestamp (microseconds since epoch)
     pub timestamp: u64,
+    /// Per-key TTL in milliseconds (0 = no expiry).
+    pub ttl_ms: u64,
+    /// Whether this entry is a deletion tombstone.
+    pub is_tombstone: bool,
 }
 
 /// Snapshot entry for Event primitive
@@ -125,27 +135,50 @@ pub struct EventSnapshotEntry {
     pub timestamp: u64,
 }
 
-/// Snapshot entry for Run primitive
+/// Snapshot entry for Branch primitive (v2 format)
 ///
 /// Format:
-/// key_len(4) + key + value_len(4) + value + version(8) + timestamp(8)
+/// branch_id(16) + key_len(4) + key + value_len(4) + value + version(8)
+/// + timestamp(8) + is_tombstone(1)
+///
+/// The explicit `branch_id` field was added in the T3-E5 follow-up so
+/// install can dispatch entries to the correct branch on reopen. In today's
+/// engine all branch metadata lives under the global nil-UUID sentinel
+/// (see `strata_engine::primitives::branch::index::global_branch_id`),
+/// but the DTO carries the id explicitly so future per-branch metadata
+/// scoping works without another format break.
+///
+/// `is_tombstone` is explicit (matching the KV/JSON/Vector pattern) so
+/// `branches.delete(name)` round-trips losslessly through checkpoint +
+/// compact + reopen without install having to infer tombstone status from
+/// a zero-length value payload.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BranchSnapshotEntry {
+    /// Branch identifier this entry belongs to (UUID bytes).
+    pub branch_id: [u8; 16],
     /// Branch primitive storage key in the global namespace.
     pub key: String,
-    /// Serialized `Value` bytes for the branch entry.
+    /// Serialized `Value` bytes for the branch entry. Empty when
+    /// `is_tombstone` is true.
     pub value: Vec<u8>,
     /// MVCC commit version
     pub version: u64,
     /// Timestamp (microseconds)
     pub timestamp: u64,
+    /// Whether this entry is a branch-metadata deletion tombstone.
+    pub is_tombstone: bool,
 }
 
-/// Snapshot entry for Json primitive
+/// Snapshot entry for Json primitive (v2 format)
 ///
 /// Format:
 /// branch_id(16) + space_len(4) + space + doc_id_len(4) + doc_id
-/// + content_len(4) + content + version(8) + timestamp(8)
+/// + content_len(4) + content + version(8) + timestamp(8) + is_tombstone(1)
+///
+/// JSON documents can be deleted via the `destroy` operation; the tombstone
+/// marker preserves that state through checkpoint + compact + reopen.
+/// When `is_tombstone` is true, `content` is conventionally empty but
+/// serialized identically so the layout stays fixed.
 #[derive(Debug, Clone, PartialEq)]
 pub struct JsonSnapshotEntry {
     /// Branch identifier (UUID bytes)
@@ -154,12 +187,14 @@ pub struct JsonSnapshotEntry {
     pub space: String,
     /// Document identifier
     pub doc_id: String,
-    /// JSON content bytes (pre-codec)
+    /// JSON content bytes (pre-codec). Empty when `is_tombstone` is true.
     pub content: Vec<u8>,
     /// Version counter
     pub version: u64,
     /// Timestamp (microseconds)
     pub timestamp: u64,
+    /// Whether this document entry is a deletion tombstone.
+    pub is_tombstone: bool,
 }
 
 /// Snapshot entry for Vector primitive (collection level)
@@ -186,12 +221,17 @@ pub struct VectorCollectionSnapshotEntry {
     pub vectors: Vec<VectorSnapshotEntry>,
 }
 
-/// Individual vector within a collection
+/// Individual vector within a collection (v2 format)
 ///
 /// Format:
 /// key_len(4) + key + vector_id(8) + dimensions(4) + [f32...]
 /// + metadata_len(4) + metadata + raw_value_len(4) + raw_value
-/// + version(8) + timestamp(8)
+/// + version(8) + timestamp(8) + is_tombstone(1)
+///
+/// Individual vector rows can be deleted (remove-by-vector-id), so the
+/// tombstone marker preserves that state through checkpoint + compact +
+/// reopen. Collection-level config does not carry a tombstone — collection
+/// lifecycle is branch-scoped, not per-row.
 #[derive(Debug, Clone, PartialEq)]
 pub struct VectorSnapshotEntry {
     /// Vector key
@@ -208,6 +248,8 @@ pub struct VectorSnapshotEntry {
     pub version: u64,
     /// Timestamp for this vector entry
     pub timestamp: u64,
+    /// Whether this vector row is a deletion tombstone.
+    pub is_tombstone: bool,
 }
 
 /// Serializer for snapshot primitive data
@@ -221,7 +263,7 @@ impl SnapshotSerializer {
         SnapshotSerializer { codec }
     }
 
-    /// Serialize KV entries to bytes
+    /// Serialize KV entries to bytes (v2 format).
     pub fn serialize_kv(&self, entries: &[KvSnapshotEntry]) -> Vec<u8> {
         let mut data = Vec::new();
 
@@ -240,7 +282,7 @@ impl SnapshotSerializer {
             data.extend_from_slice(&(entry.user_key.len() as u32).to_le_bytes());
             data.extend_from_slice(&entry.user_key);
 
-            // Value (through codec)
+            // Value (through codec). Empty for tombstones.
             let value_bytes = self.codec.encode(&entry.value);
             data.extend_from_slice(&(value_bytes.len() as u32).to_le_bytes());
             data.extend_from_slice(&value_bytes);
@@ -248,12 +290,16 @@ impl SnapshotSerializer {
             // Version and timestamp
             data.extend_from_slice(&entry.version.to_le_bytes());
             data.extend_from_slice(&entry.timestamp.to_le_bytes());
+
+            // Retention metadata (v2)
+            data.extend_from_slice(&entry.ttl_ms.to_le_bytes());
+            data.push(if entry.is_tombstone { 1 } else { 0 });
         }
 
         data
     }
 
-    /// Deserialize KV entries from bytes
+    /// Deserialize KV entries from bytes (v2 format).
     pub fn deserialize_kv(
         &self,
         data: &[u8],
@@ -269,6 +315,8 @@ impl SnapshotSerializer {
             let value = self.codec.decode(r.read_blob()?)?;
             let version = r.read_u64()?;
             let timestamp = r.read_u64()?;
+            let ttl_ms = r.read_u64()?;
+            let is_tombstone = r.read_u8()? != 0;
             entries.push(KvSnapshotEntry {
                 branch_id,
                 space,
@@ -277,6 +325,8 @@ impl SnapshotSerializer {
                 value,
                 version,
                 timestamp,
+                ttl_ms,
+                is_tombstone,
             });
         }
         Ok(entries)
@@ -335,13 +385,15 @@ impl SnapshotSerializer {
         Ok(entries)
     }
 
-    /// Serialize Run entries to bytes
+    /// Serialize Branch entries to bytes (v2 format).
     pub fn serialize_branches(&self, entries: &[BranchSnapshotEntry]) -> Vec<u8> {
         let mut data = Vec::new();
 
         data.extend_from_slice(&(entries.len() as u32).to_le_bytes());
 
         for entry in entries {
+            data.extend_from_slice(&entry.branch_id);
+
             let key_bytes = entry.key.as_bytes();
             data.extend_from_slice(&(key_bytes.len() as u32).to_le_bytes());
             data.extend_from_slice(key_bytes);
@@ -352,12 +404,16 @@ impl SnapshotSerializer {
 
             data.extend_from_slice(&entry.version.to_le_bytes());
             data.extend_from_slice(&entry.timestamp.to_le_bytes());
+
+            // Retention metadata (v2): explicit tombstone marker, matching
+            // the KV/JSON/Vector pattern instead of inferring from empty bytes.
+            data.push(if entry.is_tombstone { 1 } else { 0 });
         }
 
         data
     }
 
-    /// Deserialize Run entries from bytes
+    /// Deserialize Branch entries from bytes (v2 format).
     pub fn deserialize_branches(
         &self,
         data: &[u8],
@@ -366,15 +422,19 @@ impl SnapshotSerializer {
         let count = r.read_u32()? as usize;
         let mut entries = Vec::with_capacity(count);
         for _ in 0..count {
+            let branch_id: [u8; 16] = r.read_exact(16)?.try_into().unwrap();
             let key = r.read_string()?;
             let value = self.codec.decode(r.read_blob()?)?;
             let version = r.read_u64()?;
             let timestamp = r.read_u64()?;
+            let is_tombstone = r.read_u8()? != 0;
             entries.push(BranchSnapshotEntry {
+                branch_id,
                 key,
                 value,
                 version,
                 timestamp,
+                is_tombstone,
             });
         }
         Ok(entries)
@@ -403,12 +463,15 @@ impl SnapshotSerializer {
 
             data.extend_from_slice(&entry.version.to_le_bytes());
             data.extend_from_slice(&entry.timestamp.to_le_bytes());
+
+            // Retention metadata (v2): tombstone marker.
+            data.push(if entry.is_tombstone { 1 } else { 0 });
         }
 
         data
     }
 
-    /// Deserialize Json entries from bytes
+    /// Deserialize Json entries from bytes (v2 format).
     pub fn deserialize_json(
         &self,
         data: &[u8],
@@ -423,6 +486,7 @@ impl SnapshotSerializer {
             let content = self.codec.decode(r.read_blob()?)?;
             let version = r.read_u64()?;
             let timestamp = r.read_u64()?;
+            let is_tombstone = r.read_u8()? != 0;
             entries.push(JsonSnapshotEntry {
                 branch_id,
                 space,
@@ -430,6 +494,7 @@ impl SnapshotSerializer {
                 content,
                 version,
                 timestamp,
+                is_tombstone,
             });
         }
         Ok(entries)
@@ -485,13 +550,16 @@ impl SnapshotSerializer {
                 data.extend_from_slice(&vector.raw_value);
                 data.extend_from_slice(&vector.version.to_le_bytes());
                 data.extend_from_slice(&vector.timestamp.to_le_bytes());
+
+                // Retention metadata (v2): per-vector tombstone marker.
+                data.push(if vector.is_tombstone { 1 } else { 0 });
             }
         }
 
         data
     }
 
-    /// Deserialize Vector collections from bytes
+    /// Deserialize Vector collections from bytes (v2 format).
     pub fn deserialize_vectors(
         &self,
         data: &[u8],
@@ -522,6 +590,7 @@ impl SnapshotSerializer {
                 let raw_value = r.read_blob()?.to_vec();
                 let version = r.read_u64()?;
                 let timestamp = r.read_u64()?;
+                let is_tombstone = r.read_u8()? != 0;
                 vectors.push(VectorSnapshotEntry {
                     key,
                     vector_id,
@@ -530,6 +599,7 @@ impl SnapshotSerializer {
                     raw_value,
                     version,
                     timestamp,
+                    is_tombstone,
                 });
             }
 
@@ -589,6 +659,8 @@ mod tests {
                 value: b"value1".to_vec(),
                 version: 1,
                 timestamp: 1000,
+                ttl_ms: 0,
+                is_tombstone: false,
             },
             KvSnapshotEntry {
                 branch_id: test_branch(2),
@@ -598,6 +670,8 @@ mod tests {
                 value: b"value2".to_vec(),
                 version: 2,
                 timestamp: 2000,
+                ttl_ms: 60_000,
+                is_tombstone: false,
             },
         ];
 
@@ -630,6 +704,8 @@ mod tests {
             value: "value_\u{4E2D}\u{6587}_chinese".as_bytes().to_vec(),
             version: 42,
             timestamp: 9999,
+            ttl_ms: 0,
+            is_tombstone: false,
         }];
 
         let data = serializer.serialize_kv(&entries);
@@ -650,6 +726,8 @@ mod tests {
             value: b"value".to_vec(),
             version: 7,
             timestamp: 12_345,
+            ttl_ms: 0,
+            is_tombstone: false,
         }];
 
         let data = serializer.serialize_kv(&entries);
@@ -691,12 +769,24 @@ mod tests {
     fn test_branches_roundtrip() {
         let serializer = test_serializer();
 
-        let entries = vec![BranchSnapshotEntry {
-            key: "my-branch".to_string(),
-            value: b"{}".to_vec(),
-            version: 17,
-            timestamp: 1000,
-        }];
+        let entries = vec![
+            BranchSnapshotEntry {
+                branch_id: test_branch(0),
+                key: "my-branch".to_string(),
+                value: b"{}".to_vec(),
+                version: 17,
+                timestamp: 1000,
+                is_tombstone: false,
+            },
+            BranchSnapshotEntry {
+                branch_id: test_branch(0),
+                key: "deleted-branch".to_string(),
+                value: Vec::new(),
+                version: 18,
+                timestamp: 2000,
+                is_tombstone: true,
+            },
+        ];
 
         let data = serializer.serialize_branches(&entries);
         let parsed = serializer.deserialize_branches(&data).unwrap();
@@ -716,6 +806,7 @@ mod tests {
                 content: b"{\"name\":\"test\"}".to_vec(),
                 version: 1,
                 timestamp: 1000,
+                is_tombstone: false,
             },
             JsonSnapshotEntry {
                 branch_id: test_branch(6),
@@ -724,6 +815,7 @@ mod tests {
                 content: b"{\"value\":42}".to_vec(),
                 version: 2,
                 timestamp: 2000,
+                is_tombstone: false,
             },
         ];
 
@@ -753,6 +845,7 @@ mod tests {
                     raw_value: b"raw-vec1".to_vec(),
                     version: 31,
                     timestamp: 2222,
+                    is_tombstone: false,
                 },
                 VectorSnapshotEntry {
                     key: "vec2".to_string(),
@@ -762,6 +855,7 @@ mod tests {
                     raw_value: b"raw-vec2".to_vec(),
                     version: 32,
                     timestamp: 3333,
+                    is_tombstone: false,
                 },
             ],
         }];
@@ -794,6 +888,7 @@ mod tests {
                 raw_value: vec![1, 2, 3, 4],
                 version: 51,
                 timestamp: 5555,
+                is_tombstone: false,
             }],
         }];
 

--- a/crates/durability/src/format/snapshot.rs
+++ b/crates/durability/src/format/snapshot.rs
@@ -26,8 +26,15 @@ use std::path::{Path, PathBuf};
 /// Magic bytes: "SNAP" (0x534E4150)
 pub const SNAPSHOT_MAGIC: [u8; 4] = *b"SNAP";
 
-/// Snapshot format version for forward compatibility
-pub const SNAPSHOT_FORMAT_VERSION: u32 = 1;
+/// Snapshot format version.
+///
+/// v2 added retention metadata to the per-primitive DTOs (tombstone markers
+/// on KV/JSON/Vector; `ttl_ms` on KV; explicit `branch_id` on Branch). Old
+/// v1 snapshots are rejected on load — the T3-E5 follow-up deliberately
+/// made a clean break rather than maintaining dual-format deserializers,
+/// since no pre-release database ships with committed `.chk` fixtures and
+/// any live database can be re-checkpointed after upgrade.
+pub const SNAPSHOT_FORMAT_VERSION: u32 = 2;
 
 /// Snapshot header size in bytes
 pub const SNAPSHOT_HEADER_SIZE: usize = 64;
@@ -112,7 +119,7 @@ impl SnapshotHeader {
                 actual: self.magic,
             });
         }
-        if self.format_version > SNAPSHOT_FORMAT_VERSION {
+        if self.format_version != SNAPSHOT_FORMAT_VERSION {
             return Err(SnapshotHeaderError::UnsupportedVersion {
                 version: self.format_version,
                 max_supported: SNAPSHOT_FORMAT_VERSION,
@@ -268,11 +275,20 @@ mod tests {
             Err(SnapshotHeaderError::InvalidMagic { .. })
         ));
 
-        // Unsupported version
+        // Future version is rejected (exact match required).
         let mut future_header = header.clone();
-        future_header.format_version = 999;
+        future_header.format_version = SNAPSHOT_FORMAT_VERSION + 1;
         assert!(matches!(
             future_header.validate(),
+            Err(SnapshotHeaderError::UnsupportedVersion { .. })
+        ));
+
+        // Past version (pre-retention) is also rejected — the clean break
+        // from v1 is deliberate; see module docs on SNAPSHOT_FORMAT_VERSION.
+        let mut legacy_header = header.clone();
+        legacy_header.format_version = 1;
+        assert!(matches!(
+            legacy_header.validate(),
             Err(SnapshotHeaderError::UnsupportedVersion { .. })
         ));
     }

--- a/crates/engine/src/database/compaction.rs
+++ b/crates/engine/src/database/compaction.rs
@@ -1,7 +1,7 @@
 //! Flush, checkpoint, and compaction.
 
 use std::sync::Arc;
-use strata_core::id::TxnId;
+use strata_core::id::{CommitVersion, TxnId};
 use strata_core::types::{Key, TypeTag};
 use strata_core::{StrataError, StrataResult};
 use strata_durability::__internal::WalWriterEngineExt;
@@ -251,36 +251,59 @@ impl Database {
         let mut vector_collections = Vec::new();
 
         for branch_id in self.storage.branch_ids() {
-            // KV entries
-            for (key, vv) in self.storage.list_by_type(&branch_id, TypeTag::KV) {
-                let value_bytes = serde_json::to_vec(&vv.value).unwrap_or_default();
+            // KV entries — use the version-scoped listing so tombstones survive
+            // into the snapshot payload and retention metadata (timestamp,
+            // ttl_ms) is preserved. `list_by_type_at_version(…, MAX)` returns
+            // every logical key's latest version including deletions.
+            for entry in
+                self.storage
+                    .list_by_type_at_version(&branch_id, TypeTag::KV, CommitVersion::MAX)
+            {
+                let value_bytes = if entry.is_tombstone {
+                    Vec::new()
+                } else {
+                    serde_json::to_vec(&entry.value).unwrap_or_default()
+                };
                 kv_entries.push(KvSnapshotEntry {
                     branch_id: *branch_id.as_bytes(),
-                    space: key.namespace.space.clone(),
+                    space: entry.key.namespace.space.clone(),
                     type_tag: TypeTag::KV.as_byte(),
-                    user_key: key.user_key.to_vec(),
+                    user_key: entry.key.user_key.to_vec(),
                     value: value_bytes,
-                    version: vv.version.as_u64(),
-                    timestamp: vv.timestamp.as_micros(),
+                    version: entry.commit_id.as_u64(),
+                    timestamp: entry.timestamp_micros,
+                    ttl_ms: entry.ttl_ms,
+                    is_tombstone: entry.is_tombstone,
                 });
             }
 
-            // Graph entries share the same value encoding as KV but keep their
-            // graph type tag and namespace so recovery can reconstruct them exactly.
-            for (key, vv) in self.storage.list_by_type(&branch_id, TypeTag::Graph) {
-                let value_bytes = serde_json::to_vec(&vv.value).unwrap_or_default();
+            // Graph entries share the KV section (discriminated by `type_tag`).
+            // Same retention-complete treatment.
+            for entry in
+                self.storage
+                    .list_by_type_at_version(&branch_id, TypeTag::Graph, CommitVersion::MAX)
+            {
+                let value_bytes = if entry.is_tombstone {
+                    Vec::new()
+                } else {
+                    serde_json::to_vec(&entry.value).unwrap_or_default()
+                };
                 kv_entries.push(KvSnapshotEntry {
                     branch_id: *branch_id.as_bytes(),
-                    space: key.namespace.space.clone(),
+                    space: entry.key.namespace.space.clone(),
                     type_tag: TypeTag::Graph.as_byte(),
-                    user_key: key.user_key.to_vec(),
+                    user_key: entry.key.user_key.to_vec(),
                     value: value_bytes,
-                    version: vv.version.as_u64(),
-                    timestamp: vv.timestamp.as_micros(),
+                    version: entry.commit_id.as_u64(),
+                    timestamp: entry.timestamp_micros,
+                    ttl_ms: entry.ttl_ms,
+                    is_tombstone: entry.is_tombstone,
                 });
             }
 
-            // Event entries
+            // Event entries — events are append-only, so tombstones should not
+            // appear. Stay on the live-only `list_by_type` for clarity; if a
+            // future primitive change introduces event retraction, revisit.
             for (key, vv) in self.storage.list_by_type(&branch_id, TypeTag::Event) {
                 // Skip metadata keys (internal implementation details, reconstructed on restore)
                 if *key.user_key == *b"__meta__" || key.user_key.starts_with(b"__tidx__") {
@@ -302,42 +325,74 @@ impl Database {
                 });
             }
 
-            // Branch entries
-            for (key, vv) in self.storage.list_by_type(&branch_id, TypeTag::Branch) {
-                // Skip index keys
-                if key.user_key.starts_with(b"__idx_") {
+            // Branch entries — retention-complete via version-scoped listing.
+            // The DTO now carries `branch_id` explicitly so snapshot install
+            // can dispatch. `__idx_` keys are derived indices and are
+            // deliberately excluded from snapshots (rebuilt at read time).
+            for entry in self.storage.list_by_type_at_version(
+                &branch_id,
+                TypeTag::Branch,
+                CommitVersion::MAX,
+            ) {
+                if entry.key.user_key.starts_with(b"__idx_") {
                     continue;
                 }
-                let key_string = match key.user_key_string() {
+                let key_string = match entry.key.user_key_string() {
                     Some(key_string) => key_string,
                     None => continue,
                 };
-                let value = serde_json::to_vec(&vv.value).unwrap_or_default();
+                let value = if entry.is_tombstone {
+                    Vec::new()
+                } else {
+                    serde_json::to_vec(&entry.value).unwrap_or_default()
+                };
                 branch_entries.push(BranchSnapshotEntry {
+                    branch_id: *branch_id.as_bytes(),
                     key: key_string,
                     value,
-                    version: vv.version.as_u64(),
-                    timestamp: vv.timestamp.as_micros(),
+                    version: entry.commit_id.as_u64(),
+                    timestamp: entry.timestamp_micros,
+                    is_tombstone: entry.is_tombstone,
                 });
             }
 
-            // JSON entries
-            for (key, vv) in self.storage.list_by_type(&branch_id, TypeTag::Json) {
-                let content = serde_json::to_vec(&vv.value).unwrap_or_default();
+            // JSON entries — retention-complete with tombstone preservation.
+            for entry in
+                self.storage
+                    .list_by_type_at_version(&branch_id, TypeTag::Json, CommitVersion::MAX)
+            {
+                let content = if entry.is_tombstone {
+                    Vec::new()
+                } else {
+                    serde_json::to_vec(&entry.value).unwrap_or_default()
+                };
                 json_entries.push(JsonSnapshotEntry {
                     branch_id: *branch_id.as_bytes(),
-                    space: key.namespace.space.clone(),
-                    doc_id: key.user_key_string().unwrap_or_default(),
+                    space: entry.key.namespace.space.clone(),
+                    doc_id: entry.key.user_key_string().unwrap_or_default(),
                     content,
-                    version: vv.version.as_u64(),
-                    timestamp: vv.timestamp.as_micros(),
+                    version: entry.commit_id.as_u64(),
+                    timestamp: entry.timestamp_micros,
+                    is_tombstone: entry.is_tombstone,
                 });
             }
 
-            // Vector collection configs (stored under TypeTag::Vector with __config__/ prefix)
-            for (key, vv) in self.storage.list_by_type(&branch_id, TypeTag::Vector) {
-                // Only process config entries (user_key starts with "__config__/")
-                let user_key_str = match key.user_key_string() {
+            // Vector collection configs (stored under TypeTag::Vector with
+            // __config__/ prefix). Per-vector rows get tombstone preservation
+            // via the version-scoped listing; config entries don't need a
+            // tombstone (collection lifecycle is branch-scoped, not per-row).
+            for entry in self.storage.list_by_type_at_version(
+                &branch_id,
+                TypeTag::Vector,
+                CommitVersion::MAX,
+            ) {
+                if entry.is_tombstone {
+                    // Config tombstones indicate the collection was dropped;
+                    // ignore here since any trailing vector rows below are
+                    // tombstoned too and round-trip correctly on install.
+                    continue;
+                }
+                let user_key_str = match entry.key.user_key_string() {
                     Some(s) => s,
                     None => continue,
                 };
@@ -346,28 +401,48 @@ impl Database {
                     None => continue,
                 };
 
-                let config_bytes = match &vv.value {
+                let config_bytes = match &entry.value {
                     strata_core::value::Value::Bytes(b) => b.clone(),
-                    _ => serde_json::to_vec(&vv.value).unwrap_or_default(),
+                    _ => serde_json::to_vec(&entry.value).unwrap_or_default(),
                 };
 
-                // Collect vectors belonging to this collection
-                let ns = key.namespace.clone();
+                // Per-collection vector rows — also via version-scoped listing
+                // so deleted vectors survive the checkpoint as tombstones.
+                let ns = entry.key.namespace.clone();
                 let prefix = Key::vector_collection_prefix(ns, &collection_name);
                 let mut snapshot_vectors = Vec::new();
-                for (vec_key, vec_vv) in self.storage.list_by_type(&branch_id, TypeTag::Vector) {
-                    if !vec_key.starts_with(&prefix) {
+                for vec_entry in self.storage.list_by_type_at_version(
+                    &branch_id,
+                    TypeTag::Vector,
+                    CommitVersion::MAX,
+                ) {
+                    if !vec_entry.key.starts_with(&prefix) {
                         continue;
                     }
-                    // Extract vector key: user_key = "collection/vector_key"
-                    let vec_key_str = vec_key.user_key_string().unwrap_or_default();
+                    let vec_key_str = vec_entry.key.user_key_string().unwrap_or_default();
                     let vector_key = vec_key_str
                         .strip_prefix(&format!("{}/", collection_name))
                         .unwrap_or(&vec_key_str)
                         .to_string();
 
-                    // Deserialize VectorRecord from bytes
-                    if let strata_core::value::Value::Bytes(bytes) = &vec_vv.value {
+                    if vec_entry.is_tombstone {
+                        // Tombstoned vector row — preserve the delete through
+                        // checkpoint. Embedding/metadata/raw_value are empty
+                        // since the row no longer carries payload.
+                        snapshot_vectors.push(VectorSnapshotEntry {
+                            key: vector_key,
+                            vector_id: 0,
+                            embedding: Vec::new(),
+                            metadata: Vec::new(),
+                            raw_value: Vec::new(),
+                            version: vec_entry.commit_id.as_u64(),
+                            timestamp: vec_entry.timestamp_micros,
+                            is_tombstone: true,
+                        });
+                        continue;
+                    }
+
+                    if let strata_core::value::Value::Bytes(bytes) = &vec_entry.value {
                         if let Ok(record) = VectorRecord::from_bytes(bytes) {
                             let metadata_bytes = record
                                 .metadata
@@ -380,8 +455,9 @@ impl Database {
                                 embedding: record.embedding,
                                 metadata: metadata_bytes,
                                 raw_value: bytes.clone(),
-                                version: vec_vv.version.as_u64(),
-                                timestamp: vec_vv.timestamp.as_micros(),
+                                version: vec_entry.commit_id.as_u64(),
+                                timestamp: vec_entry.timestamp_micros,
+                                is_tombstone: false,
                             });
                         }
                     }
@@ -389,11 +465,11 @@ impl Database {
 
                 vector_collections.push(VectorCollectionSnapshotEntry {
                     branch_id: *branch_id.as_bytes(),
-                    space: key.namespace.space.clone(),
+                    space: entry.key.namespace.space.clone(),
                     name: collection_name,
                     config: config_bytes,
-                    config_version: vv.version.as_u64(),
-                    config_timestamp: vv.timestamp.as_micros(),
+                    config_version: entry.commit_id.as_u64(),
+                    config_timestamp: entry.timestamp_micros,
                     vectors: snapshot_vectors,
                 });
             }

--- a/crates/engine/src/database/snapshot_install.rs
+++ b/crates/engine/src/database/snapshot_install.rs
@@ -9,14 +9,13 @@
 //! Recovery calls this from the `on_snapshot` callback passed to
 //! `RecoveryCoordinator::recover` so checkpoint-only restart (no WAL covering
 //! some pre-snapshot range) produces the same observable state as the
-//! original commits.
+//! original commits. The T3-E5 follow-up made snapshot install
+//! retention-complete: tombstones are installed as `DecodedSnapshotValue::
+//! Tombstone` so deletes survive checkpoint+compact+reopen; KV TTL carries
+//! through; and the Branch section is dispatched via the new `branch_id`
+//! field on `BranchSnapshotEntry`.
 //!
-//! Branch-primitive sections are currently skipped with a warning: their
-//! snapshot DTO does not carry `branch_id` so install cannot know which
-//! branch to target. Branch metadata remains recoverable through WAL replay;
-//! a DTO fix for Branch is tracked separately from T3-E5.
-//!
-//! Graph-primitive standalone sections are also skipped: today
+//! Graph-primitive standalone sections are still skipped — today
 //! `collect_checkpoint_data` emits Graph entries inside the KV section with
 //! `type_tag = TypeTag::Graph`, and the KV decoder below routes them to the
 //! correct storage type. A future standalone Graph section would need its
@@ -36,27 +35,36 @@ use tracing::warn;
 /// Counts of entries installed per primitive during a snapshot install.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub(crate) struct InstallStats {
-    /// KV entries installed (TypeTag::KV).
+    /// KV entries installed (TypeTag::KV). Includes tombstones.
     pub kv: usize,
     /// Graph entries installed (TypeTag::Graph) — routed through the KV section.
     pub graph: usize,
     /// Event entries installed.
     pub events: usize,
-    /// JSON entries installed.
+    /// JSON entries installed. Includes tombstones.
     pub json: usize,
     /// Vector collection configs installed (the `__config__/{name}` rows).
     pub vector_configs: usize,
-    /// Individual vector records installed.
+    /// Individual vector records installed. Includes tombstones.
     pub vectors: usize,
+    /// Branch metadata entries installed.
+    pub branches: usize,
     /// Sections that were present in the snapshot but intentionally skipped
-    /// (Branch section today; Graph standalone section if ever non-empty).
+    /// (standalone Graph section when non-empty — today KV-section routing
+    /// handles all graph entries).
     pub sections_skipped: usize,
 }
 
 impl InstallStats {
     /// Total number of logical entries written into storage.
     pub(crate) fn total_installed(&self) -> usize {
-        self.kv + self.graph + self.events + self.json + self.vector_configs + self.vectors
+        self.kv
+            + self.graph
+            + self.events
+            + self.json
+            + self.vector_configs
+            + self.vectors
+            + self.branches
     }
 }
 
@@ -89,18 +97,7 @@ pub(crate) fn install_snapshot(
                 install_vector_section(&serializer, &section.data, storage, &mut stats)?
             }
             primitive_tags::BRANCH => {
-                // BranchSnapshotEntry does not carry a `branch_id` field today,
-                // so install cannot dispatch per-branch correctly. Branch
-                // metadata is also recorded in the WAL, so delta-replay
-                // reconstitutes it. Log and skip.
-                warn!(
-                    target: "strata::recovery",
-                    section = "Branch",
-                    bytes = section.data.len(),
-                    "Skipping Branch snapshot section: DTO lacks branch_id; \
-                     Branch metadata will be reconstituted from WAL"
-                );
-                stats.sections_skipped += 1;
+                install_branch_section(&serializer, &section.data, storage, &mut stats)?
             }
             primitive_tags::GRAPH => {
                 // Graph entries are written inside the KV section today; a
@@ -132,7 +129,8 @@ pub(crate) fn install_snapshot(
 /// Decode one KV section and install entries grouped by `(branch_id, type_tag)`.
 ///
 /// The KV section carries both KV and Graph entries (`type_tag` discriminates);
-/// install routes them to the appropriate storage type.
+/// install routes them to the appropriate storage type. Tombstones are
+/// installed as `DecodedSnapshotValue::Tombstone`; TTL is propagated.
 fn install_kv_section(
     serializer: &SnapshotSerializer,
     data: &[u8],
@@ -145,17 +143,18 @@ fn install_kv_section(
 
     let mut groups: HashMap<([u8; 16], u8), Vec<DecodedSnapshotEntry>> = HashMap::new();
     for entry in entries {
-        let value = decode_value_json(&entry.value, "KV")?;
+        let payload = if entry.is_tombstone {
+            DecodedSnapshotValue::Tombstone
+        } else {
+            DecodedSnapshotValue::Value(decode_value_json(&entry.value, "KV")?)
+        };
         let decoded = DecodedSnapshotEntry {
             space: entry.space,
             user_key: entry.user_key,
-            payload: DecodedSnapshotValue::Value(value),
+            payload,
             version: CommitVersion(entry.version),
             timestamp_micros: entry.timestamp,
-            // KV snapshot DTO does not carry TTL today; T3-E4 flagged this
-            // as a retention-completeness follow-up. 0 = no expiry, matching
-            // pre-snapshot-install behavior.
-            ttl_ms: 0,
+            ttl_ms: entry.ttl_ms,
         };
         groups
             .entry((entry.branch_id, entry.type_tag))
@@ -215,7 +214,8 @@ fn install_event_section(
 }
 
 /// Decode a JSON section and install entries per-branch with doc-id as the
-/// user key (matching the Json primitive's key encoding).
+/// user key (matching the Json primitive's key encoding). Tombstones on
+/// deleted documents are preserved as `DecodedSnapshotValue::Tombstone`.
 fn install_json_section(
     serializer: &SnapshotSerializer,
     data: &[u8],
@@ -228,11 +228,15 @@ fn install_json_section(
 
     let mut groups: HashMap<[u8; 16], Vec<DecodedSnapshotEntry>> = HashMap::new();
     for entry in entries {
-        let value = decode_value_json(&entry.content, "Json")?;
+        let payload = if entry.is_tombstone {
+            DecodedSnapshotValue::Tombstone
+        } else {
+            DecodedSnapshotValue::Value(decode_value_json(&entry.content, "Json")?)
+        };
         let decoded = DecodedSnapshotEntry {
             space: entry.space,
             user_key: entry.doc_id.into_bytes(),
-            payload: DecodedSnapshotValue::Value(value),
+            payload,
             version: CommitVersion(entry.version),
             timestamp_micros: entry.timestamp,
             ttl_ms: 0,
@@ -243,6 +247,58 @@ fn install_json_section(
         let branch_id = BranchId::from_bytes(branch_bytes);
         let count = storage.install_snapshot_entries(branch_id, TypeTag::Json, &group_entries)?;
         stats.json += count;
+    }
+    Ok(())
+}
+
+/// Decode a Branch section and install entries grouped by `branch_id`.
+///
+/// Branch metadata in today's engine lives under the global nil-UUID sentinel
+/// (see `strata_engine::primitives::branch::index::global_branch_id`), but
+/// the DTO carries the id explicitly so install stays robust against future
+/// per-branch scoping without another format break.
+///
+/// `user_key` is the UTF-8 bytes of the original key string. Values are
+/// stored as JSON-encoded bytes (matching the checkpoint collector) unless
+/// the entry is a tombstone, in which case the value is empty.
+fn install_branch_section(
+    serializer: &SnapshotSerializer,
+    data: &[u8],
+    storage: &SegmentedStore,
+    stats: &mut InstallStats,
+) -> StrataResult<()> {
+    let entries = serializer
+        .deserialize_branches(data)
+        .map_err(|e| StrataError::corruption(format!("Branch section decode failed: {}", e)))?;
+
+    let mut groups: HashMap<[u8; 16], Vec<DecodedSnapshotEntry>> = HashMap::new();
+    for entry in entries {
+        // Explicit tombstone marker (matches KV/JSON/Vector). Using the flag
+        // instead of inferring from empty-value bytes prevents a silent
+        // misclassification if a live entry ever serializes to zero bytes.
+        let payload = if entry.is_tombstone {
+            DecodedSnapshotValue::Tombstone
+        } else {
+            DecodedSnapshotValue::Value(decode_value_json(&entry.value, "Branch")?)
+        };
+        let decoded = DecodedSnapshotEntry {
+            // Branch metadata lives in the conventional "default" space per
+            // `Namespace::for_branch`; install reconstructs the full
+            // `Namespace` from branch_id + space inside
+            // `SegmentedStore::install_snapshot_entries`.
+            space: "default".to_string(),
+            user_key: entry.key.into_bytes(),
+            payload,
+            version: CommitVersion(entry.version),
+            timestamp_micros: entry.timestamp,
+            ttl_ms: 0,
+        };
+        groups.entry(entry.branch_id).or_default().push(decoded);
+    }
+    for (branch_bytes, group_entries) in groups {
+        let branch_id = BranchId::from_bytes(branch_bytes);
+        let count = storage.install_snapshot_entries(branch_id, TypeTag::Branch, &group_entries)?;
+        stats.branches += count;
     }
     Ok(())
 }
@@ -287,16 +343,21 @@ fn install_vector_section(
 
         for vector in collection.vectors {
             let vec_key = format!("{}/{}", name, vector.key).into_bytes();
+            let payload = if vector.is_tombstone {
+                DecodedSnapshotValue::Tombstone
+            } else {
+                // `raw_value` is the original serialized `VectorRecord`
+                // bytes; reinstalling as `Value::Bytes` preserves the exact
+                // payload that subsystem recovery expects to decode.
+                DecodedSnapshotValue::Value(Value::Bytes(vector.raw_value))
+            };
             groups
                 .entry(branch_bytes)
                 .or_default()
                 .push(DecodedSnapshotEntry {
                     space: space.clone(),
                     user_key: vec_key,
-                    // `raw_value` is the original serialized `VectorRecord`
-                    // bytes; reinstalling as `Value::Bytes` preserves the
-                    // exact payload that subsystem recovery expects to decode.
-                    payload: DecodedSnapshotValue::Value(Value::Bytes(vector.raw_value)),
+                    payload,
                     version: CommitVersion(vector.version),
                     timestamp_micros: vector.timestamp,
                     ttl_ms: 0,
@@ -373,6 +434,8 @@ mod tests {
                 value: serde_json::to_vec(&Value::Int(1)).unwrap(),
                 version: 5,
                 timestamp: 1_000,
+                ttl_ms: 0,
+                is_tombstone: false,
             },
             KvSnapshotEntry {
                 branch_id: *branch_id.as_bytes(),
@@ -382,6 +445,8 @@ mod tests {
                 value: serde_json::to_vec(&Value::String("two".into())).unwrap(),
                 version: 6,
                 timestamp: 2_000,
+                ttl_ms: 0,
+                is_tombstone: false,
             },
         ]);
 
@@ -434,6 +499,8 @@ mod tests {
                 value: serde_json::to_vec(&Value::String("node-one".into())).unwrap(),
                 version: 10,
                 timestamp: 100,
+                ttl_ms: 0,
+                is_tombstone: false,
             },
             KvSnapshotEntry {
                 branch_id: *branch_id.as_bytes(),
@@ -443,6 +510,8 @@ mod tests {
                 value: serde_json::to_vec(&Value::Int(42)).unwrap(),
                 version: 11,
                 timestamp: 200,
+                ttl_ms: 0,
+                is_tombstone: false,
             },
         ]);
 
@@ -481,6 +550,8 @@ mod tests {
             value: serde_json::to_vec(&Value::Int(7)).unwrap(),
             version: 999,
             timestamp: 1_234_567,
+            ttl_ms: 0,
+            is_tombstone: false,
         }]);
 
         let info = writer_for(dir.path())
@@ -553,6 +624,7 @@ mod tests {
             content: serde_json::to_vec(&Value::String("content".into())).unwrap(),
             version: 100,
             timestamp: 77,
+            is_tombstone: false,
         }]);
 
         let info = writer_for(dir.path())
@@ -596,6 +668,7 @@ mod tests {
                 raw_value: b"raw-record-bytes".to_vec(),
                 version: 13,
                 timestamp: 1_600,
+                is_tombstone: false,
             }],
         }]);
 
@@ -643,28 +716,178 @@ mod tests {
     }
 
     #[test]
-    fn install_branch_section_is_skipped_with_warning() {
+    fn install_round_trips_branch_entries() {
         let dir = tempfile::tempdir().unwrap();
+        // Branch metadata lives under the nil-UUID global branch today;
+        // the DTO carries it explicitly so install dispatches correctly.
+        let global_branch = BranchId::from_bytes([0; 16]);
 
-        // Empty Branch section is accepted; non-empty is skipped with a warning.
-        // We use an empty payload here so the test does not rely on the Branch
-        // deserializer's internal format.
+        let branch_bytes = strata_durability::SnapshotSerializer::new(Box::new(IdentityCodec))
+            .serialize_branches(&[strata_durability::format::BranchSnapshotEntry {
+                branch_id: *global_branch.as_bytes(),
+                key: "my-branch".to_string(),
+                value: serde_json::to_vec(&Value::String("branch-metadata".into())).unwrap(),
+                version: 42,
+                timestamp: 1_234,
+                is_tombstone: false,
+            }]);
+
         let info = writer_for(dir.path())
             .create_snapshot(
                 7,
-                0,
-                vec![SnapshotSection::new(
-                    primitive_tags::BRANCH,
-                    vec![0, 0, 0, 0], // entry count = 0
-                )],
+                42,
+                vec![SnapshotSection::new(primitive_tags::BRANCH, branch_bytes)],
             )
             .unwrap();
         let snapshot = load_snapshot(&info.path);
 
         let storage = SegmentedStore::new();
         let stats = install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
-        assert_eq!(stats.sections_skipped, 1);
-        assert_eq!(stats.total_installed(), 0);
+        assert_eq!(stats.branches, 1);
+        assert_eq!(stats.sections_skipped, 0);
+
+        // The entry must land under the (global_branch, "default",
+        // TypeTag::Branch) cell with the original key as user_key bytes.
+        let ns = Arc::new(Namespace::for_branch(global_branch));
+        let key = Key::new(ns, TypeTag::Branch, b"my-branch".to_vec());
+        let entry = storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("branch entry must be installed");
+        assert_eq!(entry.value, Value::String("branch-metadata".into()));
+        assert_eq!(entry.version, Version::Txn(42));
+    }
+
+    #[test]
+    fn install_propagates_branch_tombstone_as_tombstone() {
+        // An explicit tombstone in `BranchSnapshotEntry` installs as a
+        // storage-level tombstone so deleted branch metadata round-trips
+        // through checkpoint + compact + reopen as a deletion, not as a
+        // resurrected live record.
+        let dir = tempfile::tempdir().unwrap();
+        let global_branch = BranchId::from_bytes([0; 16]);
+
+        let branch_bytes = strata_durability::SnapshotSerializer::new(Box::new(IdentityCodec))
+            .serialize_branches(&[strata_durability::format::BranchSnapshotEntry {
+                branch_id: *global_branch.as_bytes(),
+                key: "dropped".to_string(),
+                value: Vec::new(),
+                version: 99,
+                timestamp: 2_000,
+                is_tombstone: true,
+            }]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                12,
+                99,
+                vec![SnapshotSection::new(primitive_tags::BRANCH, branch_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
+
+        let ns = Arc::new(Namespace::for_branch(global_branch));
+        let key = Key::new(ns, TypeTag::Branch, b"dropped".to_vec());
+        let observed = storage.get_versioned(&key, CommitVersion::MAX).unwrap();
+        assert!(
+            observed.is_none(),
+            "branch tombstone must hide the entry on reads"
+        );
+    }
+
+    #[test]
+    fn install_propagates_kv_tombstone_as_tombstone() {
+        // A tombstoned KV entry must be installed as a storage-level
+        // tombstone so reads return `None` after snapshot-only restart.
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let kv_bytes = serializer().serialize_kv(&[KvSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "default".to_string(),
+            type_tag: TypeTag::KV.as_byte(),
+            user_key: b"deleted".to_vec(),
+            value: Vec::new(),
+            version: 10,
+            timestamp: 500,
+            ttl_ms: 0,
+            is_tombstone: true,
+        }]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                10,
+                10,
+                vec![SnapshotSection::new(primitive_tags::KV, kv_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
+
+        // A tombstoned snapshot entry surfaces as `None` on read.
+        let key = Key::new_kv(ns(branch_id, "default"), "deleted");
+        let observed = storage.get_versioned(&key, CommitVersion::MAX).unwrap();
+        assert!(observed.is_none(), "tombstone must hide the key from reads");
+    }
+
+    #[test]
+    fn install_propagates_kv_ttl_into_storage() {
+        // A KV entry with a non-zero ttl_ms must expire at the correct
+        // timestamp after snapshot install — the TTL barrier survives
+        // checkpoint + compact + reopen.
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+        let ttl_ms: u64 = 30_000;
+        let commit_ts_micros: u64 = 1_000_000;
+
+        let kv_bytes = serializer().serialize_kv(&[KvSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "default".to_string(),
+            type_tag: TypeTag::KV.as_byte(),
+            user_key: b"expires".to_vec(),
+            value: serde_json::to_vec(&Value::String("temporary".into())).unwrap(),
+            version: 1,
+            timestamp: commit_ts_micros,
+            ttl_ms,
+            is_tombstone: false,
+        }]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                11,
+                1,
+                vec![SnapshotSection::new(primitive_tags::KV, kv_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
+
+        let key = Key::new_kv(ns(branch_id, "default"), "expires");
+
+        // Before the TTL elapses, the entry is visible.
+        let pre_expiry = storage
+            .get_at_timestamp(&key, commit_ts_micros + ttl_ms * 1_000 - 1)
+            .unwrap();
+        assert!(
+            pre_expiry.is_some(),
+            "entry must be visible before TTL elapses"
+        );
+
+        // Past the TTL window, the entry expires.
+        let post_expiry = storage
+            .get_at_timestamp(&key, commit_ts_micros + ttl_ms * 1_000 + 1)
+            .unwrap();
+        assert!(
+            post_expiry.is_none(),
+            "TTL barrier from the snapshot must expire the entry after the configured window"
+        );
     }
 
     #[test]

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -707,10 +707,14 @@ fn test_checkpoint_creates_snapshot() {
 }
 
 #[test]
-fn test_checkpoint_then_compact_without_flush_fails() {
-    // Issue #1730: compact() after checkpoint-only must fail because
-    // recovery cannot load snapshots. WAL compaction is only safe
-    // when driven by the flush watermark (data in SST segments).
+fn test_checkpoint_then_compact_without_flush_succeeds() {
+    // Inverted in the T3-E5 follow-up (retention-complete DTOs + install).
+    //
+    // Pre-retention, compact() refused on snapshot-only coverage because
+    // recovery was either WAL-only or lacked tombstone/TTL/Branch fidelity.
+    // Now that snapshot install is retention-complete, the snapshot
+    // watermark is an authoritative recovery input and compact() succeeds
+    // without a flush watermark.
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("db");
     let db = Database::open(&db_path).unwrap();
@@ -719,19 +723,18 @@ fn test_checkpoint_then_compact_without_flush_fails() {
     let ns = create_test_namespace(branch_id);
     let key = Key::new_kv(ns, "compact_test");
 
-    // Write data
     db.transaction(branch_id, |txn| {
         txn.put(key.clone(), Value::Int(42))?;
         Ok(())
     })
     .unwrap();
 
-    // Checkpoint creates snapshot but no flush watermark
-    assert!(db.checkpoint().is_ok());
+    db.checkpoint()
+        .expect("checkpoint must succeed to populate the snapshot watermark");
 
-    // Compact must fail — snapshot watermark alone is not safe
-    let result = db.compact();
-    assert!(result.is_err());
+    // Compact now succeeds on snapshot-only coverage.
+    db.compact()
+        .expect("compact() must succeed once recovery consumes retention-complete snapshots");
 }
 
 #[test]
@@ -1592,17 +1595,19 @@ fn test_issue_1697_compaction_preserves_snapshot_versions() {
 #[test]
 #[serial(open_databases)]
 fn test_issue_1730_checkpoint_compact_recovery_data_loss() {
-    // Issue #1730: checkpoint+compact deletes WAL segments, but recovery
-    // is WAL-only and never loads snapshots. This causes data loss.
+    // Inverted in the T3-E5 follow-up.
     //
-    // After the fix, compact() must refuse to delete WAL segments based
-    // on the snapshot watermark alone, since recovery cannot load snapshots.
+    // Pre-retention, recovery was either WAL-only or lacked tombstone/TTL
+    // fidelity, so `compact()` had to refuse WAL deletion on snapshot-only
+    // coverage (`#1730`). Now that snapshot install is retention-complete
+    // (tombstones, TTL, branch metadata round-trip), compact() succeeds,
+    // WAL is reclaimed, and the committed data survives reopen through
+    // snapshot install alone.
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("db");
 
     let branch_id = BranchId::new();
 
-    // Step 1: Write data
     {
         let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
         let ns = create_test_namespace(branch_id);
@@ -1614,51 +1619,35 @@ fn test_issue_1730_checkpoint_compact_recovery_data_loss() {
         })
         .unwrap();
 
-        // Step 2: Checkpoint (creates snapshot, sets watermark in MANIFEST)
         db.checkpoint().unwrap();
 
-        // Step 3: Compact — should NOT delete WAL segments since recovery
-        // cannot load snapshots. With the fix, this returns an error.
-        let compact_result = db.compact();
-        assert!(
-            compact_result.is_err(),
-            "compact() must fail when only snapshot watermark exists \
-             (no flush watermark) because recovery cannot load snapshots"
-        );
+        // compact() now succeeds on snapshot-only coverage.
+        db.compact()
+            .expect("compact() must succeed once snapshot coverage is trusted");
     }
-    // Database dropped (simulates clean shutdown)
 
-    // Clear the registry so reopen doesn't return the cached instance
     OPEN_DATABASES.lock().clear();
 
-    // Step 4: Reopen — recovery replays WAL
     {
         let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
-
         let ns = create_test_namespace(branch_id);
         let key = Key::new_kv(ns, "critical_data");
 
-        // Step 5: Data MUST still be present
         let result = db
             .storage()
             .get_versioned(&key, CommitVersion::MAX)
-            .unwrap();
-        assert!(
-            result.is_some(),
-            "CRITICAL: Data lost after checkpoint+compact+recovery! \
-             WAL segments were deleted but recovery never loaded the snapshot."
-        );
-        assert_eq!(
-            result.unwrap().value,
-            Value::String("must_survive".to_string())
-        );
+            .unwrap()
+            .expect("data must survive checkpoint+compact+recovery via snapshot install");
+        assert_eq!(result.value, Value::String("must_survive".to_string()));
     }
 }
 
 #[test]
 #[serial(open_databases)]
 fn test_issue_1730_standard_durability() {
-    // Same as above but with Standard durability mode (disk-based, batched fsync).
+    // Inverted twin for Standard durability mode. Same contract: compact
+    // succeeds on snapshot-only coverage, data round-trips via snapshot
+    // install.
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("db");
 
@@ -1679,17 +1668,13 @@ fn test_issue_1730_standard_durability() {
         })
         .unwrap();
 
-        // Ensure WAL is flushed to disk
+        // Flush ensures the record is on disk before checkpoint so the
+        // snapshot + MANIFEST watermark reflect the transaction.
         db.flush().unwrap();
-
         db.checkpoint().unwrap();
 
-        // compact() must fail — only snapshot watermark, no flush watermark
-        let compact_result = db.compact();
-        assert!(
-            compact_result.is_err(),
-            "compact() after checkpoint-only must fail under Standard durability"
-        );
+        db.compact()
+            .expect("compact() must succeed on snapshot-only watermark under Standard durability");
     }
 
     OPEN_DATABASES.lock().clear();
@@ -1703,12 +1688,9 @@ fn test_issue_1730_standard_durability() {
         let result = db
             .storage()
             .get_versioned(&key, CommitVersion::MAX)
-            .unwrap();
-        assert!(
-            result.is_some(),
-            "Data must survive checkpoint+failed-compact+recovery under Standard durability"
-        );
-        assert_eq!(result.unwrap().value, Value::String("durable".to_string()));
+            .unwrap()
+            .expect("data must survive checkpoint+compact+recovery under Standard durability");
+        assert_eq!(result.value, Value::String("durable".to_string()));
     }
 }
 
@@ -2212,7 +2194,11 @@ fn test_checkpoint_data_preserves_vector_space_metadata() {
 }
 
 #[test]
-fn test_checkpoint_data_omits_tombstones_from_live_only_collection() {
+fn test_checkpoint_data_includes_tombstones() {
+    // Inverted from the pre-retention `test_checkpoint_data_omits_tombstones_*`.
+    // The collector now uses `list_by_type_at_version(…, MAX)` which preserves
+    // tombstones, so a deleted key must appear in the checkpoint payload as
+    // an `is_tombstone = true` entry.
     let db = Database::cache().unwrap();
     let branch_id = BranchId::from_bytes([4; 16]);
     let key = Key::new_kv(create_test_namespace(branch_id), "deleted");
@@ -2225,16 +2211,26 @@ fn test_checkpoint_data_omits_tombstones_from_live_only_collection() {
         .unwrap();
 
     let kv_entries = db.collect_checkpoint_data().kv.unwrap_or_default();
+    let entry = kv_entries
+        .iter()
+        .find(|e| e.user_key == b"deleted".to_vec())
+        .expect("deleted key must appear in checkpoint as a tombstone entry");
     assert!(
-        !kv_entries
-            .iter()
-            .any(|entry| entry.user_key == b"deleted".to_vec()),
-        "Deleted keys are omitted because checkpoint collection uses live-only list_by_type()"
+        entry.is_tombstone,
+        "deleted key must surface with is_tombstone=true, got: {:?}",
+        entry
+    );
+    assert_eq!(
+        entry.version, 2,
+        "tombstone must carry the delete's commit version, not the prior put's"
     );
 }
 
 #[test]
-fn test_checkpoint_data_omits_ttl_metadata() {
+fn test_checkpoint_data_includes_ttl_metadata() {
+    // Inverted from the pre-retention `test_checkpoint_data_omits_ttl_metadata`.
+    // The KV snapshot DTO now carries `ttl_ms`, so the collected entry
+    // reflects the per-key TTL exactly.
     let db = Database::cache().unwrap();
     let branch_id = BranchId::from_bytes([5; 16]);
     let key = Key::new_kv(create_test_namespace(branch_id), "ttl_key");
@@ -2261,33 +2257,15 @@ fn test_checkpoint_data_omits_ttl_metadata() {
         .find(|entry| entry.user_key == b"ttl_key".to_vec())
         .expect("should find ttl_key in checkpoint");
 
-    assert!(
-        db.storage
-            .get_at_timestamp(
-                &key,
-                snapshot_entry
-                    .timestamp
-                    .saturating_add(ttl_ms.saturating_mul(1_000))
-                    .saturating_add(1),
-            )
-            .unwrap()
-            .is_none(),
-        "Storage entry should expire once TTL elapses"
-    );
-
     assert_eq!(
-        snapshot_entry,
-        &KvSnapshotEntry {
-            branch_id: *branch_id.as_bytes(),
-            space: "default".to_string(),
-            type_tag: TypeTag::KV.as_byte(),
-            user_key: b"ttl_key".to_vec(),
-            value: serde_json::to_vec(&value).unwrap(),
-            version: version.as_u64(),
-            timestamp: snapshot_entry.timestamp,
-        },
-        "TTL exists in storage but is not represented in the KV snapshot DTO"
+        snapshot_entry.ttl_ms, ttl_ms,
+        "snapshot entry must carry the original TTL value"
     );
+    assert!(
+        !snapshot_entry.is_tombstone,
+        "live entry must not be tombstoned"
+    );
+    assert_eq!(snapshot_entry.version, version.as_u64());
 }
 
 /// Issue #1738 / 9.2.A: begin_transaction() does not check accepting_transactions.
@@ -4144,4 +4122,163 @@ fn test_follower_open_installs_checkpoint_snapshot() {
             .unwrap_or_else(|| panic!("follower must see k{} via snapshot install", i));
         assert_eq!(stored.value, Value::String(format!("v{}", i)));
     }
+}
+
+// ============================================================================
+// T3-E5 follow-up: retention-complete checkpoint + compact + reopen
+// ============================================================================
+
+/// Tombstones survive checkpoint + compact + reopen.
+///
+/// Write K, delete K, checkpoint, compact (reclaims WAL), reopen — the
+/// key must stay hidden from reads because the snapshot install
+/// reconstructs the tombstone barrier. Before the follow-up, this was
+/// the corruption mode: the WAL delete record vanished with the WAL
+/// and the snapshot didn't carry tombstones, so K would reappear.
+#[test]
+#[serial(open_databases)]
+fn test_checkpoint_compact_preserves_tombstones() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    let key = Key::new_kv(ns, "deleted");
+
+    {
+        let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+        db.transaction(branch_id, |txn| {
+            txn.put(key.clone(), Value::Int(1))?;
+            Ok(())
+        })
+        .unwrap();
+        db.transaction(branch_id, |txn| {
+            txn.delete(key.clone())?;
+            Ok(())
+        })
+        .unwrap();
+        db.checkpoint().unwrap();
+        db.compact()
+            .expect("compact must succeed on snapshot-only coverage");
+    }
+    OPEN_DATABASES.lock().clear();
+
+    let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+    let observed = db
+        .storage()
+        .get_versioned(&key, CommitVersion::MAX)
+        .unwrap();
+    assert!(
+        observed.is_none(),
+        "deleted key must remain hidden after checkpoint+compact+reopen (tombstone survived)"
+    );
+}
+
+/// TTL-bound entries still expire at the original deadline after
+/// checkpoint + compact + reopen.
+///
+/// Today's engine has no public TTL-aware transaction API, so the TTL
+/// key is injected directly via the recovery write path and the
+/// coordinator version is advanced via a separate normal transaction
+/// (so `checkpoint()` writes a non-zero watermark and `compact()` can
+/// run). The critical invariants — `ttl_ms` round-trips through the
+/// snapshot and `get_at_timestamp` still honors the original deadline —
+/// are preserved regardless of which write path set the TTL.
+#[test]
+#[serial(open_databases)]
+fn test_checkpoint_compact_preserves_ttl() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    let ttl_key = Key::new_kv(ns.clone(), "expires");
+    let ttl = Duration::from_millis(60_000);
+    let version_for_ttl = CommitVersion(1_000);
+
+    let commit_ts_micros: u64;
+    {
+        let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+
+        // Bump coordinator via a normal transaction so checkpoint writes a
+        // real watermark (quiesced_version > 0).
+        let warmup_key = Key::new_kv(ns.clone(), "warmup");
+        db.transaction(branch_id, |txn| {
+            txn.put(warmup_key.clone(), Value::Int(1))?;
+            Ok(())
+        })
+        .unwrap();
+
+        // Inject the TTL-bound entry at a known commit version above the
+        // coordinator's current floor.
+        db.storage
+            .put_with_version_mode(
+                ttl_key.clone(),
+                Value::String("temporary".into()),
+                version_for_ttl,
+                Some(ttl),
+                WriteMode::Append,
+            )
+            .unwrap();
+        commit_ts_micros = db
+            .storage()
+            .get_versioned(&ttl_key, CommitVersion::MAX)
+            .unwrap()
+            .unwrap()
+            .timestamp
+            .as_micros();
+
+        db.checkpoint().unwrap();
+        db.compact()
+            .expect("compact must succeed on snapshot-only coverage");
+    }
+    OPEN_DATABASES.lock().clear();
+
+    let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+
+    // Before expiry: visible.
+    let pre = db
+        .storage()
+        .get_at_timestamp(&ttl_key, commit_ts_micros + ttl.as_micros() as u64 - 1)
+        .unwrap();
+    assert!(pre.is_some(), "entry must be visible before TTL expiry");
+
+    // After expiry: gone.
+    let post = db
+        .storage()
+        .get_at_timestamp(&ttl_key, commit_ts_micros + ttl.as_micros() as u64 + 1)
+        .unwrap();
+    assert!(
+        post.is_none(),
+        "TTL barrier must survive checkpoint+compact+reopen"
+    );
+}
+
+/// Branch metadata survives checkpoint + compact + reopen.
+///
+/// Create a user branch, checkpoint, compact, reopen — `branches.exists`
+/// must still return true. The Branch section install decoder routes
+/// branch-metadata entries back into the global branch index under the
+/// nil-UUID sentinel so the in-memory branch registry repopulates on
+/// reopen from the snapshot alone.
+#[test]
+#[serial(open_databases)]
+fn test_checkpoint_compact_preserves_branch_metadata() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_name = "retention-ctx";
+
+    {
+        let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+        db.branches().create(branch_name).unwrap();
+        assert!(db.branches().exists(branch_name).unwrap());
+        db.checkpoint().unwrap();
+        db.compact()
+            .expect("compact must succeed on snapshot-only coverage");
+    }
+    OPEN_DATABASES.lock().clear();
+
+    let db = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
+    assert!(
+        db.branches().exists(branch_name).unwrap(),
+        "branch metadata must survive checkpoint+compact+reopen via snapshot install"
+    );
 }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -196,7 +196,9 @@ pub struct MaterializeResult {
 // ---------------------------------------------------------------------------
 
 /// Entry from version-scoped listing that preserves tombstone status.
-/// Used by three-way merge to reconstruct ancestor state including deletions.
+/// Used by three-way merge to reconstruct ancestor state including deletions,
+/// and by checkpoint collection to carry retention metadata (timestamp, TTL)
+/// into snapshot DTOs without a second storage pass.
 #[derive(Debug, Clone)]
 pub struct VersionedEntry {
     /// The decoded user key.
@@ -207,6 +209,10 @@ pub struct VersionedEntry {
     pub is_tombstone: bool,
     /// The MVCC commit version that wrote this entry.
     pub commit_id: CommitVersion,
+    /// Original commit timestamp in microseconds.
+    pub timestamp_micros: u64,
+    /// Per-key TTL in milliseconds (0 = no expiry).
+    pub ttl_ms: u64,
 }
 
 /// Entry from a branch's own sources (excluding inherited layers).
@@ -2085,6 +2091,8 @@ impl SegmentedStore {
                 value: entry.value.clone(),
                 is_tombstone: entry.is_tombstone,
                 commit_id,
+                timestamp_micros: entry.timestamp.as_micros(),
+                ttl_ms: entry.ttl_ms,
             })
         })
         .collect()

--- a/docs/design/execution/tranche-3-durability.md
+++ b/docs/design/execution/tranche-3-durability.md
@@ -198,13 +198,13 @@ Implementation note:
   - `.meta` sidecar rebuild
   - Codec mismatch rejection
   - Non-identity codec round-trip
-  - Pre-DR-5 `.chk` fixtures consumable
+  - Snapshot format version enforcement (v1 rejected on load; clean break per pre-release policy — see DR-5 notes in the architecture scope)
   - Vector double-recovery (no state conflicts)
 
 ### Acceptance Criteria
 
 - [ ] All 13 checkpoint recovery test scenarios pass
-- [ ] Pre-DR-5 `.chk` fixtures remain consumable
+- [ ] Snapshot format version enforcement rejects stale formats on load (no v1 compatibility shim while pre-release — see DR-5 notes in the architecture scope)
 - [ ] `test_issue_1730` inverted (compact succeeds)
 - [ ] Codec mismatch rejected with clear error at open
 - [ ] Non-identity codec survives write→crash→reopen→read

--- a/docs/design/implementation/tranche-3-durability.md
+++ b/docs/design/implementation/tranche-3-durability.md
@@ -561,7 +561,7 @@ The old test asserted that checkpoint compact recovery must fail. It now asserts
 - Test: missing/stale `.meta` sidecar rebuild works.
 - Test: codec mismatch rejected before WAL bytes are read.
 - Test: non-identity codec write, crash, reopen, read works.
-- Test: pre-DR-5 `.chk` fixtures remain consumable.
+- Test: snapshot format version is enforced on load (v1 rejected, only the current retention-complete `SNAPSHOT_FORMAT_VERSION` is accepted). Strata is pre-release with no deployed databases, so the T3-E5 retention follow-up makes a clean break to v2 rather than maintaining a v1 deserializer. A `.chk` compatibility shim can be reintroduced if a supported release ever persists v2 checkpoints.
 - Test: vector double-recovery does not conflict with `VectorSubsystem::recover`.
 - Test: `test_issue_1730` is inverted to success.
 - Benchmark: WAL latency, YCSB, redb, open-time latency.


### PR DESCRIPTION
## Summary
Closes the retention hole left open by T3-E5 (#2416): snapshots now carry tombstones, TTL, and branch metadata, so `checkpoint() + compact() + reopen` is fully lossless. `effective_watermark` is re-flipped to trust snapshot coverage alongside flush coverage, and the reverted `test_issue_1730_*` pinning tests are re-inverted as the proof gate.

## What changed

### Format (clean break to v2)
- `SNAPSHOT_FORMAT_VERSION`: 1 → 2. `SnapshotHeader::validate` now requires exact match — v1 snapshots are rejected on load. No committed `.chk` fixtures; pre-release databases must re-checkpoint after upgrade.
- DTO fields:
  - `KvSnapshotEntry`: `+ ttl_ms`, `+ is_tombstone`
  - `JsonSnapshotEntry`: `+ is_tombstone`
  - `VectorSnapshotEntry` (per-vector row): `+ is_tombstone`
  - `BranchSnapshotEntry`: `+ branch_id` (required for install dispatch)
  - `EventSnapshotEntry`: unchanged (append-only; no deletion or TTL semantics)

### Collector (`compaction.rs::collect_checkpoint_data`)
Switched from live-only `list_by_type` to tombstone-preserving `list_by_type_at_version(…, CommitVersion::MAX)` for KV/Graph/Branch/JSON/Vector. Events stay on the live-only path. Each primitive's per-entry `ttl_ms` / `is_tombstone` are populated from the new `VersionedEntry` fields. Branch entries emit explicit `branch_id` so install dispatches correctly.

### Installer (`snapshot_install.rs`)
Removed the `ttl_ms: 0` hardcoding and the unconditional `Value` wrapper. Tombstones now install as `DecodedSnapshotValue::Tombstone` for KV/JSON/Vector. Implemented `install_branch_section` (deserialize → group by `branch_id` → install into `TypeTag::Branch` under the conventional "default" space). Dropped the "skip Branch section with warning" path.

### Cutover (`wal_only.rs::effective_watermark`)
Re-flipped to `max(flushed_through_commit_id, snapshot_watermark)`. Snapshot coverage is now retention-complete, so `compact()` deleting WAL segments covered by either source is safe.

### Test inversions
- `test_issue_1730_checkpoint_compact_recovery_data_loss` → asserts compact succeeds and data survives via snapshot install.
- `test_issue_1730_standard_durability` → same under Standard durability.
- `test_checkpoint_then_compact_without_flush_fails` → `_succeeds`.
- `test_wal_truncation_ignores_snapshot_watermark` → `_accepts_snapshot_watermark_alone`.
- Omission tests `test_checkpoint_data_omits_tombstones_*` / `_omits_ttl_*` replaced with presence tests `_includes_*`.

### New retention tests
- 4 unit tests in `snapshot_install.rs` (Branch round-trip, KV tombstone install, KV TTL install, Graph non-empty standalone skip).
- 3 engine integration tests: `test_checkpoint_compact_preserves_{tombstones,ttl,branch_metadata}` — end-to-end checkpoint+compact+reopen fidelity.

## Change class
**Intentional semantic change** (snapshot wire format v1→v2, new DTO fields) + **cutover** (effective_watermark flip restored). Atomic per reviewer request.

## Assurance class
S4 — affects WAL retention, recovery, and commit ordering. The inverted `test_issue_1730_*` tests serve as the proof-of-completeness gate: they only pass when the snapshot path is retention-complete end-to-end.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --lib -- --test-threads=1` — all green (917 engine lib tests)
- [x] `cargo test -p strata-engine --lib test_checkpoint_compact` — 3 retention integration tests pass
- [x] `cargo test -p strata-engine --lib test_issue_1730` — re-inverted tests pass
- [x] `cargo test -p strata-durability --lib wal_truncation` — re-inverted durability unit test passes
- [ ] `cargo run --release -p strata-benchmarks --bin regression` — full regression against a fresh baseline (recommended before merge)

## Related
Follow-up to #2416. Closes the retention-complete gap reviewer findings 1 and 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)