### PR TITLE
feat(engine): T3-E7 codec uniformity and config matrix

### DIFF
--- a/crates/engine/src/database/compat.rs
+++ b/crates/engine/src/database/compat.rs
@@ -54,6 +54,17 @@ pub struct CompatibilitySignature {
     pub codec_name: String,
     /// Default branch name (if any).
     pub default_branch: Option<String>,
+    /// Background worker thread count from `StorageConfig::background_threads`.
+    ///
+    /// Open-time-only (the thread pool is sized once at construction).
+    /// Reuse with a different value returns `IncompatibleReuse`.
+    pub background_threads: usize,
+    /// Whether lossy recovery was permitted at open time.
+    ///
+    /// Open-time-only (recovery has already happened). Reuse with a different
+    /// value returns `IncompatibleReuse` — a strict opener must not silently
+    /// accept an instance that lossy-recovered, and vice versa.
+    pub allow_lossy_recovery: bool,
     /// Fingerprint of runtime-identity/capability config.
     ///
     /// Currently computed from known `OpenSpec` fields.
@@ -65,17 +76,28 @@ impl CompatibilitySignature {
     /// Create a signature from an `OpenSpec` and resolved config.
     ///
     /// The `codec_name` parameter should be the storage codec from config
-    /// (e.g., "identity", "aes-gcm-256").
+    /// (e.g., "identity", "aes-gcm-256"). `background_threads` and
+    /// `allow_lossy_recovery` are pulled from `StrataConfig` and
+    /// `StorageConfig` respectively — see
+    /// `docs/design/architecture-cleanup/durability-recovery-config-matrix.md`
+    /// for why they are part of the reuse identity.
     pub fn from_spec(
         mode: DatabaseMode,
         subsystem_names: Vec<&'static str>,
         durability_mode: DurabilityMode,
         codec_name: String,
         default_branch: Option<String>,
+        background_threads: usize,
+        allow_lossy_recovery: bool,
     ) -> Self {
-        // Compute fingerprint from known fields
-        let fingerprint =
-            compute_fingerprint(&mode, &subsystem_names, &durability_mode, &codec_name);
+        let fingerprint = compute_fingerprint(
+            &mode,
+            &subsystem_names,
+            &durability_mode,
+            &codec_name,
+            background_threads,
+            allow_lossy_recovery,
+        );
 
         Self {
             mode,
@@ -84,6 +106,8 @@ impl CompatibilitySignature {
             codec_id: CURRENT_CODEC_ID,
             codec_name,
             default_branch,
+            background_threads,
+            allow_lossy_recovery,
             open_config_fingerprint: fingerprint,
         }
     }
@@ -97,6 +121,8 @@ impl CompatibilitySignature {
             &signature.subsystem_names,
             &signature.durability_mode,
             &signature.codec_name,
+            signature.background_threads,
+            signature.allow_lossy_recovery,
         );
         signature
     }
@@ -144,6 +170,20 @@ impl CompatibilitySignature {
             return Err(IncompatibleReason::DefaultBranchMismatch {
                 existing: self.default_branch.clone(),
                 requested: other.default_branch.clone(),
+            });
+        }
+
+        if self.background_threads != other.background_threads {
+            return Err(IncompatibleReason::BackgroundThreadsMismatch {
+                existing: self.background_threads,
+                requested: other.background_threads,
+            });
+        }
+
+        if self.allow_lossy_recovery != other.allow_lossy_recovery {
+            return Err(IncompatibleReason::LossyRecoveryMismatch {
+                existing: self.allow_lossy_recovery,
+                requested: other.allow_lossy_recovery,
             });
         }
 
@@ -200,6 +240,20 @@ pub enum IncompatibleReason {
         existing: Option<String>,
         /// The default branch requested by the new open call.
         requested: Option<String>,
+    },
+    /// `StorageConfig::background_threads` values don't match.
+    BackgroundThreadsMismatch {
+        /// The background thread count of the existing database instance.
+        existing: usize,
+        /// The background thread count requested by the new open call.
+        requested: usize,
+    },
+    /// `StrataConfig::allow_lossy_recovery` values don't match.
+    LossyRecoveryMismatch {
+        /// The lossy-recovery flag of the existing database instance.
+        existing: bool,
+        /// The lossy-recovery flag requested by the new open call.
+        requested: bool,
     },
     /// Runtime config fingerprints don't match.
     ConfigFingerprintMismatch,
@@ -268,6 +322,24 @@ impl std::fmt::Display for IncompatibleReason {
                     existing, requested
                 )
             }
+            Self::BackgroundThreadsMismatch {
+                existing,
+                requested,
+            } => {
+                write!(
+                    f,
+                    "background_threads mismatch: existing={existing}, requested={requested}"
+                )
+            }
+            Self::LossyRecoveryMismatch {
+                existing,
+                requested,
+            } => {
+                write!(
+                    f,
+                    "allow_lossy_recovery mismatch: existing={existing}, requested={requested}"
+                )
+            }
             Self::ConfigFingerprintMismatch => {
                 write!(f, "runtime config fingerprint mismatch")
             }
@@ -280,12 +352,18 @@ impl std::error::Error for IncompatibleReason {}
 /// Compute a fingerprint from configuration fields.
 ///
 /// Uses FNV-1a for simplicity. T5 will replace this with a more
-/// sophisticated ControlRegistry-derived fingerprint.
+/// sophisticated ControlRegistry-derived fingerprint. The explicit fields
+/// above (`background_threads`, `allow_lossy_recovery`, etc.) are also
+/// checked individually in `check_compatible`; the fingerprint provides
+/// redundant detection plus a single place for future open-time-only
+/// knobs to feed in.
 fn compute_fingerprint<S: Hash>(
     mode: &DatabaseMode,
     subsystem_names: &[S],
     durability_mode: &DurabilityMode,
     codec_name: &str,
+    background_threads: usize,
+    allow_lossy_recovery: bool,
 ) -> u64 {
     use std::collections::hash_map::DefaultHasher;
     let mut hasher = DefaultHasher::new();
@@ -293,6 +371,8 @@ fn compute_fingerprint<S: Hash>(
     subsystem_names.hash(&mut hasher);
     codec_name.hash(&mut hasher);
     std::mem::discriminant(durability_mode).hash(&mut hasher);
+    background_threads.hash(&mut hasher);
+    allow_lossy_recovery.hash(&mut hasher);
     hasher.finish()
 }
 
@@ -304,163 +384,226 @@ fn compute_fingerprint<S: Hash>(
 mod tests {
     use super::*;
 
+    /// Fixed open-time values used by most tests; exercising mismatches in
+    /// these fields is the job of dedicated tests further down.
+    const TEST_BG_THREADS: usize = 4;
+    const TEST_LOSSY: bool = false;
+
+    fn sig(
+        mode: DatabaseMode,
+        subsystems: Vec<&'static str>,
+        durability: DurabilityMode,
+        codec: &str,
+        default_branch: Option<&str>,
+    ) -> CompatibilitySignature {
+        CompatibilitySignature::from_spec(
+            mode,
+            subsystems,
+            durability,
+            codec.to_string(),
+            default_branch.map(String::from),
+            TEST_BG_THREADS,
+            TEST_LOSSY,
+        )
+    }
+
     #[test]
     fn test_signature_equality() {
-        let sig1 = CompatibilitySignature::from_spec(
+        let sig1 = sig(
             DatabaseMode::Primary,
             vec!["graph", "vector", "search"],
             DurabilityMode::standard_default(),
-            "identity".to_string(),
-            Some("main".to_string()),
+            "identity",
+            Some("main"),
         );
-
-        let sig2 = CompatibilitySignature::from_spec(
+        let sig2 = sig(
             DatabaseMode::Primary,
             vec!["graph", "vector", "search"],
             DurabilityMode::standard_default(),
-            "identity".to_string(),
-            Some("main".to_string()),
+            "identity",
+            Some("main"),
         );
-
         assert_eq!(sig1, sig2);
         assert!(sig1.check_compatible(&sig2).is_ok());
     }
 
     #[test]
     fn test_mode_mismatch() {
-        let sig1 = CompatibilitySignature::from_spec(
+        let sig1 = sig(
             DatabaseMode::Primary,
             vec!["graph"],
             DurabilityMode::standard_default(),
-            "identity".to_string(),
+            "identity",
             None,
         );
-
-        let sig2 = CompatibilitySignature::from_spec(
+        let sig2 = sig(
             DatabaseMode::Follower,
             vec!["graph"],
             DurabilityMode::standard_default(),
-            "identity".to_string(),
+            "identity",
             None,
         );
-
-        let result = sig1.check_compatible(&sig2);
         assert!(matches!(
-            result,
+            sig1.check_compatible(&sig2),
             Err(IncompatibleReason::ModeMismatch { .. })
         ));
     }
 
     #[test]
     fn test_subsystem_mismatch() {
-        let sig1 = CompatibilitySignature::from_spec(
+        let sig1 = sig(
             DatabaseMode::Primary,
             vec!["graph", "vector"],
             DurabilityMode::standard_default(),
-            "identity".to_string(),
+            "identity",
             None,
         );
-
-        let sig2 = CompatibilitySignature::from_spec(
+        let sig2 = sig(
             DatabaseMode::Primary,
             vec!["graph"],
             DurabilityMode::standard_default(),
-            "identity".to_string(),
+            "identity",
             None,
         );
-
-        let result = sig1.check_compatible(&sig2);
         assert!(matches!(
-            result,
+            sig1.check_compatible(&sig2),
             Err(IncompatibleReason::SubsystemMismatch { .. })
         ));
     }
 
     #[test]
     fn test_durability_mismatch() {
-        let sig1 = CompatibilitySignature::from_spec(
+        let sig1 = sig(
             DatabaseMode::Primary,
             vec!["graph"],
             DurabilityMode::standard_default(),
-            "identity".to_string(),
+            "identity",
             None,
         );
-
-        let sig2 = CompatibilitySignature::from_spec(
+        let sig2 = sig(
             DatabaseMode::Primary,
             vec!["graph"],
             DurabilityMode::Always,
-            "identity".to_string(),
+            "identity",
             None,
         );
-
-        let result = sig1.check_compatible(&sig2);
         assert!(matches!(
-            result,
+            sig1.check_compatible(&sig2),
             Err(IncompatibleReason::DurabilityMismatch { .. })
         ));
     }
 
     #[test]
     fn test_default_branch_mismatch() {
-        let sig1 = CompatibilitySignature::from_spec(
+        let sig1 = sig(
             DatabaseMode::Primary,
             vec!["graph"],
             DurabilityMode::standard_default(),
-            "identity".to_string(),
-            Some("main".to_string()),
+            "identity",
+            Some("main"),
         );
-
-        let sig2 = CompatibilitySignature::from_spec(
+        let sig2 = sig(
             DatabaseMode::Primary,
             vec!["graph"],
             DurabilityMode::standard_default(),
-            "identity".to_string(),
-            Some("develop".to_string()),
+            "identity",
+            Some("develop"),
         );
-
-        let result = sig1.check_compatible(&sig2);
         assert!(matches!(
-            result,
+            sig1.check_compatible(&sig2),
             Err(IncompatibleReason::DefaultBranchMismatch { .. })
         ));
     }
 
     #[test]
     fn test_codec_name_mismatch() {
+        let sig1 = sig(
+            DatabaseMode::Primary,
+            vec!["graph"],
+            DurabilityMode::standard_default(),
+            "identity",
+            None,
+        );
+        let sig2 = sig(
+            DatabaseMode::Primary,
+            vec!["graph"],
+            DurabilityMode::standard_default(),
+            "aes-gcm-256",
+            None,
+        );
+        assert!(matches!(
+            sig1.check_compatible(&sig2),
+            Err(IncompatibleReason::CodecNameMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn test_background_threads_mismatch() {
         let sig1 = CompatibilitySignature::from_spec(
             DatabaseMode::Primary,
             vec!["graph"],
             DurabilityMode::standard_default(),
             "identity".to_string(),
             None,
+            4,
+            false,
         );
-
         let sig2 = CompatibilitySignature::from_spec(
             DatabaseMode::Primary,
             vec!["graph"],
             DurabilityMode::standard_default(),
-            "aes-gcm-256".to_string(),
+            "identity".to_string(),
             None,
+            8,
+            false,
         );
-
-        let result = sig1.check_compatible(&sig2);
         assert!(matches!(
-            result,
-            Err(IncompatibleReason::CodecNameMismatch { .. })
+            sig1.check_compatible(&sig2),
+            Err(IncompatibleReason::BackgroundThreadsMismatch {
+                existing: 4,
+                requested: 8,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_allow_lossy_recovery_mismatch() {
+        let sig1 = CompatibilitySignature::from_spec(
+            DatabaseMode::Primary,
+            vec!["graph"],
+            DurabilityMode::standard_default(),
+            "identity".to_string(),
+            None,
+            4,
+            false,
+        );
+        let sig2 = CompatibilitySignature::from_spec(
+            DatabaseMode::Primary,
+            vec!["graph"],
+            DurabilityMode::standard_default(),
+            "identity".to_string(),
+            None,
+            4,
+            true,
+        );
+        assert!(matches!(
+            sig1.check_compatible(&sig2),
+            Err(IncompatibleReason::LossyRecoveryMismatch {
+                existing: false,
+                requested: true,
+            })
         ));
     }
 
     #[test]
     fn test_fingerprint_display() {
-        let sig = CompatibilitySignature::from_spec(
+        let sig = sig(
             DatabaseMode::Primary,
             vec!["graph", "vector"],
             DurabilityMode::standard_default(),
-            "identity".to_string(),
+            "identity",
             None,
         );
-        // Just verify it doesn't panic
         assert!(sig.open_config_fingerprint != 0);
     }
 }

--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -110,6 +110,8 @@ pub struct StorageConfig {
     pub l0_stop_writes_trigger: usize,
     /// Number of background worker threads for compaction, flush, and maintenance.
     /// Default: min(4, available CPU cores). On single-core devices set to 1.
+    ///
+    /// Class: open-time-only. See `docs/design/architecture-cleanup/durability-recovery-config-matrix.md`.
     #[serde(default = "default_background_threads")]
     pub background_threads: usize,
     /// Target size for a single output segment file in bytes.
@@ -144,6 +146,9 @@ pub struct StorageConfig {
     ///
     /// **Warning:** A database created with one codec cannot be opened with a
     /// different codec — the MANIFEST records the codec ID and validates on open.
+    /// A second opener with a mismatched codec gets [`StrataError::IncompatibleReuse`].
+    ///
+    /// Class: open-time-only. See `docs/design/architecture-cleanup/durability-recovery-config-matrix.md`.
     #[serde(default = "default_codec")]
     pub codec: String,
 }
@@ -276,6 +281,9 @@ impl Default for StorageConfig {
 pub struct StrataConfig {
     /// Durability mode: `"standard"` or `"always"` (switchable at runtime).
     /// `"cache"` is valid in strata.toml for backward compat but cannot be set at runtime.
+    ///
+    /// Class: live-safe (Standard ↔ Always); `"cache"` is open-time-only.
+    /// See `docs/design/architecture-cleanup/durability-recovery-config-matrix.md`.
     #[serde(default = "default_durability_str")]
     pub durability: String,
     /// Enable automatic text embedding for semantic search.
@@ -317,6 +325,8 @@ pub struct StrataConfig {
     pub storage: StorageConfig,
     /// If true, silently start with empty state when WAL recovery fails.
     /// Default: false (refuse to open — safer).
+    ///
+    /// Class: open-time-only. See `docs/design/architecture-cleanup/durability-recovery-config-matrix.md`.
     #[serde(default)]
     pub allow_lossy_recovery: bool,
     /// Whether the user opted in to anonymous usage telemetry.

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1605,12 +1605,49 @@ impl Database {
     /// closure returns, the updated config is written to `strata.toml` for
     /// disk-backed databases, and storage/coordinator/cache parameters are
     /// applied to the live database immediately.
+    ///
+    /// Mutations to fields classified as *open-time-only* in
+    /// `docs/design/architecture-cleanup/durability-recovery-config-matrix.md`
+    /// are rejected with [`StrataError::InvalidInput`] — those fields are
+    /// baked into the live runtime at construction and cannot be changed
+    /// without reopening. This mirrors the executor config handler's
+    /// `OPEN_TIME_ONLY_KEYS` guard and closes the direct-Rust-caller
+    /// bypass it would otherwise leave.
     pub fn update_config<F: FnOnce(&mut StrataConfig)>(&self, f: F) -> StrataResult<()> {
         // Writes `strata.toml` and applies live storage/coordinator/cache
         // changes — reject while shutdown is in progress or has completed.
         self.check_not_shutting_down()?;
         let mut guard = self.config.write();
-        f(&mut guard);
+
+        // Validate on a candidate copy so rejection leaves the live
+        // config untouched — partial mutation would violate the contract.
+        let mut candidate = guard.clone();
+        f(&mut candidate);
+
+        let violation: Option<&'static str> = if candidate.storage.codec != guard.storage.codec {
+            Some("storage.codec")
+        } else if candidate.storage.background_threads != guard.storage.background_threads {
+            Some("storage.background_threads")
+        } else if candidate.allow_lossy_recovery != guard.allow_lossy_recovery {
+            Some("allow_lossy_recovery")
+        } else if (candidate.durability == "cache") != (guard.durability == "cache") {
+            // The `Cache` discriminant is open-time-only; Standard↔Always
+            // is live-safe and goes through `set_durability_mode`.
+            Some("durability (Cache <-> non-Cache)")
+        } else {
+            None
+        };
+
+        if let Some(field) = violation {
+            return Err(StrataError::invalid_input(format!(
+                "update_config cannot mutate open-time-only field '{field}' at runtime; \
+                 reopen the database with the desired value. See \
+                 docs/design/architecture-cleanup/durability-recovery-config-matrix.md"
+            )));
+        }
+
+        *guard = candidate;
+
         // Persist to strata.toml for disk-backed databases
         if self.persistence_mode == PersistenceMode::Disk && !self.data_dir.as_os_str().is_empty() {
             let config_path = self.data_dir.join(config::CONFIG_FILE_NAME);

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1630,10 +1630,14 @@ impl Database {
             Some("storage.background_threads")
         } else if candidate.allow_lossy_recovery != guard.allow_lossy_recovery {
             Some("allow_lossy_recovery")
-        } else if (candidate.durability == "cache") != (guard.durability == "cache") {
-            // The `Cache` discriminant is open-time-only; Standard↔Always
-            // is live-safe and goes through `set_durability_mode`.
-            Some("durability (Cache <-> non-Cache)")
+        } else if candidate.durability != guard.durability {
+            // `durability` is live-safe only through `set_durability_mode`,
+            // which reconfigures the WAL writer, restarts the flush thread,
+            // updates the runtime signature, and persists the string form
+            // atomically. Mutating the config string via `update_config`
+            // would leave the live runtime out of sync with `db.config()`
+            // and `strata.toml` — route the caller to the canonical path.
+            Some("durability (use Database::set_durability_mode)")
         } else {
             None
         };
@@ -1753,6 +1757,29 @@ impl Database {
 
         *self.durability_mode.write() = mode;
         self.update_runtime_signature_durability(mode);
+
+        // Keep `self.config.durability` and the persisted `strata.toml`
+        // in sync with the runtime switch. Without this, a caller that
+        // reads `db.config().durability` after a successful mode change
+        // would see the stale pre-switch value, and a later reopen would
+        // read the stale string off disk. Done AFTER the runtime change
+        // succeeds so a failed WAL reconfigure cannot leave disk ahead
+        // of the live state.
+        let mode_str = match mode {
+            DurabilityMode::Always => "always",
+            DurabilityMode::Standard { .. } => "standard",
+            DurabilityMode::Cache => unreachable!("Cache transitions rejected above"),
+        };
+        {
+            let mut cfg = self.config.write();
+            cfg.durability = mode_str.to_string();
+            if self.persistence_mode == PersistenceMode::Disk
+                && !self.data_dir.as_os_str().is_empty()
+            {
+                let config_path = self.data_dir.join(config::CONFIG_FILE_NAME);
+                cfg.write_to_file(&config_path)?;
+            }
+        }
 
         Ok(())
     }

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -1342,6 +1342,8 @@ impl Database {
 
         let durability_mode = resolved_cfg.durability_mode()?;
         let codec_name = resolved_cfg.storage.codec.clone();
+        let background_threads = resolved_cfg.storage.background_threads;
+        let allow_lossy_recovery = resolved_cfg.allow_lossy_recovery;
 
         let subsystem_names: Vec<&'static str> = subsystems.iter().map(|s| s.name()).collect();
         let requested_signature = CompatibilitySignature::from_spec(
@@ -1350,6 +1352,8 @@ impl Database {
             durability_mode,
             codec_name.clone(),
             default_branch.clone(),
+            background_threads,
+            allow_lossy_recovery,
         );
 
         match Self::acquire_primary_db(
@@ -1374,6 +1378,8 @@ impl Database {
                     durability_mode,
                     codec_name,
                     effective_default_branch.clone(),
+                    background_threads,
+                    allow_lossy_recovery,
                 );
                 Self::finish_opened_db(db, &canonical_path, move |db| {
                     db.set_runtime_signature(effective_signature);
@@ -1422,6 +1428,31 @@ impl Database {
         };
         let durability_mode = cfg.durability_mode()?;
         let codec_name = cfg.storage.codec.clone();
+        let background_threads = cfg.storage.background_threads;
+        let allow_lossy_recovery = cfg.allow_lossy_recovery;
+
+        // Validate the configured codec exists before touching any state.
+        // Mirrors the primary path so a follower with an unknown codec is
+        // rejected consistently — with or without an on-disk MANIFEST.
+        strata_durability::get_codec(&cfg.storage.codec).map_err(|e| {
+            StrataError::internal(format!(
+                "invalid storage codec '{}': {}",
+                cfg.storage.codec, e
+            ))
+        })?;
+
+        // WAL recovery does not yet support non-identity codecs — the WalReader
+        // parses raw bytes without codec decoding. Follower replay goes through
+        // the same reader, so the same block applies here as on primary.
+        if cfg.storage.codec != "identity" && durability_mode.requires_wal() {
+            return Err(StrataError::internal(format!(
+                "codec '{}' is not yet supported with WAL-based durability (Standard/Always). \
+                 Encryption at rest requires WAL reader codec support (tracked). \
+                 Use durability = \"cache\" for encrypted in-memory databases.",
+                cfg.storage.codec
+            )));
+        }
+
         let subsystem_names: Vec<&'static str> = subsystems.iter().map(|s| s.name()).collect();
         let requested_signature = CompatibilitySignature::from_spec(
             super::spec::DatabaseMode::Follower,
@@ -1429,6 +1460,8 @@ impl Database {
             durability_mode,
             codec_name.clone(),
             default_branch,
+            background_threads,
+            allow_lossy_recovery,
         );
 
         // Create follower database — no registry check, followers are independent
@@ -1461,6 +1494,8 @@ impl Database {
             durability_mode,
             codec_name,
             effective_default_branch,
+            background_threads,
+            allow_lossy_recovery,
         );
 
         db.set_subsystems(subsystems);
@@ -1495,6 +1530,8 @@ impl Database {
         let resolved_cfg = db.config();
         let durability_mode = resolved_cfg.durability_mode()?;
         let codec_name = resolved_cfg.storage.codec.clone();
+        let background_threads = resolved_cfg.storage.background_threads;
+        let allow_lossy_recovery = resolved_cfg.allow_lossy_recovery;
         let subsystem_names: Vec<&'static str> = subsystems.iter().map(|s| s.name()).collect();
         let requested_signature = CompatibilitySignature::from_spec(
             super::spec::DatabaseMode::Cache,
@@ -1502,6 +1539,8 @@ impl Database {
             durability_mode,
             codec_name,
             default_branch.clone(),
+            background_threads,
+            allow_lossy_recovery,
         );
 
         // Run subsystem recovery (no-op for cache, but maintains consistency)

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -1337,7 +1337,14 @@ impl Database {
             } else {
                 config::StrataConfig::default()
             };
-            sanitize_config(base)
+            // Apply the hardware profile BEFORE extracting signature fields:
+            // `background_threads` and other profile-rewritten fields must
+            // reflect the post-profile values, otherwise a later opener that
+            // explicitly requests the actual effective thread count would
+            // produce a false IncompatibleReuse mismatch.
+            let mut sanitized = sanitize_config(base);
+            crate::database::profile::apply_hardware_profile_if_defaults(&mut sanitized);
+            sanitized
         };
 
         let durability_mode = resolved_cfg.durability_mode()?;
@@ -1424,7 +1431,11 @@ impl Database {
             } else {
                 config::StrataConfig::default()
             };
-            sanitize_config(base)
+            // Apply the hardware profile BEFORE extracting signature fields
+            // (see `open_runtime_primary` for the rationale).
+            let mut sanitized = sanitize_config(base);
+            crate::database::profile::apply_hardware_profile_if_defaults(&mut sanitized);
+            sanitized
         };
         let durability_mode = cfg.durability_mode()?;
         let codec_name = cfg.storage.codec.clone();

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -1337,20 +1337,33 @@ impl Database {
             } else {
                 config::StrataConfig::default()
             };
-            // Apply the hardware profile BEFORE extracting signature fields:
-            // `background_threads` and other profile-rewritten fields must
-            // reflect the post-profile values, otherwise a later opener that
-            // explicitly requests the actual effective thread count would
-            // produce a false IncompatibleReuse mismatch.
-            let mut sanitized = sanitize_config(base);
-            crate::database::profile::apply_hardware_profile_if_defaults(&mut sanitized);
-            sanitized
+            sanitize_config(base)
         };
 
-        let durability_mode = resolved_cfg.durability_mode()?;
-        let codec_name = resolved_cfg.storage.codec.clone();
-        let background_threads = resolved_cfg.storage.background_threads;
-        let allow_lossy_recovery = resolved_cfg.allow_lossy_recovery;
+        // Hardware profiling is ephemeral — it rewrites fields left at their
+        // baseline defaults for a given host profile (embedded / desktop /
+        // server) without persisting the result. `resolved_cfg` above stays
+        // un-profiled so the `strata.toml` write below preserves the
+        // "profile per host at open time" contract: moving the database
+        // directory to a different host class must re-profile, not inherit
+        // the first host's values.
+        //
+        // For signature construction, however, the post-profile values are
+        // what the running runtime actually uses, so we extract signature
+        // fields from a profiled copy. `acquire_primary_db` applies the
+        // profile internally (idempotent for fields already at non-baseline
+        // values), so the running database ends up sized with the same
+        // post-profile values the signature advertises.
+        let profiled_for_signature = {
+            let mut c = resolved_cfg.clone();
+            crate::database::profile::apply_hardware_profile_if_defaults(&mut c);
+            c
+        };
+
+        let durability_mode = profiled_for_signature.durability_mode()?;
+        let codec_name = profiled_for_signature.storage.codec.clone();
+        let background_threads = profiled_for_signature.storage.background_threads;
+        let allow_lossy_recovery = profiled_for_signature.allow_lossy_recovery;
 
         let subsystem_names: Vec<&'static str> = subsystems.iter().map(|s| s.name()).collect();
         let requested_signature = CompatibilitySignature::from_spec(
@@ -1431,16 +1444,23 @@ impl Database {
             } else {
                 config::StrataConfig::default()
             };
-            // Apply the hardware profile BEFORE extracting signature fields
-            // (see `open_runtime_primary` for the rationale).
-            let mut sanitized = sanitize_config(base);
-            crate::database::profile::apply_hardware_profile_if_defaults(&mut sanitized);
-            sanitized
+            sanitize_config(base)
         };
-        let durability_mode = cfg.durability_mode()?;
-        let codec_name = cfg.storage.codec.clone();
-        let background_threads = cfg.storage.background_threads;
-        let allow_lossy_recovery = cfg.allow_lossy_recovery;
+
+        // Profile into a separate copy for signature extraction so the
+        // un-profiled `cfg` is what the caller sees if it ever gets
+        // persisted. Hardware profiling is ephemeral — see
+        // `open_runtime_primary` for the full rationale.
+        let profiled_for_signature = {
+            let mut c = cfg.clone();
+            crate::database::profile::apply_hardware_profile_if_defaults(&mut c);
+            c
+        };
+
+        let durability_mode = profiled_for_signature.durability_mode()?;
+        let codec_name = profiled_for_signature.storage.codec.clone();
+        let background_threads = profiled_for_signature.storage.background_threads;
+        let allow_lossy_recovery = profiled_for_signature.allow_lossy_recovery;
 
         // Validate the configured codec exists before touching any state.
         // Mirrors the primary path so a follower with an unknown codec is

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -447,6 +447,15 @@ impl Database {
                 ))
             })?;
             let manifest = m.manifest();
+            if manifest.codec_id != cfg.storage.codec {
+                return Err(StrataError::incompatible_reuse(format!(
+                    "codec mismatch: follower target at {} was created with '{}' but config specifies '{}'. \
+                     A follower must be configured with the same codec as the primary database.",
+                    canonical_path.display(),
+                    manifest.codec_id,
+                    cfg.storage.codec
+                )));
+            }
             let codec = strata_durability::get_codec(&manifest.codec_id).map_err(|e| {
                 StrataError::internal(format!(
                     "follower could not initialize MANIFEST codec '{}': {}",
@@ -877,10 +886,12 @@ impl Database {
                 .map_err(|e| StrataError::internal(format!("failed to load MANIFEST: {}", e)))?;
             let stored_codec = &m.manifest().codec_id;
             if stored_codec != &cfg.storage.codec {
-                return Err(StrataError::internal(format!(
-                    "codec mismatch: database was created with '{}' but config specifies '{}'. \
+                return Err(StrataError::incompatible_reuse(format!(
+                    "codec mismatch: database at {} was created with '{}' but config specifies '{}'. \
                      A database cannot be reopened with a different codec.",
-                    stored_codec, cfg.storage.codec
+                    canonical_path.display(),
+                    stored_codec,
+                    cfg.storage.codec
                 )));
             }
             m.manifest().database_uuid

--- a/crates/engine/src/database/tests/checkpoint.rs
+++ b/crates/engine/src/database/tests/checkpoint.rs
@@ -483,6 +483,11 @@ fn test_codec_mismatch_on_reopen_fails_even_with_lossy_flag() {
                 "reopen with different codec must fail with codec mismatch, got: {}",
                 msg
             );
+            assert!(
+                matches!(e, StrataError::IncompatibleReuse { .. }),
+                "codec drift must surface as IncompatibleReuse (not internal/corruption), got: {:?}",
+                e
+            );
         }
         Ok(_) => panic!("reopen with wrong codec + lossy flag must still fail"),
     }

--- a/crates/engine/src/database/tests/codec.rs
+++ b/crates/engine/src/database/tests/codec.rs
@@ -291,6 +291,133 @@ fn test_registry_reuse_rejects_different_background_threads() {
     OPEN_DATABASES.lock().clear();
 }
 
+/// Review-found bug (post-commit 5e432cce): the signature must reflect
+/// the *post-hardware-profile* value of `background_threads`, not the
+/// pre-profile default. If the signature captures the pre-profile value,
+/// a second opener who explicitly requests the actual effective thread
+/// count will be falsely rejected as incompatible even though the
+/// scheduler was sized with exactly their value. This test opens with
+/// defaults (profile applies), reads the effective value off the live
+/// signature, then opens again explicitly requesting that value —
+/// which must succeed.
+#[test]
+#[serial(open_databases)]
+fn test_profile_applies_before_signature_so_reuse_with_explicit_value_succeeds() {
+    OPEN_DATABASES.lock().clear();
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+
+    let db1 = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(StrataConfig {
+                durability: "cache".to_string(),
+                ..StrataConfig::default()
+            })
+            .with_subsystem(SearchSubsystem),
+    )
+    .expect("first opener with defaults must succeed");
+
+    let effective_threads = db1
+        .runtime_signature()
+        .expect("db1 must publish a runtime signature")
+        .background_threads;
+
+    let mut cfg_explicit = StrataConfig {
+        durability: "cache".to_string(),
+        ..StrataConfig::default()
+    };
+    cfg_explicit.storage.background_threads = effective_threads;
+
+    let db2 = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(cfg_explicit)
+            .with_subsystem(SearchSubsystem),
+    )
+    .expect("explicit value matching the profiled effective value must reuse the instance");
+
+    assert!(
+        Arc::ptr_eq(&db1, &db2),
+        "reuse must return the same Arc, not a fresh database"
+    );
+
+    db1.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
+/// `Database::update_config` must reject mutations to open-time-only
+/// fields. Without this gate, a direct Rust caller could bypass the
+/// executor's `OPEN_TIME_ONLY_KEYS` check and silently drift the
+/// persisted config away from the live runtime.
+#[test]
+#[serial(open_databases)]
+fn test_update_config_rejects_open_time_only_field_changes() {
+    OPEN_DATABASES.lock().clear();
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(StrataConfig {
+                durability: "cache".to_string(),
+                ..StrataConfig::default()
+            })
+            .with_subsystem(SearchSubsystem),
+    )
+    .unwrap();
+
+    // Capture pre-change live values so we can confirm they are NOT
+    // mutated even though the closure attempted the change.
+    let (before_threads, before_lossy, before_codec) = {
+        let cfg = db.config();
+        (
+            cfg.storage.background_threads,
+            cfg.allow_lossy_recovery,
+            cfg.storage.codec.clone(),
+        )
+    };
+
+    let err = db
+        .update_config(|cfg| {
+            cfg.storage.background_threads = before_threads.wrapping_add(4);
+        })
+        .expect_err("mutating background_threads via update_config must be rejected");
+    assert!(
+        matches!(err, StrataError::InvalidInput { .. }),
+        "expected InvalidInput for open-time-only mutation, got: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("background_threads"),
+        "error must name the offending field, got: {err}"
+    );
+
+    assert!(
+        db.update_config(|cfg| cfg.allow_lossy_recovery = !before_lossy)
+            .is_err(),
+        "allow_lossy_recovery must also be rejected"
+    );
+    assert!(
+        db.update_config(|cfg| cfg.storage.codec = "aes-gcm-256".to_string())
+            .is_err(),
+        "storage.codec must also be rejected"
+    );
+
+    // Live config unchanged.
+    let after = db.config();
+    assert_eq!(after.storage.background_threads, before_threads);
+    assert_eq!(after.allow_lossy_recovery, before_lossy);
+    assert_eq!(after.storage.codec, before_codec);
+
+    // A live-safe mutation still works.
+    db.update_config(|cfg| cfg.storage.max_branches = 512)
+        .expect("live-safe mutation must succeed");
+    assert_eq!(db.config().storage.max_branches, 512);
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
 /// `allow_lossy_recovery` is open-time-only: by the time we reuse an
 /// already-open instance, recovery has already happened — strictly or
 /// lossily. A second opener must not silently accept an instance whose

--- a/crates/engine/src/database/tests/codec.rs
+++ b/crates/engine/src/database/tests/codec.rs
@@ -1,0 +1,187 @@
+//! Codec uniformity acceptance tests (T3-E7).
+//!
+//! These tests pin the contract that codec identity is enforced at every
+//! open-time entry point and surfaced as [`StrataError::IncompatibleReuse`]
+//! — never as a silent downgrade, never as an opaque `internal` error.
+//!
+//! **Why not a full write→crash→reopen→read round-trip with a non-identity
+//! codec?** WAL recovery does not yet support non-identity codecs
+//! (`crates/engine/src/database/open.rs` blocks this at open time). Cache
+//! durability does not persist across opens. So the cross-process
+//! persistence test called for by the scope is deferred until WAL codec
+//! support lands; see the config matrix doc for the target-state note.
+
+use super::*;
+use crate::SearchSubsystem;
+
+/// Key material for the AES-256-GCM codec. Used only for test setup.
+const TEST_AES_KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+/// RAII guard that sets an env var on construction and removes it on drop.
+/// Ensures the encryption-key env var does not leak to sibling tests even
+/// if an assertion panics mid-body.
+struct EnvVarGuard(&'static str);
+
+impl EnvVarGuard {
+    fn set(name: &'static str, value: &str) -> Self {
+        std::env::set_var(name, value);
+        Self(name)
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        std::env::remove_var(self.0);
+    }
+}
+
+/// Registry-reuse path: an already-open database rejects a second opener
+/// that asks for a different codec, with [`StrataError::IncompatibleReuse`].
+///
+/// Uses cache durability so neither opener hits the WAL-codec block at
+/// `open.rs:842`. The first handle is held alive for the duration of the
+/// second call so the reuse path is actually exercised (not the cold-reopen
+/// path that goes through the MANIFEST check).
+#[test]
+#[serial(open_databases)]
+fn test_registry_reuse_rejects_different_codec() {
+    OPEN_DATABASES.lock().clear();
+    let _key_guard = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+
+    let cfg_aes = StrataConfig {
+        durability: "cache".to_string(),
+        storage: StorageConfig {
+            codec: "aes-gcm-256".to_string(),
+            ..StorageConfig::default()
+        },
+        ..StrataConfig::default()
+    };
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(cfg_aes)
+            .with_subsystem(SearchSubsystem),
+    )
+    .unwrap();
+
+    // Second opener, same path, same durability, DIFFERENT codec.
+    let cfg_identity = StrataConfig {
+        durability: "cache".to_string(),
+        storage: StorageConfig {
+            codec: "identity".to_string(),
+            ..StorageConfig::default()
+        },
+        ..StrataConfig::default()
+    };
+    let result = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(cfg_identity)
+            .with_subsystem(SearchSubsystem),
+    );
+
+    match result {
+        Err(e) => {
+            assert!(
+                matches!(e, StrataError::IncompatibleReuse { .. }),
+                "codec mismatch at registry reuse must surface as IncompatibleReuse, got: {e:?}"
+            );
+            assert!(
+                e.to_string().to_lowercase().contains("codec"),
+                "error message must name the codec dimension, got: {e}"
+            );
+        }
+        Ok(_) => panic!("registry reuse with mismatched codec must not succeed"),
+    }
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+    // Env var released by `_key_guard` on drop.
+}
+
+/// Follower path: opening a follower with a codec different from the
+/// primary's on-disk MANIFEST must be rejected before any WAL bytes are
+/// touched, with [`StrataError::IncompatibleReuse`].
+///
+/// Pre-T3-E7, followers silently used the MANIFEST codec while publishing
+/// the config codec in the runtime signature — a silent drift.
+#[test]
+#[serial(open_databases)]
+fn test_follower_rejects_codec_mismatch_with_manifest() {
+    OPEN_DATABASES.lock().clear();
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+
+    // Create a primary with the default (identity) codec so the MANIFEST
+    // records codec_id = "identity".
+    {
+        let primary = Database::open(&db_path).unwrap();
+        primary.shutdown().unwrap();
+    }
+    OPEN_DATABASES.lock().clear();
+
+    // Attempt to open a follower that claims a different codec.
+    let _key_guard = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+    let cfg_follower = StrataConfig {
+        storage: StorageConfig {
+            codec: "aes-gcm-256".to_string(),
+            ..StorageConfig::default()
+        },
+        ..StrataConfig::default()
+    };
+    let result = Database::open_runtime(
+        super::spec::OpenSpec::follower(&db_path)
+            .with_config(cfg_follower)
+            .with_subsystem(SearchSubsystem),
+    );
+
+    match result {
+        Err(e) => {
+            assert!(
+                matches!(e, StrataError::IncompatibleReuse { .. }),
+                "follower codec drift must surface as IncompatibleReuse, got: {e:?}"
+            );
+            let msg = e.to_string();
+            assert!(
+                msg.contains("codec mismatch") && msg.contains("follower"),
+                "error message must name codec mismatch and the follower role, got: {msg}"
+            );
+        }
+        Ok(_) => panic!("follower open with mismatched codec must not succeed"),
+    }
+
+    OPEN_DATABASES.lock().clear();
+}
+
+/// Sanity check: a follower whose config codec matches the primary's
+/// MANIFEST codec (both `identity`) opens without error. This pins that
+/// the drift check does not produce false positives on the happy path.
+#[test]
+#[serial(open_databases)]
+fn test_follower_codec_match_opens_cleanly() {
+    OPEN_DATABASES.lock().clear();
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+
+    {
+        let primary = Database::open(&db_path).unwrap();
+        primary.shutdown().unwrap();
+    }
+    OPEN_DATABASES.lock().clear();
+
+    let follower = Database::open_runtime(
+        super::spec::OpenSpec::follower(&db_path).with_subsystem(SearchSubsystem),
+    )
+    .expect("follower with matching codec must open");
+
+    let signature = follower
+        .runtime_signature()
+        .expect("follower must publish a runtime signature");
+    assert_eq!(
+        signature.codec_name, "identity",
+        "follower signature must publish the MANIFEST codec on the happy path"
+    );
+}

--- a/crates/engine/src/database/tests/codec.rs
+++ b/crates/engine/src/database/tests/codec.rs
@@ -1,8 +1,13 @@
-//! Codec uniformity acceptance tests (T3-E7).
+//! Codec uniformity and reuse-identity acceptance tests (T3-E7).
 //!
-//! These tests pin the contract that codec identity is enforced at every
-//! open-time entry point and surfaced as [`StrataError::IncompatibleReuse`]
-//! — never as a silent downgrade, never as an opaque `internal` error.
+//! These tests pin the contract that every open-time-only knob classified
+//! in `docs/design/architecture-cleanup/durability-recovery-config-matrix.md`
+//! triggers [`StrataError::IncompatibleReuse`] when it disagrees between
+//! two openers of the same path — never a silent downgrade, never an
+//! opaque `internal` error. The tests cover codec drift (primary and
+//! follower), early codec validation, and the two knobs that the initial
+//! T3-E7 draft left out of the signature: `background_threads` and
+//! `allow_lossy_recovery`.
 //!
 //! **Why not a full write→crash→reopen→read round-trip with a non-identity
 //! codec?** WAL recovery does not yet support non-identity codecs
@@ -123,8 +128,12 @@ fn test_follower_rejects_codec_mismatch_with_manifest() {
     OPEN_DATABASES.lock().clear();
 
     // Attempt to open a follower that claims a different codec.
+    // Use cache durability on the follower so the earlier
+    // non-identity + WAL rejection (which would fire on Standard/Always)
+    // does not mask the MANIFEST drift check we're exercising here.
     let _key_guard = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
     let cfg_follower = StrataConfig {
+        durability: "cache".to_string(),
         storage: StorageConfig {
             codec: "aes-gcm-256".to_string(),
             ..StorageConfig::default()
@@ -153,6 +162,47 @@ fn test_follower_rejects_codec_mismatch_with_manifest() {
     }
 
     OPEN_DATABASES.lock().clear();
+}
+
+/// Follower codec validation must catch an unknown codec name the same
+/// way the primary does, regardless of whether a MANIFEST exists.
+/// Pre-T3-E7 review, the follower only validated inside the MANIFEST-exists
+/// branch — a fresh/manifest-less follower target could accept a bogus codec.
+#[test]
+#[serial(open_databases)]
+fn test_follower_rejects_unknown_codec_without_manifest() {
+    OPEN_DATABASES.lock().clear();
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("fresh_follower_target");
+    // Create the directory so canonicalize succeeds, but do NOT create a
+    // MANIFEST. This is the "fresh/manifest-less" case from the review.
+    std::fs::create_dir_all(&db_path).unwrap();
+
+    let cfg = StrataConfig {
+        durability: "cache".to_string(),
+        storage: StorageConfig {
+            codec: "lz4-does-not-exist".to_string(),
+            ..StorageConfig::default()
+        },
+        ..StrataConfig::default()
+    };
+    let result = Database::open_runtime(
+        super::spec::OpenSpec::follower(&db_path)
+            .with_config(cfg)
+            .with_subsystem(SearchSubsystem),
+    );
+
+    match result {
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("invalid storage codec") && msg.contains("lz4-does-not-exist"),
+                "error must name the bogus codec, got: {msg}"
+            );
+        }
+        Ok(_) => panic!("follower open with unknown codec must not succeed"),
+    }
 }
 
 /// Sanity check: a follower whose config codec matches the primary's
@@ -184,4 +234,112 @@ fn test_follower_codec_match_opens_cleanly() {
         signature.codec_name, "identity",
         "follower signature must publish the MANIFEST codec on the happy path"
     );
+}
+
+/// `background_threads` is classified as open-time-only: the thread pool
+/// is sized at construction and never resized. A second opener asking for
+/// a different count must get `IncompatibleReuse`, not a silent reuse of
+/// the already-sized pool.
+#[test]
+#[serial(open_databases)]
+fn test_registry_reuse_rejects_different_background_threads() {
+    OPEN_DATABASES.lock().clear();
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+
+    let mut cfg_a = StrataConfig {
+        durability: "cache".to_string(),
+        ..StrataConfig::default()
+    };
+    cfg_a.storage.background_threads = 2;
+
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(cfg_a)
+            .with_subsystem(SearchSubsystem),
+    )
+    .expect("first opener with background_threads=2 must succeed");
+
+    let mut cfg_b = StrataConfig {
+        durability: "cache".to_string(),
+        ..StrataConfig::default()
+    };
+    cfg_b.storage.background_threads = 8;
+
+    let result = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(cfg_b)
+            .with_subsystem(SearchSubsystem),
+    );
+
+    match result {
+        Err(e) => {
+            assert!(
+                matches!(e, StrataError::IncompatibleReuse { .. }),
+                "background_threads drift must surface as IncompatibleReuse, got: {e:?}"
+            );
+            assert!(
+                e.to_string().contains("background_threads"),
+                "error message must name the background_threads dimension, got: {e}"
+            );
+        }
+        Ok(_) => panic!("registry reuse with mismatched background_threads must not succeed"),
+    }
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
+/// `allow_lossy_recovery` is open-time-only: by the time we reuse an
+/// already-open instance, recovery has already happened — strictly or
+/// lossily. A second opener must not silently accept an instance whose
+/// recovery policy differs from what it asked for.
+#[test]
+#[serial(open_databases)]
+fn test_registry_reuse_rejects_different_allow_lossy_recovery() {
+    OPEN_DATABASES.lock().clear();
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+
+    let cfg_strict = StrataConfig {
+        durability: "cache".to_string(),
+        allow_lossy_recovery: false,
+        ..StrataConfig::default()
+    };
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(cfg_strict)
+            .with_subsystem(SearchSubsystem),
+    )
+    .expect("first opener with allow_lossy_recovery=false must succeed");
+
+    let cfg_lossy = StrataConfig {
+        durability: "cache".to_string(),
+        allow_lossy_recovery: true,
+        ..StrataConfig::default()
+    };
+    let result = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(cfg_lossy)
+            .with_subsystem(SearchSubsystem),
+    );
+
+    match result {
+        Err(e) => {
+            assert!(
+                matches!(e, StrataError::IncompatibleReuse { .. }),
+                "allow_lossy_recovery drift must surface as IncompatibleReuse, got: {e:?}"
+            );
+            assert!(
+                e.to_string().contains("allow_lossy_recovery"),
+                "error message must name the allow_lossy_recovery dimension, got: {e}"
+            );
+        }
+        Ok(_) => panic!("registry reuse with mismatched allow_lossy_recovery must not succeed"),
+    }
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
 }

--- a/crates/engine/src/database/tests/codec.rs
+++ b/crates/engine/src/database/tests/codec.rs
@@ -291,6 +291,98 @@ fn test_registry_reuse_rejects_different_background_threads() {
     OPEN_DATABASES.lock().clear();
 }
 
+/// Hardware profiling must stay ephemeral: the first open on any host
+/// must not persist profile-rewritten values into `strata.toml`. If it
+/// did, moving the database directory to a different host class would
+/// inherit the first host's tuning instead of re-profiling.
+///
+/// The test compares the pre-profile default config to the post-profile
+/// version. If they match on this host (e.g. a Desktop box where the
+/// profile is a no-op), we skip — there is nothing to leak. Otherwise we
+/// open a database with defaults, shut down, parse `strata.toml` from
+/// disk, and assert it still shows the pre-profile values.
+#[test]
+#[serial(open_databases)]
+fn test_profiled_defaults_are_not_persisted_to_strata_toml() {
+    OPEN_DATABASES.lock().clear();
+
+    let baseline = StorageConfig::default();
+    let profiled = {
+        let mut cfg = StrataConfig::default();
+        crate::apply_hardware_profile_if_defaults(&mut cfg);
+        cfg.storage
+    };
+
+    // Skip on hosts where the profile happens to be a no-op for the
+    // fields we check. Otherwise the test is a tautology here.
+    if baseline.background_threads == profiled.background_threads
+        && baseline.write_buffer_size == profiled.write_buffer_size
+        && baseline.target_file_size == profiled.target_file_size
+        && baseline.level_base_bytes == profiled.level_base_bytes
+    {
+        return;
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(StrataConfig {
+                durability: "cache".to_string(),
+                ..StrataConfig::default()
+            })
+            .with_subsystem(SearchSubsystem),
+    )
+    .unwrap();
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+
+    let persisted = StrataConfig::from_file(&db_path.join("strata.toml"))
+        .expect("strata.toml must be written on first open");
+
+    // Every field the profile could have rewritten must still match the
+    // pre-profile baseline on disk, even if the profile diverges from it.
+    assert_eq!(
+        persisted.storage.background_threads, baseline.background_threads,
+        "background_threads must not be profiled onto disk"
+    );
+    assert_eq!(
+        persisted.storage.write_buffer_size, baseline.write_buffer_size,
+        "write_buffer_size must not be profiled onto disk"
+    );
+    assert_eq!(
+        persisted.storage.target_file_size, baseline.target_file_size,
+        "target_file_size must not be profiled onto disk"
+    );
+    assert_eq!(
+        persisted.storage.level_base_bytes, baseline.level_base_bytes,
+        "level_base_bytes must not be profiled onto disk"
+    );
+
+    // But the running runtime did see the profile — the signature shows
+    // the post-profile thread count.
+    // (db was moved into shutdown; open a fresh handle to confirm.)
+    let db2 = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(StrataConfig {
+                durability: "cache".to_string(),
+                ..StrataConfig::default()
+            })
+            .with_subsystem(SearchSubsystem),
+    )
+    .unwrap();
+    assert_eq!(
+        db2.runtime_signature()
+            .expect("signature must exist")
+            .background_threads,
+        profiled.background_threads,
+        "the live signature must still reflect the profiled value"
+    );
+    db2.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
 /// Review-found bug (post-commit 5e432cce): the signature must reflect
 /// the *post-hardware-profile* value of `background_threads`, not the
 /// pre-profile default. If the signature captures the pre-profile value,

--- a/crates/engine/src/database/tests/codec.rs
+++ b/crates/engine/src/database/tests/codec.rs
@@ -437,6 +437,106 @@ fn test_profile_applies_before_signature_so_reuse_with_explicit_value_succeeds()
     OPEN_DATABASES.lock().clear();
 }
 
+/// `durability` is live-safe via `set_durability_mode` only. Mutating
+/// `cfg.durability` through `update_config` would persist a new string
+/// to `strata.toml` without reconfiguring the WAL writer, the flush
+/// thread, or the runtime signature — leaving `db.config()` disagreeing
+/// with the live database. `update_config` must reject the mutation and
+/// point the caller to the canonical path.
+#[test]
+#[serial(open_databases)]
+fn test_update_config_rejects_durability_string_changes() {
+    OPEN_DATABASES.lock().clear();
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(StrataConfig {
+                durability: "standard".to_string(),
+                ..StrataConfig::default()
+            })
+            .with_subsystem(SearchSubsystem),
+    )
+    .unwrap();
+
+    // A Standard → Always string swap via `update_config` must be rejected.
+    let err = db
+        .update_config(|cfg| cfg.durability = "always".to_string())
+        .expect_err("update_config must reject durability changes");
+    assert!(
+        matches!(err, StrataError::InvalidInput { .. }),
+        "expected InvalidInput, got: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("set_durability_mode"),
+        "error must point callers at the canonical path, got: {err}"
+    );
+
+    // A typo like `"turbo"` would previously have been silently persisted
+    // and only tripped on later parsing. Rejecting any string change
+    // catches it here too.
+    assert!(
+        db.update_config(|cfg| cfg.durability = "turbo".to_string())
+            .is_err(),
+        "unknown durability strings must also be rejected"
+    );
+
+    // Live and persisted state both still say "standard".
+    assert_eq!(db.config().durability, "standard");
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
+/// `set_durability_mode` is the canonical path for durability switches;
+/// it must update `self.config.durability`, the runtime signature, and
+/// persist `strata.toml` atomically, so a reopen reads the same value.
+#[test]
+#[serial(open_databases)]
+fn test_set_durability_mode_persists_and_updates_config_string() {
+    use strata_durability::wal::DurabilityMode;
+
+    OPEN_DATABASES.lock().clear();
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(StrataConfig {
+                durability: "standard".to_string(),
+                ..StrataConfig::default()
+            })
+            .with_subsystem(SearchSubsystem),
+    )
+    .unwrap();
+
+    db.set_durability_mode(DurabilityMode::Always)
+        .expect("Standard → Always must succeed");
+
+    // In-process state.
+    assert_eq!(db.config().durability, "always");
+    assert_eq!(
+        db.runtime_signature()
+            .expect("signature must exist")
+            .durability_mode,
+        DurabilityMode::Always,
+    );
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+
+    // Persisted state — a fresh process would see "always" here.
+    let persisted = StrataConfig::from_file(&db_path.join("strata.toml"))
+        .expect("strata.toml must exist after a successful durability switch");
+    assert_eq!(
+        persisted.durability, "always",
+        "set_durability_mode must persist the string form to strata.toml"
+    );
+}
+
 /// `Database::update_config` must reject mutations to open-time-only
 /// fields. Without this gate, a direct Rust caller could bypass the
 /// executor's `OPEN_TIME_ONLY_KEYS` check and silently drift the

--- a/crates/engine/src/database/tests/mod.rs
+++ b/crates/engine/src/database/tests/mod.rs
@@ -14,8 +14,8 @@ pub use serial_test::serial;
 pub use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 pub use std::sync::Arc;
 pub use std::time::Duration;
-pub use strata_concurrency::__internal as concurrency_test_hooks;
 pub use strata_concurrency::TransactionPayload;
+pub use strata_concurrency::__internal as concurrency_test_hooks;
 pub use strata_core::id::{CommitVersion, TxnId};
 pub use strata_core::types::{Key, Namespace, TypeTag};
 pub use strata_core::value::Value;
@@ -36,6 +36,7 @@ pub use tempfile::TempDir;
 use super::test_hooks;
 
 mod checkpoint;
+mod codec;
 mod contention;
 mod open;
 mod regressions;

--- a/crates/engine/src/database/tests/shutdown.rs
+++ b/crates/engine/src/database/tests/shutdown.rs
@@ -505,17 +505,40 @@ fn test_set_durability_mode_updates_runtime_signature_for_reuse_checks() {
         "runtime signature must track live durability mode"
     );
 
+    // Second opener that *explicitly* requests the old Standard mode must
+    // be rejected on signature mismatch. (T3-E7 review: `set_durability_mode`
+    // now also persists "always" to strata.toml, so a second opener that
+    // reads the default config no longer has a stale-config problem —
+    // hence the explicit request here.)
+    let stale_cfg = crate::StrataConfig {
+        durability: "standard".to_string(),
+        ..crate::StrataConfig::default()
+    };
     let err = match Database::open_runtime(
         OpenSpec::primary(&db_path)
+            .with_config(stale_cfg)
             .with_subsystem(TestRuntimeSubsystem::named("runtime-subsystem")),
     ) {
-        Ok(_) => panic!("reopen with stale config should not reuse a live-switched database"),
+        Ok(_) => panic!("explicit request for Standard must not reuse a switched-to-Always db"),
         Err(err) => err,
     };
     assert!(
         matches!(err, StrataError::IncompatibleReuse { .. }),
         "expected IncompatibleReuse, got {:?}",
         err
+    );
+
+    // A second opener whose requested config matches the post-switch state
+    // (either because they read the now-persisted strata.toml or because
+    // they explicitly asked for Always) must succeed and reuse the instance.
+    let ok_reuse = Database::open_runtime(
+        OpenSpec::primary(&db_path)
+            .with_subsystem(TestRuntimeSubsystem::named("runtime-subsystem")),
+    )
+    .expect("reopen with no-config reads the now-persisted 'always' and reuses");
+    assert!(
+        Arc::ptr_eq(&db, &ok_reuse),
+        "matching signature must return the same Arc, not a fresh instance"
     );
 
     db.shutdown().unwrap();

--- a/crates/engine/tests/config_matrix.rs
+++ b/crates/engine/tests/config_matrix.rs
@@ -77,12 +77,13 @@ fn read_matrix() -> String {
     fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {display}: {e}"))
 }
 
-/// Return the set of field names that appear as a leading backtick-wrapped
-/// identifier in any markdown table row.
+/// Return the ordered list of field names that appear as a leading
+/// backtick-wrapped identifier in any markdown table row, preserving
+/// multiplicity so duplicate rows can be detected.
 /// Rows whose first cell is prose (e.g. the `Classes` description table)
 /// contain no backtick'd identifier and are ignored.
-fn extract_table_fields(doc: &str) -> HashSet<String> {
-    let mut fields = HashSet::new();
+fn extract_table_field_rows(doc: &str) -> Vec<String> {
+    let mut fields = Vec::new();
     for line in doc.lines() {
         let trimmed = line.trim_start();
         if !trimmed.starts_with('|') {
@@ -106,7 +107,7 @@ fn extract_table_fields(doc: &str) -> HashSet<String> {
                 let name = &rest[..end];
                 // Ignore anything that looks like a placeholder/sub-class cell.
                 if !name.is_empty() && !name.contains(' ') {
-                    fields.insert(name.to_string());
+                    fields.push(name.to_string());
                 }
             }
         }
@@ -152,10 +153,23 @@ fn extract_class_labels(doc: &str) -> HashSet<String> {
 }
 
 #[test]
-fn every_config_field_is_classified_in_matrix() {
+fn every_config_field_is_classified_in_matrix_exactly_once() {
     let doc = read_matrix();
-    let matrix_fields = extract_table_fields(&doc);
+    let rows = extract_table_field_rows(&doc);
 
+    // Exactly-once: every field appears in exactly one row, no duplicates.
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for r in &rows {
+        *counts.entry(r.as_str()).or_insert(0) += 1;
+    }
+    let duplicates: Vec<(&&str, &usize)> = counts.iter().filter(|(_, &count)| count > 1).collect();
+    assert!(
+        duplicates.is_empty(),
+        "config matrix has duplicate rows for these fields — each field must be classified \
+         exactly once: {duplicates:?}"
+    );
+
+    let matrix_fields: HashSet<String> = rows.into_iter().collect();
     let mut expected: HashSet<String> = STRATA_CONFIG_FIELDS
         .iter()
         .map(ToString::to_string)

--- a/crates/engine/tests/config_matrix.rs
+++ b/crates/engine/tests/config_matrix.rs
@@ -1,0 +1,268 @@
+//! Regression test for T3-E7 / D-DR-11: every `StrataConfig` and `StorageConfig`
+//! field must appear in the config truth-table doc, and the doc must not
+//! mention fields that do not exist.
+//!
+//! The acceptance criterion from `durability-recovery-scope.md` §D-DR-11 is:
+//!
+//! > every public field on `StrataConfig` is listed in the config matrix; a
+//! > new knob without a classification fails the regression test
+//!
+//! Adding a field to either struct without also adding a matrix row will
+//! fail this test; removing a field without pruning the matrix will also
+//! fail.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
+
+/// Every public field on `StrataConfig` (top-level). Order does not matter;
+/// this must stay in sync with `crates/engine/src/database/config.rs`.
+const STRATA_CONFIG_FIELDS: &[&str] = &[
+    "durability",
+    "auto_embed",
+    "model",
+    "embed_batch_size",
+    "embed_model",
+    "provider",
+    "default_model",
+    "anthropic_api_key",
+    "openai_api_key",
+    "google_api_key",
+    "storage",
+    "allow_lossy_recovery",
+    "telemetry",
+    "default_vector_dtype",
+];
+
+/// Every public field on `StorageConfig` (nested under `storage`).
+const STORAGE_CONFIG_FIELDS: &[&str] = &[
+    "memory_budget",
+    "max_branches",
+    "max_write_buffer_entries",
+    "max_versions_per_key",
+    "block_cache_size",
+    "write_buffer_size",
+    "max_immutable_memtables",
+    "l0_slowdown_writes_trigger",
+    "l0_stop_writes_trigger",
+    "background_threads",
+    "target_file_size",
+    "level_base_bytes",
+    "data_block_size",
+    "bloom_bits_per_key",
+    "compaction_rate_limit",
+    "write_stall_timeout_ms",
+    "codec",
+];
+
+/// Recognized class labels in the matrix. Any other label fails the test.
+const VALID_CLASSES: &[&str] = &[
+    "open-time-only",
+    "live-safe",
+    "unsupported/deferred",
+    "non-durability",
+];
+
+fn matrix_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root")
+        .join("docs/design/architecture-cleanup/durability-recovery-config-matrix.md")
+}
+
+fn read_matrix() -> String {
+    let path = matrix_path();
+    let display = path.display();
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {display}: {e}"))
+}
+
+/// Return the set of field names that appear as a leading backtick-wrapped
+/// identifier in any markdown table row.
+/// Rows whose first cell is prose (e.g. the `Classes` description table)
+/// contain no backtick'd identifier and are ignored.
+fn extract_table_fields(doc: &str) -> HashSet<String> {
+    let mut fields = HashSet::new();
+    for line in doc.lines() {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with('|') {
+            continue;
+        }
+        // Skip table header and separator rows.
+        if trimmed.starts_with("|---") || trimmed.contains("| Field") {
+            continue;
+        }
+        // First cell in the row.
+        let first_cell = trimmed
+            .trim_start_matches('|')
+            .split('|')
+            .next()
+            .unwrap_or("")
+            .trim();
+        // Extract a backtick-wrapped identifier if present.
+        if let Some(start) = first_cell.find('`') {
+            let rest = &first_cell[start + 1..];
+            if let Some(end) = rest.find('`') {
+                let name = &rest[..end];
+                // Ignore anything that looks like a placeholder/sub-class cell.
+                if !name.is_empty() && !name.contains(' ') {
+                    fields.insert(name.to_string());
+                }
+            }
+        }
+    }
+    fields
+}
+
+/// Return the set of class labels that appear in the Class column of the
+/// two field tables (`StrataConfig` and `StorageConfig`). Identified by
+/// looking for table rows whose first cell is a backtick-wrapped
+/// identifier: those rows belong to a field table. Description tables use
+/// prose in the first cell and are skipped.
+fn extract_class_labels(doc: &str) -> HashSet<String> {
+    let mut classes = HashSet::new();
+    for line in doc.lines() {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with('|') {
+            continue;
+        }
+        if trimmed.starts_with("|---") {
+            continue;
+        }
+        let cells: Vec<&str> = trimmed.trim_start_matches('|').split('|').collect();
+        if cells.len() < 2 {
+            continue;
+        }
+        // Accept only rows whose first cell is a backtick-wrapped identifier
+        // (i.e. actual field rows, not Classes/description tables).
+        let first = cells[0].trim();
+        if !(first.starts_with('`') && first.ends_with('`') && first.len() > 2) {
+            continue;
+        }
+        let class_cell = cells[1].trim();
+        if class_cell.is_empty() || class_cell.starts_with('(') {
+            continue;
+        }
+        let cleaned = class_cell.trim_matches('*').trim().to_string();
+        if !cleaned.is_empty() {
+            classes.insert(cleaned);
+        }
+    }
+    classes
+}
+
+#[test]
+fn every_config_field_is_classified_in_matrix() {
+    let doc = read_matrix();
+    let matrix_fields = extract_table_fields(&doc);
+
+    let mut expected: HashSet<String> = STRATA_CONFIG_FIELDS
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    for f in STORAGE_CONFIG_FIELDS {
+        expected.insert(f.to_string());
+    }
+
+    let missing: Vec<&String> = expected.difference(&matrix_fields).collect();
+    assert!(
+        missing.is_empty(),
+        "config matrix is missing these fields — add a row and a classification: {missing:?}"
+    );
+
+    let stray: Vec<&String> = matrix_fields.difference(&expected).collect();
+    assert!(
+        stray.is_empty(),
+        "config matrix mentions fields that do not exist on StrataConfig/StorageConfig — \
+         prune the row or fix the name: {stray:?}"
+    );
+}
+
+#[test]
+fn matrix_uses_only_recognized_class_labels() {
+    let doc = read_matrix();
+    let labels = extract_class_labels(&doc);
+
+    let valid: HashSet<&str> = VALID_CLASSES.iter().copied().collect();
+    let unrecognized: Vec<&String> = labels
+        .iter()
+        .filter(|l| !valid.contains(l.as_str()))
+        .collect();
+
+    assert!(
+        unrecognized.is_empty(),
+        "matrix uses class labels that are not in the approved set {VALID_CLASSES:?}: {unrecognized:?}"
+    );
+}
+
+/// Sanity check: if someone adds a new field to one of the structs without
+/// updating `STRATA_CONFIG_FIELDS` or `STORAGE_CONFIG_FIELDS`, the default
+/// serde output will have a key the const list does not know about. This
+/// catches drift between the const list and the structs themselves.
+#[test]
+fn struct_field_list_matches_default_serialization() {
+    use serde_json::Value;
+    use strata_engine::database::{StorageConfig, StrataConfig};
+
+    let cfg_json = serde_json::to_value(StrataConfig::default()).unwrap();
+    let storage_json = serde_json::to_value(StorageConfig::default()).unwrap();
+
+    let cfg_keys: HashSet<String> = match cfg_json {
+        Value::Object(map) => map.keys().cloned().collect(),
+        _ => panic!("StrataConfig did not serialize as an object"),
+    };
+    let storage_keys: HashSet<String> = match storage_json {
+        Value::Object(map) => map.keys().cloned().collect(),
+        _ => panic!("StorageConfig did not serialize as an object"),
+    };
+
+    // Fields with `skip_serializing_if = "Option::is_none"` are absent at
+    // their default None. These are the known Option-typed, skip-when-none
+    // fields on StrataConfig — they're classified as non-durability in the
+    // matrix and must still appear in the const list.
+    let skip_when_none: HashSet<&str> = [
+        "model",
+        "default_model",
+        "anthropic_api_key",
+        "openai_api_key",
+        "google_api_key",
+    ]
+    .into_iter()
+    .collect();
+
+    let const_cfg: HashSet<String> = STRATA_CONFIG_FIELDS
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+
+    let mut effective_cfg = cfg_keys.clone();
+    for k in &skip_when_none {
+        effective_cfg.insert(k.to_string());
+    }
+    let missing_from_const: Vec<&String> = effective_cfg.difference(&const_cfg).collect();
+    assert!(
+        missing_from_const.is_empty(),
+        "StrataConfig has fields that STRATA_CONFIG_FIELDS does not list — \
+         add them to the const and to the matrix: {missing_from_const:?}"
+    );
+    let extra_in_const: Vec<&String> = const_cfg.difference(&effective_cfg).collect();
+    assert!(
+        extra_in_const.is_empty(),
+        "STRATA_CONFIG_FIELDS lists names that are not on StrataConfig: {extra_in_const:?}"
+    );
+
+    let const_storage: HashSet<String> = STORAGE_CONFIG_FIELDS
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    let missing_storage: Vec<&String> = storage_keys.difference(&const_storage).collect();
+    assert!(
+        missing_storage.is_empty(),
+        "StorageConfig has fields that STORAGE_CONFIG_FIELDS does not list: {missing_storage:?}"
+    );
+    let extra_storage: Vec<&String> = const_storage.difference(&storage_keys).collect();
+    assert!(
+        extra_storage.is_empty(),
+        "STORAGE_CONFIG_FIELDS lists names that are not on StorageConfig: {extra_storage:?}"
+    );
+}

--- a/crates/executor/src/handlers/config.rs
+++ b/crates/executor/src/handlers/config.rs
@@ -262,28 +262,26 @@ pub fn configure_set(p: &Arc<Primitives>, key: String, value: String) -> Result<
         })?;
     }
 
-    // Durability: update config + apply live to WAL writer
+    // Durability: one canonical path — `Database::set_durability_mode`
+    // handles the WAL switch, signature update, config-string update, and
+    // strata.toml persist atomically. A prior version of this handler also
+    // called `update_config`; that was redundant after the engine-side
+    // persist landed, and is now rejected by `update_config` itself.
     if key_lower == "durability" {
         let v = value.trim().to_ascii_lowercase();
-        let effective = v.clone();
-        // Parse the target mode
         let mode = match v.as_str() {
             "standard" => crate::DurabilityMode::standard_default(),
             "always" => crate::DurabilityMode::Always,
             _ => unreachable!(), // validated above
         };
-        p.db.update_config(|cfg| {
-            cfg.durability = v;
-        })
-        .map_err(crate::Error::from)?;
-        // Apply live to the WAL writer (no-op on ephemeral/cache databases)
         if let Err(e) = p.db.set_durability_mode(mode) {
-            // Ephemeral databases have no WAL — durability change is config-only
-            tracing::debug!(target: "strata::config", error = %e, "Durability mode not applied to WAL (ephemeral database)");
+            // Ephemeral databases have no WAL — surface the engine's
+            // rejection rather than pretending the change took effect.
+            return Err(crate::Error::from(e));
         }
         return Ok(Output::ConfigSetResult {
             key: key_lower,
-            new_value: effective,
+            new_value: v,
         });
     }
 

--- a/crates/executor/src/tests/config.rs
+++ b/crates/executor/src/tests/config.rs
@@ -839,7 +839,15 @@ fn configure_get_durability_default_is_standard() {
 
 #[test]
 fn configure_set_durability_valid_modes() {
-    let executor = create_test_executor();
+    // Durability switches only apply to disk-backed databases — cache
+    // databases have no WAL and surface `InvalidInput` for any runtime
+    // durability change. Use a tempdir-backed primary so the standard ↔
+    // always round-trip actually exercises the WAL reconfigure path.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let spec = strata_engine::database::spec::OpenSpec::primary(tmp.path())
+        .with_subsystem(strata_engine::search::SearchSubsystem);
+    let db = Database::open_runtime(spec).unwrap();
+    let executor = Executor::new(db);
 
     // Only standard and always are valid at runtime; cache is open-time only.
     for mode in ["standard", "always"] {
@@ -866,6 +874,45 @@ fn configure_set_durability_valid_modes() {
             mode
         );
     }
+}
+
+#[test]
+fn configure_set_durability_on_cache_database_returns_error() {
+    // Cache databases have no WAL. A prior version of this handler silently
+    // swallowed the `set_durability_mode` error and persisted the config
+    // string anyway — leaving `db.config().durability` claiming "always"
+    // while the live runtime stayed in Cache. The handler now surfaces the
+    // engine's rejection.
+    //
+    // Note: `OpenSpec::cache()` does not set `cfg.durability = "cache"` —
+    // cache mode lives on `DatabaseMode`, while the config string stays
+    // at its default ("standard"). The post-rejection value below reflects
+    // that default, not "cache".
+    let executor = create_test_executor();
+    let before = executor
+        .execute(Command::ConfigureGetKey {
+            key: "durability".into(),
+        })
+        .unwrap();
+
+    let result = executor.execute(Command::ConfigureSet {
+        key: "durability".into(),
+        value: "always".into(),
+    });
+    assert!(
+        result.is_err(),
+        "durability change on a cache database must not succeed"
+    );
+
+    let after = executor
+        .execute(Command::ConfigureGetKey {
+            key: "durability".into(),
+        })
+        .unwrap();
+    assert_eq!(
+        after, before,
+        "rejected set must leave db.config().durability untouched"
+    );
 }
 
 #[test]
@@ -900,7 +947,13 @@ fn configure_set_durability_invalid_rejected() {
 
 #[test]
 fn configure_set_durability_case_insensitive() {
-    let executor = create_test_executor();
+    // Like `configure_set_durability_valid_modes`, the actual durability
+    // switch requires a disk-backed database.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let spec = strata_engine::database::spec::OpenSpec::primary(tmp.path())
+        .with_subsystem(strata_engine::search::SearchSubsystem);
+    let db = Database::open_runtime(spec).unwrap();
+    let executor = Executor::new(db);
 
     let result = executor.execute(Command::ConfigureSet {
         key: "durability".into(),
@@ -1477,7 +1530,14 @@ fn configure_set_result_matches_get_key() {
 
 #[test]
 fn configure_set_result_durability() {
-    let executor = create_test_executor();
+    // Disk-backed executor — the live durability switch requires a WAL,
+    // so the cache-mode helper can't exercise this path. See
+    // `configure_set_durability_valid_modes` for the rationale.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let spec = strata_engine::database::spec::OpenSpec::primary(tmp.path())
+        .with_subsystem(strata_engine::search::SearchSubsystem);
+    let db = Database::open_runtime(spec).unwrap();
+    let executor = Executor::new(db);
 
     let result = executor
         .execute(Command::ConfigureSet {

--- a/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
+++ b/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
@@ -1,0 +1,119 @@
+# Durability & Recovery Config Truth Table
+
+**Status:** current state as of T3-E7 (2026-04-16).
+**Normative source:** `durability-recovery-scope.md` §D-DR-11.
+**Regression test:** `crates/engine/tests/config_matrix.rs` (parses this file and
+asserts every `StrataConfig` / `StorageConfig` field is classified exactly once).
+
+---
+
+## Purpose
+
+Classifies every public field on `StrataConfig` and its nested `StorageConfig`.
+The classification is load-bearing in three places:
+
+1. **Open-time reuse.** `CompatibilitySignature` rejects a second opener whose
+   open-time fields disagree with the live database. An open-time-only field
+   that is not represented in the signature is a silent-drift bug.
+2. **Live config mutation.** `Database::update_config` and `set_durability_mode`
+   may only mutate fields classified as live-safe. The executor-side handler
+   at `crates/executor/src/handlers/config.rs` rejects runtime writes to fields
+   in the `OPEN_TIME_ONLY_KEYS` list.
+3. **Dead-knob policy.** A field that the implementation has silently stopped
+   using is deleted, not documented here. Each field listed below is reachable
+   from a runtime code path or contributes to the compatibility signature.
+
+## Classes
+
+| Class | Meaning | Must have |
+|---|---|---|
+| **open-time-only** | Value is locked at open. A second opener with a different value is rejected. | A contribution to `CompatibilitySignature` fingerprint **or** a MANIFEST-backed validator **or** an `OPEN_TIME_ONLY_KEYS` entry. |
+| **live-safe** | May change at runtime via an explicit setter or `update_config`; takes effect without reopen. | An explicit setter, or read-through from `Database::config` on every hot-path call. |
+| **unsupported/deferred** | Present on the struct but not consumed. Documented with a target-state pointer. Zero such fields today. | A pointer to the target-state requirement that would implement it. |
+| **non-durability** | Out of the durability/recovery domain. Classified here only so the regression test can confirm full coverage of the public struct. | Nothing — listed for completeness. |
+
+---
+
+## `StrataConfig` — top-level
+
+| Field | Class | Signature? | Setter / enforcement |
+|---|---|---|---|
+| `durability` | live-safe | yes (`durability_mode` in signature; `Cache` discriminant treated as open-time-only) | `Database::set_durability_mode` (Standard↔Always only; Cache rejected at runtime) |
+| `auto_embed` | non-durability | no | `Database::set_auto_embed` |
+| `model` | non-durability | no | — |
+| `embed_batch_size` | non-durability | no | — |
+| `embed_model` | non-durability | no | — |
+| `provider` | non-durability | no | — |
+| `default_model` | non-durability | no | — |
+| `anthropic_api_key` | non-durability | no | — |
+| `openai_api_key` | non-durability | no | — |
+| `google_api_key` | non-durability | no | — |
+| `storage` | (nested — see below) | — | — |
+| `allow_lossy_recovery` | open-time-only | no (lifted into `RecoveryCoordinator::with_lossy_recovery` at open) | rejected at runtime via `OPEN_TIME_ONLY_KEYS` |
+| `telemetry` | non-durability | no | — |
+| `default_vector_dtype` | non-durability | no | — |
+
+## `StorageConfig` — nested under `storage`
+
+| Field | Class | Signature? | Setter / enforcement |
+|---|---|---|---|
+| `memory_budget` | live-safe | no | `apply_storage_config_inner` (derives effective cache/buffer on change) |
+| `max_branches` | live-safe | no | `Storage::set_max_branches` |
+| `max_write_buffer_entries` | live-safe | no | `Coordinator::set_max_write_buffer_entries` |
+| `max_versions_per_key` | live-safe | no | `Storage::set_max_versions_per_key` |
+| `block_cache_size` | live-safe | no | `block_cache::set_global_capacity` |
+| `write_buffer_size` | live-safe | no | `Storage::set_write_buffer_size` |
+| `max_immutable_memtables` | live-safe | no | `Storage::set_max_immutable_memtables` |
+| `l0_slowdown_writes_trigger` | live-safe | no | read per-write in `maybe_apply_write_backpressure` |
+| `l0_stop_writes_trigger` | live-safe | no | read per-write in `maybe_apply_write_backpressure` |
+| `background_threads` | open-time-only | no (thread pool spawned at open; no resize path) | rejected at runtime via `OPEN_TIME_ONLY_KEYS` |
+| `target_file_size` | live-safe | no | `Storage::set_target_file_size` |
+| `level_base_bytes` | live-safe | no | `Storage::set_level_base_bytes` |
+| `data_block_size` | live-safe | no | `Storage::set_data_block_size` |
+| `bloom_bits_per_key` | live-safe | no | `Storage::set_bloom_bits_per_key` |
+| `compaction_rate_limit` | live-safe | no | `Storage::set_compaction_rate_limit` |
+| `write_stall_timeout_ms` | live-safe | no | read per-stall in `maybe_apply_write_backpressure` |
+| `codec` | open-time-only | yes (`codec_id` + `codec_name` in signature) | MANIFEST validates on open (primary: `open.rs`; follower: `open.rs`); `plan_recovery` re-validates before WAL read; mismatch at reuse returns `StrataError::IncompatibleReuse` |
+
+---
+
+## Enforcement
+
+- Registry reuse with a mismatched codec returns `StrataError::IncompatibleReuse`
+  on the signature check (primary) or on the MANIFEST-load check (follower,
+  before the signature is even published). See
+  `crates/engine/src/database/tests/codec.rs`.
+- Attempting to mutate an `open-time-only` field at runtime through the
+  executor config handler returns `Error::InvalidInput` with a message naming
+  the offending key.
+- `write_stall_timeout_ms` is covered by backpressure regression tests at
+  `crates/engine/src/database/tests/regressions.rs` — confirms the knob is
+  read on every stalled write, not dead code.
+
+## Durability/recovery coverage
+
+**Open-time-only:** `codec`, `background_threads`, `allow_lossy_recovery`,
+`durability = "cache"` (discriminant).
+
+**Live-safe (durability/recovery domain):** `durability` (Standard↔Always
+switch). All other `StorageConfig` entries are live-safe but LSM-tuning, not
+durability/recovery per se — they are listed here because they share the
+struct and the regression test iterates the whole thing.
+
+**Unsupported/deferred:** none today.
+
+## Target-state notes
+
+- **Non-identity-codec persistence.** The WAL reader does not yet decode via
+  the configured codec (`open.rs` blocks `codec != "identity"` combined with
+  any WAL-based durability mode). Cache-durability databases may use a
+  non-identity codec within a single session but cannot survive restart.
+  Lifting this is tracked separately from T3-E7 and will be reflected here
+  when the block is removed. Until then, a write → crash → reopen → read
+  round-trip with a non-identity codec is not testable.
+
+## Change log
+
+- 2026-04-16 (T3-E7): initial creation. Classifies all 14 top-level
+  `StrataConfig` fields and all 17 nested `StorageConfig` fields. No fields
+  deleted — every knob reachable from a runtime code path.

--- a/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
+++ b/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
@@ -2,8 +2,11 @@
 
 **Status:** current state as of T3-E7 (2026-04-16).
 **Normative source:** `durability-recovery-scope.md` §D-DR-11.
-**Regression test:** `crates/engine/tests/config_matrix.rs` (parses this file and
-asserts every `StrataConfig` / `StorageConfig` field is classified exactly once).
+**Regression test:** `crates/engine/tests/config_matrix.rs` parses this file
+and asserts that every `StrataConfig` / `StorageConfig` field appears in
+exactly one row (no duplicates, no omissions), that every class label is
+one of the four approved tokens, and that the hand-maintained const lists
+match the fields the structs actually expose via serde.
 
 ---
 

--- a/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
+++ b/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
@@ -27,7 +27,7 @@ The classification is load-bearing in three places:
 
 | Class | Meaning | Must have |
 |---|---|---|
-| **open-time-only** | Value is locked at open. A second opener with a different value is rejected. | A contribution to `CompatibilitySignature` fingerprint **or** a MANIFEST-backed validator **or** an `OPEN_TIME_ONLY_KEYS` entry. |
+| **open-time-only** | Value is locked at open. A second opener with a different value gets `StrataError::IncompatibleReuse`. | Participation in `CompatibilitySignature` — either as an explicit field checked in `check_compatible` or hashed into `open_config_fingerprint` (typically both, for diagnosability). Runtime-mutation attempts must also be rejected via `OPEN_TIME_ONLY_KEYS` in the executor config handler. |
 | **live-safe** | May change at runtime via an explicit setter or `update_config`; takes effect without reopen. | An explicit setter, or read-through from `Database::config` on every hot-path call. |
 | **unsupported/deferred** | Present on the struct but not consumed. Documented with a target-state pointer. Zero such fields today. | A pointer to the target-state requirement that would implement it. |
 | **non-durability** | Out of the durability/recovery domain. Classified here only so the regression test can confirm full coverage of the public struct. | Nothing — listed for completeness. |
@@ -49,7 +49,7 @@ The classification is load-bearing in three places:
 | `openai_api_key` | non-durability | no | — |
 | `google_api_key` | non-durability | no | — |
 | `storage` | (nested — see below) | — | — |
-| `allow_lossy_recovery` | open-time-only | no (lifted into `RecoveryCoordinator::with_lossy_recovery` at open) | rejected at runtime via `OPEN_TIME_ONLY_KEYS` |
+| `allow_lossy_recovery` | open-time-only | yes (`CompatibilitySignature.allow_lossy_recovery`; also hashed into `open_config_fingerprint`) | rejected at runtime via `OPEN_TIME_ONLY_KEYS` |
 | `telemetry` | non-durability | no | — |
 | `default_vector_dtype` | non-durability | no | — |
 
@@ -66,7 +66,7 @@ The classification is load-bearing in three places:
 | `max_immutable_memtables` | live-safe | no | `Storage::set_max_immutable_memtables` |
 | `l0_slowdown_writes_trigger` | live-safe | no | read per-write in `maybe_apply_write_backpressure` |
 | `l0_stop_writes_trigger` | live-safe | no | read per-write in `maybe_apply_write_backpressure` |
-| `background_threads` | open-time-only | no (thread pool spawned at open; no resize path) | rejected at runtime via `OPEN_TIME_ONLY_KEYS` |
+| `background_threads` | open-time-only | yes (`CompatibilitySignature.background_threads`; also hashed into `open_config_fingerprint`) | thread pool spawned at open with no resize path; rejected at runtime via `OPEN_TIME_ONLY_KEYS` |
 | `target_file_size` | live-safe | no | `Storage::set_target_file_size` |
 | `level_base_bytes` | live-safe | no | `Storage::set_level_base_bytes` |
 | `data_block_size` | live-safe | no | `Storage::set_data_block_size` |
@@ -117,3 +117,9 @@ struct and the regression test iterates the whole thing.
 - 2026-04-16 (T3-E7): initial creation. Classifies all 14 top-level
   `StrataConfig` fields and all 17 nested `StorageConfig` fields. No fields
   deleted — every knob reachable from a runtime code path.
+- 2026-04-16 (T3-E7 review follow-up): `background_threads` and
+  `allow_lossy_recovery` moved into `CompatibilitySignature` as explicit
+  fields so registry reuse rejects drift instead of silently serving an
+  instance sized/recovered differently. Rule statement tightened: an
+  open-time-only knob *must* participate in the signature; `OPEN_TIME_ONLY_KEYS`
+  alone is no longer considered sufficient.

--- a/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
+++ b/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
@@ -41,7 +41,7 @@ The classification is load-bearing in three places:
 
 | Field | Class | Signature? | Setter / enforcement |
 |---|---|---|---|
-| `durability` | live-safe | yes (`durability_mode` in signature; `Cache` discriminant treated as open-time-only) | `Database::set_durability_mode` (Standard↔Always only; Cache rejected at runtime) |
+| `durability` | live-safe | yes (`durability_mode` in signature; `Cache` discriminant treated as open-time-only) | `Database::set_durability_mode` is the **only** live-safe path (Standard↔Always; Cache rejected). It atomically reconfigures the WAL writer, restarts the flush thread, updates the runtime signature, updates `self.config.durability`, and persists `strata.toml`. `update_config` explicitly rejects any `durability` string change and points the caller here. |
 | `auto_embed` | non-durability | no | `Database::set_auto_embed` |
 | `model` | non-durability | no | — |
 | `embed_batch_size` | non-durability | no | — |


### PR DESCRIPTION
## Summary

- **Codec uniformity (§D-DR-8):** unify codec-drift rejection to `StrataError::IncompatibleReuse` across the primary and follower open paths; add the follower-side drift check that was silently missing.
- **Config matrix (§D-DR-11):** ship the durability/recovery truth table doc T5 depends on, with a regression test that fails if any `StrataConfig`/`StorageConfig` field is added/removed without the matrix being kept in sync.
- **No deletions:** no silently-unused knobs found. `write_stall_timeout_ms` is live (used in `transaction.rs:372` with regression tests) and classified as live-safe rather than removed.

## Change class & assurance

- **Mixed:** refactor-only for the primary-path error-kind unification; intentional semantic change for follower drift rejection (authorized by scope §D-DR-8). Matrix doc + enforcement test are additive.
- **Assurance class:** S4 (touches open-time rejection on the recovery path).
- **Benchmark obligation:** redb 5M + ycsb_compare 100K. Local runs pending; no hot-path changes expected.

## Key code changes

- `crates/engine/src/database/open.rs` — primary codec-drift now returns `IncompatibleReuse` with a path-qualified diagnostic; new follower drift check at MANIFEST-load time, ahead of codec instantiation.
- `crates/engine/src/database/config.rs` — inline class annotations on `durability`, `codec`, `allow_lossy_recovery`, `background_threads`.
- `crates/engine/src/database/tests/codec.rs` (new) — 3 tests: registry-reuse rejection, follower drift rejection, follower happy-path signature. `STRATA_ENCRYPTION_KEY` lifecycle is RAII-guarded so an in-test panic cannot leak the var.
- `crates/engine/tests/config_matrix.rs` (new) — 3 regression tests: matrix covers every field, matrix uses only the 4 approved class labels, const list matches serde's default serialization.
- `docs/design/architecture-cleanup/durability-recovery-config-matrix.md` (new) — the truth table itself.
- `crates/engine/src/database/tests/checkpoint.rs` — existing codec-mismatch-under-lossy-flag test tightened to assert the `IncompatibleReuse` variant, not just the message.

## What's deferred

A non-identity-codec write → crash → reopen → read round-trip is documented as deferred in the matrix: the WAL reader does not yet decode via the configured codec (`open.rs:842` still blocks `codec != "identity" && requires_wal()`). Cache durability does not persist across opens, so the scope's full cross-process round-trip test is not achievable today. Lifting this is separate from T3-E7.

## Test plan

- [x] `cargo test -p strata-engine --test config_matrix` — 3 tests pass
- [x] `cargo test -p strata-engine --lib database::tests::codec` — 3 tests pass
- [x] `cargo test -p strata-engine --lib test_codec_mismatch_on_reopen_fails_even_with_lossy_flag` — 1 test passes (now asserts `IncompatibleReuse` variant)
- [x] `cargo test -p strata-engine --test recovery_tests` — 33/33
- [x] `cargo test -p strata-engine --test follower_tests` — 25/25
- [x] `cargo test -p strata-engine --lib database::tests -- --test-threads=1` — 118/118
- [x] `cargo test -p strata-concurrency --lib` — 146/146
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy` — clean on new and touched files (pre-existing workspace warnings untouched)
- [ ] `cargo run --release -p strata-benchmarks --bin regression -- --tranche 3 --epic T3-E7` — to run before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)