### PR TITLE
T3-E12 Phase 2 (WIP): v3 envelope + codec-aware WAL reader

### DIFF
--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -22,7 +22,7 @@ use strata_core::{StrataError, StrataResult};
 use strata_durability::codec::{clone_codec, StorageCodec};
 use strata_durability::format::{snapshot_path, SegmentMeta, WalRecord, WalSegment};
 use strata_durability::layout::DatabaseLayout;
-use strata_durability::wal::WalReader;
+use strata_durability::wal::{WalReader, WalReaderError};
 use strata_durability::{LoadedSnapshot, ManifestManager, SnapshotReader};
 use strata_storage::SegmentedStore;
 use tracing::{info, warn};
@@ -354,13 +354,19 @@ impl RecoveryCoordinator {
         if self.allow_lossy_recovery {
             reader = reader.with_lossy_recovery();
         }
+        // T3-E12 §D3 Site 1: thread the coordinator's codec so
+        // codec-encoded payloads (AES-GCM etc.) decode correctly.
+        // Without a codec installed, the reader treats each payload as
+        // identity — the pre-T3-E12 behavior for non-encrypted databases.
+        if let Some(c) = self.codec.as_deref() {
+            reader = reader.with_codec(clone_codec(c));
+        }
         let records_iter = reader
             .iter_all(self.layout.wal_dir())
-            .map_err(|e| StrataError::storage(format!("WAL read failed: {}", e)))?;
+            .map_err(wal_read_error_to_strata_error)?;
 
         for record_result in records_iter {
-            let record = record_result
-                .map_err(|e| StrataError::storage(format!("WAL segment read failed: {}", e)))?;
+            let record = record_result.map_err(wal_read_error_to_strata_error)?;
 
             // Delta-WAL replay: records at or below the snapshot watermark
             // are already reflected in the installed snapshot. Skip them to
@@ -540,6 +546,25 @@ impl RecoveryCoordinator {
 /// engine open paths that drive the callback-driven [`RecoveryCoordinator::recover`]
 /// directly can reuse the exact same apply semantics in their `on_record`
 /// closure without duplicating the decode/apply ladder.
+/// Map a `WalReaderError` to the matching typed `StrataError` variant.
+///
+/// T3-E12 §D8: `CodecDecode` and `LegacyFormat` get typed pass-through
+/// so the engine's open path can `matches!(err, StrataError::LegacyFormat { .. })`
+/// to skip the lossy wipe (D6) and so
+/// `LossyErrorKind::from_strata_error` can classify codec-decode
+/// failures as `LossyErrorKind::CodecDecode` (D5). Everything else
+/// renders as `StrataError::storage`.
+fn wal_read_error_to_strata_error(err: WalReaderError) -> StrataError {
+    match err {
+        WalReaderError::CodecDecode { detail, .. } => StrataError::codec_decode(detail),
+        WalReaderError::LegacyFormat {
+            found_version,
+            hint,
+        } => StrataError::legacy_format(found_version, hint),
+        other => StrataError::storage(format!("WAL read failed: {}", other)),
+    }
+}
+
 pub fn apply_wal_record_to_memory_storage(
     storage: &SegmentedStore,
     record: &WalRecord,

--- a/crates/durability/src/compaction/wal_only.rs
+++ b/crates/durability/src/compaction/wal_only.rs
@@ -256,16 +256,14 @@ impl WalOnlyCompactor {
             )));
         }
 
-        let header = SegmentHeader::from_bytes_slice(&file_data).ok_or_else(|| {
-            CompactionError::internal(format!("Invalid segment {} header", segment_number))
-        })?;
-
-        if !header.is_valid() {
-            return Err(CompactionError::internal(format!(
-                "Segment {} has invalid magic",
-                segment_number
-            )));
-        }
+        let header =
+            SegmentHeader::from_bytes_slice(&file_data, Some(segment_number)).map_err(|e| {
+                CompactionError::internal(format!("Invalid segment {segment_number} header: {e}"))
+            })?;
+        // `from_bytes_slice` now enforces magic + segment-number match,
+        // so the earlier `is_valid` / segment-number re-check is folded
+        // into the typed-error path above.
+        debug_assert!(header.is_valid());
 
         // Determine actual header size based on format version
         let actual_header_size = if header.format_version >= 2 {

--- a/crates/durability/src/format/mod.rs
+++ b/crates/durability/src/format/mod.rs
@@ -26,8 +26,9 @@ pub use snapshot::{
     SNAPSHOT_MAGIC,
 };
 pub use wal_record::{
-    SegmentHeader, WalRecord, WalRecordError, WalSegment, SEGMENT_FORMAT_VERSION,
-    SEGMENT_HEADER_SIZE, SEGMENT_HEADER_SIZE_V2, SEGMENT_MAGIC, WAL_RECORD_FORMAT_VERSION,
+    SegmentHeader, SegmentHeaderError, WalRecord, WalRecordError, WalSegment, WalSegmentError,
+    MIN_SUPPORTED_SEGMENT_FORMAT_VERSION, SEGMENT_FORMAT_VERSION, SEGMENT_HEADER_SIZE,
+    SEGMENT_HEADER_SIZE_V2, SEGMENT_MAGIC, WAL_RECORD_FORMAT_VERSION,
 };
 pub use writeset::{Mutation, Writeset, WritesetError};
 

--- a/crates/durability/src/format/wal_record.rs
+++ b/crates/durability/src/format/wal_record.rs
@@ -30,6 +30,22 @@
 //! ```
 //!
 //! v1 records (FmtVer=1) lack the LenCRC field and are still readable.
+//!
+//! # Segment format versions
+//!
+//! * v1: original 32-byte header, no CRC. Read-only compatibility path
+//!       (pre-March 2026).
+//! * v2: 36-byte header with CRC32 over the first 32 bytes (March 2026,
+//!       commit 77e9f258 / issue #1577). Records within the segment
+//!       carry their own `LenCRC` for torn-write detection.
+//! * v3: adds a per-record outer envelope `[u32 outer_len][u32 outer_len_crc]`
+//!       wrapping the codec-encoded inner record (T3-E12 Phase 2, this
+//!       build). The envelope is required so codec-encoded payloads
+//!       (AES-GCM, etc.) have discoverable record boundaries — without
+//!       it the reader cannot find the start of the next record on an
+//!       encrypted WAL. Pre-v3 segments are rejected with
+//!       [`SegmentHeaderError::LegacyFormat`]; clean break, no dual-path
+//!       parsing.
 
 use crc32fast::Hasher;
 use std::fs::{File, OpenOptions};
@@ -40,8 +56,17 @@ use strata_core::id::TxnId;
 /// Magic bytes identifying a WAL segment file: "STRA"
 pub const SEGMENT_MAGIC: [u8; 4] = *b"STRA";
 
-/// Current segment format version (v2 adds header CRC)
-pub const SEGMENT_FORMAT_VERSION: u32 = 2;
+/// Current segment format version.
+///
+/// * v2 added the header CRC.
+/// * v3 adds the per-record outer envelope for codec-aware reads.
+pub const SEGMENT_FORMAT_VERSION: u32 = 3;
+
+/// Oldest segment format version this build can read. Segments with a
+/// `format_version` below this value are rejected with
+/// [`SegmentHeaderError::LegacyFormat`] — operators must wipe `wal/`
+/// and reopen.
+pub const MIN_SUPPORTED_SEGMENT_FORMAT_VERSION: u32 = 3;
 
 /// Size of v1 segment header in bytes (without CRC)
 pub const SEGMENT_HEADER_SIZE: usize = 32;
@@ -51,6 +76,94 @@ pub const SEGMENT_HEADER_SIZE_V2: usize = 36;
 
 /// Current WAL record format version (v2 adds length CRC — see issue #1577)
 pub const WAL_RECORD_FORMAT_VERSION: u8 = 2;
+
+/// Typed errors from [`SegmentHeader::from_bytes_slice`].
+///
+/// Segment-header parsing folds minimum-size, magic, version, and CRC
+/// checks into a single call so callers see a typed variant rather than
+/// the `io::Error` / `Option<Self>` collapse the pre-T3-E12 code used.
+/// `LegacyFormat` in particular is the load-bearing diagnostic the
+/// engine's open path routes to [`strata_core::StrataError::LegacyFormat`]
+/// — see the T3-E12 tracking doc §D6 / §D8.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SegmentHeaderError {
+    /// Fewer than `SEGMENT_HEADER_SIZE` bytes available. Typical cause:
+    /// truncated segment file (disk full mid-create).
+    #[error(
+        "segment file too small for header: have {got} bytes, need at least {minimum_required}"
+    )]
+    InsufficientData {
+        /// Bytes actually available.
+        got: usize,
+        /// Minimum header size required (`SEGMENT_HEADER_SIZE`).
+        minimum_required: usize,
+    },
+
+    /// Magic bytes do not match [`SEGMENT_MAGIC`]. Typical cause: file
+    /// is not a Strata WAL segment, or the leading bytes were corrupted.
+    #[error("invalid segment magic bytes")]
+    InvalidMagic,
+
+    /// Segment was written by an older build whose on-disk format this
+    /// build does not support. Operator action is required — the hint
+    /// names the remediation (filesystem only; no CLI tool promised).
+    #[error("legacy segment format: found version {found_version}. {hint}")]
+    LegacyFormat {
+        /// Format version read from disk.
+        found_version: u32,
+        /// Operator remediation hint.
+        hint: String,
+    },
+
+    /// Segment was written by a newer build; this build refuses to
+    /// guess at unfamiliar layouts.
+    #[error("segment format version {found_version} is newer than this build supports (max {max_supported}). Upgrade Strata to read this database.")]
+    FutureFormat {
+        /// Format version read from disk.
+        found_version: u32,
+        /// Highest format version this build understands.
+        max_supported: u32,
+    },
+
+    /// v2+ header CRC mismatch. Header bytes were corrupted in place
+    /// (bit flip, partial overwrite).
+    #[error("segment header CRC mismatch: expected {expected:#010x}, computed {computed:#010x}")]
+    CrcMismatch {
+        /// CRC read from disk.
+        expected: u32,
+        /// CRC recomputed over the header bytes.
+        computed: u32,
+    },
+
+    /// Segment header's `segment_number` disagrees with the file name
+    /// (`wal-NNNNNN.seg`). File was renamed or the header was swapped in.
+    #[error("segment number mismatch: expected {expected}, header reports {got}")]
+    SegmentNumberMismatch {
+        /// Segment number derived from the file name.
+        expected: u64,
+        /// Segment number recorded in the header body.
+        got: u64,
+    },
+}
+
+/// Typed errors from [`WalSegment::open_read`] / [`WalSegment::open_append`].
+///
+/// Separates genuine I/O failures (disk full, permission denied) from
+/// header-level failures (`Header(SegmentHeaderError::LegacyFormat)`,
+/// etc.) so the reader layer can propagate typed `WalReaderError`
+/// variants — T3-E12 §D8.
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum WalSegmentError {
+    /// Genuine filesystem-layer error (open failed, read failed, etc.).
+    #[error("WAL segment I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Header-level failure surfaced from [`SegmentHeader::from_bytes_slice`].
+    #[error("WAL segment header error: {0}")]
+    Header(#[from] SegmentHeaderError),
+}
 
 /// WAL segment header (32 bytes for v1, 36 bytes for v2).
 ///
@@ -116,69 +229,100 @@ impl SegmentHeader {
         bytes
     }
 
-    /// Deserialize header from a byte slice.
+    /// Deserialize and validate a segment header from a byte slice.
     ///
-    /// Accepts both v1 (32-byte) and v2 (36-byte) headers.
-    /// For v2, validates the CRC; for v1, CRC is set to 0.
-    pub fn from_bytes_slice(bytes: &[u8]) -> Option<Self> {
+    /// This method is the single validation point for header-level
+    /// failures: it folds the minimum-size, magic, version, CRC, and
+    /// segment-number-mismatch checks that pre-T3-E12 callers performed
+    /// ad-hoc with `io::Error` construction. Callers propagate the typed
+    /// [`SegmentHeaderError`] via `?` and never fall back to generic
+    /// `InvalidData` for header reasons (T3-E12 §D8).
+    ///
+    /// Segments with `format_version < MIN_SUPPORTED_SEGMENT_FORMAT_VERSION`
+    /// are rejected with [`SegmentHeaderError::LegacyFormat`] — the
+    /// hint names the manual filesystem remediation.
+    ///
+    /// `expected_segment_number`, when provided, enforces that the
+    /// header's recorded segment number matches the file name; pass
+    /// `None` when parsing a header slice without a corresponding file.
+    pub fn from_bytes_slice(
+        bytes: &[u8],
+        expected_segment_number: Option<u64>,
+    ) -> Result<Self, SegmentHeaderError> {
         if bytes.len() < SEGMENT_HEADER_SIZE {
-            return None;
+            return Err(SegmentHeaderError::InsufficientData {
+                got: bytes.len(),
+                minimum_required: SEGMENT_HEADER_SIZE,
+            });
         }
 
-        let magic: [u8; 4] = bytes[0..4].try_into().ok()?;
+        let magic: [u8; 4] = bytes[0..4].try_into().expect("4-byte slice fits [u8;4]");
         if magic != SEGMENT_MAGIC {
-            return None;
+            return Err(SegmentHeaderError::InvalidMagic);
         }
-        let format_version = u32::from_le_bytes(bytes[4..8].try_into().ok()?);
+
+        let format_version =
+            u32::from_le_bytes(bytes[4..8].try_into().expect("4-byte slice fits [u8;4]"));
         if format_version > SEGMENT_FORMAT_VERSION {
-            tracing::error!(
-                target: "strata::format",
-                format_version,
-                max_supported = SEGMENT_FORMAT_VERSION,
-                "WAL segment format version {} is newer than this build supports (max {}). \
-                 Upgrade Strata to read this database.",
-                format_version,
-                SEGMENT_FORMAT_VERSION,
-            );
-            return None;
+            return Err(SegmentHeaderError::FutureFormat {
+                found_version: format_version,
+                max_supported: SEGMENT_FORMAT_VERSION,
+            });
         }
-        let segment_number = u64::from_le_bytes(bytes[8..16].try_into().ok()?);
-        let database_uuid: [u8; 16] = bytes[16..32].try_into().ok()?;
+        if format_version < MIN_SUPPORTED_SEGMENT_FORMAT_VERSION {
+            return Err(SegmentHeaderError::LegacyFormat {
+                found_version: format_version,
+                hint: format!(
+                    "this build requires segment format version {required} \
+                     (T3-E12 added a per-record outer envelope for codec-aware reads). \
+                     Delete the `wal/` subdirectory and reopen with a fresh state.",
+                    required = MIN_SUPPORTED_SEGMENT_FORMAT_VERSION,
+                ),
+            });
+        }
 
-        let header_crc = if format_version >= 2 && bytes.len() >= SEGMENT_HEADER_SIZE_V2 {
-            let stored_crc = u32::from_le_bytes(bytes[32..36].try_into().ok()?);
-
-            // Verify CRC
-            let mut hasher = Hasher::new();
-            hasher.update(&bytes[0..SEGMENT_HEADER_SIZE]);
-            let computed_crc = hasher.finalize();
-            if stored_crc != computed_crc {
-                return None; // CRC mismatch — header corrupted
+        let segment_number =
+            u64::from_le_bytes(bytes[8..16].try_into().expect("8-byte slice fits [u8;8]"));
+        if let Some(expected) = expected_segment_number {
+            if segment_number != expected {
+                return Err(SegmentHeaderError::SegmentNumberMismatch {
+                    expected,
+                    got: segment_number,
+                });
             }
-            stored_crc
-        } else {
-            tracing::warn!(
-                target: "strata::format",
-                segment_number,
-                format_version,
-                "Reading v1 segment header without CRC — lacks integrity protection. \
-                 Will be replaced after next checkpoint + compaction cycle.",
-            );
-            0 // v1 header, no CRC
-        };
+        }
+        let database_uuid: [u8; 16] = bytes[16..32]
+            .try_into()
+            .expect("16-byte slice fits [u8;16]");
 
-        Some(SegmentHeader {
+        // v3+ segments always carry the CRC (v3 inherited the v2 CRC
+        // layout). Short reads would have been caught by the initial
+        // minimum-size check for a v2/v3 header length.
+        if bytes.len() < SEGMENT_HEADER_SIZE_V2 {
+            return Err(SegmentHeaderError::InsufficientData {
+                got: bytes.len(),
+                minimum_required: SEGMENT_HEADER_SIZE_V2,
+            });
+        }
+        let stored_crc =
+            u32::from_le_bytes(bytes[32..36].try_into().expect("4-byte slice fits [u8;4]"));
+        let mut hasher = Hasher::new();
+        hasher.update(&bytes[0..SEGMENT_HEADER_SIZE]);
+        let computed_crc = hasher.finalize();
+        if stored_crc != computed_crc {
+            return Err(SegmentHeaderError::CrcMismatch {
+                expected: stored_crc,
+                computed: computed_crc,
+            });
+        }
+
+        Ok(SegmentHeader {
             magic,
             format_version,
             segment_number,
             database_uuid,
-            header_crc,
+            header_crc: stored_crc,
         })
-    }
-
-    /// Deserialize header from a fixed-size v1 byte array (backward compat).
-    pub fn from_bytes(bytes: &[u8; SEGMENT_HEADER_SIZE]) -> Option<Self> {
-        Self::from_bytes_slice(bytes)
     }
 
     /// Validate the header has correct magic bytes.
@@ -269,67 +413,19 @@ impl WalSegment {
 
     /// Open an existing WAL segment for reading.
     ///
-    /// Validates the header and positions at the end for size calculation.
-    /// Handles both v1 (32-byte) and v2 (36-byte) headers.
-    pub fn open_read(dir: &Path, segment_number: u64) -> std::io::Result<Self> {
+    /// Validates the header through the typed [`SegmentHeader::from_bytes_slice`]
+    /// path — magic, version, CRC, and segment-number-matches-filename
+    /// checks all surface as [`SegmentHeaderError`] variants rather than
+    /// generic `io::Error::InvalidData` strings (T3-E12 §D8).
+    pub fn open_read(dir: &Path, segment_number: u64) -> Result<Self, WalSegmentError> {
         let path = Self::segment_path(dir, segment_number);
-
         let mut file = OpenOptions::new().read(true).open(&path)?;
 
-        // Try reading v2 header (36 bytes); fall back to v1 (32 bytes) if file is too small
-        let mut header_buf = [0u8; SEGMENT_HEADER_SIZE_V2];
-        let bytes_read = {
-            let mut total = 0;
-            loop {
-                match file.read(&mut header_buf[total..]) {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        total += n;
-                        if total >= SEGMENT_HEADER_SIZE_V2 {
-                            break;
-                        }
-                    }
-                    Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-                    Err(e) => return Err(e),
-                }
-            }
-            total
-        };
-
-        if bytes_read < SEGMENT_HEADER_SIZE {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Segment file too small for header",
-            ));
-        }
-
+        // Read the full v2/v3-size header. `from_bytes_slice` treats a
+        // short read as `SegmentHeaderError::InsufficientData`.
+        let (header_buf, bytes_read) = Self::read_header_bytes(&mut file)?;
         let header =
-            SegmentHeader::from_bytes_slice(&header_buf[..bytes_read]).ok_or_else(|| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid segment header")
-            })?;
-
-        if !header.is_valid() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Invalid segment magic bytes",
-            ));
-        }
-
-        if header.segment_number != segment_number {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "Segment number mismatch: expected {}, got {}",
-                    segment_number, header.segment_number
-                ),
-            ));
-        }
-
-        let actual_header_size = if header.format_version >= 2 {
-            SEGMENT_HEADER_SIZE_V2
-        } else {
-            SEGMENT_HEADER_SIZE
-        };
+            SegmentHeader::from_bytes_slice(&header_buf[..bytes_read], Some(segment_number))?;
 
         let write_position = file.seek(SeekFrom::End(0))?;
 
