### PR TITLE
D7: retention + control-artifact persistence — snapshot pruning, search cleanup, atomic strata.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ all-MiniLM-L6-v2/
 
 # Website
 stratadb.org/
+
+.env
+/docs

--- a/crates/durability/src/layout.rs
+++ b/crates/durability/src/layout.rs
@@ -90,7 +90,7 @@ impl DatabaseLayout {
 
     /// Returns the snapshots directory path.
     ///
-    /// Checkpoint files are stored as `snapshot-NNNNNNNNNN.chk` files.
+    /// Checkpoint files are stored as `snap-NNNNNN.chk` files.
     #[inline]
     pub fn snapshots_dir(&self) -> &Path {
         &self.snapshots_dir

--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -190,7 +190,7 @@ pub mod __internal {
         /// Returns whether a background sync is currently in flight.
         fn sync_in_flight(&self) -> bool;
         /// Refreshes the Standard-mode inline-sync deadline without clearing dirty state.
-        fn refresh_sync_deadline(&mut self);
+        fn refresh_inline_sync_deadline(&mut self);
     }
 
     impl BackgroundSyncError {
@@ -245,8 +245,8 @@ pub mod __internal {
             crate::wal::writer::WalWriter::sync_in_flight(self)
         }
 
-        fn refresh_sync_deadline(&mut self) {
-            crate::wal::writer::WalWriter::refresh_sync_deadline(self)
+        fn refresh_inline_sync_deadline(&mut self) {
+            crate::wal::writer::WalWriter::refresh_inline_sync_deadline(self)
         }
     }
 }

--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -189,6 +189,8 @@ pub mod __internal {
         fn clear_bg_error(&mut self);
         /// Returns whether a background sync is currently in flight.
         fn sync_in_flight(&self) -> bool;
+        /// Refreshes the Standard-mode inline-sync deadline without clearing dirty state.
+        fn refresh_sync_deadline(&mut self);
     }
 
     impl BackgroundSyncError {
@@ -241,6 +243,10 @@ pub mod __internal {
 
         fn sync_in_flight(&self) -> bool {
             crate::wal::writer::WalWriter::sync_in_flight(self)
+        }
+
+        fn refresh_sync_deadline(&mut self) {
+            crate::wal::writer::WalWriter::refresh_sync_deadline(self)
         }
     }
 }

--- a/crates/durability/src/wal/writer.rs
+++ b/crates/durability/src/wal/writer.rs
@@ -153,6 +153,14 @@ pub struct WalWriter {
     /// Last fsync time (for Standard mode)
     last_sync_time: Instant,
 
+    /// Last timestamp used by the inline sync safety net.
+    ///
+    /// This normally tracks `last_sync_time`, but the engine may refresh it
+    /// after unrelated durable control-artifact writes so `maybe_sync` does
+    /// not misinterpret that latency as a stalled background WAL thread.
+    /// The real background sync deadline still uses `last_sync_time`.
+    last_inline_sync_time: Instant,
+
     /// Current segment number
     current_segment_number: u64,
 
@@ -210,6 +218,7 @@ impl WalWriter {
                 bytes_since_sync: 0,
                 writes_since_sync: 0,
                 last_sync_time: Instant::now(),
+                last_inline_sync_time: Instant::now(),
                 current_segment_number: 0,
                 current_segment_meta: None,
                 has_unsynced_data: false,
@@ -275,6 +284,7 @@ impl WalWriter {
             bytes_since_sync: 0,
             writes_since_sync: 0,
             last_sync_time: Instant::now(),
+            last_inline_sync_time: Instant::now(),
             current_segment_number: segment_number,
             current_segment_meta,
             has_unsynced_data: false,
@@ -461,7 +471,7 @@ impl WalWriter {
                 if self.sync_in_flight {
                     return Ok(());
                 }
-                let elapsed_ms = self.last_sync_time.elapsed().as_millis() as u64;
+                let elapsed_ms = self.last_inline_sync_time.elapsed().as_millis() as u64;
                 if self.has_unsynced_data && elapsed_ms >= interval_ms {
                     debug!(target: "strata::wal",
                         elapsed_ms,
@@ -500,6 +510,7 @@ impl WalWriter {
         self.bytes_since_sync = 0;
         self.writes_since_sync = 0;
         self.last_sync_time = Instant::now();
+        self.last_inline_sync_time = self.last_sync_time;
         self.has_unsynced_data = false;
         self.bg_error = None;
     }
@@ -635,6 +646,7 @@ impl WalWriter {
         self.bytes_since_sync -= snapshot.bytes_since_sync;
         self.writes_since_sync -= snapshot.writes_since_sync;
         self.last_sync_time = Instant::now().max(snapshot.last_sync_time);
+        self.last_inline_sync_time = self.last_sync_time;
         self.has_unsynced_data = self.bytes_since_sync > 0 || self.writes_since_sync > 0;
         self.bg_error = None;
 
@@ -704,8 +716,12 @@ impl WalWriter {
     /// The engine uses this after unrelated durable control-artifact writes
     /// (`strata.toml`, MANIFEST-like metadata) so their fsync cost does not
     /// make `maybe_sync` treat the background WAL thread as overdue.
-    pub(crate) fn refresh_sync_deadline(&mut self) {
-        self.last_sync_time = Instant::now();
+    ///
+    /// This intentionally does NOT move `last_sync_time`: the background
+    /// flush thread and `sync_if_overdue()` must still observe the real WAL
+    /// fsync deadline for already-dirty data.
+    pub(crate) fn refresh_inline_sync_deadline(&mut self) {
+        self.last_inline_sync_time = Instant::now();
     }
 
     /// Get the current durability mode.
@@ -1530,6 +1546,7 @@ mod tests {
         // the preconditions rather than relying on timing.
         writer.has_unsynced_data = true;
         writer.last_sync_time = Instant::now() - std::time::Duration::from_millis(100);
+        writer.last_inline_sync_time = writer.last_sync_time;
 
         let sync_calls_before = writer.total_sync_calls;
         writer.maybe_sync().unwrap();
@@ -1596,6 +1613,7 @@ mod tests {
 
         // Force last_sync_time into the past so deadline is exceeded
         writer.last_sync_time = Instant::now() - std::time::Duration::from_millis(100);
+        writer.last_inline_sync_time = writer.last_sync_time;
 
         let sync_calls_before = writer.total_sync_calls;
         writer.maybe_sync().unwrap();
@@ -1627,6 +1645,7 @@ mod tests {
         // Set last_sync_time to just past interval_ms ago (but well under 3×interval_ms)
         writer.has_unsynced_data = true;
         writer.last_sync_time = Instant::now() - std::time::Duration::from_millis(interval_ms + 10);
+        writer.last_inline_sync_time = writer.last_sync_time;
 
         let sync_calls_before = writer.total_sync_calls;
         writer.maybe_sync().unwrap();
@@ -2046,6 +2065,39 @@ mod tests {
         assert_eq!(writer.bytes_since_sync, bytes_before);
         assert_eq!(writer.writes_since_sync, writes_before);
 
+        writer.abort_background_sync(handle, io::Error::other("test cleanup"));
+    }
+
+    #[test]
+    fn test_refresh_inline_sync_deadline_does_not_delay_background_sync() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+        let mut writer = make_writer(
+            &wal_dir,
+            DurabilityMode::Standard {
+                interval_ms: 60_000,
+                batch_size: 1_000,
+            },
+        );
+
+        writer.append(&make_record(1)).unwrap();
+        let overdue = Instant::now() - std::time::Duration::from_secs(3600);
+        writer.last_sync_time = overdue;
+        writer.last_inline_sync_time = overdue;
+
+        writer.refresh_inline_sync_deadline();
+
+        let sync_calls_before = writer.total_sync_calls;
+        writer.maybe_sync().unwrap();
+        assert_eq!(
+            writer.total_sync_calls, sync_calls_before,
+            "inline fallback should be suppressed by the control-artifact write"
+        );
+
+        let handle = writer
+            .begin_background_sync()
+            .unwrap()
+            .expect("background sync should still see the real overdue WAL deadline");
         writer.abort_background_sync(handle, io::Error::other("test cleanup"));
     }
 

--- a/crates/durability/src/wal/writer.rs
+++ b/crates/durability/src/wal/writer.rs
@@ -699,6 +699,15 @@ impl WalWriter {
         self.sync_in_flight
     }
 
+    /// Refresh the Standard-mode inline-sync deadline without clearing dirty state.
+    ///
+    /// The engine uses this after unrelated durable control-artifact writes
+    /// (`strata.toml`, MANIFEST-like metadata) so their fsync cost does not
+    /// make `maybe_sync` treat the background WAL thread as overdue.
+    pub(crate) fn refresh_sync_deadline(&mut self) {
+        self.last_sync_time = Instant::now();
+    }
+
     /// Get the current durability mode.
     pub fn durability_mode(&self) -> DurabilityMode {
         self.durability

--- a/crates/engine/src/database/compaction.rs
+++ b/crates/engine/src/database/compaction.rs
@@ -166,6 +166,14 @@ impl Database {
             "Checkpoint created"
         );
 
+        if let Err(e) = self.prune_snapshots_once() {
+            tracing::warn!(
+                target: "strata::durability",
+                error = %e,
+                "Snapshot pruning failed after checkpoint (non-fatal)"
+            );
+        }
+
         Ok(())
     }
 

--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -263,6 +263,32 @@ impl Default for StorageConfig {
     }
 }
 
+/// Snapshot retention policy.
+///
+/// Controls how many on-disk checkpoint snapshots (`snap-NNNNNN.chk`) are kept
+/// after each successful checkpoint. The snapshot referenced by the live
+/// MANIFEST is always retained regardless of `retain_count` so recovery is
+/// never broken by pruning.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SnapshotRetentionPolicy {
+    /// Maximum number of snapshot files to keep. Must be `>= 1`.
+    /// Default: 10.
+    #[serde(default = "default_snapshot_retain_count")]
+    pub retain_count: usize,
+}
+
+fn default_snapshot_retain_count() -> usize {
+    10
+}
+
+impl Default for SnapshotRetentionPolicy {
+    fn default() -> Self {
+        Self {
+            retain_count: default_snapshot_retain_count(),
+        }
+    }
+}
+
 /// Database configuration loaded from `strata.toml`.
 ///
 /// # Example
@@ -338,6 +364,11 @@ pub struct StrataConfig {
     /// Individual collections can override via VectorConfig.
     #[serde(default = "default_vector_dtype")]
     pub default_vector_dtype: String,
+    /// Snapshot retention policy. Controls how many `snap-NNNNNN.chk` files
+    /// are kept on disk after each successful checkpoint. The live MANIFEST
+    /// snapshot is always retained.
+    #[serde(default)]
+    pub snapshot_retention: SnapshotRetentionPolicy,
 }
 
 fn default_durability_str() -> String {
@@ -377,6 +408,7 @@ impl Default for StrataConfig {
             allow_lossy_recovery: false,
             telemetry: false,
             default_vector_dtype: default_vector_dtype(),
+            snapshot_retention: SnapshotRetentionPolicy::default(),
         }
     }
 }
@@ -497,6 +529,12 @@ auto_embed = false
 # data_block_size = 4096        # 4 KiB; segment data block size
 # bloom_bits_per_key = 10       # bloom filter bits per key
 # compaction_rate_limit = 0     # 0 = unlimited; bytes/sec cap for compaction I/O
+
+# Snapshot retention. After each successful checkpoint, snapshot files older
+# than the retain window are pruned. The snapshot referenced by the live
+# MANIFEST is always retained.
+# [snapshot_retention]
+# retain_count = 10             # keep last N snap-NNNNNN.chk files
 "#
     }
 
@@ -550,13 +588,7 @@ auto_embed = false
     /// Returns `Ok(())` whether the file was created or already existed.
     pub fn write_default_if_missing(path: &Path) -> StrataResult<()> {
         if !path.exists() {
-            std::fs::write(path, Self::default_toml()).map_err(|e| {
-                StrataError::internal(format!(
-                    "Failed to write default config file '{}': {}",
-                    path.display(),
-                    e
-                ))
-            })?;
+            atomic_write_config(path, Self::default_toml().as_bytes())?;
             restrict_config_permissions(path)?;
         }
         Ok(())
@@ -566,15 +598,55 @@ auto_embed = false
     pub fn write_to_file(&self, path: &Path) -> StrataResult<()> {
         let content = toml::to_string_pretty(self)
             .map_err(|e| StrataError::internal(format!("Failed to serialize config: {}", e)))?;
-        std::fs::write(path, content).map_err(|e| {
-            StrataError::internal(format!(
-                "Failed to write config file '{}': {}",
-                path.display(),
-                e
-            ))
-        })?;
+        atomic_write_config(path, content.as_bytes())?;
         restrict_config_permissions(path)
     }
+}
+
+/// Crash-safe write of `strata.toml` content via temp-file + atomic rename
+/// (closes DG-018: atomicity).
+///
+/// **Atomicity:** Reader of `strata.toml` never observes a partially-written
+/// file — the rename is atomic. Crash mid-write leaves either the previous
+/// content or the new content, never garbage. This matches the publish
+/// pattern used by MANIFEST and segment files
+/// (`crates/storage/src/manifest.rs`, `crates/storage/src/segment_builder.rs`).
+///
+/// **Durability gap (intentional):** This function deliberately does NOT
+/// `fsync` the file or the parent directory. `set_durability_mode` calls
+/// `write_to_file` while holding the config write lock, and the WAL flush
+/// thread's "inline sync fallback" in `WalWriter::maybe_sync` fires when
+/// `interval_ms` has elapsed since the last sync. Adding a multi-millisecond
+/// fsync here pushes the elapsed past tight test intervals (10ms in the
+/// shutdown halt-latch suite) and makes the inline fallback win the race
+/// against the background sync thread, which silently consumes injected
+/// commit-sync failures and breaks 6 timing-sensitive WAL halt tests
+/// (`database::tests::shutdown::test_*_sync_failure_halts_writer_*`).
+///
+/// Until the WAL halt tests are decoupled from the per-call cost of
+/// `set_durability_mode`, full fsync remains a planned follow-up. Page-cache
+/// data is still flushed by the kernel within ~5 seconds in normal operation.
+fn atomic_write_config(path: &Path, content: &[u8]) -> StrataResult<()> {
+    let tmp_path = path.with_extension("toml.tmp");
+
+    std::fs::write(&tmp_path, content).map_err(|e| {
+        StrataError::internal(format!(
+            "Failed to write temp config file '{}': {}",
+            tmp_path.display(),
+            e
+        ))
+    })?;
+
+    std::fs::rename(&tmp_path, path).map_err(|e| {
+        StrataError::internal(format!(
+            "Failed to rename temp config '{}' to '{}': {}",
+            tmp_path.display(),
+            path.display(),
+            e
+        ))
+    })?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -643,6 +715,40 @@ mod tests {
 
         let config = StrataConfig::from_file(&path).unwrap();
         assert_eq!(config.durability, "always");
+    }
+
+    /// DG-018: atomic write must not leave a `*.toml.tmp` artifact behind.
+    #[test]
+    fn write_to_file_leaves_no_tmp_artifact() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(CONFIG_FILE_NAME);
+
+        let cfg = StrataConfig::default();
+        cfg.write_to_file(&path).unwrap();
+        assert!(path.exists(), "config file must be present");
+
+        let tmp = path.with_extension("toml.tmp");
+        assert!(!tmp.exists(), "atomic write must rename away the .tmp file");
+
+        // Re-write with mutated content; same invariant.
+        let mut cfg2 = StrataConfig::default();
+        cfg2.snapshot_retention.retain_count = 42;
+        cfg2.write_to_file(&path).unwrap();
+        assert!(!tmp.exists());
+        let reloaded = StrataConfig::from_file(&path).unwrap();
+        assert_eq!(reloaded.snapshot_retention.retain_count, 42);
+    }
+
+    /// DG-018: `write_default_if_missing` also takes the atomic path.
+    #[test]
+    fn write_default_leaves_no_tmp_artifact() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(CONFIG_FILE_NAME);
+
+        StrataConfig::write_default_if_missing(&path).unwrap();
+        assert!(path.exists());
+        let tmp = path.with_extension("toml.tmp");
+        assert!(!tmp.exists());
     }
 
     #[test]

--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -604,38 +604,51 @@ auto_embed = false
 }
 
 /// Crash-safe write of `strata.toml` content via temp-file + atomic rename
-/// (closes DG-018: atomicity).
+/// (closes DG-018: atomicity + durability).
 ///
 /// **Atomicity:** Reader of `strata.toml` never observes a partially-written
 /// file — the rename is atomic. Crash mid-write leaves either the previous
 /// content or the new content, never garbage. This matches the publish
 /// pattern used by MANIFEST and segment files
 /// (`crates/storage/src/manifest.rs`, `crates/storage/src/segment_builder.rs`).
-///
-/// **Durability gap (intentional):** This function deliberately does NOT
-/// `fsync` the file or the parent directory. `set_durability_mode` calls
-/// `write_to_file` while holding the config write lock, and the WAL flush
-/// thread's "inline sync fallback" in `WalWriter::maybe_sync` fires when
-/// `interval_ms` has elapsed since the last sync. Adding a multi-millisecond
-/// fsync here pushes the elapsed past tight test intervals (10ms in the
-/// shutdown halt-latch suite) and makes the inline fallback win the race
-/// against the background sync thread, which silently consumes injected
-/// commit-sync failures and breaks 6 timing-sensitive WAL halt tests
-/// (`database::tests::shutdown::test_*_sync_failure_halts_writer_*`).
-///
-/// Until the WAL halt tests are decoupled from the per-call cost of
-/// `set_durability_mode`, full fsync remains a planned follow-up. Page-cache
-/// data is still flushed by the kernel within ~5 seconds in normal operation.
 fn atomic_write_config(path: &Path, content: &[u8]) -> StrataResult<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            StrataError::internal(format!(
+                "Failed to create config directory '{}': {}",
+                parent.display(),
+                e
+            ))
+        })?;
+    }
+
     let tmp_path = path.with_extension("toml.tmp");
 
-    std::fs::write(&tmp_path, content).map_err(|e| {
-        StrataError::internal(format!(
-            "Failed to write temp config file '{}': {}",
-            tmp_path.display(),
-            e
-        ))
-    })?;
+    {
+        use std::io::Write;
+
+        let mut file = std::fs::File::create(&tmp_path).map_err(|e| {
+            StrataError::internal(format!(
+                "Failed to create temp config file '{}': {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+        file.write_all(content).map_err(|e| {
+            StrataError::internal(format!(
+                "Failed to write temp config file '{}': {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+        file.sync_all().map_err(|e| {
+            StrataError::internal(format!(
+                "Failed to fsync temp config file '{}': {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+    }
 
     std::fs::rename(&tmp_path, path).map_err(|e| {
         StrataError::internal(format!(
@@ -645,6 +658,17 @@ fn atomic_write_config(path: &Path, content: &[u8]) -> StrataResult<()> {
             e
         ))
     })?;
+
+    let dir_path = path.parent().unwrap_or(Path::new("."));
+    std::fs::File::open(dir_path)
+        .and_then(|dir| dir.sync_all())
+        .map_err(|e| {
+            StrataError::internal(format!(
+                "Failed to fsync config directory '{}': {}",
+                dir_path.display(),
+                e
+            ))
+        })?;
 
     Ok(())
 }

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -6,6 +6,7 @@ use strata_core::id::{CommitVersion, TxnId};
 use strata_core::traits::Storage;
 use strata_core::types::{BranchId, Key};
 use strata_core::{StrataError, StrataResult};
+use strata_durability::{ManifestError, ManifestManager};
 use tracing::{info, warn};
 
 use super::refresh::{
@@ -114,6 +115,114 @@ impl Database {
             .storage
             .expire_ttl_keys(strata_core::Timestamp::now().as_micros());
         (safe_point, pruned, expired)
+    }
+
+    /// Prune old checkpoint snapshot files according to the configured
+    /// `snapshot_retention.retain_count` (DG-015).
+    ///
+    /// Always retains:
+    ///   - the `retain_count` newest snapshots, and
+    ///   - the snapshot referenced by the live MANIFEST (recovery-critical).
+    ///
+    /// Best-effort: per-file delete failures are logged but do not abort the
+    /// loop. The snapshots directory is fsynced once at the end if any file
+    /// was actually removed. Returns the number of files deleted.
+    ///
+    /// Skipped (returns `Ok(0)`) for ephemeral mode, follower mode, and
+    /// while shutdown is in progress.
+    ///
+    /// Called from `Database::checkpoint` after the new snapshot is durable.
+    /// A future executor / CLI surface will expose this as an admin entry
+    /// point — see `docs/design/durability/durability-storage-closure-epics.md`
+    /// "What Comes After" section.
+    pub(crate) fn prune_snapshots_once(&self) -> StrataResult<usize> {
+        if self.check_not_shutting_down().is_err() {
+            return Ok(0);
+        }
+        if self.persistence_mode == PersistenceMode::Ephemeral || self.follower {
+            return Ok(0);
+        }
+
+        let snapshots_dir = self.data_dir.join("snapshots");
+        if !snapshots_dir.exists() {
+            return Ok(0);
+        }
+
+        let retain_count = self.config.read().snapshot_retention.retain_count.max(1);
+
+        let manifest_path = self.data_dir.join("MANIFEST");
+        let live_snapshot_id = if ManifestManager::exists(&manifest_path) {
+            ManifestManager::load(manifest_path)
+                .map_err(|e: ManifestError| {
+                    StrataError::internal(format!(
+                        "prune_snapshots: failed to load MANIFEST: {}",
+                        e
+                    ))
+                })?
+                .manifest()
+                .snapshot_id
+        } else {
+            None
+        };
+
+        let snapshots = strata_durability::list_snapshots(&snapshots_dir).map_err(|e| {
+            StrataError::internal(format!(
+                "prune_snapshots: failed to list snapshots in {}: {}",
+                snapshots_dir.display(),
+                e
+            ))
+        })?;
+
+        if snapshots.len() <= retain_count {
+            return Ok(0);
+        }
+
+        let keep_from = snapshots.len().saturating_sub(retain_count);
+        let mut deleted = 0usize;
+
+        for (i, (id, path)) in snapshots.iter().enumerate() {
+            if i >= keep_from {
+                break;
+            }
+            if Some(*id) == live_snapshot_id {
+                continue;
+            }
+            match std::fs::remove_file(path) {
+                Ok(_) => deleted += 1,
+                Err(e) => {
+                    warn!(
+                        target: "strata::durability",
+                        snapshot_id = id,
+                        path = ?path,
+                        error = %e,
+                        "Failed to delete pruned snapshot file"
+                    );
+                }
+            }
+        }
+
+        if deleted > 0 {
+            let dir_fd = std::fs::File::open(&snapshots_dir).map_err(|e| {
+                StrataError::internal(format!(
+                    "prune_snapshots: failed to open snapshots dir for fsync: {}",
+                    e
+                ))
+            })?;
+            dir_fd.sync_all().map_err(|e| {
+                StrataError::internal(format!(
+                    "prune_snapshots: failed to fsync snapshots dir: {}",
+                    e
+                ))
+            })?;
+            info!(
+                target: "strata::durability",
+                deleted,
+                retained = retain_count,
+                "Snapshot pruning complete"
+            );
+        }
+
+        Ok(deleted)
     }
 
     /// Remove the per-branch commit lock after a branch is deleted.

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1929,7 +1929,7 @@ impl Database {
                 // The durable control-artifact write is unrelated to WAL
                 // backlog; do not let its fsync cost make Standard mode's
                 // inline fallback think the background sync thread is late.
-                wal.lock().refresh_sync_deadline();
+                wal.lock().refresh_inline_sync_deadline();
             }
         }
         // Apply storage/coordinator/cache parameters to the live database
@@ -2058,7 +2058,7 @@ impl Database {
             }
         }
         if wrote_config {
-            wal.lock().refresh_sync_deadline();
+            wal.lock().refresh_inline_sync_deadline();
         }
 
         Ok(())

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1915,14 +1915,25 @@ impl Database {
         }
 
         *guard = candidate;
-
-        // Persist to strata.toml for disk-backed databases
-        if self.persistence_mode == PersistenceMode::Disk && !self.data_dir.as_os_str().is_empty() {
+        let applied_cfg = guard.clone();
+        let wrote_config =
+            self.persistence_mode == PersistenceMode::Disk && !self.data_dir.as_os_str().is_empty();
+        if wrote_config {
             let config_path = self.data_dir.join(config::CONFIG_FILE_NAME);
-            guard.write_to_file(&config_path)?;
+            applied_cfg.write_to_file(&config_path)?;
+        }
+        drop(guard);
+
+        if wrote_config {
+            if let Some(wal) = &self.wal_writer {
+                // The durable control-artifact write is unrelated to WAL
+                // backlog; do not let its fsync cost make Standard mode's
+                // inline fallback think the background sync thread is late.
+                wal.lock().refresh_sync_deadline();
+            }
         }
         // Apply storage/coordinator/cache parameters to the live database
-        self.apply_storage_config_inner(&guard);
+        self.apply_storage_config_inner(&applied_cfg);
         Ok(())
     }
 
@@ -2034,6 +2045,7 @@ impl Database {
             DurabilityMode::Standard { .. } => "standard",
             DurabilityMode::Cache => unreachable!("Cache transitions rejected above"),
         };
+        let mut wrote_config = false;
         {
             let mut cfg = self.config.write();
             cfg.durability = mode_str.to_string();
@@ -2042,7 +2054,11 @@ impl Database {
             {
                 let config_path = self.data_dir.join(config::CONFIG_FILE_NAME);
                 cfg.write_to_file(&config_path)?;
+                wrote_config = true;
             }
+        }
+        if wrote_config {
+            wal.lock().refresh_sync_deadline();
         }
 
         Ok(())

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -1,7 +1,9 @@
 //! Database opening and initialization.
 
 use super::config::StorageConfig;
-use super::refresh::{load_persisted_follower_state, validate_blocked_state};
+use super::refresh::{
+    clear_persisted_follower_state, load_persisted_follower_state, validate_blocked_state,
+};
 use crate::background::BackgroundScheduler;
 use crate::coordinator::TransactionCoordinator;
 use dashmap::DashMap;
@@ -633,6 +635,13 @@ impl Database {
                         reason = %reason,
                         "Ignoring inconsistent persisted follower state"
                     );
+                    if let Err(error) = clear_persisted_follower_state(&canonical_path) {
+                        warn!(
+                            target: "strata::db",
+                            error = %error,
+                            "Failed to clear inconsistent persisted follower state"
+                        );
+                    }
                     None
                 }
             },

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -1558,6 +1558,8 @@ impl Database {
         let background_threads = profiled_for_signature.storage.background_threads;
         let allow_lossy_recovery = profiled_for_signature.allow_lossy_recovery;
 
+        let requested_runtime_cfg = config.as_ref().map(|_| profiled_for_signature.clone());
+
         let subsystem_names: Vec<&'static str> = subsystems.iter().map(|s| s.name()).collect();
         let requested_signature = CompatibilitySignature::from_spec(
             super::spec::DatabaseMode::Primary,
@@ -1581,6 +1583,9 @@ impl Database {
                 // authoritative. Signature check ensures the caller's request is
                 // compatible with the running instance.
                 let db = Self::wait_for_opened_db(db)?;
+                if let Some(requested_cfg) = requested_runtime_cfg.as_ref() {
+                    Self::validate_requested_config_reuse(&db, requested_cfg)?;
+                }
                 Self::validate_control_artifact_reuse(&db, &config_path)?;
                 Ok(db)
             }
@@ -1918,6 +1923,21 @@ impl Database {
             )));
         }
 
+        Ok(())
+    }
+
+    fn validate_requested_config_reuse(
+        db: &Arc<Self>,
+        requested_cfg: &StrataConfig,
+    ) -> StrataResult<()> {
+        let live_cfg = db.config.read();
+        if *requested_cfg != *live_cfg {
+            return Err(StrataError::incompatible_reuse(
+                "requested explicit configuration diverged from the running database \
+                 configuration; shut down and reopen the database to apply programmatic \
+                 config changes",
+            ));
+        }
         Ok(())
     }
 

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -1580,7 +1580,9 @@ impl Database {
                 // On reuse, do NOT overwrite config — the existing DB's config is
                 // authoritative. Signature check ensures the caller's request is
                 // compatible with the running instance.
-                Self::wait_for_opened_db(db)
+                let db = Self::wait_for_opened_db(db)?;
+                Self::validate_control_artifact_reuse(&db, &config_path)?;
+                Ok(db)
             }
             AcquiredDatabase::New { db, canonical_path } => {
                 let effective_default_branch =
@@ -1881,6 +1883,42 @@ impl Database {
                 unreachable!("wait returned while still initializing")
             }
         }
+    }
+
+    fn validate_control_artifact_reuse(db: &Arc<Self>, config_path: &Path) -> StrataResult<()> {
+        if db.persistence_mode != PersistenceMode::Disk || db.data_dir.as_os_str().is_empty() {
+            return Ok(());
+        }
+
+        let live_cfg = db.config.read();
+        if !config_path.exists() {
+            return Err(StrataError::incompatible_reuse(format!(
+                "on-disk strata.toml '{}' is missing while a database instance for this path \
+                 is already open",
+                config_path.display()
+            )));
+        }
+
+        let mut on_disk_cfg = config::StrataConfig::from_file(config_path).map_err(|e| {
+            StrataError::incompatible_reuse(format!(
+                "on-disk strata.toml '{}' is invalid while a database instance for this path \
+                 is already open: {}",
+                config_path.display(),
+                e
+            ))
+        })?;
+        on_disk_cfg = sanitize_config(on_disk_cfg);
+        crate::database::profile::apply_hardware_profile_if_defaults(&mut on_disk_cfg);
+
+        if on_disk_cfg != *live_cfg {
+            return Err(StrataError::incompatible_reuse(format!(
+                "on-disk strata.toml '{}' diverged from the running database configuration; \
+                 shut down and reopen the database to apply file edits",
+                config_path.display()
+            )));
+        }
+
+        Ok(())
     }
 
     fn finish_opened_db<F>(

--- a/crates/engine/src/database/tests/mod.rs
+++ b/crates/engine/src/database/tests/mod.rs
@@ -40,7 +40,9 @@ mod codec;
 mod contention;
 mod open;
 mod regressions;
+mod search_branch_cleanup;
 mod shutdown;
+mod snapshot_retention;
 mod transactions;
 
 // ========================================================================

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -233,6 +233,37 @@ fn test_open_same_path_returns_same_instance() {
 
 #[test]
 #[serial(open_databases)]
+fn test_open_with_config_rejects_registry_reuse_when_requested_config_drifted() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("reuse_requested_config_drift");
+
+    let db = Database::open(&db_path).unwrap();
+
+    let mut drifted = StrataConfig::default();
+    drifted.snapshot_retention.retain_count = 1;
+
+    let err = match Database::open_with_config(&db_path, drifted) {
+        Ok(_) => panic!("drifted explicit config must not silently reuse the running database"),
+        Err(err) => err,
+    };
+    assert!(
+        matches!(err, StrataError::IncompatibleReuse { .. }),
+        "expected IncompatibleReuse for explicit config drift, got {:?}",
+        err
+    );
+    assert!(
+        err.to_string().contains("programmatic config")
+            || err.to_string().contains("explicit configuration"),
+        "reuse rejection should name the explicit-config surface, got: {}",
+        err
+    );
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
+#[test]
+#[serial(open_databases)]
 fn test_open_rejects_registry_reuse_when_strata_toml_drifted() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("reuse_strata_toml_drift");
@@ -285,33 +316,34 @@ fn test_ephemeral_not_registered() {
     assert!(!Arc::ptr_eq(&db1, &db2));
 }
 
-/// Test that opening the same path twice returns the same Arc via registry.
-///
-/// NOTE: This test is temporarily ignored because the singleton registry has a
-/// race condition when the same path is opened concurrently. The registry lookup
-/// and insert are not atomic, so two threads can both pass the "not in registry"
-/// check and then both try to open the database, with one failing on the lock.
-/// Issue: stratalab/strata-core#TBD
 #[test]
-#[ignore = "singleton registry race condition - needs fix"]
-fn test_open_uses_registry() {
-    use std::time::{SystemTime, UNIX_EPOCH};
+#[serial(open_databases)]
+fn test_concurrent_open_same_path_returns_same_instance() {
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
     let temp_dir = TempDir::new().unwrap();
-    // Use a unique subdir name to avoid registry collisions in parallel tests
-    let unique_id = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let db_path = temp_dir
-        .path()
-        .join(format!("singleton_via_open_{}", unique_id));
+    let db_path = temp_dir.path().join("singleton_via_open_concurrent");
+    let barrier = Arc::new(Barrier::new(3));
 
-    // Open via Database::open twice
-    let db1 = Database::open(&db_path).unwrap();
-    let db2 = Database::open(&db_path).unwrap();
+    let spawn_open = |barrier: Arc<Barrier>, path: std::path::PathBuf| {
+        thread::spawn(move || {
+            barrier.wait();
+            Database::open(&path).unwrap()
+        })
+    };
 
-    // Should be same instance
+    let h1 = spawn_open(Arc::clone(&barrier), db_path.clone());
+    let h2 = spawn_open(Arc::clone(&barrier), db_path.clone());
+    barrier.wait();
+
+    let db1 = h1.join().expect("first opener thread panicked");
+    let db2 = h2.join().expect("second opener thread panicked");
+
     assert!(Arc::ptr_eq(&db1, &db2));
+
+    db1.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
 }
 
 #[test]

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -232,6 +232,37 @@ fn test_open_same_path_returns_same_instance() {
 }
 
 #[test]
+#[serial(open_databases)]
+fn test_open_rejects_registry_reuse_when_strata_toml_drifted() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("reuse_strata_toml_drift");
+
+    let db = Database::open(&db_path).unwrap();
+
+    let mut drifted = db.config();
+    drifted.snapshot_retention.retain_count = 1;
+    drifted.write_to_file(&db_path.join("strata.toml")).unwrap();
+
+    let err = match Database::open(&db_path) {
+        Ok(_) => panic!("stale on-disk strata.toml must not silently reuse the running database"),
+        Err(err) => err,
+    };
+    assert!(
+        matches!(err, StrataError::IncompatibleReuse { .. }),
+        "expected IncompatibleReuse for strata.toml drift, got {:?}",
+        err
+    );
+    assert!(
+        err.to_string().contains("strata.toml"),
+        "reuse rejection should name the control artifact, got: {}",
+        err
+    );
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
+#[test]
 fn test_open_different_paths_returns_different_instances() {
     let temp_dir = TempDir::new().unwrap();
     let path1 = temp_dir.path().join("db1");

--- a/crates/engine/src/database/tests/search_branch_cleanup.rs
+++ b/crates/engine/src/database/tests/search_branch_cleanup.rs
@@ -1,0 +1,140 @@
+//! Regression tests for D7 / DG-017 — `SearchSubsystem::cleanup_deleted_branch`.
+
+use super::*;
+use crate::primitives::branch::resolve_branch_name;
+use crate::recovery::Subsystem;
+use crate::search::{EntityRef, InvertedIndex, SearchSubsystem};
+
+fn kv_ref(branch_id: BranchId, key: &str) -> EntityRef {
+    EntityRef::Kv {
+        branch_id,
+        space: "default".to_string(),
+        key: key.to_string(),
+    }
+}
+
+#[test]
+fn search_subsystem_cleans_deleted_branch() {
+    // Note: docs are indexed under the executor branch_id (deterministic
+    // from name), which is what `BranchIndex::delete_branch` passes to the
+    // subsystem cleanup hook. The metadata UUID on `BranchMetadata` is a
+    // different value and would not match the cleanup's filter.
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let db = Database::open_runtime(
+        crate::database::OpenSpec::primary(&db_path).with_subsystem(SearchSubsystem),
+    )
+    .unwrap();
+
+    let index = db.extension::<InvertedIndex>().unwrap();
+    let branches = db.branches();
+    branches.create("keeper").unwrap();
+    branches.create("victim").unwrap();
+    let branch_keep = resolve_branch_name("keeper");
+    let branch_drop = resolve_branch_name("victim");
+
+    index.index_document(&kv_ref(branch_keep, "k1"), "alpha shared text", None);
+    index.index_document(&kv_ref(branch_drop, "v1"), "victim only document", None);
+    index.index_document(&kv_ref(branch_drop, "v2"), "another victim record", None);
+    assert_eq!(index.total_docs(), 3);
+
+    branches.delete("victim").unwrap();
+
+    // Subsystem hook ran inline on delete: victim docs are gone, keeper stays.
+    assert_eq!(index.total_docs(), 1);
+    assert_eq!(index.doc_freq("victim"), 0);
+    assert_eq!(index.doc_freq("alpha"), 1);
+}
+
+#[test]
+fn search_cleanup_persists_to_manifest() {
+    // After cleanup_deleted_branch fires, the persisted manifest must not
+    // reference the deleted branch's docs — otherwise reopen would
+    // resurrect them.
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+
+    let branch_keep = resolve_branch_name("keeper");
+    let branch_drop = resolve_branch_name("victim");
+
+    {
+        let db = Database::open_runtime(
+            crate::database::OpenSpec::primary(&db_path).with_subsystem(SearchSubsystem),
+        )
+        .unwrap();
+
+        let index = db.extension::<InvertedIndex>().unwrap();
+        let branches = db.branches();
+        branches.create("keeper").unwrap();
+        branches.create("victim").unwrap();
+
+        index.index_document(&kv_ref(branch_keep, "k1"), "alpha shared text", None);
+        index.index_document(&kv_ref(branch_drop, "v1"), "victim only document", None);
+
+        // Force a freeze before the delete so the persisted manifest contains
+        // the victim doc — that guarantees we are testing rewrite-on-cleanup
+        // rather than just an unfrozen state.
+        SearchSubsystem.freeze(&db).unwrap();
+
+        branches.delete("victim").unwrap();
+
+        // Shutdown freezes the index again; cleanup_deleted_branch should
+        // already have done so but a final shutdown freeze is a fair test.
+        db.shutdown().unwrap();
+    }
+
+    // Reopen and check that the recovered index has no victim docs.
+    let db = Database::open_runtime(
+        crate::database::OpenSpec::primary(&db_path).with_subsystem(SearchSubsystem),
+    )
+    .unwrap();
+
+    let index = db.extension::<InvertedIndex>().unwrap();
+
+    // Live document count reflects the post-cleanup state, not the
+    // pre-cleanup snapshot. Sealed-segment doc_freq is unaffected (it
+    // tracks raw term counts and relies on tombstones at query time),
+    // so the right invariants here are total_docs and has_document.
+    assert_eq!(
+        index.total_docs(),
+        1,
+        "total_docs must reflect cleanup after reopen"
+    );
+    assert!(
+        index.has_document(&kv_ref(branch_keep, "k1")),
+        "keeper doc must survive reopen"
+    );
+    assert!(
+        !index.has_document(&kv_ref(branch_drop, "v1")),
+        "victim doc must not be present after reopen"
+    );
+}
+
+#[test]
+fn search_cleanup_is_noop_for_branch_with_no_indexed_docs() {
+    // A branch deletion when the branch has zero indexed documents must
+    // be a clean noop — no spurious freeze, no error.
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let db = Database::open_runtime(
+        crate::database::OpenSpec::primary(&db_path).with_subsystem(SearchSubsystem),
+    )
+    .unwrap();
+
+    let index = db.extension::<InvertedIndex>().unwrap();
+    let branches = db.branches();
+    branches.create("keeper").unwrap();
+    branches.create("empty").unwrap();
+    let branch_keep = resolve_branch_name("keeper");
+
+    // Only the keeper branch has indexed docs; the empty branch never gets
+    // an `index_document` call.
+    index.index_document(&kv_ref(branch_keep, "k1"), "alpha", None);
+    assert_eq!(index.total_docs(), 1);
+
+    branches.delete("empty").unwrap();
+
+    // Keeper untouched; empty's deletion did not error and removed nothing.
+    assert_eq!(index.total_docs(), 1);
+    assert!(index.has_document(&kv_ref(branch_keep, "k1")));
+}

--- a/crates/engine/src/database/tests/snapshot_retention.rs
+++ b/crates/engine/src/database/tests/snapshot_retention.rs
@@ -1,0 +1,178 @@
+//! Regression tests for D7 / DG-015 snapshot retention.
+
+use super::*;
+use strata_durability::list_snapshots;
+
+fn write_one(db: &Database, branch_id: BranchId, key_name: &str) {
+    let ns = create_test_namespace(branch_id);
+    let key = Key::new_kv(ns, key_name);
+    db.transaction(branch_id, |txn| {
+        txn.put(key.clone(), Value::String("payload".into()))?;
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn prune_keeps_retain_count_newest_snapshots() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let db = Database::open(&db_path).unwrap();
+
+    {
+        let mut cfg = db.config.write();
+        cfg.snapshot_retention.retain_count = 3;
+    }
+
+    let branch_id = BranchId::new();
+    for i in 0..10 {
+        write_one(&db, branch_id, &format!("k{}", i));
+        db.checkpoint().unwrap();
+    }
+
+    let snapshots_dir = db_path.canonicalize().unwrap().join("snapshots");
+    let snapshots = list_snapshots(&snapshots_dir).unwrap();
+    assert_eq!(
+        snapshots.len(),
+        3,
+        "expected exactly retain_count=3 snapshots after 10 checkpoints"
+    );
+
+    // The kept ids should be the three highest. Snapshot ids start at 1.
+    let kept_ids: Vec<u64> = snapshots.iter().map(|(id, _)| *id).collect();
+    assert_eq!(kept_ids, vec![8, 9, 10]);
+}
+
+#[test]
+fn prune_preserves_live_manifest_snapshot_in_steady_state() {
+    // Steady-state check: with retain_count=1 and a sequence of
+    // checkpoints, the post-checkpoint pruner always preserves the live
+    // MANIFEST snapshot because in normal operation MANIFEST.snapshot_id ==
+    // the newest snap-id.
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let db = Database::open(&db_path).unwrap();
+
+    {
+        let mut cfg = db.config.write();
+        cfg.snapshot_retention.retain_count = 1;
+    }
+
+    let branch_id = BranchId::new();
+    for i in 0..5 {
+        write_one(&db, branch_id, &format!("k{}", i));
+        db.checkpoint().unwrap();
+    }
+
+    let snapshots_dir = db_path.canonicalize().unwrap().join("snapshots");
+    let kept_ids: Vec<u64> = list_snapshots(&snapshots_dir)
+        .unwrap()
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect();
+
+    assert_eq!(
+        kept_ids.len(),
+        1,
+        "retain_count=1 should leave one snapshot"
+    );
+
+    let manifest_path = db_path.canonicalize().unwrap().join("MANIFEST");
+    let manifest = strata_durability::ManifestManager::load(manifest_path).unwrap();
+    let live_id = manifest.manifest().snapshot_id.unwrap();
+    assert_eq!(kept_ids[0], live_id);
+}
+
+#[test]
+fn prune_preserves_live_manifest_snapshot_when_outside_retain_window() {
+    // Corner case: MANIFEST.snapshot_id points to an OLD snapshot that
+    // would otherwise fall outside `retain_count`. This can happen in
+    // production if a checkpoint wrote the snap-N+1 file but failed to
+    // update MANIFEST (so MANIFEST still points at N, while snap-N+1 is
+    // an orphan on disk).
+    //
+    // The guard must keep both:
+    //   - the `retain_count` newest snapshots
+    //   - the live MANIFEST snapshot, even if not in the newest window
+    //
+    // Engineered here by manually rewriting MANIFEST to point at an older
+    // snapshot and then calling `prune_snapshots_once` directly.
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let db = Database::open(&db_path).unwrap();
+
+    {
+        let mut cfg = db.config.write();
+        cfg.snapshot_retention.retain_count = 10;
+    }
+
+    let branch_id = BranchId::new();
+    for i in 0..5 {
+        write_one(&db, branch_id, &format!("k{}", i));
+        db.checkpoint().unwrap();
+    }
+
+    let canonical = db_path.canonicalize().unwrap();
+    let snapshots_dir = canonical.join("snapshots");
+    let manifest_path = canonical.join("MANIFEST");
+
+    // Snap ids are 1..=5; MANIFEST currently points at 5. Rewrite to 2.
+    {
+        let mut manifest = strata_durability::ManifestManager::load(manifest_path.clone()).unwrap();
+        let prev_watermark_txn = TxnId(manifest.manifest().snapshot_watermark.unwrap_or(0));
+        manifest
+            .set_snapshot_watermark(2, prev_watermark_txn)
+            .unwrap();
+    }
+
+    // Now tighten retain_count to 2 and prune.
+    {
+        let mut cfg = db.config.write();
+        cfg.snapshot_retention.retain_count = 2;
+    }
+    db.prune_snapshots_once().unwrap();
+
+    let mut kept_ids: Vec<u64> = list_snapshots(&snapshots_dir)
+        .unwrap()
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect();
+    kept_ids.sort_unstable();
+
+    // Newest 2 (4, 5) plus live MANIFEST (2) = 3 files retained.
+    // Ids 1 and 3 are pruned (in delete window, not live).
+    assert_eq!(
+        kept_ids,
+        vec![2, 4, 5],
+        "live MANIFEST snapshot (2) must be preserved alongside the retain_count=2 newest (4, 5)"
+    );
+}
+
+#[test]
+fn prune_noop_when_under_retain_count() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let db = Database::open(&db_path).unwrap();
+
+    let branch_id = BranchId::new();
+    write_one(&db, branch_id, "k0");
+    db.checkpoint().unwrap();
+    write_one(&db, branch_id, "k1");
+    db.checkpoint().unwrap();
+
+    // Default retain_count is 10; only 2 snapshots → noop.
+    let snapshots_dir = db_path.canonicalize().unwrap().join("snapshots");
+    let snapshots = list_snapshots(&snapshots_dir).unwrap();
+    assert_eq!(snapshots.len(), 2);
+
+    // Direct invocation also reports zero deletions.
+    assert_eq!(db.prune_snapshots_once().unwrap(), 0);
+}
+
+#[test]
+fn prune_skipped_for_ephemeral_database() {
+    let db = Database::cache().unwrap();
+    // Ephemeral mode has no on-disk snapshots; pruner returns 0.
+    assert_eq!(db.prune_snapshots_once().unwrap(), 0);
+}

--- a/crates/engine/src/search/index.rs
+++ b/crates/engine/src/search/index.rs
@@ -1322,6 +1322,34 @@ impl InvertedIndex {
         n
     }
 
+    /// Remove every indexed document whose `EntityRef` lives in `branch_id`,
+    /// regardless of space. Returns the number of refs removed.
+    ///
+    /// Same lock discipline as `remove_documents_in_space` (snapshot under
+    /// read lock, drop, then per-doc removal under write locks).
+    ///
+    /// Used by `SearchSubsystem::cleanup_deleted_branch` after a branch
+    /// delete to purge persisted document metadata so the next freeze writes
+    /// a manifest with the deleted branch's docs gone (closes DG-017).
+    pub fn remove_documents_in_branch(&self, branch_id: BranchId) -> usize {
+        if !self.is_enabled() {
+            return 0;
+        }
+        let to_remove: Vec<EntityRef> = {
+            let guard = self.doc_id_map.id_to_ref.read().unwrap();
+            guard
+                .iter()
+                .filter(|r| r.branch_id() == branch_id)
+                .cloned()
+                .collect()
+        };
+        let n = to_remove.len();
+        for r in &to_remove {
+            self.remove_document(r);
+        }
+        n
+    }
+
     // ========================================================================
     // Seal & Persistence
     // ========================================================================
@@ -1875,6 +1903,52 @@ mod tests {
         assert_eq!(index.doc_freq("hello"), 0); // old term gone
         assert_eq!(index.doc_freq("planet"), 1); // new term present
         assert_eq!(index.doc_freq("world"), 1); // shared term still 1
+    }
+
+    /// DG-017: `remove_documents_in_branch` purges every doc owned by a
+    /// branch and leaves docs in other branches untouched. Asserts on the
+    /// per-doc presence (`has_document`) and live count (`total_docs`); raw
+    /// `doc_freq` is unaffected for tombstoned sealed-segment terms by
+    /// design and so is not used here.
+    #[test]
+    fn test_remove_documents_in_branch() {
+        let index = InvertedIndex::new();
+        index.enable();
+
+        let branch_a = BranchId::new();
+        let branch_b = BranchId::new();
+
+        let make_ref = |branch_id, key: &str| EntityRef::Kv {
+            branch_id,
+            space: "default".to_string(),
+            key: key.to_string(),
+        };
+
+        let a1 = make_ref(branch_a, "a1");
+        let a2 = make_ref(branch_a, "a2");
+        let b1 = make_ref(branch_b, "b1");
+
+        index.index_document(&a1, "alpha doc one", None);
+        index.index_document(&a2, "alpha doc two", None);
+        index.index_document(&b1, "beta doc only", None);
+        assert_eq!(index.total_docs(), 3);
+
+        let removed = index.remove_documents_in_branch(branch_a);
+        assert_eq!(removed, 2);
+        assert_eq!(index.total_docs(), 1);
+
+        assert!(!index.has_document(&a1));
+        assert!(!index.has_document(&a2));
+        assert!(index.has_document(&b1));
+
+        // Calling again on the now-empty branch is idempotent w.r.t. state
+        // (total_docs unchanged, has_document still false). Mirrors
+        // `remove_documents_in_space`: the count returned reflects matching
+        // doc_id_map entries (not actual removals), and the underlying
+        // `remove_document` is a noop for already-removed docs.
+        let _ = index.remove_documents_in_branch(branch_a);
+        assert_eq!(index.total_docs(), 1);
+        assert!(!index.has_document(&a1));
     }
 
     // ====================================================================

--- a/crates/engine/src/search/manifest.rs
+++ b/crates/engine/src/search/manifest.rs
@@ -6,7 +6,7 @@
 //! - Global stats (total_docs, total_doc_len, next_segment_id)
 //! - Per-segment tombstone sets (deleted doc_ids)
 //!
-//! Written atomically via temp + rename (same as vector mmap pattern).
+//! Written atomically via temp + rename + parent-dir fsync.
 
 use super::types::EntityRef;
 use serde::{Deserialize, Serialize};
@@ -77,7 +77,7 @@ pub(crate) struct SegmentManifestEntry {
 // Read / Write
 // ============================================================================
 
-/// Write manifest data to a file atomically (temp + rename).
+/// Write manifest data to a file atomically (temp + rename + parent-dir fsync).
 pub(crate) fn write_manifest(path: &Path, data: &ManifestData) -> io::Result<()> {
     let dir = path.parent().unwrap_or(Path::new("."));
     std::fs::create_dir_all(dir)?;
@@ -92,7 +92,9 @@ pub(crate) fn write_manifest(path: &Path, data: &ManifestData) -> io::Result<()>
     buf.extend_from_slice(&MANIFEST_VERSION.to_le_bytes());
     buf.extend_from_slice(&payload);
 
-    // Atomic write: temp + fsync + rename
+    // Atomic publish: temp + file fsync + rename + directory fsync.
+    // Because the manifest is written after any new `.sidx` files, the final
+    // directory fsync also makes those earlier rename operations durable.
     let tmp_path = path.with_extension("manifest.tmp");
     {
         use std::io::Write;
@@ -101,6 +103,7 @@ pub(crate) fn write_manifest(path: &Path, data: &ManifestData) -> io::Result<()>
         file.sync_all()?;
     }
     std::fs::rename(&tmp_path, path)?;
+    std::fs::File::open(dir)?.sync_all()?;
     Ok(())
 }
 

--- a/crates/engine/src/search/recovery.rs
+++ b/crates/engine/src/search/recovery.rs
@@ -560,6 +560,68 @@ impl crate::recovery::Subsystem for SearchSubsystem {
     fn freeze(&self, db: &crate::database::Database) -> strata_core::StrataResult<()> {
         db.freeze_search_index()
     }
+
+    /// Production owner for search-cache deletion on branch drop (closes
+    /// DG-017). Two-phase, best-effort:
+    ///
+    ///   1. In-memory: remove all documents in the deleted branch from the
+    ///      shared `InvertedIndex` so subsequent searches don't return stale
+    ///      hits.
+    ///   2. On-disk: re-freeze the index so the persisted `search.manifest`
+    ///      no longer references the deleted branch's `doc_id_map` entries.
+    ///      Without this, a restart would resurrect the stale documents.
+    ///
+    /// Search uses a single global manifest (not per-branch directories),
+    /// so the cleanup is surgical rather than directory-wipe (contrast with
+    /// `VectorSubsystem::cleanup_deleted_branch`). Sealed `.sidx` segment
+    /// files retain tombstones for the removed docs and self-clean on the
+    /// next seal/compaction cycle — DG-017 only requires the deletion to
+    /// have an owner, not a stronger physical compaction.
+    ///
+    /// Errors are logged at `warn!` and swallowed: the branch deletion is
+    /// already committed when this hook runs, per the trait contract at
+    /// `crates/engine/src/recovery/subsystem.rs`.
+    ///
+    /// **Concurrency note:** `freeze_search_index` writes the global
+    /// `search.manifest` via a fixed `search.manifest.tmp` path with no
+    /// inter-call serialization. Two concurrent branch deletes (or a
+    /// concurrent freeze on shutdown) can race on that temp file. The race
+    /// is pre-existing — `InvertedIndex::freeze_to_disk` is documented as a
+    /// single-writer operation and is not introduced by this hook. If the
+    /// race surfaces in practice, an internal mutex inside `freeze_to_disk`
+    /// is the right place to fix it.
+    fn cleanup_deleted_branch(
+        &self,
+        db: &std::sync::Arc<crate::database::Database>,
+        branch_id: &strata_core::types::BranchId,
+        branch_name: &str,
+    ) -> strata_core::StrataResult<()> {
+        let Ok(index) = db.extension::<InvertedIndex>() else {
+            return Ok(());
+        };
+
+        let removed = index.remove_documents_in_branch(*branch_id);
+
+        if removed > 0 {
+            if let Err(e) = db.freeze_search_index() {
+                tracing::warn!(
+                    target: "strata::search",
+                    branch = branch_name,
+                    error = %e,
+                    "Failed to persist search index after branch cleanup"
+                );
+            } else {
+                tracing::info!(
+                    target: "strata::search",
+                    branch = branch_name,
+                    removed,
+                    "Search index purged for deleted branch"
+                );
+            }
+        }
+
+        Ok(())
+    }
 }
 
 // =============================================================================

--- a/crates/engine/tests/config_matrix.rs
+++ b/crates/engine/tests/config_matrix.rs
@@ -32,6 +32,7 @@ const STRATA_CONFIG_FIELDS: &[&str] = &[
     "allow_lossy_recovery",
     "telemetry",
     "default_vector_dtype",
+    "snapshot_retention",
 ];
 
 /// Every public field on `StorageConfig` (nested under `storage`).

--- a/crates/engine/tests/follower_tests.rs
+++ b/crates/engine/tests/follower_tests.rs
@@ -2012,6 +2012,10 @@ fn test_follower_rejects_tampered_blocked_state_on_reopen() {
         !status.is_blocked(),
         "tampered state must be rejected; reopen must not carry the bogus blocked txn"
     );
+    assert!(
+        !state_path.exists(),
+        "reopen should clear the rejected follower_state.json instead of leaving stale state behind"
+    );
 }
 
 /// D6: a persisted hook-failure blocked state must keep the post-apply

--- a/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
+++ b/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
@@ -55,6 +55,7 @@ The classification is load-bearing in three places:
 | `allow_lossy_recovery` | open-time-only | yes (`CompatibilitySignature.allow_lossy_recovery`; also hashed into `open_config_fingerprint`) | rejected at runtime via `OPEN_TIME_ONLY_KEYS`. When `true`, any recovery error triggers a whole-database wipe-and-reopen; the fallback is observable via `Database::last_lossy_recovery_report()` (`Option<LossyRecoveryReport>`) and tracing target `strata::recovery::lossy` (see DR-011 and D-DR-9 in `durability-recovery-scope.md`). |
 | `telemetry` | non-durability | no | — |
 | `default_vector_dtype` | non-durability | no | — |
+| `snapshot_retention` | live-safe | no | `Database::prune_snapshots_once` (pub(crate)); invoked automatically post-checkpoint. Knob: `snapshot_retention.retain_count` (defaults to 10). The live MANIFEST snapshot is always preserved regardless of retain_count. Closes DG-015. |
 
 ## `StorageConfig` — nested under `storage`
 


### PR DESCRIPTION
## Summary

Closes the four storage-independent durability gaps in epic **D7** (`docs/design/durability/durability-storage-closure-epics.md`).

- **DG-015** (snapshot retention owner) — `SnapshotRetentionPolicy.retain_count` (default 10) on `StrataConfig` + `pub(crate) Database::prune_snapshots_once` invoked best-effort post-checkpoint. Always preserves the live MANIFEST snapshot even when it falls outside the retain window.
- **DG-017** (search-cache deletion owner) — `SearchSubsystem::cleanup_deleted_branch` purges in-memory docs via new `InvertedIndex::remove_documents_in_branch`, then re-freezes the global `search.manifest` so reopen does not resurrect stale state. `search::manifest::write_manifest` also gained a parent-dir fsync.
- **DG-018** (atomic + durable + reopen-coherent `strata.toml`) —
  - **Atomicity + durability:** `StrataConfig::write_to_file` and `write_default_if_missing` publish via temp-file + file fsync + atomic rename + parent-dir fsync.
  - **WAL deadline isolation:** `WalWriter` now tracks `last_sync_time` (the real WAL fsync deadline used by the background flush thread) and `last_inline_sync_time` (the Standard-mode inline-fallback safety net) separately. After every control-artifact write the engine calls `refresh_inline_sync_deadline`, which advances only the inline-fallback timestamp — the background flush thread still observes any actual overdue WAL backlog.
  - **Reopen coherence:** `Database::open` rejects registry reuse with `IncompatibleReuse` when **either** the on-disk `strata.toml` drifted from the running instance (`validate_control_artifact_reuse`) **or** the explicit programmatic config passed to `open_with_config` diverges from the running instance's config (`validate_requested_config_reuse`).
- **DG-019** (snapshot naming doc drift) — fixed `crates/durability/src/layout.rs:93` from `snapshot-NNNNNNNNNN.chk` to actual `snap-NNNNNN.chk`.

### Adjacent durability cleanup

- **Stale follower_state cleanup:** when `Database::open` rejects a persisted `follower_state.json` as inconsistent, the file is now deleted from disk so the bad state isn't re-read on every subsequent reopen. Best-effort: errors logged.

## Surface impact

- 1 new `pub` config struct: `SnapshotRetentionPolicy` (reachable via `StrataConfig`, listed in `durability-recovery-config-matrix.md`, registered in `config_matrix` regression).
- 1 new `pub fn` on internal `InvertedIndex`: `remove_documents_in_branch`.
- 1 new `pub(crate)` method `WalWriter::refresh_inline_sync_deadline` (exposed through the `__internal::WalWriterEngineExt` trait already used by the engine).
- Neither changes the engine D4 surface.

## Change class / Assurance

Mixed: intentional semantic change for retention/cleanup/reuse-policy (S3); refactor-only for atomic write + doc fix (S2).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets` no errors
- [x] `cargo test -p strata-engine` 1013 lib tests + all integration suites pass
- [x] `cargo test -p strata-durability` 352 passed
- [x] `cargo fmt --all -- --check` clean
- [x] D7 targeted regressions:
  - `database::tests::snapshot_retention` (4 tests): retain-count enforcement, live-snap preservation in steady state, **live-snap preservation when outside the retain window** (engineered via direct MANIFEST manipulation), under-count noop, ephemeral skip
  - `database::tests::search_branch_cleanup` (3 tests): in-memory cleanup, persistence-across-reopen, **empty-branch noop**
  - `search::index::tests::test_remove_documents_in_branch` (1 test): branch isolation + idempotence
  - `database::tests::open::test_open_rejects_registry_reuse_when_strata_toml_drifted` (1 test): on-disk strata.toml drift → `IncompatibleReuse`
  - `database::tests::open::test_open_with_config_rejects_registry_reuse_when_requested_config_drifted` (1 test): explicit programmatic config drift → `IncompatibleReuse`
  - `database::tests::open::test_concurrent_open_same_path_returns_same_instance` (1 test): replaces a long-`#[ignore]`d singleton-race test with a real `Barrier`-based concurrent open assertion (`Arc::ptr_eq`)
  - `wal::writer::tests::test_refresh_inline_sync_deadline_does_not_delay_background_sync` (1 test): pins that refreshing the inline-fallback deadline does **not** delay the real background WAL sync deadline
  - `tests::test_follower_rejects_tampered_blocked_state_on_reopen` extended to assert the rejected `follower_state.json` is deleted, not left on disk
- [x] All shutdown halt-latch tests (`database::tests::shutdown::*`) green — `WalWriter::refresh_inline_sync_deadline` is called after every `set_durability_mode` / `update_config` write so the inline-sync fallback no longer races

🤖 Generated with [Claude Code](https://claude.com/claude-code)