### PR TITLE
T3-E8: historical cleanup + architecture doc + doc-truth regression

### DIFF
--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -85,7 +85,7 @@ impl RecoveryPlan {
 
 /// Coordinates database recovery after crash or restart.
 ///
-/// Epic 5 reshapes the coordinator into a callback-driven driver:
+/// The coordinator is a callback-driven driver:
 ///
 /// 1. `plan_recovery` validates MANIFEST codec identity before any WAL read.
 /// 2. `recover(on_snapshot, on_record)` streams snapshot install and WAL
@@ -93,8 +93,10 @@ impl RecoveryPlan {
 ///    directory layout and record streaming; the engine owns storage
 ///    construction and application.
 ///
-/// The legacy `recover_into_memory_storage` wrapper preserves the pre-Epic-5
-/// engine open surface until the callback-driven open path lands.
+/// A `recover_into_memory_storage` convenience wrapper is kept for
+/// in-crate tests and snapshot-less tooling paths that construct the
+/// coordinator directly; `Database::open_runtime` uses the direct
+/// callback API with a codec wired in.
 pub struct RecoveryCoordinator {
     /// Canonical database layout.
     layout: DatabaseLayout,
@@ -103,9 +105,10 @@ pub struct RecoveryCoordinator {
     /// When true, WAL reader scans past corrupted regions instead of erroring.
     allow_lossy_recovery: bool,
     /// Storage codec used to decode snapshot payloads. When unset, the
-    /// coordinator skips snapshot loading — callers that stay on the legacy
-    /// `recover_into_memory_storage` wrapper preserve WAL-only behavior until
-    /// they migrate to the direct callback API with a codec wired in.
+    /// coordinator skips snapshot loading and falls back to full WAL
+    /// replay. The `recover_into_memory_storage` wrapper does not
+    /// install a codec; engine opens drive `recover` directly and
+    /// install the codec via `with_codec`.
     codec: Option<Box<dyn StorageCodec>>,
 }
 
@@ -284,9 +287,11 @@ impl RecoveryCoordinator {
     ///
     /// The engine owns storage construction; the coordinator only:
     ///
-    /// 1. (future) Loads the snapshot declared in the MANIFEST and invokes
-    ///    `on_snapshot` with the decoded `LoadedSnapshot`. Snapshot loading
-    ///    is wired in Epic 5 Chunk 2 — until then `on_snapshot` never fires.
+    /// 1. Loads the snapshot declared in the MANIFEST (when a codec is
+    ///    installed via `with_codec`) and invokes `on_snapshot` with the
+    ///    decoded `LoadedSnapshot`. When no codec is installed the
+    ///    coordinator skips snapshot loading and falls back to full WAL
+    ///    replay; `on_snapshot` does not fire in that path.
     /// 2. Streams committed WAL records and invokes `on_record` for each,
     ///    preserving arrival order. Partial tails on the active segment
     ///    are truncated before return so reopens land on clean boundaries.
@@ -315,8 +320,9 @@ impl RecoveryCoordinator {
         // `with_codec()`, the coordinator consults the MANIFEST for a
         // recorded snapshot and invokes `on_snapshot` with the decoded
         // `LoadedSnapshot`. When no codec is installed, snapshot loading
-        // is skipped to preserve the pre-Epic-5 WAL-only behavior that the
-        // compat wrapper depends on.
+        // is skipped — the WAL-only replay path still produces
+        // `RecoveryStats` and the `recover_into_memory_storage`
+        // convenience wrapper depends on this no-codec default.
         //
         // The snapshot's `watermark_txn` is the max TxnId covered by the
         // snapshot and is folded into `max_txn_id` so the txn-id counter
@@ -372,7 +378,7 @@ impl RecoveryCoordinator {
             // are already reflected in the installed snapshot. Skip them to
             // avoid double-apply of puts/deletes. `snapshot_watermark_txn`
             // is zero when no snapshot was loaded, which degenerates to
-            // full WAL replay (the pre-Epic-5 behavior).
+            // full WAL replay (the no-codec fallback path).
             //
             // We still account for the txn id in `max_txn_id` so the
             // downstream coordinator sees the true max id across both
@@ -505,17 +511,17 @@ impl RecoveryCoordinator {
         }
     }
 
-    /// Legacy convenience wrapper that constructs a fresh `SegmentedStore`
-    /// rooted at the layout's segments directory and applies all WAL records
-    /// into it, returning the fully-materialized `RecoveryResult`.
+    /// Convenience wrapper that constructs a fresh `SegmentedStore` rooted
+    /// at the layout's segments directory and applies all WAL records into
+    /// it, returning the fully-materialized `RecoveryResult`.
     ///
-    /// This preserves the pre-Epic-5 surface so the engine open paths and
-    /// existing tests keep working while callback-driven recovery is staged.
-    /// Snapshot loading is not performed here; that arrives in later Epic 5
-    /// chunks alongside the engine-side decoder.
-    ///
-    /// Epic 5 Chunk 3 removes this wrapper once `Database::open` drives
-    /// `recover` directly with its own snapshot and WAL apply closures.
+    /// Used by in-crate tests and snapshot-less tooling paths that
+    /// construct the coordinator directly. `Database::open_runtime`
+    /// drives `recover` directly with its own snapshot and WAL apply
+    /// closures, so the shipped open path does not go through this
+    /// wrapper. Snapshot loading is not performed here — this entry
+    /// point intentionally skips the codec + snapshot path to keep
+    /// test fixtures simple.
     pub fn recover_into_memory_storage(self) -> StrataResult<RecoveryResult> {
         let storage = SegmentedStore::with_dir(
             self.layout.segments_dir().to_path_buf(),
@@ -1603,7 +1609,7 @@ mod tests {
     }
 
     // ========================================
-    // Epic 5 Chunk 1: plan_recovery + callback API
+    // plan_recovery + callback API tests
     // ========================================
 
     use strata_durability::ManifestManager;
@@ -1671,8 +1677,8 @@ mod tests {
         assert!(message.contains("aes-gcm-256"));
     }
 
-    /// plan_recovery reports snapshot identity and watermark so Epic 5
-    /// Chunk 2 can drive snapshot-install from the plan.
+    /// plan_recovery reports snapshot identity and watermark so the
+    /// coordinator's snapshot-install path can drive from the plan.
     #[test]
     fn test_plan_recovery_reports_snapshot_identity_and_watermark() {
         let temp_dir = TempDir::new().unwrap();
@@ -1693,8 +1699,9 @@ mod tests {
     }
 
     /// The callback-driven `recover()` fires `on_record` once per WAL record
-    /// in ascending txn-id order, never fires `on_snapshot` (Chunk 1 stub),
-    /// and returns aggregated stats matching the pre-Epic-5 surface.
+    /// in ascending txn-id order, does not fire `on_snapshot` when no codec
+    /// is installed, and returns aggregated stats matching the
+    /// `recover_into_memory_storage` convenience wrapper's semantics.
     #[test]
     fn test_recover_callback_fires_on_record_in_order() {
         let temp_dir = TempDir::new().unwrap();
@@ -1956,7 +1963,7 @@ mod tests {
     }
 
     // ========================================
-    // Epic 5 Chunk 2: coordinator snapshot loading
+    // Coordinator snapshot-loading tests
     // ========================================
 
     use strata_durability::disk_snapshot::{SnapshotSection, SnapshotWriter};

--- a/crates/engine/tests/architecture_doc_truth.rs
+++ b/crates/engine/tests/architecture_doc_truth.rs
@@ -1,0 +1,109 @@
+//! Regression test for T3-E8 / D-DR-12: `docs/architecture/durability-and-recovery.md`
+//! must describe the shipped durability path. Any forward-looking claim must
+//! be explicitly labeled with `[TARGET STATE]` on the same line so readers
+//! never confuse a planned behavior for a shipped one.
+//!
+//! The acceptance criterion from `durability-recovery-scope.md` Phase DR-10
+//! and the tranche-3 implementation plan Epic 8 is:
+//!
+//! > Add a grep-style regression test that fails on unlabeled target-state
+//! > phrases in the durability architecture doc.
+//!
+//! Adding a target-state phrase without the `[TARGET STATE]` label will fail
+//! this test. Removing the "current state as of" banner will also fail.
+//!
+//! If a legitimate use of a trigger word appears in prose where it is not
+//! claiming target-state (for example, "not yet" meaning "not until some
+//! runtime condition"), rephrase the sentence — the trigger list is narrow
+//! enough that the false-positive rate is intentionally low.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Phrases that, without an accompanying `[TARGET STATE]` marker on the same
+/// line, indicate the doc is describing unshipped behavior as if it had
+/// shipped. Matched case-insensitively against the line content.
+const TARGET_STATE_TRIGGERS: &[&str] = &[
+    "not yet",
+    "to be implemented",
+    "will be implemented",
+    "is planned",
+    "future work",
+    "in the future",
+    "eventually",
+    "upcoming",
+    "tbd",
+    "todo",
+    "fixme",
+    "will be added",
+    "will land",
+    "planned for",
+];
+
+/// The literal marker that labels a target-state claim as such.
+const TARGET_STATE_MARKER: &str = "[TARGET STATE]";
+
+/// The banner prefix that every architecture doc under this regime must carry
+/// so the reader knows the "as of" commit/date anchor.
+const CURRENT_STATE_BANNER: &str = "Current state as of";
+
+fn doc_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root")
+        .join("docs/architecture/durability-and-recovery.md")
+}
+
+fn read_doc() -> String {
+    let path = doc_path();
+    let display = path.display();
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {display}: {e}"))
+}
+
+#[test]
+fn durability_doc_has_current_state_banner() {
+    let doc = read_doc();
+    assert!(
+        doc.contains(CURRENT_STATE_BANNER),
+        "architecture doc at {} must contain a \"{CURRENT_STATE_BANNER} <commit/date>\" banner \
+         so readers know what state the doc describes",
+        doc_path().display()
+    );
+}
+
+#[test]
+fn durability_doc_has_no_unlabeled_target_state_claims() {
+    let doc = read_doc();
+    let mut violations: Vec<(usize, String, &str)> = Vec::new();
+
+    for (lineno, line) in doc.lines().enumerate() {
+        let lower = line.to_lowercase();
+        for trigger in TARGET_STATE_TRIGGERS {
+            if !lower.contains(trigger) {
+                continue;
+            }
+            if line.contains(TARGET_STATE_MARKER) {
+                continue;
+            }
+            violations.push((lineno + 1, line.to_string(), trigger));
+        }
+    }
+
+    if violations.is_empty() {
+        return;
+    }
+
+    let mut msg = format!(
+        "architecture doc at {} contains target-state phrases without a `{TARGET_STATE_MARKER}` label on the same line.\n\
+         Either remove the forward-looking phrasing or add `{TARGET_STATE_MARKER}` to make the target-state claim explicit.\n\n\
+         Offending lines:\n",
+        doc_path().display()
+    );
+    for (lineno, line, trigger) in &violations {
+        msg.push_str(&format!(
+            "  line {lineno}: trigger=\"{trigger}\"\n    {line}\n"
+        ));
+    }
+    panic!("{msg}");
+}

--- a/docs/architecture/durability-and-recovery.md
+++ b/docs/architecture/durability-and-recovery.md
@@ -1,0 +1,122 @@
+# Durability and Recovery
+
+> **Current state as of commit `5025903e` (2026-04-17), Tranche 3 Epics 1–12 (all of T3 except this doc's own landing).** This document describes the shipped behavior at that point. Any claim about behavior that has not yet landed is labeled **[TARGET STATE]** inline; everything else describes what the code does today. If you add new target-state material, label it inline so the doc-truth regression test at `crates/engine/tests/architecture_doc_truth.rs` does not fail.
+
+Strata's durability and recovery spine sits in three crates:
+
+- `strata_durability` owns physical formats — WAL segments, snapshots, MANIFEST — and the codec trait.
+- `strata_concurrency` owns `RecoveryCoordinator`, which plans recovery from the MANIFEST and drives snapshot install + WAL replay through callbacks.
+- `strata_engine` owns the `Database` runtime — open, commit, background flush, follower refresh, shutdown — and wires the coordinator into the open path.
+
+Nothing else writes the WAL, the MANIFEST, or snapshots, and no other crate is allowed to decide recovery ordering.
+
+## Recovery path on open
+
+`Database::open` walks the recovery pipeline once before the engine serves any traffic. The pipeline is the same for every `OpenSpec` mode (`primary`, `follower`, `cache`); only the post-recovery behavior differs (for example, `follower` skips `Subsystem::bootstrap` writes).
+
+1. **Plan recovery.** `RecoveryCoordinator::plan_recovery(expected_codec_id)` reads the MANIFEST if it exists. It produces a `RecoveryPlan` containing the manifest-present flag, the codec id, optional snapshot id and watermark, the flushed-through commit id, and the database UUID. Codec validation happens here: if the MANIFEST codec id does not match the coordinator's expected codec id, `plan_recovery` short-circuits with `StrataError::Corruption { message: "codec mismatch: …" }` before any WAL byte is read. A fresh database (no MANIFEST) returns a zero-valued plan.
+2. **Load snapshot.** When a codec has been installed via `RecoveryCoordinator::with_codec` and the MANIFEST records a snapshot, the coordinator reads the snapshot file, validates its magic/CRC/codec, and invokes the caller-supplied `on_snapshot` callback with the decoded `LoadedSnapshot`. The snapshot carries retention-complete state: tombstones and TTL metadata are installed verbatim alongside keys and versions, so restart does not resurrect deleted data or reset TTL expiry. When no codec is installed, snapshot load is skipped and recovery falls back to full WAL replay.
+3. **Delta-WAL replay.** The coordinator streams committed WAL records one segment at a time via `WalReader::iter_all`. Records with `txn_id <= snapshot_watermark` are skipped (they are already reflected in the installed snapshot); remaining records are handed to the caller-supplied `on_record` callback in arrival order. `Database::open` supplies an `on_record` closure that applies each record to the engine-owned `SegmentedStore` using `apply_wal_record_to_memory_storage`.
+4. **Partial-tail truncation.** After streaming, the coordinator truncates any partially-written bytes at the tail of the last WAL segment so the reopened WAL writer lands on a clean boundary.
+5. **Sidecar rebuild.** If a segment's `.meta` sidecar is missing or fails CRC, the coordinator rebuilds it by scanning the segment header. Existing sidecars are trusted.
+6. **Stats.** The coordinator returns `RecoveryStats` summarizing records replayed, records skipped below the snapshot watermark, writes and deletes applied, the max commit version, and the max txn id. The engine uses these to bootstrap the `TransactionManager` counters above the last committed state.
+
+The coordinator does not construct storage, does not open the WAL writer, and does not start any background thread. Those are engine responsibilities so the recovery coordinator has no latent global state of its own.
+
+## WAL write path
+
+Commits drive a three-phase WAL sync that prevents counter-reset races:
+
+1. **Append.** The WAL writer appends the record to the active segment buffer and returns an unsynced in-flight handle to the caller.
+2. **Fsync.** A background sync loop (one thread per database) fsyncs batches of in-flight handles. Only after the fsync returns does the writer's "durable-through" counter advance.
+3. **Visibility.** `Transaction::commit` blocks on its handle until the durable-through counter crosses the commit's record position, then publishes the commit via `CommitObserver`.
+
+If the fsync fails, the writer halts: it stores the error in `bg_error`, refuses further appends, and surfaces the failure through `Database::wal_writer_health()` as `WalWriterHealth::Halted { reason, first_observed_at, failed_sync_count }`. Commits that were appended and fsynced at the point of halt observe `StrataError::DurableButNotVisible { txn_id, commit_version }` (the record is on disk but the durable-through watermark could not advance); commits arriving after the halt observe `StrataError::WriterHalted`. Both are retryable after a successful resume. The writer only clears its halt on an explicit `Database::resume_wal_writer(confirm_reason)` call, which requires a fresh sync to succeed before the health flips back to `Healthy`. There is no silent retry — operator intent is required because a halt typically indicates a full disk, permission change, or filesystem corruption that must be addressed out-of-band.
+
+## Follower refresh
+
+Followers receive replicated records and apply them on `Database::refresh`. The shipped path serializes refresh through a single-flight gate and advances two watermarks:
+
+- **Received watermark** — the highest txn id accepted into the follower's local WAL.
+- **Applied (contiguous) watermark** — the highest txn id for which every prior record has been successfully applied to storage and every registered `RefreshHook` has returned.
+
+`ContiguousWatermark` is the contract: `Database::refresh` returns a `RefreshOutcome` whose applied watermark must never skip. If a `RefreshHook` returns an error, the failing record and every later record stay unreported to observers; the follower surfaces `BlockedTxn` with the offending txn id and `BlockReason` via `Database::follower_status()`. Operators skip a blocked record via `Database::admin_skip_blocked_record(txn_id, reason)`, which requires an exact txn id match (mismatch returns `UnblockError`) and writes a durable audit entry to `follower_audit.log`.
+
+`ReplayObserver::on_replay(ReplayInfo)` fires only after the applied watermark advances past a record, so observers never see replayed state that a later hook will reject. The replay observer and the commit observer are mutually exclusive (commit observers fire on primary writes; replay observers fire on follower replay).
+
+## Snapshots and checkpoints
+
+Snapshots are written by the background compaction pipeline, not by commit. A snapshot is a point-in-time materialization of a branch's committed state at a specific `snapshot_watermark` txn id, written to disk in the codec's on-disk format. The MANIFEST records the snapshot id, watermark, and the flushed-through commit id, so recovery can pick up from the snapshot and only replay the delta WAL above its watermark.
+
+Payload fidelity is retention-complete: tombstones and TTL expiry state round-trip through checkpoint install so restart preserves delete/expiry barriers. This is a deliberate Tranche 3 invariant — earlier drafts shipped a lossy checkpoint payload that required WAL replay to rebuild tombstones. That class of lossy reopen is gone.
+
+Pre-DR-5 `.chk` fixtures (from snapshots that were written but never loaded) are still consumable: Tranche 3 reads the existing snapshot format without a migration step.
+
+## Authoritative shutdown
+
+`Database::shutdown` is the one authoritative close barrier. It is the only supported way to close a database that guarantees on-disk durability of in-memory state. The fixed ordering:
+
+1. **Quiesce new work.** Flip `accepting_transactions` to `false` so `Database::begin_transaction` returns an `InvalidInput` error (`"Database is shutting down"`) and drain the background scheduler so no new transactions spawn through internal paths. On a subsequent timeout, the flag is restored so the database stays usable.
+2. **Wait for idle.** Block until active transactions drain. `shutdown_with_deadline(d)` returns `StrataError::ShutdownTimeout { active_txn_count }` without forcing abort if the deadline elapses; the database stays open and the caller decides whether to abort, extend, or retry.
+3. **Freeze subsystems.** Call `Subsystem::freeze()` on every registered subsystem in installation order.
+4. **Drain WAL.** Block until the WAL writer reports the durable-through counter equals the last appended record position.
+5. **Flush storage.** Drive a final memtable rotation and flush so the on-disk segment state reflects every durable commit.
+6. **Fsync MANIFEST.** Rewrite and fsync the MANIFEST so the next open's `plan_recovery` sees a consistent checkpoint id, flushed-through commit id, and codec id.
+7. **Stop background threads.** Signal the sync loop, the follower refresh loop (if any), and the compaction loop to exit, then join them.
+
+`ShutdownTimeout` is retryable — the caller may call `shutdown_with_deadline` again after intervening work completes. There is no warn-and-proceed fallback: shutdown either completes every step or returns the first failure with the database still open and its state unchanged.
+
+**[TARGET STATE]** Forced transaction abort on `ShutdownTimeout` is not provided. Tranche 3 deliberately returns the timeout and leaves retry/abort decisions to callers; a future product-layer policy may layer forced abort on top.
+
+## Codec uniformity
+
+One `CompatibilitySignature` describes the on-disk encoding for a database and is shared by the WAL, snapshots, and the MANIFEST. The codec id in the signature is the single fact that recovery, snapshot load, and runtime reuse (`OPEN_DATABASES` registry) all validate against. There is no separate "WAL codec" vs. "snapshot codec" — a mismatched codec fails at `plan_recovery` before any WAL byte is read and before any cached `Database` handle is reused.
+
+### WAL codec threading (Tranche 3 Epic 12)
+
+Every WAL read path decodes through the configured codec. A database configured with `codec = "aes-gcm-256"` + `durability = "standard"` writes encrypted WAL records and recovers them on restart without special-case rejection. Four reader construction sites are threaded with the codec: `RecoveryCoordinator::recover` at open time, `Database::refresh` on follower replay via a cached `Database.wal_codec` field, `WalReader::iter_all` for segment-at-a-time streaming, and the writer's `rebuild_meta_for_segment` for metadata-sidecar rebuilds on writer reopen.
+
+Each WAL record on disk uses the v3 per-record envelope:
+
+```
+[u32 outer_len] [u32 outer_len_crc] [ codec.encode(WalRecord::to_bytes()) ]
+```
+
+`outer_len_crc = crc32(&outer_len.to_le_bytes())` — mirrors the inner `LenCRC` pattern so a torn write to the outer length field is detectable before the reader tries to consume `outer_len` bytes. For the identity codec the envelope adds 8 bytes per record; for `aes-gcm-256` the codec itself adds 28 bytes (12-byte nonce + 16-byte auth tag) around the same inner record.
+
+`SEGMENT_FORMAT_VERSION` is 3 as of Tranche 3 Epic 12. Pre-v3 segments surface as `StrataError::LegacyFormat { found_version, hint }` on open — the hint names the operator action (delete `wal/` and reopen). The lossy-recovery wipe path does not bypass format incompatibility; both strict and lossy open reject pre-v3 segments with the same typed error. Legacy-format is classified separately from the whole-DB wipe triggered by codec-decode failures (see below).
+
+Codec decode failures — wrong key, AES-GCM auth-tag mismatch, corrupt ciphertext — surface as `WalReaderError::CodecDecode { offset, detail }` at the reader layer and `StrataError::CodecDecode` at the engine boundary. Under `allow_lossy_recovery = true` the decode failure routes to the whole-DB wipe-and-reopen path (same path used for other recoverable corruption) and the resulting `LossyRecoveryReport` carries `error_kind = LossyErrorKind::CodecDecode`, letting operators distinguish wrong-key scenarios from raw-byte storage corruption programmatically.
+
+A follower opening against a database without a persisted MANIFEST falls back to `get_codec(&cfg.storage.codec)` so encrypted WAL-only recovery works even before the first checkpoint has written a MANIFEST.
+
+## Insertion points for callers
+
+Callers that extend the recovery path work through a small set of engine-owned traits and callbacks:
+
+- **`CommitObserver`** — fires after a commit is visible on the primary. Used by triggers, intelligence subsystems, and downstream indexers.
+- **`ReplayObserver`** — fires on a follower after the applied watermark advances. Never fires on the primary.
+- **`RefreshHook`** (in-tree; not part of the public D4 surface) — fallible per-record follower hook. A hook failure blocks the contiguous watermark.
+- **`Subsystem::freeze`** — per-subsystem shutdown hook, invoked by `Database::shutdown` before the MANIFEST is fsynced.
+
+`RecoveryCoordinator::with_codec` is internal wiring, not a user-facing insertion point: `Database::open` installs the codec that matches the MANIFEST, and external callers never construct a coordinator directly.
+
+## What this document does not cover
+
+- Branch-aware storage retention above the recovery fidelity delivered in Tranche 3. That contract is defined by the branch-primitives scope (Tranche 4).
+- Product-layer shutdown policy such as forced abort on timeout. See `product-control-surface-scope.md` for how `ControlRegistry` classifies shutdown knobs.
+- Compaction scheduling and segment-merge policy beyond what is needed for recovery correctness. That lives in the storage and compaction design docs.
+
+## Where to look in the code
+
+| Concern | Crate | Entry point |
+|---------|-------|-------------|
+| Recovery planning and driver | `strata_concurrency` | `crates/concurrency/src/recovery.rs` |
+| WAL reader and segment format | `strata_durability` | `crates/durability/src/wal/` and `crates/durability/src/format/` |
+| Snapshot reader/writer | `strata_durability` | `crates/durability/src/disk_snapshot/` |
+| MANIFEST manager | `strata_durability` | `crates/durability/src/format/manifest.rs` |
+| Database layout | `strata_durability` | `crates/durability/src/layout.rs` |
+| Open path | `strata_engine` | `crates/engine/src/database/open.rs` |
+| WAL writer halt/resume | `strata_engine` | `crates/engine/src/database/mod.rs` (`wal_writer_health`, `resume_wal_writer`) |
+| Follower refresh and contiguous watermark | `strata_engine` | `crates/engine/src/database/lifecycle.rs` (`refresh`, `follower_status`, `admin_skip_blocked_record`); machinery in `refresh.rs` |
+| Shutdown barrier | `strata_engine` | `crates/engine/src/database/lifecycle.rs` (`shutdown`, `shutdown_with_deadline`) |

--- a/docs/design/execution/tranche-3-durability.md
+++ b/docs/design/execution/tranche-3-durability.md
@@ -292,7 +292,7 @@ Implementation note:
 - [ ] **Historical cleanup (DR-6):**
   - Delete M2-phase comments from `crates/concurrency/src/recovery.rs`
   - Delete dead `with_snapshot_path()` stub if still present
-  - Update research docs: mark Gap 1 resolved, update prioritized-fixes, refresh architectural-gaps
+  - Research-docs updates: not executable against this tree — the `research/core-engine/` directory that the T3 planning corpus references (`gaps/01-checkpoint-recovery-gap.md`, `prioritized-fixes.md`, `architectural-gaps.md`) was never checked into this repo. Confirmed by grep in the T3-E8 PR; this bullet is closed with the inventory mismatch documented rather than by manufacturing research docs.
   - Delete or mark `checkpoint-recovery-unification-plan.md` as superseded
 - [ ] **Doc alignment (DR-10):**
   - Add "current state as of [commit/date]" banner


### PR DESCRIPTION
## Summary

Final epic of Tranche 3. After this PR merges, T3 is done.

## Three deliverables

### 1. Strip historical framing from `recovery.rs`

10 doc-comment sites + 2 section-header sites rewritten to describe current behavior without \"Epic N / Chunk N / pre-Epic-N / (future)\" planning-epoch markers. Semantics unchanged. Grep verification:

```
$ git grep -nE 'Epic [0-9]|Chunk [0-9]|pre-Epic|pre-Chunk|\(future\)' crates/concurrency/src/recovery.rs
# no output
```

`with_snapshot_path()` stub: already absent on main. Nothing to delete.

### 2. New tracked architecture doc: `docs/architecture/durability-and-recovery.md`

Complete durability/recovery doc (122 lines) describing:
- Recovery path on open (`plan_recovery` → snapshot load → delta-WAL replay → partial-tail truncation → sidecar rebuild → stats)
- WAL three-phase sync (append / fsync / visibility) + halt-and-resume via `WalWriterHealth`
- Follower refresh with `ContiguousWatermark` (received vs applied watermarks, `BlockedTxn`, `admin_skip_blocked_record` audit trail)
- Snapshots / checkpoints with retention-complete payload fidelity
- Authoritative shutdown barrier
- **Codec uniformity** with a new \"WAL codec threading\" subsection covering T3-E12's Phase 2 deliverables (v3 envelope, `SEGMENT_FORMAT_VERSION` bump, four reader threading sites, typed `LegacyFormat` + `CodecDecode` error classification, follower no-MANIFEST config-codec fallback)
- Insertion points for callers (`CommitObserver`, `ReplayObserver`, `RefreshHook`, `Subsystem::freeze`)

Banner: **\"Current state as of commit `5025903e` (2026-04-17), Tranche 3 Epics 1–12.\"**

One `[TARGET STATE]` label retained (forced transaction abort on `ShutdownTimeout`) — explicitly out of scope per the tranche doc.

### 3. New tracked regression test: `crates/engine/tests/architecture_doc_truth.rs`

Two tests pin the doc's truth contract:

- `durability_doc_has_current_state_banner` — fails if the \"Current state as of\" anchor disappears.
- `durability_doc_has_no_unlabeled_target_state_claims` — greps the doc for 13 target-state trigger phrases (`not yet`, `to be implemented`, `will be implemented`, `is planned`, `future work`, `in the future`, `eventually`, `upcoming`, `tbd`, `todo`, `fixme`, `will be added`, `will land`, `planned for`). A hit without an accompanying `[TARGET STATE]` label on the same line fails the test. Adding forward-looking claims to the doc now requires either rephrasing or an explicit label.

```
$ cargo test -p strata-engine --test architecture_doc_truth
test durability_doc_has_current_state_banner ... ok
test durability_doc_has_no_unlabeled_target_state_claims ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

## Research-docs sub-task: closed via inventory acknowledgment

The tranche doc's \"Update research docs: mark Gap 1 resolved, update prioritized-fixes, refresh architectural-gaps\" bullet references a `research/core-engine/` directory that was **never checked into this repo**. Confirmed by grep across the full workspace and git history. Rather than manufacture research docs out of thin air, the bullet is replaced with a one-line inventory-mismatch note. If those docs exist in an external corpus, they should be updated there; they are explicitly not a gate for closing T3-E8.

`checkpoint-recovery-unification-plan.md`: already retired per the requirements + scope docs. File does not exist. Nothing to do.

## Change class & assurance

- **Change class:** doc comment edits + new architecture doc + new regression test
- **Assurance:** S2 (doc alignment) + S2 (new regression test)
- **Benchmark:** not required (tranche benchmark table explicitly marks E8 as \"—, doc-only\")

## Tranche 3 closeout status (all merged)

- ✅ T3-E1 through T3-E7 — #2411 through #2421
- ✅ T3-E9 contract hardening — #2422
- ✅ T3-E10 lossy telemetry — #2423
- ✅ T3-E11 policy matrix regression guard — #2425
- ✅ T3-E12 Phase 1 / 2 / 3a+3b — #2426 / #2427 / #2428
- ➡ **T3-E8 (this PR) — historical cleanup + architecture doc + doc-truth test**

After merge, CLAUDE.md's Active Tranche can flip to Tranche 4.

## Test plan

- [x] `cargo test -p strata-engine --test architecture_doc_truth` — 2/2 pass
- [x] `cargo test -p strata-concurrency --lib` — 146/146 pass (no regression from recovery.rs doc-comment edits)
- [x] `cargo check --workspace` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Grep verification: no historical framing remains in `crates/concurrency/src/recovery.rs`

## Rollback

Trivially reversible. Doc-comment edits in `recovery.rs` are revertible; the architecture doc and doc-truth test are net-new files (straight revert). The tranche-doc bullet change is one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)