### PR TITLE
SE4: branch resurrection fix — get_mut install + typed refusal at 6 compaction/materialize sites

### DIFF
--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::io;
 use std::path::PathBuf;
 
@@ -9,6 +10,41 @@ use crate::segmented::{DegradationClass, RecoveryFault};
 
 /// Result alias for storage-local operations that can raise [`StorageError`].
 pub type StorageResult<T> = Result<T, StorageError>;
+
+/// Identifies the storage operation that observed a deleted branch mid-flight.
+///
+/// Used exclusively as a diagnostic tag on [`StorageError::BranchDeletedDuringOp`].
+/// This is **not** a lifecycle primitive and carries no behavior; Tranche 4
+/// owns the final branch-lifecycle shape (generation counter, tombstone map,
+/// per-branch lock). See `docs/design/architecture-cleanup/branch-primitives-scope.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BranchOp {
+    /// `SegmentedStore::compact_branch` (all-L0 merge).
+    CompactBranch,
+    /// `SegmentedStore::compact_tier` (subset-of-L0 merge).
+    CompactTier,
+    /// `SegmentedStore::compact_l0_to_l1` (L0 → L1 leveled merge).
+    CompactL0ToL1,
+    /// `SegmentedStore::compact_level` (level N → N+1 leveled merge,
+    /// including the metadata-only trivial-move path).
+    CompactLevel,
+    /// `SegmentedStore::materialize_layer` (inherited-layer copy-down).
+    MaterializeLayer,
+}
+
+impl fmt::Display for BranchOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            BranchOp::CompactBranch => "compact_branch",
+            BranchOp::CompactTier => "compact_tier",
+            BranchOp::CompactL0ToL1 => "compact_l0_to_l1",
+            BranchOp::CompactLevel => "compact_level",
+            BranchOp::MaterializeLayer => "materialize_layer",
+        };
+        f.write_str(name)
+    }
+}
 
 /// Storage-local failures that need finer classification than raw `io::Error`.
 #[derive(Debug, Error)]
@@ -91,6 +127,24 @@ pub enum StorageError {
         /// requires a fresh reopen.
         class: DegradationClass,
     },
+
+    /// An in-flight compaction or materialize observed that `branch_id` was
+    /// removed from `self.branches` (via `clear_branch`) during the long-I/O
+    /// gap between snapshot and install. The op cleaned up any outputs it
+    /// built and refused to re-create the branch entry — a deletion proof
+    /// must be stronger than the later install.
+    ///
+    /// Current-state race fix only; Tranche 4 owns the final lifecycle shape
+    /// (generation counter, tombstone map, per-branch lock). Callers that
+    /// treat best-effort operations (background compaction, materialize) as
+    /// non-fatal should log this and continue.
+    #[error("branch {branch_id} was deleted during {op}; operation refused to resurrect")]
+    BranchDeletedDuringOp {
+        /// Branch that was removed from `self.branches` mid-operation.
+        branch_id: BranchId,
+        /// Identifies which storage op observed the deletion, for diagnostics.
+        op: BranchOp,
+    },
 }
 
 impl StorageError {
@@ -108,7 +162,8 @@ impl StorageError {
             StorageError::RecoveryAlreadyApplied
             | StorageError::RecoveryHealthResetRequiresSuccessfulRecovery
             | StorageError::GcRefusedDegradedRecovery { .. }
-            | StorageError::RecoveryHealthResetRequiresReopen { .. } => io::ErrorKind::Other,
+            | StorageError::RecoveryHealthResetRequiresReopen { .. }
+            | StorageError::BranchDeletedDuringOp { .. } => io::ErrorKind::Other,
         }
     }
 }
@@ -156,6 +211,9 @@ impl From<StorageError> for StrataError {
                     "reset_recovery_health() requires a fresh reopen after degraded recovery ({class:?})"
                 ))
             }
+            StorageError::BranchDeletedDuringOp { branch_id, op } => StrataError::storage(
+                format!("branch {branch_id} was deleted during {op}; operation refused to resurrect"),
+            ),
         }
     }
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -33,7 +33,7 @@ pub mod ttl;
 
 pub use bloom::BloomFilter;
 pub use compaction::{CompactionIterator, CompactionScheduler, TierMergeCandidate};
