### PR TITLE
D3: unified recovery orchestration + typed taxonomy through coordinator seam

### DIFF
--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -35,7 +35,7 @@ pub mod __internal {
 pub use manager::TransactionManager;
 pub use payload::TransactionPayload;
 pub use recovery::{
-    apply_wal_record_to_memory_storage, manifest_error_to_strata_error, RecoveryCoordinator,
-    RecoveryPlan, RecoveryResult, RecoveryStats,
+    apply_wal_record_to_memory_storage, manifest_error_to_strata_error, CoordinatorRecoveryError,
+    RecoveryCoordinator, RecoveryPlan, RecoveryResult, RecoveryStats,
 };
 pub use transaction::{CommitError, JsonStoreExt, TransactionContext, TransactionStatus};

--- a/crates/concurrency/src/recovery.rs
+++ b/crates/concurrency/src/recovery.rs
@@ -15,6 +15,8 @@
 //! 5. Apply records via `on_record`; truncate partial WAL tail on the active segment.
 //! 6. Return `RecoveryStats`; caller owns storage and txn-manager construction.
 
+use std::path::PathBuf;
+
 use crate::payload::TransactionPayload;
 use crate::TransactionManager;
 use strata_core::id::{CommitVersion, TxnId};
@@ -114,6 +116,110 @@ pub struct RecoveryCoordinator {
     codec: Option<Box<dyn StorageCodec>>,
 }
 
+/// Typed recovery failures produced by [`RecoveryCoordinator::recover_typed`].
+///
+/// `recover()` remains the legacy `StrataResult` wrapper for the wider
+/// workspace; engine recovery uses this typed form so D3 can preserve
+/// snapshot/WAL taxonomy past the coordinator boundary.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum CoordinatorRecoveryError {
+    /// `plan_recovery()` failed while resolving snapshot state.
+    #[error(transparent)]
+    Plan(StrataError),
+
+    /// MANIFEST references a snapshot file that does not exist.
+    #[error("MANIFEST references snapshot {snapshot_id} but {path} is missing")]
+    SnapshotMissing {
+        /// Snapshot id recorded in the MANIFEST.
+        snapshot_id: u64,
+        /// Expected snapshot file path.
+        path: PathBuf,
+    },
+
+    /// Snapshot load failed after the MANIFEST pointed at the file.
+    #[error("failed to load snapshot {snapshot_id} at {path}: {source}")]
+    SnapshotRead {
+        /// Snapshot id recorded in the MANIFEST.
+        snapshot_id: u64,
+        /// Snapshot file path.
+        path: PathBuf,
+        /// Underlying typed snapshot read error.
+        #[source]
+        source: SnapshotReadError,
+    },
+
+    /// WAL reader failed while scanning committed records.
+    #[error("WAL read failed: {0}")]
+    WalRead(#[source] WalReaderError),
+
+    /// Transaction payload bytes inside a WAL record were invalid.
+    #[error("Failed to decode transaction payload for txn {txn_id}: {detail}")]
+    PayloadDecode {
+        /// Transaction id of the record whose payload could not be decoded.
+        txn_id: TxnId,
+        /// Decoder error detail.
+        detail: String,
+    },
+
+    /// Caller-supplied snapshot or record callback returned an error.
+    #[error(transparent)]
+    Callback(StrataError),
+}
+
+impl CoordinatorRecoveryError {
+    /// Returns `true` when the error is a hard legacy-format rejection that
+    /// must bypass lossy recovery.
+    pub fn is_legacy_format(&self) -> bool {
+        matches!(
+            self,
+            CoordinatorRecoveryError::SnapshotRead {
+                source: SnapshotReadError::LegacyFormat { .. },
+                ..
+            } | CoordinatorRecoveryError::WalRead(WalReaderError::LegacyFormat { .. })
+        )
+    }
+
+    /// Returns `true` when the engine must bypass its lossy WAL fallback.
+    ///
+    /// Coordinator `Plan(...)` failures come from the MANIFEST /
+    /// snapshot-planning step rather than WAL bytes, so recreating the
+    /// in-memory store cannot heal them.
+    pub fn should_bypass_lossy(&self) -> bool {
+        matches!(self, CoordinatorRecoveryError::Plan(_)) || self.is_legacy_format()
+    }
+}
+
+impl From<CoordinatorRecoveryError> for StrataError {
+    fn from(value: CoordinatorRecoveryError) -> Self {
+        match value {
+            CoordinatorRecoveryError::Plan(inner) | CoordinatorRecoveryError::Callback(inner) => {
+                inner
+            }
+            CoordinatorRecoveryError::SnapshotMissing { snapshot_id, path } => {
+                StrataError::corruption(format!(
+                    "MANIFEST references snapshot {snapshot_id} but {} is missing",
+                    path.display()
+                ))
+            }
+            CoordinatorRecoveryError::SnapshotRead {
+                snapshot_id,
+                path,
+                source,
+            } => map_snapshot_read_error_to_strata_error(source, |other| {
+                StrataError::corruption(format!(
+                    "failed to load snapshot {snapshot_id} at {}: {other}",
+                    path.display(),
+                ))
+            }),
+            CoordinatorRecoveryError::WalRead(inner) => wal_read_error_to_strata_error(inner),
+            CoordinatorRecoveryError::PayloadDecode { txn_id, detail } => StrataError::storage(
+                format!("Failed to decode transaction payload for txn {txn_id}: {detail}"),
+            ),
+        }
+    }
+}
+
 impl RecoveryCoordinator {
     /// Create a recovery coordinator from a canonical database layout.
     ///
@@ -208,11 +314,13 @@ impl RecoveryCoordinator {
     ///
     /// # Errors
     ///
-    /// - `StrataError::corruption` if the MANIFEST cannot be parsed.
-    /// - `StrataError::corruption` if the MANIFEST codec does not match
-    ///   `expected_codec_id`. Returning the corruption variant keeps the
-    ///   error visible to operators without widening `StrataError` in this
-    ///   change class; the error text is structured for the taxonomy pass.
+    /// - `StrataError::corruption` (or `StrataError::LegacyFormat` for pre-v2
+    ///   MANIFESTs) if the MANIFEST cannot be parsed.
+    /// - `StrataError::IncompatibleReuse` if the MANIFEST codec does not match
+    ///   `expected_codec_id`. Codec mismatch is a configuration error, not
+    ///   data corruption — the engine open paths at `database/open.rs` surface
+    ///   the same variant so the coordinator-only codepath agrees (Epic D3
+    ///   recovery-parity requirement).
     pub fn plan_recovery(&self, expected_codec_id: &str) -> StrataResult<RecoveryPlan> {
         let manifest_path = self.layout.manifest_path();
         if !ManifestManager::exists(manifest_path) {
@@ -222,7 +330,7 @@ impl RecoveryCoordinator {
             .map_err(manifest_error_to_strata_error)?;
         let m = mgr.manifest();
         if m.codec_id != expected_codec_id {
-            return Err(StrataError::corruption(format!(
+            return Err(StrataError::incompatible_reuse(format!(
                 "codec mismatch: database was created with '{}' but config specifies '{}'. \
                  A database cannot be reopened with a different codec.",
                 m.codec_id, expected_codec_id
@@ -252,31 +360,27 @@ impl RecoveryCoordinator {
     fn load_snapshot_if_present(
         &self,
         codec: &dyn StorageCodec,
-    ) -> StrataResult<Option<LoadedSnapshot>> {
-        let plan = self.plan_recovery(codec.codec_id())?;
+    ) -> Result<Option<LoadedSnapshot>, CoordinatorRecoveryError> {
+        let plan = self
+            .plan_recovery(codec.codec_id())
+            .map_err(CoordinatorRecoveryError::Plan)?;
         let snapshot_id = match plan.snapshot_id {
             Some(id) => id,
             None => return Ok(None),
         };
         let path = snapshot_path(self.layout.snapshots_dir(), snapshot_id);
         if !path.exists() {
-            return Err(StrataError::corruption(format!(
-                "MANIFEST references snapshot {} but {} is missing",
-                snapshot_id,
-                path.display()
-            )));
+            return Err(CoordinatorRecoveryError::SnapshotMissing { snapshot_id, path });
         }
         let reader = SnapshotReader::new(clone_codec(codec));
-        let snapshot = reader.load(&path).map_err(|err| {
-            map_snapshot_read_error_to_strata_error(err, |other| {
-                StrataError::corruption(format!(
-                    "failed to load snapshot {} at {}: {}",
+        let snapshot =
+            reader
+                .load(&path)
+                .map_err(|source| CoordinatorRecoveryError::SnapshotRead {
                     snapshot_id,
-                    path.display(),
-                    other
-                ))
-            })
-        })?;
+                    path: path.clone(),
+                    source,
+                })?;
         info!(
             target: "strata::recovery",
             snapshot_id,
@@ -306,12 +410,17 @@ impl RecoveryCoordinator {
     /// callers that need the decoded payload perform their own decode
     /// inside `on_record` to preserve the inline-decode invariant.
     ///
-    /// # Errors
+    /// Typed recovery driver used by the engine's D3 recovery
+    /// orchestration.
     ///
-    /// Propagates errors from `on_snapshot`, `on_record`, and WAL reading.
-    /// A hard error from `on_record` halts replay immediately — the caller
-    /// is expected to surface it.
-    pub fn recover<FS, FR>(self, on_snapshot: FS, mut on_record: FR) -> StrataResult<RecoveryStats>
+    /// The legacy [`recover`](Self::recover) API is a thin wrapper over this
+    /// method that maps the typed error back to the historical
+    /// `StrataError` surface for existing callers.
+    pub fn recover_typed<FS, FR>(
+        self,
+        on_snapshot: FS,
+        mut on_record: FR,
+    ) -> Result<RecoveryStats, CoordinatorRecoveryError>
     where
         FS: FnOnce(LoadedSnapshot) -> StrataResult<()>,
         FR: FnMut(&WalRecord) -> StrataResult<()>,
@@ -346,7 +455,7 @@ impl RecoveryCoordinator {
                 stats.from_checkpoint = true;
                 snapshot_watermark_txn = snapshot.watermark_txn();
                 max_txn_id = max_txn_id.max(snapshot_watermark_txn);
-                on_snapshot(snapshot)?;
+                on_snapshot(snapshot).map_err(CoordinatorRecoveryError::Callback)?;
             }
         }
 
@@ -373,10 +482,10 @@ impl RecoveryCoordinator {
         }
         let records_iter = reader
             .iter_all(self.layout.wal_dir())
-            .map_err(wal_read_error_to_strata_error)?;
+            .map_err(CoordinatorRecoveryError::WalRead)?;
 
         for record_result in records_iter {
-            let record = record_result.map_err(wal_read_error_to_strata_error)?;
+            let record = record_result.map_err(CoordinatorRecoveryError::WalRead)?;
 
             // Delta-WAL replay: records at or below the snapshot watermark
             // are already reflected in the installed snapshot. Skip them to
@@ -394,16 +503,16 @@ impl RecoveryCoordinator {
             }
 
             let payload = TransactionPayload::from_bytes(&record.writeset).map_err(|e| {
-                StrataError::storage(format!(
-                    "Failed to decode transaction payload for txn {}: {}",
-                    record.txn_id, e
-                ))
+                CoordinatorRecoveryError::PayloadDecode {
+                    txn_id: record.txn_id,
+                    detail: e.to_string(),
+                }
             })?;
 
             // Invoke the caller before bumping stats so a failing callback
             // never leaves behind inflated counts claiming work that was
             // never applied.
-            on_record(&record)?;
+            on_record(&record).map_err(CoordinatorRecoveryError::Callback)?;
 
             max_txn_id = max_txn_id.max(record.txn_id.as_u64());
             max_version = max_version.max(payload.version);
@@ -426,6 +535,23 @@ impl RecoveryCoordinator {
         stats.max_txn_id = TxnId(max_txn_id);
 
         Ok(stats)
+    }
+
+    /// Drive recovery through caller-supplied callbacks and map the typed
+    /// coordinator error back to the historical `StrataError` surface.
+    ///
+    /// # Errors
+    ///
+    /// Propagates errors from `on_snapshot`, `on_record`, and WAL reading.
+    /// A hard error from `on_record` halts replay immediately — the caller
+    /// is expected to surface it.
+    pub fn recover<FS, FR>(self, on_snapshot: FS, on_record: FR) -> StrataResult<RecoveryStats>
+    where
+        FS: FnOnce(LoadedSnapshot) -> StrataResult<()>,
+        FR: FnMut(&WalRecord) -> StrataResult<()>,
+    {
+        self.recover_typed(on_snapshot, on_record)
+            .map_err(StrataError::from)
     }
 
     /// Best-effort sidecar rebuild for closed WAL segments whose `.meta`

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -27,6 +27,8 @@ pub mod dag_hook;
 pub mod merge_registry;
 pub mod observers;
 pub mod profile;
+pub(crate) mod recovery;
+mod recovery_error;
 mod registry;
 pub mod spec;
 
@@ -49,6 +51,7 @@ pub use observers::{
     BranchOpObserverRegistry, CommitInfo, CommitObserver, CommitObserverRegistry, ObserverError,
     ObserverErrorKind, ReplayInfo, ReplayObserver, ReplayObserverRegistry,
 };
+pub use recovery_error::{ErrorRole, RecoveryError};
 pub use refresh::{
     AdvanceError, BlockReason, BlockedTxn, FollowerStatus, RefreshHookError, RefreshOutcome,
     UnblockError,

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -1,9 +1,6 @@
 //! Database opening and initialization.
 
 use super::config::StorageConfig;
-use super::refresh::{
-    clear_persisted_follower_state, load_persisted_follower_state, validate_blocked_state,
-};
 use crate::background::BackgroundScheduler;
 use crate::coordinator::TransactionCoordinator;
 use dashmap::DashMap;
@@ -12,23 +9,20 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
-use strata_concurrency::{
-    apply_wal_record_to_memory_storage, manifest_error_to_strata_error, RecoveryCoordinator,
-    RecoveryStats,
-};
 use strata_durability::__internal::WalWriterEngineExt;
 use strata_durability::codec::clone_codec;
 use strata_durability::layout::DatabaseLayout;
 use strata_durability::wal::{DurabilityMode, WalConfig, WalWriter};
-use strata_durability::{ManifestError, ManifestManager};
 use strata_storage::SegmentedStore;
 use tracing::{info, warn};
 
 /// Apply all storage configuration settings to a SegmentedStore.
 ///
 /// Centralizes the 7 storage-config setters so every open path
-/// (primary, follower, cache) applies the same set of knobs.
-fn apply_storage_config(storage: &SegmentedStore, cfg: &StorageConfig) {
+/// (primary, follower, cache) applies the same set of knobs. Visible to
+/// `super::recovery` so the unified `run_recovery` entry point can apply
+/// the same knobs after it finishes MANIFEST + WAL + segment recovery.
+pub(crate) fn apply_storage_config(storage: &SegmentedStore, cfg: &StorageConfig) {
     storage.set_max_branches(cfg.max_branches);
     storage.set_max_versions_per_key(cfg.max_versions_per_key);
     storage.set_max_immutable_memtables(cfg.effective_max_immutable_memtables());
@@ -47,7 +41,7 @@ use strata_core::{StrataError, StrataResult};
 /// Restrict a directory to owner-only access (rwx------).
 /// Best-effort: logs a warning on failure but does not block database open.
 #[cfg(unix)]
-fn restrict_dir(path: &Path) {
+pub(crate) fn restrict_dir(path: &Path) {
     use std::os::unix::fs::PermissionsExt;
     if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)) {
         warn!(target: "strata::db", path = %path.display(), error = %e,
@@ -56,7 +50,7 @@ fn restrict_dir(path: &Path) {
 }
 
 #[cfg(not(unix))]
-fn restrict_dir(_path: &Path) {}
+pub(crate) fn restrict_dir(_path: &Path) {}
 
 /// Sanitize config for runtime consistency across all modes.
 ///
@@ -89,7 +83,7 @@ fn restrict_file(_path: &Path) {}
 
 use super::config::{self, StrataConfig};
 use super::registry::OPEN_DATABASES;
-use super::{Database, LossyErrorKind, LossyRecoveryReport, PersistenceMode, WalWriterHealth};
+use super::{Database, PersistenceMode, WalWriterHealth};
 
 enum AcquiredDatabase {
     Existing(Arc<Database>),
@@ -432,283 +426,36 @@ impl Database {
         // Build canonical layout for this database
         let layout = DatabaseLayout::from_root(&canonical_path);
         let wal_dir = layout.wal_dir().to_path_buf();
-        let manifest_path = layout.manifest_path().to_path_buf();
 
-        // Read-only MANIFEST inspection: the follower derives its codec from
-        // whatever the database was created with. Failures here match the
-        // primary's error handling — a MANIFEST that exists but cannot be
-        // parsed is corruption, and a codec id the local build cannot
-        // initialize is a configuration mismatch. Both produce hard errors
-        // so a snapshot-aware compact on the primary does not cause the
-        // follower to silently serve stale / empty state once pre-snapshot
-        // WAL has been reclaimed. Only a genuinely absent MANIFEST (fresh
-        // database) degrades to WAL-only recovery.
-        let manifest_exists = ManifestManager::exists(&manifest_path);
-        let (database_uuid, follower_codec) = if manifest_exists {
-            let m = ManifestManager::load(manifest_path.clone()).map_err(|err| match err {
-                legacy @ ManifestError::LegacyFormat { .. } => {
-                    manifest_error_to_strata_error(legacy)
-                }
-                other => StrataError::corruption(format!(
-                    "follower could not load MANIFEST at {}: {}",
-                    manifest_path.display(),
-                    other
-                )),
-            })?;
-            let manifest = m.manifest();
-            if manifest.codec_id != cfg.storage.codec {
-                return Err(StrataError::incompatible_reuse(format!(
-                    "codec mismatch: follower target at {} was created with '{}' but config specifies '{}'. \
-                     A follower must be configured with the same codec as the primary database.",
-                    canonical_path.display(),
-                    manifest.codec_id,
-                    cfg.storage.codec
-                )));
-            }
-            let codec = strata_durability::get_codec(&manifest.codec_id).map_err(|e| {
-                StrataError::internal(format!(
-                    "follower could not initialize MANIFEST codec '{}': {}",
-                    manifest.codec_id, e
-                ))
-            })?;
-            (manifest.database_uuid, Some(codec))
-        } else {
-            ([0u8; 16], None)
-        };
-
-        if !manifest_exists {
-            match layout
-                .segments_dir()
-                .try_exists()
-                .map_err(StrataError::from)?
-            {
-                true => {}
-                false => {
-                    layout.create_segments_dir().map_err(StrataError::from)?;
-                    restrict_dir(layout.segments_dir());
-                }
-            }
-        }
-
-        // T3-E12 §D7: follower-without-MANIFEST falls back to the
-        // follower's own config codec so encrypted WAL-only recovery
-        // works. Primary and cache paths already use `cfg.storage.codec`
-        // directly; the follower now matches that when MANIFEST is
-        // absent. `follower_codec` (Some/None) stays meaningful for
-        // snapshot-install wiring below, which is only wired with a
-        // MANIFEST-persisted codec — without MANIFEST we don't know
-        // which snapshot schema to install against.
-        let wal_codec: Box<dyn strata_durability::codec::StorageCodec> = match &follower_codec {
-            Some(c) => clone_codec(c.as_ref()),
-            None => strata_durability::get_codec(&cfg.storage.codec).map_err(|e| {
-                StrataError::internal(format!(
-                    "follower (MANIFEST absent) could not initialize config codec '{}': {}",
-                    cfg.storage.codec, e
-                ))
-            })?,
-        };
-
-        // Drive recovery via the callback-driven API. Snapshot install is
-        // wired only when a codec was resolved from the MANIFEST above;
-        // otherwise the coordinator falls back to WAL-only, matching
-        // the pre-Chunk-3 follower behavior. The WAL reader, however,
-        // is always codec-aware via `wal_codec` so encrypted WAL-only
-        // recovery works even without a MANIFEST (T3-E12 §D7).
-        let mut storage = SegmentedStore::with_dir(
-            layout.segments_dir().to_path_buf(),
-            cfg.storage.effective_write_buffer_size(),
-        );
-        let mut recovery =
-            RecoveryCoordinator::new(layout.clone(), cfg.storage.effective_write_buffer_size())
-                .with_lossy_recovery(cfg.allow_lossy_recovery);
-        recovery = recovery.with_codec(clone_codec(wal_codec.as_ref()));
-        let install_codec_for_follower = follower_codec.as_ref().map(|c| clone_codec(c.as_ref()));
-
-        // Count records applied before any coordinator error so the lossy
-        // branch below can surface how far recovery progressed.
-        let records_applied_before_failure = Arc::new(AtomicU64::new(0));
-
-        let recover_result = {
-            let storage_ref = &storage;
-            let install_codec_ref = install_codec_for_follower.as_deref();
-            let counter = Arc::clone(&records_applied_before_failure);
-            recovery.recover(
-                |snapshot| {
-                    if let Some(install_codec) = install_codec_ref {
-                        let installed = super::snapshot_install::install_snapshot(
-                            &snapshot,
-                            install_codec,
-                            storage_ref,
-                        )?;
-                        info!(
-                            target: "strata::recovery",
-                            snapshot_id = snapshot.snapshot_id(),
-                            watermark = snapshot.watermark_txn(),
-                            entries = installed.total_installed(),
-                            "Follower installed snapshot into SegmentedStore"
-                        );
-                    }
-                    Ok(())
-                },
-                |record| {
-                    let result = apply_wal_record_to_memory_storage(storage_ref, record);
-                    if result.is_ok() {
-                        counter.fetch_add(1, Ordering::SeqCst);
-                    }
-                    result
-                },
-            )
-        };
-
-        let mut lossy_report: Option<LossyRecoveryReport> = None;
-        let mut stats = match recover_result {
-            Ok(stats) => stats,
-            Err(e) => {
-                // T3-E12 §D6: LegacyFormat is a hard-fail error that
-                // MUST NOT route through the lossy wipe (the wipe only
-                // recreates in-memory state and leaves pre-v3 segments
-                // on disk to re-poison every subsequent open). Operator
-                // must wipe `wal/` manually.
-                if matches!(e, StrataError::LegacyFormat { .. }) {
-                    return Err(e);
-                }
-
-                if cfg.allow_lossy_recovery {
-                    let report = LossyRecoveryReport {
-                        error: e.to_string(),
-                        error_kind: LossyErrorKind::from_strata_error(&e),
-                        records_applied_before_failure: records_applied_before_failure
-                            .load(Ordering::SeqCst),
-                        version_reached_before_failure: CommitVersion(storage.version()),
-                        discarded_on_wipe: true,
-                    };
-                    warn!(
-                        target: "strata::recovery::lossy",
-                        error = %e,
-                        error_kind = %report.error_kind,
-                        records_applied_before_failure = report.records_applied_before_failure,
-                        version_reached_before_failure =
-                            report.version_reached_before_failure.as_u64(),
-                        discarded_on_wipe = report.discarded_on_wipe,
-                        follower = true,
-                        "Lossy recovery fallback — discarding pre-failure state"
-                    );
-                    warn!(target: "strata::db",
-                        error = %e,
-                        "Follower recovery failed — starting with empty state");
-                    lossy_report = Some(report);
-                    storage = SegmentedStore::with_dir(
-                        layout.segments_dir().to_path_buf(),
-                        cfg.storage.effective_write_buffer_size(),
-                    );
-                    RecoveryStats::default()
-                } else {
-                    return Err(StrataError::corruption(format!(
-                        "WAL recovery failed in follower mode: {}. \
-                         Set allow_lossy_recovery=true to force open.",
-                        e
-                    )));
-                }
-            }
-        };
-
-        // Fold snapshot-installed storage version into stats so the follower's
-        // TransactionCoordinator bootstraps above snapshot entries.
-        stats.final_version = stats.final_version.max(CommitVersion(storage.version()));
-
-        info!(target: "strata::db",
-            txns_replayed = stats.txns_replayed,
-            writes_applied = stats.writes_applied,
-            from_checkpoint = stats.from_checkpoint,
-            "Follower recovery complete");
-
-        let result = strata_concurrency::RecoveryResult {
-            storage,
-            txn_manager: strata_concurrency::TransactionManager::with_txn_id(
-                stats.final_version,
-                stats.max_txn_id,
-            ),
-            stats,
-        };
-
-        let persisted_follower_state = match load_persisted_follower_state(&canonical_path) {
-            Ok(Some(state)) => match validate_blocked_state(
-                &state,
-                result.stats.max_txn_id,
-                result.stats.final_version,
-            ) {
-                Ok(()) => Some(state),
-                Err(reason) => {
-                    warn!(
-                        target: "strata::db",
-                        received = state.received_watermark.as_u64(),
-                        applied = state.applied_watermark.as_u64(),
-                        visible_version = state.visible_version.as_u64(),
-                        blocked_txn = state.blocked.blocked.txn_id.as_u64(),
-                        recovered_txn = result.stats.max_txn_id.as_u64(),
-                        recovered_version = result.stats.final_version.as_u64(),
-                        reason = %reason,
-                        "Ignoring inconsistent persisted follower state"
-                    );
-                    if let Err(error) = clear_persisted_follower_state(&canonical_path) {
-                        warn!(
-                            target: "strata::db",
-                            error = %error,
-                            "Failed to clear inconsistent persisted follower state"
-                        );
-                    }
-                    None
-                }
-            },
-            Ok(None) => None,
-            Err(e) => {
-                warn!(
-                    target: "strata::db",
-                    error = %e,
-                    "Failed to load persisted follower state"
-                );
-                None
-            }
-        };
-        let watermark = if let Some(state) = &persisted_follower_state {
-            super::refresh::ContiguousWatermark::from_state(
-                state.received_watermark,
-                state.applied_watermark,
-                Some(state.blocked.clone()),
-            )
-        } else {
-            super::refresh::ContiguousWatermark::new(result.stats.max_txn_id)
-        };
-
-        let coordinator = TransactionCoordinator::from_recovery_with_limits(
-            &result,
-            cfg.storage.max_write_buffer_entries,
-        );
-
-        let storage = Arc::new(result.storage);
-        apply_storage_config(&storage, &cfg.storage);
+        // Epic D3: unified recovery orchestration. `run_recovery` owns
+        // the follower-specific MANIFEST-or-config codec resolution,
+        // WAL-only-on-missing-MANIFEST branch, coordinator recovery
+        // with lossy fallback, segment recovery, and persisted
+        // follower-state restore. Pre-D3 this was ~260 inline lines
+        // with string-factory error wraps at four sites.
+        let outcome = Database::run_recovery(
+            &canonical_path,
+            &layout,
+            &cfg,
+            super::recovery::RecoveryMode::Follower,
+        )
+        .map_err(StrataError::from)?;
 
         let bg_threads = cfg.storage.background_threads.max(1);
 
-        Self::recover_segments_and_apply(&storage, &coordinator, cfg.allow_lossy_recovery)?;
-
-        // `database_uuid` was already resolved from the MANIFEST above (or
-        // defaulted when absent) before recovery ran, so the snapshot-install
-        // codec and the instance UUID come from the same read.
-
         let db = Arc::new(Self {
             data_dir: canonical_path,
-            database_uuid,
-            storage,
+            database_uuid: outcome.database_uuid,
+            storage: outcome.storage,
             wal_writer: None, // No WAL writer — read-only
-            wal_codec,
+            wal_codec: outcome.wal_codec,
 
             persistence_mode: PersistenceMode::Disk,
-            coordinator,
+            coordinator: outcome.coordinator,
             durability_mode: parking_lot::RwLock::new(DurabilityMode::Cache), // Irrelevant for follower
             accepting_transactions: Arc::new(AtomicBool::new(true)),
             wal_writer_health: Arc::new(ParkingMutex::new(WalWriterHealth::Healthy)),
-            last_lossy_recovery_report: Arc::new(ParkingMutex::new(lossy_report)),
+            last_lossy_recovery_report: Arc::new(ParkingMutex::new(outcome.lossy_report)),
             extensions: DashMap::new(),
             config: parking_lot::RwLock::new(cfg),
             flush_shutdown: Arc::new(AtomicBool::new(false)),
@@ -722,7 +469,7 @@ impl Database {
             backpressure_counter: AtomicU64::new(0),
             lock_file: parking_lot::Mutex::new(None), // No lock acquired
             wal_dir,
-            watermark,
+            watermark: outcome.watermark,
             refresh_gate: super::refresh::RefreshGate::new(),
             refresh_publish_barrier: parking_lot::RwLock::new(()),
             follower: true,
@@ -744,7 +491,7 @@ impl Database {
             merge_registry: super::MergeHandlerRegistry::new(),
         });
 
-        if let Some(state) = persisted_follower_state {
+        if let Some(state) = outcome.persisted_follower_state {
             db.storage.set_version(state.visible_version);
             db.coordinator
                 .restore_visible_version(state.visible_version);
@@ -945,61 +692,6 @@ impl Database {
         }
     }
 
-    /// Recover on-disk segments and apply the typed outcome to the coordinator.
-    ///
-    /// Storage returns a self-contained `RecoveredState` (SE2) carrying the
-    /// version floor, per-branch version map, and a classified
-    /// `RecoveryHealth`. This entry point:
-    ///
-    /// - Emits telemetry summarising the outcome.
-    /// - Forwards the outcome through `coordinator.apply_storage_recovery`
-    ///   (single entry point for floor adoption post-SE2).
-    /// - On `Err(StorageError)` (pre-walk I/O failure), preserves the
-    ///   existing `allow_lossy` split: lossy callers log and continue, strict
-    ///   callers convert to `StrataError::corruption`.
-    ///
-    /// Strict-vs-lossy policy on `outcome.health` (e.g. refusing on
-    /// `DegradationClass::DataLoss`) is intentionally NOT applied here —
-    /// that is D4's scope, implemented inside the unified
-    /// `Database::run_recovery` orchestrator that D3 introduces. SE2
-    /// produces the classified outcome; D4 decides what to do with it.
-    fn recover_segments_and_apply(
-        storage: &Arc<SegmentedStore>,
-        coordinator: &TransactionCoordinator,
-        allow_lossy: bool,
-    ) -> StrataResult<()> {
-        match storage.recover_segments() {
-            Ok(outcome) => {
-                if outcome.segments_loaded > 0 {
-                    info!(target: "strata::db",
-                        branches = outcome.branches_recovered,
-                        segments = outcome.segments_loaded,
-                        "Recovered segments from disk");
-                }
-                if let strata_storage::RecoveryHealth::Degraded { faults, class } = &outcome.health
-                {
-                    warn!(
-                        target: "strata::recovery::health",
-                        class = ?class,
-                        fault_count = faults.len(),
-                        "storage recovered with degraded state"
-                    );
-                }
-                coordinator.apply_storage_recovery(&outcome);
-            }
-            Err(e) => {
-                warn!(target: "strata::db", error = %e, "Segment recovery failed");
-                if !allow_lossy {
-                    return Err(StrataError::corruption(format!(
-                        "Segment recovery failed: {}",
-                        e
-                    )));
-                }
-            }
-        }
-        Ok(())
-    }
-
     /// Shared tail of database open: recovery, WAL writer, coordinator, flush thread.
     fn open_finish(
         canonical_path: PathBuf,
@@ -1007,27 +699,29 @@ impl Database {
         cfg: StrataConfig,
         lock_file: Option<std::fs::File>,
     ) -> StrataResult<Arc<Self>> {
-        // Validate the configured codec exists before touching any state.
-        // This prevents creating a MANIFEST with an invalid codec_id.
-        strata_durability::get_codec(&cfg.storage.codec).map_err(|e| {
-            StrataError::internal(format!(
-                "invalid storage codec '{}': {}",
-                cfg.storage.codec, e
-            ))
-        })?;
-
-        // T3-E12 Phase 2 removed the codec+WAL rejection that used to
-        // live here. Non-identity codecs now round-trip through the
-        // v3 outer envelope + codec-aware reader. Codec name is still
-        // validated earlier via `get_codec(&cfg.storage.codec)`;
-        // MANIFEST codec-mismatch checks on reopen stay as-is.
-
         // Build canonical layout for this database
         let layout = DatabaseLayout::from_root(&canonical_path);
 
-        // Create only the non-authoritative support directories up front.
-        // Recreating `segments/` here on reopen would mask authoritative
-        // flushed-state loss before storage recovery has a chance to classify it.
+        // Epic D3: unified recovery orchestration. `run_recovery` owns
+        // codec validation (before any recovery-managed artifact
+        // creation), MANIFEST
+        // load-or-create, WAL replay with its lossy-fallback branch,
+        // coordinator construction, and SE2's segment recovery
+        // plus `coordinator.apply_storage_recovery`. Pre-D3 each of
+        // those steps lived inline here with string-factory error
+        // wraps scattered across 250 lines.
+        let outcome = Database::run_recovery(
+            &canonical_path,
+            &layout,
+            &cfg,
+            super::recovery::RecoveryMode::Primary,
+        )
+        .map_err(StrataError::from)?;
+
+        // Create only the non-authoritative support directories after
+        // recovery has validated the configured codec. Recreating
+        // `segments/` here on reopen would mask authoritative flushed-state
+        // loss before storage recovery has a chance to classify it.
         layout
             .create_non_segment_dirs()
             .map_err(StrataError::from)?;
@@ -1035,226 +729,39 @@ impl Database {
         restrict_dir(layout.snapshots_dir());
 
         let wal_dir = layout.wal_dir().to_path_buf();
-        let manifest_path = layout.manifest_path().to_path_buf();
-        let manifest_exists = ManifestManager::exists(&manifest_path);
 
-        // Load or create MANIFEST before recovery runs so the coordinator can
-        // consult it for snapshot identity and codec validation. On first
-        // open: generate a new UUID and persist it with the configured codec.
-        // On subsequent opens: load the existing UUID and reject codec drift.
-        //
-        // The coordinator's `plan_recovery` also validates codec, but only
-        // while inside `recover()`, whose error path is subject to the
-        // lossy-recovery fallback. Codec mismatch is a configuration error,
-        // not data corruption, and must NOT be swallowed by lossy mode —
-        // otherwise a misconfigured reopen would silently discard the
-        // database instead of alerting the operator. Keeping the check here
-        // keeps it ahead of the lossy branch.
-        let database_uuid = if manifest_exists {
-            let m = ManifestManager::load(manifest_path.clone())
-                .map_err(manifest_error_to_strata_error)?;
-            let stored_codec = &m.manifest().codec_id;
-            if stored_codec != &cfg.storage.codec {
-                return Err(StrataError::incompatible_reuse(format!(
-                    "codec mismatch: database at {} was created with '{}' but config specifies '{}'. \
-                     A database cannot be reopened with a different codec.",
-                    canonical_path.display(),
-                    stored_codec,
-                    cfg.storage.codec
-                )));
-            }
-            m.manifest().database_uuid
-        } else {
-            layout.create_segments_dir().map_err(StrataError::from)?;
-            restrict_dir(layout.segments_dir());
-            let uuid = *uuid::Uuid::new_v4().as_bytes();
-            ManifestManager::create(manifest_path, uuid, cfg.storage.codec.clone())
-                .map_err(|e| StrataError::internal(format!("failed to create MANIFEST: {}", e)))?;
-            uuid
-        };
-
+        // Defensive: tighten segments-dir permissions on reopen. On
+        // first-open `run_recovery` already restricted it via
+        // `prepare_manifest`; on reopen we don't know the historical
+        // perms of an existing dir.
         if matches!(layout.segments_dir().try_exists(), Ok(true)) {
             restrict_dir(layout.segments_dir());
         }
 
-        // Instantiate the configured storage codec (identity or aes-gcm-256).
-        // One instance is owned here for the WAL writer; a clone is handed to
-        // the coordinator for snapshot decode.
-        let codec = strata_durability::get_codec(&cfg.storage.codec).map_err(|e| {
-            StrataError::internal(format!("failed to initialize storage codec: {}", e))
-        })?;
+        // Clone the WAL codec once for the follower-refresh path kept
+        // on `Database.wal_codec`; the original moves into
+        // `WalWriter::new` below.
+        let wal_codec_for_db = clone_codec(outcome.wal_codec.as_ref());
 
-        // Drive recovery via the callback-driven API so the engine owns
-        // storage construction and snapshot install decoding.
-        let mut storage = SegmentedStore::with_dir(
-            layout.segments_dir().to_path_buf(),
-            cfg.storage.effective_write_buffer_size(),
-        );
-        let recovery_codec_for_install = clone_codec(codec.as_ref());
-        let recovery =
-            RecoveryCoordinator::new(layout.clone(), cfg.storage.effective_write_buffer_size())
-                .with_lossy_recovery(cfg.allow_lossy_recovery)
-                .with_codec(clone_codec(codec.as_ref()));
-
-        // Count records applied by `on_record` before a coordinator error so
-        // a subsequent lossy-fallback branch can surface how far recovery
-        // got. The coordinator drops its own stats on error; we track
-        // independently on the engine side.
-        let records_applied_before_failure = Arc::new(AtomicU64::new(0));
-
-        let recover_result = {
-            let storage_ref = &storage;
-            let install_codec = recovery_codec_for_install.as_ref();
-            let counter = Arc::clone(&records_applied_before_failure);
-            recovery.recover(
-                |snapshot| {
-                    let installed = super::snapshot_install::install_snapshot(
-                        &snapshot,
-                        install_codec,
-                        storage_ref,
-                    )?;
-                    info!(
-                        target: "strata::recovery",
-                        snapshot_id = snapshot.snapshot_id(),
-                        watermark = snapshot.watermark_txn(),
-                        entries = installed.total_installed(),
-                        "Installed snapshot into SegmentedStore"
-                    );
-                    Ok(())
-                },
-                |record| {
-                    let result = apply_wal_record_to_memory_storage(storage_ref, record);
-                    if result.is_ok() {
-                        counter.fetch_add(1, Ordering::SeqCst);
-                    }
-                    result
-                },
-            )
-        };
-
-        let mut lossy_report: Option<LossyRecoveryReport> = None;
-        let mut stats = match recover_result {
-            Ok(stats) => stats,
-            Err(e) => {
-                // T3-E12 §D6: LegacyFormat is a hard-fail error that
-                // MUST NOT route through the lossy wipe — the lossy
-                // branch only recreates the in-memory `SegmentedStore`
-                // and does NOT delete `wal/` on disk, so a pre-v3
-                // segment would re-poison the next open in an
-                // infinite loop. Operator must wipe `wal/` manually.
-                if matches!(e, StrataError::LegacyFormat { .. }) {
-                    return Err(e);
-                }
-
-                if cfg.allow_lossy_recovery {
-                    // Sample partial progress BEFORE the wipe so the
-                    // `LossyRecoveryReport` reflects what was discarded.
-                    let report = LossyRecoveryReport {
-                        error: e.to_string(),
-                        error_kind: LossyErrorKind::from_strata_error(&e),
-                        records_applied_before_failure: records_applied_before_failure
-                            .load(Ordering::SeqCst),
-                        version_reached_before_failure: CommitVersion(storage.version()),
-                        discarded_on_wipe: true,
-                    };
-                    warn!(
-                        target: "strata::recovery::lossy",
-                        error = %e,
-                        error_kind = %report.error_kind,
-                        records_applied_before_failure = report.records_applied_before_failure,
-                        version_reached_before_failure =
-                            report.version_reached_before_failure.as_u64(),
-                        discarded_on_wipe = report.discarded_on_wipe,
-                        follower = false,
-                        "Lossy recovery fallback — discarding pre-failure state"
-                    );
-                    warn!(
-                        target: "strata::db",
-                        error = %e,
-                        "Recovery failed — starting with empty state (allow_lossy_recovery=true)"
-                    );
-                    lossy_report = Some(report);
-                    // Discard any partial writes accumulated before the
-                    // failure so lossy-mode semantics match the pre-Epic-5
-                    // `RecoveryResult::empty()` fallback: no user data
-                    // surfaces from a failed recovery pass.
-                    storage = SegmentedStore::with_dir(
-                        layout.segments_dir().to_path_buf(),
-                        cfg.storage.effective_write_buffer_size(),
-                    );
-                    RecoveryStats::default()
-                } else {
-                    return Err(StrataError::corruption(format!(
-                        "WAL recovery failed: {}. Set allow_lossy_recovery=true to force open with data loss.",
-                        e
-                    )));
-                }
-            }
-        };
-
-        // Snapshot install advances `storage.version` beyond the per-record
-        // WAL versions the coordinator tracks in `stats.final_version`.
-        // Fold the storage-side counter back into stats so the downstream
-        // `TransactionCoordinator::from_recovery_with_limits` bootstraps
-        // above the snapshot's max commit version. Missing this leaves the
-        // commit version counter below installed data, producing monotonicity
-        // violations on the first post-reopen commit.
-        stats.final_version = stats.final_version.max(CommitVersion(storage.version()));
-
-        info!(
-            target: "strata::db",
-            txns_replayed = stats.txns_replayed,
-            writes_applied = stats.writes_applied,
-            deletes_applied = stats.deletes_applied,
-            final_version = stats.final_version.as_u64(),
-            from_checkpoint = stats.from_checkpoint,
-            "Recovery complete"
-        );
-
-        // T3-E12 §D3 Site 2: clone codec BEFORE the move into WalWriter
-        // so the Database can cache its own copy for the follower-
-        // refresh path (via `Database.wal_codec`). Primary doesn't
-        // typically call `refresh()`, but we populate uniformly across
-        // all three constructors so the field type stays
-        // `Box<dyn StorageCodec>` rather than `Option`.
-        let wal_codec_for_db = clone_codec(codec.as_ref());
-
-        // Open segmented WAL writer for appending
+        // Open segmented WAL writer for appending.
         let wal_writer = WalWriter::new(
             wal_dir.clone(),
-            database_uuid,
+            outcome.database_uuid,
             durability_mode,
             WalConfig::default(),
-            codec,
+            outcome.wal_codec,
         )?;
-
-        // Re-assemble the legacy `RecoveryResult` shape for downstream code
-        // paths (coordinator bootstrap, segment recovery bump). Chunk 3
-        // collapses this by introducing a stats-only coordinator constructor.
-        let result = strata_concurrency::RecoveryResult {
-            storage,
-            txn_manager: strata_concurrency::TransactionManager::with_txn_id(
-                stats.final_version,
-                stats.max_txn_id,
-            ),
-            stats,
-        };
-
-        let watermark = super::refresh::ContiguousWatermark::new(result.stats.max_txn_id);
 
         let wal_arc = Arc::new(ParkingMutex::new(wal_writer));
         let flush_shutdown = Arc::new(AtomicBool::new(false));
-        // Pre-create Arc-wrapped fields that need to be shared with flush thread
+        // Pre-create Arc-wrapped fields that need to be shared with flush thread.
         let accepting_transactions = Arc::new(AtomicBool::new(true));
         let wal_writer_health = Arc::new(ParkingMutex::new(WalWriterHealth::Healthy));
 
-        // Create coordinator with write buffer limit from config (before moving result.storage)
-        let coordinator = TransactionCoordinator::from_recovery_with_limits(
-            &result,
-            cfg.storage.max_write_buffer_entries,
-        );
-
-        // Configure block cache capacity before any segment reads
+        // Configure block cache capacity. `run_recovery` already
+        // completed segment recovery; post-open reads will hit this
+        // cache, so configuring it here is functionally equivalent to
+        // the pre-D3 ordering.
         {
             use strata_storage::block_cache;
             let effective_cache = cfg.storage.effective_block_cache_size();
@@ -1276,26 +783,20 @@ impl Database {
             );
         }
 
-        // Apply storage resource limits from config
-        let storage = Arc::new(result.storage);
-        apply_storage_config(&storage, &cfg.storage);
-
         let bg_threads = cfg.storage.background_threads.max(1);
-
-        Self::recover_segments_and_apply(&storage, &coordinator, cfg.allow_lossy_recovery)?;
 
         let db = Arc::new(Self {
             data_dir: canonical_path.clone(),
-            database_uuid,
-            storage,
+            database_uuid: outcome.database_uuid,
+            storage: outcome.storage,
             wal_writer: Some(Arc::clone(&wal_arc)),
             wal_codec: wal_codec_for_db,
             persistence_mode: PersistenceMode::Disk,
-            coordinator,
+            coordinator: outcome.coordinator,
             durability_mode: parking_lot::RwLock::new(durability_mode),
             accepting_transactions: Arc::clone(&accepting_transactions),
             wal_writer_health: Arc::clone(&wal_writer_health),
-            last_lossy_recovery_report: Arc::new(ParkingMutex::new(lossy_report)),
+            last_lossy_recovery_report: Arc::new(ParkingMutex::new(outcome.lossy_report)),
             extensions: DashMap::new(),
             config: parking_lot::RwLock::new(cfg),
             flush_shutdown: Arc::clone(&flush_shutdown),
@@ -1309,7 +810,7 @@ impl Database {
             backpressure_counter: AtomicU64::new(0),
             lock_file: parking_lot::Mutex::new(lock_file),
             wal_dir,
-            watermark,
+            watermark: outcome.watermark,
             refresh_gate: super::refresh::RefreshGate::new(),
             refresh_publish_barrier: parking_lot::RwLock::new(()),
             follower: false,

--- a/crates/engine/src/database/recovery.rs
+++ b/crates/engine/src/database/recovery.rs
@@ -1,0 +1,579 @@
+//! Unified recovery orchestration for primary and follower opens
+//! (Epic D3).
+//!
+//! `Database::run_recovery` is the single recovery entry point used
+//! by both `open_finish` (primary) and `acquire_follower_db`. Before
+//! D3 each mode had its own inline ladder across ~260 lines of
+//! `open.rs`, producing recovery errors as
+//! `StrataError::{internal,corruption,storage}(format!(...))` at seven
+//! sites. That duplication and its string-factory error construction
+//! is what D3 deletes.
+//!
+//! # Scope
+//!
+//! D3 owns orchestration + typed taxonomy only. The strict-vs-lossy
+//! policy branch on `RecoveryHealth::Degraded` is D4 — it hangs inside
+//! the storage step here (between `recover_segments()?` and
+//! `apply_storage_recovery(&outcome)`). The WAL-replay lossy fallback
+//! (populates `LossyRecoveryReport`, wipes the in-memory
+//! `SegmentedStore`) is preserved behaviour; it moves from `open.rs`
+//! into this module's `handle_wal_recovery_outcome` helper without
+//! semantic change.
+//!
+//! # First-open ordering (safety-critical)
+//!
+//! Configured-codec validation runs **before** any recovery-managed
+//! directory is created or MANIFEST is written. Without that ordering, a fresh
+//! database with an invalid codec id would get a MANIFEST recording
+//! the invalid id on disk before the codec-init failure returned,
+//! leaving a poisoned directory that the next open could not repair.
+//! Preserves the pre-D3 behaviour at `open.rs:1010-1017`.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use strata_concurrency::{
+    apply_wal_record_to_memory_storage, CoordinatorRecoveryError, RecoveryCoordinator,
+    RecoveryResult, RecoveryStats, TransactionManager,
+};
+use strata_core::id::CommitVersion;
+use strata_core::StrataError;
+use strata_durability::codec::{clone_codec, StorageCodec};
+use strata_durability::layout::DatabaseLayout;
+use strata_durability::ManifestManager;
+use strata_storage::{RecoveryHealth, SegmentedStore};
+use tracing::{info, warn};
+
+use super::config::StrataConfig;
+use super::open::{apply_storage_config, restrict_dir};
+use super::recovery_error::{
+    classify_manifest_load_error, from_coordinator_error, ErrorRole, RecoveryError,
+};
+use super::refresh::{
+    clear_persisted_follower_state, load_persisted_follower_state, validate_blocked_state,
+    ContiguousWatermark, PersistedFollowerState,
+};
+use super::snapshot_install::install_snapshot;
+use super::{Database, LossyErrorKind, LossyRecoveryReport};
+use crate::coordinator::TransactionCoordinator;
+
+/// Recovery orchestration mode.
+///
+/// Cache/ephemeral databases never recover (no disk state), so they do
+/// not call `run_recovery`; only primary and follower opens do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RecoveryMode {
+    /// Primary (exclusive, read-write) open. Creates a MANIFEST on
+    /// first open; full snapshot + WAL replay + segment recovery.
+    Primary,
+    /// Follower (shared, read-only) open. Never creates a MANIFEST;
+    /// snapshot install wired only when an on-disk MANIFEST records a
+    /// codec id; follower-state restore runs at the end.
+    Follower,
+}
+
+impl RecoveryMode {
+    /// Downcast to the narrower `ErrorRole` used inside operator-UX
+    /// error messages. The two enums carry the same information; they
+    /// are separate types because `ErrorRole` lives alongside
+    /// `RecoveryError` so the error type stays self-contained.
+    fn as_error_role(self) -> ErrorRole {
+        match self {
+            RecoveryMode::Primary => ErrorRole::Primary,
+            RecoveryMode::Follower => ErrorRole::Follower,
+        }
+    }
+}
+
+/// Output of [`Database::run_recovery`].
+///
+/// Carries the owned resources the caller needs to finish constructing
+/// `Arc<Database>`. All public fields are `pub(crate)` because
+/// `RecoveryOutcome` is an implementation detail of `open.rs`; it is
+/// not part of the D4 public surface.
+pub(crate) struct RecoveryOutcome {
+    /// MANIFEST-recorded database UUID (or `[0u8; 16]` for follower
+    /// without a MANIFEST).
+    pub(crate) database_uuid: [u8; 16],
+    /// WAL codec used by both the writer and the follower-refresh
+    /// reader path.
+    pub(crate) wal_codec: Box<dyn StorageCodec>,
+    /// Recovered, config-applied store. Already wrapped in `Arc` so
+    /// the caller can hand it straight to the `Database` struct.
+    pub(crate) storage: Arc<SegmentedStore>,
+    /// Coordinator bootstrapped from replay stats. Already has
+    /// `apply_storage_recovery(&outcome)` applied.
+    pub(crate) coordinator: TransactionCoordinator,
+    /// Watermark derived from replayed state (fresh) or persisted
+    /// follower-state (restored).
+    pub(crate) watermark: ContiguousWatermark,
+    /// `Some(_)` when the lossy WAL-replay fallback fired; `None`
+    /// otherwise.
+    pub(crate) lossy_report: Option<LossyRecoveryReport>,
+    /// `Some(_)` when a follower's persisted state passed validation
+    /// and should be re-installed on the `Database`; always `None` for
+    /// primary.
+    pub(crate) persisted_follower_state: Option<PersistedFollowerState>,
+}
+
+impl Database {
+    /// Unified recovery entry point (Epic D3).
+    ///
+    /// Orchestrates:
+    /// 1. Configured-codec validation (before any recovery-managed
+    ///    directory or MANIFEST creation).
+    /// 2. MANIFEST load or primary-mode create.
+    /// 3. WAL codec resolution (stored id on reopen, configured id on
+    ///    first-open or follower-without-MANIFEST).
+    /// 4. `SegmentedStore` construction at the segments directory.
+    /// 5. `RecoveryCoordinator::recover` — snapshot install + WAL
+    ///    replay via caller-supplied closures.
+    /// 6. WAL-replay lossy fallback (preserved pre-D3 behaviour).
+    /// 7. Snapshot-version fold.
+    /// 8. `TransactionCoordinator::from_recovery_with_limits` +
+    ///    `apply_storage_config`.
+    /// 9. `SegmentedStore::recover_segments` → SE2's classified
+    ///    outcome → `coordinator.apply_storage_recovery`. **D4
+    ///    inserts the strict-vs-lossy policy match between those two
+    ///    calls.**
+    /// 10. Follower-state restore (follower mode only).
+    /// 11. Watermark construction.
+    #[allow(clippy::too_many_lines)] // orchestrator: splitting further would scatter sequential state.
+    pub(crate) fn run_recovery(
+        canonical_path: &Path,
+        layout: &DatabaseLayout,
+        cfg: &StrataConfig,
+        mode: RecoveryMode,
+    ) -> Result<RecoveryOutcome, RecoveryError> {
+        // 1. Configured-codec validation before any recovery-managed
+        //    directory or MANIFEST creation — preserves the pre-D3
+        //    first-open safety guard.
+        strata_durability::get_codec(&cfg.storage.codec).map_err(|e| RecoveryError::CodecInit {
+            codec_id: cfg.storage.codec.clone(),
+            detail: e.to_string(),
+        })?;
+
+        // 2. MANIFEST load or create.
+        let ManifestPreparation {
+            database_uuid,
+            install_codec_for_snapshot,
+        } = prepare_manifest(canonical_path, layout, cfg, mode)?;
+
+        // 3. WAL codec resolution. On reopen we fetch by stored id;
+        //    on first-open / follower-without-MANIFEST we fetch by
+        //    config id (already validated in step 1).
+        let wal_codec_id = install_codec_for_snapshot
+            .as_ref()
+            .map_or(cfg.storage.codec.as_str(), |c| c.codec_id());
+        let wal_codec =
+            strata_durability::get_codec(wal_codec_id).map_err(|e| RecoveryError::CodecInit {
+                codec_id: wal_codec_id.to_owned(),
+                detail: e.to_string(),
+            })?;
+
+        // 4. SegmentedStore at the segments directory.
+        let mut storage = SegmentedStore::with_dir(
+            layout.segments_dir().to_path_buf(),
+            cfg.storage.effective_write_buffer_size(),
+        );
+
+        // 5. RecoveryCoordinator::recover via callbacks.
+        let records_applied_before_failure = Arc::new(AtomicU64::new(0));
+        let recover_result = run_coordinator_recovery(
+            layout,
+            cfg,
+            wal_codec.as_ref(),
+            install_codec_for_snapshot.as_deref(),
+            &storage,
+            &records_applied_before_failure,
+        );
+
+        // 6. Lossy fallback on WAL-replay error.
+        let (mut stats, lossy_report) = handle_wal_recovery_outcome(
+            recover_result,
+            cfg,
+            layout,
+            &mut storage,
+            records_applied_before_failure.load(Ordering::SeqCst),
+            mode,
+        )?;
+
+        // 7. Snapshot-version fold.
+        stats.final_version = stats.final_version.max(CommitVersion(storage.version()));
+
+        info!(
+            target: "strata::db",
+            txns_replayed = stats.txns_replayed,
+            writes_applied = stats.writes_applied,
+            deletes_applied = stats.deletes_applied,
+            final_version = stats.final_version.as_u64(),
+            from_checkpoint = stats.from_checkpoint,
+            mode = match mode {
+                RecoveryMode::Primary => "primary",
+                RecoveryMode::Follower => "follower",
+            },
+            "Recovery complete"
+        );
+
+        // 8. Coordinator bootstrap + storage config.
+        let result = RecoveryResult {
+            storage,
+            txn_manager: TransactionManager::with_txn_id(stats.final_version, stats.max_txn_id),
+            stats,
+        };
+        let coordinator = TransactionCoordinator::from_recovery_with_limits(
+            &result,
+            cfg.storage.max_write_buffer_entries,
+        );
+        let storage = Arc::new(result.storage);
+        apply_storage_config(&storage, &cfg.storage);
+
+        // 9. Storage recovery (SE2 outcome). D3 plumbs only; D4 adds
+        //    the health-policy branch between these two lines.
+        let seg_outcome = storage.recover_segments().map_err(RecoveryError::from)?;
+        if seg_outcome.segments_loaded > 0 {
+            info!(
+                target: "strata::db",
+                branches = seg_outcome.branches_recovered,
+                segments = seg_outcome.segments_loaded,
+                "Recovered segments from disk"
+            );
+        }
+        if let RecoveryHealth::Degraded { faults, class } = &seg_outcome.health {
+            warn!(
+                target: "strata::recovery::health",
+                class = ?class,
+                fault_count = faults.len(),
+                "storage recovered with degraded state"
+            );
+        }
+        // ─── D4 inserts health-policy branch here ──────────────────
+        coordinator.apply_storage_recovery(&seg_outcome);
+
+        // 10. Follower state restore.
+        let persisted_follower_state = match mode {
+            RecoveryMode::Primary => None,
+            RecoveryMode::Follower => restore_follower_state(
+                canonical_path,
+                result.stats.max_txn_id,
+                result.stats.final_version,
+            ),
+        };
+
+        // 11. Watermark.
+        let watermark = match persisted_follower_state.as_ref() {
+            Some(follower_state) => ContiguousWatermark::from_state(
+                follower_state.received_watermark,
+                follower_state.applied_watermark,
+                Some(follower_state.blocked.clone()),
+            ),
+            None => ContiguousWatermark::new(result.stats.max_txn_id),
+        };
+
+        Ok(RecoveryOutcome {
+            database_uuid,
+            wal_codec,
+            storage,
+            coordinator,
+            watermark,
+            lossy_report,
+            persisted_follower_state,
+        })
+    }
+}
+
+/// Output of [`prepare_manifest`].
+struct ManifestPreparation {
+    database_uuid: [u8; 16],
+    /// `Some(clone)` when an on-disk MANIFEST exists and its codec is
+    /// available; `None` for a primary first-open (no MANIFEST yet)
+    /// and for follower-without-MANIFEST where the coordinator falls
+    /// back to WAL-only recovery. Used to gate the snapshot-install
+    /// callback in `run_coordinator_recovery`.
+    install_codec_for_snapshot: Option<Box<dyn StorageCodec>>,
+}
+
+/// MANIFEST load or create. Primary mode creates on absent; follower
+/// mode defers (mirrors `open.rs:479-491` pre-D3 behaviour).
+///
+/// Error mapping preserves the pre-D3 variants: codec mismatch →
+/// `IncompatibleReuse`, parse failure → `Corruption`, create failure
+/// → `Internal`, codec-init failure → `Internal`.
+fn prepare_manifest(
+    canonical_path: &Path,
+    layout: &DatabaseLayout,
+    cfg: &StrataConfig,
+    mode: RecoveryMode,
+) -> Result<ManifestPreparation, RecoveryError> {
+    let manifest_path = layout.manifest_path().to_path_buf();
+    let manifest_exists = ManifestManager::exists(&manifest_path);
+    let role = mode.as_error_role();
+
+    if manifest_exists {
+        let mgr = ManifestManager::load(manifest_path.clone())
+            .map_err(|e| classify_manifest_load_error(manifest_path.clone(), role, e))?;
+        let manifest = mgr.manifest();
+        if manifest.codec_id != cfg.storage.codec {
+            return Err(RecoveryError::ManifestCodecMismatch {
+                stored: manifest.codec_id.clone(),
+                configured: cfg.storage.codec.clone(),
+                db_path: canonical_path.to_path_buf(),
+                role,
+            });
+        }
+        let codec = strata_durability::get_codec(&manifest.codec_id).map_err(|e| {
+            RecoveryError::CodecInit {
+                codec_id: manifest.codec_id.clone(),
+                detail: e.to_string(),
+            }
+        })?;
+        return Ok(ManifestPreparation {
+            database_uuid: manifest.database_uuid,
+            install_codec_for_snapshot: Some(codec),
+        });
+    }
+
+    match mode {
+        RecoveryMode::Primary => {
+            // First-open: create segments dir + MANIFEST. Codec was
+            // already validated in `run_recovery` step 1.
+            layout.create_segments_dir().map_err(RecoveryError::Io)?;
+            restrict_dir(layout.segments_dir());
+            let uuid = *uuid::Uuid::new_v4().as_bytes();
+            ManifestManager::create(
+                layout.manifest_path().to_path_buf(),
+                uuid,
+                cfg.storage.codec.clone(),
+            )
+            .map_err(RecoveryError::ManifestCreate)?;
+            Ok(ManifestPreparation {
+                database_uuid: uuid,
+                install_codec_for_snapshot: None,
+            })
+        }
+        RecoveryMode::Follower => {
+            // Follower-without-MANIFEST falls back to WAL-only
+            // recovery. We still ensure the segments dir exists so
+            // `SegmentedStore::with_dir` has something to read.
+            if !layout
+                .segments_dir()
+                .try_exists()
+                .map_err(RecoveryError::Io)?
+            {
+                layout.create_segments_dir().map_err(RecoveryError::Io)?;
+                restrict_dir(layout.segments_dir());
+            }
+            Ok(ManifestPreparation {
+                database_uuid: [0u8; 16],
+                install_codec_for_snapshot: None,
+            })
+        }
+    }
+}
+
+/// Drive the coordinator's callback-based recovery (`plan_recovery`,
+/// snapshot install, WAL replay) and return its typed coordinator error.
+///
+/// Error classification into `RecoveryError` is deferred to
+/// [`handle_wal_recovery_outcome`] so the lossy-fallback arm can run
+/// `LossyErrorKind::from_strata_error(&e)` on the original
+/// `StrataError` before the engine maps the failure into a typed
+/// `RecoveryError`.
+fn run_coordinator_recovery(
+    layout: &DatabaseLayout,
+    cfg: &StrataConfig,
+    wal_codec: &dyn StorageCodec,
+    install_codec: Option<&dyn StorageCodec>,
+    storage: &SegmentedStore,
+    records_counter: &Arc<AtomicU64>,
+) -> Result<RecoveryStats, CoordinatorRecoveryError> {
+    let recovery =
+        RecoveryCoordinator::new(layout.clone(), cfg.storage.effective_write_buffer_size())
+            .with_lossy_recovery(cfg.allow_lossy_recovery)
+            .with_codec(clone_codec(wal_codec));
+
+    let counter = Arc::clone(records_counter);
+    recovery.recover_typed(
+        |snapshot| {
+            if let Some(codec) = install_codec {
+                let installed = install_snapshot(&snapshot, codec, storage)?;
+                info!(
+                    target: "strata::recovery",
+                    snapshot_id = snapshot.snapshot_id(),
+                    watermark = snapshot.watermark_txn(),
+                    entries = installed.total_installed(),
+                    "Installed snapshot into SegmentedStore"
+                );
+            }
+            Ok(())
+        },
+        |record| {
+            let result = apply_wal_record_to_memory_storage(storage, record);
+            if result.is_ok() {
+                counter.fetch_add(1, Ordering::SeqCst);
+            }
+            result
+        },
+    )
+}
+
+/// Classify the outcome of `RecoveryCoordinator::recover` and apply
+/// the WAL-replay lossy fallback when configured.
+///
+/// - `Ok(stats)` → `(stats, None)`.
+/// - `Err(CoordinatorRecoveryError)` from the coordinator's planning step or
+///   carrying a legacy-format source is a hard-fail regardless of
+///   `allow_lossy_recovery`. The lossy wipe only recreates in-memory
+///   `SegmentedStore` state; it cannot heal a MANIFEST/snapshot plan failure
+///   and would re-observe legacy on-disk artifacts on the next open.
+/// - `Err(e)` with `cfg.allow_lossy_recovery=false` →
+///   typed `RecoveryError` via `from_coordinator_error`.
+/// - `Err(e)` with lossy enabled → build `LossyRecoveryReport`,
+///   replace `storage` with a fresh `SegmentedStore::with_dir`,
+///   return `(RecoveryStats::default(), Some(report))`.
+fn handle_wal_recovery_outcome(
+    recover_result: Result<RecoveryStats, CoordinatorRecoveryError>,
+    cfg: &StrataConfig,
+    layout: &DatabaseLayout,
+    storage: &mut SegmentedStore,
+    records_applied_before_failure: u64,
+    mode: RecoveryMode,
+) -> Result<(RecoveryStats, Option<LossyRecoveryReport>), RecoveryError> {
+    let err = match recover_result {
+        Ok(stats) => return Ok((stats, None)),
+        Err(e) => e,
+    };
+
+    if err.should_bypass_lossy() {
+        return Err(from_coordinator_error(mode.as_error_role(), err));
+    }
+
+    if !cfg.allow_lossy_recovery {
+        return Err(from_coordinator_error(mode.as_error_role(), err));
+    }
+
+    let err = StrataError::from(err);
+
+    // Sample progress BEFORE the wipe so the report reflects what was
+    // discarded.
+    let version_reached_before_failure = CommitVersion(storage.version());
+    let error_kind = LossyErrorKind::from_strata_error(&err);
+    let report = LossyRecoveryReport {
+        error: err.to_string(),
+        error_kind,
+        records_applied_before_failure,
+        version_reached_before_failure,
+        discarded_on_wipe: true,
+    };
+    let follower_flag = matches!(mode, RecoveryMode::Follower);
+    warn!(
+        target: "strata::recovery::lossy",
+        error = %err,
+        error_kind = %report.error_kind,
+        records_applied_before_failure = report.records_applied_before_failure,
+        version_reached_before_failure = report.version_reached_before_failure.as_u64(),
+        discarded_on_wipe = report.discarded_on_wipe,
+        follower = follower_flag,
+        "Lossy recovery fallback — discarding pre-failure state"
+    );
+    let db_target_message = if follower_flag {
+        "Follower recovery failed — starting with empty state"
+    } else {
+        "Recovery failed — starting with empty state (allow_lossy_recovery=true)"
+    };
+    warn!(target: "strata::db", error = %err, "{}", db_target_message);
+
+    // Discard any partial writes accumulated before the failure so
+    // lossy-mode semantics match the pre-Epic-5 `RecoveryResult::empty()`
+    // fallback: no user data surfaces from a failed recovery pass.
+    *storage = SegmentedStore::with_dir(
+        layout.segments_dir().to_path_buf(),
+        cfg.storage.effective_write_buffer_size(),
+    );
+
+    Ok((RecoveryStats::default(), Some(report)))
+}
+
+/// Load and validate the persisted follower blocked-state slot. On
+/// validation failure the slot is cleared so a restart does not
+/// re-observe the inconsistent state.
+///
+/// Mirrors the pre-D3 block at `open.rs:634-672` verbatim.
+fn restore_follower_state(
+    canonical_path: &Path,
+    recovered_max_txn: strata_core::id::TxnId,
+    recovered_final_version: CommitVersion,
+) -> Option<PersistedFollowerState> {
+    let loaded = match load_persisted_follower_state(canonical_path) {
+        Ok(state) => state,
+        Err(e) => {
+            warn!(
+                target: "strata::db",
+                error = %e,
+                "Failed to load persisted follower state"
+            );
+            return None;
+        }
+    };
+    let state = loaded?;
+    match validate_blocked_state(&state, recovered_max_txn, recovered_final_version) {
+        Ok(()) => Some(state),
+        Err(reason) => {
+            warn!(
+                target: "strata::db",
+                received = state.received_watermark.as_u64(),
+                applied = state.applied_watermark.as_u64(),
+                visible_version = state.visible_version.as_u64(),
+                blocked_txn = state.blocked.blocked.txn_id.as_u64(),
+                recovered_txn = recovered_max_txn.as_u64(),
+                recovered_version = recovered_final_version.as_u64(),
+                reason = %reason,
+                "Ignoring inconsistent persisted follower state"
+            );
+            if let Err(error) = clear_persisted_follower_state(canonical_path) {
+                warn!(
+                    target: "strata::db",
+                    error = %error,
+                    "Failed to clear inconsistent persisted follower state"
+                );
+            }
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn coordinator_plan_failure_bypasses_lossy_fallback() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let mut storage = SegmentedStore::new();
+        let cfg = StrataConfig {
+            allow_lossy_recovery: true,
+            ..StrataConfig::default()
+        };
+
+        let result = handle_wal_recovery_outcome(
+            Err(CoordinatorRecoveryError::Plan(
+                StrataError::incompatible_reuse("codec mismatch while re-reading MANIFEST"),
+            )),
+            &cfg,
+            &layout,
+            &mut storage,
+            0,
+            RecoveryMode::Primary,
+        );
+
+        match result {
+            Err(RecoveryError::CoordinatorPlan(inner)) => {
+                assert!(matches!(inner, StrataError::IncompatibleReuse { .. }));
+            }
+            other => panic!("plan failure must hard-fail without lossy wipe, got: {other:?}"),
+        }
+    }
+}

--- a/crates/engine/src/database/recovery_error.rs
+++ b/crates/engine/src/database/recovery_error.rs
@@ -1,0 +1,612 @@
+//! Typed recovery-error vocabulary for the engine (Epic D3).
+//!
+//! `RecoveryError` is the engine-level error emitted by
+//! `Database::run_recovery` (see [`super::recovery`]). It replaces the
+//! ad-hoc `StrataError::{internal,corruption,storage}(format!(...))`
+//! wraps that were previously scattered across `open.rs`.
+//!
+//! D3's load-bearing requirement is that snapshot and WAL recovery
+//! failures survive the coordinator seam in typed form. The engine still
+//! converts `RecoveryError` back into `StrataError` at the public open
+//! entry points, but `run_recovery()` itself now exposes the structured
+//! taxonomy that D4's policy work will build on.
+
+use std::io;
+use std::path::PathBuf;
+
+use strata_concurrency::CoordinatorRecoveryError;
+use strata_core::id::TxnId;
+use strata_core::StrataError;
+use strata_durability::wal::WalReaderError;
+use strata_durability::{ManifestError, SnapshotReadError};
+use strata_storage::{RecoveryHealth, StorageError};
+use thiserror::Error;
+
+/// Which open path is emitting a recovery error.
+///
+/// Public because it appears in public [`RecoveryError`] variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ErrorRole {
+    /// Primary (exclusive, read-write) open.
+    Primary,
+    /// Follower (shared, read-only) open.
+    Follower,
+}
+
+impl ErrorRole {
+    fn is_follower(self) -> bool {
+        matches!(self, ErrorRole::Follower)
+    }
+}
+
+/// Typed engine-level recovery errors.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum RecoveryError {
+    /// A non-legacy [`ManifestError`] observed directly during the engine's
+    /// MANIFEST load step.
+    #[error("failed to load MANIFEST at {path}: {inner}")]
+    ManifestLoad {
+        /// Path of the MANIFEST file that failed to parse.
+        path: PathBuf,
+        /// Which open path observed the failure.
+        role: ErrorRole,
+        /// The underlying manifest-format error.
+        #[source]
+        inner: ManifestError,
+    },
+
+    /// [`ManifestError::LegacyFormat`] extracted structurally so
+    /// `StrataError::LegacyFormat` can be reconstructed exactly.
+    #[error("MANIFEST legacy format (version {found_version}): {hint}")]
+    ManifestLegacyFormat {
+        /// Version number recorded on disk.
+        found_version: u32,
+        /// Supported-range + remediation text shown to operators.
+        hint: String,
+    },
+
+    /// The stored codec id in the MANIFEST does not match the configured
+    /// codec id.
+    #[error("codec mismatch at {db_path}: stored='{stored}', configured='{configured}'")]
+    ManifestCodecMismatch {
+        /// Codec id recorded in the on-disk MANIFEST.
+        stored: String,
+        /// Codec id supplied in the runtime configuration.
+        configured: String,
+        /// Database directory path.
+        db_path: PathBuf,
+        /// Which open path observed the mismatch.
+        role: ErrorRole,
+    },
+
+    /// `ManifestManager::create` failed during first-open MANIFEST creation.
+    #[error("failed to create MANIFEST: {0}")]
+    ManifestCreate(#[source] ManifestError),
+
+    /// `strata_durability::get_codec(id)` returned an error.
+    #[error("could not initialize storage codec '{codec_id}': {detail}")]
+    CodecInit {
+        /// Codec id that could not be resolved.
+        codec_id: String,
+        /// Display text of the underlying `get_codec` error.
+        detail: String,
+    },
+
+    /// Hard failure from the coordinator's `plan_recovery()` step.
+    ///
+    /// This is the coordinator's second MANIFEST read while it resolves
+    /// snapshot state. The engine preserves the original `StrataError`
+    /// verbatim because the lossy WAL fallback cannot heal a planning
+    /// failure.
+    #[error(transparent)]
+    CoordinatorPlan(StrataError),
+
+    /// MANIFEST referenced a snapshot file that was absent on disk.
+    #[error("MANIFEST references snapshot {snapshot_id} but {path} is missing")]
+    SnapshotMissing {
+        /// Which open path observed the failure.
+        role: ErrorRole,
+        /// Snapshot id recorded in the MANIFEST.
+        snapshot_id: u64,
+        /// Snapshot path that was missing.
+        path: PathBuf,
+    },
+
+    /// Snapshot load failed after the MANIFEST pointed at the file.
+    #[error("failed to load snapshot {snapshot_id} at {path}: {inner}")]
+    SnapshotRead {
+        /// Which open path observed the failure.
+        role: ErrorRole,
+        /// Snapshot id recorded in the MANIFEST.
+        snapshot_id: u64,
+        /// Snapshot file path.
+        path: PathBuf,
+        /// Underlying typed snapshot read error.
+        #[source]
+        inner: SnapshotReadError,
+    },
+
+    /// Legacy WAL segment format — surfaced directly from the typed
+    /// coordinator seam.
+    #[error("legacy WAL format (version {found_version}): {hint}")]
+    WalLegacyFormat {
+        /// Version number read from disk.
+        found_version: u32,
+        /// Remediation hint text.
+        hint: String,
+    },
+
+    /// Codec decode failure while reading a WAL record.
+    #[error("WAL codec decode failure at byte offset {offset}: {detail}")]
+    WalCodecDecode {
+        /// Byte offset within the segment where decode failed.
+        offset: u64,
+        /// Decode error detail.
+        detail: String,
+    },
+
+    /// Mid-segment checksum corruption while reading WAL bytes.
+    #[error("WAL checksum mismatch at byte offset {offset}")]
+    WalChecksum {
+        /// Which open path observed the failure.
+        role: ErrorRole,
+        /// Byte offset where corruption was detected.
+        offset: u64,
+        /// Number of valid records before the corrupted region.
+        records_before: usize,
+    },
+
+    /// Other typed WAL reader failure.
+    #[error("WAL read failed: {inner}")]
+    WalRead {
+        /// Which open path observed the failure.
+        role: ErrorRole,
+        /// Underlying WAL reader error.
+        #[source]
+        inner: WalReaderError,
+    },
+
+    /// Transaction payload bytes inside a WAL record were invalid.
+    #[error("Failed to decode transaction payload for txn {txn_id}: {detail}")]
+    PayloadDecode {
+        /// Which open path observed the failure.
+        role: ErrorRole,
+        /// Transaction id of the record whose payload failed to decode.
+        txn_id: TxnId,
+        /// Decoder error detail.
+        detail: String,
+    },
+
+    /// Fallback bucket for callback or future coordinator failures that do not
+    /// map to one of the typed recovery variants above.
+    #[error("WAL recovery failed: {inner}")]
+    WalRecoveryFailed {
+        /// Which open path observed the failure.
+        role: ErrorRole,
+        /// Opaque callback/plan error from the coordinator path.
+        #[source]
+        inner: StrataError,
+    },
+
+    /// [`SegmentedStore::recover_segments`] returned a classified
+    /// `RecoveryHealth::Degraded` outcome carried as-is.
+    #[error("storage recovered in degraded state")]
+    StorageDegraded(RecoveryHealth),
+
+    /// [`SegmentedStore::recover_segments`] returned `Err(StorageError)`.
+    #[error("Segment recovery failed: {0}")]
+    Storage(#[source] StorageError),
+
+    /// I/O error observed inside `run_recovery` outside of the paths above.
+    #[error("recovery I/O error: {0}")]
+    Io(#[source] io::Error),
+}
+
+impl From<RecoveryError> for StrataError {
+    #[allow(clippy::too_many_lines)] // sequential variant mapping; splitting scatters message shape.
+    fn from(value: RecoveryError) -> Self {
+        match value {
+            RecoveryError::ManifestLegacyFormat {
+                found_version,
+                hint,
+            }
+            | RecoveryError::WalLegacyFormat {
+                found_version,
+                hint,
+            } => StrataError::legacy_format(found_version, hint),
+            RecoveryError::WalCodecDecode { detail, .. } => StrataError::codec_decode(detail),
+            RecoveryError::CoordinatorPlan(inner) => inner,
+            RecoveryError::ManifestCodecMismatch {
+                stored,
+                configured,
+                db_path,
+                role,
+            } => {
+                let message = if role.is_follower() {
+                    format!(
+                        "codec mismatch: follower target at {} was created with '{}' but config specifies '{}'. \
+                         A follower must be configured with the same codec as the primary database.",
+                        db_path.display(),
+                        stored,
+                        configured,
+                    )
+                } else {
+                    format!(
+                        "codec mismatch: database at {} was created with '{}' but config specifies '{}'. \
+                         A database cannot be reopened with a different codec.",
+                        db_path.display(),
+                        stored,
+                        configured,
+                    )
+                };
+                StrataError::incompatible_reuse(message)
+            }
+            RecoveryError::ManifestLoad { path, role, inner } => {
+                let message = if role.is_follower() {
+                    format!(
+                        "follower could not load MANIFEST at {}: {inner}",
+                        path.display()
+                    )
+                } else {
+                    format!("failed to load MANIFEST: {inner}")
+                };
+                StrataError::corruption(message)
+            }
+            RecoveryError::ManifestCreate(inner) => {
+                StrataError::internal(format!("failed to create MANIFEST: {inner}"))
+            }
+            RecoveryError::CodecInit { codec_id, detail } => StrataError::internal(format!(
+                "could not initialize storage codec '{codec_id}': {detail}"
+            )),
+            RecoveryError::SnapshotMissing {
+                role,
+                snapshot_id,
+                path,
+            } => StrataError::corruption(strict_recovery_message(
+                role,
+                &format!(
+                    "MANIFEST references snapshot {snapshot_id} but {} is missing",
+                    path.display()
+                ),
+            )),
+            RecoveryError::SnapshotRead {
+                role,
+                snapshot_id,
+                path,
+                inner,
+            } => match inner {
+                SnapshotReadError::LegacyFormat {
+                    detected_version,
+                    supported_range,
+                    remediation,
+                } => StrataError::legacy_format(
+                    detected_version,
+                    format!("{supported_range}. {remediation}"),
+                ),
+                other => StrataError::corruption(strict_recovery_message(
+                    role,
+                    &format!(
+                        "failed to load snapshot {snapshot_id} at {}: {other}",
+                        path.display(),
+                    ),
+                )),
+            },
+            RecoveryError::WalChecksum {
+                role,
+                offset,
+                records_before,
+            } => StrataError::corruption(strict_recovery_message(
+                role,
+                &format!(
+                    "WAL read failed: Corrupted WAL segment at byte offset {offset} ({records_before} valid records before corruption)"
+                ),
+            )),
+            RecoveryError::WalRead { role, inner } => StrataError::corruption(
+                strict_recovery_message(role, &format!("WAL read failed: {inner}")),
+            ),
+            RecoveryError::PayloadDecode {
+                role,
+                txn_id,
+                detail,
+            } => StrataError::corruption(strict_recovery_message(
+                role,
+                &format!("Failed to decode transaction payload for txn {txn_id}: {detail}"),
+            )),
+            RecoveryError::WalRecoveryFailed { role, inner } => {
+                StrataError::corruption(strict_recovery_message(role, &inner.to_string()))
+            }
+            RecoveryError::StorageDegraded(health) => StrataError::corruption(format!(
+                "storage recovered in degraded state: {health:?}"
+            )),
+            RecoveryError::Storage(inner) => {
+                StrataError::corruption(format!("Segment recovery failed: {inner}"))
+            }
+            RecoveryError::Io(inner) => StrataError::from(inner),
+        }
+    }
+}
+
+impl From<io::Error> for RecoveryError {
+    fn from(value: io::Error) -> Self {
+        RecoveryError::Io(value)
+    }
+}
+
+impl From<StorageError> for RecoveryError {
+    fn from(value: StorageError) -> Self {
+        RecoveryError::Storage(value)
+    }
+}
+
+fn strict_recovery_message(role: ErrorRole, detail: &str) -> String {
+    if role.is_follower() {
+        format!(
+            "WAL recovery failed in follower mode: {detail}. \
+             Set allow_lossy_recovery=true to force open."
+        )
+    } else {
+        format!(
+            "WAL recovery failed: {detail}. \
+             Set allow_lossy_recovery=true to force open with data loss."
+        )
+    }
+}
+
+/// Classify a `ManifestError` observed during MANIFEST load into the right
+/// `RecoveryError` variant, carrying the role + path that the operator-UX
+/// messages need.
+pub(crate) fn classify_manifest_load_error(
+    path: PathBuf,
+    role: ErrorRole,
+    err: ManifestError,
+) -> RecoveryError {
+    match err {
+        ManifestError::LegacyFormat {
+            detected_version,
+            supported_range,
+            remediation,
+        } => RecoveryError::ManifestLegacyFormat {
+            found_version: detected_version,
+            hint: format!("{supported_range}. {remediation}"),
+        },
+        inner => RecoveryError::ManifestLoad { path, role, inner },
+    }
+}
+
+/// Classify a typed coordinator failure into the engine's public
+/// `RecoveryError` taxonomy.
+pub(crate) fn from_coordinator_error(
+    role: ErrorRole,
+    err: CoordinatorRecoveryError,
+) -> RecoveryError {
+    match err {
+        CoordinatorRecoveryError::Plan(inner) => RecoveryError::CoordinatorPlan(inner),
+        CoordinatorRecoveryError::SnapshotMissing { snapshot_id, path } => {
+            RecoveryError::SnapshotMissing {
+                role,
+                snapshot_id,
+                path,
+            }
+        }
+        CoordinatorRecoveryError::SnapshotRead {
+            snapshot_id,
+            path,
+            source,
+        } => RecoveryError::SnapshotRead {
+            role,
+            snapshot_id,
+            path,
+            inner: source,
+        },
+        CoordinatorRecoveryError::WalRead(WalReaderError::LegacyFormat {
+            found_version,
+            hint,
+        }) => RecoveryError::WalLegacyFormat {
+            found_version,
+            hint,
+        },
+        CoordinatorRecoveryError::WalRead(WalReaderError::CodecDecode { offset, detail }) => {
+            RecoveryError::WalCodecDecode { offset, detail }
+        }
+        CoordinatorRecoveryError::WalRead(WalReaderError::CorruptedSegment {
+            offset,
+            records_before,
+        }) => RecoveryError::WalChecksum {
+            role,
+            offset: offset as u64,
+            records_before,
+        },
+        CoordinatorRecoveryError::WalRead(inner) => RecoveryError::WalRead { role, inner },
+        CoordinatorRecoveryError::PayloadDecode { txn_id, detail } => {
+            RecoveryError::PayloadDecode {
+                role,
+                txn_id,
+                detail,
+            }
+        }
+        CoordinatorRecoveryError::Callback(inner) => {
+            RecoveryError::WalRecoveryFailed { role, inner }
+        }
+        _ => RecoveryError::WalRecoveryFailed {
+            role,
+            inner: StrataError::internal("unknown coordinator recovery error"),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_legacy_roundtrips_to_legacy_format() {
+        let err = RecoveryError::ManifestLegacyFormat {
+            found_version: 1,
+            hint: "supported range v2-v2. wipe wal/".into(),
+        };
+        let strata = StrataError::from(err);
+        assert!(matches!(strata, StrataError::LegacyFormat { .. }));
+    }
+
+    #[test]
+    fn wal_codec_decode_roundtrips_to_codec_decode() {
+        let err = RecoveryError::WalCodecDecode {
+            offset: 42,
+            detail: "auth tag mismatch".into(),
+        };
+        let strata = StrataError::from(err);
+        assert!(matches!(strata, StrataError::CodecDecode { .. }));
+    }
+
+    #[test]
+    fn codec_mismatch_roundtrips_to_incompatible_reuse() {
+        let err = RecoveryError::ManifestCodecMismatch {
+            stored: "aes-gcm-256".into(),
+            configured: "identity".into(),
+            db_path: PathBuf::from("/tmp/db"),
+            role: ErrorRole::Primary,
+        };
+        let strata = StrataError::from(err);
+        assert!(matches!(strata, StrataError::IncompatibleReuse { .. }));
+    }
+
+    #[test]
+    fn follower_codec_mismatch_message_names_follower() {
+        let err = RecoveryError::ManifestCodecMismatch {
+            stored: "identity".into(),
+            configured: "aes-gcm-256".into(),
+            db_path: PathBuf::from("/tmp/follower-db"),
+            role: ErrorRole::Follower,
+        };
+        let msg = StrataError::from(err).to_string();
+        assert!(msg.contains("codec mismatch"), "message: {msg}");
+        assert!(msg.contains("follower"), "message: {msg}");
+    }
+
+    #[test]
+    fn follower_manifest_load_message_names_path() {
+        let err = RecoveryError::ManifestLoad {
+            path: PathBuf::from("/tmp/db/MANIFEST"),
+            role: ErrorRole::Follower,
+            inner: ManifestError::InvalidMagic,
+        };
+        let msg = StrataError::from(err).to_string();
+        assert!(
+            msg.contains("follower could not load MANIFEST"),
+            "message: {msg}"
+        );
+        assert!(msg.contains("/tmp/db/MANIFEST"), "message: {msg}");
+    }
+
+    #[test]
+    fn strict_wal_recovery_failed_message_hints_lossy() {
+        let err = RecoveryError::WalRecoveryFailed {
+            role: ErrorRole::Primary,
+            inner: StrataError::storage("WAL read failed: bad checksum"),
+        };
+        let strata = StrataError::from(err);
+        assert!(matches!(strata, StrataError::Corruption { .. }));
+        let msg = strata.to_string();
+        assert!(msg.contains("WAL recovery failed"), "message: {msg}");
+        assert!(msg.contains("allow_lossy_recovery"), "message: {msg}");
+    }
+
+    #[test]
+    fn storage_error_roundtrips_to_corruption() {
+        let err = RecoveryError::Storage(StorageError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "segments dir missing",
+        )));
+        let strata = StrataError::from(err);
+        assert!(matches!(strata, StrataError::Corruption { .. }));
+        let msg = strata.to_string();
+        assert!(msg.contains("Segment recovery failed"), "message: {msg}");
+    }
+
+    #[test]
+    fn snapshot_legacy_roundtrips_to_legacy_format() {
+        let err = RecoveryError::SnapshotRead {
+            role: ErrorRole::Primary,
+            snapshot_id: 7,
+            path: PathBuf::from("/tmp/db/snapshots/snap-7.chk"),
+            inner: SnapshotReadError::LegacyFormat {
+                detected_version: 1,
+                supported_range: "this build requires snapshot format version 2".into(),
+                remediation: "delete the offending snapshot".into(),
+            },
+        };
+        let strata = StrataError::from(err);
+        assert!(matches!(strata, StrataError::LegacyFormat { .. }));
+    }
+
+    #[test]
+    fn coordinator_plan_roundtrips_to_original_variant() {
+        let err = from_coordinator_error(
+            ErrorRole::Follower,
+            CoordinatorRecoveryError::Plan(StrataError::incompatible_reuse(
+                "codec mismatch while re-reading MANIFEST",
+            )),
+        );
+        let strata = StrataError::from(err);
+        assert!(matches!(strata, StrataError::IncompatibleReuse { .. }));
+    }
+
+    #[test]
+    fn coordinator_plan_legacy_roundtrips_to_legacy_format() {
+        let err = from_coordinator_error(
+            ErrorRole::Primary,
+            CoordinatorRecoveryError::Plan(StrataError::legacy_format(
+                1,
+                "this build requires MANIFEST format version 2",
+            )),
+        );
+        let strata = StrataError::from(err);
+        assert!(matches!(strata, StrataError::LegacyFormat { .. }));
+    }
+
+    #[test]
+    fn coordinator_snapshot_read_maps_to_typed_variant() {
+        let err = CoordinatorRecoveryError::SnapshotRead {
+            snapshot_id: 9,
+            path: PathBuf::from("/tmp/db/snapshots/snap-9.chk"),
+            source: SnapshotReadError::CrcMismatch {
+                stored: 1,
+                computed: 2,
+            },
+        };
+        assert!(matches!(
+            from_coordinator_error(ErrorRole::Primary, err),
+            RecoveryError::SnapshotRead { snapshot_id: 9, .. }
+        ));
+    }
+
+    #[test]
+    fn coordinator_wal_checksum_maps_to_typed_variant() {
+        let err = CoordinatorRecoveryError::WalRead(WalReaderError::CorruptedSegment {
+            offset: 128,
+            records_before: 3,
+        });
+        assert!(matches!(
+            from_coordinator_error(ErrorRole::Follower, err),
+            RecoveryError::WalChecksum {
+                role: ErrorRole::Follower,
+                offset: 128,
+                records_before: 3,
+            }
+        ));
+    }
+
+    #[test]
+    fn coordinator_callback_falls_back_to_wal_recovery_failed() {
+        let err = CoordinatorRecoveryError::Callback(StrataError::storage("apply failed"));
+        assert!(matches!(
+            from_coordinator_error(ErrorRole::Primary, err),
+            RecoveryError::WalRecoveryFailed {
+                role: ErrorRole::Primary,
+                ..
+            }
+        ));
+    }
+}

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -437,6 +437,87 @@ fn corrupt_wal_segment(db_path: &std::path::Path) -> PathBuf {
     wal_dir
 }
 
+fn run_primary_recovery(
+    db_path: &std::path::Path,
+    cfg: StrataConfig,
+) -> Result<crate::database::recovery::RecoveryOutcome, crate::database::RecoveryError> {
+    let layout = strata_durability::layout::DatabaseLayout::from_root(db_path);
+    Database::run_recovery(
+        db_path,
+        &layout,
+        &cfg,
+        crate::database::recovery::RecoveryMode::Primary,
+    )
+}
+
+fn seed_snapshot_fixture(db_path: &std::path::Path, snapshot_id: u64, watermark: u64) -> PathBuf {
+    const TEST_UUID: [u8; 16] = [0xAA; 16];
+
+    let snapshots_dir = db_path.join("snapshots");
+    std::fs::create_dir_all(&snapshots_dir).unwrap();
+    let writer = strata_durability::SnapshotWriter::new(
+        snapshots_dir.clone(),
+        Box::new(strata_durability::codec::IdentityCodec),
+        TEST_UUID,
+    )
+    .unwrap();
+    let sections = vec![strata_durability::SnapshotSection::new(
+        strata_durability::format::primitive_tags::KV,
+        vec![0, 0, 0, 0],
+    )];
+    let info = writer
+        .create_snapshot(snapshot_id, watermark, sections)
+        .unwrap();
+
+    let mut mgr = strata_durability::ManifestManager::create(
+        db_path.join("MANIFEST"),
+        TEST_UUID,
+        "identity".to_string(),
+    )
+    .unwrap();
+    mgr.set_snapshot_watermark(snapshot_id, TxnId(watermark))
+        .unwrap();
+
+    info.path
+}
+
+fn write_invalid_payload_wal(db_path: &std::path::Path) {
+    let wal_dir = db_path.join("wal");
+    std::fs::create_dir_all(&wal_dir).unwrap();
+    let mut wal = strata_durability::wal::WalWriter::new(
+        wal_dir,
+        [0u8; 16],
+        strata_durability::wal::DurabilityMode::Always,
+        WalConfig::for_testing(),
+        Box::new(strata_durability::codec::IdentityCodec),
+    )
+    .unwrap();
+    let record = WalRecord::new(TxnId(1), [7u8; 16], now_micros(), vec![0xFF]);
+    wal.append(&record).unwrap();
+    wal.flush().unwrap();
+}
+
+fn seed_outer_len_crc_mismatch(db_path: &std::path::Path) {
+    let wal_dir = db_path.join("wal");
+    std::fs::create_dir_all(&wal_dir).unwrap();
+
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    write_wal_txn(
+        &wal_dir,
+        1,
+        branch_id,
+        vec![(Key::new_kv(ns, "crc"), Value::Bytes(b"value".to_vec()))],
+        vec![],
+        1,
+    );
+
+    let segment_path = wal_dir.join("wal-000001.seg");
+    let mut bytes = std::fs::read(&segment_path).unwrap();
+    bytes[strata_durability::SEGMENT_HEADER_SIZE_V2 + 5] ^= 0xFF;
+    std::fs::write(&segment_path, &bytes).unwrap();
+}
+
 #[test]
 fn test_open_corrupted_wal_fails_by_default() {
     let temp_dir = TempDir::new().unwrap();
@@ -1003,4 +1084,105 @@ fn test_legacy_snapshot_under_lossy_flag_still_hard_fails() {
         matches!(result2, Err(StrataError::LegacyFormat { .. })),
         "second open must reproduce the same typed LegacyFormat error",
     );
+}
+
+#[test]
+fn test_run_recovery_reports_snapshot_missing_typed() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let snapshot_path = seed_snapshot_fixture(&db_path, 7, 100);
+    std::fs::remove_file(&snapshot_path).unwrap();
+
+    let err = match run_primary_recovery(&db_path, StrataConfig::default()) {
+        Ok(_) => panic!("missing snapshot must fail recovery"),
+        Err(err) => err,
+    };
+
+    match err {
+        crate::database::RecoveryError::SnapshotMissing {
+            role: crate::database::ErrorRole::Primary,
+            snapshot_id,
+            path,
+        } => {
+            assert_eq!(snapshot_id, 7);
+            assert_eq!(path, snapshot_path);
+        }
+        other => panic!("expected typed SnapshotMissing, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_run_recovery_reports_snapshot_crc_typed() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let snapshot_path = seed_snapshot_fixture(&db_path, 9, 101);
+
+    let mut bytes = std::fs::read(&snapshot_path).unwrap();
+    let corrupt_idx = bytes.len() - 7;
+    bytes[corrupt_idx] ^= 0xFF;
+    std::fs::write(&snapshot_path, &bytes).unwrap();
+
+    let err = match run_primary_recovery(&db_path, StrataConfig::default()) {
+        Ok(_) => panic!("corrupt snapshot must fail recovery"),
+        Err(err) => err,
+    };
+
+    match err {
+        crate::database::RecoveryError::SnapshotRead {
+            role: crate::database::ErrorRole::Primary,
+            snapshot_id,
+            path,
+            inner: strata_durability::SnapshotReadError::CrcMismatch { .. },
+        } => {
+            assert_eq!(snapshot_id, 9);
+            assert_eq!(path, snapshot_path);
+        }
+        other => panic!("expected typed SnapshotRead::CrcMismatch, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_run_recovery_reports_wal_checksum_typed() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    seed_outer_len_crc_mismatch(&db_path);
+
+    let err = match run_primary_recovery(&db_path, StrataConfig::default()) {
+        Ok(_) => panic!("outer envelope CRC mismatch must fail recovery"),
+        Err(err) => err,
+    };
+
+    match err {
+        crate::database::RecoveryError::WalChecksum {
+            role: crate::database::ErrorRole::Primary,
+            records_before,
+            ..
+        } => {
+            assert_eq!(records_before, 0);
+        }
+        other => panic!("expected typed WalChecksum, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_run_recovery_reports_payload_decode_typed() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    write_invalid_payload_wal(&db_path);
+
+    let err = match run_primary_recovery(&db_path, StrataConfig::default()) {
+        Ok(_) => panic!("invalid transaction payload must fail recovery"),
+        Err(err) => err,
+    };
+
+    match err {
+        crate::database::RecoveryError::PayloadDecode {
+            role: crate::database::ErrorRole::Primary,
+            txn_id,
+            ..
+        } => {
+            assert_eq!(txn_id, TxnId(1));
+        }
+        other => panic!("expected typed PayloadDecode, got: {other:?}"),
+    }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -43,9 +43,9 @@ pub use database::profile::{
     Profile,
 };
 pub use database::{
-    CacheMetrics, Database, DatabaseDiskUsage, HealthReport, LossyErrorKind, LossyRecoveryReport,
-    ModelConfig, StorageConfig, StorageMetricsSummary, StrataConfig, SubsystemHealth,
-    SubsystemStatus, SystemMetrics, WalWriterHealth,
+    CacheMetrics, Database, DatabaseDiskUsage, ErrorRole, HealthReport, LossyErrorKind,
+    LossyRecoveryReport, ModelConfig, RecoveryError, StorageConfig, StorageMetricsSummary,
+    StrataConfig, SubsystemHealth, SubsystemStatus, SystemMetrics, WalWriterHealth,
 };
 pub use instrumentation::PerfTrace;
 pub use recovery::Subsystem;

--- a/crates/engine/tests/recovery_parity.rs
+++ b/crates/engine/tests/recovery_parity.rs
@@ -1,0 +1,280 @@
+//! Epic D3 recovery-parity tests.
+//!
+//! For each of the five MANIFEST failure shapes the D3 plan calls out
+//! (missing magic, checksum mismatch, codec id mismatch, unsupported
+//! version, truncated), assert that all three recovery entry points
+//! surface the **same** `StrataError` variant:
+//!
+//! 1. Primary — `Database::open_runtime(OpenSpec::primary(path))`.
+//! 2. Follower — `Database::open_runtime(OpenSpec::follower(path))`.
+//! 3. Coordinator-only — `RecoveryCoordinator::new(layout, 0).plan_recovery("identity")`.
+//!
+//! Before D3, the coordinator-only leg diverged on codec mismatch
+//! (returned `StrataError::Corruption` while both engine paths returned
+//! `StrataError::IncompatibleReuse`). The one-line fix in
+//! `strata_concurrency::recovery::plan_recovery` closed that hole.
+//!
+//! # First-open safety regression
+//!
+//! Also pins the ordering invariant from the D3 plan (reviewer finding
+//! 3): codec validation runs before MANIFEST creation, so a brand-new
+//! database with an invalid codec id fails without persisting anything
+//! to disk.
+
+use serial_test::serial;
+use std::fs;
+use std::mem;
+use std::path::Path;
+use strata_concurrency::RecoveryCoordinator;
+use strata_core::StrataError;
+use strata_durability::format::{MANIFEST_FORMAT_VERSION, MANIFEST_MAGIC};
+use strata_durability::layout::DatabaseLayout;
+use strata_engine::database::OpenSpec;
+use strata_engine::{Database, SearchSubsystem};
+use tempfile::TempDir;
+
+/// Build MANIFEST bytes with optional per-field overrides. Returns
+/// bytes that would otherwise be a valid v2 manifest.
+fn valid_manifest_bytes(codec_id: &str) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(64);
+    bytes.extend_from_slice(&MANIFEST_MAGIC);
+    bytes.extend_from_slice(&MANIFEST_FORMAT_VERSION.to_le_bytes());
+    bytes.extend_from_slice(&[0u8; 16]); // database_uuid
+    let codec_bytes = codec_id.as_bytes();
+    bytes.extend_from_slice(&u32::try_from(codec_bytes.len()).unwrap().to_le_bytes());
+    bytes.extend_from_slice(codec_bytes);
+    bytes.extend_from_slice(&1u64.to_le_bytes()); // active_wal_segment
+    bytes.extend_from_slice(&0u64.to_le_bytes()); // snapshot_watermark
+    bytes.extend_from_slice(&0u64.to_le_bytes()); // snapshot_id
+    bytes.extend_from_slice(&0u64.to_le_bytes()); // flushed_through_commit_id
+    let crc = crc32fast::hash(&bytes);
+    bytes.extend_from_slice(&crc.to_le_bytes());
+    bytes
+}
+
+/// Write a corrupt MANIFEST into `db_path`. Creates the directory as a
+/// side effect; does **not** create a segments directory — only the
+/// minimum layout the MANIFEST parser touches.
+fn write_raw_manifest(db_path: &Path, bytes: &[u8]) {
+    fs::create_dir_all(db_path).unwrap();
+    let manifest = db_path.join("MANIFEST");
+    fs::write(&manifest, bytes).unwrap();
+}
+
+/// Three-leg probe: primary open, follower open, coordinator-only
+/// `plan_recovery`. Returns the three errors captured, after
+/// `OPEN_DATABASES` has been cleared between legs so a cached handle
+/// from an earlier test cannot short-circuit a later one.
+fn probe_three_legs(
+    db_path: &Path,
+    expected_codec: &str,
+) -> (StrataError, StrataError, StrataError) {
+    strata_engine::database::OPEN_DATABASES.lock().clear();
+
+    let Err(primary_err) =
+        Database::open_runtime(OpenSpec::primary(db_path).with_subsystem(SearchSubsystem))
+    else {
+        panic!("primary open must fail on corrupt MANIFEST")
+    };
+
+    strata_engine::database::OPEN_DATABASES.lock().clear();
+
+    let Err(follower_err) =
+        Database::open_runtime(OpenSpec::follower(db_path).with_subsystem(SearchSubsystem))
+    else {
+        panic!("follower open must fail on corrupt MANIFEST")
+    };
+
+    strata_engine::database::OPEN_DATABASES.lock().clear();
+
+    let layout = DatabaseLayout::from_root(db_path);
+    let coord_err = RecoveryCoordinator::new(layout, 0)
+        .plan_recovery(expected_codec)
+        .err()
+        .unwrap_or_else(|| panic!("coordinator plan_recovery must fail on corrupt MANIFEST"));
+
+    (primary_err, follower_err, coord_err)
+}
+
+fn assert_same_variant(a: &StrataError, b: &StrataError, label: &str) {
+    assert_eq!(
+        mem::discriminant(a),
+        mem::discriminant(b),
+        "{label}: variant mismatch\n  left  = {a:?}\n  right = {b:?}"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Shape 1: missing magic bytes
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[serial(open_databases)]
+fn parity_missing_magic() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("db");
+    let mut bytes = valid_manifest_bytes("identity");
+    // Overwrite the 4-byte magic so the parser sees InvalidMagic.
+    bytes[0..4].copy_from_slice(b"XXXX");
+    write_raw_manifest(&db_path, &bytes);
+
+    let (primary, follower, coord) = probe_three_legs(&db_path, "identity");
+    assert!(
+        matches!(primary, StrataError::Corruption { .. }),
+        "primary: expected Corruption, got {primary:?}"
+    );
+    assert_same_variant(&primary, &follower, "primary vs follower");
+    assert_same_variant(&primary, &coord, "primary vs coordinator");
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Shape 2: checksum mismatch
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[serial(open_databases)]
+fn parity_checksum_mismatch() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("db");
+    let mut bytes = valid_manifest_bytes("identity");
+    let len = bytes.len();
+    // Flip one byte inside the CRC region — magic/version still valid.
+    bytes[len - 1] ^= 0xFF;
+    write_raw_manifest(&db_path, &bytes);
+
+    let (primary, follower, coord) = probe_three_legs(&db_path, "identity");
+    assert!(
+        matches!(primary, StrataError::Corruption { .. }),
+        "primary: expected Corruption, got {primary:?}"
+    );
+    assert_same_variant(&primary, &follower, "primary vs follower");
+    assert_same_variant(&primary, &coord, "primary vs coordinator");
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Shape 3: codec id mismatch (requires fix landed in concurrency)
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[serial(open_databases)]
+fn parity_codec_id_mismatch() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("db");
+    // Write a valid manifest that records codec_id = "identity", then
+    // probe with expected_codec = "aes-gcm-256". The Primary / Follower
+    // legs use `Database::open_runtime` with the default config (identity),
+    // so we invert: write MANIFEST with a non-default codec and open
+    // with the default.
+    let bytes = valid_manifest_bytes("aes-gcm-256");
+    write_raw_manifest(&db_path, &bytes);
+
+    // Pre-D3: coordinator plan_recovery returned Corruption while the
+    // engine paths returned IncompatibleReuse. D3's one-line fix in
+    // strata_concurrency makes all three agree on IncompatibleReuse.
+    let (primary, follower, coord) = probe_three_legs(&db_path, "identity");
+    assert!(
+        matches!(primary, StrataError::IncompatibleReuse { .. }),
+        "primary: expected IncompatibleReuse, got {primary:?}"
+    );
+    assert_same_variant(&primary, &follower, "primary vs follower");
+    assert_same_variant(&primary, &coord, "primary vs coordinator");
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Shape 4: unsupported version (future version)
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[serial(open_databases)]
+fn parity_unsupported_version() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("db");
+    let mut bytes = valid_manifest_bytes("identity");
+    // Overwrite the version field (bytes 4..8) with a higher-than-max version.
+    bytes[4..8].copy_from_slice(&99u32.to_le_bytes());
+    // Recompute the CRC so we hit UnsupportedVersion, not ChecksumMismatch.
+    let crc_region = &bytes[..bytes.len() - 4];
+    let crc = crc32fast::hash(crc_region);
+    let len = bytes.len();
+    bytes[len - 4..].copy_from_slice(&crc.to_le_bytes());
+    write_raw_manifest(&db_path, &bytes);
+
+    let (primary, follower, coord) = probe_three_legs(&db_path, "identity");
+    assert!(
+        matches!(primary, StrataError::Corruption { .. }),
+        "primary: expected Corruption, got {primary:?}"
+    );
+    assert_same_variant(&primary, &follower, "primary vs follower");
+    assert_same_variant(&primary, &coord, "primary vs coordinator");
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Shape 5: truncated manifest (< 64 bytes)
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[serial(open_databases)]
+fn parity_truncated() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("db");
+    // Write just 32 bytes so `bytes.len() < 64` fires TooShort.
+    let bytes = vec![0u8; 32];
+    write_raw_manifest(&db_path, &bytes);
+
+    let (primary, follower, coord) = probe_three_legs(&db_path, "identity");
+    assert!(
+        matches!(primary, StrataError::Corruption { .. }),
+        "primary: expected Corruption, got {primary:?}"
+    );
+    assert_same_variant(&primary, &follower, "primary vs follower");
+    assert_same_variant(&primary, &coord, "primary vs coordinator");
+}
+
+// ────────────────────────────────────────────────────────────────────
+// First-open safety: configured codec validated before MANIFEST touch
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[serial(open_databases)]
+fn first_open_rejects_invalid_codec_without_touching_disk() {
+    // Reviewer finding 3 on the D3 plan: codec validation must precede
+    // MANIFEST creation so a bad codec id does not leave a poisoned
+    // MANIFEST on disk that the next open cannot repair.
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("new_db");
+    assert!(!db_path.exists());
+
+    let mut cfg = strata_engine::database::config::StrataConfig::default();
+    cfg.storage.codec = "does-not-exist".to_string();
+    cfg.durability = "cache".to_string();
+
+    strata_engine::database::OPEN_DATABASES.lock().clear();
+    let Err(err) = Database::open_runtime(
+        OpenSpec::primary(&db_path)
+            .with_config(cfg)
+            .with_subsystem(SearchSubsystem),
+    ) else {
+        panic!("open with invalid codec id must fail")
+    };
+
+    assert!(
+        matches!(err, StrataError::Internal { .. }),
+        "invalid codec id must surface as Internal, got {err:?}"
+    );
+
+    // `open_runtime_primary` creates the root db directory before it can
+    // canonicalize the path, so the root may exist here. The D3 safety
+    // invariant is narrower: a rejected codec id must not persist any
+    // recovery-managed artifacts or support directories.
+    for path in [
+        db_path.join("MANIFEST"),
+        db_path.join("segments"),
+        db_path.join("wal"),
+        db_path.join("snapshots"),
+    ] {
+        assert!(
+            !path.exists(),
+            "rejected codec id must not leave recovery artifacts on disk; found {path:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **Unified recovery entry point** — new `Database::run_recovery` at `crates/engine/src/database/recovery.rs` replaces the two ~250-line inline recovery ladders in `open_finish` (primary) and `acquire_follower_db` (follower). `open.rs` drops 572 lines.
- **Typed vocabulary end-to-end** — new `RecoveryError` enum at `crates/engine/src/database/recovery_error.rs` with engine-direct, coordinator-seam typed-survivor, and storage-health variants. Seven recovery-path `StrataError::{internal,corruption,storage}(format!(...))` wraps in `open.rs` are deleted.
- **Typed coordinator seam** — new `CoordinatorRecoveryError` in `strata_concurrency` with `recover_typed()` driver; legacy `recover()` stays as a `map_err(StrataError::from)` wrapper so 40+ existing callers in concurrency are unchanged. Variants carry the underlying `SnapshotReadError` / `WalReaderError` as `#[source]` so the engine's `from_coordinator_error` can branch on concrete causes (`SnapshotMissing`, `SnapshotRead`, `WalLegacyFormat`, `WalCodecDecode`, `WalChecksum`, `WalRead`, `PayloadDecode`, `CoordinatorPlan`).
- **Coordinator-parity fix** — `plan_recovery` on codec mismatch returns `StrataError::IncompatibleReuse` instead of `StrataError::Corruption`, matching the engine paths so the parity tests' coordinator-only leg can pass.
- **Hard-fail on plan failures** — `CoordinatorRecoveryError::should_bypass_lossy()` classifies planning failures and legacy-format sources so the lossy WAL wipe cannot mask a MANIFEST/snapshot planning failure.
- **First-open safety strengthened** — `layout.create_non_segment_dirs()` now runs *after* `run_recovery` validates the configured codec, so a rejected codec id leaves **no** MANIFEST, segments/, wal/, or snapshots/ directory on disk.
- **D4 hook point** — labelled comment inside the storage step between `storage.recover_segments().map_err(RecoveryError::from)?` and `coordinator.apply_storage_recovery(&outcome)` is where D4 will insert its `RecoveryHealth::Degraded` policy branch.
- **`recover_segments_and_apply` deleted** — lives in history only.

### D4 public surface additions

`RecoveryError` and `ErrorRole` land in the "Errors" bucket of CLAUDE.md §"Engine Public API Surface" by analogy with `BranchDagError` / `BranchDagErrorKind` and `ObserverError` / `ObserverErrorKind`. `RecoveryMode` and `RecoveryOutcome` stay `pub(crate)` — orchestration internals, not part of the surface.

### Scope boundaries

D3 owns orchestration + typed taxonomy. The strict-vs-lossy policy on `RecoveryHealth::Degraded` is D4, inserted at the labelled hook point inside the storage step. The pre-D3 WAL-replay lossy fallback (populates `LossyRecoveryReport`, wipes the in-memory `SegmentedStore`) is preserved — it moves from `open.rs` into `handle_wal_recovery_outcome` without semantic change.

### Change class / assurance

- **Cutover**: old call sites and `recover_segments_and_apply` deleted; no parallel recovery paths remain. Concurrency's `recover()` is retained as a thin wrapper to keep test call sites stable (the typed driver is `recover_typed`).
- **S4**: recovery is on the runtime-open/replay list. Parity tests + typed-variant tests pin the new taxonomy; existing `recovery_tests.rs`, `database/tests/open.rs`, `database/tests/codec.rs` suites stay green.

Closes (tracker): DG-007, DG-008, DG-011, DG-013, DG-014.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test -p strata-engine --lib` — 1031/1032 (1 pre-existing flaky injection test unrelated to D3, passes standalone)
- [x] `cargo test -p strata-engine --test recovery_parity` — 6/6
- [x] `cargo test -p strata-concurrency` — 160/160
- [x] 13 new `recovery_error` unit tests + 1 `recovery::tests::coordinator_plan_failure_bypasses_lossy_fallback`
- [x] 4 new typed-variant tests in `database/tests/open.rs` exercise `SnapshotMissing`, `SnapshotRead::CrcMismatch`, `WalChecksum`, and `PayloadDecode` through `Database::run_recovery` end-to-end with hand-seeded fixtures
- [x] Hygiene: `rg 'recover_segments_and_apply' crates/engine/src` → 0 hits; `rg 'fn run_recovery' crates/engine/src/database/recovery.rs` → 1; `Database::run_recovery` call sites in `open.rs` → exactly 2 (primary + follower); recovery-path `format!` sites in `open.rs` → 5 (all non-recovery; was 18 pre-D3)
- [x] First-open safety regression: `first_open_rejects_invalid_codec_without_touching_disk` now checks for MANIFEST, segments/, wal/, and snapshots/ absence (strengthened from MANIFEST-only in original commit)
- [x] No forbidden crate deps; concurrency does not import engine

## Follow-ups (out of scope)

- **D4 storage-fault policy** — inserts the strict-vs-lossy `RecoveryHealth` match at the labelled hook point in `run_recovery`'s storage step.
- Deduplicating the double MANIFEST read on primary reopen (engine `prepare_manifest` + coordinator `plan_recovery`). Idempotent and cheap; structural cleanup for a later epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
