### PR TITLE
D5: MANIFEST + snapshot legacy-format parity with WAL

### DIFF
--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -35,7 +35,7 @@ pub mod __internal {
 pub use manager::TransactionManager;
 pub use payload::TransactionPayload;
 pub use recovery::{
-    apply_wal_record_to_memory_storage, RecoveryCoordinator, RecoveryPlan, RecoveryResult,
-    RecoveryStats,
+    apply_wal_record_to_memory_storage, manifest_error_to_strata_error, RecoveryCoordinator,
+    RecoveryPlan, RecoveryResult, RecoveryStats,
 };
 pub use transaction::{CommitError, JsonStoreExt, TransactionContext, TransactionStatus};

--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -23,7 +23,9 @@ use strata_durability::codec::{clone_codec, StorageCodec};
 use strata_durability::format::{snapshot_path, SegmentMeta, WalRecord, WalSegment};
 use strata_durability::layout::DatabaseLayout;
 use strata_durability::wal::{WalReader, WalReaderError};
-use strata_durability::{LoadedSnapshot, ManifestManager, SnapshotReader};
+use strata_durability::{
+    LoadedSnapshot, ManifestError, ManifestManager, SnapshotReadError, SnapshotReader,
+};
 use strata_storage::SegmentedStore;
 use tracing::{info, warn};
 
@@ -217,7 +219,7 @@ impl RecoveryCoordinator {
             return Ok(RecoveryPlan::fresh());
         }
         let mgr = ManifestManager::load(manifest_path.to_path_buf())
-            .map_err(|e| StrataError::corruption(format!("failed to load MANIFEST: {}", e)))?;
+            .map_err(manifest_error_to_strata_error)?;
         let m = mgr.manifest();
         if m.codec_id != expected_codec_id {
             return Err(StrataError::corruption(format!(
@@ -265,14 +267,7 @@ impl RecoveryCoordinator {
             )));
         }
         let reader = SnapshotReader::new(clone_codec(codec));
-        let snapshot = reader.load(&path).map_err(|e| {
-            StrataError::corruption(format!(
-                "failed to load snapshot {} at {}: {}",
-                snapshot_id,
-                path.display(),
-                e
-            ))
-        })?;
+        let snapshot = reader.load(&path).map_err(snapshot_read_error_to_strata_error)?;
         info!(
             target: "strata::recovery",
             snapshot_id,
@@ -568,6 +563,41 @@ fn wal_read_error_to_strata_error(err: WalReaderError) -> StrataError {
             hint,
         } => StrataError::legacy_format(found_version, hint),
         other => StrataError::storage(format!("WAL read failed: {}", other)),
+    }
+}
+
+/// Map a `ManifestError` into a typed `StrataError`, passing `LegacyFormat`
+/// through so the engine's open path can `matches!(err, StrataError::LegacyFormat { .. })`
+/// to skip the lossy wipe. Everything else collapses to
+/// `StrataError::corruption` — the same generic surface callers had before.
+pub fn manifest_error_to_strata_error(err: ManifestError) -> StrataError {
+    match err {
+        ManifestError::LegacyFormat {
+            detected_version,
+            supported_range,
+            remediation,
+        } => StrataError::legacy_format(
+            detected_version,
+            format!("{supported_range}. {remediation}"),
+        ),
+        other => StrataError::corruption(format!("failed to load MANIFEST: {other}")),
+    }
+}
+
+/// Map a `SnapshotReadError` into a typed `StrataError`, passing `LegacyFormat`
+/// through so the engine's open path can hard-fail the lossy branch on a
+/// pre-v2 snapshot. Everything else collapses to `StrataError::corruption`.
+pub(crate) fn snapshot_read_error_to_strata_error(err: SnapshotReadError) -> StrataError {
+    match err {
+        SnapshotReadError::LegacyFormat {
+            detected_version,
+            supported_range,
+            remediation,
+        } => StrataError::legacy_format(
+            detected_version,
+            format!("{supported_range}. {remediation}"),
+        ),
+        other => StrataError::corruption(format!("failed to load snapshot: {other}")),
     }
 }
 

--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -267,7 +267,16 @@ impl RecoveryCoordinator {
             )));
         }
         let reader = SnapshotReader::new(clone_codec(codec));
-        let snapshot = reader.load(&path).map_err(snapshot_read_error_to_strata_error)?;
+        let snapshot = reader.load(&path).map_err(|err| {
+            map_snapshot_read_error_to_strata_error(err, |other| {
+                StrataError::corruption(format!(
+                    "failed to load snapshot {} at {}: {}",
+                    snapshot_id,
+                    path.display(),
+                    other
+                ))
+            })
+        })?;
         info!(
             target: "strata::recovery",
             snapshot_id,
@@ -584,10 +593,10 @@ pub fn manifest_error_to_strata_error(err: ManifestError) -> StrataError {
     }
 }
 
