### PR TITLE
B2: branch-truth model lock-in — canonical BranchId::from_user_name + lineage/lifecycle types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,9 @@ architecture scope documents. The current allowed surface:
 `Subsystem` trait, `CommitObserver`/`CommitInfo`, `ReplayObserver`/`ReplayInfo`,
 `BranchOpObserver`/`BranchOpEvent`, `ObserverError`/`ObserverErrorKind`
 
-**Branch:** `BranchService` (full API), `BranchDagHook`, `BranchDagError`, `BranchId`,
-`BranchRef`, `BranchLifecycleStatus`, `EventStreamLifecycleStatus`, `ConflictPolicy`,
+**Branch:** `BranchService` (full API), `BranchDagHook`, `BranchDagError`, `BranchId`
+(with `BranchId::from_user_name`), `BranchRef`, `BranchGeneration`, `BranchLifecycleStatus`,
+`ForkAnchor`, `BranchControlRecord`, `EventStreamLifecycleStatus`, `ConflictPolicy`,
 `BranchMutationContract`, `PrimitiveLifecycleContract`, `ModeBehavior`
 
 **Durability:** `WalWriterHealth`, `FollowerStatus`, `ContiguousWatermark`,

--- a/crates/core/src/branch.rs
+++ b/crates/core/src/branch.rs
@@ -50,6 +50,16 @@ pub(crate) const BRANCH_NAMESPACE: Uuid = Uuid::from_bytes([
     0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8,
 ]);
 
