### PR TITLE
B3.3: lineage edges + merge-base cutover — store-authoritative with AD8 point semantics

### DIFF
--- a/crates/engine/src/branch_ops/branch_control_store.rs
+++ b/crates/engine/src/branch_ops/branch_control_store.rs
@@ -931,15 +931,20 @@ impl BranchControlStore {
     /// Compute the merge base of two lifecycle instances as a
     /// `MergeBasePoint` per AD8.
     ///
-    /// Semantics (B3.1 subset, extended in B3.3):
+    /// Algorithm (B3.3 point semantics):
     ///
-    /// - If one branch is the other's fork ancestor, returns the fork
-    ///   anchor point.
-    /// - If both share a common fork ancestor, returns that ancestor at
-    ///   `min(fork_point_from_a, fork_point_from_b)`.
-    /// - If either branch has a merge edge whose `merge_base` records a
-    ///   later shared point, returns the most recent such point
-    ///   (repeated-merge advancement).
+    /// 1. Build each branch's ancestor chain — its own history expanded
+    ///    through every `Fork → parent` anchor and every `Merge → source`
+    ///    edge, with the commit version at which each event made the
+    ///    ancestor visible on this branch.
+    /// 2. Intersect the two chains on `BranchRef`; for each shared
+    ///    `BranchRef`, the shared visibility point is
+    ///    `min(a_commit_version, b_commit_version)`.
+    /// 3. Return the candidate with the largest shared commit version —
+    ///    the most recent shared point. Repeated merges between the same
+    ///    two generations advance the base because each merge adds a
+    ///    fresh point to the target's chain.
+    ///
     /// - Returns `None` if the branches are unrelated.
     /// - Returns `Err(BranchLineageUnavailable)` on an unmigrated
     ///   follower (AD5).
@@ -959,7 +964,9 @@ impl BranchControlStore {
         let chain_a = self.ancestor_chain(a)?;
         let chain_b = self.ancestor_chain(b)?;
 
-        // Build a "how far can A see this branch" map.
+        // Build a "how far can A see this branch" map. Repeated points
+        // for the same branch (e.g. multiple merges from the same source)
+        // collapse to the most recent visibility.
         let mut reach_a: HashMap<BranchRef, CommitVersion> = HashMap::new();
         for point in &chain_a {
             reach_a
@@ -972,47 +979,51 @@ impl BranchControlStore {
                 .or_insert(point.commit_version);
         }
 
-        // Search B's chain for a `BranchRef` A can also see; take
-        // min(reach_a, reach_b) as the shared visibility point. Keep the
-        // most recent such point (largest shared commit version).
-        let mut best: Option<MergeBasePoint> = None;
+        // Collapse B's chain the same way so the search picks the most
+        // recent point per branch even when the chain contains duplicates
+        // (repeated merges).
+        let mut reach_b: HashMap<BranchRef, CommitVersion> = HashMap::new();
         for point in &chain_b {
-            let Some(cv_a) = reach_a.get(&point.branch) else {
+            reach_b
+                .entry(point.branch)
+                .and_modify(|cv| {
+                    if point.commit_version > *cv {
+                        *cv = point.commit_version;
+                    }
+                })
+                .or_insert(point.commit_version);
+        }
+
+        // Intersect: shared visibility is min(reach_a, reach_b); keep the
+        // candidate with the largest shared commit version.
+        //
+        // Sort by `(id bytes, generation)` before iteration so two
+        // candidates with identical shared commit versions resolve to a
+        // deterministic winner. `HashMap` iteration order is randomised
+        // per-process; without sorting, a tie would produce
+        // non-deterministic `merge_base` results across runs and — worse
+        // — across replicas reading the same lineage.
+        let mut ordered_b: Vec<(BranchRef, CommitVersion)> =
+            reach_b.iter().map(|(k, v)| (*k, *v)).collect();
+        ordered_b.sort_by(|a, b| {
+            a.0.id
+                .as_bytes()
+                .cmp(b.0.id.as_bytes())
+                .then(a.0.generation.cmp(&b.0.generation))
+        });
+        let mut best: Option<MergeBasePoint> = None;
+        for (branch, cv_b) in ordered_b {
+            let Some(cv_a) = reach_a.get(&branch) else {
                 continue;
             };
-            let shared_cv = (*cv_a).min(point.commit_version);
+            let shared_cv = (*cv_a).min(cv_b);
             match best {
                 Some(cur) if shared_cv <= cur.commit_version => {}
                 _ => {
                     best = Some(MergeBasePoint {
-                        branch: point.branch,
+                        branch,
                         commit_version: shared_cv,
                     })
-                }
-            }
-        }
-
-        // Merge-edge advancement (AD8, point semantics): only direct
-        // merge edges between the compared lifecycle instances can
-        // advance the base. One-sided merges with unrelated third
-        // branches must not affect this pair's merge base.
-        for edge in self.edges_for(a)?.into_iter() {
-            if edge.kind == LineageEdgeKind::Merge && edge.source == Some(b) {
-                if let Some(mb) = edge.merge_base {
-                    match best {
-                        Some(cur) if mb.commit_version <= cur.commit_version => {}
-                        _ => best = Some(mb),
-                    }
-                }
-            }
-        }
-        for edge in self.edges_for(b)?.into_iter() {
-            if edge.kind == LineageEdgeKind::Merge && edge.source == Some(a) {
-                if let Some(mb) = edge.merge_base {
-                    match best {
-                        Some(cur) if mb.commit_version <= cur.commit_version => {}
-                        _ => best = Some(mb),
-                    }
                 }
             }
         }
@@ -1322,9 +1333,23 @@ impl BranchControlStore {
         }
     }
 
-    /// Walk fork anchors back from `branch` to the root, producing the
-    /// lineage chain as points. Starting branch is its own point at
-    /// `CommitVersion::MAX` (it can see all of its own history).
+    /// Produce the ancestor chain for `branch`: every `BranchRef` whose
+    /// state `branch` has visibility into, with the commit version at
+    /// which that visibility was established. The chain is the union of:
+    ///
+    /// 1. `branch` itself at [`CommitVersion::MAX`] (it can see all of
+    ///    its own history).
+    /// 2. The fork anchor of every walked ancestor — each fork parent
+    ///    appears at `fork.point`, the version of the parent at which
+    ///    the descendant was branched.
+    /// 3. Every merge source that ever landed on the walked chain,
+    ///    recorded at the merge commit version — the version of the
+    ///    source at which its state flowed into the target.
+    ///
+    /// Cycle-safe: each `BranchRef` is walked at most once. Merge-edge
+    /// traversal is bounded by the lineage DAG already persisted in the
+    /// store, so every new point is either a fresh fork parent or a
+    /// fresh merge source.
     fn ancestor_chain(&self, branch: BranchRef) -> StrataResult<Vec<MergeBasePoint>> {
         let mut chain = vec![MergeBasePoint {
             branch,
@@ -1332,22 +1357,54 @@ impl BranchControlStore {
         }];
         let mut visited: HashSet<BranchRef> = HashSet::new();
         visited.insert(branch);
-        let mut current = branch;
-        loop {
-            let Some(rec) = self.get_record(current)? else {
-                break;
-            };
-            let Some(anchor) = rec.fork else {
-                break;
-            };
-            if !visited.insert(anchor.parent) {
-                break;
+
+        // BFS over fork parents and merge sources. Starts at `branch`
+        // and expands through its fork anchor and every merge edge, then
+        // through those ancestors' own fork anchors and merge edges.
+        let mut queue: Vec<BranchRef> = vec![branch];
+        while let Some(current) = queue.pop() {
+            // Fork anchor: the parent's version at the fork point.
+            if let Some(rec) = self.get_record(current)? {
+                if let Some(anchor) = rec.fork {
+                    if visited.insert(anchor.parent) {
+                        chain.push(MergeBasePoint {
+                            branch: anchor.parent,
+                            commit_version: anchor.point,
+                        });
+                        queue.push(anchor.parent);
+                    } else {
+                        // Seen before — still record the point so a
+                        // later fork of the same ancestor at a different
+                        // version is visible in the chain.
+                        chain.push(MergeBasePoint {
+                            branch: anchor.parent,
+                            commit_version: anchor.point,
+                        });
+                    }
+                }
             }
-            chain.push(MergeBasePoint {
-                branch: anchor.parent,
-                commit_version: anchor.point,
-            });
-            current = anchor.parent;
+
+            // Merge edges landing on `current`: every merge introduces
+            // visibility into the source's history at the merge commit
+            // version. Revert / CherryPick edges do not advance merge
+            // visibility — revert is a target-only rewind, cherry-pick
+            // applies a cherry-picked subset without claiming full merge
+            // incorporation.
+            for edge in self.edges_for(current)?.into_iter() {
+                if edge.kind != LineageEdgeKind::Merge {
+                    continue;
+                }
+                let Some(source) = edge.source else {
+                    continue;
+                };
+                chain.push(MergeBasePoint {
+                    branch: source,
+                    commit_version: edge.commit_version,
+                });
+                if visited.insert(source) {
+                    queue.push(source);
+                }
+            }
         }
         Ok(chain)
     }

--- a/crates/engine/src/branch_ops/branch_control_store.rs
+++ b/crates/engine/src/branch_ops/branch_control_store.rs
@@ -41,7 +41,7 @@
 //! Tombstoned records (`lifecycle = Deleted`) remain in the store so the
 //! counter can be reconstructed after recovery.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Arc, Once};
 
 /// One-shot warn latch for follower legacy synthesis mode (AD5).
@@ -684,6 +684,20 @@ impl BranchControlStore {
         Ok(())
     }
 
+    /// Delete a lineage edge at the exact `(target, commit_version)` key.
+    ///
+    /// Used by `BranchMutation` rollback when a later DAG write fails after the
+    /// authoritative edge has already been persisted.
+    pub(crate) fn delete_edge(
+        &self,
+        target: BranchRef,
+        commit_version: CommitVersion,
+        txn: &mut TransactionContext,
+    ) -> StrataResult<()> {
+        txn.delete(edge_key(target, commit_version))?;
+        Ok(())
+    }
+
     // =========================================================================
     // Read-path methods (open their own transaction)
     // =========================================================================
@@ -1138,43 +1152,43 @@ impl BranchControlStore {
     /// Rebuild the `_branch_dag` projection from the authoritative
     /// control-store snapshot.
     ///
-    /// Best-effort per AD3: rebuild failures are logged and do not fail
-    /// database open. B3.1 rebuilds the current read-side DAG projection
-    /// from control records + lineage edges; later B3 work re-keys the
-    /// live helpers to the canonical `BranchRef` node encoding.
-    pub(crate) fn rebuild_dag_projection(db: &Arc<Database>) {
-        let rebuild = || -> StrataResult<()> {
-            let hook = match db.dag_hook().get() {
-                Some(hook) => hook,
-                None => return Ok(()),
-            };
+    /// Best-effort per AD3 when called from open/recovery paths, but callers
+    /// may also use the returned `Err` to fail-closed after a DAG write
+    /// partially succeeded. If replay fails after `reset_projection()`, the
+    /// hook is reset a second time so callers do not keep a half-rebuilt DAG.
+    pub(crate) fn rebuild_dag_projection(db: &Arc<Database>) -> StrataResult<()> {
+        let hook = match db.dag_hook().get() {
+            Some(hook) => hook,
+            None => return Ok(()),
+        };
 
-            let records = db.transaction(global_branch_id(), |txn| {
-                let mut out = Vec::new();
-                for (_k, v) in txn.scan_prefix(&control_record_prefix_all())? {
-                    out.push(from_stored_value::<BranchControlRecord>(&v)?);
-                }
-                Ok::<_, StrataError>(out)
-            })?;
-            let edges = db.transaction(global_branch_id(), |txn| {
-                let prefix = Key::new(
-                    global_namespace(),
-                    TypeTag::Branch,
-                    CTL_EDGE_PREFIX.as_bytes().to_vec(),
-                );
-                let mut out = Vec::new();
-                for (_k, v) in txn.scan_prefix(&prefix)? {
-                    out.push(from_stored_value::<LineageEdgeRecord>(&v)?);
-                }
-                Ok::<_, StrataError>(out)
-            })?;
+        let records = db.transaction(global_branch_id(), |txn| {
+            let mut out = Vec::new();
+            for (_k, v) in txn.scan_prefix(&control_record_prefix_all())? {
+                out.push(from_stored_value::<BranchControlRecord>(&v)?);
+            }
+            Ok::<_, StrataError>(out)
+        })?;
+        let edges = db.transaction(global_branch_id(), |txn| {
+            let prefix = Key::new(
+                global_namespace(),
+                TypeTag::Branch,
+                CTL_EDGE_PREFIX.as_bytes().to_vec(),
+            );
+            let mut out = Vec::new();
+            for (_k, v) in txn.scan_prefix(&prefix)? {
+                out.push(from_stored_value::<LineageEdgeRecord>(&v)?);
+            }
+            Ok::<_, StrataError>(out)
+        })?;
 
-            hook.reset_projection().map_err(|e| {
-                StrataError::internal(format!(
-                    "failed to reset DAG projection before rebuild: {e}"
-                ))
-            })?;
+        hook.reset_projection().map_err(|e| {
+            StrataError::internal(format!(
+                "failed to reset DAG projection before rebuild: {e}"
+            ))
+        })?;
 
+        let replay = || -> StrataResult<()> {
             let mut names = HashMap::new();
             for rec in &records {
                 names.insert(rec.branch, rec.name.clone());
@@ -1324,13 +1338,18 @@ impl BranchControlStore {
             Ok(())
         };
 
-        if let Err(e) = rebuild() {
-            warn!(
-                target: "strata::branch::dag_rebuild",
-                error = %e,
-                "DAG projection rebuild failed; will retry on next open"
-            );
+        if let Err(replay_error) = replay() {
+            if let Err(reset_error) = hook.reset_projection() {
+                return Err(StrataError::corruption(format!(
+                    "failed to rebuild DAG projection ({replay_error}) and failed to reset partial projection ({reset_error})"
+                )));
+            }
+            return Err(StrataError::internal(format!(
+                "failed to rebuild DAG projection: {replay_error}"
+            )));
         }
+
+        Ok(())
     }
 
     /// Produce the ancestor chain for `branch`: every `BranchRef` whose
@@ -1342,44 +1361,45 @@ impl BranchControlStore {
     /// 2. The fork anchor of every walked ancestor — each fork parent
     ///    appears at `fork.point`, the version of the parent at which
     ///    the descendant was branched.
-    /// 3. Every merge source that ever landed on the walked chain,
-    ///    recorded at the merge commit version — the version of the
-    ///    source at which its state flowed into the target.
+    /// 3. Every merge source that landed on the walked chain *at or before the
+    ///    currently-visible point* for that branch, recorded at the merge
+    ///    commit version — the version of the source at which its state flowed
+    ///    into the target.
     ///
-    /// Cycle-safe: each `BranchRef` is walked at most once. Merge-edge
-    /// traversal is bounded by the lineage DAG already persisted in the
-    /// store, so every new point is either a fresh fork parent or a
-    /// fresh merge source.
+    /// Visibility-safe: the walk carries a `visible_until` bound for every
+    /// queued `BranchRef`. A merge that landed on `feature` at `v20` must not
+    /// become visible through `main` merely because `main` merged `feature` at
+    /// `v10`; only edges with `edge.commit_version <= visible_until` are
+    /// traversed. Repeated merges can expose *more* of the same ancestor, so we
+    /// revisit a `BranchRef` when a later path reaches it at a higher visible
+    /// version than any prior path.
     fn ancestor_chain(&self, branch: BranchRef) -> StrataResult<Vec<MergeBasePoint>> {
         let mut chain = vec![MergeBasePoint {
             branch,
             commit_version: CommitVersion::MAX,
         }];
-        let mut visited: HashSet<BranchRef> = HashSet::new();
-        visited.insert(branch);
+        let mut explored_until: HashMap<BranchRef, CommitVersion> = HashMap::new();
+        explored_until.insert(branch, CommitVersion::MAX);
 
-        // BFS over fork parents and merge sources. Starts at `branch`
-        // and expands through its fork anchor and every merge edge, then
-        // through those ancestors' own fork anchors and merge edges.
-        let mut queue: Vec<BranchRef> = vec![branch];
-        while let Some(current) = queue.pop() {
+        // DFS over fork parents and merge sources, carrying the maximum commit
+        // version of `current` that is actually visible on the original branch.
+        let mut queue: Vec<(BranchRef, CommitVersion)> = vec![(branch, CommitVersion::MAX)];
+        while let Some((current, visible_until)) = queue.pop() {
             // Fork anchor: the parent's version at the fork point.
             if let Some(rec) = self.get_record(current)? {
                 if let Some(anchor) = rec.fork {
-                    if visited.insert(anchor.parent) {
-                        chain.push(MergeBasePoint {
-                            branch: anchor.parent,
-                            commit_version: anchor.point,
-                        });
-                        queue.push(anchor.parent);
-                    } else {
-                        // Seen before — still record the point so a
-                        // later fork of the same ancestor at a different
-                        // version is visible in the chain.
-                        chain.push(MergeBasePoint {
-                            branch: anchor.parent,
-                            commit_version: anchor.point,
-                        });
+                    let parent_visible_until = visible_until.min(anchor.point);
+                    chain.push(MergeBasePoint {
+                        branch: anchor.parent,
+                        commit_version: parent_visible_until,
+                    });
+                    let should_enqueue = match explored_until.get(&anchor.parent) {
+                        Some(prev) if *prev >= parent_visible_until => false,
+                        _ => true,
+                    };
+                    if should_enqueue {
+                        explored_until.insert(anchor.parent, parent_visible_until);
+                        queue.push((anchor.parent, parent_visible_until));
                     }
                 }
             }
@@ -1394,6 +1414,9 @@ impl BranchControlStore {
                 if edge.kind != LineageEdgeKind::Merge {
                     continue;
                 }
+                if edge.commit_version > visible_until {
+                    continue;
+                }
                 let Some(source) = edge.source else {
                     continue;
                 };
@@ -1401,8 +1424,13 @@ impl BranchControlStore {
                     branch: source,
                     commit_version: edge.commit_version,
                 });
-                if visited.insert(source) {
-                    queue.push(source);
+                let should_enqueue = match explored_until.get(&source) {
+                    Some(prev) if *prev >= edge.commit_version => false,
+                    _ => true,
+                };
+                if should_enqueue {
+                    explored_until.insert(source, edge.commit_version);
+                    queue.push((source, edge.commit_version));
                 }
             }
         }
@@ -2026,6 +2054,90 @@ mod tests {
             base.commit_version,
             CommitVersion(5),
             "merge-base between main and feature must not advance from a merge involving an unrelated third branch"
+        );
+    }
+
+    #[test]
+    fn find_merge_base_does_not_leak_future_source_merges_into_target() {
+        let (db, store) = fresh_store();
+        let main = BranchRef::new(BranchId::from_user_name("main"), 0);
+        let feature = BranchRef::new(BranchId::from_user_name("feature"), 0);
+        let bugfix = BranchRef::new(BranchId::from_user_name("bugfix"), 0);
+
+        write(&db, |txn| {
+            store.put_record(
+                &BranchControlRecord {
+                    branch: main,
+                    name: "main".to_string(),
+                    lifecycle: BranchLifecycleStatus::Active,
+                    fork: None,
+                },
+                txn,
+            )?;
+            store.put_record(
+                &BranchControlRecord {
+                    branch: feature,
+                    name: "feature".to_string(),
+                    lifecycle: BranchLifecycleStatus::Active,
+                    fork: Some(strata_core::ForkAnchor {
+                        parent: main,
+                        point: CommitVersion(5),
+                    }),
+                },
+                txn,
+            )?;
+            store.put_record(
+                &BranchControlRecord {
+                    branch: bugfix,
+                    name: "bugfix".to_string(),
+                    lifecycle: BranchLifecycleStatus::Active,
+                    fork: None,
+                },
+                txn,
+            )?;
+            // main sees feature only through this merge at v10.
+            store.append_edge(
+                &LineageEdgeRecord {
+                    kind: LineageEdgeKind::Merge,
+                    target: main,
+                    source: Some(feature),
+                    commit_version: CommitVersion(10),
+                    merge_base: Some(MergeBasePoint {
+                        branch: feature,
+                        commit_version: CommitVersion(10),
+                    }),
+                },
+                txn,
+            )?;
+            // feature later merges bugfix at v20. main must NOT inherit
+            // bugfix@v20 through feature because feature was only visible on
+            // main through v10.
+            store.append_edge(
+                &LineageEdgeRecord {
+                    kind: LineageEdgeKind::Merge,
+                    target: feature,
+                    source: Some(bugfix),
+                    commit_version: CommitVersion(20),
+                    merge_base: Some(MergeBasePoint {
+                        branch: bugfix,
+                        commit_version: CommitVersion(20),
+                    }),
+                },
+                txn,
+            )
+        });
+
+        assert!(
+            store.find_merge_base(main, bugfix).unwrap().is_none(),
+            "main must not see bugfix through a later merge that only landed on feature after main merged feature"
+        );
+
+        let base = store.find_merge_base(main, feature).unwrap().unwrap();
+        assert_eq!(base.branch, feature);
+        assert_eq!(
+            base.commit_version,
+            CommitVersion(10),
+            "main sees feature only through the merge that landed on main"
         );
     }
 
@@ -2888,7 +3000,7 @@ mod tests {
             )
         });
 
-        BranchControlStore::rebuild_dag_projection(&db);
+        BranchControlStore::rebuild_dag_projection(&db).unwrap();
 
         assert_eq!(*hook.reset_count.lock().unwrap(), 1);
         let events = hook.events.lock().unwrap().clone();

--- a/crates/engine/src/branch_ops/mod.rs
+++ b/crates/engine/src/branch_ops/mod.rs
@@ -1497,54 +1497,43 @@ pub enum MergeActionKind {
 
 /// Compute the merge base between two branches.
 ///
-/// Priority:
-/// 1. `merge_base_override` from the executor (DAG-derived, covers repeated merges
-///    and materialized branches).
-/// 2. Storage-level fork info from `InheritedLayer` (fast path for COW branches).
-/// 3. None (unrelated branches → two-way fallback).
+/// B3.3 cutover: delegates to [`BranchControlStore::find_merge_base`].
+/// The store's lineage edges are the single authority — no caller
+/// override, no storage-fork fallback, no DAG fallback. This matches
+/// the [`crate::database::BranchService::merge_base`] inspection path so
+/// both `merge` apply and `merge_base` inspection read from the same
+/// lineage (see B3.3 done-when in
+/// `docs/design/branching/b3-phasing-plan.md`).
 fn compute_merge_base(
     db: &Arc<Database>,
     source_id: BranchId,
     target_id: BranchId,
-    merge_base_override: Option<(BranchId, u64)>,
-) -> Option<MergeBase> {
-    // 1. Executor-provided override (from DAG)
-    if let Some((branch_id, version)) = merge_base_override {
-        return Some(MergeBase {
-            branch_id,
-            version: CommitVersion(version),
-        });
-    }
+) -> StrataResult<Option<MergeBase>> {
+    let store = BranchControlStore::new(db.clone());
+    let Some(source_gen) = store.active_generation_for_id(source_id)? else {
+        return Ok(None);
+    };
+    let Some(target_gen) = store.active_generation_for_id(target_id)? else {
+        return Ok(None);
+    };
+    let source_ref = BranchRef::new(source_id, source_gen);
+    let target_ref = BranchRef::new(target_id, target_gen);
 
-    // 2. Check storage for fork relationship
-    let storage = db.storage();
+    let Some(point) = store.find_merge_base(source_ref, target_ref)? else {
+        return Ok(None);
+    };
 
-    // Case A: source was forked from target (child merging into parent)
-    if let Some((parent_id, fork_version)) = storage.get_fork_info(&source_id) {
-        if parent_id == target_id {
-            // Ancestor is the target (parent) at fork_version.
-            // The child inherited from the parent at this version, so reading
-            // the child at fork_version returns the same data as the parent
-            // at fork_version (via inherited layers).
-            return Some(MergeBase {
-                branch_id: source_id,
-                version: fork_version,
-            });
-        }
-    }
-
-    // Case B: target was forked from source (parent merging into child)
-    if let Some((parent_id, fork_version)) = storage.get_fork_info(&target_id) {
-        if parent_id == source_id {
-            return Some(MergeBase {
-                branch_id: target_id,
-                version: fork_version,
-            });
-        }
-    }
-
-    // No relationship found
-    None
+    // Apply-path reads are keyed by `BranchId` + version via
+    // `list_by_type_at_version`. The `BranchRef` generation is preserved
+    // on the stored edge and surfaced by `BranchControlStore` queries;
+    // here we collapse back to a plain `MergeBase` because the ancestor
+    // read path does not need generation disambiguation (same-name
+    // recreate yields a new id-equivalent generation, and storage reads
+    // are keyed by `BranchId` regardless).
+    Ok(Some(MergeBase {
+        branch_id: point.branch.id,
+        version: point.commit_version,
+    }))
 }
 
 /// Per-(space, type_tag) entry slices gathered for a three-way merge.
@@ -1909,9 +1898,8 @@ fn reload_secondary_backends(db: &Arc<Database>, target_id: BranchId, source_id:
 /// between the branches, then classifies each key using a 14-case decision matrix.
 /// Correctly handles delete propagation and preserves target-only changes.
 ///
-/// The `merge_base_override` parameter is populated by the executor from DAG data,
-/// covering repeated merges and materialized branches where storage-level fork
-/// info is no longer available.
+/// B3.3: merge base comes from [`BranchControlStore::find_merge_base`] — no
+/// caller-supplied override.
 ///
 /// # Errors
 ///
@@ -1928,17 +1916,8 @@ pub fn merge_branches(
     source: &str,
     target: &str,
     strategy: MergeStrategy,
-    merge_base_override: Option<(BranchId, u64)>,
 ) -> StrataResult<MergeInfo> {
-    merge_branches_with_metadata(
-        db,
-        source,
-        target,
-        strategy,
-        merge_base_override,
-        None,
-        None,
-    )
+    merge_branches_with_metadata(db, source, target, strategy, None, None)
 }
 
 /// Same as [`merge_branches`] but records `message` and `creator` on the
@@ -1946,23 +1925,18 @@ pub fn merge_branches(
 ///
 /// The executor's `branch_merge` handler calls this variant so that
 /// user-supplied audit metadata flows through to the DAG.
-#[allow(clippy::too_many_arguments)]
 pub fn merge_branches_with_metadata(
     db: &Arc<Database>,
     source: &str,
     target: &str,
     strategy: MergeStrategy,
-    merge_base_override: Option<(BranchId, u64)>,
     message: Option<&str>,
     creator: Option<&str>,
 ) -> StrataResult<MergeInfo> {
     let source_id = resolve_and_verify(db, source)?;
     let target_id = resolve_and_verify(db, target)?;
 
-    // Compute merge base
-    let merge_base = compute_merge_base(db, source_id, target_id, merge_base_override);
-
-    let merge_base = match merge_base {
+    let merge_base = match compute_merge_base(db, source_id, target_id)? {
         Some(mb) => mb,
         None => {
             return Err(StrataError::invalid_input(format!(
@@ -2181,9 +2155,8 @@ pub fn merge_branches_with_metadata(
 /// without applying any merge strategy. This is useful for inspection
 /// before deciding to merge.
 ///
-/// The `merge_base_override` parameter is populated by the executor from DAG data,
-/// covering repeated merges and materialized branches where storage-level fork
-/// info is no longer available.
+/// B3.3: merge base comes from [`BranchControlStore::find_merge_base`] —
+/// no caller-supplied override.
 ///
 /// # Errors
 ///
@@ -2193,15 +2166,11 @@ pub fn diff_three_way(
     db: &Arc<Database>,
     source: &str,
     target: &str,
-    merge_base_override: Option<(BranchId, u64)>,
 ) -> StrataResult<ThreeWayDiffResult> {
     let source_id = resolve_and_verify(db, source)?;
     let target_id = resolve_and_verify(db, target)?;
 
-    // Compute merge base
-    let merge_base = compute_merge_base(db, source_id, target_id, merge_base_override);
-
-    let merge_base = match merge_base {
+    let merge_base = match compute_merge_base(db, source_id, target_id)? {
         Some(mb) => mb,
         None => {
             return Err(StrataError::invalid_input(format!(
@@ -2304,9 +2273,8 @@ pub fn diff_three_way(
 ///
 /// Returns `None` if the branches have no fork or merge relationship.
 ///
-/// The `merge_base_override` parameter is populated by the executor from DAG data,
-/// covering repeated merges and materialized branches where storage-level fork
-/// info is no longer available.
+/// B3.3: merge base comes from [`BranchControlStore::find_merge_base`] —
+/// no caller-supplied override.
 ///
 /// # Errors
 ///
@@ -2315,14 +2283,11 @@ pub fn get_merge_base(
     db: &Arc<Database>,
     source: &str,
     target: &str,
-    merge_base_override: Option<(BranchId, u64)>,
 ) -> StrataResult<Option<MergeBaseInfo>> {
     let source_id = resolve_and_verify(db, source)?;
     let target_id = resolve_and_verify(db, target)?;
 
-    let merge_base = compute_merge_base(db, source_id, target_id, merge_base_override);
-
-    match merge_base {
+    match compute_merge_base(db, source_id, target_id)? {
         None => Ok(None),
         Some(mb) => {
             // Resolve merge base branch_id back to a name
@@ -3099,20 +3064,19 @@ fn check_graph_action_atomicity(
 ///
 /// This is a selective merge: computes the three-way diff between source and
 /// target, then applies only the changes that match the filter criteria.
+///
+/// B3.3: merge base comes from [`BranchControlStore::find_merge_base`] —
+/// no caller-supplied override.
 pub fn cherry_pick_from_diff(
     db: &Arc<Database>,
     source: &str,
     target: &str,
     filter: CherryPickFilter,
-    merge_base_override: Option<(BranchId, u64)>,
 ) -> StrataResult<CherryPickInfo> {
     let source_id = resolve_and_verify(db, source)?;
     let target_id = resolve_and_verify(db, target)?;
 
-    // Compute merge base
-    let merge_base = compute_merge_base(db, source_id, target_id, merge_base_override);
-
-    let merge_base = match merge_base {
+    let merge_base = match compute_merge_base(db, source_id, target_id)? {
         Some(mb) => mb,
         None => {
             return Err(StrataError::invalid_input(format!(
@@ -3364,8 +3328,10 @@ mod tests {
 
     fn setup_with_branch(name: &str) -> (TempDir, Arc<Database>) {
         let (temp_dir, db) = setup();
-        let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch(name).unwrap();
+        // Go through BranchService so the canonical BranchControlRecord
+        // is written alongside the legacy metadata — merge_base reads
+        // from the control store after B3.3.
+        db.branches().create(name).unwrap();
         (temp_dir, db)
     }
 
@@ -3469,7 +3435,7 @@ mod tests {
     fn test_fork_destination_exists() {
         let (_temp, db) = setup_with_branch("source");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("dest").unwrap();
+        db.branches().create("dest").unwrap();
 
         let result = fork_branch(&db, "source", "dest");
         assert!(result.is_err());
@@ -3555,7 +3521,7 @@ mod tests {
     fn test_diff_empty_branches() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         let diff = diff_branches(&db, "a", "b").unwrap();
         assert_eq!(diff.summary.total_added, 0);
@@ -3567,7 +3533,7 @@ mod tests {
     fn test_diff_one_populated() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         write_kv(&db, "a", "default", "k1", Value::Int(1));
         write_kv(&db, "a", "default", "k2", Value::Int(2));
@@ -3588,7 +3554,7 @@ mod tests {
     fn test_diff_modifications() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         write_kv(&db, "a", "default", "shared", Value::Int(1));
         write_kv(&db, "b", "default", "shared", Value::Int(2));
@@ -3610,7 +3576,7 @@ mod tests {
     fn test_diff_multi_space() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         let space_index = SpaceIndex::new(db.clone());
         let id_a = resolve_branch_name("a");
@@ -3657,7 +3623,7 @@ mod tests {
         );
 
         let info =
-            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins, None).unwrap();
+            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
         assert!(
             info.keys_applied >= 2,
             "shared (conflict resolved) + new_key"
@@ -3684,7 +3650,7 @@ mod tests {
         write_kv(&db, "target", "default", "target_key", Value::Int(1));
         write_kv(&db, "source", "default", "source_key", Value::Int(2));
 
-        let info = merge_branches(&db, "source", "target", MergeStrategy::Strict, None).unwrap();
+        let info = merge_branches(&db, "source", "target", MergeStrategy::Strict).unwrap();
         assert!(info.keys_applied >= 1);
 
         assert_eq!(
@@ -3708,7 +3674,7 @@ mod tests {
         write_kv(&db, "target", "default", "shared", Value::Int(10));
         write_kv(&db, "source", "default", "shared", Value::Int(2));
 
-        let result = merge_branches(&db, "source", "target", MergeStrategy::Strict, None);
+        let result = merge_branches(&db, "source", "target", MergeStrategy::Strict);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -3734,7 +3700,7 @@ mod tests {
         write_kv(&db, "target", "default", "target_only", Value::Int(1));
         write_kv(&db, "source", "default", "source_only", Value::Int(2));
 
-        merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins, None).unwrap();
+        merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
 
         // Both keys should exist on target
         assert_eq!(
@@ -3769,7 +3735,7 @@ mod tests {
         let versions_before = history_before.len();
 
         // Merge (both modified from ancestor=1 → conflict, LWW takes source=99)
-        merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins, None).unwrap();
+        merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
 
         // Check version history after merge — should have one more version
         let ns2 = Arc::new(Namespace::for_branch_space(target_id, "default"));
@@ -3813,7 +3779,7 @@ mod tests {
 
         // Merge source into target
         let info =
-            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins, None).unwrap();
+            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
         assert_eq!(info.keys_applied, 1, "Binary key entry should be merged");
 
         // Verify the binary key data is in target
@@ -3847,7 +3813,7 @@ mod tests {
         );
 
         let info =
-            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins, None).unwrap();
+            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
 
         // Should report the conflict even though LWW resolved it
         assert_eq!(info.conflicts.len(), 1, "Should report 1 conflict");
@@ -3867,7 +3833,7 @@ mod tests {
         write_kv(&db, "source", "default", "k1", Value::String("v1".into()));
 
         let info =
-            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins, None).unwrap();
+            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
         assert!(info.keys_applied >= 1);
         assert_eq!(
             read_kv(&db, "target", "default", "k1"),
@@ -3880,12 +3846,12 @@ mod tests {
         // Two branches with no fork relationship should fail
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         write_kv(&db, "a", "default", "k1", Value::Int(1));
         write_kv(&db, "b", "default", "k2", Value::Int(2));
 
-        let result = merge_branches(&db, "a", "b", MergeStrategy::LastWriterWins, None);
+        let result = merge_branches(&db, "a", "b", MergeStrategy::LastWriterWins);
         assert!(result.is_err(), "Merging unrelated branches should error");
         let err = result.unwrap_err().to_string();
         assert!(
@@ -3903,7 +3869,7 @@ mod tests {
     fn test_diff_filter_by_primitive_kv_only() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         // Write KV and JSON data to branch A only
         write_kv(&db, "a", "default", "kv1", Value::Int(1));
@@ -3936,7 +3902,7 @@ mod tests {
     fn test_diff_filter_by_multiple_primitives() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         write_kv(&db, "a", "default", "kv1", Value::Int(1));
         write_json(&db, "a", "default", "j1", Value::String("doc".into()));
@@ -3962,7 +3928,7 @@ mod tests {
     fn test_diff_filter_by_space() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         let space_index = SpaceIndex::new(db.clone());
         let id_a = resolve_branch_name("a");
@@ -4017,7 +3983,7 @@ mod tests {
     fn test_diff_filter_combined_primitive_and_space() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         let space_index = SpaceIndex::new(db.clone());
         let id_a = resolve_branch_name("a");
@@ -4050,7 +4016,7 @@ mod tests {
     fn test_diff_filter_empty_primitives_returns_empty() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         write_kv(&db, "a", "default", "k1", Value::Int(1));
 
@@ -4077,7 +4043,7 @@ mod tests {
     fn test_diff_filter_nonexistent_space_returns_empty() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         write_kv(&db, "a", "default", "k1", Value::Int(1));
 
@@ -4103,7 +4069,7 @@ mod tests {
     fn test_diff_as_of_sees_old_values() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         // Write initial value to A
         write_kv(&db, "a", "default", "key", Value::Int(1));
@@ -4151,7 +4117,7 @@ mod tests {
     fn test_diff_as_of_before_any_writes_returns_empty() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         // Record a timestamp before any data writes
         let before_ts = std::time::SystemTime::now()
@@ -4182,7 +4148,7 @@ mod tests {
     fn test_diff_as_of_with_filter() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         // Write KV data
         write_kv(&db, "a", "default", "kv1", Value::Int(1));
@@ -4217,7 +4183,7 @@ mod tests {
         // produces the same result as diff_branches
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         write_kv(&db, "a", "default", "k1", Value::Int(1));
         write_kv(&db, "b", "default", "k1", Value::Int(2));
@@ -4234,7 +4200,7 @@ mod tests {
         // Verify that complex Value types round-trip through diff correctly
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
         let complex_val = Value::Array(Box::new(vec![
             Value::Int(1),
@@ -4293,16 +4259,16 @@ mod tests {
         // Write to source
         write_kv(&db, "source", "default", "shared", Value::Int(1));
 
-        // Fork — capture fork_version for later (needed after materialization)
-        let fork_info = fork_branch(&db, "source", "dest").unwrap();
-        let fork_version = fork_info.fork_version.unwrap();
-        let dest_id = resolve_branch_name("dest");
+        // Fork — control-store `ForkAnchor` persists after materialization
+        // so merge_base survives storage-layer flattening.
+        let _fork_info = fork_branch(&db, "source", "dest").unwrap();
 
         // Write different data to dest
         write_kv(&db, "dest", "default", "dest_only", Value::Int(42));
 
-        // Materialize dest — this removes inherited layers, so storage
-        // can no longer determine the fork relationship
+        // Materialize dest — this removes inherited layers from storage,
+        // but the `BranchControlStore` fork anchor survives so
+        // merge_base is still computable.
         let mat_info = materialize_branch(&db, "dest").unwrap();
         assert!(mat_info.layers_collapsed > 0);
 
@@ -4313,16 +4279,12 @@ mod tests {
             "dest_only should show as added in dest"
         );
 
-        // Merge dest → source: must pass merge base explicitly since inherited
-        // layers are gone (in production, the executor reads this from the DAG)
-        let merge_info = merge_branches(
-            &db,
-            "dest",
-            "source",
-            MergeStrategy::LastWriterWins,
-            Some((dest_id, fork_version)),
-        )
-        .unwrap();
+        // Merge dest → source: B3.3 derives merge base from the control
+        // store's persisted `ForkAnchor`, so the merge succeeds without
+        // a caller-supplied override even though storage's fork info
+        // was flattened by materialization.
+        let merge_info =
+            merge_branches(&db, "dest", "source", MergeStrategy::LastWriterWins).unwrap();
         assert!(merge_info.keys_applied > 0);
 
         // Source should now have dest_only
@@ -4652,7 +4614,7 @@ mod tests {
         {
             let db = Database::open(temp_dir.path()).unwrap();
             let branch_index = BranchIndex::new(db.clone());
-            branch_index.create_branch("main").unwrap();
+            db.branches().create("main").unwrap();
 
             write_kv(
                 &db,
@@ -4701,7 +4663,7 @@ mod tests {
         // Use a cache (in-memory) database where storage fork must fail
         let db = Database::cache().unwrap();
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("source").unwrap();
+        db.branches().create("source").unwrap();
 
         write_kv(&db, "source", "default", "k1", Value::String("v1".into()));
 
@@ -4732,7 +4694,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let db = Database::open(temp_dir.path()).unwrap();
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("main").unwrap();
+        db.branches().create("main").unwrap();
 
         write_kv(
             &db,
@@ -4953,7 +4915,7 @@ mod tests {
 
         // Merge child → parent
         let info =
-            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins, None).unwrap();
+            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins).unwrap();
         assert!(info.keys_deleted >= 1, "should have deleted at least 1 key");
 
         // Verify: "a" still exists, "b" is gone
@@ -4975,7 +4937,7 @@ mod tests {
 
         // Child does nothing. Merge child → parent.
         let info =
-            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins, None).unwrap();
+            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins).unwrap();
         assert_eq!(info.keys_deleted, 0, "nothing should be deleted");
 
         // Verify: both "a" and "b" still exist on parent
@@ -4999,7 +4961,7 @@ mod tests {
         write_kv(&db, "child", "default", "b", Value::Int(20));
 
         // Merge child → parent
-        merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins, None).unwrap();
+        merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins).unwrap();
 
         // Verify: a=10 (parent's change preserved), b=20 (child's change applied), c=3 (unchanged)
         assert_eq!(read_kv(&db, "parent", "default", "a"), Some(Value::Int(10)));
@@ -5021,7 +4983,7 @@ mod tests {
         write_kv(&db, "child", "default", "a", Value::Int(20));
 
         // Strict merge should fail
-        let result = merge_branches(&db, "child", "parent", MergeStrategy::Strict, None);
+        let result = merge_branches(&db, "child", "parent", MergeStrategy::Strict);
         assert!(result.is_err(), "Strict merge should fail on conflict");
 
         // Parent's value should be unchanged
@@ -5029,7 +4991,7 @@ mod tests {
 
         // LWW merge should succeed with source's value
         let info =
-            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins, None).unwrap();
+            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins).unwrap();
         assert!(info.keys_applied >= 1);
         assert_eq!(read_kv(&db, "parent", "default", "a"), Some(Value::Int(20)));
     }
@@ -5043,7 +5005,7 @@ mod tests {
         write_kv(&db, "child", "default", "b", Value::Int(2));
 
         let info =
-            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins, None).unwrap();
+            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins).unwrap();
         assert!(
             info.merge_version.is_some(),
             "merge should return a version"
@@ -5144,7 +5106,7 @@ mod tests {
         write_kv(&db, "parent", "default", "a", Value::Int(10));
         write_kv(&db, "child", "default", "b", Value::Int(20));
 
-        let result = diff_three_way(&db, "child", "parent", None).unwrap();
+        let result = diff_three_way(&db, "child", "parent").unwrap();
 
         // Should see: a=TargetChanged, b=SourceChanged
         let a_entry = result.entries.iter().find(|e| e.key == "a").unwrap();
@@ -5164,7 +5126,7 @@ mod tests {
 
         let fork_info = fork_branch(&db, "parent", "child").unwrap();
 
-        let base = get_merge_base(&db, "child", "parent", None).unwrap();
+        let base = get_merge_base(&db, "child", "parent").unwrap();
         assert!(base.is_some());
         let base = base.unwrap();
         assert_eq!(base.version, CommitVersion(fork_info.fork_version.unwrap()));
@@ -5174,9 +5136,9 @@ mod tests {
     fn test_get_merge_base_unrelated() {
         let (_temp, db) = setup_with_branch("a");
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("b").unwrap();
+        db.branches().create("b").unwrap();
 
-        let base = get_merge_base(&db, "a", "b", None).unwrap();
+        let base = get_merge_base(&db, "a", "b").unwrap();
         assert!(base.is_none());
     }
 
@@ -5311,7 +5273,7 @@ mod tests {
             spaces: None,
             primitives: None,
         };
-        let info = cherry_pick_from_diff(&db, "child", "parent", filter, None).unwrap();
+        let info = cherry_pick_from_diff(&db, "child", "parent", filter).unwrap();
         assert_eq!(info.keys_applied, 1);
 
         // Only "b" should be changed
@@ -5655,7 +5617,7 @@ mod tests {
 
             barrier.wait();
             let result =
-                merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins, None);
+                merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins);
             writer.join().unwrap();
 
             // Both merge and concurrent write have committed at this point.
@@ -5752,8 +5714,7 @@ mod tests {
                     "source1",
                     "target",
                     MergeStrategy::LastWriterWins,
-                    None,
-                )
+                    )
             });
             let t2 = thread::spawn(move || {
                 b2.wait();
@@ -5762,8 +5723,7 @@ mod tests {
                     "source2",
                     "target",
                     MergeStrategy::LastWriterWins,
-                    None,
-                )
+                    )
             });
 
             let r1 = t1.join().unwrap();
@@ -5807,8 +5767,8 @@ mod tests {
         // concurrent writes don't produce an inconsistent diff.
         let (_temp, db) = setup();
         let branch_index = BranchIndex::new(db.clone());
-        branch_index.create_branch("snap-a").unwrap();
-        branch_index.create_branch("snap-b").unwrap();
+        db.branches().create("snap-a").unwrap();
+        db.branches().create("snap-b").unwrap();
 
         // Write different data to each branch
         write_kv(&db, "snap-a", "default", "shared", Value::Int(1));

--- a/crates/engine/src/branch_ops/mod.rs
+++ b/crates/engine/src/branch_ops/mod.rs
@@ -49,7 +49,7 @@ use strata_core::{
 };
 use tracing::info;
 
-use crate::branch_ops::branch_control_store::BranchControlStore;
+use crate::branch_ops::branch_control_store::{active_ptr_key, BranchControlStore, MergeBasePoint};
 
 // =============================================================================
 // Constants and key-format helpers
@@ -1504,6 +1504,103 @@ pub enum MergeActionKind {
 /// both `merge` apply and `merge_base` inspection read from the same
 /// lineage (see B3.3 done-when in
 /// `docs/design/branching/b3-phasing-plan.md`).
+fn compute_merge_base_for_refs(
+    db: &Arc<Database>,
+    source_ref: BranchRef,
+    target_ref: BranchRef,
+) -> StrataResult<Option<MergeBase>> {
+    let Some(point) = compute_merge_base_point_for_refs(db, source_ref, target_ref)? else {
+        return Ok(None);
+    };
+
+    Ok(Some(MergeBase {
+        branch_id: point.branch.id,
+        version: point.commit_version,
+    }))
+}
+
+fn compute_merge_base_point_for_refs(
+    db: &Arc<Database>,
+    source_ref: BranchRef,
+    target_ref: BranchRef,
+) -> StrataResult<Option<MergeBasePoint>> {
+    let store = BranchControlStore::new(db.clone());
+    store.find_merge_base(source_ref, target_ref)
+}
+
+fn verify_expected_active_ref(
+    db: &Arc<Database>,
+    branch_name: &str,
+    expected: BranchRef,
+) -> StrataResult<()> {
+    let store = BranchControlStore::new(db.clone());
+    match store.active_generation_for_id(expected.id)? {
+        Some(current_generation) if current_generation == expected.generation => Ok(()),
+        Some(current_generation) => Err(StrataError::conflict(format!(
+            "branch '{}' lifecycle advanced from generation {} to {} during operation",
+            branch_name, expected.generation, current_generation
+        ))),
+        None => Err(StrataError::conflict(format!(
+            "branch '{}' lifecycle no longer has active generation {} during operation",
+            branch_name, expected.generation
+        ))),
+    }
+}
+
+fn resolve_and_verify_with_expected(
+    db: &Arc<Database>,
+    name: &str,
+    expected: Option<BranchRef>,
+) -> StrataResult<BranchId> {
+    if let Some(expected) = expected {
+        verify_expected_active_ref(db, name, expected)?;
+        return Ok(expected.id);
+    }
+    resolve_and_verify(db, name)
+}
+
+fn verify_expected_active_ref_in_txn(
+    txn: &mut strata_concurrency::TransactionContext,
+    branch_name: &str,
+    expected: BranchRef,
+) -> StrataResult<()> {
+    let key = active_ptr_key(expected.id);
+    txn.set_allow_cross_branch(true);
+    let current = txn.get(&key)?;
+    txn.set_allow_cross_branch(false);
+
+    let current_generation = match current {
+        Some(Value::Int(v)) if v >= 0 => v as u64,
+        Some(other) => {
+            return Err(StrataError::corruption(format!(
+                "branch '{}' lifecycle guard stored invalid active generation value: {:?}",
+                branch_name, other
+            )));
+        }
+        None => {
+            return Err(StrataError::conflict(format!(
+                "branch '{}' lifecycle no longer has active generation {} during operation",
+                branch_name, expected.generation
+            )));
+        }
+    };
+
+    if current_generation != expected.generation {
+        return Err(StrataError::conflict(format!(
+            "branch '{}' lifecycle advanced from generation {} to {} during operation",
+            branch_name, expected.generation, current_generation
+        )));
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+pub(crate) struct MergeExecutionResult {
+    pub info: MergeInfo,
+    pub merge_base_used: MergeBasePoint,
+}
+
 fn compute_merge_base(
     db: &Arc<Database>,
     source_id: BranchId,
@@ -1519,10 +1616,6 @@ fn compute_merge_base(
     let source_ref = BranchRef::new(source_id, source_gen);
     let target_ref = BranchRef::new(target_id, target_gen);
 
-    let Some(point) = store.find_merge_base(source_ref, target_ref)? else {
-        return Ok(None);
-    };
-
     // Apply-path reads are keyed by `BranchId` + version via
     // `list_by_type_at_version`. The `BranchRef` generation is preserved
     // on the stored edge and surfaced by `BranchControlStore` queries;
@@ -1530,10 +1623,7 @@ fn compute_merge_base(
     // read path does not need generation disambiguation (same-name
     // recreate yields a new id-equivalent generation, and storage reads
     // are keyed by `BranchId` regardless).
-    Ok(Some(MergeBase {
-        branch_id: point.branch.id,
-        version: point.commit_version,
-    }))
+    compute_merge_base_for_refs(db, source_ref, target_ref)
 }
 
 /// Per-(space, type_tag) entry slices gathered for a three-way merge.
@@ -1933,11 +2023,80 @@ pub fn merge_branches_with_metadata(
     message: Option<&str>,
     creator: Option<&str>,
 ) -> StrataResult<MergeInfo> {
-    let source_id = resolve_and_verify(db, source)?;
-    let target_id = resolve_and_verify(db, target)?;
+    Ok(
+        merge_branches_with_metadata_expected_detailed(
+            db, source, target, strategy, message, creator, None, None,
+        )?
+        .info,
+    )
+}
 
-    let merge_base = match compute_merge_base(db, source_id, target_id)? {
-        Some(mb) => mb,
+pub(crate) fn merge_branches_with_metadata_expected(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+    strategy: MergeStrategy,
+    message: Option<&str>,
+    creator: Option<&str>,
+    expected_source_ref: Option<BranchRef>,
+    expected_target_ref: Option<BranchRef>,
+) -> StrataResult<MergeInfo> {
+    Ok(
+        merge_branches_with_metadata_expected_detailed(
+            db,
+            source,
+            target,
+            strategy,
+            message,
+            creator,
+            expected_source_ref,
+            expected_target_ref,
+        )?
+        .info,
+    )
+}
+
+pub(crate) fn merge_branches_with_metadata_expected_detailed(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+    strategy: MergeStrategy,
+    message: Option<&str>,
+    creator: Option<&str>,
+    expected_source_ref: Option<BranchRef>,
+    expected_target_ref: Option<BranchRef>,
+) -> StrataResult<MergeExecutionResult> {
+    let source_id = resolve_and_verify_with_expected(db, source, expected_source_ref)?;
+    let target_id = resolve_and_verify_with_expected(db, target, expected_target_ref)?;
+
+    let merge_base_point = match match (expected_source_ref, expected_target_ref) {
+        (Some(source_ref), Some(target_ref)) => {
+            compute_merge_base_point_for_refs(db, source_ref, target_ref)?
+        }
+        _ => {
+            let store = BranchControlStore::new(db.clone());
+            let Some(source_gen) = store.active_generation_for_id(source_id)? else {
+                return Err(StrataError::invalid_input(format!(
+                    "Cannot merge '{}' into '{}': no fork or merge relationship found. \
+                     Branches must be related by fork or a previous merge.",
+                    source, target
+                )));
+            };
+            let Some(target_gen) = store.active_generation_for_id(target_id)? else {
+                return Err(StrataError::invalid_input(format!(
+                    "Cannot merge '{}' into '{}': no fork or merge relationship found. \
+                     Branches must be related by fork or a previous merge.",
+                    source, target
+                )));
+            };
+            compute_merge_base_point_for_refs(
+                db,
+                BranchRef::new(source_id, source_gen),
+                BranchRef::new(target_id, target_gen),
+            )?
+        }
+    } {
+        Some(point) => point,
         None => {
             return Err(StrataError::invalid_input(format!(
                 "Cannot merge '{}' into '{}': no fork or merge relationship found. \
@@ -1945,6 +2104,10 @@ pub fn merge_branches_with_metadata(
                 source, target
             )));
         }
+    };
+    let merge_base = MergeBase {
+        branch_id: merge_base_point.branch.id,
+        version: merge_base_point.commit_version,
     };
 
     // Collect spaces from both branches
@@ -2072,6 +2235,12 @@ pub fn merge_branches_with_metadata(
         // Apply in a single transaction, capturing the merge version.
         // Read each target key first to populate read_set for OCC (#1917).
         let ((), version) = db.transaction_with_version(target_id, |txn| {
+            if let Some(expected) = expected_source_ref {
+                verify_expected_active_ref_in_txn(txn, source, expected)?;
+            }
+            if let Some(expected) = expected_target_ref {
+                verify_expected_active_ref_in_txn(txn, target, expected)?;
+            }
             // Validate target hasn't changed since the diff snapshot (#1917).
             // txn.get() populates read_set, enabling OCC conflict detection.
             for (key, expected) in &expected_targets {
@@ -2142,7 +2311,10 @@ pub fn merge_branches_with_metadata(
 
     dispatch_merge_hook(db, &info, strategy, message, creator);
 
-    Ok(info)
+    Ok(MergeExecutionResult {
+        info,
+        merge_base_used: merge_base_point,
+    })
 }
 
 // =============================================================================
@@ -2739,6 +2911,18 @@ pub fn revert_version_range_with_metadata(
     message: Option<&str>,
     creator: Option<&str>,
 ) -> StrataResult<RevertInfo> {
+    revert_version_range_with_expected(db, branch, from_version, to_version, message, creator, None)
+}
+
+pub(crate) fn revert_version_range_with_expected(
+    db: &Arc<Database>,
+    branch: &str,
+    from_version: CommitVersion,
+    to_version: CommitVersion,
+    message: Option<&str>,
+    creator: Option<&str>,
+    expected_branch_ref: Option<BranchRef>,
+) -> StrataResult<RevertInfo> {
     // Validate range
     if from_version == CommitVersion::ZERO {
         return Err(StrataError::invalid_input("from_version must be > 0"));
@@ -2757,7 +2941,7 @@ pub fn revert_version_range_with_metadata(
         )));
     }
 
-    let branch_id = resolve_and_verify(db, branch)?;
+    let branch_id = resolve_and_verify_with_expected(db, branch, expected_branch_ref)?;
     let storage = db.storage();
 
     let mut puts: Vec<(Key, Value)> = Vec::new();
@@ -2825,6 +3009,9 @@ pub fn revert_version_range_with_metadata(
 
     if !puts.is_empty() || !deletes.is_empty() {
         let ((), version) = db.transaction_with_version(branch_id, |txn| {
+            if let Some(expected) = expected_branch_ref {
+                verify_expected_active_ref_in_txn(txn, branch, expected)?;
+            }
             for (key, value) in &puts {
                 txn.put(key.clone(), value.clone())?;
             }
@@ -2899,8 +3086,19 @@ pub fn cherry_pick_keys(
     target: &str,
     keys: &[(String, String)], // (space, key) pairs
 ) -> StrataResult<CherryPickInfo> {
-    let source_id = resolve_and_verify(db, source)?;
-    let target_id = resolve_and_verify(db, target)?;
+    cherry_pick_keys_expected(db, source, target, keys, None, None)
+}
+
+pub(crate) fn cherry_pick_keys_expected(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+    keys: &[(String, String)],
+    expected_source_ref: Option<BranchRef>,
+    expected_target_ref: Option<BranchRef>,
+) -> StrataResult<CherryPickInfo> {
+    let source_id = resolve_and_verify_with_expected(db, source, expected_source_ref)?;
+    let target_id = resolve_and_verify_with_expected(db, target, expected_target_ref)?;
     let storage = db.storage();
     let space_index = SpaceIndex::new(db.clone());
 
@@ -2931,6 +3129,12 @@ pub fn cherry_pick_keys(
 
     if !puts.is_empty() {
         let ((), version) = db.transaction_with_version(target_id, |txn| {
+            if let Some(expected) = expected_source_ref {
+                verify_expected_active_ref_in_txn(txn, source, expected)?;
+            }
+            if let Some(expected) = expected_target_ref {
+                verify_expected_active_ref_in_txn(txn, target, expected)?;
+            }
             for (key, value) in &puts {
                 txn.put(key.clone(), value.clone())?;
             }
@@ -3073,10 +3277,26 @@ pub fn cherry_pick_from_diff(
     target: &str,
     filter: CherryPickFilter,
 ) -> StrataResult<CherryPickInfo> {
-    let source_id = resolve_and_verify(db, source)?;
-    let target_id = resolve_and_verify(db, target)?;
+    cherry_pick_from_diff_expected(db, source, target, filter, None, None)
+}
 
-    let merge_base = match compute_merge_base(db, source_id, target_id)? {
+pub(crate) fn cherry_pick_from_diff_expected(
+    db: &Arc<Database>,
+    source: &str,
+    target: &str,
+    filter: CherryPickFilter,
+    expected_source_ref: Option<BranchRef>,
+    expected_target_ref: Option<BranchRef>,
+) -> StrataResult<CherryPickInfo> {
+    let source_id = resolve_and_verify_with_expected(db, source, expected_source_ref)?;
+    let target_id = resolve_and_verify_with_expected(db, target, expected_target_ref)?;
+
+    let merge_base = match match (expected_source_ref, expected_target_ref) {
+        (Some(source_ref), Some(target_ref)) => {
+            compute_merge_base_for_refs(db, source_ref, target_ref)?
+        }
+        _ => compute_merge_base(db, source_id, target_id)?,
+    } {
         Some(mb) => mb,
         None => {
             return Err(StrataError::invalid_input(format!(
@@ -3237,6 +3457,12 @@ pub fn cherry_pick_from_diff(
 
     if !puts.is_empty() || !deletes.is_empty() {
         let ((), version) = db.transaction_with_version(target_id, |txn| {
+            if let Some(expected) = expected_source_ref {
+                verify_expected_active_ref_in_txn(txn, source, expected)?;
+            }
+            if let Some(expected) = expected_target_ref {
+                verify_expected_active_ref_in_txn(txn, target, expected)?;
+            }
             // Validate target hasn't changed since diff snapshot (#1917)
             for (key, expected) in &expected_targets {
                 let current = txn.get(key)?;
@@ -3622,8 +3848,7 @@ mod tests {
             Value::String("new".into()),
         );
 
-        let info =
-            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
+        let info = merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
         assert!(
             info.keys_applied >= 2,
             "shared (conflict resolved) + new_key"
@@ -3778,8 +4003,7 @@ mod tests {
         .unwrap();
 
         // Merge source into target
-        let info =
-            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
+        let info = merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
         assert_eq!(info.keys_applied, 1, "Binary key entry should be merged");
 
         // Verify the binary key data is in target
@@ -3812,8 +4036,7 @@ mod tests {
             Value::String("new".into()),
         );
 
-        let info =
-            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
+        let info = merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
 
         // Should report the conflict even though LWW resolved it
         assert_eq!(info.conflicts.len(), 1, "Should report 1 conflict");
@@ -3832,8 +4055,7 @@ mod tests {
 
         write_kv(&db, "source", "default", "k1", Value::String("v1".into()));
 
-        let info =
-            merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
+        let info = merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins).unwrap();
         assert!(info.keys_applied >= 1);
         assert_eq!(
             read_kv(&db, "target", "default", "k1"),
@@ -4914,8 +5136,7 @@ mod tests {
         delete_kv(&db, "child", "default", "b");
 
         // Merge child → parent
-        let info =
-            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins).unwrap();
+        let info = merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins).unwrap();
         assert!(info.keys_deleted >= 1, "should have deleted at least 1 key");
 
         // Verify: "a" still exists, "b" is gone
@@ -4936,8 +5157,7 @@ mod tests {
         write_kv(&db, "parent", "default", "b", Value::Int(2));
 
         // Child does nothing. Merge child → parent.
-        let info =
-            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins).unwrap();
+        let info = merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins).unwrap();
         assert_eq!(info.keys_deleted, 0, "nothing should be deleted");
 
         // Verify: both "a" and "b" still exist on parent
@@ -4990,8 +5210,7 @@ mod tests {
         assert_eq!(read_kv(&db, "parent", "default", "a"), Some(Value::Int(10)));
 
         // LWW merge should succeed with source's value
-        let info =
-            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins).unwrap();
+        let info = merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins).unwrap();
         assert!(info.keys_applied >= 1);
         assert_eq!(read_kv(&db, "parent", "default", "a"), Some(Value::Int(20)));
     }
@@ -5004,8 +5223,7 @@ mod tests {
         fork_branch(&db, "parent", "child").unwrap();
         write_kv(&db, "child", "default", "b", Value::Int(2));
 
-        let info =
-            merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins).unwrap();
+        let info = merge_branches(&db, "child", "parent", MergeStrategy::LastWriterWins).unwrap();
         assert!(
             info.merge_version.is_some(),
             "merge should return a version"
@@ -5616,8 +5834,7 @@ mod tests {
             });
 
             barrier.wait();
-            let result =
-                merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins);
+            let result = merge_branches(&db, "source", "target", MergeStrategy::LastWriterWins);
             writer.join().unwrap();
 
             // Both merge and concurrent write have committed at this point.
@@ -5709,21 +5926,11 @@ mod tests {
 
             let t1 = thread::spawn(move || {
                 b1.wait();
-                merge_branches(
-                    &db1,
-                    "source1",
-                    "target",
-                    MergeStrategy::LastWriterWins,
-                    )
+                merge_branches(&db1, "source1", "target", MergeStrategy::LastWriterWins)
             });
             let t2 = thread::spawn(move || {
                 b2.wait();
-                merge_branches(
-                    &db2,
-                    "source2",
-                    "target",
-                    MergeStrategy::LastWriterWins,
-                    )
+                merge_branches(&db2, "source2", "target", MergeStrategy::LastWriterWins)
             });
 
             let r1 = t1.join().unwrap();

--- a/crates/engine/src/branch_ops/mod.rs
+++ b/crates/engine/src/branch_ops/mod.rs
@@ -2023,12 +2023,10 @@ pub fn merge_branches_with_metadata(
     message: Option<&str>,
     creator: Option<&str>,
 ) -> StrataResult<MergeInfo> {
-    Ok(
-        merge_branches_with_metadata_expected_detailed(
-            db, source, target, strategy, message, creator, None, None,
-        )?
-        .info,
-    )
+    Ok(merge_branches_with_metadata_expected_detailed(
+        db, source, target, strategy, message, creator, None, None,
+    )?
+    .info)
 }
 
 pub(crate) fn merge_branches_with_metadata_expected(
@@ -2041,19 +2039,17 @@ pub(crate) fn merge_branches_with_metadata_expected(
     expected_source_ref: Option<BranchRef>,
     expected_target_ref: Option<BranchRef>,
 ) -> StrataResult<MergeInfo> {
-    Ok(
-        merge_branches_with_metadata_expected_detailed(
-            db,
-            source,
-            target,
-            strategy,
-            message,
-            creator,
-            expected_source_ref,
-            expected_target_ref,
-        )?
-        .info,
-    )
+    Ok(merge_branches_with_metadata_expected_detailed(
+        db,
+        source,
+        target,
+        strategy,
+        message,
+        creator,
+        expected_source_ref,
+        expected_target_ref,
+    )?
+    .info)
 }
 
 pub(crate) fn merge_branches_with_metadata_expected_detailed(

--- a/crates/engine/src/database/branch_mutation.rs
+++ b/crates/engine/src/database/branch_mutation.rs
@@ -62,7 +62,7 @@ use std::sync::Arc;
 use strata_core::id::CommitVersion;
 use strata_core::types::{BranchId, Key, Namespace};
 use strata_core::value::Value;
-use strata_core::{BranchControlRecord, StrataError, StrataResult, VersionedValue};
+use strata_core::{BranchControlRecord, BranchRef, StrataError, StrataResult, VersionedValue};
 use tracing::{error, info, warn};
 
 use super::dag_hook::{BranchDagError, BranchDagHook, DagEvent};
@@ -111,6 +111,13 @@ enum RollbackAction {
         from_version: CommitVersion,
         /// Last version written by the failed mutation.
         to_version: CommitVersion,
+    },
+    /// Delete a control-store lineage edge written before a later failure.
+    DeleteLineageEdge {
+        /// Lifecycle instance that owns the edge.
+        target: BranchRef,
+        /// Commit version encoded into the edge key.
+        commit_version: CommitVersion,
     },
     /// Restore a branch snapshot captured before delete.
     RestoreBranchSnapshot(Box<BranchSnapshot>),
@@ -178,6 +185,22 @@ impl RollbackAction {
                     "Executing rollback: revert branch version range"
                 );
                 rollback_branch_range(db, &name, from_version, to_version)
+            }
+            Self::DeleteLineageEdge {
+                target,
+                commit_version,
+            } => {
+                info!(
+                    target: "strata::branch_mutation",
+                    branch_id = %target.id,
+                    generation = target.generation,
+                    commit_version = commit_version.as_u64(),
+                    "Executing rollback: delete lineage edge"
+                );
+                let control_store = BranchControlStore::new(db.clone());
+                db.transaction(global_branch_id(), |txn| {
+                    control_store.delete_edge(target, commit_version, txn)
+                })
             }
             Self::RestoreBranchSnapshot(snapshot) => {
                 info!(
@@ -537,6 +560,19 @@ impl<'a> BranchMutation<'a> {
             });
     }
 
+    /// Register a rollback action to delete a previously-written lineage edge.
+    pub fn on_rollback_delete_lineage_edge(
+        &mut self,
+        target: BranchRef,
+        commit_version: CommitVersion,
+    ) {
+        self.rollback_actions
+            .push(RollbackAction::DeleteLineageEdge {
+                target,
+                commit_version,
+            });
+    }
+
     /// Capture a branch snapshot and register it for restore-on-rollback.
     pub fn on_rollback_restore_branch(&mut self, name: &str) -> StrataResult<()> {
         let snapshot = BranchSnapshot::capture(self.db, name)?;
@@ -599,6 +635,18 @@ impl<'a> BranchMutation<'a> {
             return Err(StrataError::corruption(format!(
                 "rollback failed after DAG write failure: dag_error={}, rollback_error={}",
                 dag_error, rollback_error
+            )));
+        }
+
+        if let Err(rebuild_error) = BranchControlStore::rebuild_dag_projection(self.db) {
+            error!(
+                target: "strata::branch_mutation",
+                dag_error = %dag_error,
+                rebuild_error = %rebuild_error,
+                "CRITICAL: DAG rollback succeeded but projection rebuild failed"
+            );
+            return Err(StrataError::corruption(format!(
+                "rollback succeeded after DAG write failure ({dag_error}) but DAG projection rebuild failed: {rebuild_error}"
             )));
         }
 

--- a/crates/engine/src/database/branch_service.rs
+++ b/crates/engine/src/database/branch_service.rs
@@ -26,10 +26,12 @@ use strata_core::EntityRef;
 use strata_core::{BranchControlRecord, BranchRef, StrataError, StrataResult};
 
 use crate::branch_ops::with_branch_dag_hooks_suppressed;
+use crate::branch_ops::branch_control_store::{
+    BranchControlStore, LineageEdgeKind, LineageEdgeRecord, MergeBasePoint,
+};
 use crate::branch_ops::{
-    self, branch_control_store::BranchControlStore, BranchDiffResult, CherryPickFilter,
-    CherryPickInfo, DiffOptions, ForkInfo, MergeInfo, MergeStrategy, NoteInfo, RevertInfo, TagInfo,
-    ThreeWayDiffResult,
+    self, BranchDiffResult, CherryPickFilter, CherryPickInfo, DiffOptions, ForkInfo, MergeInfo,
+    MergeStrategy, NoteInfo, RevertInfo, TagInfo, ThreeWayDiffResult,
 };
 use crate::database::branch_mutation::BranchMutation;
 use crate::database::dag_hook::{BranchDagError, DagEvent, DagHookSlot, MergeBaseResult};
@@ -46,12 +48,17 @@ use crate::SYSTEM_BRANCH;
 // =============================================================================
 
 /// Options for branch merge operations.
+///
+/// B3.3 removed the `merge_base` field. Merge base is derived from the
+/// authoritative [`BranchControlStore`] lineage (fork anchors + merge
+/// edges) — callers can no longer inject a synthetic base. Unrelated
+/// branches now refuse to merge; before B3.3 a caller-supplied override
+/// could bypass that check, which silently produced incorrect ancestor
+/// reads.
 #[derive(Debug, Clone)]
 pub struct MergeOptions {
     /// Conflict resolution strategy.
     pub strategy: MergeStrategy,
-    /// Optional merge base override (branch_id, version).
-    pub merge_base: Option<(BranchId, u64)>,
     /// Optional commit message.
     pub message: Option<String>,
     /// Optional creator identifier.
@@ -62,7 +69,6 @@ impl Default for MergeOptions {
     fn default() -> Self {
         Self {
             strategy: MergeStrategy::LastWriterWins,
-            merge_base: None,
             message: None,
             creator: None,
         }
@@ -87,12 +93,6 @@ impl MergeOptions {
     /// Set the creator identifier.
     pub fn with_creator(mut self, creator: impl Into<String>) -> Self {
         self.creator = Some(creator.into());
-        self
-    }
-
-    /// Set the merge base override.
-    pub fn with_merge_base(mut self, branch_id: BranchId, version: u64) -> Self {
-        self.merge_base = Some((branch_id, version));
         self
     }
 }
@@ -379,20 +379,11 @@ impl BranchService {
     }
 
     /// Three-way diff between branches.
-    pub fn diff3(
-        &self,
-        source: &str,
-        target: &str,
-        merge_base: Option<(BranchId, u64)>,
-    ) -> StrataResult<ThreeWayDiffResult> {
-        let merge_base = match merge_base {
-            Some(merge_base) => Some(merge_base),
-            None if self.dag_hook().get().is_some() => self
-                .merge_base(source, target)?
-                .map(|mb| (mb.branch_id, mb.commit_version.0)),
-            None => None,
-        };
-        branch_ops::diff_three_way(&self.db, source, target, merge_base)
+    ///
+    /// B3.3: merge base is derived from the authoritative
+    /// [`BranchControlStore`] — callers no longer inject a base.
+    pub fn diff3(&self, source: &str, target: &str) -> StrataResult<ThreeWayDiffResult> {
+        branch_ops::diff_three_way(&self.db, source, target)
     }
 
     // =========================================================================
@@ -522,6 +513,11 @@ impl BranchService {
     ///
     /// Requires a DAG hook to be installed — merges without DAG recording would
     /// lose merge provenance and break merge-base computation.
+    ///
+    /// B3.3: merge base is always derived from the authoritative
+    /// [`BranchControlStore`]; after a successful merge, a
+    /// `LineageEdgeRecord::Merge` edge is appended to the store so
+    /// subsequent `find_merge_base` calls advance past this merge point.
     pub fn merge_with_options(
         &self,
         source: &str,
@@ -536,12 +532,19 @@ impl BranchService {
         // Merge requires DAG — without it, merge provenance is lost
         mutation.require_dag_hook("merge")?;
 
-        let merge_base = match options.merge_base {
-            Some(merge_base) => Some(merge_base),
-            None => self
-                .merge_base(source, target)?
-                .map(|mb| (mb.branch_id, mb.commit_version.0)),
-        };
+        // Snapshot source / target `BranchRef`s + the pre-merge base
+        // BEFORE the merge runs. The stored edge records the merge base
+        // that was actually used for ancestor reads, which is what future
+        // audit / replay consumers need — not the post-merge advanced
+        // base (the latter is derivable from the chain anyway).
+        let store = BranchControlStore::new(self.db.clone());
+        let source_rec = store
+            .find_active_by_name(source)?
+            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(source)))?;
+        let target_rec = store
+            .find_active_by_name(target)?
+            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(target)))?;
+        let pre_merge_base = store.find_merge_base(source_rec.branch, target_rec.branch)?;
 
         let info = with_branch_dag_hooks_suppressed(|| {
             branch_ops::merge_branches_with_metadata(
@@ -549,16 +552,20 @@ impl BranchService {
                 source,
                 target,
                 options.strategy,
-                merge_base,
                 options.message.as_deref(),
                 options.creator.as_deref(),
             )
         })?;
 
         // Record to DAG — only if merge actually committed changes
-        let source_id = resolve_branch_name(source);
-        let target_id = resolve_branch_name(target);
+        let source_id = source_rec.branch.id;
+        let target_id = target_rec.branch.id;
         if let Some(merge_version) = info.merge_version {
+            // Register rollback FIRST so every downstream failure
+            // (DAG write, edge write) triggers a compensating revert
+            // of the merge commit range. Without this, a failure later
+            // in the block would leave the merge commit applied with
+            // no lineage authority and no compensating revert.
             mutation.on_rollback_revert_range(
                 target,
                 CommitVersion(merge_version),
@@ -580,6 +587,21 @@ impl BranchService {
                 event = event.with_creator(creator.clone());
             }
             mutation.record_dag_event(&event)?;
+
+            // Persist lineage edge LAST so a failed write triggers
+            // `BranchMutation`'s drop-time rollback, which reverts the
+            // merge commit range and leaves no stale edge referencing
+            // a rolled-back commit. The DAG event written above becomes
+            // stale (log-only surface tolerates that after B4); the
+            // merge-base authority stays consistent with target state.
+            append_merge_edge(
+                &self.db,
+                &store,
+                target_rec.branch,
+                source_rec.branch,
+                CommitVersion(merge_version),
+                pre_merge_base,
+            )?;
 
             // Commit: fires observers
             let strategy_str = match options.strategy {
@@ -631,7 +653,14 @@ impl BranchService {
         // Revert requires DAG — without it, revert history is lost
         mutation.require_dag_hook("revert")?;
 
-        let branch_id = resolve_branch_name(branch);
+        // Resolve target `BranchRef` before the revert so a concurrent
+        // delete+recreate between here and the edge write cannot land
+        // the revert edge on the wrong lifecycle instance.
+        let store = BranchControlStore::new(self.db.clone());
+        let branch_rec = store
+            .find_active_by_name(branch)?
+            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(branch)))?;
+        let branch_id = branch_rec.branch.id;
 
         // Execute the revert
         let info = with_branch_dag_hooks_suppressed(|| {
@@ -640,9 +669,15 @@ impl BranchService {
 
         // Record to DAG — only if revert actually committed changes
         if let Some(revert_version) = info.revert_version {
+            // Register rollback FIRST; edge + DAG writes are the
+            // downstream steps a failure mid-path needs to compensate.
             mutation.on_rollback_revert_range(branch, revert_version, revert_version);
             let event = DagEvent::revert(branch_id, branch, revert_version, info.clone());
             mutation.record_dag_event(&event)?;
+
+            // Edge LAST so a failed write triggers `BranchMutation`
+            // drop-time rollback and leaves no stale edge.
+            append_revert_edge(&self.db, &store, branch_rec.branch, revert_version)?;
 
             // Commit: fires observers
             let observer_event = BranchOpEvent::revert(
@@ -682,8 +717,15 @@ impl BranchService {
         // Cherry-pick requires DAG — without it, cherry-pick history is lost
         mutation.require_dag_hook("cherry_pick")?;
 
-        let source_id = resolve_branch_name(source);
-        let target_id = resolve_branch_name(target);
+        let store = BranchControlStore::new(self.db.clone());
+        let source_rec = store
+            .find_active_by_name(source)?
+            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(source)))?;
+        let target_rec = store
+            .find_active_by_name(target)?
+            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(target)))?;
+        let source_id = source_rec.branch.id;
+        let target_id = target_rec.branch.id;
 
         // Execute the cherry-pick
         let info = with_branch_dag_hooks_suppressed(|| {
@@ -692,6 +734,7 @@ impl BranchService {
 
         // Record to DAG — only if cherry-pick actually committed changes
         if let Some(cp_version) = info.cherry_pick_version {
+            // Register rollback FIRST.
             mutation.on_rollback_revert_range(
                 target,
                 CommitVersion(cp_version),
@@ -706,6 +749,15 @@ impl BranchService {
                 info.clone(),
             );
             mutation.record_dag_event(&event)?;
+
+            // Edge LAST so failure is cleaned up by drop-time rollback.
+            append_cherry_pick_edge(
+                &self.db,
+                &store,
+                target_rec.branch,
+                source_rec.branch,
+                CommitVersion(cp_version),
+            )?;
 
             // Commit: fires observers
             let observer_event = BranchOpEvent::cherry_pick(
@@ -737,7 +789,6 @@ impl BranchService {
         source: &str,
         target: &str,
         filter: CherryPickFilter,
-        merge_base: Option<(BranchId, u64)>,
     ) -> StrataResult<CherryPickInfo> {
         reject_system_branch(source, "cherry-pick from")?;
         reject_system_branch(target, "cherry-pick into")?;
@@ -747,22 +798,24 @@ impl BranchService {
         // Cherry-pick requires DAG — without it, cherry-pick history is lost
         mutation.require_dag_hook("cherry_pick")?;
 
-        let source_id = resolve_branch_name(source);
-        let target_id = resolve_branch_name(target);
-        let merge_base = match merge_base {
-            Some(merge_base) => Some(merge_base),
-            None => self
-                .merge_base(source, target)?
-                .map(|mb| (mb.branch_id, mb.commit_version.0)),
-        };
+        let store = BranchControlStore::new(self.db.clone());
+        let source_rec = store
+            .find_active_by_name(source)?
+            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(source)))?;
+        let target_rec = store
+            .find_active_by_name(target)?
+            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(target)))?;
+        let source_id = source_rec.branch.id;
+        let target_id = target_rec.branch.id;
 
         // Execute the cherry-pick
         let info = with_branch_dag_hooks_suppressed(|| {
-            branch_ops::cherry_pick_from_diff(&self.db, source, target, filter, merge_base)
+            branch_ops::cherry_pick_from_diff(&self.db, source, target, filter)
         })?;
 
         // Record to DAG — only if cherry-pick actually committed changes
         if let Some(cp_version) = info.cherry_pick_version {
+            // Register rollback FIRST.
             mutation.on_rollback_revert_range(
                 target,
                 CommitVersion(cp_version),
@@ -777,6 +830,15 @@ impl BranchService {
                 info.clone(),
             );
             mutation.record_dag_event(&event)?;
+
+            // Edge LAST so failure is cleaned up by drop-time rollback.
+            append_cherry_pick_edge(
+                &self.db,
+                &store,
+                target_rec.branch,
+                source_rec.branch,
+                CommitVersion(cp_version),
+            )?;
 
             // Commit: fires observers
             let observer_event = BranchOpEvent::cherry_pick(
@@ -820,20 +882,46 @@ impl BranchService {
     /// Find the merge base (common ancestor) of two branches.
     ///
     /// Returns `None` if no common ancestor exists (unrelated branches).
+    ///
+    /// B3.3 cutover: authority is `BranchControlStore::find_merge_base`
+    /// — no DAG fallback, no storage fallback. The store's lineage edges
+    /// cover every fork/merge that B3.1 migration backfilled plus every
+    /// new write from B3.2/B3.3, so a `None` result means the two
+    /// generations are genuinely unrelated.
     pub fn merge_base(
         &self,
         branch_a: &str,
         branch_b: &str,
     ) -> StrataResult<Option<MergeBaseResult>> {
-        BranchControlStore::new(self.db.clone()).ensure_lineage_read_available()?;
-        let hook = self
-            .dag_hook()
-            .require("merge_base")
-            .map_err(dag_to_strata)?;
+        let store = BranchControlStore::new(self.db.clone());
 
-        // Pass branch names directly — DAG is keyed by name, not BranchId UUID
-        hook.find_merge_base(branch_a, branch_b)
-            .map_err(dag_to_strata)
+        let a_rec = store
+            .find_active_by_name(branch_a)?
+            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(branch_a)))?;
+        let b_rec = store
+            .find_active_by_name(branch_b)?
+            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(branch_b)))?;
+
+        let Some(point) = store.find_merge_base(a_rec.branch, b_rec.branch)? else {
+            return Ok(None);
+        };
+
+        let branch_name = if point.branch == a_rec.branch {
+            a_rec.name
+        } else if point.branch == b_rec.branch {
+            b_rec.name
+        } else {
+            store
+                .get_record(point.branch)?
+                .map(|r| r.name)
+                .unwrap_or_else(|| point.branch.id.to_string())
+        };
+
+        Ok(Some(MergeBaseResult {
+            branch_id: point.branch.id,
+            branch_name,
+            commit_version: point.commit_version,
+        }))
     }
 
     /// Get the history log for a branch.
@@ -1025,6 +1113,74 @@ impl BranchService {
 
 fn dag_to_strata(e: BranchDagError) -> StrataError {
     StrataError::invalid_input(e.message)
+}
+
+// =============================================================================
+// Lineage edge writers (B3.3)
+// =============================================================================
+//
+// Lineage edges live on the engine-global control-store namespace (nil
+// UUID branch, "default" space) rather than the user's target branch,
+// so edge writes use a transaction keyed on the global branch id — not
+// the target branch's id. This matches how `BranchControlStore::put_record`
+// participates in create / fork transactions, and keeps lineage writes
+// out of the user branch's OCC read/write sets.
+
+fn append_merge_edge(
+    db: &Arc<Database>,
+    store: &BranchControlStore,
+    target: BranchRef,
+    source: BranchRef,
+    commit_version: CommitVersion,
+    merge_base: Option<MergeBasePoint>,
+) -> StrataResult<()> {
+    let edge = LineageEdgeRecord {
+        kind: LineageEdgeKind::Merge,
+        target,
+        source: Some(source),
+        commit_version,
+        merge_base,
+    };
+    db.transaction(BranchId::from_bytes([0u8; 16]), |txn| {
+        store.append_edge(&edge, txn)
+    })
+}
+
+fn append_revert_edge(
+    db: &Arc<Database>,
+    store: &BranchControlStore,
+    target: BranchRef,
+    commit_version: CommitVersion,
+) -> StrataResult<()> {
+    let edge = LineageEdgeRecord {
+        kind: LineageEdgeKind::Revert,
+        target,
+        source: None,
+        commit_version,
+        merge_base: None,
+    };
+    db.transaction(BranchId::from_bytes([0u8; 16]), |txn| {
+        store.append_edge(&edge, txn)
+    })
+}
+
+fn append_cherry_pick_edge(
+    db: &Arc<Database>,
+    store: &BranchControlStore,
+    target: BranchRef,
+    source: BranchRef,
+    commit_version: CommitVersion,
+) -> StrataResult<()> {
+    let edge = LineageEdgeRecord {
+        kind: LineageEdgeKind::CherryPick,
+        target,
+        source: Some(source),
+        commit_version,
+        merge_base: None,
+    };
+    db.transaction(BranchId::from_bytes([0u8; 16]), |txn| {
+        store.append_edge(&edge, txn)
+    })
 }
 
 // =============================================================================

--- a/crates/engine/src/database/branch_service.rs
+++ b/crates/engine/src/database/branch_service.rs
@@ -1213,10 +1213,10 @@ fn append_cherry_pick_edge(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
     use super::*;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
+    use std::sync::Mutex;
 
     use crate::database::dag_hook::{AncestryEntry, BranchDagHook, DagEventKind};
     use crate::database::dag_hook::{BranchDagError, MergeBaseResult as DagMergeBaseResult};
@@ -1509,7 +1509,8 @@ mod tests {
             "failed merge must not leave a partial merge event visible in branch history"
         );
         assert!(
-            log.iter().any(|event| event.kind == DagEventKind::BranchCreate),
+            log.iter()
+                .any(|event| event.kind == DagEventKind::BranchCreate),
             "projection rebuild should preserve authoritative pre-existing history"
         );
     }

--- a/crates/engine/src/database/branch_service.rs
+++ b/crates/engine/src/database/branch_service.rs
@@ -25,10 +25,10 @@ use strata_core::types::BranchId;
 use strata_core::EntityRef;
 use strata_core::{BranchControlRecord, BranchRef, StrataError, StrataResult};
 
-use crate::branch_ops::with_branch_dag_hooks_suppressed;
 use crate::branch_ops::branch_control_store::{
     BranchControlStore, LineageEdgeKind, LineageEdgeRecord, MergeBasePoint,
 };
+use crate::branch_ops::with_branch_dag_hooks_suppressed;
 use crate::branch_ops::{
     self, BranchDiffResult, CherryPickFilter, CherryPickInfo, DiffOptions, ForkInfo, MergeInfo,
     MergeStrategy, NoteInfo, RevertInfo, TagInfo, ThreeWayDiffResult,
@@ -532,11 +532,13 @@ impl BranchService {
         // Merge requires DAG — without it, merge provenance is lost
         mutation.require_dag_hook("merge")?;
 
-        // Snapshot source / target `BranchRef`s + the pre-merge base
-        // BEFORE the merge runs. The stored edge records the merge base
-        // that was actually used for ancestor reads, which is what future
-        // audit / replay consumers need — not the post-merge advanced
-        // base (the latter is derivable from the chain anyway).
+        // Snapshot source / target `BranchRef`s before the merge runs so
+        // the low-level path can enforce the same lifecycle instances end
+        // to end. The merge base persisted on the edge must come from the
+        // low-level merge execution itself, not a separately-taken service
+        // snapshot, otherwise concurrent lineage changes on the same
+        // generations can make the edge describe a different ancestor point
+        // than the merge actually used.
         let store = BranchControlStore::new(self.db.clone());
         let source_rec = store
             .find_active_by_name(source)?
@@ -544,18 +546,23 @@ impl BranchService {
         let target_rec = store
             .find_active_by_name(target)?
             .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(target)))?;
-        let pre_merge_base = store.find_merge_base(source_rec.branch, target_rec.branch)?;
 
-        let info = with_branch_dag_hooks_suppressed(|| {
-            branch_ops::merge_branches_with_metadata(
+        let merge_exec = with_branch_dag_hooks_suppressed(|| {
+            branch_ops::merge_branches_with_metadata_expected_detailed(
                 &self.db,
                 source,
                 target,
                 options.strategy,
                 options.message.as_deref(),
                 options.creator.as_deref(),
+                Some(source_rec.branch),
+                Some(target_rec.branch),
             )
         })?;
+        let crate::branch_ops::MergeExecutionResult {
+            info,
+            merge_base_used,
+        } = merge_exec;
 
         // Record to DAG — only if merge actually committed changes
         let source_id = source_rec.branch.id;
@@ -571,6 +578,20 @@ impl BranchService {
                 CommitVersion(merge_version),
                 CommitVersion(merge_version),
             );
+            // Persist lineage edge BEFORE the DAG event. If the later DAG write
+            // fails, rollback deletes this edge so neither authority leaks a
+            // partially-recorded merge.
+            mutation
+                .on_rollback_delete_lineage_edge(target_rec.branch, CommitVersion(merge_version));
+            append_merge_edge(
+                &self.db,
+                &store,
+                target_rec.branch,
+                source_rec.branch,
+                CommitVersion(merge_version),
+                Some(merge_base_used),
+            )?;
+
             let mut event = DagEvent::merge(
                 target_id,
                 target,
@@ -587,21 +608,6 @@ impl BranchService {
                 event = event.with_creator(creator.clone());
             }
             mutation.record_dag_event(&event)?;
-
-            // Persist lineage edge LAST so a failed write triggers
-            // `BranchMutation`'s drop-time rollback, which reverts the
-            // merge commit range and leaves no stale edge referencing
-            // a rolled-back commit. The DAG event written above becomes
-            // stale (log-only surface tolerates that after B4); the
-            // merge-base authority stays consistent with target state.
-            append_merge_edge(
-                &self.db,
-                &store,
-                target_rec.branch,
-                source_rec.branch,
-                CommitVersion(merge_version),
-                pre_merge_base,
-            )?;
 
             // Commit: fires observers
             let strategy_str = match options.strategy {
@@ -664,7 +670,15 @@ impl BranchService {
 
         // Execute the revert
         let info = with_branch_dag_hooks_suppressed(|| {
-            branch_ops::revert_version_range(&self.db, branch, from_version, to_version)
+            branch_ops::revert_version_range_with_expected(
+                &self.db,
+                branch,
+                from_version,
+                to_version,
+                None,
+                None,
+                Some(branch_rec.branch),
+            )
         })?;
 
         // Record to DAG — only if revert actually committed changes
@@ -672,12 +686,10 @@ impl BranchService {
             // Register rollback FIRST; edge + DAG writes are the
             // downstream steps a failure mid-path needs to compensate.
             mutation.on_rollback_revert_range(branch, revert_version, revert_version);
+            mutation.on_rollback_delete_lineage_edge(branch_rec.branch, revert_version);
+            append_revert_edge(&self.db, &store, branch_rec.branch, revert_version)?;
             let event = DagEvent::revert(branch_id, branch, revert_version, info.clone());
             mutation.record_dag_event(&event)?;
-
-            // Edge LAST so a failed write triggers `BranchMutation`
-            // drop-time rollback and leaves no stale edge.
-            append_revert_edge(&self.db, &store, branch_rec.branch, revert_version)?;
 
             // Commit: fires observers
             let observer_event = BranchOpEvent::revert(
@@ -729,7 +741,14 @@ impl BranchService {
 
         // Execute the cherry-pick
         let info = with_branch_dag_hooks_suppressed(|| {
-            branch_ops::cherry_pick_keys(&self.db, source, target, keys)
+            branch_ops::cherry_pick_keys_expected(
+                &self.db,
+                source,
+                target,
+                keys,
+                Some(source_rec.branch),
+                Some(target_rec.branch),
+            )
         })?;
 
         // Record to DAG — only if cherry-pick actually committed changes
@@ -740,6 +759,14 @@ impl BranchService {
                 CommitVersion(cp_version),
                 CommitVersion(cp_version),
             );
+            mutation.on_rollback_delete_lineage_edge(target_rec.branch, CommitVersion(cp_version));
+            append_cherry_pick_edge(
+                &self.db,
+                &store,
+                target_rec.branch,
+                source_rec.branch,
+                CommitVersion(cp_version),
+            )?;
             let event = DagEvent::cherry_pick(
                 target_id,
                 target,
@@ -749,15 +776,6 @@ impl BranchService {
                 info.clone(),
             );
             mutation.record_dag_event(&event)?;
-
-            // Edge LAST so failure is cleaned up by drop-time rollback.
-            append_cherry_pick_edge(
-                &self.db,
-                &store,
-                target_rec.branch,
-                source_rec.branch,
-                CommitVersion(cp_version),
-            )?;
 
             // Commit: fires observers
             let observer_event = BranchOpEvent::cherry_pick(
@@ -810,7 +828,14 @@ impl BranchService {
 
         // Execute the cherry-pick
         let info = with_branch_dag_hooks_suppressed(|| {
-            branch_ops::cherry_pick_from_diff(&self.db, source, target, filter)
+            branch_ops::cherry_pick_from_diff_expected(
+                &self.db,
+                source,
+                target,
+                filter,
+                Some(source_rec.branch),
+                Some(target_rec.branch),
+            )
         })?;
 
         // Record to DAG — only if cherry-pick actually committed changes
@@ -821,6 +846,14 @@ impl BranchService {
                 CommitVersion(cp_version),
                 CommitVersion(cp_version),
             );
+            mutation.on_rollback_delete_lineage_edge(target_rec.branch, CommitVersion(cp_version));
+            append_cherry_pick_edge(
+                &self.db,
+                &store,
+                target_rec.branch,
+                source_rec.branch,
+                CommitVersion(cp_version),
+            )?;
             let event = DagEvent::cherry_pick(
                 target_id,
                 target,
@@ -830,15 +863,6 @@ impl BranchService {
                 info.clone(),
             );
             mutation.record_dag_event(&event)?;
-
-            // Edge LAST so failure is cleaned up by drop-time rollback.
-            append_cherry_pick_edge(
-                &self.db,
-                &store,
-                target_rec.branch,
-                source_rec.branch,
-                CommitVersion(cp_version),
-            )?;
 
             // Commit: fires observers
             let observer_event = BranchOpEvent::cherry_pick(
@@ -1189,11 +1213,96 @@ fn append_cherry_pick_edge(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    use crate::database::dag_hook::{AncestryEntry, BranchDagHook, DagEventKind};
+    use crate::database::dag_hook::{BranchDagError, MergeBaseResult as DagMergeBaseResult};
     use crate::database::OpenSpec;
+    use crate::primitives::kv::KVStore;
     use strata_core::types::{Key, TypeTag};
     use strata_core::value::Value;
+    use tempfile::TempDir;
 
+    struct ToggleFailDagHook {
+        fail_writes: AtomicBool,
+        fail_after_record_once: AtomicBool,
+        events: Mutex<Vec<DagEvent>>,
+    }
+
+    impl ToggleFailDagHook {
+        fn new() -> Self {
+            Self {
+                fail_writes: AtomicBool::new(false),
+                fail_after_record_once: AtomicBool::new(false),
+                events: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn set_fail_writes(&self, fail: bool) {
+            self.fail_writes.store(fail, Ordering::SeqCst);
+        }
+
+        fn set_fail_after_record_once(&self, fail: bool) {
+            self.fail_after_record_once.store(fail, Ordering::SeqCst);
+        }
+    }
+
+    impl BranchDagHook for ToggleFailDagHook {
+        fn name(&self) -> &'static str {
+            "toggle-fail"
+        }
+
+        fn record_event(&self, event: &DagEvent) -> Result<(), BranchDagError> {
+            if self.fail_after_record_once.swap(false, Ordering::SeqCst) {
+                self.events.lock().unwrap().push(event.clone());
+                return Err(BranchDagError::write_failed(
+                    "injected DAG partial write failure",
+                ));
+            }
+            if self.fail_writes.load(Ordering::SeqCst) {
+                Err(BranchDagError::write_failed("injected DAG write failure"))
+            } else {
+                self.events.lock().unwrap().push(event.clone());
+                Ok(())
+            }
+        }
+
+        fn reset_projection(&self) -> Result<(), BranchDagError> {
+            self.events.lock().unwrap().clear();
+            Ok(())
+        }
+
+        fn find_merge_base(
+            &self,
+            _branch_a: &str,
+            _branch_b: &str,
+        ) -> Result<Option<DagMergeBaseResult>, BranchDagError> {
+            Ok(None)
+        }
+
+        fn log(&self, branch: &str, limit: usize) -> Result<Vec<DagEvent>, BranchDagError> {
+            let mut events: Vec<DagEvent> = self
+                .events
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|event| {
+                    event.branch_name == branch
+                        || event.source_branch_name.as_deref() == Some(branch)
+                })
+                .cloned()
+                .collect();
+            events.truncate(limit);
+            Ok(events)
+        }
+
+        fn ancestors(&self, _branch: &str) -> Result<Vec<AncestryEntry>, BranchDagError> {
+            Ok(Vec::new())
+        }
+    }
     fn seed_legacy_branch_metadata(db: &Arc<Database>, name: &str) {
         let meta = BranchMetadata::new(name);
         let json = serde_json::to_string(&meta).unwrap();
@@ -1317,5 +1426,139 @@ mod tests {
 
         let ancestors_err = db.branches().ancestors("legacy").unwrap_err();
         assert!(ancestors_err.is_branch_lineage_unavailable());
+    }
+
+    #[test]
+    fn test_merge_dag_failure_rolls_back_prewritten_lineage_edge() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = Database::open_runtime(
+            OpenSpec::primary(temp_dir.path()).with_subsystem(crate::search::SearchSubsystem),
+        )
+        .unwrap();
+        let hook = Arc::new(ToggleFailDagHook::new());
+        db.install_dag_hook(hook.clone()).unwrap();
+
+        db.branches().create("main").unwrap();
+        let kv = KVStore::new(db.clone());
+        let main_id = BranchId::from_user_name("main");
+        kv.put(&main_id, "default", "seed", Value::Int(1)).unwrap();
+        let fork_info = db.branches().fork("main", "feature").unwrap();
+        let feature_id = BranchId::from_user_name("feature");
+        kv.put(&feature_id, "default", "delta", Value::Int(2))
+            .unwrap();
+
+        let main_ref = db
+            .branches()
+            .control_record("main")
+            .unwrap()
+            .unwrap()
+            .branch;
+
+        hook.set_fail_writes(true);
+        let err = db.branches().merge("feature", "main").unwrap_err();
+        assert!(
+            err.to_string().contains("DAG")
+                || err.to_string().contains("projection rebuild failed"),
+            "expected DAG-related failure, got {err}"
+        );
+
+        let store = BranchControlStore::new(db.clone());
+        assert!(
+            store.edges_for(main_ref).unwrap().is_empty(),
+            "rollback must delete the prewritten lineage edge when DAG recording fails"
+        );
+
+        let mb = db
+            .branches()
+            .merge_base("main", "feature")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            mb.commit_version,
+            fork_info.fork_version.map(CommitVersion).unwrap(),
+            "failed merge must not advance the authoritative merge base"
+        );
+    }
+
+    #[test]
+    fn test_partial_dag_failure_rebuilds_projection_before_return() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = Database::open_runtime(
+            OpenSpec::primary(temp_dir.path()).with_subsystem(crate::search::SearchSubsystem),
+        )
+        .unwrap();
+        let hook = Arc::new(ToggleFailDagHook::new());
+        db.install_dag_hook(hook.clone()).unwrap();
+
+        db.branches().create("main").unwrap();
+        let kv = KVStore::new(db.clone());
+        let main_id = BranchId::from_user_name("main");
+        kv.put(&main_id, "default", "seed", Value::Int(1)).unwrap();
+        db.branches().fork("main", "feature").unwrap();
+        let feature_id = BranchId::from_user_name("feature");
+        kv.put(&feature_id, "default", "delta", Value::Int(2))
+            .unwrap();
+
+        hook.set_fail_after_record_once(true);
+        let err = db.branches().merge("feature", "main").unwrap_err();
+        assert!(err.to_string().contains("DAG write error"));
+
+        let log = db.branches().log("main", 100).unwrap();
+        assert!(
+            !log.iter().any(|event| event.kind == DagEventKind::Merge),
+            "failed merge must not leave a partial merge event visible in branch history"
+        );
+        assert!(
+            log.iter().any(|event| event.kind == DagEventKind::BranchCreate),
+            "projection rebuild should preserve authoritative pre-existing history"
+        );
+    }
+
+    #[test]
+    fn test_merge_expected_refs_conflict_after_source_recreate() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = Database::open_runtime(
+            OpenSpec::primary(temp_dir.path()).with_subsystem(crate::search::SearchSubsystem),
+        )
+        .unwrap();
+        let hook = Arc::new(ToggleFailDagHook::new());
+        db.install_dag_hook(hook).unwrap();
+        db.branches().create("main").unwrap();
+        let kv = KVStore::new(db.clone());
+        let main_id = BranchId::from_user_name("main");
+        kv.put(&main_id, "default", "seed", Value::Int(1)).unwrap();
+        db.branches().fork("main", "feature").unwrap();
+
+        let store = BranchControlStore::new(db.clone());
+        let target_ref = store.find_active_by_name("main").unwrap().unwrap().branch;
+        let stale_source_ref = store
+            .find_active_by_name("feature")
+            .unwrap()
+            .unwrap()
+            .branch;
+
+        db.branches().delete("feature").unwrap();
+        db.branches().create("feature").unwrap();
+
+        let err = crate::branch_ops::merge_branches_with_metadata_expected(
+            &db,
+            "feature",
+            "main",
+            MergeOptions::default().strategy,
+            None,
+            None,
+            Some(stale_source_ref),
+            Some(target_ref),
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(err, StrataError::Conflict { .. }),
+            "expected stale BranchRef mismatch to fail as a conflict, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("lifecycle advanced"),
+            "conflict should explain that the branch generation changed"
+        );
     }
 }

--- a/crates/executor/src/handlers/branch.rs
+++ b/crates/executor/src/handlers/branch.rs
@@ -225,7 +225,7 @@ pub fn branch_diff_three_way(
     // Route through BranchService — it resolves DAG-backed merge bases when
     // the graph subsystem is installed and falls back to storage-level fork
     // info otherwise.
-    let result = convert_result(p.db.branches().diff3(&branch_a, &branch_b, None))?;
+    let result = convert_result(p.db.branches().diff3(&branch_a, &branch_b))?;
 
     Ok(Output::ThreeWayDiff(result))
 }
@@ -294,7 +294,7 @@ pub fn branch_cherry_pick(
             primitives: filter_primitives,
         };
         p.db.branches()
-            .cherry_pick_from_diff(&source, &target, filter, None)
+            .cherry_pick_from_diff(&source, &target, filter)
     })?;
 
     Ok(Output::BranchCherryPicked(info))

--- a/tests/integration/branching.rs
+++ b/tests/integration/branching.rs
@@ -1993,7 +1993,7 @@ fn cherry_pick_graph_disjoint_node_additions_succeeds() {
     test_db
         .db
         .branches()
-        .cherry_pick_from_diff("source", "target", CherryPickFilter::default(), None)
+        .cherry_pick_from_diff("source", "target", CherryPickFilter::default())
         .expect("cherry-pick of disjoint graph divergences must succeed");
 
     // Target now has all four nodes, with bidirectional consistency on the
@@ -2085,7 +2085,7 @@ fn cherry_pick_graph_dangling_edge_rejected() {
     let err = test_db
         .db
         .branches()
-        .cherry_pick_from_diff("source", "target", CherryPickFilter::default(), None)
+        .cherry_pick_from_diff("source", "target", CherryPickFilter::default())
         .expect_err("dangling-edge cherry-pick must be rejected");
     let msg = err.to_string();
     assert!(
@@ -2152,7 +2152,7 @@ fn cherry_pick_graph_atomic_filter_with_keys_rejected() {
     let err = test_db
         .db
         .branches()
-        .cherry_pick_from_diff("source", "target", filter, None)
+        .cherry_pick_from_diff("source", "target", filter)
         .expect_err("partial graph key filter must be rejected");
     let msg = err.to_string();
     assert!(
@@ -2218,7 +2218,7 @@ fn cherry_pick_graph_excluded_via_primitives_filter_works() {
     let info = test_db
         .db
         .branches()
-        .cherry_pick_from_diff("source", "target", filter, None)
+        .cherry_pick_from_diff("source", "target", filter)
         .expect("KV-only cherry-pick must succeed even with divergent graph");
     assert!(info.keys_applied >= 1, "expected the kv_only put to apply");
 
@@ -2298,7 +2298,7 @@ fn cherry_pick_graph_dropped_via_non_graph_key_filter_succeeds() {
     let info = test_db
         .db
         .branches()
-        .cherry_pick_from_diff("source", "target", filter, None)
+        .cherry_pick_from_diff("source", "target", filter)
         .expect("filter that drops all graph actions atomically must NOT raise atomicity error");
     assert_eq!(info.keys_applied, 1, "only doc/bar should have applied");
 
@@ -2342,7 +2342,7 @@ fn cherry_pick_kv_only_no_graph_changes_works() {
     let info = test_db
         .db
         .branches()
-        .cherry_pick_from_diff("source", "target", CherryPickFilter::default(), None)
+        .cherry_pick_from_diff("source", "target", CherryPickFilter::default())
         .expect("KV-only cherry-pick must succeed");
     assert!(info.keys_applied >= 1);
     assert_eq!(
@@ -4720,7 +4720,7 @@ fn vector_cherry_pick_refreshes_hnsw_backend() {
     test_db
         .db
         .branches()
-        .cherry_pick_from_diff("source", "target", CherryPickFilter::default(), None)
+        .cherry_pick_from_diff("source", "target", CherryPickFilter::default())
         .expect("vector cherry-pick should succeed");
 
     // The cherry-picked vector must be visible AND searchable. The
@@ -5553,7 +5553,7 @@ fn json_merge_path_level_via_cherry_pick() {
     test_db
         .db
         .branches()
-        .cherry_pick_from_diff("source", "target", CherryPickFilter::default(), None)
+        .cherry_pick_from_diff("source", "target", CherryPickFilter::default())
         .expect("cherry-pick of a disjoint-path JSON edit should succeed");
 
     let merged = json
@@ -7169,7 +7169,6 @@ fn dag_records_cherry_pick() {
             "dag_cp_source",
             "dag_cp_target",
             CherryPickFilter::default(),
-            None,
         )
         .unwrap();
     assert_eq!(

--- a/tests/integration/branching_merge_lineage_edges.rs
+++ b/tests/integration/branching_merge_lineage_edges.rs
@@ -199,7 +199,10 @@ fn merge_base_does_not_cross_generations_after_recreate() {
         .control_record("feature_g")
         .unwrap()
         .unwrap();
-    assert_eq!(new_rec.branch.generation, 1, "recreate MUST bump generation");
+    assert_eq!(
+        new_rec.branch.generation, 1,
+        "recreate MUST bump generation"
+    );
 
     // Note: feature_g@gen1 is created without forking from parent_g, so
     // there is no shared lineage between feature_g@gen1 and parent_g.

--- a/tests/integration/branching_merge_lineage_edges.rs
+++ b/tests/integration/branching_merge_lineage_edges.rs
@@ -1,0 +1,369 @@
+//! B3.3 — lineage edges and store-authoritative merge base.
+//!
+//! Exercises the cutover landed in B3.3: merge / revert / cherry-pick
+//! persist `LineageEdgeRecord`s on the control store, `merge_base`
+//! reads from the store with AD8 point semantics, and
+//! `MergeOptions::merge_base` is removed from the public surface.
+//!
+//! Invariants covered (from `docs/design/branching/b3-phasing-plan.md`):
+//!
+//! - Fork → store-derived merge base is the fork anchor point.
+//! - Merge advancement: after each source → target merge, the merge
+//!   base advances to `(source_ref, merge_version)` — repeated merges
+//!   move forward, they do not snap back to the fork anchor.
+//! - Same-lifecycle repeat: merging the same generation twice returns
+//!   the *more recent* merge point (point semantics, not bare
+//!   `BranchRef`).
+//! - Generation wall: after delete + recreate, a merge from the new
+//!   generation does not inherit the tombstoned generation's merge
+//!   points — lineage is scoped by `BranchRef`, not by name.
+//! - Unrelated branches return `None` — no fallback, no fabricated base.
+
+#![cfg(not(miri))]
+
+use crate::common::*;
+use strata_core::value::Value;
+use strata_engine::{MergeOptions, MergeStrategy};
+
+fn resolve(name: &str) -> BranchId {
+    BranchId::from_user_name(name)
+}
+
+/// Create `parent`, write an initial KV on it, fork to `child`, write
+/// one extra KV on the child. Returns the fork version.
+fn setup_fork(test_db: &TestDb, parent: &str, child: &str) -> u64 {
+    let branches = test_db.db.branches();
+    let kv = test_db.kv();
+    let parent_id = resolve(parent);
+
+    branches.create(parent).unwrap();
+    kv.put(&parent_id, "default", "parent_seed", Value::Int(1))
+        .unwrap();
+
+    let info = branches.fork(parent, child).unwrap();
+    let fork_version = info
+        .fork_version
+        .expect("fork must report fork_version for COW relationship");
+
+    let child_id = resolve(child);
+    kv.put(&child_id, "default", "child_seed", Value::Int(2))
+        .unwrap();
+
+    fork_version
+}
+
+// =============================================================================
+// Fork only: merge_base returns the fork anchor
+// =============================================================================
+
+#[test]
+fn merge_base_after_fork_is_fork_anchor() {
+    let test_db = TestDb::new();
+    let fork_version = setup_fork(&test_db, "parent", "feature");
+
+    let mb = test_db
+        .db
+        .branches()
+        .merge_base("parent", "feature")
+        .expect("store-backed merge_base MUST not error for fresh fork")
+        .expect("fresh fork MUST report a merge base");
+
+    assert_eq!(mb.branch_name, "parent");
+    assert_eq!(
+        mb.commit_version.0, fork_version,
+        "fresh fork's merge base MUST equal the fork version"
+    );
+}
+
+// =============================================================================
+// Single merge: merge_base advances past the fork anchor
+// =============================================================================
+
+#[test]
+fn merge_base_advances_after_first_merge() {
+    let test_db = TestDb::new();
+    let fork_version = setup_fork(&test_db, "parent_s", "feature_s");
+
+    // Merge feature_s → parent_s. MergeInfo.merge_version is the commit
+    // version at which the merge landed on parent_s.
+    let info = test_db
+        .db
+        .branches()
+        .merge("feature_s", "parent_s")
+        .expect("merge of fresh fork must succeed");
+    let merge_version = info
+        .merge_version
+        .expect("non-empty merge MUST report merge_version");
+    assert!(merge_version > fork_version);
+
+    let mb = test_db
+        .db
+        .branches()
+        .merge_base("feature_s", "parent_s")
+        .unwrap()
+        .expect("post-merge merge_base MUST be Some");
+
+    // After feature_s → parent_s, parent_s has incorporated feature_s's
+    // state at merge_version. The new merge base is feature_s at
+    // merge_version — strictly advanced past the fork anchor.
+    assert_eq!(
+        mb.branch_name, "feature_s",
+        "post-merge base MUST be the source branch, not the fork parent"
+    );
+    assert_eq!(
+        mb.commit_version.0, merge_version,
+        "post-merge base MUST equal the merge commit version"
+    );
+    assert!(
+        mb.commit_version.0 > fork_version,
+        "post-merge base MUST advance past the fork anchor"
+    );
+}
+
+// =============================================================================
+// Repeated merge: merge_base advances on each merge (point semantics)
+// =============================================================================
+
+#[test]
+fn merge_base_advances_on_repeated_merge() {
+    let test_db = TestDb::new();
+    let _fork_version = setup_fork(&test_db, "parent_r", "feature_r");
+    let feature_id = resolve("feature_r");
+    let kv = test_db.kv();
+
+    // First merge.
+    let first = test_db
+        .db
+        .branches()
+        .merge("feature_r", "parent_r")
+        .expect("first merge must succeed");
+    let first_version = first.merge_version.expect("first merge_version");
+
+    // Write again on feature_r so the second merge is non-empty.
+    kv.put(&feature_id, "default", "post_first", Value::Int(42))
+        .unwrap();
+
+    let second = test_db
+        .db
+        .branches()
+        .merge("feature_r", "parent_r")
+        .expect("second merge must succeed");
+    let second_version = second.merge_version.expect("second merge_version");
+    assert!(
+        second_version > first_version,
+        "second merge MUST commit at a later version than the first"
+    );
+
+    let mb = test_db
+        .db
+        .branches()
+        .merge_base("feature_r", "parent_r")
+        .unwrap()
+        .expect("merge_base MUST be Some after two merges");
+
+    // Point semantics: the store keeps each merge as its own point, so
+    // `find_merge_base` returns the most recent shared (branch, version)
+    // pair — second_version, not first_version.
+    assert_eq!(
+        mb.commit_version.0, second_version,
+        "repeated-merge MUST return the most recent merge commit version"
+    );
+    assert_eq!(mb.branch_name, "feature_r");
+}
+
+// =============================================================================
+// Generation wall: delete + recreate does not inherit tombstoned lineage
+// =============================================================================
+
+#[test]
+fn merge_base_does_not_cross_generations_after_recreate() {
+    let test_db = TestDb::new();
+    let fork_version_gen0 = setup_fork(&test_db, "parent_g", "feature_g");
+
+    // Merge once on the gen-0 lifecycle so there's a stale edge on
+    // parent_g whose source ref carries generation 0.
+    let gen0_merge = test_db
+        .db
+        .branches()
+        .merge("feature_g", "parent_g")
+        .unwrap();
+    let _gen0_merge_version = gen0_merge.merge_version.unwrap();
+
+    // Delete + recreate feature_g → its new `BranchRef` has generation 1,
+    // which is a distinct lifecycle instance from the tombstoned gen 0.
+    test_db.db.branches().delete("feature_g").unwrap();
+    test_db.db.branches().create("feature_g").unwrap();
+    let new_rec = test_db
+        .db
+        .branches()
+        .control_record("feature_g")
+        .unwrap()
+        .unwrap();
+    assert_eq!(new_rec.branch.generation, 1, "recreate MUST bump generation");
+
+    // Note: feature_g@gen1 is created without forking from parent_g, so
+    // there is no shared lineage between feature_g@gen1 and parent_g.
+    // The find_merge_base over the new BranchRef must return None —
+    // the old gen-0 edges belong to a different lifecycle instance and
+    // MUST NOT be surfaced for the new one.
+    let mb = test_db
+        .db
+        .branches()
+        .merge_base("feature_g", "parent_g")
+        .unwrap();
+    assert!(
+        mb.is_none(),
+        "recreated feature_g@gen1 is unrelated to parent_g; got {mb:?}"
+    );
+
+    // Parent's original fork anchor for the gen-0 child stays valid and
+    // recoverable via `get_record` of the tombstoned `BranchRef`. We
+    // don't assert this here — Scenario A covers the happy path for
+    // gen-0 lineage before recreate.
+    let _ = fork_version_gen0;
+}
+
+// =============================================================================
+// Revert then merge: revert edge present but does not advance merge base
+// =============================================================================
+
+#[test]
+fn revert_edge_does_not_shift_merge_base() {
+    let test_db = TestDb::new();
+    let _fork_version = setup_fork(&test_db, "parent_v", "feature_v");
+    let feature_id = resolve("feature_v");
+    let kv = test_db.kv();
+
+    // Write once more on feature_v so we have a commit to revert.
+    kv.put(&feature_id, "default", "to_revert", Value::Int(1))
+        .unwrap();
+    let version_before_revert = test_db.db.current_version();
+    kv.put(&feature_id, "default", "post_revert", Value::Int(2))
+        .unwrap();
+    let version_after = test_db.db.current_version();
+    assert!(version_after > version_before_revert);
+
+    // Revert the mid-range. Revert writes a `Revert` edge on feature_v
+    // but is a target-only rewind — it has no source and MUST NOT shift
+    // the merge base between feature_v and parent_v.
+    test_db
+        .db
+        .branches()
+        .revert(
+            "feature_v",
+            strata_core::id::CommitVersion(version_before_revert.0 + 1),
+            version_after,
+        )
+        .expect("revert must succeed");
+
+    let post_revert = test_db
+        .db
+        .branches()
+        .merge("feature_v", "parent_v")
+        .expect("merge after revert must succeed");
+    let post_merge_version = post_revert.merge_version.unwrap();
+
+    let mb = test_db
+        .db
+        .branches()
+        .merge_base("feature_v", "parent_v")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        mb.commit_version.0, post_merge_version,
+        "merge base MUST reflect the post-revert merge, not the revert itself"
+    );
+    assert_eq!(mb.branch_name, "feature_v");
+}
+
+// =============================================================================
+// Cherry-pick edge present but does not advance merge_base
+// =============================================================================
+
+/// Cherry-pick applies a selective subset of a source's state; unlike a
+/// full merge, the target has not fully incorporated the source's
+/// history at the cherry-pick commit. `ancestor_chain` skips
+/// `LineageEdgeKind::CherryPick` for merge-base advancement, so a
+/// cherry-pick from source → target does NOT shift merge_base to the
+/// cherry-pick commit version. This test locks that behavior so a
+/// future refactor that treats cherry-pick as a "weak merge" can't
+/// silently change merge-base semantics.
+#[test]
+fn cherry_pick_edge_does_not_shift_merge_base() {
+    let test_db = TestDb::new();
+    let fork_version = setup_fork(&test_db, "parent_cp", "feature_cp");
+    let feature_id = resolve("feature_cp");
+    let kv = test_db.kv();
+
+    // Add a key on feature that cherry-pick will ship over to parent.
+    kv.put(&feature_id, "default", "pick_me", Value::Int(7))
+        .unwrap();
+
+    // Cherry-pick feature_cp → parent_cp. Writes a CherryPick edge but
+    // does not fully "merge" source into target.
+    // `cherry_pick` keys are `(space, key)` pairs.
+    let cp_info = test_db
+        .db
+        .branches()
+        .cherry_pick(
+            "feature_cp",
+            "parent_cp",
+            &[("default".into(), "pick_me".into())],
+        )
+        .expect("cherry-pick must succeed");
+    assert_eq!(
+        cp_info.keys_applied, 1,
+        "exactly one key should have been picked"
+    );
+
+    let mb = test_db
+        .db
+        .branches()
+        .merge_base("feature_cp", "parent_cp")
+        .unwrap()
+        .expect("merge_base MUST still report the fork anchor, not the cherry-pick commit");
+
+    // Merge base stays at the fork anchor — cherry-pick edges are
+    // skipped in ancestor-chain traversal. This is distinct from the
+    // merge-advancement test; even with a later commit on parent via
+    // cherry-pick, the shared-visibility point is still the fork.
+    assert_eq!(
+        mb.branch_name, "parent_cp",
+        "cherry-pick MUST NOT flip the merge base to the cherry-pick source"
+    );
+    assert_eq!(
+        mb.commit_version.0, fork_version,
+        "cherry-pick MUST NOT advance merge base past the fork anchor"
+    );
+}
+
+// =============================================================================
+// Unrelated branches: no fallback, returns None
+// =============================================================================
+
+#[test]
+fn unrelated_branches_return_none_for_merge_base() {
+    let test_db = TestDb::new();
+    let branches = test_db.db.branches();
+    branches.create("alpha").unwrap();
+    branches.create("beta").unwrap();
+
+    let mb = branches.merge_base("alpha", "beta").unwrap();
+    assert!(
+        mb.is_none(),
+        "unrelated branches MUST return None — no DAG fallback, no storage fallback"
+    );
+
+    let err = branches
+        .merge_with_options(
+            "alpha",
+            "beta",
+            MergeOptions::with_strategy(MergeStrategy::LastWriterWins),
+        )
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("no fork or merge relationship found"),
+        "unrelated merge MUST refuse with the locked error vocabulary; got: {msg}"
+    );
+}

--- a/tests/integration/data/branching_transitional_shapes.json
+++ b/tests/integration/data/branching_transitional_shapes.json
@@ -4,7 +4,7 @@
   "shapes": {
     "branch_id_random_new_sites": 722,
     "branch_namespace_const_sites": 1,
-    "merge_base_override_occurrences": 12,
+    "merge_base_override_occurrences": 0,
     "merge_strategy_lastwriterwins_literals": 75
   }
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -12,6 +12,7 @@ mod common;
 
 mod branching;
 mod branching_guardrails;
+mod branching_merge_lineage_edges;
 mod branching_recreate_state_machine;
 mod merge_base_characterization;
 mod modes;

--- a/tests/integration/merge_base_characterization.rs
+++ b/tests/integration/merge_base_characterization.rs
@@ -26,6 +26,12 @@
 //! as inline `#[cfg(test)]` cases in `crates/engine/src/branch_ops/mod.rs`
 //! (search for `merge_branches(&db, ...)`).
 //!
+//! B3.3 update: the store-backed merge-base authority replaced the old
+//! DAG-derived plus caller-override pair. Scenarios A1/A2/B/D/F are
+//! preserved verbatim as the B1 characterization floor; Scenario E is
+//! rewritten to assert the override no longer exists; Scenario G is
+//! added to lock the store-authoritative path.
+//!
 //! ## Scenarios covered
 //!
 //! - **A1**: parent forks child, child→parent merge succeeds with locked
@@ -36,9 +42,13 @@
 //!   vocabulary.
 //! - **D**: `db.branches().merge_base()` returns a DAG-derived merge base
 //!   for fresh forks and `Ok(None)` for unrelated branches.
-//! - **E**: `MergeOptions::merge_base` override is honored by
-//!   `BranchService::merge_with_options` even between storage-unrelated
-//!   branches — the contract B3 will remove.
+//! - **E**: `MergeOptions::merge_base` override no longer exists (B3.3).
+//!   Compile-time: `MergeOptions` has no `merge_base` field and no
+//!   `with_merge_base` builder. Runtime: unrelated branches still refuse
+//!   to merge with the locked `no fork or merge relationship` vocabulary.
+//! - **G**: store-derived `merge_base` remains correct whether the DAG
+//!   hook is installed or not — the control store is authoritative and
+//!   does not depend on the DAG projection.
 
 use crate::common::*;
 use strata_engine::{MergeOptions, MergeStrategy};
@@ -239,49 +249,85 @@ fn d_branchservice_merge_base_negative_for_unrelated_branches() {
 }
 
 // =============================================================================
-// Scenario E: MergeOptions.merge_base override is honored
+// Scenario E: MergeOptions.merge_base override no longer exists (B3.3)
 // =============================================================================
 
-/// `BranchService::merge_with_options` honors a caller-supplied
-/// `merge_base` override even between storage-unrelated branches.
-/// This is the externally-visible form of the
-/// `branch_ops::merge_base_override` plumbing that B3 will remove from
-/// the engine surface entirely.
+/// After B3.3, `MergeOptions` has no `merge_base` field and no
+/// `with_merge_base` builder. The previous (pre-B3.3) externally-visible
+/// override that let callers synthesize an ancestor between unrelated
+/// branches was deliberately removed: merge-base authority moved to
+/// `BranchControlStore`, and a synthetic base would silently corrupt
+/// downstream lineage reads.
+///
+/// Compile-time guard: `MergeOptions` must be constructable without a
+/// `merge_base` field and without a `with_merge_base` builder. The
+/// construction pattern in this test is the only surface we lock.
+///
+/// Runtime guard: unrelated branches still refuse to merge (identical
+/// to Scenario B) — no surviving back-door restores the old behavior.
 #[test]
-fn e_branchservice_merge_with_options_honors_override() {
+fn e_merge_base_override_no_longer_exists() {
+    // Compile-time: constructs `MergeOptions` with the B3.3 surface only.
+    // Any reintroduction of `.with_merge_base(...)` or a `merge_base`
+    // field would break this line and surface as a clear signal.
+    let _opts: MergeOptions = MergeOptions::with_strategy(MergeStrategy::LastWriterWins);
+
     let test_db = TestDb::new();
     let branches = test_db.db.branches();
     branches.create("alpha_e").unwrap();
     branches.create("beta_e").unwrap();
-    let alpha_id = resolve("alpha_e");
     test_db
         .kv()
-        .put(&alpha_id, "default", "k", Value::Int(1))
+        .put(&resolve("alpha_e"), "default", "k", Value::Int(1))
         .unwrap();
 
-    // Without override: refused (Scenario B locks this).
-    assert!(branches.merge("alpha_e", "beta_e").is_err());
-
-    // With explicit override: merge proceeds. This is the contract B3 removes.
-    let opts =
-        MergeOptions::with_strategy(MergeStrategy::LastWriterWins).with_merge_base(alpha_id, 0);
-    let result = branches.merge_with_options("alpha_e", "beta_e", opts);
+    // No override path exists; unrelated branches refuse to merge.
+    let err = branches
+        .merge_with_options(
+            "alpha_e",
+            "beta_e",
+            MergeOptions::with_strategy(MergeStrategy::LastWriterWins),
+        )
+        .unwrap_err();
+    let msg = format!("{err}");
     assert!(
-        result.is_ok(),
-        "BranchService merge_with_options MUST honor merge_base override; got {result:?}"
+        msg.contains("no fork or merge relationship found"),
+        "unrelated merge_with_options MUST refuse with the locked error; got: {msg}"
     );
-    let info = result.unwrap();
-    assert_eq!(info.source, "alpha_e");
-    assert_eq!(info.target, "beta_e");
-    assert_eq!(info.conflicts.len(), 0);
-    // Locked: the synthetic ancestor at version 0 sees an empty alpha,
-    // so alpha's single key `k` flows to beta as a new application.
+}
+
+// =============================================================================
+// Scenario G: store-derived merge_base correct with and without DAG hook
+// =============================================================================
+
+/// B3.3 moves merge-base authority to `BranchControlStore`. The DAG hook
+/// becomes a read-side acceleration for `log` / `ancestors` — it is not
+/// required for `merge_base`. This test locks that behavior: a
+/// freshly-forked pair returns a valid merge base regardless of whether
+/// a DAG hook is installed. Since `TestDb::new` installs the default DAG
+/// hook, the "no hook" case is locked by Scenario D elsewhere (the
+/// internal branch_ops test `setup_with_branch` exercises the same
+/// store-backed path with no DAG hook attached).
+#[test]
+fn g_store_derived_merge_base_correct_with_dag_hook() {
+    let test_db = TestDb::new();
+    let fork_version = setup_parent_child_fork(&test_db, "parent_g", "child_g");
+
+    let mb = test_db
+        .db
+        .branches()
+        .merge_base("parent_g", "child_g")
+        .expect("merge_base lookup MUST not error")
+        .expect("fresh fork MUST have a store-derived merge base");
+
     assert_eq!(
-        info.keys_applied, 1,
-        "alpha's key `k` must apply to beta; saw keys_applied={}",
-        info.keys_applied
+        mb.branch_name, "parent_g",
+        "store-derived merge base should resolve to the parent name for a fresh fork"
     );
-    assert!(info.merge_version.is_some());
+    assert_eq!(
+        mb.commit_version.0, fork_version,
+        "store-derived merge base version MUST equal the fork version"
+    );
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- `merge_base()` becomes store-authoritative: reads from `BranchControlStore::find_merge_base` with AD8 point semantics (`BranchRef` + `CommitVersion`); no DAG fallback, no storage fallback, no caller override.
- `merge` / `revert` / `cherry_pick` / `cherry_pick_from_diff` persist `LineageEdgeRecord`s so subsequent `find_merge_base` advances past each operation. Tripwire `merge_base_override_occurrences` 12 → 0.
- `MergeOptions::merge_base` field and `with_merge_base()` builder removed from the public surface; `diff3` and `cherry_pick_from_diff` drop their `merge_base` param; `branch_ops::{merge_branches, merge_branches_with_metadata, diff_three_way, get_merge_base, cherry_pick_from_diff}` drop `merge_base_override`.

## Algorithm

`find_merge_base(a, b)` builds each branch's ancestor chain (self at `MAX`, fork parents at `fork.point`, merge sources at merge commit version), intersects on `BranchRef`, and picks the candidate with the largest shared `min(a_cv, b_cv)`. Repeated merges advance the base because each merge adds a fresh point. Cherry-pick and revert edges are skipped in ancestor traversal — cherry-pick is partial, revert is a target-only rewind.

Visibility-bounded walk: each BFS frame carries a `visible_until` bound. A merge that landed on `feature` at `v20` must NOT become visible through `main` merely because `main` merged `feature` at `v10`. Branches may be re-visited when a later path reaches them at higher visibility.

Deterministic tie-break: candidates with identical shared commit versions resolve by `(id bytes, generation)` sort, so two replicas reading the same lineage produce the same result.

## Correctness

- Rollback-via-delete-edge: edges are written BEFORE the DAG event; `RollbackAction::DeleteLineageEdge` cleans up on downstream failure. `BranchMutation` drop-time rollback also rebuilds the DAG projection from the control store so the two authorities don't diverge after partial failure.
- Expected-BranchRef OCC guard: `BranchService` snapshots `BranchRef`s and the low-level `_expected_detailed` entry points re-verify the active generation inside the merge OCC transaction. A concurrent delete+recreate between snapshot and apply now fails with `Conflict`.
- Merge base actually used: the apply path returns `MergeExecutionResult { info, merge_base_used }`; the service persists THAT on the edge so a separately-taken snapshot can't diverge from the applied base.

## Test plan

- [x] `cargo test -p strata-engine --lib` — 1092 passed (4 new B3.3 tests)
- [x] `cargo test -p stratadb --test integration` — 175 passed (7 new B3.3 integration tests)
- [x] `cargo test -p strata-executor --lib` — 618 passed
- [x] `rg merge_base_override crates/` — 0 production refs
- [x] B1 characterization (`merge_base_characterization`) — A1/A2/B/D/F preserved, E rewritten (override no longer exists), G added (store-derived merge_base correct with DAG hook)
- [x] `branching_merge_lineage_edges.rs` locks: fork anchor, single-merge advancement, repeated-merge point semantics, generation wall across delete+recreate, revert doesn't shift base, cherry-pick doesn't shift base, unrelated branches return None
- [x] New in-file tests: visibility-bounded chain walk, DAG failure → edge deletion, partial DAG failure → projection rebuild, stale expected `BranchRef` → conflict
- [x] `branching_guardrails` — tripwire bumped 12 → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)