### PR TITLE
B4.1: lifecycle write gate — typed BranchArchived end-to-end

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -483,6 +483,24 @@ pub enum StrataError {
         branch_id: BranchId,
     },
 
+    /// Branch not found (user-facing name preserved)
+    ///
+    /// The specified branch does not exist, and the caller supplied a
+    /// user-facing branch name that should survive error conversion.
+    ///
+    /// This is used by branch lifecycle gates that operate on names but still
+    /// want the canonical `BranchId` attached for diagnostics and internal
+    /// classification.
+    ///
+    /// Wire code: `NotFound`
+    #[error("branch not found: {name}")]
+    BranchNotFoundByName {
+        /// User-facing branch name that was not found.
+        name: String,
+        /// Canonical branch id derived from the provided name.
+        branch_id: BranchId,
+    },
+
     /// Branch is archived
     ///
     /// The specified branch exists but is in the `Archived` lifecycle state and
@@ -1090,6 +1108,14 @@ impl StrataError {
         StrataError::BranchNotFound { branch_id }
     }
 
+    /// Create a BranchNotFound error that preserves the user-facing branch
+    /// name while still carrying the canonical `BranchId`.
+    pub fn branch_not_found_by_name(name: impl Into<String>) -> Self {
+        let name = name.into();
+        let branch_id = BranchId::from_user_name(&name);
+        StrataError::BranchNotFoundByName { name, branch_id }
+    }
+
     /// Create a `BranchArchived` error for the given user-facing name.
     ///
     /// ## Example
