### PR TITLE
fix(ci): feature-matrix cleanup — #1704 drain + anthropic-gated cloud test

### DIFF
--- a/crates/engine/src/branch_ops/mod.rs
+++ b/crates/engine/src/branch_ops/mod.rs
@@ -4521,6 +4521,19 @@ mod tests {
             layers_before,
         );
 
+        // Drain any background compaction chain left over from the setup
+        // writes. `schedule_background_compaction` deduplicates via the
+        // `compaction_in_flight` flag, and the chain only calls
+        // `run_materialization` at `idle_count == 0`. If we skip this drain,
+        // under heavy parallel test contention (feature-matrix CI) the leftover
+        // chain is still spinning idle rounds when our trigger write fires,
+        // the trigger's `schedule_background_compaction` is a no-op, and
+        // materialization never runs for the newly-built fork chain — see
+        // `database/transaction.rs:compaction_round` for the idle-round state
+        // machine. Draining here guarantees the flag is clear before we trigger,
+        // so the next chain starts fresh at `idle_count == 0`.
+        db.scheduler().drain();
+
         // Write to root — triggers schedule_flush_if_needed().
         // Root's memtable is NOT full, so branches_needing_flush() returns
         // empty. Pre-fix, this early-returned and skipped materialization.

--- a/crates/engine/src/database/tests/shutdown.rs
+++ b/crates/engine/src/database/tests/shutdown.rs
@@ -2082,19 +2082,14 @@ fn shutdown_timeout_halt_interleaving_preserves_invariant() {
         let blocker_key = Key::new_kv(ns.clone(), "blocker");
         let trigger_key = Key::new_kv(ns.clone(), "halt_trigger");
 
-        // Stage the sync failure BEFORE shutdown. The trigger commit
-        // queues dirty WAL bytes, but the actual `sync_all` happens on the
-        // next flush-thread tick (every 5ms). By varying how long after
-        // shutdown starts we set things up, the halt publishes at
-        // different points relative to the timeout-cleanup window.
-        super::test_hooks::inject_sync_failure(&db_path, std::io::ErrorKind::Other);
-        db.transaction(branch_id, |txn| {
-            txn.put(trigger_key.clone(), Value::Int(i as i64))?;
-            Ok(())
-        })
-        .unwrap();
-
         // Blocker txn — keeps `wait_for_idle` busy so shutdown must time out.
+        // Spawn and await its `begin_transaction` *before* staging the sync
+        // failure: the flush thread's 5ms tick could otherwise observe the
+        // trigger's dirty WAL bytes and halt the writer before the blocker
+        // enters the open-txn state, rejecting it with `WriterHalted` (which
+        // the test doesn't model). Under `perf-trace` instrumentation the
+        // trigger-commit → blocker-begin window stretched past 5ms on busy
+        // CI runners and flaked deterministically.
         let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
         let (started_tx, started_rx) = std::sync::mpsc::channel();
         let db_blocker = Arc::clone(&db);
@@ -2109,6 +2104,18 @@ fn shutdown_timeout_halt_interleaving_preserves_invariant() {
             db_blocker.end_transaction(txn);
         });
         started_rx.recv().unwrap();
+
+        // Stage the sync failure. The trigger commit queues dirty WAL bytes,
+        // but the actual `sync_all` happens on the next flush-thread tick
+        // (every 5ms). By varying how long after shutdown starts we set
+        // things up, the halt publishes at different points relative to the
+        // timeout-cleanup window.
+        super::test_hooks::inject_sync_failure(&db_path, std::io::ErrorKind::Other);
+        db.transaction(branch_id, |txn| {
+            txn.put(trigger_key.clone(), Value::Int(i as i64))?;
+            Ok(())
+        })
+        .unwrap();
 
         // Per-iteration jitter before shutdown positions the halt so it
         // has to publish *during* or *just after* the timeout-cleanup

--- a/crates/intelligence/src/generate.rs
+++ b/crates/intelligence/src/generate.rs
@@ -416,8 +416,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "anthropic")]
     fn create_cloud_engine_compatible_with_with_engine() {
-        // Verify the with_engine helper works with non-cached entries
+        // Verify the with_engine helper works with non-cached entries.
+        // Gated on `anthropic`: without it, `GenerationEngine::cloud(Anthropic, ...)`
+        // returns `NotSupported` and `CachedEngine.inner` carries that error, so
+        // `with_engine` cannot produce Ok. The assertion here is checking the
+        // happy path (engine constructed), which only holds with the feature on.
         let entry = GenerateModelState::create_cloud_engine(
             ProviderKind::Anthropic,
             "sk-test".into(),
@@ -425,8 +430,6 @@ mod tests {
         )
         .unwrap();
 
-        // Should be able to call with_engine — the engine is valid (Anthropic
-        // provider constructed successfully), so the closure runs
         let result = with_engine(&entry, |engine| engine.provider());
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), ProviderKind::Anthropic);


### PR DESCRIPTION
## Summary

Fixes the flake in `branch_ops::tests::test_issue_1704_materialization_runs_without_pending_flush` that was failing `feature-matrix` CI on PRs #2443 / #2444 while passing locally in isolation.

## Root cause

Interaction between two independent pieces of state in `database/transaction.rs`:

1. **`compaction_in_flight` dedup** — `schedule_background_compaction` uses a single AtomicBool flag. Second and later callers early-return while a chain is running.
2. **`idle_count` state machine** — the chain only calls `run_materialization` at `idle_count == 0`. Rounds 1..MAX_IDLE_ROUNDS (=5) skip materialization and just re-submit; round 5 clears the flag and stops.

The test's setup calls `write_kv` six times (root + 5 sources), each of which triggers `schedule_background_compaction`. The first call starts a chain; subsequent ones are no-ops. The storage-level `fork_branch` calls that build leaf's 5-layer inherited chain don't touch the engine scheduler, so they happen *while* the compaction chain is mid-flight at `idle_count > 0`.

When the test then writes the final `trigger` record, its `schedule_background_compaction` sees the flag still set and no-ops. Drain waits for the chain to run through remaining idle rounds — none of which call `run_materialization`. Result: `layers_after == layers_before == 5` and the assertion fails.

Under light load (local) the first chain finishes before the trigger write and a fresh chain runs materialization. Under heavy parallel load (`feature-matrix` runs many feature-combination test binaries concurrently) the chain is still spinning when the trigger fires → flake.

## Fix

Add one `db.scheduler().drain()` before the trigger write. This guarantees the setup's compaction chain reached `MAX_IDLE_ROUNDS`, cleared the flag, and exited before the trigger. The trigger then starts a fresh chain at `idle_count == 0`, and materialization runs deterministically.

No production code change — the coalescing + periodic-materialization pattern is correct for real workloads where writes reset `idle_count` regularly. The test needed explicit sequencing because its storage-level `fork_branch` calls (used to bypass engine-level materialization during chain construction, to isolate from #1724) leave the engine scheduler unaware that new materialization work appeared mid-chain.

## Test plan

- [x] Stress loop: 20× isolated runs, all pass
- [x] 5× full `branch_ops::tests` suite runs (simulates the contention profile that triggers the flake), all pass
- [x] `cargo test -p strata-engine --lib` — 1032/1032 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)