+/// `true` if `name` resolves to the reserved nil-UUID branch sentinel without
+/// being the literal `"default"` branch name.
+///
+/// Public, user-facing engine/executor validation rejects these aliases so
+/// callers cannot address the nil-UUID sentinel branch by alternate spellings
+/// such as the canonical all-zero UUID string.
+pub fn aliases_default_branch_sentinel(name: &str) -> bool {
+    name != "default" && BranchId::from_user_name(name) == BranchId::from_bytes([0u8; 16])
+}
+
 impl BranchId {
     /// Canonical derivation from a user-facing branch name.
     ///
@@ -59,6 +69,8 @@ impl BranchId {
     ///    other casing hits the v5 path.
     /// 2. Input that parses as a UUID → passed through verbatim. This is how
     ///    synthetic/generated branch ids round-trip without being re-hashed.
+    ///    Public engine/executor validation rejects non-literal aliases of the
+    ///    nil-UUID default-branch sentinel.
     /// 3. Otherwise → deterministic UUID-v5 over (`BRANCH_NAMESPACE`, name).
     ///
     /// This is the only code path in the workspace that performs branch
@@ -125,10 +137,10 @@ impl BranchRef {
 
 /// Canonical branch lifecycle status.
 ///
-/// Replaces the three parallel `BranchStatus` enums that exist today in
-/// engine, executor, and core-branch-types. `Active` is writable, `Archived`
-/// is readable only, `Deleted` is neither writable nor treated as a live
-/// branch. Write-gate enforcement lands in B4.
+/// This becomes the canonical replacement for the parallel `BranchStatus`
+/// enums that exist today in engine, executor, and core-branch-types. B2
+/// lands the shared type; later epics migrate runtime users and enforce the
+/// write gate.
 ///
 /// The four-variant event-stream enum at
 /// `crates/core/src/branch_types.rs::BranchStatus` is distinct — it describes
@@ -139,9 +151,9 @@ impl BranchRef {
 pub enum BranchLifecycleStatus {
     /// Writable. Reads and writes both proceed.
     Active,
-    /// Readable, not writable. Mutating operations return `BranchArchived`.
+    /// Intended read-only state. B4 wires this into the branch write gate.
     Archived,
-    /// Not writable, not visible. Treated as branch-not-found.
+    /// Intended tombstoned state. B4 hides it from live branch surfaces.
     Deleted,
 }
 
@@ -270,6 +282,26 @@ mod tests {
         assert_eq!(*BranchId::from_user_name("default").as_bytes(), nil);
         assert_ne!(*BranchId::from_user_name("DEFAULT").as_bytes(), nil);
         assert_ne!(*BranchId::from_user_name("Default").as_bytes(), nil);
+    }
+
+    #[test]
+    fn aliases_default_branch_sentinel_only_matches_non_literal_nil_aliases() {
+        assert!(!aliases_default_branch_sentinel("default"));
+        assert!(aliases_default_branch_sentinel(
+            "00000000-0000-0000-0000-000000000000"
+        ));
+        assert!(aliases_default_branch_sentinel(
+            "00000000000000000000000000000000"
+        ));
+        assert!(aliases_default_branch_sentinel(
+            "00000000-0000-0000-0000-000000000000"
+                .to_uppercase()
+                .as_str()
+        ));
+        assert!(!aliases_default_branch_sentinel(
+            "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+        ));
+        assert!(!aliases_default_branch_sentinel("main"));
     }
 
     #[test]

--- a/crates/core/src/branch.rs
+++ b/crates/core/src/branch.rs
@@ -1,0 +1,408 @@
+//! Canonical branch-truth types.
+//!
+//! This module is the single source of truth for branch identity, lineage
+//! identity, and lifecycle status. It implements epic B2 of
+//! `docs/design/branching/branching-execution-plan.md`, which collapses the
+//! previously-duplicated `BRANCH_NAMESPACE` derivations (engine + executor)
+//! into one canonical `BranchId::from_user_name` and introduces the
+//! generation-aware identity and lifecycle types later epics consume.
+//!
+//! ## Authority map
+//!
+//! - Branch control truth = engine-owned control records (`BranchControlRecord`
+//!   minimum shape is defined here; the store itself lands in B3/B5).
+//! - `_branch_dag` = derived lineage projection, not a competing authority.
+//! - Storage fork info (inherited layers, fork manifests, refcounts) =
+//!   execution truth for `CoW` storage, not branch-control or lineage truth.
+//!
+//! ## What lives here
+//!
+//! - `BRANCH_NAMESPACE` — the deterministic UUID-v5 namespace for
+//!   name-to-id derivation. `pub(crate)`; consumers go through
+//!   `BranchId::from_user_name`.
+//! - `BranchId::from_user_name` — the only code path in the workspace that
+//!   performs branch name → UUID derivation.
+//! - `BranchGeneration` — monotonic per-name lifecycle counter (type alias).
+//! - `BranchRef` — `(id, generation)` identity carried by lineage-bearing
+//!   surfaces (events, hooks, DAG, control records). Wiring into those
+//!   surfaces is B3 work; B2 only lands the type.
+//! - `BranchLifecycleStatus` — canonical three-state lifecycle
+//!   (`Active`, `Archived`, `Deleted`). Write-gate enforcement is B4.
+//! - `ForkAnchor` / `BranchControlRecord` — the minimum control-record
+//!   shape the later engine-owned `BranchControlStore` will use.
+
+use crate::id::CommitVersion;
+use crate::types::BranchId;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// =============================================================================
+// Namespace + canonical name derivation
+// =============================================================================
+
+/// Deterministic UUID-v5 namespace used by `BranchId::from_user_name`.
+///
+/// The byte value is load-bearing: it appears in every existing disk-backed
+/// database's branch ids. Changing it renames every branch in every database.
+/// Locked by `crates/engine/tests/branch_id_characterization.rs` and the
+/// executor-side parity test in `crates/executor/src/bridge.rs`.
+pub(crate) const BRANCH_NAMESPACE: Uuid = Uuid::from_bytes([
+    0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8,
+]);
+
+impl BranchId {
+    /// Canonical derivation from a user-facing branch name.
+    ///
+    /// The algorithm:
+    /// 1. `"default"` → nil UUID (all-zero bytes). Load-bearing sentinel used
+    ///    by storage isolation and global-index keys. Case-sensitive: any
+    ///    other casing hits the v5 path.
+    /// 2. Input that parses as a UUID → passed through verbatim. This is how
+    ///    synthetic/generated branch ids round-trip without being re-hashed.
+    /// 3. Otherwise → deterministic UUID-v5 over (`BRANCH_NAMESPACE`, name).
+    ///
+    /// This is the only code path in the workspace that performs branch
+    /// name-to-UUID derivation. Both engine (`resolve_branch_name`) and
+    /// executor (`to_core_branch_id`) delegate here.
+    pub fn from_user_name(name: &str) -> Self {
+        if name == "default" {
+            Self::from_bytes([0u8; 16])
+        } else if let Ok(u) = Uuid::parse_str(name) {
+            Self::from_bytes(*u.as_bytes())
+        } else {
+            let uuid = Uuid::new_v5(&BRANCH_NAMESPACE, name.as_bytes());
+            Self::from_bytes(*uuid.as_bytes())
+        }
+    }
+}
+
+// =============================================================================
+// Generation + lineage identity
+// =============================================================================
+
+/// Monotonic per-name lifecycle generation counter.
+///
+/// `BranchId` is deterministic over the name, so two lifecycle instances of
+/// the same branch name share the same id. `BranchGeneration` distinguishes
+/// them: delete-and-recreate increments the generation so lineage surfaces
+/// can tell the old instance from the new one.
+///
+/// B3 wires this into `BranchOpEvent`, `BranchDagHook`, and the branch DAG
+/// keys; B2 only lands the type.
+pub type BranchGeneration = u64;
+
+/// Generation-aware branch identifier.
+///
+/// `BranchId` alone is the canonical storage/locking identity — same name =
+/// same physical KV namespace, regardless of lifecycle instance. `BranchRef`
+/// adds the per-name `generation` counter so ancestry, hooks, events, and
+/// the branch control overlay can distinguish between lifecycle instances
+/// of the same name.
+///
+/// Used by every surface that carries branch lineage post-B3: events,
+/// hooks, merge-base queries, DAG keys, control records. `BranchId` alone
+/// remains valid for storage isolation and for API inputs that address
+/// "whatever generation is currently live for this name."
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BranchRef {
+    /// Canonical id, derived via [`BranchId::from_user_name`].
+    pub id: BranchId,
+    /// Monotonic per-name lifecycle counter.
+    pub generation: BranchGeneration,
+}
+
+impl BranchRef {
+    /// Construct from an id and generation.
+    #[inline]
+    pub const fn new(id: BranchId, generation: BranchGeneration) -> Self {
+        Self { id, generation }
+    }
+}
+
+// =============================================================================
+// Lifecycle status
+// =============================================================================
+
+/// Canonical branch lifecycle status.
+///
+/// Replaces the three parallel `BranchStatus` enums that exist today in
+/// engine, executor, and core-branch-types. `Active` is writable, `Archived`
+/// is readable only, `Deleted` is neither writable nor treated as a live
+/// branch. Write-gate enforcement lands in B4.
+///
+/// The four-variant event-stream enum at
+/// `crates/core/src/branch_types.rs::BranchStatus` is distinct — it describes
+/// event-stream durability lifecycles and is renamed to
+/// `EventStreamLifecycleStatus` in a later epic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum BranchLifecycleStatus {
+    /// Writable. Reads and writes both proceed.
+    Active,
+    /// Readable, not writable. Mutating operations return `BranchArchived`.
+    Archived,
+    /// Not writable, not visible. Treated as branch-not-found.
+    Deleted,
+}
+
+impl BranchLifecycleStatus {
+    /// `true` iff mutation is allowed on a branch with this status.
+    #[inline]
+    pub const fn allows_writes(&self) -> bool {
+        matches!(self, Self::Active)
+    }
+
+    /// `true` iff the branch is visible to list/read surfaces.
+    /// `Deleted` is treated as branch-not-found.
+    #[inline]
+    pub const fn is_visible(&self) -> bool {
+        matches!(self, Self::Active | Self::Archived)
+    }
+}
+
+// =============================================================================
+// Control record minimum shape
+// =============================================================================
+
+/// Fork anchor: the parent branch and commit version a child was forked from.
+///
+/// Part of the `BranchControlRecord` minimum shape. The actual engine-owned
+/// control store lands in B3/B5; B2 freezes the record shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ForkAnchor {
+    /// The parent branch this one was forked from.
+    pub parent: BranchRef,
+    /// The parent commit the fork was taken at.
+    pub point: CommitVersion,
+}
+
+/// Minimum engine-owned branch control record shape.
+///
+/// This is the record the future `BranchControlStore` (B3/B5) holds as the
+/// authoritative per-branch control truth. B2 freezes the shape so later
+/// epics are execution work, not fresh schema design.
+///
+/// Fields:
+/// - `branch`: generation-aware identity of this lifecycle instance.
+/// - `name`: user-facing handle. Distinct from `branch.id`, which is the
+///   deterministic UUID derivation of the name.
+/// - `lifecycle`: canonical lifecycle status (B4 enforces it at the write gate).
+/// - `fork`: `None` for a root branch (e.g. `"default"`), `Some(_)` for a
+///   child forked from a parent at a specific commit version.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BranchControlRecord {
+    /// Generation-aware identity of this branch's lifecycle instance.
+    pub branch: BranchRef,
+    /// User-facing branch name.
+    pub name: String,
+    /// Canonical lifecycle status.
+    pub lifecycle: BranchLifecycleStatus,
+    /// Fork anchor, if this branch was forked from another.
+    pub fork: Option<ForkAnchor>,
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Locked baseline for the `BRANCH_NAMESPACE` bytes. Mirrors the B1
+    /// characterization test baseline in
+    /// `crates/engine/tests/branch_id_characterization.rs` and the
+    /// executor-side `B1_BRANCH_NAMESPACE_BYTES` in
+    /// `crates/executor/src/bridge.rs`. Any drift here is a BREAKING
+    /// compatibility change.
+    const LOCKED_NAMESPACE_BYTES: [u8; 16] = [
+        0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30,
+        0xc8,
+    ];
+
+    /// Hardcoded byte anchors for a subset of branch names. These MUST match
+    /// the engine and executor B1 anchor tables exactly — drift between any
+    /// of the three tables is a parity break.
+    const HARDCODED_ANCHORS: &[(&str, [u8; 16])] = &[
+        ("default", [0u8; 16]),
+        (
+            "main",
+            [
+                0x1f, 0x64, 0xc0, 0x67, 0xac, 0xf2, 0x50, 0x34, 0xa5, 0xd0, 0x92, 0xd5, 0x76, 0x41,
+                0x38, 0xec,
+            ],
+        ),
+        (
+            "_system_",
+            [
+                0x0d, 0x39, 0x06, 0xa0, 0xd8, 0x09, 0x58, 0x17, 0xb9, 0x0b, 0x09, 0xb6, 0x0e, 0x63,
+                0xc9, 0x7d,
+            ],
+        ),
+        (
+            "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            [
+                0xf4, 0x7a, 0xc1, 0x0b, 0x58, 0xcc, 0x43, 0x72, 0xa5, 0x67, 0x0e, 0x02, 0xb2, 0xc3,
+                0xd4, 0x79,
+            ],
+        ),
+    ];
+
+    #[test]
+    fn branch_namespace_bytes_are_locked() {
+        assert_eq!(
+            BRANCH_NAMESPACE.as_bytes(),
+            &LOCKED_NAMESPACE_BYTES,
+            "BRANCH_NAMESPACE drifted from the B1 locked baseline. This is a \
+             BREAKING compatibility change — it renames every branch in every \
+             existing database."
+        );
+    }
+
+    #[test]
+    fn from_user_name_default_is_nil_uuid() {
+        assert_eq!(*BranchId::from_user_name("default").as_bytes(), [0u8; 16]);
+    }
+
+    #[test]
+    fn from_user_name_default_sentinel_is_case_sensitive() {
+        let nil = [0u8; 16];
+        assert_eq!(*BranchId::from_user_name("default").as_bytes(), nil);
+        assert_ne!(*BranchId::from_user_name("DEFAULT").as_bytes(), nil);
+        assert_ne!(*BranchId::from_user_name("Default").as_bytes(), nil);
+    }
+
+    #[test]
+    fn from_user_name_matches_hardcoded_anchors() {
+        for &(name, expected) in HARDCODED_ANCHORS {
+            let actual = *BranchId::from_user_name(name).as_bytes();
+            assert_eq!(
+                actual, expected,
+                "BranchId::from_user_name({name:?}) drifted from its B1 hardcoded \
+                 anchor.\nexpected {expected:02x?}\nactual   {actual:02x?}"
+            );
+        }
+    }
+
+    #[test]
+    fn from_user_name_uuid_string_passes_through() {
+        let name = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
+        let expected = *Uuid::parse_str(name).unwrap().as_bytes();
+        assert_eq!(*BranchId::from_user_name(name).as_bytes(), expected);
+    }
+
+    #[test]
+    fn from_user_name_tolerates_uuid_case_and_hyphenation() {
+        let canonical = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
+        let upper = "F47AC10B-58CC-4372-A567-0E02B2C3D479";
+        let hyphenless = "f47ac10b58cc4372a5670e02b2c3d479";
+        let a = *BranchId::from_user_name(canonical).as_bytes();
+        let b = *BranchId::from_user_name(upper).as_bytes();
+        let c = *BranchId::from_user_name(hyphenless).as_bytes();
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+    }
+
+    #[test]
+    fn from_user_name_is_deterministic() {
+        let a = *BranchId::from_user_name("feature/stability").as_bytes();
+        let b = *BranchId::from_user_name("feature/stability").as_bytes();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn from_user_name_distinct_inputs_produce_distinct_ids() {
+        let a = *BranchId::from_user_name("main").as_bytes();
+        let b = *BranchId::from_user_name("production").as_bytes();
+        let c = *BranchId::from_user_name("feature/abc").as_bytes();
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(b, c);
+    }
+
+    #[test]
+    fn from_user_name_empty_string_resolves_via_v5() {
+        let expected = *Uuid::new_v5(&BRANCH_NAMESPACE, b"").as_bytes();
+        let actual = *BranchId::from_user_name("").as_bytes();
+        assert_eq!(actual, expected);
+        assert_ne!(actual, [0u8; 16]);
+    }
+
+    #[test]
+    fn branch_ref_round_trips_through_serde() {
+        let id = BranchId::from_user_name("feature/serde");
+        let original = BranchRef::new(id, 7);
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: BranchRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, original);
+        assert_eq!(restored.generation, 7);
+    }
+
+    #[test]
+    fn branch_lifecycle_status_allows_writes_only_when_active() {
+        assert!(BranchLifecycleStatus::Active.allows_writes());
+        assert!(!BranchLifecycleStatus::Archived.allows_writes());
+        assert!(!BranchLifecycleStatus::Deleted.allows_writes());
+    }
+
+    #[test]
+    fn branch_lifecycle_status_is_visible_hides_deleted() {
+        assert!(BranchLifecycleStatus::Active.is_visible());
+        assert!(BranchLifecycleStatus::Archived.is_visible());
+        assert!(!BranchLifecycleStatus::Deleted.is_visible());
+    }
+
+    #[test]
+    fn branch_lifecycle_status_round_trips_through_serde() {
+        for s in [
+            BranchLifecycleStatus::Active,
+            BranchLifecycleStatus::Archived,
+            BranchLifecycleStatus::Deleted,
+        ] {
+            let json = serde_json::to_string(&s).unwrap();
+            let restored: BranchLifecycleStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(restored, s);
+        }
+    }
+
+    #[test]
+    fn fork_anchor_round_trips_through_serde() {
+        let anchor = ForkAnchor {
+            parent: BranchRef::new(BranchId::from_user_name("main"), 0),
+            point: CommitVersion(42),
+        };
+        let json = serde_json::to_string(&anchor).unwrap();
+        let restored: ForkAnchor = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, anchor);
+    }
+
+    #[test]
+    fn branch_control_record_round_trips_through_serde() {
+        let record = BranchControlRecord {
+            branch: BranchRef::new(BranchId::from_user_name("feature/x"), 1),
+            name: "feature/x".to_string(),
+            lifecycle: BranchLifecycleStatus::Active,
+            fork: Some(ForkAnchor {
+                parent: BranchRef::new(BranchId::from_user_name("main"), 0),
+                point: CommitVersion(100),
+            }),
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        let restored: BranchControlRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, record);
+    }
+
+    #[test]
+    fn branch_control_record_root_branch_has_no_fork() {
+        let record = BranchControlRecord {
+            branch: BranchRef::new(BranchId::from_user_name("default"), 0),
+            name: "default".to_string(),
+            lifecycle: BranchLifecycleStatus::Active,
+            fork: None,
+        };
+        assert!(record.fork.is_none());
+        let json = serde_json::to_string(&record).unwrap();
+        let restored: BranchControlRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, record);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,6 +12,7 @@
 //! - Contract types: EntityRef, Versioned<T>, Version, Timestamp, PrimitiveType, BranchName
 
 // Module declarations
+pub mod branch; // Canonical branch-truth types (B2)
 pub mod branch_dag; // Branch DAG types and constants
 pub mod branch_types; // Branch lifecycle types
 pub mod contract; // contract types
@@ -23,6 +24,11 @@ pub mod primitives; // primitive types (Event, Vector, JSON types)
 pub mod traits;
 pub mod types;
 pub mod value;
+
+// Re-export canonical branch-truth types at crate root.
+pub use branch::{
+    BranchControlRecord, BranchGeneration, BranchLifecycleStatus, BranchRef, ForkAnchor,
+};
 
 // Re-export commonly used types and traits
 pub use branch_types::{BranchEventOffsets, BranchMetadata, BranchStatus};

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -11,16 +11,25 @@ use std::fmt;
 use std::sync::Arc;
 use uuid::Uuid;
 
-/// Unique identifier for an agent branch
+/// Unique identifier for a branch storage namespace.
 ///
-/// A BranchId is a wrapper around a UUID v4, providing unique identification
-/// for each agent execution branch. BranchIds are used throughout the system
-/// to scope data and enable branch-specific queries.
+/// `BranchId` is an opaque UUID wrapper used throughout the system for storage
+/// isolation, locking, and branch-scoped queries.
+///
+/// For user-facing branch names, the canonical mapping is
+/// [`BranchId::from_user_name`], which derives deterministic ids for normal
+/// names and preserves a few load-bearing sentinel cases. [`BranchId::new`] is
+/// still valid for synthetic or test-only ids, but it is not the canonical path
+/// for user-facing branch creation after B2.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct BranchId(Uuid);
 
 impl BranchId {
-    /// Create a new random BranchId using UUID v4
+    /// Create a new random `BranchId` using UUID v4.
+    ///
+    /// Use this for synthetic/internal ids and tests. User-facing branch names
+    /// should normally go through [`BranchId::from_user_name`] so the branch
+    /// namespace remains deterministic across engine and executor.
     pub fn new() -> Self {
         Self(Uuid::new_v4())
     }

--- a/crates/engine/src/database/branch_service.rs
+++ b/crates/engine/src/database/branch_service.rs
@@ -33,7 +33,9 @@ use crate::database::branch_mutation::BranchMutation;
 use crate::database::dag_hook::{BranchDagError, DagEvent, DagHookSlot, MergeBaseResult};
 use crate::database::observers::{BranchOpEvent, BranchOpKind};
 use crate::database::Database;
-use crate::primitives::branch::{resolve_branch_name, BranchIndex, BranchMetadata};
+use crate::primitives::branch::{
+    aliases_default_branch_sentinel, resolve_branch_name, BranchIndex, BranchMetadata,
+};
 use crate::primitives::event::EventLog;
 use crate::SYSTEM_BRANCH;
 
@@ -155,6 +157,12 @@ fn validate_branch_name(name: &str) -> StrataResult<()> {
     if name.chars().any(|c| c.is_control()) {
         return Err(StrataError::invalid_input(
             "branch name cannot contain control characters",
+        ));
+    }
+
+    if aliases_default_branch_sentinel(name) {
+        return Err(StrataError::invalid_input(
+            "branch name aliases reserved default-branch sentinel",
         ));
     }
 
@@ -922,6 +930,7 @@ mod tests {
         assert!(validate_branch_name("feature-x").is_ok());
         assert!(validate_branch_name("feature/foo").is_ok());
         assert!(validate_branch_name("a").is_ok());
+        assert!(validate_branch_name("f47ac10b-58cc-4372-a567-0e02b2c3d479").is_ok());
 
         // Invalid: empty
         assert!(validate_branch_name("").is_err());
@@ -941,6 +950,25 @@ mod tests {
         // Invalid: control characters
         assert!(validate_branch_name("foo\nbar").is_err());
         assert!(validate_branch_name("foo\x00bar").is_err());
+
+        // Invalid: aliases the load-bearing default-branch nil UUID sentinel.
+        assert!(validate_branch_name("00000000-0000-0000-0000-000000000000").is_err());
+        assert!(validate_branch_name("00000000000000000000000000000000").is_err());
+        let upper_nil = "00000000-0000-0000-0000-000000000000".to_uppercase();
+        assert!(validate_branch_name(&upper_nil).is_err());
+    }
+
+    #[test]
+    fn test_create_rejects_default_branch_nil_uuid_alias() {
+        let db = Database::cache().unwrap();
+        let err = db
+            .branches()
+            .create("00000000-0000-0000-0000-000000000000")
+            .unwrap_err();
+        assert!(matches!(err, StrataError::InvalidInput { .. }));
+        assert!(err
+            .to_string()
+            .contains("aliases reserved default-branch sentinel"));
     }
 
     #[test]

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -1145,21 +1145,23 @@ impl Database {
                     Self::validate_requested_config_reuse(&db, requested_cfg)?;
                 }
                 Self::validate_control_artifact_reuse(&db, &config_path)?;
+                crate::primitives::branch::validate_reserved_branch_aliases(&db)?;
                 Ok(db)
             }
             AcquiredDatabase::New { db, canonical_path } => {
-                let effective_default_branch =
-                    Self::resolve_effective_default_branch(&db, default_branch.clone())?;
-                let effective_signature = CompatibilitySignature::from_spec(
-                    super::spec::DatabaseMode::Primary,
-                    subsystem_names,
-                    durability_mode,
-                    codec_name,
-                    effective_default_branch.clone(),
-                    background_threads,
-                    allow_lossy_recovery,
-                );
                 Self::finish_opened_db(db, &canonical_path, move |db| {
+                    crate::primitives::branch::validate_reserved_branch_aliases(db)?;
+                    let effective_default_branch =
+                        Self::resolve_effective_default_branch(db, default_branch.clone())?;
+                    let effective_signature = CompatibilitySignature::from_spec(
+                        super::spec::DatabaseMode::Primary,
+                        subsystem_names,
+                        durability_mode,
+                        codec_name,
+                        effective_default_branch.clone(),
+                        background_threads,
+                        allow_lossy_recovery,
+                    );
                     db.set_runtime_signature(effective_signature);
                     // Write the *sanitized* resolved_cfg, not the original config.
                     // This ensures persisted config matches runtime state (e.g.,
@@ -1267,6 +1269,7 @@ impl Database {
             );
         }
 
+        crate::primitives::branch::validate_reserved_branch_aliases(&db)?;
         let effective_default_branch =
             Self::resolve_effective_default_branch(&db, requested_signature.default_branch)?;
         let effective_signature = CompatibilitySignature::from_spec(
@@ -1342,6 +1345,7 @@ impl Database {
 
         // Run lifecycle hooks (initialize and bootstrap)
         Self::run_lifecycle_hooks(&db, true)?;
+        crate::primitives::branch::validate_reserved_branch_aliases(&db)?;
 
         // Ensure default branch if specified
         if let Some(branch_name) = &default_branch {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -141,5 +141,11 @@ pub use strata_core::branch_dag::{
     BRANCH_DAG_GRAPH, SYSTEM_BRANCH,
 };
 
+// Re-export canonical branch-truth types (B2). `BranchId::from_user_name`
+// lives on the `BranchId` inherent impl and is reachable via `strata_core`.
+pub use strata_core::{
+    BranchControlRecord, BranchGeneration, BranchLifecycleStatus, BranchRef, ForkAnchor,
+};
+
 #[cfg(feature = "perf-trace")]
 pub use instrumentation::{PerfBreakdown, PerfStats};

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -45,6 +45,55 @@ pub fn resolve_branch_name(name: &str) -> BranchId {
     BranchId::from_user_name(name)
 }
 
+/// `true` if `name` resolves to the nil-UUID default-branch sentinel without
+/// being the literal `"default"` branch name.
+///
+/// These aliases are forbidden at user-facing boundaries because they collide
+/// with the reserved nil-UUID branch sentinel used by the literal `"default"`
+/// branch and branch-control paths.
+pub(crate) fn aliases_default_branch_sentinel(name: &str) -> bool {
+    strata_core::branch::aliases_default_branch_sentinel(name)
+}
+
+/// Reject persisted branch-control artifacts that still address the reserved
+/// nil-UUID branch sentinel by a non-literal alias.
+///
+/// This quarantines historical bad state from older builds before branch
+/// operations can resolve the alias back to the nil UUID and touch the wrong
+/// namespace during open/reopen. Runs on primary, follower, and cache
+/// open paths, so scans go through the read-only storage surface rather
+/// than `db.transaction()` (followers cannot commit).
+pub(crate) fn validate_reserved_branch_aliases(db: &Arc<Database>) -> StrataResult<()> {
+    if let Some(name) = read_default_branch_marker(db.as_ref())? {
+        if aliases_default_branch_sentinel(&name) {
+            return Err(StrataError::corruption(format!(
+                "persisted default branch marker uses reserved default-branch sentinel alias '{name}'"
+            )));
+        }
+    }
+
+    let prefix = Key::new_branch_with_id(global_namespace(), "");
+    let rows = db.storage().scan_prefix(&prefix, CommitVersion::MAX)?;
+    for (key, _) in rows {
+        let Ok(name) = String::from_utf8(key.user_key.to_vec()) else {
+            continue;
+        };
+        if name.contains("__idx_")
+            || name == DEFAULT_BRANCH_MARKER_KEY
+            || strata_core::branch_dag::is_system_branch(&name)
+        {
+            continue;
+        }
+        if aliases_default_branch_sentinel(&name) {
+            return Err(StrataError::corruption(format!(
+                "branch metadata contains reserved default-branch sentinel alias '{name}'"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 // ========== Global Branch ID for BranchIndex Operations ==========
 
 /// Get the global BranchId used for BranchIndex operations
@@ -267,6 +316,12 @@ impl BranchIndex {
     /// ## Errors
     /// - `InvalidInput` if branch already exists
     pub(crate) fn create_branch(&self, branch_id: &str) -> StrataResult<Versioned<BranchMetadata>> {
+        if aliases_default_branch_sentinel(branch_id) {
+            return Err(StrataError::invalid_input(
+                "branch name aliases reserved default-branch sentinel",
+            ));
+        }
+
         let result = self.db.transaction(global_branch_id(), |txn| {
             let key = self.key_for(branch_id);
 
@@ -556,6 +611,55 @@ mod tests {
         ri.create_branch("test-run").unwrap();
         let result = ri.create_branch("test-run");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_create_branch_rejects_default_branch_nil_uuid_alias() {
+        let (_temp, _db, ri) = setup();
+
+        let err = ri
+            .create_branch("00000000-0000-0000-0000-000000000000")
+            .unwrap_err();
+        assert!(matches!(err, StrataError::InvalidInput { .. }));
+        assert!(err
+            .to_string()
+            .contains("aliases reserved default-branch sentinel"));
+    }
+
+    #[test]
+    fn test_validate_reserved_branch_aliases_rejects_historical_branch_metadata() {
+        let (_temp, _db, ri) = setup();
+        let bad_name = "00000000-0000-0000-0000-000000000000";
+
+        ri.db
+            .transaction(global_branch_id(), |txn| {
+                txn.put(
+                    ri.key_for(bad_name),
+                    to_stored_value(&BranchMetadata::new(bad_name))?,
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        let err = validate_reserved_branch_aliases(&ri.db).unwrap_err();
+        assert!(matches!(err, StrataError::Corruption { .. }));
+        assert!(err
+            .to_string()
+            .contains("branch metadata contains reserved default-branch sentinel alias"));
+    }
+
+    #[test]
+    fn test_validate_reserved_branch_aliases_rejects_historical_default_marker() {
+        let (_temp, _db, ri) = setup();
+        let bad_name = "00000000-0000-0000-0000-000000000000";
+
+        write_default_branch_marker(&ri.db, bad_name).unwrap();
+
+        let err = validate_reserved_branch_aliases(&ri.db).unwrap_err();
+        assert!(matches!(err, StrataError::Corruption { .. }));
+        assert!(err.to_string().contains(
+            "persisted default branch marker uses reserved default-branch sentinel alias"
+        ));
     }
 
     #[test]

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -29,33 +29,20 @@ use strata_core::value::Value;
 use strata_core::StrataError;
 use strata_core::StrataResult;
 use tracing::{info, warn};
-use uuid::Uuid;
-
-/// Namespace UUID for generating deterministic branch IDs from names.
-/// Must match the executor's BRANCH_NAMESPACE for consistency.
-const BRANCH_NAMESPACE: Uuid = Uuid::from_bytes([
-    0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8,
-]);
 
 /// Internal metadata key storing the effective default branch name for
 /// disk-backed databases. This lets follower and reopened primary handles
 /// recover branch semantics across process boundaries.
 const DEFAULT_BRANCH_MARKER_KEY: &str = "__default_branch__";
 
-/// Resolve a branch name to a core BranchId using the same logic as the executor.
+/// Resolve a branch name to a core `BranchId`.
 ///
-/// - "default" → nil UUID (all zeros)
-/// - Valid UUID string → parsed directly
-/// - Any other string → deterministic UUID v5 from name
+/// Passthrough to the canonical [`BranchId::from_user_name`] in
+/// `strata_core::branch` (B2 collapsed the duplicated engine/executor
+/// derivations). Kept as a free function so existing engine call sites
+/// read unchanged.
 pub fn resolve_branch_name(name: &str) -> BranchId {
-    if name == "default" {
-        BranchId::from_bytes([0u8; 16])
-    } else if let Ok(u) = Uuid::parse_str(name) {
-        BranchId::from_bytes(*u.as_bytes())
-    } else {
-        let uuid = Uuid::new_v5(&BRANCH_NAMESPACE, name.as_bytes());
-        BranchId::from_bytes(*uuid.as_bytes())
-    }
+    BranchId::from_user_name(name)
 }
 
 // ========== Global Branch ID for BranchIndex Operations ==========

--- a/crates/engine/src/primitives/branch/mod.rs
+++ b/crates/engine/src/primitives/branch/mod.rs
@@ -8,5 +8,8 @@ mod handle;
 mod index;
 
 pub use handle::{BranchHandle, EventHandle, JsonHandle, KvHandle};
-pub(crate) use index::{read_default_branch_marker, write_default_branch_marker, BranchIndex};
+pub(crate) use index::{
+    aliases_default_branch_sentinel, read_default_branch_marker, validate_reserved_branch_aliases,
+    write_default_branch_marker, BranchIndex,
+};
 pub use index::{resolve_branch_name, BranchMetadata, BranchStatus};

--- a/crates/engine/tests/branch_id_characterization.rs
+++ b/crates/engine/tests/branch_id_characterization.rs
@@ -18,7 +18,13 @@
 //! `crates/executor/src/bridge.rs` (mod tests) because `to_core_branch_id`
 //! is `pub(crate)`.
 
-use strata_engine::primitives::resolve_branch_name;
+use std::sync::Arc;
+
+use strata_core::types::{BranchId, Key, Namespace};
+use strata_core::Value;
+use strata_engine::database::OpenSpec;
+use strata_engine::primitives::{resolve_branch_name, BranchMetadata};
+use strata_engine::{Database, SearchSubsystem};
 use uuid::Uuid;
 
 /// The RFC 4122 namespace UUID used to derive branch IDs from names.
@@ -258,4 +264,40 @@ fn engine_empty_string_resolves_to_v5_of_empty_input() {
     assert_eq!(actual, expected);
     // Empty MUST NOT collide with the default sentinel.
     assert_ne!(actual, [0u8; 16]);
+}
+
+/// Historical nil-UUID alias branch metadata must be quarantined on reopen
+/// before branch resolution can silently map it back onto the reserved nil
+/// sentinel namespace.
+#[test]
+fn engine_reopen_rejects_historical_default_branch_nil_uuid_alias_metadata() {
+    let temp = tempfile::tempdir().unwrap();
+    let db = Database::open_runtime(OpenSpec::primary(temp.path()).with_subsystem(SearchSubsystem))
+        .unwrap();
+
+    let bad_name = "00000000-0000-0000-0000-000000000000";
+    let nil_branch = BranchId::from_bytes([0u8; 16]);
+    let namespace = Arc::new(Namespace::for_branch(nil_branch));
+    let key = Key::new_branch_with_id(namespace, bad_name);
+    let bad_meta = BranchMetadata::new(bad_name);
+    let stored = serde_json::to_string(&bad_meta).unwrap();
+
+    db.transaction(nil_branch, |txn| {
+        txn.put(key.clone(), Value::String(stored.clone()))?;
+        Ok(())
+    })
+    .unwrap();
+    db.shutdown().unwrap();
+    drop(db);
+
+    let err = match Database::open_runtime(
+        OpenSpec::primary(temp.path()).with_subsystem(SearchSubsystem),
+    ) {
+        Ok(_) => panic!("reopen should reject historical nil-UUID alias metadata"),
+        Err(err) => err,
+    };
+    assert!(matches!(err, strata_core::StrataError::Corruption { .. }));
+    assert!(err
+        .to_string()
+        .contains("branch metadata contains reserved default-branch sentinel alias"));
 }

--- a/crates/executor/src/bridge.rs
+++ b/crates/executor/src/bridge.rs
@@ -76,12 +76,20 @@ impl Primitives {
 /// derivation. The algorithm is identical to the pre-B2 inline body:
 ///
 /// - `"default"` → nil UUID (all zeros)
-/// - Valid UUID string → parsed UUID bytes
+/// - Valid UUID string → parsed UUID bytes, except the reserved nil-UUID
+///   default-branch alias which is rejected as invalid input
 /// - Any other string → deterministic UUID-v5 over the canonical namespace
 ///
 /// This is the executor's adapter from user-facing branch names to the
 /// engine's canonical [`strata_core::types::BranchId`].
 pub fn to_core_branch_id(branch: &BranchId) -> crate::Result<strata_core::types::BranchId> {
+    if strata_core::branch::aliases_default_branch_sentinel(branch.as_str()) {
+        return Err(StrataError::invalid_input(
+            "branch name aliases reserved default-branch sentinel",
+        )
+        .into());
+    }
+
     Ok(strata_core::types::BranchId::from_user_name(
         branch.as_str(),
     ))
@@ -621,6 +629,22 @@ mod tests {
                  executor {executor:02x?}\n\
                  engine   {engine:02x?}"
             );
+        }
+    }
+
+    #[test]
+    fn b2_executor_to_core_branch_id_rejects_reserved_default_branch_aliases() {
+        for name in [
+            "00000000-0000-0000-0000-000000000000",
+            "00000000000000000000000000000000",
+            "00000000-0000-0000-0000-000000000000"
+                .to_uppercase()
+                .as_str(),
+        ] {
+            let err = to_core_branch_id(&BranchId::from(name)).unwrap_err();
+            assert!(err
+                .to_string()
+                .contains("aliases reserved default-branch sentinel"));
         }
     }
 }

--- a/crates/executor/src/bridge.rs
+++ b/crates/executor/src/bridge.rs
@@ -70,32 +70,21 @@ impl Primitives {
 // BranchId Conversion
 // =============================================================================
 
-/// Namespace UUID for generating deterministic branch IDs.
-/// This is a fixed UUID used as the namespace for UUID v5 generation.
-const BRANCH_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([
-    0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8,
-]);
-
 /// Convert executor's string-based BranchId to core BranchId.
 ///
-/// - "default" → `BranchId` with UUID::nil (all zeros)
-/// - Valid UUID string → `BranchId` with parsed UUID bytes
-/// - Any other string → `BranchId` with deterministic UUID v5 generated from name
+/// Delegates to the canonical [`strata_core::BranchId::from_user_name`]
+/// derivation. The algorithm is identical to the pre-B2 inline body:
 ///
-/// This allows users to use human-readable branch names like "main", "experiment-1",
-/// etc. while still providing a unique UUID for internal namespacing.
+/// - `"default"` → nil UUID (all zeros)
+/// - Valid UUID string → parsed UUID bytes
+/// - Any other string → deterministic UUID-v5 over the canonical namespace
+///
+/// This is the executor's adapter from user-facing branch names to the
+/// engine's canonical [`strata_core::types::BranchId`].
 pub fn to_core_branch_id(branch: &BranchId) -> crate::Result<strata_core::types::BranchId> {
-    let s = branch.as_str();
-    if s == "default" {
-        Ok(strata_core::types::BranchId::from_bytes([0u8; 16]))
-    } else if let Ok(u) = uuid::Uuid::parse_str(s) {
-        // If it's already a valid UUID, use it directly
-        Ok(strata_core::types::BranchId::from_bytes(*u.as_bytes()))
-    } else {
-        // Generate a deterministic UUID v5 from the branch name
-        let uuid = uuid::Uuid::new_v5(&BRANCH_NAMESPACE, s.as_bytes());
-        Ok(strata_core::types::BranchId::from_bytes(*uuid.as_bytes()))
-    }
+    Ok(strata_core::types::BranchId::from_user_name(
+        branch.as_str(),
+    ))
 }
 
 // =============================================================================
@@ -500,20 +489,21 @@ mod tests {
     // B1 characterization: byte-stable executor → core BranchId derivation.
     //
     // Companion to crates/engine/tests/branch_id_characterization.rs (which
-    // locks the engine path). These tests pin the EXECUTOR side of the
-    // currently-duplicated derivation. B2 will collapse both into one
-    // canonical `BranchId::from_user_name` in `strata_core`. Until then,
-    // executor and engine MUST agree byte-for-byte; these anchors are the
-    // shared ground truth.
+    // locks the engine path) and to crates/core/src/branch.rs tests (which
+    // lock the canonical core derivation). These tests pin the EXECUTOR
+    // path. After B2, all three share the one canonical derivation in
+    // `strata_core::BranchId::from_user_name`, but the executor keeps its
+    // own anchor table so the "both local anchor tables changed together"
+    // regression hole stays closed.
     //
     // Keep the LOCKED_INPUTS / HARDCODED_ANCHORS arrays IDENTICAL to the
     // engine-side test. Drift between the two is a parity break.
     // =========================================================================
 
-    /// Locked baseline for the BRANCH_NAMESPACE constant. Mirrors
-    /// `BRANCH_NAMESPACE` defined at the top of this file (line 75) and the
-    /// engine-side `BRANCH_NAMESPACE` at
-    /// `crates/engine/src/primitives/branch/index.rs:36`.
+    /// Locked baseline for the branch-namespace constant, mirroring the
+    /// `BRANCH_NAMESPACE` bytes in `strata_core::branch` and the engine-side
+    /// anchors in `crates/engine/tests/branch_id_characterization.rs`. Drift
+    /// here is a BREAKING compatibility change.
     const B1_BRANCH_NAMESPACE_BYTES: [u8; 16] = [
         0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30,
         0xc8,
@@ -575,18 +565,29 @@ mod tests {
         }
     }
 
+    /// The canonical namespace lives in `strata_core::branch` as of B2.
+    /// This test locks the executor path end-to-end against the B1 bytes:
+    /// any drift in the core namespace constant, the v5 input ordering, or
+    /// the executor's call into `BranchId::from_user_name` is caught here.
     #[test]
-    fn b1_executor_branch_namespace_constant_is_locked() {
+    fn b1_executor_branch_namespace_is_locked_in_core() {
+        let sample = "b1-executor-namespace-sample";
+        let ns = uuid::Uuid::from_bytes(B1_BRANCH_NAMESPACE_BYTES);
+        let expected = *uuid::Uuid::new_v5(&ns, sample.as_bytes()).as_bytes();
+        let actual = *to_core_branch_id(&BranchId::from(sample))
+            .unwrap()
+            .as_bytes();
         assert_eq!(
-            BRANCH_NAMESPACE.as_bytes(),
-            &B1_BRANCH_NAMESPACE_BYTES,
-            "Executor BRANCH_NAMESPACE drifted from the locked B1 baseline.\n\
-             This is a BREAKING compatibility change."
+            actual, expected,
+            "Executor path drifted from the locked B1 BRANCH_NAMESPACE \
+             bytes. The canonical constant now lives in `strata_core::branch` \
+             — this failure means the core namespace changed. BREAKING \
+             compatibility change."
         );
     }
 
     /// Cross-implementation parity oracle: `to_core_branch_id` MUST match
-    /// the documented algorithm (see bridge.rs:79-99) byte-for-byte.
+    /// the documented algorithm byte-for-byte.
     #[test]
     fn b1_executor_to_core_branch_id_matches_documented_algorithm() {
         for &name in B1_LOCKED_INPUTS {

--- a/tests/integration/branching_guardrails.rs
+++ b/tests/integration/branching_guardrails.rs
@@ -25,10 +25,9 @@
 //!
 //! ## What's tracked today
 //!
-//! - `BRANCH_NAMESPACE` const sites — duplicated in
-//!   `crates/engine/src/primitives/branch/index.rs` and
-//!   `crates/executor/src/bridge.rs`. B2 collapses to one canonical
-//!   `BranchId::from_user_name` in `strata_core`.
+//! - `BRANCH_NAMESPACE` const sites — collapsed by B2 to the single
+//!   canonical declaration in `crates/core/src/branch.rs`. The guardrail
+//!   is kept (value = 1) so any future second site is caught immediately.
 //! - `merge_base_override` occurrences — the executor → engine override
 //!   plumbing B3 removes when lineage moves into `BranchControlStore`.
 //! - `MergeStrategy::LastWriterWins` literals — B5 renames to a name
@@ -66,8 +65,10 @@ const LOCKED_PATTERNS: &[Pattern] = &[
         // Trailing `:` so we match only `const BRANCH_NAMESPACE: <ty> = ...`
         // declarations, not test fixtures named `BRANCH_NAMESPACE_BYTES`.
         needle: "const BRANCH_NAMESPACE:",
-        rationale: "B2 will collapse the duplicated BRANCH_NAMESPACE consts \
-                    (engine + executor) into one canonical derivation in strata_core.",
+        rationale: "B2 collapsed the duplicated BRANCH_NAMESPACE consts \
+                    (engine + executor) into one canonical declaration in \
+                    strata_core::branch. The floor of 1 catches any \
+                    regression that would reintroduce a second site.",
     },
     Pattern {
         snapshot_key: "merge_base_override_occurrences",

--- a/tests/integration/data/branching_transitional_shapes.json
+++ b/tests/integration/data/branching_transitional_shapes.json
@@ -3,7 +3,7 @@
   "description": "Locked counts of branching transitional shapes. See tests/integration/branching_guardrails.rs for what each key tracks and why.",
   "shapes": {
     "branch_id_random_new_sites": 722,
-    "branch_namespace_const_sites": 2,
+    "branch_namespace_const_sites": 1,
     "merge_base_override_occurrences": 12,
     "merge_strategy_lastwriterwins_literals": 75
   }


### PR DESCRIPTION
## Summary

Epic **B2** of the branching execution plan
(`docs/design/branching/branching-execution-plan.md`). Collapses the two
duplicated `const BRANCH_NAMESPACE: Uuid` sites (engine + executor) into
one canonical `BranchId::from_user_name` in `strata_core::branch`, and
lands the generation-aware identity and lifecycle types later epics
(B3–B6) will consume. Production-surface cutover; B1 characterization
anchors pass byte-identically.

- **Change class:** cutover (removes duplicate const; routes both callers through core)
- **Assurance class:** S3 (byte-stable; anchor-locked by B1 characterization)
- **Stacked on:** B1 (#2446, merged)
- **Next epic:** B3 (canonical identity, generations, lineage authority)

## Commits in this PR

1. **`0582e1d2` — initial B2 implementation:** core types, engine/executor cutover, D4 surface amendment, guardrail snapshot bump 2→1.
2. **`aaa856ed` — fix-ups:** close the nil-UUID default-branch alias gap (`"00000000-0000-0000-0000-000000000000"` + hyphenless/uppercase variants resolve onto the reserved nil sentinel via the UUID-parse passthrough); add follower-safe storage-direct scan so the new open-time quarantine doesn't break follower mode.

## Authority map (published in `crates/core/src/branch.rs` module docs)

- Branch **control truth** = engine-owned control records
  (`BranchControlRecord` minimum shape lands in this PR; the
  `BranchControlStore` itself is B3/B5).
- `_branch_dag` = derived lineage projection, **not** a competing authority.
- Storage **fork info** (inherited layers, fork manifests, refcounts) =
  execution truth for CoW, not branch-control or lineage truth.

## What's in this PR

### New canonical types in `strata_core::branch`
- `impl BranchId { pub fn from_user_name(&str) -> Self }` — the only code
  path in the workspace that performs branch name → UUID derivation.
- `BranchGeneration = u64` — monotonic per-name lifecycle counter.
- `BranchRef { id: BranchId, generation: BranchGeneration }` — generation-aware
  identity. B3 wires it into `BranchOpEvent`/`BranchDagHook`/DAG keys;
  B2 only lands the type.
- `BranchLifecycleStatus { Active, Archived, Deleted }` (`#[non_exhaustive]`,
  with `allows_writes()`/`is_visible()` helpers). Write-gate enforcement
  is B4.
- `ForkAnchor { parent: BranchRef, point: CommitVersion }`
- `BranchControlRecord { branch, name, lifecycle, fork }` — minimum
  engine-owned control-record shape.
- `aliases_default_branch_sentinel(&str) -> bool` — detection primitive
  that returns `true` iff a name resolves to the nil UUID without being
  the literal `"default"`. Consumed by the three validation layers below.

### Production-surface cutover
- `crates/engine/src/primitives/branch/index.rs`: delete local
  `const BRANCH_NAMESPACE`; `resolve_branch_name` is a one-line
  passthrough to `BranchId::from_user_name`.
- `crates/executor/src/bridge.rs`: delete local `const BRANCH_NAMESPACE`;
  `to_core_branch_id` delegates to `BranchId::from_user_name`. Replace
  the const-lock test with a core-namespace-lock test that verifies the
  executor path end-to-end against the B1 bytes.

### Nil-UUID alias defense (added in the fix-up commit)
`BranchId::from_user_name` has a UUID-parse passthrough so synthetic
UUID-string ids round-trip without re-hashing. That same passthrough
accepts the nil UUID and its hyphenless/uppercase variants, which
alias onto the reserved nil-UUID namespace used by `"default"` and
global branch-index operations. Defense is applied at three layers:

- `BranchService::validate_branch_name` (engine `create` + `fork`
  destinations) → `StrataError::InvalidInput`.
- `BranchIndex::create_branch` (low-level primitive; belt-and-suspenders
  for any path that bypasses `BranchService`) → `InvalidInput`.
- `to_core_branch_id` (executor adapter; rejects aliases before even
  hitting the derivation) → `InvalidInput`.

Historical-data quarantine `validate_reserved_branch_aliases` runs on
every open path (primary-reuse, primary-new, follower, cache) before
default-branch resolution, so legacy databases containing the alias
fail fast with `StrataError::Corruption` instead of silently resolving
onto the wrong namespace. Scans go through
`db.storage().scan_prefix(...)` directly (same read-only pattern as
`read_default_branch_marker`) so follower-mode opens don't hit the
"cannot commit: database opened in follower mode" path.

### Guardrail snapshot bump
- `tests/integration/data/branching_transitional_shapes.json`:
  `branch_namespace_const_sites: 2 → 1` (intentional; expected per B1 plan
  section `branching-execution-plan.md:482-486`).

### D4 surface amendment (CLAUDE.md)
"Branch" allowed surface adds `BranchGeneration`, `ForkAnchor`,
`BranchControlRecord`, and annotates `BranchId` with the
`from_user_name` constructor.

## Explicitly out of scope (deferred to later epics)
- No `BranchMetadata.branch_id: String` migration (B3).
- No same-name recreate generation allocation (B3).
- No `_branch_dag` re-keying (B3).
- No lifecycle write-gate enforcement (B4).
- No retention / branch-aware GC / materialization contract (B5).
- Existing `BranchStatus` enums (engine, executor, core event-stream) are
  untouched. B3 retires the engine/executor stubs; B4 renames the core
  four-variant enum to `EventStreamLifecycleStatus`.

## Verification

- **17 `strata-core` `branch::tests`** unit tests (namespace bytes,
  anchor parity with B1, alias detection, serde round-trip for all new
  types).
- **11/11** engine `branch_id_characterization` tests pass, including
  the new `engine_reopen_rejects_historical_default_branch_nil_uuid_alias_metadata`
  end-to-end test (write bad metadata → shutdown → reopen → expect
  `Corruption`).
- **15/15** executor bridge tests pass, including
  `b2_executor_to_core_branch_id_rejects_reserved_default_branch_aliases`.
- **16/16** engine `primitives::branch` tests including the three new
  historical-data quarantine tests.
- **6/6** engine `database::branch_service` tests including the new
  create-rejects-alias test.
- **5887/5887** full `cargo test --workspace` across 57 test binaries.
- `cargo check --workspace` / `cargo fmt` clean.

## Engine invariant re-audit

All members of the minimum set
(`branch-truth-invariant-impact-matrix.md` Section 4) are **unchanged**
— the namespace byte value did not change; only the code location did,
plus the new alias quarantine is an additive safety check:

| Invariant | Method | Rationale |
|-----------|--------|-----------|
| `ARCH-003` (KV single source of truth) | unchanged | No storage touched; alias scan is read-only. |
| `ARCH-004` (one recovery model) | unchanged | No WAL/MANIFEST format edits. |
| `ACID-005` (recovery replay idempotent) | unchanged | Byte-identical derivation. Alias scan has no replay-visible effects. |
| `COW-005` (inherited-layer recovery ordering) | unchanged | No storage edits. |
| `ARCH-007` (manifest/WAL separate authority) | unchanged | N/A. |

## Test plan

- [x] Core branch module unit tests (`cargo test -p strata-core branch::tests`)
- [x] B1 engine characterization byte-identical (`cargo test -p strata-engine --test branch_id_characterization`)
- [x] B1 executor parity tests (`cargo test -p strata-executor --lib bridge::tests`)
- [x] B1 integration guardrail with bumped snapshot (`cargo test -p stratadb --test integration branching_guardrails`)
- [x] Full workspace tests (`cargo test --workspace` — 5887/5887)
- [x] `cargo check --workspace` / `cargo fmt --all -- --check` clean
- [ ] CI branch-latency regression smoke (algorithmic no-op; expected Δ ≈ 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