@@ -340,63 +436,46 @@ impl WalSegment {
             path,
             closed: true, // Opened for reading = treat as closed
             database_uuid: header.database_uuid,
-            header_size: actual_header_size,
+            header_size: SEGMENT_HEADER_SIZE_V2,
         })
+    }
+
+    /// Read exactly `SEGMENT_HEADER_SIZE_V2` bytes (or fewer if EOF) into
+    /// a fresh buffer. Retries on `Interrupted`. Shared between
+    /// `open_read` and `open_append`.
+    fn read_header_bytes(
+        file: &mut File,
+    ) -> std::io::Result<([u8; SEGMENT_HEADER_SIZE_V2], usize)> {
+        let mut header_buf = [0u8; SEGMENT_HEADER_SIZE_V2];
+        let mut total = 0;
+        loop {
+            match file.read(&mut header_buf[total..]) {
+                Ok(0) => break,
+                Ok(n) => {
+                    total += n;
+                    if total >= SEGMENT_HEADER_SIZE_V2 {
+                        break;
+                    }
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        Ok((header_buf, total))
     }
 
     /// Open an existing WAL segment for appending.
     ///
     /// Used when resuming writes to an existing active segment.
-    /// Handles both v1 (32-byte) and v2 (36-byte) headers.
-    pub fn open_append(dir: &Path, segment_number: u64) -> std::io::Result<Self> {
+    /// Shares the typed [`SegmentHeader::from_bytes_slice`] validation
+    /// path with [`WalSegment::open_read`].
+    pub fn open_append(dir: &Path, segment_number: u64) -> Result<Self, WalSegmentError> {
         let path = Self::segment_path(dir, segment_number);
-
         let mut file = OpenOptions::new().read(true).write(true).open(&path)?;
 
-        // Try reading v2 header (36 bytes); fall back to v1 (32 bytes) if file is too small
-        let mut header_buf = [0u8; SEGMENT_HEADER_SIZE_V2];
-        let bytes_read = {
-            let mut total = 0;
-            loop {
-                match file.read(&mut header_buf[total..]) {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        total += n;
-                        if total >= SEGMENT_HEADER_SIZE_V2 {
-                            break;
-                        }
-                    }
-                    Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-                    Err(e) => return Err(e),
-                }
-            }
-            total
-        };
-
-        if bytes_read < SEGMENT_HEADER_SIZE {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Segment file too small for header",
-            ));
-        }
-
+        let (header_buf, bytes_read) = Self::read_header_bytes(&mut file)?;
         let header =
-            SegmentHeader::from_bytes_slice(&header_buf[..bytes_read]).ok_or_else(|| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid segment header")
-            })?;
-
-        if !header.is_valid() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Invalid segment magic bytes",
-            ));
-        }
-
-        let actual_header_size = if header.format_version >= 2 {
-            SEGMENT_HEADER_SIZE_V2
-        } else {
-            SEGMENT_HEADER_SIZE
-        };
+            SegmentHeader::from_bytes_slice(&header_buf[..bytes_read], Some(segment_number))?;
 
         // Seek to end for appending
         let write_position = file.seek(SeekFrom::End(0))?;
@@ -408,7 +487,7 @@ impl WalSegment {
             path,
             closed: false,
             database_uuid: header.database_uuid,
-            header_size: actual_header_size,
+            header_size: SEGMENT_HEADER_SIZE_V2,
         })
     }
 
