### PR TITLE
T3-E10: lossy recovery telemetry + pinned contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ architecture scope documents. The current allowed surface:
 
 **Durability:** `WalWriterHealth`, `FollowerStatus`, `ContiguousWatermark`,
 `RefreshOutcome`, `BlockedTxn`, `BlockReason`, `DatabaseLayout`, `RefreshHookError`,
-`AdvanceError`, `UnblockError`, `LossyRecoveryReport`
+`AdvanceError`, `UnblockError`, `LossyRecoveryReport`, `LossyErrorKind`
 
 **Product:** `SystemBranchCapability` (`pub` type, `pub(crate)` constructor), `Provider`,
 `ControlRegistry`, `ControlEntry`, `ControlOwner`, `BehaviorClass`, `PersistenceClass`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ architecture scope documents. The current allowed surface:
 
 **Durability:** `WalWriterHealth`, `FollowerStatus`, `ContiguousWatermark`,
 `RefreshOutcome`, `BlockedTxn`, `BlockReason`, `DatabaseLayout`, `RefreshHookError`,
-`AdvanceError`, `UnblockError`
+`AdvanceError`, `UnblockError`, `LossyRecoveryReport`
 
 **Product:** `SystemBranchCapability` (`pub` type, `pub(crate)` constructor), `Provider`,
 `ControlRegistry`, `ControlEntry`, `ControlOwner`, `BehaviorClass`, `PersistenceClass`

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -231,6 +231,47 @@ pub struct DatabaseDiskUsage {
     pub snapshot_bytes: u64,
 }
 
