### PR TITLE
SE2: storage recovery integrity — self-contained RecoveredState outcome

### DIFF
--- a/crates/durability/src/layout.rs
+++ b/crates/durability/src/layout.rs
@@ -129,10 +129,25 @@ impl DatabaseLayout {
     ///
     /// Returns an IO error if directory creation fails.
     pub fn create_dirs(&self) -> std::io::Result<()> {
+        self.create_non_segment_dirs()?;
+        self.create_segments_dir()?;
+        Ok(())
+    }
+
+    /// Ensure the non-authoritative support directories exist.
+    ///
+    /// Creates `wal/` and `snapshots/` if needed, but intentionally leaves
+    /// `segments/` alone so reopen flows can distinguish a missing storage
+    /// root from a fresh database with no flushed state yet.
+    pub fn create_non_segment_dirs(&self) -> std::io::Result<()> {
         std::fs::create_dir_all(&self.wal_dir)?;
-        std::fs::create_dir_all(&self.segments_dir)?;
         std::fs::create_dir_all(&self.snapshots_dir)?;
         Ok(())
+    }
+
+    /// Ensure the storage root exists.
+    pub fn create_segments_dir(&self) -> std::io::Result<()> {
+        std::fs::create_dir_all(&self.segments_dir)
     }
 
     /// Check if the WAL directory exists.
@@ -195,6 +210,21 @@ mod tests {
 
         // MANIFEST is not created by create_dirs
         assert!(!layout.manifest_exists());
+    }
+
+    #[test]
+    fn test_create_non_segment_dirs_skips_segments() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(dir.path());
+
+        layout.create_non_segment_dirs().unwrap();
+
+        assert!(layout.wal_dir().exists());
+        assert!(layout.snapshots_dir().exists());
+        assert!(
+            !layout.segments_dir().exists(),
+            "support-dir creation must not recreate the authoritative storage root"
+        );
     }
 
     #[test]

--- a/crates/engine/src/coordinator.rs
+++ b/crates/engine/src/coordinator.rs
@@ -21,7 +21,7 @@ use strata_core::types::BranchId;
 use strata_core::StrataError;
 use strata_core::StrataResult;
 use strata_durability::wal::WalWriter;
-use strata_storage::SegmentedStore;
+use strata_storage::{RecoveredState, SegmentedStore};
 use tracing::{debug, info, warn};
 
 /// Transaction coordinator for the database
@@ -405,6 +405,27 @@ impl TransactionCoordinator {
         self.manager.bump_version_floor(floor);
     }
 
+    /// Apply a completed storage recovery to the coordinator.
+    ///
+    /// This is the single entry point through which storage hands its
+    /// self-contained recovery outcome to the engine. It adopts the
+    /// version floor carried by the outcome; per-branch `max_version` state
+    /// and classified recovery health are already installed storage-side
+    /// (storage calls `BranchState::track_version` during the walk and
+    /// stores the classified health on the `SegmentedStore` itself, so
+    /// there is nothing to mirror here).
+    ///
+    /// Callers should invoke this exactly once per recovery, immediately
+    /// after `storage.recover_segments()` returns `Ok`. Strict-vs-lossy
+    /// policy on `outcome.health` is the engine's concern (D4); this entry
+    /// point does not refuse, log, or interpret the health — it only wires
+    /// the version floor.
+    pub fn apply_storage_recovery(&self, outcome: &RecoveredState) {
+        if outcome.version_floor > CommitVersion::ZERO {
+            self.manager.bump_version_floor(outcome.version_floor);
+        }
+    }
+
     /// Get the current version after draining all in-flight commits (#1710).
     pub fn quiesced_version(&self) -> u64 {
         self.manager.quiesced_version()
@@ -728,10 +749,10 @@ mod tests {
 
         let seg_info = result.storage.recover_segments().unwrap();
         assert_eq!(seg_info.segments_loaded, 1);
-        assert_eq!(seg_info.max_commit_id, CommitVersion(100));
+        assert_eq!(seg_info.version_floor, CommitVersion(100));
 
         let coordinator = TransactionCoordinator::from_recovery_with_limits(&result, 0);
-        coordinator.bump_version_floor(seg_info.max_commit_id);
+        coordinator.apply_storage_recovery(&seg_info);
         assert_eq!(coordinator.current_version(), CommitVersion(100));
     }
 

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -961,8 +961,7 @@ impl Database {
                         segments = outcome.segments_loaded,
                         "Recovered segments from disk");
                 }
