### PR TITLE
T3-E9: ContiguousWatermark strict contiguity + follower close-barrier

### DIFF
--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -189,9 +189,15 @@ impl Database {
     ///
     /// # Errors
     ///
-    /// Returns `UnblockError::Mismatch` if `txn_id` doesn't match the blocked
-    /// transaction, `UnblockError::NotBlocked` if the follower isn't blocked,
-    /// or `UnblockError::NotFollower` if this isn't a follower database.
+    /// - `UnblockError::NotFollower` — this isn't a follower database.
+    /// - `UnblockError::DatabaseClosed` — the database has been shut down;
+    ///   admin skip is rejected to prevent a stale handle from mutating a
+    ///   fresh instance's recovery artifacts after a reopen.
+    /// - `UnblockError::Mismatch` — `txn_id` doesn't match the blocked
+    ///   transaction's id.
+    /// - `UnblockError::NotBlocked` — the follower isn't currently blocked.
+    /// - `UnblockError::NotSkippable` — the blocked record's block reason
+    ///   flags it as unsafe to skip.
     pub fn admin_skip_blocked_record(
         &self,
         txn_id: TxnId,

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -200,6 +200,13 @@ impl Database {
         if !self.follower {
             return Err(UnblockError::NotFollower);
         }
+        // Admin skip writes the audit log, advances the watermark, and
+        // bumps storage version — all mutating operations. Reject on a
+        // closed handle so a stale `Arc<Database>` can't mutate a fresh
+        // instance's recovery artifacts if one opens on the same path.
+        if self.shutdown_complete.load(Ordering::Acquire) {
+            return Err(UnblockError::DatabaseClosed);
+        }
 
         let blocked = self.watermark.unblock_exact(txn_id)?;
         if let Some(version) = blocked.visibility_version {
@@ -283,6 +290,19 @@ impl Database {
             return RefreshOutcome::CaughtUp {
                 applied: 0,
                 applied_through: TxnId::ZERO,
+            };
+        }
+
+        // Close-barrier guard. A follower returns `Ok(())` from
+        // `shutdown_with_deadline` after quiescing, but nothing in the
+        // mutating follower APIs checked `shutdown_complete` before this
+        // change. Post-shutdown `refresh()` would still touch the WAL and
+        // watermark. Treat a closed follower as a no-op that reports the
+        // last applied state, matching the non-follower branch above.
+        if self.shutdown_complete.load(Ordering::Acquire) {
+            return RefreshOutcome::CaughtUp {
+                applied: 0,
+                applied_through: self.watermark.applied(),
             };
         }
 

--- a/crates/engine/src/database/refresh.rs
+++ b/crates/engine/src/database/refresh.rs
@@ -251,6 +251,8 @@ pub enum UnblockError {
     },
     /// This database is not a follower.
     NotFollower,
+    /// The database has been shut down.
+    DatabaseClosed,
 }
 
 impl fmt::Display for UnblockError {
@@ -272,6 +274,9 @@ impl fmt::Display for UnblockError {
                 )
             }
             UnblockError::NotFollower => write!(f, "this database is not a follower"),
+            UnblockError::DatabaseClosed => {
+                write!(f, "database has been shut down; admin skip rejected")
+            }
         }
     }
 }
@@ -287,6 +292,16 @@ pub enum AdvanceError {
         /// Transaction currently blocking contiguous advancement.
         blocked_at: TxnId,
     },
+    /// Cannot advance: provided txn id is not the next contiguous id.
+    ///
+    /// The watermark advances only through strictly contiguous successful
+    /// records. A caller that supplies a gap or a duplicate is rejected.
+    NonContiguous {
+        /// The next txn id the watermark was ready to accept.
+        expected: TxnId,
+        /// The txn id the caller tried to advance to.
+        provided: TxnId,
+    },
     /// Cannot advance: not a follower database.
     NotFollower,
 }
