### PR TITLE
D4: storage-fault policy — strict refusal + recovery_health() surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,8 @@ architecture scope documents. The current allowed surface:
 
 **Durability:** `WalWriterHealth`, `FollowerStatus`, `ContiguousWatermark`,
 `RefreshOutcome`, `BlockedTxn`, `BlockReason`, `DatabaseLayout`, `RefreshHookError`,
-`AdvanceError`, `UnblockError`, `LossyRecoveryReport`, `LossyErrorKind`
+`AdvanceError`, `UnblockError`, `LossyRecoveryReport`, `LossyErrorKind`,
+`RecoveryHealth`, `DegradationClass`
 
 **Product:** `SystemBranchCapability` (`pub` type, `pub(crate)` constructor), `Provider`,
 `ControlRegistry`, `ControlEntry`, `ControlOwner`, `BehaviorClass`, `PersistenceClass`

--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -355,6 +355,15 @@ pub struct StrataConfig {
     /// Class: open-time-only. See `docs/design/architecture-cleanup/durability-recovery-config-matrix.md`.
     #[serde(default)]
     pub allow_lossy_recovery: bool,
+    /// If true, open is permitted when storage recovery only observed
+    /// `DegradationClass::PolicyDowngrade` (currently emitted by the
+    /// no-`segments.manifest` legacy-L0-promotion fallback). `DataLoss`
+    /// is still refused unless `allow_lossy_recovery` is also set.
+    /// Default: false.
+    ///
+    /// Class: open-time-only.
+    #[serde(default)]
+    pub allow_missing_manifest: bool,
     /// Whether the user opted in to anonymous usage telemetry.
     /// Default: false (opt-in, never on by default).
     #[serde(default)]
@@ -406,6 +415,7 @@ impl Default for StrataConfig {
             google_api_key: None,
             storage: StorageConfig::default(),
             allow_lossy_recovery: false,
+            allow_missing_manifest: false,
             telemetry: false,
             default_vector_dtype: default_vector_dtype(),
             snapshot_retention: SnapshotRetentionPolicy::default(),

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1921,6 +1921,8 @@ impl Database {
             Some("storage.background_threads")
         } else if candidate.allow_lossy_recovery != guard.allow_lossy_recovery {
             Some("allow_lossy_recovery")
+        } else if candidate.allow_missing_manifest != guard.allow_missing_manifest {
+            Some("allow_missing_manifest")
         } else if candidate.durability != guard.durability {
             // `durability` is live-safe only through `set_durability_mode`,
             // which reconfigures the WAL writer, restarts the flush thread,

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -83,7 +83,7 @@ use strata_core::types::{BranchId, Key};
 use strata_core::{StrataError, StrataResult, VersionedValue};
 use strata_durability::__internal::{BackgroundSyncError, WalWriterEngineExt};
 use strata_durability::wal::{DurabilityMode, WalWriter};
-use strata_storage::{SegmentedStore, StorageIterator};
+use strata_storage::{RecoveryHealth, SegmentedStore, StorageIterator};
 
 // ============================================================================
 // Persistence Mode (Storage/Durability Split)
@@ -1443,6 +1443,30 @@ impl Database {
     /// pinned lossy-recovery contract.
     pub fn last_lossy_recovery_report(&self) -> Option<LossyRecoveryReport> {
         self.last_lossy_recovery_report.lock().clone()
+    }
+
+    /// Post-recovery storage-state classification from the most recent open.
+    ///
+    /// `Healthy` after a clean recovery. `Degraded` means SE2 observed one
+    /// or more storage recovery faults during this open; the `class` field
+    /// tells operators whether authoritative state was lost
+    /// (`DegradationClass::DataLoss`), a legacy-compatible fallback was
+    /// engaged (`PolicyDowngrade`), or a rebuildable cache failed
+    /// (`Telemetry`).
+    ///
+    /// Distinct from [`Self::last_lossy_recovery_report`]:
+    /// `recovery_health` reports on segment-level recovery and never
+    /// implies a data wipe, whereas `last_lossy_recovery_report` is
+    /// populated only by the DR-011 WAL wipe-and-reopen fallback. Both
+    /// can be consulted independently; neither implies the other.
+    ///
+    /// Read-through to the storage layer — no per-`Database` cache. In
+    /// strict mode any `DataLoss` (and `PolicyDowngrade` without the
+    /// `allow_missing_manifest` flag) refuses the open before this
+    /// accessor can be called, so a strict-mode `Database` handle will
+    /// only ever observe `Healthy` or `Telemetry`.
+    pub fn recovery_health(&self) -> RecoveryHealth {
+        (*self.storage.last_recovery_health()).clone()
     }
 
     /// Attempt to resume a halted WAL writer.

--- a/crates/engine/src/database/recovery.rs
+++ b/crates/engine/src/database/recovery.rs
@@ -255,8 +255,8 @@ impl Database {
         // `LossyRecoveryReport` untouched because no WAL wipe occurred;
         // operators read the classification via `Database::recovery_health()`.
         if let RecoveryHealth::Degraded { class, .. } = &seg_outcome.health {
-            let permitted = cfg.allow_lossy_recovery
-                || !policy_refuses(*class, cfg.allow_missing_manifest);
+            let permitted =
+                cfg.allow_lossy_recovery || !policy_refuses(*class, cfg.allow_missing_manifest);
             if !permitted {
                 return Err(RecoveryError::StorageDegraded(seg_outcome.health.clone()));
             }

--- a/crates/engine/src/database/recovery.rs
+++ b/crates/engine/src/database/recovery.rs
@@ -42,7 +42,7 @@ use strata_core::StrataError;
 use strata_durability::codec::{clone_codec, StorageCodec};
 use strata_durability::layout::DatabaseLayout;
 use strata_durability::ManifestManager;
-use strata_storage::{RecoveryHealth, SegmentedStore};
+use strata_storage::{DegradationClass, RecoveryHealth, SegmentedStore};
 use tracing::{info, warn};
 
 use super::config::StrataConfig;
@@ -248,7 +248,19 @@ impl Database {
                 "storage recovered with degraded state"
             );
         }
-        // ─── D4 inserts health-policy branch here ──────────────────
+        // D4 health-policy branch. Strict mode refuses authoritative
+        // loss; the no-manifest legacy fallback is opt-in; rebuildable
+        // caches are always accepted. Lossy recovery (`allow_lossy_recovery`)
+        // is the blanket escape hatch and permits every class — it leaves
+        // `LossyRecoveryReport` untouched because no WAL wipe occurred;
+        // operators read the classification via `Database::recovery_health()`.
+        if let RecoveryHealth::Degraded { class, .. } = &seg_outcome.health {
+            let permitted = cfg.allow_lossy_recovery
+                || !policy_refuses(*class, cfg.allow_missing_manifest);
+            if !permitted {
+                return Err(RecoveryError::StorageDegraded(seg_outcome.health.clone()));
+            }
+        }
         coordinator.apply_storage_recovery(&seg_outcome);
 
         // 10. Follower state restore.
@@ -280,6 +292,31 @@ impl Database {
             lossy_report,
             persisted_follower_state,
         })
+    }
+}
+
+/// D4 strict-mode policy. `true` = refuse to open on this class; `false`
+/// = accept. The caller combines this with `allow_lossy_recovery` so
+/// that lossy mode is a blanket override regardless of class.
+///
+/// - `DataLoss` — authoritative storage lost (corrupt segment/manifest,
+///   manifest-listed-but-missing segment, dropped inherited layer). Always
+///   refused; only `allow_lossy_recovery` permits it.
+/// - `PolicyDowngrade` — legacy-compatible fallback engaged (e.g.
+///   no-manifest L0 promotion). Refused unless `allow_missing_manifest`
+///   is set so operators consent explicitly to reading an unmanifested
+///   database.
+/// - `Telemetry` — rebuildable-cache failure. Never refused.
+/// - Unknown future variants default to refusal (conservative for
+///   `#[non_exhaustive]` evolution).
+fn policy_refuses(class: DegradationClass, allow_missing_manifest: bool) -> bool {
+    match class {
+        DegradationClass::PolicyDowngrade => !allow_missing_manifest,
+        DegradationClass::Telemetry => false,
+        // `DegradationClass::DataLoss` and any future #[non_exhaustive]
+        // variant: refuse. Only `allow_lossy_recovery` overrides refusal
+        // (applied by the caller).
+        _ => true,
     }
 }
 

--- a/crates/engine/src/database/tests/codec.rs
+++ b/crates/engine/src/database/tests/codec.rs
@@ -562,11 +562,12 @@ fn test_update_config_rejects_open_time_only_field_changes() {
 
     // Capture pre-change live values so we can confirm they are NOT
     // mutated even though the closure attempted the change.
-    let (before_threads, before_lossy, before_codec) = {
+    let (before_threads, before_lossy, before_missing_manifest, before_codec) = {
         let cfg = db.config();
         (
             cfg.storage.background_threads,
             cfg.allow_lossy_recovery,
+            cfg.allow_missing_manifest,
             cfg.storage.codec.clone(),
         )
     };
@@ -590,6 +591,13 @@ fn test_update_config_rejects_open_time_only_field_changes() {
             .is_err(),
         "allow_lossy_recovery must also be rejected"
     );
+    let err = db
+        .update_config(|cfg| cfg.allow_missing_manifest = !before_missing_manifest)
+        .expect_err("allow_missing_manifest must also be rejected");
+    assert!(
+        err.to_string().contains("allow_missing_manifest"),
+        "error must name the offending field, got: {err}"
+    );
     assert!(
         db.update_config(|cfg| cfg.storage.codec = "aes-gcm-256".to_string())
             .is_err(),
@@ -600,6 +608,7 @@ fn test_update_config_rejects_open_time_only_field_changes() {
     let after = db.config();
     assert_eq!(after.storage.background_threads, before_threads);
     assert_eq!(after.allow_lossy_recovery, before_lossy);
+    assert_eq!(after.allow_missing_manifest, before_missing_manifest);
     assert_eq!(after.storage.codec, before_codec);
 
     // A live-safe mutation still works.

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -54,6 +54,7 @@ pub use strata_durability::wal::DurabilityMode;
 pub use strata_durability::WalCounters;
 pub use strata_storage::StorageIterator;
 pub use strata_storage::VersionedEntry;
+pub use strata_storage::{DegradationClass, RecoveryHealth};
 pub use transaction::{ScopedTransaction, Transaction, TransactionPool, MAX_POOL_SIZE};
 pub use transaction_ops::TransactionOps;
 

--- a/crates/engine/tests/config_matrix.rs
+++ b/crates/engine/tests/config_matrix.rs
@@ -30,6 +30,7 @@ const STRATA_CONFIG_FIELDS: &[&str] = &[
     "google_api_key",
     "storage",
     "allow_lossy_recovery",
+    "allow_missing_manifest",
     "telemetry",
     "default_vector_dtype",
     "snapshot_retention",

--- a/crates/engine/tests/recovery_storage_policy.rs
+++ b/crates/engine/tests/recovery_storage_policy.rs
@@ -54,9 +54,7 @@ fn assert_storage_degraded_refusal(err: StrataError, expected_class: Degradation
                 "storage-degraded refusal must name expected class {needle:?}; got: {message}"
             );
         }
-        other => panic!(
-            "expected StrataError::Corruption from D4 strict refusal, got {other:?}"
-        ),
+        other => panic!("expected StrataError::Corruption from D4 strict refusal, got {other:?}"),
     }
 }
 
@@ -91,7 +89,8 @@ fn seed_branch_with_manifest(db_path: &Path) -> BranchId {
         Database::open_runtime(OpenSpec::primary(db_path).with_subsystem(SearchSubsystem)).unwrap();
 
     let kv = KVStore::new(db.clone());
-    kv.put(&branch_id, "default", "seed", Value::Int(1)).unwrap();
+    kv.put(&branch_id, "default", "seed", Value::Int(1))
+        .unwrap();
 
     db.storage().rotate_memtable(&branch_id);
     db.storage().flush_oldest_frozen(&branch_id).unwrap();
@@ -255,8 +254,8 @@ fn clean_reopen_is_healthy() {
     seed_branch_with_manifest(&db_path);
     clear_open_handles();
 
-    let db =
-        Database::open_runtime(OpenSpec::primary(&db_path).with_subsystem(SearchSubsystem)).unwrap();
+    let db = Database::open_runtime(OpenSpec::primary(&db_path).with_subsystem(SearchSubsystem))
+        .unwrap();
 
     assert!(
         matches!(db.recovery_health(), RecoveryHealth::Healthy),
@@ -284,10 +283,9 @@ fn wal_lossy_report_unchanged_and_recovery_health_healthy() {
     // the post-wipe segment walk sees a clean directory and reports
     // Healthy. Pattern matches follower_tests.rs test_follower_lossy_recovery_populates_report.
     {
-        let db = Database::open_runtime(
-            OpenSpec::primary(&db_path).with_subsystem(SearchSubsystem),
-        )
-        .unwrap();
+        let db =
+            Database::open_runtime(OpenSpec::primary(&db_path).with_subsystem(SearchSubsystem))
+                .unwrap();
         let kv = KVStore::new(db.clone());
         kv.put(&branch_id, "default", "k1", Value::Int(1)).unwrap();
         db.flush().unwrap();

--- a/crates/engine/tests/recovery_storage_policy.rs
+++ b/crates/engine/tests/recovery_storage_policy.rs
@@ -1,0 +1,328 @@
+//! D4 storage-fault policy parity tests.
+//!
+//! Pins the strict-vs-lossy policy branch added inside
+//! `Database::run_recovery` plus the separate `Database::recovery_health()`
+//! observability surface:
+//!
+//! - Strict opens refuse `DegradationClass::DataLoss` (corrupt branch
+//!   manifest, missing manifest-listed segment, …) and refuse
+//!   `PolicyDowngrade` (no-manifest legacy fallback) unless
+//!   `StrataConfig::allow_missing_manifest` is set.
+//! - Lossy opens (`allow_lossy_recovery = true`) permit every degraded
+//!   class and leave `last_lossy_recovery_report()` untouched because
+//!   no WAL wipe occurred — the health is observable only through
+//!   `recovery_health()`.
+//! - The WAL wipe-and-reopen contract (DR-011) remains distinct: a
+//!   WAL-replay failure with `allow_lossy_recovery = true` still
+//!   populates `last_lossy_recovery_report()` exactly as before D4 and
+//!   leaves `recovery_health()` at `Healthy`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serial_test::serial;
+use strata_core::types::BranchId;
+use strata_core::value::Value;
+use strata_core::StrataError;
+use strata_engine::database::OpenSpec;
+use strata_engine::{
+    Database, DegradationClass, KVStore, RecoveryHealth, SearchSubsystem, StrataConfig,
+};
+use tempfile::TempDir;
+
+/// Assert that a strict-open error is the D4 storage-degraded refusal,
+/// not some other corruption surfaced from elsewhere in the recovery
+/// ladder. `RecoveryError::StorageDegraded(health)` maps to
+/// `StrataError::Corruption` with the `Debug` form of the health in the
+/// message (see `recovery_error.rs::From<RecoveryError> for StrataError`),
+/// so the expected class name must appear in the rendered message.
+fn assert_storage_degraded_refusal(err: StrataError, expected_class: DegradationClass) {
+    match err {
+        StrataError::Corruption { message } => {
+            let needle = match expected_class {
+                DegradationClass::DataLoss => "DataLoss",
+                DegradationClass::PolicyDowngrade => "PolicyDowngrade",
+                DegradationClass::Telemetry => "Telemetry",
+                _ => panic!("unexpected DegradationClass in test helper"),
+            };
+            assert!(
+                message.contains("storage recovered in degraded state"),
+                "strict refusal must route through RecoveryError::StorageDegraded; got: {message}"
+            );
+            assert!(
+                message.contains(needle),
+                "storage-degraded refusal must name expected class {needle:?}; got: {message}"
+            );
+        }
+        other => panic!(
+            "expected StrataError::Corruption from D4 strict refusal, got {other:?}"
+        ),
+    }
+}
+
+fn hex_encode_branch(branch_id: &BranchId) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(32);
+    for &b in branch_id.as_bytes() {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+fn branch_manifest_path(db_path: &Path, branch_id: &BranchId) -> PathBuf {
+    db_path
+        .join("segments")
+        .join(hex_encode_branch(branch_id))
+        .join("segments.manifest")
+}
+
+fn clear_open_handles() {
+    strata_engine::database::OPEN_DATABASES.lock().clear();
+}
+
+/// Open the database, seed one KV, force a memtable rotate + flush so a
+/// per-branch `segments.manifest` + `.sst` land on disk, then shut down.
+/// Mirrors the storage-level fault-injection setup at
+/// `crates/storage/src/segmented/tests/gc_under_degradation.rs:17-24` so
+/// the engine-level D4 tests can corrupt / delete the same artifacts.
+fn seed_branch_with_manifest(db_path: &Path) -> BranchId {
+    let branch_id = BranchId::new();
+    let db =
+        Database::open_runtime(OpenSpec::primary(db_path).with_subsystem(SearchSubsystem)).unwrap();
+
+    let kv = KVStore::new(db.clone());
+    kv.put(&branch_id, "default", "seed", Value::Int(1)).unwrap();
+
+    db.storage().rotate_memtable(&branch_id);
+    db.storage().flush_oldest_frozen(&branch_id).unwrap();
+    db.flush().unwrap();
+    db.shutdown().unwrap();
+    branch_id
+}
+
+/// Strict open with a corrupt branch manifest must refuse. The caller
+/// observes an error (`StrataError::Corruption` via D3's
+/// `RecoveryError::StorageDegraded` mapping).
+#[test]
+#[serial(open_databases)]
+fn strict_refuses_corrupt_manifest_as_data_loss() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().to_path_buf();
+
+    let branch_id = seed_branch_with_manifest(&db_path);
+    clear_open_handles();
+
+    let path = branch_manifest_path(&db_path, &branch_id);
+    let mut bytes = fs::read(&path).unwrap();
+    let mid = bytes.len() / 2;
+    bytes[mid] ^= 0xFF;
+    fs::write(&path, &bytes).unwrap();
+
+    let strict =
+        Database::open_runtime(OpenSpec::primary(&db_path).with_subsystem(SearchSubsystem));
+    match strict {
+        Ok(_) => panic!("strict open must refuse corrupt branch manifest (DataLoss)"),
+        Err(err) => assert_storage_degraded_refusal(err, DegradationClass::DataLoss),
+    }
+}
+
+/// Lossy open with the same corrupt manifest succeeds; `recovery_health()`
+/// surfaces the degraded classification and `last_lossy_recovery_report()`
+/// stays `None` because no WAL wipe occurred.
+#[test]
+#[serial(open_databases)]
+fn lossy_accepts_corrupt_manifest_and_exposes_degraded_health() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().to_path_buf();
+
+    let branch_id = seed_branch_with_manifest(&db_path);
+    clear_open_handles();
+
+    let path = branch_manifest_path(&db_path, &branch_id);
+    let mut bytes = fs::read(&path).unwrap();
+    let mid = bytes.len() / 2;
+    bytes[mid] ^= 0xFF;
+    fs::write(&path, &bytes).unwrap();
+
+    let cfg = StrataConfig {
+        allow_lossy_recovery: true,
+        ..StrataConfig::default()
+    };
+    let db = Database::open_runtime(
+        OpenSpec::primary(&db_path)
+            .with_subsystem(SearchSubsystem)
+            .with_config(cfg),
+    )
+    .expect("lossy open must accept DataLoss health");
+
+    match db.recovery_health() {
+        RecoveryHealth::Degraded { class, .. } => {
+            assert_eq!(
+                class,
+                DegradationClass::DataLoss,
+                "corrupt branch manifest must classify as DataLoss"
+            );
+        }
+        RecoveryHealth::Healthy => {
+            panic!("recovery_health must be Degraded after corrupt manifest")
+        }
+        other => panic!("unexpected health variant: {other:?}"),
+    }
+    assert!(
+        db.last_lossy_recovery_report().is_none(),
+        "storage-degradation lossy path must not populate \
+         last_lossy_recovery_report — no WAL wipe occurred"
+    );
+}
+
+/// Strict open refuses `PolicyDowngrade` (the no-manifest legacy
+/// fallback) when `allow_missing_manifest` is not set.
+#[test]
+#[serial(open_databases)]
+fn strict_refuses_no_manifest_fallback_as_policy_downgrade() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().to_path_buf();
+
+    let branch_id = seed_branch_with_manifest(&db_path);
+    clear_open_handles();
+
+    fs::remove_file(branch_manifest_path(&db_path, &branch_id)).unwrap();
+
+    let strict =
+        Database::open_runtime(OpenSpec::primary(&db_path).with_subsystem(SearchSubsystem));
+    match strict {
+        Ok(_) => panic!("strict open must refuse PolicyDowngrade without allow_missing_manifest"),
+        Err(err) => assert_storage_degraded_refusal(err, DegradationClass::PolicyDowngrade),
+    }
+}
+
+/// With `allow_missing_manifest = true`, the no-manifest fallback is
+/// accepted and `recovery_health()` reports `PolicyDowngrade`.
+/// `allow_lossy_recovery` is deliberately left `false` — this is the
+/// narrow opt-in for unmanifested databases, not a blanket lossy mode.
+#[test]
+#[serial(open_databases)]
+fn allow_missing_manifest_accepts_policy_downgrade() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().to_path_buf();
+
+    let branch_id = seed_branch_with_manifest(&db_path);
+    clear_open_handles();
+
+    fs::remove_file(branch_manifest_path(&db_path, &branch_id)).unwrap();
+
+    let cfg = StrataConfig {
+        allow_missing_manifest: true,
+        ..StrataConfig::default()
+    };
+    let db = Database::open_runtime(
+        OpenSpec::primary(&db_path)
+            .with_subsystem(SearchSubsystem)
+            .with_config(cfg),
+    )
+    .expect("allow_missing_manifest must accept PolicyDowngrade");
+
+    match db.recovery_health() {
+        RecoveryHealth::Degraded { class, .. } => {
+            assert_eq!(class, DegradationClass::PolicyDowngrade);
+        }
+        other => panic!("expected Degraded/PolicyDowngrade, got {other:?}"),
+    }
+    assert!(
+        db.last_lossy_recovery_report().is_none(),
+        "PolicyDowngrade without WAL failure must not populate the WAL-wipe report"
+    );
+
+    // The PolicyDowngrade fallback promotes orphan segments to L0, so the
+    // seed value must still be queryable — otherwise the opt-in would be a
+    // silent data-loss path rather than a legacy-compat one.
+    let kv = KVStore::new(db.clone());
+    assert_eq!(
+        kv.get(&branch_id, "default", "seed").unwrap(),
+        Some(Value::Int(1)),
+        "no-manifest L0 promotion must preserve flushed seed data"
+    );
+}
+
+/// A clean reopen (no injected faults) must report
+/// `RecoveryHealth::Healthy`.
+#[test]
+#[serial(open_databases)]
+fn clean_reopen_is_healthy() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().to_path_buf();
+
+    seed_branch_with_manifest(&db_path);
+    clear_open_handles();
+
+    let db =
+        Database::open_runtime(OpenSpec::primary(&db_path).with_subsystem(SearchSubsystem)).unwrap();
+
+    assert!(
+        matches!(db.recovery_health(), RecoveryHealth::Healthy),
+        "clean reopen must be Healthy, got {:?}",
+        db.recovery_health()
+    );
+    assert!(db.last_lossy_recovery_report().is_none());
+}
+
+/// Contract regression for DR-011. A WAL-replay failure with
+/// `allow_lossy_recovery = true` still populates
+/// `last_lossy_recovery_report()` exactly as before D4 (the wipe +
+/// `LossyRecoveryReport` path is unchanged), and leaves
+/// `recovery_health()` at `Healthy` because no storage-side degradation
+/// occurred. This pins that the two observability surfaces never
+/// conflate.
+#[test]
+#[serial(open_databases)]
+fn wal_lossy_report_unchanged_and_recovery_health_healthy() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().to_path_buf();
+    let branch_id = BranchId::new();
+
+    // Write a record to the WAL without producing on-disk segments, so
+    // the post-wipe segment walk sees a clean directory and reports
+    // Healthy. Pattern matches follower_tests.rs test_follower_lossy_recovery_populates_report.
+    {
+        let db = Database::open_runtime(
+            OpenSpec::primary(&db_path).with_subsystem(SearchSubsystem),
+        )
+        .unwrap();
+        let kv = KVStore::new(db.clone());
+        kv.put(&branch_id, "default", "k1", Value::Int(1)).unwrap();
+        db.flush().unwrap();
+        db.shutdown().unwrap();
+    }
+    clear_open_handles();
+
+    // Append a garbage WAL segment so the reader errors mid-recovery.
+    let wal_dir = db_path.join("wal");
+    let corrupt_segment = wal_dir.join("wal-000099.seg");
+    fs::write(&corrupt_segment, b"GARBAGE_NOT_A_VALID_SEGMENT_HEADER").unwrap();
+
+    let cfg = StrataConfig {
+        allow_lossy_recovery: true,
+        ..StrataConfig::default()
+    };
+    let db = Database::open_runtime(
+        OpenSpec::primary(&db_path)
+            .with_subsystem(SearchSubsystem)
+            .with_config(cfg),
+    )
+    .expect("WAL wipe-and-reopen must succeed with allow_lossy_recovery");
+
+    let report = db
+        .last_lossy_recovery_report()
+        .expect("WAL-replay failure must populate LossyRecoveryReport as before D4");
+    assert!(
+        report.discarded_on_wipe,
+        "whole-database wipe is the DR-011 pinned contract"
+    );
+    assert!(!report.error.is_empty());
+    assert!(
+        matches!(db.recovery_health(), RecoveryHealth::Healthy),
+        "WAL wipe rebuilds an empty in-memory store and segment recovery \
+         walks a clean directory — recovery_health must stay Healthy, got {:?}",
+        db.recovery_health()
+    );
+}

--- a/crates/executor/src/handlers/config.rs
+++ b/crates/executor/src/handlers/config.rs
@@ -499,6 +499,7 @@ pub fn configure_get_key(p: &Arc<Primitives>, key: String) -> Result<Output> {
         // Open-time only keys still readable
         "background_threads" => Some(cfg.storage.background_threads.to_string()),
         "allow_lossy_recovery" => Some(cfg.allow_lossy_recovery.to_string()),
+        "allow_missing_manifest" => Some(cfg.allow_missing_manifest.to_string()),
         _ => unreachable!(),
     };
 

--- a/crates/executor/src/handlers/config.rs
+++ b/crates/executor/src/handlers/config.rs
@@ -66,10 +66,15 @@ const KNOWN_KEYS: &[&str] = &[
     // Open-time only (rejected at runtime with clear error)
     "background_threads",
     "allow_lossy_recovery",
+    "allow_missing_manifest",
 ];
 
 /// Keys that can only be set at database open time.
-const OPEN_TIME_ONLY_KEYS: &[&str] = &["background_threads", "allow_lossy_recovery"];
+const OPEN_TIME_ONLY_KEYS: &[&str] = &[
+    "background_threads",
+    "allow_lossy_recovery",
+    "allow_missing_manifest",
+];
 
 /// Storage keys that accept usize values (≥ 0).
 const STORAGE_USIZE_KEYS: &[&str] = &[

--- a/crates/executor/src/tests/config.rs
+++ b/crates/executor/src/tests/config.rs
@@ -1663,7 +1663,11 @@ fn configure_set_storage_param_invalid_value_rejected() {
 fn configure_set_open_time_only_keys_rejected() {
     let executor = create_test_executor();
 
-    for key in ["background_threads", "allow_lossy_recovery"] {
+    for key in [
+        "background_threads",
+        "allow_lossy_recovery",
+        "allow_missing_manifest",
+    ] {
         let result = executor.execute(Command::ConfigureSet {
             key: key.into(),
             value: "4".into(),
@@ -1683,7 +1687,7 @@ fn configure_set_open_time_only_keys_rejected() {
 fn configure_get_open_time_only_keys_readable() {
     let executor = create_test_executor();
 
-    // background_threads and allow_lossy_recovery should be readable even though not settable
+    // Open-time-only keys should stay readable even though they are not settable.
     let result = executor
         .execute(Command::ConfigureGetKey {
             key: "background_threads".into(),
@@ -1708,5 +1712,16 @@ fn configure_get_open_time_only_keys_readable() {
         result,
         Output::ConfigValue(Some("false".into())),
         "allow_lossy_recovery default should be false"
+    );
+
+    let result = executor
+        .execute(Command::ConfigureGetKey {
+            key: "allow_missing_manifest".into(),
+        })
+        .unwrap();
+    assert_eq!(
+        result,
+        Output::ConfigValue(Some("false".into())),
+        "allow_missing_manifest default should be false"
     );
 }

--- a/crates/executor/src/tests/config.rs
+++ b/crates/executor/src/tests/config.rs
@@ -1311,7 +1311,7 @@ fn unknown_key_error_lists_all_new_keys() {
     }
     // Keys beyond the 10-candidate display cap are summarised as "and N more"
     assert!(
-        msg.contains("and 18 more"),
+        msg.contains("and 19 more"),
         "Error should indicate truncated keys: {}",
         msg
     );

--- a/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
+++ b/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
@@ -53,6 +53,7 @@ The classification is load-bearing in three places:
 | `google_api_key` | non-durability | no | — |
 | `storage` | (nested — see below) | — | — |
 | `allow_lossy_recovery` | open-time-only | yes (`CompatibilitySignature.allow_lossy_recovery`; also hashed into `open_config_fingerprint`) | rejected at runtime via `OPEN_TIME_ONLY_KEYS`. When `true`, any recovery error triggers a whole-database wipe-and-reopen; the fallback is observable via `Database::last_lossy_recovery_report()` (`Option<LossyRecoveryReport>`) and tracing target `strata::recovery::lossy` (see DR-011 and D-DR-9 in `durability-recovery-scope.md`). |
+| `allow_missing_manifest` | open-time-only | no | narrow opt-in that permits strict open when storage recovery only observed `DegradationClass::PolicyDowngrade` (currently the no-`segments.manifest` legacy-L0-promotion fallback). `DataLoss` remains refused unless `allow_lossy_recovery` is also set. D4 policy branch at `crates/engine/src/database/recovery.rs`; observability via `Database::recovery_health()` (`RecoveryHealth`) and tracing target `strata::recovery::health`. Intentionally **not** in `CompatibilitySignature` (unlike `allow_lossy_recovery`): D4's scope is the first-open policy decision only, so a second opener reusing the live handle via `OPEN_DATABASES` inherits the first opener's `recovery_health()` regardless of their own flag. Runtime mutation still rejected via `OPEN_TIME_ONLY_KEYS`. |
 | `telemetry` | non-durability | no | — |
 | `default_vector_dtype` | non-durability | no | — |
 | `snapshot_retention` | live-safe | no | `Database::prune_snapshots_once` (pub(crate)); invoked automatically post-checkpoint. Knob: `snapshot_retention.retain_count` (defaults to 10). The live MANIFEST snapshot is always preserved regardless of retain_count. Closes DG-015. |
@@ -97,7 +98,7 @@ The classification is load-bearing in three places:
 ## Durability/recovery coverage
 
 **Open-time-only:** `codec`, `background_threads`, `allow_lossy_recovery`,
-`durability = "cache"` (discriminant).
+`allow_missing_manifest`, `durability = "cache"` (discriminant).
 
 **Live-safe (durability/recovery domain):** `durability` (Standard↔Always
 switch). All other `StorageConfig` entries are live-safe but LSM-tuning, not


### PR DESCRIPTION
## Summary

- Adds the strict-vs-lossy policy branch inside `Database::run_recovery` between SE2's classified `RecoveryHealth` and D3's `coordinator.apply_storage_recovery` call. Closes DG-005, DG-006, and SG-006 (identity-mapped).
- Introduces `Database::recovery_health()` as a separate observability surface from `last_lossy_recovery_report()` — storage-recovery degradation never implies a WAL wipe.
- New narrow opt-in `StrataConfig::allow_missing_manifest` for the no-manifest legacy-L0-promotion fallback, distinct from the blanket `allow_lossy_recovery`.

## Policy matrix

| Class | strict | `allow_missing_manifest` | `allow_lossy_recovery` |
|---|:---:|:---:|:---:|
| `DataLoss` | refuse | refuse | accept |
| `PolicyDowngrade` | refuse | accept | accept |
| `Telemetry` | accept | accept | accept |

`RecoveryHealth` and `DegradationClass` added to the D4 public API surface in CLAUDE.md. `allow_missing_manifest` wired into `OPEN_TIME_ONLY_KEYS` so the executor config handler rejects runtime mutation.

## Test plan

- [x] `cargo test -p strata-engine --test recovery_storage_policy` — 6 new parity tests
  - strict `CorruptManifest` refusal (typed `Corruption` + "DataLoss" in message)
  - lossy `CorruptManifest` accept + `recovery_health() == Degraded { DataLoss }` + `last_lossy_recovery_report() == None`
  - strict `NoManifestFallbackUsed` refusal (typed + "PolicyDowngrade")
  - `allow_missing_manifest=true` accept + data preserved via `KVStore::get`
  - clean reopen is `Healthy`
  - DR-011 regression: WAL-wipe populates `last_lossy_recovery_report` unchanged and leaves `recovery_health()` at `Healthy`
- [x] `cargo test -p strata-engine` (1032 tests, recovery + follower + parity + config-matrix all green)
- [x] `cargo test -p strata-executor` (613 tests; updated `unknown_key_error_lists_all_new_keys` for the new key)
- [x] `cargo clippy -p strata-engine -p strata-executor` — clean on D4 lines
- [x] `cargo check --workspace` — clean

## Scope notes

- Does **not** touch `open.rs`, does **not** extend `LossyRecoveryReport`, does **not** reshape orchestration (epic-scope pins).
- Intentionally NOT in `CompatibilitySignature` — scope is first-open policy only; reuse-time enforcement is future work. Documented in the config matrix.
- Pre-existing `flush_pipeline_tests::lifecycle_crash_before_flush` failure is not caused by this branch (verified via `git stash` on `origin/main`).

Change class: intentional semantic change + new public API. Assurance: S4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)