### PR TITLE
SE1: publication barrier — propagate manifest publish + dir fsync failures

### DIFF
--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -1,0 +1,109 @@
+//! Storage-crate typed error surface.
+//!
+//! [`StorageError`] is the return type for storage operations where the
+//! caller needs richer context than [`std::io::Error`] provides (notably,
+//! the branch identity behind a failed manifest publish, and the directory
+//! path behind a failed `sync_all`).
+//!
+//! Internal storage code still composes `io::Result<T>` inside storage
+//! functions via the `From<io::Error>` conversion; the typed variants are
+//! constructed only at the two sites that own the additional context
+//! ([`crate::segmented::SegmentedStore::write_branch_manifest`] and
+//! [`crate::manifest::write_manifest`]).
+
+use std::io;
+use std::path::PathBuf;
+
+use strata_core::types::BranchId;
+use strata_core::StrataError;
+use thiserror::Error;
+
+/// Typed errors produced by storage-layer publish and durability
+/// primitives.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum StorageError {
+    /// Publishing the on-disk branch manifest failed.
+    ///
+    /// Returned by `write_branch_manifest` when the branch directory
+    /// cannot be created or the manifest file cannot be written/renamed.
+    /// Callers must treat this as a refused publish: any deletion of the
+    /// old input segments that was gated on a successful publish is not
+    /// performed.
+    #[error("manifest publish failed for branch {branch_id}: {inner}")]
+    ManifestPublish {
+        /// Branch whose manifest failed to publish.
+        branch_id: BranchId,
+        /// Underlying I/O error.
+        #[source]
+        inner: io::Error,
+    },
+
+    /// Fsync on a parent directory failed.
+    ///
+    /// Used by `write_manifest` and any other durability primitive that
+    /// needs to prove a rename is durable on crash. The underlying rename
+    /// may have succeeded, so callers should treat this as a durability
+    /// failure rather than a content failure.
+    #[error("directory fsync failed for {}: {inner}", dir.display())]
+    DirFsync {
+        /// Directory that failed to fsync.
+        dir: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        inner: io::Error,
+    },
+
+    /// An otherwise-uncategorised storage I/O error.
+    ///
+    /// Preserves the original [`io::Error`] so callers that pattern-match
+    /// on [`io::ErrorKind`] continue to work after the migration from
+    /// `io::Result<T>`.
+    #[error("storage i/o error: {0}")]
+    Io(#[from] io::Error),
+}
+
+impl StorageError {
+    /// Return the underlying [`io::ErrorKind`].
+    ///
+    /// Preserves the `io::ErrorKind` inspection API that callers had when
+    /// storage functions returned `io::Result<T>`. For variants that do not
+    /// wrap an [`io::Error`], returns [`io::ErrorKind::Other`].
+    pub fn kind(&self) -> io::ErrorKind {
+        match self {
+            StorageError::ManifestPublish { inner, .. } => inner.kind(),
+            StorageError::DirFsync { inner, .. } => inner.kind(),
+            StorageError::Io(e) => e.kind(),
+        }
+    }
+}
+
+/// Convenience alias for `Result<T, StorageError>`.
+pub type StorageResult<T> = Result<T, StorageError>;
+
+/// Cross-layer conversion so engine-layer code can use `?` to surface
+/// storage failures as [`StrataError`].
+///
+/// - [`StorageError::ManifestPublish`] → [`StrataError::Corruption`] (publish
+///   barrier violation is a durable-state correctness failure). The inner
+///   [`io::Error`]'s description is embedded in the message because
+///   `StrataError::Corruption` has no source field today.
+/// - [`StorageError::DirFsync`] → [`StrataError::Storage`] with the original
+///   [`io::Error`] preserved as `source` (durability failure, not content
+///   corruption).
+/// - [`StorageError::Io`] → [`StrataError::Storage`] with source preserved —
+///   matches the existing `From<io::Error> for StrataError` behavior.
+impl From<StorageError> for StrataError {
+    fn from(e: StorageError) -> Self {
+        match e {
+            StorageError::ManifestPublish { branch_id, inner } => StrataError::corruption(
+                format!("manifest publish failed for branch {branch_id}: {inner}"),
+            ),
+            StorageError::DirFsync { dir, inner } => StrataError::storage_with_source(
+                format!("directory fsync failed for {}", dir.display()),
+                inner,
+            ),
+            StorageError::Io(io) => StrataError::from(io),
+        }
+    }
+}

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -96,9 +96,9 @@ pub type StorageResult<T> = Result<T, StorageError>;
 impl From<StorageError> for StrataError {
     fn from(e: StorageError) -> Self {
         match e {
-            StorageError::ManifestPublish { branch_id, inner } => StrataError::corruption(
-                format!("manifest publish failed for branch {branch_id}: {inner}"),
-            ),
+            StorageError::ManifestPublish { branch_id, inner } => StrataError::corruption(format!(
+                "manifest publish failed for branch {branch_id}: {inner}"
+            )),
             StorageError::DirFsync { dir, inner } => StrataError::storage_with_source(
                 format!("directory fsync failed for {}", dir.display()),
                 inner,

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -32,8 +32,8 @@ pub mod test_hooks;
 pub mod ttl;
 
 pub use bloom::BloomFilter;
-pub use error::{StorageError, StorageResult};
 pub use compaction::{CompactionIterator, CompactionScheduler, TierMergeCandidate};
+pub use error::{StorageError, StorageResult};
 pub use index::{BranchIndex, TypeIndex};
 pub use memory_stats::{BranchMemoryStats, StorageMemoryStats};
 pub use pressure::{MemoryPressure, PressureLevel};

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod block_cache;
 pub mod bloom;
 pub mod compaction;
+pub mod error;
 pub mod index;
 pub mod key_encoding;
 pub mod manifest;
@@ -26,9 +27,12 @@ pub mod segment;
 pub mod segment_builder;
 pub mod segmented;
 pub mod stored_value;
+#[doc(hidden)]
+pub mod test_hooks;
 pub mod ttl;
 
 pub use bloom::BloomFilter;
+pub use error::{StorageError, StorageResult};
 pub use compaction::{CompactionIterator, CompactionScheduler, TierMergeCandidate};
 pub use index::{BranchIndex, TypeIndex};
 pub use memory_stats::{BranchMemoryStats, StorageMemoryStats};

--- a/crates/storage/src/manifest.rs
+++ b/crates/storage/src/manifest.rs
@@ -19,9 +19,12 @@
 
 use std::io;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use strata_core::id::CommitVersion;
 use strata_core::types::BranchId;
+
+use crate::error::{StorageError, StorageResult};
 
 /// Magic bytes for segment manifest: "STRAMFST"
 const MANIFEST_MAGIC: [u8; 8] = *b"STRAMFST";
@@ -34,6 +37,9 @@ const HEADER_SIZE: usize = 20;
 
 /// Manifest file name.
 const MANIFEST_FILENAME: &str = "segments.manifest";
+
+/// Monotonic counter for unique `write_manifest` temp-file names.
+static TMP_NONCE: AtomicU64 = AtomicU64::new(0);
 
 /// A single entry in the manifest.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -66,12 +72,15 @@ pub struct SegmentManifest {
     pub inherited_layers: Vec<ManifestInheritedLayer>,
 }
 
-/// Write a manifest file to `dir/segments.manifest` atomically (temp + rename).
+/// Write a manifest file to `dir/segments.manifest` atomically (temp + rename + dir fsync).
+///
+/// Returns `Err(StorageError::DirFsync)` if the final parent-directory fsync fails.
+/// Other I/O failures (create/write/rename) are surfaced as `StorageError::Io`.
 pub fn write_manifest(
     dir: &Path,
     entries: &[ManifestEntry],
     inherited_layers: &[ManifestInheritedLayer],
-) -> io::Result<()> {
+) -> StorageResult<()> {
     let mut buf = Vec::with_capacity(HEADER_SIZE + entries.len() * 20 + 4);
 
     // Header
@@ -101,9 +110,22 @@ pub fn write_manifest(
     let crc = crc32fast::hash(&buf);
     buf.extend_from_slice(&crc.to_le_bytes());
 
-    // Atomic write: temp file + fsync + rename + dir fsync
+    // Atomic write: temp file + fsync + rename + dir fsync.
+    //
+    // The temp filename includes a per-call nonce (pid + monotonic counter)
+    // so two concurrent `write_manifest` calls on the same directory do not
+    // race on the same tmp path. Without this, one caller's `rename(tmp,
+    // final)` can observe ENOENT if the other caller's rename already moved
+    // the shared tmp away. The final path is still a single contended name,
+    // but `rename` is atomic per-call on POSIX so concurrent renames yield
+    // well-defined last-write-wins semantics.
     let final_path = dir.join(MANIFEST_FILENAME);
-    let tmp_path = dir.join(format!("{}.tmp", MANIFEST_FILENAME));
+    let tmp_path = dir.join(format!(
+        "{}.tmp.{}.{}",
+        MANIFEST_FILENAME,
+        std::process::id(),
+        TMP_NONCE.fetch_add(1, Ordering::Relaxed),
+    ));
 
     // Write and fsync the temp file before rename — ensures data is
     // durable on disk, not just in the page cache.
@@ -115,11 +137,26 @@ pub fn write_manifest(
 
     std::fs::rename(&tmp_path, &final_path)?;
 
-    // Fsync the parent directory to make the rename durable.
-    // Failure here is non-fatal (rename already succeeded).
-    if let Ok(dir_fd) = std::fs::File::open(dir) {
-        let _ = dir_fd.sync_all();
+    // Test-only fault injection — consumed once per armed failure.
+    if let Some(inner) = crate::test_hooks::maybe_inject_dir_fsync_failure() {
+        return Err(StorageError::DirFsync {
+            dir: dir.to_path_buf(),
+            inner,
+        });
     }
+
+    // Fsync the parent directory to make the rename durable. The rename has
+    // already landed in the page cache, but without this fsync the directory
+    // entry may not survive a crash — so a failure here is a durability
+    // failure surfaced to the caller rather than silently dropped.
+    let dir_fd = std::fs::File::open(dir).map_err(|inner| StorageError::DirFsync {
+        dir: dir.to_path_buf(),
+        inner,
+    })?;
+    dir_fd.sync_all().map_err(|inner| StorageError::DirFsync {
+        dir: dir.to_path_buf(),
+        inner,
+    })?;
 
     Ok(())
 }

--- a/crates/storage/src/segment_builder.rs
+++ b/crates/storage/src/segment_builder.rs
@@ -463,9 +463,8 @@ impl SegmentBuilder {
 
         // 10. Fsync parent directory so the rename is durable on crash.
         if let Some(parent) = path.parent() {
-            if let Ok(dir_fd) = std::fs::File::open(parent) {
-                let _ = dir_fd.sync_all();
-            }
+            let dir_fd = std::fs::File::open(parent)?;
+            dir_fd.sync_all()?;
         }
 
         Ok(SegmentMeta {

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -168,7 +168,7 @@ impl SegmentedStore {
         &self,
         branch_id: &BranchId,
         prune_floor: CommitVersion,
-    ) -> io::Result<Option<PickAndCompactResult>> {
+    ) -> StorageResult<Option<PickAndCompactResult>> {
         if self.segments_dir.is_none() {
             return Ok(None);
         }
@@ -214,7 +214,7 @@ impl SegmentedStore {
         &self,
         branch_id: &BranchId,
         prune_floor: CommitVersion,
-    ) -> io::Result<Option<CompactionResult>> {
+    ) -> StorageResult<Option<CompactionResult>> {
         let segments_dir = match &self.segments_dir {
             Some(d) => d,
             None => return Ok(None),
@@ -270,12 +270,12 @@ impl SegmentedStore {
             Ok(meta) => meta,
             Err(e) => {
                 cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-                return Err(e);
+                return Err(e.into());
             }
         };
         if let Err(e) = check_corruption_flags(&corruption_flags) {
             cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-            return Err(e);
+            return Err(e.into());
         }
 
         // Open the newly written segment.
@@ -283,7 +283,7 @@ impl SegmentedStore {
             Ok(seg) => seg,
             Err(e) => {
                 cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-                return Err(e);
+                return Err(e.into());
             }
         };
 
@@ -315,9 +315,9 @@ impl SegmentedStore {
 
         // Persist manifest BEFORE deleting old files — if we crash after
         // delete but before manifest write, recovery would reference missing
-        // segments. Writing manifest first ensures crash recovery can always
-        // find the new compacted segment.
-        self.write_branch_manifest(branch_id);
+        // segments. A publish failure here short-circuits before the delete
+        // loop below, so old inputs survive an unobserved publish.
+        self.write_branch_manifest(branch_id)?;
 
         // Now safe to delete old segment files (refcount-guarded).
         for seg in &old_segments {
@@ -364,7 +364,7 @@ impl SegmentedStore {
         branch_id: &BranchId,
         segment_indices: &[usize],
         prune_floor: CommitVersion,
-    ) -> io::Result<Option<CompactionResult>> {
+    ) -> StorageResult<Option<CompactionResult>> {
         if segment_indices.len() < 2 {
             return Ok(None);
         }
@@ -428,19 +428,19 @@ impl SegmentedStore {
             Ok(meta) => meta,
             Err(e) => {
                 cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-                return Err(e);
+                return Err(e.into());
             }
         };
         if let Err(e) = check_corruption_flags(&corruption_flags) {
             cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-            return Err(e);
+            return Err(e.into());
         }
 
         let new_segment = match KVSegment::open(&seg_path) {
             Ok(seg) => seg,
             Err(e) => {
                 cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-                return Err(e);
+                return Err(e.into());
             }
         };
 
@@ -470,8 +470,10 @@ impl SegmentedStore {
             refresh_level_targets(&mut branch, self.level_base_bytes());
         }
 
-        // Persist manifest BEFORE deleting old files (crash safety).
-        self.write_branch_manifest(branch_id);
+        // Persist manifest BEFORE deleting old files (crash safety). A
+        // publish failure short-circuits before the delete loop, leaving
+        // old inputs intact.
+        self.write_branch_manifest(branch_id)?;
 
         // Delete old segment files (refcount-guarded).
         for seg in &selected_segments {
@@ -500,7 +502,7 @@ impl SegmentedStore {
         &self,
         branch_id: &BranchId,
         prune_floor: CommitVersion,
-    ) -> io::Result<Option<CompactionResult>> {
+    ) -> StorageResult<Option<CompactionResult>> {
         let segments_dir = match &self.segments_dir {
             Some(d) => d,
             None => return Ok(None),
@@ -634,14 +636,14 @@ impl SegmentedStore {
             Err(e) => {
                 let end_id = next_id.load(Ordering::Relaxed);
                 cleanup_partial_compaction_outputs(&branch_dir, start_id, end_id);
-                return Err(e);
+                return Err(e.into());
             }
         };
         if let Err(e) = check_corruption_flags(&corruption_flags) {
             for (path, _) in &outputs {
                 let _ = std::fs::remove_file(path);
             }
-            return Err(e);
+            return Err(e.into());
         }
 
         let output_entries: u64 = outputs.iter().map(|(_, m)| m.entry_count).sum();
@@ -656,7 +658,7 @@ impl SegmentedStore {
                     for (p, _) in &outputs {
                         let _ = std::fs::remove_file(p);
                     }
-                    return Err(e);
+                    return Err(e.into());
                 }
             }
         }
@@ -692,8 +694,9 @@ impl SegmentedStore {
             refresh_level_targets(&mut branch, self.level_base_bytes());
         }
 
-        // Persist manifest BEFORE deleting old files (crash safety).
-        self.write_branch_manifest(branch_id);
+        // Persist manifest BEFORE deleting old files (crash safety). A
+        // publish failure short-circuits before the delete loops below.
+        self.write_branch_manifest(branch_id)?;
 
         // Now safe to delete old files (refcount-guarded).
         for seg in &l0_segs {
@@ -730,7 +733,7 @@ impl SegmentedStore {
         branch_id: &BranchId,
         level: usize,
         prune_floor: CommitVersion,
-    ) -> io::Result<Option<CompactionResult>> {
+    ) -> StorageResult<Option<CompactionResult>> {
         if level >= NUM_LEVELS - 1 {
             return Ok(None); // can't compact the last level further
         }
@@ -852,7 +855,11 @@ impl SegmentedStore {
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
             refresh_level_targets(&mut branch, self.level_base_bytes());
             drop(branch);
-            self.write_branch_manifest(branch_id);
+            // Trivial move: no files were written or deleted, only a
+            // metadata-only level shift. A publish failure here leaves the
+            // in-memory state ahead of the on-disk manifest; recovery will
+            // reload the pre-move manifest — still consistent.
+            self.write_branch_manifest(branch_id)?;
 
             return Ok(Some(CompactionResult {
                 segments_merged: 1,
@@ -947,14 +954,14 @@ impl SegmentedStore {
             Err(e) => {
                 let end_id = next_id.load(Ordering::Relaxed);
                 cleanup_partial_compaction_outputs(&branch_dir, start_id, end_id);
-                return Err(e);
+                return Err(e.into());
             }
         };
         if let Err(e) = check_corruption_flags(&corruption_flags) {
             for (path, _) in &outputs {
                 let _ = std::fs::remove_file(path);
             }
-            return Err(e);
+            return Err(e.into());
         }
 
         let output_entries: u64 = outputs.iter().map(|(_, m)| m.entry_count).sum();
@@ -969,7 +976,7 @@ impl SegmentedStore {
                     for (p, _) in &outputs {
                         let _ = std::fs::remove_file(p);
                     }
-                    return Err(e);
+                    return Err(e.into());
                 }
             }
         }
@@ -1005,8 +1012,9 @@ impl SegmentedStore {
 
         // ── 5. Cleanup ─────────────────────────────────────────────────
 
-        // Persist manifest BEFORE deleting old files (crash safety).
-        self.write_branch_manifest(branch_id);
+        // Persist manifest BEFORE deleting old files (crash safety). A
+        // publish failure short-circuits before the delete loops below.
+        self.write_branch_manifest(branch_id)?;
 
         // Delete old segment files (refcount-guarded).
         for seg in &input_segs {

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -316,7 +316,11 @@ impl SegmentedStore {
         // Persist manifest BEFORE deleting old files — if we crash after
         // delete but before manifest write, recovery would reference missing
         // segments. A publish failure here short-circuits before the delete
-        // loop below, so old inputs survive an unobserved publish.
+        // loop below, so old inputs survive an unobserved publish. In-memory
+        // state is left ahead of the on-disk manifest by design: the next
+        // successful publish on this branch re-persists the full version; if
+        // we crash before then, recovery reloads the pre-compaction manifest
+        // and the new output segment is reclaimed by orphan-GC (SE3).
         self.write_branch_manifest(branch_id)?;
 
         // Now safe to delete old segment files (refcount-guarded).
@@ -472,7 +476,11 @@ impl SegmentedStore {
 
         // Persist manifest BEFORE deleting old files (crash safety). A
         // publish failure short-circuits before the delete loop, leaving
-        // old inputs intact.
+        // old inputs intact. In-memory state is left ahead of the on-disk
+        // manifest by design: a later successful publish re-persists the
+        // full version, and a pre-publish crash reloads the pre-compaction
+        // manifest with the new output treated as an orphan (reclaimed by
+        // SE3 orphan-GC).
         self.write_branch_manifest(branch_id)?;
 
         // Delete old segment files (refcount-guarded).
@@ -696,6 +704,10 @@ impl SegmentedStore {
 
         // Persist manifest BEFORE deleting old files (crash safety). A
         // publish failure short-circuits before the delete loops below.
+        // In-memory state is left ahead of the on-disk manifest by design:
+        // a later successful publish re-persists the full version, and a
+        // pre-publish crash reloads the pre-compaction manifest with the
+        // new L1 outputs treated as orphans (reclaimed by SE3 orphan-GC).
         self.write_branch_manifest(branch_id)?;
 
         // Now safe to delete old files (refcount-guarded).

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -920,7 +920,10 @@ impl SegmentedStore {
         layer_segments: &Arc<SegmentVersion>,
         new_segments: &[Arc<KVSegment>],
     ) {
-        let new_ids: HashSet<u64> = new_segments.iter().map(|segment| segment.file_id()).collect();
+        let new_ids: HashSet<u64> = new_segments
+            .iter()
+            .map(|segment| segment.file_id())
+            .collect();
 
         if let Some(mut branch) = self.branches.get_mut(child_branch_id) {
             let cur_ver = branch.version.load();
@@ -1422,9 +1425,7 @@ impl SegmentedStore {
             let branch = match self.branches.get(child_branch_id) {
                 Some(b) => b,
                 None => {
-                    return Err(
-                        io::Error::new(io::ErrorKind::NotFound, "branch not found").into(),
-                    )
+                    return Err(io::Error::new(io::ErrorKind::NotFound, "branch not found").into())
                 }
             };
             if layer_index >= branch.inherited_layers.len() {
@@ -1472,9 +1473,7 @@ impl SegmentedStore {
             let mut branch = match self.branches.get_mut(child_branch_id) {
                 Some(b) => b,
                 None => {
-                    return Err(
-                        io::Error::new(io::ErrorKind::NotFound, "branch not found").into(),
-                    )
+                    return Err(io::Error::new(io::ErrorKind::NotFound, "branch not found").into())
                 }
             };
             if layer_index < branch.inherited_layers.len() {

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -846,6 +846,10 @@ impl SegmentedStore {
     }
 
     fn cleanup_created_segment_files(&self, paths: &[PathBuf]) {
+        // Best-effort: rollback paths only run after a refused publish, so any
+        // file left behind is already unreferenced by the durable manifest and
+        // will be reclaimed by orphan-GC (SE3). Propagating errors here would
+        // mask the original ManifestPublish error the caller must see.
         let mut parent_dirs = HashSet::new();
         for path in paths {
             if let Some(parent) = path.parent() {
@@ -884,6 +888,8 @@ impl SegmentedStore {
             }
         }
 
+        // Best-effort: the refused publish means this file is unreferenced
+        // by any durable manifest, so any leftover is SE3 orphan-GC territory.
         let _ = std::fs::remove_file(new_segment.file_path());
         if let Some(parent) = new_segment.file_path().parent() {
             let _ = std::fs::remove_dir(parent);
@@ -1929,11 +1935,14 @@ impl SegmentedStore {
 
         // 6. Attach to dest branch, rejecting if a concurrent fork already installed layers.
         let dest_layers_for_rollback = dest_layers.clone();
-        let dest_was_new = !self.branches.contains_key(dest_id);
-        let mut dest = self
-            .branches
-            .entry(*dest_id)
-            .or_insert_with(BranchState::new);
+        // Capture dest_was_new from inside the insert path so it reflects the
+        // atomic decision, not a prior contains_key probe that can race with a
+        // concurrent insert.
+        let mut dest_was_new = false;
+        let mut dest = self.branches.entry(*dest_id).or_insert_with(|| {
+            dest_was_new = true;
+            BranchState::new()
+        });
         if !dest.inherited_layers.is_empty() {
             drop(dest);
             // Undo refcount increments from step 2.

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -25,6 +25,7 @@ use crate::segment_builder::{SegmentBuilder, SplittingSegmentBuilder};
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::io;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -844,6 +845,187 @@ impl SegmentedStore {
         }
     }
 
+    fn cleanup_created_segment_files(&self, paths: &[PathBuf]) {
+        let mut parent_dirs = HashSet::new();
+        for path in paths {
+            if let Some(parent) = path.parent() {
+                parent_dirs.insert(parent.to_path_buf());
+            }
+            let _ = std::fs::remove_file(path);
+        }
+        for dir in parent_dirs {
+            let _ = std::fs::remove_dir(&dir);
+        }
+    }
+
+    fn rollback_flush_publish_failure(
+        &self,
+        branch_id: &BranchId,
+        frozen_mt: &Arc<Memtable>,
+        new_segment: &KVSegment,
+    ) {
+        crate::block_cache::global_cache().invalidate_file(new_segment.file_id());
+
+        if let Some(mut branch) = self.branches.get_mut(branch_id) {
+            let cur_ver = branch.version.load();
+            let mut new_levels = cur_ver.levels.clone();
+            let old_l0_len = new_levels[0].len();
+            new_levels[0].retain(|seg| seg.file_id() != new_segment.file_id());
+            if new_levels[0].len() != old_l0_len {
+                branch
+                    .version
+                    .store(Arc::new(SegmentVersion { levels: new_levels }));
+                refresh_level_targets(&mut branch, self.level_base_bytes());
+            }
+
+            if !branch.frozen.iter().any(|mt| mt.id() == frozen_mt.id()) {
+                branch.frozen.push(Arc::clone(frozen_mt));
+                self.total_frozen_count.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let _ = std::fs::remove_file(new_segment.file_path());
+        if let Some(parent) = new_segment.file_path().parent() {
+            let _ = std::fs::remove_dir(parent);
+        }
+    }
+
+    fn rollback_materialize_status(
+        &self,
+        child_branch_id: &BranchId,
+        source_branch_id: BranchId,
+        fork_version: CommitVersion,
+    ) {
+        if let Some(mut branch) = self.branches.get_mut(child_branch_id) {
+            if let Some(layer) = branch.inherited_layers.iter_mut().find(|layer| {
+                layer.source_branch_id == source_branch_id && layer.fork_version == fork_version
+            }) {
+                layer.status = LayerStatus::Active;
+            }
+        }
+    }
+
+    fn rollback_materialize_install(
+        &self,
+        child_branch_id: &BranchId,
+        layer_index: usize,
+        source_branch_id: BranchId,
+        fork_version: CommitVersion,
+        layer_segments: &Arc<SegmentVersion>,
+        new_segments: &[Arc<KVSegment>],
+    ) {
+        let new_ids: HashSet<u64> = new_segments.iter().map(|segment| segment.file_id()).collect();
+
+        if let Some(mut branch) = self.branches.get_mut(child_branch_id) {
+            let cur_ver = branch.version.load();
+            let mut new_levels = cur_ver.levels.clone();
+            let old_l0_len = new_levels[0].len();
+            new_levels[0].retain(|seg| !new_ids.contains(&seg.file_id()));
+            if new_levels[0].len() != old_l0_len {
+                branch
+                    .version
+                    .store(Arc::new(SegmentVersion { levels: new_levels }));
+            }
+
+            if let Some(layer) = branch.inherited_layers.iter_mut().find(|layer| {
+                layer.source_branch_id == source_branch_id && layer.fork_version == fork_version
+            }) {
+                layer.status = LayerStatus::Active;
+            } else {
+                let restore_index = layer_index.min(branch.inherited_layers.len());
+                branch.inherited_layers.insert(
+                    restore_index,
+                    InheritedLayer {
+                        source_branch_id,
+                        fork_version,
+                        segments: Arc::clone(layer_segments),
+                        status: LayerStatus::Active,
+                    },
+                );
+            }
+
+            refresh_level_targets(&mut branch, self.level_base_bytes());
+        }
+
+        for segment in new_segments {
+            crate::block_cache::global_cache().invalidate_file(segment.file_id());
+        }
+        let created_paths: Vec<_> = new_segments
+            .iter()
+            .map(|segment| segment.file_path().to_path_buf())
+            .collect();
+        self.cleanup_created_segment_files(&created_paths);
+    }
+
+    fn rollback_fork_source_publish_failure(
+        &self,
+        source_id: &BranchId,
+        old_active: Arc<Memtable>,
+        old_frozen: Vec<Arc<Memtable>>,
+        old_version: Arc<SegmentVersion>,
+        old_level_targets: compaction::LevelTargets,
+        source_flush_paths: &[PathBuf],
+        dest_layers: &[InheritedLayer],
+    ) {
+        if let Some(mut source) = self.branches.get_mut(source_id) {
+            let current_frozen = source.frozen.len();
+            let restored_frozen = old_frozen.len();
+            if restored_frozen > current_frozen {
+                self.total_frozen_count
+                    .fetch_add(restored_frozen - current_frozen, Ordering::Relaxed);
+            } else if current_frozen > restored_frozen {
+                self.total_frozen_count
+                    .fetch_sub(current_frozen - restored_frozen, Ordering::Relaxed);
+            }
+
+            source.active = old_active;
+            source.frozen = old_frozen;
+            source.version.store(old_version);
+            source.level_targets = old_level_targets;
+        }
+
+        self.cleanup_created_segment_files(source_flush_paths);
+        for layer in dest_layers {
+            for level in &layer.segments.levels {
+                for seg in level {
+                    self.ref_registry.decrement(seg.file_id());
+                }
+            }
+        }
+    }
+
+    fn rollback_fork_dest_publish_failure(
+        &self,
+        dest_id: &BranchId,
+        dest_layers: &[InheritedLayer],
+        dest_was_new: bool,
+    ) {
+        for layer in dest_layers {
+            for level in &layer.segments.levels {
+                for seg in level {
+                    self.ref_registry.decrement(seg.file_id());
+                }
+            }
+        }
+
+        let mut remove_branch = false;
+        if let Some(mut dest) = self.branches.get_mut(dest_id) {
+            dest.inherited_layers.clear();
+            dest.max_version.store(0, Ordering::Release);
+            if dest_was_new
+                && dest.active.is_empty()
+                && dest.frozen.is_empty()
+                && dest.version.load().levels.iter().all(Vec::is_empty)
+            {
+                remove_branch = true;
+            }
+        }
+
+        if remove_branch {
+            self.branches.remove(dest_id);
+        }
+    }
+
     // ========================================================================
     // Inherent methods
     // ========================================================================
@@ -1293,7 +1475,10 @@ impl SegmentedStore {
                 branch.inherited_layers[layer_index].status = LayerStatus::Materializing;
             }
         }
-        self.write_branch_manifest(child_branch_id)?;
+        if let Err(e) = self.write_branch_manifest(child_branch_id) {
+            self.rollback_materialize_status(child_branch_id, source_branch_id, fork_version);
+            return Err(e);
+        }
 
         // 2c. Build materialized entries (no locks held — I/O heavy)
         let mut entries = Self::collect_unshadowed_entries(
@@ -1314,7 +1499,7 @@ impl SegmentedStore {
         // 2d. Build segment file(s) (no locks held).
         // Use SplittingSegmentBuilder to avoid creating oversized L0 segments
         // from large inherited layers (#1671).
-        let new_segments: Vec<KVSegment> = if !entries.is_empty() {
+        let new_segments: Vec<Arc<KVSegment>> = if !entries.is_empty() {
             let branch_hex = hex_encode_branch(child_branch_id);
             let branch_dir = segments_dir.join(&branch_hex);
             std::fs::create_dir_all(&branch_dir)?;
@@ -1329,7 +1514,7 @@ impl SegmentedStore {
 
             let mut segments = Vec::with_capacity(built.len());
             for (path, _meta) in built {
-                let seg = KVSegment::open(&path)?;
+                let seg = Arc::new(KVSegment::open(&path)?);
                 segments.push(seg);
             }
             segments
@@ -1350,8 +1535,8 @@ impl SegmentedStore {
                 let old_ver = branch.version.load();
                 let mut new_l0 =
                     Vec::with_capacity(old_ver.l0_segments().len() + new_segments.len());
-                for seg in new_segments {
-                    new_l0.push(Arc::new(seg));
+                for seg in &new_segments {
+                    new_l0.push(Arc::clone(seg));
                 }
                 new_l0.extend(old_ver.l0_segments().iter().cloned());
                 let mut new_levels = old_ver.levels.clone();
@@ -1374,7 +1559,17 @@ impl SegmentedStore {
         }
 
         // 2f. Cleanup
-        self.write_branch_manifest(child_branch_id)?;
+        if let Err(e) = self.write_branch_manifest(child_branch_id) {
+            self.rollback_materialize_install(
+                child_branch_id,
+                layer_index,
+                source_branch_id,
+                fork_version,
+                &layer_segments,
+                &new_segments,
+            );
+            return Err(e);
+        }
 
         // Decrement refcounts for each segment in the removed layer.
         for level in &layer_segments.levels {
@@ -1573,7 +1768,17 @@ impl SegmentedStore {
         //    CRITICAL: Increment refcounts BEFORE dropping the source guard.
         //    Without this, concurrent parent compaction can delete segments
         //    between the snapshot and the refcount increment (see #1662).
-        let (dest_layers, segments_shared, fork_version, source_manifest_dirty) = {
+        let (
+            dest_layers,
+            segments_shared,
+            fork_version,
+            source_manifest_dirty,
+            source_old_active,
+            source_old_frozen,
+            source_old_version,
+            source_old_level_targets,
+            source_flush_paths,
+        ) = {
             let mut source = match self.branches.get_mut(source_id) {
                 Some(b) => b,
                 None => {
@@ -1584,6 +1789,10 @@ impl SegmentedStore {
                     .into())
                 }
             };
+            let source_old_active = Arc::clone(&source.active);
+            let source_old_frozen = source.frozen.clone();
+            let source_old_version = source.version.load_full();
+            let source_old_level_targets = source.level_targets.clone();
 
             // Inline-rotate: move straggler writes from active to frozen.
             if !source.active.is_empty() {
@@ -1598,6 +1807,7 @@ impl SegmentedStore {
             // holding the exclusive guard.  Typically 0–1 tiny memtables
             // (only the stragglers from above), so I/O is bounded.
             let mut source_manifest_dirty = false;
+            let mut source_flush_paths = Vec::new();
             if let Some(segments_dir) = &self.segments_dir {
                 while let Some(mt) = source.frozen.last().cloned() {
                     let seg_id = self.next_segment_id.fetch_add(1, Ordering::Relaxed);
@@ -1609,6 +1819,7 @@ impl SegmentedStore {
                         .make_segment_builder()
                         .with_compression(crate::segment_builder::CompressionCodec::None);
                     builder.build_from_iter(mt.iter_all(), &seg_path)?;
+                    source_flush_paths.push(seg_path.clone());
                     let segment = KVSegment::open(&seg_path)?;
 
                     // Install segment into source's SegmentVersion.
@@ -1686,16 +1897,39 @@ impl SegmentedStore {
                 }
             }
 
-            (layers, shared, fork_version, source_manifest_dirty)
+            (
+                layers,
+                shared,
+                fork_version,
+                source_manifest_dirty,
+                source_old_active,
+                source_old_frozen,
+                source_old_version,
+                source_old_level_targets,
+                source_flush_paths,
+            )
             // source DashMap guard drops here — segments are now protected
         };
 
         // Persist source manifest if we inline-flushed segments.
         if source_manifest_dirty {
-            self.write_branch_manifest(source_id)?;
+            if let Err(e) = self.write_branch_manifest(source_id) {
+                self.rollback_fork_source_publish_failure(
+                    source_id,
+                    source_old_active,
+                    source_old_frozen,
+                    source_old_version,
+                    source_old_level_targets,
+                    &source_flush_paths,
+                    &dest_layers,
+                );
+                return Err(e);
+            }
         }
 
         // 6. Attach to dest branch, rejecting if a concurrent fork already installed layers.
+        let dest_layers_for_rollback = dest_layers.clone();
+        let dest_was_new = !self.branches.contains_key(dest_id);
         let mut dest = self
             .branches
             .entry(*dest_id)
@@ -1723,7 +1957,14 @@ impl SegmentedStore {
         drop(dest);
 
         // 7. Write manifest
-        self.write_branch_manifest(dest_id)?;
+        if let Err(e) = self.write_branch_manifest(dest_id) {
+            self.rollback_fork_dest_publish_failure(
+                dest_id,
+                &dest_layers_for_rollback,
+                dest_was_new,
+            );
+            return Err(e);
+        }
 
         Ok((fork_version, segments_shared))
     }
@@ -2731,7 +2972,7 @@ impl SegmentedStore {
             .with_compression(crate::segment_builder::CompressionCodec::None);
         builder.build_from_iter(frozen_mt.iter_all(), &seg_path)?;
 
-        let segment = KVSegment::open(&seg_path)?;
+        let segment = Arc::new(KVSegment::open(&seg_path)?);
 
         // Atomically: remove the frozen memtable we just flushed and install
         // the segment, under a single DashMap guard.
@@ -2769,7 +3010,7 @@ impl SegmentedStore {
             // Build new version with the new segment prepended (newest first).
             let old_ver = branch.version.load();
             let mut new_l0 = Vec::with_capacity(old_ver.l0_segments().len() + 1);
-            new_l0.push(Arc::new(segment));
+            new_l0.push(Arc::clone(&segment));
             new_l0.extend(old_ver.l0_segments().iter().cloned());
             let mut new_levels = old_ver.levels.clone();
             new_levels[0] = new_l0;
@@ -2780,7 +3021,10 @@ impl SegmentedStore {
 
             // Persist level assignments
             drop(branch);
-            self.write_branch_manifest(branch_id)?;
+            if let Err(e) = self.write_branch_manifest(branch_id) {
+                self.rollback_flush_publish_failure(branch_id, &frozen_mt, &segment);
+                return Err(e);
+            }
         } else {
             // Another thread already flushed this memtable; discard the
             // duplicate segment file we just built.

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -9,6 +9,7 @@
 //! The first match for a key at commit_id ≤ snapshot wins.
 
 use crate::compaction::CompactionIterator;
+use crate::error::{StorageError, StorageResult};
 use crate::key_encoding::{
     encode_typed_key, encode_typed_key_prefix, rewrite_branch_id_bytes, InternalKey,
     COMMIT_ID_SUFFIX_LEN,
@@ -1171,14 +1172,15 @@ impl SegmentedStore {
         &self,
         child_branch_id: &BranchId,
         layer_index: usize,
-    ) -> io::Result<MaterializeResult> {
+    ) -> StorageResult<MaterializeResult> {
         let segments_dir = match &self.segments_dir {
             Some(d) => d,
             None => {
                 return Err(io::Error::new(
                     io::ErrorKind::Unsupported,
                     "materialize_layer requires a disk-backed store",
-                ))
+                )
+                .into())
             }
         };
 
@@ -1231,7 +1233,11 @@ impl SegmentedStore {
         let (layer_segments, source_branch_id, fork_version, own_version, closer_layers) = {
             let branch = match self.branches.get(child_branch_id) {
                 Some(b) => b,
-                None => return Err(io::Error::new(io::ErrorKind::NotFound, "branch not found")),
+                None => {
+                    return Err(
+                        io::Error::new(io::ErrorKind::NotFound, "branch not found").into(),
+                    )
+                }
             };
             if layer_index >= branch.inherited_layers.len() {
                 // Layer was already removed by a concurrent materialization that
@@ -1277,13 +1283,17 @@ impl SegmentedStore {
         {
             let mut branch = match self.branches.get_mut(child_branch_id) {
                 Some(b) => b,
-                None => return Err(io::Error::new(io::ErrorKind::NotFound, "branch not found")),
+                None => {
+                    return Err(
+                        io::Error::new(io::ErrorKind::NotFound, "branch not found").into(),
+                    )
+                }
             };
             if layer_index < branch.inherited_layers.len() {
                 branch.inherited_layers[layer_index].status = LayerStatus::Materializing;
             }
         }
-        self.write_branch_manifest(child_branch_id);
+        self.write_branch_manifest(child_branch_id)?;
 
         // 2c. Build materialized entries (no locks held — I/O heavy)
         let mut entries = Self::collect_unshadowed_entries(
@@ -1364,7 +1374,7 @@ impl SegmentedStore {
         }
 
         // 2f. Cleanup
-        self.write_branch_manifest(child_branch_id);
+        self.write_branch_manifest(child_branch_id)?;
 
         // Decrement refcounts for each segment in the removed layer.
         for level in &layer_segments.levels {
@@ -1539,12 +1549,12 @@ impl SegmentedStore {
         &self,
         source_id: &BranchId,
         dest_id: &BranchId,
-    ) -> io::Result<(CommitVersion, usize)> {
+    ) -> StorageResult<(CommitVersion, usize)> {
         if source_id == dest_id {
-            return Err(io::Error::new(
+            return Err(StorageError::Io(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "fork_branch: source and destination must be different branches",
-            ));
+            )));
         }
 
         // 1. Flush bulk memtable data to segments (outside exclusive lock).
@@ -1570,7 +1580,8 @@ impl SegmentedStore {
                     return Err(io::Error::new(
                         io::ErrorKind::NotFound,
                         "fork_branch: source branch no longer exists",
-                    ))
+                    )
+                    .into())
                 }
             };
 
@@ -1681,7 +1692,7 @@ impl SegmentedStore {
 
         // Persist source manifest if we inline-flushed segments.
         if source_manifest_dirty {
-            self.write_branch_manifest(source_id);
+            self.write_branch_manifest(source_id)?;
         }
 
         // 6. Attach to dest branch, rejecting if a concurrent fork already installed layers.
@@ -1699,10 +1710,10 @@ impl SegmentedStore {
                     }
                 }
             }
-            return Err(io::Error::new(
+            return Err(StorageError::Io(io::Error::new(
                 io::ErrorKind::AlreadyExists,
                 "fork_branch: destination already has inherited layers (concurrent fork race)",
-            ));
+            )));
         }
         dest.inherited_layers = dest_layers;
         // Propagate fork_version so subsequent forks from this child
@@ -1712,7 +1723,7 @@ impl SegmentedStore {
         drop(dest);
 
         // 7. Write manifest
-        self.write_branch_manifest(dest_id);
+        self.write_branch_manifest(dest_id)?;
 
         Ok((fork_version, segments_shared))
     }
@@ -2641,7 +2652,7 @@ impl SegmentedStore {
     /// After this call, all data written during the bulk load is flushed to
     /// frozen memtables (and to disk segments if a directory is configured).
     /// Normal rotation behavior resumes.
-    pub fn end_bulk_load(&self, branch_id: &BranchId) -> io::Result<()> {
+    pub fn end_bulk_load(&self, branch_id: &BranchId) -> StorageResult<()> {
         self.bulk_load_branches.remove(branch_id);
 
         // Rotate the active memtable (unconditionally — it may be large)
@@ -2689,7 +2700,7 @@ impl SegmentedStore {
     /// The frozen memtable stays in the read path during I/O so concurrent
     /// readers never see a gap.  It is only removed when the segment is
     /// installed, in a single DashMap guard.
-    pub fn flush_oldest_frozen(&self, branch_id: &BranchId) -> io::Result<bool> {
+    pub fn flush_oldest_frozen(&self, branch_id: &BranchId) -> StorageResult<bool> {
         let segments_dir = match &self.segments_dir {
             Some(d) => d,
             None => return Ok(false),
@@ -2769,7 +2780,7 @@ impl SegmentedStore {
 
             // Persist level assignments
             drop(branch);
-            self.write_branch_manifest(branch_id);
+            self.write_branch_manifest(branch_id)?;
         } else {
             // Another thread already flushed this memtable; discard the
             // duplicate segment file we just built.
@@ -4200,29 +4211,42 @@ impl SegmentedStore {
 
     /// Write the manifest file for a branch, reflecting current level assignments
     /// and inherited layers.
-    fn write_branch_manifest(&self, branch_id: &BranchId) {
+    ///
+    /// Publication is a real barrier: a failure to create the branch
+    /// directory, write the manifest, or fsync the parent dir is surfaced
+    /// as a typed [`StorageError`]. Callers that gate old-input deletion on
+    /// a successful publish rely on this.
+    ///
+    /// Returns `Ok(())` unchanged when the store is ephemeral
+    /// (`segments_dir == None`) or the branch has been dropped between
+    /// call and manifest build — both are legitimate no-op cases.
+    fn write_branch_manifest(&self, branch_id: &BranchId) -> StorageResult<()> {
         let segments_dir = match &self.segments_dir {
             Some(d) => d,
-            None => return,
+            None => return Ok(()),
         };
         let branch = match self.branches.get(branch_id) {
             Some(b) => b,
-            None => return,
+            None => return Ok(()),
         };
+
+        // Test-only fault injection — consumed once per armed failure.
+        if let Some(inner) = crate::test_hooks::maybe_inject_manifest_publish_failure() {
+            return Err(StorageError::ManifestPublish {
+                branch_id: *branch_id,
+                inner,
+            });
+        }
         let ver = branch.version.load();
         let branch_hex = hex_encode_branch(branch_id);
         let branch_dir = segments_dir.join(&branch_hex);
 
         // Ensure the branch directory exists (needed for COW forks with
         // no own segments but inherited layers that need a manifest).
-        if let Err(e) = std::fs::create_dir_all(&branch_dir) {
-            tracing::warn!(
-                branch = %branch_hex,
-                error = %e,
-                "failed to create branch directory for manifest"
-            );
-            return;
-        }
+        std::fs::create_dir_all(&branch_dir).map_err(|inner| StorageError::ManifestPublish {
+            branch_id: *branch_id,
+            inner,
+        })?;
 
         let mut entries = Vec::new();
         for (level_idx, level) in ver.levels.iter().enumerate() {
@@ -4274,13 +4298,18 @@ impl SegmentedStore {
             })
             .collect();
 
-        if let Err(e) = crate::manifest::write_manifest(&branch_dir, &entries, &inherited) {
-            tracing::warn!(
-                branch = %branch_hex,
-                error = %e,
-                "failed to write branch manifest"
-            );
-        }
+        crate::manifest::write_manifest(&branch_dir, &entries, &inherited).map_err(|e| match e {
+            // Wrap generic I/O failures (create/write/rename) in the
+            // branch-aware `ManifestPublish` variant so callers can
+            // distinguish "publish refused" from other storage errors.
+            StorageError::Io(inner) => StorageError::ManifestPublish {
+                branch_id: *branch_id,
+                inner,
+            },
+            // `DirFsync` already carries `dir: PathBuf` context; pass
+            // through unchanged.
+            other => other,
+        })
     }
 }
 

--- a/crates/storage/src/segmented/tests/materialize.rs
+++ b/crates/storage/src/segmented/tests/materialize.rs
@@ -456,7 +456,7 @@ fn materialize_crash_recovery_resets_status() {
             let mut child = store.branches.get_mut(&child_branch()).unwrap();
             child.inherited_layers[0].status = LayerStatus::Materializing;
         }
-        store.write_branch_manifest(&child_branch());
+        store.write_branch_manifest(&child_branch()).unwrap();
     }
 
     // Second store: recover from manifest — Materializing should reset to Active
@@ -522,7 +522,7 @@ fn materialize_crash_recovery_with_partial_segment() {
             let mut child = store.branches.get_mut(&child_branch()).unwrap();
             child.inherited_layers[0].status = LayerStatus::Materializing;
         }
-        store.write_branch_manifest(&child_branch());
+        store.write_branch_manifest(&child_branch()).unwrap();
 
         // "crash" — store drops
     }
@@ -609,7 +609,7 @@ fn materialize_crash_recovery_with_valid_orphan_segment() {
             let mut child = store.branches.get_mut(&child_branch()).unwrap();
             child.inherited_layers[0].status = LayerStatus::Materializing;
         }
-        store.write_branch_manifest(&child_branch());
+        store.write_branch_manifest(&child_branch()).unwrap();
     }
 
     // Phase 2: Recover
@@ -658,8 +658,8 @@ fn recovery_surfaces_missing_source_branch() {
             .unwrap();
 
         // Write manifest for both branches
-        store.write_branch_manifest(&parent_branch());
-        store.write_branch_manifest(&child_branch());
+        store.write_branch_manifest(&parent_branch()).unwrap();
+        store.write_branch_manifest(&child_branch()).unwrap();
     }
 
     // Sabotage: delete the parent's branch directory (simulating missing source)

--- a/crates/storage/src/segmented/tests/mod.rs
+++ b/crates/storage/src/segmented/tests/mod.rs
@@ -104,3 +104,4 @@ mod fork;
 mod leveled;
 mod lifecycle;
 mod materialize;
+mod publish_barrier;

--- a/crates/storage/src/segmented/tests/publish_barrier.rs
+++ b/crates/storage/src/segmented/tests/publish_barrier.rs
@@ -178,6 +178,43 @@ fn flush_oldest_frozen_surfaces_publish_failure() {
 }
 
 #[test]
+fn flush_oldest_frozen_publish_failure_rolls_back_state() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&b);
+    assert_eq!(store.branch_frozen_count(&b), 1);
+    assert_eq!(store.branch_segment_count(&b), 0);
+
+    test_hooks::inject_manifest_publish_failure(io::ErrorKind::PermissionDenied);
+    let result = store.flush_oldest_frozen(&b);
+    test_hooks::clear_manifest_publish_failure();
+
+    match result {
+        Err(StorageError::ManifestPublish { .. }) => {}
+        other => panic!("expected ManifestPublish, got {other:?}"),
+    }
+
+    assert_eq!(store.branch_frozen_count(&b), 1, "frozen memtable must be restored");
+    assert_eq!(store.branch_segment_count(&b), 0, "failed publish must not leave installed segment");
+    assert_eq!(
+        store.get_value_direct(&kv_key("k")).unwrap(),
+        Some(Value::Int(1)),
+        "failed publish must preserve readable branch state for retry"
+    );
+
+    assert_eq!(
+        store.flush_oldest_frozen(&b).unwrap(),
+        true,
+        "retry after publish failure must succeed"
+    );
+    assert_eq!(store.branch_frozen_count(&b), 0);
+    assert_eq!(store.branch_segment_count(&b), 1);
+}
+
+#[test]
 fn fork_branch_surfaces_publish_failure() {
     // Seed a parent with flushed segments so that the fork dest publish is
     // the next `write_branch_manifest` that runs (source-side publish only
@@ -192,6 +229,73 @@ fn fork_branch_surfaces_publish_failure() {
         Err(StorageError::ManifestPublish { .. }) => {}
         other => panic!("expected ManifestPublish, got {other:?}"),
     }
+}
+
+#[test]
+fn fork_branch_dest_publish_failure_rolls_back_child_state() {
+    let (_tmp_dir, store) = setup_parent_with_segments(&[("k1", 1, 1)]);
+
+    test_hooks::inject_manifest_publish_failure(io::ErrorKind::PermissionDenied);
+    let result = store.fork_branch(&parent_branch(), &child_branch());
+    test_hooks::clear_manifest_publish_failure();
+
+    match result {
+        Err(StorageError::ManifestPublish { .. }) => {}
+        other => panic!("expected ManifestPublish, got {other:?}"),
+    }
+
+    assert!(
+        store.branches.get(&child_branch()).is_none(),
+        "failed destination publish must not leave a child branch installed in memory"
+    );
+
+    let retry = store.fork_branch(&parent_branch(), &child_branch()).unwrap();
+    assert!(retry.1 > 0, "retry should perform the storage fork normally");
+    assert_eq!(store.inherited_layer_count(&child_branch()), 1);
+    assert_eq!(
+        store.get_value_direct(&child_kv("k1")).unwrap(),
+        Some(Value::Int(1)),
+        "successful retry must expose inherited data"
+    );
+}
+
+#[test]
+fn fork_branch_source_publish_failure_rolls_back_source_flush() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    seed(&store, parent_kv("k1"), Value::Int(1), 1);
+    assert_eq!(
+        store.get_value_direct(&parent_kv("k1")).unwrap(),
+        Some(Value::Int(1)),
+        "source data must exist before fork"
+    );
+
+    test_hooks::inject_manifest_publish_failure(io::ErrorKind::PermissionDenied);
+    let result = store.fork_branch(&parent_branch(), &child_branch());
+    test_hooks::clear_manifest_publish_failure();
+
+    match result {
+        Err(StorageError::ManifestPublish { .. }) => {}
+        other => panic!("expected ManifestPublish, got {other:?}"),
+    }
+
+    assert!(
+        store.branches.get(&child_branch()).is_none(),
+        "failed source publish must not install a child branch"
+    );
+    assert_eq!(
+        store.get_value_direct(&parent_kv("k1")).unwrap(),
+        Some(Value::Int(1)),
+        "failed source publish must restore the source branch state"
+    );
+
+    store.fork_branch(&parent_branch(), &child_branch()).unwrap();
+    assert_eq!(
+        store.get_value_direct(&child_kv("k1")).unwrap(),
+        Some(Value::Int(1)),
+        "retry after source publish failure must succeed"
+    );
 }
 
 #[test]
@@ -210,6 +314,63 @@ fn materialize_layer_surfaces_publish_failure() {
         Err(StorageError::ManifestPublish { .. }) => {}
         other => panic!("expected ManifestPublish, got {other:?}"),
     }
+}
+
+#[test]
+fn materialize_layer_first_publish_failure_rolls_back_status() {
+    let (_tmp_dir, store) = setup_parent_with_segments(&[("k1", 1, 1), ("k2", 2, 2)]);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    test_hooks::inject_manifest_publish_failure(io::ErrorKind::PermissionDenied);
+    let result = store.materialize_layer(&child_branch(), 0);
+    test_hooks::clear_manifest_publish_failure();
+
+    match result {
+        Err(StorageError::ManifestPublish { .. }) => {}
+        other => panic!("expected ManifestPublish, got {other:?}"),
+    }
+
+    let child = store.branches.get(&child_branch()).unwrap();
+    assert_eq!(child.inherited_layers.len(), 1);
+    assert_eq!(child.inherited_layers[0].status, LayerStatus::Active);
+    drop(child);
+
+    let retry = store.materialize_layer(&child_branch(), 0).unwrap();
+    assert_eq!(retry.entries_materialized, 2);
+    assert_eq!(store.inherited_layer_count(&child_branch()), 0);
+}
+
+#[test]
+fn materialize_layer_second_publish_failure_rolls_back_install() {
+    let (_tmp_dir, store) = setup_parent_with_segments(&[("k1", 1, 1), ("k2", 2, 2)]);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    test_hooks::inject_manifest_publish_failure_after(1, io::ErrorKind::PermissionDenied);
+    let result = store.materialize_layer(&child_branch(), 0);
+    test_hooks::clear_manifest_publish_failure();
+
+    match result {
+        Err(StorageError::ManifestPublish { .. }) => {}
+        other => panic!("expected ManifestPublish, got {other:?}"),
+    }
+
+    let child = store.branches.get(&child_branch()).unwrap();
+    assert_eq!(child.inherited_layers.len(), 1);
+    assert_eq!(child.inherited_layers[0].status, LayerStatus::Active);
+    assert_eq!(
+        child.version.load().total_segment_count(),
+        0,
+        "failed final publish must not leave materialized segments installed"
+    );
+    drop(child);
+
+    let retry = store.materialize_layer(&child_branch(), 0).unwrap();
+    assert_eq!(retry.entries_materialized, 2);
+    assert_eq!(store.inherited_layer_count(&child_branch()), 0);
 }
 
 // ── Dir fsync — write_manifest surfaces DirFsync (SG-003) ─────────────

--- a/crates/storage/src/segmented/tests/publish_barrier.rs
+++ b/crates/storage/src/segmented/tests/publish_barrier.rs
@@ -53,11 +53,7 @@ fn seed_two_segments(store: &SegmentedStore, b: &BranchId) {
 /// Assert that every file present before an operation is still present after,
 /// i.e. the operation did not delete any pre-existing `.sst` file. New files
 /// (e.g. an orphaned compaction output) are allowed.
-fn assert_no_files_deleted(
-    branch_dir: &std::path::Path,
-    before: &BTreeSet<String>,
-    context: &str,
-) {
+fn assert_no_files_deleted(branch_dir: &std::path::Path, before: &BTreeSet<String>, context: &str) {
     let after = sst_names(branch_dir);
     let deleted: Vec<_> = before.difference(&after).collect();
     assert!(
@@ -197,8 +193,16 @@ fn flush_oldest_frozen_publish_failure_rolls_back_state() {
         other => panic!("expected ManifestPublish, got {other:?}"),
     }
 
-    assert_eq!(store.branch_frozen_count(&b), 1, "frozen memtable must be restored");
-    assert_eq!(store.branch_segment_count(&b), 0, "failed publish must not leave installed segment");
+    assert_eq!(
+        store.branch_frozen_count(&b),
+        1,
+        "frozen memtable must be restored"
+    );
+    assert_eq!(
+        store.branch_segment_count(&b),
+        0,
+        "failed publish must not leave installed segment"
+    );
     assert_eq!(
         store.get_value_direct(&kv_key("k")).unwrap(),
         Some(Value::Int(1)),
@@ -249,8 +253,13 @@ fn fork_branch_dest_publish_failure_rolls_back_child_state() {
         "failed destination publish must not leave a child branch installed in memory"
     );
 
-    let retry = store.fork_branch(&parent_branch(), &child_branch()).unwrap();
-    assert!(retry.1 > 0, "retry should perform the storage fork normally");
+    let retry = store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+    assert!(
+        retry.1 > 0,
+        "retry should perform the storage fork normally"
+    );
     assert_eq!(store.inherited_layer_count(&child_branch()), 1);
     assert_eq!(
         store.get_value_direct(&child_kv("k1")).unwrap(),
@@ -290,7 +299,9 @@ fn fork_branch_source_publish_failure_rolls_back_source_flush() {
         "failed source publish must restore the source branch state"
     );
 
-    store.fork_branch(&parent_branch(), &child_branch()).unwrap();
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
     assert_eq!(
         store.get_value_direct(&child_kv("k1")).unwrap(),
         Some(Value::Int(1)),

--- a/crates/storage/src/segmented/tests/publish_barrier.rs
+++ b/crates/storage/src/segmented/tests/publish_barrier.rs
@@ -1,0 +1,237 @@
+//! Regression tests for the manifest-publication barrier (SG-001, SG-002, SG-003).
+//!
+//! These tests arm the storage-level fault-injection hooks in
+//! `crate::test_hooks` to force a manifest publish or directory fsync
+//! failure, then assert that:
+//!
+//! - The failing operation returns `Err(StorageError::ManifestPublish)` or
+//!   `Err(StorageError::DirFsync)` (no silent `Ok(())` from a swallowed warn).
+//! - For compaction paths: every old input `.sst` file is still on disk — the
+//!   delete loop is strictly gated on publish success.
+//!
+//! The hooks in `crate::test_hooks` are thread-local, so tests do not need
+//! external serialization to isolate their injections from one another.
+//!
+//! Covers: SG-001 (publish not a barrier), SG-002 (compaction-delete after
+//! unobserved publish), SG-003 (dir fsync swallowed).
+
+use super::*;
+use crate::error::StorageError;
+use crate::test_hooks;
+use std::collections::BTreeSet;
+use std::io;
+
+/// Collect the set of `.sst` filenames in a branch directory.
+fn sst_names(branch_dir: &std::path::Path) -> BTreeSet<String> {
+    std::fs::read_dir(branch_dir)
+        .map(|iter| {
+            iter.filter_map(|e| e.ok())
+                .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("sst"))
+                .filter_map(|e| e.file_name().into_string().ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn seed_two_segments(store: &SegmentedStore, b: &BranchId) {
+    for commit in 1..=2u64 {
+        seed(
+            store,
+            Key::new(
+                Arc::new(Namespace::new(*b, "default".to_string())),
+                TypeTag::KV,
+                format!("k{commit}").into_bytes(),
+            ),
+            Value::Int(commit as i64),
+            commit,
+        );
+        store.rotate_memtable(b);
+        store.flush_oldest_frozen(b).unwrap();
+    }
+}
+
+/// Assert that every file present before an operation is still present after,
+/// i.e. the operation did not delete any pre-existing `.sst` file. New files
+/// (e.g. an orphaned compaction output) are allowed.
+fn assert_no_files_deleted(
+    branch_dir: &std::path::Path,
+    before: &BTreeSet<String>,
+    context: &str,
+) {
+    let after = sst_names(branch_dir);
+    let deleted: Vec<_> = before.difference(&after).collect();
+    assert!(
+        deleted.is_empty(),
+        "{context}: failed publish must not delete any old input — missing files: {deleted:?}",
+    );
+}
+
+// ── Compaction paths — old inputs must survive a failed publish ────────
+
+#[test]
+fn compact_branch_refuses_delete_on_publish_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+    seed_two_segments(&store, &b);
+
+    let branch_dir = dir.path().join(hex_encode_branch(&b));
+    let before = sst_names(&branch_dir);
+    assert_eq!(before.len(), 2, "two input segments before compaction");
+
+    test_hooks::inject_manifest_publish_failure(io::ErrorKind::PermissionDenied);
+    let result = store.compact_branch(&b, CommitVersion(0));
+    test_hooks::clear_manifest_publish_failure();
+
+    match result {
+        Err(StorageError::ManifestPublish { .. }) => {}
+        other => panic!("expected ManifestPublish, got {other:?}"),
+    }
+    assert_no_files_deleted(&branch_dir, &before, "compact_branch");
+}
+
+#[test]
+fn compact_tier_refuses_delete_on_publish_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 4096);
+    let b = branch();
+    seed_two_segments(&store, &b);
+
+    let branch_dir = dir.path().join(hex_encode_branch(&b));
+    let before = sst_names(&branch_dir);
+    assert_eq!(before.len(), 2, "two input segments before compaction");
+
+    test_hooks::inject_manifest_publish_failure(io::ErrorKind::PermissionDenied);
+    let result = store.compact_tier(&b, &[0, 1], CommitVersion(0));
+    test_hooks::clear_manifest_publish_failure();
+
+    match result {
+        Err(StorageError::ManifestPublish { .. }) => {}
+        other => panic!("expected ManifestPublish, got {other:?}"),
+    }
+    assert_no_files_deleted(&branch_dir, &before, "compact_tier");
+}
+
+#[test]
+fn compact_l0_to_l1_refuses_delete_on_publish_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 4096);
+    let b = branch();
+    seed_two_segments(&store, &b);
+
+    let branch_dir = dir.path().join(hex_encode_branch(&b));
+    let before = sst_names(&branch_dir);
+    assert_eq!(before.len(), 2, "two input segments before compaction");
+
+    test_hooks::inject_manifest_publish_failure(io::ErrorKind::PermissionDenied);
+    let result = store.compact_l0_to_l1(&b, CommitVersion(0));
+    test_hooks::clear_manifest_publish_failure();
+
+    match result {
+        Err(StorageError::ManifestPublish { .. }) => {}
+        other => panic!("expected ManifestPublish, got {other:?}"),
+    }
+    assert_no_files_deleted(&branch_dir, &before, "compact_l0_to_l1");
+}
+
+#[test]
+fn compact_level_refuses_delete_on_publish_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 4096);
+    let b = branch();
+    seed_two_segments(&store, &b);
+
+    let branch_dir = dir.path().join(hex_encode_branch(&b));
+    let before = sst_names(&branch_dir);
+    assert_eq!(before.len(), 2, "two input segments before compaction");
+
+    test_hooks::inject_manifest_publish_failure(io::ErrorKind::PermissionDenied);
+    let result = store.compact_level(&b, 0, CommitVersion(0));
+    test_hooks::clear_manifest_publish_failure();
+
+    match result {
+        Err(StorageError::ManifestPublish { .. }) => {}
+        other => panic!("expected ManifestPublish, got {other:?}"),
+    }
+    assert_no_files_deleted(&branch_dir, &before, "compact_level");
+}
+
+// ── Non-compaction publish paths ──────────────────────────────────────
+
+#[test]
+fn flush_oldest_frozen_surfaces_publish_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&b);
+
+    test_hooks::inject_manifest_publish_failure(io::ErrorKind::PermissionDenied);
+    let result = store.flush_oldest_frozen(&b);
+    test_hooks::clear_manifest_publish_failure();
+
+    match result {
+        Err(StorageError::ManifestPublish { .. }) => {}
+        other => panic!("expected ManifestPublish, got {other:?}"),
+    }
+}
+
+#[test]
+fn fork_branch_surfaces_publish_failure() {
+    // Seed a parent with flushed segments so that the fork dest publish is
+    // the next `write_branch_manifest` that runs (source-side publish only
+    // triggers when inline-flush is needed).
+    let (_tmp_dir, store) = setup_parent_with_segments(&[("k1", 1, 1)]);
+
+    test_hooks::inject_manifest_publish_failure(io::ErrorKind::PermissionDenied);
+    let result = store.fork_branch(&parent_branch(), &child_branch());
+    test_hooks::clear_manifest_publish_failure();
+
+    match result {
+        Err(StorageError::ManifestPublish { .. }) => {}
+        other => panic!("expected ManifestPublish, got {other:?}"),
+    }
+}
+
+#[test]
+fn materialize_layer_surfaces_publish_failure() {
+    let (_tmp_dir, store) = setup_parent_with_segments(&[("k1", 1, 1), ("k2", 2, 2)]);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+    assert_eq!(store.inherited_layer_count(&child_branch()), 1);
+
+    test_hooks::inject_manifest_publish_failure(io::ErrorKind::PermissionDenied);
+    let result = store.materialize_layer(&child_branch(), 0);
+    test_hooks::clear_manifest_publish_failure();
+
+    match result {
+        Err(StorageError::ManifestPublish { .. }) => {}
+        other => panic!("expected ManifestPublish, got {other:?}"),
+    }
+}
+
+// ── Dir fsync — write_manifest surfaces DirFsync (SG-003) ─────────────
+
+#[test]
+fn write_manifest_surfaces_dir_fsync_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&b);
+
+    test_hooks::inject_dir_fsync_failure(io::ErrorKind::Other);
+    let result = store.flush_oldest_frozen(&b);
+    test_hooks::clear_dir_fsync_failure();
+
+    // The dir-fsync failure surfaces via `write_manifest` → is returned
+    // by `write_branch_manifest` unchanged (DirFsync variant carries its
+    // own dir context) → bubbles up through flush.
+    match result {
+        Err(StorageError::DirFsync { .. }) => {}
+        other => panic!("expected DirFsync, got {other:?}"),
+    }
+}

--- a/crates/storage/src/test_hooks.rs
+++ b/crates/storage/src/test_hooks.rs
@@ -18,37 +18,76 @@
 use std::cell::Cell;
 use std::io;
 
+#[derive(Clone, Copy)]
+struct ArmedFailure {
+    remaining_skips: usize,
+    kind: io::ErrorKind,
+}
+
 thread_local! {
-    static MANIFEST_PUBLISH_FAILURE: Cell<Option<io::ErrorKind>> = const { Cell::new(None) };
+    static MANIFEST_PUBLISH_FAILURE: Cell<Option<ArmedFailure>> = const { Cell::new(None) };
     static DIR_FSYNC_FAILURE: Cell<Option<io::ErrorKind>> = const { Cell::new(None) };
 }
 
 /// Arm one manifest-publish failure for the next call to
 /// `SegmentedStore::write_branch_manifest` on the current thread.
 /// Consumed exactly once.
+#[cfg(test)]
 pub(crate) fn inject_manifest_publish_failure(kind: io::ErrorKind) {
-    MANIFEST_PUBLISH_FAILURE.with(|slot| slot.set(Some(kind)));
+    inject_manifest_publish_failure_after(0, kind);
+}
+
+/// Arm one manifest-publish failure after `remaining_skips` successful
+/// `write_branch_manifest` calls on the current thread.
+///
+/// `remaining_skips = 0` means "fail the next publish".
+#[cfg(test)]
+pub(crate) fn inject_manifest_publish_failure_after(
+    remaining_skips: usize,
+    kind: io::ErrorKind,
+) {
+    MANIFEST_PUBLISH_FAILURE.with(|slot| {
+        slot.set(Some(ArmedFailure {
+            remaining_skips,
+            kind,
+        }))
+    });
 }
 
 /// Clear any pending manifest-publish failure on the current thread.
+#[cfg(test)]
 pub(crate) fn clear_manifest_publish_failure() {
     MANIFEST_PUBLISH_FAILURE.with(|slot| slot.set(None));
 }
 
 /// Consume an armed manifest-publish failure on the current thread, if any.
 pub(crate) fn maybe_inject_manifest_publish_failure() -> Option<io::Error> {
-    MANIFEST_PUBLISH_FAILURE
-        .with(|slot| slot.take())
-        .map(|kind| io::Error::new(kind, "injected manifest publish failure"))
+    MANIFEST_PUBLISH_FAILURE.with(|slot| match slot.get() {
+        Some(ArmedFailure {
+            remaining_skips: 0,
+            kind,
+        }) => {
+            slot.set(None);
+            Some(io::Error::new(kind, "injected manifest publish failure"))
+        }
+        Some(mut armed) => {
+            armed.remaining_skips -= 1;
+            slot.set(Some(armed));
+            None
+        }
+        None => None,
+    })
 }
 
 /// Arm one directory-fsync failure for the next call to
 /// `manifest::write_manifest` on the current thread. Consumed exactly once.
+#[cfg(test)]
 pub(crate) fn inject_dir_fsync_failure(kind: io::ErrorKind) {
     DIR_FSYNC_FAILURE.with(|slot| slot.set(Some(kind)));
 }
 
 /// Clear any pending dir-fsync failure on the current thread.
+#[cfg(test)]
 pub(crate) fn clear_dir_fsync_failure() {
     DIR_FSYNC_FAILURE.with(|slot| slot.set(None));
 }

--- a/crates/storage/src/test_hooks.rs
+++ b/crates/storage/src/test_hooks.rs
@@ -42,10 +42,7 @@ pub(crate) fn inject_manifest_publish_failure(kind: io::ErrorKind) {
 ///
 /// `remaining_skips = 0` means "fail the next publish".
 #[cfg(test)]
-pub(crate) fn inject_manifest_publish_failure_after(
-    remaining_skips: usize,
-    kind: io::ErrorKind,
-) {
+pub(crate) fn inject_manifest_publish_failure_after(remaining_skips: usize, kind: io::ErrorKind) {
     MANIFEST_PUBLISH_FAILURE.with(|slot| {
         slot.set(Some(ArmedFailure {
             remaining_skips,

--- a/crates/storage/src/test_hooks.rs
+++ b/crates/storage/src/test_hooks.rs
@@ -1,0 +1,61 @@
+//! Test-only fault-injection hooks for the storage publish path.
+//!
+//! Mirrors the engine-side `test_hooks` module pattern (see
+//! `crates/engine/src/database/test_hooks.rs`), but scoped to the caller's
+//! thread so that parallel test execution does not leak injections across
+//! tests. Each test runs on its own thread in the cargo test runner, and
+//! the operations that consume these hooks (`write_branch_manifest` and
+//! `write_manifest`) always run synchronously on the caller's thread.
+//!
+//! Hooks are consumed on read — injecting one failure arms it for the next
+//! matching call site on the same thread; the call site clears the slot
+//! after consuming.
+//!
+//! The hooks compile into release builds but are only ever armed by tests:
+//! production code never calls `inject_*` functions, so the slots stay
+//! `None` and the consuming `maybe_inject_*` calls are cheap no-ops.
+
+use std::cell::Cell;
+use std::io;
+
+thread_local! {
+    static MANIFEST_PUBLISH_FAILURE: Cell<Option<io::ErrorKind>> = const { Cell::new(None) };
+    static DIR_FSYNC_FAILURE: Cell<Option<io::ErrorKind>> = const { Cell::new(None) };
+}
+
+/// Arm one manifest-publish failure for the next call to
+/// `SegmentedStore::write_branch_manifest` on the current thread.
+/// Consumed exactly once.
+pub(crate) fn inject_manifest_publish_failure(kind: io::ErrorKind) {
+    MANIFEST_PUBLISH_FAILURE.with(|slot| slot.set(Some(kind)));
+}
+
+/// Clear any pending manifest-publish failure on the current thread.
+pub(crate) fn clear_manifest_publish_failure() {
+    MANIFEST_PUBLISH_FAILURE.with(|slot| slot.set(None));
+}
+
+/// Consume an armed manifest-publish failure on the current thread, if any.
+pub(crate) fn maybe_inject_manifest_publish_failure() -> Option<io::Error> {
+    MANIFEST_PUBLISH_FAILURE
+        .with(|slot| slot.take())
+        .map(|kind| io::Error::new(kind, "injected manifest publish failure"))
+}
+
+/// Arm one directory-fsync failure for the next call to
+/// `manifest::write_manifest` on the current thread. Consumed exactly once.
+pub(crate) fn inject_dir_fsync_failure(kind: io::ErrorKind) {
+    DIR_FSYNC_FAILURE.with(|slot| slot.set(Some(kind)));
+}
+
+/// Clear any pending dir-fsync failure on the current thread.
+pub(crate) fn clear_dir_fsync_failure() {
+    DIR_FSYNC_FAILURE.with(|slot| slot.set(None));
+}
+
+/// Consume an armed dir-fsync failure on the current thread, if any.
+pub(crate) fn maybe_inject_dir_fsync_failure() -> Option<io::Error> {
+    DIR_FSYNC_FAILURE
+        .with(|slot| slot.take())
+        .map(|kind| io::Error::new(kind, "injected dir fsync failure"))
+}


### PR DESCRIPTION
## Summary

Closes **SG-001, SG-002, SG-003** from `docs/design/durability/durability-storage-closure-epics.md` §SE1.

- `write_branch_manifest` now returns `Result<(), StorageError>` — removes the log-and-swallow fallthrough at `crates/storage/src/segmented/mod.rs:4277-4283`. All callers (`flush_oldest_frozen`, `fork_branch`, `materialize_layer`, all three compaction variants) propagate with `?`.
- Compaction's old-input deletion loops are now gated on publish success. On refused publish, `.sst` inputs remain on disk for a future orphan-GC pass (SE3).
- Parent-directory `sync_all` results are checked at `manifest.rs:120-122` and `segment_builder.rs:465-468` — no more `let _ = dir_fd.sync_all()`.
- New typed surface `StorageError::{ManifestPublish, DirFsync}` with `#[non_exhaustive]`. Cross-layer conversion maps `ManifestPublish → StrataError::Corruption`, `DirFsync → StrataError::Storage` with source preserved.
- New fault-injection test `segmented/tests/publish_barrier.rs` + `test_hooks.rs` proves: refused publish returns `Err`, old inputs still present on disk, existing "deletes old inputs" test updated to pin "deletes only on publish success."

**Change class:** Cutover (removes log-and-swallow path).
**Assurance class:** S4 (touches WAL/manifest/commit ordering — needs second reviewer per `non-regression-requirements.md`).

## Test plan

- [ ] `cargo test -p strata_storage` passes, including the new `publish_barrier` suite
- [ ] `cargo test --workspace` passes (cross-layer `StorageError → StrataError` conversion)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Regression benchmarks: `cargo run --release -p strata-benchmarks --bin regression -- --tranche 2 --epic SE1` — redb/ycsb within thresholds (max 5% throughput, 10% tail)
- [ ] Second reviewer sign-off (S4 requirement)
- [ ] Manual check: inject manifest rename failure → compaction returns `Err`, old `.sst` retained
- [ ] Manual check: inject dir fsync failure → operation returns `Err` instead of silently succeeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)