### PR TITLE
fix(engine): clippy errors exposed by Rust 1.94 lint tightening

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -186,9 +186,10 @@ impl std::fmt::Display for SubsystemStatus {
 /// is resolved and [`Database::resume_wal_writer`] is called. A successful
 /// resume requires that a sync operation succeed, proving the underlying
 /// storage is healthy again.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub enum WalWriterHealth {
     /// Writer is accepting transactions normally.
+    #[default]
     Healthy,
     /// Writer has halted due to a background sync failure.
     ///
@@ -202,12 +203,6 @@ pub enum WalWriterHealth {
         /// Number of consecutive failed sync attempts.
         failed_sync_count: u64,
     },
-}
-
-impl Default for WalWriterHealth {
-    fn default() -> Self {
-        WalWriterHealth::Healthy
-    }
 }
 
 impl std::fmt::Display for WalWriterHealth {

--- a/crates/engine/src/database/tests.rs
+++ b/crates/engine/src/database/tests.rs
@@ -3085,8 +3085,7 @@ fn test_durable_but_not_visible_is_surfaced_and_recovers_on_reopen() {
             ),
         }
 
-        let visible_now: Option<Value> =
-            db.transaction(branch_id, |txn| Ok(txn.get(&key)?)).unwrap();
+        let visible_now: Option<Value> = db.transaction(branch_id, |txn| txn.get(&key)).unwrap();
         assert!(
             visible_now.is_none(),
             "write must remain invisible in the current process"
@@ -3098,7 +3097,7 @@ fn test_durable_but_not_visible_is_surfaced_and_recovers_on_reopen() {
 
     let reopened = Database::open_with_durability(&db_path, DurabilityMode::Always).unwrap();
     let recovered: Option<Value> = reopened
-        .transaction(branch_id, |txn| Ok(txn.get(&key)?))
+        .transaction(branch_id, |txn| txn.get(&key))
         .unwrap();
     assert_eq!(
         recovered,

--- a/crates/engine/src/search/recovery.rs
+++ b/crates/engine/src/search/recovery.rs
@@ -141,18 +141,18 @@ fn visible_search_documents_for_branch(
     let mut docs = Vec::new();
 
     for (key, vv) in visible_entries_by_type(db, branch_id, TypeTag::KV) {
-        if let Some(op) = index_replayed_document(&key, &vv.value) {
-            if let SearchRefreshOp::Index { entity_ref, text } = op {
-                docs.push((entity_ref, text));
-            }
+        if let Some(SearchRefreshOp::Index { entity_ref, text }) =
+            index_replayed_document(&key, &vv.value)
+        {
+            docs.push((entity_ref, text));
         }
     }
 
     for (key, vv) in visible_entries_by_type(db, branch_id, TypeTag::Event) {
-        if let Some(op) = index_replayed_document(&key, &vv.value) {
-            if let SearchRefreshOp::Index { entity_ref, text } = op {
-                docs.push((entity_ref, text));
-            }
+        if let Some(SearchRefreshOp::Index { entity_ref, text }) =
+            index_replayed_document(&key, &vv.value)
+        {
+            docs.push((entity_ref, text));
         }
     }
 
@@ -163,10 +163,10 @@ fn visible_search_documents_for_branch(
     }
 
     for (key, vv) in visible_entries_by_type(db, branch_id, TypeTag::Json) {
-        if let Some(op) = index_replayed_document(&key, &vv.value) {
-            if let SearchRefreshOp::Index { entity_ref, text } = op {
-                docs.push((entity_ref, text));
-            }
+        if let Some(SearchRefreshOp::Index { entity_ref, text }) =
+            index_replayed_document(&key, &vv.value)
+        {
+            docs.push((entity_ref, text));
         }
     }
 
@@ -289,9 +289,7 @@ fn index_replayed_document(key: &Key, value: &Value) -> Option<SearchRefreshOp> 
             if is_json_internal_space(&key.namespace.space) {
                 return None;
             }
-            let Some(doc_id) = key.user_key_string() else {
-                return None;
-            };
+            let doc_id = key.user_key_string()?;
             let Ok(doc) = crate::primitives::json::JsonStore::deserialize_doc(value) else {
                 return None;
             };


### PR DESCRIPTION
## Summary
Mechanical clippy fixes for 7 errors in strata-engine that Rust 1.94 promoted into the default lint set. Surfaced by T3-E5's \`/epic-verify\` — the T3-E5 files themselves were clean; these are all pre-existing code paths where the lint tightening caught older patterns.

## Changes
- \`database/mod.rs\`: \`WalWriterHealth\` moves from manual \`impl Default\` to \`#[derive(Default)]\` + \`#[default]\` on the \`Healthy\` variant. (\`clippy::derivable_impls\`)
- \`search/recovery.rs\`: collapse three nested \`if let Some(op) = …\` / \`if let SearchRefreshOp::Index { … } = op\` patterns into single \`if let Some(SearchRefreshOp::Index { … }) = …\` destructures. (\`clippy::collapsible_if_let\`)
- \`search/recovery.rs\`: rewrite one \`let … else { return None }\` as \`?\`. (\`clippy::question_mark\`)
- \`database/tests.rs\`: drop two \`Ok(txn.get(&key)?)\` wrappers. (\`clippy::needless_question_mark\`)

## Change class
Refactor-only. No behavior, storage format, or public API change.

## Test plan
- [x] \`cargo clippy -p strata-concurrency -p strata-durability -p strata-engine -p strata-storage --all-targets\` — 0 errors (was 7)
- [x] \`cargo test -p strata-engine --lib -- --test-threads=1\` — 918/918 green
- [x] \`cargo fmt --all -- --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)