-/// Map a `SnapshotReadError` into a typed `StrataError`, passing `LegacyFormat`
-/// through so the engine's open path can hard-fail the lossy branch on a
-/// pre-v2 snapshot. Everything else collapses to `StrataError::corruption`.
-pub(crate) fn snapshot_read_error_to_strata_error(err: SnapshotReadError) -> StrataError {
+fn map_snapshot_read_error_to_strata_error<F>(err: SnapshotReadError, non_legacy: F) -> StrataError
+where
+    F: FnOnce(SnapshotReadError) -> StrataError,
+{
     match err {
         SnapshotReadError::LegacyFormat {
             detected_version,
@@ -597,7 +606,7 @@ pub(crate) fn snapshot_read_error_to_strata_error(err: SnapshotReadError) -> Str
             detected_version,
             format!("{supported_range}. {remediation}"),
         ),
-        other => StrataError::corruption(format!("failed to load snapshot: {other}")),
+        other => non_legacy(other),
     }
 }
 
@@ -1921,6 +1930,34 @@ mod tests {
             message.to_lowercase().contains("manifest"),
             "error should mention MANIFEST, got: {}",
             message
+        );
+    }
+
+    /// Snapshot load failures must keep the snapshot id and on-disk path in the
+    /// surfaced corruption message so operators can delete the exact artifact.
+    #[test]
+    fn test_recover_reports_snapshot_id_and_path_on_snapshot_load_failure() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = test_layout(temp_dir.path());
+        seed_snapshot(&layout, 9, 100);
+
+        let snap = strata_durability::format::snapshot_path(layout.snapshots_dir(), 9);
+        std::fs::write(&snap, b"bad").unwrap();
+
+        let coord = RecoveryCoordinator::new(layout, 0).with_codec(Box::new(IdentityCodec));
+        let err = coord
+            .recover(|_| Ok(()), |_| Ok(()))
+            .expect_err("corrupt snapshot must surface as corruption");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to load snapshot 9"),
+            "error should name the snapshot id, got: {}",
+            msg
+        );
+        assert!(
+            msg.contains(&snap.display().to_string()),
+            "error should name the snapshot path, got: {}",
+            msg
         );
     }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -862,21 +862,22 @@ pub enum StrataError {
         source: Option<Box<dyn std::error::Error + Send + Sync>>,
     },
 
-    /// Legacy WAL segment format
+    /// Legacy on-disk format
     ///
-    /// A WAL segment on disk has a `SEGMENT_FORMAT_VERSION` older than
-    /// this build supports. Hard fail — not a lossy-recoverable error.
-    /// The operator must delete the `wal/` subdirectory under the
-    /// database path and reopen with a fresh state.
+    /// A durability artifact on disk — WAL segment, MANIFEST, or snapshot
+    /// — has a `format_version` older than this build supports. Hard fail
+    /// — not a lossy-recoverable error. The operator must delete the
+    /// offending artifact (`wal/` subdirectory, `MANIFEST` file, or
+    /// `snap-*.chk` file) under the database path and reopen.
     ///
-    /// **Staging note (T3-E12 Phase 1):** the variant is declared
-    /// here; Phase 2's segment-header reader is the first producer.
-    /// The `hint` string carries the full operator-facing message
-    /// (typical content: *"this build requires segment format
-    /// version 3. Delete the `wal/` subdirectory and reopen."*)
-    /// so the error's `Display` rendering stays stable across
-    /// future `SEGMENT_FORMAT_VERSION` bumps without needing a
-    /// dedicated `required_version` struct field.
+    /// The `hint` string carries the full operator-facing message,
+    /// including the artifact kind and the required version (typical
+    /// content: *"this build requires segment format version 3. Delete
+    /// the `wal/` subdirectory and reopen."*). Keeping the artifact kind
+    /// inside the hint means the `Display` prefix stays stable across
+    /// future format bumps without needing a separate `artifact` struct
+    /// field. D5 extended the producer set from WAL only to WAL +
+    /// MANIFEST + snapshot.
     ///
     /// Wire code: `StorageError`
     ///
@@ -885,17 +886,19 @@ pub enum StrataError {
     /// # use strata_core::StrataError;
     /// StrataError::LegacyFormat {
     ///     found_version: 2,
-    ///     hint: "this build requires version 3. Delete the `wal/` subdirectory and reopen.".to_string(),
+    ///     hint: "this build requires segment format version 3. \
+    ///            Delete the `wal/` subdirectory and reopen.".to_string(),
     /// };
     /// ```
-    #[error("legacy WAL segment format: found version {found_version}. {hint}")]
+    #[error("legacy on-disk format: found version {found_version}. {hint}")]
     LegacyFormat {
-        /// Segment format version read from disk.
+        /// Format version read from disk.
         found_version: u32,
         /// Operator remediation hint — filesystem action only (no CLI
-        /// tool is promised by this error variant). The hint is
-        /// expected to include the required version number so the
-        /// rendered diagnostic is self-contained.
+        /// tool is promised by this error variant). The hint is expected
+        /// to name the affected artifact kind (WAL, MANIFEST, snapshot)
+        /// and the required version number so the rendered diagnostic
+        /// is self-contained.
         hint: String,
     },
 

--- a/crates/durability/src/disk_snapshot/reader.rs
+++ b/crates/durability/src/disk_snapshot/reader.rs
@@ -9,7 +9,8 @@ use std::path::Path;
 use crate::codec::{CodecError, StorageCodec};
 use crate::format::primitive_tags;
 use crate::format::snapshot::{
-    SectionHeader, SnapshotHeader, SNAPSHOT_HEADER_SIZE, SNAPSHOT_MAGIC,
+    SectionHeader, SnapshotHeader, MIN_SUPPORTED_SNAPSHOT_FORMAT_VERSION, SNAPSHOT_FORMAT_VERSION,
+    SNAPSHOT_HEADER_SIZE, SNAPSHOT_MAGIC,
 };
 
 /// Snapshot reader for recovery
@@ -54,10 +55,30 @@ impl SnapshotReader {
             });
         }
 
