### PR TITLE
D8a: storage regression suite — publish failures, post-restart fork, cross-branch GC safety

### DIFF
--- a/crates/storage/src/segmented/tests/gc_under_degradation.rs
+++ b/crates/storage/src/segmented/tests/gc_under_degradation.rs
@@ -11,6 +11,26 @@ use super::*;
 use crate::segmented::{DegradationClass, RecoveryFault, RecoveryHealth};
 use crate::StorageError;
 
+fn kv_key_for(branch_id: BranchId, name: &str) -> Key {
+    Key::new(
+        Arc::new(Namespace::new(branch_id, "default".to_string())),
+        TypeTag::KV,
+        name.as_bytes().to_vec(),
+    )
+}
+
+fn seed_branch(store: &SegmentedStore, branch_id: BranchId, key: &str, value: i64, version: u64) {
+    store
+        .put_with_version_mode(
+            kv_key_for(branch_id, key),
+            Value::Int(value),
+            CommitVersion(version),
+            None,
+            WriteMode::Append,
+        )
+        .unwrap();
+}
+
 /// After a corrupt-manifest recovery, `gc_orphan_segments()` must refuse
 /// and leave the would-be-orphaned `.sst` files on disk.
 #[test]
@@ -297,4 +317,71 @@ fn clear_branch_succeeds_under_degraded_recovery() {
         store.branches.get(&branch()).is_none(),
         "branch must be removed from the in-memory map regardless of gc refusal"
     );
+}
+
+/// After a degraded recovery skips one branch, `clear_branch()` on another
+/// branch must not let orphan GC delete the skipped branch's authoritative
+/// files. The degraded health snapshot must remain visible after the clear.
+#[test]
+fn clear_branch_under_degraded_recovery_preserves_skipped_branch_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let skipped = BranchId::from_bytes([31; 16]);
+    let cleared = BranchId::from_bytes([32; 16]);
+
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    seed_branch(&store, skipped, "lost", 11, 11);
+    store.rotate_memtable(&skipped);
+    store.flush_oldest_frozen(&skipped).unwrap();
+
+    seed_branch(&store, cleared, "live", 22, 22);
+    store.rotate_memtable(&cleared);
+    store.flush_oldest_frozen(&cleared).unwrap();
+    drop(store);
+
+    let skipped_dir = dir.path().join(super::hex_encode_branch(&skipped));
+    let skipped_ssts: Vec<_> = std::fs::read_dir(&skipped_dir)
+        .unwrap()
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("sst"))
+        .collect();
+    assert!(
+        !skipped_ssts.is_empty(),
+        "setup must produce authoritative skipped-branch SSTs"
+    );
+
+    let skipped_manifest = skipped_dir.join("segments.manifest");
+    let mut manifest_bytes = std::fs::read(&skipped_manifest).unwrap();
+    let mid = manifest_bytes.len() / 2;
+    manifest_bytes[mid] ^= 0xFF;
+    std::fs::write(&skipped_manifest, &manifest_bytes).unwrap();
+
+    let reopened = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = reopened.recover_segments().unwrap();
+    assert!(matches!(
+        outcome.health,
+        RecoveryHealth::Degraded {
+            class: DegradationClass::DataLoss,
+            ..
+        }
+    ));
+    assert!(reopened.branches.get(&skipped).is_none());
+    assert!(reopened.branches.get(&cleared).is_some());
+
+    assert!(reopened.clear_branch(&cleared));
+    assert!(reopened.branches.get(&cleared).is_none());
+    assert!(matches!(
+        &*reopened.last_recovery_health(),
+        RecoveryHealth::Degraded {
+            class: DegradationClass::DataLoss,
+            ..
+        }
+    ));
+
+    for sst in &skipped_ssts {
+        assert!(
+            sst.exists(),
+            "skipped branch SST {sst:?} must survive clear_branch while GC refuses"
+        );
+    }
 }

