### PR TITLE
SE3: deletion safety under degraded recovery — gate gc_orphan_segments on RecoveryHealth

### DIFF
--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -5,7 +5,7 @@ use strata_core::types::BranchId;
 use strata_core::StrataError;
 use thiserror::Error;
 
-use crate::segmented::RecoveryFault;
+use crate::segmented::{DegradationClass, RecoveryFault};
 
 /// Result alias for storage-local operations that can raise [`StorageError`].
 pub type StorageResult<T> = Result<T, StorageError>;
@@ -53,6 +53,19 @@ pub enum StorageError {
     /// [`RecoveredState`]: crate::segmented::RecoveredState
     #[error(transparent)]
     RecoveryFault(#[from] RecoveryFault),
+
+    /// Orphan-segment GC refused to run because the most recent recovery
+    /// produced a degradation class that could make deletion unsafe
+    /// (`DataLoss` or `PolicyDowngrade`). Callers log this as a
+    /// retention-debt signal and continue; GC resumes after an explicit
+    /// `SegmentedStore::reset_recovery_health()` admin action.
+    #[error("gc refused: last recovery degradation class {class:?} is not safe for deletion")]
+    GcRefusedDegradedRecovery {
+        /// Classified severity of the most recent recovery. Any class other
+        /// than `Telemetry` blocks deletion; `DataLoss` and `PolicyDowngrade`
+        /// both route here.
+        class: DegradationClass,
+    },
 }
 
 impl StorageError {
@@ -64,10 +77,11 @@ impl StorageError {
     pub fn kind(&self) -> io::ErrorKind {
         match self {
             StorageError::Io(inner) => inner.kind(),
-            StorageError::RecoveryAlreadyApplied => io::ErrorKind::Other,
             StorageError::ManifestPublish { inner, .. } => inner.kind(),
             StorageError::DirFsync { inner, .. } => inner.kind(),
             StorageError::RecoveryFault(fault) => recovery_fault_kind(fault),
+            StorageError::RecoveryAlreadyApplied
+            | StorageError::GcRefusedDegradedRecovery { .. } => io::ErrorKind::Other,
         }
     }
 }
@@ -104,6 +118,9 @@ impl From<StorageError> for StrataError {
             StorageError::RecoveryFault(fault) => {
                 StrataError::storage_with_source("recovery fault", fault)
             }
+            StorageError::GcRefusedDegradedRecovery { class } => StrataError::storage(format!(
+                "gc refused under degraded recovery ({class:?})"
+            )),
         }
     }
 }

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -22,6 +22,14 @@ pub enum StorageError {
     #[error("recover_segments() can only run once per SegmentedStore instance")]
     RecoveryAlreadyApplied,
 
+    /// `reset_recovery_health()` can only clear the GC refusal after this
+    /// store instance successfully completed `recover_segments()` and
+    /// installed the recovered branch/refcount view. Hard pre-walk recovery
+    /// failures never reach that point, so clearing the health bit on the
+    /// same instance would let GC treat every on-disk `.sst` as unseen.
+    #[error("reset_recovery_health() requires a successfully applied recover_segments() on this store instance")]
+    RecoveryHealthResetRequiresSuccessfulRecovery,
+
     /// Publishing a branch manifest failed before the atomic rename completed.
     #[error("failed to publish segment manifest for branch {branch_id}: {inner}")]
     ManifestPublish {
@@ -57,13 +65,30 @@ pub enum StorageError {
     /// Orphan-segment GC refused to run because the most recent recovery
     /// produced a degradation class that could make deletion unsafe
     /// (`DataLoss` or `PolicyDowngrade`). Callers log this as a
-    /// retention-debt signal and continue; GC resumes after an explicit
-    /// `SegmentedStore::reset_recovery_health()` admin action.
+    /// retention-debt signal and continue; `PolicyDowngrade` can be cleared
+    /// in-place via `SegmentedStore::reset_recovery_health()`, while
+    /// `DataLoss` requires a fresh reopen.
     #[error("gc refused: last recovery degradation class {class:?} is not safe for deletion")]
     GcRefusedDegradedRecovery {
         /// Classified severity of the most recent recovery. Any class other
         /// than `Telemetry` blocks deletion; `DataLoss` and `PolicyDowngrade`
         /// both route here.
+        class: DegradationClass,
+    },
+
+    /// `reset_recovery_health()` cannot clear this degraded recovery on the
+    /// same store instance. After authoritative loss, operators may restore
+    /// manifests or `.sst`s on disk, but this store's in-memory
+    /// `self.branches` / refcount view is a one-shot snapshot from the
+    /// original reopen. Re-enabling GC without a fresh reopen would let it
+    /// delete restored files that recovery never reloaded. Any future
+    /// degradation class that is not explicitly allowlisted also routes here.
+    #[error("reset_recovery_health() requires a fresh reopen after degraded recovery ({class:?})")]
+    RecoveryHealthResetRequiresReopen {
+        /// Classified severity that blocks an in-place reset. `PolicyDowngrade`
+        /// is the only allowlisted degraded class for in-place reset;
+        /// `Telemetry` never refuses GC, and any other current or future class
+        /// requires a fresh reopen.
         class: DegradationClass,
     },
 }
@@ -81,7 +106,9 @@ impl StorageError {
             StorageError::DirFsync { inner, .. } => inner.kind(),
             StorageError::RecoveryFault(fault) => recovery_fault_kind(fault),
             StorageError::RecoveryAlreadyApplied
-            | StorageError::GcRefusedDegradedRecovery { .. } => io::ErrorKind::Other,
+            | StorageError::RecoveryHealthResetRequiresSuccessfulRecovery
+            | StorageError::GcRefusedDegradedRecovery { .. }
+            | StorageError::RecoveryHealthResetRequiresReopen { .. } => io::ErrorKind::Other,
         }
     }
 }