@@ -296,6 +311,13 @@ impl fmt::Display for AdvanceError {
         match self {
             AdvanceError::Blocked { blocked_at } => {
                 write!(f, "cannot advance: blocked at {}", blocked_at)
+            }
+            AdvanceError::NonContiguous { expected, provided } => {
+                write!(
+                    f,
+                    "cannot advance: non-contiguous txn id (expected {}, provided {})",
+                    expected, provided
+                )
             }
             AdvanceError::NotFollower => write!(f, "cannot advance: not a follower"),
         }
@@ -506,14 +528,40 @@ impl ContiguousWatermark {
     /// Advance the applied watermark after successful processing.
     ///
     /// This should only be called after storage apply AND all hooks succeed.
+    /// The provided `txn_id` must equal `applied + 1`. A gap or duplicate
+    /// returns `AdvanceError::NonContiguous` so the contiguity invariant
+    /// advertised by the type is load-bearing on the type itself, not only
+    /// on refresh-loop discipline.
+    ///
+    /// Contention is nil: callers hold `RefreshGate` (single-flight), so the
+    /// load-then-CAS dance never races. The CAS is kept so the semantic is
+    /// still correct if the gate is ever relaxed.
     pub(crate) fn try_advance(&self, txn_id: TxnId) -> Result<(), AdvanceError> {
         if let Some(blocked) = self.blocked.read().as_ref() {
             return Err(AdvanceError::Blocked {
                 blocked_at: blocked.blocked.txn_id,
             });
         }
-        self.applied.fetch_max(txn_id.as_u64(), Ordering::SeqCst);
-        Ok(())
+        let current = self.applied.load(Ordering::SeqCst);
+        let expected = TxnId(current + 1);
+        if txn_id != expected {
+            return Err(AdvanceError::NonContiguous {
+                expected,
+                provided: txn_id,
+            });
+        }
+        match self.applied.compare_exchange(
+            current,
+            txn_id.as_u64(),
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            Ok(_) => Ok(()),
+            Err(actual) => Err(AdvanceError::NonContiguous {
+                expected: TxnId(actual + 1),
+                provided: txn_id,
+            }),
+        }
     }
 
     /// Mark the watermark as blocked at a specific transaction.
@@ -708,5 +756,137 @@ impl RefreshHooks {
     /// Get all registered hooks.
     pub fn hooks(&self) -> Vec<Arc<dyn RefreshHook>> {
         self.hooks.read().clone()
+    }
+}
+
+#[cfg(test)]
+mod watermark_contiguity_tests {
+    use super::*;
+
+    fn blocked_state(txn_id: TxnId) -> BlockedTxnState {
+        BlockedTxnState {
+            blocked: BlockedTxn {
+                txn_id,
+                reason: BlockReason::Decode {
+                    message: "test".into(),
+                },
+            },
+            visibility_version: None,
+            skip_allowed: true,
+        }
+    }
+
+    #[test]
+    fn try_advance_accepts_next_contiguous_id() {
+        let wm = ContiguousWatermark::new(TxnId(10));
+        assert_eq!(wm.applied(), TxnId(10));
+        assert_eq!(wm.try_advance(TxnId(11)), Ok(()));
+        assert_eq!(wm.applied(), TxnId(11));
+        assert_eq!(wm.try_advance(TxnId(12)), Ok(()));
+        assert_eq!(wm.applied(), TxnId(12));
+    }
+
+    #[test]
+    fn try_advance_rejects_gap() {
+        let wm = ContiguousWatermark::new(TxnId(10));
+        assert_eq!(
+            wm.try_advance(TxnId(12)),
+            Err(AdvanceError::NonContiguous {
+                expected: TxnId(11),
+                provided: TxnId(12),
+            })
+        );
+        // Watermark unchanged after rejection.
+        assert_eq!(wm.applied(), TxnId(10));
+    }
+
+    #[test]
+    fn try_advance_rejects_duplicate() {
+        let wm = ContiguousWatermark::new(TxnId(10));
+        assert_eq!(
+            wm.try_advance(TxnId(10)),
+            Err(AdvanceError::NonContiguous {
+                expected: TxnId(11),
+                provided: TxnId(10),
+            })
+        );
+        assert_eq!(wm.applied(), TxnId(10));
+    }
+
+    #[test]
+    fn try_advance_rejects_stale_below_applied() {
+        let wm = ContiguousWatermark::new(TxnId(10));
+        assert_eq!(
+            wm.try_advance(TxnId(5)),
+            Err(AdvanceError::NonContiguous {
+                expected: TxnId(11),
+                provided: TxnId(5),
+            })
+        );
+        assert_eq!(wm.applied(), TxnId(10));
+    }
+
+    #[test]
+    fn blocked_state_takes_precedence_over_contiguity() {
+        let wm = ContiguousWatermark::new(TxnId(10));
+        wm.block_at(blocked_state(TxnId(11)));
+        // Even the perfectly-contiguous next id is rejected when blocked.
+        assert_eq!(
+            wm.try_advance(TxnId(11)),
+            Err(AdvanceError::Blocked {
+                blocked_at: TxnId(11),
+            })
+        );
+        assert_eq!(wm.applied(), TxnId(10));
+    }
+
+    #[test]
+    fn skip_flow_preserves_contiguity() {
+        // Setup: applied at 99, blocked at 100.
+        let wm = ContiguousWatermark::new(TxnId(99));
+        wm.block_at(blocked_state(TxnId(100)));
+
+        // Admin skip the blocked txn.
+        let result = wm.unblock_exact(TxnId(100));
+        assert!(result.is_ok(), "unblock should succeed on exact match");
+        assert_eq!(wm.applied(), TxnId(100));
+        assert!(wm.blocked().is_none());
+
+        // Next refresh cycle's first advance is to 101 — still contiguous.
+        assert_eq!(wm.try_advance(TxnId(101)), Ok(()));
+        assert_eq!(wm.applied(), TxnId(101));
+    }
+
+    #[test]
+    fn unblock_mismatch_leaves_watermark_untouched() {
+        let wm = ContiguousWatermark::new(TxnId(99));
+        wm.block_at(blocked_state(TxnId(100)));
+
+        let err = wm.unblock_exact(TxnId(101)).expect_err("mismatch expected");
+        assert!(matches!(
+            err,
+            UnblockError::Mismatch {
+                expected: TxnId(100),
+                provided: TxnId(101),
+            }
+        ));
+        assert_eq!(wm.applied(), TxnId(99));
+        assert!(wm.blocked().is_some());
+    }
+
+    #[test]
+    fn from_state_respects_contiguity_on_next_advance() {
+        // Follower restarted with persisted state: received=105, applied=100, blocked at 101.
+        let wm = ContiguousWatermark::from_state(
+            TxnId(105),
+            TxnId(100),
+            Some(blocked_state(TxnId(101))),
+        );
+        assert_eq!(wm.applied(), TxnId(100));
+
+        // Skip, then the first advance from the resume point is to 101.
+        wm.unblock_exact(TxnId(101)).unwrap();
+        assert_eq!(wm.applied(), TxnId(101));
+        assert_eq!(wm.try_advance(TxnId(102)), Ok(()));
     }
 }

--- a/crates/engine/src/database/refresh.rs
+++ b/crates/engine/src/database/refresh.rs
@@ -543,7 +543,16 @@ impl ContiguousWatermark {
             });
         }
         let current = self.applied.load(Ordering::SeqCst);