--- a/crates/storage/src/segmented/tests/mod.rs
+++ b/crates/storage/src/segmented/tests/mod.rs
@@ -105,4 +105,6 @@ mod gc_under_degradation;
 mod leveled;
 mod lifecycle;
 mod materialize;
+mod post_restart_branch;
+mod publish_failures;
 mod resurrection;

--- a/crates/storage/src/segmented/tests/post_restart_branch.rs
+++ b/crates/storage/src/segmented/tests/post_restart_branch.rs
@@ -1,0 +1,78 @@
+use std::sync::atomic::Ordering;
+
+use super::*;
+
+fn kv_key_for(branch_id: BranchId, name: &str) -> Key {
+    Key::new(
+        Arc::new(Namespace::new(branch_id, "default".to_string())),
+        TypeTag::KV,
+        name.as_bytes().to_vec(),
+    )
+}
+
+fn seed_branch(store: &SegmentedStore, branch_id: BranchId, key: &str, value: i64, version: u64) {
+    store
+        .put_with_version_mode(
+            kv_key_for(branch_id, key),
+            Value::Int(value),
+            CommitVersion(version),
+            None,
+            WriteMode::Append,
+        )
+        .unwrap();
+}
+
+#[test]
+fn fork_after_restart_propagates_rebuilt_max_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let parent = BranchId::from_bytes([41; 16]);
+    let child = BranchId::from_bytes([42; 16]);
+    let grandchild = BranchId::from_bytes([43; 16]);
+
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    for version in [7_u64, 19, 42] {
+        seed_branch(
+            &store,
+            parent,
+            &format!("k{version:02}"),
+            version as i64,
+            version,
+        );
+        store.rotate_memtable(&parent);
+        store.flush_oldest_frozen(&parent).unwrap();
+    }
+    drop(store);
+
+    let reopened = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = reopened.recover_segments().unwrap();
+    assert_eq!(
+        outcome.branch_versions.get(&parent),
+        Some(&CommitVersion(42))
+    );
+    assert!(matches!(outcome.health, RecoveryHealth::Healthy));
+
+    let parent_state = reopened.branches.get(&parent).unwrap();
+    assert_eq!(
+        parent_state.max_version.load(Ordering::Acquire),
+        42,
+        "recovery must rebuild parent branch.max_version before post-restart forks"
+    );
+    drop(parent_state);
+
+    let (fork_version, shared) = reopened.fork_branch(&parent, &child).unwrap();
+    assert_eq!(fork_version, CommitVersion(42));
+    assert!(shared > 0);
+
+    let child_state = reopened.branches.get(&child).unwrap();
+    assert_eq!(
+        child_state.max_version.load(Ordering::Acquire),
+        42,
+        "forked child must inherit the rebuilt max_version so subsequent forks stay correct"
+    );
+    drop(child_state);
+
+    let (grandchild_fork_version, grandchild_shared) =
+        reopened.fork_branch(&child, &grandchild).unwrap();
+    assert_eq!(grandchild_fork_version, CommitVersion(42));
+    assert!(grandchild_shared > 0);
+}