+// ============================================================================
+// Lossy Recovery Report
+// ============================================================================
+
+/// Report surfaced when `allow_lossy_recovery` triggers a whole-database
+/// wipe-and-reopen fallback during [`Database::open`].
+///
+/// DR-011's acceptance contract requires lossy recovery to be an "explicit
+/// and narrow" escape hatch: opt-in via config, and surfaced in status /
+/// telemetry so operators can tell the difference between "this database
+/// opened empty" and "this database fell back to empty because recovery
+/// failed." This report is the observability surface that satisfies the
+/// second half of that contract.
+///
+/// Retrieve via [`Database::last_lossy_recovery_report`]. The report is
+/// `Some(_)` only when the most recent open triggered the lossy branch;
+/// successful strict opens leave it `None`.
+///
+/// Tracing target `strata::recovery::lossy` emits the same fields at
+/// `warn` level for push-style observability.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct LossyRecoveryReport {
+    /// Root error (rendered via `Display`) that triggered the lossy fallback.
+    pub error: String,
+    /// Count of WAL records the engine's `on_record` callback applied
+    /// successfully before the recovery coordinator returned `Err`. These
+    /// records were installed into storage and then discarded when lossy
+    /// mode wiped the segment directory.
+    pub records_applied_before_failure: u64,
+    /// Storage commit version reached before the wipe. `CommitVersion::ZERO`
+    /// when the error occurred before any record was applied (for example,
+    /// snapshot load or codec validation failure).
+    pub version_reached_before_failure: strata_core::id::CommitVersion,
+    /// Whether the lossy path discarded all pre-failure state. Always
+    /// `true` under the current "whole-DB wipe" contract; reserved as a
+    /// field so future narrower modes can set it to `false` without a
+    /// breaking change.
+    pub discarded_on_wipe: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LifecycleState {
     Uninitialized,
@@ -409,6 +450,12 @@ pub struct Database {
     /// `resume_wal_writer()` succeeds. Per-database, not process-global.
     /// Arc-wrapped to share with the flush thread (for halt behavior).
     wal_writer_health: Arc<ParkingMutex<WalWriterHealth>>,
+
+    /// Report populated by [`Database::open`] when the lossy recovery
+    /// fallback fired. `None` for strict (default) opens and for lossy
+    /// opens that did not need to fall back. Read via
+    /// [`Database::last_lossy_recovery_report`]. Per-database.
+    last_lossy_recovery_report: Arc<ParkingMutex<Option<LossyRecoveryReport>>>,
 
     /// Type-erased extension storage for primitive state
     ///
@@ -1197,6 +1244,21 @@ impl Database {
     /// ```
     pub fn wal_writer_health(&self) -> WalWriterHealth {
         self.wal_writer_health.lock().clone()
+    }
+
+    /// Returns the report from the most recent lossy-recovery fallback, if
+    /// the current open triggered one.
+    ///
+    /// `Some(LossyRecoveryReport)` when `allow_lossy_recovery = true` was set
+    /// AND recovery errored during this open, causing the engine to wipe the
+    /// segment directory and reopen empty. `None` on strict (default) opens
+    /// and on lossy opens that recovered cleanly.
+    ///
+    /// See [`LossyRecoveryReport`] for field semantics and DR-011 in
+    /// `docs/requirements/durability-recovery-requirements.md` for the
+    /// pinned lossy-recovery contract.
+    pub fn last_lossy_recovery_report(&self) -> Option<LossyRecoveryReport> {
+        self.last_lossy_recovery_report.lock().clone()
     }
 
     /// Attempt to resume a halted WAL writer.

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -235,6 +235,61 @@ pub struct DatabaseDiskUsage {
 // Lossy Recovery Report
 // ============================================================================
 
+/// Typed classification of the error that triggered a lossy-recovery
+/// fallback, alongside the human-readable `error` field on
+/// [`LossyRecoveryReport`]. Lets callers dispatch on failure category
+/// without string-matching — per CLAUDE.md Quality Rule §26 ("typed
+/// reason enums replace string-factory error methods").
+///
+/// The mapping is derived from the underlying [`StrataError`] variant
+/// via [`LossyErrorKind::from_strata_error`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LossyErrorKind {
+    /// The MANIFEST, snapshot, or codec validation detected a
+    /// corruption signal that the coordinator surfaced as
+    /// `StrataError::Corruption`. Typical triggers: codec mismatch
+    /// against the MANIFEST record, snapshot magic/CRC failure.
+    Corruption,
+    /// A lower-level storage or WAL read operation failed and the
+    /// coordinator surfaced `StrataError::Storage`. Typical triggers:
+    /// WAL segment garbage / header parse failure, partial record at
+    /// segment tail, storage-apply I/O error, disk full, permission
+    /// denied. Note: WAL-level "the bytes on disk look wrong" errors
+    /// currently classify here (not under `Corruption`) because
+    /// `RecoveryCoordinator` wraps WAL read failures with
+    /// `StrataError::storage(...)`.
+    Storage,
+    /// The coordinator returned an error whose variant does not map to
+    /// the categories above. The `error` string on the report remains
+    /// the canonical diagnostic.
+    Other,
+}
+
+impl LossyErrorKind {
+    /// Classify a [`StrataError`] for the `error_kind` field on
+    /// [`LossyRecoveryReport`]. Unrecognized variants return
+    /// [`LossyErrorKind::Other`] rather than panicking, so the enum
+    /// stays forward-compatible with new [`StrataError`] variants.
+    pub fn from_strata_error(err: &StrataError) -> Self {
+        match err {
+            StrataError::Corruption { .. } => LossyErrorKind::Corruption,
+            StrataError::Storage { .. } => LossyErrorKind::Storage,
+            _ => LossyErrorKind::Other,
+        }
+    }
+}
+
+impl std::fmt::Display for LossyErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LossyErrorKind::Corruption => write!(f, "corruption"),
+            LossyErrorKind::Storage => write!(f, "storage"),
+            LossyErrorKind::Other => write!(f, "other"),
+        }
+    }
+}
+
 /// Report surfaced when `allow_lossy_recovery` triggers a whole-database
 /// wipe-and-reopen fallback during [`Database::open`].
 ///