-        let expected = TxnId(current + 1);
+        // `checked_add` guards the practically-impossible case of applied ==
+        // u64::MAX. In release builds plain `+` would wrap silently; in debug
+        // it panics. Treat overflow as a non-contiguous advance so the error
+        // shape stays uniform.
+        let expected = current.checked_add(1).map(TxnId).ok_or({
+            AdvanceError::NonContiguous {
+                expected: TxnId(u64::MAX),
+                provided: txn_id,
+            }
+        })?;
         if txn_id != expected {
             return Err(AdvanceError::NonContiguous {
                 expected,
@@ -557,10 +566,13 @@ impl ContiguousWatermark {
             Ordering::SeqCst,
         ) {
             Ok(_) => Ok(()),
-            Err(actual) => Err(AdvanceError::NonContiguous {
-                expected: TxnId(actual + 1),
-                provided: txn_id,
-            }),
+            Err(actual) => {
+                let expected = actual.checked_add(1).map(TxnId).unwrap_or(TxnId(u64::MAX));
+                Err(AdvanceError::NonContiguous {
+                    expected,
+                    provided: txn_id,
+                })
+            }
         }
     }
 
@@ -872,6 +884,20 @@ mod watermark_contiguity_tests {
         ));
         assert_eq!(wm.applied(), TxnId(99));
         assert!(wm.blocked().is_some());
+    }
+
+    #[test]
+    fn try_advance_handles_applied_at_u64_max_without_panicking() {
+        // Defensive: u64::MAX is practically unreachable (18 quintillion txns)
+        // but debug builds would panic on `current + 1` without `checked_add`.
+        // A caller at saturation must see a NonContiguous error, not a panic.
+        let wm = ContiguousWatermark::new(TxnId(u64::MAX));
+        let err = wm
+            .try_advance(TxnId(0))
+            .expect_err("advance at saturation must fail without panic");
+        assert!(matches!(err, AdvanceError::NonContiguous { .. }));
+        // Watermark remains at saturation.
+        assert_eq!(wm.applied(), TxnId(u64::MAX));
     }
 
     #[test]