--- a/crates/storage/src/segmented/tests/publish_failures.rs
+++ b/crates/storage/src/segmented/tests/publish_failures.rs
@@ -1,0 +1,482 @@
+use std::path::{Path, PathBuf};
+
+use super::*;
+
+fn kv_key_for(branch_id: BranchId, name: &str) -> Key {
+    Key::new(
+        Arc::new(Namespace::new(branch_id, "default".to_string())),
+        TypeTag::KV,
+        name.as_bytes().to_vec(),
+    )
+}
+
+fn seed_branch(store: &SegmentedStore, branch_id: BranchId, key: &str, value: i64, version: u64) {
+    store
+        .put_with_version_mode(
+            kv_key_for(branch_id, key),
+            Value::Int(value),
+            CommitVersion(version),
+            None,
+            WriteMode::Append,
+        )
+        .unwrap();
+}
+
+fn flush_entries(store: &SegmentedStore, branch_id: &BranchId, entries: &[(&str, i64, u64)]) {
+    for &(key, value, version) in entries {
+        seed_branch(store, *branch_id, key, value, version);
+    }
+    store.rotate_memtable(branch_id);
+    store.flush_oldest_frozen(branch_id).unwrap();
+}
+
+fn branch_dir(root: &Path, branch_id: &BranchId) -> PathBuf {
+    root.join(super::hex_encode_branch(branch_id))
+}
+
+fn sst_paths(root: &Path, branch_id: &BranchId) -> Vec<PathBuf> {
+    let dir = branch_dir(root, branch_id);
+    let mut paths: Vec<_> = std::fs::read_dir(&dir)
+        .ok()
+        .into_iter()
+        .flat_map(std::iter::Iterator::flatten)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("sst"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn reopen_store(root: &Path) -> SegmentedStore {
+    let store = SegmentedStore::with_dir(root.to_path_buf(), 0);
+    store.recover_segments().unwrap();
+    store
+}
+
+fn assert_int_value(store: &SegmentedStore, branch_id: BranchId, key: &str, expected: i64) {
+    let value = store
+        .get_versioned(&kv_key_for(branch_id, key), CommitVersion::MAX)
+        .unwrap()
+        .unwrap_or_else(|| {
+            panic!(
+                "missing key {key} on branch {}",
+                super::hex_encode_branch(&branch_id)
+            )
+        });
+    assert_eq!(value.value, Value::Int(expected));
+}
+
+fn compact_level_merge_fixture(store: &SegmentedStore, branch_id: &BranchId) {
+    flush_entries(store, branch_id, &[("a", 1, 1), ("b", 2, 1)]);
+    store.compact_level(branch_id, 0, CommitVersion(0)).unwrap();
+    store.compact_level(branch_id, 1, CommitVersion(0)).unwrap();
+
+    flush_entries(store, branch_id, &[("b", 20, 2), ("c", 30, 2)]);
+    store.compact_level(branch_id, 0, CommitVersion(0)).unwrap();
+
+    assert_eq!(store.level_segment_count(branch_id, 1), 1);
+    assert_eq!(store.level_segment_count(branch_id, 2), 1);
+}
+
+#[test]
+fn flush_manifest_publish_failure_reopen_keeps_pre_publish_state() {
+    crate::test_hooks::clear_manifest_publish_failure();
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    seed(&store, kv_key("a"), Value::Int(1), 1);
+    store.rotate_memtable(&b);
+
+    crate::test_hooks::inject_manifest_publish_failure(std::io::ErrorKind::Other);
+    let err = store.flush_oldest_frozen(&b).unwrap_err();
+    assert!(matches!(err, crate::StorageError::ManifestPublish { .. }));
+    assert!(sst_paths(dir.path(), &b).is_empty());
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.branch_segment_count(&b), 0);
+    assert!(reopened
+        .get_versioned(&kv_key("a"), CommitVersion::MAX)
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn flush_dir_fsync_failure_reopen_keeps_installed_segment() {
+    crate::test_hooks::clear_manifest_dir_fsync_failure();
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    seed(&store, kv_key("a"), Value::Int(1), 1);
+    store.rotate_memtable(&b);
+
+    crate::test_hooks::inject_manifest_dir_fsync_failure(std::io::ErrorKind::Other);
+    assert!(store.flush_oldest_frozen(&b).unwrap());
+    assert!(store.publish_health().is_some());
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.branch_segment_count(&b), 1);
+    assert_int_value(&reopened, b, "a", 1);
+}
+
+#[test]
+fn compact_branch_manifest_publish_failure_reopen_keeps_pre_publish_state() {
+    crate::test_hooks::clear_manifest_publish_failure();
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    flush_entries(&store, &b, &[("a", 1, 1)]);
+    flush_entries(&store, &b, &[("b", 2, 2)]);
+    let inputs = sst_paths(dir.path(), &b);
+    assert_eq!(inputs.len(), 2);
+
+    crate::test_hooks::inject_manifest_publish_failure(std::io::ErrorKind::Other);
+    let err = store.compact_branch(&b, CommitVersion(0)).unwrap_err();
+    assert!(matches!(err, crate::StorageError::ManifestPublish { .. }));
+    assert!(inputs.iter().all(|path| path.exists()));
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.l0_segment_count(&b), 2);
+    assert_int_value(&reopened, b, "a", 1);
+    assert_int_value(&reopened, b, "b", 2);
+}
+
+#[test]
+fn compact_branch_dir_fsync_failure_reopen_keeps_forward_progress() {
+    crate::test_hooks::clear_manifest_dir_fsync_failure();
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    flush_entries(&store, &b, &[("a", 1, 1)]);
+    flush_entries(&store, &b, &[("b", 2, 2)]);
+    let inputs = sst_paths(dir.path(), &b);
+    assert_eq!(inputs.len(), 2);
+
+    crate::test_hooks::inject_manifest_dir_fsync_failure(std::io::ErrorKind::Other);
+    let err = store.compact_branch(&b, CommitVersion(0)).unwrap_err();
+    assert!(matches!(err, crate::StorageError::DirFsync { .. }));
+    assert!(inputs.iter().all(|path| path.exists()));
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.branch_segment_count(&b), 1);
+    assert_int_value(&reopened, b, "a", 1);
+    assert_int_value(&reopened, b, "b", 2);
+}
+
+#[test]
+fn compact_tier_manifest_publish_failure_reopen_keeps_pre_publish_state() {
+    crate::test_hooks::clear_manifest_publish_failure();
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    for commit in 1..=4_u64 {
+        let key = format!("k{commit}");
+        flush_entries(&store, &b, &[(&key, commit as i64, commit)]);
+    }
+    let inputs = sst_paths(dir.path(), &b);
+    assert_eq!(inputs.len(), 4);
+
+    crate::test_hooks::inject_manifest_publish_failure(std::io::ErrorKind::Other);
+    let err = store
+        .compact_tier(&b, &[0, 1, 2, 3], CommitVersion(0))
+        .unwrap_err();
+    assert!(matches!(err, crate::StorageError::ManifestPublish { .. }));
+    assert!(inputs.iter().all(|path| path.exists()));
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.l0_segment_count(&b), 4);
+    for commit in 1..=4_i64 {
+        assert_int_value(&reopened, b, &format!("k{commit}"), commit);
+    }
+}
+
+#[test]
+fn compact_tier_dir_fsync_failure_reopen_keeps_forward_progress() {
+    crate::test_hooks::clear_manifest_dir_fsync_failure();
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    for commit in 1..=4_u64 {
+        let key = format!("k{commit}");
+        flush_entries(&store, &b, &[(&key, commit as i64, commit)]);
+    }
+    let inputs = sst_paths(dir.path(), &b);
+    assert_eq!(inputs.len(), 4);
+
+    crate::test_hooks::inject_manifest_dir_fsync_failure(std::io::ErrorKind::Other);
+    let err = store
+        .compact_tier(&b, &[0, 1, 2, 3], CommitVersion(0))
+        .unwrap_err();
+    assert!(matches!(err, crate::StorageError::DirFsync { .. }));
+    assert!(inputs.iter().all(|path| path.exists()));
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.branch_segment_count(&b), 1);
+    for commit in 1..=4_i64 {
+        assert_int_value(&reopened, b, &format!("k{commit}"), commit);
+    }
+}
+
+#[test]
+fn compact_l0_to_l1_manifest_publish_failure_reopen_keeps_pre_publish_state() {
+    crate::test_hooks::clear_manifest_publish_failure();
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    flush_entries(&store, &b, &[("a", 1, 1)]);
+    flush_entries(&store, &b, &[("b", 2, 2)]);
+    flush_entries(&store, &b, &[("c", 3, 3)]);
+    let inputs = sst_paths(dir.path(), &b);
+    assert_eq!(inputs.len(), 3);
+
+    crate::test_hooks::inject_manifest_publish_failure(std::io::ErrorKind::Other);
+    let err = store.compact_l0_to_l1(&b, CommitVersion(0)).unwrap_err();
+    assert!(matches!(err, crate::StorageError::ManifestPublish { .. }));
+    assert!(inputs.iter().all(|path| path.exists()));
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.l0_segment_count(&b), 3);
+    assert_eq!(reopened.l1_segment_count(&b), 0);
+    assert_int_value(&reopened, b, "a", 1);
+    assert_int_value(&reopened, b, "b", 2);
+    assert_int_value(&reopened, b, "c", 3);
+}
+
+#[test]
+fn compact_l0_to_l1_dir_fsync_failure_reopen_keeps_forward_progress() {
+    crate::test_hooks::clear_manifest_dir_fsync_failure();
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    flush_entries(&store, &b, &[("a", 1, 1)]);
+    flush_entries(&store, &b, &[("b", 2, 2)]);
+    flush_entries(&store, &b, &[("c", 3, 3)]);
+    let inputs = sst_paths(dir.path(), &b);
+    assert_eq!(inputs.len(), 3);
+
+    crate::test_hooks::inject_manifest_dir_fsync_failure(std::io::ErrorKind::Other);
+    let err = store.compact_l0_to_l1(&b, CommitVersion(0)).unwrap_err();
+    assert!(matches!(err, crate::StorageError::DirFsync { .. }));
+    assert!(inputs.iter().all(|path| path.exists()));
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.l0_segment_count(&b), 0);
+    assert!(reopened.l1_segment_count(&b) >= 1);
+    assert_int_value(&reopened, b, "a", 1);
+    assert_int_value(&reopened, b, "b", 2);
+    assert_int_value(&reopened, b, "c", 3);
+}
+
+#[test]
+fn compact_level_trivial_move_manifest_publish_failure_reopen_keeps_pre_publish_state() {
+    crate::test_hooks::clear_manifest_publish_failure();
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    flush_entries(&store, &b, &[("x", 1, 1)]);
+    store.compact_level(&b, 0, CommitVersion(0)).unwrap();
+    let inputs = sst_paths(dir.path(), &b);
+    assert_eq!(store.level_segment_count(&b, 1), 1);
+    assert_eq!(store.level_segment_count(&b, 2), 0);
+
+    crate::test_hooks::inject_manifest_publish_failure(std::io::ErrorKind::Other);
+    let err = store.compact_level(&b, 1, CommitVersion(0)).unwrap_err();
+    assert!(matches!(err, crate::StorageError::ManifestPublish { .. }));
+    assert!(inputs.iter().all(|path| path.exists()));
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.level_segment_count(&b, 1), 1);
+    assert_eq!(reopened.level_segment_count(&b, 2), 0);
+    assert_int_value(&reopened, b, "x", 1);
+}
+
+#[test]
+fn compact_level_trivial_move_dir_fsync_failure_reopen_keeps_forward_progress() {
+    crate::test_hooks::clear_manifest_dir_fsync_failure();
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+
+    flush_entries(&store, &b, &[("x", 1, 1)]);
+    store.compact_level(&b, 0, CommitVersion(0)).unwrap();
+    let inputs = sst_paths(dir.path(), &b);
+    assert_eq!(store.level_segment_count(&b, 1), 1);
+    assert_eq!(store.level_segment_count(&b, 2), 0);
+
+    crate::test_hooks::inject_manifest_dir_fsync_failure(std::io::ErrorKind::Other);
+    let err = store.compact_level(&b, 1, CommitVersion(0)).unwrap_err();
+    assert!(matches!(err, crate::StorageError::DirFsync { .. }));
+    assert!(inputs.iter().all(|path| path.exists()));
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.level_segment_count(&b, 1), 0);
+    assert_eq!(reopened.level_segment_count(&b, 2), 1);
+    assert_int_value(&reopened, b, "x", 1);
+}
+
+#[test]
+fn compact_level_merge_manifest_publish_failure_reopen_keeps_pre_publish_state() {
+    crate::test_hooks::clear_manifest_publish_failure();
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+    compact_level_merge_fixture(&store, &b);
+    let inputs = sst_paths(dir.path(), &b);
+
+    crate::test_hooks::inject_manifest_publish_failure(std::io::ErrorKind::Other);
+    let err = store.compact_level(&b, 1, CommitVersion(0)).unwrap_err();
+    assert!(matches!(err, crate::StorageError::ManifestPublish { .. }));
+    assert!(inputs.iter().all(|path| path.exists()));
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.level_segment_count(&b, 1), 1);
+    assert_eq!(reopened.level_segment_count(&b, 2), 1);
+    assert_int_value(&reopened, b, "a", 1);
+    assert_int_value(&reopened, b, "b", 20);
+    assert_int_value(&reopened, b, "c", 30);
+}
+
+#[test]
+fn compact_level_merge_dir_fsync_failure_reopen_keeps_forward_progress() {
+    crate::test_hooks::clear_manifest_dir_fsync_failure();
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let b = branch();
+    compact_level_merge_fixture(&store, &b);
+    let inputs = sst_paths(dir.path(), &b);
+
+    crate::test_hooks::inject_manifest_dir_fsync_failure(std::io::ErrorKind::Other);
+    let err = store.compact_level(&b, 1, CommitVersion(0)).unwrap_err();
+    assert!(matches!(err, crate::StorageError::DirFsync { .. }));
+    assert!(inputs.iter().all(|path| path.exists()));
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.level_segment_count(&b, 1), 0);
+    assert!(reopened.level_segment_count(&b, 2) >= 1);
+    assert_int_value(&reopened, b, "a", 1);
+    assert_int_value(&reopened, b, "b", 20);
+    assert_int_value(&reopened, b, "c", 30);
+}
+
+#[test]
+fn fork_manifest_publish_failure_reopen_keeps_child_absent() {
+    crate::test_hooks::clear_manifest_publish_failure();
+
+    let (dir, store) = setup_parent_with_segments(&[("a", 1, 1), ("b", 2, 2)]);
+    crate::test_hooks::inject_manifest_publish_failure(std::io::ErrorKind::Other);
+
+    let err = store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap_err();
+    assert!(matches!(err, crate::StorageError::ManifestPublish { .. }));
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert!(reopened.branches.get(&child_branch()).is_none());
+    assert_int_value(&reopened, parent_branch(), "a", 1);
+    assert_int_value(&reopened, parent_branch(), "b", 2);
+}
+
+#[test]
+fn fork_dir_fsync_failure_reopen_keeps_child_visible() {
+    crate::test_hooks::clear_manifest_dir_fsync_failure();
+
+    let (dir, store) = setup_parent_with_segments(&[("a", 1, 1), ("b", 2, 2)]);
+    crate::test_hooks::inject_manifest_dir_fsync_failure(std::io::ErrorKind::Other);
+
+    let (fork_version, shared) = store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+    assert!(fork_version > CommitVersion::ZERO);
+    assert!(shared > 0);
+    assert!(store.publish_health().is_some());
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.inherited_layer_count(&child_branch()), 1);
+    let child_value = reopened
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(child_value.value, Value::Int(1));
+}
+
+#[test]
+fn materialize_manifest_publish_failure_reopen_keeps_inherited_layer() {
+    crate::test_hooks::clear_manifest_publish_failure();
+
+    let (dir, store) = setup_parent_with_segments(&[("a", 1, 1), ("b", 2, 2)]);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    crate::test_hooks::inject_manifest_publish_failure(std::io::ErrorKind::Other);
+    let err = store.materialize_layer(&child_branch(), 0).unwrap_err();
+    assert!(matches!(err, crate::StorageError::ManifestPublish { .. }));
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.inherited_layer_count(&child_branch()), 1);
+    let child_value = reopened
+        .get_versioned(&child_kv("b"), CommitVersion::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(child_value.value, Value::Int(2));
+}
+
+#[test]
+fn materialize_dir_fsync_failure_reopen_keeps_materialized_state() {
+    crate::test_hooks::clear_manifest_dir_fsync_failure();
+
+    let (dir, store) = setup_parent_with_segments(&[("a", 1, 1), ("b", 2, 2)]);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    crate::test_hooks::inject_manifest_dir_fsync_failure(std::io::ErrorKind::Other);
+    let result = store.materialize_layer(&child_branch(), 0).unwrap();
+    assert_eq!(result.entries_materialized, 2);
+    assert!(store.publish_health().is_some());
+    drop(store);
+
+    let reopened = reopen_store(dir.path());
+    assert_eq!(reopened.inherited_layer_count(&child_branch()), 0);
+    assert!(reopened.branch_segment_count(&child_branch()) > 0);
+    let child_value = reopened
+        .get_versioned(&child_kv("a"), CommitVersion::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(child_value.value, Value::Int(1));
+}


### PR DESCRIPTION
## Summary

Lands the three storage-level D8a regression files that the G1 gate in `docs/design/durability/durability-storage-closure-epics.md` calls for as "what runs before G1". These pin the contracts SE1/SE2/SE3 changed; the broader D8b program (fuzz, corpora, crash matrix, multi-process) waits until after G1.

- **SG-016** — `crates/storage/src/segmented/tests/publish_failures.rs` (NEW, 16 tests)
- **SG-017** — extends `gc_under_degradation.rs` (+1 test)
- **SG-018** — `post_restart_branch.rs` (NEW, 1 test)

## What each file pins

### SG-016: manifest write + dir fsync failure matrix

Two failure modes × 8 ops (flush, compact_branch, compact_tier, compact_l0_to_l1, compact_level trivial-move, compact_level merge, fork, materialize). The publish-failure and dir-fsync-failure variants are intentionally asymmetric:

| Failure mode | Typed error | Old inputs | Reopened state |
|---|---|---|---|
| Manifest publish | `StorageError::ManifestPublish` | Survive | Pre-publish (change rolled back) |
| Dir fsync | `StorageError::DirFsync` | Survive | Forward progress preserved; `publish_health()` set |

Misreading these as symmetric would either lose writes (treating publish failure as committed) or refuse to make forward progress on a healthy filesystem (treating dir-fsync failure as a rollback).

### SG-017: cross-branch GC safety under degraded recovery

Two-branch setup (skipped + cleared) with corrupted skipped-branch manifest. Proves that `clear_branch(cleared)` succeeds on the live branch while SE3's GC refusal keeps the skipped branch's authoritative SSTs intact and `last_recovery_health()` stays `Degraded`. A same-branch test would not have exercised the actual orphan-confusion hazard the refusal was protecting against.

### SG-018: post-restart `branch.max_version` rebuild (transitive)

Commits at versions 7/19/42 on parent; drops; reopens; triple-fork chain (parent → child → grandchild). Both forks must see `CommitVersion(42)` — a single parent-only assertion would have missed transitive breakage of the rebuild through the fork chain.

## Test plan

- [x] `cargo test -p strata-storage --lib segmented::tests::publish_failures` — 16/16 pass
- [x] `cargo test -p strata-storage --lib segmented::tests::post_restart_branch` — 1/1 pass
- [x] `cargo test -p strata-storage --lib segmented::tests::gc_under_degradation` — 7/7 pass (original 6 + new 1)
- [x] `cargo test -p strata-storage` — 718/718 pass (all existing + 18 new)
- [x] `cargo clippy -p strata-storage --tests` — clean on the new files after one redundant-closure fix at `publish_failures.rs:42`
- [x] Test hooks (`test_hooks::inject_manifest_publish_failure` / `clear_manifest_publish_failure` / `_dir_fsync_` pairs) are cleared at the start of each test to avoid cross-test leakage — the hooks are process-wide

## Scope notes

- Independent of PR #2443 (CI fix for `lifecycle_crash_before_flush`). Branches off `main`; PR #2443 can merge before or after this.
- Part of the **D8a targeted regression** bundle, not D8b. Phase 3's comprehensive reliability program (corpus, fuzz, proptest, crash matrix, multi-process) is gated on G1 and lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)