@@ -104,6 +131,9 @@ impl From<StorageError> for StrataError {
             StorageError::RecoveryAlreadyApplied => {
                 StrataError::storage("segment recovery already applied on this store instance")
             }
+            StorageError::RecoveryHealthResetRequiresSuccessfulRecovery => StrataError::storage(
+                "reset_recovery_health() requires a successfully applied recovery on this store instance",
+            ),
             StorageError::ManifestPublish { branch_id, inner } => StrataError::storage_with_source(
                 format!("failed to publish segment manifest for branch {branch_id}"),
                 inner,
@@ -121,6 +151,11 @@ impl From<StorageError> for StrataError {
             StorageError::GcRefusedDegradedRecovery { class } => StrataError::storage(format!(
                 "gc refused under degraded recovery ({class:?})"
             )),
+            StorageError::RecoveryHealthResetRequiresReopen { class } => {
+                StrataError::storage(format!(
+                    "reset_recovery_health() requires a fresh reopen after degraded recovery ({class:?})"
+                ))
+            }
         }
     }
 }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -966,19 +966,48 @@ impl SegmentedStore {
         self.last_recovery_health.load_full()
     }
 
-    /// Reset recovery health back to [`RecoveryHealth::Healthy`], lifting the
-    /// orphan-segment GC refusal that SE3 installs after a degraded recovery.
+    /// Reset recovery health back to [`RecoveryHealth::Healthy`] when an
+    /// in-place reset is actually safe.
     ///
     /// **Destructive admin.** S4 per the durability-storage-closure plan.
