### PR TITLE
D2: WAL read-path unification — codec-aware compaction + prefix-preserving follower refresh

### DIFF
--- a/crates/durability/src/compaction/wal_only.rs
+++ b/crates/durability/src/compaction/wal_only.rs
@@ -20,10 +20,10 @@
 //! - Only removes segments fully covered by snapshot
 //! - Requires a valid snapshot to exist
 
+use crate::codec::{clone_codec, StorageCodec};
 use crate::format::segment_meta::SegmentMeta;
-use crate::format::{
-    ManifestManager, SegmentHeader, WalRecord, WalRecordError, SEGMENT_HEADER_SIZE,
-};
+use crate::format::ManifestManager;
+use crate::wal::WalReader;
 use parking_lot::Mutex;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -37,12 +37,27 @@ use super::{CompactInfo, CompactMode, CompactionError};
 pub struct WalOnlyCompactor {
     wal_dir: PathBuf,
     manifest: Arc<Mutex<ManifestManager>>,
+    codec: Option<Box<dyn StorageCodec>>,
 }
 
 impl WalOnlyCompactor {
     /// Create a new WAL-only compactor
     pub fn new(wal_dir: PathBuf, manifest: Arc<Mutex<ManifestManager>>) -> Self {
-        WalOnlyCompactor { wal_dir, manifest }
+        WalOnlyCompactor {
+            wal_dir,
+            manifest,
+            codec: None,
+        }
+    }
+
+    /// Install a storage codec so the `.meta`-miss fallback reads records
+    /// through the same codec-aware `WalReader` the runtime uses (D2 /
+    /// DG-001). Without this, encrypted-WAL databases would fall back to
+    /// raw-byte parsing and retention decisions could diverge from the
+    /// shipped v3 envelope + codec format.
+    pub fn with_codec(mut self, codec: Box<dyn StorageCodec>) -> Self {
+        self.codec = Some(codec);
+        self
     }
 
     /// Perform WAL-only compaction
@@ -239,69 +254,40 @@ impl WalOnlyCompactor {
         self.segment_covered_by_watermark_full_scan(segment_number, watermark)
     }
 
-    /// Full-scan fallback: read all records to determine max txn_id.
+    /// Full-scan fallback: read all records via the codec-aware
+    /// [`WalReader`] to determine max txn_id.
+    ///
+    /// D2 / DG-001: the previous raw-byte scan called
+    /// `WalRecord::from_bytes` directly against segment bytes, bypassing
+    /// both the per-record outer envelope (v3 format) and the installed
+    /// [`StorageCodec`]. On encrypted WAL the raw scan could never decode
+    /// records and retention decisions silently diverged from the shipped
+    /// format. Routing through `WalReader` reuses the one canonical parse
+    /// path for the outer envelope + codec decode.
     fn segment_covered_by_watermark_full_scan(
         &self,
         segment_number: u64,
         watermark: u64,
     ) -> Result<bool, CompactionError> {
-        let segment_path = segment_path(&self.wal_dir, segment_number);
-        let file_data = std::fs::read(&segment_path)?;
-
-        // Validate segment header (need at least v1 header size)
-        if file_data.len() < SEGMENT_HEADER_SIZE {
-            return Err(CompactionError::internal(format!(
-                "Segment {} too small for header",
-                segment_number
-            )));
+        let mut reader = WalReader::new();
+        if let Some(codec) = self.codec.as_deref() {
+            reader = reader.with_codec(clone_codec(codec));
         }
-
-        let header =
-            SegmentHeader::from_bytes_slice(&file_data, Some(segment_number)).map_err(|e| {
-                CompactionError::internal(format!("Invalid segment {segment_number} header: {e}"))
+        let (records, _, _, _) = reader
+            .read_segment(&self.wal_dir, segment_number)
+            .map_err(|e| {
+                CompactionError::internal(format!(
+                    "Failed to read segment {segment_number} for coverage check: {e}"
+                ))
             })?;
-        // `from_bytes_slice` now enforces magic + segment-number match,
-        // so the earlier `is_valid` / segment-number re-check is folded
-        // into the typed-error path above.
-        debug_assert!(header.is_valid());
 
-        // Determine actual header size based on format version
-        let actual_header_size = if header.format_version >= 2 {
-            crate::format::SEGMENT_HEADER_SIZE_V2
-        } else {
-            SEGMENT_HEADER_SIZE
-        };
-
-        // Empty segment (just header) is considered covered
-        if file_data.len() <= actual_header_size {
-            return Ok(true);
-        }
-
-        // Find highest txn_id in segment
-        let mut cursor = actual_header_size;
-        let mut max_txn_id = 0u64;
-
-        while cursor < file_data.len() {
-            match WalRecord::from_bytes(&file_data[cursor..]) {
-                Ok((record, consumed)) => {
-                    max_txn_id = max_txn_id.max(record.txn_id.as_u64());
-                    cursor += consumed;
-                }
-                Err(WalRecordError::InsufficientData) => {
-                    break;
-                }
-                Err(WalRecordError::ChecksumMismatch { .. }) => {
-                    break;
-                }
-                Err(e) => {
-                    warn!(target: "strata::compaction", error = %e, cursor = cursor,
-                        "Unexpected WAL record error during compaction scan, stopping");
-                    break;
-                }
-            }
-        }
-
-        // Segment is covered if all records are at or below watermark
+        // Empty segment (no records after the header) is covered by any
+        // watermark — preserves the legacy empty-segment semantics.
+        let max_txn_id = records
+            .iter()
+            .map(|r| r.txn_id.as_u64())
+            .max()
+            .unwrap_or(0);
         Ok(max_txn_id <= watermark)
     }
 
@@ -345,7 +331,7 @@ fn segment_path(dir: &Path, segment_number: u64) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::format::WalSegment;
+    use crate::format::{WalRecord, WalSegment};
     use strata_core::id::{CommitVersion, TxnId};
     use tempfile::tempdir;
 
@@ -379,7 +365,21 @@ mod tests {
                 txn_id * 1000,
                 vec![txn_id as u8; 10],
             );
-            segment.write(&record.to_bytes())?;
+            // Wrap in the v3 per-record outer envelope so the codec-aware
+            // `WalReader` can parse it. The writer path uses the same
+            // `[u32 outer_len][u32 outer_len_crc][payload]` layout with
+            // identity-codec payload = `record.to_bytes()` (D2 / DG-001).
+            let encoded = record.to_bytes();
+            let outer_len: u32 = encoded.len() as u32;
+            let outer_len_bytes = outer_len.to_le_bytes();
+            let outer_len_crc = {
+                let mut h = crc32fast::Hasher::new();
+                h.update(&outer_len_bytes);
+                h.finalize()
+            };
+            segment.write(&outer_len_bytes)?;
+            segment.write(&outer_len_crc.to_le_bytes())?;
+            segment.write(&encoded)?;
         }
 
         segment.close()?;

--- a/crates/durability/src/compaction/wal_only.rs
+++ b/crates/durability/src/compaction/wal_only.rs
@@ -273,21 +273,18 @@ impl WalOnlyCompactor {
         if let Some(codec) = self.codec.as_deref() {
             reader = reader.with_codec(clone_codec(codec));
         }
-        let (records, _, _, _) = reader
-            .read_segment(&self.wal_dir, segment_number)
-            .map_err(|e| {
-                CompactionError::internal(format!(
-                    "Failed to read segment {segment_number} for coverage check: {e}"
-                ))
-            })?;
+        let (records, _, _, _) =
+            reader
+                .read_segment(&self.wal_dir, segment_number)
+                .map_err(|e| {
+                    CompactionError::internal(format!(
+                        "Failed to read segment {segment_number} for coverage check: {e}"
+                    ))
+                })?;
 
         // Empty segment (no records after the header) is covered by any
         // watermark — preserves the legacy empty-segment semantics.
-        let max_txn_id = records
-            .iter()
-            .map(|r| r.txn_id.as_u64())
-            .max()
-            .unwrap_or(0);
+        let max_txn_id = records.iter().map(|r| r.txn_id.as_u64()).max().unwrap_or(0);
         Ok(max_txn_id <= watermark)
     }
 

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -655,16 +655,40 @@ impl WalReader {
 
             // Decode via installed codec or pass through for identity.
             // Preserve the already-read prefix on codec-decode failure
-            // (D2 / DG-002) and surface the real failing offset through
-            // `ReadStopReason::CodecDecode` so the follower-refresh
-            // blocked-state is anchored on a real record rather than a
-            // synthetic `received_watermark + 1`.
+            // (D2 / DG-002). If scan-forward finds only stale records at or
+            // below `next_expected`, skip past them just like the
+            // checksum/parse paths; otherwise surface the first missing txn as
+            // blocked and include the next readable anchor when one exists.
             let decoded = match self.decode_payload(payload, offset as u64) {
                 Ok(d) => d,
                 Err(WalReaderError::CodecDecode {
                     offset: fail_offset,
                     detail,
                 }) => {
+                    if let Some((scan_offset, next_record)) =
+                        self.scan_forward_to_valid_envelope(&buffer, offset + 1)
+                    {
+                        let candidate_txn = next_record.txn_id.as_u64();
+                        if candidate_txn <= next_expected {
+                            offset = scan_offset;
+                            continue;
+                        }
+                        return Ok(WatermarkReadResult {
+                            records,
+                            blocked: Some(WatermarkBlockedRecord {
+                                txn_id: TxnId(next_expected),
+                                detail: format!(
+                                    "codec decode failed: {detail}; next readable txn is {next}",
+                                    next = next_record.txn_id,
+                                ),
+                                skip_allowed: true,
+                                stop_reason: ReadStopReason::CodecDecode {
+                                    offset: fail_offset as usize,
+                                    detail,
+                                },
+                            }),
+                        });
+                    }
                     return Ok(WatermarkReadResult {
                         records,
                         blocked: Some(WatermarkBlockedRecord {
@@ -2512,6 +2536,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_read_all_after_watermark_contiguous_skips_stale_codec_failure_before_watermark() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+        let records: Vec<_> = (1..=3)
+            .map(|i| WalRecord::new(TxnId(i), [5u8; 16], i * 1000, vec![i as u8; 16]))
+            .collect();
+        write_records(&wal_dir, &records);
+
+        let reader =
+            WalReader::new().with_codec(Box::new(RejectTxnDecodeCodec { reject_txn_id: 1 }));
+        let resumed = reader
+            .read_all_after_watermark_contiguous(&wal_dir, 2)
+            .unwrap();
+
+        assert_eq!(
+            resumed
+                .records
+                .iter()
+                .map(|r| r.txn_id.as_u64())
+                .collect::<Vec<_>>(),
+            vec![3],
+            "codec-decode failure on an already-applied txn must not block later contiguous records"
+        );
+        assert!(
+            resumed.blocked.is_none(),
+            "stale codec-decode failures below the watermark should be skipped when the next expected txn is readable"
+        );
+    }
+
     // ========================================================================
     // T3-E12 Phase 2 — envelope-parse + codec-error taxonomy
     // ========================================================================
@@ -2542,6 +2596,45 @@ mod tests {
 
         fn clone_box(&self) -> Box<dyn StorageCodec> {
             Box::new(AlwaysFailDecodeCodec)
+        }
+    }
+
+    /// Test-only codec that rejects a specific txn id while passing all other
+    /// payloads through unchanged. The contiguous reader uses this to prove
+    /// codec-decode failures below the watermark can be scanned past without
+    /// blocking later records.
+    struct RejectTxnDecodeCodec {
+        reject_txn_id: u64,
+    }
+
+    impl StorageCodec for RejectTxnDecodeCodec {
+        fn encode(&self, data: &[u8]) -> Vec<u8> {
+            data.to_vec()
+        }
+
+        fn decode(&self, data: &[u8]) -> Result<Vec<u8>, crate::codec::CodecError> {
+            let txn_id = data
+                .get(9..17)
+                .and_then(|bytes| bytes.try_into().ok())
+                .map(u64::from_le_bytes);
+            if txn_id == Some(self.reject_txn_id) {
+                return Err(crate::codec::CodecError::decode(
+                    format!("test codec rejects txn {}", self.reject_txn_id),
+                    "reject-txn-decode",
+                    data.len(),
+                ));
+            }
+            Ok(data.to_vec())
+        }
+
+        fn codec_id(&self) -> &str {
+            "reject-txn-decode"
+        }
+
+        fn clone_box(&self) -> Box<dyn StorageCodec> {
+            Box::new(Self {
+                reject_txn_id: self.reject_txn_id,
+            })
         }
     }
 

--- a/crates/durability/src/wal/reader.rs
+++ b/crates/durability/src/wal/reader.rs
@@ -654,8 +654,32 @@ impl WalReader {
             let payload = &buffer[payload_start..payload_end];
 
             // Decode via installed codec or pass through for identity.
-            // Codec decode failures surface unconditionally (T3-E12 §D5).
-            let decoded = self.decode_payload(payload, offset as u64)?;
+            // Preserve the already-read prefix on codec-decode failure
+            // (D2 / DG-002) and surface the real failing offset through
+            // `ReadStopReason::CodecDecode` so the follower-refresh
+            // blocked-state is anchored on a real record rather than a
+            // synthetic `received_watermark + 1`.
+            let decoded = match self.decode_payload(payload, offset as u64) {
+                Ok(d) => d,
+                Err(WalReaderError::CodecDecode {
+                    offset: fail_offset,
+                    detail,
+                }) => {
+                    return Ok(WatermarkReadResult {
+                        records,
+                        blocked: Some(WatermarkBlockedRecord {
+                            txn_id: TxnId(next_expected),
+                            detail: format!("codec decode failed: {detail}"),
+                            skip_allowed: false,
+                            stop_reason: ReadStopReason::CodecDecode {
+                                offset: fail_offset as usize,
+                                detail,
+                            },
+                        }),
+                    });
+                }
+                Err(e) => return Err(e),
+            };
 
             match WalRecord::from_bytes(&decoded) {
                 Ok((record, _consumed)) => {

--- a/crates/engine/src/database/compaction.rs
+++ b/crates/engine/src/database/compaction.rs
@@ -197,8 +197,14 @@ impl Database {
             .map(|w| w.lock().current_segment())
             .unwrap_or(0);
 
-        // Create compactor and run with the writer's active segment override
-        let compactor = WalOnlyCompactor::new(wal_dir, manifest_arc);
+        // Create compactor and run with the writer's active segment override.
+        // D2 / DG-001: thread the cached `wal_codec` so the `.meta`-miss
+        // fallback parses records through the codec-aware reader rather
+        // than the raw-byte path that bypasses both the v3 envelope and
+        // the installed codec.
+        let compactor = WalOnlyCompactor::new(wal_dir, manifest_arc).with_codec(
+            strata_durability::codec::clone_codec(self.wal_codec.as_ref()),
+        );
         let compact_info = compactor
             .compact_with_active_override(writer_active)
             .map_err(|e: CompactionError| match e {

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -341,30 +341,22 @@ impl Database {
         // encrypted followers recover at open and then get stuck on
         // the first refresh with a codec-decode error on the first
         // new record (pre-T3-E12 part 4 behavior).
+        //
+        // D2 / DG-002: codec-decode, gap, checksum, and parse failures all
+        // come back via `Ok(WatermarkReadResult { blocked: Some(..) })` so
+        // the prefix of already-decoded records is preserved and the blocked
+        // txn id is the real failing record. The stop-reason match further
+        // below dispatches each class uniformly through `BlockReason`.
+        // Residual `Err(_)` cases — directory-list I/O, segment-open I/O,
+        // legacy-format header — would mean the follower can no longer read
+        // its WAL at all; treat them as follower-fatal rather than synthesize
+        // a misleading blocked-at txn id.
         let reader = strata_durability::wal::WalReader::new().with_codec(
             strata_durability::codec::clone_codec(self.wal_codec.as_ref()),
         );
-        let read_result =
-            match reader.read_all_after_watermark_contiguous(&self.wal_dir, received_watermark) {
-                Ok(r) => r,
-                Err(e) => {
-                    let blocked = make_blocked_state(
-                        TxnId(received_watermark.saturating_add(1)),
-                        BlockReason::Decode {
-                            message: format!("WAL read failed: {}", e),
-                        },
-                        None,
-                        false,
-                    );
-                    self.watermark.block_at(blocked.clone());
-                    self.persist_blocked_follower_state(&blocked);
-                    return RefreshOutcome::Stuck {
-                        applied: 0,
-                        applied_through: self.watermark.applied(),
-                        blocked_at: blocked.blocked,
-                    };
-                }
-            };
+        let read_result = reader
+            .read_all_after_watermark_contiguous(&self.wal_dir, received_watermark)
+            .expect("follower WAL read failed: I/O or format error; codec-decode is Ok(blocked)");
 
         if read_result.records.is_empty() && read_result.blocked.is_none() {
             return RefreshOutcome::CaughtUp {

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -347,16 +347,37 @@ impl Database {
         // the prefix of already-decoded records is preserved and the blocked
         // txn id is the real failing record. The stop-reason match further
         // below dispatches each class uniformly through `BlockReason`.
+        //
         // Residual `Err(_)` cases — directory-list I/O, segment-open I/O,
-        // legacy-format header — would mean the follower can no longer read
-        // its WAL at all; treat them as follower-fatal rather than synthesize
-        // a misleading blocked-at txn id.
+        // legacy-format header — mean the reader failed before it could
+        // identify a concrete blocked record. Refresh must still degrade into
+        // the documented blocked-state path rather than panic the process, so
+        // pin the follower at the next expected txn with the typed error
+        // detail for operator visibility.
         let reader = strata_durability::wal::WalReader::new().with_codec(
             strata_durability::codec::clone_codec(self.wal_codec.as_ref()),
         );
-        let read_result = reader
-            .read_all_after_watermark_contiguous(&self.wal_dir, received_watermark)
-            .expect("follower WAL read failed: I/O or format error; codec-decode is Ok(blocked)");
+        let read_result =
+            match reader.read_all_after_watermark_contiguous(&self.wal_dir, received_watermark) {
+                Ok(r) => r,
+                Err(e) => {
+                    let blocked = make_blocked_state(
+                        TxnId(received_watermark.saturating_add(1)),
+                        BlockReason::Decode {
+                            message: format!("WAL read failed: {}", e),
+                        },
+                        None,
+                        false,
+                    );
+                    self.watermark.block_at(blocked.clone());
+                    self.persist_blocked_follower_state(&blocked);
+                    return RefreshOutcome::Stuck {
+                        applied: 0,
+                        applied_through: self.watermark.applied(),
+                        blocked_at: blocked.blocked,
+                    };
+                }
+            };
 
         if read_result.records.is_empty() && read_result.blocked.is_none() {
             return RefreshOutcome::CaughtUp {

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -220,7 +220,12 @@ impl Database {
             loop {
                 match self.storage.flush_oldest_frozen(branch_id) {
                     Ok(true) => {
-                        Self::update_flush_watermark(&self.storage, &self.data_dir, &self.wal_dir);
+                        Self::update_flush_watermark(
+                            &self.storage,
+                            &self.data_dir,
+                            &self.wal_dir,
+                            self.wal_codec.as_ref(),
+                        );
                     }
                     Ok(false) => break,
                     Err(e) => {
@@ -273,6 +278,7 @@ impl Database {
             let data_dir = self.data_dir.clone();
             let wal_dir = self.wal_dir.clone();
             let flush_flag = Arc::clone(&self.flush_in_flight);
+            let wal_codec = strata_durability::codec::clone_codec(self.wal_codec.as_ref());
             let _ = self
                 .scheduler
                 .submit(crate::background::TaskPriority::High, move || {
@@ -290,7 +296,12 @@ impl Database {
                             loop {
                                 match storage.flush_oldest_frozen(branch_id) {
                                     Ok(true) => {
-                                        Self::update_flush_watermark(&storage, &data_dir, &wal_dir);
+                                        Self::update_flush_watermark(
+                                            &storage,
+                                            &data_dir,
+                                            &wal_dir,
+                                            wal_codec.as_ref(),
+                                        );
                                     }
                                     Ok(false) => break,
                                     Err(e) => {
@@ -469,8 +480,17 @@ impl Database {
     /// across all branches. WAL segments fully below this watermark are safe
     /// to delete because their data is in segments.
     ///
+    /// `wal_codec` threads the same codec the runtime uses so retention
+    /// decisions on non-identity-codec databases don't diverge from the
+    /// shipped v3 envelope format (D2 / DG-001).
+    ///
     /// Best-effort: errors are logged, not propagated.
-    fn update_flush_watermark(storage: &SegmentedStore, data_dir: &Path, wal_dir: &Path) {
+    fn update_flush_watermark(
+        storage: &SegmentedStore,
+        data_dir: &Path,
+        wal_dir: &Path,
+        wal_codec: &dyn strata_durability::codec::StorageCodec,
+    ) {
         // Compute global flush watermark: min of max_flushed_commit across all branches
         let branch_ids = storage.branch_ids();
         if branch_ids.is_empty() {
@@ -522,7 +542,8 @@ impl Database {
 
         // Truncate WAL segments below watermark
         let manifest_arc = Arc::new(ParkingMutex::new(mgr));
-        let compactor = WalOnlyCompactor::new(wal_dir.to_path_buf(), manifest_arc);
+        let compactor = WalOnlyCompactor::new(wal_dir.to_path_buf(), manifest_arc)
+            .with_codec(strata_durability::codec::clone_codec(wal_codec));
         match compactor.compact() {
             Ok(info) => {
                 if info.wal_segments_removed > 0 {

--- a/crates/engine/tests/follower_tests.rs
+++ b/crates/engine/tests/follower_tests.rs
@@ -1601,6 +1601,75 @@ fn test_follower_refresh_with_non_identity_codec() {
     follower.shutdown().unwrap();
 }
 
+/// D2 regression: follower refresh must degrade into persisted blocked state
+/// on residual WAL-read failures instead of panicking the process.
+#[test]
+#[serial(open_databases)]
+fn test_follower_refresh_corrupt_wal_returns_stuck_instead_of_panicking() {
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+
+    let primary =
+        Database::open_runtime(OpenSpec::primary(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+    primary_put(&primary, branch, "base", "v1");
+    primary.flush().unwrap();
+
+    let follower =
+        Database::open_runtime(OpenSpec::follower(dir.path()).with_subsystem(SearchSubsystem))
+            .unwrap();
+    assert_eq!(read_kv(&follower, branch, "base").as_deref(), Some("v1"));
+
+    let corrupt_segment = dir.path().join("wal").join("wal-000099.seg");
+    std::fs::write(&corrupt_segment, b"GARBAGE_NOT_A_VALID_SEGMENT_HEADER").unwrap();
+
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| follower.refresh()))
+        .expect("refresh must return blocked state instead of panicking on malformed WAL");
+    let blocked_at = match outcome {
+        strata_engine::RefreshOutcome::Stuck {
+            applied,
+            blocked_at,
+            ..
+        } => {
+            assert_eq!(
+                applied, 0,
+                "malformed WAL should block before new records apply"
+            );
+            blocked_at
+        }
+        other => panic!(
+            "malformed WAL during refresh must return Stuck, not {:?}",
+            other
+        ),
+    };
+
+    assert_eq!(
+        blocked_at.txn_id.as_u64(),
+        2,
+        "residual WAL read failure should pin the next expected txn"
+    );
+    assert!(
+        blocked_at.reason.to_string().contains("WAL read failed"),
+        "blocked reason must preserve the reader failure detail: {:?}",
+        blocked_at
+    );
+
+    let status = follower.follower_status();
+    assert!(status.is_blocked(), "follower must surface blocked status");
+    assert!(
+        dir.path().join("follower_state.json").exists(),
+        "blocked refresh must persist follower_state.json"
+    );
+    assert_eq!(
+        read_kv(&follower, branch, "base").as_deref(),
+        Some("v1"),
+        "existing visible state must remain readable after blocked refresh"
+    );
+
+    primary.shutdown().unwrap();
+    follower.shutdown().unwrap();
+}
+
 /// T3-E12 §D7: follower-without-MANIFEST falls back to
 /// `get_codec(&cfg.storage.codec)` so encrypted WAL-only recovery
 /// works even when no MANIFEST has been persisted yet.


### PR DESCRIPTION
## Summary

- **DG-001:** WAL compaction fallback now routes through the codec-aware `WalReader` instead of the raw-byte `WalRecord::from_bytes` loop that bypassed both the v3 outer envelope and the installed `StorageCodec`. Retention decisions on non-identity-codec databases no longer diverge from the shipped format.
- **DG-002:** Follower refresh preserves the already-decoded prefix on codec-decode failure. Codec-decode mirrors the checksum/parse scan-forward contract: stale codec failures at/below the watermark get skipped; above the watermark the blocked record reports the real failing offset via `ReadStopReason::CodecDecode`, with a readable-anchor hint when one exists.
- Residual whole-WAL failures (I/O, legacy-format) degrade gracefully into the documented `Stuck` path with persisted follower state — they never panic the process.
- One canonical WAL read path: compaction, recovery, and follower refresh all flow through `WalReader`.

## Changes

1. `crates/durability/src/compaction/wal_only.rs` — `WalOnlyCompactor` gains optional codec via `with_codec(...)`; `.meta`-miss fallback delegates to `WalReader::read_segment`; raw-byte parse loop deleted. Test helper wraps records in the v3 outer envelope.
2. `crates/durability/src/wal/reader.rs` — `read_segment_after_watermark_contiguous` catches codec-decode, scans forward (skipping stale records ≤ watermark), and returns `Ok(WatermarkReadResult { records, blocked: Some(CodecDecode) })` with the anchor txn surfaced when available.
3. `crates/engine/src/database/lifecycle.rs` — codec-decode now flows through the existing `ReadStopReason::CodecDecode` match arm (no longer unreachable); residual `Err(_)` (I/O, legacy-format) still pins the follower at `received_watermark + 1` with typed error detail — the synthesis is kept only for whole-WAL failures where there is no concrete record to anchor on.
4. `crates/engine/src/database/compaction.rs` and `crates/engine/src/database/transaction.rs` — thread the cached `wal_codec` through both `WalOnlyCompactor` call sites.

## Spec reference

Epic D2 of `docs/design/durability/durability-storage-closure-epics.md`. Change class: **cutover** (raw-byte path deleted). Assurance: **S4**.

## Test plan

- [x] `cargo test -p strata-durability` — 349 passed / 0 failed (new: `test_read_all_after_watermark_contiguous_skips_stale_codec_failure_before_watermark`)
- [x] `cargo test -p strata-engine --lib` — 965 passed / 0 failed
- [x] `cargo test -p strata-engine --test follower_tests` — 32 passed (new: `test_follower_refresh_corrupt_wal_returns_stuck_instead_of_panicking`)
- [x] `cargo test -p strata-engine --test flush_pipeline_tests` — 7 passed
- [x] `cargo test -p strata-engine --test recovery_tests` — 33 passed
- [x] `cargo test -p strata-executor` — 613 passed
- [x] `cargo check --workspace --tests` — clean
- [ ] Regression bench — WAL compaction on 5M-record dataset (run via `/epic-verify`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