--- a/crates/engine/tests/follower_tests.rs
+++ b/crates/engine/tests/follower_tests.rs
@@ -1389,6 +1389,8 @@ fn test_admin_skip_rejects_after_shutdown() {
         Database::open_runtime(OpenSpec::follower(dir.path()).with_subsystem(SearchSubsystem))
             .unwrap();
 
+    let status_before = follower.follower_status();
+
     follower.shutdown().unwrap();
 
     let result = follower.admin_skip_blocked_record(TxnId(1), "post-shutdown attempt");
@@ -1396,5 +1398,22 @@ fn test_admin_skip_rejects_after_shutdown() {
         matches!(result, Err(UnblockError::DatabaseClosed)),
         "expected DatabaseClosed after shutdown, got {:?}",
         result
+    );
+
+    // Defence-in-depth: the guard must reject *before* any state mutates. If
+    // a future refactor inadvertently reorders guards past the audit / watermark
+    // writes, this assertion catches it.
+    let status_after = follower.follower_status();
+    assert_eq!(
+        status_after.received_watermark, status_before.received_watermark,
+        "received_watermark must not drift after a rejected admin_skip"
+    );
+    assert_eq!(
+        status_after.applied_watermark, status_before.applied_watermark,
+        "applied_watermark must not drift after a rejected admin_skip"
+    );
+    assert!(
+        status_after.blocked_at.is_none(),
+        "admin_skip on a non-blocked follower must not introduce a blocked_at state"
     );
 }

--- a/crates/engine/tests/follower_tests.rs
+++ b/crates/engine/tests/follower_tests.rs
@@ -1321,3 +1321,80 @@ fn test_concurrent_refresh_serialized() {
         );
     }
 }
