### PR TITLE
B3.2: generation-safe branch write paths — create/delete/fork wired to BranchControlStore

### DIFF
--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 use strata_core::id::{CommitVersion, TxnId};
 use strata_core::primitives::json::{get_at_path, JsonPatch, JsonPath, JsonValue};
 use strata_core::traits::{Storage, WriteMode};
-use strata_core::types::{BranchId, Key};
+use strata_core::types::{BranchId, Key, TypeTag};
 use strata_core::value::Value;
 use strata_core::StrataError;
 use strata_core::StrataResult;
@@ -450,6 +450,26 @@ pub struct TransactionContext {
     pub txn_id: TxnId,
     /// Branch this transaction belongs to
     pub branch_id: BranchId,
+    /// Active branch generation observed when the transaction started.
+    ///
+    /// When present, commit rechecks that the branch still points at this
+    /// generation before applying writes. This prevents pre-delete
+    /// transactions on `foo@gen0` from committing into a freshly recreated
+    /// `foo@gen1` while the public transaction API is still keyed by
+    /// `BranchId` alone (B3.2).
+    pub branch_generation_guard: Option<u64>,
+    /// Snapshot key for the active-generation pointer row that backs
+    /// `branch_generation_guard`.
+    ///
+    /// For ordinary branches this is seeded into `read_set` at BEGIN.
+    /// For the nil-UUID `"default"` branch it is armed lazily only when the
+    /// transaction touches branch data, so internal global-metadata traffic
+    /// on the same nil namespace is not spuriously coupled to default-branch
+    /// lifecycle churn.
+    branch_generation_guard_key: Option<Key>,
+    /// Whether the active-generation pointer row has been seeded into
+    /// `read_set` for OCC validation.
+    branch_generation_guard_seeded: bool,
 
     // Snapshot isolation
     /// Version at transaction start (snapshot version)
@@ -583,6 +603,9 @@ impl TransactionContext {
         TransactionContext {
             txn_id,
             branch_id,
+            branch_generation_guard: None,
+            branch_generation_guard_key: None,
+            branch_generation_guard_seeded: false,
             start_version,
             store: None,
             read_set: HashMap::new(),
@@ -633,6 +656,9 @@ impl TransactionContext {
         TransactionContext {
             txn_id,
             branch_id,
+            branch_generation_guard: None,
+            branch_generation_guard_key: None,
+            branch_generation_guard_seeded: false,
             start_version,
             store: Some(store),
             read_set: HashMap::new(),
@@ -916,6 +942,22 @@ impl TransactionContext {
     /// and read-set tracking is skipped, saving memory on large scans.
     pub fn set_read_only(&mut self, read_only: bool) {
         self.read_only = read_only;
+    }
+
+    /// Pin the active generation this transaction is allowed to write to.
+    pub fn set_branch_generation_guard(&mut self, generation: Option<u64>) {
+        self.branch_generation_guard = generation;
+    }
+
+    /// Register the snapshot key used to validate the active generation row.
+    pub fn set_branch_generation_guard_key(&mut self, key: Option<Key>, seeded: bool) {
+        self.branch_generation_guard_key = key;
+        self.branch_generation_guard_seeded = seeded;
+    }
+
+    /// `true` iff the lifecycle guard row has been seeded into `read_set`.
+    pub fn branch_generation_guard_is_seeded(&self) -> bool {
+        self.branch_generation_guard_seeded
     }
 
     /// Allow operations on keys whose branch_id differs from this transaction's.
@@ -1447,9 +1489,42 @@ impl TransactionContext {
 
     /// Common pre-operation guard: verify the transaction is active and the key
     /// belongs to this transaction's branch.
-    fn guard(&self, key: &Key) -> StrataResult<()> {
+    fn guard(&mut self, key: &Key) -> StrataResult<()> {
         self.ensure_active()?;
+        self.maybe_seed_branch_generation_read_guard(key)?;
         self.enforce_branch_scope(key)
+    }
+
+    fn maybe_seed_branch_generation_read_guard(&mut self, key: &Key) -> StrataResult<()> {
+        if self.read_only
+            || self.branch_generation_guard.is_none()
+            || self.branch_generation_guard_seeded
+        {
+            return Ok(());
+        }
+
+        let Some(guard_key) = self.branch_generation_guard_key.clone() else {
+            return Ok(());
+        };
+
+        let nil_branch = BranchId::from_bytes([0u8; 16]);
+        if self.branch_id == nil_branch
+            && (self.allow_cross_branch || key.type_tag == TypeTag::Branch)
+        {
+            return Ok(());
+        }
+
+        let Some(store) = self.store.as_ref() else {
+            return Ok(());
+        };
+
+        let version = store
+            .get_versioned(&guard_key, self.start_version)?
+            .map(|entry| CommitVersion(entry.version.as_u64()))
+            .unwrap_or(CommitVersion::ZERO);
+        self.read_set.insert(guard_key, version);
+        self.branch_generation_guard_seeded = true;
+        Ok(())
     }
 
     /// Reject if the same key already has a CAS operation in this transaction.
@@ -1867,6 +1942,9 @@ impl TransactionContext {
         // Update identity
         self.txn_id = txn_id;
         self.branch_id = branch_id;
+        self.branch_generation_guard = None;
+        self.branch_generation_guard_key = None;
+        self.branch_generation_guard_seeded = false;
 
         // Update store and version
         self.start_version = store

--- a/crates/engine/src/branch_ops/branch_control_store.rs
+++ b/crates/engine/src/branch_ops/branch_control_store.rs
@@ -757,6 +757,37 @@ impl BranchControlStore {
         self.synthesize_from_legacy(name, id)
     }
 
+    /// Return the currently-active generation for `id`, if any.
+    ///
+    /// This is the branch-lifecycle guard used by transaction begin/commit:
+    /// transactions snapshot the active generation at start, then abort on
+    /// commit if the branch has been deleted or recreated in the meantime.
+    pub(crate) fn active_generation_for_id(&self, id: BranchId) -> StrataResult<Option<u64>> {
+        let ap_key = active_ptr_key(id);
+        match self
+            .db
+            .storage()
+            .get_versioned(&ap_key, CommitVersion::MAX)?
+        {
+            Some(v) => Ok(Some(decode_u64_value(&v.value)?)),
+            None => {
+                for (_k, v) in self
+                    .db
+                    .storage()
+                    .scan_prefix(&control_record_prefix_for_id(id), CommitVersion::MAX)?
+                {
+                    let rec: BranchControlRecord = from_stored_value(&v.value)?;
+                    if matches!(rec.lifecycle, BranchLifecycleStatus::Active) {
+                        return Err(StrataError::corruption(format!(
+                            "control-store active pointer missing for branch id={id} with active record present"
+                        )));
+                    }
+                }
+                Ok(None)
+            }
+        }
+    }
+
     /// Synthesize a gen-0 `BranchControlRecord` for a follower running
     /// in legacy mode (AD5). Returns `None` if there is no legacy
     /// metadata for `name` either. Fork anchor is derived from storage.

--- a/crates/engine/src/branch_ops/branch_control_store.rs
+++ b/crates/engine/src/branch_ops/branch_control_store.rs
@@ -620,6 +620,35 @@ impl BranchControlStore {
         Ok(())
     }
 
+    /// Read the active-pointer row and `mark_deleted` the resulting
+    /// `BranchRef` inside `txn`.
+    ///
+    /// Used by `BranchService::delete` so the active-generation lookup
+    /// is part of the delete transaction's read set — OCC then rejects
+    /// any concurrent `delete` + `create` that advances the active
+    /// pointer between the read and commit, preventing divergence
+    /// between the legacy metadata purge and the control-record
+    /// lifecycle flip.
+    ///
+    /// Returns `Ok(Some(branch_ref))` with the marked ref, `Ok(None)` if
+    /// there was no active record for `name`, or `Err` if the record
+    /// referenced by the active pointer is missing / corrupted.
+    pub(crate) fn mark_deleted_by_name(
+        &self,
+        name: &str,
+        txn: &mut TransactionContext,
+    ) -> StrataResult<Option<BranchRef>> {
+        let id = BranchId::from_user_name(name);
+        let ap_key = active_ptr_key(id);
+        let Some(v) = txn.get(&ap_key)? else {
+            return Ok(None);
+        };
+        let generation = decode_u64_value(&v)?;
+        let branch_ref = BranchRef::new(id, generation);
+        self.mark_deleted(branch_ref, txn)?;
+        Ok(Some(branch_ref))
+    }
+
     /// Allocate the next unused generation for `id` and advance the
     /// persisted counter. The returned value is unique within the database
     /// lifetime even across delete-and-recreate cycles.

--- a/crates/engine/src/branch_ops/mod.rs
+++ b/crates/engine/src/branch_ops/mod.rs
@@ -747,8 +747,8 @@ fn resolve_and_verify(db: &Arc<Database>, name: &str) -> StrataResult<BranchId> 
 /// human-readable message and creator that flow into the branch DAG event
 /// for audit / lineage queries.
 pub fn fork_branch(db: &Arc<Database>, source: &str, destination: &str) -> StrataResult<ForkInfo> {
-    let (parent_ref, dest_gen) = resolve_fork_lineage(db, source, destination)?;
-    fork_branch_with_metadata(db, source, destination, None, None, parent_ref, dest_gen)
+    let dest_gen = resolve_fork_generation(db, destination)?;
+    fork_branch_with_metadata(db, source, destination, None, None, dest_gen)
 }
 
 /// Same as [`fork_branch`] but records `message` and `creator` on the
@@ -759,20 +759,19 @@ pub fn fork_branch(db: &Arc<Database>, source: &str, destination: &str) -> Strat
 /// flows through to the DAG. Engine-direct callers (tests, internal
 /// subsystems) typically use the no-metadata [`fork_branch`] wrapper.
 ///
-/// `parent_ref` and `dest_gen` are resolved by the caller (see
-/// [`resolve_fork_lineage`]) and threaded through so the KV metadata
-/// transaction can write the new `BranchControlRecord` atomically with
-/// the legacy `BranchMetadata` row (B3.2, AD6). Storage-fork-first
-/// ordering is preserved: the storage fork commits before the KV txn,
-/// so a crash between them leaves harmless orphan storage (refcounts
-/// rebuild from manifests on recovery).
+/// `dest_gen` is preallocated by the caller (see
+/// [`resolve_fork_generation`]). The source `BranchRef` is resolved
+/// inside fork's quiesce guard so the control-store fork anchor points
+/// at the same lifecycle instance whose storage snapshot is being
+/// forked. Storage-fork-first ordering is preserved: the storage fork
+/// commits before the KV txn, so a crash between them leaves harmless
+/// orphan storage (refcounts rebuild from manifests on recovery).
 pub fn fork_branch_with_metadata(
     db: &Arc<Database>,
     source: &str,
     destination: &str,
     message: Option<&str>,
     creator: Option<&str>,
-    parent_ref: BranchRef,
     dest_gen: BranchGeneration,
 ) -> StrataResult<ForkInfo> {
     let branch_index = BranchIndex::new(db.clone());
@@ -845,7 +844,7 @@ pub fn fork_branch_with_metadata(
     // commit() acquires quiesce.read() → branch_commit_lock, so nesting
     // branch_commit_lock inside quiesce.write() would invert the lock order
     // and deadlock with concurrent commits on the source branch.
-    let (fork_version, _segments_shared) = {
+    let (parent_ref, fork_version, _segments_shared) = {
         let _quiesce_guard = db.quiesce_commits();
         if db.is_branch_deleting(&source_id) {
             return Err(StrataError::invalid_input(format!(
@@ -853,9 +852,14 @@ pub fn fork_branch_with_metadata(
                 source
             )));
         }
-        storage
+        let parent_ref = match control_store.find_active_by_name(source)? {
+            Some(rec) => rec.branch,
+            None => BranchRef::new(source_id, 0),
+        };
+        let (fork_version, shared) = storage
             .fork_branch(&source_id, &dest_id)
-            .map_err(|e| StrataError::storage(format!("fork failed: {}", e)))?
+            .map_err(|e| StrataError::storage(format!("fork failed: {}", e)))?;
+        (parent_ref, fork_version, shared)
     };
 
     // 5. Create destination branch in KV metadata (WAL-protected) AND
@@ -914,31 +918,22 @@ pub fn fork_branch_with_metadata(
     Ok(info)
 }
 
-/// Resolve the parent `BranchRef` and allocate the child's generation for
-/// a fork, using the `BranchControlStore` as the authority.
+/// Allocate the child's next generation for a fork.
 ///
-/// The parent ref comes from `find_active_by_name(source)`; if the store
-/// has no active record for the source (e.g. a fresh cache database that
-/// hasn't routed creates through `BranchService`), the parent is
-/// synthesized at gen 0 so low-level callers (`fork_branch`, test
-/// fixtures) still work. `dest_gen` is allocated via a dedicated tiny
-/// transaction so the counter bump is durable before the KV metadata
-/// transaction runs.
+/// The source `BranchRef` is resolved later, under fork's quiesce guard,
+/// so the fork anchor is derived from the exact lifecycle instance whose
+/// storage snapshot is being copied.
 ///
 /// Checks the destination up-front before bumping the counter so a
 /// trivially-failing fork (duplicate destination) does not leak a
 /// generation from the monotonic counter.
-pub(crate) fn resolve_fork_lineage(
+pub(crate) fn resolve_fork_generation(
     db: &Arc<Database>,
-    source: &str,
     destination: &str,
-) -> StrataResult<(BranchRef, BranchGeneration)> {
+) -> StrataResult<BranchGeneration> {
     let store = BranchControlStore::new(db.clone());
-    let parent_ref = match store.find_active_by_name(source)? {
-        Some(rec) => rec.branch,
-        None => BranchRef::new(resolve_branch_name(source), 0),
-    };
-    if store.find_active_by_name(destination)?.is_some() {
+    let branch_index = BranchIndex::new(db.clone());
+    if branch_index.exists(destination)? || store.find_active_by_name(destination)?.is_some() {
         return Err(StrataError::invalid_input(format!(
             "Destination branch '{}' already exists",
             destination
@@ -948,7 +943,7 @@ pub(crate) fn resolve_fork_lineage(
     let dest_gen = db.transaction(BranchId::from_bytes([0u8; 16]), |txn| {
         store.next_generation(dest_id, txn)
     })?;
-    Ok((parent_ref, dest_gen))
+    Ok(dest_gen)
 }
 
 // =============================================================================

--- a/crates/engine/src/branch_ops/mod.rs
+++ b/crates/engine/src/branch_ops/mod.rs
@@ -37,13 +37,19 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
+use strata_core::branch::BranchLifecycleStatus;
 use strata_core::id::CommitVersion;
 use strata_core::types::{BranchId, Key, Namespace, TypeTag};
 use strata_core::value::Value;
 use strata_core::StrataError;
 use strata_core::StrataResult;
-use strata_core::{PrimitiveType, Version, VersionedValue};
+use strata_core::{
+    BranchControlRecord, BranchGeneration, BranchRef, ForkAnchor, PrimitiveType, Version,
+    VersionedValue,
+};
 use tracing::info;
+
+use crate::branch_ops::branch_control_store::BranchControlStore;
 
 // =============================================================================
 // Constants and key-format helpers
@@ -741,7 +747,8 @@ fn resolve_and_verify(db: &Arc<Database>, name: &str) -> StrataResult<BranchId> 
 /// human-readable message and creator that flow into the branch DAG event
 /// for audit / lineage queries.
 pub fn fork_branch(db: &Arc<Database>, source: &str, destination: &str) -> StrataResult<ForkInfo> {
-    fork_branch_with_metadata(db, source, destination, None, None)
+    let (parent_ref, dest_gen) = resolve_fork_lineage(db, source, destination)?;
+    fork_branch_with_metadata(db, source, destination, None, None, parent_ref, dest_gen)
 }
 
 /// Same as [`fork_branch`] but records `message` and `creator` on the
@@ -751,15 +758,26 @@ pub fn fork_branch(db: &Arc<Database>, source: &str, destination: &str) -> Strat
 /// user-supplied audit metadata (`fork_with_options(message, creator)`)
 /// flows through to the DAG. Engine-direct callers (tests, internal
 /// subsystems) typically use the no-metadata [`fork_branch`] wrapper.
+///
+/// `parent_ref` and `dest_gen` are resolved by the caller (see
+/// [`resolve_fork_lineage`]) and threaded through so the KV metadata
+/// transaction can write the new `BranchControlRecord` atomically with
+/// the legacy `BranchMetadata` row (B3.2, AD6). Storage-fork-first
+/// ordering is preserved: the storage fork commits before the KV txn,
+/// so a crash between them leaves harmless orphan storage (refcounts
+/// rebuild from manifests on recovery).
 pub fn fork_branch_with_metadata(
     db: &Arc<Database>,
     source: &str,
     destination: &str,
     message: Option<&str>,
     creator: Option<&str>,
+    parent_ref: BranchRef,
+    dest_gen: BranchGeneration,
 ) -> StrataResult<ForkInfo> {
     let branch_index = BranchIndex::new(db.clone());
     let space_index = SpaceIndex::new(db.clone());
+    let control_store = BranchControlStore::new(db.clone());
 
     // 1. Verify source exists
     branch_index.get_branch(source)?.ok_or_else(|| {
@@ -840,9 +858,24 @@ pub fn fork_branch_with_metadata(
             .map_err(|e| StrataError::storage(format!("fork failed: {}", e)))?
     };
 
-    // 5. Create destination branch in KV metadata (WAL-protected).
-    //    If this fails, rollback the storage fork.
-    if let Err(e) = branch_index.create_branch(destination) {
+    // 5. Create destination branch in KV metadata (WAL-protected) AND
+    //    write the new BranchControlRecord atomically in the same
+    //    transaction (B3.2). If either fails, rollback the storage fork
+    //    so the visibility invariant holds (AD6).
+    let child_ref = BranchRef::new(dest_id, dest_gen);
+    let control_record = BranchControlRecord {
+        branch: child_ref,
+        name: destination.to_string(),
+        lifecycle: BranchLifecycleStatus::Active,
+        fork: Some(ForkAnchor {
+            parent: parent_ref,
+            point: fork_version,
+        }),
+    };
+    let kv_result = branch_index.create_branch_with_hook(destination, |txn| {
+        control_store.put_record(&control_record, txn)
+    });
+    if let Err(e) = kv_result {
         storage.clear_branch(&dest_id);
         return Err(e);
     }
@@ -863,6 +896,8 @@ pub fn fork_branch_with_metadata(
         source,
         destination,
         fork_version = fork_version.as_u64(),
+        parent_generation = parent_ref.generation,
+        dest_generation = dest_gen,
         "Branch forked (COW)"
     );
 
@@ -877,6 +912,43 @@ pub fn fork_branch_with_metadata(
     dispatch_fork_hook(db, &info, message, creator);
 
     Ok(info)
+}
+
+/// Resolve the parent `BranchRef` and allocate the child's generation for
+/// a fork, using the `BranchControlStore` as the authority.
+///
+/// The parent ref comes from `find_active_by_name(source)`; if the store
+/// has no active record for the source (e.g. a fresh cache database that
+/// hasn't routed creates through `BranchService`), the parent is
+/// synthesized at gen 0 so low-level callers (`fork_branch`, test
+/// fixtures) still work. `dest_gen` is allocated via a dedicated tiny
+/// transaction so the counter bump is durable before the KV metadata
+/// transaction runs.
+///
+/// Checks the destination up-front before bumping the counter so a
+/// trivially-failing fork (duplicate destination) does not leak a
+/// generation from the monotonic counter.
+pub(crate) fn resolve_fork_lineage(
+    db: &Arc<Database>,
+    source: &str,
+    destination: &str,
+) -> StrataResult<(BranchRef, BranchGeneration)> {
+    let store = BranchControlStore::new(db.clone());
+    let parent_ref = match store.find_active_by_name(source)? {
+        Some(rec) => rec.branch,
+        None => BranchRef::new(resolve_branch_name(source), 0),
+    };
+    if store.find_active_by_name(destination)?.is_some() {
+        return Err(StrataError::invalid_input(format!(
+            "Destination branch '{}' already exists",
+            destination
+        )));
+    }
+    let dest_id = resolve_branch_name(destination);
+    let dest_gen = db.transaction(BranchId::from_bytes([0u8; 16]), |txn| {
+        store.next_generation(dest_id, txn)
+    })?;
+    Ok((parent_ref, dest_gen))
 }
 
 // =============================================================================

--- a/crates/engine/src/bundle.rs
+++ b/crates/engine/src/bundle.rs
@@ -236,8 +236,9 @@ pub fn import_branch(db: &Arc<Database>, path: &Path) -> StrataResult<ImportInfo
         )));
     }
 
-    // 3. Create branch via BranchIndex
-    branch_index.create_branch(branch_id_str)?;
+    // 3. Create branch through the canonical branch service so B3.2's
+    // control-record / generation model applies to imported branches too.
+    db.branches().create(branch_id_str)?;
 
     // 4. Resolve BranchId for namespace
     let branch_meta = branch_index
@@ -277,11 +278,11 @@ pub fn import_branch(db: &Arc<Database>, path: &Path) -> StrataResult<ImportInfo
         keys_written += put_count;
     }
 
-    // Note: the DAG `on_create` hook already fired from inside
-    // `BranchIndex::create_branch(branch_id_str)` above (step 3). We do
-    // NOT fire it again here — doing so would upsert the branch node and
-    // clobber the timestamps from the first fire. Branch import shows up
-    // in the lineage graph as a freshly-created branch automatically.
+    // Note: the DAG create event already fired from inside
+    // `BranchService::create(branch_id_str)` above (step 3). We do NOT fire
+    // it again here — doing so would upsert the branch node and clobber the
+    // timestamps from the first fire. Branch import shows up in the lineage
+    // graph as a freshly-created branch automatically.
 
     Ok(ImportInfo {
         branch_id: branch_id_str.to_string(),
@@ -336,8 +337,7 @@ mod tests {
 
     fn setup_with_branch(branch_name: &str) -> (TempDir, Arc<Database>) {
         let (temp_dir, db) = setup();
-        let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch(branch_name).unwrap();
+        db.branches().create(branch_name).unwrap();
         (temp_dir, db)
     }
 
@@ -453,6 +453,33 @@ mod tests {
         let import_info = import_branch(&import_db, &bundle_path).unwrap();
         assert_eq!(import_info.branch_id, "export-branch");
         assert!(import_info.transactions_applied > 0);
+        let control = import_db
+            .branches()
+            .control_record("export-branch")
+            .unwrap()
+            .expect("imported branch should have a control record");
+        assert_eq!(control.branch.generation, 0);
+    }
+
+    #[test]
+    fn test_imported_branch_recreate_bumps_generation() {
+        let (temp_dir, db) = setup_with_branch("export-branch");
+        let bundle_path = temp_dir.path().join("export.branchbundle.tar.zst");
+        export_branch(&db, "export-branch", &bundle_path).unwrap();
+
+        let import_dir = TempDir::new().unwrap();
+        let import_db = Database::open(import_dir.path()).unwrap();
+        import_branch(&import_db, &bundle_path).unwrap();
+
+        import_db.branches().delete("export-branch").unwrap();
+        import_db.branches().create("export-branch").unwrap();
+
+        let control = import_db
+            .branches()
+            .control_record("export-branch")
+            .unwrap()
+            .expect("recreated imported branch should stay on the control-store path");
+        assert_eq!(control.branch.generation, 1);
     }
 
     #[test]

--- a/crates/engine/src/database/branch_mutation.rs
+++ b/crates/engine/src/database/branch_mutation.rs
@@ -62,13 +62,14 @@ use std::sync::Arc;
 use strata_core::id::CommitVersion;
 use strata_core::types::{BranchId, Key, Namespace};
 use strata_core::value::Value;
-use strata_core::{StrataError, StrataResult, VersionedValue};
+use strata_core::{BranchControlRecord, StrataError, StrataResult, VersionedValue};
 use tracing::{error, info, warn};
 
 use super::dag_hook::{BranchDagError, BranchDagHook, DagEvent};
 use super::observers::BranchOpEvent;
 use super::Database;
-use crate::branch_ops::{is_user_visible_space, DATA_TYPE_TAGS};
+use crate::branch_ops::branch_control_store::BranchControlStore;
+use crate::branch_ops::{is_user_visible_space, with_branch_dag_hooks_suppressed, DATA_TYPE_TAGS};
 use crate::primitives::branch::{resolve_branch_name, BranchIndex, BranchMetadata};
 use crate::SpaceIndex;
 
@@ -131,23 +132,35 @@ impl RollbackAction {
                 );
 
                 let branch_index = BranchIndex::new(db.clone());
+                let control_store = BranchControlStore::new(db.clone());
                 let branch_id = crate::primitives::branch::resolve_branch_name(&name);
+                let metadata_exists = branch_index.exists(&name)?;
 
-                // Delete from KV metadata
-                if let Err(e) = branch_index.delete_branch(&name) {
-                    // Branch might not exist if the mutation that created it
-                    // failed before KV write
-                    warn!(
-                        target: "strata::branch_mutation",
-                        branch = %name,
-                        error = %e,
-                        "Rollback delete_branch failed (branch may not exist)"
-                    );
-                }
-
-                // Clear storage if requested
-                if clear_storage {
-                    db.clear_branch_storage(&branch_id);
+                if metadata_exists {
+                    if let Err(e) = with_branch_dag_hooks_suppressed(|| {
+                        branch_index.delete_branch_with_hook(&name, |txn| {
+                            match control_store.mark_deleted_by_name(&name, txn)? {
+                                Some(_) => Ok(()),
+                                None => Err(StrataError::corruption(format!(
+                                    "rollback delete for branch '{name}' found legacy metadata without an active control record"
+                                ))),
+                            }
+                        })
+                    }) {
+                        warn!(
+                            target: "strata::branch_mutation",
+                            branch = %name,
+                            error = %e,
+                            "Rollback delete_branch failed"
+                        );
+                    }
+                } else if let Some(rec) = control_store.find_active_by_name(&name)? {
+                    db.transaction(global_branch_id(), |txn| {
+                        control_store.mark_deleted(rec.branch, txn)
+                    })?;
+                    if clear_storage {
+                        db.clear_branch_storage(&branch_id);
+                    }
                 }
 
                 Ok(())
@@ -183,6 +196,7 @@ impl RollbackAction {
 struct BranchSnapshot {
     name: String,
     metadata: BranchMetadata,
+    control_record: BranchControlRecord,
     executor_branch_id: BranchId,
     metadata_branch_id: Option<BranchId>,
     entries: Vec<(Key, Value)>,
@@ -192,10 +206,17 @@ struct BranchSnapshot {
 impl BranchSnapshot {
     fn capture(db: &Arc<Database>, name: &str) -> StrataResult<Self> {
         let branch_index = BranchIndex::new(db.clone());
+        let control_store = BranchControlStore::new(db.clone());
         let metadata = branch_index
             .get_branch(name)?
             .ok_or_else(|| StrataError::invalid_input(format!("Branch '{}' not found", name)))?
             .value;
+        let control_record = control_store.find_active_by_name(name)?.ok_or_else(|| {
+            StrataError::corruption(format!(
+                "branch '{}' has legacy metadata but no active control record",
+                name
+            ))
+        })?;
 
         let executor_branch_id = resolve_branch_name(name);
         let metadata_branch_id = BranchId::from_string(&metadata.branch_id)
@@ -214,6 +235,7 @@ impl BranchSnapshot {
         Ok(Self {
             name: name.to_string(),
             metadata,
+            control_record,
             executor_branch_id,
             metadata_branch_id,
             entries,
@@ -224,10 +246,12 @@ impl BranchSnapshot {
     fn restore(self, db: &Arc<Database>) -> StrataResult<()> {
         let meta_key = Key::new_branch_with_id(global_namespace(), &self.name);
         let metadata_value = stored_branch_metadata_value(&self.metadata)?;
+        let control_store = BranchControlStore::new(db.clone());
 
         db.transaction(global_branch_id(), |txn| {
             txn.set_allow_cross_branch(true);
             txn.put(meta_key.clone(), metadata_value.clone())?;
+            control_store.put_record(&self.control_record, txn)?;
             for (key, value) in &self.entries {
                 txn.put(key.clone(), value.clone())?;
             }
@@ -813,12 +837,12 @@ mod tests {
     fn test_mutation_dag_failure_triggers_rollback() {
         let db = Database::cache().unwrap();
         let hook = Arc::new(TestDagHook::new());
-        hook.set_should_fail(true);
         db.install_dag_hook(hook.clone()).unwrap();
 
         // Create a branch that will be rolled back
+        db.branches().create("rollback-test").unwrap();
+        hook.set_should_fail(true);
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("rollback-test").unwrap();
         assert!(branch_index.exists("rollback-test").unwrap());
 
         let mut mutation = BranchMutation::new(&db);
@@ -831,6 +855,42 @@ mod tests {
 
         // Branch should be deleted by rollback
         assert!(!branch_index.exists("rollback-test").unwrap());
+        let store = BranchControlStore::new(db.clone());
+        let tombstone = store
+            .get_record(strata_core::BranchRef::new(
+                resolve_branch_name("rollback-test"),
+                0,
+            ))
+            .unwrap()
+            .expect("rollback should leave a tombstone control record");
+        assert!(matches!(
+            tombstone.lifecycle,
+            strata_core::branch::BranchLifecycleStatus::Deleted
+        ));
+    }
+
+    #[test]
+    fn test_rollback_delete_does_not_emit_best_effort_delete_hook() {
+        let db = Database::cache().unwrap();
+        let hook = Arc::new(TestDagHook::new());
+        db.install_dag_hook(hook.clone()).unwrap();
+
+        db.branches().create("rollback-hook-test").unwrap();
+        assert_eq!(
+            hook.event_count(),
+            1,
+            "branch creation should record exactly one canonical DAG event"
+        );
+
+        let mut mutation = BranchMutation::new(&db);
+        mutation.on_rollback_delete_branch("rollback-hook-test", false);
+        mutation.abort().unwrap();
+
+        assert_eq!(
+            hook.event_count(),
+            1,
+            "rollback delete must not emit a best-effort DAG delete hook"
+        );
     }
 
     #[test]
@@ -838,8 +898,8 @@ mod tests {
         let db = Database::cache().unwrap();
 
         // Create a branch
+        db.branches().create("inject-test").unwrap();
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("inject-test").unwrap();
 
         let mut mutation = BranchMutation::new(&db);
         mutation.on_rollback_delete_branch("inject-test", false);
@@ -852,6 +912,18 @@ mod tests {
 
         // Branch should be deleted
         assert!(!branch_index.exists("inject-test").unwrap());
+        let store = BranchControlStore::new(db.clone());
+        let tombstone = store
+            .get_record(strata_core::BranchRef::new(
+                resolve_branch_name("inject-test"),
+                0,
+            ))
+            .unwrap()
+            .expect("rollback should leave a tombstone control record");
+        assert!(matches!(
+            tombstone.lifecycle,
+            strata_core::branch::BranchLifecycleStatus::Deleted
+        ));
     }
 
     #[test]
@@ -859,8 +931,8 @@ mod tests {
         let db = Database::cache().unwrap();
 
         // Create a branch
+        db.branches().create("abort-test").unwrap();
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("abort-test").unwrap();
 
         let mut mutation = BranchMutation::new(&db);
         mutation.on_rollback_delete_branch("abort-test", false);
@@ -870,6 +942,18 @@ mod tests {
 
         // Branch should be deleted
         assert!(!branch_index.exists("abort-test").unwrap());
+        let store = BranchControlStore::new(db.clone());
+        let tombstone = store
+            .get_record(strata_core::BranchRef::new(
+                resolve_branch_name("abort-test"),
+                0,
+            ))
+            .unwrap()
+            .expect("rollback should leave a tombstone control record");
+        assert!(matches!(
+            tombstone.lifecycle,
+            strata_core::branch::BranchLifecycleStatus::Deleted
+        ));
     }
 
     #[test]
@@ -877,8 +961,8 @@ mod tests {
         let db = Database::cache().unwrap();
 
         // Create a branch
+        db.branches().create("drop-test").unwrap();
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("drop-test").unwrap();
 
         {
             let mut mutation = BranchMutation::new(&db);
@@ -888,6 +972,54 @@ mod tests {
 
         // Branch should be deleted by drop
         assert!(!branch_index.exists("drop-test").unwrap());
+        let store = BranchControlStore::new(db.clone());
+        let tombstone = store
+            .get_record(strata_core::BranchRef::new(
+                resolve_branch_name("drop-test"),
+                0,
+            ))
+            .unwrap()
+            .expect("rollback should leave a tombstone control record");
+        assert!(matches!(
+            tombstone.lifecycle,
+            strata_core::branch::BranchLifecycleStatus::Deleted
+        ));
+    }
+
+    #[test]
+    fn test_rollback_restore_branch_restores_active_control_record() {
+        let db = Database::cache().unwrap();
+        db.branches().create("restore-test").unwrap();
+
+        let mut mutation = BranchMutation::new(&db);
+        mutation.on_rollback_restore_branch("restore-test").unwrap();
+
+        let branch_index = BranchIndex::new(db.clone());
+        let store = BranchControlStore::new(db.clone());
+        branch_index
+            .delete_branch_with_hook("restore-test", |txn| {
+                match store.mark_deleted_by_name("restore-test", txn)? {
+                    Some(_) => Ok(()),
+                    None => Err(StrataError::corruption(
+                        "test setup deleted branch without active control record".to_string(),
+                    )),
+                }
+            })
+            .unwrap();
+
+        mutation.abort().unwrap();
+
+        assert!(branch_index.exists("restore-test").unwrap());
+        let restored = db
+            .branches()
+            .control_record("restore-test")
+            .unwrap()
+            .expect("rollback restore must reactivate the control record");
+        assert!(matches!(
+            restored.lifecycle,
+            strata_core::branch::BranchLifecycleStatus::Active
+        ));
+        assert_eq!(restored.branch.generation, 0);
     }
 
     #[test]

--- a/crates/engine/src/database/branch_service.rs
+++ b/crates/engine/src/database/branch_service.rs
@@ -257,11 +257,11 @@ impl BranchService {
         // B3.2: recreating a previously-deleted name must yield a
         // writable branch. `BranchIndex::delete_branch` intentionally
         // leaves the `is_branch_deleting` mark set to reject pre-delete
-        // in-flight commits (#1916); the mark must be cleared once a
-        // fresh lifecycle instance is in place so its own writes can
-        // commit. Stale in-flight commits from pre-delete txns that
-        // race with the fresh lifecycle instance will be addressed by
-        // the B4 generation-aware lifecycle write gate.
+        // in-flight commits (#1916); the mark is cleared once the fresh
+        // lifecycle instance is durable. Transactions now snapshot the
+        // branch's active generation at start and recheck it on commit,
+        // so stale pre-delete txns abort instead of writing into the new
+        // lifecycle instance.
         self.db.unmark_branch_deleting(&branch_id);
 
         // Rollback: delete the branch on DAG failure
@@ -307,13 +307,17 @@ impl BranchService {
         // the delete txn's read set → OCC fails it on conflict rather
         // than silently operating on a stale `BranchRef`.
         //
-        // `None` means no active record for this name (databases that
-        // skipped B3.1 migration, or the record was tombstoned between
-        // the BranchIndex metadata read and the hook); the delete
-        // degrades to the legacy-metadata-only path in that case.
+        // A missing active record here is corruption: the legacy metadata
+        // row exists (BranchIndex resolved it) but the authoritative
+        // control store has no active lifecycle for the same branch name.
         let delete_result = with_branch_dag_hooks_suppressed(|| {
             index.delete_branch_with_hook(name, |txn| {
-                store.mark_deleted_by_name(name, txn).map(|_| ())
+                match store.mark_deleted_by_name(name, txn)? {
+                    Some(_) => Ok(()),
+                    None => Err(StrataError::corruption(format!(
+                        "live branch '{name}' has legacy metadata but no active control record"
+                    ))),
+                }
             })
         });
 
@@ -422,34 +426,18 @@ impl BranchService {
         // Fork requires DAG — without it, lineage is lost
         mutation.require_dag_hook("fork")?;
 
-        // B3.2: resolve the parent's canonical `BranchRef` and preallocate
-        // the child's generation so the KV metadata transaction (inside
-        // `fork_branch_with_metadata`) can write the `BranchControlRecord`
-        // with a fork anchor pointing at the exact parent lifecycle
-        // instance.
-        //
-        // Known narrow race: a concurrent `delete` + `create` on the
-        // source name that completes between this lookup and fork's
-        // quiesce guard can leave `parent_ref` pointing at the prior
-        // generation while storage forks from the new one. The
-        // `is_branch_deleting` check inside the quiesce guard catches
-        // in-progress deletes; a completed delete+recreate escapes it
-        // because `unmark_branch_deleting` runs at the end of the new
-        // `create`. The B4 generation-aware lifecycle write gate will
-        // close this window structurally.
+        // B3.2: preallocate only the destination generation here. The
+        // source `BranchRef` must be resolved inside fork's quiesce
+        // guard so the fork anchor points at the exact lifecycle
+        // instance whose storage snapshot is being forked.
         let store = BranchControlStore::new(self.db.clone());
-        let parent_ref = store
-            .find_active_by_name(source)?
-            .map(|rec| rec.branch)
-            .ok_or_else(|| {
-                StrataError::invalid_input(format!("Source branch '{}' not found", source))
-            })?;
+        let branch_index = BranchIndex::new(self.db.clone());
 
         // Fail the duplicate-destination case before bumping the
         // next-generation counter; otherwise a spurious `fork` attempt to
         // an existing name burns a generation before `fork_branch_with_metadata`
         // ever observes the collision.
-        if store.find_active_by_name(destination)?.is_some() {
+        if branch_index.exists(destination)? || store.find_active_by_name(destination)?.is_some() {
             return Err(StrataError::invalid_input(format!(
                 "Destination branch '{}' already exists",
                 destination
@@ -471,7 +459,6 @@ impl BranchService {
                 destination,
                 options.message.as_deref(),
                 options.creator.as_deref(),
-                parent_ref,
                 dest_gen,
             )
         })?;

--- a/crates/engine/src/database/branch_service.rs
+++ b/crates/engine/src/database/branch_service.rs
@@ -19,10 +19,11 @@
 
 use std::sync::Arc;
 
+use strata_core::branch::BranchLifecycleStatus;
 use strata_core::id::CommitVersion;
 use strata_core::types::BranchId;
 use strata_core::EntityRef;
-use strata_core::{StrataError, StrataResult};
+use strata_core::{BranchControlRecord, BranchRef, StrataError, StrataResult};
 
 use crate::branch_ops::with_branch_dag_hooks_suppressed;
 use crate::branch_ops::{
@@ -217,14 +218,51 @@ impl BranchService {
     /// Create a new branch.
     ///
     /// Emits a DAG create event if a DAG hook is installed.
+    ///
+    /// B3.2: writes a canonical `BranchControlRecord` atomically with the
+    /// legacy `BranchMetadata`. Same-name recreate allocates a fresh
+    /// generation via `BranchControlStore::next_generation`.
     pub fn create(&self, name: &str) -> StrataResult<BranchMetadata> {
         validate_branch_name(name)?;
 
         let mut mutation = BranchMutation::new(&self.db);
         let branch_id = resolve_branch_name(name);
+        let store = BranchControlStore::new(self.db.clone());
+
+        // Defense-in-depth: reject if an active record already exists.
+        // The per-txn duplicate check inside `create_branch_with_hook`
+        // is the atomic guard; this early check surfaces a cleaner error
+        // and short-circuits the name-lookup + counter-bump work.
+        if store.find_active_by_name(name)?.is_some() {
+            return Err(StrataError::invalid_input(format!(
+                "Branch '{}' already exists",
+                name
+            )));
+        }
 
         let index = BranchIndex::new(self.db.clone());
-        let versioned = with_branch_dag_hooks_suppressed(|| index.create_branch(name))?;
+        let versioned = with_branch_dag_hooks_suppressed(|| {
+            index.create_branch_with_hook(name, |txn| {
+                let generation = store.next_generation(branch_id, txn)?;
+                let record = BranchControlRecord {
+                    branch: BranchRef::new(branch_id, generation),
+                    name: name.to_string(),
+                    lifecycle: BranchLifecycleStatus::Active,
+                    fork: None,
+                };
+                store.put_record(&record, txn)
+            })
+        })?;
+
+        // B3.2: recreating a previously-deleted name must yield a
+        // writable branch. `BranchIndex::delete_branch` intentionally
+        // leaves the `is_branch_deleting` mark set to reject pre-delete
+        // in-flight commits (#1916); the mark must be cleared once a
+        // fresh lifecycle instance is in place so its own writes can
+        // commit. Stale in-flight commits from pre-delete txns that
+        // race with the fresh lifecycle instance will be addressed by
+        // the B4 generation-aware lifecycle write gate.
+        self.db.unmark_branch_deleting(&branch_id);
 
         // Rollback: delete the branch on DAG failure
         mutation.on_rollback_delete_branch(name, false);
@@ -242,6 +280,11 @@ impl BranchService {
     /// Delete a branch.
     ///
     /// Emits a DAG delete event if a DAG hook is installed.
+    ///
+    /// B3.2: flips the canonical `BranchControlRecord` to `Deleted` and
+    /// clears the active-pointer atomically with the legacy purge. A
+    /// subsequent `create` with the same name allocates a fresh
+    /// generation.
     pub fn delete(&self, name: &str) -> StrataResult<()> {
         reject_system_branch(name, "delete")?;
         reject_default_branch(&self.db, name, "delete")?;
@@ -250,12 +293,31 @@ impl BranchService {
         let branch_id = resolve_branch_name(name);
 
         let index = BranchIndex::new(self.db.clone());
+        let store = BranchControlStore::new(self.db.clone());
 
         if mutation.has_dag_hook() {
             mutation.on_rollback_restore_branch(name)?;
         }
 
-        if let Err(e) = with_branch_dag_hooks_suppressed(|| index.delete_branch(name)) {
+        // B3.2: look up and mark the active control record INSIDE the
+        // delete transaction so a racing `delete` + `create` between a
+        // pre-txn lookup and the txn commit can't leave the control
+        // store pointing at a live record whose legacy metadata was
+        // just purged. The read of the active-pointer row is part of
+        // the delete txn's read set → OCC fails it on conflict rather
+        // than silently operating on a stale `BranchRef`.
+        //
+        // `None` means no active record for this name (databases that
+        // skipped B3.1 migration, or the record was tombstoned between
+        // the BranchIndex metadata read and the hook); the delete
+        // degrades to the legacy-metadata-only path in that case.
+        let delete_result = with_branch_dag_hooks_suppressed(|| {
+            index.delete_branch_with_hook(name, |txn| {
+                store.mark_deleted_by_name(name, txn).map(|_| ())
+            })
+        });
+
+        if let Err(e) = delete_result {
             mutation.cancel();
             return Err(e);
         }
@@ -360,6 +422,47 @@ impl BranchService {
         // Fork requires DAG — without it, lineage is lost
         mutation.require_dag_hook("fork")?;
 
+        // B3.2: resolve the parent's canonical `BranchRef` and preallocate
+        // the child's generation so the KV metadata transaction (inside
+        // `fork_branch_with_metadata`) can write the `BranchControlRecord`
+        // with a fork anchor pointing at the exact parent lifecycle
+        // instance.
+        //
+        // Known narrow race: a concurrent `delete` + `create` on the
+        // source name that completes between this lookup and fork's
+        // quiesce guard can leave `parent_ref` pointing at the prior
+        // generation while storage forks from the new one. The
+        // `is_branch_deleting` check inside the quiesce guard catches
+        // in-progress deletes; a completed delete+recreate escapes it
+        // because `unmark_branch_deleting` runs at the end of the new
+        // `create`. The B4 generation-aware lifecycle write gate will
+        // close this window structurally.
+        let store = BranchControlStore::new(self.db.clone());
+        let parent_ref = store
+            .find_active_by_name(source)?
+            .map(|rec| rec.branch)
+            .ok_or_else(|| {
+                StrataError::invalid_input(format!("Source branch '{}' not found", source))
+            })?;
+
+        // Fail the duplicate-destination case before bumping the
+        // next-generation counter; otherwise a spurious `fork` attempt to
+        // an existing name burns a generation before `fork_branch_with_metadata`
+        // ever observes the collision.
+        if store.find_active_by_name(destination)?.is_some() {
+            return Err(StrataError::invalid_input(format!(
+                "Destination branch '{}' already exists",
+                destination
+            )));
+        }
+
+        let dest_id = resolve_branch_name(destination);
+        let dest_gen = self
+            .db
+            .transaction(BranchId::from_bytes([0u8; 16]), |txn| {
+                store.next_generation(dest_id, txn)
+            })?;
+
         // Execute the fork
         let info = with_branch_dag_hooks_suppressed(|| {
             branch_ops::fork_branch_with_metadata(
@@ -368,6 +471,8 @@ impl BranchService {
                 destination,
                 options.message.as_deref(),
                 options.creator.as_deref(),
+                parent_ref,
+                dest_gen,
             )
         })?;
 
@@ -702,6 +807,23 @@ impl BranchService {
         }
 
         Ok(info)
+    }
+
+    // =========================================================================
+    // Control-record queries (B3.2)
+    // =========================================================================
+
+    /// Look up the currently-active `BranchControlRecord` for `name`.
+    ///
+    /// Returns `None` if no such branch exists. Propagates
+    /// `branch_lineage_unavailable` on an unmigrated follower (AD5).
+    ///
+    /// This is the canonical surface for observing a branch's
+    /// generation-aware identity (`BranchRef`), lifecycle, and fork
+    /// anchor. Both runtime consumers and tests use it to verify
+    /// generation-safe write-path invariants (B3.2).
+    pub fn control_record(&self, name: &str) -> StrataResult<Option<BranchControlRecord>> {
+        BranchControlStore::new(self.db.clone()).find_active_by_name(name)
     }
 
     // =========================================================================

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -7,12 +7,13 @@ use std::sync::Arc;
 use strata_concurrency::TransactionContext;
 use strata_core::id::CommitVersion;
 use strata_core::types::BranchId;
-use strata_core::{StrataError, StrataResult};
+use strata_core::{Storage, StrataError, StrataResult};
 use strata_durability::wal::DurabilityMode;
 use strata_durability::{ManifestManager, WalOnlyCompactor};
 use strata_storage::SegmentedStore;
 
 use super::Database;
+use crate::branch_ops::branch_control_store::{active_ptr_key, BranchControlStore};
 use crate::transaction::{Transaction, TransactionPool};
 
 /// Return freed heap pages to the OS.
@@ -754,6 +755,13 @@ impl Database {
         // Override start_version set by pool acquire (which reads storage.version()
         // directly, bypassing the visible_version wait) (#1913).
         txn.start_version = snapshot_version;
+        let branch_generation_guard = self.branch_generation_guard_for(branch_id)?;
+        txn.set_branch_generation_guard(branch_generation_guard);
+        let seeded = self.seed_branch_generation_read_guard(&mut txn)?;
+        txn.set_branch_generation_guard_key(
+            branch_generation_guard.map(|_| active_ptr_key(branch_id)),
+            seeded,
+        );
         txn.set_max_write_entries(self.coordinator.max_write_buffer_entries());
         Ok(txn)
     }
@@ -832,6 +840,12 @@ impl Database {
         }
 
         let had_writes = !txn.is_read_only();
+        if had_writes {
+            if let Err(e) = self.validate_branch_generation_guard(txn) {
+                self.abort_transaction_in_place(txn, format!("Commit failed: {}", e));
+                return Err(e);
+            }
+        }
         // Admission control: reject writes when L0 is saturated (#1924).
         // Must run BEFORE commit so the caller gets a clean error.
         if had_writes {
@@ -860,6 +874,59 @@ impl Database {
             self.schedule_flush_if_needed();
         }
         Ok(version.as_u64())
+    }
+
+    fn branch_generation_guard_for(&self, branch_id: BranchId) -> StrataResult<Option<u64>> {
+        BranchControlStore::new(Self::shared(self)).active_generation_for_id(branch_id)
+    }
+
+    fn seed_branch_generation_read_guard(
+        &self,
+        txn: &mut TransactionContext,
+    ) -> StrataResult<bool> {
+        if txn.branch_generation_guard.is_none() {
+            return Ok(false);
+        }
+
+        if txn.branch_id == BranchId::from_bytes([0u8; 16]) {
+            return Ok(false);
+        }
+
+        let key = active_ptr_key(txn.branch_id);
+        let version = self
+            .storage
+            .get_versioned(&key, txn.start_version)?
+            .map(|entry| CommitVersion(entry.version.as_u64()))
+            .unwrap_or(CommitVersion::ZERO);
+        txn.read_set.insert(key, version);
+        Ok(true)
+    }
+
+    fn validate_branch_generation_guard(&self, txn: &TransactionContext) -> StrataResult<()> {
+        if !txn.branch_generation_guard_is_seeded() {
+            return Ok(());
+        }
+        let Some(expected_generation) = txn.branch_generation_guard else {
+            return Ok(());
+        };
+
+        let current_generation =
+            BranchControlStore::new(Self::shared(self)).active_generation_for_id(txn.branch_id)?;
+        match current_generation {
+            Some(current_generation) if current_generation == expected_generation => Ok(()),
+            Some(current_generation) => Err(StrataError::TransactionAborted {
+                reason: format!(
+                    "Branch {} lifecycle advanced from generation {} to {}",
+                    txn.branch_id, expected_generation, current_generation
+                ),
+            }),
+            None => Err(StrataError::TransactionAborted {
+                reason: format!(
+                    "Branch {} lifecycle no longer has active generation {}",
+                    txn.branch_id, expected_generation
+                ),
+            }),
+        }
     }
 
     /// Legacy compatibility shim for callers still routing through Database.

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -22,6 +22,7 @@ use crate::branch_ops::dag_hooks::{dispatch_create_hook, dispatch_delete_hook};
 use crate::database::Database;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use strata_concurrency::TransactionContext;
 use strata_core::contract::{Timestamp, Version, Versioned};
 use strata_core::id::CommitVersion;
 use strata_core::traits::Storage;
@@ -323,6 +324,24 @@ impl BranchIndex {
     /// ## Errors
     /// - `InvalidInput` if branch already exists
     pub(crate) fn create_branch(&self, branch_id: &str) -> StrataResult<Versioned<BranchMetadata>> {
+        self.create_branch_with_hook(branch_id, |_| Ok(()))
+    }
+
+    /// Create a new branch, running `pre_commit` inside the same KV
+    /// transaction that writes the legacy `BranchMetadata` row.
+    ///
+    /// Used by `BranchService::create` (B3.2) to write the new
+    /// `BranchControlRecord` atomically with the metadata row. The hook
+    /// runs after the metadata is staged; if it returns an error the
+    /// entire transaction rolls back.
+    pub(crate) fn create_branch_with_hook<F>(
+        &self,
+        branch_id: &str,
+        pre_commit: F,
+    ) -> StrataResult<Versioned<BranchMetadata>>
+    where
+        F: FnOnce(&mut TransactionContext) -> StrataResult<()>,
+    {
         if aliases_default_branch_sentinel(branch_id) {
             return Err(StrataError::invalid_input(
                 "branch name aliases reserved default-branch sentinel",
@@ -330,21 +349,8 @@ impl BranchIndex {
         }
 
         let result = self.db.transaction(global_branch_id(), |txn| {
-            let key = self.key_for(branch_id);
-
-            // Check if branch already exists
-            if txn.get(&key)?.is_some() {
-                return Err(StrataError::invalid_input(format!(
-                    "Branch '{}' already exists",
-                    branch_id
-                )));
-            }
-
-            let branch_meta = BranchMetadata::new(branch_id);
-            txn.put(key, to_stored_value(&branch_meta)?)?;
-
-            info!(target: "strata::branch", %branch_id, "Branch created");
-            Ok(branch_meta.into_versioned())
+            self.create_branch_in_txn(branch_id, txn)
+                .and_then(|versioned| pre_commit(txn).map(|_| versioned))
         })?;
 
         // Note: DAG recording is handled by BranchService.create(), which is
@@ -354,6 +360,43 @@ impl BranchIndex {
         dispatch_create_hook(&self.db, branch_id);
 
         Ok(result)
+    }
+
+    /// Create a new branch's legacy `BranchMetadata` row inside an
+    /// externally-owned transaction.
+    ///
+    /// Low-level entry point used by fork and hooked-create paths that
+    /// need to batch the metadata write with additional control-store
+    /// writes in one atomic commit (B3.2). Does not dispatch any DAG
+    /// hooks — that is the caller's responsibility.
+    ///
+    /// ## Errors
+    /// - `InvalidInput` if branch already exists or name aliases the
+    ///   reserved default-branch sentinel.
+    pub(crate) fn create_branch_in_txn(
+        &self,
+        branch_id: &str,
+        txn: &mut TransactionContext,
+    ) -> StrataResult<Versioned<BranchMetadata>> {
+        if aliases_default_branch_sentinel(branch_id) {
+            return Err(StrataError::invalid_input(
+                "branch name aliases reserved default-branch sentinel",
+            ));
+        }
+
+        let key = self.key_for(branch_id);
+        if txn.get(&key)?.is_some() {
+            return Err(StrataError::invalid_input(format!(
+                "Branch '{}' already exists",
+                branch_id
+            )));
+        }
+
+        let branch_meta = BranchMetadata::new(branch_id);
+        txn.put(key, to_stored_value(&branch_meta)?)?;
+
+        info!(target: "strata::branch", %branch_id, "Branch created");
+        Ok(branch_meta.into_versioned())
     }
 
     /// Get branch metadata
@@ -425,6 +468,26 @@ impl BranchIndex {
     ///
     /// USE WITH CAUTION - this is irreversible!
     pub(crate) fn delete_branch(&self, branch_id: &str) -> StrataResult<()> {
+        self.delete_branch_with_hook(branch_id, |_| Ok(()))
+    }
+
+    /// Delete a branch and ALL its data, running `pre_commit` inside the
+    /// same KV transaction that purges the legacy metadata + namespace
+    /// data.
+    ///
+    /// Used by `BranchService::delete` (B3.2) to atomically mark the
+    /// corresponding `BranchControlRecord` as `Deleted` alongside the
+    /// legacy purge. The hook runs after namespace data is staged for
+    /// removal and before the metadata row is dropped; if it errors the
+    /// entire delete transaction rolls back and the branch remains live.
+    pub(crate) fn delete_branch_with_hook<F>(
+        &self,
+        branch_id: &str,
+        pre_commit: F,
+    ) -> StrataResult<()>
+    where
+        F: FnOnce(&mut TransactionContext) -> StrataResult<()>,
+    {
         // First get the branch metadata (read-only, no WAL after #970)
         let branch_meta = self
             .get_branch(branch_id)?
@@ -472,6 +535,12 @@ impl BranchIndex {
 
             // Delete the branch metadata entry
             txn.delete(meta_key.clone())?;
+
+            // B3.2: run the caller-supplied hook (e.g. mark_deleted on the
+            // BranchControlRecord) inside the same transaction so legacy
+            // metadata purge and control-record lifecycle flip commit
+            // together.
+            pre_commit(txn)?;
 
             info!(target: "strata::branch", %branch_id, "Branch deleted");
             Ok(())

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -117,6 +117,25 @@ fn global_namespace() -> Arc<Namespace> {
     Arc::new(Namespace::for_branch(global_branch_id()))
 }
 
+/// Internal transaction branch id used for global branch-index metadata work.
+///
+/// Most delete operations can run on the global/nil branch because the target
+/// branch lock is distinct and the global branch id is convenient. Literal
+/// `"default"` is special: it resolves to the same nil BranchId used by
+/// global branch-index operations. In that case, using the nil branch for an
+/// internal metadata transaction can self-conflict with delete marks / commit
+/// locks that intentionally remain on the real branch while a lifecycle
+/// cutover is in progress. Route the internal metadata transaction through
+/// `_system_` instead while leaving the target delete mark/lock on the actual
+/// branch being created/deleted.
+fn admin_transaction_branch_id(target_branch_id: BranchId) -> BranchId {
+    if target_branch_id == global_branch_id() {
+        resolve_branch_name(crate::SYSTEM_BRANCH)
+    } else {
+        global_branch_id()
+    }
+}
+
 fn default_branch_marker_key() -> Key {
     Key::new_branch_with_id(global_namespace(), DEFAULT_BRANCH_MARKER_KEY)
 }
@@ -348,7 +367,9 @@ impl BranchIndex {
             ));
         }
 
-        let result = self.db.transaction(global_branch_id(), |txn| {
+        let txn_branch_id = admin_transaction_branch_id(resolve_branch_name(branch_id));
+        let result = self.db.transaction(txn_branch_id, |txn| {
+            txn.set_allow_cross_branch(true);
             self.create_branch_in_txn(branch_id, txn)
                 .and_then(|versioned| pre_commit(txn).map(|_| versioned))
         })?;
@@ -521,7 +542,8 @@ impl BranchIndex {
         let target_lock = self.db.branch_commit_lock(&executor_branch_id);
         let _target_guard = target_lock.lock();
 
-        let result = self.db.transaction(global_branch_id(), |txn| {
+        let txn_branch_id = admin_transaction_branch_id(executor_branch_id);
+        let result = self.db.transaction(txn_branch_id, |txn| {
             txn.set_allow_cross_branch(true);
             // Delete data from the executor's namespace
             Self::delete_namespace_data(txn, executor_branch_id)?;
@@ -587,10 +609,19 @@ impl BranchIndex {
 
         // Clean up storage-layer segments, manifest, and refcounts (#1702).
         // Must happen after logical deletion so in-progress reads see the
-        // deletion before files disappear. clear_branch_storage also
-        // retries directory removal after gc_orphan_segments as a safety
-        // net for anything drain() may have missed.
-        self.db.clear_branch_storage(&executor_branch_id);
+        // deletion before files disappear.
+        //
+        // Literal `"default"` is special: its canonical BranchId is the same
+        // nil branch id used by global branch-index/control-store metadata.
+        // The delete transaction above already tombstones user primitive rows
+        // in that namespace. A physical `clear_branch_storage(nil)` would also
+        // wipe the branch-control ledger itself (next-generation counters,
+        // active pointers, metadata rows for other branches), breaking
+        // generation-safe recreate. Keep nil/default deletion logical-only at
+        // the storage layer; later compaction/GC will reclaim the user data.
+        if executor_branch_id != global_branch_id() {
+            self.db.clear_branch_storage(&executor_branch_id);
+        }
 
         let subsystems = self.db.installed_subsystems();
         for subsystem in subsystems.iter() {

--- a/tests/integration/branching_recreate_state_machine.rs
+++ b/tests/integration/branching_recreate_state_machine.rs
@@ -28,7 +28,9 @@ use crate::common::*;
 use std::sync::{Arc, Barrier};
 use std::thread;
 use strata_core::branch::BranchLifecycleStatus;
+use strata_core::value::Value;
 use strata_core::{BranchId, BranchRef};
+use strata_engine::primitives::extensions::KVStoreExt;
 
 fn resolve(name: &str) -> BranchId {
     BranchId::from_user_name(name)
@@ -350,6 +352,78 @@ fn recreate_cycles_from_cross_thread_creates_allocate_monotonic_generations() {
         rec.branch.generation, 3,
         "three full cycles yield gen 3 regardless of which thread performed the create"
     );
+}
+
+#[test]
+fn stale_pre_delete_transaction_cannot_commit_into_recreated_generation() {
+    let test_db = TestDb::new();
+    let db = test_db.db.clone();
+    let branches = db.branches();
+
+    branches.create("guarded").unwrap();
+    let branch_id = resolve("guarded");
+    let mut txn = db.begin_transaction(branch_id).unwrap();
+    txn.kv_put("late-write", Value::Int(7)).unwrap();
+
+    branches.delete("guarded").unwrap();
+    branches.create("guarded").unwrap();
+
+    let err = txn.commit().unwrap_err();
+    assert!(
+        err.to_string().contains("lifecycle advanced")
+            || err.to_string().contains("no longer has active generation"),
+        "stale pre-delete txn must be rejected after recreate; got: {err}"
+    );
+
+    assert!(
+        test_db
+            .kv()
+            .get(&branch_id, "default", "late-write")
+            .unwrap()
+            .is_none(),
+        "stale transaction must not write into the recreated branch"
+    );
+    let rec = branches.control_record("guarded").unwrap().unwrap();
+    assert_eq!(rec.branch.generation, 1);
+}
+
+#[test]
+fn stale_pre_delete_transaction_cannot_commit_into_recreated_literal_default_branch() {
+    let test_db = TestDb::new();
+    let db = test_db.db.clone();
+    let branches = db.branches();
+
+    branches.create("default").unwrap();
+    let branch_id = resolve("default");
+    let mut txn = db.begin_transaction(branch_id).unwrap();
+    txn.kv_put("late-default-write", Value::Int(9)).unwrap();
+
+    branches.delete("default").unwrap();
+    branches.create("default").unwrap();
+
+    let err = txn.commit().unwrap_err();
+    // Literal "default" shares the nil BranchId with internal global
+    // branch-index operations, so its generation guard is lazily seeded via
+    // the active-pointer read key rather than the eager per-branch guard used
+    // by ordinary branches. The important invariant is rejection of the stale
+    // pre-delete transaction, not the exact error variant.
+    assert!(
+        err.to_string().contains("lifecycle advanced")
+            || err.to_string().contains("no longer has active generation")
+            || err.to_string().contains("Validation failed"),
+        "stale pre-delete txn on literal default branch must be rejected after recreate; got: {err}"
+    );
+
+    assert!(
+        test_db
+            .kv()
+            .get(&branch_id, "default", "late-default-write")
+            .unwrap()
+            .is_none(),
+        "stale transaction must not write into the recreated literal default branch"
+    );
+    let rec = branches.control_record("default").unwrap().unwrap();
+    assert_eq!(rec.branch.generation, 1);
 }
 
 // ============================================================================

--- a/tests/integration/branching_recreate_state_machine.rs
+++ b/tests/integration/branching_recreate_state_machine.rs
@@ -1,0 +1,429 @@
+//! B3.2 — generation-safe branch write paths.
+//!
+//! Exercises the `BranchService` → `BranchControlStore` wiring landed in
+//! B3.2. Each test observes the control record through the canonical
+//! `BranchService::control_record` accessor so the generation bump,
+//! lifecycle flip, and fork anchor propagation are asserted against the
+//! engine's own authority, not inferred from downstream side-effects.
+//!
+//! Invariants covered (from `docs/design/branching/b3-phasing-plan.md`):
+//!
+//! - Same-name `create` / `delete` cycles bump `BranchGeneration`
+//!   monotonically without reusing previous lifecycle identities.
+//! - `delete` flips the record to `Deleted` and clears the active
+//!   pointer atomically with the legacy metadata purge.
+//! - `fork` records the parent's live `BranchRef` (generation-aware)
+//!   as the fork anchor, so a fork taken after recreate references the
+//!   new generation, not the tombstoned one.
+//! - Storage-fork-first ordering (AD6) holds even when the KV
+//!   transaction aborts — an orphaned storage fork is harmless and the
+//!   subsequent create-after-failure still works.
+//! - Concurrent create-after-delete races are serialized by the
+//!   branch-commit lock and generation allocation rather than producing
+//!   duplicate active records.
+
+#![cfg(not(miri))]
+
+use crate::common::*;
+use std::sync::{Arc, Barrier};
+use std::thread;
+use strata_core::branch::BranchLifecycleStatus;
+use strata_core::{BranchId, BranchRef};
+
+fn resolve(name: &str) -> BranchId {
+    BranchId::from_user_name(name)
+}
+
+/// Seed a single KV write on `name` so the storage layer materialises a
+/// branch — COW fork fails if the source has no memtable/segments.
+fn seed_storage(test_db: &TestDb, name: &str) {
+    let kv = test_db.kv();
+    let branch_id = resolve(name);
+    kv.put(&branch_id, "default", "_seed_", Value::Int(1))
+        .expect("seed write succeeds");
+}
+
+// ============================================================================
+// Generation bump across delete + recreate
+// ============================================================================
+
+#[test]
+fn create_allocates_gen_zero_active_record() {
+    let test_db = TestDb::new();
+    let branches = test_db.db.branches();
+
+    branches.create("main").unwrap();
+
+    let rec = branches
+        .control_record("main")
+        .unwrap()
+        .expect("create writes an active control record");
+    assert_eq!(rec.branch, BranchRef::new(resolve("main"), 0));
+    assert!(matches!(rec.lifecycle, BranchLifecycleStatus::Active));
+    assert!(rec.fork.is_none(), "root creates have no fork anchor");
+}
+
+#[test]
+fn delete_flips_record_to_deleted_and_clears_active_pointer() {
+    let test_db = TestDb::new();
+    let branches = test_db.db.branches();
+
+    branches.create("scratch").unwrap();
+    assert!(branches.control_record("scratch").unwrap().is_some());
+
+    branches.delete("scratch").unwrap();
+
+    // Active-pointer is cleared → find_active_by_name returns None.
+    assert!(
+        branches.control_record("scratch").unwrap().is_none(),
+        "deleting a branch must clear its active pointer"
+    );
+
+    // Recreate — must allocate gen 1 (the tombstone is still at gen 0).
+    branches.create("scratch").unwrap();
+    let rec = branches.control_record("scratch").unwrap().unwrap();
+    assert_eq!(
+        rec.branch,
+        BranchRef::new(resolve("scratch"), 1),
+        "recreate after delete must bump generation to 1"
+    );
+    assert!(matches!(rec.lifecycle, BranchLifecycleStatus::Active));
+}
+
+#[test]
+fn two_full_delete_recreate_cycles_reach_generation_two() {
+    let test_db = TestDb::new();
+    let branches = test_db.db.branches();
+
+    branches.create("cycle").unwrap();
+    branches.delete("cycle").unwrap();
+    branches.create("cycle").unwrap(); // gen 1
+    branches.delete("cycle").unwrap();
+    branches.create("cycle").unwrap(); // gen 2
+
+    let rec = branches.control_record("cycle").unwrap().unwrap();
+    assert_eq!(
+        rec.branch,
+        BranchRef::new(resolve("cycle"), 2),
+        "two full cycles must yield generation 2"
+    );
+}
+
+#[test]
+fn recreate_reuses_branch_id_but_distinct_branch_ref() {
+    let test_db = TestDb::new();
+    let branches = test_db.db.branches();
+
+    branches.create("alt").unwrap();
+    let before = branches.control_record("alt").unwrap().unwrap().branch;
+
+    branches.delete("alt").unwrap();
+    branches.create("alt").unwrap();
+    let after = branches.control_record("alt").unwrap().unwrap().branch;
+
+    assert_eq!(before.id, after.id, "BranchId is deterministic from name");
+    assert_ne!(
+        before, after,
+        "distinct lifecycle instances must produce distinct BranchRefs"
+    );
+}
+
+// ============================================================================
+// Fork anchors pick up the parent's live generation
+// ============================================================================
+
+#[test]
+fn fork_anchor_references_parent_generation_zero() {
+    let test_db = TestDb::new();
+    let branches = test_db.db.branches();
+
+    branches.create("main").unwrap();
+    seed_storage(&test_db, "main");
+    let parent_ref = branches.control_record("main").unwrap().unwrap().branch;
+
+    branches.fork("main", "feature-a").unwrap();
+
+    let child = branches.control_record("feature-a").unwrap().unwrap();
+    let anchor = child.fork.expect("child fork has an anchor");
+    assert_eq!(anchor.parent, parent_ref);
+    assert_eq!(
+        anchor.parent,
+        BranchRef::new(resolve("main"), 0),
+        "fork from a gen-0 parent must capture generation 0"
+    );
+}
+
+#[test]
+fn fork_after_recreate_anchors_to_new_parent_generation() {
+    let test_db = TestDb::new();
+    let branches = test_db.db.branches();
+
+    // main@gen0 → feature-a anchored at {main, 0}
+    branches.create("main").unwrap();
+    seed_storage(&test_db, "main");
+    branches.fork("main", "feature-a").unwrap();
+    let feature_a_anchor = branches
+        .control_record("feature-a")
+        .unwrap()
+        .unwrap()
+        .fork
+        .unwrap();
+    assert_eq!(feature_a_anchor.parent.generation, 0);
+
+    // Recycle main → gen 1
+    branches.delete("feature-a").unwrap();
+    branches.delete("main").unwrap();
+    branches.create("main").unwrap();
+    seed_storage(&test_db, "main");
+    let new_parent = branches.control_record("main").unwrap().unwrap().branch;
+    assert_eq!(new_parent.generation, 1);
+
+    // Fork from main@gen1 — anchor must point at {main, 1}, not {main, 0}.
+    branches.fork("main", "feature-b").unwrap();
+    let feature_b = branches.control_record("feature-b").unwrap().unwrap();
+    let anchor = feature_b.fork.expect("fork anchor present");
+    assert_eq!(anchor.parent, new_parent);
+    assert_eq!(
+        anchor.parent.generation, 1,
+        "post-recreate fork must pick up the parent's new generation"
+    );
+
+    // The earlier feature-a anchor is still correctly pinned to gen 0
+    // (even though gen 0 is tombstoned — lineage is immutable).
+    assert_eq!(feature_a_anchor.parent.generation, 0);
+}
+
+#[test]
+fn child_gets_fresh_generation_independent_of_parent() {
+    let test_db = TestDb::new();
+    let branches = test_db.db.branches();
+
+    branches.create("main").unwrap();
+    seed_storage(&test_db, "main");
+    branches.fork("main", "first-child").unwrap();
+    branches.fork("main", "second-child").unwrap();
+
+    let first = branches.control_record("first-child").unwrap().unwrap();
+    let second = branches.control_record("second-child").unwrap().unwrap();
+    assert_eq!(first.branch.generation, 0);
+    assert_eq!(
+        second.branch.generation, 0,
+        "sibling forks each start at their own gen 0"
+    );
+    assert_ne!(first.branch.id, second.branch.id);
+}
+
+#[test]
+fn forked_child_recreate_bumps_child_generation() {
+    let test_db = TestDb::new();
+    let branches = test_db.db.branches();
+
+    branches.create("main").unwrap();
+    seed_storage(&test_db, "main");
+    branches.fork("main", "feature").unwrap();
+    assert_eq!(
+        branches
+            .control_record("feature")
+            .unwrap()
+            .unwrap()
+            .branch
+            .generation,
+        0
+    );
+
+    branches.delete("feature").unwrap();
+    branches.fork("main", "feature").unwrap();
+
+    let rec = branches.control_record("feature").unwrap().unwrap();
+    assert_eq!(
+        rec.branch.generation, 1,
+        "refork after delete must allocate a new child generation"
+    );
+    let anchor = rec.fork.unwrap();
+    assert_eq!(
+        anchor.parent.generation, 0,
+        "parent still on its original generation"
+    );
+}
+
+// ============================================================================
+// Invariants: legacy metadata + control record remain coherent
+// ============================================================================
+
+#[test]
+fn legacy_metadata_and_control_record_stay_in_sync() {
+    let test_db = TestDb::new();
+    let branches = test_db.db.branches();
+
+    branches.create("dual").unwrap();
+
+    // Both surfaces report the branch.
+    assert!(branches.exists("dual").unwrap());
+    assert!(branches.control_record("dual").unwrap().is_some());
+    assert!(branches.list().unwrap().contains(&"dual".to_string()));
+
+    branches.delete("dual").unwrap();
+
+    // Both surfaces agree that the branch is gone.
+    assert!(!branches.exists("dual").unwrap());
+    assert!(branches.control_record("dual").unwrap().is_none());
+    assert!(!branches.list().unwrap().contains(&"dual".to_string()));
+}
+
+#[test]
+fn create_duplicate_live_branch_is_rejected() {
+    let test_db = TestDb::new();
+    let branches = test_db.db.branches();
+
+    branches.create("dup").unwrap();
+    let err = branches.create("dup").unwrap_err();
+    assert!(
+        err.to_string().contains("already exists"),
+        "duplicate create must surface a clean error; got: {err}"
+    );
+
+    // The existing record is untouched.
+    let rec = branches.control_record("dup").unwrap().unwrap();
+    assert_eq!(rec.branch.generation, 0);
+}
+
+// ============================================================================
+// Concurrent create-after-delete
+// ============================================================================
+
+#[test]
+fn concurrent_create_after_delete_serializes_via_commit_lock() {
+    let test_db = TestDb::new();
+    let db = test_db.db.clone();
+    db.branches().create("race").unwrap();
+    db.branches().delete("race").unwrap();
+
+    let barrier = Arc::new(Barrier::new(4));
+    let mut handles = Vec::new();
+    for _ in 0..4 {
+        let db = db.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            db.branches().create("race")
+        }));
+    }
+
+    let mut successes = 0;
+    let mut failures = 0;
+    for h in handles {
+        match h.join().unwrap() {
+            Ok(_) => successes += 1,
+            Err(_) => failures += 1,
+        }
+    }
+
+    assert_eq!(successes, 1, "exactly one create must win the race");
+    assert_eq!(failures, 3, "the other three must surface duplicate errors");
+
+    // The winner's record: gen 1 (one prior full cycle).
+    let rec = db.branches().control_record("race").unwrap().unwrap();
+    assert_eq!(rec.branch.generation, 1);
+    assert!(matches!(rec.lifecycle, BranchLifecycleStatus::Active));
+}
+
+#[test]
+fn recreate_cycles_from_cross_thread_creates_allocate_monotonic_generations() {
+    // Three sequential delete+create cycles where each `create` runs on
+    // a fresh thread. Not a race test — each iteration joins before the
+    // next begins. Purpose: prove that allocating a generation from
+    // another thread (which sees the counter through an Arc<Database>,
+    // not via thread-local state) still bumps monotonically.
+    let test_db = TestDb::new();
+    let db = test_db.db.clone();
+    db.branches().create("spin").unwrap();
+
+    for _ in 0..3 {
+        db.branches().delete("spin").unwrap();
+        let db2 = db.clone();
+        let h = thread::spawn(move || db2.branches().create("spin"));
+        h.join().unwrap().unwrap();
+    }
+
+    let rec = db.branches().control_record("spin").unwrap().unwrap();
+    assert_eq!(
+        rec.branch.generation, 3,
+        "three full cycles yield gen 3 regardless of which thread performed the create"
+    );
+}
+
+// ============================================================================
+// Storage-first ordering: aborted KV txn leaves no control record
+// ============================================================================
+
+#[test]
+fn create_duplicate_after_partial_failure_still_succeeds_once_cleared() {
+    // AD6: when the KV transaction fails after storage fork commits, the
+    // fork leaves harmless orphan storage state. The next attempt must
+    // succeed because no control record was ever written.
+    //
+    // We exercise the same guarantee without injecting storage
+    // failures: fork to an existing destination → the metadata-write
+    // transaction fails, and subsequent successful fork to the same
+    // name works cleanly.
+    let test_db = TestDb::new();
+    let branches = test_db.db.branches();
+
+    branches.create("main").unwrap();
+    seed_storage(&test_db, "main");
+    branches.create("feature").unwrap();
+
+    // First fork fails because destination already exists.
+    let err = branches.fork("main", "feature").unwrap_err();
+    assert!(
+        err.to_string().contains("already exists"),
+        "fork to existing dest must surface a duplicate-destination error; got: {err}"
+    );
+
+    // No stray control record was created for the failed attempt —
+    // feature's record remains the one from the earlier `create`.
+    let rec = branches.control_record("feature").unwrap().unwrap();
+    assert!(
+        rec.fork.is_none(),
+        "failed fork must not retroactively mutate the existing record"
+    );
+
+    // Delete + re-fork: clean path lands with a fork anchor.
+    branches.delete("feature").unwrap();
+    branches.fork("main", "feature").unwrap();
+
+    let rec = branches.control_record("feature").unwrap().unwrap();
+    assert_eq!(rec.branch.generation, 1, "second feature is gen 1");
+    let anchor = rec.fork.expect("re-forked child has anchor");
+    assert_eq!(anchor.parent, BranchRef::new(resolve("main"), 0));
+}
+
+// ============================================================================
+// Reopen preserves generation counter
+// ============================================================================
+
+#[test]
+fn recreate_after_reopen_continues_generation_sequence() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("persist").unwrap();
+    test_db.db.branches().delete("persist").unwrap();
+    test_db.db.branches().create("persist").unwrap();
+
+    // After reopen, the persisted next-gen counter must still see the
+    // existing lifecycle instances so a further recreate picks gen 2.
+    test_db.reopen();
+
+    test_db.db.branches().delete("persist").unwrap();
+    test_db.db.branches().create("persist").unwrap();
+
+    let rec = test_db
+        .db
+        .branches()
+        .control_record("persist")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        rec.branch.generation, 2,
+        "generation counter must survive reopen"
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -12,6 +12,7 @@ mod common;
 
 mod branching;
 mod branching_guardrails;
+mod branching_recreate_state_machine;
 mod merge_base_characterization;
 mod modes;
 mod primitives;


### PR DESCRIPTION
## Summary

Wires `BranchService::create/delete/fork_with_options` through the engine-owned `BranchControlStore` so the canonical `BranchControlRecord` becomes authoritative for per-branch lifecycle identity alongside the existing legacy `BranchMetadata`. Implements the B3.2 sub-phase from `docs/design/branching/b3-phasing-plan.md`.

- Same-name recreate allocates a fresh `BranchGeneration` via `BranchControlStore::next_generation`; `delete` flips the record to `Deleted` and clears the active pointer atomically with the legacy namespace purge; `fork` records the parent's live `BranchRef` on the child's `ForkAnchor`.
- Storage-fork-first ordering (AD6) preserved: the storage COW fork commits before the KV metadata transaction; the `BranchControlRecord` write is batched into the same KV txn via a new `BranchIndex::create_branch_with_hook`. Crash between storage and KV still leaves harmless orphan storage.
- Delete's control-record lookup is OCC-safe: `mark_deleted_by_name` reads the active-pointer row inside the delete transaction, so a racing `delete` + `create` on the same name can't leave the control store diverged from legacy metadata.

## Changes

**Transactional primitives:**
- `BranchIndex::{create_branch_in_txn, create_branch_with_hook, delete_branch_with_hook}` — accept an externally-owned `TransactionContext` or pre-commit hook so control-record writes commit atomically with legacy metadata.
- `BranchControlStore::mark_deleted_by_name(name, txn)` — OCC-safe active-pointer read + lifecycle flip in one transaction.
- `branch_ops::resolve_fork_lineage(db, source, dest)` — parent lookup + destination preflight + child-gen allocation used by the low-level `fork_branch` wrapper (no counter leak on duplicate-destination failure).

**Public surface (D4):**
- `BranchService::control_record(name) -> Option<BranchControlRecord>` — canonical observation point for a branch's generation-aware identity, lifecycle, and fork anchor. `BranchControlRecord` is already on the D4 allowed surface.
- `fork_branch_with_metadata` gains `parent_ref: BranchRef` and `dest_gen: BranchGeneration` parameters, threaded through from `BranchService::fork_with_options`. The public `fork_branch` wrapper resolves both internally. Both types are on the D4 allowed surface.

**Lifecycle gate bridge:**
- Recreate now clears the `#1916` deleting flag so a fresh lifecycle instance is writable. Stale pre-delete in-flight commits racing with the fresh instance will be addressed structurally by the B4 generation-aware lifecycle write gate.

**Tests:** 14 new integration tests in `tests/integration/branching_recreate_state_machine.rs` covering:
- gen-0 baseline, `delete` → Deleted + active-cleared, recreate → gen bump, two-cycle → gen 2
- Fork anchor tracks parent's live generation; post-recreate fork picks up the new parent gen
- Sibling forks get independent child generations
- Duplicate create rejection, duplicate destination rejection without counter leak
- Concurrent create-after-delete serialization via OCC (exactly one winner of four racers)
- Reopen preserves the generation counter

## Change class / assurance class

- **Change class:** refactor + additive. No storage-format change, no new `TypeTag`. Legacy `BranchMetadata` continues to be written (removal is B5+).
- **Assurance class:** S4 (branch identity/lifecycle). Meets the characterization-before-refactor rule via the B3.1-landed in-module tests and the new integration suite.

## Merge ordering

Per the B3 phasing plan: B3.3 may be developed in parallel but must merge *after* B3.2. B3.4 waits on both.

## Test plan
- [x] `cargo test --workspace` — 57 suites, 0 failures
- [x] `cargo test -p stratadb --test integration branching_recreate_state_machine` — 14/14 pass
- [x] Existing `branching`, `branch_isolation_tests`, `merge_base_characterization`, `branching_guardrails`, `branch_id_characterization` — green, no drift
- [x] `cargo clippy --workspace --all-targets` — 0 errors
- [x] `cargo fmt --all -- --check` — clean
- [x] Quick regression benchmarks (`cargo run --release --bin regression -- --quick`) — completed cleanly, nominal ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)