-    /// Callers are expected to have reconciled the retention debt before
-    /// invoking this (either by restoring the degraded branches or by
-    /// confirming they are intentionally absent). Calling without that
-    /// reconciliation risks `.sst` deletions that remove the last surviving
-    /// copy of authoritative state. The engine-level wrapper on `Database`
-    /// is owned by D4.
-    pub fn reset_recovery_health(&self) {
-        self.last_recovery_health
-            .store(Arc::new(RecoveryHealth::Healthy));
+    /// The reset is intentionally narrower than "clear whatever happened":
+    ///
+    /// - `recover_segments()` must have successfully installed this store's
+    ///   branch/refcount view. Hard pre-walk failures never reached an
+    ///   authoritative in-memory snapshot, so GC cannot be re-enabled on the
+    ///   same instance.
+    /// - `DataLoss` degradations require a fresh reopen after reconciliation.
+    ///   This store's recovery view is one-shot; if an operator restores a
+    ///   manifest or `.sst` after reopen, the same instance cannot reload it,
+    ///   and clearing the health bit would let GC delete the restored file.
+    ///
+    /// `PolicyDowngrade` can be cleared in-place after a successful recovery
+    /// because the store already loaded every discovered `.sst` into its live
+    /// graph. `Telemetry` does not block GC in the first place.
+    pub fn reset_recovery_health(&self) -> StorageResult<()> {
+        let health = self.last_recovery_health.load_full();
+        match &*health {
+            RecoveryHealth::Healthy => Ok(()),
+            RecoveryHealth::Degraded {
+                class: DegradationClass::PolicyDowngrade,
+                ..
+            } => {
+                if !self.recovery_applied.load(Ordering::Acquire) {
+                    return Err(StorageError::RecoveryHealthResetRequiresSuccessfulRecovery);
+                }
+
+                self.last_recovery_health
+                    .store(Arc::new(RecoveryHealth::Healthy));
+                Ok(())
+            }
+            RecoveryHealth::Degraded { class, .. } => {
+                if !self.recovery_applied.load(Ordering::Acquire) {
+                    return Err(StorageError::RecoveryHealthResetRequiresSuccessfulRecovery);
+                }
+
+                Err(StorageError::RecoveryHealthResetRequiresReopen { class: *class })
+            }
+        }
     }
 
     /// Test-only hook: install an arbitrary [`RecoveryHealth`] value so tests
@@ -1416,7 +1445,7 @@ impl SegmentedStore {
             // any .sst on disk not referenced by a live branch or the refcount
             // registry. A degraded recovery (SE3) makes GC refuse; branch
             // clearing still succeeds, but the retention debt accumulates
-            // until an operator calls `reset_recovery_health()`.
+            // until a safe reset or fresh reopen re-establishes GC trust.
             if let Err(e) = self.gc_orphan_segments() {
                 tracing::warn!(
                     target: "strata::storage::gc",
@@ -1468,9 +1497,10 @@ impl SegmentedStore {
     /// branch set may not reflect every branch that still has authoritative
     /// on-disk state, so "not in `live_ids`" is not a safe deletion proof.
     /// [`DegradationClass::Telemetry`] is not a refusal cause — rebuildable
-    /// caches do not compromise deletion safety. The refusal is lifted by
-    /// [`SegmentedStore::reset_recovery_health`] after an operator has
-    /// reconciled the retention debt.
+    /// caches do not compromise deletion safety. `PolicyDowngrade` can be
+    /// cleared in-place via [`SegmentedStore::reset_recovery_health`] after a
+    /// successful recovery; `DataLoss` requires a fresh reopen because the
+    /// current store instance cannot reload later-restored files.
     pub fn gc_orphan_segments(&self) -> StorageResult<GcReport> {
         match &**self.last_recovery_health.load() {
             RecoveryHealth::Healthy => {}

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -828,6 +828,18 @@ fn missing_segments_dir_error(path: &std::path::Path) -> io::Error {
     )
 }
 
+/// Outcome of [`SegmentedStore::gc_orphan_segments`].
+///
+/// A successful call reports how many orphan `.sst` files were actually
+/// reaped. A refusal surfaces as [`StorageError::GcRefusedDegradedRecovery`]
+/// on the `Err` arm and does not produce a [`GcReport`].
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct GcReport {
+    /// Number of orphan segment files removed from disk in this call.
+    pub files_deleted: usize,
+}
+
 impl SegmentedStore {
     /// Create a new ephemeral segmented store (no disk segments).
     ///
@@ -952,6 +964,29 @@ impl SegmentedStore {
     /// invalidate this handle.
     pub fn last_recovery_health(&self) -> Arc<RecoveryHealth> {
         self.last_recovery_health.load_full()
+    }
+
+    /// Reset recovery health back to [`RecoveryHealth::Healthy`], lifting the
+    /// orphan-segment GC refusal that SE3 installs after a degraded recovery.
+    ///
+    /// **Destructive admin.** S4 per the durability-storage-closure plan.
+    /// Callers are expected to have reconciled the retention debt before
+    /// invoking this (either by restoring the degraded branches or by
+    /// confirming they are intentionally absent). Calling without that
+    /// reconciliation risks `.sst` deletions that remove the last surviving
+    /// copy of authoritative state. The engine-level wrapper on `Database`
+    /// is owned by D4.
+    pub fn reset_recovery_health(&self) {
+        self.last_recovery_health
+            .store(Arc::new(RecoveryHealth::Healthy));
+    }
+
+    /// Test-only hook: install an arbitrary [`RecoveryHealth`] value so tests
+    /// can exercise the GC refusal and telemetry-passthrough paths without
+    /// driving a full recovery.
+    #[cfg(test)]
+    pub(crate) fn set_recovery_health_for_test(&self, health: RecoveryHealth) {
+        self.last_recovery_health.store(Arc::new(health));
     }
 
     /// Increment version and return new value.
@@ -1379,8 +1414,18 @@ impl SegmentedStore {
             // Refcount decrements above may have released the last reference to
             // segments whose parent already compacted them away. GC deletes
             // any .sst on disk not referenced by a live branch or the refcount
-            // registry.
-            self.gc_orphan_segments();
+            // registry. A degraded recovery (SE3) makes GC refuse; branch
+            // clearing still succeeds, but the retention debt accumulates
+            // until an operator calls `reset_recovery_health()`.
+            if let Err(e) = self.gc_orphan_segments() {
+                tracing::warn!(
+                    target: "strata::storage::gc",
+                    branch_id = %hex_encode_branch(branch_id),
+                    op = "clear_branch",
+                    error = %e,
+                    "gc_orphan_segments refused; retention debt accumulated",
+                );
+            }
 
             // 5. Retry directory removal after gc — gc may have deleted
             // .sst files from in-flight compaction that landed between
@@ -1415,11 +1460,33 @@ impl SegmentedStore {
     /// to 0) without being able to delete the file (the parent might still
     /// own it at that time).
     ///
-    /// Returns the number of files deleted.
-    pub fn gc_orphan_segments(&self) -> usize {
-        let segments_dir = match &self.segments_dir {
-            Some(d) => d,
-            None => return 0,
+    /// # Refusal under degraded recovery (SE3 / SG-009)
+    ///
+    /// GC refuses when [`SegmentedStore::last_recovery_health`] is
+    /// `Degraded` with class [`DegradationClass::DataLoss`] or
+    /// [`DegradationClass::PolicyDowngrade`]: in either case the in-memory
+    /// branch set may not reflect every branch that still has authoritative
+    /// on-disk state, so "not in `live_ids`" is not a safe deletion proof.
+    /// [`DegradationClass::Telemetry`] is not a refusal cause — rebuildable
+    /// caches do not compromise deletion safety. The refusal is lifted by
+    /// [`SegmentedStore::reset_recovery_health`] after an operator has
+    /// reconciled the retention debt.
+    pub fn gc_orphan_segments(&self) -> StorageResult<GcReport> {
+        match &**self.last_recovery_health.load() {
+            RecoveryHealth::Healthy => {}
+            RecoveryHealth::Degraded {
+                class: DegradationClass::Telemetry,
+                ..
+            } => {
+                // Rebuildable-cache errors don't compromise deletion safety.
+            }
+            RecoveryHealth::Degraded { class, .. } => {
+                return Err(StorageError::GcRefusedDegradedRecovery { class: *class });
+            }
+        }
+
+        let Some(segments_dir) = &self.segments_dir else {
+            return Ok(GcReport { files_deleted: 0 });
         };
 
         // Build the set of all segment file_id values currently live in any
@@ -1444,9 +1511,8 @@ impl SegmentedStore {
         let mut deleted = 0usize;
 
         // Scan all branch directories.
-        let entries = match std::fs::read_dir(segments_dir) {
-            Ok(e) => e,
-            Err(_) => return 0,
+        let Ok(entries) = std::fs::read_dir(segments_dir) else {
+            return Ok(GcReport { files_deleted: 0 });
         };
         for entry in entries.flatten() {
             let path = entry.path();
@@ -1476,7 +1542,9 @@ impl SegmentedStore {
             }
         }
 
-        deleted
+        Ok(GcReport {
+            files_deleted: deleted,
+        })
     }
 
     /// Number of inherited layers for a branch.
@@ -1775,8 +1843,18 @@ impl SegmentedStore {
 
         // Garbage-collect orphan segment files (#1705).
         // Refcount decrements above may have released the last reference to
-        // segments whose parent already compacted them away.
-        self.gc_orphan_segments();
+        // segments whose parent already compacted them away. A degraded
+        // recovery (SE3) makes GC refuse; materialize still succeeds and
+        // the retention debt is logged.
+        if let Err(e) = self.gc_orphan_segments() {
+            tracing::warn!(
+                target: "strata::storage::gc",
+                branch_id = %hex_encode_branch(child_branch_id),
+                op = "materialize_layer",
+                error = %e,
+                "gc_orphan_segments refused; retention debt accumulated",
+            );
+        }
 
         if let Some(err) = initial_not_durable {
             tracing::warn!(

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -1503,13 +1503,13 @@ impl SegmentedStore {
     /// current store instance cannot reload later-restored files.
     pub fn gc_orphan_segments(&self) -> StorageResult<GcReport> {
         match &**self.last_recovery_health.load() {
-            RecoveryHealth::Healthy => {}
-            RecoveryHealth::Degraded {
+            // Healthy and Telemetry-only degradation (rebuildable-cache errors)
+            // do not compromise deletion safety, so GC proceeds normally.
+            RecoveryHealth::Healthy
+            | RecoveryHealth::Degraded {
                 class: DegradationClass::Telemetry,
                 ..
-            } => {
-                // Rebuildable-cache errors don't compromise deletion safety.
-            }
+            } => {}
             RecoveryHealth::Degraded { class, .. } => {
                 return Err(StorageError::GcRefusedDegradedRecovery { class: *class });
             }

--- a/crates/storage/src/segmented/tests/gc_under_degradation.rs
+++ b/crates/storage/src/segmented/tests/gc_under_degradation.rs
@@ -1,0 +1,215 @@
+//! SE3 regressions for `gc_orphan_segments` refusal under degraded recovery.
+//!
+//! Pins the SG-009 contract: after a recovery that produced `DataLoss` or
+//! `PolicyDowngrade` health, orphan-segment GC refuses to run. `Telemetry`
+//! degradation does not block GC. The refusal is lifted by
+//! `reset_recovery_health()`.
+
+use super::*;
+use crate::segmented::{
+    DegradationClass, RecoveryFault, RecoveryHealth,
+};
+use crate::StorageError;
+
+/// After a corrupt-manifest recovery, `gc_orphan_segments()` must refuse
+/// and leave the would-be-orphaned `.sst` files on disk.
+#[test]
+fn gc_refuses_after_corrupt_manifest_recovery() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    // Flush a real segment so we get a valid manifest + SST on disk.
+    seed(&store, kv_key("real"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    let branch_hex = super::hex_encode_branch(&branch());
+    let branch_dir = dir.path().join(&branch_hex);
+
+    // Collect the .sst files that would be candidates for orphan GC if the
+    // branch were dropped by recovery.
+    let ssts_before: Vec<_> = std::fs::read_dir(&branch_dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("sst"))
+        .collect();
+    assert!(!ssts_before.is_empty(), "setup must produce at least one sst");
+
+    // Corrupt the manifest — recovery must classify this as DataLoss.
+    let manifest_path = branch_dir.join("segments.manifest");
+    let mut data = std::fs::read(&manifest_path).unwrap();
+    let mid = data.len() / 2;
+    data[mid] ^= 0xFF;
+    std::fs::write(&manifest_path, &data).unwrap();
+
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = store2.recover_segments().unwrap();
+    match &outcome.health {
+        RecoveryHealth::Degraded { class, faults } => {
+            assert_eq!(*class, DegradationClass::DataLoss);
+            assert!(
+                faults
+                    .iter()
+                    .any(|f| matches!(f, RecoveryFault::CorruptManifest { .. })),
+                "expected CorruptManifest fault in {faults:?}"
+            );
+        }
+        other => panic!("expected Degraded after corrupt manifest; got {other:?}"),
+    }
+
+    let err = store2
+        .gc_orphan_segments()
+        .expect_err("gc must refuse under DataLoss recovery");
+    match err {
+        StorageError::GcRefusedDegradedRecovery { class } => {
+            assert_eq!(class, DegradationClass::DataLoss);
+        }
+        other => panic!("expected GcRefusedDegradedRecovery; got {other:?}"),
+    }
+
+    // Orphan .sst files from the skipped branch must remain on disk: the
+    // degraded recovery did not track them in self.branches, so without the
+    // refusal they would have been mistaken for orphans and reaped.
+    for sst in &ssts_before {
+        assert!(
+            sst.exists(),
+            "sst {sst:?} would have been unsafely reaped without SE3 refusal"
+        );
+    }
+}
+
+/// After `reset_recovery_health()`, GC unblocks — the admin path lifts the
+/// refusal that SE3 installs.
+#[test]
+fn gc_runs_after_reset_recovery_health() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    seed(&store, kv_key("real"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    let branch_hex = super::hex_encode_branch(&branch());
+    let manifest_path = dir.path().join(&branch_hex).join("segments.manifest");
+    let mut data = std::fs::read(&manifest_path).unwrap();
+    let mid = data.len() / 2;
+    data[mid] ^= 0xFF;
+    std::fs::write(&manifest_path, &data).unwrap();
+
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let _ = store2.recover_segments().unwrap();
+    assert!(store2.gc_orphan_segments().is_err(), "GC must refuse first");
+
+    store2.reset_recovery_health();
+    assert!(matches!(
+        &*store2.last_recovery_health(),
+        RecoveryHealth::Healthy
+    ));
+    store2
+        .gc_orphan_segments()
+        .expect("GC must succeed after reset_recovery_health");
+}
+
+/// A clean recovery leaves the store in `Healthy`; GC runs and returns a
+/// `GcReport` with `files_deleted` == 0 when there are no orphans.
+#[test]
+fn gc_runs_under_clean_recovery() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    seed(&store, kv_key("real"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = store2.recover_segments().unwrap();
+    assert!(matches!(outcome.health, RecoveryHealth::Healthy));
+    assert!(matches!(
+        &*store2.last_recovery_health(),
+        RecoveryHealth::Healthy
+    ));
+
+    let report = store2
+        .gc_orphan_segments()
+        .expect("clean recovery; gc must succeed");
+    assert_eq!(report.files_deleted, 0);
+}
+
+/// `PolicyDowngrade` class (e.g. no-manifest fallback engaged during
+/// recovery) must block GC for the same reason `DataLoss` does: the
+/// in-memory branch set cannot be treated as authoritative, so "not in
+/// `live_ids`" is not a safe deletion proof.
+#[test]
+fn gc_refuses_under_policy_downgrade_degradation() {
+    let store = SegmentedStore::new();
+    store.set_recovery_health_for_test(RecoveryHealth::Degraded {
+        faults: std::sync::Arc::from(vec![RecoveryFault::NoManifestFallbackUsed {
+            branch_id: branch(),
+            segments_promoted: 3,
+        }]),
+        class: DegradationClass::PolicyDowngrade,
+    });
+
+    let err = store
+        .gc_orphan_segments()
+        .expect_err("gc must refuse under PolicyDowngrade");
+    match err {
+        StorageError::GcRefusedDegradedRecovery { class } => {
+            assert_eq!(class, DegradationClass::PolicyDowngrade);
+        }
+        other => panic!("expected GcRefusedDegradedRecovery; got {other:?}"),
+    }
+}
+
+/// `Telemetry`-class degradation does not compromise deletion safety —
+/// rebuildable-cache errors must not block GC.
+#[test]
+fn gc_runs_under_telemetry_only_degradation() {
+    let store = SegmentedStore::new();
+    store.set_recovery_health_for_test(RecoveryHealth::Degraded {
+        faults: std::sync::Arc::from(vec![RecoveryFault::Io(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "synthetic rebuildable-cache glitch",
+        ))]),
+        class: DegradationClass::Telemetry,
+    });
+
+    store
+        .gc_orphan_segments()
+        .expect("Telemetry-class degradation must not block GC");
+}
+
+/// `clear_branch` must succeed even when GC refuses: the primary task
+/// (removing the target branch from `self.branches` and its on-disk
+/// segments) is independent of orphan GC, which only accumulates
+/// retention debt on refusal.
+#[test]
+fn clear_branch_succeeds_under_degraded_recovery() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    seed(&store, kv_key("target"), Value::Int(7), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    // Simulate a degraded recovery state without actually corrupting
+    // anything — exercises the log-and-continue path inside clear_branch.
+    store.set_recovery_health_for_test(RecoveryHealth::Degraded {
+        faults: std::sync::Arc::from(vec![RecoveryFault::InheritedLayerLost {
+            child: branch(),
+            source_branch: branch(),
+            fork_version: CommitVersion(0),
+        }]),
+        class: DegradationClass::DataLoss,
+    });
+
+    assert!(
+        store.clear_branch(&branch()),
+        "clear_branch must succeed even when gc refuses under degraded recovery"
+    );
+    assert!(
+        store.branches.get(&branch()).is_none(),
+        "branch must be removed from the in-memory map regardless of gc refusal"
+    );
+}

--- a/crates/storage/src/segmented/tests/gc_under_degradation.rs
+++ b/crates/storage/src/segmented/tests/gc_under_degradation.rs
@@ -2,8 +2,10 @@
 //!
 //! Pins the SG-009 contract: after a recovery that produced `DataLoss` or
 //! `PolicyDowngrade` health, orphan-segment GC refuses to run. `Telemetry`
-//! degradation does not block GC. The refusal is lifted by
-//! `reset_recovery_health()`.
+//! degradation does not block GC. `reset_recovery_health()` only clears
+//! `PolicyDowngrade` after a successful recovery install; `DataLoss`
+//! requires a fresh reopen and hard pre-walk recovery failures cannot be
+//! cleared on the same instance.
 
 use super::*;
 use crate::segmented::{
@@ -79,10 +81,11 @@ fn gc_refuses_after_corrupt_manifest_recovery() {
     }
 }
 
-/// After `reset_recovery_health()`, GC unblocks — the admin path lifts the
-/// refusal that SE3 installs.
+/// `DataLoss` recovery cannot be reset in-place: the store's in-memory
+/// recovery graph is a one-shot snapshot, so a fresh reopen is required
+/// before GC can trust restored files.
 #[test]
-fn gc_runs_after_reset_recovery_health() {
+fn reset_recovery_health_refuses_after_data_loss_recovery() {
     let dir = tempfile::tempdir().unwrap();
     let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
 
@@ -101,14 +104,26 @@ fn gc_runs_after_reset_recovery_health() {
     let _ = store2.recover_segments().unwrap();
     assert!(store2.gc_orphan_segments().is_err(), "GC must refuse first");
 
-    store2.reset_recovery_health();
+    let err = store2
+        .reset_recovery_health()
+        .expect_err("DataLoss reset must require a fresh reopen");
+    match err {
+        StorageError::RecoveryHealthResetRequiresReopen { class } => {
+            assert_eq!(class, DegradationClass::DataLoss);
+        }
+        other => panic!("expected RecoveryHealthResetRequiresReopen; got {other:?}"),
+    }
     assert!(matches!(
         &*store2.last_recovery_health(),
-        RecoveryHealth::Healthy
+        RecoveryHealth::Degraded {
+            class: DegradationClass::DataLoss,
+            ..
+        }
     ));
-    store2
-        .gc_orphan_segments()
-        .expect("GC must succeed after reset_recovery_health");
+    assert!(
+        store2.gc_orphan_segments().is_err(),
+        "failed reset must leave GC refusal in place"
+    );
 }
 
 /// A clean recovery leaves the store in `Healthy`; GC runs and returns a
@@ -162,6 +177,45 @@ fn gc_refuses_under_policy_downgrade_degradation() {
     }
 }
 
+/// After a successful `PolicyDowngrade` recovery install, the operator can
+/// explicitly clear the GC refusal in-place.
+#[test]
+fn gc_runs_after_reset_recovery_health_under_policy_downgrade() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+
+    seed(&store, kv_key("real"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    let branch_hex = super::hex_encode_branch(&branch());
+    std::fs::remove_file(dir.path().join(&branch_hex).join("segments.manifest")).unwrap();
+
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = store2.recover_segments().unwrap();
+    assert!(matches!(
+        outcome.health,
+        RecoveryHealth::Degraded {
+            class: DegradationClass::PolicyDowngrade,
+            ..
+        }
+    ));
+    assert!(store2.gc_orphan_segments().is_err(), "GC must refuse first");
+
+    store2
+        .reset_recovery_health()
+        .expect("PolicyDowngrade reset should succeed after successful recovery");
+    assert!(matches!(
+        &*store2.last_recovery_health(),
+        RecoveryHealth::Healthy
+    ));
+
+    let report = store2
+        .gc_orphan_segments()
+        .expect("GC must succeed after reset_recovery_health");
+    assert_eq!(report.files_deleted, 0);
+}
+
 /// `Telemetry`-class degradation does not compromise deletion safety —
 /// rebuildable-cache errors must not block GC.
 #[test]
@@ -178,6 +232,36 @@ fn gc_runs_under_telemetry_only_degradation() {
     store
         .gc_orphan_segments()
         .expect("Telemetry-class degradation must not block GC");
+}
+
+/// Hard pre-walk recovery failures publish degraded health but never install
+/// an authoritative branch/refcount snapshot, so the reset must refuse on
+/// the same store instance.
+#[test]
+fn reset_recovery_health_refuses_after_prewalk_hard_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let not_a_dir = dir.path().join("segments-file");
+    std::fs::write(&not_a_dir, b"not a directory").unwrap();
+
+    let store = SegmentedStore::with_dir(not_a_dir, 0);
+    store
+        .recover_segments()
+        .expect_err("top-level read_dir failure should still return Err");
+
+    let err = store
+        .reset_recovery_health()
+        .expect_err("hard pre-walk failure never installed recovery state");
+    assert!(matches!(
+        err,
+        StorageError::RecoveryHealthResetRequiresSuccessfulRecovery
+    ));
+    assert!(matches!(
+        &*store.last_recovery_health(),
+        RecoveryHealth::Degraded {
+            class: DegradationClass::DataLoss,
+            ..
+        }
+    ));
 }
 
 /// `clear_branch` must succeed even when GC refuses: the primary task

--- a/crates/storage/src/segmented/tests/gc_under_degradation.rs
+++ b/crates/storage/src/segmented/tests/gc_under_degradation.rs
@@ -8,9 +8,7 @@
 //! cleared on the same instance.
 
 use super::*;
-use crate::segmented::{
-    DegradationClass, RecoveryFault, RecoveryHealth,
-};
+use crate::segmented::{DegradationClass, RecoveryFault, RecoveryHealth};
 use crate::StorageError;
 
 /// After a corrupt-manifest recovery, `gc_orphan_segments()` must refuse
@@ -36,7 +34,10 @@ fn gc_refuses_after_corrupt_manifest_recovery() {
         .map(|e| e.path())
         .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("sst"))
         .collect();
-    assert!(!ssts_before.is_empty(), "setup must produce at least one sst");
+    assert!(
+        !ssts_before.is_empty(),
+        "setup must produce at least one sst"
+    );
 
     // Corrupt the manifest — recovery must classify this as DataLoss.
     let manifest_path = branch_dir.join("segments.manifest");

--- a/crates/storage/src/segmented/tests/lifecycle.rs
+++ b/crates/storage/src/segmented/tests/lifecycle.rs
@@ -1004,8 +1004,13 @@ fn gc_orphan_segments_cleans_leaked_files() {
     }
 
     // Calling GC again should find nothing to delete.
-    let deleted = store.gc_orphan_segments();
-    assert_eq!(deleted, 0, "no orphans should remain after clear_branch GC");
+    let report = store
+        .gc_orphan_segments()
+        .expect("clean recovery; gc must succeed");
+    assert_eq!(
+        report.files_deleted, 0,
+        "no orphans should remain after clear_branch GC"
+    );
 }
 
 /// #1705: materialize_layer must GC orphaned segments after decrementing refcounts.
@@ -1094,9 +1099,11 @@ fn test_issue_1705_materialize_layer_gc_orphan_segments() {
     }
 
     // Calling GC again should find nothing to delete.
-    let deleted = store.gc_orphan_segments();
+    let report = store
+        .gc_orphan_segments()
+        .expect("clean recovery; gc must succeed");
     assert_eq!(
-        deleted, 0,
+        report.files_deleted, 0,
         "no orphans should remain after materialize_layer GC"
     );
 

--- a/crates/storage/src/segmented/tests/mod.rs
+++ b/crates/storage/src/segmented/tests/mod.rs
@@ -101,6 +101,7 @@ mod compact;
 mod concurrency;
 mod flush;
 mod fork;
+mod gc_under_degradation;
 mod leveled;
 mod lifecycle;
 mod materialize;


### PR DESCRIPTION
## Summary

- Closes **SG-009** by gating `gc_orphan_segments` on SE2's classified `RecoveryHealth`: `DataLoss` and `PolicyDowngrade` refuse; `Telemetry` does not block deletion.
- `gc_orphan_segments` now returns `Result<GcReport, StorageError>`; refusal surfaces as `StorageError::GcRefusedDegradedRecovery { class }`. `clear_branch` and `materialize_layer` log-and-continue via the `strata::storage::gc` tracing target so branch-removal stays non-fatal.
- **`reset_recovery_health()` is a narrowed, typed admin** — not an unconditional clear. The store's in-memory `self.branches` / refcount view is a **one-shot snapshot** of the reopen, so the policy is:
  - `PolicyDowngrade` → clears in-place after a successful `recover_segments()` (the no-manifest fallback already loaded every discovered `.sst` into the live graph, so the in-memory view is complete)
  - `DataLoss` → returns `StorageError::RecoveryHealthResetRequiresReopen { class }`; operator must reopen after reconciliation, because this instance cannot reload a manifest/`.sst` an operator restores after the fact
  - Hard pre-walk recovery failure (never reached `invocation.commit()`) → returns `StorageError::RecoveryHealthResetRequiresSuccessfulRecovery`
  - `Healthy` → idempotent `Ok(())`
- The engine-level wrapper (`Database::recovery_health()` / `reset_recovery_health()`) is owned by D4.

Epic plan: `docs/design/durability/durability-storage-closure-epics.md` § *Epic SE3*.
Scope constraint respected: no manifest-aware GC (post-T4), no new `BranchState` fields, no new locks, no tombstone/generation shape.

**Change class:** intentional semantic change. **Assurance:** S4.

## Test plan

- [x] `cargo test -p strata-storage` — **691 pass** (8 new SE3 regressions + 683 existing), 3 ignored, 0 fail
- [x] `cargo test --workspace --lib` — **4,419 pass**, 0 fail
- [x] `cargo check --workspace` — clean
- [x] `cargo clippy -p strata-storage --all-targets` — zero SE3-introduced findings
- [x] Regressions in `crates/storage/src/segmented/tests/gc_under_degradation.rs`:
  - `gc_refuses_after_corrupt_manifest_recovery` — real fault injection; asserts `.sst` files that would have been reaped are still on disk
  - `gc_refuses_under_policy_downgrade_degradation` — `NoManifestFallbackUsed` via test hook
  - `gc_runs_under_telemetry_only_degradation` — rebuildable-cache errors do not block GC
  - `gc_runs_under_clean_recovery` — happy-path pin
  - `reset_recovery_health_refuses_after_data_loss_recovery` — asserts `RecoveryHealthResetRequiresReopen { DataLoss }` and that GC stays refused
  - `reset_recovery_health_refuses_after_prewalk_hard_error` — pre-walk failure path; asserts `RecoveryHealthResetRequiresSuccessfulRecovery`
  - `gc_runs_after_reset_recovery_health_under_policy_downgrade` — missing-manifest injection → classified as `PolicyDowngrade` → reset succeeds → GC runs
  - `clear_branch_succeeds_under_degraded_recovery` — log-and-continue contract
- [x] Regression bench (`benchmarks/ regression -- --quick`): baseline at commit `0d6724dc` is 9 days stale (pre-SE1/SE2); the FAILs reproduce on unchanged `main`. SE3 adds only an `ArcSwap::load()` + enum match in cold-path `clear_branch`/`materialize_layer` and is performance-neutral by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