@@ -1539,7 +1565,9 @@ impl StrataError {
         match self {
             // NotFound errors
             StrataError::NotFound { .. } => ErrorCode::NotFound,
-            StrataError::BranchNotFound { .. } => ErrorCode::NotFound,
+            StrataError::BranchNotFound { .. } | StrataError::BranchNotFoundByName { .. } => {
+                ErrorCode::NotFound
+            }
 
             // Lifecycle-state errors (B4): branch exists but is not writable.
             StrataError::BranchArchived { .. } => ErrorCode::ConstraintViolation,
@@ -1608,6 +1636,9 @@ impl StrataError {
             StrataError::BranchNotFound { branch_id } => {
                 ErrorDetails::new().with_string("branch_id", branch_id.to_string())
             }
+            StrataError::BranchNotFoundByName { name, branch_id } => ErrorDetails::new()
+                .with_string("branch", name)
+                .with_string("branch_id", branch_id.to_string()),
             StrataError::BranchArchived { name } => ErrorDetails::new().with_string("branch", name),
             StrataError::WrongType { expected, actual } => ErrorDetails::new()
                 .with_string("expected", expected)
@@ -1737,6 +1768,7 @@ impl StrataError {
         match self {
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchNotFoundByName { .. }
             | StrataError::PathNotFound { .. } => true,
 
             StrataError::BranchArchived { .. }
@@ -1792,6 +1824,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchNotFoundByName { .. }
             | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::WrongType { .. }
@@ -1832,6 +1865,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchNotFoundByName { .. }
             | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::Conflict { .. }
@@ -1885,6 +1919,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchNotFoundByName { .. }
             | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::Conflict { .. }
@@ -1939,6 +1974,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchNotFoundByName { .. }
             | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::Conflict { .. }
@@ -1991,6 +2027,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchNotFoundByName { .. }
             | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::Conflict { .. }
@@ -2051,6 +2088,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchNotFoundByName { .. }
             | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::WrongType { .. }
@@ -2107,6 +2145,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchNotFoundByName { .. }
             | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::Conflict { .. }
@@ -2155,6 +2194,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchNotFoundByName { .. }
             | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::Conflict { .. }
@@ -2237,7 +2277,8 @@ impl StrataError {
     /// ```
     pub fn branch_id(&self) -> Option<BranchId> {
         match self {
-            StrataError::BranchNotFound { branch_id } => Some(*branch_id),
+            StrataError::BranchNotFound { branch_id }
+            | StrataError::BranchNotFoundByName { branch_id, .. } => Some(*branch_id),
             _ => self.entity_ref().map(|e| e.branch_id()),
         }
     }
@@ -2325,6 +2366,20 @@ mod strata_error_tests {
         assert!(!e.is_conflict());
         assert_eq!(e.branch_id(), Some(branch_id));
         assert!(e.entity_ref().is_none());
+    }
+
+    #[test]
+    fn test_branch_not_found_by_name_constructor() {
+        let e = StrataError::branch_not_found_by_name("release/2026-03");
+
+        assert!(e.is_not_found());
+        assert!(!e.is_conflict());
+        assert_eq!(
+            e.branch_id(),
+            Some(BranchId::from_user_name("release/2026-03"))
+        );
+        assert!(e.entity_ref().is_none());
+        assert_eq!(e.to_string(), "branch not found: release/2026-03");
     }
 
     #[test]
@@ -2831,6 +2886,12 @@ mod strata_error_tests {
     #[test]
     fn test_error_code_mapping_branch_not_found() {
         let e = StrataError::branch_not_found(BranchId::new());
+        assert_eq!(e.code(), ErrorCode::NotFound);
+    }
+
+    #[test]
+    fn test_error_code_mapping_branch_not_found_by_name() {
+        let e = StrataError::branch_not_found_by_name("release/2026-03");
         assert_eq!(e.code(), ErrorCode::NotFound);
     }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -483,6 +483,28 @@ pub enum StrataError {
         branch_id: BranchId,
     },
 
+    /// Branch is archived
+    ///
+    /// The specified branch exists but is in the `Archived` lifecycle state and
+    /// does not accept writes. Read operations against the branch still
+    /// succeed; this error is raised at the `BranchService` write gate when a
+    /// mutation targets an archived lifecycle instance.
+    ///
+    /// Surfaced by `BranchControlStore::require_writable_by_name` (B4).
+    ///
+    /// Wire code: `ConstraintViolation` — the caller attempted a mutation that
+    /// violates the archived-branch read-only contract.
+    #[error("branch is archived: {name}")]
+    BranchArchived {
+        /// User-facing name of the archived branch.
+        ///
+        /// Carries the name rather than a `BranchId` because the typed error
+        /// is intended to be operator-usable end to end (CLI / executor
+        /// error responses); callers already have the name in hand when the
+        /// gate rejects them.
+        name: String,
+    },
+
     // =========================================================================
     // Type Errors
     // =========================================================================
@@ -1068,6 +1090,17 @@ impl StrataError {
         StrataError::BranchNotFound { branch_id }
     }
 
+    /// Create a `BranchArchived` error for the given user-facing name.
+    ///
+    /// ## Example
+    /// ```no_run
+    /// # use strata_core::StrataError;
+    /// StrataError::branch_archived("release/2026-03");
+    /// ```
+    pub fn branch_archived(name: impl Into<String>) -> Self {
+        StrataError::BranchArchived { name: name.into() }
+    }
+
     /// Create a VersionConflict error
     ///
     /// ## Example
@@ -1508,6 +1541,9 @@ impl StrataError {
             StrataError::NotFound { .. } => ErrorCode::NotFound,
             StrataError::BranchNotFound { .. } => ErrorCode::NotFound,
 
+            // Lifecycle-state errors (B4): branch exists but is not writable.
+            StrataError::BranchArchived { .. } => ErrorCode::ConstraintViolation,
+
             // WrongType errors
             StrataError::WrongType { .. } => ErrorCode::WrongType,
 
@@ -1572,6 +1608,7 @@ impl StrataError {
             StrataError::BranchNotFound { branch_id } => {
                 ErrorDetails::new().with_string("branch_id", branch_id.to_string())
             }
+            StrataError::BranchArchived { name } => ErrorDetails::new().with_string("branch", name),
             StrataError::WrongType { expected, actual } => ErrorDetails::new()
                 .with_string("expected", expected)
                 .with_string("actual", actual),
@@ -1702,7 +1739,8 @@ impl StrataError {
             | StrataError::BranchNotFound { .. }
             | StrataError::PathNotFound { .. } => true,
 
-            StrataError::Conflict { .. }
+            StrataError::BranchArchived { .. }
+            | StrataError::Conflict { .. }
             | StrataError::VersionConflict { .. }
             | StrataError::WriteConflict { .. }
             | StrataError::WrongType { .. }
@@ -1754,6 +1792,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::WrongType { .. }
             | StrataError::TransactionAborted { .. }
@@ -1793,6 +1832,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::Conflict { .. }
             | StrataError::VersionConflict { .. }
@@ -1845,6 +1885,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::Conflict { .. }
             | StrataError::VersionConflict { .. }
@@ -1898,6 +1939,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::Conflict { .. }
             | StrataError::VersionConflict { .. }
@@ -1949,6 +1991,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::Conflict { .. }
             | StrataError::VersionConflict { .. }
@@ -2008,6 +2051,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::WrongType { .. }
             | StrataError::TransactionTimeout { .. }
@@ -2063,6 +2107,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::Conflict { .. }
             | StrataError::VersionConflict { .. }
@@ -2110,6 +2155,7 @@ impl StrataError {
 
             StrataError::NotFound { .. }
             | StrataError::BranchNotFound { .. }
+            | StrataError::BranchArchived { .. }
             | StrataError::PathNotFound { .. }
             | StrataError::Conflict { .. }
             | StrataError::VersionConflict { .. }
@@ -2279,6 +2325,27 @@ mod strata_error_tests {
         assert!(!e.is_conflict());
         assert_eq!(e.branch_id(), Some(branch_id));
         assert!(e.entity_ref().is_none());
+    }
+
+    #[test]
+    fn test_branch_archived_classifier() {
+        // B4: archived is a distinct lifecycle-state error, not a
+        // not-found, not a conflict, not retryable, not serious. Wire
+        // code is `ConstraintViolation` — the caller violated the
+        // archived-branch read-only contract.
+        let e = StrataError::branch_archived("release/2026-03");
+
+        assert!(!e.is_not_found());
+        assert!(!e.is_conflict());
+        assert!(!e.is_wrong_type());
+        assert!(!e.is_transaction_error());
+        assert!(!e.is_validation_error());
+        assert!(!e.is_storage_error());
+        assert!(!e.is_retryable());
+        assert!(!e.is_serious());
+        assert!(!e.is_resource_error());
+        assert_eq!(e.code(), ErrorCode::ConstraintViolation);
+        assert!(format!("{e}").contains("release/2026-03"));
     }
 
     #[test]

--- a/crates/engine/src/branch_ops/branch_control_store.rs
+++ b/crates/engine/src/branch_ops/branch_control_store.rs
@@ -22,8 +22,11 @@
 //!
 //! - `__ctl__/<id_hex>/<generation>` — `BranchControlRecord` (JSON)
 //! - `__ctl__next_gen__/<id_hex>` — `u64` next-unused generation
-//! - `__ctl__active__/<id_hex>` — `u64` currently-active generation (absent
-//!   if no active lifecycle instance)
+//! - `__ctl__active__/<id_hex>` — `u64` pointer at the **live** (non-Deleted)
+//!   lifecycle generation. Set for `Active` and `Archived` records; cleared
+//!   when the record transitions to `Deleted` (B4 widened this from
+//!   Active-only so the lifecycle write gate can distinguish
+//!   `BranchArchived` from `BranchNotFound`).
 //! - `__ctl__edge__/<id_hex>/<generation>/<commit_version_padded>` —
 //!   `LineageEdgeRecord` (JSON). Commit version is zero-padded decimal
 //!   (20 digits, covering `u64::MAX`) so lexical order on the key
@@ -561,10 +564,19 @@ impl BranchControlStore {
 
     /// Write or overwrite a control record.
     ///
-    /// Also updates the `__ctl__active__/<id>` pointer:
-    /// - if `rec.lifecycle == Active`: pointer is set to `rec.branch.generation`
-    /// - if Archived / Deleted: pointer is cleared when it matches this
-    ///   generation (we never stomp on a different active generation).
+    /// Also updates the `__ctl__active__/<id>` pointer, which addresses the
+    /// **live** (non-Deleted) lifecycle generation:
+    ///
+    /// - `Active` / `Archived`: pointer is set to `rec.branch.generation`.
+    ///   Archived branches remain findable by name so the B4 lifecycle write
+    ///   gate can return `BranchArchived` instead of `BranchNotFound`.
+    /// - `Deleted` (or any future non-live variant): pointer is cleared only
+    ///   when it still points at *this* generation; we never stomp on a
+    ///   different live generation.
+    ///
+    /// `BranchLifecycleStatus` is `#[non_exhaustive]`; unknown future
+    /// variants fall through to the Deleted arm because, by definition,
+    /// they are not currently-live lifecycle instances.
     pub(crate) fn put_record(
         &self,
         rec: &BranchControlRecord,
@@ -573,15 +585,9 @@ impl BranchControlStore {
         txn.put(control_record_key(rec.branch), to_stored_value(rec)?)?;
         let ap_key = active_ptr_key(rec.branch.id);
         match rec.lifecycle {
-            BranchLifecycleStatus::Active => {
+            BranchLifecycleStatus::Active | BranchLifecycleStatus::Archived => {
                 txn.put(ap_key, encode_u64_value(rec.branch.generation))?;
             }
-            // Archived / Deleted / future non-live variants: clear the
-            // active pointer only when it still points at *this* generation.
-            // `BranchLifecycleStatus` is `#[non_exhaustive]` — unknown future
-            // variants fall through to the same clear-if-matches path
-            // because they are by definition not the currently-writable
-            // lifecycle instance.
             _ => {
                 if let Some(v) = txn.get(&ap_key)? {
                     if decode_u64_value(&v)? == rec.branch.generation {
@@ -743,8 +749,12 @@ impl BranchControlStore {
             })
     }
 
-    /// Look up the currently-active record for a branch name. Uses the
-    /// O(1) active-pointer index row (AD4).
+    /// Look up the currently-live (non-Deleted) record for a branch name.
+    /// Uses the O(1) active-pointer index row (AD4).
+    ///
+    /// Returns the record for both `Active` and `Archived` lifecycle states
+    /// (the pointer tracks live generations per B4/KD1). Callers who need a
+    /// writability guarantee should use [`require_writable_by_name`] instead.
     ///
     /// On an unmigrated follower (AD5), falls back to synthesizing a
     /// gen-0 [`BranchControlRecord`] from legacy `BranchMetadata` + fork
@@ -761,7 +771,7 @@ impl BranchControlStore {
                 let mut has_live_record = false;
                 for (_k, v) in txn.scan_prefix(&control_record_prefix_for_id(id))? {
                     let rec: BranchControlRecord = from_stored_value(&v)?;
-                    if matches!(rec.lifecycle, BranchLifecycleStatus::Active) {
+                    if rec.lifecycle.is_visible() {
                         has_live_record = true;
                         break;
                     }
@@ -778,9 +788,9 @@ impl BranchControlStore {
             match txn.get(&rec_key)? {
                 Some(rv) => {
                     let rec: BranchControlRecord = from_stored_value(&rv)?;
-                    if !matches!(rec.lifecycle, BranchLifecycleStatus::Active) {
+                    if !rec.lifecycle.is_visible() {
                         return Err(StrataError::corruption(format!(
-                            "control-store active pointer for branch '{name}' (id={id}, gen={gen}) points to a non-active record"
+                            "control-store active pointer for branch '{name}' (id={id}, gen={gen}) points to a non-live record"
                         )));
                     }
                     Ok(Some(rec))
@@ -797,6 +807,46 @@ impl BranchControlStore {
             return Ok(None);
         }
         self.synthesize_from_legacy(name, id)
+    }
+
+    /// Require a **writable** (lifecycle = `Active`) control record for `name`.
+    ///
+    /// Maps onto the lifecycle write gate installed at every `BranchService`
+    /// mutation entry point (B4):
+    ///
+    /// - `Active` → `Ok(record)`.
+    /// - `Archived` → `Err(StrataError::BranchArchived { name })`.
+    /// - `Deleted` or missing → `Err(StrataError::BranchNotFound { .. })`.
+    /// - Follower-synthesis refusal (AD5) → propagates
+    ///   `BranchLineageUnavailable`.
+    pub(crate) fn require_writable_by_name(&self, name: &str) -> StrataResult<BranchControlRecord> {
+        let record = self
+            .find_active_by_name(name)?
+            .ok_or_else(|| StrataError::branch_not_found(BranchId::from_user_name(name)))?;
+        if record.lifecycle.allows_writes() {
+            Ok(record)
+        } else {
+            // The only non-writable live variant that `find_active_by_name`
+            // can return is `Archived`; `Deleted` clears the pointer and is
+            // handled by the `ok_or_else` arm above. Future non-live
+            // variants would have to add their own arm before landing.
+            Err(StrataError::branch_archived(name))
+        }
+    }
+
+    /// Require a **visible** (lifecycle = `Active` or `Archived`) control
+    /// record for `name`.
+    ///
+    /// Used for source-side checks on fork / merge / cherry-pick where the
+    /// source is read, not written:
+    ///
+    /// - `Active` or `Archived` → `Ok(record)`.
+    /// - `Deleted` or missing → `Err(StrataError::BranchNotFound { .. })`.
+    /// - Follower-synthesis refusal (AD5) → propagates
+    ///   `BranchLineageUnavailable`.
+    pub(crate) fn require_visible_by_name(&self, name: &str) -> StrataResult<BranchControlRecord> {
+        self.find_active_by_name(name)?
+            .ok_or_else(|| StrataError::branch_not_found(BranchId::from_user_name(name)))
     }
 
     /// Return the currently-active generation for `id`, if any.
@@ -819,9 +869,9 @@ impl BranchControlStore {
                     .scan_prefix(&control_record_prefix_for_id(id), CommitVersion::MAX)?
                 {
                     let rec: BranchControlRecord = from_stored_value(&v.value)?;
-                    if matches!(rec.lifecycle, BranchLifecycleStatus::Active) {
+                    if rec.lifecycle.is_visible() {
                         return Err(StrataError::corruption(format!(
-                            "control-store active pointer missing for branch id={id} with active record present"
+                            "control-store active pointer missing for branch id={id} with live record present"
                         )));
                     }
                 }
@@ -3141,5 +3191,190 @@ mod tests {
             )
         });
         assert!(store.find_merge_base(a, b).unwrap().is_none());
+    }
+
+    // =========================================================================
+    // B4.1: lifecycle write gate helpers
+    // =========================================================================
+
+    /// Build an `Archived` record for `name@generation` directly through
+    /// `put_record`. No public engine path produces `Archived` today (B4
+    /// explicitly deferred the archive operation); tests synthesize it to
+    /// exercise the gate.
+    fn seed_archived_record(
+        db: &Arc<Database>,
+        store: &BranchControlStore,
+        name: &str,
+    ) -> BranchRef {
+        let id = BranchId::from_user_name(name);
+        let branch = BranchRef::new(id, 0);
+        write(db, |txn| {
+            store.put_record(
+                &BranchControlRecord {
+                    branch,
+                    name: name.to_string(),
+                    lifecycle: BranchLifecycleStatus::Archived,
+                    fork: None,
+                },
+                txn,
+            )
+        });
+        branch
+    }
+
+    #[test]
+    fn put_archived_record_sets_active_pointer() {
+        // KD1: Archived keeps the pointer set so lifecycle gates can
+        // distinguish `BranchArchived` from `BranchNotFound`.
+        let (db, store) = fresh_store();
+        let branch = seed_archived_record(&db, &store, "retired");
+        let found = store
+            .find_active_by_name("retired")
+            .unwrap()
+            .expect("archived record must remain findable by name");
+        assert_eq!(found.branch, branch);
+        assert_eq!(found.lifecycle, BranchLifecycleStatus::Archived);
+    }
+
+    #[test]
+    fn transitioning_active_to_archived_keeps_pointer_at_same_generation() {
+        let (db, store) = fresh_store();
+        let id = BranchId::from_user_name("promote-demote");
+        let branch = BranchRef::new(id, 7);
+        write(&db, |txn| {
+            store.put_record(
+                &BranchControlRecord {
+                    branch,
+                    name: "promote-demote".to_string(),
+                    lifecycle: BranchLifecycleStatus::Active,
+                    fork: None,
+                },
+                txn,
+            )
+        });
+        write(&db, |txn| {
+            store.put_record(
+                &BranchControlRecord {
+                    branch,
+                    name: "promote-demote".to_string(),
+                    lifecycle: BranchLifecycleStatus::Archived,
+                    fork: None,
+                },
+                txn,
+            )
+        });
+        assert_eq!(store.active_generation_for_id(id).unwrap(), Some(7));
+        let rec = store
+            .find_active_by_name("promote-demote")
+            .unwrap()
+            .expect("archived record stays findable by name");
+        assert_eq!(rec.lifecycle, BranchLifecycleStatus::Archived);
+    }
+
+    #[test]
+    fn require_writable_accepts_active() {
+        let (db, store) = fresh_store();
+        let branch = BranchRef::new(BranchId::from_user_name("writable"), 0);
+        write(&db, |txn| {
+            store.put_record(
+                &BranchControlRecord {
+                    branch,
+                    name: "writable".to_string(),
+                    lifecycle: BranchLifecycleStatus::Active,
+                    fork: None,
+                },
+                txn,
+            )
+        });
+        let rec = store.require_writable_by_name("writable").unwrap();
+        assert_eq!(rec.branch, branch);
+        assert!(rec.lifecycle.allows_writes());
+    }
+
+    #[test]
+    fn require_writable_rejects_archived_with_branch_archived() {
+        let (db, store) = fresh_store();
+        seed_archived_record(&db, &store, "frozen");
+        let err = store.require_writable_by_name("frozen").unwrap_err();
+        match err {
+            StrataError::BranchArchived { name } => assert_eq!(name, "frozen"),
+            other => panic!("expected BranchArchived, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn require_writable_rejects_deleted_with_branch_not_found() {
+        let (db, store) = fresh_store();
+        let branch = BranchRef::new(BranchId::from_user_name("tombstone"), 0);
+        write(&db, |txn| {
+            store.put_record(
+                &BranchControlRecord {
+                    branch,
+                    name: "tombstone".to_string(),
+                    lifecycle: BranchLifecycleStatus::Deleted,
+                    fork: None,
+                },
+                txn,
+            )
+        });
+        let err = store.require_writable_by_name("tombstone").unwrap_err();
+        assert!(
+            matches!(err, StrataError::BranchNotFound { .. }),
+            "deleted record must surface as BranchNotFound, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn require_writable_rejects_missing_with_branch_not_found() {
+        let (_db, store) = fresh_store();
+        let err = store.require_writable_by_name("never-existed").unwrap_err();
+        assert!(matches!(err, StrataError::BranchNotFound { .. }));
+    }
+
+    #[test]
+    fn require_visible_accepts_active_and_archived() {
+        let (db, store) = fresh_store();
+        let active = BranchRef::new(BranchId::from_user_name("live"), 0);
+        write(&db, |txn| {
+            store.put_record(
+                &BranchControlRecord {
+                    branch: active,
+                    name: "live".to_string(),
+                    lifecycle: BranchLifecycleStatus::Active,
+                    fork: None,
+                },
+                txn,
+            )
+        });
+        seed_archived_record(&db, &store, "frozen");
+
+        let live_rec = store.require_visible_by_name("live").unwrap();
+        assert_eq!(live_rec.lifecycle, BranchLifecycleStatus::Active);
+
+        let frozen_rec = store.require_visible_by_name("frozen").unwrap();
+        assert_eq!(frozen_rec.lifecycle, BranchLifecycleStatus::Archived);
+    }
+
+    #[test]
+    fn require_visible_rejects_deleted_and_missing_with_branch_not_found() {
+        let (db, store) = fresh_store();
+        let branch = BranchRef::new(BranchId::from_user_name("gone"), 0);
+        write(&db, |txn| {
+            store.put_record(
+                &BranchControlRecord {
+                    branch,
+                    name: "gone".to_string(),
+                    lifecycle: BranchLifecycleStatus::Deleted,
+                    fork: None,
+                },
+                txn,
+            )
+        });
+
+        let err_deleted = store.require_visible_by_name("gone").unwrap_err();
+        assert!(matches!(err_deleted, StrataError::BranchNotFound { .. }));
+
+        let err_missing = store.require_visible_by_name("never").unwrap_err();
+        assert!(matches!(err_missing, StrataError::BranchNotFound { .. }));
     }
 }

--- a/crates/engine/src/branch_ops/branch_control_store.rs
+++ b/crates/engine/src/branch_ops/branch_control_store.rs
@@ -816,13 +816,13 @@ impl BranchControlStore {
     ///
     /// - `Active` → `Ok(record)`.
     /// - `Archived` → `Err(StrataError::BranchArchived { name })`.
-    /// - `Deleted` or missing → `Err(StrataError::BranchNotFound { .. })`.
+    /// - `Deleted` or missing → `Err(StrataError::BranchNotFoundByName { .. })`.
     /// - Follower-synthesis refusal (AD5) → propagates
     ///   `BranchLineageUnavailable`.
     pub(crate) fn require_writable_by_name(&self, name: &str) -> StrataResult<BranchControlRecord> {
         let record = self
             .find_active_by_name(name)?
-            .ok_or_else(|| StrataError::branch_not_found(BranchId::from_user_name(name)))?;
+            .ok_or_else(|| StrataError::branch_not_found_by_name(name))?;
         if record.lifecycle.allows_writes() {
             Ok(record)
         } else {
@@ -841,12 +841,12 @@ impl BranchControlStore {
     /// source is read, not written:
     ///
     /// - `Active` or `Archived` → `Ok(record)`.
-    /// - `Deleted` or missing → `Err(StrataError::BranchNotFound { .. })`.
+    /// - `Deleted` or missing → `Err(StrataError::BranchNotFoundByName { .. })`.
     /// - Follower-synthesis refusal (AD5) → propagates
     ///   `BranchLineageUnavailable`.
     pub(crate) fn require_visible_by_name(&self, name: &str) -> StrataResult<BranchControlRecord> {
         self.find_active_by_name(name)?
-            .ok_or_else(|| StrataError::branch_not_found(BranchId::from_user_name(name)))
+            .ok_or_else(|| StrataError::branch_not_found_by_name(name))
     }
 
     /// Return the currently-active generation for `id`, if any.
@@ -3318,17 +3318,24 @@ mod tests {
             )
         });
         let err = store.require_writable_by_name("tombstone").unwrap_err();
-        assert!(
-            matches!(err, StrataError::BranchNotFound { .. }),
-            "deleted record must surface as BranchNotFound, got {err:?}"
-        );
+        match err {
+            StrataError::BranchNotFoundByName { name, .. } => assert_eq!(name, "tombstone"),
+            other => panic!(
+                "deleted record must surface as name-preserving BranchNotFound, got {other:?}"
+            ),
+        }
     }
 
     #[test]
     fn require_writable_rejects_missing_with_branch_not_found() {
         let (_db, store) = fresh_store();
         let err = store.require_writable_by_name("never-existed").unwrap_err();
-        assert!(matches!(err, StrataError::BranchNotFound { .. }));
+        match err {
+            StrataError::BranchNotFoundByName { name, .. } => assert_eq!(name, "never-existed"),
+            other => panic!(
+                "missing branch must surface as name-preserving BranchNotFound, got {other:?}"
+            ),
+        }
     }
 
     #[test]
@@ -3372,9 +3379,19 @@ mod tests {
         });
 
         let err_deleted = store.require_visible_by_name("gone").unwrap_err();
-        assert!(matches!(err_deleted, StrataError::BranchNotFound { .. }));
+        match err_deleted {
+            StrataError::BranchNotFoundByName { name, .. } => assert_eq!(name, "gone"),
+            other => panic!(
+                "deleted branch must surface as name-preserving BranchNotFound, got {other:?}"
+            ),
+        }
 
         let err_missing = store.require_visible_by_name("never").unwrap_err();
-        assert!(matches!(err_missing, StrataError::BranchNotFound { .. }));
+        match err_missing {
+            StrataError::BranchNotFoundByName { name, .. } => assert_eq!(name, "never"),
+            other => panic!(
+                "missing branch must surface as name-preserving BranchNotFound, got {other:?}"
+            ),
+        }
     }
 }

--- a/crates/engine/src/branch_ops/mod.rs
+++ b/crates/engine/src/branch_ops/mod.rs
@@ -85,6 +85,31 @@ fn note_prefix(branch: &str) -> String {
     format!("note:{branch}:")
 }
 
+/// Delete all branch-scoped tag/note annotation rows for `branch` inside an
+/// existing transaction.
+///
+/// Tags and notes live under the `_system_` branch, so branch deletion must
+/// clear them explicitly; deleting the user branch namespace alone is not
+/// sufficient. Keeping this cleanup in the same transaction as branch metadata
+/// deletion prevents same-name recreate from inheriting stale annotations.
+pub(crate) fn delete_annotations_for_branch_in_txn(
+    txn: &mut strata_concurrency::TransactionContext,
+    branch: &str,
+) -> StrataResult<()> {
+    let system_id = resolve_branch_name(SYSTEM_BRANCH);
+    let ns = Arc::new(Namespace::for_branch_space(system_id, "default"));
+
+    for prefix in [tag_prefix(branch), note_prefix(branch)] {
+        let prefix_key = Key::new(ns.clone(), TypeTag::KV, prefix.into_bytes());
+        let entries = txn.scan_prefix(&prefix_key)?;
+        for (key, _) in entries {
+            txn.delete(key)?;
+        }
+    }
+
+    Ok(())
+}
+
 // =============================================================================
 // Snapshot map builders (ENG-DEBT-001)
 // =============================================================================
@@ -2613,7 +2638,21 @@ pub fn create_tag(
     message: Option<&str>,
     creator: Option<&str>,
 ) -> StrataResult<TagInfo> {
-    resolve_and_verify(db, branch)?;
+    create_tag_with_expected(db, branch, name, version, message, creator, None)
+}
+
+/// Create a tag on a branch while pinning the expected branch lifecycle
+/// instance.
+pub(crate) fn create_tag_with_expected(
+    db: &Arc<Database>,
+    branch: &str,
+    name: &str,
+    version: Option<u64>,
+    message: Option<&str>,
+    creator: Option<&str>,
+    expected_branch_ref: Option<BranchRef>,
+) -> StrataResult<TagInfo> {
+    resolve_and_verify_with_expected(db, branch, expected_branch_ref)?;
 
     if branch.contains(':') {
         return Err(StrataError::invalid_input("Branch name cannot contain ':'"));
@@ -2646,7 +2685,10 @@ pub fn create_tag(
     let tag_value = serde_json::to_string(&tag_info)
         .map_err(|e| StrataError::internal(format!("Failed to serialize tag: {}", e)))?;
 
-    db.transaction(system_id, |txn| {
+    db.transaction(system_id, move |txn| {
+        if let Some(expected) = expected_branch_ref {
+            verify_expected_active_ref_in_txn(txn, branch, expected)?;
+        }
         let ns = Arc::new(Namespace::for_branch_space(system_id, "default"));
         let key = Key::new(ns, TypeTag::KV, tag_key.as_bytes().to_vec());
         txn.put(key, Value::String(tag_value.clone()))?;
@@ -2660,6 +2702,18 @@ pub fn create_tag(
 ///
 /// Returns `true` if the tag existed and was deleted.
 pub fn delete_tag(db: &Arc<Database>, branch: &str, name: &str) -> StrataResult<bool> {
+    delete_tag_with_expected(db, branch, name, None)
+}
+
+/// Delete a tag while pinning the expected branch lifecycle instance.
+pub(crate) fn delete_tag_with_expected(
+    db: &Arc<Database>,
+    branch: &str,
+    name: &str,
+    expected_branch_ref: Option<BranchRef>,
+) -> StrataResult<bool> {
+    resolve_and_verify_with_expected(db, branch, expected_branch_ref)?;
+
     let system_id = resolve_branch_name(SYSTEM_BRANCH);
     let tag_key = tag_key(branch, name);
 
@@ -2670,7 +2724,10 @@ pub fn delete_tag(db: &Arc<Database>, branch: &str, name: &str) -> StrataResult<
         .any(|(k, _)| k.namespace.space == "default" && *k.user_key == *tag_key.as_bytes());
 
     if exists {
-        db.transaction(system_id, |txn| {
+        db.transaction(system_id, move |txn| {
+            if let Some(expected) = expected_branch_ref {
+                verify_expected_active_ref_in_txn(txn, branch, expected)?;
+            }
             let ns = Arc::new(Namespace::for_branch_space(system_id, "default"));
             let key = Key::new(ns, TypeTag::KV, tag_key.as_bytes().to_vec());
             txn.delete(key)?;
@@ -2763,7 +2820,20 @@ pub fn add_note(
     author: Option<&str>,
     metadata: Option<Value>,
 ) -> StrataResult<NoteInfo> {
-    resolve_and_verify(db, branch)?;
+    add_note_with_expected(db, branch, version, message, author, metadata, None)
+}
+
+/// Add a note while pinning the expected branch lifecycle instance.
+pub(crate) fn add_note_with_expected(
+    db: &Arc<Database>,
+    branch: &str,
+    version: CommitVersion,
+    message: &str,
+    author: Option<&str>,
+    metadata: Option<Value>,
+    expected_branch_ref: Option<BranchRef>,
+) -> StrataResult<NoteInfo> {
+    resolve_and_verify_with_expected(db, branch, expected_branch_ref)?;
 
     if branch.contains(':') {
         return Err(StrataError::invalid_input("Branch name cannot contain ':'"));
@@ -2784,7 +2854,10 @@ pub fn add_note(
     let note_value = serde_json::to_string(&note)
         .map_err(|e| StrataError::internal(format!("Failed to serialize note: {}", e)))?;
 
-    db.transaction(system_id, |txn| {
+    db.transaction(system_id, move |txn| {
+        if let Some(expected) = expected_branch_ref {
+            verify_expected_active_ref_in_txn(txn, branch, expected)?;
+        }
         let ns = Arc::new(Namespace::for_branch_space(system_id, "default"));
         let key = Key::new(ns, TypeTag::KV, note_key.as_bytes().to_vec());
         txn.put(key, Value::String(note_value.clone()))?;
@@ -2836,6 +2909,18 @@ pub fn get_notes(
 ///
 /// Returns `true` if the note existed and was deleted.
 pub fn delete_note(db: &Arc<Database>, branch: &str, version: CommitVersion) -> StrataResult<bool> {
+    delete_note_with_expected(db, branch, version, None)
+}
+
+/// Delete a note while pinning the expected branch lifecycle instance.
+pub(crate) fn delete_note_with_expected(
+    db: &Arc<Database>,
+    branch: &str,
+    version: CommitVersion,
+    expected_branch_ref: Option<BranchRef>,
+) -> StrataResult<bool> {
+    resolve_and_verify_with_expected(db, branch, expected_branch_ref)?;
+
     let system_id = resolve_branch_name(SYSTEM_BRANCH);
     let note_key = note_key(branch, version.as_u64());
 
@@ -2846,7 +2931,10 @@ pub fn delete_note(db: &Arc<Database>, branch: &str, version: CommitVersion) -> 
         .any(|(k, _)| k.namespace.space == "default" && *k.user_key == *note_key.as_bytes());
 
     if exists {
-        db.transaction(system_id, |txn| {
+        db.transaction(system_id, move |txn| {
+            if let Some(expected) = expected_branch_ref {
+                verify_expected_active_ref_in_txn(txn, branch, expected)?;
+            }
             let ns = Arc::new(Namespace::for_branch_space(system_id, "default"));
             let key = Key::new(ns, TypeTag::KV, note_key.as_bytes().to_vec());
             txn.delete(key)?;
@@ -5263,6 +5351,40 @@ mod tests {
         assert_eq!(tags[0].name, "t2");
     }
 
+    #[test]
+    fn test_tag_with_expected_rejects_recreated_branch_generation() {
+        let (_temp, db) = setup_with_branch("main");
+        let store = BranchControlStore::new(db.clone());
+        let stale_ref = store.require_writable_by_name("main").unwrap().branch;
+
+        db.branches().delete("main").unwrap();
+        db.branches().create("main").unwrap();
+
+        let err = create_tag_with_expected(&db, "main", "v1.0", None, None, None, Some(stale_ref))
+            .unwrap_err();
+        assert!(
+            matches!(err, StrataError::Conflict { .. }),
+            "recreated branch must reject stale expected ref, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_delete_clears_tags_before_same_name_recreate() {
+        let (_temp, db) = setup_with_branch("main");
+        create_tag(&db, "main", "v1.0", None, None, None).unwrap();
+
+        db.branches().delete("main").unwrap();
+        db.branches().create("main").unwrap();
+
+        assert!(
+            list_tags(&db, "main").unwrap().is_empty(),
+            "recreated branch must not inherit tags from the prior lifecycle"
+        );
+
+        create_tag(&db, "main", "v1.0", None, None, None)
+            .expect("same-name recreate must allow reusing a deleted lifecycle's tag name");
+    }
+
     // =========================================================================
     // Note Tests
     // =========================================================================
@@ -5303,6 +5425,42 @@ mod tests {
         let notes = get_notes(&db, "main", None).unwrap();
         assert_eq!(notes.len(), 1);
         assert_eq!(notes[0].version, 2);
+    }
+
+    #[test]
+    fn test_delete_note_with_expected_rejects_recreated_branch_generation() {
+        let (_temp, db) = setup_with_branch("main");
+        add_note(&db, "main", CommitVersion(1), "note1", None, None).unwrap();
+
+        let store = BranchControlStore::new(db.clone());
+        let stale_ref = store.require_writable_by_name("main").unwrap().branch;
+
+        db.branches().delete("main").unwrap();
+        db.branches().create("main").unwrap();
+
+        let err =
+            delete_note_with_expected(&db, "main", CommitVersion(1), Some(stale_ref)).unwrap_err();
+        assert!(
+            matches!(err, StrataError::Conflict { .. }),
+            "recreated branch must reject stale expected ref, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_delete_clears_notes_before_same_name_recreate() {
+        let (_temp, db) = setup_with_branch("main");
+        add_note(&db, "main", CommitVersion(1), "note1", None, None).unwrap();
+
+        db.branches().delete("main").unwrap();
+        db.branches().create("main").unwrap();
+
+        assert!(
+            get_notes(&db, "main", None).unwrap().is_empty(),
+            "recreated branch must not inherit notes from the prior lifecycle"
+        );
+
+        add_note(&db, "main", CommitVersion(1), "note1", None, None)
+            .expect("same-name recreate must allow reusing a deleted lifecycle's note slot");
     }
 
     // =========================================================================

--- a/crates/engine/src/database/branch_service.rs
+++ b/crates/engine/src/database/branch_service.rs
@@ -1076,10 +1076,10 @@ impl BranchService {
 
         let a_rec = store
             .find_active_by_name(branch_a)?
-            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(branch_a)))?;
+            .ok_or_else(|| StrataError::branch_not_found_by_name(branch_a))?;
         let b_rec = store
             .find_active_by_name(branch_b)?
-            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(branch_b)))?;
+            .ok_or_else(|| StrataError::branch_not_found_by_name(branch_b))?;
 
         let Some(point) = store.find_merge_base(a_rec.branch, b_rec.branch)? else {
             return Ok(None);
@@ -1120,7 +1120,7 @@ impl BranchService {
                         branch
                     )));
                 }
-                return Err(StrataError::branch_not_found(resolve_branch_name(branch)));
+                return Err(StrataError::branch_not_found_by_name(branch));
             }
         }
         let hook = self.dag_hook().require("log").map_err(dag_to_strata)?;
@@ -1143,7 +1143,7 @@ impl BranchService {
                         branch
                     )));
                 }
-                return Err(StrataError::branch_not_found(resolve_branch_name(branch)));
+                return Err(StrataError::branch_not_found_by_name(branch));
             }
         }
         let hook = self
@@ -1177,7 +1177,15 @@ impl BranchService {
         let branch_rec = store.require_writable_by_name(branch)?;
         let branch_ref = branch_rec.branch;
 
-        let info = branch_ops::create_tag(&self.db, branch, name, version, message, creator)?;
+        let info = branch_ops::create_tag_with_expected(
+            &self.db,
+            branch,
+            name,
+            version,
+            message,
+            creator,
+            Some(branch_ref),
+        )?;
 
         let branch_id = branch_rec.branch.id;
         let event = BranchOpEvent {
@@ -1216,7 +1224,8 @@ impl BranchService {
         let store = BranchControlStore::new(self.db.clone());
         let branch_rec = store.require_writable_by_name(branch)?;
 
-        let deleted = branch_ops::delete_tag(&self.db, branch, name)?;
+        let deleted =
+            branch_ops::delete_tag_with_expected(&self.db, branch, name, Some(branch_rec.branch))?;
 
         if deleted {
             let branch_id = branch_rec.branch.id;
@@ -1279,14 +1288,31 @@ impl BranchService {
         reject_system_branch(branch, "add note to")?;
 
         // B4/KD4: notes are branch-scoped writes; same gate as tags.
-        BranchControlStore::new(self.db.clone()).require_writable_by_name(branch)?;
+        let branch_rec =
+            BranchControlStore::new(self.db.clone()).require_writable_by_name(branch)?;
 
-        let note = branch_ops::add_note(&self.db, branch, version, message, author, metadata)?;
+        let note = branch_ops::add_note_with_expected(
+            &self.db,
+            branch,
+            version,
+            message,
+            author,
+            metadata,
+            Some(branch_rec.branch),
+        )?;
 
         let system_branch_id = resolve_branch_name(SYSTEM_BRANCH);
         let payload = strata_core::value::Value::object(
             [
                 ("branch".to_string(), branch.into()),
+                (
+                    "branch_id".to_string(),
+                    branch_rec.branch.id.to_string().into(),
+                ),
+                (
+                    "branch_generation".to_string(),
+                    strata_core::Value::Int(branch_rec.branch.generation as i64),
+                ),
                 (
                     "version".to_string(),
                     strata_core::Value::Int(version.0 as i64),
@@ -1326,9 +1352,10 @@ impl BranchService {
         reject_system_branch(branch, "delete note from")?;
 
         // B4/KD4: note deletion follows the same gate as creation.
-        BranchControlStore::new(self.db.clone()).require_writable_by_name(branch)?;
+        let branch_rec =
+            BranchControlStore::new(self.db.clone()).require_writable_by_name(branch)?;
 
-        branch_ops::delete_note(&self.db, branch, version)
+        branch_ops::delete_note_with_expected(&self.db, branch, version, Some(branch_rec.branch))
     }
 
     // =========================================================================
@@ -1652,6 +1679,32 @@ mod tests {
     }
 
     #[test]
+    fn test_history_reads_preserve_missing_branch_name_in_not_found() {
+        let db = Database::cache().unwrap();
+
+        let merge_err = db
+            .branches()
+            .merge_base("missing-a", "missing-b")
+            .unwrap_err();
+        assert!(
+            matches!(merge_err, StrataError::BranchNotFoundByName { ref name, .. } if name == "missing-a"),
+            "merge_base should preserve the user branch name, got {merge_err:?}"
+        );
+
+        let log_err = db.branches().log("missing-log", 10).unwrap_err();
+        assert!(
+            matches!(log_err, StrataError::BranchNotFoundByName { ref name, .. } if name == "missing-log"),
+            "log should preserve the user branch name, got {log_err:?}"
+        );
+
+        let ancestors_err = db.branches().ancestors("missing-ancestors").unwrap_err();
+        assert!(
+            matches!(ancestors_err, StrataError::BranchNotFoundByName { ref name, .. } if name == "missing-ancestors"),
+            "ancestors should preserve the user branch name, got {ancestors_err:?}"
+        );
+    }
+
+    #[test]
     fn test_merge_dag_failure_rolls_back_prewritten_lineage_edge() {
         let temp_dir = TempDir::new().unwrap();
         let db = Database::open_runtime(
@@ -1839,6 +1892,55 @@ mod tests {
         assert!(
             matches!(err, StrataError::BranchArchived { ref name } if name == "release"),
             "expected BranchArchived on archived branch tag, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_branch_note_audit_payload_carries_generation() {
+        let db = Database::cache().unwrap();
+        db.branches().create("release").unwrap();
+        db.branches()
+            .add_note("release", CommitVersion(1), "gen0", None, None)
+            .unwrap();
+
+        db.branches().delete("release").unwrap();
+        db.branches().create("release").unwrap();
+        db.branches()
+            .add_note("release", CommitVersion(2), "gen1", None, None)
+            .unwrap();
+
+        let system_branch_id = resolve_branch_name(SYSTEM_BRANCH);
+        let events = EventLog::new(db.clone())
+            .get_by_type(&system_branch_id, "default", "branch.note", None, None)
+            .unwrap();
+        assert_eq!(events.len(), 2, "expected one audit event per note write");
+
+        let payload0 = events[0]
+            .value
+            .payload
+            .as_object()
+            .expect("branch.note payload must be an object");
+        assert_eq!(
+            payload0.get("branch").and_then(|v| v.as_str()),
+            Some("release")
+        );
+        assert_eq!(
+            payload0.get("branch_generation").and_then(|v| v.as_int()),
+            Some(0)
+        );
+        assert!(payload0
+            .get("branch_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|id| !id.is_empty()));
+
+        let payload1 = events[1]
+            .value
+            .payload
+            .as_object()
+            .expect("branch.note payload must be an object");
+        assert_eq!(
+            payload1.get("branch_generation").and_then(|v| v.as_int()),
+            Some(1)
         );
     }
 

--- a/crates/engine/src/database/branch_service.rs
+++ b/crates/engine/src/database/branch_service.rs
@@ -394,11 +394,19 @@ impl BranchService {
         reject_system_branch(name, "delete")?;
         reject_default_branch(&self.db, name, "delete")?;
 
+        let store = BranchControlStore::new(self.db.clone());
+
+        // B4 lifecycle gate: delete is permitted for `Active` and `Archived`
+        // targets; `Deleted` and missing branches surface as
+        // `BranchNotFound`. Archived records stay visible via the widened
+        // active-pointer semantics (KD1). Runs before `BranchMutation::new`
+        // so a lifecycle-refused delete never registers rollback actions.
+        store.require_visible_by_name(name)?;
+
         let mut mutation = BranchMutation::new(&self.db);
         let branch_id = resolve_branch_name(name);
 
         let index = BranchIndex::new(self.db.clone());
-        let store = BranchControlStore::new(self.db.clone());
 
         if mutation.has_dag_hook() {
             mutation.on_rollback_restore_branch(name)?;
@@ -529,29 +537,29 @@ impl BranchService {
         reject_system_branch(source, "fork from")?;
         validate_branch_name(destination)?;
 
-        // Create mutation context for atomicity
-        let mut mutation = BranchMutation::new(&self.db);
-
-        // Fork requires DAG — without it, lineage is lost
-        mutation.require_dag_hook("fork")?;
-
-        // B3.2: preallocate only the destination generation here. The
-        // source `BranchRef` must be resolved inside fork's quiesce
-        // guard so the fork anchor points at the exact lifecycle
-        // instance whose storage snapshot is being forked.
         let store = BranchControlStore::new(self.db.clone());
         let branch_index = BranchIndex::new(self.db.clone());
 
-        // Fail the duplicate-destination case before bumping the
-        // next-generation counter; otherwise a spurious `fork` attempt to
-        // an existing name burns a generation before `fork_branch_with_metadata`
-        // ever observes the collision.
+        // B4 lifecycle gate: fork is a read-then-create op. The source
+        // needs to be visible (Active or Archived — copying a frozen
+        // snapshot is valid); the destination must have no live record,
+        // which preserves the pre-B4 duplicate semantics after the
+        // active-pointer widening (KD1: an Archived record also counts
+        // as a live duplicate for name allocation, not as a fork-from
+        // lifecycle state the gate can override).
+        store.require_visible_by_name(source)?;
         if branch_index.exists(destination)? || store.find_active_by_name(destination)?.is_some() {
             return Err(StrataError::invalid_input(format!(
                 "Destination branch '{}' already exists",
                 destination
             )));
         }
+
+        // Create mutation context for atomicity
+        let mut mutation = BranchMutation::new(&self.db);
+
+        // Fork requires DAG — without it, lineage is lost
+        mutation.require_dag_hook("fork")?;
 
         let dest_id = resolve_branch_name(destination);
         let dest_gen = self
@@ -677,25 +685,23 @@ impl BranchService {
         reject_system_branch(source, "merge from")?;
         reject_system_branch(target, "merge into")?;
 
+        // B4 lifecycle gate: source must be visible (Active or Archived —
+        // merging from a frozen snapshot is valid); target must be
+        // writable. An archived target refuses with `BranchArchived`.
+        //
+        // Gate reads the same records the low-level merge needs for
+        // generation-scoped lineage, so we snapshot them here rather than
+        // re-reading inside the merge body. Placed before
+        // `BranchMutation::new` so a lifecycle-refused merge never
+        // registers rollback actions.
+        let store = BranchControlStore::new(self.db.clone());
+        let source_rec = store.require_visible_by_name(source)?;
+        let target_rec = store.require_writable_by_name(target)?;
+
         let mut mutation = BranchMutation::new(&self.db);
 
         // Merge requires DAG — without it, merge provenance is lost
         mutation.require_dag_hook("merge")?;
-
-        // Snapshot source / target `BranchRef`s before the merge runs so
-        // the low-level path can enforce the same lifecycle instances end
-        // to end. The merge base persisted on the edge must come from the
-        // low-level merge execution itself, not a separately-taken service
-        // snapshot, otherwise concurrent lineage changes on the same
-        // generations can make the edge describe a different ancestor point
-        // than the merge actually used.
-        let store = BranchControlStore::new(self.db.clone());
-        let source_rec = store
-            .find_active_by_name(source)?
-            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(source)))?;
-        let target_rec = store
-            .find_active_by_name(target)?
-            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(target)))?;
 
         let merge_exec = with_branch_dag_hooks_suppressed(|| {
             branch_ops::merge_branches_with_metadata_expected_detailed(
@@ -806,19 +812,17 @@ impl BranchService {
     ) -> StrataResult<RevertInfo> {
         reject_system_branch(branch, "revert")?;
 
+        // B4 lifecycle gate: revert targets must be writable. The captured
+        // `BranchRef` also pins the lifecycle instance against a concurrent
+        // delete+recreate between here and the edge write.
+        let store = BranchControlStore::new(self.db.clone());
+        let branch_rec = store.require_writable_by_name(branch)?;
+        let branch_id = branch_rec.branch.id;
+
         let mut mutation = BranchMutation::new(&self.db);
 
         // Revert requires DAG — without it, revert history is lost
         mutation.require_dag_hook("revert")?;
-
-        // Resolve target `BranchRef` before the revert so a concurrent
-        // delete+recreate between here and the edge write cannot land
-        // the revert edge on the wrong lifecycle instance.
-        let store = BranchControlStore::new(self.db.clone());
-        let branch_rec = store
-            .find_active_by_name(branch)?
-            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(branch)))?;
-        let branch_id = branch_rec.branch.id;
 
         // Execute the revert
         let info = with_branch_dag_hooks_suppressed(|| {
@@ -877,20 +881,17 @@ impl BranchService {
         reject_system_branch(source, "cherry-pick from")?;
         reject_system_branch(target, "cherry-pick into")?;
 
+        // B4 lifecycle gate: source must be visible, target must be writable.
+        let store = BranchControlStore::new(self.db.clone());
+        let source_rec = store.require_visible_by_name(source)?;
+        let target_rec = store.require_writable_by_name(target)?;
+        let source_id = source_rec.branch.id;
+        let target_id = target_rec.branch.id;
+
         let mut mutation = BranchMutation::new(&self.db);
 
         // Cherry-pick requires DAG — without it, cherry-pick history is lost
         mutation.require_dag_hook("cherry_pick")?;
-
-        let store = BranchControlStore::new(self.db.clone());
-        let source_rec = store
-            .find_active_by_name(source)?
-            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(source)))?;
-        let target_rec = store
-            .find_active_by_name(target)?
-            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(target)))?;
-        let source_id = source_rec.branch.id;
-        let target_id = target_rec.branch.id;
 
         // Execute the cherry-pick
         let info = with_branch_dag_hooks_suppressed(|| {
@@ -966,18 +967,15 @@ impl BranchService {
         reject_system_branch(source, "cherry-pick from")?;
         reject_system_branch(target, "cherry-pick into")?;
 
+        // B4 lifecycle gate: source must be visible, target must be writable.
+        let store = BranchControlStore::new(self.db.clone());
+        let source_rec = store.require_visible_by_name(source)?;
+        let target_rec = store.require_writable_by_name(target)?;
+
         let mut mutation = BranchMutation::new(&self.db);
 
         // Cherry-pick requires DAG — without it, cherry-pick history is lost
         mutation.require_dag_hook("cherry_pick")?;
-
-        let store = BranchControlStore::new(self.db.clone());
-        let source_rec = store
-            .find_active_by_name(source)?
-            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(source)))?;
-        let target_rec = store
-            .find_active_by_name(target)?
-            .ok_or_else(|| StrataError::branch_not_found(resolve_branch_name(target)))?;
         let source_id = source_rec.branch.id;
         let target_id = target_rec.branch.id;
 
@@ -1171,20 +1169,17 @@ impl BranchService {
         creator: Option<&str>,
     ) -> StrataResult<TagInfo> {
         reject_system_branch(branch, "tag")?;
+
+        // B4/KD4: annotation writes follow the same lifecycle gate as
+        // structural mutations. Tags on an Archived branch are refused —
+        // an archived lifecycle instance is read-only.
+        let store = BranchControlStore::new(self.db.clone());
+        let branch_rec = store.require_writable_by_name(branch)?;
+        let branch_ref = branch_rec.branch;
+
         let info = branch_ops::create_tag(&self.db, branch, name, version, message, creator)?;
 
-        // Emit observer event with the tagged branch's generation-aware
-        // identity (B3.4). `create_tag` already verified the branch exists,
-        // so the active control record is the authoritative `BranchRef`.
-        let branch_id = resolve_branch_name(branch);
-        let branch_ref = BranchControlStore::new(self.db.clone())
-            .find_active_by_name(branch)?
-            .map(|rec| rec.branch)
-            .ok_or_else(|| {
-                StrataError::corruption(format!(
-                    "tagged branch '{branch}' has no active control record after successful tag write"
-                ))
-            })?;
+        let branch_id = branch_rec.branch.id;
         let event = BranchOpEvent {
             kind: BranchOpKind::Tag,
             branch_id,
@@ -1214,20 +1209,18 @@ impl BranchService {
     /// Emits a `BranchOpEvent::Untag` to observers if the tag existed.
     pub fn untag(&self, branch: &str, name: &str) -> StrataResult<bool> {
         reject_system_branch(branch, "untag")?;
+
+        // B4/KD4: tag deletion is a branch-scoped write; same gate as tag
+        // creation. Archived → `BranchArchived`; Deleted/missing →
+        // `BranchNotFound`.
+        let store = BranchControlStore::new(self.db.clone());
+        let branch_rec = store.require_writable_by_name(branch)?;
+
         let deleted = branch_ops::delete_tag(&self.db, branch, name)?;
 
         if deleted {
-            // Emit observer event with the branch's generation-aware
-            // identity (B3.4).
-            let branch_id = resolve_branch_name(branch);
-            let branch_ref = BranchControlStore::new(self.db.clone())
-                .find_active_by_name(branch)?
-                .map(|rec| rec.branch)
-                .ok_or_else(|| {
-                    StrataError::corruption(format!(
-                        "untagged branch '{branch}' has no active control record after successful tag delete"
-                    ))
-                })?;
+            let branch_id = branch_rec.branch.id;
+            let branch_ref = branch_rec.branch;
             let event = BranchOpEvent {
                 kind: BranchOpKind::Untag,
                 branch_id,
@@ -1284,6 +1277,10 @@ impl BranchService {
         metadata: Option<strata_core::Value>,
     ) -> StrataResult<NoteInfo> {
         reject_system_branch(branch, "add note to")?;
+
+        // B4/KD4: notes are branch-scoped writes; same gate as tags.
+        BranchControlStore::new(self.db.clone()).require_writable_by_name(branch)?;
+
         let note = branch_ops::add_note(&self.db, branch, version, message, author, metadata)?;
 
         let system_branch_id = resolve_branch_name(SYSTEM_BRANCH);
@@ -1327,6 +1324,10 @@ impl BranchService {
     /// Delete a note from a specific version on a branch.
     pub fn delete_note(&self, branch: &str, version: CommitVersion) -> StrataResult<bool> {
         reject_system_branch(branch, "delete note from")?;
+
+        // B4/KD4: note deletion follows the same gate as creation.
+        BranchControlStore::new(self.db.clone()).require_writable_by_name(branch)?;
+
         branch_ops::delete_note(&self.db, branch, version)
     }
 
@@ -1734,6 +1735,131 @@ mod tests {
             log.iter()
                 .any(|event| event.kind == DagEventKind::BranchCreate),
             "projection rebuild should preserve authoritative pre-existing history"
+        );
+    }
+
+    // =========================================================================
+    // B4.1: lifecycle write gate end-to-end smoke
+    // =========================================================================
+    //
+    // Unit coverage for `require_writable_by_name` / `require_visible_by_name`
+    // lives in `branch_control_store::tests`. These tests prove the gate is
+    // actually wired into `BranchService` entry points; exhaustive
+    // operation × lifecycle matrix coverage is B4.2.
+
+    /// Helper: flip a branch's control record to `Archived` directly through
+    /// the store. No public engine path produces `Archived` today (B4
+    /// deferred the archive op).
+    fn archive_branch_for_test(db: &Arc<Database>, name: &str) -> BranchRef {
+        let store = BranchControlStore::new(db.clone());
+        let rec = store
+            .find_active_by_name(name)
+            .unwrap()
+            .expect("branch must exist before archiving");
+        db.transaction(BranchId::from_bytes([0u8; 16]), |txn| {
+            store.put_record(
+                &BranchControlRecord {
+                    branch: rec.branch,
+                    name: rec.name.clone(),
+                    lifecycle: BranchLifecycleStatus::Archived,
+                    fork: rec.fork,
+                },
+                txn,
+            )
+        })
+        .unwrap();
+        rec.branch
+    }
+
+    #[test]
+    fn test_merge_into_archived_target_returns_branch_archived() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = Database::open_runtime(OpenSpec::primary(temp_dir.path())).unwrap();
+        let hook = Arc::new(ToggleFailDagHook::new());
+        db.install_dag_hook(hook).unwrap();
+        db.branches().create("main").unwrap();
+        let kv = KVStore::new(db.clone());
+        let main_id = BranchId::from_user_name("main");
+        kv.put(&main_id, "default", "seed", Value::Int(1)).unwrap();
+        db.branches().fork("main", "feature").unwrap();
+
+        // Archive the merge target.
+        archive_branch_for_test(&db, "main");
+
+        let err = db
+            .branches()
+            .merge_with_options("feature", "main", MergeOptions::default())
+            .unwrap_err();
+        match err {
+            StrataError::BranchArchived { ref name } => assert_eq!(name, "main"),
+            other => panic!("expected BranchArchived on archived merge target, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_merge_from_archived_source_succeeds_archived_is_visible() {
+        // KD-matrix: source needs `require_visible`; Archived is visible, so
+        // merging *from* a frozen snapshot must still be allowed.
+        let temp_dir = TempDir::new().unwrap();
+        let db = Database::open_runtime(OpenSpec::primary(temp_dir.path())).unwrap();
+        let hook = Arc::new(ToggleFailDagHook::new());
+        db.install_dag_hook(hook).unwrap();
+        db.branches().create("main").unwrap();
+        let kv = KVStore::new(db.clone());
+        let main_id = BranchId::from_user_name("main");
+        kv.put(&main_id, "default", "seed", Value::Int(1)).unwrap();
+        db.branches().fork("main", "feature").unwrap();
+        let feature_id = BranchId::from_user_name("feature");
+        kv.put(&feature_id, "default", "feature-key", Value::Int(42))
+            .unwrap();
+
+        archive_branch_for_test(&db, "feature");
+
+        // Merge archived source → active target. Gate allows this;
+        // real work completes with an archived source snapshot.
+        db.branches()
+            .merge_with_options("feature", "main", MergeOptions::default())
+            .expect("merge from archived source must succeed");
+    }
+
+    #[test]
+    fn test_tag_on_archived_branch_returns_branch_archived() {
+        // KD4: annotation writes follow the same gate as structural mutations.
+        let temp_dir = TempDir::new().unwrap();
+        let db = Database::open_runtime(OpenSpec::primary(temp_dir.path())).unwrap();
+        let hook = Arc::new(ToggleFailDagHook::new());
+        db.install_dag_hook(hook).unwrap();
+        db.branches().create("release").unwrap();
+        archive_branch_for_test(&db, "release");
+
+        let err = db
+            .branches()
+            .tag("release", "v1.0", None, None, None)
+            .unwrap_err();
+        assert!(
+            matches!(err, StrataError::BranchArchived { ref name } if name == "release"),
+            "expected BranchArchived on archived branch tag, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_delete_on_archived_branch_is_allowed() {
+        // Delete uses `require_visible`, not `require_writable`: archived
+        // lifecycle instances remain deletable so operators can retire them.
+        let temp_dir = TempDir::new().unwrap();
+        let db = Database::open_runtime(OpenSpec::primary(temp_dir.path())).unwrap();
+        let hook = Arc::new(ToggleFailDagHook::new());
+        db.install_dag_hook(hook).unwrap();
+        db.branches().create("retired").unwrap();
+        archive_branch_for_test(&db, "retired");
+
+        db.branches()
+            .delete("retired")
+            .expect("delete must accept an archived target");
+        let store = BranchControlStore::new(db.clone());
+        assert!(
+            store.find_active_by_name("retired").unwrap().is_none(),
+            "delete of archived branch must clear the active pointer"
         );
     }
 

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -17,8 +17,8 @@
 //! - Primary key format: `<global_namespace>:<TypeTag::Branch>:<branch_id>`
 //! - BranchIndex uses a global namespace (not branch-scoped) since it manages branches themselves.
 
-use crate::branch_ops::branch_control_store::is_control_store_key;
 use crate::branch_ops::dag_hooks::{dispatch_create_hook, dispatch_delete_hook};
+use crate::branch_ops::{self, branch_control_store::is_control_store_key};
 use crate::database::Database;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -554,6 +554,12 @@ impl BranchIndex {
                     Self::delete_namespace_data(txn, meta_id)?;
                 }
             }
+
+            // Branch-scoped annotations live under the `_system_` branch, not
+            // under the user branch namespace. Clear them in the same
+            // transaction so same-name recreate cannot inherit stale tags or
+            // notes from the prior lifecycle instance.
+            branch_ops::delete_annotations_for_branch_in_txn(txn, branch_id)?;
 
             // Delete the branch metadata entry
             txn.delete(meta_key.clone())?;

--- a/crates/executor/src/convert.rs
+++ b/crates/executor/src/convert.rs
@@ -45,6 +45,11 @@ impl From<StrataError> for Error {
                 hint: None,
             },
 
+            StrataError::BranchNotFoundByName { name, .. } => Error::BranchNotFound {
+                branch: name,
+                hint: None,
+            },
+
             // Archived lifecycle: distinct operator-visible state (B4).
             // Never flattened into InvalidInput / ConstraintViolation /
             // Internal — the whole point of the typed variant is that the
@@ -334,6 +339,19 @@ mod tests {
                 assert!(hint.is_none());
             }
             other => panic!("expected Error::BranchArchived, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn branch_not_found_by_name_maps_to_typed_variant_with_user_name() {
+        let err = StrataError::branch_not_found_by_name("release/2026-03");
+        let converted: Error = err.into();
+        match converted {
+            Error::BranchNotFound { branch, hint } => {
+                assert_eq!(branch, "release/2026-03");
+                assert!(hint.is_none());
+            }
+            other => panic!("expected Error::BranchNotFound, got {other:?}"),
         }
     }
 }

--- a/crates/executor/src/convert.rs
+++ b/crates/executor/src/convert.rs
@@ -45,6 +45,15 @@ impl From<StrataError> for Error {
                 hint: None,
             },
 
+            // Archived lifecycle: distinct operator-visible state (B4).
+            // Never flattened into InvalidInput / ConstraintViolation /
+            // Internal — the whole point of the typed variant is that the
+            // archived state survives the boundary.
+            StrataError::BranchArchived { name } => Error::BranchArchived {
+                branch: name,
+                hint: None,
+            },
+
             // Type errors
             StrataError::WrongType { expected, actual } => Error::WrongType {
                 expected,
@@ -308,6 +317,23 @@ mod tests {
                 assert_eq!(actual, 768);
             }
             _ => panic!("Expected DimensionMismatch"),
+        }
+    }
+
+    #[test]
+    fn branch_archived_maps_to_typed_variant_not_flattened() {
+        // KD2: the whole point of the typed executor variant is that
+        // archived state survives the boundary. Confirm the conversion
+        // does not collapse into InvalidInput / ConstraintViolation /
+        // Internal.
+        let err = StrataError::branch_archived("release/2026-03");
+        let converted: Error = err.into();
+        match converted {
+            Error::BranchArchived { branch, hint } => {
+                assert_eq!(branch, "release/2026-03");
+                assert!(hint.is_none());
+            }
+            other => panic!("expected Error::BranchArchived, got {other:?}"),
         }
     }
 }

--- a/crates/executor/src/error.rs
+++ b/crates/executor/src/error.rs
@@ -194,6 +194,24 @@ pub enum Error {
         branch: String,
     },
 
+    /// Branch is archived (read-only lifecycle state)
+    ///
+    /// The branch exists and is visible to reads, but its lifecycle has been
+    /// set to `Archived` and writes are refused at the engine's
+    /// lifecycle write gate (B4).
+    ///
+    /// Distinct from `BranchClosed` — this is the typed state error for
+    /// B3's canonical `BranchLifecycleStatus::Archived`, not a legacy
+    /// event-stream-closure failure.
+    #[error("branch is archived: {branch}{}", hint.as_deref().map(|h| format!(". {}", h)).unwrap_or_default())]
+    BranchArchived {
+        /// The archived branch identifier.
+        branch: String,
+        /// Optional actionable hint.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hint: Option<String>,
+    },
+
     /// Collection already exists
     #[error("collection already exists: {collection}")]
     CollectionExists {


### PR DESCRIPTION
## Summary

- **Enforces `BranchLifecycleStatus` at every `BranchService` mutation entry point.** Archived branches refuse writes with a typed `StrataError::BranchArchived` that propagates through the executor boundary as `Error::BranchArchived` — never flattened into `InvalidInput` / `ConstraintViolation` / `Internal`.
- **Widens the `__ctl__active__` pointer** (KD1) to address the live (non-Deleted) lifecycle instance — set for `Active` and `Archived`, cleared only for `Deleted`. Safe today because nothing in B3 produces `Archived` records; makes the B4 gate's "archived vs not-found" distinction work.
- **Canonical gate helpers** `BranchControlStore::require_writable_by_name` and `require_visible_by_name` — `pub(crate)`, tested. Every `BranchService` mutation calls the matching helper before `BranchMutation::new` (KD3), with source/target split (source uses `require_visible`; target uses `require_writable`).

## What changed

| Area | Change |
|---|---|
| `StrataError` | New `BranchArchived { name: String }` additive on the `#[non_exhaustive]` enum; wire code `ConstraintViolation`; 11 classifier methods updated explicitly. |
| `executor::Error` | New `BranchArchived { branch, hint }` additive on the `#[non_exhaustive]` enum; typed `From<StrataError>` arm. |
| `BranchControlStore::put_record` | `Active \| Archived` → pointer set; `Deleted` → pointer cleared. |
| `BranchService` | Gate wired into `delete`, `fork_with_options`, `merge_with_options`, `revert`, `cherry_pick`, `cherry_pick_from_diff`, `tag`, `untag`, `add_note`, `delete_note`. |
| Tests | 8 new control-store unit tests; 4 new branch-service end-to-end smokes; 1 new classifier test; 1 new executor-conversion test. |

**Annotation writes (tag/untag/add_note/delete_note) now require branch existence** where they didn't before — the lifecycle-and-mutation audit flagged this as a gap (KD4). Confirmed no workspace test relied on the old permissive behavior.

## Change class & scope

- **Change class:** intentional semantic change (active-pointer widening) + new enforced write gate.
- **Assurance class:** S4.
- **D4 surface:** additive variants on `StrataError` and `executor::Error` only — both already `#[non_exhaustive]` and already on the D4 surface. No new public types. The new helpers are `pub(crate)`.
- **Non-goals respected:** no archive/unarchive op, no GC/retention changes, no `BranchMutation` contract change, no rename of `find_active_by_name`, no branch-info/list status cutover.

## Plan & phasing

Follows `docs/design/branching/b4-phasing-plan.md` §B4.1. Next sub-epics: B4.2 (mutation-path coverage matrix), B4.3 (bypass collapse), B4.4 (same-name serialization hardening).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets` — no new errors from this epic
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace --lib` — ~4800 lib unit tests pass
- [x] `cargo test -p stratadb --tests` — ~860 integration tests pass, including 140 branching
- [x] `cargo hack --feature-powerset --depth 2 check -p strata-core -p strata-engine -p strata-executor` — clean on all three touched crates
- [x] Quick regression benchmark ran clean (fork p50 ~69µs, merge_small p50 ~986µs, create p50 ~49µs — within expected range)
- [x] B1/B2/B3 acceptance tests all green unchanged
- [x] New typed-variant coverage: `require_writable_rejects_archived_with_branch_archived`, `require_writable_rejects_deleted_with_branch_not_found`, `test_merge_into_archived_target_returns_branch_archived`, `test_tag_on_archived_branch_returns_branch_archived`, `test_delete_on_archived_branch_is_allowed`, `branch_archived_maps_to_typed_variant_not_flattened`, `test_branch_archived_classifier`

🤖 Generated with [Claude Code](https://claude.com/claude-code)