-        // Validate header
+        // Legacy-format detection runs before the generic header validation
+        // so a pre-v2 snapshot produces the typed `LegacyFormat` diagnostic
+        // the operator can act on, rather than collapsing into a generic
+        // `HeaderValidation` string (parity with WAL).
+        if header.format_version < MIN_SUPPORTED_SNAPSHOT_FORMAT_VERSION {
+            return Err(SnapshotReadError::LegacyFormat {
+                detected_version: header.format_version,
+                supported_range: format!(
+                    "this build requires snapshot format version {MIN_SUPPORTED_SNAPSHOT_FORMAT_VERSION}"
+                ),
+                remediation: "delete the offending `snap-*.chk` file and reopen \
+                              — the database will replay from the next snapshot \
+                              or the WAL tail."
+                    .to_string(),
+            });
+        }
+
+        // Validate header (future versions surface as `HeaderValidation`).
         header
             .validate()
             .map_err(|e| SnapshotReadError::HeaderValidation(e.to_string()))?;
+        // Belt-and-suspenders: the only path that leaves format_version
+        // untouched is equality with the current one.
+        debug_assert_eq!(header.format_version, SNAPSHOT_FORMAT_VERSION);
 
         // Read codec ID
         let codec_id_len = header.codec_id_len as usize;
@@ -261,6 +282,26 @@ pub enum SnapshotReadError {
     /// Header validation failed
     #[error("Header validation failed: {0}")]
     HeaderValidation(String),
+    /// Legacy snapshot format — rejected hard, even under lossy recovery.
+    ///
+    /// Produced when the snapshot's `format_version` is older than
+    /// [`crate::format::snapshot::MIN_SUPPORTED_SNAPSHOT_FORMAT_VERSION`].
+    /// Surfaces unconditionally (strict and lossy open alike); the engine's
+    /// open path re-raises as
+    /// [`strata_core::StrataError::LegacyFormat`] and the operator must
+    /// delete the file manually before reopening. Mirrors the WAL
+    /// `SegmentHeaderError::LegacyFormat` contract.
+    #[error(
+        "legacy snapshot format: found version {detected_version}. {supported_range}. {remediation}"
+    )]
+    LegacyFormat {
+        /// Format version read from disk.
+        detected_version: u32,
+        /// Operator-facing description of the range this build accepts.
+        supported_range: String,
+        /// Operator remediation hint — filesystem action only.
+        remediation: String,
+    },
     /// Invalid codec ID
     #[error("Invalid codec ID (not valid UTF-8)")]
     InvalidCodecId,
@@ -537,6 +578,53 @@ mod tests {
             result,
             Err(SnapshotReadError::FileTooSmall { .. })
         ));