-pub use error::{StorageError, StorageResult};
+pub use error::{BranchOp, StorageError, StorageResult};
 pub use index::{BranchIndex, TypeIndex};
 pub use memory_stats::{BranchMemoryStats, StorageMemoryStats};
 pub use pressure::{MemoryPressure, PressureLevel};

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -293,10 +293,7 @@ impl SegmentedStore {
         // Use get_mut (not entry().or_insert_with) to avoid resurrecting a
         // branch that was concurrently deleted by clear_branch (SE4 / SG-010).
         #[cfg(test)]
-        crate::test_hooks::maybe_pause(
-            crate::test_hooks::pause_tag::COMPACT_BRANCH,
-            *branch_id,
-        );
+        crate::test_hooks::maybe_pause(crate::test_hooks::pause_tag::COMPACT_BRANCH, *branch_id);
         {
             let mut branch = match self.branches.get_mut(branch_id) {
                 Some(b) => b,
@@ -464,10 +461,7 @@ impl SegmentedStore {
         // Use get_mut (not entry().or_insert_with) to avoid resurrecting a
         // branch that was concurrently deleted by clear_branch (SE4 / SG-010).
         #[cfg(test)]
-        crate::test_hooks::maybe_pause(
-            crate::test_hooks::pause_tag::COMPACT_TIER,
-            *branch_id,
-        );
+        crate::test_hooks::maybe_pause(crate::test_hooks::pause_tag::COMPACT_TIER, *branch_id);
         {
             let mut branch = match self.branches.get_mut(branch_id) {
                 Some(b) => b,
@@ -694,10 +688,7 @@ impl SegmentedStore {
         // Use get_mut (not entry().or_insert_with) to avoid resurrecting a
         // branch that was concurrently deleted by clear_branch (SE4 / SG-010).
         #[cfg(test)]
-        crate::test_hooks::maybe_pause(
-            crate::test_hooks::pause_tag::COMPACT_L0_TO_L1,
-            *branch_id,
-        );
+        crate::test_hooks::maybe_pause(crate::test_hooks::pause_tag::COMPACT_L0_TO_L1, *branch_id);
         {
             let mut branch = match self.branches.get_mut(branch_id) {
                 Some(b) => b,
@@ -881,10 +872,7 @@ impl SegmentedStore {
             // No new files were built in the trivial-move path — only metadata
             // needs to be discarded, which happens naturally by not installing.
             #[cfg(test)]
-            crate::test_hooks::maybe_pause(
-                crate::test_hooks::pause_tag::COMPACT_LEVEL,
-                *branch_id,
-            );
+            crate::test_hooks::maybe_pause(crate::test_hooks::pause_tag::COMPACT_LEVEL, *branch_id);
             let mut branch = match self.branches.get_mut(branch_id) {
                 Some(b) => b,
                 None => {
@@ -1040,10 +1028,7 @@ impl SegmentedStore {
         // Use get_mut (not entry().or_insert_with) to avoid resurrecting a
         // branch that was concurrently deleted by clear_branch (SE4 / SG-010).
         #[cfg(test)]
-        crate::test_hooks::maybe_pause(
-            crate::test_hooks::pause_tag::COMPACT_LEVEL,
-            *branch_id,
-        );
+        crate::test_hooks::maybe_pause(crate::test_hooks::pause_tag::COMPACT_LEVEL, *branch_id);
         {
             let mut branch = match self.branches.get_mut(branch_id) {
                 Some(b) => b,

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -168,7 +168,7 @@ impl SegmentedStore {
         &self,
         branch_id: &BranchId,
         prune_floor: CommitVersion,
-    ) -> io::Result<Option<PickAndCompactResult>> {
+    ) -> StorageResult<Option<PickAndCompactResult>> {
         if self.segments_dir.is_none() {
             return Ok(None);
         }
@@ -214,7 +214,7 @@ impl SegmentedStore {
         &self,
         branch_id: &BranchId,
         prune_floor: CommitVersion,
-    ) -> io::Result<Option<CompactionResult>> {
+    ) -> StorageResult<Option<CompactionResult>> {
         let segments_dir = match &self.segments_dir {
             Some(d) => d,
             None => return Ok(None),
@@ -270,12 +270,12 @@ impl SegmentedStore {
             Ok(meta) => meta,
             Err(e) => {
                 cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-                return Err(e.into());
+                return Err(e);
             }
         };
         if let Err(e) = check_corruption_flags(&corruption_flags) {
             cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-            return Err(e);
+            return Err(e.into());
         }
 
         // Open the newly written segment.
@@ -283,17 +283,31 @@ impl SegmentedStore {
             Ok(seg) => seg,
             Err(e) => {
                 cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-                return Err(e);
+                return Err(e.into());
             }
         };
 
         // Swap: remove only the segments we compacted, insert the new one.
         // Any segments added by concurrent flushes (not in old_segments) are kept.
+        //
+        // Use get_mut (not entry().or_insert_with) to avoid resurrecting a
+        // branch that was concurrently deleted by clear_branch (SE4 / SG-010).
+        #[cfg(test)]
+        crate::test_hooks::maybe_pause(
+            crate::test_hooks::pause_tag::COMPACT_BRANCH,
+            *branch_id,
+        );
         {
-            let mut branch = self
-                .branches
-                .entry(*branch_id)
-                .or_insert_with(BranchState::new);
+            let mut branch = match self.branches.get_mut(branch_id) {
+                Some(b) => b,
+                None => {
+                    cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
+                    return Err(StorageError::BranchDeletedDuringOp {
+                        branch_id: *branch_id,
+                        op: BranchOp::CompactBranch,
+                    });
+                }
+            };
             let cur_ver = branch.version.load();
             let mut new_l0: Vec<Arc<KVSegment>> = cur_ver
                 .l0_segments()
@@ -364,7 +378,7 @@ impl SegmentedStore {
         branch_id: &BranchId,
         segment_indices: &[usize],
         prune_floor: CommitVersion,
-    ) -> io::Result<Option<CompactionResult>> {
+    ) -> StorageResult<Option<CompactionResult>> {
         if segment_indices.len() < 2 {
             return Ok(None);
         }
@@ -428,29 +442,43 @@ impl SegmentedStore {
             Ok(meta) => meta,
             Err(e) => {
                 cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-                return Err(e.into());
+                return Err(e);
             }
         };
         if let Err(e) = check_corruption_flags(&corruption_flags) {
             cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-            return Err(e);
+            return Err(e.into());
         }
 
         let new_segment = match KVSegment::open(&seg_path) {
             Ok(seg) => seg,
             Err(e) => {
                 cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
-                return Err(e);
+                return Err(e.into());
             }
         };
 
         // Swap: remove only the segments we compacted, insert the new one.
         // Any segments added by concurrent flushes (not in selected_segments) are kept.
+        //
+        // Use get_mut (not entry().or_insert_with) to avoid resurrecting a
+        // branch that was concurrently deleted by clear_branch (SE4 / SG-010).
+        #[cfg(test)]
+        crate::test_hooks::maybe_pause(
+            crate::test_hooks::pause_tag::COMPACT_TIER,
+            *branch_id,
+        );
         {
-            let mut branch = self
-                .branches
-                .entry(*branch_id)
-                .or_insert_with(BranchState::new);
+            let mut branch = match self.branches.get_mut(branch_id) {
+                Some(b) => b,
+                None => {
+                    cleanup_partial_compaction_outputs(&branch_dir, seg_id, seg_id + 1);
+                    return Err(StorageError::BranchDeletedDuringOp {
+                        branch_id: *branch_id,
+                        op: BranchOp::CompactTier,
+                    });
+                }
+            };
             let cur_ver = branch.version.load();
             let mut new_l0: Vec<Arc<KVSegment>> = cur_ver
                 .l0_segments()
@@ -500,7 +528,7 @@ impl SegmentedStore {
         &self,
         branch_id: &BranchId,
         prune_floor: CommitVersion,
-    ) -> io::Result<Option<CompactionResult>> {
+    ) -> StorageResult<Option<CompactionResult>> {
         let segments_dir = match &self.segments_dir {
             Some(d) => d,
             None => return Ok(None),
@@ -634,14 +662,14 @@ impl SegmentedStore {
             Err(e) => {
                 let end_id = next_id.load(Ordering::Relaxed);
                 cleanup_partial_compaction_outputs(&branch_dir, start_id, end_id);
-                return Err(e.into());
+                return Err(e);
             }
         };
         if let Err(e) = check_corruption_flags(&corruption_flags) {
             for (path, _) in &outputs {
                 let _ = std::fs::remove_file(path);
             }
-            return Err(e);
+            return Err(e.into());
         }
 
         let output_entries: u64 = outputs.iter().map(|(_, m)| m.entry_count).sum();
@@ -656,17 +684,36 @@ impl SegmentedStore {
                     for (p, _) in &outputs {
                         let _ = std::fs::remove_file(p);
                     }
-                    return Err(e);
+                    return Err(e.into());
                 }
             }
         }
 
         // Atomic swap: L0 = only concurrently-flushed segments, L1 = non-overlapping + new
+        //
+        // Use get_mut (not entry().or_insert_with) to avoid resurrecting a
+        // branch that was concurrently deleted by clear_branch (SE4 / SG-010).
+        #[cfg(test)]
+        crate::test_hooks::maybe_pause(
+            crate::test_hooks::pause_tag::COMPACT_L0_TO_L1,
+            *branch_id,
+        );
         {
-            let mut branch = self
-                .branches
-                .entry(*branch_id)
-                .or_insert_with(BranchState::new);
+            let mut branch = match self.branches.get_mut(branch_id) {
+                Some(b) => b,
+                None => {
+                    for seg in &new_l1_segments {
+                        crate::block_cache::global_cache().invalidate_file(seg.file_id());
+                    }
+                    for (path, _) in &outputs {
+                        let _ = std::fs::remove_file(path);
+                    }
+                    return Err(StorageError::BranchDeletedDuringOp {
+                        branch_id: *branch_id,
+                        op: BranchOp::CompactL0ToL1,
+                    });
+                }
+            };
             let cur_ver = branch.version.load();
 
             // Keep only L0 segments that were added concurrently (not in our snapshot)
@@ -730,7 +777,7 @@ impl SegmentedStore {
         branch_id: &BranchId,
         level: usize,
         prune_floor: CommitVersion,
-    ) -> io::Result<Option<CompactionResult>> {
+    ) -> StorageResult<Option<CompactionResult>> {
         if level >= NUM_LEVELS - 1 {
             return Ok(None); // can't compact the last level further
         }
@@ -829,10 +876,24 @@ impl SegmentedStore {
         {
             // Metadata-only move: shift file to level+1 without I/O
             let moved_seg = Arc::clone(&input_segs[0]);
-            let mut branch = self
-                .branches
-                .entry(*branch_id)
-                .or_insert_with(BranchState::new);
+            // Use get_mut (not entry().or_insert_with) to avoid resurrecting a
+            // branch that was concurrently deleted by clear_branch (SE4 / SG-010).
+            // No new files were built in the trivial-move path — only metadata
+            // needs to be discarded, which happens naturally by not installing.
+            #[cfg(test)]
+            crate::test_hooks::maybe_pause(
+                crate::test_hooks::pause_tag::COMPACT_LEVEL,
+                *branch_id,
+            );
+            let mut branch = match self.branches.get_mut(branch_id) {
+                Some(b) => b,
+                None => {
+                    return Err(StorageError::BranchDeletedDuringOp {
+                        branch_id: *branch_id,
+                        op: BranchOp::CompactLevel,
+                    });
+                }
+            };
             let cur_ver = branch.version.load();
             let mut new_levels = cur_ver.levels.clone();
 
@@ -947,14 +1008,14 @@ impl SegmentedStore {
             Err(e) => {
                 let end_id = next_id.load(Ordering::Relaxed);
                 cleanup_partial_compaction_outputs(&branch_dir, start_id, end_id);
-                return Err(e.into());
+                return Err(e);
             }
         };
         if let Err(e) = check_corruption_flags(&corruption_flags) {
             for (path, _) in &outputs {
                 let _ = std::fs::remove_file(path);
             }
-            return Err(e);
+            return Err(e.into());
         }
 
         let output_entries: u64 = outputs.iter().map(|(_, m)| m.entry_count).sum();
@@ -969,17 +1030,36 @@ impl SegmentedStore {
                     for (p, _) in &outputs {
                         let _ = std::fs::remove_file(p);
                     }
-                    return Err(e);
+                    return Err(e.into());
                 }
             }
         }
 
         // ── 4. Atomic version swap ─────────────────────────────────────
+        //
+        // Use get_mut (not entry().or_insert_with) to avoid resurrecting a
+        // branch that was concurrently deleted by clear_branch (SE4 / SG-010).
+        #[cfg(test)]
+        crate::test_hooks::maybe_pause(
+            crate::test_hooks::pause_tag::COMPACT_LEVEL,
+            *branch_id,
+        );
         {
-            let mut branch = self
-                .branches
-                .entry(*branch_id)
-                .or_insert_with(BranchState::new);
+            let mut branch = match self.branches.get_mut(branch_id) {
+                Some(b) => b,
+                None => {
+                    for seg in &new_output_segments {
+                        crate::block_cache::global_cache().invalidate_file(seg.file_id());
+                    }
+                    for (path, _) in &outputs {
+                        let _ = std::fs::remove_file(path);
+                    }
+                    return Err(StorageError::BranchDeletedDuringOp {
+                        branch_id: *branch_id,
+                        op: BranchOp::CompactLevel,
+                    });
+                }
+            };
             let cur_ver = branch.version.load();
             let mut new_levels = cur_ver.levels.clone();
 

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -20,7 +20,7 @@ use crate::pressure::{MemoryPressure, PressureLevel};
 use crate::seekable::{self, SeekableIterator as _};
 use crate::segment::{KVSegment, LevelSegmentIter, OwnedSegmentIter, SegmentEntry};
 use crate::segment_builder::{SegmentBuilder, SplittingSegmentBuilder};
-use crate::{StorageError, StorageResult};
+use crate::{BranchOp, StorageError, StorageResult};
 
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
@@ -1802,11 +1802,32 @@ impl SegmentedStore {
         let segments_created = new_segments.len();
 
         // 2e. Atomic install (under DashMap write guard)
+        //
+        // Use get_mut (not entry().or_insert_with) to avoid resurrecting a
+        // branch that was concurrently deleted by clear_branch (SE4 / SG-011).
+        #[cfg(test)]
+        crate::test_hooks::maybe_pause(
+            crate::test_hooks::pause_tag::MATERIALIZE_LAYER,
+            *child_branch_id,
+        );
         {
-            let mut branch = self
-                .branches
-                .entry(*child_branch_id)
-                .or_insert_with(BranchState::new);
+            let mut branch = match self.branches.get_mut(child_branch_id) {
+                Some(b) => b,
+                None => {
+                    let created_paths: Vec<_> = new_segments
+                        .iter()
+                        .map(|segment| segment.file_path().to_path_buf())
+                        .collect();
+                    for segment in &new_segments {
+                        crate::block_cache::global_cache().invalidate_file(segment.file_id());
+                    }
+                    self.cleanup_created_segment_files(&created_paths);
+                    return Err(StorageError::BranchDeletedDuringOp {
+                        branch_id: *child_branch_id,
+                        op: BranchOp::MaterializeLayer,
+                    });
+                }
+            };
 
             // Prepend new segments to L0
             if !new_segments.is_empty() {

--- a/crates/storage/src/segmented/tests/mod.rs
+++ b/crates/storage/src/segmented/tests/mod.rs
@@ -105,3 +105,4 @@ mod gc_under_degradation;
 mod leveled;
 mod lifecycle;
 mod materialize;
+mod resurrection;

--- a/crates/storage/src/segmented/tests/resurrection.rs
+++ b/crates/storage/src/segmented/tests/resurrection.rs
@@ -1,0 +1,421 @@
+//! SE4 regression tests: branch-resurrection race fix (SG-010, SG-011) +
+//! contract pins for SG-012 and SG-015.
+//!
+//! **SG-010 / SG-011** — an in-flight compaction or `materialize_layer` must
+//! not resurrect a branch that `clear_branch` removed during the long-I/O gap
+//! between snapshot and install. The fix replaces `entry().or_insert_with`
+//! with `get_mut()`; on `None` the op cleans up its outputs and returns
+//! `StorageError::BranchDeletedDuringOp`.
+//!
+//! **SG-012 / SG-015** — pin the current caller-serialized compaction
+//! contract and the current best-effort cleanup behavior of `clear_branch`
+//! interleaved with compaction, so Tranche 4 has a green baseline to reshape
+//! against.
+//!
+//! Race determinism comes from `crate::test_hooks::install_pause`, which
+//! parks the install phase so the test thread can land its `clear_branch`
+//! first. See `crates/storage/src/test_hooks.rs`.
+
+use super::*;
+use crate::error::{BranchOp, StorageError};
+use crate::test_hooks::{arm, pause_tag, release, wait_until_entered};
+use std::sync::{Arc, Barrier};
+
+/// Unique branch-id per test so parallel runs don't collide on the install-
+/// pause keyspace (which is `(op_tag, branch_id)`). The byte tag is chosen
+/// to be disjoint from `branch()` / `parent_branch()` / `child_branch()` and
+/// from every other test in this file.
+fn test_branch(tag: u8) -> BranchId {
+    BranchId::from_bytes([tag; 16])
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Populate a branch with two L0 segments so compaction has real inputs.
+fn seed_two_l0_segments(store: &SegmentedStore, b: BranchId) {
+    let ns = Arc::new(Namespace::new(b, "default".to_string()));
+    for i in 0_i64..50 {
+        store
+            .put_with_version_mode(
+                Key::new(Arc::clone(&ns), TypeTag::KV, format!("a{i:04}").into_bytes()),
+                Value::Int(i),
+                CommitVersion(1),
+                None,
+                WriteMode::Append,
+            )
+            .unwrap();
+    }
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+    for i in 0_i64..50 {
+        store
+            .put_with_version_mode(
+                Key::new(Arc::clone(&ns), TypeTag::KV, format!("b{i:04}").into_bytes()),
+                Value::Int(i),
+                CommitVersion(2),
+                None,
+                WriteMode::Append,
+            )
+            .unwrap();
+    }
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+}
+
+fn count_sst_files(branch_dir: &std::path::Path) -> usize {
+    if !branch_dir.exists() {
+        return 0;
+    }
+    std::fs::read_dir(branch_dir)
+        .map_or(0, |rd| {
+            rd.filter_map(Result::ok)
+                .filter(|e| e.path().extension().is_some_and(|ext| ext == "sst"))
+                .count()
+        })
+}
+
+fn assert_branch_deleted_during_op(err: &StorageError, expected_op: BranchOp) {
+    match err {
+        StorageError::BranchDeletedDuringOp { op, .. } => assert_eq!(*op, expected_op),
+        other => panic!("expected BranchDeletedDuringOp({expected_op:?}), got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SG-010: compaction resurrection race
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compact_branch_does_not_resurrect_cleared_branch() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+    let b = test_branch(0xA0);
+    seed_two_l0_segments(&store, b);
+
+    let branch_hex = hex_encode_branch(&b);
+    let branch_dir = dir.path().join(&branch_hex);
+    let sst_before = count_sst_files(&branch_dir);
+    assert_eq!(sst_before, 2);
+
+    let pause = arm(pause_tag::COMPACT_BRANCH, b);
+    let s = Arc::clone(&store);
+    let handle = std::thread::spawn(move || s.compact_branch(&b, CommitVersion(0)));
+
+    wait_until_entered(&pause);
+    assert!(store.clear_branch(&b));
+    release(&pause);
+
+    let result = handle.join().unwrap();
+    drop(pause);
+
+    let err = result.expect_err("compaction must refuse to resurrect");
+    assert_branch_deleted_during_op(&err, BranchOp::CompactBranch);
+
+    assert!(
+        !store.branches.contains_key(&b),
+        "branch must stay absent after clear_branch",
+    );
+    // New compaction output file was cleaned up on the refusal path.
+    // (The two original L0 segments were removed by clear_branch.)
+    assert_eq!(
+        count_sst_files(&branch_dir),
+        0,
+        "no orphan .sst files after refused compaction",
+    );
+}
+
+#[test]
+fn compact_l0_to_l1_does_not_resurrect_cleared_branch() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+    let b = test_branch(0xA1);
+    seed_two_l0_segments(&store, b);
+
+    let branch_hex = hex_encode_branch(&b);
+    let branch_dir = dir.path().join(&branch_hex);
+
+    let pause = arm(pause_tag::COMPACT_L0_TO_L1, b);
+    let s = Arc::clone(&store);
+    let handle = std::thread::spawn(move || s.compact_l0_to_l1(&b, CommitVersion(0)));
+
+    wait_until_entered(&pause);
+    assert!(store.clear_branch(&b));
+    release(&pause);
+
+    let result = handle.join().unwrap();
+    drop(pause);
+
+    let err = result.expect_err("L0→L1 compaction must refuse to resurrect");
+    assert_branch_deleted_during_op(&err, BranchOp::CompactL0ToL1);
+
+    assert!(!store.branches.contains_key(&b));
+    assert_eq!(count_sst_files(&branch_dir), 0);
+}
+
+#[test]
+fn compact_level_does_not_resurrect_cleared_branch() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+    let b = test_branch(0xA2);
+    seed_two_l0_segments(&store, b);
+
+    let branch_hex = hex_encode_branch(&b);
+    let branch_dir = dir.path().join(&branch_hex);
+
+    // compact_level(0, ...) pushes L0 → L1; hits the atomic-swap path.
+    let pause = arm(pause_tag::COMPACT_LEVEL, b);
+    let s = Arc::clone(&store);
+    let handle = std::thread::spawn(move || s.compact_level(&b, 0, CommitVersion(0)));
+
+    wait_until_entered(&pause);
+    assert!(store.clear_branch(&b));
+    release(&pause);
+
+    let result = handle.join().unwrap();
+    drop(pause);
+
+    let err = result.expect_err("compact_level must refuse to resurrect");
+    assert_branch_deleted_during_op(&err, BranchOp::CompactLevel);
+
+    assert!(!store.branches.contains_key(&b));
+    assert_eq!(count_sst_files(&branch_dir), 0);
+}
+
+#[test]
+fn compact_tier_does_not_resurrect_cleared_branch() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+    let b = test_branch(0xA3);
+    seed_two_l0_segments(&store, b);
+
+    let branch_hex = hex_encode_branch(&b);
+    let branch_dir = dir.path().join(&branch_hex);
+
+    let pause = arm(pause_tag::COMPACT_TIER, b);
+    let s = Arc::clone(&store);
+    let handle = std::thread::spawn(move || s.compact_tier(&b, &[0, 1], CommitVersion(0)));
+
+    wait_until_entered(&pause);
+    assert!(store.clear_branch(&b));
+    release(&pause);
+
+    let result = handle.join().unwrap();
+    drop(pause);
+
+    let err = result.expect_err("compact_tier must refuse to resurrect");
+    assert_branch_deleted_during_op(&err, BranchOp::CompactTier);
+
+    assert!(!store.branches.contains_key(&b));
+    assert_eq!(count_sst_files(&branch_dir), 0);
+}
+
+// ---------------------------------------------------------------------------
+// SG-011: materialize_layer resurrection race
+// ---------------------------------------------------------------------------
+
+#[test]
+fn materialize_layer_does_not_resurrect_cleared_branch() {
+    // Dedicated parent/child ids for this test — avoid the shared
+    // `parent_branch()` / `child_branch()` helpers so parallel tests that use
+    // them can't collide on the install-pause keyspace.
+    let parent = test_branch(0xB0);
+    let child = test_branch(0xB1);
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+    let parent_ns = Arc::new(Namespace::new(parent, "default".to_string()));
+    for (k, v, ver) in [("a", 1, 1), ("b", 2, 2)] {
+        store
+            .put_with_version_mode(
+                Key::new(Arc::clone(&parent_ns), TypeTag::KV, k.as_bytes().to_vec()),
+                Value::Int(v),
+                CommitVersion(ver),
+                None,
+                WriteMode::Append,
+            )
+            .unwrap();
+    }
+    store.rotate_memtable(&parent);
+    store.flush_oldest_frozen(&parent).unwrap();
+
+    store
+        .branches
+        .entry(child)
+        .or_insert_with(BranchState::new);
+    store.fork_branch(&parent, &child).unwrap();
+    assert_eq!(store.inherited_layer_count(&child), 1);
+
+    let child_hex = hex_encode_branch(&child);
+    let child_dir = dir.path().join(&child_hex);
+
+    let pause = arm(pause_tag::MATERIALIZE_LAYER, child);
+    let s = Arc::clone(&store);
+    let handle = std::thread::spawn(move || s.materialize_layer(&child, 0));
+
+    wait_until_entered(&pause);
+    assert!(store.clear_branch(&child));
+    release(&pause);
+
+    let result = handle.join().unwrap();
+    drop(pause);
+
+    let err = result.expect_err("materialize_layer must refuse to resurrect");
+    assert_branch_deleted_during_op(&err, BranchOp::MaterializeLayer);
+
+    assert!(!store.branches.contains_key(&child));
+    // Any materialize output was cleaned up on the refusal path.
+    assert_eq!(
+        count_sst_files(&child_dir),
+        0,
+        "no orphan .sst files after refused materialize",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SG-015: same-branch compactions serialized by caller → deterministic
+// ---------------------------------------------------------------------------
+
+#[test]
+fn serialized_same_branch_compactions_are_deterministic() {
+    // Two serialized compact_branch calls on the same branch must leave the
+    // store in a deterministic state. This pins the existing caller-serialized
+    // contract; explicit per-branch compaction locking is T4's choice.
+
+    fn segment_file_ids(store: &SegmentedStore, b: &BranchId) -> Vec<u64> {
+        let branch = store.branches.get(b).unwrap();
+        let ver = branch.version.load();
+        let mut ids: Vec<u64> = ver
+            .levels
+            .iter()
+            .flat_map(|level| level.iter().map(|s| s.file_id()))
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    fn run_once() -> Vec<u64> {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+        let b = branch();
+        seed_two_l0_segments(&store, b);
+        let _ = store.compact_branch(&b, CommitVersion(0)).unwrap();
+        let _ = store.compact_branch(&b, CommitVersion(0)).unwrap();
+        segment_file_ids(&store, &b)
+    }
+
+    let a = run_once();
+    let b = run_once();
+    // Same shape across runs: one L0 segment, deterministic count.
+    assert_eq!(a.len(), b.len());
+    assert_eq!(a.len(), 1, "two compactions should collapse to one segment");
+}
+
+// ---------------------------------------------------------------------------
+// SG-012: clear_branch interleaved with compaction → clean reopen
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clear_branch_interleaved_with_compaction_reopens_clean() {
+    // After compaction is refused mid-flight by clear_branch, a reopen must:
+    //   (a) not see the deleted branch,
+    //   (b) not find orphan .sst files in the branch dir,
+    //   (c) report healthy recovery.
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+    let b = test_branch(0xA4);
+    seed_two_l0_segments(&store, b);
+
+    let branch_hex = hex_encode_branch(&b);
+    let branch_dir = dir.path().join(&branch_hex);
+
+    let pause = arm(pause_tag::COMPACT_BRANCH, b);
+    let s = Arc::clone(&store);
+    let b_clone = b;
+    let handle = std::thread::spawn(move || s.compact_branch(&b_clone, CommitVersion(0)));
+
+    wait_until_entered(&pause);
+    assert!(store.clear_branch(&b));
+    release(&pause);
+
+    let race_result = handle.join().unwrap();
+    drop(pause);
+
+    // Confirm the race actually hit the refusal path — otherwise the reopen
+    // assertions below would pass trivially for the wrong reason.
+    let err = race_result.expect_err("compaction must refuse to resurrect");
+    assert_branch_deleted_during_op(&err, BranchOp::CompactBranch);
+
+    drop(store);
+
+    // Reopen.
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = store2.recover_segments().unwrap();
+
+    assert!(
+        !store2.branches.contains_key(&b),
+        "reopened store must not contain the cleared branch",
+    );
+    assert_eq!(
+        count_sst_files(&branch_dir),
+        0,
+        "no orphan .sst files after reopen (best-effort cleanup + GC succeeded)",
+    );
+    // Recovery is healthy when there is nothing on disk to recover for this branch.
+    assert!(
+        matches!(outcome.health, crate::segmented::RecoveryHealth::Healthy),
+        "expected Healthy recovery, got {:?}",
+        outcome.health,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sanity: arming a pause has zero effect when the op isn't invoked
+// ---------------------------------------------------------------------------
+
+#[test]
+fn install_pause_only_triggers_matching_op_and_branch() {
+    // Arm COMPACT_L0_TO_L1 on the test branch but run compact_branch (different
+    // tag) — it must not block. Then arm the matching tag on a DIFFERENT
+    // branch_id and run compact_branch on our branch — still must not block,
+    // proving the key is (op_tag, branch_id) not just op_tag.
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = test_branch(0xC0);
+    seed_two_l0_segments(&store, b);
+
+    // (a) unrelated tag, same branch — must not trigger.
+    let pause_a = arm(pause_tag::COMPACT_L0_TO_L1, b);
+    let barrier = Arc::new(Barrier::new(2));
+    let b1 = Arc::clone(&barrier);
+    let done = std::thread::scope(|scope| {
+        let h = scope.spawn(|| {
+            b1.wait();
+            store.compact_branch(&b, CommitVersion(0))
+        });
+        barrier.wait();
+        h.join().unwrap()
+    });
+    done.expect("compact_branch must complete when unrelated tag is armed");
+    drop(pause_a);
+
+    // (b) same tag, unrelated branch — must not trigger.
+    let other_branch = test_branch(0xC1);
+    let pause_b = arm(pause_tag::COMPACT_BRANCH, other_branch);
+
+    // Give ourselves two fresh L0 segments to compact again.
+    seed_two_l0_segments(&store, b);
+    let barrier = Arc::new(Barrier::new(2));
+    let b1 = Arc::clone(&barrier);
+    let done = std::thread::scope(|scope| {
+        let h = scope.spawn(|| {
+            b1.wait();
+            store.compact_branch(&b, CommitVersion(0))
+        });
+        barrier.wait();
+        h.join().unwrap()
+    });
+    done.expect("compact_branch must complete when arm targets a different branch");
+    drop(pause_b);
+}

--- a/crates/storage/src/segmented/tests/resurrection.rs
+++ b/crates/storage/src/segmented/tests/resurrection.rs
@@ -39,7 +39,11 @@ fn seed_two_l0_segments(store: &SegmentedStore, b: BranchId) {
     for i in 0_i64..50 {
         store
             .put_with_version_mode(
-                Key::new(Arc::clone(&ns), TypeTag::KV, format!("a{i:04}").into_bytes()),
+                Key::new(
+                    Arc::clone(&ns),
+                    TypeTag::KV,
+                    format!("a{i:04}").into_bytes(),
+                ),
                 Value::Int(i),
                 CommitVersion(1),
                 None,
@@ -52,9 +56,30 @@ fn seed_two_l0_segments(store: &SegmentedStore, b: BranchId) {
     for i in 0_i64..50 {
         store
             .put_with_version_mode(
-                Key::new(Arc::clone(&ns), TypeTag::KV, format!("b{i:04}").into_bytes()),
+                Key::new(
+                    Arc::clone(&ns),
+                    TypeTag::KV,
+                    format!("b{i:04}").into_bytes(),
+                ),
                 Value::Int(i),
                 CommitVersion(2),
+                None,
+                WriteMode::Append,
+            )
+            .unwrap();
+    }
+    store.rotate_memtable(&b);
+    store.flush_oldest_frozen(&b).unwrap();
+}
+
+fn flush_branch_data(store: &SegmentedStore, b: BranchId, entries: &[(&str, i64, u64)]) {
+    let ns = Arc::new(Namespace::new(b, "default".to_string()));
+    for &(key_name, value, commit) in entries {
+        store
+            .put_with_version_mode(
+                Key::new(Arc::clone(&ns), TypeTag::KV, key_name.as_bytes().to_vec()),
+                Value::Int(value),
+                CommitVersion(commit),
                 None,
                 WriteMode::Append,
             )
@@ -68,12 +93,11 @@ fn count_sst_files(branch_dir: &std::path::Path) -> usize {
     if !branch_dir.exists() {
         return 0;
     }
-    std::fs::read_dir(branch_dir)
-        .map_or(0, |rd| {
-            rd.filter_map(Result::ok)
-                .filter(|e| e.path().extension().is_some_and(|ext| ext == "sst"))
-                .count()
-        })
+    std::fs::read_dir(branch_dir).map_or(0, |rd| {
+        rd.filter_map(Result::ok)
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "sst"))
+            .count()
+    })
 }
 
 fn assert_branch_deleted_during_op(err: &StorageError, expected_op: BranchOp) {
@@ -184,6 +208,40 @@ fn compact_level_does_not_resurrect_cleared_branch() {
 }
 
 #[test]
+fn compact_level_trivial_move_does_not_resurrect_cleared_branch() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+    let b = test_branch(0xA5);
+
+    // Create exactly one L1 segment and no L2 overlap so compact_level(1, ...)
+    // takes the trivial-move path rather than the full rewrite path.
+    flush_branch_data(&store, b, &[("x", 1, 1)]);
+    store.compact_level(&b, 0, CommitVersion(0)).unwrap();
+    assert_eq!(store.level_segment_count(&b, 1), 1);
+    assert_eq!(store.level_segment_count(&b, 2), 0);
+
+    let branch_hex = hex_encode_branch(&b);
+    let branch_dir = dir.path().join(&branch_hex);
+
+    let pause = arm(pause_tag::COMPACT_LEVEL, b);
+    let s = Arc::clone(&store);
+    let handle = std::thread::spawn(move || s.compact_level(&b, 1, CommitVersion(0)));
+
+    wait_until_entered(&pause);
+    assert!(store.clear_branch(&b));
+    release(&pause);
+
+    let result = handle.join().unwrap();
+    drop(pause);
+
+    let err = result.expect_err("trivial-move compact_level must refuse to resurrect");
+    assert_branch_deleted_during_op(&err, BranchOp::CompactLevel);
+
+    assert!(!store.branches.contains_key(&b));
+    assert_eq!(count_sst_files(&branch_dir), 0);
+}
+
+#[test]
 fn compact_tier_does_not_resurrect_cleared_branch() {
     let dir = tempfile::tempdir().unwrap();
     let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
@@ -240,10 +298,7 @@ fn materialize_layer_does_not_resurrect_cleared_branch() {
     store.rotate_memtable(&parent);
     store.flush_oldest_frozen(&parent).unwrap();
 
-    store
-        .branches
-        .entry(child)
-        .or_insert_with(BranchState::new);
+    store.branches.entry(child).or_insert_with(BranchState::new);
     store.fork_branch(&parent, &child).unwrap();
     assert_eq!(store.inherited_layer_count(&child), 1);
 
@@ -283,33 +338,57 @@ fn serialized_same_branch_compactions_are_deterministic() {
     // store in a deterministic state. This pins the existing caller-serialized
     // contract; explicit per-branch compaction locking is T4's choice.
 
-    fn segment_file_ids(store: &SegmentedStore, b: &BranchId) -> Vec<u64> {
-        let branch = store.branches.get(b).unwrap();
-        let ver = branch.version.load();
-        let mut ids: Vec<u64> = ver
-            .levels
-            .iter()
-            .flat_map(|level| level.iter().map(|s| s.file_id()))
-            .collect();
-        ids.sort_unstable();
-        ids
+    #[derive(Debug, PartialEq)]
+    struct DeterministicOutcome {
+        first: Option<CompactionResult>,
+        second: Option<CompactionResult>,
+        level_counts: Vec<usize>,
+        entries: Vec<(Vec<u8>, Value, u64)>,
     }
 
-    fn run_once() -> Vec<u64> {
+    fn branch_entries(store: &SegmentedStore, b: &BranchId) -> Vec<(Vec<u8>, Value, u64)> {
+        let mut entries: Vec<_> = store
+            .list_branch(b)
+            .into_iter()
+            .map(|(key, value)| (key.user_key.into_vec(), value.value, value.version.as_u64()))
+            .collect();
+        entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        entries
+    }
+
+    fn level_counts(store: &SegmentedStore, b: &BranchId) -> Vec<usize> {
+        let branch = store.branches.get(b).unwrap();
+        let ver = branch.version.load();
+        ver.levels.iter().map(std::vec::Vec::len).collect()
+    }
+
+    fn run_once() -> DeterministicOutcome {
         let dir = tempfile::tempdir().unwrap();
         let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
         let b = branch();
         seed_two_l0_segments(&store, b);
-        let _ = store.compact_branch(&b, CommitVersion(0)).unwrap();
-        let _ = store.compact_branch(&b, CommitVersion(0)).unwrap();
-        segment_file_ids(&store, &b)
+        let first = store.compact_branch(&b, CommitVersion(0)).unwrap();
+        let second = store.compact_branch(&b, CommitVersion(0)).unwrap();
+        DeterministicOutcome {
+            first,
+            second,
+            level_counts: level_counts(&store, &b),
+            entries: branch_entries(&store, &b),
+        }
     }
 
     let a = run_once();
     let b = run_once();
-    // Same shape across runs: one L0 segment, deterministic count.
-    assert_eq!(a.len(), b.len());
-    assert_eq!(a.len(), 1, "two compactions should collapse to one segment");
+    assert_eq!(a, b, "serialized compact_branch outcome must be stable");
+    assert!(a.first.is_some(), "first compaction should perform work");
+    assert_eq!(
+        a.second, None,
+        "second compaction should be a deterministic no-op"
+    );
+    assert_eq!(
+        a.level_counts[0], 1,
+        "two compactions should deterministically collapse to one L0 segment",
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/storage/src/test_hooks.rs
+++ b/crates/storage/src/test_hooks.rs
@@ -14,6 +14,127 @@ thread_local! {
     static MANIFEST_DIR_FSYNC_FAILURE: Cell<Option<io::ErrorKind>> = const { Cell::new(None) };
 }
 
+// ---------------------------------------------------------------------------
+// SE4 install-pause hook (test-only)
+// ---------------------------------------------------------------------------
+//
+// Coordination primitive for SE4 regression tests: lets a test thread park
+// compaction / materialize just after the I/O phase and just before the
+// atomic install, so the race against `clear_branch` is deterministic rather
+// than barrier-probabilistic.
+//
+// Entirely behind `#[cfg(test)]` — production builds contain no reference to
+// this state and pay zero runtime cost.
+
+#[cfg(test)]
+pub(crate) use install_pause::{arm, maybe_pause, release, wait_until_entered};
+
+#[cfg(test)]
+mod install_pause {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Condvar, Mutex, OnceLock};
+    use strata_core::types::BranchId;
+
+    // Keyed by (op_tag, branch_id) so parallel tests on distinct branches
+    // don't collide on a shared global slot. Production callers pass their
+    // own (branch_id, op_tag); if no test has registered that exact key, the
+    // lookup is a HashMap miss and the call returns immediately.
+    type Key = (&'static str, BranchId);
+
+    struct PauseState {
+        entered: bool,
+        released: bool,
+    }
+
+    pub(crate) struct ArmedPause {
+        key: Key,
+        inner: Arc<Inner>,
+    }
+
+    struct Inner {
+        lock: Mutex<PauseState>,
+        cv: Condvar,
+    }
+
+    static SLOTS: OnceLock<Mutex<HashMap<Key, Arc<Inner>>>> = OnceLock::new();
+
+    fn slots() -> &'static Mutex<HashMap<Key, Arc<Inner>>> {
+        SLOTS.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    pub(crate) fn arm(op_tag: &'static str, branch_id: BranchId) -> ArmedPause {
+        let inner = Arc::new(Inner {
+            lock: Mutex::new(PauseState {
+                entered: false,
+                released: false,
+            }),
+            cv: Condvar::new(),
+        });
+        let key = (op_tag, branch_id);
+        let prev = slots().lock().unwrap().insert(key, Arc::clone(&inner));
+        assert!(
+            prev.is_none(),
+            "install_pause: already armed for ({}, {:?}); use a distinct \
+             branch_id per test to keep parallel tests independent",
+            key.0,
+            key.1,
+        );
+        ArmedPause { key, inner }
+    }
+
+    impl Drop for ArmedPause {
+        fn drop(&mut self) {
+            // Remove our entry from the global slot so later calls to
+            // `maybe_pause` with the same key pass through.
+            slots().lock().unwrap().remove(&self.key);
+            // Release any thread that is currently blocked on our condvar.
+            // Without this, a test that panics between `arm()` and `release()`
+            // would leak a compaction thread stuck in `maybe_pause` forever
+            // (the thread holds its own `Arc<Inner>` cloned out of the map,
+            // so removal alone does not wake it).
+            let mut state = self.inner.lock.lock().unwrap();
+            state.released = true;
+            self.inner.cv.notify_all();
+        }
+    }
+
+    pub(crate) fn wait_until_entered(pause: &ArmedPause) {
+        let mut state = pause.inner.lock.lock().unwrap();
+        while !state.entered {
+            state = pause.inner.cv.wait(state).unwrap();
+        }
+    }
+
+    pub(crate) fn release(pause: &ArmedPause) {
+        let mut state = pause.inner.lock.lock().unwrap();
+        state.released = true;
+        pause.inner.cv.notify_all();
+    }
+
+    pub(crate) fn maybe_pause(op_tag: &'static str, branch_id: BranchId) {
+        let entry = slots().lock().unwrap().get(&(op_tag, branch_id)).cloned();
+        if let Some(inner) = entry {
+            let mut state = inner.lock.lock().unwrap();
+            state.entered = true;
+            inner.cv.notify_all();
+            while !state.released {
+                state = inner.cv.wait(state).unwrap();
+            }
+        }
+    }
+}
+
+/// Op tags for install-pause coordination. Keyed jointly with a `BranchId`
+/// so parallel tests on distinct branches don't collide.
+#[cfg(test)]
+pub(crate) mod pause_tag {
+    pub(crate) const COMPACT_BRANCH: &str = "compact_branch";
+    pub(crate) const COMPACT_TIER: &str = "compact_tier";
+    pub(crate) const COMPACT_L0_TO_L1: &str = "compact_l0_to_l1";
+    pub(crate) const COMPACT_LEVEL: &str = "compact_level";
+    pub(crate) const MATERIALIZE_LAYER: &str = "materialize_layer";
+}
+
 #[cfg(not(test))]
 fn manifest_publish_failure_slot() -> &'static Mutex<Option<io::ErrorKind>> {
     static MANIFEST_PUBLISH_FAILURE: OnceLock<Mutex<Option<io::ErrorKind>>> = OnceLock::new();


### PR DESCRIPTION
## Summary
- Replaces `entry().or_insert_with(BranchState::new)` with `get_mut()` in all five compaction install sites (`compact_branch`, `compact_tier`, `compact_l0_to_l1`, `compact_level` trivial-move, `compact_level` atomic-swap) and `materialize_layer`'s atomic install. On `None`, each site cleans up the outputs it built and returns the new typed variant `StorageError::BranchDeletedDuringOp { branch_id, op: BranchOp }` instead of silently recreating a deleted branch. Closes **SG-010** (compaction) and **SG-011** (materialize).
- Compaction signatures shift from `io::Result<_>` to `StorageResult<_>` so the typed refusal can be returned directly; existing `From<io::Error> for StorageError` keeps internal `?` clean and callers that already log a generic error (engine's background compaction and materialize coordinators) are unaffected.
- Regression coverage in `crates/storage/src/segmented/tests/resurrection.rs` (9 tests): six race refusals covering every install site — including both the trivial-move and atomic-swap paths of `compact_level` (SG-010/SG-011); a deterministic same-branch serialized-compaction pin that asserts full outcome equality — `CompactionResult` shape, no-op second call, level counts, and actual `(key, value, version)` content (SG-015); a clean-reopen after interleaved `clear_branch` (SG-012); and a sanity test proving the install-pause hook's `(op_tag, branch_id)` keying isolates parallel tests.
- Race determinism uses a new test-only `install_pause` hook entirely behind `#[cfg(test)]` — zero production overhead.

## Scope discipline
Explicitly out of scope per the epic (deferred to T4): generation counter, tombstone map, per-branch compaction lock, fork quiesce (SG-014). No changes to `BranchState`, `clear_branch`, or `fork_branch`. Same control-flow contract as the shipped flush fix (#2108).

## Change class & assurance
- Intentional semantic change (new `StorageError` variant + typed signature). `#[non_exhaustive]` preserves backward-compat.
- Install-site edits are refactor-only at each site (local `entry` → `get_mut`).
- Assurance **S4**.

## Test plan
- [x] `cargo test -p strata-storage --lib` — 700 passed, 0 failed (incl. 9 new resurrection tests, parallel-safe).
- [x] `cargo test --workspace --lib` — all green (13 test-result blocks, 0 failures).
- [x] `cargo test -p strata-engine --tests` — 1014 + integration tests green; only pre-existing `lifecycle_crash_before_flush` failure remains (confirmed present on `main` before this branch).
- [x] `cargo clippy -p strata-storage --all-targets` — 0 errors.
- [x] `cargo check --workspace` — clean.
- [ ] `cargo run --release -p strata-benchmarks --bin regression -- --quick` (benchmarks live in sibling repo; hot path is behavior-neutral — `get_mut` and `entry().or_insert_with` are identical when the key exists, so no regression is expected on benchmark workloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