+
+/// T3-E9: a follower that has been shut down no longer accepts `refresh()` —
+/// the follower-side shutdown barrier now short-circuits the refresh path
+/// rather than mutating WAL/watermark state through a stale handle.
+#[test]
+fn test_follower_refresh_is_noop_after_shutdown() {
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+
+    let primary =
+        Database::open_runtime(OpenSpec::primary(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+    primary_put(&primary, branch, "k1", "v1");
+    primary.flush().unwrap();
+
+    let follower =
+        Database::open_runtime(OpenSpec::follower(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+
+    let applied_before = follower.follower_status().applied_watermark;
+
+    // Explicit shutdown on the follower. Per T3-E6, this quiesces the
+    // follower and returns Ok; per T3-E9, a follower refresh after shutdown
+    // must not mutate watermarks.
+    follower.shutdown().unwrap();
+
+    let outcome = follower.refresh();
+    // Post-shutdown refresh reports CaughtUp at the last-applied watermark
+    // (matching the non-follower / ephemeral branch semantics) — no new
+    // records are processed.
+    use strata_engine::RefreshOutcome;
+    match outcome {
+        RefreshOutcome::CaughtUp {
+            applied,
+            applied_through,
+        } => {
+            assert_eq!(applied, 0, "post-shutdown refresh applies zero records");
+            assert_eq!(
+                applied_through, applied_before,
+                "applied watermark must not move after shutdown"
+            );
+        }
+        other => panic!("expected CaughtUp after shutdown, got {:?}", other),
+    }
+    // Watermark is stable: the stale handle has not advanced state.
+    assert_eq!(
+        follower.follower_status().applied_watermark,
+        applied_before,
+        "follower_status must show no post-shutdown drift"
+    );
+}
+
+/// T3-E9: admin_skip on a shut-down follower returns `UnblockError::DatabaseClosed`
+/// rather than mutating watermarks / writing audit logs through a stale handle.
+#[test]
+fn test_admin_skip_rejects_after_shutdown() {
+    use strata_core::id::TxnId;
+    use strata_engine::UnblockError;
+
+    let dir = tempdir().unwrap();
+
+    let _primary =
+        Database::open_runtime(OpenSpec::primary(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+    let follower =
+        Database::open_runtime(OpenSpec::follower(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+
+    follower.shutdown().unwrap();
+
+    let result = follower.admin_skip_blocked_record(TxnId(1), "post-shutdown attempt");
+    assert!(
+        matches!(result, Err(UnblockError::DatabaseClosed)),
+        "expected DatabaseClosed after shutdown, got {:?}",
+        result
+    );
+}


### PR DESCRIPTION
## Summary

Closes two contract gaps against Tranche 3 surfaced by independent review, as part of the T3 closeout plan:

- **DR-012 (ContiguousWatermark):** `try_advance` used `fetch_max` with no contiguity check. The "never skips" invariant lived only in refresh-loop discipline, not on the type. Now enforces `txn_id == applied + 1` and returns `AdvanceError::NonContiguous { expected, provided }` on any gap, duplicate, or stale id. The single production caller already feeds strictly contiguous txn ids, so the check is load-bearing without changing any legitimate call pattern.
- **DR-015 (follower close-barrier):** `refresh()` and `admin_skip_blocked_record()` did not consult `shutdown_complete`. A stale `Arc<Database>` could still mutate watermarks and write to `follower_audit.log` after a clean shutdown returned `Ok(())`. Now both short-circuit post-shutdown: `refresh()` returns `CaughtUp { applied: 0, applied_through: wm.applied() }` (matching the non-follower branch), and `admin_skip_blocked_record()` returns new variant `UnblockError::DatabaseClosed`.

## Change class

Additive. New enum variants (`AdvanceError::NonContiguous`, `UnblockError::DatabaseClosed`) — both enums are already `#[non_exhaustive]`. No public semantic regression; the skip flow (`unblock_exact` → next cycle's `try_advance`) stays contiguous because skip advances `applied` to the skipped txn, and the next advance targets `applied + 1`.

## Tests

- 8 new unit tests for watermark contiguity in `refresh.rs`:
  - contiguous advance accepted
  - gap / duplicate / stale-below rejected with `NonContiguous`
  - blocked state takes precedence over contiguity
  - skip flow preserves contiguity across admin-skip
  - mismatch leaves watermark untouched
  - `from_state` respects contiguity on next advance
- 2 new integration tests in `follower_tests.rs`:
  - `test_follower_refresh_is_noop_after_shutdown` — post-shutdown `refresh()` returns `CaughtUp { applied: 0 }`; watermark stable
  - `test_admin_skip_rejects_after_shutdown` — post-shutdown `admin_skip_blocked_record` returns `UnblockError::DatabaseClosed`
- All 952 existing `strata-engine` lib tests pass serially (pre-existing tmp-file-lock flake under parallel load is unrelated to this change)
- All 27 existing `follower_tests.rs` integration tests pass

## Test plan

- [x] `cargo test -p strata-engine --lib database::refresh::watermark_contiguity_tests` — 8/8 pass
- [x] `cargo test -p strata-engine --test follower_tests` — 27/27 pass (25 existing + 2 new)
- [x] `cargo test -p strata-engine --lib -- --test-threads=1` — 952/952 pass (no regressions)
- [x] `cargo clippy -p strata-engine --all-targets` — no new errors
- [x] `cargo fmt -p strata-engine --check` — clean
- [ ] YCSB smoke benchmark (cold path; pre-PR baseline captured as needed — will run on CI)

## Part of the T3 closeout plan

This is PR 1 of 5 for Tranche 3 closeout:
1. **T3-E9 (this PR)** — contract hardening
2. T3-E10 — lossy recovery telemetry + pinning
3. T3-E11 — follower open/refresh policy matrix docs
4. T3-E12 — WAL codec threading (the big one, closes DR-009)
5. T3-E8 — historical cleanup + architecture doc closeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)