### PR TITLE
SE1 v2: publication barrier — forward-only DirFsync + engine health latch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { submodules: true }
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-deny
       - name: Format check
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { submodules: true }
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --workspace
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { submodules: true }
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-hack
       - name: Feature powerset check
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { submodules: true }
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@v2
       - name: Release build
         run: cargo build --release --all

--- a/crates/durability/src/format/wal_record.rs
+++ b/crates/durability/src/format/wal_record.rs
@@ -34,18 +34,18 @@
 //! # Segment format versions
 //!
 //! * v1: original 32-byte header, no CRC. Read-only compatibility path
-//!       (pre-March 2026).
+//!   (pre-March 2026).
 //! * v2: 36-byte header with CRC32 over the first 32 bytes (March 2026,
-//!       commit 77e9f258 / issue #1577). Records within the segment
-//!       carry their own `LenCRC` for torn-write detection.
+//!   commit 77e9f258 / issue #1577). Records within the segment
+//!   carry their own `LenCRC` for torn-write detection.
 //! * v3: adds a per-record outer envelope `[u32 outer_len][u32 outer_len_crc]`
-//!       wrapping the codec-encoded inner record (T3-E12 Phase 2, this
-//!       build). The envelope is required so codec-encoded payloads
-//!       (AES-GCM, etc.) have discoverable record boundaries — without
-//!       it the reader cannot find the start of the next record on an
-//!       encrypted WAL. Pre-v3 segments are rejected with
-//!       [`SegmentHeaderError::LegacyFormat`]; clean break, no dual-path
-//!       parsing.
+//!   wrapping the codec-encoded inner record (T3-E12 Phase 2, this
+//!   build). The envelope is required so codec-encoded payloads
+//!   (AES-GCM, etc.) have discoverable record boundaries — without
+//!   it the reader cannot find the start of the next record on an
+//!   encrypted WAL. Pre-v3 segments are rejected with
+//!   [`SegmentHeaderError::LegacyFormat`]; clean break, no dual-path
+//!   parsing.
 
 use crc32fast::Hasher;
 use std::fs::{File, OpenOptions};

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -231,10 +231,7 @@ impl WalReader {
             // for identity). Codec errors surface as
             // `WalReaderError::CodecDecode` with NO demotion to
             // `PartialRecord` — even at the segment tail (T3-E12 §D5).
-            let decoded = match self.decode_payload(payload, offset as u64) {
-                Ok(d) => d,
-                Err(e) => return Err(e),
-            };
+            let decoded = self.decode_payload(payload, offset as u64)?;
             let raw_record_bytes: &[u8] = &decoded;
 
             match WalRecord::from_bytes(raw_record_bytes) {
@@ -620,7 +617,7 @@ impl WalReader {
                         self.scan_forward_to_valid_envelope(&buffer, offset + 1)
                     {
                         let candidate_txn = next_record.txn_id.as_u64();
-                        if candidate_txn < next_expected || candidate_txn == next_expected {
+                        if candidate_txn <= next_expected {
                             offset = scan_offset;
                             continue;
                         }
@@ -658,10 +655,7 @@ impl WalReader {
 
             // Decode via installed codec or pass through for identity.
             // Codec decode failures surface unconditionally (T3-E12 §D5).
-            let decoded = match self.decode_payload(payload, offset as u64) {
-                Ok(d) => d,
-                Err(e) => return Err(e),
-            };
+            let decoded = self.decode_payload(payload, offset as u64)?;
 
             match WalRecord::from_bytes(&decoded) {
                 Ok((record, _consumed)) => {
@@ -697,7 +691,7 @@ impl WalReader {
                         self.scan_forward_to_valid_envelope(&buffer, offset + 1)
                     {
                         let candidate_txn = next_record.txn_id.as_u64();
-                        if candidate_txn < next_expected || candidate_txn == next_expected {
+                        if candidate_txn <= next_expected {
                             offset = scan_offset;
                             continue;
                         }
@@ -2708,7 +2702,7 @@ mod tests {
         header[32..36].copy_from_slice(&crc.to_le_bytes());
 
         let seg_path = WalSegment::segment_path(&wal_dir, 1);
-        std::fs::write(&seg_path, &header).unwrap();
+        std::fs::write(&seg_path, header).unwrap();
 
         let reader = WalReader::new();
         match reader.read_segment(&wal_dir, 1) {
@@ -2761,7 +2755,7 @@ mod tests {
         header[32..36].copy_from_slice(&crc.to_le_bytes());
 
         let seg_path = WalSegment::segment_path(&wal_dir, 1);
-        std::fs::write(&seg_path, &header).unwrap();
+        std::fs::write(&seg_path, header).unwrap();
 
         match WalSegment::open_read(&wal_dir, 1) {
             Err(WalSegmentError::Header(SegmentHeaderError::LegacyFormat {

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1314,6 +1314,15 @@ impl Database {
         }
     }
 
+    pub(crate) fn storage_publish_error(&self) -> Option<StrataError> {
+        self.storage.publish_health().map(|health| {
+            StrataError::storage(format!(
+                "storage publication durability is degraded: {}",
+                health.message
+            ))
+        })
+    }
+
     pub(crate) fn ensure_writer_healthy(&self) -> StrataResult<()> {
         if let Some(err) = self.writer_halted_error() {
             return Err(err);
@@ -1547,14 +1556,30 @@ impl Database {
         let mut subsystems = Vec::new();
 
         // 1. Storage
-        subsystems.push(SubsystemHealth {
-            name: "storage".into(),
-            status: SubsystemStatus::Healthy,
-            message: Some(format!(
-                "{} branches, {} entries",
-                m.storage.total_branches, m.storage.total_entries
-            )),
-        });
+        {
+            let (status, message) = if let Some(health) = self.storage.publish_health() {
+                (
+                    SubsystemStatus::Unhealthy,
+                    Some(format!(
+                        "{} branches, {} entries; publication durability degraded: {}",
+                        m.storage.total_branches, m.storage.total_entries, health.message
+                    )),
+                )
+            } else {
+                (
+                    SubsystemStatus::Healthy,
+                    Some(format!(
+                        "{} branches, {} entries",
+                        m.storage.total_branches, m.storage.total_entries
+                    )),
+                )
+            };
+            subsystems.push(SubsystemHealth {
+                name: "storage".into(),
+                status,
+                message,
+            });
+        }
 
         // 2. WAL
         {

--- a/crates/engine/src/database/tests/codec.rs
+++ b/crates/engine/src/database/tests/codec.rs
@@ -715,7 +715,7 @@ fn test_aes_gcm_wal_durability_clean_shutdown_roundtrip() {
         for i in 0..12u8 {
             blind_write(
                 &db,
-                Key::new_kv(ns.clone(), &format!("k{i}")),
+                Key::new_kv(ns.clone(), format!("k{i}")),
                 Value::Bytes(vec![i; 64]),
             );
         }
@@ -732,7 +732,7 @@ fn test_aes_gcm_wal_durability_clean_shutdown_roundtrip() {
     .expect("reopen after clean shutdown must succeed");
 
     for i in 0..12u8 {
-        let key = Key::new_kv(ns.clone(), &format!("k{i}"));
+        let key = Key::new_kv(ns.clone(), format!("k{i}"));
         let got = db
             .storage()
             .get_versioned(&key, CommitVersion::MAX)
@@ -774,7 +774,7 @@ fn test_aes_gcm_wal_crash_recovery() {
         for i in 0..8u8 {
             blind_write(
                 &db,
-                Key::new_kv(ns.clone(), &format!("crash_k{i}")),
+                Key::new_kv(ns.clone(), format!("crash_k{i}")),
                 Value::Bytes(vec![i ^ 0x55; 32]),
             );
         }
@@ -792,7 +792,7 @@ fn test_aes_gcm_wal_crash_recovery() {
     .expect("reopen after crash must succeed via WAL recovery");
 
     for i in 0..8u8 {
-        let key = Key::new_kv(ns.clone(), &format!("crash_k{i}"));
+        let key = Key::new_kv(ns.clone(), format!("crash_k{i}"));
         let got = db
             .storage()
             .get_versioned(&key, CommitVersion::MAX)
@@ -902,7 +902,7 @@ fn test_aes_gcm_wrong_key_classifies_as_codec_decode() {
         for i in 0..4u8 {
             blind_write(
                 &db,
-                Key::new_kv(ns.clone(), &format!("enc_k{i}")),
+                Key::new_kv(ns.clone(), format!("enc_k{i}")),
                 Value::Bytes(vec![i; 16]),
             );
         }
@@ -943,7 +943,7 @@ fn test_aes_gcm_wrong_key_classifies_as_codec_decode() {
         let got = db
             .storage()
             .get_versioned(
-                &Key::new_kv(ns.clone(), &format!("enc_k{i}")),
+                &Key::new_kv(ns.clone(), format!("enc_k{i}")),
                 CommitVersion::MAX,
             )
             .unwrap();
@@ -994,7 +994,7 @@ fn test_aes_gcm_partial_tail_truncates_cleanly() {
         for i in 0..record_count {
             blind_write(
                 &db,
-                Key::new_kv(ns.clone(), &format!("tail_k{i}")),
+                Key::new_kv(ns.clone(), format!("tail_k{i}")),
                 Value::Bytes(vec![i; 16]),
             );
         }
@@ -1035,7 +1035,7 @@ fn test_aes_gcm_partial_tail_truncates_cleanly() {
         let got = db
             .storage()
             .get_versioned(
-                &Key::new_kv(ns.clone(), &format!("tail_k{i}")),
+                &Key::new_kv(ns.clone(), format!("tail_k{i}")),
                 CommitVersion::MAX,
             )
             .unwrap();
@@ -1083,7 +1083,7 @@ fn test_aes_gcm_mid_segment_corruption_not_silently_truncated() {
         for i in 0..4u8 {
             blind_write(
                 &db,
-                Key::new_kv(ns.clone(), &format!("mid_k{i}")),
+                Key::new_kv(ns.clone(), format!("mid_k{i}")),
                 Value::Bytes(vec![i ^ 0x77; 32]),
             );
         }
@@ -1120,7 +1120,7 @@ fn test_aes_gcm_mid_segment_corruption_not_silently_truncated() {
                 let got = db
                     .storage()
                     .get_versioned(
-                        &Key::new_kv(ns.clone(), &format!("mid_k{i}")),
+                        &Key::new_kv(ns.clone(), format!("mid_k{i}")),
                         CommitVersion::MAX,
                     )
                     .unwrap();

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -654,7 +654,7 @@ fn test_legacy_format_under_lossy_flag_still_hard_fails() {
     header[32..36].copy_from_slice(&header_crc.to_le_bytes());
 
     let segment_path = wal_dir.join("wal-000001.seg");
-    std::fs::write(&segment_path, &header).unwrap();
+    std::fs::write(&segment_path, header).unwrap();
 
     // Snapshot the on-disk bytes BEFORE the open attempt so we can
     // prove no wipe occurred.

--- a/crates/engine/src/database/tests/transactions.rs
+++ b/crates/engine/src/database/tests/transactions.rs
@@ -165,3 +165,30 @@ fn test_owned_transaction_commit_emits_one_commit_observer_event() {
         "successful manual commits should emit exactly one observer event"
     );
 }
+
+#[test]
+fn test_storage_publication_health_blocks_new_transactions() {
+    let temp_dir = TempDir::new().unwrap();
+    let db = Database::open(temp_dir.path().join("db")).unwrap();
+
+    db.storage()
+        .latch_publish_health("manifest rename may not be durable");
+
+    let err = match db.begin_transaction(BranchId::new()) {
+        Ok(_) => panic!("begin_transaction should fail when storage publish health is latched"),
+        Err(err) => err,
+    };
+    assert!(matches!(err, StrataError::Storage { .. }));
+
+    let report = db.health();
+    let storage = report
+        .subsystems
+        .iter()
+        .find(|subsystem| subsystem.name == "storage")
+        .expect("storage subsystem present");
+    assert_eq!(storage.status, SubsystemStatus::Unhealthy);
+    assert!(storage
+        .message
+        .as_ref()
+        .is_some_and(|message| message.contains("publication durability degraded")));
+}

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -193,6 +193,10 @@ impl Database {
     /// - The database is shutting down (`InvalidInput`)
     /// - The WAL writer is halted due to sync failure (`WriterHalted`)
     fn check_accepting(&self) -> StrataResult<()> {
+        if let Some(err) = self.storage_publish_error() {
+            return Err(err);
+        }
+
         if !self.accepting_transactions.load(Ordering::Acquire) {
             // Check if writer is halted (more specific error)
             if let Some(err) = self.writer_halted_error() {
@@ -210,7 +214,7 @@ impl Database {
     /// Synchronous flush of all frozen memtables. Used only during write
     /// backpressure to ensure L0 count is accurate before stall decisions.
     /// Normal writes use the async path in `schedule_flush_if_needed`.
-    fn flush_frozen_sync(&self) {
+    fn flush_frozen_sync(&self) -> StrataResult<()> {
         let branches = self.storage.branches_needing_flush();
         for branch_id in &branches {
             loop {
@@ -220,18 +224,21 @@ impl Database {
                     }
                     Ok(false) => break,
                     Err(e) => {
+                        let message = format!("sync flush failed for branch {branch_id}: {e}");
+                        self.storage.latch_publish_health(message.clone());
                         tracing::warn!(
                             target: "strata::flush",
                             ?branch_id,
                             error = %e,
                             "sync flush failed"
                         );
-                        break;
+                        return Err(StrataError::storage_with_source(message, e));
                     }
                 }
             }
         }
         release_freed_memory();
+        Ok(())
     }
 
     /// Schedule flush and compaction on the background thread.
@@ -287,6 +294,9 @@ impl Database {
                                     }
                                     Ok(false) => break,
                                     Err(e) => {
+                                        storage.latch_publish_health(format!(
+                                            "background flush failed for branch {branch_id}: {e}"
+                                        ));
                                         tracing::warn!(
                                             target: "strata::flush",
                                             ?branch_id,
@@ -377,7 +387,7 @@ impl Database {
             // If frozen memtables are pending, drain them synchronously so
             // L0 count is accurate for backpressure.
             if self.storage.total_frozen_count() > 0 {
-                self.flush_frozen_sync();
+                self.flush_frozen_sync()?;
             }
             let l0_count = self.storage.max_l0_segment_count();
 

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -1,0 +1,76 @@
+use std::io;
+use std::path::PathBuf;
+
+use strata_core::types::BranchId;
+use strata_core::StrataError;
+use thiserror::Error;
+
+/// Result alias for storage-local operations that can raise [`StorageError`].
+pub type StorageResult<T> = Result<T, StorageError>;
+
+/// Storage-local failures that need finer classification than raw `io::Error`.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum StorageError {
+    /// Generic storage I/O failure.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+
+    /// Publishing a branch manifest failed before the atomic rename completed.
+    #[error("failed to publish segment manifest for branch {branch_id}: {inner}")]
+    ManifestPublish {
+        /// Branch whose manifest publication failed.
+        branch_id: BranchId,
+        /// Underlying filesystem error from temp-file write, sync, or rename.
+        #[source]
+        inner: io::Error,
+    },
+
+    /// The manifest rename may already be visible, but the parent-directory
+    /// fsync failed so rename durability is unconfirmed.
+    #[error("segment manifest rename may not be durable for directory {dir:?}: {inner}")]
+    DirFsync {
+        /// Directory that could not be fsynced after rename.
+        dir: PathBuf,
+        /// Underlying directory-open or directory-fsync error.
+        #[source]
+        inner: io::Error,
+    },
+}
+
+impl StorageError {
+    /// Returns the underlying `io::ErrorKind` for callers and tests that only
+    /// need the coarse I/O classification.
+    pub fn kind(&self) -> io::ErrorKind {
+        match self {
+            StorageError::Io(inner) => inner.kind(),
+            StorageError::ManifestPublish { inner, .. } => inner.kind(),
+            StorageError::DirFsync { inner, .. } => inner.kind(),
+        }
+    }
+}
+
+impl From<StorageError> for StrataError {
+    fn from(value: StorageError) -> Self {
+        match value {
+            StorageError::Io(inner) => StrataError::storage_with_source("storage I/O error", inner),
+            StorageError::ManifestPublish { branch_id, inner } => StrataError::storage_with_source(
+                format!("failed to publish segment manifest for branch {branch_id}"),
+                inner,
+            ),
+            StorageError::DirFsync { dir, inner } => StrataError::storage_with_source(
+                format!(
+                    "segment manifest rename may not be durable for directory {}",
+                    dir.display()
+                ),
+                inner,
+            ),
+        }
+    }
+}
+
+impl From<StorageError> for io::Error {
+    fn from(value: StorageError) -> Self {
+        io::Error::other(value)
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -13,6 +13,8 @@
 pub mod block_cache;
 pub mod bloom;
 pub mod compaction;
+/// Storage-local error types used by publication barriers and manifest I/O.
+pub mod error;
 pub mod index;
 pub mod key_encoding;
 pub mod manifest;
@@ -26,10 +28,12 @@ pub mod segment;
 pub mod segment_builder;
 pub mod segmented;
 pub mod stored_value;
+mod test_hooks;
 pub mod ttl;
 
 pub use bloom::BloomFilter;
 pub use compaction::{CompactionIterator, CompactionScheduler, TierMergeCandidate};
+pub use error::{StorageError, StorageResult};
 pub use index::{BranchIndex, TypeIndex};
 pub use memory_stats::{BranchMemoryStats, StorageMemoryStats};
 pub use pressure::{MemoryPressure, PressureLevel};
@@ -38,6 +42,6 @@ pub use segment::{KVSegment, OwnedSegmentIter};
 pub use segment_builder::{CompressionCodec, SegmentBuilder, SegmentMeta, SplittingSegmentBuilder};
 pub use segmented::{
     CompactionResult, DecodedSnapshotEntry, DecodedSnapshotValue, MaterializeResult,
-    PickAndCompactResult, SegmentedStore, StorageIterator, VersionedEntry,
+    PickAndCompactResult, PublishHealth, SegmentedStore, StorageIterator, VersionedEntry,
 };
 pub use ttl::TTLIndex;

--- a/crates/storage/src/manifest.rs
+++ b/crates/storage/src/manifest.rs
@@ -23,6 +23,8 @@ use std::path::Path;
 use strata_core::id::CommitVersion;
 use strata_core::types::BranchId;
 
+use crate::{StorageError, StorageResult};
+
 /// Magic bytes for segment manifest: "STRAMFST"
 const MANIFEST_MAGIC: [u8; 8] = *b"STRAMFST";
 
@@ -71,7 +73,7 @@ pub fn write_manifest(
     dir: &Path,
     entries: &[ManifestEntry],
     inherited_layers: &[ManifestInheritedLayer],
-) -> io::Result<()> {
+) -> StorageResult<()> {
     let mut buf = Vec::with_capacity(HEADER_SIZE + entries.len() * 20 + 4);
 
     // Header
@@ -115,11 +117,24 @@ pub fn write_manifest(
 
     std::fs::rename(&tmp_path, &final_path)?;
 
-    // Fsync the parent directory to make the rename durable.
-    // Failure here is non-fatal (rename already succeeded).
-    if let Ok(dir_fd) = std::fs::File::open(dir) {
-        let _ = dir_fd.sync_all();
+    // Fsync the parent directory to make the rename durable. Failure here
+    // means the rename may already be visible, but its durability is
+    // unconfirmed and must be surfaced distinctly.
+    if let Some(inner) = crate::test_hooks::maybe_inject_manifest_dir_fsync_failure() {
+        return Err(StorageError::DirFsync {
+            dir: dir.to_path_buf(),
+            inner,
+        });
     }
+
+    let dir_fd = std::fs::File::open(dir).map_err(|inner| StorageError::DirFsync {
+        dir: dir.to_path_buf(),
+        inner,
+    })?;
+    dir_fd.sync_all().map_err(|inner| StorageError::DirFsync {
+        dir: dir.to_path_buf(),
+        inner,
+    })?;
 
     Ok(())
 }

--- a/crates/storage/src/segment_builder.rs
+++ b/crates/storage/src/segment_builder.rs
@@ -19,6 +19,7 @@
 use crate::bloom::BloomFilter;
 use crate::key_encoding::{InternalKey, COMMIT_ID_SUFFIX_LEN};
 use crate::memtable::MemtableEntry;
+use crate::{StorageError, StorageResult};
 use strata_core::id::CommitVersion;
 use strata_core::value::Value;
 
@@ -164,7 +165,7 @@ impl SegmentBuilder {
     ///
     /// Writes to a temporary file then atomically renames to `path`.
     /// The iterator MUST yield entries in `InternalKey` order (ascending).
-    pub fn build_from_iter<I>(&self, iter: I, path: &Path) -> io::Result<SegmentMeta>
+    pub fn build_from_iter<I>(&self, iter: I, path: &Path) -> StorageResult<SegmentMeta>
     where
         I: Iterator<Item = (InternalKey, MemtableEntry)>,
     {
@@ -463,9 +464,14 @@ impl SegmentBuilder {
 
         // 10. Fsync parent directory so the rename is durable on crash.
         if let Some(parent) = path.parent() {
-            if let Ok(dir_fd) = std::fs::File::open(parent) {
-                let _ = dir_fd.sync_all();
-            }
+            let dir_fd = std::fs::File::open(parent).map_err(|inner| StorageError::DirFsync {
+                dir: parent.to_path_buf(),
+                inner,
+            })?;
+            dir_fd.sync_all().map_err(|inner| StorageError::DirFsync {
+                dir: parent.to_path_buf(),
+                inner,
+            })?;
         }
 
         Ok(SegmentMeta {
@@ -1479,7 +1485,7 @@ impl SplittingSegmentBuilder {
         &self,
         iter: I,
         path_fn: F,
-    ) -> io::Result<Vec<(std::path::PathBuf, SegmentMeta)>>
+    ) -> StorageResult<Vec<(std::path::PathBuf, SegmentMeta)>>
     where
         I: Iterator<Item = (InternalKey, MemtableEntry)>,
         F: Fn(usize) -> std::path::PathBuf,
@@ -1502,7 +1508,7 @@ impl SplittingSegmentBuilder {
         iter: I,
         path_fn: F,
         mut should_split: P,
-    ) -> io::Result<Vec<(std::path::PathBuf, SegmentMeta)>>
+    ) -> StorageResult<Vec<(std::path::PathBuf, SegmentMeta)>>
     where
         I: Iterator<Item = (InternalKey, MemtableEntry)>,
         F: Fn(usize) -> std::path::PathBuf,

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -270,7 +270,7 @@ impl SegmentedStore {
             Ok(meta) => meta,
             Err(e) => {
                 cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-                return Err(e);
+                return Err(e.into());
             }
         };
         if let Err(e) = check_corruption_flags(&corruption_flags) {
@@ -317,7 +317,7 @@ impl SegmentedStore {
         // delete but before manifest write, recovery would reference missing
         // segments. Writing manifest first ensures crash recovery can always
         // find the new compacted segment.
-        self.write_branch_manifest(branch_id);
+        self.write_branch_manifest(branch_id)?;
 
         // Now safe to delete old segment files (refcount-guarded).
         for seg in &old_segments {
@@ -428,7 +428,7 @@ impl SegmentedStore {
             Ok(meta) => meta,
             Err(e) => {
                 cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-                return Err(e);
+                return Err(e.into());
             }
         };
         if let Err(e) = check_corruption_flags(&corruption_flags) {
@@ -471,7 +471,7 @@ impl SegmentedStore {
         }
 
         // Persist manifest BEFORE deleting old files (crash safety).
-        self.write_branch_manifest(branch_id);
+        self.write_branch_manifest(branch_id)?;
 
         // Delete old segment files (refcount-guarded).
         for seg in &selected_segments {
@@ -634,7 +634,7 @@ impl SegmentedStore {
             Err(e) => {
                 let end_id = next_id.load(Ordering::Relaxed);
                 cleanup_partial_compaction_outputs(&branch_dir, start_id, end_id);
-                return Err(e);
+                return Err(e.into());
             }
         };
         if let Err(e) = check_corruption_flags(&corruption_flags) {
@@ -693,7 +693,7 @@ impl SegmentedStore {
         }
 
         // Persist manifest BEFORE deleting old files (crash safety).
-        self.write_branch_manifest(branch_id);
+        self.write_branch_manifest(branch_id)?;
 
         // Now safe to delete old files (refcount-guarded).
         for seg in &l0_segs {
@@ -852,7 +852,7 @@ impl SegmentedStore {
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
             refresh_level_targets(&mut branch, self.level_base_bytes());
             drop(branch);
-            self.write_branch_manifest(branch_id);
+            self.write_branch_manifest(branch_id)?;
 
             return Ok(Some(CompactionResult {
                 segments_merged: 1,
@@ -947,7 +947,7 @@ impl SegmentedStore {
             Err(e) => {
                 let end_id = next_id.load(Ordering::Relaxed);
                 cleanup_partial_compaction_outputs(&branch_dir, start_id, end_id);
-                return Err(e);
+                return Err(e.into());
             }
         };
         if let Err(e) = check_corruption_flags(&corruption_flags) {
@@ -1006,7 +1006,7 @@ impl SegmentedStore {
         // ── 5. Cleanup ─────────────────────────────────────────────────
 
         // Persist manifest BEFORE deleting old files (crash safety).
-        self.write_branch_manifest(branch_id);
+        self.write_branch_manifest(branch_id)?;
 
         // Delete old segment files (refcount-guarded).
         for seg in &input_segs {

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -20,15 +20,18 @@ use crate::pressure::{MemoryPressure, PressureLevel};
 use crate::seekable::{self, SeekableIterator as _};
 use crate::segment::{KVSegment, LevelSegmentIter, OwnedSegmentIter, SegmentEntry};
 use crate::segment_builder::{SegmentBuilder, SplittingSegmentBuilder};
+use crate::{StorageError, StorageResult};
 
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
+use parking_lot::Mutex;
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::io;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 // ── Read-path profiling (STRATA_PROFILE_READ=1) ────────────────────────────
 
@@ -754,6 +757,22 @@ pub struct SegmentedStore {
     data_block_size: AtomicUsize,
     /// Bloom filter bits per key (base value). Default: 10.
     bloom_bits_per_key: AtomicUsize,
+    /// Latched publication durability issue for this process.
+    publish_health: Mutex<Option<PublishHealth>>,
+}
+
+/// Latched storage publication durability issue for the current process.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublishHealth {
+    /// First time the issue was observed in this process.
+    pub first_observed_at: SystemTime,
+    /// Human-readable detail for operator/debugging surfaces.
+    pub message: String,
+}
+
+enum PublishOutcome {
+    Durable,
+    NotDurable(StorageError),
 }
 
 impl SegmentedStore {
@@ -782,6 +801,7 @@ impl SegmentedStore {
             level_base_bytes: AtomicU64::new(LEVEL_BASE_BYTES),
             data_block_size: AtomicUsize::new(4096),
             bloom_bits_per_key: AtomicUsize::new(10),
+            publish_health: Mutex::new(None),
         }
     }
 
@@ -811,6 +831,7 @@ impl SegmentedStore {
             level_base_bytes: AtomicU64::new(LEVEL_BASE_BYTES),
             data_block_size: AtomicUsize::new(4096),
             bloom_bits_per_key: AtomicUsize::new(10),
+            publish_health: Mutex::new(None),
         }
     }
 
@@ -840,6 +861,7 @@ impl SegmentedStore {
             level_base_bytes: AtomicU64::new(LEVEL_BASE_BYTES),
             data_block_size: AtomicUsize::new(4096),
             bloom_bits_per_key: AtomicUsize::new(10),
+            publish_health: Mutex::new(None),
         }
     }
 
@@ -953,6 +975,268 @@ impl SegmentedStore {
             bloom_bits_per_key: self.bloom_bits_per_key(),
             ..SegmentBuilder::default()
         }
+    }
+
+    fn record_publish_health(&self, message: String) {
+        let mut slot = self.publish_health.lock();
+        if slot.is_none() {
+            *slot = Some(PublishHealth {
+                first_observed_at: SystemTime::now(),
+                message,
+            });
+        }
+    }
+
+    /// Latch a storage publication failure observed by an upper-layer
+    /// background path (for example, engine-driven flush) so new writers can
+    /// be rejected and health surfaces can report the failure.
+    pub fn latch_publish_health(&self, message: impl Into<String>) {
+        self.record_publish_health(message.into());
+    }
+
+    /// Returns the latched storage publication durability issue, if any.
+    pub fn publish_health(&self) -> Option<PublishHealth> {
+        self.publish_health.lock().clone()
+    }
+
+    fn manifest_payload_from_state(
+        ver: &SegmentVersion,
+        inherited_layers: &[InheritedLayer],
+    ) -> (
+        Vec<crate::manifest::ManifestEntry>,
+        Vec<crate::manifest::ManifestInheritedLayer>,
+    ) {
+        let mut entries = Vec::new();
+        for (level_idx, level) in ver.levels.iter().enumerate() {
+            for seg in level {
+                if let Some(name) = seg.file_path().file_name().and_then(|n| n.to_str()) {
+                    entries.push(crate::manifest::ManifestEntry {
+                        filename: name.to_string(),
+                        level: level_idx as u8,
+                    });
+                }
+            }
+        }
+
+        let inherited = inherited_layers
+            .iter()
+            .map(|layer| {
+                let layer_entries = layer
+                    .segments
+                    .levels
+                    .iter()
+                    .enumerate()
+                    .flat_map(|(level_idx, level)| {
+                        level.iter().filter_map(move |seg| {
+                            seg.file_path()
+                                .file_name()
+                                .and_then(|n| n.to_str())
+                                .map(|name| crate::manifest::ManifestEntry {
+                                    filename: name.to_string(),
+                                    level: level_idx as u8,
+                                })
+                        })
+                    })
+                    .collect();
+
+                let status = match layer.status {
+                    LayerStatus::Active => 0,
+                    LayerStatus::Materializing => 1,
+                    LayerStatus::Materialized => 2,
+                };
+
+                crate::manifest::ManifestInheritedLayer {
+                    source_branch_id: layer.source_branch_id,
+                    fork_version: layer.fork_version,
+                    status,
+                    entries: layer_entries,
+                }
+            })
+            .collect();
+
+        (entries, inherited)
+    }
+
+    fn write_branch_manifest_from_state(
+        &self,
+        branch_id: &BranchId,
+        ver: &SegmentVersion,
+        inherited_layers: &[InheritedLayer],
+    ) -> StorageResult<()> {
+        let segments_dir = match &self.segments_dir {
+            Some(d) => d,
+            None => return Ok(()),
+        };
+
+        if let Some(inner) = crate::test_hooks::maybe_inject_manifest_publish_failure() {
+            return Err(StorageError::ManifestPublish {
+                branch_id: *branch_id,
+                inner,
+            });
+        }
+
+        let branch_hex = hex_encode_branch(branch_id);
+        let branch_dir = segments_dir.join(&branch_hex);
+        std::fs::create_dir_all(&branch_dir).map_err(|inner| StorageError::ManifestPublish {
+            branch_id: *branch_id,
+            inner,
+        })?;
+
+        let (entries, inherited) = Self::manifest_payload_from_state(ver, inherited_layers);
+        crate::manifest::write_manifest(&branch_dir, &entries, &inherited).map_err(|e| match e {
+            StorageError::Io(inner) => StorageError::ManifestPublish {
+                branch_id: *branch_id,
+                inner,
+            },
+            other => other,
+        })
+    }
+
+    fn publish_locked_branch_manifest(
+        &self,
+        branch_id: &BranchId,
+        branch: &BranchState,
+    ) -> Result<PublishOutcome, StorageError> {
+        let ver = branch.version.load();
+        match self.write_branch_manifest_from_state(branch_id, &ver, &branch.inherited_layers) {
+            Ok(()) => Ok(PublishOutcome::Durable),
+            Err(StorageError::DirFsync { dir, inner }) => {
+                let err = StorageError::DirFsync { dir, inner };
+                self.record_publish_health(format!("{}", err));
+                Ok(PublishOutcome::NotDurable(err))
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn cleanup_created_segment_files(&self, paths: &[PathBuf]) {
+        let mut parent_dirs = HashSet::new();
+        for path in paths {
+            if let Some(parent) = path.parent() {
+                parent_dirs.insert(parent.to_path_buf());
+            }
+            let _ = std::fs::remove_file(path);
+        }
+        for dir in parent_dirs {
+            let _ = std::fs::remove_dir(&dir);
+        }
+    }
+
+    fn rollback_flush_publish_failure_locked(
+        &self,
+        branch: &mut BranchState,
+        frozen_mt: &Arc<Memtable>,
+        new_segment: &KVSegment,
+    ) {
+        crate::block_cache::global_cache().invalidate_file(new_segment.file_id());
+
+        let cur_ver = branch.version.load();
+        let mut new_levels = cur_ver.levels.clone();
+        let old_l0_len = new_levels[0].len();
+        new_levels[0].retain(|seg| seg.file_id() != new_segment.file_id());
+        if new_levels[0].len() != old_l0_len {
+            branch
+                .version
+                .store(Arc::new(SegmentVersion { levels: new_levels }));
+            refresh_level_targets(branch, self.level_base_bytes());
+        }
+
+        if !branch.frozen.iter().any(|mt| mt.id() == frozen_mt.id()) {
+            branch.frozen.push(Arc::clone(frozen_mt));
+            self.total_frozen_count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn rollback_materialize_status_locked(
+        branch: &mut BranchState,
+        source_branch_id: BranchId,
+        fork_version: CommitVersion,
+    ) {
+        if let Some(layer) = branch.inherited_layers.iter_mut().find(|layer| {
+            layer.source_branch_id == source_branch_id && layer.fork_version == fork_version
+        }) {
+            layer.status = LayerStatus::Active;
+        }
+    }
+
+    fn rollback_materialize_install_locked(
+        &self,
+        branch: &mut BranchState,
+        layer_index: usize,
+        source_branch_id: BranchId,
+        fork_version: CommitVersion,
+        layer_segments: &Arc<SegmentVersion>,
+        new_segments: &[Arc<KVSegment>],
+    ) {
+        let new_ids: HashSet<u64> = new_segments
+            .iter()
+            .map(|segment| segment.file_id())
+            .collect();
+
+        let cur_ver = branch.version.load();
+        let mut new_levels = cur_ver.levels.clone();
+        let old_l0_len = new_levels[0].len();
+        new_levels[0].retain(|seg| !new_ids.contains(&seg.file_id()));
+        if new_levels[0].len() != old_l0_len {
+            branch
+                .version
+                .store(Arc::new(SegmentVersion { levels: new_levels }));
+        }
+
+        if let Some(layer) = branch.inherited_layers.iter_mut().find(|layer| {
+            layer.source_branch_id == source_branch_id && layer.fork_version == fork_version
+        }) {
+            layer.status = LayerStatus::Active;
+        } else {
+            let restore_index = layer_index.min(branch.inherited_layers.len());
+            branch.inherited_layers.insert(
+                restore_index,
+                InheritedLayer {
+                    source_branch_id,
+                    fork_version,
+                    segments: Arc::clone(layer_segments),
+                    status: LayerStatus::Active,
+                },
+            );
+        }
+
+        refresh_level_targets(branch, self.level_base_bytes());
+    }
+
+    fn rollback_fork_source_publish_failure_locked(
+        &self,
+        source: &mut BranchState,
+        old_active: Arc<Memtable>,
+        old_frozen: Vec<Arc<Memtable>>,
+        old_version: Arc<SegmentVersion>,
+        old_level_targets: compaction::LevelTargets,
+    ) {
+        let current_frozen = source.frozen.len();
+        let restored_frozen = old_frozen.len();
+        if restored_frozen > current_frozen {
+            self.total_frozen_count
+                .fetch_add(restored_frozen - current_frozen, Ordering::Relaxed);
+        } else if current_frozen > restored_frozen {
+            self.total_frozen_count
+                .fetch_sub(current_frozen - restored_frozen, Ordering::Relaxed);
+        }
+
+        source.active = old_active;
+        source.frozen = old_frozen;
+        source.version.store(old_version);
+        source.level_targets = old_level_targets;
+    }
+
+    fn rollback_fork_dest_publish_failure_locked(
+        dest: &mut BranchState,
+        dest_was_new: bool,
+    ) -> bool {
+        dest.inherited_layers.clear();
+        dest.max_version.store(0, Ordering::Release);
+        dest_was_new
+            && dest.active.is_empty()
+            && dest.frozen.is_empty()
+            && dest.version.load().levels.iter().all(Vec::is_empty)
     }
 
     /// Iterate over all branch IDs that have data.
@@ -1171,14 +1455,15 @@ impl SegmentedStore {
         &self,
         child_branch_id: &BranchId,
         layer_index: usize,
-    ) -> io::Result<MaterializeResult> {
+    ) -> StorageResult<MaterializeResult> {
         let segments_dir = match &self.segments_dir {
             Some(d) => d,
             None => {
                 return Err(io::Error::new(
                     io::ErrorKind::Unsupported,
                     "materialize_layer requires a disk-backed store",
-                ))
+                )
+                .into());
             }
         };
 
@@ -1231,7 +1516,9 @@ impl SegmentedStore {
         let (layer_segments, source_branch_id, fork_version, own_version, closer_layers) = {
             let branch = match self.branches.get(child_branch_id) {
                 Some(b) => b,
-                None => return Err(io::Error::new(io::ErrorKind::NotFound, "branch not found")),
+                None => {
+                    return Err(io::Error::new(io::ErrorKind::NotFound, "branch not found").into())
+                }
             };
             if layer_index >= branch.inherited_layers.len() {
                 // Layer was already removed by a concurrent materialization that
@@ -1273,17 +1560,32 @@ impl SegmentedStore {
             // DashMap guard drops here
         };
 
-        // 2b. Set status to Materializing
+        // 2b. Set status to Materializing and publish that state while the
+        // branch guard still excludes same-branch mutation.
+        let mut initial_not_durable = None;
         {
             let mut branch = match self.branches.get_mut(child_branch_id) {
                 Some(b) => b,
-                None => return Err(io::Error::new(io::ErrorKind::NotFound, "branch not found")),
+                None => {
+                    return Err(io::Error::new(io::ErrorKind::NotFound, "branch not found").into())
+                }
             };
             if layer_index < branch.inherited_layers.len() {
                 branch.inherited_layers[layer_index].status = LayerStatus::Materializing;
             }
+            match self.publish_locked_branch_manifest(child_branch_id, &branch) {
+                Ok(PublishOutcome::Durable) => {}
+                Ok(PublishOutcome::NotDurable(err)) => initial_not_durable = Some(err),
+                Err(e) => {
+                    Self::rollback_materialize_status_locked(
+                        &mut branch,
+                        source_branch_id,
+                        fork_version,
+                    );
+                    return Err(e);
+                }
+            }
         }
-        self.write_branch_manifest(child_branch_id);
 
         // 2c. Build materialized entries (no locks held — I/O heavy)
         let mut entries = Self::collect_unshadowed_entries(
@@ -1304,7 +1606,7 @@ impl SegmentedStore {
         // 2d. Build segment file(s) (no locks held).
         // Use SplittingSegmentBuilder to avoid creating oversized L0 segments
         // from large inherited layers (#1671).
-        let new_segments: Vec<KVSegment> = if !entries.is_empty() {
+        let new_segments: Vec<Arc<KVSegment>> = if !entries.is_empty() {
             let branch_hex = hex_encode_branch(child_branch_id);
             let branch_dir = segments_dir.join(&branch_hex);
             std::fs::create_dir_all(&branch_dir)?;
@@ -1319,7 +1621,7 @@ impl SegmentedStore {
 
             let mut segments = Vec::with_capacity(built.len());
             for (path, _meta) in built {
-                let seg = KVSegment::open(&path)?;
+                let seg = Arc::new(KVSegment::open(&path)?);
                 segments.push(seg);
             }
             segments
@@ -1340,8 +1642,8 @@ impl SegmentedStore {
                 let old_ver = branch.version.load();
                 let mut new_l0 =
                     Vec::with_capacity(old_ver.l0_segments().len() + new_segments.len());
-                for seg in new_segments {
-                    new_l0.push(Arc::new(seg));
+                for seg in &new_segments {
+                    new_l0.push(Arc::clone(seg));
                 }
                 new_l0.extend(old_ver.l0_segments().iter().cloned());
                 let mut new_levels = old_ver.levels.clone();
@@ -1361,10 +1663,35 @@ impl SegmentedStore {
             }
 
             refresh_level_targets(&mut branch, self.level_base_bytes());
+            match self.publish_locked_branch_manifest(child_branch_id, &branch) {
+                Ok(PublishOutcome::Durable) => {}
+                Ok(PublishOutcome::NotDurable(err)) => {
+                    if initial_not_durable.is_none() {
+                        initial_not_durable = Some(err);
+                    }
+                }
+                Err(e) => {
+                    self.rollback_materialize_install_locked(
+                        &mut branch,
+                        layer_index,
+                        source_branch_id,
+                        fork_version,
+                        &layer_segments,
+                        &new_segments,
+                    );
+                    let created_paths: Vec<_> = new_segments
+                        .iter()
+                        .map(|segment| segment.file_path().to_path_buf())
+                        .collect();
+                    drop(branch);
+                    for segment in &new_segments {
+                        crate::block_cache::global_cache().invalidate_file(segment.file_id());
+                    }
+                    self.cleanup_created_segment_files(&created_paths);
+                    return Err(e);
+                }
+            }
         }
-
-        // 2f. Cleanup
-        self.write_branch_manifest(child_branch_id);
 
         // Decrement refcounts for each segment in the removed layer.
         for level in &layer_segments.levels {
@@ -1377,6 +1704,14 @@ impl SegmentedStore {
         // Refcount decrements above may have released the last reference to
         // segments whose parent already compacted them away.
         self.gc_orphan_segments();
+
+        if let Some(err) = initial_not_durable {
+            tracing::warn!(
+                branch = %hex_encode_branch(child_branch_id),
+                error = %err,
+                "materialize_layer completed with unconfirmed manifest durability"
+            );
+        }
 
         Ok(MaterializeResult {
             entries_materialized,
@@ -1539,12 +1874,12 @@ impl SegmentedStore {
         &self,
         source_id: &BranchId,
         dest_id: &BranchId,
-    ) -> io::Result<(CommitVersion, usize)> {
+    ) -> StorageResult<(CommitVersion, usize)> {
         if source_id == dest_id {
-            return Err(io::Error::new(
+            return Err(StorageError::Io(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "fork_branch: source and destination must be different branches",
-            ));
+            )));
         }
 
         // 1. Flush bulk memtable data to segments (outside exclusive lock).
@@ -1563,16 +1898,22 @@ impl SegmentedStore {
         //    CRITICAL: Increment refcounts BEFORE dropping the source guard.
         //    Without this, concurrent parent compaction can delete segments
         //    between the snapshot and the refcount increment (see #1662).
-        let (dest_layers, segments_shared, fork_version, source_manifest_dirty) = {
+        let (dest_layers, segments_shared, fork_version) = {
             let mut source = match self.branches.get_mut(source_id) {
                 Some(b) => b,
                 None => {
                     return Err(io::Error::new(
                         io::ErrorKind::NotFound,
                         "fork_branch: source branch no longer exists",
-                    ))
+                    )
+                    .into())
                 }
             };
+            let source_old_active = Arc::clone(&source.active);
+            let source_old_frozen = source.frozen.clone();
+            let source_old_version = source.version.load_full();
+            let source_old_level_targets = source.level_targets.clone();
+            let mut source_flush_paths = Vec::new();
 
             // Inline-rotate: move straggler writes from active to frozen.
             if !source.active.is_empty() {
@@ -1598,6 +1939,7 @@ impl SegmentedStore {
                         .make_segment_builder()
                         .with_compression(crate::segment_builder::CompressionCodec::None);
                     builder.build_from_iter(mt.iter_all(), &seg_path)?;
+                    source_flush_paths.push(seg_path.clone());
                     let segment = KVSegment::open(&seg_path)?;
 
                     // Install segment into source's SegmentVersion.
@@ -1624,6 +1966,28 @@ impl SegmentedStore {
                 }
                 if source_manifest_dirty {
                     refresh_level_targets(&mut source, self.level_base_bytes());
+                    match self.publish_locked_branch_manifest(source_id, &source) {
+                        Ok(PublishOutcome::Durable) => {}
+                        Ok(PublishOutcome::NotDurable(err)) => {
+                            tracing::warn!(
+                                branch = %hex_encode_branch(source_id),
+                                error = %err,
+                                "fork source manifest rename landed but durability is unconfirmed"
+                            );
+                        }
+                        Err(e) => {
+                            self.rollback_fork_source_publish_failure_locked(
+                                &mut source,
+                                source_old_active,
+                                source_old_frozen,
+                                source_old_version,
+                                source_old_level_targets,
+                            );
+                            drop(source);
+                            self.cleanup_created_segment_files(&source_flush_paths);
+                            return Err(e);
+                        }
+                    }
                 }
             }
 
@@ -1675,20 +2039,16 @@ impl SegmentedStore {
                 }
             }
 
-            (layers, shared, fork_version, source_manifest_dirty)
+            (layers, shared, fork_version)
             // source DashMap guard drops here — segments are now protected
         };
 
-        // Persist source manifest if we inline-flushed segments.
-        if source_manifest_dirty {
-            self.write_branch_manifest(source_id);
-        }
-
         // 6. Attach to dest branch, rejecting if a concurrent fork already installed layers.
-        let mut dest = self
-            .branches
-            .entry(*dest_id)
-            .or_insert_with(BranchState::new);
+        let mut dest_was_new = false;
+        let mut dest = self.branches.entry(*dest_id).or_insert_with(|| {
+            dest_was_new = true;
+            BranchState::new()
+        });
         if !dest.inherited_layers.is_empty() {
             drop(dest);
             // Undo refcount increments from step 2.
@@ -1699,20 +2059,43 @@ impl SegmentedStore {
                     }
                 }
             }
-            return Err(io::Error::new(
+            return Err(StorageError::Io(io::Error::new(
                 io::ErrorKind::AlreadyExists,
                 "fork_branch: destination already has inherited layers (concurrent fork race)",
-            ));
+            )));
         }
-        dest.inherited_layers = dest_layers;
+        dest.inherited_layers = dest_layers.clone();
         // Propagate fork_version so subsequent forks from this child
         // correctly report the inherited data's version range.
         dest.max_version
             .fetch_max(fork_version.as_u64(), Ordering::Release);
+        match self.publish_locked_branch_manifest(dest_id, &dest) {
+            Ok(PublishOutcome::Durable) => {}
+            Ok(PublishOutcome::NotDurable(err)) => {
+                tracing::warn!(
+                    branch = %hex_encode_branch(dest_id),
+                    error = %err,
+                    "fork destination manifest rename landed but durability is unconfirmed"
+                );
+            }
+            Err(e) => {
+                let remove_branch =
+                    Self::rollback_fork_dest_publish_failure_locked(&mut dest, dest_was_new);
+                drop(dest);
+                for layer in &dest_layers {
+                    for level in &layer.segments.levels {
+                        for seg in level {
+                            self.ref_registry.decrement(seg.file_id());
+                        }
+                    }
+                }
+                if remove_branch {
+                    self.branches.remove(dest_id);
+                }
+                return Err(e);
+            }
+        }
         drop(dest);
-
-        // 7. Write manifest
-        self.write_branch_manifest(dest_id);
 
         Ok((fork_version, segments_shared))
     }
@@ -2641,7 +3024,7 @@ impl SegmentedStore {
     /// After this call, all data written during the bulk load is flushed to
     /// frozen memtables (and to disk segments if a directory is configured).
     /// Normal rotation behavior resumes.
-    pub fn end_bulk_load(&self, branch_id: &BranchId) -> io::Result<()> {
+    pub fn end_bulk_load(&self, branch_id: &BranchId) -> StorageResult<()> {
         self.bulk_load_branches.remove(branch_id);
 
         // Rotate the active memtable (unconditionally — it may be large)
@@ -2689,7 +3072,7 @@ impl SegmentedStore {
     /// The frozen memtable stays in the read path during I/O so concurrent
     /// readers never see a gap.  It is only removed when the segment is
     /// installed, in a single DashMap guard.
-    pub fn flush_oldest_frozen(&self, branch_id: &BranchId) -> io::Result<bool> {
+    pub fn flush_oldest_frozen(&self, branch_id: &BranchId) -> StorageResult<bool> {
         let segments_dir = match &self.segments_dir {
             Some(d) => d,
             None => return Ok(false),
@@ -2720,7 +3103,7 @@ impl SegmentedStore {
             .with_compression(crate::segment_builder::CompressionCodec::None);
         builder.build_from_iter(frozen_mt.iter_all(), &seg_path)?;
 
-        let segment = KVSegment::open(&seg_path)?;
+        let segment = Arc::new(KVSegment::open(&seg_path)?);
 
         // Atomically: remove the frozen memtable we just flushed and install
         // the segment, under a single DashMap guard.
@@ -2758,7 +3141,7 @@ impl SegmentedStore {
             // Build new version with the new segment prepended (newest first).
             let old_ver = branch.version.load();
             let mut new_l0 = Vec::with_capacity(old_ver.l0_segments().len() + 1);
-            new_l0.push(Arc::new(segment));
+            new_l0.push(Arc::clone(&segment));
             new_l0.extend(old_ver.l0_segments().iter().cloned());
             let mut new_levels = old_ver.levels.clone();
             new_levels[0] = new_l0;
@@ -2767,9 +3150,26 @@ impl SegmentedStore {
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
             refresh_level_targets(&mut branch, self.level_base_bytes());
 
-            // Persist level assignments
+            match self.publish_locked_branch_manifest(branch_id, &branch) {
+                Ok(PublishOutcome::Durable) => {}
+                Ok(PublishOutcome::NotDurable(err)) => {
+                    tracing::warn!(
+                        branch = %hex_encode_branch(branch_id),
+                        error = %err,
+                        "flush installed segment but manifest durability is unconfirmed"
+                    );
+                }
+                Err(e) => {
+                    self.rollback_flush_publish_failure_locked(&mut branch, &frozen_mt, &segment);
+                    drop(branch);
+                    let _ = std::fs::remove_file(segment.file_path());
+                    if let Some(parent) = segment.file_path().parent() {
+                        let _ = std::fs::remove_dir(parent);
+                    }
+                    return Err(e);
+                }
+            }
             drop(branch);
-            self.write_branch_manifest(branch_id);
         } else {
             // Another thread already flushed this memtable; discard the
             // duplicate segment file we just built.
@@ -4200,87 +4600,13 @@ impl SegmentedStore {
 
     /// Write the manifest file for a branch, reflecting current level assignments
     /// and inherited layers.
-    fn write_branch_manifest(&self, branch_id: &BranchId) {
-        let segments_dir = match &self.segments_dir {
-            Some(d) => d,
-            None => return,
-        };
+    fn write_branch_manifest(&self, branch_id: &BranchId) -> StorageResult<()> {
         let branch = match self.branches.get(branch_id) {
             Some(b) => b,
-            None => return,
+            None => return Ok(()),
         };
         let ver = branch.version.load();
-        let branch_hex = hex_encode_branch(branch_id);
-        let branch_dir = segments_dir.join(&branch_hex);
-
-        // Ensure the branch directory exists (needed for COW forks with
-        // no own segments but inherited layers that need a manifest).
-        if let Err(e) = std::fs::create_dir_all(&branch_dir) {
-            tracing::warn!(
-                branch = %branch_hex,
-                error = %e,
-                "failed to create branch directory for manifest"
-            );
-            return;
-        }
-
-        let mut entries = Vec::new();
-        for (level_idx, level) in ver.levels.iter().enumerate() {
-            for seg in level {
-                if let Some(name) = seg.file_path().file_name().and_then(|n| n.to_str()) {
-                    entries.push(crate::manifest::ManifestEntry {
-                        filename: name.to_string(),
-                        level: level_idx as u8,
-                    });
-                }
-            }
-        }
-
-        // Serialize inherited layers
-        let inherited: Vec<crate::manifest::ManifestInheritedLayer> = branch
-            .inherited_layers
-            .iter()
-            .map(|layer| {
-                let layer_entries: Vec<crate::manifest::ManifestEntry> = layer
-                    .segments
-                    .levels
-                    .iter()
-                    .enumerate()
-                    .flat_map(|(level_idx, level)| {
-                        level.iter().filter_map(move |seg| {
-                            seg.file_path()
-                                .file_name()
-                                .and_then(|n| n.to_str())
-                                .map(|name| crate::manifest::ManifestEntry {
-                                    filename: name.to_string(),
-                                    level: level_idx as u8,
-                                })
-                        })
-                    })
-                    .collect();
-
-                let status = match layer.status {
-                    LayerStatus::Active => 0,
-                    LayerStatus::Materializing => 1,
-                    LayerStatus::Materialized => 2,
-                };
-
-                crate::manifest::ManifestInheritedLayer {
-                    source_branch_id: layer.source_branch_id,
-                    fork_version: layer.fork_version,
-                    status,
-                    entries: layer_entries,
-                }
-            })
-            .collect();
-
-        if let Err(e) = crate::manifest::write_manifest(&branch_dir, &entries, &inherited) {
-            tracing::warn!(
-                branch = %branch_hex,
-                error = %e,
-                "failed to write branch manifest"
-            );
-        }
+        self.write_branch_manifest_from_state(branch_id, &ver, &branch.inherited_layers)
     }
 }
 

--- a/crates/storage/src/segmented/tests/flush.rs
+++ b/crates/storage/src/segmented/tests/flush.rs
@@ -79,6 +79,40 @@ fn flush_without_dir_is_noop() {
 }
 
 #[test]
+fn flush_manifest_publish_failure_rolls_back_and_keeps_frozen_memtable() {
+    crate::test_hooks::clear_manifest_publish_failure();
+    crate::test_hooks::inject_manifest_publish_failure(std::io::ErrorKind::Other);
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    seed(&store, kv_key("a"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+
+    let err = store.flush_oldest_frozen(&branch()).unwrap_err();
+    assert!(matches!(err, crate::StorageError::ManifestPublish { .. }));
+    assert_eq!(store.branch_frozen_count(&branch()), 1);
+    assert_eq!(store.branch_segment_count(&branch()), 0);
+    assert!(store.publish_health().is_none());
+}
+
+#[test]
+fn flush_dir_fsync_failure_keeps_installed_segment_and_latches_health() {
+    crate::test_hooks::clear_manifest_dir_fsync_failure();
+    crate::test_hooks::inject_manifest_dir_fsync_failure(std::io::ErrorKind::Other);
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    seed(&store, kv_key("a"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+
+    let flushed = store.flush_oldest_frozen(&branch()).unwrap();
+    assert!(flushed);
+    assert_eq!(store.branch_frozen_count(&branch()), 0);
+    assert_eq!(store.branch_segment_count(&branch()), 1);
+    assert!(store.publish_health().is_some());
+}
+
+#[test]
 fn rotation_triggers_at_threshold() {
     let dir = tempfile::tempdir().unwrap();
     let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 1);

--- a/crates/storage/src/segmented/tests/fork.rs
+++ b/crates/storage/src/segmented/tests/fork.rs
@@ -238,6 +238,36 @@ fn inherited_layer_delete_shadows() {
 }
 
 #[test]
+fn fork_manifest_publish_failure_rolls_back_destination_branch() {
+    crate::test_hooks::clear_manifest_publish_failure();
+
+    let (_dir, store) = setup_parent_with_segments(&[("a", 1, 1)]);
+    crate::test_hooks::inject_manifest_publish_failure(std::io::ErrorKind::Other);
+    let err = store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap_err();
+    assert!(matches!(err, crate::StorageError::ManifestPublish { .. }));
+    assert!(store.branches.get(&child_branch()).is_none());
+    assert!(store.publish_health().is_none());
+}
+
+#[test]
+fn fork_dir_fsync_failure_keeps_child_branch_and_latches_health() {
+    crate::test_hooks::clear_manifest_dir_fsync_failure();
+
+    let (_dir, store) = setup_parent_with_segments(&[("a", 1, 1)]);
+    crate::test_hooks::inject_manifest_dir_fsync_failure(std::io::ErrorKind::Other);
+    let (fork_version, segments_shared) = store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    assert!(fork_version > CommitVersion::ZERO);
+    assert!(segments_shared > 0);
+    assert_eq!(store.inherited_layer_count(&child_branch()), 1);
+    assert!(store.publish_health().is_some());
+}
+
+#[test]
 fn inherited_layer_range_scan() {
     let (_dir, store) = setup_parent_with_segments(&[
         ("user:alice", 1, 1),

--- a/crates/storage/src/segmented/tests/materialize.rs
+++ b/crates/storage/src/segmented/tests/materialize.rs
@@ -250,6 +250,41 @@ fn materialize_skips_shadowed_by_closer_layer() {
 }
 
 #[test]
+fn materialize_manifest_publish_failure_restores_active_layer_status() {
+    crate::test_hooks::clear_manifest_publish_failure();
+
+    let (_dir, store) = setup_parent_with_segments(&[("a", 1, 1)]);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    crate::test_hooks::inject_manifest_publish_failure(std::io::ErrorKind::Other);
+    let err = store.materialize_layer(&child_branch(), 0).unwrap_err();
+    assert!(matches!(err, crate::StorageError::ManifestPublish { .. }));
+
+    let child = store.branches.get(&child_branch()).unwrap();
+    assert_eq!(child.inherited_layers.len(), 1);
+    assert_eq!(child.inherited_layers[0].status, LayerStatus::Active);
+    assert!(store.publish_health().is_none());
+}
+
+#[test]
+fn materialize_dir_fsync_failure_is_forward_only_and_latches_health() {
+    crate::test_hooks::clear_manifest_dir_fsync_failure();
+
+    let (_dir, store) = setup_parent_with_segments(&[("a", 1, 1), ("b", 2, 2)]);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    crate::test_hooks::inject_manifest_dir_fsync_failure(std::io::ErrorKind::Other);
+    let result = store.materialize_layer(&child_branch(), 0).unwrap();
+    assert_eq!(result.entries_materialized, 2);
+    assert_eq!(store.inherited_layer_count(&child_branch()), 0);
+    assert!(store.publish_health().is_some());
+}
+
+#[test]
 fn materialize_deepest_first() {
     let dir = tempfile::tempdir().unwrap();
     let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
@@ -456,7 +491,7 @@ fn materialize_crash_recovery_resets_status() {
             let mut child = store.branches.get_mut(&child_branch()).unwrap();
             child.inherited_layers[0].status = LayerStatus::Materializing;
         }
-        store.write_branch_manifest(&child_branch());
+        store.write_branch_manifest(&child_branch()).unwrap();
     }
 
     // Second store: recover from manifest — Materializing should reset to Active
@@ -522,7 +557,7 @@ fn materialize_crash_recovery_with_partial_segment() {
             let mut child = store.branches.get_mut(&child_branch()).unwrap();
             child.inherited_layers[0].status = LayerStatus::Materializing;
         }
-        store.write_branch_manifest(&child_branch());
+        store.write_branch_manifest(&child_branch()).unwrap();
 
         // "crash" — store drops
     }
@@ -609,7 +644,7 @@ fn materialize_crash_recovery_with_valid_orphan_segment() {
             let mut child = store.branches.get_mut(&child_branch()).unwrap();
             child.inherited_layers[0].status = LayerStatus::Materializing;
         }
-        store.write_branch_manifest(&child_branch());
+        store.write_branch_manifest(&child_branch()).unwrap();
     }
 
     // Phase 2: Recover
@@ -658,8 +693,8 @@ fn recovery_surfaces_missing_source_branch() {
             .unwrap();
 
         // Write manifest for both branches
-        store.write_branch_manifest(&parent_branch());
-        store.write_branch_manifest(&child_branch());
+        store.write_branch_manifest(&parent_branch()).unwrap();
+        store.write_branch_manifest(&child_branch()).unwrap();
     }
 
     // Sabotage: delete the parent's branch directory (simulating missing source)

--- a/crates/storage/src/test_hooks.rs
+++ b/crates/storage/src/test_hooks.rs
@@ -1,0 +1,94 @@
+#[cfg(test)]
+use std::cell::Cell;
+use std::io;
+
+#[cfg(not(test))]
+use std::sync::OnceLock;
+
+#[cfg(not(test))]
+use std::sync::Mutex;
+
+#[cfg(test)]
+thread_local! {
+    static MANIFEST_PUBLISH_FAILURE: Cell<Option<io::ErrorKind>> = const { Cell::new(None) };
+    static MANIFEST_DIR_FSYNC_FAILURE: Cell<Option<io::ErrorKind>> = const { Cell::new(None) };
+}
+
+#[cfg(not(test))]
+fn manifest_publish_failure_slot() -> &'static Mutex<Option<io::ErrorKind>> {
+    static MANIFEST_PUBLISH_FAILURE: OnceLock<Mutex<Option<io::ErrorKind>>> = OnceLock::new();
+    MANIFEST_PUBLISH_FAILURE.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(not(test))]
+fn manifest_dir_fsync_failure_slot() -> &'static Mutex<Option<io::ErrorKind>> {
+    static MANIFEST_DIR_FSYNC_FAILURE: OnceLock<Mutex<Option<io::ErrorKind>>> = OnceLock::new();
+    MANIFEST_DIR_FSYNC_FAILURE.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(test)]
+pub(crate) fn inject_manifest_publish_failure(kind: io::ErrorKind) {
+    MANIFEST_PUBLISH_FAILURE.with(|slot| slot.set(Some(kind)));
+}
+
+#[cfg(test)]
+pub(crate) fn clear_manifest_publish_failure() {
+    MANIFEST_PUBLISH_FAILURE.with(|slot| slot.set(None));
+}
+
+pub(crate) fn maybe_inject_manifest_publish_failure() -> Option<io::Error> {
+    #[cfg(test)]
+    let kind = MANIFEST_PUBLISH_FAILURE.with(|slot| slot.take());
+    #[cfg(not(test))]
+    let kind = manifest_publish_failure_slot().lock().unwrap().take();
+
+    kind.map(|kind| io::Error::new(kind, "injected manifest publish failure"))
+}
+
+#[cfg(test)]
+pub(crate) fn inject_manifest_dir_fsync_failure(kind: io::ErrorKind) {
+    MANIFEST_DIR_FSYNC_FAILURE.with(|slot| slot.set(Some(kind)));
+}
+
+#[cfg(test)]
+pub(crate) fn clear_manifest_dir_fsync_failure() {
+    MANIFEST_DIR_FSYNC_FAILURE.with(|slot| slot.set(None));
+}
+
+pub(crate) fn maybe_inject_manifest_dir_fsync_failure() -> Option<io::Error> {
+    #[cfg(test)]
+    let kind = MANIFEST_DIR_FSYNC_FAILURE.with(|slot| slot.take());
+    #[cfg(not(test))]
+    let kind = manifest_dir_fsync_failure_slot().lock().unwrap().take();
+
+    kind.map(|kind| io::Error::new(kind, "injected manifest dir fsync failure"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_manifest_publish_failure_hook_consumes_one_failure() {
+        clear_manifest_publish_failure();
+        assert!(maybe_inject_manifest_publish_failure().is_none());
+
+        inject_manifest_publish_failure(io::ErrorKind::Other);
+        let err =
+            maybe_inject_manifest_publish_failure().expect("expected injected publish failure");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert!(maybe_inject_manifest_publish_failure().is_none());
+    }
+
+    #[test]
+    fn test_manifest_dir_fsync_failure_hook_consumes_one_failure() {
+        clear_manifest_dir_fsync_failure();
+        assert!(maybe_inject_manifest_dir_fsync_failure().is_none());
+
+        inject_manifest_dir_fsync_failure(io::ErrorKind::Other);
+        let err =
+            maybe_inject_manifest_dir_fsync_failure().expect("expected injected fsync failure");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert!(maybe_inject_manifest_dir_fsync_failure().is_none());
+    }
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.94.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Supersedes #2430. Also unblocks main CI (red since 2026-04-09).

## Summary

SE1 v2 implements the publication barrier with the architecture the #2430 review demanded (three findings — all now resolved):

1. **DirFsync is forward-only, not destructive.** New `PublishOutcome::{Durable, NotDurable(StorageError)}` splits content failure (`ManifestPublish`, rollback-safe) from durability-unconfirmed (`DirFsync`, rename may already be visible — **never** delete files or reverse in-memory state, just latch health). Old approach conflated them and could delete files named by an already-landed manifest.
2. **Publishes hold the branch guard.** Rollback helpers are `*_locked` methods taking `&mut BranchState`; callers hold the DashMap write guard across in-memory install → publish → rollback, closing the race where concurrent flush/compaction could observe or clobber the rollback. Source/dest fork pairs hold their respective guards.
3. **Errors reach DB callers.** `SegmentedStore::{latch_publish_health, publish_health}` latches a `PublishHealth` on DirFsync or engine-observed sync-flush failure. `Database::storage_publish_error()` reads it; `check_accepting()` short-circuits new `begin_transaction`; `health()` reports storage Unhealthy. `flush_frozen_sync` now returns `StrataResult<()>` and propagates via `?`.

**Scope §4**: both `manifest.rs` and `segment_builder.rs` dir-fsync sites are now wired to the typed error (the old PR fixed only manifest.rs).

**Compaction**: all four variants propagate via `?`; on failure, old-input delete loop short-circuits. In-memory left ahead of durable — next successful publish re-persists.

## Commits

1. `ci: pin rust-toolchain to 1.94.1 and fix latent clippy errors` — unblocks main CI. Pins `rust-toolchain.toml` and all `dtolnay/rust-toolchain@stable` actions to `1.94.1`, ending the local↔CI rustfmt flip-flop that kept main red for 9 days. Clears 30 latent clippy errors (doc-list-overindented, match→?, double-comparisons, needless-borrows) that had accumulated while `Format check` blocked everything downstream.
2. `SE1: publication barrier — forward-only DirFsync, latched publish health` — the rework itself.

## Test plan

- [x] `cargo test -p strata-storage --lib` — 672 passed, 0 failed in parallel mode. Thread-local injection slots in `test_hooks.rs` eliminate cross-test interference.
- [x] `cargo test -p strata-engine --lib test_storage_publication_health_blocks_new_transactions` — passes.
- [x] `cargo +1.94.1 fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets --all-features` — exit 0.
- [ ] Regression benchmarks: `cargo run --release -p strata-benchmarks --bin regression -- --tranche 2 --epic SE1` — A/B vs main showed SE1 within threshold on all gated metrics last round (redb bulk_load −2.2%, ycsb p50/p99 flat). Needs re-run against this rework since publish now holds the branch guard across fs writes + fsync — theoretically higher tail latency under same-branch contention; should be measured.
- [ ] Second reviewer sign-off (S4 requirement).

## Notes for the reviewer

- The first commit (CI unblock) is mechanically separable; if you prefer, I can split it into its own PR that lands first.
- Held-guard-across-publish is a deliberate concurrency/latency trade-off. If benchmarks show a regression on same-branch concurrent writes, we can revisit with per-branch publish locks.
- No `Database::resume_storage_publish()` yet — once latched, the DB is degraded until restart. Matches the WAL-writer-halt shape but deserves a counterpart. Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)