-                if let strata_storage::RecoveryHealth::Degraded { faults, class } =
-                    &outcome.health
+                if let strata_storage::RecoveryHealth::Degraded { faults, class } = &outcome.health
                 {
                     warn!(
                         target: "strata::recovery::health",

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -675,7 +675,7 @@ impl Database {
 
         let bg_threads = cfg.storage.background_threads.max(1);
 
-        Self::recover_segments_and_bump(&storage, &coordinator, cfg.allow_lossy_recovery)?;
+        Self::recover_segments_and_apply(&storage, &coordinator, cfg.allow_lossy_recovery)?;
 
         // `database_uuid` was already resolved from the MANIFEST above (or
         // defaulted when absent) before recovery ran, so the snapshot-install
@@ -930,24 +930,48 @@ impl Database {
         }
     }
 
-    /// Recover on-disk segments and bump the coordinator's version floor.
-    fn recover_segments_and_bump(
+    /// Recover on-disk segments and apply the typed outcome to the coordinator.
+    ///
+    /// Storage returns a self-contained `RecoveredState` (SE2) carrying the
+    /// version floor, per-branch version map, and a classified
+    /// `RecoveryHealth`. This entry point:
+    ///
+    /// - Emits telemetry summarising the outcome.
+    /// - Forwards the outcome through `coordinator.apply_storage_recovery`
+    ///   (single entry point for floor adoption post-SE2).
+    /// - On `Err(StorageError)` (pre-walk I/O failure), preserves the
+    ///   existing `allow_lossy` split: lossy callers log and continue, strict
+    ///   callers convert to `StrataError::corruption`.
+    ///
+    /// Strict-vs-lossy policy on `outcome.health` (e.g. refusing on
+    /// `DegradationClass::DataLoss`) is intentionally NOT applied here —
+    /// that is D4's scope, implemented inside the unified
+    /// `Database::run_recovery` orchestrator that D3 introduces. SE2
+    /// produces the classified outcome; D4 decides what to do with it.
+    fn recover_segments_and_apply(
         storage: &Arc<SegmentedStore>,
         coordinator: &TransactionCoordinator,
         allow_lossy: bool,
     ) -> StrataResult<()> {
         match storage.recover_segments() {
-            Ok(seg_info) => {
-                if seg_info.segments_loaded > 0 {
+            Ok(outcome) => {
+                if outcome.segments_loaded > 0 {
                     info!(target: "strata::db",
-                        branches = seg_info.branches_recovered,
-                        segments = seg_info.segments_loaded,
-                        errors_skipped = seg_info.errors_skipped,
+                        branches = outcome.branches_recovered,
+                        segments = outcome.segments_loaded,
                         "Recovered segments from disk");
                 }
-                if seg_info.max_commit_id > CommitVersion::ZERO {
-                    coordinator.bump_version_floor(seg_info.max_commit_id);
+                if let strata_storage::RecoveryHealth::Degraded { faults, class } =
+                    &outcome.health
+                {
+                    warn!(
+                        target: "strata::recovery::health",
+                        class = ?class,
+                        fault_count = faults.len(),
+                        "storage recovered with degraded state"
+                    );
                 }
+                coordinator.apply_storage_recovery(&outcome);
             }
             Err(e) => {
                 warn!(target: "strata::db", error = %e, "Segment recovery failed");
@@ -1234,7 +1258,7 @@ impl Database {
 
         let bg_threads = cfg.storage.background_threads.max(1);
 
-        Self::recover_segments_and_bump(&storage, &coordinator, cfg.allow_lossy_recovery)?;
+        Self::recover_segments_and_apply(&storage, &coordinator, cfg.allow_lossy_recovery)?;
 
         let db = Arc::new(Self {
             data_dir: canonical_path.clone(),

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -443,7 +443,8 @@ impl Database {
         // follower to silently serve stale / empty state once pre-snapshot
         // WAL has been reclaimed. Only a genuinely absent MANIFEST (fresh
         // database) degrades to WAL-only recovery.
-        let (database_uuid, follower_codec) = if ManifestManager::exists(&manifest_path) {
+        let manifest_exists = ManifestManager::exists(&manifest_path);
+        let (database_uuid, follower_codec) = if manifest_exists {
             let m = ManifestManager::load(manifest_path.clone()).map_err(|err| match err {
                 legacy @ ManifestError::LegacyFormat { .. } => {
                     manifest_error_to_strata_error(legacy)
@@ -474,6 +475,20 @@ impl Database {
         } else {
             ([0u8; 16], None)
         };
+
+        if !manifest_exists {
+            match layout
+                .segments_dir()
+                .try_exists()
+                .map_err(StrataError::from)?
+            {
+                true => {}
+                false => {
+                    layout.create_segments_dir().map_err(StrataError::from)?;
+                    restrict_dir(layout.segments_dir());
+                }
+            }
+        }
 
         // T3-E12 §D7: follower-without-MANIFEST falls back to the
         // follower's own config codec so encrypted WAL-only recovery
@@ -1010,14 +1025,18 @@ impl Database {
         // Build canonical layout for this database
         let layout = DatabaseLayout::from_root(&canonical_path);
 
-        // Create directories (WAL, segments, snapshots)
-        layout.create_dirs().map_err(StrataError::from)?;
+        // Create only the non-authoritative support directories up front.
+        // Recreating `segments/` here on reopen would mask authoritative
+        // flushed-state loss before storage recovery has a chance to classify it.
+        layout
+            .create_non_segment_dirs()
+            .map_err(StrataError::from)?;
         restrict_dir(layout.wal_dir());
-        restrict_dir(layout.segments_dir());
         restrict_dir(layout.snapshots_dir());
 
         let wal_dir = layout.wal_dir().to_path_buf();
         let manifest_path = layout.manifest_path().to_path_buf();
+        let manifest_exists = ManifestManager::exists(&manifest_path);
 
         // Load or create MANIFEST before recovery runs so the coordinator can
         // consult it for snapshot identity and codec validation. On first
@@ -1031,7 +1050,7 @@ impl Database {
         // otherwise a misconfigured reopen would silently discard the
         // database instead of alerting the operator. Keeping the check here
         // keeps it ahead of the lossy branch.
-        let database_uuid = if ManifestManager::exists(&manifest_path) {
+        let database_uuid = if manifest_exists {
             let m = ManifestManager::load(manifest_path.clone())
                 .map_err(manifest_error_to_strata_error)?;
             let stored_codec = &m.manifest().codec_id;
@@ -1046,11 +1065,17 @@ impl Database {
             }
             m.manifest().database_uuid
         } else {
+            layout.create_segments_dir().map_err(StrataError::from)?;
+            restrict_dir(layout.segments_dir());
             let uuid = *uuid::Uuid::new_v4().as_bytes();
             ManifestManager::create(manifest_path, uuid, cfg.storage.codec.clone())
                 .map_err(|e| StrataError::internal(format!("failed to create MANIFEST: {}", e)))?;
             uuid
         };
+
+        if matches!(layout.segments_dir().try_exists(), Ok(true)) {
+            restrict_dir(layout.segments_dir());
+        }
 
         // Instantiate the configured storage codec (identity or aes-gcm-256).
         // One instance is owned here for the WAL writer; a clone is handed to

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -233,6 +233,50 @@ fn test_open_same_path_returns_same_instance() {
 
 #[test]
 #[serial(open_databases)]
+fn test_open_rejects_missing_segments_root_after_manifest_exists() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("missing_segments_root");
+    let branch_id = BranchId::new();
+    let ns = Arc::new(Namespace::new(branch_id, "default".to_string()));
+
+    {
+        let db = Database::open(&db_path).unwrap();
+        db.transaction(branch_id, |txn| {
+            txn.put(
+                Key::new_kv(ns.clone(), "persistent"),
+                Value::Bytes(b"segment-backed".to_vec()),
+            )?;
+            Ok(())
+        })
+        .unwrap();
+        db.flush().unwrap();
+        db.shutdown().unwrap();
+    }
+    OPEN_DATABASES.lock().clear();
+
+    let segments_dir = db_path.join("segments");
+    assert!(
+        segments_dir.exists(),
+        "test setup must create the authoritative storage root before deleting it"
+    );
+    std::fs::remove_dir_all(&segments_dir).unwrap();
+
+    let err = match Database::open(&db_path) {
+        Ok(_) => panic!("strict reopen must refuse a database whose segments root vanished"),
+        Err(err) => err,
+    };
+    assert!(
+        matches!(err, StrataError::Corruption { .. }),
+        "missing authoritative segments root must surface as corruption, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("segments directory"),
+        "error should name the missing storage root, got: {err}"
+    );
+}
+
+#[test]
+#[serial(open_databases)]
 fn test_open_with_config_rejects_registry_reuse_when_requested_config_drifted() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("reuse_requested_config_drift");

--- a/crates/engine/tests/follower_tests.rs
+++ b/crates/engine/tests/follower_tests.rs
@@ -1756,6 +1756,47 @@ fn test_follower_without_manifest_uses_config_codec() {
     follower.shutdown().unwrap();
 }
 
+/// SE2 follow-up: a MANIFEST-absent follower open is a WAL-only bootstrap
+/// case, so it must not fail just because `segments/` is absent.
+#[test]
+#[serial(open_databases)]
+fn test_follower_without_manifest_tolerates_missing_segments_root() {
+    let dir = tempdir().unwrap();
+    let branch = BranchId::default();
+
+    {
+        let primary =
+            Database::open_runtime(OpenSpec::primary(dir.path()).with_subsystem(SearchSubsystem))
+                .unwrap();
+        primary_put(&primary, branch, "k", "v-from-primary");
+        primary.shutdown().unwrap();
+    }
+
+    let manifest_path = dir.path().join("MANIFEST");
+    if manifest_path.exists() {
+        std::fs::remove_file(&manifest_path).unwrap();
+    }
+    let segments_dir = dir.path().join("segments");
+    if segments_dir.exists() {
+        std::fs::remove_dir_all(&segments_dir).unwrap();
+    }
+
+    let follower =
+        Database::open_runtime(OpenSpec::follower(dir.path()).with_subsystem(SearchSubsystem))
+            .expect(
+                "MANIFEST-absent follower open must stay WAL-only even when the \
+         segments root is absent",
+            );
+
+    assert_eq!(
+        read_kv(&follower, branch, "k").as_deref(),
+        Some("v-from-primary"),
+        "follower should recover from WAL without requiring a preexisting segments root",
+    );
+
+    follower.shutdown().unwrap();
+}
+
 /// T3-E11 / DR-011 regression guard for the follower open/refresh policy matrix.
 ///
 /// The mixed policy is documented in

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -18,6 +18,10 @@ pub enum StorageError {
     #[error(transparent)]
     Io(#[from] io::Error),
 
+    /// `recover_segments()` was invoked more than once on the same store.
+    #[error("recover_segments() can only run once per SegmentedStore instance")]
+    RecoveryAlreadyApplied,
+
     /// Publishing a branch manifest failed before the atomic rename completed.
     #[error("failed to publish segment manifest for branch {branch_id}: {inner}")]
     ManifestPublish {
@@ -60,6 +64,7 @@ impl StorageError {
     pub fn kind(&self) -> io::ErrorKind {
         match self {
             StorageError::Io(inner) => inner.kind(),
+            StorageError::RecoveryAlreadyApplied => io::ErrorKind::Other,
             StorageError::ManifestPublish { inner, .. } => inner.kind(),
             StorageError::DirFsync { inner, .. } => inner.kind(),
             StorageError::RecoveryFault(fault) => recovery_fault_kind(fault),
@@ -82,6 +87,9 @@ impl From<StorageError> for StrataError {
     fn from(value: StorageError) -> Self {
         match value {
             StorageError::Io(inner) => StrataError::storage_with_source("storage I/O error", inner),
+            StorageError::RecoveryAlreadyApplied => {
+                StrataError::storage("segment recovery already applied on this store instance")
+            }
             StorageError::ManifestPublish { branch_id, inner } => StrataError::storage_with_source(
                 format!("failed to publish segment manifest for branch {branch_id}"),
                 inner,

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -5,6 +5,8 @@ use strata_core::types::BranchId;
 use strata_core::StrataError;
 use thiserror::Error;
 
+use crate::segmented::RecoveryFault;
+
 /// Result alias for storage-local operations that can raise [`StorageError`].
 pub type StorageResult<T> = Result<T, StorageError>;
 
@@ -36,17 +38,43 @@ pub enum StorageError {
         #[source]
         inner: io::Error,
     },
+
+    /// A single [`RecoveryFault`] surfaced through an error boundary.
+    ///
+    /// Recovery itself returns [`StorageResult<RecoveredState>`] with the full
+    /// classified health; this variant exists for call sites that need to
+    /// carry exactly one fault across a `Result` boundary without reshaping
+    /// the outcome type (e.g. cross-crate conversions into `StrataError`).
+    ///
+    /// [`RecoveredState`]: crate::segmented::RecoveredState
+    #[error(transparent)]
+    RecoveryFault(#[from] RecoveryFault),
 }
 
 impl StorageError {
     /// Returns the underlying `io::ErrorKind` for callers and tests that only
     /// need the coarse I/O classification.
+    ///
+    /// Returns [`io::ErrorKind::Other`] for [`StorageError::RecoveryFault`]
+    /// variants that do not wrap an `io::Error`.
     pub fn kind(&self) -> io::ErrorKind {
         match self {
             StorageError::Io(inner) => inner.kind(),
             StorageError::ManifestPublish { inner, .. } => inner.kind(),
             StorageError::DirFsync { inner, .. } => inner.kind(),
+            StorageError::RecoveryFault(fault) => recovery_fault_kind(fault),
         }
+    }
+}
+
+fn recovery_fault_kind(fault: &RecoveryFault) -> io::ErrorKind {
+    match fault {
+        RecoveryFault::CorruptSegment { inner, .. }
+        | RecoveryFault::CorruptManifest { inner, .. }
+        | RecoveryFault::Io(inner) => inner.kind(),
+        RecoveryFault::MissingManifestListed { .. }
+        | RecoveryFault::InheritedLayerLost { .. }
+        | RecoveryFault::NoManifestFallbackUsed { .. } => io::ErrorKind::Other,
     }
 }
 
@@ -65,6 +93,9 @@ impl From<StorageError> for StrataError {
                 ),
                 inner,
             ),
+            StorageError::RecoveryFault(fault) => {
+                StrataError::storage_with_source("recovery fault", fault)
+            }
         }
     }
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -41,7 +41,8 @@ pub use rate_limiter::RateLimiter;
 pub use segment::{KVSegment, OwnedSegmentIter};
 pub use segment_builder::{CompressionCodec, SegmentBuilder, SegmentMeta, SplittingSegmentBuilder};
 pub use segmented::{
-    CompactionResult, DecodedSnapshotEntry, DecodedSnapshotValue, MaterializeResult,
-    PickAndCompactResult, PublishHealth, SegmentedStore, StorageIterator, VersionedEntry,
+    CompactionResult, DecodedSnapshotEntry, DecodedSnapshotValue, DegradationClass,
+    MaterializeResult, PickAndCompactResult, PublishHealth, RecoveredState, RecoveryFault,
+    RecoveryHealth, SegmentedStore, StorageIterator, VersionedEntry,
 };
 pub use ttl::TTLIndex;

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -764,6 +764,10 @@ pub struct SegmentedStore {
     /// store has nothing to have gone wrong. Read by SE3's GC refusal and
     /// D4's engine-side health accessor; written only by `recover_segments`.
     last_recovery_health: ArcSwap<RecoveryHealth>,
+    /// `recover_segments()` is a one-shot bootstrap primitive. Once it
+    /// successfully installs recovered state, calling it again on the same
+    /// store instance would duplicate recovered segments and refcounts.
+    recovery_applied: AtomicBool,
 }
 
 /// Latched storage publication durability issue for the current process.
@@ -787,6 +791,41 @@ enum PublishOutcome {
 struct InheritedResolveStats {
     max_commit_id: CommitVersion,
     segments_loaded: usize,
+}
+
+struct RecoveryInvocationGuard<'a> {
+    flag: &'a AtomicBool,
+    committed: bool,
+}
+
+impl<'a> RecoveryInvocationGuard<'a> {
+    fn begin(flag: &'a AtomicBool) -> StorageResult<Self> {
+        flag.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| StorageError::RecoveryAlreadyApplied)?;
+        Ok(Self {
+            flag,
+            committed: false,
+        })
+    }
+
+    fn commit(&mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for RecoveryInvocationGuard<'_> {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.flag.store(false, Ordering::Release);
+        }
+    }
+}
+
+fn missing_segments_dir_error(path: &std::path::Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::NotFound,
+        format!("segments directory {} is missing", path.display()),
+    )
 }
 
 impl SegmentedStore {
@@ -817,6 +856,7 @@ impl SegmentedStore {
             bloom_bits_per_key: AtomicUsize::new(10),
             publish_health: Mutex::new(None),
             last_recovery_health: ArcSwap::from_pointee(RecoveryHealth::Healthy),
+            recovery_applied: AtomicBool::new(false),
         }
     }
 
@@ -848,6 +888,7 @@ impl SegmentedStore {
             bloom_bits_per_key: AtomicUsize::new(10),
             publish_health: Mutex::new(None),
             last_recovery_health: ArcSwap::from_pointee(RecoveryHealth::Healthy),
+            recovery_applied: AtomicBool::new(false),
         }
     }
 
@@ -879,6 +920,7 @@ impl SegmentedStore {
             bloom_bits_per_key: AtomicUsize::new(10),
             publish_health: Mutex::new(None),
             last_recovery_health: ArcSwap::from_pointee(RecoveryHealth::Healthy),
+            recovery_applied: AtomicBool::new(false),
         }
     }
 
@@ -3292,7 +3334,7 @@ impl SegmentedStore {
         self.segments_dir.as_ref()
     }
 
-    /// Recover flushed segments from disk.
+    /// Recover flushed segments from disk into a fresh store.
     ///
     /// Scans `segments_dir` for branch subdirectories (hex-encoded BranchId),
     /// opens `.sst` files within each, and installs them into the store. On
@@ -3303,28 +3345,51 @@ impl SegmentedStore {
     /// with defects captured inside `RecoveredState::health` as typed
     /// [`RecoveryFault`]s. The `Err` arm is reserved for pre-walk I/O
     /// failures — e.g. the top-level `read_dir(segments_dir)` itself
-    /// failing. Those hard errors still publish a degraded
-    /// `last_recovery_health()` snapshot before returning. Per-branch failures
-    /// classify into faults and continue.
+    /// failing or the authoritative `segments_dir` being missing. Those hard
+    /// errors still publish a degraded `last_recovery_health()` snapshot
+    /// before returning. Per-branch failures classify into faults and
+    /// continue.
+    ///
+    /// This is a one-shot bootstrap primitive. A second successful call on
+    /// the same `SegmentedStore` instance would duplicate recovered state, so
+    /// repeated invocations return [`StorageError::RecoveryAlreadyApplied`].
     ///
     /// Callers should pass the returned outcome to
     /// `TransactionCoordinator::apply_storage_recovery` rather than reading
     /// individual fields: that entry point owns version-floor adoption and
     /// future per-branch version wiring.
     pub fn recover_segments(&self) -> StorageResult<RecoveredState> {
+        let mut invocation = RecoveryInvocationGuard::begin(&self.recovery_applied)?;
         let segments_dir = match &self.segments_dir {
             Some(d) => d,
             None => {
                 self.last_recovery_health
                     .store(Arc::new(RecoveryHealth::Healthy));
+                invocation.commit();
                 return Ok(RecoveredState::empty());
             }
         };
 
-        if !segments_dir.exists() {
-            self.last_recovery_health
-                .store(Arc::new(RecoveryHealth::Healthy));
-            return Ok(RecoveredState::empty());
+        match std::fs::metadata(segments_dir) {
+            Ok(_) => {}
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                let health = RecoveryHealth::from_faults(vec![RecoveryFault::Io(
+                    missing_segments_dir_error(segments_dir),
+                )]);
+                self.last_recovery_health.store(Arc::new(health));
+                return Err(missing_segments_dir_error(segments_dir).into());
+            }
+            Err(e) => {
+                let health = RecoveryHealth::from_faults(vec![RecoveryFault::Io(io::Error::new(
+                    e.kind(),
+                    format!(
+                        "failed to stat segments directory {}: {e}",
+                        segments_dir.display()
+                    ),
+                ))]);
+                self.last_recovery_health.store(Arc::new(health));
+                return Err(e.into());
+            }
         }
 
         let mut faults: Vec<RecoveryFault> = Vec::new();
@@ -3626,6 +3691,7 @@ impl SegmentedStore {
 
         let health = RecoveryHealth::from_faults(faults);
         self.last_recovery_health.store(Arc::new(health.clone()));
+        invocation.commit();
 
         Ok(RecoveredState {
             version_floor,

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -26,7 +26,7 @@ use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -759,6 +759,11 @@ pub struct SegmentedStore {
     bloom_bits_per_key: AtomicUsize,
     /// Latched publication durability issue for this process.
     publish_health: Mutex<Option<PublishHealth>>,
+    /// Classified health from the most recent `recover_segments()` call.
+    /// Initialized to [`RecoveryHealth::Healthy`] — a fresh or ephemeral
+    /// store has nothing to have gone wrong. Read by SE3's GC refusal and
+    /// D4's engine-side health accessor; written only by `recover_segments`.
+    last_recovery_health: ArcSwap<RecoveryHealth>,
 }
 
 /// Latched storage publication durability issue for the current process.
@@ -773,6 +778,15 @@ pub struct PublishHealth {
 enum PublishOutcome {
     Durable,
     NotDurable(StorageError),
+}
+
+/// Internal stats produced by `resolve_inherited_layers` for its caller to
+/// fold into the final `RecoveredState`. Scope is intentionally narrow —
+/// only the fields `recover_segments` needs to aggregate.
+#[derive(Default)]
+struct InheritedResolveStats {
+    max_commit_id: CommitVersion,
+    segments_loaded: usize,
 }
 
 impl SegmentedStore {
@@ -802,6 +816,7 @@ impl SegmentedStore {
             data_block_size: AtomicUsize::new(4096),
             bloom_bits_per_key: AtomicUsize::new(10),
             publish_health: Mutex::new(None),
+            last_recovery_health: ArcSwap::from_pointee(RecoveryHealth::Healthy),
         }
     }
 
@@ -832,6 +847,7 @@ impl SegmentedStore {
             data_block_size: AtomicUsize::new(4096),
             bloom_bits_per_key: AtomicUsize::new(10),
             publish_health: Mutex::new(None),
+            last_recovery_health: ArcSwap::from_pointee(RecoveryHealth::Healthy),
         }
     }
 
@@ -862,6 +878,7 @@ impl SegmentedStore {
             data_block_size: AtomicUsize::new(4096),
             bloom_bits_per_key: AtomicUsize::new(10),
             publish_health: Mutex::new(None),
+            last_recovery_health: ArcSwap::from_pointee(RecoveryHealth::Healthy),
         }
     }
 
@@ -879,6 +896,17 @@ impl SegmentedStore {
     #[inline]
     pub fn branch_count(&self) -> usize {
         self.branches.len()
+    }
+
+    /// Classified health of the most recent `recover_segments()` call.
+    ///
+    /// Returns [`RecoveryHealth::Healthy`] for stores that have never run
+    /// recovery. SE3 uses this to refuse orphan GC under degraded recovery;
+    /// D4 exposes it through the engine's public `recovery_health()`
+    /// accessor. The returned `Arc` is a snapshot — subsequent recovery
+    /// calls replace the stored value but do not invalidate this handle.
+    pub fn last_recovery_health(&self) -> Arc<RecoveryHealth> {
+        self.last_recovery_health.load_full()
     }
 
     /// Increment version and return new value.
@@ -3264,28 +3292,57 @@ impl SegmentedStore {
     /// Recover flushed segments from disk.
     ///
     /// Scans `segments_dir` for branch subdirectories (hex-encoded BranchId),
-    /// opens `.sst` files within each, and installs them into the store.
+    /// opens `.sst` files within each, and installs them into the store. On
+    /// return, `last_recovery_health()` reflects the classified outcome.
     ///
-    /// Returns `Ok(info)` with recovery statistics, or `Err` on fatal I/O errors.
-    /// Individual corrupt `.sst` files are skipped (counted in `errors_skipped`).
-    pub fn recover_segments(&self) -> io::Result<RecoverSegmentsInfo> {
+    /// Returns [`Ok(RecoveredState)`] for every outcome the walk can reach,
+    /// with defects captured inside `RecoveredState::health` as typed
+    /// [`RecoveryFault`]s. The `Err` arm is reserved for pre-walk I/O
+    /// failures — e.g. the top-level `read_dir(segments_dir)` itself
+    /// failing. Per-branch failures classify into faults and continue.
+    ///
+    /// Callers should pass the returned outcome to
+    /// `TransactionCoordinator::apply_storage_recovery` rather than reading
+    /// individual fields: that entry point owns version-floor adoption and
+    /// future per-branch version wiring.
+    pub fn recover_segments(&self) -> StorageResult<RecoveredState> {
         let segments_dir = match &self.segments_dir {
             Some(d) => d,
-            None => return Ok(RecoverSegmentsInfo::default()),
+            None => {
+                self.last_recovery_health
+                    .store(Arc::new(RecoveryHealth::Healthy));
+                return Ok(RecoveredState::empty());
+            }
         };
 
         if !segments_dir.exists() {
-            return Ok(RecoverSegmentsInfo::default());
+            self.last_recovery_health
+                .store(Arc::new(RecoveryHealth::Healthy));
+            return Ok(RecoveredState::empty());
         }
 
-        let mut info = RecoverSegmentsInfo::default();
+        let mut faults: Vec<RecoveryFault> = Vec::new();
+        let mut branch_versions: HashMap<BranchId, CommitVersion> = HashMap::new();
+        let mut version_floor = CommitVersion::ZERO;
+        let mut segments_loaded: usize = 0;
+        let mut branches_recovered: usize = 0;
 
         // Collect inherited layer info for deferred resolution (second pass).
         let mut deferred_inherited: Vec<(BranchId, Vec<crate::manifest::ManifestInheritedLayer>)> =
             Vec::new();
 
-        for entry in std::fs::read_dir(segments_dir)? {
-            let entry = entry?;
+        // Top-level read_dir failure is pre-walk: we cannot even enumerate
+        // branches, so surface it as a hard error.
+        let top_entries = std::fs::read_dir(segments_dir)?;
+
+        for entry in top_entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    faults.push(RecoveryFault::Io(e));
+                    continue;
+                }
+            };
             let path = entry.path();
             if !path.is_dir() {
                 continue;
@@ -3303,8 +3360,24 @@ impl SegmentedStore {
 
             let mut branch_segments: Vec<Arc<KVSegment>> = Vec::new();
 
-            for seg_entry in std::fs::read_dir(&path)? {
-                let seg_entry = seg_entry?;
+            // Per-branch read_dir failure is a fault for this branch; other
+            // branches can still recover.
+            let seg_entries = match std::fs::read_dir(&path) {
+                Ok(it) => it,
+                Err(e) => {
+                    faults.push(RecoveryFault::Io(e));
+                    continue;
+                }
+            };
+
+            for seg_entry in seg_entries {
+                let seg_entry = match seg_entry {
+                    Ok(e) => e,
+                    Err(e) => {
+                        faults.push(RecoveryFault::Io(e));
+                        continue;
+                    }
+                };
                 let seg_path = seg_entry.path();
                 if seg_path.extension().and_then(|e| e.to_str()) != Some("sst") {
                     continue;
@@ -3319,12 +3392,14 @@ impl SegmentedStore {
                                     .fetch_max(file_seg_id + 1, Ordering::Relaxed);
                             }
                         }
-                        // Track max commit_id for version counter restoration (#1726)
-                        info.max_commit_id = info.max_commit_id.max(seg.commit_range().1);
+                        version_floor = version_floor.max(seg.commit_range().1);
                         branch_segments.push(Arc::new(seg));
                     }
-                    Err(_) => {
-                        info.errors_skipped += 1;
+                    Err(e) => {
+                        faults.push(RecoveryFault::CorruptSegment {
+                            file: seg_path,
+                            inner: e,
+                        });
                     }
                 }
             }
@@ -3342,10 +3417,38 @@ impl SegmentedStore {
                         error = %e,
                         "corrupt manifest, skipping branch (own segments not loaded)"
                     );
-                    info.corrupt_manifest_branches += 1;
+                    faults.push(RecoveryFault::CorruptManifest {
+                        branch_id,
+                        inner: e,
+                    });
                     continue;
                 }
             };
+
+            // Validate manifest-listed filenames against what is actually on
+            // disk. Missing files are authoritative loss and must surface
+            // regardless of whether we proceed to install this branch (e.g.
+            // even if the branch appears "empty" because the sole listed file
+            // was deleted).
+            if let Some(ref manifest) = manifest {
+                let on_disk_names: std::collections::HashSet<String> = branch_segments
+                    .iter()
+                    .filter_map(|seg| {
+                        seg.file_path()
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .map(|n| n.to_string())
+                    })
+                    .collect();
+                for entry in &manifest.entries {
+                    if !on_disk_names.contains(&entry.filename) {
+                        faults.push(RecoveryFault::MissingManifestListed {
+                            branch_id,
+                            file: entry.filename.clone(),
+                        });
+                    }
+                }
+            }
 
             // Skip branches with no segments and no inherited layers
             let has_inherited = manifest
@@ -3383,6 +3486,9 @@ impl SegmentedStore {
                     if let Some(seg) = seg_by_name.get(&entry.filename) {
                         level_segs[level].push(Arc::clone(seg));
                     } else {
+                        // Missing-file fault was already emitted by the
+                        // manifest-vs-disk validation pass above; no action
+                        // here beyond the structural tracing::warn.
                         tracing::warn!(
                             branch = %dir_name,
                             segment = %entry.filename,
@@ -3391,7 +3497,10 @@ impl SegmentedStore {
                     }
                 }
 
-                // Log orphan files (on disk but not in manifest — not loaded).
+                // Orphan files (on disk but not in manifest) stay informational
+                // only — they are the expected shape of shared segments that
+                // live on disk for COW children, and orphan GC (once SE3
+                // lands) reclaims them later. Not a fault.
                 for seg in branch_segments.iter() {
                     let filename = seg
                         .file_path()
@@ -3404,12 +3513,18 @@ impl SegmentedStore {
                             segment = %filename,
                             "orphan segment on disk (not in manifest), skipping"
                         );
-                        info.orphans_skipped += 1;
                     }
                 }
             } else {
-                // No manifest → all segments go to L0 (backward compat)
+                // No manifest → all segments go to L0 (backward compat).
+                // Classified as PolicyDowngrade so strict callers can refuse
+                // while lossy callers with explicit opt-in continue.
+                let promoted = branch_segments.len();
                 level_segs[0] = branch_segments.clone();
+                faults.push(RecoveryFault::NoManifestFallbackUsed {
+                    branch_id,
+                    segments_promoted: promoted,
+                });
             }
 
             // L0: sorted by commit_max descending (newest first)
@@ -3424,7 +3539,21 @@ impl SegmentedStore {
                 .entry(branch_id)
                 .or_insert_with(BranchState::new);
 
-            info.segments_loaded += level_segs.iter().map(|l| l.len()).sum::<usize>();
+            segments_loaded += level_segs.iter().map(|l| l.len()).sum::<usize>();
+
+            // Rebuild branch.max_version from the loaded segments before we
+            // install the version. Mirrors the snapshot-install pattern: post
+            // -restart fork_branch reads this atomic to pick the fork source
+            // version. Pre-SE2 the recovery walk skipped this and left it at
+            // the constructor default (0).
+            let mut branch_max = CommitVersion::ZERO;
+            for level in &level_segs {
+                for seg in level {
+                    let v = seg.commit_range().1;
+                    branch.track_version(v);
+                    branch_max = branch_max.max(v);
+                }
+            }
 
             // Build new version: merge existing segments with recovered ones
             let old_ver = branch.version.load();
@@ -3447,6 +3576,11 @@ impl SegmentedStore {
                 .store(Arc::new(SegmentVersion { levels: new_levels }));
             refresh_level_targets(&mut branch, self.level_base_bytes());
 
+            if branch_max > CommitVersion::ZERO {
+                let entry = branch_versions.entry(branch_id).or_insert(CommitVersion::ZERO);
+                *entry = (*entry).max(branch_max);
+            }
+
             // Collect inherited layer info for second pass (deferred resolution).
             if let Some(manifest) = manifest {
                 if !manifest.inherited_layers.is_empty() {
@@ -3454,23 +3588,61 @@ impl SegmentedStore {
                 }
             }
 
-            info.branches_recovered += 1;
+            branches_recovered += 1;
         }
 
-        // Second pass + refcount rebuild
-        self.resolve_inherited_layers(segments_dir, deferred_inherited, &mut info);
+        // Second pass + refcount rebuild. Inherited layers contribute their
+        // own segment commit_max to version_floor and to the child branch's
+        // branch_versions entry, and per-layer failures append faults.
+        let inherited_stats = self.resolve_inherited_layers(
+            segments_dir,
+            deferred_inherited,
+            &mut branch_versions,
+            &mut faults,
+        );
+        version_floor = version_floor.max(inherited_stats.max_commit_id);
+        segments_loaded += inherited_stats.segments_loaded;
 
-        Ok(info)
+        let health = RecoveryHealth::from_faults(faults);
+        self.last_recovery_health.store(Arc::new(match &health {
+            RecoveryHealth::Healthy => RecoveryHealth::Healthy,
+            RecoveryHealth::Degraded { class, .. } => RecoveryHealth::Degraded {
+                faults: Vec::new(),
+                class: *class,
+            },
+        }));
+        // The stored handle carries classification only — faults are not
+        // cloneable (io::Error). The RecoveredState returned to the caller
+        // carries the full fault list. Callers who need specific faults
+        // consume the outcome directly; the stored handle is for health-only
+        // queries (SE3 GC refusal, D4 recovery_health accessor).
+
+        Ok(RecoveredState {
+            version_floor,
+            branch_versions,
+            segments_loaded,
+            branches_recovered,
+            health,
+        })
     }
 
     /// Second pass of recovery: resolve inherited layers from manifests and
     /// rebuild segment refcounts.
+    ///
+    /// Folds each inherited layer segment's `commit_range().1` into both the
+    /// child branch's entry in `branch_versions` and the returned
+    /// `max_commit_id`, so the caller's `version_floor` accounts for versions
+    /// visible only via inheritance. Layers whose entire source is
+    /// unreachable produce a [`RecoveryFault::InheritedLayerLost`] in
+    /// `faults`.
     fn resolve_inherited_layers(
         &self,
         segments_dir: &std::path::Path,
         deferred_inherited: Vec<(BranchId, Vec<crate::manifest::ManifestInheritedLayer>)>,
-        info: &mut RecoverSegmentsInfo,
-    ) {
+        branch_versions: &mut HashMap<BranchId, CommitVersion>,
+        faults: &mut Vec<RecoveryFault>,
+    ) -> InheritedResolveStats {
+        let mut stats = InheritedResolveStats::default();
         for (child_id, manifest_layers) in deferred_inherited {
             let mut inherited_layers = Vec::new();
 
@@ -3478,6 +3650,7 @@ impl SegmentedStore {
                 let source_dir = segments_dir.join(hex_encode_branch(&ml.source_branch_id));
                 let mut layer_levels: Vec<Vec<Arc<KVSegment>>> = vec![Vec::new(); NUM_LEVELS];
                 let mut any_found = false;
+                let mut layer_max = CommitVersion::ZERO;
 
                 for entry in &ml.entries {
                     let level = (entry.level as usize).min(NUM_LEVELS - 1);
@@ -3490,7 +3663,10 @@ impl SegmentedStore {
                                         .fetch_max(file_seg_id + 1, Ordering::Relaxed);
                                 }
                             }
-                            info.max_commit_id = info.max_commit_id.max(seg.commit_range().1);
+                            let seg_max = seg.commit_range().1;
+                            stats.max_commit_id = stats.max_commit_id.max(seg_max);
+                            layer_max = layer_max.max(seg_max);
+                            stats.segments_loaded += 1;
                             layer_levels[level].push(Arc::new(seg));
                             any_found = true;
                         }
@@ -3507,8 +3683,17 @@ impl SegmentedStore {
                 }
 
                 if !any_found {
-                    info.layers_dropped.push((child_id, ml.source_branch_id));
+                    faults.push(RecoveryFault::InheritedLayerLost {
+                        child: child_id,
+                        source_branch: ml.source_branch_id,
+                    });
                     continue;
+                }
+
+                if layer_max > CommitVersion::ZERO {
+                    let child_entry =
+                        branch_versions.entry(child_id).or_insert(CommitVersion::ZERO);
+                    *child_entry = (*child_entry).max(layer_max);
                 }
 
                 layer_levels[0].sort_by(|a, b| b.commit_range().1.cmp(&a.commit_range().1));
@@ -3536,6 +3721,12 @@ impl SegmentedStore {
 
             if !inherited_layers.is_empty() {
                 if let Some(mut branch) = self.branches.get_mut(&child_id) {
+                    // Fold inherited-layer max versions into the child's
+                    // own max_version so post-restart fork_branch on the
+                    // child picks up inherited data (#SG-008 broadening).
+                    if let Some(v) = branch_versions.get(&child_id) {
+                        branch.track_version(*v);
+                    }
                     branch.inherited_layers = inherited_layers;
                 }
             }
@@ -3549,6 +3740,8 @@ impl SegmentedStore {
                 }
             }
         }
+
+        stats
     }
 
     /// Check whether the active memtable should be rotated and do so inline.
@@ -4610,34 +4803,6 @@ impl SegmentedStore {
     }
 }
 
-/// Statistics returned by [`SegmentedStore::recover_segments`].
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct RecoverSegmentsInfo {
-    /// Number of branch subdirectories successfully loaded.
-    pub branches_recovered: usize,
-    /// Total number of `.sst` segments loaded across all branches.
-    pub segments_loaded: usize,
-    /// Number of `.sst` files that failed to open (corrupt/invalid).
-    pub errors_skipped: usize,
-    /// Inherited layers that were dropped because their source branch
-    /// was missing. Each entry is `(child_branch_id, source_branch_id)`.
-    /// Non-empty means the child branch may be missing data that was
-    /// visible before the crash.
-    pub layers_dropped: Vec<(BranchId, BranchId)>,
-    /// Number of orphan `.sst` files on disk that were not in the manifest.
-    /// These are skipped during recovery to prevent stale data from shadowing
-    /// compacted data (#1701).
-    pub orphans_skipped: usize,
-    /// Number of branches skipped because their manifest was corrupt (#1691).
-    /// Own segments for these branches are not loaded, but their segment
-    /// files remain on disk for children to open directly.
-    pub corrupt_manifest_branches: usize,
-    /// Maximum commit_id seen across all loaded segments (#1726).
-    /// Used to bump the version counter so new transactions don't collide
-    /// with data already persisted in segments.
-    pub max_commit_id: CommitVersion,
-}
-
 impl Default for SegmentedStore {
     fn default() -> Self {
         Self::new()
@@ -5125,7 +5290,10 @@ fn check_corruption(flags: &[Arc<AtomicBool>]) -> StrataResult<()> {
 }
 
 mod compaction;
+mod recovery;
 mod ref_registry;
+
+pub use recovery::{DegradationClass, RecoveredState, RecoveryFault, RecoveryHealth};
 
 #[cfg(test)]
 mod tests;

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -898,13 +898,16 @@ impl SegmentedStore {
         self.branches.len()
     }
 
-    /// Classified health of the most recent `recover_segments()` call.
+    /// Classified health of the most recent attempted `recover_segments()`
+    /// call.
     ///
     /// Returns [`RecoveryHealth::Healthy`] for stores that have never run
-    /// recovery. SE3 uses this to refuse orphan GC under degraded recovery;
-    /// D4 exposes it through the engine's public `recovery_health()`
-    /// accessor. The returned `Arc` is a snapshot — subsequent recovery
-    /// calls replace the stored value but do not invalidate this handle.
+    /// recovery. Hard pre-walk I/O failures also publish a degraded snapshot
+    /// here before `recover_segments()` returns `Err`. SE3 uses this to refuse
+    /// orphan GC under degraded recovery; D4 exposes it through the engine's
+    /// public `recovery_health()` accessor. The returned `Arc` is a snapshot
+    /// — subsequent recovery calls replace the stored value but do not
+    /// invalidate this handle.
     pub fn last_recovery_health(&self) -> Arc<RecoveryHealth> {
         self.last_recovery_health.load_full()
     }
@@ -3293,13 +3296,16 @@ impl SegmentedStore {
     ///
     /// Scans `segments_dir` for branch subdirectories (hex-encoded BranchId),
     /// opens `.sst` files within each, and installs them into the store. On
-    /// return, `last_recovery_health()` reflects the classified outcome.
+    /// return or hard pre-walk failure, `last_recovery_health()` reflects the
+    /// most recent classified recovery attempt.
     ///
     /// Returns [`Ok(RecoveredState)`] for every outcome the walk can reach,
     /// with defects captured inside `RecoveredState::health` as typed
     /// [`RecoveryFault`]s. The `Err` arm is reserved for pre-walk I/O
     /// failures — e.g. the top-level `read_dir(segments_dir)` itself
-    /// failing. Per-branch failures classify into faults and continue.
+    /// failing. Those hard errors still publish a degraded
+    /// `last_recovery_health()` snapshot before returning. Per-branch failures
+    /// classify into faults and continue.
     ///
     /// Callers should pass the returned outcome to
     /// `TransactionCoordinator::apply_storage_recovery` rather than reading
@@ -3332,8 +3338,22 @@ impl SegmentedStore {
             Vec::new();
 
         // Top-level read_dir failure is pre-walk: we cannot even enumerate
-        // branches, so surface it as a hard error.
-        let top_entries = std::fs::read_dir(segments_dir)?;
+        // branches, so surface it as a hard error. Still publish a degraded
+        // health snapshot so observers do not retain stale prior state.
+        let top_entries = match std::fs::read_dir(segments_dir) {
+            Ok(entries) => entries,
+            Err(e) => {
+                let health = RecoveryHealth::from_faults(vec![RecoveryFault::Io(io::Error::new(
+                    e.kind(),
+                    format!(
+                        "failed to enumerate segments directory {}: {e}",
+                        segments_dir.display()
+                    ),
+                ))]);
+                self.last_recovery_health.store(Arc::new(health));
+                return Err(e.into());
+            }
+        };
 
         for entry in top_entries {
             let entry = match entry {
@@ -3679,6 +3699,7 @@ impl SegmentedStore {
                     faults.push(RecoveryFault::InheritedLayerLost {
                         child: child_id,
                         source_branch: ml.source_branch_id,
+                        fork_version: ml.fork_version,
                     });
                     continue;
                 }
@@ -3687,6 +3708,7 @@ impl SegmentedStore {
                     faults.push(RecoveryFault::InheritedLayerLost {
                         child: child_id,
                         source_branch: ml.source_branch_id,
+                        fork_version: ml.fork_version,
                     });
                 }
 

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -3325,7 +3325,7 @@ impl SegmentedStore {
         let mut branch_versions: HashMap<BranchId, CommitVersion> = HashMap::new();
         let mut version_floor = CommitVersion::ZERO;
         let mut segments_loaded: usize = 0;
-        let mut branches_recovered: usize = 0;
+        let mut recovered_branches: HashSet<BranchId> = HashSet::new();
 
         // Collect inherited layer info for deferred resolution (second pass).
         let mut deferred_inherited: Vec<(BranchId, Vec<crate::manifest::ManifestInheritedLayer>)> =
@@ -3359,6 +3359,7 @@ impl SegmentedStore {
             };
 
             let mut branch_segments: Vec<Arc<KVSegment>> = Vec::new();
+            let mut sst_names_on_disk: HashSet<String> = HashSet::new();
 
             // Per-branch read_dir failure is a fault for this branch; other
             // branches can still recover.
@@ -3381,6 +3382,9 @@ impl SegmentedStore {
                 let seg_path = seg_entry.path();
                 if seg_path.extension().and_then(|e| e.to_str()) != Some("sst") {
                     continue;
+                }
+                if let Some(name) = seg_path.file_name().and_then(|n| n.to_str()) {
+                    sst_names_on_disk.insert(name.to_string());
                 }
 
                 match KVSegment::open(&seg_path) {
@@ -3431,17 +3435,8 @@ impl SegmentedStore {
             // even if the branch appears "empty" because the sole listed file
             // was deleted).
             if let Some(ref manifest) = manifest {
-                let on_disk_names: std::collections::HashSet<String> = branch_segments
-                    .iter()
-                    .filter_map(|seg| {
-                        seg.file_path()
-                            .file_name()
-                            .and_then(|n| n.to_str())
-                            .map(|n| n.to_string())
-                    })
-                    .collect();
                 for entry in &manifest.entries {
-                    if !on_disk_names.contains(&entry.filename) {
+                    if !sst_names_on_disk.contains(&entry.filename) {
                         faults.push(RecoveryFault::MissingManifestListed {
                             branch_id,
                             file: entry.filename.clone(),
@@ -3539,7 +3534,11 @@ impl SegmentedStore {
                 .entry(branch_id)
                 .or_insert_with(BranchState::new);
 
-            segments_loaded += level_segs.iter().map(|l| l.len()).sum::<usize>();
+            let own_segments_loaded = level_segs.iter().map(|l| l.len()).sum::<usize>();
+            segments_loaded += own_segments_loaded;
+            if own_segments_loaded > 0 {
+                recovered_branches.insert(branch_id);
+            }
 
             // Rebuild branch.max_version from the loaded segments before we
             // install the version. Mirrors the snapshot-install pattern: post
@@ -3577,7 +3576,9 @@ impl SegmentedStore {
             refresh_level_targets(&mut branch, self.level_base_bytes());
 
             if branch_max > CommitVersion::ZERO {
-                let entry = branch_versions.entry(branch_id).or_insert(CommitVersion::ZERO);
+                let entry = branch_versions
+                    .entry(branch_id)
+                    .or_insert(CommitVersion::ZERO);
                 *entry = (*entry).max(branch_max);
             }
 
@@ -3587,8 +3588,6 @@ impl SegmentedStore {
                     deferred_inherited.push((branch_id, manifest.inherited_layers));
                 }
             }
-
-            branches_recovered += 1;
         }
 
         // Second pass + refcount rebuild. Inherited layers contribute their
@@ -3598,24 +3597,15 @@ impl SegmentedStore {
             segments_dir,
             deferred_inherited,
             &mut branch_versions,
+            &mut recovered_branches,
             &mut faults,
         );
         version_floor = version_floor.max(inherited_stats.max_commit_id);
         segments_loaded += inherited_stats.segments_loaded;
+        let branches_recovered = recovered_branches.len();
 
         let health = RecoveryHealth::from_faults(faults);
-        self.last_recovery_health.store(Arc::new(match &health {
-            RecoveryHealth::Healthy => RecoveryHealth::Healthy,
-            RecoveryHealth::Degraded { class, .. } => RecoveryHealth::Degraded {
-                faults: Vec::new(),
-                class: *class,
-            },
-        }));
-        // The stored handle carries classification only — faults are not
-        // cloneable (io::Error). The RecoveredState returned to the caller
-        // carries the full fault list. Callers who need specific faults
-        // consume the outcome directly; the stored handle is for health-only
-        // queries (SE3 GC refusal, D4 recovery_health accessor).
+        self.last_recovery_health.store(Arc::new(health.clone()));
 
         Ok(RecoveredState {
             version_floor,
@@ -3640,6 +3630,7 @@ impl SegmentedStore {
         segments_dir: &std::path::Path,
         deferred_inherited: Vec<(BranchId, Vec<crate::manifest::ManifestInheritedLayer>)>,
         branch_versions: &mut HashMap<BranchId, CommitVersion>,
+        recovered_branches: &mut HashSet<BranchId>,
         faults: &mut Vec<RecoveryFault>,
     ) -> InheritedResolveStats {
         let mut stats = InheritedResolveStats::default();
@@ -3650,6 +3641,7 @@ impl SegmentedStore {
                 let source_dir = segments_dir.join(hex_encode_branch(&ml.source_branch_id));
                 let mut layer_levels: Vec<Vec<Arc<KVSegment>>> = vec![Vec::new(); NUM_LEVELS];
                 let mut any_found = false;
+                let mut missing_entries = false;
                 let mut layer_max = CommitVersion::ZERO;
 
                 for entry in &ml.entries {
@@ -3671,6 +3663,7 @@ impl SegmentedStore {
                             any_found = true;
                         }
                         Err(e) => {
+                            missing_entries = true;
                             tracing::warn!(
                                 child = %hex_encode_branch(&child_id),
                                 source = %hex_encode_branch(&ml.source_branch_id),
@@ -3690,9 +3683,17 @@ impl SegmentedStore {
                     continue;
                 }
 
+                if missing_entries {
+                    faults.push(RecoveryFault::InheritedLayerLost {
+                        child: child_id,
+                        source_branch: ml.source_branch_id,
+                    });
+                }
+
                 if layer_max > CommitVersion::ZERO {
-                    let child_entry =
-                        branch_versions.entry(child_id).or_insert(CommitVersion::ZERO);
+                    let child_entry = branch_versions
+                        .entry(child_id)
+                        .or_insert(CommitVersion::ZERO);
                     *child_entry = (*child_entry).max(layer_max);
                 }
 
@@ -3717,6 +3718,7 @@ impl SegmentedStore {
                     }),
                     status,
                 });
+                recovered_branches.insert(child_id);
             }
 
             if !inherited_layers.is_empty() {

--- a/crates/storage/src/segmented/recovery.rs
+++ b/crates/storage/src/segmented/recovery.rs
@@ -24,6 +24,7 @@
 use std::collections::HashMap;
 use std::io;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use strata_core::id::CommitVersion;
 use strata_core::types::BranchId;
@@ -77,7 +78,7 @@ impl RecoveredState {
 /// Callers match on the variant (and, for `Degraded`, on
 /// [`DegradationClass`]) to decide strict-vs-lossy policy. They do not
 /// iterate `faults` to reconstruct what storage already knows.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum RecoveryHealth {
     /// Recovery completed with no observed faults.
@@ -85,7 +86,7 @@ pub enum RecoveryHealth {
     /// Recovery completed but observed one or more faults.
     Degraded {
         /// Ordered list of faults observed during the walk.
-        faults: Vec<RecoveryFault>,
+        faults: Arc<[RecoveryFault]>,
         /// Severity-dominant classification across `faults`.
         class: DegradationClass,
     },
@@ -172,9 +173,10 @@ pub enum RecoveryFault {
         /// Filename recorded in the manifest but not found on disk.
         file: String,
     },
-    /// A child branch's inherited layer could not be resolved because no
-    /// segment of the source branch was loadable. The child loses visibility
-    /// into data that was visible before the crash.
+    /// A child branch's inherited layer lost one or more required segment
+    /// entries during recovery. The child loses visibility into data that was
+    /// visible before the crash, even if some entries from the same layer
+    /// were still loadable.
     #[error("inherited layer lost for branch {child} (source {source_branch})")]
     InheritedLayerLost {
         /// Child branch whose layer was dropped.
@@ -223,7 +225,10 @@ impl RecoveryHealth {
             RecoveryHealth::Healthy
         } else {
             let class = DegradationClass::worst(&faults);
-            RecoveryHealth::Degraded { faults, class }
+            RecoveryHealth::Degraded {
+                faults: faults.into(),
+                class,
+            }
         }
     }
 }

--- a/crates/storage/src/segmented/recovery.rs
+++ b/crates/storage/src/segmented/recovery.rs
@@ -177,7 +177,9 @@ pub enum RecoveryFault {
     /// entries during recovery. The child loses visibility into data that was
     /// visible before the crash, even if some entries from the same layer
     /// were still loadable.
-    #[error("inherited layer lost for branch {child} (source {source_branch})")]
+    #[error(
+        "inherited layer lost for branch {child} (source {source_branch}, fork_version {fork_version})"
+    )]
     InheritedLayerLost {
         /// Child branch whose layer was dropped.
         child: BranchId,
@@ -185,6 +187,9 @@ pub enum RecoveryFault {
         /// rather than `source` to avoid collision with thiserror's magic
         /// `#[source]` field detection.
         source_branch: BranchId,
+        /// Fork version that, together with `source_branch`, identifies the
+        /// inherited layer whose visibility was degraded.
+        fork_version: CommitVersion,
     },
     /// A branch had no manifest on disk; recovery promoted every discovered
     /// `.sst` to L0 for backward compatibility. Strict callers refuse; lossy

--- a/crates/storage/src/segmented/recovery.rs
+++ b/crates/storage/src/segmented/recovery.rs
@@ -1,0 +1,261 @@
+//! Typed outcome for [`SegmentedStore::recover_segments`].
+//!
+//! Before SE2 this API returned `RecoverSegmentsInfo` — a stats struct whose
+//! fields the engine had to interpret (`max_commit_id` fed directly into a
+//! version-floor bump; `layers_dropped` and `corrupt_manifest_branches` carried
+//! meaning only for specific branch paths). That shape left three problems:
+//!
+//! 1. Callers reimplemented classification (was this "lossy but safe" or
+//!    "authoritative data gone"?).
+//! 2. Callers managed version-floor semantics on storage's behalf.
+//! 3. Silent-skip arms inside the walk never surfaced anywhere: corrupt `.sst`
+//!    and missing manifest-listed segments just moved a counter.
+//!
+//! The types here collapse that into one self-contained restart primitive:
+//!
+//! - [`RecoveredState`] — every piece of state the caller needs (version floor,
+//!   per-branch version map, count summary, classified health).
+//! - [`RecoveryHealth`] — `Healthy` or `Degraded { faults, class }`.
+//! - [`DegradationClass`] — lets callers (D4) branch on severity without
+//!   iterating raw faults: `DataLoss` is authoritative; `PolicyDowngrade` is
+//!   operator-consentable; `Telemetry` is rebuildable.
+//! - [`RecoveryFault`] — the specific defects the walk observed, one per site.
+
+use std::collections::HashMap;
+use std::io;
+use std::path::PathBuf;
+
+use strata_core::id::CommitVersion;
+use strata_core::types::BranchId;
+use thiserror::Error;
+
+/// Self-contained outcome of [`SegmentedStore::recover_segments`].
+///
+/// The engine consumes this directly via
+/// `TransactionCoordinator::apply_storage_recovery`; it never needs to reach
+/// into storage internals to rebuild version state or interpret a raw fault
+/// list.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct RecoveredState {
+    /// Version floor the coordinator should adopt — the max `CommitVersion`
+    /// observed across every loaded segment (own and inherited). Zero when
+    /// recovery found no segments.
+    pub version_floor: CommitVersion,
+    /// Per-branch max `CommitVersion` seen in loaded segments. Mirrors the
+    /// value now installed on `BranchState::max_version` for each branch
+    /// touched during recovery. Authoritative for post-restart `fork_branch`
+    /// and snapshot-driven version arithmetic. Keyed by `BranchId` (which
+    /// does not implement `Ord`, so `HashMap` rather than `BTreeMap`).
+    pub branch_versions: HashMap<BranchId, CommitVersion>,
+    /// Total number of `.sst` segments loaded across all branches.
+    pub segments_loaded: usize,
+    /// Number of branch subdirectories that contributed at least one loaded
+    /// segment or inherited layer.
+    pub branches_recovered: usize,
+    /// Classified recovery health. See [`RecoveryHealth`] and
+    /// [`DegradationClass`].
+    pub health: RecoveryHealth,
+}
+
+impl RecoveredState {
+    /// A clean-recovery outcome with nothing loaded (e.g. ephemeral store or
+    /// an empty segments directory).
+    pub fn empty() -> Self {
+        Self {
+            version_floor: CommitVersion::ZERO,
+            branch_versions: HashMap::new(),
+            segments_loaded: 0,
+            branches_recovered: 0,
+            health: RecoveryHealth::Healthy,
+        }
+    }
+}
+
+/// Classified health of a storage recovery.
+///
+/// Callers match on the variant (and, for `Degraded`, on
+/// [`DegradationClass`]) to decide strict-vs-lossy policy. They do not
+/// iterate `faults` to reconstruct what storage already knows.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum RecoveryHealth {
+    /// Recovery completed with no observed faults.
+    Healthy,
+    /// Recovery completed but observed one or more faults.
+    Degraded {
+        /// Ordered list of faults observed during the walk.
+        faults: Vec<RecoveryFault>,
+        /// Severity-dominant classification across `faults`.
+        class: DegradationClass,
+    },
+}
+
+/// Severity class for a [`RecoveryHealth::Degraded`] outcome.
+///
+/// Strict callers refuse `DataLoss`. `PolicyDowngrade` is operator-consentable
+/// (explicit `--allow-missing-manifest` or equivalent). `Telemetry` is
+/// always acceptable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DegradationClass {
+    /// Authoritative state was lost: corrupt segment, corrupt manifest,
+    /// manifest-listed-but-missing segment, inherited layer whose source
+    /// branch is gone, or a per-entry I/O failure.
+    DataLoss,
+    /// A legacy-compatible fallback was engaged (e.g. no-manifest → L0
+    /// promotion). Safe to continue only with explicit operator consent.
+    PolicyDowngrade,
+    /// A rebuildable-cache failure was skipped. Not currently emitted; the
+    /// variant exists so future faults that fit this category can be
+    /// classified without widening the enum.
+    Telemetry,
+}
+
+impl DegradationClass {
+    /// Pick the worst class across a list of faults. Returns `Telemetry` only
+    /// when every fault classifies there (or the list is empty, which
+    /// callers should never observe — they classify `Healthy` first).
+    pub fn worst(faults: &[RecoveryFault]) -> Self {
+        let mut worst = DegradationClass::Telemetry;
+        for fault in faults {
+            let class = fault.class();
+            if class.severity() > worst.severity() {
+                worst = class;
+            }
+        }
+        worst
+    }
+
+    fn severity(self) -> u8 {
+        match self {
+            DegradationClass::Telemetry => 0,
+            DegradationClass::PolicyDowngrade => 1,
+            DegradationClass::DataLoss => 2,
+        }
+    }
+}
+
+/// A single defect observed during storage recovery.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum RecoveryFault {
+    /// A `.sst` file failed to open as a segment. The file on disk is
+    /// retained; subsequent orphan GC may reclaim it once a known-good
+    /// manifest is present.
+    #[error("corrupt segment file {file:?}: {inner}")]
+    CorruptSegment {
+        /// Absolute path to the segment file that failed to open.
+        file: PathBuf,
+        /// Underlying I/O or decode error from `KVSegment::open`.
+        #[source]
+        inner: io::Error,
+    },
+    /// A branch's `segments.manifest` failed to parse. The branch's own
+    /// segments are NOT loaded (would reintroduce orphans — #1680); children
+    /// inheriting from this branch may still pick up segments individually.
+    #[error("corrupt manifest for branch {branch_id}: {inner}")]
+    CorruptManifest {
+        /// Branch whose manifest could not be parsed.
+        branch_id: BranchId,
+        /// Underlying read/parse error.
+        #[source]
+        inner: io::Error,
+    },
+    /// The manifest listed a segment filename that is not on disk. The branch
+    /// continues loading the segments that are present; the missing one
+    /// represents authoritative loss.
+    #[error("manifest for branch {branch_id} lists missing file {file}")]
+    MissingManifestListed {
+        /// Branch whose manifest references the missing file.
+        branch_id: BranchId,
+        /// Filename recorded in the manifest but not found on disk.
+        file: String,
+    },
+    /// A child branch's inherited layer could not be resolved because no
+    /// segment of the source branch was loadable. The child loses visibility
+    /// into data that was visible before the crash.
+    #[error("inherited layer lost for branch {child} (source {source_branch})")]
+    InheritedLayerLost {
+        /// Child branch whose layer was dropped.
+        child: BranchId,
+        /// Source branch from which the layer derived. Named `source_branch`
+        /// rather than `source` to avoid collision with thiserror's magic
+        /// `#[source]` field detection.
+        source_branch: BranchId,
+    },
+    /// A branch had no manifest on disk; recovery promoted every discovered
+    /// `.sst` to L0 for backward compatibility. Strict callers refuse; lossy
+    /// callers with explicit operator opt-in accept.
+    #[error("no manifest for branch {branch_id}; {segments_promoted} segments promoted to L0 via legacy fallback")]
+    NoManifestFallbackUsed {
+        /// Branch whose segments were promoted.
+        branch_id: BranchId,
+        /// Number of segments promoted to L0.
+        segments_promoted: usize,
+    },
+    /// A per-entry I/O failure that prevented a single branch or segment
+    /// from loading but did not block the rest of the walk. Pre-walk I/O
+    /// failures are returned as `Err(StorageError)` instead.
+    #[error("recovery I/O error: {0}")]
+    Io(#[source] io::Error),
+}
+
+impl RecoveryFault {
+    /// Classify this fault into a [`DegradationClass`].
+    pub fn class(&self) -> DegradationClass {
+        match self {
+            RecoveryFault::CorruptSegment { .. }
+            | RecoveryFault::CorruptManifest { .. }
+            | RecoveryFault::MissingManifestListed { .. }
+            | RecoveryFault::InheritedLayerLost { .. }
+            | RecoveryFault::Io(_) => DegradationClass::DataLoss,
+            RecoveryFault::NoManifestFallbackUsed { .. } => DegradationClass::PolicyDowngrade,
+        }
+    }
+}
+
+impl RecoveryHealth {
+    /// Construct a [`RecoveryHealth`] from a fault vec: `Healthy` when empty,
+    /// `Degraded` otherwise with the severity-dominant class precomputed.
+    pub fn from_faults(faults: Vec<RecoveryFault>) -> Self {
+        if faults.is_empty() {
+            RecoveryHealth::Healthy
+        } else {
+            let class = DegradationClass::worst(&faults);
+            RecoveryHealth::Degraded { faults, class }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worst_picks_data_loss_over_policy_downgrade() {
+        let faults = vec![
+            RecoveryFault::NoManifestFallbackUsed {
+                branch_id: BranchId::from_bytes([1; 16]),
+                segments_promoted: 2,
+            },
+            RecoveryFault::CorruptSegment {
+                file: PathBuf::from("/tmp/x.sst"),
+                inner: io::Error::new(io::ErrorKind::InvalidData, "bad"),
+            },
+        ];
+        assert_eq!(DegradationClass::worst(&faults), DegradationClass::DataLoss);
+    }
+
+    #[test]
+    fn worst_picks_policy_downgrade_when_no_data_loss() {
+        let faults = vec![RecoveryFault::NoManifestFallbackUsed {
+            branch_id: BranchId::from_bytes([2; 16]),
+            segments_promoted: 1,
+        }];
+        assert_eq!(
+            DegradationClass::worst(&faults),
+            DegradationClass::PolicyDowngrade
+        );
+    }
+}

--- a/crates/storage/src/segmented/tests/concurrency.rs
+++ b/crates/storage/src/segmented/tests/concurrency.rs
@@ -211,7 +211,7 @@ fn test_issue_1680_corrupt_manifest_rejects_orphan_loading() {
     let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
     let info = store2.recover_segments().unwrap();
     let faults = match &info.health {
-        crate::segmented::RecoveryHealth::Degraded { faults, .. } => faults.as_slice(),
+        crate::segmented::RecoveryHealth::Degraded { faults, .. } => &faults[..],
         crate::segmented::RecoveryHealth::Healthy => &[],
     };
     assert!(

--- a/crates/storage/src/segmented/tests/concurrency.rs
+++ b/crates/storage/src/segmented/tests/concurrency.rs
@@ -210,8 +210,14 @@ fn test_issue_1680_corrupt_manifest_rejects_orphan_loading() {
     // so other branches remain functional (#1691).
     let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
     let info = store2.recover_segments().unwrap();
+    let faults = match &info.health {
+        crate::segmented::RecoveryHealth::Degraded { faults, .. } => faults.as_slice(),
+        crate::segmented::RecoveryHealth::Healthy => &[],
+    };
     assert!(
-        info.corrupt_manifest_branches > 0,
+        faults
+            .iter()
+            .any(|f| matches!(f, crate::segmented::RecoveryFault::CorruptManifest { .. })),
         "corrupt manifest must be reported, not silently load as L0"
     );
     // The orphan SST must NOT be accessible (no L0 fallback).

--- a/crates/storage/src/segmented/tests/flush.rs
+++ b/crates/storage/src/segmented/tests/flush.rs
@@ -412,7 +412,7 @@ fn recover_segments_loads_flushed_data() {
     let info = store2.recover_segments().unwrap();
     assert_eq!(info.branches_recovered, 1);
     assert_eq!(info.segments_loaded, 1);
-    assert_eq!(info.errors_skipped, 0);
+    assert!(matches!(info.health, super::RecoveryHealth::Healthy));
 
     for i in 1..=50u64 {
         let result = store2
@@ -496,7 +496,14 @@ fn recover_segments_skips_corrupt_files() {
     let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
     let info = store2.recover_segments().unwrap();
     assert_eq!(info.segments_loaded, 1);
-    assert_eq!(info.errors_skipped, 1);
+    let corrupt_count = match &info.health {
+        super::RecoveryHealth::Degraded { faults, .. } => faults
+            .iter()
+            .filter(|f| matches!(f, super::RecoveryFault::CorruptSegment { .. }))
+            .count(),
+        super::RecoveryHealth::Healthy => 0,
+    };
+    assert_eq!(corrupt_count, 1);
     assert!(store2
         .get_versioned(&kv_key("k"), CommitVersion::MAX)
         .unwrap()
@@ -508,7 +515,9 @@ fn recover_segments_empty_dir_is_noop() {
     let dir = tempfile::tempdir().unwrap();
     let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
     let info = store.recover_segments().unwrap();
-    assert_eq!(info, super::RecoverSegmentsInfo::default());
+    assert_eq!(info.branches_recovered, 0);
+    assert_eq!(info.segments_loaded, 0);
+    assert!(matches!(info.health, super::RecoveryHealth::Healthy));
 }
 
 #[test]
@@ -622,4 +631,172 @@ fn frozen_memtable_reads_correct_order() {
             .value,
         Value::Int(1),
     );
+}
+
+// ===== SE2 recovery-fault regression tests =====
+
+#[test]
+fn recover_corrupt_segment_produces_fault() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Seed one good segment
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    // Drop a garbage "segment" file next to the real one
+    let branch_hex = super::hex_encode_branch(&branch());
+    let corrupt_path = dir.path().join(&branch_hex).join("99999.sst");
+    std::fs::write(&corrupt_path, b"not a valid segment").unwrap();
+
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = store2.recover_segments().unwrap();
+
+    match &outcome.health {
+        super::RecoveryHealth::Degraded { faults, class } => {
+            assert_eq!(*class, super::DegradationClass::DataLoss);
+            let corrupt = faults.iter().find(|f| matches!(
+                f,
+                super::RecoveryFault::CorruptSegment { file, .. } if file == &corrupt_path
+            ));
+            assert!(corrupt.is_some(), "expected CorruptSegment for {corrupt_path:?}");
+        }
+        other => panic!("expected Degraded, got {other:?}"),
+    }
+
+    // Good segment still loads.
+    assert!(store2
+        .get_versioned(&kv_key("k"), CommitVersion::MAX)
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn recover_missing_manifest_listed_produces_fault() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    // Capture the on-disk segment filename before dropping the store.
+    let branch_hex = super::hex_encode_branch(&branch());
+    let branch_dir = dir.path().join(&branch_hex);
+    let sst_name = std::fs::read_dir(&branch_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .find(|e| e.path().extension().and_then(|x| x.to_str()) == Some("sst"))
+        .expect("expected exactly one .sst file")
+        .file_name()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    drop(store);
+
+    // Delete the real .sst but leave the manifest (which still references it).
+    std::fs::remove_file(branch_dir.join(&sst_name)).unwrap();
+
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = store2.recover_segments().unwrap();
+
+    match &outcome.health {
+        super::RecoveryHealth::Degraded { faults, class } => {
+            assert_eq!(*class, super::DegradationClass::DataLoss);
+            let missing = faults.iter().find(|f| matches!(
+                f,
+                super::RecoveryFault::MissingManifestListed { file, .. } if file == &sst_name
+            ));
+            assert!(
+                missing.is_some(),
+                "expected MissingManifestListed fault for {sst_name}"
+            );
+        }
+        other => panic!("expected Degraded, got {other:?}"),
+    }
+}
+
+#[test]
+fn recover_rebuilds_branch_max_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Seed segments whose commit versions span [1, 50].
+    for i in 1..=50u64 {
+        seed(
+            &store,
+            kv_key(&format!("k{:04}", i)),
+            Value::Int(i as i64),
+            i,
+        );
+    }
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = store2.recover_segments().unwrap();
+
+    // Version floor must reflect the highest commit id in the segments.
+    assert_eq!(outcome.version_floor, CommitVersion(50));
+    // Per-branch version map must carry the same for this branch.
+    assert_eq!(
+        outcome.branch_versions.get(&branch()).copied(),
+        Some(CommitVersion(50))
+    );
+    // Critically: the `BranchState::max_version` atomic must have been
+    // rebuilt. Pre-SE2 this stayed at the constructor default (0),
+    // causing post-restart `fork_branch` to under-claim the fork source
+    // version (SG-008). A weaker "segments have the right commit range"
+    // check would not catch a regression where the atomic is left at 0.
+    let b = store2.branches.get(&branch()).unwrap();
+    assert_eq!(
+        b.max_version.load(std::sync::atomic::Ordering::Acquire),
+        50,
+        "branch.max_version must be rebuilt from loaded segment commit ids"
+    );
+    assert!(matches!(outcome.health, super::RecoveryHealth::Healthy));
+}
+
+#[test]
+fn last_recovery_health_tracks_classification_across_calls() {
+    // Degraded recovery first: last_recovery_health() must classify as
+    // DataLoss (corrupt segment). Then a clean recovery on an empty dir
+    // must reset last_recovery_health() to Healthy.
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    // Drop a garbage .sst to trigger a CorruptSegment fault on next recovery.
+    let branch_hex = super::hex_encode_branch(&branch());
+    let corrupt_path = dir.path().join(&branch_hex).join("77777.sst");
+    std::fs::write(&corrupt_path, b"garbage").unwrap();
+
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    // Pre-recovery: accessor must return Healthy (nothing has run yet).
+    assert!(matches!(
+        &*store2.last_recovery_health(),
+        super::RecoveryHealth::Healthy
+    ));
+    store2.recover_segments().unwrap();
+    // Post-recovery: accessor reflects the classified outcome.
+    match &*store2.last_recovery_health() {
+        super::RecoveryHealth::Degraded { class, .. } => {
+            assert_eq!(*class, super::DegradationClass::DataLoss);
+        }
+        other => panic!("expected Degraded, got {other:?}"),
+    }
+
+    // A fresh store pointed at a clean directory must reset the accessor to
+    // Healthy after a successful recovery — the field is rewritten per call.
+    let clean = tempfile::tempdir().unwrap();
+    let store3 = SegmentedStore::with_dir(clean.path().to_path_buf(), 0);
+    store3.recover_segments().unwrap();
+    assert!(matches!(
+        &*store3.last_recovery_health(),
+        super::RecoveryHealth::Healthy
+    ));
 }

--- a/crates/storage/src/segmented/tests/flush.rs
+++ b/crates/storage/src/segmented/tests/flush.rs
@@ -656,11 +656,16 @@ fn recover_corrupt_segment_produces_fault() {
     match &outcome.health {
         super::RecoveryHealth::Degraded { faults, class } => {
             assert_eq!(*class, super::DegradationClass::DataLoss);
-            let corrupt = faults.iter().find(|f| matches!(
-                f,
-                super::RecoveryFault::CorruptSegment { file, .. } if file == &corrupt_path
-            ));
-            assert!(corrupt.is_some(), "expected CorruptSegment for {corrupt_path:?}");
+            let corrupt = faults.iter().find(|f| {
+                matches!(
+                    f,
+                    super::RecoveryFault::CorruptSegment { file, .. } if file == &corrupt_path
+                )
+            });
+            assert!(
+                corrupt.is_some(),
+                "expected CorruptSegment for {corrupt_path:?}"
+            );
         }
         other => panic!("expected Degraded, got {other:?}"),
     }
@@ -705,10 +710,12 @@ fn recover_missing_manifest_listed_produces_fault() {
     match &outcome.health {
         super::RecoveryHealth::Degraded { faults, class } => {
             assert_eq!(*class, super::DegradationClass::DataLoss);
-            let missing = faults.iter().find(|f| matches!(
-                f,
-                super::RecoveryFault::MissingManifestListed { file, .. } if file == &sst_name
-            ));
+            let missing = faults.iter().find(|f| {
+                matches!(
+                    f,
+                    super::RecoveryFault::MissingManifestListed { file, .. } if file == &sst_name
+                )
+            });
             assert!(
                 missing.is_some(),
                 "expected MissingManifestListed fault for {sst_name}"
@@ -716,6 +723,57 @@ fn recover_missing_manifest_listed_produces_fault() {
         }
         other => panic!("expected Degraded, got {other:?}"),
     }
+}
+
+#[test]
+fn recover_corrupt_manifest_listed_segment_is_not_reported_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+    drop(store);
+
+    let branch_hex = super::hex_encode_branch(&branch());
+    let branch_dir = dir.path().join(&branch_hex);
+    let listed_sst = std::fs::read_dir(&branch_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .find(|e| e.path().extension().and_then(|x| x.to_str()) == Some("sst"))
+        .expect("expected one manifest-listed .sst")
+        .path();
+    std::fs::write(&listed_sst, b"not a valid segment anymore").unwrap();
+
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = store2.recover_segments().unwrap();
+
+    match &outcome.health {
+        super::RecoveryHealth::Degraded { faults, class } => {
+            assert_eq!(*class, super::DegradationClass::DataLoss);
+            let corrupt_count = faults
+                .iter()
+                .filter(|f| matches!(f, super::RecoveryFault::CorruptSegment { .. }))
+                .count();
+            let missing_count = faults
+                .iter()
+                .filter(|f| matches!(f, super::RecoveryFault::MissingManifestListed { .. }))
+                .count();
+            assert_eq!(
+                corrupt_count, 1,
+                "listed corrupt segment should surface exactly one CorruptSegment fault"
+            );
+            assert_eq!(
+                missing_count, 0,
+                "listed corrupt segment exists on disk and must not be misreported as missing"
+            );
+        }
+        other => panic!("expected Degraded, got {other:?}"),
+    }
+    assert_eq!(
+        outcome.branches_recovered, 0,
+        "branch with no loadable own or inherited segments must not be counted as recovered"
+    );
 }
 
 #[test]
@@ -781,13 +839,39 @@ fn last_recovery_health_tracks_classification_across_calls() {
         &*store2.last_recovery_health(),
         super::RecoveryHealth::Healthy
     ));
-    store2.recover_segments().unwrap();
+    let outcome = store2.recover_segments().unwrap();
     // Post-recovery: accessor reflects the classified outcome.
-    match &*store2.last_recovery_health() {
-        super::RecoveryHealth::Degraded { class, .. } => {
-            assert_eq!(*class, super::DegradationClass::DataLoss);
+    match (&outcome.health, &*store2.last_recovery_health()) {
+        (
+            super::RecoveryHealth::Degraded {
+                faults: outcome_faults,
+                class: outcome_class,
+            },
+            super::RecoveryHealth::Degraded {
+                faults: stored_faults,
+                class: stored_class,
+            },
+        ) => {
+            assert_eq!(*outcome_class, super::DegradationClass::DataLoss);
+            assert_eq!(*stored_class, super::DegradationClass::DataLoss);
+            assert_eq!(
+                outcome_faults.len(),
+                stored_faults.len(),
+                "stored recovery health must preserve the same fault count as the returned outcome"
+            );
+            assert_eq!(
+                *outcome_class, *stored_class,
+                "stored recovery health must preserve the same degradation class"
+            );
+            assert!(
+                stored_faults.iter().any(|f| matches!(
+                    f,
+                    super::RecoveryFault::CorruptSegment { file, .. } if file == &corrupt_path
+                )),
+                "stored recovery health must preserve the original CorruptSegment fault"
+            );
         }
-        other => panic!("expected Degraded, got {other:?}"),
+        other => panic!("expected matching Degraded outcomes, got {other:?}"),
     }
 
     // A fresh store pointed at a clean directory must reset the accessor to

--- a/crates/storage/src/segmented/tests/flush.rs
+++ b/crates/storage/src/segmented/tests/flush.rs
@@ -884,3 +884,50 @@ fn last_recovery_health_tracks_classification_across_calls() {
         super::RecoveryHealth::Healthy
     ));
 }
+
+#[test]
+fn last_recovery_health_updates_on_prewalk_hard_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let not_a_dir = dir.path().join("segments-file");
+    std::fs::write(&not_a_dir, b"not a directory").unwrap();
+
+    let store = SegmentedStore::with_dir(not_a_dir.clone(), 0);
+    assert!(matches!(
+        &*store.last_recovery_health(),
+        super::RecoveryHealth::Healthy
+    ));
+
+    let err = store
+        .recover_segments()
+        .expect_err("top-level read_dir failure should still return Err");
+    let returned_kind = err.kind();
+
+    match &*store.last_recovery_health() {
+        super::RecoveryHealth::Degraded { faults, class } => {
+            assert_eq!(
+                *class,
+                super::DegradationClass::DataLoss,
+                "pre-walk I/O failures should publish degraded recovery health"
+            );
+            let io_fault = faults
+                .iter()
+                .find_map(|fault| match fault {
+                    super::RecoveryFault::Io(inner) => Some(inner),
+                    _ => None,
+                })
+                .expect("stored recovery health should preserve the pre-walk I/O failure");
+            assert_eq!(
+                io_fault.kind(),
+                returned_kind,
+                "stored recovery health should preserve the returned error kind"
+            );
+            assert!(
+                io_fault
+                    .to_string()
+                    .contains(not_a_dir.to_string_lossy().as_ref()),
+                "stored recovery health should identify the segments path that failed"
+            );
+        }
+        other => panic!("expected degraded health after pre-walk error, got {other:?}"),
+    }
+}

--- a/crates/storage/src/segmented/tests/flush.rs
+++ b/crates/storage/src/segmented/tests/flush.rs
@@ -528,6 +528,57 @@ fn recover_segments_no_dir_is_noop() {
 }
 
 #[test]
+fn recover_segments_missing_dir_is_hard_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("segments-missing");
+    let store = SegmentedStore::with_dir(missing.clone(), 0);
+
+    let err = store
+        .recover_segments()
+        .expect_err("missing authoritative segments dir must hard-fail");
+    assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+
+    match &*store.last_recovery_health() {
+        super::RecoveryHealth::Degraded { faults, class } => {
+            assert_eq!(
+                *class,
+                super::DegradationClass::DataLoss,
+                "missing storage root is authoritative loss"
+            );
+            let io_fault = faults
+                .iter()
+                .find_map(|fault| match fault {
+                    super::RecoveryFault::Io(inner) => Some(inner),
+                    _ => None,
+                })
+                .expect("missing-dir hard failure must be reflected in recovery health");
+            assert_eq!(io_fault.kind(), std::io::ErrorKind::NotFound);
+            assert!(
+                io_fault
+                    .to_string()
+                    .contains(missing.to_string_lossy().as_ref()),
+                "stored recovery health should name the missing storage root"
+            );
+        }
+        other => panic!("expected degraded recovery health, got {other:?}"),
+    }
+}
+
+#[test]
+fn recover_segments_rejects_second_call_on_same_store() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    let first = store.recover_segments().unwrap();
+    assert!(matches!(first.health, super::RecoveryHealth::Healthy));
+
+    let err = store
+        .recover_segments()
+        .expect_err("recovery bootstrap must be single-shot per store instance");
+    assert!(matches!(err, crate::StorageError::RecoveryAlreadyApplied));
+}
+
+#[test]
 fn recover_segments_ordering() {
     let dir = tempfile::tempdir().unwrap();
     let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);

--- a/crates/storage/src/segmented/tests/leveled.rs
+++ b/crates/storage/src/segmented/tests/leveled.rs
@@ -965,9 +965,30 @@ fn recover_without_manifest_all_l0() {
         std::fs::remove_file(&manifest_path).unwrap();
     }
 
-    // Recover — all segments go to L0 (backward compat)
+    // Recover — backward-compat L0 promotion still happens, but SE2 now
+    // emits a `NoManifestFallbackUsed` fault classified as
+    // `PolicyDowngrade` so strict callers (D4) can refuse.
     let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
-    store2.recover_segments().unwrap();
+    let info = store2.recover_segments().unwrap();
+
+    match &info.health {
+        super::RecoveryHealth::Degraded { faults, class } => {
+            assert_eq!(
+                *class,
+                super::DegradationClass::PolicyDowngrade,
+                "no-manifest fallback must classify as PolicyDowngrade"
+            );
+            assert!(
+                faults.iter().any(|f| matches!(
+                    f,
+                    super::RecoveryFault::NoManifestFallbackUsed { segments_promoted, .. }
+                    if *segments_promoted == 2
+                )),
+                "should emit NoManifestFallbackUsed fault with 2 segments promoted"
+            );
+        }
+        other => panic!("expected Degraded, got {other:?}"),
+    }
 
     assert_eq!(store2.l0_segment_count(&b), 2);
     assert_eq!(store2.l1_segment_count(&b), 0);
@@ -999,13 +1020,26 @@ fn recover_manifest_corrupt_returns_error() {
 
     // Recover — corrupt manifest must NOT silently load all as L0 (#1680).
     // The branch is skipped (own segments not loaded), but recovery itself
-    // succeeds so other branches are unaffected (#1691).
+    // succeeds so other branches are unaffected (#1691). Post-SE2 the
+    // defect surfaces as a `CorruptManifest` fault classified as `DataLoss`.
     let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
     let info = store2.recover_segments().unwrap();
-    assert!(
-        info.corrupt_manifest_branches > 0,
-        "corrupt manifest branch must be reported"
-    );
+    match &info.health {
+        super::RecoveryHealth::Degraded { faults, class } => {
+            assert_eq!(
+                *class,
+                super::DegradationClass::DataLoss,
+                "corrupt manifest must classify as DataLoss"
+            );
+            assert!(
+                faults
+                    .iter()
+                    .any(|f| matches!(f, super::RecoveryFault::CorruptManifest { .. })),
+                "corrupt manifest branch must be reported as CorruptManifest fault"
+            );
+        }
+        other => panic!("expected Degraded, got {other:?}"),
+    }
     // The corrupt branch's data must NOT be accessible.
     assert!(
         store2

--- a/crates/storage/src/segmented/tests/lifecycle.rs
+++ b/crates/storage/src/segmented/tests/lifecycle.rs
@@ -569,10 +569,12 @@ fn recovery_skips_orphan_sst_not_in_manifest() {
     // Drop store and recover
     drop(store);
     let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
-    let info = store2.recover_segments().unwrap();
+    let _info = store2.recover_segments().unwrap();
 
-    // The orphan should be skipped (not loaded as L0)
-    assert!(info.orphans_skipped >= 1, "expected orphan to be counted");
+    // The orphan should be skipped (not loaded as L0). Orphan-file telemetry
+    // lives internally to `recover_segments` (it is neither a fault nor a
+    // field on `RecoveredState`); the structural assertion below is what
+    // verifies the contract.
     let parent_state = store2.branches.get(&parent_branch()).unwrap();
     // Should have exactly 1 segment (the real one), not 2
     assert_eq!(
@@ -763,8 +765,15 @@ fn test_issue_1691_inherited_layer_recovery_independent_of_source() {
     // 7. The parent branch should NOT have been loaded with its own
     //    segments (corrupt manifest → skipped).  The parent's segment
     //    files still exist on disk, so the child's direct opens worked.
+    let parent_corrupt_reported = matches!(
+        &info.health,
+        super::RecoveryHealth::Degraded { faults, .. }
+            if faults
+                .iter()
+                .any(|f| matches!(f, super::RecoveryFault::CorruptManifest { .. }))
+    );
     assert!(
-        info.corrupt_manifest_branches > 0,
+        parent_corrupt_reported,
         "should report parent's corrupt manifest"
     );
     // Parent branch must not have its own segments loaded.

--- a/crates/storage/src/segmented/tests/materialize.rs
+++ b/crates/storage/src/segmented/tests/materialize.rs
@@ -567,9 +567,16 @@ fn materialize_crash_recovery_with_partial_segment() {
         let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
         let info = store.recover_segments().unwrap();
         assert!(info.branches_recovered >= 2, "both branches should recover");
+        let corrupt_segment_count = match &info.health {
+            super::RecoveryHealth::Degraded { faults, .. } => faults
+                .iter()
+                .filter(|f| matches!(f, super::RecoveryFault::CorruptSegment { .. }))
+                .count(),
+            super::RecoveryHealth::Healthy => 0,
+        };
         assert!(
-            info.errors_skipped >= 1,
-            "corrupt orphan .sst should be skipped"
+            corrupt_segment_count >= 1,
+            "corrupt orphan .sst should produce a CorruptSegment fault"
         );
 
         // Materializing status should be reset to Active
@@ -707,13 +714,30 @@ fn recovery_surfaces_missing_source_branch() {
         let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
         let info = store.recover_segments().unwrap();
 
-        // layers_dropped should report the missing parent
-        assert!(
-            !info.layers_dropped.is_empty(),
+        // An InheritedLayerLost fault should report the missing parent.
+        let faults = match &info.health {
+            super::RecoveryHealth::Degraded { faults, class } => {
+                assert_eq!(
+                    *class,
+                    super::DegradationClass::DataLoss,
+                    "inherited-layer loss classifies as DataLoss"
+                );
+                faults.as_slice()
+            }
+            super::RecoveryHealth::Healthy => &[],
+        };
+        let dropped = faults.iter().find_map(|f| match f {
+            super::RecoveryFault::InheritedLayerLost {
+                child,
+                source_branch,
+            } => Some((*child, *source_branch)),
+            _ => None,
+        });
+        assert_eq!(
+            dropped,
+            Some((child_branch(), parent_branch())),
             "should report dropped inherited layer"
         );
-        assert_eq!(info.layers_dropped[0].0, child_branch());
-        assert_eq!(info.layers_dropped[0].1, parent_branch());
 
         // Child should still exist but with no inherited layers
         let child = store.branches.get(&child_branch()).unwrap();

--- a/crates/storage/src/segmented/tests/materialize.rs
+++ b/crates/storage/src/segmented/tests/materialize.rs
@@ -683,6 +683,7 @@ fn materialize_crash_recovery_with_valid_orphan_segment() {
 #[test]
 fn recovery_surfaces_missing_source_branch() {
     let dir = tempfile::tempdir().unwrap();
+    let expected_fork_version;
 
     // Phase 1: Create parent and fork child
     {
@@ -702,6 +703,18 @@ fn recovery_surfaces_missing_source_branch() {
         // Write manifest for both branches
         store.write_branch_manifest(&parent_branch()).unwrap();
         store.write_branch_manifest(&child_branch()).unwrap();
+
+        let child_hex = hex_encode_branch(&child_branch());
+        let child_dir = dir.path().join(&child_hex);
+        let child_manifest = crate::manifest::read_manifest(&child_dir)
+            .unwrap()
+            .expect("child manifest should exist after fork");
+        assert_eq!(
+            child_manifest.inherited_layers.len(),
+            1,
+            "test setup should create exactly one inherited layer"
+        );
+        expected_fork_version = child_manifest.inherited_layers[0].fork_version;
     }
 
     // Sabotage: delete the parent's branch directory (simulating missing source)
@@ -714,7 +727,7 @@ fn recovery_surfaces_missing_source_branch() {
         let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
         let info = store.recover_segments().unwrap();
 
-        // An InheritedLayerLost fault should report the missing parent.
+        // An InheritedLayerLost fault should report the exact missing layer.
         let faults = match &info.health {
             super::RecoveryHealth::Degraded { faults, class } => {
                 assert_eq!(
@@ -730,13 +743,14 @@ fn recovery_surfaces_missing_source_branch() {
             super::RecoveryFault::InheritedLayerLost {
                 child,
                 source_branch,
-            } => Some((*child, *source_branch)),
+                fork_version,
+            } => Some((*child, *source_branch, *fork_version)),
             _ => None,
         });
         assert_eq!(
             dropped,
-            Some((child_branch(), parent_branch())),
-            "should report dropped inherited layer"
+            Some((child_branch(), parent_branch(), expected_fork_version)),
+            "should report the dropped inherited layer by source and fork version"
         );
         assert_eq!(
             info.branches_recovered, 0,
@@ -759,6 +773,7 @@ fn recovery_surfaces_missing_source_branch() {
 #[test]
 fn recovery_surfaces_partial_inherited_layer_loss() {
     let dir = tempfile::tempdir().unwrap();
+    let expected_fork_version;
 
     {
         let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
@@ -779,6 +794,18 @@ fn recovery_surfaces_partial_inherited_layer_loss() {
             .unwrap();
         store.write_branch_manifest(&parent_branch()).unwrap();
         store.write_branch_manifest(&child_branch()).unwrap();
+
+        let child_hex = hex_encode_branch(&child_branch());
+        let child_dir = dir.path().join(&child_hex);
+        let child_manifest = crate::manifest::read_manifest(&child_dir)
+            .unwrap()
+            .expect("child manifest should exist after fork");
+        assert_eq!(
+            child_manifest.inherited_layers.len(),
+            1,
+            "test setup should create exactly one inherited layer"
+        );
+        expected_fork_version = child_manifest.inherited_layers[0].fork_version;
     }
 
     let parent_hex = hex_encode_branch(&parent_branch());
@@ -815,9 +842,12 @@ fn recovery_surfaces_partial_inherited_layer_loss() {
             super::RecoveryFault::InheritedLayerLost {
                 child,
                 source_branch,
-            } if *child == child_branch() && *source_branch == parent_branch()
+                fork_version,
+            } if *child == child_branch()
+                && *source_branch == parent_branch()
+                && *fork_version == expected_fork_version
         )),
-        "partial inherited-layer loss must surface InheritedLayerLost"
+        "partial inherited-layer loss must surface the exact inherited layer"
     );
 
     let child = store.branches.get(&child_branch()).unwrap();

--- a/crates/storage/src/segmented/tests/materialize.rs
+++ b/crates/storage/src/segmented/tests/materialize.rs
@@ -722,7 +722,7 @@ fn recovery_surfaces_missing_source_branch() {
                     super::DegradationClass::DataLoss,
                     "inherited-layer loss classifies as DataLoss"
                 );
-                faults.as_slice()
+                &faults[..]
             }
             super::RecoveryHealth::Healthy => &[],
         };
@@ -738,6 +738,10 @@ fn recovery_surfaces_missing_source_branch() {
             Some((child_branch(), parent_branch())),
             "should report dropped inherited layer"
         );
+        assert_eq!(
+            info.branches_recovered, 0,
+            "child with no own segments and no recoverable inherited entries must not be counted"
+        );
 
         // Child should still exist but with no inherited layers
         let child = store.branches.get(&child_branch()).unwrap();
@@ -746,6 +750,81 @@ fn recovery_surfaces_missing_source_branch() {
             "inherited layer should be dropped (source missing)"
         );
     }
+}
+
+/// SE2 follow-up: if an inherited layer partially loads, recovery must still
+/// surface `InheritedLayerLost` rather than silently accepting a truncated
+/// child view. The child may keep the surviving inherited entries, but the
+/// authoritative loss must be visible in the typed fault set.
+#[test]
+fn recovery_surfaces_partial_inherited_layer_loss() {
+    let dir = tempfile::tempdir().unwrap();
+
+    {
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+        seed(&store, parent_kv("a"), Value::Int(1), 1);
+        store.rotate_memtable(&parent_branch());
+        store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+        seed(&store, parent_kv("b"), Value::Int(2), 2);
+        store.rotate_memtable(&parent_branch());
+        store.flush_oldest_frozen(&parent_branch()).unwrap();
+
+        store
+            .branches
+            .entry(child_branch())
+            .or_insert_with(BranchState::new);
+        store
+            .fork_branch(&parent_branch(), &child_branch())
+            .unwrap();
+        store.write_branch_manifest(&parent_branch()).unwrap();
+        store.write_branch_manifest(&child_branch()).unwrap();
+    }
+
+    let parent_hex = hex_encode_branch(&parent_branch());
+    let parent_dir = dir.path().join(&parent_hex);
+    let mut sst_paths: Vec<_> = std::fs::read_dir(&parent_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("sst"))
+        .collect();
+    sst_paths.sort();
+    let removed = sst_paths
+        .pop()
+        .expect("expected parent .sst files to exist");
+    std::fs::remove_file(&removed).unwrap();
+
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let info = store.recover_segments().unwrap();
+
+    let faults = match &info.health {
+        super::RecoveryHealth::Degraded { faults, class } => {
+            assert_eq!(
+                *class,
+                super::DegradationClass::DataLoss,
+                "partial inherited-layer loss is authoritative data loss"
+            );
+            &faults[..]
+        }
+        other => panic!("expected Degraded, got {other:?}"),
+    };
+    assert!(
+        faults.iter().any(|f| matches!(
+            f,
+            super::RecoveryFault::InheritedLayerLost {
+                child,
+                source_branch,
+            } if *child == child_branch() && *source_branch == parent_branch()
+        )),
+        "partial inherited-layer loss must surface InheritedLayerLost"
+    );
+
+    let child = store.branches.get(&child_branch()).unwrap();
+    assert!(
+        !child.inherited_layers.is_empty(),
+        "surviving inherited entries should still be installed for the child"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Replaces `SegmentedStore::recover_segments()`'s legacy `RecoverSegmentsInfo` stats with a typed self-contained `RecoveredState` (version floor, per-branch version map, classified `RecoveryHealth`). Closes SG-004, SG-005, SG-007, SG-008, SG-013 (and by identity-map DG-005, DG-006).
- Silent-skip arms become typed `RecoveryFault`s (`CorruptSegment`, `CorruptManifest`, `MissingManifestListed`, `InheritedLayerLost`, `NoManifestFallbackUsed`, `Io`); `DegradationClass` (`DataLoss` / `PolicyDowngrade` / `Telemetry`) lets callers branch on severity without iterating faults.
- `BranchState::max_version` is now rebuilt during recovery from loaded segment commit ranges — closes **SG-008** (post-restart `fork_branch` no longer under-claims the fork-source version).
- Engine integration: new `TransactionCoordinator::apply_storage_recovery(&RecoveredState)` single entry point (replaces direct `bump_version_floor` from recovery). `Database::recover_segments_and_bump` → `recover_segments_and_apply`, emits `strata::recovery::health` warn on `Degraded`.
- Storage stores classified health on `SegmentedStore.last_recovery_health` (ArcSwap); accessor ready for SE3 GC refusal and D4 engine-side `recovery_health()`.

Strict-vs-lossy policy on `Degraded` is **intentionally not here** — D4's scope, inside D3's `run_recovery` orchestrator. SE2 produces the classified outcome; D4 decides what to do with it.

**Change class:** intentional semantic change (cutover) — `RecoverSegmentsInfo` deleted; all consumers migrated in the same PR.
**Assurance class:** S4 (recovery path).

## Test plan

- [x] `cargo test -p strata-storage --lib` — 678 passed (adds 4 SE2 regressions: corrupt-segment fault, missing-manifest-listed fault, branch.max_version rebuild via the atomic directly, last_recovery_health accessor classification across calls)
- [x] `cargo test -p strata-engine` — 1013 lib + integration suites (flush_pipeline_tests, recovery, shutdown) all green
- [x] `cargo check --workspace` clean
- [x] `cargo clippy -p strata-storage -p strata-engine --all-targets` — no new warnings (only pre-existing unreachable_pub noise)
- [x] D4 surface: only new `pub` is `apply_storage_recovery` method on already-pub `TransactionCoordinator` (analogous to existing `bump_version_floor`); no new pub types in engine
- [x] Crate DAG: `engine → storage` edge already allowed; new `RecoveredState` import adds no new dependency
- [ ] Full benchmark suite (non-`--quick`) — deferred to tranche gate. Baseline is 9 days stale (predates D1/D2/D5/D6/D7/SE1); `--quick` regressions are cumulative program drift, not SE2-attributable. SE2 touches only the recovery path (one-shot at startup); hot paths unchanged.

## Pre-PR audit findings (fixed in this PR)

- `recover_rebuilds_branch_max_version` originally asserted on segment commit_range instead of `BranchState::max_version` atomic — strengthened to assert the atomic directly (the actual state SG-008 requires rebuilt).
- `last_recovery_health()` accessor was untested — added regression covering pre-recovery Healthy, post-degraded DataLoss, and reset-to-Healthy on clean recovery.
- Early draft emitted `MissingManifestListed` only inside the level-partition loop, which was skipped when a branch had no on-disk segments — moved validation ahead of the empty-branch skip so authoritative loss surfaces even when nothing gets installed.

## Parent plan

Per `docs/design/durability/durability-storage-closure-epics.md` Epic SE2 (SG-004/005/007/008/013). Follow-ups: SE3 (GC refusal under degraded recovery) reads `last_recovery_health`; D3 plumbs `RecoveredState` through the unified `Database::run_recovery`; D4 adds the strict-vs-lossy policy branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)