@@ -845,7 +924,7 @@ mod tests {
 
         let bytes = header.to_bytes();
         assert_eq!(bytes.len(), SEGMENT_HEADER_SIZE_V2);
-        let parsed = SegmentHeader::from_bytes_slice(&bytes).unwrap();
+        let parsed = SegmentHeader::from_bytes_slice(&bytes, Some(12345)).unwrap();
 
         assert_eq!(parsed.magic, SEGMENT_MAGIC);
         assert_eq!(parsed.format_version, SEGMENT_FORMAT_VERSION);
@@ -853,6 +932,46 @@ mod tests {
         assert_eq!(parsed.database_uuid, [0xAB; 16]);
         assert!(parsed.is_valid());
         assert_ne!(parsed.header_crc, 0);
+    }
+
+    #[test]
+    fn test_segment_header_rejects_pre_v3_as_legacy_format() {
+        // T3-E12 Phase 2: v2 (and older) segment headers must surface
+        // a typed `LegacyFormat` error, not silently parse. This is the
+        // discriminator the engine's open path uses to produce
+        // `StrataError::LegacyFormat` and skip the T3-E10 wipe.
+        let mut bytes = [0u8; SEGMENT_HEADER_SIZE_V2];
+        bytes[0..4].copy_from_slice(&SEGMENT_MAGIC);
+        bytes[4..8].copy_from_slice(&2u32.to_le_bytes()); // v2
+        bytes[8..16].copy_from_slice(&1u64.to_le_bytes());
+        bytes[16..32].copy_from_slice(&[0xAB; 16]);
+        let crc = {
+            let mut h = Hasher::new();
+            h.update(&bytes[0..SEGMENT_HEADER_SIZE]);
+            h.finalize()
+        };
+        bytes[32..36].copy_from_slice(&crc.to_le_bytes());
+
+        match SegmentHeader::from_bytes_slice(&bytes, Some(1)) {
+            Err(SegmentHeaderError::LegacyFormat {
+                found_version,
+                hint,
+            }) => {
+                assert_eq!(found_version, 2);
+                assert!(
+                    hint.contains(&format!(
+                        "requires segment format version {}",
+                        MIN_SUPPORTED_SEGMENT_FORMAT_VERSION
+                    )),
+                    "hint should name the required version, got: {hint}"
+                );
+                assert!(
+                    hint.contains("wal/"),
+                    "hint should name the wal/ directory for remediation, got: {hint}"
+                );
+            }
+            other => panic!("expected LegacyFormat, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1045,51 +1164,40 @@ mod tests {
     // D-10: V1/V2 segment header tests
     // ========================================================================
 
-    #[test]
-    fn test_v1_header_still_readable() {
-        // Construct a 32-byte v1 header manually (format_version=1, no CRC)
-        let mut bytes = [0u8; SEGMENT_HEADER_SIZE];
-        bytes[0..4].copy_from_slice(&SEGMENT_MAGIC);
-        bytes[4..8].copy_from_slice(&1u32.to_le_bytes()); // format_version = 1
-        bytes[8..16].copy_from_slice(&42u64.to_le_bytes()); // segment_number = 42
-        bytes[16..32].copy_from_slice(&[0xAB; 16]); // database_uuid
-
-        let header = SegmentHeader::from_bytes_slice(&bytes).unwrap();
-        assert!(header.is_valid());
-        assert_eq!(header.format_version, 1);
-        assert_eq!(header.segment_number, 42);
-        assert_eq!(header.database_uuid, [0xAB; 16]);
-        assert_eq!(header.header_crc, 0); // v1 has no CRC
-    }
+    // T3-E12 Phase 2: v1 and v2 segment headers are no longer readable.
+    // The `test_v1_header_still_readable` test was intentionally removed
+    // with the `SEGMENT_FORMAT_VERSION` 2→3 bump; its replacement
+    // (`test_segment_header_rejects_pre_v3_as_legacy_format` above)
+    // covers the new typed-rejection contract.
 
     #[test]
-    fn test_v2_header_rejects_bad_crc() {
-        // Create a valid v2 header, then corrupt the CRC
+    fn test_segment_header_rejects_bad_crc() {
+        // Create a valid (v3) header, then corrupt the CRC.
         let header = SegmentHeader::new(1, [0; 16]);
         let mut bytes = header.to_bytes();
-
-        // Corrupt the CRC bytes (last 4 bytes of the 36-byte header)
         bytes[32] ^= 0xFF;
 
-        let result = SegmentHeader::from_bytes_slice(&bytes);
-        assert!(result.is_none(), "Should reject v2 header with bad CRC");
+        assert!(matches!(
+            SegmentHeader::from_bytes_slice(&bytes, Some(1)),
+            Err(SegmentHeaderError::CrcMismatch { .. })
+        ));
     }
 
     #[test]
-    fn test_v2_header_rejects_corrupted_payload() {
-        // Create a valid v2 header, then corrupt a data byte (not the CRC)
+    fn test_segment_header_rejects_corrupted_payload() {
+        // Create a valid (v3) header, then corrupt a byte inside the
+        // `database_uuid` field (bytes 16..32). CRC recomputation
+        // mismatches the stored CRC. We deliberately avoid the
+        // `segment_number` bytes (8..16) so the earlier
+        // `SegmentNumberMismatch` check does not fire first.
         let header = SegmentHeader::new(42, [0xCC; 16]);
         let mut bytes = header.to_bytes();
+        bytes[20] ^= 0xFF;
 
-        // Corrupt a byte in the segment_number field
-        bytes[10] ^= 0xFF;
-
-        // CRC should now mismatch because the payload changed
-        let result = SegmentHeader::from_bytes_slice(&bytes);
-        assert!(
-            result.is_none(),
-            "Should reject v2 header with corrupted payload"
-        );
+        assert!(matches!(
+            SegmentHeader::from_bytes_slice(&bytes, Some(42)),
+            Err(SegmentHeaderError::CrcMismatch { .. })
+        ));
     }
 
     /// Issue #1711: WalSegment::create() must fsync the parent directory so the
@@ -1139,35 +1247,18 @@ mod tests {
         dir_fd.sync_all().unwrap();
     }
 
-    #[test]
-    fn test_v1_header_with_trailing_data_not_confused_as_v2() {
-        // 32-byte v1 header followed by 4 bytes of unrelated data.
-        // from_bytes_slice should parse it as v1 (format_version=1),
-        // not try to read a CRC from the trailing bytes.
-        let mut bytes = [0u8; 36];
-        bytes[0..4].copy_from_slice(&SEGMENT_MAGIC);
-        bytes[4..8].copy_from_slice(&1u32.to_le_bytes()); // format_version = 1
-        bytes[8..16].copy_from_slice(&7u64.to_le_bytes()); // segment_number = 7
-        bytes[16..32].copy_from_slice(&[0xBB; 16]); // database_uuid
-        bytes[32..36].copy_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]); // garbage trailing
-
-        let header = SegmentHeader::from_bytes_slice(&bytes).unwrap();
-        assert!(header.is_valid());
-        assert_eq!(header.format_version, 1);
-        assert_eq!(header.segment_number, 7);
-        // v1 path — trailing bytes ignored, CRC set to 0
-        assert_eq!(header.header_crc, 0);
-    }
+    // T3-E12 Phase 2: the v1-trailing-data test was deleted with the
+    // 2→3 bump — v1/v2 headers now surface `LegacyFormat`, not a
+    // successful parse.
 
     #[test]
     fn test_segment_header_rejects_future_version() {
-        // Build a header with format_version = 99 (far beyond current)
+        // Build a header with format_version = 99 (far beyond current).
         let mut bytes = [0u8; SEGMENT_HEADER_SIZE_V2];
         bytes[0..4].copy_from_slice(&SEGMENT_MAGIC);
-        bytes[4..8].copy_from_slice(&99u32.to_le_bytes()); // future version
-        bytes[8..16].copy_from_slice(&1u64.to_le_bytes()); // segment_number
-        bytes[16..32].copy_from_slice(&[0xAA; 16]); // database_uuid
-                                                    // CRC of first 32 bytes (would be valid if version were accepted)
+        bytes[4..8].copy_from_slice(&99u32.to_le_bytes());
+        bytes[8..16].copy_from_slice(&1u64.to_le_bytes());
+        bytes[16..32].copy_from_slice(&[0xAA; 16]);
         let crc = {
             let mut hasher = Hasher::new();
             hasher.update(&bytes[0..SEGMENT_HEADER_SIZE]);
@@ -1175,10 +1266,15 @@ mod tests {
         };
         bytes[32..36].copy_from_slice(&crc.to_le_bytes());
 
-        let result = SegmentHeader::from_bytes_slice(&bytes);
-        assert!(
-            result.is_none(),
-            "Expected None for future segment format version 99",
-        );
+        match SegmentHeader::from_bytes_slice(&bytes, Some(1)) {
+            Err(SegmentHeaderError::FutureFormat {
+                found_version,
+                max_supported,
+            }) => {
+                assert_eq!(found_version, 99);
+                assert_eq!(max_supported, SEGMENT_FORMAT_VERSION);
+            }
+            other => panic!("expected FutureFormat, got {other:?}"),
+        }
     }
 }

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -314,10 +314,18 @@ impl WalReader {
     }
 
     /// Scan forward within `buffer` looking for the next offset at which
-    /// a valid outer envelope header parses. Used by lossy recovery to
+    /// a valid outer envelope header parses AND whose codec-decoded
+    /// payload parses as a valid `WalRecord`. Used by lossy recovery to
     /// resume reading past a corrupted region. Returns the byte offset
     /// of the next readable envelope, or `None` if none is found within
     /// the scan window.
+    ///
+    /// Codec-awareness matters: on encrypted WAL (`aes-gcm-256`) the
+    /// payload bytes between the envelope header and the next envelope
+    /// are ciphertext. Without routing candidate payloads through
+    /// `decode_payload` first, the inner-record sanity check would
+    /// always fail on encrypted databases and lossy scan-forward would
+    /// never resume past corruption.
     fn scan_forward_for_envelope(&self, buffer: &[u8], scan_start: usize) -> Option<usize> {
         let scan_end = scan_start
             .saturating_add(MAX_RECOVERY_SCAN_WINDOW)
@@ -332,14 +340,20 @@ impl WalReader {
                     .and_then(|p| p.checked_add(outer_len as usize));
                 match payload_end {
                     Some(end) if end <= buffer.len() => {
-                        // Sanity-check: the claimed payload must parse
-                        // as a valid WalRecord. Without this, a random
-                        // 4-byte value could match its own CRC by luck
-                        // once in ~4 billion attempts and we would
-                        // resume at garbage.
                         let payload = &buffer[candidate + WAL_RECORD_ENVELOPE_OVERHEAD..end];
-                        if WalRecord::from_bytes(payload).is_ok() {
-                            return Some(candidate);
+                        // Decode through the installed codec first
+                        // (identity = pass-through). If decode fails,
+                        // this candidate cannot be the start of a valid
+                        // record — keep scanning.
+                        if let Ok(decoded) = self.decode_payload(payload, candidate as u64) {
+                            // Sanity-check: the decoded payload must
+                            // parse as a valid WalRecord. Without this,
+                            // a random 4-byte value could match its own
+                            // CRC by luck once in ~4 billion attempts
+                            // and we would resume at garbage.
+                            if WalRecord::from_bytes(&decoded).is_ok() {
+                                return Some(candidate);
+                            }
                         }
                     }
                     _ => continue,
@@ -722,9 +736,14 @@ impl WalReader {
     }
 
     /// Scan forward for the next byte offset at which a valid v3 outer
-    /// envelope parses AND whose payload parses as a valid `WalRecord`.
-    /// Returns the scan offset and the decoded record. Used by
-    /// follower-refresh lossy-scan paths.
+    /// envelope parses AND whose codec-decoded payload parses as a
+    /// valid `WalRecord`. Returns the scan offset and the decoded
+    /// record. Used by follower-refresh lossy-scan paths.
+    ///
+    /// Codec-awareness matters for the same reason as
+    /// [`scan_forward_for_envelope`]: encrypted WAL payloads must be
+    /// decoded before inner-record validation, otherwise follower
+    /// exact-skip resume would fail every lookup on encrypted DBs.
     fn scan_forward_to_valid_envelope(
         &self,
         buffer: &[u8],
@@ -741,8 +760,10 @@ impl WalReader {
                 if let Some(end) = payload_end {
                     if end <= buffer.len() {
                         let payload = &buffer[candidate + WAL_RECORD_ENVELOPE_OVERHEAD..end];
-                        if let Ok((record, _)) = WalRecord::from_bytes(payload) {
-                            return Some((candidate, record));
+                        if let Ok(decoded) = self.decode_payload(payload, candidate as u64) {
+                            if let Ok((record, _)) = WalRecord::from_bytes(&decoded) {
+                                return Some((candidate, record));
+                            }
                         }
                     }
                 }

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -2,10 +2,12 @@
 //!
 //! The reader handles reading WAL records from segments for recovery.
 
+use crate::codec::{clone_codec, StorageCodec};
 use crate::format::segment_meta::SegmentMeta;
 use crate::format::{WalRecord, WalRecordError, WalSegment};
 use crate::wal::writer::WAL_RECORD_ENVELOPE_OVERHEAD;
 use crc32fast::Hasher;
+use std::borrow::Cow;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use strata_core::id::TxnId;
@@ -45,9 +47,18 @@ fn read_outer_envelope(buf: &[u8]) -> Result<Option<u32>, (u32, u32)> {
 /// after the corrupted region) is fatal — `read_segment` returns an error.
 /// Use [`with_lossy_recovery`](WalReader::with_lossy_recovery) to opt in to
 /// the scan-ahead behavior that skips corrupted regions.
+///
+/// A codec may be installed via [`with_codec`](WalReader::with_codec).
+/// With no codec, each record's payload is passed through to
+/// `WalRecord::from_bytes` as-is (identity behavior). With a codec,
+/// the payload is decoded first; decode failures surface as
+/// `WalReaderError::CodecDecode` and are NEVER demoted to
+/// `PartialRecord` — the engine's lossy branch catches the typed
+/// error and routes to T3-E10 whole-DB wipe-and-reopen (§D5).
 #[derive(Default)]
 pub struct WalReader {
-    allow_lossy_recovery: bool,
+    pub(crate) allow_lossy_recovery: bool,
+    codec: Option<Box<dyn StorageCodec>>,
 }
 
 impl WalReader {
@@ -55,6 +66,47 @@ impl WalReader {
     pub fn new() -> Self {
         WalReader {
             allow_lossy_recovery: false,
+            codec: None,
+        }
+    }
+
+    /// Install a storage codec. Records read from segments will be
+    /// decoded via this codec before inner-record parsing. If no codec
+    /// is installed (`None`), payloads pass through as-is — equivalent
+    /// to the `IdentityCodec`.
+    ///
+    /// Codec decode failures surface as
+    /// [`WalReaderError::CodecDecode`] and NEVER demote to
+    /// `ReadStopReason::PartialRecord`. Lossy mode does not scan
+    /// forward past a codec decode failure (T3-E12 §D5) — the
+    /// operator's escape hatch is `allow_lossy_recovery=true` at open
+    /// time, which triggers the whole-DB wipe-and-reopen via T3-E10.
+    pub fn with_codec(mut self, codec: Box<dyn StorageCodec>) -> Self {
+        self.codec = Some(codec);
+        self
+    }
+
+    /// Decode one record payload through the installed codec, or pass
+    /// through unchanged if no codec is installed. Returns
+    /// `Err(WalReaderError::CodecDecode)` on decode failure, with the
+    /// caller's offset encoded in the error so operators can locate
+    /// the bad record.
+    fn decode_payload<'a>(
+        &self,
+        payload: &'a [u8],
+        offset_hint: u64,
+    ) -> Result<Cow<'a, [u8]>, WalReaderError> {
+        match self.codec.as_deref() {
+            None => Ok(Cow::Borrowed(payload)),
+            Some(codec) => {
+                codec
+                    .decode(payload)
+                    .map(Cow::Owned)
+                    .map_err(|err| WalReaderError::CodecDecode {
+                        offset: offset_hint,
+                        detail: err.to_string(),
+                    })
+            }
         }
     }
 
@@ -175,12 +227,15 @@ impl WalReader {
             };
             let payload = &buffer[payload_start..payload_end];
 
-            // Step 3: (T3-E12 Phase 2 part 2) payload is the codec-encoded
-            // inner record. With no codec installed, it is the raw
-            // `WalRecord::to_bytes()` output (identity pass-through).
-            // Phase 2 part 3 threads the real codec here and surfaces
-            // codec-decode failures as `WalReaderError::CodecDecode`.
-            let raw_record_bytes = payload;
+            // Step 3: decode via the installed codec (or pass through
+            // for identity). Codec errors surface as
+            // `WalReaderError::CodecDecode` with NO demotion to
+            // `PartialRecord` — even at the segment tail (T3-E12 §D5).
+            let decoded = match self.decode_payload(payload, offset as u64) {
+                Ok(d) => d,
+                Err(e) => return Err(e),
+            };
+            let raw_record_bytes: &[u8] = &decoded;
 
             match WalRecord::from_bytes(raw_record_bytes) {
                 Ok((record, _consumed)) => {
@@ -587,9 +642,14 @@ impl WalReader {
             };
             let payload = &buffer[payload_start..payload_end];
 
-            // Phase 2 part 2: identity-codec pass-through. Phase 3 threads
-            // the installed codec and surfaces decode failures typed.
-            match WalRecord::from_bytes(payload) {
+            // Decode via installed codec or pass through for identity.
+            // Codec decode failures surface unconditionally (T3-E12 §D5).
+            let decoded = match self.decode_payload(payload, offset as u64) {
+                Ok(d) => d,
+                Err(e) => return Err(e),
+            };
+
+            match WalRecord::from_bytes(&decoded) {
                 Ok((record, _consumed)) => {
                     offset = payload_end;
                     let txn_id = record.txn_id.as_u64();
@@ -846,6 +906,7 @@ impl WalReader {
             current_records: Vec::new(),
             current_record_idx: 0,
             allow_lossy_recovery: self.allow_lossy_recovery,
+            codec: self.codec.as_deref().map(clone_codec),
         })
     }
 }
@@ -862,6 +923,10 @@ pub struct WalRecordIterator {
     current_records: Vec<WalRecord>,
     current_record_idx: usize,
     allow_lossy_recovery: bool,
+    /// Codec installed on the parent `WalReader`; threaded into each
+    /// per-segment reader so codec-encoded payloads (AES-GCM, etc.)
+    /// decode correctly (T3-E12 §D3 Site 3).
+    codec: Option<Box<dyn StorageCodec>>,
 }
 
 impl Iterator for WalRecordIterator {
@@ -891,6 +956,9 @@ impl Iterator for WalRecordIterator {
 
             let mut reader = WalReader::new();
             reader.allow_lossy_recovery = self.allow_lossy_recovery;
+            if let Some(c) = self.codec.as_deref() {
+                reader = reader.with_codec(clone_codec(c));
+            }
             match reader.read_segment(&self.wal_dir, seg_num) {
                 Ok((records, _, _, _)) => {
                     self.current_records = records;

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -4,6 +4,8 @@
 
 use crate::format::segment_meta::SegmentMeta;
 use crate::format::{WalRecord, WalRecordError, WalSegment};
+use crate::wal::writer::WAL_RECORD_ENVELOPE_OVERHEAD;
+use crc32fast::Hasher;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use strata_core::id::TxnId;
@@ -12,6 +14,28 @@ use tracing::warn;
 /// Maximum number of bytes to scan forward when searching for the next
 /// valid record after encountering corruption during WAL recovery.
 const MAX_RECOVERY_SCAN_WINDOW: usize = 8 * 1_024 * 1_024; // 8 MB
+
+/// Parse the per-record outer envelope (T3-E12 v3):
+/// `[u32 outer_len][u32 outer_len_crc]`. Returns `Ok(Some((outer_len,
+/// bytes_consumed)))` if the envelope header parsed and the length CRC
+/// matched, `Ok(None)` if there are too few bytes to read the header
+/// (caller treats as `PartialRecord` tail), and `Err(stored_crc,
+/// computed_crc)` on CRC mismatch (caller decides strict/lossy).
+fn read_outer_envelope(buf: &[u8]) -> Result<Option<u32>, (u32, u32)> {
+    if buf.len() < WAL_RECORD_ENVELOPE_OVERHEAD {
+        return Ok(None);
+    }
+    let outer_len_bytes: [u8; 4] = buf[0..4].try_into().expect("4-byte slice");
+    let outer_len = u32::from_le_bytes(outer_len_bytes);
+    let stored_crc = u32::from_le_bytes(buf[4..8].try_into().expect("4-byte slice"));
+    let mut h = Hasher::new();
+    h.update(&outer_len_bytes);
+    let computed_crc = h.finalize();
+    if stored_crc != computed_crc {
+        return Err((stored_crc, computed_crc));
+    }
+    Ok(Some(outer_len))
+}
 
 /// WAL reader for iterating over records in segments.
 ///
@@ -59,6 +83,22 @@ impl WalReader {
     }
 
     /// Read records from an already-opened segment.
+    ///
+    /// # v3 parse taxonomy (T3-E12 §D4)
+    ///
+    /// Each record on disk is wrapped in `[u32 outer_len][u32 outer_len_crc][encoded payload]`.
+    /// The parse loop handles the envelope + payload in two steps:
+    ///
+    /// 1. Read 8-byte outer envelope. Short read → `PartialRecord`
+    ///    (genuine crash tail, truncate). CRC mismatch on the length
+    ///    field → `CorruptedSegment` (strict) or scan-forward (lossy).
+    /// 2. Read `outer_len` payload bytes. Short read → `PartialRecord`.
+    ///    Phase 3 will decode via the installed `StorageCodec` here
+    ///    (codec-decode failures return `Err(CodecDecode)`, NEVER
+    ///    demote to `PartialRecord`). For the identity-codec slot
+    ///    this is a pass-through.
+    /// 3. Feed the decoded bytes to `WalRecord::from_bytes` — existing
+    ///    inner-record parsing (LenCRC + payload CRC) runs unchanged.
     pub fn read_segment_from(
         &self,
         segment: &mut WalSegment,
@@ -84,21 +124,94 @@ impl WalReader {
         let mut skipped_corrupted = 0usize;
 
         while offset < buffer.len() {
-            // Try to decode through codec first
-            // For identity codec, this is just the raw bytes
-            let remaining = &buffer[offset..];
+            // Step 1: parse the outer envelope header.
+            let outer_len = match read_outer_envelope(&buffer[offset..]) {
+                Ok(Some(len)) => len,
+                Ok(None) => {
+                    // Short read of envelope header → genuine crash tail.
+                    stop_reason = ReadStopReason::PartialRecord;
+                    break;
+                }
+                Err(_crc_mismatch) => {
+                    // outer_len CRC mismatch is the same class as the
+                    // inner `LengthChecksumMismatch`: strict fails,
+                    // lossy scans forward byte-by-byte.
+                    if !self.allow_lossy_recovery {
+                        return Err(WalReaderError::CorruptedSegment {
+                            offset,
+                            records_before: records.len(),
+                        });
+                    }
+                    match self.scan_forward_for_envelope(&buffer, offset) {
+                        Some(new_offset) => {
+                            tracing::warn!(
+                                target: "strata::recovery",
+                                corrupted_offset = offset,
+                                resumed_offset = new_offset,
+                                skipped_bytes = new_offset - offset,
+                                "Skipped corrupted WAL region, found next valid envelope"
+                            );
+                            offset = new_offset;
+                            skipped_corrupted += 1;
+                            continue;
+                        }
+                        None => {
+                            stop_reason = ReadStopReason::ChecksumMismatch { offset };
+                            break;
+                        }
+                    }
+                }
+            };
 
-            // Try to parse a record
-            match WalRecord::from_bytes(remaining) {
-                Ok((record, consumed)) => {
+            // Step 2: read the outer_len payload bytes.
+            let payload_start = offset + WAL_RECORD_ENVELOPE_OVERHEAD;
+            let payload_end = match payload_start.checked_add(outer_len as usize) {
+                Some(end) if end <= buffer.len() => end,
+                _ => {
+                    // Short read on payload → crash tail.
+                    stop_reason = ReadStopReason::PartialRecord;
+                    break;
+                }
+            };
+            let payload = &buffer[payload_start..payload_end];
+
+            // Step 3: (T3-E12 Phase 2 part 2) payload is the codec-encoded
+            // inner record. With no codec installed, it is the raw
+            // `WalRecord::to_bytes()` output (identity pass-through).
+            // Phase 2 part 3 threads the real codec here and surfaces
+            // codec-decode failures as `WalReaderError::CodecDecode`.
+            let raw_record_bytes = payload;
+
+            match WalRecord::from_bytes(raw_record_bytes) {
+                Ok((record, _consumed)) => {
                     records.push(record);
-                    offset += consumed;
+                    offset = payload_end;
                     valid_end = hdr_size + offset as u64;
                 }
                 Err(WalRecordError::InsufficientData) => {
-                    // Partial record at end - this is expected for crash recovery
-                    stop_reason = ReadStopReason::PartialRecord;
-                    break;
+                    // Inner-record short read. This is anomalous — the
+                    // outer_len said N bytes follow, so if we couldn't
+                    // parse a full record in N bytes either the writer
+                    // wrote a malformed record or the payload is
+                    // corrupted. Treat as corruption, not partial tail,
+                    // so mid-segment writes don't get silently dropped.
+                    if !self.allow_lossy_recovery {
+                        return Err(WalReaderError::CorruptedSegment {
+                            offset,
+                            records_before: records.len(),
+                        });
+                    }
+                    match self.scan_forward_for_envelope(&buffer, offset + 1) {
+                        Some(new_offset) => {
+                            offset = new_offset;
+                            skipped_corrupted += 1;
+                            continue;
+                        }
+                        None => {
+                            stop_reason = ReadStopReason::ChecksumMismatch { offset };
+                            break;
+                        }
+                    }
                 }
                 Err(
                     WalRecordError::ChecksumMismatch { .. }
@@ -106,58 +219,33 @@ impl WalReader {
                     | WalRecordError::UnsupportedVersion(_),
                 ) => {
                     if !self.allow_lossy_recovery {
-                        // Strict mode (default): mid-segment corruption is fatal.
                         return Err(WalReaderError::CorruptedSegment {
                             offset,
                             records_before: records.len(),
                         });
                     }
-
-                    // Lossy recovery: scan forward byte-by-byte to find
-                    // the next valid record instead of trusting the corrupted length
-                    // field (which is itself part of the corrupted data).
-                    let scan_start = offset + 1;
-                    let scan_end = (offset + MAX_RECOVERY_SCAN_WINDOW).min(buffer.len());
-                    let mut found = false;
-
-                    for scan_offset in scan_start..scan_end {
-                        if WalRecord::from_bytes(&buffer[scan_offset..]).is_ok() {
+                    match self.scan_forward_for_envelope(&buffer, offset + 1) {
+                        Some(new_offset) => {
                             tracing::warn!(
                                 target: "strata::recovery",
                                 corrupted_offset = offset,
-                                resumed_offset = scan_offset,
-                                skipped_bytes = scan_offset - offset,
-                                "Skipped corrupted WAL region, found valid record"
+                                resumed_offset = new_offset,
+                                skipped_bytes = new_offset - offset,
+                                "Skipped corrupted WAL record, found next valid envelope"
                             );
-                            offset = scan_offset;
+                            offset = new_offset;
                             skipped_corrupted += 1;
-                            found = true;
+                            continue;
+                        }
+                        None => {
+                            stop_reason = ReadStopReason::ChecksumMismatch { offset };
                             break;
                         }
                     }
-
-                    if found {
-                        continue;
-                    }
-
-                    // No valid record found within scan window — stop
-                    let unscanned_bytes = buffer.len() - scan_end;
-                    if unscanned_bytes > 0 {
-                        tracing::warn!(
-                            target: "strata::recovery",
-                            corrupted_offset = offset,
-                            scan_window_bytes = MAX_RECOVERY_SCAN_WINDOW,
-                            unscanned_bytes,
-                            "Corruption scan window exhausted — unscanned data will be lost",
-                        );
-                    }
-                    stop_reason = ReadStopReason::ChecksumMismatch { offset };
-                    break;
                 }
                 Err(e) => {
-                    // CRC was valid but payload couldn't be parsed.
-                    // This indicates codec mismatch or format version incompatibility,
-                    // NOT data corruption.
+                    // CRC passed (outer + inner length) but payload didn't
+                    // parse — codec/version mismatch or bug.
                     stop_reason = ReadStopReason::ParseError {
                         offset,
                         detail: e.to_string(),
@@ -168,6 +256,42 @@ impl WalReader {
         }
 
         Ok((records, valid_end, stop_reason, skipped_corrupted))
+    }
+
+    /// Scan forward within `buffer` looking for the next offset at which
+    /// a valid outer envelope header parses. Used by lossy recovery to
+    /// resume reading past a corrupted region. Returns the byte offset
+    /// of the next readable envelope, or `None` if none is found within
+    /// the scan window.
+    fn scan_forward_for_envelope(&self, buffer: &[u8], scan_start: usize) -> Option<usize> {
+        let scan_end = scan_start
+            .saturating_add(MAX_RECOVERY_SCAN_WINDOW)
+            .min(buffer.len());
+        for candidate in scan_start..scan_end.saturating_sub(WAL_RECORD_ENVELOPE_OVERHEAD - 1) {
+            if let Ok(Some(outer_len)) = read_outer_envelope(&buffer[candidate..]) {
+                // Additionally require that the claimed payload actually
+                // fits — rejects lucky CRC matches on garbage that would
+                // have been truncated.
+                let payload_end = candidate
+                    .checked_add(WAL_RECORD_ENVELOPE_OVERHEAD)
+                    .and_then(|p| p.checked_add(outer_len as usize));
+                match payload_end {
+                    Some(end) if end <= buffer.len() => {
+                        // Sanity-check: the claimed payload must parse
+                        // as a valid WalRecord. Without this, a random
+                        // 4-byte value could match its own CRC by luck
+                        // once in ~4 billion attempts and we would
+                        // resume at garbage.
+                        let payload = &buffer[candidate + WAL_RECORD_ENVELOPE_OVERHEAD..end];
+                        if WalRecord::from_bytes(payload).is_ok() {
+                            return Some(candidate);
+                        }
+                    }
+                    _ => continue,
+                }
+            }
+        }
+        None
     }
 
     /// Read all records from all segments in a WAL directory.
@@ -417,9 +541,57 @@ impl WalReader {
         let mut next_expected = next_expected;
 
         while offset < buffer.len() {
-            match WalRecord::from_bytes(&buffer[offset..]) {
-                Ok((record, consumed)) => {
-                    offset += consumed;
+            // Parse the per-record outer envelope (T3-E12 v3) before
+            // delegating to the inner `WalRecord::from_bytes`.
+            let outer_len = match read_outer_envelope(&buffer[offset..]) {
+                Ok(Some(len)) => len,
+                Ok(None) => break, // envelope header short-read = crash tail
+                Err(_crc_mismatch) => {
+                    if let Some((scan_offset, next_record)) =
+                        self.scan_forward_to_valid_envelope(&buffer, offset + 1)
+                    {
+                        let candidate_txn = next_record.txn_id.as_u64();
+                        if candidate_txn < next_expected || candidate_txn == next_expected {
+                            offset = scan_offset;
+                            continue;
+                        }
+                        return Ok(WatermarkReadResult {
+                            records,
+                            blocked: Some(WatermarkBlockedRecord {
+                                txn_id: TxnId(next_expected),
+                                detail: format!(
+                                    "outer envelope CRC mismatch at offset {offset}; next readable txn is {next}",
+                                    next = next_record.txn_id,
+                                ),
+                                skip_allowed: true,
+                                stop_reason: ReadStopReason::ChecksumMismatch { offset },
+                            }),
+                        });
+                    }
+                    return Ok(WatermarkReadResult {
+                        records,
+                        blocked: Some(WatermarkBlockedRecord {
+                            txn_id: TxnId(next_expected),
+                            detail: format!("outer envelope CRC mismatch at offset {offset}"),
+                            skip_allowed: false,
+                            stop_reason: ReadStopReason::ChecksumMismatch { offset },
+                        }),
+                    });
+                }
+            };
+
+            let payload_start = offset + WAL_RECORD_ENVELOPE_OVERHEAD;
+            let payload_end = match payload_start.checked_add(outer_len as usize) {
+                Some(end) if end <= buffer.len() => end,
+                _ => break, // payload short-read = crash tail
+            };
+            let payload = &buffer[payload_start..payload_end];
+
+            // Phase 2 part 2: identity-codec pass-through. Phase 3 threads
+            // the installed codec and surfaces decode failures typed.
+            match WalRecord::from_bytes(payload) {
+                Ok((record, _consumed)) => {
+                    offset = payload_end;
                     let txn_id = record.txn_id.as_u64();
                     if txn_id < next_expected {
                         continue;
@@ -446,17 +618,12 @@ impl WalReader {
                         }),
                     });
                 }
-                Err(WalRecordError::InsufficientData) => break,
                 Err(err) => {
                     if let Some((scan_offset, next_record)) =
-                        self.scan_forward_to_valid_record(&buffer, offset + 1)
+                        self.scan_forward_to_valid_envelope(&buffer, offset + 1)
                     {
                         let candidate_txn = next_record.txn_id.as_u64();
-                        if candidate_txn < next_expected {
-                            offset = scan_offset;
-                            continue;
-                        }
-                        if candidate_txn == next_expected {
+                        if candidate_txn < next_expected || candidate_txn == next_expected {
                             offset = scan_offset;
                             continue;
                         }
@@ -466,8 +633,8 @@ impl WalReader {
                             blocked: Some(WatermarkBlockedRecord {
                                 txn_id: TxnId(next_expected),
                                 detail: format!(
-                                    "{}; next readable txn is {}",
-                                    err, next_record.txn_id
+                                    "{err}; next readable txn is {next}",
+                                    next = next_record.txn_id
                                 ),
                                 skip_allowed: true,
                                 stop_reason: Self::stop_reason_for_record_error(offset, &err),
@@ -494,15 +661,31 @@ impl WalReader {
         })
     }
 
-    fn scan_forward_to_valid_record(
+    /// Scan forward for the next byte offset at which a valid v3 outer
+    /// envelope parses AND whose payload parses as a valid `WalRecord`.
+    /// Returns the scan offset and the decoded record. Used by
+    /// follower-refresh lossy-scan paths.
+    fn scan_forward_to_valid_envelope(
         &self,
         buffer: &[u8],
         scan_start: usize,
     ) -> Option<(usize, WalRecord)> {
-        let scan_end = (scan_start + MAX_RECOVERY_SCAN_WINDOW).min(buffer.len());
-        for scan_offset in scan_start..scan_end {
-            if let Ok((record, _)) = WalRecord::from_bytes(&buffer[scan_offset..]) {
-                return Some((scan_offset, record));
+        let scan_end = scan_start
+            .saturating_add(MAX_RECOVERY_SCAN_WINDOW)
+            .min(buffer.len());
+        for candidate in scan_start..scan_end.saturating_sub(WAL_RECORD_ENVELOPE_OVERHEAD - 1) {
+            if let Ok(Some(outer_len)) = read_outer_envelope(&buffer[candidate..]) {
+                let payload_end = candidate
+                    .checked_add(WAL_RECORD_ENVELOPE_OVERHEAD)
+                    .and_then(|p| p.checked_add(outer_len as usize));
+                if let Some(end) = payload_end {
+                    if end <= buffer.len() {
+                        let payload = &buffer[candidate + WAL_RECORD_ENVELOPE_OVERHEAD..end];
+                        if let Ok((record, _)) = WalRecord::from_bytes(payload) {
+                            return Some((candidate, record));
+                        }
+                    }
+                }
             }
         }
         None
@@ -1124,7 +1307,7 @@ mod tests {
             let mut meta = SegmentMeta::new_empty(seg_num);
             for (&txn_id, &ts) in txn_ids.iter().zip(timestamps.iter()) {
                 let record = WalRecord::new(TxnId(txn_id), [1u8; 16], ts, vec![txn_id as u8; 10]);
-                segment.write(&record.to_bytes()).unwrap();
+                write_enveloped_record(&mut segment, &record.to_bytes());
                 meta.track_record(TxnId(txn_id), ts);
             }
             segment.close().unwrap();
@@ -1422,6 +1605,24 @@ mod tests {
     /// Segment 1 (closed): txn_ids 1-2, timestamps 1000-2000
     /// Segment 2 (closed): txn_ids 3-4, timestamps 3000-4000
     /// Segment 3 (active): txn_ids 5-6, timestamps 5000-6000, NO .meta
+    /// Manually emit the T3-E12 v3 outer envelope followed by a raw
+    /// record payload. Used by tests that bypass `WalWriter::append`
+    /// to construct specific on-disk layouts (corruption fixtures,
+    /// watermark scenarios). Mirrors the envelope logic in
+    /// `WalWriter::append_inner`.
+    fn write_enveloped_record(segment: &mut WalSegment, record_bytes: &[u8]) {
+        let outer_len = u32::try_from(record_bytes.len()).unwrap();
+        let outer_len_bytes = outer_len.to_le_bytes();
+        let outer_len_crc = {
+            let mut h = Hasher::new();
+            h.update(&outer_len_bytes);
+            h.finalize()
+        };
+        segment.write(&outer_len_bytes).unwrap();
+        segment.write(&outer_len_crc.to_le_bytes()).unwrap();
+        segment.write(record_bytes).unwrap();
+    }
+
     fn create_segments_with_active(wal_dir: &Path) {
         std::fs::create_dir_all(wal_dir).unwrap();
 
@@ -1434,7 +1635,7 @@ mod tests {
             let mut meta = SegmentMeta::new_empty(seg_num);
             for (&txn_id, &ts) in txn_ids.iter().zip(timestamps.iter()) {
                 let record = WalRecord::new(TxnId(txn_id), [1u8; 16], ts, vec![txn_id as u8; 10]);
-                segment.write(&record.to_bytes()).unwrap();
+                write_enveloped_record(&mut segment, &record.to_bytes());
                 meta.track_record(TxnId(txn_id), ts);
             }
             segment.close().unwrap();
@@ -1445,7 +1646,7 @@ mod tests {
         let mut segment = WalSegment::create(wal_dir, 3, [1u8; 16]).unwrap();
         for (&txn_id, &ts) in [5u64, 6].iter().zip([5000u64, 6000].iter()) {
             let record = WalRecord::new(TxnId(txn_id), [1u8; 16], ts, vec![txn_id as u8; 10]);
-            segment.write(&record.to_bytes()).unwrap();
+            write_enveloped_record(&mut segment, &record.to_bytes());
         }
         // Deliberately NOT closing or writing .meta — this is the active segment
     }
@@ -1844,19 +2045,27 @@ mod tests {
             .collect();
         write_records(&wal_dir, &records);
 
-        // Serialize records to find byte offsets for corruption
+        // Serialize records to find byte offsets for corruption. On-disk
+        // layout (v3+): each record is preceded by an 8-byte outer
+        // envelope `[u32 outer_len][u32 outer_len_crc]`, so record N
+        // starts at `sum(record_bytes[0..N].len()) + N * ENVELOPE`.
         let record_bytes: Vec<Vec<u8>> = records.iter().map(|r| r.to_bytes()).collect();
-        let offset_of_record_3: usize = record_bytes[0].len() + record_bytes[1].len();
+        let offset_of_record_3: usize =
+            record_bytes[0].len() + record_bytes[1].len() + 2 * WAL_RECORD_ENVELOPE_OVERHEAD; // two envelopes before record 3
 
-        // Read the segment file, corrupt record 3's payload (not the length
-        // header) so that the length field is still valid but CRC fails.
+        // Read the segment file, corrupt record 3's inner payload so the
+        // outer envelope still parses (valid outer_len + outer_len_crc)
+        // but the inner CRC fails. That tests the mid-segment corruption
+        // path after the envelope has been validated.
         let segment_path = WalSegment::segment_path(&wal_dir, 1);
         let mut seg_data = std::fs::read(&segment_path).unwrap();
-        let hdr_size = 36; // v2 segment header
-        let corrupt_start = hdr_size + offset_of_record_3;
-        // Corrupt payload bytes (skip 4-byte length prefix, flip payload bytes)
-        let payload_start = corrupt_start + 4;
-        let payload_end = corrupt_start + record_bytes[2].len() - 4; // before CRC
+        let hdr_size = 36; // v2/v3 segment header size (unchanged in v3).
+        let envelope_start = hdr_size + offset_of_record_3;
+        let inner_record_start = envelope_start + WAL_RECORD_ENVELOPE_OVERHEAD;
+        // Corrupt payload bytes (skip 4-byte inner length prefix, flip
+        // payload bytes). Inner-record CRC fails, outer envelope is fine.
+        let payload_start = inner_record_start + 4;
+        let payload_end = inner_record_start + record_bytes[2].len() - 4; // before inner CRC
         for byte in seg_data[payload_start..payload_end].iter_mut() {
             *byte ^= 0xFF;
         }
@@ -2039,18 +2248,29 @@ mod tests {
             .collect();
         write_records(&wal_dir, &records);
 
-        // Compute byte offsets to find record 3's position
+        // Compute byte offsets to find record 3's inner length field.
+        // On-disk layout (v3+): each record has an 8-byte outer
+        // envelope in front. Torn-write test target is the INNER
+        // record's length field (4 bytes into the inner record), which
+        // lives 2*ENVELOPE + sum(record_bytes[0..2]) + ENVELOPE bytes
+        // past the segment header.
         let record_bytes: Vec<Vec<u8>> = records.iter().map(|r| r.to_bytes()).collect();
-        let offset_of_record_3: usize = record_bytes[0].len() + record_bytes[1].len();
+        let offset_of_record_3_envelope: usize =
+            record_bytes[0].len() + record_bytes[1].len() + 2 * WAL_RECORD_ENVELOPE_OVERHEAD;
 
-        // Corrupt record 3's LENGTH field to a huge value (simulating a torn write)
         let segment_path = WalSegment::segment_path(&wal_dir, 1);
         let mut seg_data = std::fs::read(&segment_path).unwrap();
-        let hdr_size = 36; // v2 segment header
-        let length_offset = hdr_size + offset_of_record_3;
+        let hdr_size = 36; // v2/v3 segment header size.
+        let inner_length_offset =
+            hdr_size + offset_of_record_3_envelope + WAL_RECORD_ENVELOPE_OVERHEAD;
 
-        // Overwrite the 4-byte length prefix with 0x7FFFFFFF (2GB — way past EOF)
-        seg_data[length_offset..length_offset + 4].copy_from_slice(&0x7FFF_FFFFu32.to_le_bytes());
+        // Overwrite the 4-byte INNER length prefix with 0x7FFFFFFF
+        // (2GB — way past EOF). Outer envelope still parses cleanly,
+        // so the reader enters inner-record parsing and hits the torn
+        // length. With v2 LenCRC, the reader detects the lie and the
+        // lossy scan-forward recovers records 4-6.
+        seg_data[inner_length_offset..inner_length_offset + 4]
+            .copy_from_slice(&0x7FFF_FFFFu32.to_le_bytes());
         std::fs::write(&segment_path, &seg_data).unwrap();
 
         // Lossy reader must detect the bad length and scan forward to records 4-6.

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -53,8 +53,7 @@ impl WalReader {
         wal_dir: &Path,
         segment_number: u64,
     ) -> Result<(Vec<WalRecord>, u64, ReadStopReason, usize), WalReaderError> {
-        let mut segment = WalSegment::open_read(wal_dir, segment_number)
-            .map_err(|e: std::io::Error| WalReaderError::IoError(e.to_string()))?;
+        let mut segment = WalSegment::open_read(wal_dir, segment_number)?;
 
         self.read_segment_from(&mut segment)
     }
@@ -193,8 +192,7 @@ impl WalReader {
 
             // Check if this segment needs truncation (only the last one can)
             if idx == segments.len() - 1 {
-                let segment = WalSegment::open_read(wal_dir, *segment_num)
-                    .map_err(|e: std::io::Error| WalReaderError::IoError(e.to_string()))?;
+                let segment = WalSegment::open_read(wal_dir, *segment_num)?;
 
                 if valid_end < segment.size() {
                     truncate_info = Some(TruncateInfo {
@@ -402,8 +400,7 @@ impl WalReader {
         segment_number: u64,
         next_expected: u64,
     ) -> Result<WatermarkReadResult, WalReaderError> {
-        let mut segment = WalSegment::open_read(wal_dir, segment_number)
-            .map_err(|e: std::io::Error| WalReaderError::IoError(e.to_string()))?;
+        let mut segment = WalSegment::open_read(wal_dir, segment_number)?;
         let mut buffer = Vec::new();
         let hdr_size = segment.header_size() as u64;
 
@@ -881,14 +878,12 @@ pub enum WalReaderError {
     /// Legacy WAL segment format — rejected hard, even under lossy
     /// recovery.
     ///
-    /// **Staging note (T3-E12 Phase 1):** variant declared here;
-    /// Phase 2's segment-header reader is the first producer. When a
-    /// segment's `SEGMENT_FORMAT_VERSION` is older than this build
-    /// supports, the reader will surface this error unconditionally
-    /// (strict and lossy paths alike) and the engine will re-raise
-    /// it — the operator must delete the `wal/` subdirectory
-    /// manually before reopening. Lossy recovery does not bypass
-    /// format incompatibility (T3-E12 tracking doc §D6).
+    /// Produced when a segment's `SEGMENT_FORMAT_VERSION` is older than
+    /// this build supports. Surfaces unconditionally (strict and lossy
+    /// alike); the engine's open path re-raises as
+    /// [`strata_core::StrataError::LegacyFormat`] and the operator
+    /// must delete the `wal/` subdirectory manually before reopening.
+    /// Lossy recovery does not bypass format incompatibility (T3-E12 §D6).
     ///
     /// The `hint` carries the full operator-facing message including
     /// the required version number, so the rendered diagnostic stays
@@ -902,6 +897,27 @@ pub enum WalReaderError {
         /// hint is expected to include the required version number.
         hint: String,
     },
+}
+
+impl From<crate::format::WalSegmentError> for WalReaderError {
+    /// Preserve the typed `LegacyFormat` diagnostic; render other
+    /// header-level errors as `IoError`-wrapped strings. Genuine I/O
+    /// errors (disk full, permission denied) go through `IoError`
+    /// unchanged. T3-E12 §D8.
+    fn from(err: crate::format::WalSegmentError) -> Self {
+        use crate::format::{SegmentHeaderError, WalSegmentError};
+        match err {
+            WalSegmentError::Io(io) => WalReaderError::IoError(io.to_string()),
+            WalSegmentError::Header(SegmentHeaderError::LegacyFormat {
+                found_version,
+                hint,
+            }) => WalReaderError::LegacyFormat {
+                found_version,
+                hint,
+            },
+            WalSegmentError::Header(other) => WalReaderError::IoError(other.to_string()),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -2493,4 +2493,287 @@ mod tests {
             "without a later valid anchor, exact skip must fail closed"
         );
     }
+
+    // ========================================================================
+    // T3-E12 Phase 2 — envelope-parse + codec-error taxonomy
+    // ========================================================================
+
+    /// Test-only codec that always fails on `decode` while letting
+    /// `encode` pass through. Used to exercise the codec-decode-error
+    /// branch of the reader without pulling in `AesGcmCodec` + env
+    /// vars. `codec_id()` returns a unique name so MANIFEST checks
+    /// don't confuse it with identity.
+    struct AlwaysFailDecodeCodec;
+
+    impl StorageCodec for AlwaysFailDecodeCodec {
+        fn encode(&self, data: &[u8]) -> Vec<u8> {
+            data.to_vec()
+        }
+
+        fn decode(&self, data: &[u8]) -> Result<Vec<u8>, crate::codec::CodecError> {
+            Err(crate::codec::CodecError::decode(
+                "test codec forcibly fails decode",
+                "always-fail-decode",
+                data.len(),
+            ))
+        }
+
+        fn codec_id(&self) -> &str {
+            "always-fail-decode"
+        }
+
+        fn clone_box(&self) -> Box<dyn StorageCodec> {
+            Box::new(AlwaysFailDecodeCodec)
+        }
+    }
+
+    /// Read the outer envelope + inner record offsets for a segment
+    /// populated by `write_records`. The first record starts
+    /// immediately after the 36-byte v2/v3 segment header.
+    const V3_HEADER_SIZE: usize = 36;
+
+    /// T3-E12 §D4: an outer_len_crc mismatch is corruption, NOT a
+    /// partial-record tail. Strict mode must error immediately; lossy
+    /// mode can scan forward but must NOT demote the failure to
+    /// `Ok(stop_reason = PartialRecord)`.
+    #[test]
+    fn test_outer_len_crc_mismatch_is_corruption_not_partial_tail() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+
+        let records: Vec<_> = (1..=3)
+            .map(|i| WalRecord::new(TxnId(i), [1u8; 16], i * 1000, vec![i as u8; 12]))
+            .collect();
+        write_records(&wal_dir, &records);
+
+        // Flip a byte inside the outer_len_crc field of the first
+        // record. The envelope layout at [segment_header][record_1]
+        // is: 36 bytes segment header, then 4 bytes outer_len, then
+        // 4 bytes outer_len_crc. Byte 36+4+1 = 41 lands in outer_len_crc.
+        let seg_path = WalSegment::segment_path(&wal_dir, 1);
+        {
+            let mut data = std::fs::read(&seg_path).unwrap();
+            data[V3_HEADER_SIZE + 4 + 1] ^= 0xFF;
+            std::fs::write(&seg_path, &data).unwrap();
+        }
+
+        // Strict: expect CorruptedSegment error (NOT a PartialRecord
+        // stop reason buried in an Ok result).
+        let strict = WalReader::new();
+        match strict.read_segment(&wal_dir, 1) {
+            Err(WalReaderError::CorruptedSegment { records_before, .. }) => {
+                assert_eq!(
+                    records_before, 0,
+                    "first-record envelope CRC mismatch must fail at offset 0"
+                );
+            }
+            other => panic!(
+                "outer_len_crc mismatch in strict mode must return CorruptedSegment; got {:?}",
+                other.map(|t| format!("Ok({} records, stop_reason={:?})", t.0.len(), t.2,)),
+            ),
+        }
+    }
+
+    /// T3-E12 §D4: in lossy mode, outer_len_crc mismatch on a
+    /// middle record triggers scan-forward to the next valid envelope.
+    /// Records before the corruption are preserved; records after
+    /// the next valid envelope are recovered.
+    #[test]
+    fn test_outer_len_crc_mismatch_lossy_scans_forward() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+
+        let records: Vec<_> = (1..=4)
+            .map(|i| WalRecord::new(TxnId(i), [1u8; 16], i * 1000, vec![i as u8; 12]))
+            .collect();
+        write_records(&wal_dir, &records);
+
+        // Compute byte offset of record 2's envelope (first byte of
+        // its outer_len_crc) on disk. Each on-disk record is
+        // [8-byte envelope] + record_bytes. Record 2 starts at
+        // hdr + envelope_of_record_1 + record_bytes[0].
+        let record_bytes: Vec<Vec<u8>> = records.iter().map(|r| r.to_bytes()).collect();
+        let record_2_envelope_start =
+            V3_HEADER_SIZE + super::WAL_RECORD_ENVELOPE_OVERHEAD + record_bytes[0].len();
+        let crc_byte_offset = record_2_envelope_start + 4 + 1; // first byte of outer_len_crc
+
+        let seg_path = WalSegment::segment_path(&wal_dir, 1);
+        {
+            let mut data = std::fs::read(&seg_path).unwrap();
+            data[crc_byte_offset] ^= 0xFF;
+            std::fs::write(&seg_path, &data).unwrap();
+        }
+
+        let lossy = WalReader::new().with_lossy_recovery();
+        let (records_recovered, _, stop_reason, skipped) = lossy.read_segment(&wal_dir, 1).unwrap();
+        assert!(
+            skipped > 0,
+            "lossy scan-forward must count the skipped corrupt envelope"
+        );
+        let txn_ids: Vec<u64> = records_recovered
+            .iter()
+            .map(|r| r.txn_id.as_u64())
+            .collect();
+        assert!(
+            txn_ids.contains(&1),
+            "record 1 (before corruption) must survive; got {txn_ids:?}"
+        );
+        assert!(
+            txn_ids.contains(&3) || txn_ids.contains(&4),
+            "at least one post-corruption record must be recovered via scan-forward; got {txn_ids:?}"
+        );
+        // Sanity: the stop reason reflects either end-of-data (full
+        // recovery past corruption) or checksum mismatch (scan window
+        // exhausted before the tail). Either is acceptable — the
+        // point of this test is that lossy does NOT bail as
+        // PartialRecord on an outer_len_crc mismatch.
+        assert!(
+            !matches!(stop_reason, ReadStopReason::PartialRecord),
+            "outer_len_crc mismatch must NOT demote to PartialRecord; got {stop_reason:?}"
+        );
+    }
+
+    /// T3-E12 §D5: codec decode failures ALWAYS return
+    /// `Err(WalReaderError::CodecDecode)` — in BOTH strict and lossy
+    /// modes. No demotion to `Ok(stop_reason)` is permitted, because
+    /// the coordinator iterates records via callback and ignores
+    /// `ReadStopReason` — an `Ok(stop_reason=CodecDecode)` would
+    /// silently short-read the segment and skip the T3-E10 wipe.
+    #[test]
+    fn test_codec_decode_failure_never_partial_tail() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+
+        // Write via identity codec so the on-disk envelope is valid
+        // and the outer_len_crc passes. Then read with a codec that
+        // refuses every payload — simulates the AES-GCM wrong-key
+        // path at the reader layer, without needing env-var setup.
+        let records: Vec<_> = (1..=3)
+            .map(|i| WalRecord::new(TxnId(i), [1u8; 16], i * 1000, vec![i as u8; 16]))
+            .collect();
+        write_records(&wal_dir, &records);
+
+        let strict = WalReader::new().with_codec(Box::new(AlwaysFailDecodeCodec));
+        match strict.read_segment(&wal_dir, 1) {
+            Err(WalReaderError::CodecDecode { detail, .. }) => {
+                assert!(
+                    detail.contains("forcibly fails decode")
+                        || detail.contains("always-fail-decode"),
+                    "CodecDecode detail must carry the codec's error message; got {detail:?}"
+                );
+            }
+            other => panic!(
+                "strict codec-decode failure must return Err(CodecDecode); got {:?}",
+                other.map(|t| format!("Ok({} records)", t.0.len()))
+            ),
+        }
+
+        let lossy = WalReader::new()
+            .with_lossy_recovery()
+            .with_codec(Box::new(AlwaysFailDecodeCodec));
+        match lossy.read_segment(&wal_dir, 1) {
+            Err(WalReaderError::CodecDecode { .. }) => { /* pass — lossy does NOT demote */ }
+            other => panic!(
+                "lossy codec-decode failure must ALSO return Err(CodecDecode) \
+                 — no demotion to Ok(stop_reason); got {:?}",
+                other.map(|t| format!("Ok({} records, stop_reason={:?})", t.0.len(), t.2,)),
+            ),
+        }
+    }
+
+    /// T3-E12 §D8: a pre-v3 segment header surfaces as the typed
+    /// `WalReaderError::LegacyFormat`, not a stringified `IoError`.
+    /// This is the load-bearing piece that lets the engine's lossy
+    /// branch pattern-match on the error variant and skip the wipe
+    /// (§D6 hard-fail).
+    #[test]
+    fn test_legacy_segment_format_typed_error() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+        std::fs::create_dir_all(&wal_dir).unwrap();
+
+        // Hand-craft a v2 segment header directly (36 bytes: magic +
+        // version=2 + segment_number + database_uuid + header CRC
+        // over the first 32 bytes).
+        let mut header = [0u8; 36];
+        header[0..4].copy_from_slice(b"STRA");
+        header[4..8].copy_from_slice(&2u32.to_le_bytes());
+        header[8..16].copy_from_slice(&1u64.to_le_bytes());
+        header[16..32].copy_from_slice(&[0xAA; 16]);
+        let crc = {
+            let mut h = Hasher::new();
+            h.update(&header[0..32]);
+            h.finalize()
+        };
+        header[32..36].copy_from_slice(&crc.to_le_bytes());
+
+        let seg_path = WalSegment::segment_path(&wal_dir, 1);
+        std::fs::write(&seg_path, &header).unwrap();
+
+        let reader = WalReader::new();
+        match reader.read_segment(&wal_dir, 1) {
+            Err(WalReaderError::LegacyFormat {
+                found_version,
+                hint,
+            }) => {
+                assert_eq!(found_version, 2);
+                assert!(
+                    hint.contains("requires segment format version"),
+                    "hint must name the required version, got: {hint}"
+                );
+                assert!(
+                    hint.contains("wal/"),
+                    "hint must name the wal/ directory, got: {hint}"
+                );
+            }
+            Ok(_) => panic!("pre-v3 segment open must return an error, not succeed",),
+            Err(other) => panic!(
+                "pre-v3 segment must surface as WalReaderError::LegacyFormat, got: {other:?}",
+            ),
+        }
+    }
+
+    /// T3-E12 §D8: `WalSegment::open_read` returns the TYPED
+    /// `WalSegmentError::Header(SegmentHeaderError::LegacyFormat)`,
+    /// NOT a stringified `io::Error`. This is the layer below
+    /// `test_legacy_segment_format_typed_error` — it proves the typed
+    /// error survives from segment-file open all the way up to
+    /// `WalReader::read_segment` without collapsing into an
+    /// `io::ErrorKind::InvalidData` string.
+    #[test]
+    fn test_wal_segment_open_read_typed_propagation() {
+        use crate::format::{SegmentHeaderError, WalSegmentError};
+
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+        std::fs::create_dir_all(&wal_dir).unwrap();
+
+        let mut header = [0u8; 36];
+        header[0..4].copy_from_slice(b"STRA");
+        header[4..8].copy_from_slice(&2u32.to_le_bytes()); // legacy v2
+        header[8..16].copy_from_slice(&1u64.to_le_bytes());
+        header[16..32].copy_from_slice(&[0xCC; 16]);
+        let crc = {
+            let mut h = Hasher::new();
+            h.update(&header[0..32]);
+            h.finalize()
+        };
+        header[32..36].copy_from_slice(&crc.to_le_bytes());
+
+        let seg_path = WalSegment::segment_path(&wal_dir, 1);
+        std::fs::write(&seg_path, &header).unwrap();
+
+        match WalSegment::open_read(&wal_dir, 1) {
+            Err(WalSegmentError::Header(SegmentHeaderError::LegacyFormat {
+                found_version,
+                ..
+            })) => {
+                assert_eq!(found_version, 2);
+            }
+            Err(other) => panic!(
+                "pre-v3 segment open_read must produce typed Header(LegacyFormat), got: {other:?}"
+            ),
+            Ok(_) => panic!("pre-v3 segment open_read must refuse, not succeed"),
+        }
+    }
 }

--- a/crates/durability/src/wal/writer.rs
+++ b/crates/durability/src/wal/writer.rs
@@ -256,8 +256,11 @@ impl WalWriter {
 
         // Build initial segment metadata
         let current_segment_meta = if is_reopened {
-            // Reopening an existing segment — rebuild metadata from its records
-            Self::rebuild_meta_for_segment(&wal_dir, segment_number)
+            // Reopening an existing segment — rebuild metadata from its records.
+            // T3-E12 §D3 Site 4: pass the codec so the reader decodes the
+            // on-disk payloads for encrypted WALs; without this, rebuild
+            // on an encrypted segment would fail and `.meta` would be empty.
+            Self::rebuild_meta_for_segment(codec.as_ref(), &wal_dir, segment_number)
         } else {
             Some(SegmentMeta::new_empty(segment_number))
         };
@@ -828,8 +831,21 @@ impl WalWriter {
     ///
     /// Returns `Some(meta)` on success, or `Some(empty_meta)` if the segment
     /// cannot be read (best-effort).
-    fn rebuild_meta_for_segment(wal_dir: &Path, segment_number: u64) -> Option<SegmentMeta> {
-        let reader = WalReader::new();
+    ///
+    /// Takes `codec` as a parameter (rather than reading `self.codec`)
+    /// so it can be called from both `WalWriter::new` — which runs
+    /// BEFORE `self` exists — and from in-place segment-rotation paths
+    /// that have a live `self`. T3-E12 §D3 Site 4: threading the codec
+    /// here is load-bearing because on an encrypted WAL, reopening
+    /// without a codec would fail to rebuild `.meta` sidecars, and
+    /// follower-segment-skip via meta and compaction watermark-coverage
+    /// would then use stale / empty metadata.
+    fn rebuild_meta_for_segment(
+        codec: &dyn StorageCodec,
+        wal_dir: &Path,
+        segment_number: u64,
+    ) -> Option<SegmentMeta> {
+        let reader = WalReader::new().with_codec(crate::codec::clone_codec(codec));
         match reader.read_segment(wal_dir, segment_number) {
             Ok((records, _, _, _)) => {
                 let mut meta = SegmentMeta::new_empty(segment_number);
@@ -897,8 +913,10 @@ impl WalWriter {
                     Ok(seg) => {
                         self.segment = Some(seg);
                         self.current_segment_number = num;
+                        // T3-E12 §D3 Site 4: pass `self.codec` so rebuild
+                        // works on encrypted WALs.
                         self.current_segment_meta =
-                            Self::rebuild_meta_for_segment(&self.wal_dir, num);
+                            Self::rebuild_meta_for_segment(self.codec.as_ref(), &self.wal_dir, num);
                     }
                     Err(e) => {
                         warn!(target: "strata::wal", segment = num, error = %e,

--- a/crates/durability/src/wal/writer.rs
+++ b/crates/durability/src/wal/writer.rs
@@ -3,6 +3,7 @@
 //! The writer handles appending WAL records to segments with proper
 //! durability guarantees based on the configured mode.
 
+use crc32fast::Hasher;
 use serde::{Deserialize, Serialize};
 use strata_core::id::TxnId;
 
@@ -17,6 +18,14 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Instant, SystemTime};
 use tracing::{debug, error, info, warn};
+
+/// Per-record outer envelope overhead (v3+): `[u32 outer_len][u32 outer_len_crc]`.
+///
+/// Prefixed to every codec-encoded record by the writer so the reader
+/// can find record boundaries on codec-encoded payloads (AES-GCM, ...)
+/// that have no parseable length prefix inside the ciphertext.
+/// See T3-E12 tracking doc §D1.
+pub(crate) const WAL_RECORD_ENVELOPE_OVERHEAD: usize = 8;
 
 /// WAL disk usage summary.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -342,8 +351,11 @@ impl WalWriter {
     /// Core append logic shared by `append()`, `append_pre_serialized()`,
     /// and `append_and_flush()`.
     ///
-    /// Handles segment rotation, writing, metadata tracking, and counter updates.
-    /// Callers are responsible for encoding and post-write sync behavior.
+    /// Handles segment rotation, writing, metadata tracking, and counter
+    /// updates. Callers are responsible for encoding and post-write sync
+    /// behavior. The per-record outer envelope
+    /// `[u32 outer_len][u32 outer_len_crc]` is written here so the three
+    /// caller paths all produce the same on-disk layout (T3-E12 §D1).
     fn append_inner(
         &mut self,
         encoded: &[u8],
@@ -355,21 +367,48 @@ impl WalWriter {
             .as_mut()
             .expect("Segment should exist for non-Cache mode");
 
+        // Total on-disk bytes this append consumes: 8-byte envelope plus
+        // the codec-encoded payload. Used for both the rotation check and
+        // the accounting below.
+        let total_on_disk = encoded.len() + WAL_RECORD_ENVELOPE_OVERHEAD;
+
         // Do not rotate away from a segment while a background sync is fsyncing
         // a cloned descriptor for that same segment. The size limit is a soft
         // threshold; we can rotate on the next append after the sync commits.
-        if !self.sync_in_flight && segment.size() + encoded.len() as u64 > self.config.segment_size
+        if !self.sync_in_flight && segment.size() + total_on_disk as u64 > self.config.segment_size
         {
             self.rotate_segment()?;
         }
 
-        // Write to segment
+        // Construct the outer envelope: [u32 outer_len][u32 outer_len_crc].
+        // `outer_len_crc` mirrors the inner `LenCRC` pattern — it protects
+        // the outer length field from torn writes so a reader can detect
+        // a mid-envelope crash (see `read_segment_from` parse loop).
+        let outer_len: u32 = encoded.len().try_into().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "record too large for u32 outer_len",
+            )
+        })?;
+        let outer_len_bytes = outer_len.to_le_bytes();
+        let outer_len_crc = {
+            let mut h = Hasher::new();
+            h.update(&outer_len_bytes);
+            h.finalize()
+        };
+        let outer_len_crc_bytes = outer_len_crc.to_le_bytes();
+
+        // Write to segment: envelope header first, then encoded payload.
+        // `WalSegment::write` uses a BufWriter internally so the three
+        // writes coalesce into a single syscall.
         let segment = self.segment.as_mut().unwrap();
         let tw = if self.profile_wal {
             Some(Instant::now())
         } else {
             None
         };
+        segment.write(&outer_len_bytes)?;
+        segment.write(&outer_len_crc_bytes)?;
         segment.write(encoded)?;
         if let Some(tw) = tw {
             self.profile_write_ns += tw.elapsed().as_nanos() as u64;
@@ -381,11 +420,18 @@ impl WalWriter {
         }
 
         self.total_wal_appends += 1;
-        self.total_bytes_written += encoded.len() as u64;
+        self.total_bytes_written += total_on_disk as u64;
 
-        debug!(target: "strata::wal", txn_id = txn_id.as_u64(), record_bytes = encoded.len(), segment = self.current_segment_number, "WAL record appended");
+        debug!(
+            target: "strata::wal",
+            txn_id = txn_id.as_u64(),
+            record_bytes = encoded.len(),
+            envelope_bytes = WAL_RECORD_ENVELOPE_OVERHEAD,
+            segment = self.current_segment_number,
+            "WAL record appended",
+        );
 
-        self.bytes_since_sync += encoded.len() as u64;
+        self.bytes_since_sync += total_on_disk as u64;
         self.writes_since_sync += 1;
         self.has_unsynced_data = true;
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -51,6 +51,8 @@ criterion = { workspace = true }
 serde_json = { workspace = true }
 tracing-subscriber = { workspace = true }
 serial_test = { workspace = true }
+# Used by T3-E12 tests that craft raw pre-v3 WAL segment headers.
+crc32fast = { workspace = true }
 
 [[bench]]
 name = "transaction_benchmarks"

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -336,7 +336,14 @@ impl Database {
         };
 
         // Read the longest contiguous WAL prefix after the received watermark.
-        let reader = strata_durability::wal::WalReader::new();
+        // T3-E12 §D3 Site 2: thread the cached `wal_codec` so encrypted
+        // followers decode records on refresh. Without this wire,
+        // encrypted followers recover at open and then get stuck on
+        // the first refresh with a codec-decode error on the first
+        // new record (pre-T3-E12 part 4 behavior).
+        let reader = strata_durability::wal::WalReader::new().with_codec(
+            strata_durability::codec::clone_codec(self.wal_codec.as_ref()),
+        );
         let read_result =
             match reader.read_all_after_watermark_contiguous(&self.wal_dir, received_watermark) {
                 Ok(r) => r,

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -523,6 +523,17 @@ pub struct Database {
     /// Using parking_lot::Mutex to avoid lock poisoning on panic
     wal_writer: Option<Arc<ParkingMutex<WalWriter>>>,
 
+    /// Storage codec installed for this database's WAL read paths
+    /// (Site 2: follower refresh in [`Database::refresh`]). Populated
+    /// unconditionally at open time: primary and cache use
+    /// `get_codec(&cfg.storage.codec)`; follower with MANIFEST uses the
+    /// MANIFEST-persisted codec; follower without MANIFEST falls back
+    /// to `get_codec(&cfg.storage.codec)` (T3-E12 §D7). Without this
+    /// field, encrypted followers would recover at open but then fail
+    /// every subsequent refresh with a codec-decode error on the first
+    /// new record.
+    wal_codec: Box<dyn strata_durability::codec::StorageCodec>,
+
     /// Persistence mode (ephemeral vs disk-backed)
     persistence_mode: PersistenceMode,
 

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -523,6 +523,15 @@ impl Database {
         let mut stats = match recover_result {
             Ok(stats) => stats,
             Err(e) => {
+                // T3-E12 §D6: LegacyFormat is a hard-fail error that
+                // MUST NOT route through the lossy wipe (the wipe only
+                // recreates in-memory state and leaves pre-v3 segments
+                // on disk to re-poison every subsequent open). Operator
+                // must wipe `wal/` manually.
+                if matches!(e, StrataError::LegacyFormat { .. }) {
+                    return Err(e);
+                }
+
                 if cfg.allow_lossy_recovery {
                     let report = LossyRecoveryReport {
                         error: e.to_string(),
@@ -877,18 +886,11 @@ impl Database {
             ))
         })?;
 
-        // WAL recovery does not yet support non-identity codecs — the WalReader
-        // parses raw bytes without codec decoding. Encrypted WAL records would be
-        // unreadable on restart, causing data loss. Block until WAL codec support
-        // is implemented (requires length-prefix envelope + reader codec threading).
-        if cfg.storage.codec != "identity" && durability_mode.requires_wal() {
-            return Err(StrataError::internal(format!(
-                "codec '{}' is not yet supported with WAL-based durability (Standard/Always). \
-                 Encryption at rest requires WAL reader codec support (tracked). \
-                 Use durability = \"cache\" for encrypted in-memory databases.",
-                cfg.storage.codec
-            )));
-        }
+        // T3-E12 Phase 2 removed the codec+WAL rejection that used to
+        // live here. Non-identity codecs now round-trip through the
+        // v3 outer envelope + codec-aware reader. Codec name is still
+        // validated earlier via `get_codec(&cfg.storage.codec)`;
+        // MANIFEST codec-mismatch checks on reopen stay as-is.
 
         // Build canonical layout for this database
         let layout = DatabaseLayout::from_root(&canonical_path);
@@ -994,6 +996,16 @@ impl Database {
         let mut stats = match recover_result {
             Ok(stats) => stats,
             Err(e) => {
+                // T3-E12 §D6: LegacyFormat is a hard-fail error that
+                // MUST NOT route through the lossy wipe — the lossy
+                // branch only recreates the in-memory `SegmentedStore`
+                // and does NOT delete `wal/` on disk, so a pre-v3
+                // segment would re-poison the next open in an
+                // infinite loop. Operator must wipe `wal/` manually.
+                if matches!(e, StrataError::LegacyFormat { .. }) {
+                    return Err(e);
+                }
+
                 if cfg.allow_lossy_recovery {
                     // Sample partial progress BEFORE the wipe so the
                     // `LossyRecoveryReport` reflects what was discarded.
@@ -1546,17 +1558,9 @@ impl Database {
             ))
         })?;
 
-        // WAL recovery does not yet support non-identity codecs — the WalReader
-        // parses raw bytes without codec decoding. Follower replay goes through
-        // the same reader, so the same block applies here as on primary.
-        if cfg.storage.codec != "identity" && durability_mode.requires_wal() {
-            return Err(StrataError::internal(format!(
-                "codec '{}' is not yet supported with WAL-based durability (Standard/Always). \
-                 Encryption at rest requires WAL reader codec support (tracked). \
-                 Use durability = \"cache\" for encrypted in-memory databases.",
-                cfg.storage.codec
-            )));
-        }
+        // T3-E12 Phase 2 removed the follower codec+WAL rejection;
+        // the v3 envelope + codec-threaded reader now handle
+        // non-identity codecs on follower replay.
 
         let subsystem_names: Vec<&'static str> = subsystems.iter().map(|s| s.name()).collect();
         let requested_signature = CompatibilitySignature::from_spec(

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -467,10 +467,30 @@ impl Database {
             ([0u8; 16], None)
         };
 
+        // T3-E12 §D7: follower-without-MANIFEST falls back to the
+        // follower's own config codec so encrypted WAL-only recovery
+        // works. Primary and cache paths already use `cfg.storage.codec`
+        // directly; the follower now matches that when MANIFEST is
+        // absent. `follower_codec` (Some/None) stays meaningful for
+        // snapshot-install wiring below, which is only wired with a
+        // MANIFEST-persisted codec — without MANIFEST we don't know
+        // which snapshot schema to install against.
+        let wal_codec: Box<dyn strata_durability::codec::StorageCodec> = match &follower_codec {
+            Some(c) => clone_codec(c.as_ref()),
+            None => strata_durability::get_codec(&cfg.storage.codec).map_err(|e| {
+                StrataError::internal(format!(
+                    "follower (MANIFEST absent) could not initialize config codec '{}': {}",
+                    cfg.storage.codec, e
+                ))
+            })?,
+        };
+
         // Drive recovery via the callback-driven API. Snapshot install is
-        // wired only when a codec was resolved above; otherwise the
-        // coordinator falls back to WAL-only, matching the pre-Chunk-3
-        // follower behavior.
+        // wired only when a codec was resolved from the MANIFEST above;
+        // otherwise the coordinator falls back to WAL-only, matching
+        // the pre-Chunk-3 follower behavior. The WAL reader, however,
+        // is always codec-aware via `wal_codec` so encrypted WAL-only
+        // recovery works even without a MANIFEST (T3-E12 §D7).
         let mut storage = SegmentedStore::with_dir(
             layout.segments_dir().to_path_buf(),
             cfg.storage.effective_write_buffer_size(),
@@ -478,9 +498,7 @@ impl Database {
         let mut recovery =
             RecoveryCoordinator::new(layout.clone(), cfg.storage.effective_write_buffer_size())
                 .with_lossy_recovery(cfg.allow_lossy_recovery);
-        if let Some(ref c) = follower_codec {
-            recovery = recovery.with_codec(clone_codec(c.as_ref()));
-        }
+        recovery = recovery.with_codec(clone_codec(wal_codec.as_ref()));
         let install_codec_for_follower = follower_codec.as_ref().map(|c| clone_codec(c.as_ref()));
 
         // Count records applied before any coordinator error so the lossy
@@ -651,6 +669,7 @@ impl Database {
             database_uuid,
             storage,
             wal_writer: None, // No WAL writer — read-only
+            wal_codec,
 
             persistence_mode: PersistenceMode::Disk,
             coordinator,
@@ -1071,6 +1090,14 @@ impl Database {
             "Recovery complete"
         );
 
+        // T3-E12 §D3 Site 2: clone codec BEFORE the move into WalWriter
+        // so the Database can cache its own copy for the follower-
+        // refresh path (via `Database.wal_codec`). Primary doesn't
+        // typically call `refresh()`, but we populate uniformly across
+        // all three constructors so the field type stays
+        // `Box<dyn StorageCodec>` rather than `Option`.
+        let wal_codec_for_db = clone_codec(codec.as_ref());
+
         // Open segmented WAL writer for appending
         let wal_writer = WalWriter::new(
             wal_dir.clone(),
@@ -1141,6 +1168,7 @@ impl Database {
             database_uuid,
             storage,
             wal_writer: Some(Arc::clone(&wal_arc)),
+            wal_codec: wal_codec_for_db,
             persistence_mode: PersistenceMode::Disk,
             coordinator,
             durability_mode: parking_lot::RwLock::new(durability_mode),
@@ -1284,11 +1312,25 @@ impl Database {
         let coordinator = TransactionCoordinator::new(CommitVersion(1));
         coordinator.set_max_write_buffer_entries(cfg.storage.max_write_buffer_entries);
 
+        // T3-E12 §D7: cache-mode databases still populate `wal_codec`
+        // uniformly — the field is always `Box<dyn StorageCodec>`, not
+        // `Option`, so the type signature does not leak "this is a
+        // cache database" into the field type. `IdentityCodec` is the
+        // typical resolution here and is effectively a no-op at runtime.
+        let wal_codec_for_cache =
+            strata_durability::get_codec(&cfg.storage.codec).map_err(|e| {
+                StrataError::internal(format!(
+                    "cache database could not initialize codec '{}': {}",
+                    cfg.storage.codec, e
+                ))
+            })?;
+
         let db = Arc::new(Self {
             data_dir: PathBuf::new(), // Empty path for ephemeral
             database_uuid: [0u8; 16], // No persistence — UUID not needed
             storage: Arc::new(storage),
             wal_writer: None, // No WAL for ephemeral
+            wal_codec: wal_codec_for_cache,
 
             persistence_mode: PersistenceMode::Ephemeral,
             coordinator,

--- a/crates/engine/src/database/tests/codec.rs
+++ b/crates/engine/src/database/tests/codec.rs
@@ -1,20 +1,21 @@
-//! Codec uniformity and reuse-identity acceptance tests (T3-E7).
+//! Codec uniformity and reuse-identity acceptance tests (T3-E7 + T3-E12).
 //!
-//! These tests pin the contract that every open-time-only knob classified
-//! in `docs/design/architecture-cleanup/durability-recovery-config-matrix.md`
-//! triggers [`StrataError::IncompatibleReuse`] when it disagrees between
-//! two openers of the same path — never a silent downgrade, never an
-//! opaque `internal` error. The tests cover codec drift (primary and
-//! follower), early codec validation, and the two knobs that the initial
-//! T3-E7 draft left out of the signature: `background_threads` and
-//! `allow_lossy_recovery`.
+//! These tests pin two related contracts:
 //!
-//! **Why not a full write→crash→reopen→read round-trip with a non-identity
-//! codec?** WAL recovery does not yet support non-identity codecs
-//! (`crates/engine/src/database/open.rs` blocks this at open time). Cache
-//! durability does not persist across opens. So the cross-process
-//! persistence test called for by the scope is deferred until WAL codec
-//! support lands; see the config matrix doc for the target-state note.
+//! 1. **T3-E7 reuse identity** — every open-time-only knob classified in
+//!    `docs/design/architecture-cleanup/durability-recovery-config-matrix.md`
+//!    triggers [`StrataError::IncompatibleReuse`] when it disagrees
+//!    between two openers of the same path (codec drift, background
+//!    threads, `allow_lossy_recovery`). Never a silent downgrade,
+//!    never an opaque `internal` error.
+//!
+//! 2. **T3-E12 codec-aware WAL** — non-identity codecs (`aes-gcm-256`)
+//!    round-trip cleanly through the v3 outer envelope + codec-threaded
+//!    reader for BOTH clean-shutdown and crash-recovery, across large
+//!    records, partial tails, mid-segment corruption, and wrong-key
+//!    reopen. The T3-E12 AES-GCM tests at the bottom of this file pin
+//!    the six contract rows from the tracking doc's §Phase 2 test
+//!    list (`docs/design/execution/t3-e12-phases.md`).
 
 use super::*;
 use crate::SearchSubsystem;
@@ -657,6 +658,299 @@ fn test_registry_reuse_rejects_different_allow_lossy_recovery() {
             );
         }
         Ok(_) => panic!("registry reuse with mismatched allow_lossy_recovery must not succeed"),
+    }
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
+// ============================================================================
+// T3-E12 Phase 2 — AES-GCM + WAL-durability round-trip contract
+// ============================================================================
+//
+// These six tests pin the core Phase 2 acceptance: a database configured
+// with `codec = "aes-gcm-256"` + `durability = "standard"` (WAL-backed)
+// round-trips cleanly through the v3 outer envelope and the codec-threaded
+// WAL reader on every path the tracking doc enumerates —
+// docs/design/execution/t3-e12-phases.md §"Phase 2 Tests".
+
+/// Build a `StrataConfig` with aes-gcm-256 codec + standard durability.
+/// Shared setup for the T3-E12 round-trip tests.
+fn aes_gcm_standard_config() -> StrataConfig {
+    StrataConfig {
+        durability: "standard".to_string(),
+        storage: StorageConfig {
+            codec: "aes-gcm-256".to_string(),
+            ..StorageConfig::default()
+        },
+        ..StrataConfig::default()
+    }
+}
+
+/// T3-E12 §Phase 2 Test #1: clean-shutdown round-trip.
+///
+/// Write several records through an `aes-gcm-256 + standard` primary,
+/// call `shutdown()`, reopen with the same key + codec, verify every
+/// record is visible. Exercises the happy path for the v3 envelope
+/// writer + codec-aware reader.
+#[test]
+#[serial(open_databases)]
+fn test_aes_gcm_wal_durability_clean_shutdown_roundtrip() {
+    OPEN_DATABASES.lock().clear();
+    let _key_guard = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    {
+        let db = Database::open_runtime(
+            super::spec::OpenSpec::primary(&db_path)
+                .with_config(aes_gcm_standard_config())
+                .with_subsystem(SearchSubsystem),
+        )
+        .expect("aes-gcm-256 + standard durability must open post-T3-E12");
+
+        for i in 0..12u8 {
+            blind_write(
+                &db,
+                Key::new_kv(ns.clone(), &format!("k{i}")),
+                Value::Bytes(vec![i; 64]),
+            );
+        }
+        db.shutdown().expect("clean shutdown must succeed");
+    }
+    OPEN_DATABASES.lock().clear();
+
+    // Reopen with the same key + codec and assert every record is visible.
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(aes_gcm_standard_config())
+            .with_subsystem(SearchSubsystem),
+    )
+    .expect("reopen after clean shutdown must succeed");
+
+    for i in 0..12u8 {
+        let key = Key::new_kv(ns.clone(), &format!("k{i}"));
+        let got = db
+            .storage()
+            .get_versioned(&key, CommitVersion::MAX)
+            .expect("get must succeed on reopened encrypted DB");
+        match got.map(|v| v.value) {
+            Some(Value::Bytes(bytes)) => assert_eq!(bytes, vec![i; 64]),
+            other => panic!("key k{i} missing after reopen: {other:?}"),
+        }
+    }
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
+/// T3-E12 §Phase 2 Test #2: crash recovery (drop without shutdown).
+///
+/// Mirrors the `recovery_tests::test_kv_survives_recovery` idiom for
+/// the encrypted-WAL path: drop the DB without calling `shutdown()`,
+/// reopen, verify records survived the partial-write recovery path.
+#[test]
+#[serial(open_databases)]
+fn test_aes_gcm_wal_crash_recovery() {
+    OPEN_DATABASES.lock().clear();
+    let _key_guard = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    {
+        let db = Database::open_runtime(
+            super::spec::OpenSpec::primary(&db_path)
+                .with_config(aes_gcm_standard_config())
+                .with_subsystem(SearchSubsystem),
+        )
+        .unwrap();
+
+        for i in 0..8u8 {
+            blind_write(
+                &db,
+                Key::new_kv(ns.clone(), &format!("crash_k{i}")),
+                Value::Bytes(vec![i ^ 0x55; 32]),
+            );
+        }
+        // Force a WAL flush but DO NOT call shutdown — mirrors a crash.
+        db.flush().unwrap();
+        drop(db);
+    }
+    OPEN_DATABASES.lock().clear();
+
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(aes_gcm_standard_config())
+            .with_subsystem(SearchSubsystem),
+    )
+    .expect("reopen after crash must succeed via WAL recovery");
+
+    for i in 0..8u8 {
+        let key = Key::new_kv(ns.clone(), &format!("crash_k{i}"));
+        let got = db
+            .storage()
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap();
+        match got.map(|v| v.value) {
+            Some(Value::Bytes(bytes)) => assert_eq!(bytes, vec![i ^ 0x55; 32]),
+            other => panic!("key crash_k{i} missing after crash recovery: {other:?}"),
+        }
+    }
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
+/// T3-E12 §Phase 2 Test #3: large-record envelope.
+///
+/// Exercises the `u32 outer_len` field against a multi-MB value. A
+/// ~2 MB payload is large enough to stress the envelope but stays
+/// below the default segment-size threshold so no rotation is forced
+/// mid-record. The post-encode envelope size is comfortably within
+/// u32 range.
+#[test]
+#[serial(open_databases)]
+fn test_aes_gcm_large_record_envelope() {
+    OPEN_DATABASES.lock().clear();
+    let _key_guard = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    // ~2 MB payload — big enough to exercise the u32 outer_len field
+    // without blowing past the test-default segment size.
+    let big_value: Vec<u8> = (0u32..2 * 1024 * 1024)
+        .map(|i| (i as u8).wrapping_mul(37))
+        .collect();
+
+    {
+        let db = Database::open_runtime(
+            super::spec::OpenSpec::primary(&db_path)
+                .with_config(aes_gcm_standard_config())
+                .with_subsystem(SearchSubsystem),
+        )
+        .unwrap();
+        blind_write(
+            &db,
+            Key::new_kv(ns.clone(), "big"),
+            Value::Bytes(big_value.clone()),
+        );
+        db.shutdown().unwrap();
+    }
+    OPEN_DATABASES.lock().clear();
+
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(aes_gcm_standard_config())
+            .with_subsystem(SearchSubsystem),
+    )
+    .unwrap();
+
+    let got = db
+        .storage()
+        .get_versioned(&Key::new_kv(ns, "big"), CommitVersion::MAX)
+        .unwrap()
+        .expect("large record must round-trip through the v3 envelope");
+    match got.value {
+        Value::Bytes(bytes) => assert_eq!(
+            bytes.len(),
+            big_value.len(),
+            "recovered size must match written size"
+        ),
+        other => panic!("wrong value type: {other:?}"),
+    }
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
+/// T3-E12 §Phase 2 Test #6: wrong-key reopen classifies as
+/// `LossyErrorKind::CodecDecode`.
+///
+/// Write with key A, close, then reopen with key B + `allow_lossy_recovery=true`.
+/// The open must succeed with empty state, and
+/// `last_lossy_recovery_report()` must report
+/// `error_kind = LossyErrorKind::CodecDecode` — the typed
+/// classification that separates wrong-key scenarios from
+/// raw-byte-corruption scenarios (§D5).
+#[test]
+#[serial(open_databases)]
+fn test_aes_gcm_wrong_key_classifies_as_codec_decode() {
+    OPEN_DATABASES.lock().clear();
+    // Write with key A.
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    {
+        let _key_a = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+        let db = Database::open_runtime(
+            super::spec::OpenSpec::primary(&db_path)
+                .with_config(aes_gcm_standard_config())
+                .with_subsystem(SearchSubsystem),
+        )
+        .unwrap();
+        for i in 0..4u8 {
+            blind_write(
+                &db,
+                Key::new_kv(ns.clone(), &format!("enc_k{i}")),
+                Value::Bytes(vec![i; 16]),
+            );
+        }
+        db.shutdown().unwrap();
+    }
+    OPEN_DATABASES.lock().clear();
+
+    // Reopen with key B + lossy. Must succeed with empty state +
+    // typed CodecDecode classification in the report.
+    const TEST_AES_KEY_B: &str = "ffeeddccbbaa99887766554433221100f0e0d0c0b0a090807060504030201000";
+    let _key_b = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY_B);
+    let cfg_lossy = StrataConfig {
+        allow_lossy_recovery: true,
+        ..aes_gcm_standard_config()
+    };
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(cfg_lossy)
+            .with_subsystem(SearchSubsystem),
+    )
+    .expect("wrong-key reopen under allow_lossy_recovery=true must succeed (whole-DB wipe)");
+
+    let report = db
+        .last_lossy_recovery_report()
+        .expect("wrong-key reopen must populate a lossy report");
+    use crate::LossyErrorKind;
+    assert_eq!(
+        report.error_kind,
+        LossyErrorKind::CodecDecode,
+        "wrong key → CodecDecode (not Storage, not Corruption); got {:?} with error {:?}",
+        report.error_kind,
+        report.error,
+    );
+    assert!(report.discarded_on_wipe);
+
+    // The pre-wipe records are gone by contract (whole-DB wipe).
+    for i in 0..4u8 {
+        let got = db
+            .storage()
+            .get_versioned(
+                &Key::new_kv(ns.clone(), &format!("enc_k{i}")),
+                CommitVersion::MAX,
+            )
+            .unwrap();
+        assert!(
+            got.is_none(),
+            "record enc_k{i} must be wiped after lossy fallback; found {got:?}"
+        );
     }
 
     db.shutdown().unwrap();

--- a/crates/engine/src/database/tests/codec.rs
+++ b/crates/engine/src/database/tests/codec.rs
@@ -956,3 +956,184 @@ fn test_aes_gcm_wrong_key_classifies_as_codec_decode() {
     db.shutdown().unwrap();
     OPEN_DATABASES.lock().clear();
 }
+
+/// T3-E12 §Phase 2 Test #4: partial-tail truncation on encrypted WAL.
+///
+/// Write N records, then append a deterministic mid-outer-envelope
+/// byte run (3 bytes — less than the 8-byte envelope-header size).
+/// Reopen, assert the first N records survive. Pins the
+/// `InsufficientData → ReadStopReason::PartialRecord` branch of the
+/// envelope-parse loop, which is what differentiates genuine crash
+/// tails (truncate-and-continue) from CRC or codec failures (error).
+///
+/// Appending arbitrary garbage (the pre-§D4-rewrite fixture pattern)
+/// is non-deterministic — random bytes can happen to produce a valid
+/// outer_len_crc by luck (1 in 4 billion) or fail CRC validation
+/// (usual case), which routes through a different error branch.
+/// Truncation mid-envelope-header guarantees the short-read path is
+/// the one that fires.
+#[test]
+#[serial(open_databases)]
+fn test_aes_gcm_partial_tail_truncates_cleanly() {
+    OPEN_DATABASES.lock().clear();
+    let _key_guard = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    let record_count = 5u8;
+    let size_after_last_record: u64 = {
+        let db = Database::open_runtime(
+            super::spec::OpenSpec::primary(&db_path)
+                .with_config(aes_gcm_standard_config())
+                .with_subsystem(SearchSubsystem),
+        )
+        .unwrap();
+        for i in 0..record_count {
+            blind_write(
+                &db,
+                Key::new_kv(ns.clone(), &format!("tail_k{i}")),
+                Value::Bytes(vec![i; 16]),
+            );
+        }
+        db.flush().unwrap();
+
+        let seg_path = db_path.join("wal").join("wal-000001.seg");
+        let size = std::fs::metadata(&seg_path).unwrap().len();
+        db.shutdown().unwrap();
+        size
+    };
+    OPEN_DATABASES.lock().clear();
+
+    // Append 3 bytes — mid-outer-envelope-header for record N+1.
+    // `read_outer_envelope` returns `Ok(None)` for any buf.len() < 8,
+    // which the parse loop treats as `PartialRecord` → truncate.
+    let seg_path = db_path.join("wal").join("wal-000001.seg");
+    {
+        use std::io::Write as _;
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&seg_path)
+            .unwrap();
+        f.write_all(&[0xAB, 0xCD, 0xEF]).unwrap();
+    }
+    assert_eq!(
+        std::fs::metadata(&seg_path).unwrap().len(),
+        size_after_last_record + 3,
+    );
+
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(aes_gcm_standard_config())
+            .with_subsystem(SearchSubsystem),
+    )
+    .expect("reopen with mid-envelope partial tail must succeed (PartialRecord, not corruption)");
+
+    for i in 0..record_count {
+        let got = db
+            .storage()
+            .get_versioned(
+                &Key::new_kv(ns.clone(), &format!("tail_k{i}")),
+                CommitVersion::MAX,
+            )
+            .unwrap();
+        match got.map(|v| v.value) {
+            Some(Value::Bytes(bytes)) => assert_eq!(bytes, vec![i; 16]),
+            other => panic!("record tail_k{i} missing after partial-tail: {other:?}"),
+        }
+    }
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
+/// T3-E12 §Phase 2 Test #5: mid-segment ciphertext corruption must
+/// NOT silently truncate in strict mode.
+///
+/// Write N records, flip a byte deep inside the first record's
+/// codec-encoded payload (past the outer envelope header). AES-GCM's
+/// auth tag catches the tampered ciphertext on decode; the reader
+/// returns `Err(WalReaderError::CodecDecode)` which the coordinator
+/// maps to `StrataError::CodecDecode` and strict open refuses.
+///
+/// The key regression guard: codec decode failures are ALWAYS `Err`
+/// at the reader layer, never `Ok(stop_reason)` (D5). A silent
+/// truncation would be catastrophic — wrong-key scenarios would
+/// serve partial data without any signal to the operator.
+#[test]
+#[serial(open_databases)]
+fn test_aes_gcm_mid_segment_corruption_not_silently_truncated() {
+    OPEN_DATABASES.lock().clear();
+    let _key_guard = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    {
+        let db = Database::open_runtime(
+            super::spec::OpenSpec::primary(&db_path)
+                .with_config(aes_gcm_standard_config())
+                .with_subsystem(SearchSubsystem),
+        )
+        .unwrap();
+        for i in 0..4u8 {
+            blind_write(
+                &db,
+                Key::new_kv(ns.clone(), &format!("mid_k{i}")),
+                Value::Bytes(vec![i ^ 0x77; 32]),
+            );
+        }
+        db.shutdown().unwrap();
+    }
+    OPEN_DATABASES.lock().clear();
+
+    // Flip a byte deep inside the first record's ciphertext. The
+    // segment header is 36 bytes; add 8 for the first outer envelope;
+    // byte 50 lands comfortably inside the first encrypted payload.
+    let seg_path = db_path.join("wal").join("wal-000001.seg");
+    {
+        let mut data = std::fs::read(&seg_path).unwrap();
+        let idx = 50usize;
+        assert!(
+            idx < data.len(),
+            "segment file should have grown past offset 50"
+        );
+        data[idx] ^= 0xFF;
+        std::fs::write(&seg_path, &data).unwrap();
+    }
+
+    // Strict open must refuse; no silent truncation path may succeed.
+    let result = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(aes_gcm_standard_config())
+            .with_subsystem(SearchSubsystem),
+    );
+    match result {
+        Err(_) => { /* strict refuses; expected */ }
+        Ok(db) => {
+            let mut visible = 0usize;
+            for i in 0..4u8 {
+                let got = db
+                    .storage()
+                    .get_versioned(
+                        &Key::new_kv(ns.clone(), &format!("mid_k{i}")),
+                        CommitVersion::MAX,
+                    )
+                    .unwrap();
+                if got.is_some() {
+                    visible += 1;
+                }
+            }
+            panic!(
+                "strict open with mid-segment ciphertext corruption must \
+                 error, not silently truncate; {visible}/4 records \
+                 survived — this is a D5 regression"
+            );
+        }
+    }
+    OPEN_DATABASES.lock().clear();
+}

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -617,3 +617,101 @@ fn test_lossy_error_kind_display_covers_all_variants() {
     assert_eq!(format!("{}", LossyErrorKind::CodecDecode), "codec_decode");
     assert_eq!(format!("{}", LossyErrorKind::Other), "other");
 }
+
+/// T3-E12 §D6: a pre-v3 WAL segment on disk triggers
+/// `StrataError::LegacyFormat` and MUST NOT route through the lossy
+/// wipe, even when `allow_lossy_recovery=true`.
+///
+/// Rationale: the lossy branch only recreates the in-memory
+/// `SegmentedStore` and leaves `wal/` bytes on disk untouched. Without
+/// the hard-fail guard at `open.rs:1000` / `:540`, a pre-v3 segment
+/// would re-poison every subsequent open in an infinite loop.
+/// Operator remediation is manual — delete `wal/` and reopen.
+#[test]
+fn test_legacy_format_under_lossy_flag_still_hard_fails() {
+    use crc32fast::Hasher;
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let wal_dir = db_path.join("wal");
+    std::fs::create_dir_all(&wal_dir).unwrap();
+
+    // Craft a 36-byte v2 segment header directly — matches the pre-
+    // T3-E12 on-disk layout (magic + version=2 + segment_number +
+    // database_uuid + header_crc over the first 32 bytes). The v3
+    // reader rejects this with `SegmentHeaderError::LegacyFormat`
+    // before reading any records.
+    let mut header = [0u8; 36];
+    header[0..4].copy_from_slice(b"STRA"); // SEGMENT_MAGIC
+    header[4..8].copy_from_slice(&2u32.to_le_bytes()); // format_version = 2 (legacy)
+    header[8..16].copy_from_slice(&1u64.to_le_bytes()); // segment_number = 1
+    header[16..32].copy_from_slice(&[0xAA; 16]); // database_uuid
+    let header_crc = {
+        let mut h = Hasher::new();
+        h.update(&header[0..32]);
+        h.finalize()
+    };
+    header[32..36].copy_from_slice(&header_crc.to_le_bytes());
+
+    let segment_path = wal_dir.join("wal-000001.seg");
+    std::fs::write(&segment_path, &header).unwrap();
+
+    // Snapshot the on-disk bytes BEFORE the open attempt so we can
+    // prove no wipe occurred.
+    let bytes_before = std::fs::read(&segment_path).unwrap();
+
+    // Open with allow_lossy_recovery=true. The D6 hard-fail guard
+    // must re-raise the `LegacyFormat` error WITHOUT wiping.
+    let cfg = StrataConfig {
+        allow_lossy_recovery: true,
+        ..StrataConfig::default()
+    };
+    let result = Database::open_with_config(&db_path, cfg);
+
+    match result {
+        Err(StrataError::LegacyFormat {
+            found_version,
+            hint,
+        }) => {
+            assert_eq!(found_version, 2);
+            assert!(
+                hint.contains("requires segment format version"),
+                "hint must name required version, got: {hint}"
+            );
+            assert!(
+                hint.contains("wal/"),
+                "hint must name the wal/ directory for remediation, got: {hint}"
+            );
+        }
+        Ok(_) => panic!(
+            "legacy-format open must hard-fail even under allow_lossy_recovery=true; got Ok(Database)",
+        ),
+        Err(other) => panic!(
+            "legacy-format open must produce StrataError::LegacyFormat, got: {other:?}",
+        ),
+    }
+
+    // Filesystem observable: the pre-v3 segment bytes on disk must be
+    // unchanged after the failed open. A wipe would have replaced or
+    // cleared the segment. Re-reading identical bytes proves no
+    // `storage = SegmentedStore::with_dir(...)` branch executed and
+    // no lossy report was populated on the (failed) open attempt.
+    let bytes_after = std::fs::read(&segment_path).unwrap();
+    assert_eq!(
+        bytes_before, bytes_after,
+        "legacy-format open must NOT mutate the pre-v3 segment; the \
+         wipe branch should be skipped entirely",
+    );
+
+    // Reproducible: a second open attempt returns the same typed error
+    // — the failure is deterministic, not a transient recovery artifact.
+    let cfg2 = StrataConfig {
+        allow_lossy_recovery: true,
+        ..StrataConfig::default()
+    };
+    let result2 = Database::open_with_config(&db_path, cfg2);
+    assert!(
+        matches!(result2, Err(StrataError::LegacyFormat { .. })),
+        "second open must reproduce the same typed LegacyFormat error",
+    );
+}

--- a/crates/engine/src/database/tests/regressions.rs
+++ b/crates/engine/src/database/tests/regressions.rs
@@ -1302,9 +1302,14 @@ fn test_issue_1380_codec_mismatch_rejected() {
 }
 
 #[test]
-fn test_issue_1380_encryption_rejected_with_wal() {
-    // Non-identity codecs must be rejected when WAL recovery is required,
-    // because the WalReader does not yet support codec decoding.
+fn test_issue_1380_encryption_with_wal_succeeds_as_of_t3_e12() {
+    // Pre-T3-E12 (issue #1380) this combination was rejected at open
+    // time because the WAL reader did not decode codec-encoded
+    // payloads. T3-E12 Phase 2 added the per-record outer envelope
+    // and codec-threaded reader, so `aes-gcm-256 + durability =
+    // "standard"` now round-trips through WAL recovery. This test is
+    // flipped to a positive assertion: the open must succeed and a
+    // basic round-trip must work through the codec-aware WAL.
     let _env_guard = ENV_VAR_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let temp_dir = TempDir::new().unwrap();
     std::env::set_var(
@@ -1318,7 +1323,6 @@ fn test_issue_1380_encryption_rejected_with_wal() {
         },
         ..StrataConfig::default()
     };
-    // Note: Using config with standard durability mode
     let mut cfg_with_durability = cfg;
     cfg_with_durability.durability = "standard".to_string();
     let spec = super::spec::OpenSpec::primary(temp_dir.path())
@@ -1328,14 +1332,15 @@ fn test_issue_1380_encryption_rejected_with_wal() {
     std::env::remove_var("STRATA_ENCRYPTION_KEY");
 
     match result {
-        Err(e) => {
-            let err = e.to_string();
-            assert!(
-                err.contains("not yet supported with WAL"),
-                "error should mention WAL limitation: {}",
-                err
-            );
+        Ok(db) => {
+            // Shape assertion: a successful open is the contract;
+            // detailed round-trip coverage lives in the new AES-GCM
+            // WAL tests added in Phase 2 part 5.
+            assert!(!db.is_cache(), "standard-durability DB is not a cache DB");
         }
-        Ok(_) => panic!("should reject encryption with WAL-based durability"),
+        Err(e) => panic!(
+            "aes-gcm-256 + WAL durability must open successfully post-T3-E12, got: {}",
+            e
+        ),
     }
 }

--- a/crates/engine/tests/follower_tests.rs
+++ b/crates/engine/tests/follower_tests.rs
@@ -1495,3 +1495,106 @@ fn test_follower_lossy_recovery_populates_report() {
     // the follower path shares with the primary (Some vs None; wipe flag; error
     // non-empty; typed kind). Exact counts are covered by the primary-path test.
 }
+
+/// T3-E12 Phase 2 §D3 Site 2: follower refresh must decode records
+/// through the cached `wal_codec`.
+///
+/// Pre-part-4, `Database::refresh` at `lifecycle.rs:339` built a raw
+/// `WalReader::new()` with no codec — encrypted followers recovered
+/// cleanly at open but then failed every `refresh()` with a
+/// codec-decode error on the first new record. This test pins the
+/// contract that open + refresh + read all share a single codec all
+/// the way through. The review on PR 2427 flagged the absence of
+/// this test as the gap that let four codec-threading sites slip.
+#[test]
+fn test_follower_refresh_with_non_identity_codec() {
+    use strata_engine::StrataConfig;
+
+    // `STRATA_ENCRYPTION_KEY` is a process-wide env var and the
+    // `aes-gcm-256` codec reads it at construction. Use a stable value
+    // for the whole test so primary and follower both see the same
+    // key. Guard it with a local RAII so the var is released on drop.
+    const TEST_AES_KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+    struct KeyGuard;
+    impl Drop for KeyGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("STRATA_ENCRYPTION_KEY");
+        }
+    }
+    std::env::set_var("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+    let _key_guard = KeyGuard;
+
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+
+    let aes_cfg = StrataConfig {
+        durability: "standard".to_string(),
+        storage: strata_engine::StorageConfig {
+            codec: "aes-gcm-256".to_string(),
+            ..strata_engine::StorageConfig::default()
+        },
+        ..StrataConfig::default()
+    };
+
+    // Primary writes an initial record through the encrypted WAL.
+    let primary = Database::open_runtime(
+        OpenSpec::primary(dir.path())
+            .with_subsystem(SearchSubsystem)
+            .with_config(aes_cfg.clone()),
+    )
+    .expect("primary must open with aes-gcm-256 + standard durability");
+    primary_put(&primary, branch, "pre", "before-follower");
+    primary.flush().unwrap();
+
+    // Follower opens through the MANIFEST-resolved codec (D7) and
+    // recovers the existing record.
+    let follower = Database::open_runtime(
+        OpenSpec::follower(dir.path())
+            .with_subsystem(SearchSubsystem)
+            .with_config(aes_cfg.clone()),
+    )
+    .expect("follower must open cleanly against an encrypted WAL");
+    assert_eq!(
+        read_kv(&follower, branch, "pre").as_deref(),
+        Some("before-follower"),
+        "follower recovery must decode existing encrypted records at open",
+    );
+
+    // Primary writes NEW records post-follower-open. Without the
+    // codec threading at `lifecycle.rs:339`, the follower's
+    // `refresh()` would build a codec-less `WalReader` and fail to
+    // decode the new ciphertext records. This is exactly the gap the
+    // reviewer caught on PR 2427 pre-part-4.
+    primary_put(&primary, branch, "post1", "after-refresh-1");
+    primary_put(&primary, branch, "post2", "after-refresh-2");
+    primary.flush().unwrap();
+
+    let outcome = follower.refresh();
+    assert!(
+        outcome.is_caught_up(),
+        "refresh under aes-gcm-256 must complete without blocking; got {outcome:?}",
+    );
+    assert!(
+        outcome.applied_count() >= 2,
+        "refresh must apply both new records; got applied_count = {}",
+        outcome.applied_count(),
+    );
+    assert_eq!(
+        read_kv(&follower, branch, "post1").as_deref(),
+        Some("after-refresh-1"),
+        "first post-open record must be visible after refresh",
+    );
+    assert_eq!(
+        read_kv(&follower, branch, "post2").as_deref(),
+        Some("after-refresh-2"),
+        "second post-open record must be visible after refresh",
+    );
+    assert_eq!(
+        read_kv(&follower, branch, "pre").as_deref(),
+        Some("before-follower"),
+        "pre-refresh record must still be visible (no wipe during healthy refresh)",
+    );
+
+    primary.shutdown().unwrap();
+    follower.shutdown().unwrap();
+}

--- a/crates/engine/tests/follower_tests.rs
+++ b/crates/engine/tests/follower_tests.rs
@@ -1598,3 +1598,88 @@ fn test_follower_refresh_with_non_identity_codec() {
     primary.shutdown().unwrap();
     follower.shutdown().unwrap();
 }
+
+/// T3-E12 §D7: follower-without-MANIFEST falls back to
+/// `get_codec(&cfg.storage.codec)` so encrypted WAL-only recovery
+/// works even when no MANIFEST has been persisted yet.
+///
+/// Pre-part-4, the absent-MANIFEST branch at `open.rs:441` left
+/// `follower_codec = None` and the recovery-coordinator wire was
+/// conditional on `Some(_)`. An encrypted follower opening against a
+/// directory without a MANIFEST would then read raw ciphertext and
+/// fail.
+///
+/// This test constructs a bare `wal/` directory (no MANIFEST) with an
+/// encrypted segment pre-written by a primary that cleanly shut down
+/// its MANIFEST alongside. We then delete the MANIFEST to simulate
+/// the "MANIFEST absent" state, and open a follower with the same
+/// aes-gcm-256 config. The open must succeed; WAL records must be
+/// readable through the config-derived codec fallback.
+#[test]
+fn test_follower_without_manifest_uses_config_codec() {
+    use strata_engine::StrataConfig;
+
+    const TEST_AES_KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+    struct KeyGuard;
+    impl Drop for KeyGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("STRATA_ENCRYPTION_KEY");
+        }
+    }
+    std::env::set_var("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+    let _key_guard = KeyGuard;
+
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+
+    let aes_cfg = StrataConfig {
+        durability: "standard".to_string(),
+        storage: strata_engine::StorageConfig {
+            codec: "aes-gcm-256".to_string(),
+            ..strata_engine::StorageConfig::default()
+        },
+        ..StrataConfig::default()
+    };
+
+    // Primary writes an encrypted record then cleanly shuts down.
+    {
+        let primary = Database::open_runtime(
+            OpenSpec::primary(dir.path())
+                .with_subsystem(SearchSubsystem)
+                .with_config(aes_cfg.clone()),
+        )
+        .unwrap();
+        primary_put(&primary, branch, "k", "v-from-primary");
+        primary.flush().unwrap();
+        primary.shutdown().unwrap();
+    }
+
+    // Simulate "MANIFEST absent": remove the persisted MANIFEST but
+    // leave the encrypted WAL segments. This is the D7 fallback case
+    // the reviewer flagged (PR 2427 finding #4) — pre-part-4, the
+    // follower would resolve `follower_codec = None` and silently read
+    // raw ciphertext through a codec-less reader.
+    let manifest_path = dir.path().join("MANIFEST");
+    if manifest_path.exists() {
+        std::fs::remove_file(&manifest_path).unwrap();
+    }
+
+    let follower = Database::open_runtime(
+        OpenSpec::follower(dir.path())
+            .with_subsystem(SearchSubsystem)
+            .with_config(aes_cfg),
+    )
+    .expect(
+        "follower must fall back to cfg.storage.codec when MANIFEST is \
+         absent so encrypted WAL-only recovery works (T3-E12 §D7)",
+    );
+
+    assert_eq!(
+        read_kv(&follower, branch, "k").as_deref(),
+        Some("v-from-primary"),
+        "follower without MANIFEST must decode the encrypted WAL via \
+         config-codec fallback and expose the primary's record",
+    );
+
+    follower.shutdown().unwrap();
+}


### PR DESCRIPTION
## Summary

WIP implementation of T3-E12 Phase 2 (tracking doc: [`docs/design/execution/t3-e12-phases.md`](docs/design/execution/t3-e12-phases.md)). Closes the primary-path DR-009 acceptance: `aes-gcm-256 + durability = "standard"` now round-trips through WAL recovery without special-case rejection.

Pushing early so the format + wiring work is reviewable; follower refresh wiring + dedicated AES-GCM tests land in follow-up commits.

## What's done (3 commits)

| Commit | Summary |
|---|---|
| `0a76455f` | Typed `SegmentHeaderError` / `WalSegmentError` enums; `from_bytes_slice` typed Result; `WalSegment::open_read`/`open_append` typed signatures; **`SEGMENT_FORMAT_VERSION` 2→3** with `LegacyFormat` rejection for pre-v3 segments |
| `a2f057c5` | Per-record outer envelope `[u32 outer_len][u32 outer_len_crc]` in writer's `append_inner`; reader's `read_segment_from` and `read_all_after_watermark_contiguous` rewritten with the new envelope-aware parse taxonomy (§D4); envelope-aware lossy scan-forward |
| `39aba017` | `WalReader::with_codec` builder; `decode_payload` helper; codec threading through `WalRecordIterator`; `RecoveryCoordinator::recover` threads codec + maps `WalReaderError::CodecDecode`/`LegacyFormat` to typed `StrataError` variants; **deletes both open-time rejection blocks** (`open.rs:884-891`, `:1552-1559`); adds `LegacyFormat` guard to both lossy branches so a pre-v3 segment hard-fails even with `allow_lossy_recovery=true` (§D6) |

## Key contract proofs

- `test_issue_1380_encryption_rejected_with_wal` **flipped** to `test_issue_1380_encryption_with_wal_succeeds_as_of_t3_e12` — the exact scenario that DR-009 named ("non-identity codec + WAL-durable") now opens successfully.
- `SegmentHeader::from_bytes_slice` is a typed `Result` path that folds in the minimum-size / magic / version / CRC / segment-number-match checks that pre-T3-E12 callers performed ad-hoc with `io::Error` construction (§D8).
- Codec decode failures ALWAYS return `Err(WalReaderError::CodecDecode)`, never `Ok(stop_reason)` — lossy mode routes to T3-E10 whole-DB wipe rather than silently short-reading (§D5).
- `LegacyFormat` is a hard-fail error; both engine lossy branches pattern-match the error variant and re-raise without wiping, since the wipe only recreates in-memory state and would leave pre-v3 segments on disk to re-poison every subsequent open (§D6).

## Verification so far

- [x] `cargo check --workspace` — clean
- [x] `cargo test -p strata-core` — 678 pass
- [x] `cargo test -p strata-durability` — 343 pass (including updated v1-rejection, CRC-mismatch, torn-length, mid-segment-corruption, watermark-skip tests)
- [x] `cargo test -p strata-concurrency` — 146 pass
- [x] `cargo test -p strata-engine --lib` — passes (2 pre-existing `shutdown` parallel-test flakes; all pass when run alone; same pattern observed during Phase 1)
- [x] `test_issue_1380_encryption_with_wal_succeeds_as_of_t3_e12` green

## Not in this PR yet (pushing next)

- `Database.wal_codec` field so `lifecycle.rs` follower-refresh threads the codec into the per-refresh `WalReader` (otherwise follower refresh breaks on aes-gcm-256 segments).
- Dedicated AES-GCM tests from Phase 2 part 5:
  - clean-shutdown round-trip
  - crash + reopen
  - large-record envelope (5 MB)
  - partial-tail truncation (deterministic mid-envelope truncation, not appended garbage)
  - mid-segment corruption surfaces as error, not silent skip
  - wrong-key → `LossyErrorKind::CodecDecode`
  - legacy format under `allow_lossy_recovery=true` still hard-fails
  - follower refresh under aes-gcm-256
  - follower-without-MANIFEST codec fallback

## Benchmark gate

Baseline capture + regression run (redb 5M / YCSB / WAL-latency / BEIR) will land with the final commit before merge. Opening early so the format work is reviewable — expect 1-2 more commits before the benchmark matrix runs.

## Change class & assurance

- **Change class:** intentional semantic change (new on-disk v3 format; pre-PR WAL segments unreadable including identity-codec) + cutover (`WalReader` gains codec field; `SegmentHeader::from_bytes_slice` / `WalSegment::open_read`/`open_append` signatures changed)
- **Assurance:** S4

## T3-E12 rollout status

- ✅ #2426 — Phase 1 typed error surfaces
- ➡ **#this PR** — Phase 2 v3 envelope + codec threading + rejection removal (WIP)
- ⏭ Phase 3a — safe pre-landing doc fixes
- ⏭ Phase 3b — post-landing state flip (gated strictly after Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)