@@ -246,8 +301,10 @@ pub struct DatabaseDiskUsage {
 /// second half of that contract.
 ///
 /// Retrieve via [`Database::last_lossy_recovery_report`]. The report is
-/// `Some(_)` only when the most recent open triggered the lossy branch;
-/// successful strict opens leave it `None`.
+/// `Some(_)` when this `Database` handle's open hit a recovery error and
+/// lossy mode wiped pre-failure state; strict opens and successful lossy
+/// opens leave it `None`. Each open produces a fresh `Database`, so the
+/// report is per-handle — not a process-global log.
 ///
 /// Tracing target `strata::recovery::lossy` emits the same fields at
 /// `warn` level for push-style observability.
@@ -255,7 +312,12 @@ pub struct DatabaseDiskUsage {
 #[non_exhaustive]
 pub struct LossyRecoveryReport {
     /// Root error (rendered via `Display`) that triggered the lossy fallback.
+    /// Pair with [`Self::error_kind`] for programmatic dispatch.
     pub error: String,
+    /// Typed classification of the triggering error. Use this for
+    /// dashboard bucketing, alerting rules, and programmatic branches;
+    /// use [`Self::error`] for the human-readable detail.
+    pub error_kind: LossyErrorKind,
     /// Count of WAL records the engine's `on_record` callback applied
     /// successfully before the recovery coordinator returned `Err`. These
     /// records were installed into storage and then discarded when lossy

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -1009,6 +1009,7 @@ impl Database {
                         version_reached_before_failure =
                             report.version_reached_before_failure.as_u64(),
                         discarded_on_wipe = report.discarded_on_wipe,
+                        follower = false,
                         "Lossy recovery fallback — discarding pre-failure state"
                     );
                     warn!(

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -84,7 +84,7 @@ fn restrict_file(_path: &Path) {}
 
 use super::config::{self, StrataConfig};
 use super::registry::OPEN_DATABASES;
-use super::{Database, PersistenceMode, WalWriterHealth};
+use super::{Database, LossyRecoveryReport, PersistenceMode, WalWriterHealth};
 
 enum AcquiredDatabase {
     Existing(Arc<Database>),
@@ -483,9 +483,14 @@ impl Database {
         }
         let install_codec_for_follower = follower_codec.as_ref().map(|c| clone_codec(c.as_ref()));
 
+        // Count records applied before any coordinator error so the lossy
+        // branch below can surface how far recovery progressed.
+        let records_applied_before_failure = Arc::new(AtomicU64::new(0));
+
         let recover_result = {
             let storage_ref = &storage;
             let install_codec_ref = install_codec_for_follower.as_deref();
+            let counter = Arc::clone(&records_applied_before_failure);
             recovery.recover(
                 |snapshot| {
                     if let Some(install_codec) = install_codec_ref {
@@ -504,17 +509,42 @@ impl Database {
                     }
                     Ok(())
                 },
-                |record| apply_wal_record_to_memory_storage(storage_ref, record),
+                |record| {
+                    let result = apply_wal_record_to_memory_storage(storage_ref, record);
+                    if result.is_ok() {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                    }
+                    result
+                },
             )
         };
 
+        let mut lossy_report: Option<LossyRecoveryReport> = None;
         let mut stats = match recover_result {
             Ok(stats) => stats,
             Err(e) => {
                 if cfg.allow_lossy_recovery {
+                    let report = LossyRecoveryReport {
+                        error: e.to_string(),
+                        records_applied_before_failure: records_applied_before_failure
+                            .load(Ordering::SeqCst),
+                        version_reached_before_failure: CommitVersion(storage.version()),
+                        discarded_on_wipe: true,
+                    };
+                    warn!(
+                        target: "strata::recovery::lossy",
+                        error = %e,
+                        records_applied_before_failure = report.records_applied_before_failure,
+                        version_reached_before_failure =
+                            report.version_reached_before_failure.as_u64(),
+                        discarded_on_wipe = report.discarded_on_wipe,
+                        follower = true,
+                        "Lossy recovery fallback — discarding pre-failure state"
+                    );
                     warn!(target: "strata::db",
                         error = %e,
                         "Follower recovery failed — starting with empty state");
+                    lossy_report = Some(report);
                     storage = SegmentedStore::with_dir(
                         layout.segments_dir().to_path_buf(),
                         cfg.storage.effective_write_buffer_size(),
@@ -616,6 +646,7 @@ impl Database {
             durability_mode: parking_lot::RwLock::new(DurabilityMode::Cache), // Irrelevant for follower
             accepting_transactions: Arc::new(AtomicBool::new(true)),
             wal_writer_health: Arc::new(ParkingMutex::new(WalWriterHealth::Healthy)),
+            last_lossy_recovery_report: Arc::new(ParkingMutex::new(lossy_report)),
             extensions: DashMap::new(),
             config: parking_lot::RwLock::new(cfg),
             flush_shutdown: Arc::new(AtomicBool::new(false)),
@@ -921,9 +952,16 @@ impl Database {
                 .with_lossy_recovery(cfg.allow_lossy_recovery)
                 .with_codec(clone_codec(codec.as_ref()));
 
+        // Count records applied by `on_record` before a coordinator error so
+        // a subsequent lossy-fallback branch can surface how far recovery
+        // got. The coordinator drops its own stats on error; we track
+        // independently on the engine side.
+        let records_applied_before_failure = Arc::new(AtomicU64::new(0));
+
         let recover_result = {
             let storage_ref = &storage;
             let install_codec = recovery_codec_for_install.as_ref();
+            let counter = Arc::clone(&records_applied_before_failure);
             recovery.recover(
                 |snapshot| {
                     let installed = super::snapshot_install::install_snapshot(
@@ -940,19 +978,45 @@ impl Database {
                     );
                     Ok(())
                 },
-                |record| apply_wal_record_to_memory_storage(storage_ref, record),
+                |record| {
+                    let result = apply_wal_record_to_memory_storage(storage_ref, record);
+                    if result.is_ok() {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                    }
+                    result
+                },
             )
         };
 
+        let mut lossy_report: Option<LossyRecoveryReport> = None;
         let mut stats = match recover_result {
             Ok(stats) => stats,
             Err(e) => {
                 if cfg.allow_lossy_recovery {
+                    // Sample partial progress BEFORE the wipe so the
+                    // `LossyRecoveryReport` reflects what was discarded.
+                    let report = LossyRecoveryReport {
+                        error: e.to_string(),
+                        records_applied_before_failure: records_applied_before_failure
+                            .load(Ordering::SeqCst),
+                        version_reached_before_failure: CommitVersion(storage.version()),
+                        discarded_on_wipe: true,
+                    };
+                    warn!(
+                        target: "strata::recovery::lossy",
+                        error = %e,
+                        records_applied_before_failure = report.records_applied_before_failure,
+                        version_reached_before_failure =
+                            report.version_reached_before_failure.as_u64(),
+                        discarded_on_wipe = report.discarded_on_wipe,
+                        "Lossy recovery fallback — discarding pre-failure state"
+                    );
                     warn!(
                         target: "strata::db",
                         error = %e,
                         "Recovery failed — starting with empty state (allow_lossy_recovery=true)"
                     );
+                    lossy_report = Some(report);
                     // Discard any partial writes accumulated before the
                     // failure so lossy-mode semantics match the pre-Epic-5
                     // `RecoveryResult::empty()` fallback: no user data
@@ -1065,6 +1129,7 @@ impl Database {
             durability_mode: parking_lot::RwLock::new(durability_mode),
             accepting_transactions: Arc::clone(&accepting_transactions),
             wal_writer_health: Arc::clone(&wal_writer_health),
+            last_lossy_recovery_report: Arc::new(ParkingMutex::new(lossy_report)),
             extensions: DashMap::new(),
             config: parking_lot::RwLock::new(cfg),
             flush_shutdown: Arc::clone(&flush_shutdown),
@@ -1213,6 +1278,10 @@ impl Database {
             durability_mode: parking_lot::RwLock::new(DurabilityMode::Cache), // Irrelevant but set for consistency
             accepting_transactions: Arc::new(AtomicBool::new(true)),
             wal_writer_health: Arc::new(ParkingMutex::new(WalWriterHealth::Healthy)),
+            // Ephemeral/cache never performs WAL recovery, so lossy fallback
+            // cannot fire here — the slot stays `None` for the life of the
+            // instance.
+            last_lossy_recovery_report: Arc::new(ParkingMutex::new(None)),
             extensions: DashMap::new(),
             config: parking_lot::RwLock::new(cfg),
             flush_shutdown: Arc::new(AtomicBool::new(false)),

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -84,7 +84,7 @@ fn restrict_file(_path: &Path) {}
 
 use super::config::{self, StrataConfig};
 use super::registry::OPEN_DATABASES;
-use super::{Database, LossyRecoveryReport, PersistenceMode, WalWriterHealth};
+use super::{Database, LossyErrorKind, LossyRecoveryReport, PersistenceMode, WalWriterHealth};
 
 enum AcquiredDatabase {
     Existing(Arc<Database>),
@@ -526,6 +526,7 @@ impl Database {
                 if cfg.allow_lossy_recovery {
                     let report = LossyRecoveryReport {
                         error: e.to_string(),
+                        error_kind: LossyErrorKind::from_strata_error(&e),
                         records_applied_before_failure: records_applied_before_failure
                             .load(Ordering::SeqCst),
                         version_reached_before_failure: CommitVersion(storage.version()),
@@ -534,6 +535,7 @@ impl Database {
                     warn!(
                         target: "strata::recovery::lossy",
                         error = %e,
+                        error_kind = %report.error_kind,
                         records_applied_before_failure = report.records_applied_before_failure,
                         version_reached_before_failure =
                             report.version_reached_before_failure.as_u64(),
@@ -997,6 +999,7 @@ impl Database {
                     // `LossyRecoveryReport` reflects what was discarded.
                     let report = LossyRecoveryReport {
                         error: e.to_string(),
+                        error_kind: LossyErrorKind::from_strata_error(&e),
                         records_applied_before_failure: records_applied_before_failure
                             .load(Ordering::SeqCst),
                         version_reached_before_failure: CommitVersion(storage.version()),
@@ -1005,6 +1008,7 @@ impl Database {
                     warn!(
                         target: "strata::recovery::lossy",
                         error = %e,
+                        error_kind = %report.error_kind,
                         records_applied_before_failure = report.records_applied_before_failure,
                         version_reached_before_failure =
                             report.version_reached_before_failure.as_u64(),

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -464,6 +464,20 @@ fn test_lossy_recovery_discards_valid_data_before_corruption() {
         "storage version should have advanced past zero before the wipe, got {}",
         report.version_reached_before_failure.as_u64()
     );
+    // WAL-level corruption currently surfaces as `StrataError::Storage`
+    // (the coordinator wraps WAL read failures with
+    // `StrataError::storage(...)`), so `LossyErrorKind` classifies this
+    // scenario under `Storage`. Lock this in so a future refactor that
+    // regresses the mapping — or that reclassifies WAL corruption
+    // upstream — trips the test and forces a conscious doc/enum update.
+    use crate::LossyErrorKind;
+    assert_eq!(
+        report.error_kind,
+        LossyErrorKind::Storage,
+        "WAL read failure must classify as Storage per current upstream \
+         wrapping, got {:?}",
+        report.error_kind
+    );
 }
 
 #[test]
@@ -535,4 +549,35 @@ fn test_lossy_recovery_report_on_immediate_failure() {
     );
     assert!(report.discarded_on_wipe);
     assert!(!report.error.is_empty());
+    // See note in the sibling `_discards_valid_data_before_corruption` test:
+    // WAL-level garbage surfaces as `StrataError::Storage`.
+    use crate::LossyErrorKind;
+    assert_eq!(report.error_kind, LossyErrorKind::Storage);
+}
+
+#[test]
+fn test_lossy_error_kind_mapping_covers_relevant_variants() {
+    // Direct unit test of `LossyErrorKind::from_strata_error` — the
+    // integration tests above only exercise the Corruption path because
+    // real lossy failures come from WAL corruption. This test locks in
+    // the mapping for Storage and Other so a future refactor that
+    // regresses `from_strata_error` fails without needing a new failure
+    // fixture.
+    use crate::LossyErrorKind;
+    let corruption = StrataError::corruption("bad CRC".to_string());
+    assert_eq!(
+        LossyErrorKind::from_strata_error(&corruption),
+        LossyErrorKind::Corruption
+    );
+    let storage = StrataError::storage("disk full".to_string());
+    assert_eq!(
+        LossyErrorKind::from_strata_error(&storage),
+        LossyErrorKind::Storage
+    );
+    // Anything that isn't Corruption or Storage falls through to Other.
+    let internal = StrataError::internal("unexpected".to_string());
+    assert_eq!(
+        LossyErrorKind::from_strata_error(&internal),
+        LossyErrorKind::Other
+    );
 }

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -437,4 +437,102 @@ fn test_lossy_recovery_discards_valid_data_before_corruption() {
     );
     // Only system branch init transactions present (user data was discarded)
     assert!(db.storage().current_version() <= CommitVersion(3));
+
+    // T3-E10: lossy fallback must be observable. The report must carry the
+    // count of records applied before the coordinator errored and the
+    // storage version reached, so operators can distinguish "empty because
+    // lossy wipe" from "empty because genuinely empty".
+    let report = db
+        .last_lossy_recovery_report()
+        .expect("lossy fallback must populate LossyRecoveryReport");
+    assert!(
+        report.records_applied_before_failure >= 1,
+        "at least one valid record was applied before the corrupt segment; \
+         got records_applied_before_failure = {}",
+        report.records_applied_before_failure
+    );
+    assert!(
+        report.discarded_on_wipe,
+        "whole-database wipe is the current pinned contract"
+    );
+    assert!(
+        !report.error.is_empty(),
+        "report.error must render the coordinator error, got empty string"
+    );
+    assert!(
+        report.version_reached_before_failure > CommitVersion::ZERO,
+        "storage version should have advanced past zero before the wipe, got {}",
+        report.version_reached_before_failure.as_u64()
+    );
+}
+
+#[test]
+fn test_non_lossy_recovery_has_no_report() {
+    // A healthy, strict open leaves the lossy-report slot at `None`.
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    let wal_dir = db_path.join("wal");
+    std::fs::create_dir_all(&wal_dir).unwrap();
+    write_wal_txn(
+        &wal_dir,
+        1,
+        branch_id,
+        vec![(Key::new_kv(ns.clone(), "k"), Value::Bytes(b"v".to_vec()))],
+        vec![],
+        1,
+    );
+
+    let db = Database::open(&db_path).unwrap();
+    assert!(
+        db.last_lossy_recovery_report().is_none(),
+        "strict open must not populate a lossy-recovery report"
+    );
+
+    // Cache databases never perform recovery — also `None`.
+    let cache = Database::cache().unwrap();
+    assert!(cache.last_lossy_recovery_report().is_none());
+}
+
+#[test]
+fn test_lossy_recovery_report_on_immediate_failure() {
+    // When recovery errors before any record is applied, the report must
+    // still populate with zero counters — differentiating "lossy fired but
+    // nothing was in-flight" from "lossy did not fire".
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+
+    // Write a single corrupt segment with no preceding valid records. The
+    // coordinator will error on the first read attempt; `on_record` never
+    // fires, so records_applied_before_failure must be zero.
+    let wal_dir = db_path.join("wal");
+    std::fs::create_dir_all(&wal_dir).unwrap();
+    std::fs::write(
+        wal_dir.join("wal-000001.seg"),
+        b"GARBAGE_NOT_A_VALID_SEGMENT_HEADER",
+    )
+    .unwrap();
+
+    let cfg = StrataConfig {
+        allow_lossy_recovery: true,
+        ..StrataConfig::default()
+    };
+    let db = Database::open_with_config(&db_path, cfg).unwrap();
+
+    let report = db
+        .last_lossy_recovery_report()
+        .expect("lossy fallback must populate LossyRecoveryReport even on immediate failure");
+    assert_eq!(
+        report.records_applied_before_failure, 0,
+        "no records should have been applied before the immediate failure"
+    );
+    assert_eq!(
+        report.version_reached_before_failure,
+        CommitVersion::ZERO,
+        "storage version must stay at zero when no records applied"
+    );
+    assert!(report.discarded_on_wipe);
+    assert!(!report.error.is_empty());
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -43,9 +43,9 @@ pub use database::profile::{
     Profile,
 };
 pub use database::{
-    CacheMetrics, Database, DatabaseDiskUsage, HealthReport, LossyRecoveryReport, ModelConfig,
-    StorageConfig, StorageMetricsSummary, StrataConfig, SubsystemHealth, SubsystemStatus,
-    SystemMetrics, WalWriterHealth,
+    CacheMetrics, Database, DatabaseDiskUsage, HealthReport, LossyErrorKind, LossyRecoveryReport,
+    ModelConfig, StorageConfig, StorageMetricsSummary, StrataConfig, SubsystemHealth,
+    SubsystemStatus, SystemMetrics, WalWriterHealth,
 };
 pub use instrumentation::PerfTrace;
 pub use recovery::Subsystem;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -43,9 +43,9 @@ pub use database::profile::{
     Profile,
 };
 pub use database::{
-    CacheMetrics, Database, DatabaseDiskUsage, HealthReport, ModelConfig, StorageConfig,
-    StorageMetricsSummary, StrataConfig, SubsystemHealth, SubsystemStatus, SystemMetrics,
-    WalWriterHealth,
+    CacheMetrics, Database, DatabaseDiskUsage, HealthReport, LossyRecoveryReport, ModelConfig,
+    StorageConfig, StorageMetricsSummary, StrataConfig, SubsystemHealth, SubsystemStatus,
+    SystemMetrics, WalWriterHealth,
 };
 pub use instrumentation::PerfTrace;
 pub use recovery::Subsystem;

--- a/crates/engine/tests/follower_tests.rs
+++ b/crates/engine/tests/follower_tests.rs
@@ -1483,8 +1483,15 @@ fn test_follower_lossy_recovery_populates_report() {
         !report.error.is_empty(),
         "report.error must render the coordinator error"
     );
+    // The typed classification must be populated on the follower path just
+    // like the primary. WAL read failures surface as `StrataError::Storage`,
+    // which maps to `LossyErrorKind::Storage` (see the mod.rs doc on
+    // `LossyErrorKind::Storage` for why WAL-level corruption currently lands
+    // in this bucket).
+    use strata_engine::LossyErrorKind;
+    assert_eq!(report.error_kind, LossyErrorKind::Storage);
     // records_applied_before_failure may be 0 or positive depending on where
     // in the replay the corrupt segment lands; assert only on the invariants
     // the follower path shares with the primary (Some vs None; wipe flag; error
-    // non-empty). Exact counts are covered by the primary-path test.
+    // non-empty; typed kind). Exact counts are covered by the primary-path test.
 }

--- a/crates/engine/tests/follower_tests.rs
+++ b/crates/engine/tests/follower_tests.rs
@@ -1417,3 +1417,74 @@ fn test_admin_skip_rejects_after_shutdown() {
         "admin_skip on a non-blocked follower must not introduce a blocked_at state"
     );
 }
+
+/// T3-E10: a follower opening a corrupt WAL with `allow_lossy_recovery=true`
+/// falls back to an empty database and populates the same
+/// `LossyRecoveryReport` surface as the primary path.
+///
+/// Primary-path coverage lives in `crates/engine/src/database/tests/open.rs`.
+/// The follower lossy branch is a distinct code path in `open.rs` with its
+/// own `on_record` wrapper and lossy report construction; a regression that
+/// breaks one without the other would slip past the primary-only test.
+#[test]
+fn test_follower_lossy_recovery_populates_report() {
+    use strata_engine::StrataConfig;
+
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+
+    // Primary writes one valid record + flushes so the WAL has persisted
+    // data for the follower to discover.
+    {
+        let primary =
+            Database::open_runtime(OpenSpec::primary(dir.path()).with_subsystem(SearchSubsystem))
+                .unwrap();
+        primary_put(&primary, branch, "k1", "v1");
+        primary.flush().unwrap();
+        primary.shutdown().unwrap(); // release WAL lock + registry slot
+    }
+
+    // Append garbage to the WAL as a fresh segment so the reader fails
+    // mid-recovery. Using a new segment file avoids racing with any
+    // partial-tail truncation on the existing active segment.
+    let wal_dir = dir.path().join("wal");
+    let corrupt_segment = wal_dir.join("wal-000099.seg");
+    std::fs::write(&corrupt_segment, b"GARBAGE_NOT_A_VALID_SEGMENT_HEADER").unwrap();
+
+    // Strict follower open must refuse.
+    let strict =
+        Database::open_runtime(OpenSpec::follower(dir.path()).with_subsystem(SearchSubsystem));
+    assert!(
+        strict.is_err(),
+        "strict follower open must refuse a corrupt WAL, got {:?}",
+        strict.as_ref().map(|_| "Ok(Database)")
+    );
+
+    // Lossy follower open succeeds with an empty state + populated report.
+    let cfg = StrataConfig {
+        allow_lossy_recovery: true,
+        ..StrataConfig::default()
+    };
+    let follower = Database::open_runtime(
+        OpenSpec::follower(dir.path())
+            .with_subsystem(SearchSubsystem)
+            .with_config(cfg),
+    )
+    .expect("lossy follower open must succeed");
+
+    let report = follower
+        .last_lossy_recovery_report()
+        .expect("follower lossy fallback must populate LossyRecoveryReport");
+    assert!(
+        report.discarded_on_wipe,
+        "whole-database wipe is the pinned contract on the follower path too"
+    );
+    assert!(
+        !report.error.is_empty(),
+        "report.error must render the coordinator error"
+    );
+    // records_applied_before_failure may be 0 or positive depending on where
+    // in the replay the corrupt segment lands; assert only on the invariants
+    // the follower path shares with the primary (Some vs None; wipe flag; error
+    // non-empty). Exact counts are covered by the primary-path test.
+}

--- a/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
+++ b/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
@@ -52,7 +52,7 @@ The classification is load-bearing in three places:
 | `openai_api_key` | non-durability | no | — |
 | `google_api_key` | non-durability | no | — |
 | `storage` | (nested — see below) | — | — |
-| `allow_lossy_recovery` | open-time-only | yes (`CompatibilitySignature.allow_lossy_recovery`; also hashed into `open_config_fingerprint`) | rejected at runtime via `OPEN_TIME_ONLY_KEYS` |
+| `allow_lossy_recovery` | open-time-only | yes (`CompatibilitySignature.allow_lossy_recovery`; also hashed into `open_config_fingerprint`) | rejected at runtime via `OPEN_TIME_ONLY_KEYS`. When `true`, any recovery error triggers a whole-database wipe-and-reopen; the fallback is observable via `Database::last_lossy_recovery_report()` (`Option<LossyRecoveryReport>`) and tracing target `strata::recovery::lossy` (see DR-011 and D-DR-9 in `durability-recovery-scope.md`). |
 | `telemetry` | non-durability | no | — |
 | `default_vector_dtype` | non-durability | no | — |
 


### PR DESCRIPTION
## Summary

Closes DR-011 observability gap surfaced by the T3 closeout review: `allow_lossy_recovery=true` did a silent wipe-and-reopen on any recovery error, and callers had no way to tell whether their empty database was genuinely empty or the product of a lossy fallback.

Per the approved closeout plan, this PR **pins** the current "whole-database wipe" semantic and **makes it observable** — it does not narrow the lossy path (record-level skip would conflict with DR-012/DR-013 contiguity guarantees).

## What changed

- **`LossyRecoveryReport`** — new public type on `strata_engine`'s D4 surface carrying the triggering error, the count of records applied before the coordinator errored, the storage commit version reached, and a reserved `discarded_on_wipe` bool.
- **`Database::last_lossy_recovery_report()`** — `Option<LossyRecoveryReport>` accessor. `Some` only when the current open triggered the lossy wipe; `None` on strict opens and cache databases.
- **Partial-stats threading** — wrapped the engine's `on_record` closure in both primary and follower paths with an `Arc<AtomicU64>` counter so the report can surface pre-failure progress without touching the `RecoveryCoordinator` signature. `storage.version()` sampled before the wipe captures the commit-version replay reached.
- **Tracing target `strata::recovery::lossy`** — structured warn-level event with `error`, `records_applied_before_failure`, `version_reached_before_failure`, `discarded_on_wipe` fields; mirrors the pull accessor for push-based observability.
- **Docs**: DR-011 acceptance rewritten to state the pinned contract explicitly; D-DR-9 in `durability-recovery-scope.md` matches; config matrix `allow_lossy_recovery` row points at both observability surfaces; CLAUDE.md D4 durability list updated.

## Tests

- Augmented `test_lossy_recovery_discards_valid_data_before_corruption`: asserts `report.records_applied_before_failure >= 1`, `discarded_on_wipe == true`, `error` non-empty, `version_reached_before_failure > 0`.
- New `test_non_lossy_recovery_has_no_report`: strict open + cache open → report is `None`.
- New `test_lossy_recovery_report_on_immediate_failure`: induces error before any record is applied → report is `Some` with zero counters, `CommitVersion::ZERO` storage version.

## Test plan

- [x] `cargo test -p strata-engine --lib -- --test-threads=1` — 955/955 pass (952 pre-existing + 3 new)
- [x] `cargo clippy --workspace --all-targets` — no new errors
- [x] `cargo fmt --all --check` — clean

## Change class

**Additive.** New public type, new public accessor, new tracing target. No semantic change to existing strict or success paths; the lossy path already discarded state — this PR just makes the discard observable and pins the contract.

## Part of the T3 closeout plan

- PR 1 (T3-E9): contract hardening — merged #2422
- **PR 2 (this PR)**: lossy telemetry + pinned contract
- PR 3 (T3-E11): follower open/refresh policy matrix docs
- PR 4 (T3-E12): WAL codec threading (closes DR-009)
- PR 5 (T3-E8): historical cleanup + architecture doc closeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)