### PR TITLE
fix(test): create segments_dir in lifecycle_crash_before_flush

### DIFF
--- a/crates/engine/tests/flush_pipeline_tests.rs
+++ b/crates/engine/tests/flush_pipeline_tests.rs
@@ -170,6 +170,14 @@ fn lifecycle_crash_before_flush() {
     std::fs::create_dir_all(&wal_dir).unwrap();
     let manifest_path = dir.path().join("MANIFEST");
     let segments_dir = dir.path().join("segments");
+    // Mirror what `Database::run_recovery` does via
+    // `layout.create_segments_dir()` before every `recover_segments()`
+    // call: SE2 classifies a missing segments dir as `RecoveryFault::Io`
+    // and returns Err, so the engine guarantees the directory exists
+    // first. This storage-level test sibling (`lifecycle_crash_after_
+    // segment_before_manifest`) avoids the issue only because its
+    // flush path creates the dir as a side effect.
+    std::fs::create_dir_all(&segments_dir).unwrap();
 
     let _manifest_mgr =
         ManifestManager::create(manifest_path.clone(), test_uuid(), "identity".to_string())


### PR DESCRIPTION
## Summary

- Fixes the pre-existing CI failure in `crates/engine/tests/flush_pipeline_tests.rs::lifecycle_crash_before_flush` that has been tripping every PR since SE2 landed (commit `1b87cb34`).

## Root cause

SE2 tightened `SegmentedStore::recover_segments()` to classify a missing segments directory as `RecoveryFault::Io` and return `Err` (storage/src/segmented/mod.rs:3502-3510). The engine's real `run_recovery` path is unaffected because it calls `layout.create_segments_dir()` before every `recover_segments()` call (engine/src/database/recovery.rs:378, 401).

This storage-level integration test was relying on the pre-SE2 lenient behaviour: it constructs `SegmentedStore::with_dir(segments_dir, 0)` without creating the directory, drops the store to simulate a pre-flush crash, then calls `recover_segments().unwrap()` — which now panics with "segments directory is missing". The sibling test `lifecycle_crash_after_segment_before_manifest` happens to pass only because its flush path creates the dir as a side effect.

## Fix

Add one `fs::create_dir_all(&segments_dir)` line mirroring what the engine's `DatabaseLayout` does. Comment explains why the one-liner is load-bearing.

## Test plan

- [x] `cargo test -p strata-engine --test flush_pipeline_tests` — all 7 tests pass
- [x] The test's original intent is preserved: "crash before any flush ever happened" is still what it simulates; directory existence is orthogonal to whether anything was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)