### PR TITLE
docs(t3): closeout addendum enumerating T3-E9..E12

### DIFF
--- a/docs/design/execution/tranche-3-durability.md
+++ b/docs/design/execution/tranche-3-durability.md
@@ -391,3 +391,167 @@ Every code-changing PR runs PR-grade YCSB + BEIR per the universal gate. The tab
 | E6 | redb + ycsb | Shutdown path + MANIFEST fsync |
 | E7 | redb + ycsb | Codec validation at open |
 | E8 | — | Doc-only, no benchmark needed |
+
+---
+
+## Closeout Addendum (review-driven)
+
+**Status:** in progress (2026-04-17)
+
+After the original 8 epics shipped (#2411–#2421), independent review against
+the 17 DR-### requirements in `docs/requirements/durability-recovery-requirements.md`
+found that per-epic mechanical acceptance tests had passed but **4 aggregate
+contract gaps remained**:
+
+- DR-009 codec uniformity — non-identity codec + WAL durability rejected at
+  open time despite the acceptance clause saying it must work "without
+  special-case rejection."
+- DR-011 lossy recovery — wipe-and-reopen on any recovery error with no
+  programmatic observability; failed the "surfaced in status/telemetry"
+  clause.
+- DR-012 `ContiguousWatermark` — `try_advance` used `fetch_max` with no
+  contiguity check; the documented structural invariant lived only in
+  refresh-loop discipline, not on the type.
+- DR-015 follower close-barrier residual — follower `refresh()` and
+  `admin_skip_blocked_record()` did not honor `shutdown_complete`.
+
+The epics below are the review-driven closeout track that lands the
+corresponding fixes. They are **not part of the original tranche plan**;
+they are numbered contiguously (E9 onwards) only so PR tracking stays
+simple. The original 8-epic plan is the normative record for the tranche's
+design intent; the closeout epics are post-hoc corrections to the shipped
+contract.
+
+### Epic T3-E9: Contract Hardening
+
+**Status:** shipped 2026-04-17 (PR #2422)
+**Findings closed:** DR-012 (contiguity on the type), DR-015 follower close residual
+**Change class:** additive
+**Assurance:** S3
+**Benchmark:** YCSB smoke (cold path)
+
+#### Tasks
+
+- [x] Make `ContiguousWatermark::try_advance` enforce `txn_id == applied + 1`; return new `AdvanceError::NonContiguous { expected, provided }` on any gap, duplicate, or stale id.
+- [x] Use `checked_add` on the increment so `applied == u64::MAX` returns `NonContiguous` rather than panicking in debug or wrapping in release.
+- [x] Verify the admin-skip flow (`unblock_exact` → next cycle's `try_advance`) still produces contiguous advances.
+- [x] Add `UnblockError::DatabaseClosed` variant for admin_skip on a shut-down follower.
+- [x] Add `shutdown_complete` guard to `Database::refresh()` — short-circuit to `RefreshOutcome::CaughtUp { applied: 0, applied_through: wm.applied() }` when the follower is closed (matches the non-follower / ephemeral branch).
+- [x] Add `shutdown_complete` guard to `Database::admin_skip_blocked_record()` — return `UnblockError::DatabaseClosed` before any watermark / audit mutation.
+
+#### Acceptance Criteria
+
+- [x] `try_advance(applied + 1)` succeeds; `try_advance(applied + 2)`, `try_advance(applied)`, `try_advance(stale)` all return `NonContiguous` with correct expected/provided
+- [x] Blocked state still takes precedence over contiguity
+- [x] Skip flow preserves contiguity after unblock_exact
+- [x] Follower `refresh()` post-`shutdown()` is a no-op; watermark stable
+- [x] Follower `admin_skip_blocked_record` post-`shutdown()` returns `UnblockError::DatabaseClosed`; state-invariance assertions pass
+- [x] `try_advance` at `u64::MAX` returns `NonContiguous`, not panic
+- [x] `cargo test -p strata-engine --lib -- --test-threads=1` — 952→955 passing
+
+### Epic T3-E10: Lossy Recovery Telemetry + Pinned Contract
+
+**Status:** shipped 2026-04-17 (PR #2423)
+**Findings closed:** DR-011 observability (partial — policy-matrix half is T3-E11)
+**Change class:** additive
+**Assurance:** S3
+**Benchmark:** none (cold open-time path)
+
+#### Tasks
+
+- [x] Add `LossyRecoveryReport` struct to the engine public surface with fields `error: String`, `error_kind: LossyErrorKind`, `records_applied_before_failure: u64`, `version_reached_before_failure: CommitVersion`, `discarded_on_wipe: bool`.
+- [x] Add `LossyErrorKind` enum (`Corruption`, `Storage`, `Other`) with a `from_strata_error(&StrataError)` mapper, per CLAUDE.md Quality Rule §26 (typed reason enums replace string-factory methods).
+- [x] Add field to `Database`: `last_lossy_recovery_report: Arc<ParkingMutex<Option<LossyRecoveryReport>>>`, initialized in all three constructors (primary, follower, cache).
+- [x] Add accessor `Database::last_lossy_recovery_report(&self) -> Option<LossyRecoveryReport>`.
+- [x] Wrap the engine's `on_record` closure in both primary and follower open paths with an `Arc<AtomicU64>` counter; capture `storage.version()` before the wipe.
+- [x] Add tracing target `strata::recovery::lossy` (warn-level, structured fields `error`, `error_kind`, `records_applied_before_failure`, `version_reached_before_failure`, `discarded_on_wipe`, `follower`).
+- [x] Export `LossyRecoveryReport` and `LossyErrorKind` from `crates/engine/src/lib.rs`; add both to the CLAUDE.md D4 durability surface list and to `durability-recovery-scope.md`.
+- [x] Rewrite DR-011 "Acceptance" in `docs/requirements/durability-recovery-requirements.md` to pin the "whole-database wipe-and-reopen" semantic and list the two observability surfaces.
+- [x] Update D-DR-9 in `durability-recovery-scope.md` to match.
+- [x] Update the `allow_lossy_recovery` row in `durability-recovery-config-matrix.md` with the observability pointer.
+
+#### Acceptance Criteria
+
+- [x] Existing `test_lossy_recovery_discards_valid_data_before_corruption` passes with new report assertions (records ≥ 1, discarded_on_wipe, non-empty error, version > 0, `error_kind == Storage`)
+- [x] New `test_non_lossy_recovery_has_no_report` — strict open + cache open both leave the slot `None`
+- [x] New `test_lossy_recovery_report_on_immediate_failure` — failure before any record applied produces a report with zero counters and `CommitVersion::ZERO`
+- [x] New `test_lossy_error_kind_mapping_covers_relevant_variants` — direct unit test covering `Corruption`, `Storage`, `Other` mapping
+- [x] New `test_follower_lossy_recovery_populates_report` — follower-path coverage; confirms typed `error_kind` populates on the follower branch too
+- [x] 955→956 engine lib tests pass; clippy + fmt clean
+
+### Epic T3-E11: Follower Open/Refresh Policy Matrix
+
+**Status:** pending
+**Findings closed:** DR-011 (the policy-matrix clause that T3-E10 deferred)
+**Change class:** doc-heavy + minimal code alignment
+**Assurance:** S2 (doc) + S3 (any code alignment)
+**Benchmark:** none
+
+#### Tasks
+
+- [ ] Document the mixed policy in `docs/design/architecture-cleanup/durability-recovery-scope.md` — a new subsection (under DR-3 or adjacent to D-DR-9) stating: follower open honors `allow_lossy_recovery` via whole-DB fallback; follower refresh is strict-only (blocks on failure; operator-gated via `admin_skip_blocked_record`). Include a rationale paragraph explaining why the mixed policy is deliberate (open is one-time and caller-authorized; refresh is live and operator-observable).
+- [ ] Mirror the policy matrix in `docs/architecture/durability-and-recovery.md` (lands with T3-E8 / PR 5).
+- [ ] Add an integration test `follower_lossy_open_and_strict_refresh_coexist` — opens a follower with `allow_lossy_recovery=true` against a corrupt WAL (verifies open falls back and report populates), then corrupts a later record and confirms `refresh()` returns `RefreshOutcome::Stuck`, not a silent skip.
+- [ ] No code change required: exploration confirmed `refresh()` at `crates/engine/src/database/lifecycle.rs:281` already ignores `allow_lossy_recovery`. The policy is implemented; only undocumented.
+
+#### Acceptance Criteria
+
+- [ ] Policy matrix section exists in `durability-recovery-scope.md` with the rationale paragraph
+- [ ] Integration test demonstrates lossy open + strict refresh coexist on the same follower instance
+- [ ] DR-011's "follower open and follower refresh use a consistent documented policy matrix" acceptance clause is now satisfied
+- [ ] `cargo test -p strata-engine --test follower_tests` — all tests green
+
+### Epic T3-E12: WAL Codec Threading
+
+**Status:** pending
+**Findings closed:** DR-009 codec uniformity
+**Change class:** intentional semantic change (new WAL envelope format) + cutover (WAL reader signature)
+**Assurance:** S4 (WAL read path correctness)
+**Benchmark:** **required** — full PR-grade YCSB + WAL latency + redb + open-time + BEIR smoke; characterization tests before refactor; differential test identity-codec vs before/after
+
+#### Tasks
+
+- [ ] Design: pick WAL record envelope format (`[u32 length][codec-encoded bytes]` after the post-encode step); decide clean-break vs dual-path for identity codec.
+- [ ] Bump `WAL_FORMAT_VERSION` in `crates/durability/src/format/wal_record.rs`.
+- [ ] Add codec decode to `crates/durability/src/wal/reader.rs` — `codec` field on `WalReader`, `with_codec(codec)` builder, decode step before `WalRecord::from_bytes`.
+- [ ] Add length-prefix write wrapper to `crates/durability/src/wal/writer.rs` (writer already calls `codec.encode_cow(...)` — add the envelope).
+- [ ] Wire codec through `RecoveryCoordinator::recover()` — construct `WalReader` with the coordinator's installed codec.
+- [ ] Delete the open-time rejection blocks at `crates/engine/src/database/open.rs:847-858` (primary) and `:1475-1485` (follower).
+- [ ] Add the deferred test `write_non_identity_codec_then_crash_then_reopen_then_read` in `crates/engine/src/database/tests/codec.rs`; remove the deferral comment at lines 12-17.
+- [ ] Update `durability-recovery-config-matrix.md` — remove the "target-state note" about WAL codec; update the codec row to note all durability modes support non-identity codecs.
+- [ ] Capture a pre-PR baseline via `cargo run --release -p strata-benchmarks --bin regression -- --capture-baseline` before code changes land; gate merge on `--tranche 3 --epic "T3-E12"` within thresholds.
+
+#### Acceptance Criteria
+
+- [ ] Identity codec round-trip: existing tests pass unchanged (regression guard)
+- [ ] Non-identity codec write → crash → reopen → read succeeds with the same data visible
+- [ ] Codec mismatch on reopen is still rejected (MANIFEST codec check preserved)
+- [ ] Large record stress: envelope handles multi-MB records without overflow
+- [ ] Partial-tail truncation still works with envelope (CRC + length boundary)
+- [ ] Codec decode error surfaces distinctly from corruption; does not trigger lossy wipe unless `allow_lossy_recovery`
+- [ ] WAL latency benchmark: ≤5% regression median, ≤10% tail
+- [ ] Redb 5M benchmark: ≤5% throughput regression
+- [ ] Open-time latency: ≤5% regression
+
+### Closeout Dependency Graph
+
+```
+T3-E9  (contract hardening)  ──┐
+T3-E10 (lossy telemetry)     ──┼─→ T3-E11 (follower policy matrix)
+                                │
+                                └─→ T3-E12 (WAL codec threading) ──→ T3-E8 (arch doc closeout)
+```
+
+- T3-E9 and T3-E10 are independent and shipped in parallel.
+- T3-E11 depends on T3-E10 (lossy observability surfaces referenced in the policy doc).
+- T3-E12 is the largest-scope closeout epic and the longest pole; independent of T3-E11.
+- T3-E8 (historical cleanup + architecture doc) lands last so the architecture doc reflects all closeout-era state. See the original Epic T3-E8 entry above.
+
+### Closeout Rollback
+
+| Epic | Reversible | Notes |
+|------|-----------|-------|
+| E9 | Yes | Additive new error variants + guards; reverting restores prior behavior without on-disk changes |
+| E10 | Yes | Additive new type + accessor + tracing target; reverting removes observability but no semantic regression |
+| E11 | Yes | Doc + additive test |
+| E12 | Partially | WAL format version bump — reverting leaves pre-PR databases readable, post-PR databases unreadable. Same playbook as DR-5 snapshot v2 (pre-release clean break acceptable) |

--- a/docs/design/implementation/tranche-3-durability.md
+++ b/docs/design/implementation/tranche-3-durability.md
@@ -857,3 +857,230 @@ From sibling scopes and post-cleanup backlog:
 - Quality cleanup: full error taxonomy, visibility tightening, unsafe documentation, file decomposition, and catalog-to-test mapping.
 - Forced transaction abort on shutdown timeout. T3 deliberately returns `ShutdownTimeout` and leaves retry/abort decisions to callers.
 - Further checkpoint-format optimization beyond the retention-complete fidelity introduced here. T3's concern is restart correctness, not later throughput or storage-efficiency tuning.
+
+---
+
+## Closeout Addendum (review-driven)
+
+**Status:** in progress (2026-04-17)
+
+After the original 8 epics shipped (#2411–#2421), independent review against
+`docs/requirements/durability-recovery-requirements.md` surfaced 4 aggregate
+contract gaps that per-epic tests had not caught. This addendum tracks the
+follow-on implementation work that closes those gaps. Epics below are
+numbered E9–E12 for contiguous PR tracking; they are **not part of the
+original tranche plan**. The 8-epic plan above is the normative record for
+this tranche's design intent.
+
+See the matching addendum in `docs/design/execution/tranche-3-durability.md`
+for tasks and acceptance criteria.
+
+### Epic 9: Contract Hardening
+
+**Status:** shipped 2026-04-17 (PR #2422)
+**Goal:** make the `ContiguousWatermark` type enforce the contiguity invariant it documents, and close the follower-side shutdown barrier so post-`shutdown()` calls to `refresh()` and `admin_skip_blocked_record()` can't mutate watermark / audit state through a stale handle.
+
+**Why:** Independent review found (a) `try_advance` used `fetch_max` without a contiguity check — the "never skips a record" invariant lived in refresh-loop discipline, not on the type, making it a future footgun; and (b) follower shutdown returned `Ok(())` after setting `shutdown_complete = true`, but the two mutating follower APIs did not consult that flag. Both are structural fixes, not behavior regressions.
+
+### Changes
+
+**1. Strict contiguity on `ContiguousWatermark::try_advance`** (~30 lines)
+
+- Load the current `applied`, require `txn_id == applied + 1` or return new variant `AdvanceError::NonContiguous { expected, provided }`.
+- Use `checked_add` so `applied == u64::MAX` returns `NonContiguous` rather than panicking in debug or wrapping in release.
+- CAS the advance so the semantic stays correct even if `RefreshGate`'s single-flight discipline is ever relaxed.
+
+**2. `UnblockError::DatabaseClosed` variant** (~10 lines additive)
+
+- New variant on the existing `#[non_exhaustive]` enum. Returned by `admin_skip_blocked_record` when called on a shut-down follower.
+
+**3. Follower close-barrier guards** (~15 lines)
+
+- `Database::refresh()`: short-circuit to `RefreshOutcome::CaughtUp { applied: 0, applied_through: watermark.applied() }` when `shutdown_complete.load(Acquire)`, matching the existing non-follower / ephemeral branch.
+- `Database::admin_skip_blocked_record()`: short-circuit to `UnblockError::DatabaseClosed` before any mutating work.
+
+### Verification
+
+- Unit tests (inline in `refresh.rs`): contiguous advance / gap / duplicate / stale / blocked-precedence / skip-flow-preserves-contiguity / `from_state` contiguity / overflow-at-u64-MAX. 9 tests total.
+- Integration tests (`follower_tests.rs`): post-shutdown refresh is no-op with stable watermark; post-shutdown admin_skip returns `DatabaseClosed` with state-invariance assertions.
+- All 952 pre-existing engine lib tests pass → 955 after new unit tests (the flake under parallel tmp-file-lock contention is pre-existing on main).
+- Clippy + fmt clean.
+
+### Effort: 1 day
+
+---
+
+## Epic 10: Lossy Recovery Telemetry and Pinned Contract
+
+**Status:** shipped 2026-04-17 (PR #2423)
+**Goal:** pin the current "whole-database wipe-and-reopen" lossy semantic explicitly and make the fallback observable via both a pull accessor and a push tracing target, so DR-011's "surfaced in status/telemetry" clause is satisfied without narrowing the semantic (narrower modes conflict with DR-012/DR-013).
+
+**Why:** Current code silently replaced pre-failure recovered state with an empty store on any recovery error when `allow_lossy_recovery = true`. Callers could not distinguish "database opened empty because genuinely empty" from "database fell back to empty because recovery failed after applying N records." DR-011's acceptance required the lossy path be "surfaced in status/telemetry"; a `warn!` log alone didn't satisfy it programmatically.
+
+### Changes
+
+**1. `LossyErrorKind` enum** (~40 lines)
+
+Typed classification for the triggering error, per CLAUDE.md Quality Rule §26 ("typed reason enums replace string-factory error methods"):
+
+```rust
+pub enum LossyErrorKind { Corruption, Storage, Other }
+
+impl LossyErrorKind {
+    pub fn from_strata_error(err: &StrataError) -> Self {
+        match err {
+            StrataError::Corruption { .. } => LossyErrorKind::Corruption,
+            StrataError::Storage { .. }    => LossyErrorKind::Storage,
+            _                              => LossyErrorKind::Other,
+        }
+    }
+}
+```
+
+Note: WAL-level "bytes on disk look wrong" errors currently classify as `Storage` because `RecoveryCoordinator` wraps WAL read failures with `StrataError::storage(...)`. Documented inline and in the enum rustdoc so a future upstream reclassification is a conscious, test-gated choice.
+
+**2. `LossyRecoveryReport` struct** (~25 lines)
+
+```rust
+#[non_exhaustive]
+pub struct LossyRecoveryReport {
+    pub error: String,
+    pub error_kind: LossyErrorKind,
+    pub records_applied_before_failure: u64,
+    pub version_reached_before_failure: CommitVersion,
+    pub discarded_on_wipe: bool,
+}
+```
+
+`#[non_exhaustive]` so later narrower modes can add fields without a breaking change.
+
+**3. `Database::last_lossy_recovery_report()` accessor** (~15 lines)
+
+Mirrors `wal_writer_health`: `Arc<ParkingMutex<Option<LossyRecoveryReport>>>` field, populated in the lossy branch before the wipe, read by cloning under the lock. `None` on strict opens and on lossy opens that did not need to fall back.
+
+**4. Stats threading in `open.rs`** (~60 lines)
+
+Wrap the engine's `on_record` closure in both primary and follower paths with an `Arc<AtomicU64>` counter (increments on successful `apply_wal_record_to_memory_storage` return). Sample `storage.version()` before the wipe. Construct the report; stash into the per-Database slot.
+
+**5. Tracing target `strata::recovery::lossy`** (~10 lines, two emissions)
+
+Warn-level structured event with fields `error`, `error_kind`, `records_applied_before_failure`, `version_reached_before_failure`, `discarded_on_wipe`, `follower`. Mirrors the pull accessor so push/pull observability stay in sync.
+
+**6. Doc updates** (~50 lines)
+
+- `docs/requirements/durability-recovery-requirements.md` DR-011 "Acceptance" rewritten to state the pinned wipe-and-reopen contract and list both observability surfaces.
+- `docs/design/architecture-cleanup/durability-recovery-scope.md` D-DR-9 mirrored.
+- `docs/design/architecture-cleanup/durability-recovery-config-matrix.md` `allow_lossy_recovery` row updated with the observability pointer.
+- `CLAUDE.md` D4 durability surface list updated with `LossyRecoveryReport` and `LossyErrorKind`.
+
+### Verification
+
+- Augmented `test_lossy_recovery_discards_valid_data_before_corruption` with assertions on `records_applied_before_failure >= 1`, `discarded_on_wipe`, non-empty error, version > 0, `error_kind == Storage`.
+- New `test_non_lossy_recovery_has_no_report`: strict + cache opens leave the slot `None`.
+- New `test_lossy_recovery_report_on_immediate_failure`: error before any record applied → zero counters, `CommitVersion::ZERO`.
+- New `test_lossy_error_kind_mapping_covers_relevant_variants`: direct unit test of `from_strata_error` for `Corruption`, `Storage`, `Other`.
+- New `test_follower_lossy_recovery_populates_report`: follower-path coverage with typed `error_kind == Storage` assertion.
+- 956 engine lib tests + 28 follower integration tests all green; clippy + fmt clean.
+
+### Effort: 1 day
+
+---
+
+## Epic 11: Follower Open/Refresh Policy Matrix
+
+**Status:** pending
+**Goal:** document the mixed lossy policy — follower open honors `allow_lossy_recovery` via whole-DB fallback, while follower refresh is strict-only — and add an integration test that pins the coexistence so DR-011's "consistent documented policy matrix" acceptance clause is satisfied.
+
+**Why:** Independent review found the shipped behavior is internally consistent but undocumented. The follower `refresh()` implementation already ignores `allow_lossy_recovery`; the follower open path honors it. No code change is needed to satisfy DR-011's matrix clause — only documentation and a regression-guard test.
+
+### Changes
+
+**1. Policy matrix subsection in `durability-recovery-scope.md`** (~40 lines)
+
+Add under DR-3 or adjacent to D-DR-9:
+
+| Phase            | Lossy-capable?                        | Mechanism                                                                           |
+|------------------|---------------------------------------|-------------------------------------------------------------------------------------|
+| follower open    | yes (via `allow_lossy_recovery`)      | whole-DB fallback: wipe + start empty; surface `LossyRecoveryReport`                |
+| follower refresh | no (always strict)                    | block on failure; operator-gated unblock via `admin_skip_blocked_record`            |
+
+Plus a rationale paragraph: open is a one-time caller-authorized recovery event; refresh is a continuous ingestion loop where silent record skipping would desynchronize followers without operator knowledge. Skipping at refresh time requires an explicit admin action with audit logging (see DR-012).
+
+**2. Architecture doc mirror** — lands with T3-E8 / PR 5 (closeout doc PR), not this PR.
+
+**3. Integration test `follower_lossy_open_and_strict_refresh_coexist`** (~30 lines)
+
+Opens a follower with `allow_lossy_recovery=true` against a corrupt WAL, verifies the strict path refuses and the lossy path falls back (populates report); then corrupts a later WAL record and calls `refresh()`, verifying it returns `RefreshOutcome::Stuck` (NOT a silent skip despite `allow_lossy_recovery=true`).
+
+**4. No code change required.** Exploration confirmed `refresh()` at `crates/engine/src/database/lifecycle.rs:281` already ignores `allow_lossy_recovery`. The policy is shipped; only undocumented.
+
+### Verification
+
+- Policy matrix section exists in `durability-recovery-scope.md` with rationale paragraph
+- Integration test green on first run (the policy is already the shipped behavior)
+- DR-011 matrix clause satisfied
+
+### Effort: 1 day
+
+---
+
+## Epic 12: WAL Codec Threading
+
+**Status:** pending
+**Goal:** thread the configured codec through the WAL reader so non-identity codec + WAL durability works end-to-end. Remove the open-time rejection at `open.rs:847-858` (primary) and `:1475-1485` (follower) that currently blocks the combination.
+
+**Why:** DR-009's acceptance clause says "a database configured with a non-identity durable codec can be written, restarted, and recovered without special-case rejection." The shipped code has exactly that special-case rejection. Closing this is the largest closeout epic and the longest pole.
+
+### Changes
+
+**1. WAL record envelope format** (~40 lines)
+
+- Bump `WAL_FORMAT_VERSION` in `crates/durability/src/format/wal_record.rs`.
+- New on-disk layout: each record body is `[u32 length][codec-encoded bytes]`. Length is the post-encode byte count. Identity codec has the same envelope (no dual path in the reader).
+- Pre-release clean break per the DR-5 snapshot v2 precedent — pre-PR databases cannot be read post-PR.
+
+**2. WAL reader codec plumbing** (~80 lines)
+
+- Add `codec: Box<dyn StorageCodec>` field to `WalReader` in `crates/durability/src/wal/reader.rs`.
+- Add `with_codec(codec)` builder (parallel to existing `with_lossy_recovery`).
+- Per-record read: read length prefix, read N bytes, call `self.codec.decode(bytes)`, then `WalRecord::from_bytes(decoded)`.
+- Codec decode errors surface as a distinct `WalReadError::CodecDecode { position, source }` so lossy recovery can classify them separately from corruption.
+
+**3. WAL writer length-prefix wrapper** (~30 lines)
+
+- The writer already calls `codec.encode_cow(...)` at `crates/durability/src/wal/writer.rs:289-318`. Add the length-prefix write around the encoded bytes. CRC is over the enveloped bytes.
+
+**4. Coordinator codec wire-through** (~20 lines)
+
+- `RecoveryCoordinator::recover()` constructs `WalReader::new()` around line 353; change to clone the coordinator's installed codec into the reader via `with_codec`.
+- The coordinator already has `codec: Option<Box<dyn StorageCodec>>`. Pass it; if `None`, default to identity.
+
+**5. Remove open-time rejection** (~10 lines deleted)
+
+- Delete the block at `crates/engine/src/database/open.rs:847-858` (primary).
+- Delete the block at `:1475-1485` (follower).
+- Verify the codec is installed into the `RecoveryCoordinator` via `with_codec(get_codec(&cfg.storage.codec))` on both paths.
+
+**6. Codec round-trip test** (~80 lines)
+
+- Remove the deferral comment at `crates/engine/src/database/tests/codec.rs:12-17`.
+- Add `write_non_identity_codec_then_crash_then_reopen_then_read`: create DB with `codec = "aes-gcm-256"`, write records, drop without shutdown (simulate crash), reopen with same codec + key, verify records round-trip.
+- Large-record stress test: multi-MB record round-trip through envelope.
+- Codec decode error test: reopen with wrong key surfaces distinctly from corruption.
+
+**7. Config matrix + docs** (~30 lines)
+
+- `docs/design/architecture-cleanup/durability-recovery-config-matrix.md`: remove "target-state note" about WAL codec; update codec row to note all durability modes supported.
+- `docs/requirements/durability-recovery-requirements.md` DR-009: no change needed — the acceptance is now met.
+
+### Verification
+
+- Identity codec round-trip: existing tests pass unchanged (regression)
+- Non-identity codec round-trip: new test passes
+- Codec mismatch on reopen: existing behavior preserved (MANIFEST codec check)
+- Large record stress: envelope handles multi-MB without overflow
+- Partial-tail truncation: still works with envelope boundary
+- Codec decode error surfaces distinctly from corruption; does not trigger lossy wipe unless `allow_lossy_recovery`
+- **Benchmarks (gated for merge):** WAL latency ≤5% regression median / ≤10% tail; redb 5M throughput ≤5% regression; open-time latency ≤5% regression. Baseline captured before implementation via `cargo run --release -p strata-benchmarks --bin regression -- --capture-baseline`.
+
+### Effort: 5 days


### PR DESCRIPTION
## Summary

After the original 8 epics of Tranche 3 shipped (#2411–#2421), independent review against the 17 DR-### requirements found 4 aggregate contract gaps that per-epic tests hadn't caught. The closeout PRs started landing (#2422 T3-E9 contract hardening, #2423 T3-E10 lossy telemetry) but only existed in an out-of-band plan file — the tranche execution and implementation docs still ended at T3-E8.

This PR adds a **Closeout Addendum** section to both docs framing E9–E12 as review-driven follow-on work, **explicitly not part of the original tranche plan**. The 8-epic plan remains the normative record for the tranche's design intent; the addendum is post-hoc corrections to the shipped contract, numbered contiguously only so PR tracking stays simple.

## What's enumerated

| Epic | Status | Gap closed | PR |
|------|--------|------------|-----|
| T3-E9  | shipped 2026-04-17 | DR-012 contiguity-on-the-type, DR-015 follower close residual | #2422 |
| T3-E10 | shipped 2026-04-17 | DR-011 observability clause | #2423 |
| T3-E11 | pending            | DR-011 policy-matrix clause                                   | —     |
| T3-E12 | pending            | DR-009 codec uniformity                                       | —     |

Each addendum epic carries tasks, acceptance criteria, change class, assurance class, and benchmark obligations in the same shape as the original 8 epics. Closeout dependency graph and rollback table included.

## Change class

Doc-only. No code changes; both tranche docs are already tracked (per T3-E5 follow-up #2417).

## Test plan

- [x] Both docs render as markdown (verified via local preview)
- [x] Cross-references to existing DR-### requirements and CLAUDE.md are accurate
- [x] Shipped-epic checklists match what actually landed in #2422 and #2423
- [ ] Final doc-truth regression test (part of T3-E8 / PR 5) will verify the architecture doc banner references these closeout epics once it lands

## Part of the T3 closeout series

- ✅ #2422 — T3-E9 contract hardening
- ✅ #2423 — T3-E10 lossy recovery telemetry + pinned contract
- **this PR** — docs-only prep so the tranche docs reflect E9–E12
- ⏭ T3-E11 — follower open/refresh policy matrix
- ⏭ T3-E12 — WAL codec threading (longest pole; full S4 benchmark gate)
- ⏭ T3-E8 — historical cleanup + architecture doc closeout (lands last)

🤖 Generated with [Claude Code](https://claude.com/claude-code)