+    }
+
+    #[test]
+    fn test_snapshot_v1_rejected_as_legacy() {
+        // Craft a 64-byte v1 header (magic + format_version=1 + enough
+        // trailing body to clear the FileTooSmall guard). Parity with
+        // the WAL legacy-format contract: pre-v2 snapshots surface as
+        // `LegacyFormat`, not a generic `HeaderValidation`.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("snap-000001.chk");
+
+        let mut header = [0u8; SNAPSHOT_HEADER_SIZE];
+        header[0..4].copy_from_slice(&SNAPSHOT_MAGIC);
+        header[4..8].copy_from_slice(&1u32.to_le_bytes()); // format_version = 1
+        header[8..16].copy_from_slice(&1u64.to_le_bytes()); // snapshot_id
+        header[16..24].copy_from_slice(&100u64.to_le_bytes()); // watermark_txn
+        header[24..32].copy_from_slice(&0u64.to_le_bytes()); // created_at
+        header[32..48].copy_from_slice(&test_uuid()); // database_uuid
+        header[48] = 0; // codec_id_len = 0 (empty codec id)
+
+        // Pad body so the reader clears its minimum-size guard. The
+        // contents after the header never get parsed because LegacyFormat
+        // short-circuits — the filler bytes are arbitrary.
+        let mut bytes = header.to_vec();
+        bytes.extend_from_slice(&[0u8; 8]); // filler
+
+        std::fs::write(&path, &bytes).unwrap();
+
+        let reader = SnapshotReader::new(Box::new(IdentityCodec));
+        match reader.load(&path) {
+            Err(SnapshotReadError::LegacyFormat {
+                detected_version,
+                supported_range,
+                remediation,
+            }) => {
+                assert_eq!(detected_version, 1);
+                assert!(
+                    supported_range.contains(&MIN_SUPPORTED_SNAPSHOT_FORMAT_VERSION.to_string()),
+                    "supported_range must name the required version, got: {supported_range}"
+                );
+                assert!(
+                    remediation.contains("snap-"),
+                    "remediation must name the snapshot file shape, got: {remediation}"
+                );
+            }
+            other => panic!("expected LegacyFormat, got: {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/durability/src/format/manifest.rs
+++ b/crates/durability/src/format/manifest.rs
@@ -31,6 +31,16 @@ pub const MANIFEST_MAGIC: [u8; 4] = *b"STRM";
 /// Current MANIFEST format version
 pub const MANIFEST_FORMAT_VERSION: u32 = 2;
 
+/// Oldest MANIFEST format version this build can read. Files with a
+/// `format_version` below this value are rejected with
+/// [`ManifestError::LegacyFormat`] — mirroring the WAL clean-break contract
+/// at [`crate::format::wal_record::MIN_SUPPORTED_SEGMENT_FORMAT_VERSION`].
+/// Operators wipe the `manifest` file and reopen.
+///
+/// v2 added `flushed_through_commit_id` (required for delta-only WAL replay);
+/// no shipped build since that bump persists v1.
+pub const MIN_SUPPORTED_MANIFEST_FORMAT_VERSION: u32 = 2;
+
 /// MANIFEST file structure
 ///
 /// Contains physical storage metadata for database recovery:
@@ -112,14 +122,41 @@ impl Manifest {
 
     /// Deserialize MANIFEST from bytes
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ManifestError> {
-        // Minimum size: magic(4) + version(4) + uuid(16) + codec_len(4) + wal_seg(8) + watermark(8) + snap_id(8) + crc(4) = 56 (with empty codec)
-        if bytes.len() < 56 {
+        // Minimum size (v2, empty codec): magic(4) + version(4) + uuid(16) +
+        // codec_len(4) + wal_seg(8) + watermark(8) + snap_id(8) +
+        // flushed_through_commit_id(8) + crc(4) = 64.
+        if bytes.len() < 64 {
             return Err(ManifestError::TooShort);
         }
 
         // Check magic
         if bytes[0..4] != MANIFEST_MAGIC {
             return Err(ManifestError::InvalidMagic);
+        }
+
+        // Version check runs before CRC so a legacy-format MANIFEST produces
+        // the typed `LegacyFormat` diagnostic the operator can act on,
+        // rather than a generic `ChecksumMismatch` when the v1 layout CRC
+        // disagrees with newer assumptions. Parity with WAL
+        // `SegmentHeader::from_bytes_slice` (version before CRC).
+        let format_version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        if format_version < MIN_SUPPORTED_MANIFEST_FORMAT_VERSION {
+            return Err(ManifestError::LegacyFormat {
+                detected_version: format_version,
+                supported_range: format!(
+                    "this build requires MANIFEST format version {MIN_SUPPORTED_MANIFEST_FORMAT_VERSION}"
+                ),
+                remediation: "delete the `MANIFEST` file and reopen \
+                              — the database will rebuild its metadata \
+                              from the `wal/` and `segments/` directories."
+                    .to_string(),
+            });
+        }
+        if format_version > MANIFEST_FORMAT_VERSION {
+            return Err(ManifestError::UnsupportedVersion {
+                version: format_version,
+                max_supported: MANIFEST_FORMAT_VERSION,
+            });
         }
 
         // Verify CRC (last 4 bytes)
@@ -133,17 +170,7 @@ impl Manifest {
             });
         }
 
-        let mut cursor = 4;
-
-        // Format version
-        let format_version = u32::from_le_bytes(bytes[cursor..cursor + 4].try_into().unwrap());
-        if format_version > MANIFEST_FORMAT_VERSION {
-            return Err(ManifestError::UnsupportedVersion {
-                version: format_version,
-                max_supported: MANIFEST_FORMAT_VERSION,
-            });
-        }
-        cursor += 4;
+        let mut cursor = 8;
 
         // Database UUID
         let database_uuid: [u8; 16] = bytes[cursor..cursor + 16].try_into().unwrap();
@@ -180,14 +207,13 @@ impl Manifest {
             None
         };
 
-        // Flushed-through commit ID — v2+ only
-        let flushed_through_commit_id = if format_version >= 2 && cursor + 8 <= bytes.len() - 4 {
-            let val = u64::from_le_bytes(bytes[cursor..cursor + 8].try_into().unwrap());
-            if val > 0 {
-                Some(val)
-            } else {
-                None
-            }
+        // Flushed-through commit ID
+        if cursor + 8 > bytes.len() - 4 {
+            return Err(ManifestError::TooShort);
+        }
+        let flushed_val = u64::from_le_bytes(bytes[cursor..cursor + 8].try_into().unwrap());
+        let flushed_through_commit_id = if flushed_val > 0 {
+            Some(flushed_val)
         } else {
             None
         };
@@ -339,6 +365,26 @@ pub enum ManifestError {
         version: u32,
         /// Maximum version this build can read
         max_supported: u32,
+    },
+
+    /// Legacy MANIFEST format — rejected hard, even under lossy recovery.
+    ///
+    /// Produced when a file's `format_version` is older than
+    /// [`MIN_SUPPORTED_MANIFEST_FORMAT_VERSION`]. Surfaces unconditionally
+    /// (strict and lossy open alike); the engine's open path re-raises as
+    /// [`strata_core::StrataError::LegacyFormat`] and the operator must
+    /// delete the file manually before reopening. Mirrors the WAL
+    /// `SegmentHeaderError::LegacyFormat` contract.
+    #[error(
+        "legacy MANIFEST format: found version {detected_version}. {supported_range}. {remediation}"
+    )]
+    LegacyFormat {
+        /// Format version read from disk.
+        detected_version: u32,
+        /// Operator-facing description of the range this build accepts.
+        supported_range: String,
+        /// Operator remediation hint — filesystem action only.
+        remediation: String,
     },
 
     /// Invalid codec ID (not valid UTF-8)
@@ -588,8 +634,10 @@ mod tests {
     }
 
     #[test]
-    fn test_manifest_v1_loads_with_default_flush_watermark() {
-        // Build a v1-format manifest (no flush watermark field)
+    fn test_manifest_v1_rejected_as_legacy() {
+        // Build a v1-format manifest (no flush watermark field). Under the
+        // D5 cutover this is rejected with `LegacyFormat` rather than
+        // silently read as v1 with a defaulted flush watermark.
         let mut bytes = Vec::new();
         bytes.extend_from_slice(&MANIFEST_MAGIC);
         bytes.extend_from_slice(&1u32.to_le_bytes()); // format_version = 1
@@ -603,9 +651,47 @@ mod tests {
         let crc = crc32fast::hash(&bytes);
         bytes.extend_from_slice(&crc.to_le_bytes());
 
-        let parsed = Manifest::from_bytes(&bytes).unwrap();
-        assert_eq!(parsed.format_version, 1);
-        assert_eq!(parsed.flushed_through_commit_id, None);
+        match Manifest::from_bytes(&bytes) {
+            Err(ManifestError::LegacyFormat {
+                detected_version,
+                supported_range,
+                remediation,
+            }) => {
+                assert_eq!(detected_version, 1);
+                assert!(
+                    supported_range.contains(&MIN_SUPPORTED_MANIFEST_FORMAT_VERSION.to_string()),
+                    "supported_range must name the required version, got: {supported_range}"
+                );
+                assert!(
+                    remediation.contains("MANIFEST"),
+                    "remediation must name the MANIFEST file, got: {remediation}"
+                );
+            }
+            other => panic!("expected LegacyFormat, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_manifest_legacy_detected_before_crc() {
+        // Craft v1 bytes with a deliberately bad CRC. The version check
+        // runs first, so the caller sees `LegacyFormat` — not the generic
+        // `ChecksumMismatch` a naive ordering would produce.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&MANIFEST_MAGIC);
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.extend_from_slice(&test_uuid());
+        let codec = b"identity";
+        bytes.extend_from_slice(&(codec.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(codec);
+        bytes.extend_from_slice(&1u64.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        bytes.extend_from_slice(&0xDEADBEEFu32.to_le_bytes()); // bogus CRC
+
+        assert!(matches!(
+            Manifest::from_bytes(&bytes),
+            Err(ManifestError::LegacyFormat { detected_version: 1, .. })
+        ));
     }
 
     #[test]

--- a/crates/durability/src/format/manifest.rs
+++ b/crates/durability/src/format/manifest.rs
@@ -690,7 +690,10 @@ mod tests {
 
         assert!(matches!(
             Manifest::from_bytes(&bytes),
-            Err(ManifestError::LegacyFormat { detected_version: 1, .. })
+            Err(ManifestError::LegacyFormat {
+                detected_version: 1,
+                ..
+            })
         ));
     }
 

--- a/crates/durability/src/format/mod.rs
+++ b/crates/durability/src/format/mod.rs
@@ -22,8 +22,8 @@ pub mod writeset;
 
 pub use snapshot::{
     find_latest_snapshot, list_snapshots, parse_snapshot_id, snapshot_path, SectionHeader,
-    SnapshotHeader, SnapshotHeaderError, SNAPSHOT_FORMAT_VERSION, SNAPSHOT_HEADER_SIZE,
-    SNAPSHOT_MAGIC,
+    SnapshotHeader, SnapshotHeaderError, MIN_SUPPORTED_SNAPSHOT_FORMAT_VERSION,
+    SNAPSHOT_FORMAT_VERSION, SNAPSHOT_HEADER_SIZE, SNAPSHOT_MAGIC,
 };
 pub use wal_record::{
     SegmentHeader, SegmentHeaderError, WalRecord, WalRecordError, WalSegment, WalSegmentError,
@@ -34,6 +34,7 @@ pub use writeset::{Mutation, Writeset, WritesetError};
 
 pub use manifest::{
     Manifest, ManifestError, ManifestManager, MANIFEST_FORMAT_VERSION, MANIFEST_MAGIC,
+    MIN_SUPPORTED_MANIFEST_FORMAT_VERSION,
 };
 pub use primitives::{
     BranchSnapshotEntry, EventSnapshotEntry, JsonSnapshotEntry, KvSnapshotEntry,

--- a/crates/durability/src/format/snapshot.rs
+++ b/crates/durability/src/format/snapshot.rs
@@ -36,6 +36,15 @@ pub const SNAPSHOT_MAGIC: [u8; 4] = *b"SNAP";
 /// any live database can be re-checkpointed after upgrade.
 pub const SNAPSHOT_FORMAT_VERSION: u32 = 2;
 
+/// Oldest snapshot format version this build can read. Files with a
+/// `format_version` below this value are rejected with
+/// [`crate::disk_snapshot::SnapshotReadError::LegacyFormat`] — mirroring the
+/// WAL clean-break contract at
+/// [`crate::format::wal_record::MIN_SUPPORTED_SEGMENT_FORMAT_VERSION`].
+/// Operators wipe the affected `snap-*.chk` file and reopen; the database
+/// will replay from the next snapshot or the WAL tail.
+pub const MIN_SUPPORTED_SNAPSHOT_FORMAT_VERSION: u32 = 2;
+
 /// Snapshot header size in bytes
 pub const SNAPSHOT_HEADER_SIZE: usize = 64;
 

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -10,7 +10,10 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
-use strata_concurrency::{apply_wal_record_to_memory_storage, RecoveryCoordinator, RecoveryStats};
+use strata_concurrency::{
+    apply_wal_record_to_memory_storage, manifest_error_to_strata_error, RecoveryCoordinator,
+    RecoveryStats,
+};
 use strata_durability::__internal::WalWriterEngineExt;
 use strata_durability::codec::clone_codec;
 use strata_durability::layout::DatabaseLayout;
@@ -439,13 +442,8 @@ impl Database {
         // WAL has been reclaimed. Only a genuinely absent MANIFEST (fresh
         // database) degrades to WAL-only recovery.
         let (database_uuid, follower_codec) = if ManifestManager::exists(&manifest_path) {
-            let m = ManifestManager::load(manifest_path.clone()).map_err(|e| {
-                StrataError::corruption(format!(
-                    "follower could not load MANIFEST at {}: {}",
-                    manifest_path.display(),
-                    e
-                ))
-            })?;
+            let m = ManifestManager::load(manifest_path.clone())
+                .map_err(manifest_error_to_strata_error)?;
             let manifest = m.manifest();
             if manifest.codec_id != cfg.storage.codec {
                 return Err(StrataError::incompatible_reuse(format!(
@@ -993,7 +991,7 @@ impl Database {
         // keeps it ahead of the lossy branch.
         let database_uuid = if ManifestManager::exists(&manifest_path) {
             let m = ManifestManager::load(manifest_path.clone())
-                .map_err(|e| StrataError::internal(format!("failed to load MANIFEST: {}", e)))?;
+                .map_err(manifest_error_to_strata_error)?;
             let stored_codec = &m.manifest().codec_id;
             if stored_codec != &cfg.storage.codec {
                 return Err(StrataError::incompatible_reuse(format!(

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -18,7 +18,7 @@ use strata_durability::__internal::WalWriterEngineExt;
 use strata_durability::codec::clone_codec;
 use strata_durability::layout::DatabaseLayout;
 use strata_durability::wal::{DurabilityMode, WalConfig, WalWriter};
-use strata_durability::ManifestManager;
+use strata_durability::{ManifestError, ManifestManager};
 use strata_storage::SegmentedStore;
 use tracing::{info, warn};
 
@@ -442,8 +442,16 @@ impl Database {
         // WAL has been reclaimed. Only a genuinely absent MANIFEST (fresh
         // database) degrades to WAL-only recovery.
         let (database_uuid, follower_codec) = if ManifestManager::exists(&manifest_path) {
-            let m = ManifestManager::load(manifest_path.clone())
-                .map_err(manifest_error_to_strata_error)?;
+            let m = ManifestManager::load(manifest_path.clone()).map_err(|err| match err {
+                legacy @ ManifestError::LegacyFormat { .. } => {
+                    manifest_error_to_strata_error(legacy)
+                }
+                other => StrataError::corruption(format!(
+                    "follower could not load MANIFEST at {}: {}",
+                    manifest_path.display(),
+                    other
+                )),
+            })?;
             let manifest = m.manifest();
             if manifest.codec_id != cfg.storage.codec {
                 return Err(StrataError::incompatible_reuse(format!(

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -716,3 +716,74 @@ fn test_legacy_format_under_lossy_flag_still_hard_fails() {
         "second open must reproduce the same typed LegacyFormat error",
     );
 }
+
+/// D5: a pre-v2 MANIFEST file surfaces `StrataError::LegacyFormat` even
+/// under `allow_lossy_recovery=true`. Parity with the WAL legacy-format
+/// hard-fail contract — otherwise the lossy branch would swallow a
+/// legacy MANIFEST and silently reconstruct invalid metadata.
+#[test]
+fn test_legacy_manifest_under_lossy_flag_still_hard_fails() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    std::fs::create_dir_all(&db_path).unwrap();
+
+    // Craft a v1 MANIFEST: magic + version=1 + uuid + codec + wal_seg +
+    // watermark + snap_id + crc. No `flushed_through_commit_id` field
+    // — that was added in v2. The D5 cutover rejects this at the parser.
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"STRM"); // MANIFEST_MAGIC
+    bytes.extend_from_slice(&1u32.to_le_bytes()); // format_version = 1 (legacy)
+    bytes.extend_from_slice(&[0xAAu8; 16]); // database_uuid
+    let codec = b"identity";
+    bytes.extend_from_slice(&(codec.len() as u32).to_le_bytes());
+    bytes.extend_from_slice(codec);
+    bytes.extend_from_slice(&1u64.to_le_bytes()); // active_wal_segment
+    bytes.extend_from_slice(&0u64.to_le_bytes()); // snapshot_watermark
+    bytes.extend_from_slice(&0u64.to_le_bytes()); // snapshot_id
+    let crc = crc32fast::hash(&bytes);
+    bytes.extend_from_slice(&crc.to_le_bytes());
+
+    let manifest_path = db_path.join("MANIFEST");
+    std::fs::write(&manifest_path, &bytes).unwrap();
+
+    let cfg = StrataConfig {
+        allow_lossy_recovery: true,
+        ..StrataConfig::default()
+    };
+    let result = Database::open_with_config(&db_path, cfg);
+
+    match result {
+        Err(StrataError::LegacyFormat {
+            found_version,
+            hint,
+        }) => {
+            assert_eq!(found_version, 1);
+            assert!(
+                hint.contains("MANIFEST"),
+                "hint must name the MANIFEST surface, got: {hint}"
+            );
+            assert!(
+                hint.contains("requires"),
+                "hint must describe the required floor, got: {hint}"
+            );
+        }
+        Ok(_) => panic!(
+            "legacy MANIFEST open must hard-fail even under allow_lossy_recovery=true; \
+             got Ok(Database)",
+        ),
+        Err(other) => panic!(
+            "legacy MANIFEST open must produce StrataError::LegacyFormat, got: {other:?}",
+        ),
+    }
+
+    // Reproducible: a second open attempt returns the same typed error.
+    let cfg2 = StrataConfig {
+        allow_lossy_recovery: true,
+        ..StrataConfig::default()
+    };
+    let result2 = Database::open_with_config(&db_path, cfg2);
+    assert!(
+        matches!(result2, Err(StrataError::LegacyFormat { .. })),
+        "second open must reproduce the same typed LegacyFormat error",
+    );
+}

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -771,12 +771,122 @@ fn test_legacy_manifest_under_lossy_flag_still_hard_fails() {
             "legacy MANIFEST open must hard-fail even under allow_lossy_recovery=true; \
              got Ok(Database)",
         ),
-        Err(other) => panic!(
-            "legacy MANIFEST open must produce StrataError::LegacyFormat, got: {other:?}",
-        ),
+        Err(other) => {
+            panic!("legacy MANIFEST open must produce StrataError::LegacyFormat, got: {other:?}",)
+        }
     }
 
     // Reproducible: a second open attempt returns the same typed error.
+    let cfg2 = StrataConfig {
+        allow_lossy_recovery: true,
+        ..StrataConfig::default()
+    };
+    let result2 = Database::open_with_config(&db_path, cfg2);
+    assert!(
+        matches!(result2, Err(StrataError::LegacyFormat { .. })),
+        "second open must reproduce the same typed LegacyFormat error",
+    );
+}
+
+/// Follower MANIFEST failures must preserve the on-disk path in the surfaced
+/// diagnostic so operators can identify which database root is broken.
+#[test]
+fn test_open_follower_corrupt_manifest_names_manifest_path() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    std::fs::create_dir_all(&db_path).unwrap();
+
+    let manifest_path = db_path.join("MANIFEST");
+    std::fs::write(&manifest_path, b"not-a-manifest").unwrap();
+
+    let err = match Database::open_follower(&db_path) {
+        Err(err) => err,
+        Ok(_) => panic!("corrupt MANIFEST must fail follower"),
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("follower could not load MANIFEST"),
+        "error should name the follower MANIFEST load, got: {}",
+        msg
+    );
+    assert!(
+        msg.contains(&manifest_path.display().to_string()),
+        "error should include the MANIFEST path, got: {}",
+        msg
+    );
+}
+
+/// D5: a pre-v2 snapshot file surfaces `StrataError::LegacyFormat` even under
+/// `allow_lossy_recovery=true`. Parity with WAL and MANIFEST: the lossy branch
+/// must not wipe around a legacy snapshot artifact it cannot heal.
+#[test]
+fn test_legacy_snapshot_under_lossy_flag_still_hard_fails() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let snapshots_dir = db_path.join("snapshots");
+    std::fs::create_dir_all(&snapshots_dir).unwrap();
+
+    let mut mgr = strata_durability::ManifestManager::create(
+        db_path.join("MANIFEST"),
+        [0xAAu8; 16],
+        "identity".to_string(),
+    )
+    .unwrap();
+    mgr.set_snapshot_watermark(1, TxnId(100)).unwrap();
+
+    let snapshot_path = strata_durability::format::snapshot_path(&snapshots_dir, 1);
+    let mut header = [0u8; strata_durability::SNAPSHOT_HEADER_SIZE];
+    header[0..4].copy_from_slice(&strata_durability::SNAPSHOT_MAGIC);
+    header[4..8].copy_from_slice(&1u32.to_le_bytes()); // format_version = 1 (legacy)
+    header[8..16].copy_from_slice(&1u64.to_le_bytes()); // snapshot_id
+    header[16..24].copy_from_slice(&100u64.to_le_bytes()); // watermark_txn
+    header[24..32].copy_from_slice(&0u64.to_le_bytes()); // created_at
+    header[32..48].copy_from_slice(&[0xAAu8; 16]); // database_uuid
+    header[48] = 0; // codec_id_len = 0
+
+    // Pad beyond the reader's minimum-size guard. LegacyFormat short-circuits
+    // before codec/body parsing, so the filler bytes are arbitrary.
+    let mut bytes = header.to_vec();
+    bytes.extend_from_slice(&[0u8; 8]);
+    std::fs::write(&snapshot_path, &bytes).unwrap();
+    let bytes_before = std::fs::read(&snapshot_path).unwrap();
+
+    let cfg = StrataConfig {
+        allow_lossy_recovery: true,
+        ..StrataConfig::default()
+    };
+    let result = Database::open_with_config(&db_path, cfg);
+
+    match result {
+        Err(StrataError::LegacyFormat {
+            found_version,
+            hint,
+        }) => {
+            assert_eq!(found_version, 1);
+            assert!(
+                hint.contains("snapshot format version"),
+                "hint must name the required snapshot floor, got: {hint}"
+            );
+            assert!(
+                hint.contains("snap-"),
+                "hint must name the snapshot file shape, got: {hint}"
+            );
+        }
+        Ok(_) => panic!(
+            "legacy snapshot open must hard-fail even under allow_lossy_recovery=true; \
+             got Ok(Database)",
+        ),
+        Err(other) => {
+            panic!("legacy snapshot open must produce StrataError::LegacyFormat, got: {other:?}",)
+        }
+    }
+
+    let bytes_after = std::fs::read(&snapshot_path).unwrap();
+    assert_eq!(
+        bytes_before, bytes_after,
+        "legacy snapshot open must NOT mutate the pre-v2 snapshot file",
+    );
+
     let cfg2 = StrataConfig {
         allow_lossy_recovery: true,
         ..StrataConfig::default()


### PR DESCRIPTION
## Summary

- Snapshot and MANIFEST now surface pre-v2 artifacts as `StrataError::LegacyFormat`, so `allow_lossy_recovery=true` refuses to swallow a legacy artifact instead of silently wiping and reopening.
- Typed `LegacyFormat { detected_version, supported_range, remediation }` variants added to `ManifestError` and `SnapshotReadError`; recovery + engine open paths route through `manifest_error_to_strata_error` (new) so the existing lossy guard at `open.rs:549`/`:1080` hard-fails without a new branch.
- `StrataError::LegacyFormat` display generalized from WAL-specific to artifact-neutral (`"legacy on-disk format: ..."`); operator artifact kind and remediation stay in the `hint`.
- `Manifest::from_bytes` reordered so version is checked before CRC (parity with WAL `SegmentHeader`); minimum-size guard tightened from 56 to 64 bytes (v2 requires `flushed_through_commit_id`); v1 read-compat branch deleted (cutover).

Closes DG-012. Change class: **cutover**. Assurance: **S4**.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace --all-targets` — no new warnings from D5 code
- [x] `cargo test -p strata-core --lib` — 678/678
- [x] `cargo test -p strata-durability --lib` — 351/351
- [x] `cargo test -p strata-concurrency --lib` — 147/147
- [x] `cargo test -p strata-engine --lib` — 972/972
- [x] New unit tests:
  - `test_manifest_v1_rejected_as_legacy` — v1 MANIFEST bytes → `ManifestError::LegacyFormat`
  - `test_manifest_legacy_detected_before_crc` — v1 with bogus CRC still surfaces `LegacyFormat` (pins the version-before-CRC ordering)
  - `test_snapshot_v1_rejected_as_legacy` — v1 snapshot file → `SnapshotReadError::LegacyFormat`
- [x] New engine integration test:
  - `test_legacy_manifest_under_lossy_flag_still_hard_fails` — `allow_lossy_recovery=true` + v1 MANIFEST on disk → `StrataError::LegacyFormat`, hint names MANIFEST + required version; second open reproduces the same error (no silent wipe). Mirrors the WAL variant at `open.rs:632`.

## Files touched

| Area | Files |
|---|---|
| Core | `crates/core/src/error.rs` (generalized `StrataError::LegacyFormat` display + docs) |
| Durability | `crates/durability/src/format/manifest.rs`, `crates/durability/src/format/snapshot.rs`, `crates/durability/src/format/mod.rs`, `crates/durability/src/disk_snapshot/reader.rs` |
| Concurrency | `crates/concurrency/src/recovery.rs` (+ `lib.rs` re-export) |
| Engine | `crates/engine/src/database/open.rs` (primary + follower MANIFEST-load sites), `crates/engine/src/database/tests/open.rs` |

## Out of scope

- Snapshot/MANIFEST writer changes — we never write legacy formats.
- `SnapshotHeaderError::LegacyFormat` inner variant — `SnapshotReader::load` already flattens into `SnapshotReadError`, so the inner type adds surface for no caller benefit.
- Engine-level integration test for legacy snapshots — requires MANIFEST scaffolding pointing at a legacy `.chk`; the unit test + shared helper + shared lossy guard already cover the plumbing.
- Tracker updates for DG-012 — land with the D8a sweep per the epic doc's §Tracker Updates section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)