### PR TITLE
B4.2: mutation-path coverage matrix — gate × lifecycle × source/target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ strata-core = { path = "crates/core" }
 strata-storage = { path = "crates/storage" }
 strata-concurrency = { path = "crates/concurrency" }
 strata-durability = { path = "crates/durability" }
-strata-engine = { path = "crates/engine" }
+strata-engine = { path = "crates/engine", features = ["test-support"] }
 strata-graph = { path = "crates/graph" }
 strata-vector = { path = "crates/vector" }
 strata-intelligence = { path = "crates/intelligence" }

--- a/crates/engine/src/database/branch_service.rs
+++ b/crates/engine/src/database/branch_service.rs
@@ -1394,6 +1394,7 @@ impl BranchService {
     /// `BranchService::delete` for Deleted state in realistic flows;
     /// reserve this helper for `Archived` (or round-tripping back to
     /// `Active` in tests that need idempotency).
+    #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
     pub fn set_lifecycle_for_test(
         &self,
@@ -1420,13 +1421,14 @@ impl BranchService {
     /// Returns `Ok(0)` when `name` has no live record. Used by the B4.2
     /// coverage matrix to assert that a lifecycle-refused mutation
     /// appends no lineage edge to the target.
+    #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
-    pub fn lineage_edge_count_for_test(&self, name: &str) -> StrataResult<usize> {
+    pub fn lineage_edge_count_for_branch_ref_for_test(
+        &self,
+        branch: BranchRef,
+    ) -> StrataResult<usize> {
         let store = BranchControlStore::new(self.db.clone());
-        let Some(record) = store.find_active_by_name(name)? else {
-            return Ok(0);
-        };
-        Ok(store.edges_for(record.branch)?.len())
+        Ok(store.edges_for(branch)?.len())
     }
 
     // =========================================================================

--- a/crates/engine/src/database/branch_service.rs
+++ b/crates/engine/src/database/branch_service.rs
@@ -1359,6 +1359,77 @@ impl BranchService {
     }
 
     // =========================================================================
+    // Test-only helpers (B4.2)
+    // =========================================================================
+    //
+    // These are `#[doc(hidden)] pub` so the coverage-matrix tests in
+    // `tests/integration/branching_lifecycle_*` can synthesize lifecycle
+    // states no production path produces (most notably `Archived`) and
+    // observe the control-store's lineage surface without leaking
+    // `BranchControlStore` itself through the public API.
+    //
+    // The test hooks deliberately bypass the write gate — their whole
+    // purpose is to set up state the gate is then asserted against. Do
+    // not build product code on top of them.
+
+    /// TEST-ONLY: overwrite the live `BranchControlRecord` for `name` with
+    /// a new lifecycle status, bypassing the B4 write gate.
+    ///
+    /// Returns the `BranchRef` of the affected lifecycle instance (the
+    /// generation is unchanged). Refuses if the branch has no live record
+    /// — callers must create the branch first, then mutate its lifecycle.
+    ///
+    /// The update is atomic: the record row and the active-pointer row
+    /// are written inside one transaction, matching the same
+    /// `put_record` path the production create/delete paths take. When
+    /// `status = Deleted`, the active pointer is cleared so subsequent
+    /// `require_writable` / `require_visible` calls see a missing
+    /// lifecycle (B4/KD1).
+    ///
+    /// Caveat: flipping to `Deleted` via this helper writes the control
+    /// record but does NOT purge the legacy `BranchMetadata` the way
+    /// `BranchService::delete` does. A subsequent `create` on the same
+    /// name will observe leftover metadata and fail the
+    /// metadata/control-store consistency check. Use
+    /// `BranchService::delete` for Deleted state in realistic flows;
+    /// reserve this helper for `Archived` (or round-tripping back to
+    /// `Active` in tests that need idempotency).
+    #[doc(hidden)]
+    pub fn set_lifecycle_for_test(
+        &self,
+        name: &str,
+        status: BranchLifecycleStatus,
+    ) -> StrataResult<BranchRef> {
+        let store = BranchControlStore::new(self.db.clone());
+        let record = store
+            .find_active_by_name(name)?
+            .ok_or_else(|| StrataError::branch_not_found_by_name(name))?;
+        let branch_ref = record.branch;
+        self.db
+            .transaction(BranchId::from_bytes([0u8; 16]), |txn| {
+                let mut updated = record.clone();
+                updated.lifecycle = status;
+                store.put_record(&updated, txn)
+            })?;
+        Ok(branch_ref)
+    }
+
+    /// TEST-ONLY: number of lineage edges whose `target` is the live
+    /// lifecycle instance of `name`.
+    ///
+    /// Returns `Ok(0)` when `name` has no live record. Used by the B4.2
+    /// coverage matrix to assert that a lifecycle-refused mutation
+    /// appends no lineage edge to the target.
+    #[doc(hidden)]
+    pub fn lineage_edge_count_for_test(&self, name: &str) -> StrataResult<usize> {
+        let store = BranchControlStore::new(self.db.clone());
+        let Some(record) = store.find_active_by_name(name)? else {
+            return Ok(0);
+        };
+        Ok(store.edges_for(record.branch)?.len())
+    }
+
+    // =========================================================================
     // Internal Helpers
     // =========================================================================
 

--- a/tests/common/branching.rs
+++ b/tests/common/branching.rs
@@ -1,0 +1,152 @@
+//! Shared helpers for the B4.x branching coverage suites.
+//!
+//! Synthesize lifecycle states no production path produces (most notably
+//! `Archived`), capture branch-op observer output, and snapshot the
+//! lineage surface so tests can assert "no side effects on reject".
+//!
+//! These live next to the tests because the canonical
+//! `BranchControlStore` is `pub(crate)`; the engine exposes two
+//! `#[doc(hidden)] pub` accessors (`BranchService::set_lifecycle_for_test`
+//! and `BranchService::lineage_edge_count_for_test`) that this module
+//! wraps in an ergonomic, test-local API.
+
+#![allow(dead_code)]
+
+use std::sync::{Arc, Mutex};
+
+use strata_core::branch::BranchLifecycleStatus;
+use strata_core::BranchRef;
+use strata_engine::database::{BranchOpEvent, BranchOpObserver, ObserverError};
+use strata_engine::Database;
+
+// =============================================================================
+// Lifecycle synthesis
+// =============================================================================
+
+/// Flip the live control record of `name` to `Archived`.
+///
+/// Panics if the branch has no live record. Callers must create the
+/// branch via `db.branches().create(name)` (or fork it) first.
+pub(crate) fn archive_branch_for_test(db: &Arc<Database>, name: &str) -> BranchRef {
+    db.branches()
+        .set_lifecycle_for_test(name, BranchLifecycleStatus::Archived)
+        .unwrap_or_else(|e| panic!("archive_branch_for_test({name}): {e:?}"))
+}
+
+/// Flip the live control record of `name` to `status`.
+///
+/// Wraps `BranchService::set_lifecycle_for_test` so tests can synthesize
+/// any lifecycle state (`Active`, `Archived`, `Deleted`) without going
+/// through the production delete path (which also purges legacy
+/// metadata). Returns the affected `BranchRef`.
+pub(crate) fn set_lifecycle_for_test(
+    db: &Arc<Database>,
+    name: &str,
+    status: BranchLifecycleStatus,
+) -> BranchRef {
+    db.branches()
+        .set_lifecycle_for_test(name, status)
+        .unwrap_or_else(|e| panic!("set_lifecycle_for_test({name}, {status:?}): {e:?}"))
+}
+
+// =============================================================================
+// Observer capture
+// =============================================================================
+
+/// Capture every `BranchOpEvent` the engine fires. Register with
+/// `db.branch_op_observers().register(capturing.clone())` before the
+/// workload under test.
+pub(crate) struct CapturingBranchObserver {
+    events: Mutex<Vec<BranchOpEvent>>,
+}
+
+impl CapturingBranchObserver {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            events: Mutex::new(Vec::new()),
+        })
+    }
+
+    /// Current number of captured events. Cheap — snapshot only.
+    pub(crate) fn count(&self) -> usize {
+        self.events.lock().unwrap().len()
+    }
+
+    /// Clone of every captured event so far.
+    pub(crate) fn snapshot(&self) -> Vec<BranchOpEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl BranchOpObserver for CapturingBranchObserver {
+    fn name(&self) -> &'static str {
+        "branching_lifecycle::CapturingBranchObserver"
+    }
+
+    fn on_branch_op(&self, event: &BranchOpEvent) -> Result<(), ObserverError> {
+        self.events.lock().unwrap().push(event.clone());
+        Ok(())
+    }
+}
+
+// =============================================================================
+// Side-effect checkpoint
+// =============================================================================
+
+/// Snapshot of the observable side-effect surface for a single branch:
+/// observer event count and lineage edge count.
+///
+/// Taken before a gate-refused mutation and re-compared after — any drift
+/// means the reject path leaked a side effect.
+#[derive(Debug, Clone)]
+pub(crate) struct BranchSideEffectCheckpoint {
+    pub(crate) target_name: String,
+    pub(crate) observer_count: usize,
+    pub(crate) lineage_edge_count: usize,
+}
+
+impl BranchSideEffectCheckpoint {
+    pub(crate) fn capture(
+        db: &Arc<Database>,
+        observer: &CapturingBranchObserver,
+        target_name: &str,
+    ) -> Self {
+        // Surface the error loudly rather than silently pretending the
+        // edge count was 0 — a swallowed error here would mask real
+        // regressions (unmigrated-follower refusal, corruption) behind
+        // a passing side-effect assertion.
+        let lineage_edge_count = db
+            .branches()
+            .lineage_edge_count_for_test(target_name)
+            .unwrap_or_else(|e| {
+                panic!("lineage_edge_count_for_test({target_name}) failed while checkpointing: {e:?}")
+            });
+        Self {
+            target_name: target_name.to_string(),
+            observer_count: observer.count(),
+            lineage_edge_count,
+        }
+    }
+}
+
+/// Assert `(observer events, lineage edges)` did not change since
+/// `before`. Panics with a diagnostic when the reject path leaked a
+/// side effect.
+pub(crate) fn assert_no_side_effects_since(
+    db: &Arc<Database>,
+    observer: &CapturingBranchObserver,
+    before: &BranchSideEffectCheckpoint,
+    scenario: &str,
+) {
+    let after = BranchSideEffectCheckpoint::capture(db, observer, &before.target_name);
+    assert_eq!(
+        after.observer_count, before.observer_count,
+        "[{scenario}] BranchOpObserver fired on a lifecycle-refused mutation; expected no side effect (target={})",
+        before.target_name
+    );
+    assert_eq!(
+        after.lineage_edge_count, before.lineage_edge_count,
+        "[{scenario}] Lineage edge appended on a lifecycle-refused mutation; expected no side effect (target={})",
+        before.target_name
+    );
+}

--- a/tests/common/branching.rs
+++ b/tests/common/branching.rs
@@ -4,20 +4,24 @@
 //! `Archived`), capture branch-op observer output, and snapshot the
 //! lineage surface so tests can assert "no side effects on reject".
 //!
-//! These live next to the tests because the canonical
-//! `BranchControlStore` is `pub(crate)`; the engine exposes two
-//! `#[doc(hidden)] pub` accessors (`BranchService::set_lifecycle_for_test`
-//! and `BranchService::lineage_edge_count_for_test`) that this module
-//! wraps in an ergonomic, test-local API.
+//! These helpers stay next to the tests because the canonical
+//! `BranchControlStore` is `pub(crate)`. The engine exposes a small
+//! feature-gated `test-support` surface for lifecycle synthesis and
+//! lineage probes; production builds do not ship those accessors.
 
 #![allow(dead_code)]
 
 use std::sync::{Arc, Mutex};
 
 use strata_core::branch::BranchLifecycleStatus;
-use strata_core::BranchRef;
+use strata_core::{BranchId, BranchRef};
 use strata_engine::database::{BranchOpEvent, BranchOpObserver, ObserverError};
+use strata_engine::primitives::branch::resolve_branch_name;
 use strata_engine::Database;
+use strata_graph::branch_dag::dag_branch_node_id_for_ref;
+use strata_graph::keys::{validate_node_id, GRAPH_SPACE};
+use strata_graph::types::NodeData;
+use strata_graph::{GraphStore, BRANCH_DAG_GRAPH, SYSTEM_BRANCH};
 
 // =============================================================================
 // Lifecycle synthesis
@@ -93,16 +97,23 @@ impl BranchOpObserver for CapturingBranchObserver {
 // Side-effect checkpoint
 // =============================================================================
 
-/// Snapshot of the observable side-effect surface for a single branch:
-/// observer event count and lineage edge count.
+/// Snapshot of the observable reject-path side-effect surface:
+/// observer events, lineage edges for the tracked lifecycle instance,
+/// the tracked branch-node payloads in `_branch_dag`, and total
+/// `_branch_dag` node/edge counts.
 ///
 /// Taken before a gate-refused mutation and re-compared after — any drift
 /// means the reject path leaked a side effect.
 #[derive(Debug, Clone)]
 pub(crate) struct BranchSideEffectCheckpoint {
     pub(crate) target_name: String,
+    pub(crate) target_ref: Option<BranchRef>,
     pub(crate) observer_count: usize,
     pub(crate) lineage_edge_count: usize,
+    pub(crate) canonical_branch_node: Option<NodeData>,
+    pub(crate) legacy_branch_node: Option<NodeData>,
+    pub(crate) dag_node_count: usize,
+    pub(crate) dag_edge_count: usize,
 }
 
 impl BranchSideEffectCheckpoint {
@@ -110,35 +121,88 @@ impl BranchSideEffectCheckpoint {
         db: &Arc<Database>,
         observer: &CapturingBranchObserver,
         target_name: &str,
+        target_ref: Option<BranchRef>,
     ) -> Self {
-        // Surface the error loudly rather than silently pretending the
-        // edge count was 0 — a swallowed error here would mask real
-        // regressions (unmigrated-follower refusal, corruption) behind
-        // a passing side-effect assertion.
-        let lineage_edge_count = db
-            .branches()
-            .lineage_edge_count_for_test(target_name)
+        let lineage_edge_count = target_ref
+            .map(|branch_ref| {
+                db.branches()
+                    .lineage_edge_count_for_branch_ref_for_test(branch_ref)
+                    .unwrap_or_else(|e| {
+                        panic!(
+                            "lineage_edge_count_for_branch_ref_for_test({branch_ref:?}) failed while checkpointing {target_name}: {e:?}"
+                        )
+                    })
+            })
+            .unwrap_or(0);
+        let graph_store = GraphStore::new(db.clone());
+        let system_branch = BranchId::from_user_name(SYSTEM_BRANCH);
+        let canonical_branch_node = target_ref
+            .and_then(|branch_ref| {
+                graph_store
+                    .get_node(
+                        system_branch,
+                        GRAPH_SPACE,
+                        BRANCH_DAG_GRAPH,
+                        &dag_branch_node_id_for_ref(branch_ref),
+                    )
+                    .unwrap_or_else(|e| {
+                        panic!(
+                            "get_node(canonical branch DAG node for {branch_ref:?}) failed while checkpointing {target_name}: {e:?}"
+                        )
+                    })
+            });
+        let legacy_branch_node_id = if validate_node_id(target_name).is_ok() {
+            target_name.to_string()
+        } else {
+            format!("_branch_{}", resolve_branch_name(target_name))
+        };
+        let legacy_branch_node = graph_store
+            .get_node(
+                system_branch,
+                GRAPH_SPACE,
+                BRANCH_DAG_GRAPH,
+                &legacy_branch_node_id,
+            )
             .unwrap_or_else(|e| {
-                panic!("lineage_edge_count_for_test({target_name}) failed while checkpointing: {e:?}")
+                panic!(
+                    "get_node(legacy branch DAG node for {target_name}) failed while checkpointing: {e:?}"
+                )
+            });
+        let dag_stats = graph_store
+            .snapshot_stats(
+                system_branch,
+                GRAPH_SPACE,
+                BRANCH_DAG_GRAPH,
+            )
+            .unwrap_or_else(|e| {
+                panic!(
+                    "snapshot_stats(_system_/_branch_dag) failed while checkpointing {target_name}: {e:?}"
+                )
             });
         Self {
             target_name: target_name.to_string(),
+            target_ref,
             observer_count: observer.count(),
             lineage_edge_count,
+            canonical_branch_node,
+            legacy_branch_node,
+            dag_node_count: dag_stats.node_count,
+            dag_edge_count: dag_stats.edge_count,
         }
     }
 }
 
-/// Assert `(observer events, lineage edges)` did not change since
-/// `before`. Panics with a diagnostic when the reject path leaked a
-/// side effect.
+/// Assert `(observer events, lineage edges, tracked DAG branch nodes,
+/// DAG stats)` did not change since `before`. Panics with a diagnostic
+/// when the reject path leaked a side effect.
 pub(crate) fn assert_no_side_effects_since(
     db: &Arc<Database>,
     observer: &CapturingBranchObserver,
     before: &BranchSideEffectCheckpoint,
     scenario: &str,
 ) {
-    let after = BranchSideEffectCheckpoint::capture(db, observer, &before.target_name);
+    let after =
+        BranchSideEffectCheckpoint::capture(db, observer, &before.target_name, before.target_ref);
     assert_eq!(
         after.observer_count, before.observer_count,
         "[{scenario}] BranchOpObserver fired on a lifecycle-refused mutation; expected no side effect (target={})",
@@ -147,6 +211,26 @@ pub(crate) fn assert_no_side_effects_since(
     assert_eq!(
         after.lineage_edge_count, before.lineage_edge_count,
         "[{scenario}] Lineage edge appended on a lifecycle-refused mutation; expected no side effect (target={})",
+        before.target_name
+    );
+    assert_eq!(
+        after.canonical_branch_node, before.canonical_branch_node,
+        "[{scenario}] Canonical _branch_dag branch node mutated on a lifecycle-refused mutation; expected no DAG side effect (target={})",
+        before.target_name
+    );
+    assert_eq!(
+        after.legacy_branch_node, before.legacy_branch_node,
+        "[{scenario}] Legacy/name-keyed _branch_dag branch node mutated on a lifecycle-refused mutation; expected no DAG side effect (target={})",
+        before.target_name
+    );
+    assert_eq!(
+        after.dag_node_count, before.dag_node_count,
+        "[{scenario}] _branch_dag node count changed on a lifecycle-refused mutation; expected no DAG event (target={})",
+        before.target_name
+    );
+    assert_eq!(
+        after.dag_edge_count, before.dag_edge_count,
+        "[{scenario}] _branch_dag edge count changed on a lifecycle-refused mutation; expected no DAG event (target={})",
         before.target_name
     );
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,6 +6,8 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
+pub mod branching;
+
 use std::collections::{BTreeMap, HashMap};
 use std::fs::{self, OpenOptions};
 use std::hash::{Hash, Hasher};

--- a/tests/integration/branching_lifecycle_gate.rs
+++ b/tests/integration/branching_lifecycle_gate.rs
@@ -1,0 +1,848 @@
+//! B4.2 — mutation-path coverage matrix for the lifecycle write gate.
+//!
+//! Exercises every `BranchService` mutation (plus the bundle-import path)
+//! against every lifecycle state a target / source can be in. The B4.1
+//! gate is meant to be uniform: one helper (`require_writable_by_name`
+//! or `require_visible_by_name`) runs at the top of every mutation, and
+//! no production path should smuggle a gate-bypassing side effect past
+//! it. B4.2 locks that uniformity.
+//!
+//! ## What each cell asserts
+//!
+//! - Correct typed error on the `StrataError` enum discriminant
+//!   (`BranchArchived` / `BranchNotFoundByName` / `InvalidInput` for
+//!   name-allocation duplicates). Matched on the variant, never on
+//!   message text.
+//! - No `BranchOpEvent` fires on reject paths.
+//! - No lineage edge appends to the target on reject paths.
+//! - Repeated refused calls do not deadlock (gate runs before any
+//!   lock acquisition).
+//!
+//! ## State synthesis
+//!
+//! No production path produces the `Archived` lifecycle. The matrix
+//! uses `common::branching::set_lifecycle_for_test` (a
+//! `#[doc(hidden)] pub` hook on `BranchService`) to flip a live
+//! record's `lifecycle` field in place. `Deleted` state uses the
+//! production `BranchService::delete` path. `Missing` is "never
+//! created".
+//!
+//! Single-branch ops (`materialize`) exercise all four states as
+//! truly distinct setups: `Missing` skips creation entirely.
+//!
+//! Cross-matrix ops (fork / merge / `cherry_pick` /
+//! `cherry_pick_from_diff`) require a live fork-parent pair to set up
+//! the success cells, so the `Missing` label on a name that was first
+//! created and then unwound collapses onto the `Deleted` setup path
+//! (`reshape` calls `delete` for both). The gate surfaces the same
+//! `BranchNotFoundByName` error in both cases, so the assertion
+//! vocabulary matches; the distinction between "never existed" and
+//! "tombstoned" is covered by the single-branch matrix cells.
+//!
+//! Source × target cross-matrix applies to ops that read a source and
+//! write a target (fork / merge / `cherry_pick` / `cherry_pick_from_diff`).
+
+#![cfg(not(miri))]
+
+use crate::common::branching::{
+    archive_branch_for_test, assert_no_side_effects_since, set_lifecycle_for_test,
+    BranchSideEffectCheckpoint, CapturingBranchObserver,
+};
+use crate::common::*;
+use std::sync::Arc;
+use strata_core::branch::BranchLifecycleStatus;
+use strata_core::id::CommitVersion;
+use strata_core::value::Value;
+use strata_core::StrataError;
+use strata_engine::{bundle, CherryPickFilter, Database, MergeOptions};
+
+// =============================================================================
+// Enum of lifecycle target states and helpers to synthesize them
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetState {
+    Active,
+    Archived,
+    Deleted,
+    Missing,
+}
+
+impl TargetState {
+    fn all() -> [TargetState; 4] {
+        [
+            TargetState::Active,
+            TargetState::Archived,
+            TargetState::Deleted,
+            TargetState::Missing,
+        ]
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            TargetState::Active => "Active",
+            TargetState::Archived => "Archived",
+            TargetState::Deleted => "Deleted",
+            TargetState::Missing => "Missing",
+        }
+    }
+}
+
+/// Build `name` into `state` on `db`. For `Active`, seeds a single KV
+/// write so the storage layer materialises the branch (fork COW needs
+/// a memtable on the source).
+fn materialize(db: &Arc<Database>, name: &str, state: TargetState) {
+    match state {
+        TargetState::Active => {
+            db.branches().create(name).unwrap();
+            seed(db, name);
+        }
+        TargetState::Archived => {
+            db.branches().create(name).unwrap();
+            seed(db, name);
+            archive_branch_for_test(db, name);
+        }
+        TargetState::Deleted => {
+            db.branches().create(name).unwrap();
+            seed(db, name);
+            db.branches().delete(name).unwrap();
+        }
+        TargetState::Missing => {
+            // Intentionally no-op — the name must have no record at all.
+        }
+    }
+}
+
+/// Write a single KV row so the branch's storage layer materialises —
+/// required for fork COW and for `Archived` reads in source-side ops.
+fn seed(db: &Arc<Database>, name: &str) {
+    let bid = BranchId::from_user_name(name);
+    KVStore::new(db.clone())
+        .put(&bid, "default", "_seed_", Value::Int(1))
+        .expect("seed write succeeds");
+}
+
+// =============================================================================
+// Assertion helpers — match on enum variants, never on message text
+// =============================================================================
+
+fn assert_archived(result: Result<impl std::fmt::Debug, StrataError>, name: &str, scenario: &str) {
+    match result {
+        Err(StrataError::BranchArchived { name: n }) => {
+            assert_eq!(
+                n, name,
+                "[{scenario}] BranchArchived carries the target branch name"
+            );
+        }
+        Err(e) => panic!("[{scenario}] expected BranchArchived({name}), got: {e:?}"),
+        Ok(v) => panic!("[{scenario}] expected BranchArchived({name}), got Ok({v:?})"),
+    }
+}
+
+fn assert_not_found(result: Result<impl std::fmt::Debug, StrataError>, name: &str, scenario: &str) {
+    match result {
+        Err(StrataError::BranchNotFoundByName { name: n, .. }) => {
+            assert_eq!(
+                n, name,
+                "[{scenario}] BranchNotFoundByName carries the target branch name"
+            );
+        }
+        Err(e) => panic!("[{scenario}] expected BranchNotFoundByName({name}), got: {e:?}"),
+        Ok(v) => panic!("[{scenario}] expected BranchNotFoundByName({name}), got Ok({v:?})"),
+    }
+}
+
+fn assert_invalid_input_contains(
+    result: Result<impl std::fmt::Debug, StrataError>,
+    fragment: &str,
+    scenario: &str,
+) {
+    match result {
+        Err(StrataError::InvalidInput { message }) => {
+            assert!(
+                message.contains(fragment),
+                "[{scenario}] expected InvalidInput containing {fragment:?}, got: {message}"
+            );
+        }
+        Err(e) => panic!("[{scenario}] expected InvalidInput containing {fragment:?}, got: {e:?}"),
+        Ok(v) => panic!("[{scenario}] expected InvalidInput containing {fragment:?}, got Ok({v:?})"),
+    }
+}
+
+/// Setup: open a fresh `TestDb` with a capturing observer already
+/// registered. Returns the db wrapper and the observer handle.
+fn setup() -> (TestDb, Arc<CapturingBranchObserver>) {
+    let test_db = TestDb::new();
+    let obs = CapturingBranchObserver::new();
+    test_db.db.branch_op_observers().register(obs.clone());
+    (test_db, obs)
+}
+
+/// Take a checkpoint on `target` and return it — for use around a
+/// gate-refused call.
+fn checkpoint(
+    db: &Arc<Database>,
+    observer: &CapturingBranchObserver,
+    target: &str,
+) -> BranchSideEffectCheckpoint {
+    BranchSideEffectCheckpoint::capture(db, observer, target)
+}
+
+// =============================================================================
+// Op 1/12 — create (name-allocation semantics)
+// =============================================================================
+//
+// `create` is not a write to an existing lifecycle instance; it's a
+// name allocation. Per B4/KD1, an `Active` or `Archived` live record
+// blocks creation with a duplicate error. `Deleted` and `Missing`
+// succeed — `Deleted` allocates a strictly-greater generation.
+
+#[test]
+fn create_matrix() {
+    for state in TargetState::all() {
+        let (test_db, obs) = setup();
+        let db = test_db.db.clone();
+        let name = "target";
+        materialize(&db, name, state);
+
+        let scenario = format!("create[target={}]", state.label());
+        let before = checkpoint(&db, &obs, name);
+
+        let result = db.branches().create(name);
+        match state {
+            TargetState::Active | TargetState::Archived => {
+                assert_invalid_input_contains(result, "already exists", &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            }
+            TargetState::Deleted => {
+                result.unwrap_or_else(|e| panic!("[{scenario}] create after delete must succeed: {e:?}"));
+                let rec = db.branches().control_record(name).unwrap().unwrap();
+                assert_eq!(rec.branch.generation, 1, "[{scenario}] recreate advances generation");
+            }
+            TargetState::Missing => {
+                result.unwrap_or_else(|e| panic!("[{scenario}] create on missing must succeed: {e:?}"));
+                let rec = db.branches().control_record(name).unwrap().unwrap();
+                assert_eq!(rec.branch.generation, 0, "[{scenario}] first create is gen 0");
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Op 2/12 — delete
+// =============================================================================
+//
+// `delete` requires the target to be **visible** (Active or Archived).
+// `Deleted` / `Missing` → `BranchNotFoundByName`.
+
+#[test]
+fn delete_matrix() {
+    for state in TargetState::all() {
+        let (test_db, obs) = setup();
+        let db = test_db.db.clone();
+        let name = "target";
+        materialize(&db, name, state);
+
+        let scenario = format!("delete[target={}]", state.label());
+        let before = checkpoint(&db, &obs, name);
+
+        let result = db.branches().delete(name);
+        match state {
+            TargetState::Active | TargetState::Archived => {
+                result.unwrap_or_else(|e| panic!("[{scenario}] delete visible branch must succeed: {e:?}"));
+                assert!(
+                    db.branches().control_record(name).unwrap().is_none(),
+                    "[{scenario}] post-delete live record is absent"
+                );
+            }
+            TargetState::Deleted | TargetState::Missing => {
+                assert_not_found(result, name, &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Op 3/12 — fork (source + target cross-matrix)
+// =============================================================================
+//
+// - source: visible (Active / Archived) passes, otherwise BranchNotFound.
+// - destination: live record (Active / Archived) is a duplicate; no
+//   live record (Deleted / Missing) passes (allocates fresh generation).
+
+#[test]
+fn fork_matrix() {
+    for source_state in TargetState::all() {
+        for dest_state in TargetState::all() {
+            let (test_db, obs) = setup();
+            let db = test_db.db.clone();
+
+            // Source / dest must be distinct names.
+            let source = "src";
+            let dest = "dst";
+            materialize(&db, source, source_state);
+            materialize(&db, dest, dest_state);
+
+            let scenario =
+                format!("fork[src={}, dst={}]", source_state.label(), dest_state.label());
+            let before = checkpoint(&db, &obs, dest);
+
+            let result = db.branches().fork(source, dest);
+
+            let source_visible = matches!(
+                source_state,
+                TargetState::Active | TargetState::Archived
+            );
+            let dest_has_live =
+                matches!(dest_state, TargetState::Active | TargetState::Archived);
+
+            if !source_visible {
+                assert_not_found(result, source, &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            } else if dest_has_live {
+                assert_invalid_input_contains(result, "already exists", &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            } else {
+                result
+                    .unwrap_or_else(|e| panic!("[{scenario}] fork with visible source and free dest must succeed: {e:?}"));
+                let rec = db.branches().control_record(dest).unwrap().unwrap();
+                assert!(rec.fork.is_some(), "[{scenario}] fork anchor populated");
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Op 4/12 — merge (source + target cross-matrix)
+// =============================================================================
+//
+// - source: visible (Active / Archived) passes, otherwise BranchNotFound.
+// - target: Active writable; Archived → BranchArchived; Deleted/Missing → BranchNotFound.
+
+#[test]
+fn merge_matrix() {
+    for source_state in TargetState::all() {
+        for target_state in TargetState::all() {
+            let (test_db, obs) = setup();
+            let db = test_db.db.clone();
+
+            // Merge needs a fork relationship; otherwise `merge` will
+            // refuse on "unrelated branches" for the Active × Active
+            // success path. Setup: create `target`, seed it, fork
+            // `source` from it — then reshape both to the required
+            // states.
+            db.branches().create("base").unwrap();
+            seed(&db, "base");
+            let source_name = "source";
+            let target_name = "target";
+            db.branches().fork("base", source_name).unwrap();
+            db.branches().fork(source_name, target_name).unwrap();
+
+            // Extra source-side change so there's something to merge in
+            // the Active × Active success case.
+            KVStore::new(db.clone())
+                .put(
+                    &BranchId::from_user_name(source_name),
+                    "default",
+                    "delta",
+                    Value::Int(99),
+                )
+                .unwrap();
+
+            reshape(&db, source_name, source_state);
+            reshape(&db, target_name, target_state);
+
+            let scenario = format!(
+                "merge[src={}, tgt={}]",
+                source_state.label(),
+                target_state.label()
+            );
+            let before = checkpoint(&db, &obs, target_name);
+
+            let result = db
+                .branches()
+                .merge_with_options(source_name, target_name, MergeOptions::default());
+
+            let source_visible = matches!(
+                source_state,
+                TargetState::Active | TargetState::Archived
+            );
+
+            match (source_visible, target_state) {
+                (false, _) => {
+                    assert_not_found(result, source_name, &scenario);
+                    assert_no_side_effects_since(&db, &obs, &before, &scenario);
+                }
+                (true, TargetState::Archived) => {
+                    assert_archived(result, target_name, &scenario);
+                    assert_no_side_effects_since(&db, &obs, &before, &scenario);
+                }
+                (true, TargetState::Deleted | TargetState::Missing) => {
+                    assert_not_found(result, target_name, &scenario);
+                    assert_no_side_effects_since(&db, &obs, &before, &scenario);
+                }
+                (true, TargetState::Active) => {
+                    result.unwrap_or_else(|e| panic!("[{scenario}] merge Active → Active must succeed: {e:?}"));
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Op 5/12 — revert (single target)
+// =============================================================================
+
+#[test]
+fn revert_matrix() {
+    for state in TargetState::all() {
+        let (test_db, obs) = setup();
+        let db = test_db.db.clone();
+        let name = "target";
+        materialize(&db, name, state);
+
+        let scenario = format!("revert[target={}]", state.label());
+        let before = checkpoint(&db, &obs, name);
+
+        let result = db
+            .branches()
+            .revert(name, CommitVersion(1), CommitVersion(1));
+
+        match state {
+            TargetState::Archived => {
+                assert_archived(result, name, &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            }
+            TargetState::Deleted | TargetState::Missing => {
+                assert_not_found(result, name, &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            }
+            TargetState::Active => {
+                // revert on an Active branch against an out-of-range
+                // version may return Ok (no-op) or error, but it must
+                // NOT produce BranchArchived / BranchNotFoundByName —
+                // those are the gate-only signals we test here.
+                if let Err(e) = result {
+                    assert!(
+                        !matches!(
+                            e,
+                            StrataError::BranchArchived { .. }
+                                | StrataError::BranchNotFoundByName { .. }
+                        ),
+                        "[{scenario}] Active target must not yield gate errors, got: {e:?}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Op 6/12 — cherry_pick (source + target cross-matrix)
+// =============================================================================
+
+#[test]
+fn cherry_pick_matrix() {
+    for source_state in TargetState::all() {
+        for target_state in TargetState::all() {
+            let (test_db, obs) = setup();
+            let db = test_db.db.clone();
+
+            // Fork relationship so the Active × Active case has
+            // a source → target pair that shares lineage and a live
+            // key to copy.
+            db.branches().create("base").unwrap();
+            seed(&db, "base");
+            let source = "src";
+            let target = "tgt";
+            db.branches().fork("base", source).unwrap();
+            db.branches().fork(source, target).unwrap();
+            KVStore::new(db.clone())
+                .put(
+                    &BranchId::from_user_name(source),
+                    "default",
+                    "pickable",
+                    Value::Int(7),
+                )
+                .unwrap();
+
+            reshape(&db, source, source_state);
+            reshape(&db, target, target_state);
+
+            let scenario = format!(
+                "cherry_pick[src={}, tgt={}]",
+                source_state.label(),
+                target_state.label()
+            );
+            let before = checkpoint(&db, &obs, target);
+
+            let result = db.branches().cherry_pick(
+                source,
+                target,
+                &[("default".to_string(), "pickable".to_string())],
+            );
+
+            let source_visible = matches!(
+                source_state,
+                TargetState::Active | TargetState::Archived
+            );
+
+            match (source_visible, target_state) {
+                (false, _) => {
+                    assert_not_found(result, source, &scenario);
+                    assert_no_side_effects_since(&db, &obs, &before, &scenario);
+                }
+                (true, TargetState::Archived) => {
+                    assert_archived(result, target, &scenario);
+                    assert_no_side_effects_since(&db, &obs, &before, &scenario);
+                }
+                (true, TargetState::Deleted | TargetState::Missing) => {
+                    assert_not_found(result, target, &scenario);
+                    assert_no_side_effects_since(&db, &obs, &before, &scenario);
+                }
+                (true, TargetState::Active) => {
+                    result.unwrap_or_else(|e| panic!("[{scenario}] cherry_pick Active → Active must succeed: {e:?}"));
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Op 7/12 — cherry_pick_from_diff (source + target cross-matrix)
+// =============================================================================
+
+#[test]
+fn cherry_pick_from_diff_matrix() {
+    for source_state in TargetState::all() {
+        for target_state in TargetState::all() {
+            let (test_db, obs) = setup();
+            let db = test_db.db.clone();
+
+            db.branches().create("base").unwrap();
+            seed(&db, "base");
+            let source = "src";
+            let target = "tgt";
+            db.branches().fork("base", source).unwrap();
+            db.branches().fork(source, target).unwrap();
+            KVStore::new(db.clone())
+                .put(
+                    &BranchId::from_user_name(source),
+                    "default",
+                    "diff_picked",
+                    Value::Int(42),
+                )
+                .unwrap();
+
+            reshape(&db, source, source_state);
+            reshape(&db, target, target_state);
+
+            let scenario = format!(
+                "cherry_pick_from_diff[src={}, tgt={}]",
+                source_state.label(),
+                target_state.label()
+            );
+            let before = checkpoint(&db, &obs, target);
+
+            let result = db.branches().cherry_pick_from_diff(
+                source,
+                target,
+                CherryPickFilter::default(),
+            );
+
+            let source_visible = matches!(
+                source_state,
+                TargetState::Active | TargetState::Archived
+            );
+
+            match (source_visible, target_state) {
+                (false, _) => {
+                    assert_not_found(result, source, &scenario);
+                    assert_no_side_effects_since(&db, &obs, &before, &scenario);
+                }
+                (true, TargetState::Archived) => {
+                    assert_archived(result, target, &scenario);
+                    assert_no_side_effects_since(&db, &obs, &before, &scenario);
+                }
+                (true, TargetState::Deleted | TargetState::Missing) => {
+                    assert_not_found(result, target, &scenario);
+                    assert_no_side_effects_since(&db, &obs, &before, &scenario);
+                }
+                (true, TargetState::Active) => {
+                    result.unwrap_or_else(|e| panic!("[{scenario}] cherry_pick_from_diff Active → Active must succeed: {e:?}"));
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Ops 8/12 & 9/12 — tag / untag (single target, KD4 annotation gate)
+// =============================================================================
+
+#[test]
+fn tag_matrix() {
+    for state in TargetState::all() {
+        let (test_db, obs) = setup();
+        let db = test_db.db.clone();
+        let name = "target";
+        materialize(&db, name, state);
+
+        let scenario = format!("tag[target={}]", state.label());
+        let before = checkpoint(&db, &obs, name);
+
+        let result = db.branches().tag(name, "v1", None, None, None);
+        match state {
+            TargetState::Archived => {
+                assert_archived(result, name, &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            }
+            TargetState::Deleted | TargetState::Missing => {
+                assert_not_found(result, name, &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            }
+            TargetState::Active => {
+                result.unwrap_or_else(|e| panic!("[{scenario}] tag on Active must succeed: {e:?}"));
+            }
+        }
+    }
+}
+
+#[test]
+fn untag_matrix() {
+    for state in TargetState::all() {
+        let (test_db, obs) = setup();
+        let db = test_db.db.clone();
+        let name = "target";
+        materialize(&db, name, state);
+
+        // Lay down a tag on Active only so untag has something to hit.
+        if matches!(state, TargetState::Active) {
+            db.branches().tag(name, "v1", None, None, None).unwrap();
+        }
+
+        let scenario = format!("untag[target={}]", state.label());
+        let before = checkpoint(&db, &obs, name);
+
+        let result = db.branches().untag(name, "v1");
+        match state {
+            TargetState::Archived => {
+                assert_archived(result, name, &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            }
+            TargetState::Deleted | TargetState::Missing => {
+                assert_not_found(result, name, &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            }
+            TargetState::Active => {
+                let removed = result
+                    .unwrap_or_else(|e| panic!("[{scenario}] untag on Active must succeed: {e:?}"));
+                assert!(removed, "[{scenario}] laid-down tag should be removed");
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Ops 10/12 & 11/12 — add_note / delete_note (single target, KD4)
+// =============================================================================
+
+#[test]
+fn add_note_matrix() {
+    for state in TargetState::all() {
+        let (test_db, obs) = setup();
+        let db = test_db.db.clone();
+        let name = "target";
+        materialize(&db, name, state);
+
+        let scenario = format!("add_note[target={}]", state.label());
+        let before = checkpoint(&db, &obs, name);
+
+        let result = db
+            .branches()
+            .add_note(name, CommitVersion(1), "a note", None, None);
+        match state {
+            TargetState::Archived => {
+                assert_archived(result, name, &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            }
+            TargetState::Deleted | TargetState::Missing => {
+                assert_not_found(result, name, &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            }
+            TargetState::Active => {
+                result.unwrap_or_else(|e| panic!("[{scenario}] add_note on Active must succeed: {e:?}"));
+            }
+        }
+    }
+}
+
+#[test]
+fn delete_note_matrix() {
+    for state in TargetState::all() {
+        let (test_db, obs) = setup();
+        let db = test_db.db.clone();
+        let name = "target";
+        materialize(&db, name, state);
+
+        if matches!(state, TargetState::Active) {
+            db.branches()
+                .add_note(name, CommitVersion(1), "pre", None, None)
+                .unwrap();
+        }
+
+        let scenario = format!("delete_note[target={}]", state.label());
+        let before = checkpoint(&db, &obs, name);
+
+        let result = db.branches().delete_note(name, CommitVersion(1));
+        match state {
+            TargetState::Archived => {
+                assert_archived(result, name, &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            }
+            TargetState::Deleted | TargetState::Missing => {
+                assert_not_found(result, name, &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            }
+            TargetState::Active => {
+                let removed = result
+                    .unwrap_or_else(|e| panic!("[{scenario}] delete_note on Active must succeed: {e:?}"));
+                assert!(removed, "[{scenario}] pre-seeded note must be removed");
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Op 12/12 — bundle::import_branch (single target; KD1 duplicate rule)
+// =============================================================================
+//
+// Bundle import treats Active and Archived alike as "live duplicate
+// name" per KD1; only Deleted and Missing accept the import. This
+// locks AD7 — a tombstoned target allocates a fresh generation and
+// does not honor the bundle's generation.
+
+#[test]
+fn bundle_import_matrix() {
+    // Build one source bundle once, reuse across states.
+    let source_db = TestDb::new();
+    source_db.db.branches().create("payload").unwrap();
+    seed(&source_db.db, "payload");
+    let bundle_dir = tempfile::tempdir().expect("bundle tempdir");
+    let bundle_path = bundle_dir.path().join("payload.branchbundle.tar.zst");
+    bundle::export_branch(&source_db.db, "payload", &bundle_path).expect("export succeeds");
+
+    for state in TargetState::all() {
+        let (test_db, obs) = setup();
+        let db = test_db.db.clone();
+        // The bundle carries name "payload"; target state is on the
+        // same name in the target DB.
+        let name = "payload";
+        materialize(&db, name, state);
+
+        let scenario = format!("bundle_import[target={}]", state.label());
+        let before = checkpoint(&db, &obs, name);
+
+        let result = bundle::import_branch(&db, &bundle_path);
+
+        match state {
+            TargetState::Active | TargetState::Archived => {
+                assert_invalid_input_contains(result, "already exists", &scenario);
+                assert_no_side_effects_since(&db, &obs, &before, &scenario);
+            }
+            TargetState::Missing => {
+                result.unwrap_or_else(|e| panic!("[{scenario}] bundle import must succeed on Missing target: {e:?}"));
+                let rec = db.branches().control_record(name).unwrap().unwrap();
+                // Bundle carries generation 0 and target has no prior
+                // lineage → AD7 preserves the bundle's generation.
+                assert_eq!(
+                    rec.branch.generation, 0,
+                    "[{scenario}] fresh-target import preserves bundle generation verbatim"
+                );
+            }
+            TargetState::Deleted => {
+                result.unwrap_or_else(|e| panic!("[{scenario}] bundle import must succeed on Deleted target: {e:?}"));
+                let rec = db.branches().control_record(name).unwrap().unwrap();
+                // Tombstoned target → AD7 fresh-gen fallback. Target's
+                // next-gen counter was advanced to 1 by the prior
+                // tombstone, so the import lands at gen 1, NOT at the
+                // bundle's gen 0.
+                assert_eq!(
+                    rec.branch.generation, 1,
+                    "[{scenario}] post-tombstone import allocates fresh gen 1 (not bundle's gen 0)"
+                );
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Cross-cutting: repeated refused calls do not deadlock
+// =============================================================================
+//
+// The gate must run before any lock acquisition (KD3). If it didn't,
+// repeated refused calls could exhaust pool capacity or hold a
+// per-branch lock across the refused path. Loop one target state per
+// gate-variant (Archived → BranchArchived, Missing → BranchNotFound)
+// and assert the call returns promptly every time.
+
+#[test]
+fn refused_calls_are_side_effect_free_and_do_not_deadlock() {
+    let (test_db, obs) = setup();
+    let db = test_db.db.clone();
+    db.branches().create("target").unwrap();
+    seed(&db, "target");
+    archive_branch_for_test(&db, "target");
+
+    let before = checkpoint(&db, &obs, "target");
+
+    for _ in 0..64 {
+        let result = db.branches().tag("target", "v1", None, None, None);
+        assert_archived(result, "target", "loop-archived-tag");
+    }
+    for _ in 0..64 {
+        let result = db
+            .branches()
+            .revert("target", CommitVersion(1), CommitVersion(1));
+        assert_archived(result, "target", "loop-archived-revert");
+    }
+    for _ in 0..64 {
+        let result = db
+            .branches()
+            .merge_with_options("target", "nonexistent", MergeOptions::default());
+        // source `target` is Archived-visible; target `nonexistent` is
+        // Missing — so the failure surfaces on the target-side gate.
+        assert_not_found(result, "nonexistent", "loop-missing-merge-target");
+    }
+
+    assert_no_side_effects_since(&db, &obs, &before, "repeat-refused-loop");
+}
+
+// =============================================================================
+// Helpers — reshape a live branch into a non-Active state in place
+// =============================================================================
+//
+// `reshape` is used by the cross-matrix setups that already built a
+// live pair via `create + fork` to drive them into the target states.
+// `Missing` is produced by calling `delete` twice so the fork+seed
+// setup is unwound cleanly.
+
+fn reshape(db: &Arc<Database>, name: &str, state: TargetState) {
+    match state {
+        TargetState::Active => { /* already active */ }
+        TargetState::Archived => {
+            set_lifecycle_for_test(db, name, BranchLifecycleStatus::Archived);
+        }
+        TargetState::Deleted | TargetState::Missing => {
+            // Cross-matrix setup needs a live fork-parent pair for the
+            // Active × Active success cell, so we tear down with
+            // `delete` even for the `Missing` label. Both states
+            // resolve to the same gate outcome — `BranchNotFoundByName`
+            // — so the assertion vocabulary matches. The truly
+            // never-created `Missing` state is exercised by the
+            // single-branch matrix cells (`materialize`).
+            db.branches().delete(name).unwrap();
+        }
+    }
+}

--- a/tests/integration/branching_lifecycle_gate.rs
+++ b/tests/integration/branching_lifecycle_gate.rs
@@ -21,11 +21,10 @@
 //! ## State synthesis
 //!
 //! No production path produces the `Archived` lifecycle. The matrix
-//! uses `common::branching::set_lifecycle_for_test` (a
-//! `#[doc(hidden)] pub` hook on `BranchService`) to flip a live
-//! record's `lifecycle` field in place. `Deleted` state uses the
-//! production `BranchService::delete` path. `Missing` is "never
-//! created".
+//! uses `common::branching::set_lifecycle_for_test` (a feature-gated
+//! engine test-support hook) to flip a live record's `lifecycle`
+//! field in place. `Deleted` state uses the production
+//! `BranchService::delete` path. `Missing` is "never created".
 //!
 //! Single-branch ops (`materialize`) exercise all four states as
 //! truly distinct setups: `Missing` skips creation entirely.
@@ -53,7 +52,7 @@ use std::sync::Arc;
 use strata_core::branch::BranchLifecycleStatus;
 use strata_core::id::CommitVersion;
 use strata_core::value::Value;
-use strata_core::StrataError;
+use strata_core::{BranchRef, StrataError};
 use strata_engine::{bundle, CherryPickFilter, Database, MergeOptions};
 
 // =============================================================================
@@ -91,24 +90,28 @@ impl TargetState {
 /// Build `name` into `state` on `db`. For `Active`, seeds a single KV
 /// write so the storage layer materialises the branch (fork COW needs
 /// a memtable on the source).
-fn materialize(db: &Arc<Database>, name: &str, state: TargetState) {
+fn materialize(db: &Arc<Database>, name: &str, state: TargetState) -> Option<BranchRef> {
     match state {
         TargetState::Active => {
             db.branches().create(name).unwrap();
             seed(db, name);
+            Some(db.branches().control_record(name).unwrap().unwrap().branch)
         }
         TargetState::Archived => {
             db.branches().create(name).unwrap();
             seed(db, name);
-            archive_branch_for_test(db, name);
+            Some(archive_branch_for_test(db, name))
         }
         TargetState::Deleted => {
             db.branches().create(name).unwrap();
             seed(db, name);
+            let deleted_ref = db.branches().control_record(name).unwrap().unwrap().branch;
             db.branches().delete(name).unwrap();
+            Some(deleted_ref)
         }
         TargetState::Missing => {
             // Intentionally no-op — the name must have no record at all.
+            None
         }
     }
 }
@@ -165,7 +168,9 @@ fn assert_invalid_input_contains(
             );
         }
         Err(e) => panic!("[{scenario}] expected InvalidInput containing {fragment:?}, got: {e:?}"),
-        Ok(v) => panic!("[{scenario}] expected InvalidInput containing {fragment:?}, got Ok({v:?})"),
+        Ok(v) => {
+            panic!("[{scenario}] expected InvalidInput containing {fragment:?}, got Ok({v:?})")
+        }
     }
 }
 
@@ -184,8 +189,9 @@ fn checkpoint(
     db: &Arc<Database>,
     observer: &CapturingBranchObserver,
     target: &str,
+    target_ref: Option<BranchRef>,
 ) -> BranchSideEffectCheckpoint {
-    BranchSideEffectCheckpoint::capture(db, observer, target)
+    BranchSideEffectCheckpoint::capture(db, observer, target, target_ref)
 }
 
 // =============================================================================
@@ -203,10 +209,10 @@ fn create_matrix() {
         let (test_db, obs) = setup();
         let db = test_db.db.clone();
         let name = "target";
-        materialize(&db, name, state);
+        let target_ref = materialize(&db, name, state);
 
         let scenario = format!("create[target={}]", state.label());
-        let before = checkpoint(&db, &obs, name);
+        let before = checkpoint(&db, &obs, name, target_ref);
 
         let result = db.branches().create(name);
         match state {
@@ -215,14 +221,24 @@ fn create_matrix() {
                 assert_no_side_effects_since(&db, &obs, &before, &scenario);
             }
             TargetState::Deleted => {
-                result.unwrap_or_else(|e| panic!("[{scenario}] create after delete must succeed: {e:?}"));
+                result.unwrap_or_else(|e| {
+                    panic!("[{scenario}] create after delete must succeed: {e:?}")
+                });
                 let rec = db.branches().control_record(name).unwrap().unwrap();
-                assert_eq!(rec.branch.generation, 1, "[{scenario}] recreate advances generation");
+                assert_eq!(
+                    rec.branch.generation, 1,
+                    "[{scenario}] recreate advances generation"
+                );
             }
             TargetState::Missing => {
-                result.unwrap_or_else(|e| panic!("[{scenario}] create on missing must succeed: {e:?}"));
+                result.unwrap_or_else(|e| {
+                    panic!("[{scenario}] create on missing must succeed: {e:?}")
+                });
                 let rec = db.branches().control_record(name).unwrap().unwrap();
-                assert_eq!(rec.branch.generation, 0, "[{scenario}] first create is gen 0");
+                assert_eq!(
+                    rec.branch.generation, 0,
+                    "[{scenario}] first create is gen 0"
+                );
             }
         }
     }
@@ -241,15 +257,17 @@ fn delete_matrix() {
         let (test_db, obs) = setup();
         let db = test_db.db.clone();
         let name = "target";
-        materialize(&db, name, state);
+        let target_ref = materialize(&db, name, state);
 
         let scenario = format!("delete[target={}]", state.label());
-        let before = checkpoint(&db, &obs, name);
+        let before = checkpoint(&db, &obs, name, target_ref);
 
         let result = db.branches().delete(name);
         match state {
             TargetState::Active | TargetState::Archived => {
-                result.unwrap_or_else(|e| panic!("[{scenario}] delete visible branch must succeed: {e:?}"));
+                result.unwrap_or_else(|e| {
+                    panic!("[{scenario}] delete visible branch must succeed: {e:?}")
+                });
                 assert!(
                     db.branches().control_record(name).unwrap().is_none(),
                     "[{scenario}] post-delete live record is absent"
@@ -281,21 +299,21 @@ fn fork_matrix() {
             // Source / dest must be distinct names.
             let source = "src";
             let dest = "dst";
-            materialize(&db, source, source_state);
-            materialize(&db, dest, dest_state);
+            let _source_ref = materialize(&db, source, source_state);
+            let dest_ref = materialize(&db, dest, dest_state);
 
-            let scenario =
-                format!("fork[src={}, dst={}]", source_state.label(), dest_state.label());
-            let before = checkpoint(&db, &obs, dest);
+            let scenario = format!(
+                "fork[src={}, dst={}]",
+                source_state.label(),
+                dest_state.label()
+            );
+            let before = checkpoint(&db, &obs, dest, dest_ref);
 
             let result = db.branches().fork(source, dest);
 
-            let source_visible = matches!(
-                source_state,
-                TargetState::Active | TargetState::Archived
-            );
-            let dest_has_live =
-                matches!(dest_state, TargetState::Active | TargetState::Archived);
+            let source_visible =
+                matches!(source_state, TargetState::Active | TargetState::Archived);
+            let dest_has_live = matches!(dest_state, TargetState::Active | TargetState::Archived);
 
             if !source_visible {
                 assert_not_found(result, source, &scenario);
@@ -304,8 +322,11 @@ fn fork_matrix() {
                 assert_invalid_input_contains(result, "already exists", &scenario);
                 assert_no_side_effects_since(&db, &obs, &before, &scenario);
             } else {
-                result
-                    .unwrap_or_else(|e| panic!("[{scenario}] fork with visible source and free dest must succeed: {e:?}"));
+                result.unwrap_or_else(|e| {
+                    panic!(
+                        "[{scenario}] fork with visible source and free dest must succeed: {e:?}"
+                    )
+                });
                 let rec = db.branches().control_record(dest).unwrap().unwrap();
                 assert!(rec.fork.is_some(), "[{scenario}] fork anchor populated");
             }
@@ -350,24 +371,22 @@ fn merge_matrix() {
                 )
                 .unwrap();
 
-            reshape(&db, source_name, source_state);
-            reshape(&db, target_name, target_state);
+            let _source_ref = reshape(&db, source_name, source_state);
+            let target_ref = reshape(&db, target_name, target_state);
 
             let scenario = format!(
                 "merge[src={}, tgt={}]",
                 source_state.label(),
                 target_state.label()
             );
-            let before = checkpoint(&db, &obs, target_name);
+            let before = checkpoint(&db, &obs, target_name, target_ref);
 
-            let result = db
-                .branches()
-                .merge_with_options(source_name, target_name, MergeOptions::default());
+            let result =
+                db.branches()
+                    .merge_with_options(source_name, target_name, MergeOptions::default());
 
-            let source_visible = matches!(
-                source_state,
-                TargetState::Active | TargetState::Archived
-            );
+            let source_visible =
+                matches!(source_state, TargetState::Active | TargetState::Archived);
 
             match (source_visible, target_state) {
                 (false, _) => {
@@ -383,7 +402,9 @@ fn merge_matrix() {
                     assert_no_side_effects_since(&db, &obs, &before, &scenario);
                 }
                 (true, TargetState::Active) => {
-                    result.unwrap_or_else(|e| panic!("[{scenario}] merge Active → Active must succeed: {e:?}"));
+                    result.unwrap_or_else(|e| {
+                        panic!("[{scenario}] merge Active → Active must succeed: {e:?}")
+                    });
                 }
             }
         }
@@ -400,10 +421,10 @@ fn revert_matrix() {
         let (test_db, obs) = setup();
         let db = test_db.db.clone();
         let name = "target";
-        materialize(&db, name, state);
+        let target_ref = materialize(&db, name, state);
 
         let scenario = format!("revert[target={}]", state.label());
-        let before = checkpoint(&db, &obs, name);
+        let before = checkpoint(&db, &obs, name, target_ref);
 
         let result = db
             .branches()
@@ -467,15 +488,15 @@ fn cherry_pick_matrix() {
                 )
                 .unwrap();
 
-            reshape(&db, source, source_state);
-            reshape(&db, target, target_state);
+            let _source_ref = reshape(&db, source, source_state);
+            let target_ref = reshape(&db, target, target_state);
 
             let scenario = format!(
                 "cherry_pick[src={}, tgt={}]",
                 source_state.label(),
                 target_state.label()
             );
-            let before = checkpoint(&db, &obs, target);
+            let before = checkpoint(&db, &obs, target, target_ref);
 
             let result = db.branches().cherry_pick(
                 source,
@@ -483,10 +504,8 @@ fn cherry_pick_matrix() {
                 &[("default".to_string(), "pickable".to_string())],
             );
 
-            let source_visible = matches!(
-                source_state,
-                TargetState::Active | TargetState::Archived
-            );
+            let source_visible =
+                matches!(source_state, TargetState::Active | TargetState::Archived);
 
             match (source_visible, target_state) {
                 (false, _) => {
@@ -502,7 +521,9 @@ fn cherry_pick_matrix() {
                     assert_no_side_effects_since(&db, &obs, &before, &scenario);
                 }
                 (true, TargetState::Active) => {
-                    result.unwrap_or_else(|e| panic!("[{scenario}] cherry_pick Active → Active must succeed: {e:?}"));
+                    result.unwrap_or_else(|e| {
+                        panic!("[{scenario}] cherry_pick Active → Active must succeed: {e:?}")
+                    });
                 }
             }
         }
@@ -535,26 +556,22 @@ fn cherry_pick_from_diff_matrix() {
                 )
                 .unwrap();
 
-            reshape(&db, source, source_state);
-            reshape(&db, target, target_state);
+            let _source_ref = reshape(&db, source, source_state);
+            let target_ref = reshape(&db, target, target_state);
 
             let scenario = format!(
                 "cherry_pick_from_diff[src={}, tgt={}]",
                 source_state.label(),
                 target_state.label()
             );
-            let before = checkpoint(&db, &obs, target);
+            let before = checkpoint(&db, &obs, target, target_ref);
 
-            let result = db.branches().cherry_pick_from_diff(
-                source,
-                target,
-                CherryPickFilter::default(),
-            );
+            let result =
+                db.branches()
+                    .cherry_pick_from_diff(source, target, CherryPickFilter::default());
 
-            let source_visible = matches!(
-                source_state,
-                TargetState::Active | TargetState::Archived
-            );
+            let source_visible =
+                matches!(source_state, TargetState::Active | TargetState::Archived);
 
             match (source_visible, target_state) {
                 (false, _) => {
@@ -587,10 +604,10 @@ fn tag_matrix() {
         let (test_db, obs) = setup();
         let db = test_db.db.clone();
         let name = "target";
-        materialize(&db, name, state);
+        let target_ref = materialize(&db, name, state);
 
         let scenario = format!("tag[target={}]", state.label());
-        let before = checkpoint(&db, &obs, name);
+        let before = checkpoint(&db, &obs, name, target_ref);
 
         let result = db.branches().tag(name, "v1", None, None, None);
         match state {
@@ -615,7 +632,7 @@ fn untag_matrix() {
         let (test_db, obs) = setup();
         let db = test_db.db.clone();
         let name = "target";
-        materialize(&db, name, state);
+        let target_ref = materialize(&db, name, state);
 
         // Lay down a tag on Active only so untag has something to hit.
         if matches!(state, TargetState::Active) {
@@ -623,7 +640,7 @@ fn untag_matrix() {
         }
 
         let scenario = format!("untag[target={}]", state.label());
-        let before = checkpoint(&db, &obs, name);
+        let before = checkpoint(&db, &obs, name, target_ref);
 
         let result = db.branches().untag(name, "v1");
         match state {
@@ -654,10 +671,10 @@ fn add_note_matrix() {
         let (test_db, obs) = setup();
         let db = test_db.db.clone();
         let name = "target";
-        materialize(&db, name, state);
+        let target_ref = materialize(&db, name, state);
 
         let scenario = format!("add_note[target={}]", state.label());
-        let before = checkpoint(&db, &obs, name);
+        let before = checkpoint(&db, &obs, name, target_ref);
 
         let result = db
             .branches()
@@ -672,7 +689,9 @@ fn add_note_matrix() {
                 assert_no_side_effects_since(&db, &obs, &before, &scenario);
             }
             TargetState::Active => {
-                result.unwrap_or_else(|e| panic!("[{scenario}] add_note on Active must succeed: {e:?}"));
+                result.unwrap_or_else(|e| {
+                    panic!("[{scenario}] add_note on Active must succeed: {e:?}")
+                });
             }
         }
     }
@@ -684,7 +703,7 @@ fn delete_note_matrix() {
         let (test_db, obs) = setup();
         let db = test_db.db.clone();
         let name = "target";
-        materialize(&db, name, state);
+        let target_ref = materialize(&db, name, state);
 
         if matches!(state, TargetState::Active) {
             db.branches()
@@ -693,7 +712,7 @@ fn delete_note_matrix() {
         }
 
         let scenario = format!("delete_note[target={}]", state.label());
-        let before = checkpoint(&db, &obs, name);
+        let before = checkpoint(&db, &obs, name, target_ref);
 
         let result = db.branches().delete_note(name, CommitVersion(1));
         match state {
@@ -706,8 +725,9 @@ fn delete_note_matrix() {
                 assert_no_side_effects_since(&db, &obs, &before, &scenario);
             }
             TargetState::Active => {
-                let removed = result
-                    .unwrap_or_else(|e| panic!("[{scenario}] delete_note on Active must succeed: {e:?}"));
+                let removed = result.unwrap_or_else(|e| {
+                    panic!("[{scenario}] delete_note on Active must succeed: {e:?}")
+                });
                 assert!(removed, "[{scenario}] pre-seeded note must be removed");
             }
         }
@@ -739,10 +759,10 @@ fn bundle_import_matrix() {
         // The bundle carries name "payload"; target state is on the
         // same name in the target DB.
         let name = "payload";
-        materialize(&db, name, state);
+        let target_ref = materialize(&db, name, state);
 
         let scenario = format!("bundle_import[target={}]", state.label());
-        let before = checkpoint(&db, &obs, name);
+        let before = checkpoint(&db, &obs, name, target_ref);
 
         let result = bundle::import_branch(&db, &bundle_path);
 
@@ -752,7 +772,9 @@ fn bundle_import_matrix() {
                 assert_no_side_effects_since(&db, &obs, &before, &scenario);
             }
             TargetState::Missing => {
-                result.unwrap_or_else(|e| panic!("[{scenario}] bundle import must succeed on Missing target: {e:?}"));
+                result.unwrap_or_else(|e| {
+                    panic!("[{scenario}] bundle import must succeed on Missing target: {e:?}")
+                });
                 let rec = db.branches().control_record(name).unwrap().unwrap();
                 // Bundle carries generation 0 and target has no prior
                 // lineage → AD7 preserves the bundle's generation.
@@ -762,7 +784,9 @@ fn bundle_import_matrix() {
                 );
             }
             TargetState::Deleted => {
-                result.unwrap_or_else(|e| panic!("[{scenario}] bundle import must succeed on Deleted target: {e:?}"));
+                result.unwrap_or_else(|e| {
+                    panic!("[{scenario}] bundle import must succeed on Deleted target: {e:?}")
+                });
                 let rec = db.branches().control_record(name).unwrap().unwrap();
                 // Tombstoned target → AD7 fresh-gen fallback. Target's
                 // next-gen counter was advanced to 1 by the prior
@@ -794,8 +818,15 @@ fn refused_calls_are_side_effect_free_and_do_not_deadlock() {
     db.branches().create("target").unwrap();
     seed(&db, "target");
     archive_branch_for_test(&db, "target");
+    let target_ref = Some(
+        db.branches()
+            .control_record("target")
+            .unwrap()
+            .unwrap()
+            .branch,
+    );
 
-    let before = checkpoint(&db, &obs, "target");
+    let before = checkpoint(&db, &obs, "target", target_ref);
 
     for _ in 0..64 {
         let result = db.branches().tag("target", "v1", None, None, None);
@@ -808,9 +839,9 @@ fn refused_calls_are_side_effect_free_and_do_not_deadlock() {
         assert_archived(result, "target", "loop-archived-revert");
     }
     for _ in 0..64 {
-        let result = db
-            .branches()
-            .merge_with_options("target", "nonexistent", MergeOptions::default());
+        let result =
+            db.branches()
+                .merge_with_options("target", "nonexistent", MergeOptions::default());
         // source `target` is Archived-visible; target `nonexistent` is
         // Missing — so the failure surfaces on the target-side gate.
         assert_not_found(result, "nonexistent", "loop-missing-merge-target");
@@ -828,12 +859,18 @@ fn refused_calls_are_side_effect_free_and_do_not_deadlock() {
 // `Missing` is produced by calling `delete` twice so the fork+seed
 // setup is unwound cleanly.
 
-fn reshape(db: &Arc<Database>, name: &str, state: TargetState) {
+fn reshape(db: &Arc<Database>, name: &str, state: TargetState) -> Option<BranchRef> {
     match state {
-        TargetState::Active => { /* already active */ }
-        TargetState::Archived => {
-            set_lifecycle_for_test(db, name, BranchLifecycleStatus::Archived);
-        }
+        TargetState::Active => db
+            .branches()
+            .control_record(name)
+            .unwrap()
+            .map(|rec| rec.branch),
+        TargetState::Archived => Some(set_lifecycle_for_test(
+            db,
+            name,
+            BranchLifecycleStatus::Archived,
+        )),
         TargetState::Deleted | TargetState::Missing => {
             // Cross-matrix setup needs a live fork-parent pair for the
             // Active × Active success cell, so we tear down with
@@ -842,7 +879,9 @@ fn reshape(db: &Arc<Database>, name: &str, state: TargetState) {
             // — so the assertion vocabulary matches. The truly
             // never-created `Missing` state is exercised by the
             // single-branch matrix cells (`materialize`).
+            let deleted_ref = db.branches().control_record(name).unwrap().unwrap().branch;
             db.branches().delete(name).unwrap();
+            Some(deleted_ref)
         }
     }
 }

--- a/tests/integration/branching_lifecycle_restart.rs
+++ b/tests/integration/branching_lifecycle_restart.rs
@@ -1,0 +1,396 @@
+//! B4.2 — lifecycle persistence and same-name recreate across reopen.
+//!
+//! Locks the post-reopen half of the B4.2 coverage bar:
+//!
+//! - An `Archived` lifecycle written before reopen is still observable
+//!   after reopen and continues to refuse writes with `BranchArchived`.
+//! - Same-name delete → reopen → recreate chains produce strictly
+//!   monotone generations on the store, and `merge_base` against the
+//!   new generation never surfaces a stale fork anchor from the
+//!   tombstoned generation.
+//! - The `next_generation` counter survives reopen so the monotonicity
+//!   holds after more than one cycle.
+//! - Bundle import onto a tombstoned target ignores the bundle's
+//!   generation and allocates a fresh one (AD7), and that fresh
+//!   generation survives a subsequent reopen.
+//!
+//! These complement `branching_control_store_recovery.rs` (which
+//! proves recovery mechanics for the standard B3 flows) by focusing
+//! on the lifecycle-gate invariants introduced in B4.
+
+#![cfg(not(miri))]
+
+use crate::common::branching::archive_branch_for_test;
+use crate::common::*;
+use std::sync::Arc;
+use strata_core::value::Value;
+use strata_core::{BranchRef, StrataError};
+use strata_engine::bundle;
+use tempfile::TempDir;
+
+fn resolve(name: &str) -> BranchId {
+    BranchId::from_user_name(name)
+}
+
+/// Seed a single row so the branch materialises in storage — required
+/// for export and for some post-reopen introspection paths.
+fn seed(db: &Arc<Database>, name: &str) {
+    KVStore::new(db.clone())
+        .put(&resolve(name), "default", "_seed_", Value::Int(1))
+        .expect("seed write succeeds");
+}
+
+// =============================================================================
+// Archived lifecycle persists across reopen
+// =============================================================================
+
+#[test]
+fn archived_lifecycle_persists_across_reopen() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("frozen").unwrap();
+    seed(&test_db.db, "frozen");
+    let archived_ref = archive_branch_for_test(&test_db.db, "frozen");
+
+    test_db.reopen();
+
+    // Control record still exists, still archived.
+    let rec = test_db
+        .db
+        .branches()
+        .control_record("frozen")
+        .unwrap()
+        .expect("archived record persists across reopen");
+    assert_eq!(rec.branch, archived_ref, "reopen preserves BranchRef");
+    assert!(
+        matches!(rec.lifecycle, strata_core::branch::BranchLifecycleStatus::Archived),
+        "reopen preserves Archived lifecycle"
+    );
+}
+
+#[test]
+fn post_reopen_archived_branch_refuses_writes_with_branch_archived() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("frozen").unwrap();
+    seed(&test_db.db, "frozen");
+    // Also set up a live source so we can exercise merge-as-target
+    // against the archived branch post-reopen.
+    test_db.db.branches().create("live").unwrap();
+    seed(&test_db.db, "live");
+    archive_branch_for_test(&test_db.db, "frozen");
+
+    test_db.reopen();
+
+    // Every gated mutation must surface the typed archived error after
+    // reopen — the widened active-pointer (KD1) and the gate helpers
+    // must both survive recovery, not just the persisted record. Cover
+    // three gate surfaces: annotation (tag), annotation (add_note), and
+    // structural (revert). A regression that touched just one surface
+    // without migrating would be caught here.
+    match test_db.db.branches().tag("frozen", "v1", None, None, None) {
+        Err(StrataError::BranchArchived { name }) => {
+            assert_eq!(name, "frozen", "typed error carries the archived name");
+        }
+        other => panic!("expected BranchArchived (tag) after reopen, got {other:?}"),
+    }
+
+    match test_db.db.branches().add_note(
+        "frozen",
+        strata_core::id::CommitVersion(1),
+        "n",
+        None,
+        None,
+    ) {
+        Err(StrataError::BranchArchived { name }) => {
+            assert_eq!(name, "frozen");
+        }
+        other => panic!("expected BranchArchived (add_note) after reopen, got {other:?}"),
+    }
+
+    match test_db.db.branches().revert(
+        "frozen",
+        strata_core::id::CommitVersion(1),
+        strata_core::id::CommitVersion(1),
+    ) {
+        Err(StrataError::BranchArchived { name }) => {
+            assert_eq!(name, "frozen");
+        }
+        other => panic!("expected BranchArchived (revert) after reopen, got {other:?}"),
+    }
+}
+
+#[test]
+fn post_reopen_archived_branch_is_still_deletable() {
+    // KD1 rationale check: `delete` uses `require_visible`, so an
+    // Archived branch must remain deletable even after the gate and
+    // the widened pointer round-trip through reopen.
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("frozen").unwrap();
+    seed(&test_db.db, "frozen");
+    archive_branch_for_test(&test_db.db, "frozen");
+
+    test_db.reopen();
+
+    test_db
+        .db
+        .branches()
+        .delete("frozen")
+        .expect("Archived branch must be deletable after reopen");
+    assert!(
+        test_db.db.branches().control_record("frozen").unwrap().is_none(),
+        "post-delete record is absent"
+    );
+}
+
+// =============================================================================
+// Same-name recreate across reopen: monotone generations, no stale lineage
+// =============================================================================
+
+#[test]
+fn delete_reopen_recreate_allocates_monotone_generations() {
+    let mut test_db = TestDb::new();
+
+    // gen 0
+    test_db.db.branches().create("rolling").unwrap();
+    let gen0 = test_db
+        .db
+        .branches()
+        .control_record("rolling")
+        .unwrap()
+        .unwrap()
+        .branch;
+    assert_eq!(gen0.generation, 0);
+
+    test_db.db.branches().delete("rolling").unwrap();
+    test_db.reopen();
+    test_db.db.branches().create("rolling").unwrap();
+
+    let gen1 = test_db
+        .db
+        .branches()
+        .control_record("rolling")
+        .unwrap()
+        .unwrap()
+        .branch;
+    assert_eq!(
+        gen1,
+        BranchRef::new(resolve("rolling"), 1),
+        "post-reopen recreate must advance generation"
+    );
+
+    test_db.db.branches().delete("rolling").unwrap();
+    test_db.reopen();
+    test_db.db.branches().create("rolling").unwrap();
+
+    let gen2 = test_db
+        .db
+        .branches()
+        .control_record("rolling")
+        .unwrap()
+        .unwrap()
+        .branch;
+    assert_eq!(
+        gen2.generation, 2,
+        "next_generation counter survives multiple reopens"
+    );
+}
+
+#[test]
+fn merge_base_does_not_surface_tombstoned_generation_after_reopen() {
+    // Setup: fork feature from main at gen 0, merge once, delete feature,
+    // reopen, recreate feature at gen 1. `merge_base(main, feature)` on
+    // the new generation must not return any point from the old
+    // generation's lineage — edges are scoped by `BranchRef`, not by
+    // name, so the tombstoned feature@gen0 edges must stay invisible.
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    seed(&test_db.db, "main");
+    test_db.db.branches().fork("main", "feature").unwrap();
+    test_db
+        .kv()
+        .put(&resolve("feature"), "default", "delta", Value::Int(1))
+        .unwrap();
+    test_db.db.branches().merge("feature", "main").unwrap();
+    test_db.db.branches().delete("feature").unwrap();
+
+    test_db.reopen();
+
+    test_db.db.branches().create("feature").unwrap();
+    let new_feature = test_db
+        .db
+        .branches()
+        .control_record("feature")
+        .unwrap()
+        .unwrap()
+        .branch;
+    assert_eq!(new_feature.generation, 1);
+
+    // The new feature@gen1 was created as a fresh root (no fork), so
+    // it has no lineage relationship to main. Merge base MUST be None.
+    let mb = test_db
+        .db
+        .branches()
+        .merge_base("main", "feature")
+        .unwrap();
+    assert!(
+        mb.is_none(),
+        "recreated branch without fork inherits no lineage — merge_base must be None, got {mb:?}"
+    );
+}
+
+// =============================================================================
+// next_generation counter monotonicity across reopens
+// =============================================================================
+
+#[test]
+fn next_generation_counter_is_monotone_across_reopens() {
+    let mut test_db = TestDb::new();
+
+    for expected_gen in 0..4u64 {
+        test_db.db.branches().create("cycle").unwrap();
+        let rec = test_db
+            .db
+            .branches()
+            .control_record("cycle")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            rec.branch.generation, expected_gen,
+            "cycle {expected_gen}: generation must equal {expected_gen}"
+        );
+        test_db.db.branches().delete("cycle").unwrap();
+        test_db.reopen();
+    }
+
+    // One more create — should land at gen 4, confirming the pattern
+    // survived the final reopen as well.
+    test_db.db.branches().create("cycle").unwrap();
+    let final_rec = test_db
+        .db
+        .branches()
+        .control_record("cycle")
+        .unwrap()
+        .unwrap();
+    assert_eq!(final_rec.branch.generation, 4);
+}
+
+// =============================================================================
+// Bundle-import collision: tombstoned target + reopen preserves fresh gen
+// =============================================================================
+
+fn export_bundle(db: &Arc<Database>, branch: &str) -> (TempDir, std::path::PathBuf) {
+    let bundle_dir = TempDir::new().unwrap();
+    let path = bundle_dir
+        .path()
+        .join(format!("{branch}.branchbundle.tar.zst"));
+    bundle::export_branch(db, branch, &path).expect("export succeeds");
+    (bundle_dir, path)
+}
+
+#[test]
+fn bundle_import_after_reopen_preserves_fresh_generation() {
+    // Source DB carries `foo@gen3` — push through several cycles so the
+    // bundle's `generation` field is non-trivial.
+    let source_db = TestDb::new();
+    for _ in 0..3 {
+        source_db.db.branches().create("foo").unwrap();
+        source_db.db.branches().delete("foo").unwrap();
+    }
+    source_db.db.branches().create("foo").unwrap(); // gen 3
+    assert_eq!(
+        source_db
+            .db
+            .branches()
+            .control_record("foo")
+            .unwrap()
+            .unwrap()
+            .branch
+            .generation,
+        3
+    );
+    let (_bundle_keepalive, bundle_path) = export_bundle(&source_db.db, "foo");
+
+    // Target DB: has a single tombstone at gen 0 (one create + delete).
+    let mut target_db = TestDb::new();
+    target_db.db.branches().create("foo").unwrap();
+    target_db.db.branches().delete("foo").unwrap();
+
+    // Import — AD7 says target allocates gen 1 (from its own counter),
+    // NOT bundle's gen 3.
+    bundle::import_branch(&target_db.db, &bundle_path).unwrap();
+    let after_import = target_db
+        .db
+        .branches()
+        .control_record("foo")
+        .unwrap()
+        .unwrap()
+        .branch;
+    assert_eq!(after_import.generation, 1, "AD7: fresh gen ignores bundle's gen");
+
+    // Reopen and assert the fresh generation persists, the bundle's
+    // generation has not silently resurfaced, and a subsequent
+    // delete+create still advances monotonically from gen 1.
+    target_db.reopen();
+    let after_reopen = target_db
+        .db
+        .branches()
+        .control_record("foo")
+        .unwrap()
+        .unwrap()
+        .branch;
+    assert_eq!(
+        after_reopen, after_import,
+        "post-reopen BranchRef matches pre-reopen (gen 1, not bundle's gen 3)"
+    );
+
+    target_db.db.branches().delete("foo").unwrap();
+    target_db.db.branches().create("foo").unwrap();
+    let next_gen = target_db
+        .db
+        .branches()
+        .control_record("foo")
+        .unwrap()
+        .unwrap()
+        .branch
+        .generation;
+    assert_eq!(
+        next_gen, 2,
+        "post-import counter must advance monotonically from the allocated fresh gen"
+    );
+}
+
+// =============================================================================
+// Archived → reopen → recreate path preserves tombstoning semantics
+// =============================================================================
+
+#[test]
+fn archived_branch_after_delete_and_reopen_allows_recreate() {
+    // Archive a branch, then delete it via the production path (delete
+    // uses `require_visible`, so Archived → Deleted is allowed), reopen,
+    // recreate under the same name: must allocate a strictly-greater
+    // generation, not reuse the archived instance's BranchRef.
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("layered").unwrap();
+    seed(&test_db.db, "layered");
+    let gen0 = test_db
+        .db
+        .branches()
+        .control_record("layered")
+        .unwrap()
+        .unwrap()
+        .branch;
+    archive_branch_for_test(&test_db.db, "layered");
+    test_db.db.branches().delete("layered").unwrap();
+
+    test_db.reopen();
+
+    test_db.db.branches().create("layered").unwrap();
+    let gen1 = test_db
+        .db
+        .branches()
+        .control_record("layered")
+        .unwrap()
+        .unwrap()
+        .branch;
+    assert_ne!(gen0, gen1, "post-reopen recreate must not reuse prior BranchRef");
+    assert_eq!(gen1.generation, 1);
+}

--- a/tests/integration/branching_lifecycle_restart.rs
+++ b/tests/integration/branching_lifecycle_restart.rs
@@ -62,7 +62,10 @@ fn archived_lifecycle_persists_across_reopen() {
         .expect("archived record persists across reopen");
     assert_eq!(rec.branch, archived_ref, "reopen preserves BranchRef");
     assert!(
-        matches!(rec.lifecycle, strata_core::branch::BranchLifecycleStatus::Archived),
+        matches!(
+            rec.lifecycle,
+            strata_core::branch::BranchLifecycleStatus::Archived
+        ),
         "reopen preserves Archived lifecycle"
     );
 }
@@ -136,7 +139,12 @@ fn post_reopen_archived_branch_is_still_deletable() {
         .delete("frozen")
         .expect("Archived branch must be deletable after reopen");
     assert!(
-        test_db.db.branches().control_record("frozen").unwrap().is_none(),
+        test_db
+            .db
+            .branches()
+            .control_record("frozen")
+            .unwrap()
+            .is_none(),
         "post-delete record is absent"
     );
 }
@@ -226,11 +234,7 @@ fn merge_base_does_not_surface_tombstoned_generation_after_reopen() {
 
     // The new feature@gen1 was created as a fresh root (no fork), so
     // it has no lineage relationship to main. Merge base MUST be None.
-    let mb = test_db
-        .db
-        .branches()
-        .merge_base("main", "feature")
-        .unwrap();
+    let mb = test_db.db.branches().merge_base("main", "feature").unwrap();
     assert!(
         mb.is_none(),
         "recreated branch without fork inherits no lineage — merge_base must be None, got {mb:?}"
@@ -324,7 +328,10 @@ fn bundle_import_after_reopen_preserves_fresh_generation() {
         .unwrap()
         .unwrap()
         .branch;
-    assert_eq!(after_import.generation, 1, "AD7: fresh gen ignores bundle's gen");
+    assert_eq!(
+        after_import.generation, 1,
+        "AD7: fresh gen ignores bundle's gen"
+    );
 
     // Reopen and assert the fresh generation persists, the bundle's
     // generation has not silently resurfaced, and a subsequent
@@ -391,6 +398,9 @@ fn archived_branch_after_delete_and_reopen_allows_recreate() {
         .unwrap()
         .unwrap()
         .branch;
-    assert_ne!(gen0, gen1, "post-reopen recreate must not reuse prior BranchRef");
+    assert_ne!(
+        gen0, gen1,
+        "post-reopen recreate must not reuse prior BranchRef"
+    );
     assert_eq!(gen1.generation, 1);
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -14,6 +14,8 @@ mod branching;
 mod branching_control_store_recovery;
 mod branching_generation_migration;
 mod branching_guardrails;
+mod branching_lifecycle_gate;
+mod branching_lifecycle_restart;
 mod branching_merge_lineage_edges;
 mod branching_recreate_state_machine;
 mod merge_base_characterization;


### PR DESCRIPTION
## Summary

- Locks uniform enforcement of the B4.1 lifecycle write gate across every `BranchService` mutation via a full 12 ops × 4 states matrix.
- Proves lifecycle persistence across reopen — Archived records, monotone generations, `next_generation` counter survival, and AD7 bundle-collision preservation.
- Test-only epic: no semantic changes to engine code. Two engine test hooks on `BranchService` are gated behind a new `test-support` cargo feature — production builds don't carry them.

## What ships

**`tests/integration/branching_lifecycle_gate.rs` (13 tests)** — matrix across 12 ops: `create`, `delete`, `fork`, `merge`, `revert`, `cherry_pick`, `cherry_pick_from_diff`, `tag`, `untag`, `add_note`, `delete_note`, `bundle::import_branch`. Each cell asserts:

- Correct typed error variant on `StrataError` enum discriminant (never on message text).
- No `BranchOpEvent` fires on reject paths.
- No lineage edge appends to the target's lifecycle instance on reject paths (checked by `BranchRef`, so tombstoned targets are covered too).
- No `_branch_dag` mutation on reject paths — canonical branch-node payload, legacy name-keyed branch-node payload, and total node/edge counts all frozen.
- Repeated refused calls (192 iterations) do not deadlock — gate runs before any lock acquisition (KD3).

Source × target cross-matrix for `fork` / `merge` / `cherry_pick` / `cherry_pick_from_diff`. `bundle_import_matrix` locks the KD1 duplicate rule: live `Active` or `Archived` record refuses import; `Deleted` target allocates fresh gen 1 (AD7); `Missing` target preserves bundle gen 0.

**`tests/integration/branching_lifecycle_restart.rs` (8 tests)** — reopen persistence:

- Archived record + lifecycle survives reopen; `BranchRef` preserved.
- Post-reopen Archived branch refuses writes on annotation (`tag`, `add_note`) and structural (`revert`) gate surfaces.
- Archived branch remains deletable after reopen (KD1 rationale).
- Same-name delete → reopen → recreate produces strictly monotone generations.
- `merge_base` on a recreated branch does not surface edges from the tombstoned generation.
- Bundle import onto a tombstoned target preserves the fresh-generation allocation across reopen.

**`tests/common/branching.rs`** — shared helpers: `archive_branch_for_test`, `set_lifecycle_for_test`, `CapturingBranchObserver`, `BranchSideEffectCheckpoint` (tracks observer count, lineage edges by BranchRef, `_branch_dag` branch nodes, and `_branch_dag` stats; panics loudly on capture errors rather than silently zeroing).

**`crates/engine/src/database/branch_service.rs`** — two test hooks behind `#[cfg(any(test, feature = "test-support"))]`:

- `set_lifecycle_for_test(name, status) -> BranchRef` — synthesizes `Archived` state no production path produces, via `BranchControlStore::put_record` inside a transaction.
- `lineage_edge_count_for_branch_ref_for_test(BranchRef) -> usize` — wraps `pub(crate) BranchControlStore::edges_for`. Keyed by `BranchRef` so tombstoned branches (whose active pointer is cleared) can still be probed.

Neither is on the D4 public API surface. Production builds (no `test-support` feature) do not compile these methods.

**`crates/engine/Cargo.toml`** — declares `test-support = []` feature. **Root `Cargo.toml`** — enables `test-support` on the engine dev-dep so integration tests see the hooks.

## Change class & assurance

- **Change class:** refactor-only (test additions + feature-gated test hooks; no production semantic changes).
- **Assurance class:** S2 (test-only epic). No benchmark required per `docs/design/branching/b4-phasing-plan.md` §B4.2.

## Scope compliance

Per `docs/design/branching/b4-phasing-plan.md` B4.2 "Done when":

- [x] Matrix covers 12 ops × 4 lifecycle states (with source × target where applicable); all cells pass.
- [x] Archived lifecycle persists across reopen and continues to gate writes.
- [x] Side-effect absence verified on every reject path (no observer, no lineage edge, no DAG node/edge change).

No production `pub` additions. No forbidden crate edges. Test-only symbols live behind `#[cfg(any(test, feature = "test-support"))]`.

## Test plan

- [x] `cargo check -p strata-engine` (no features) — clean
- [x] `cargo check -p strata-engine --features test-support` — clean
- [x] `cargo check --workspace` — clean
- [x] `cargo test -p stratadb --test integration branching_lifecycle` → 21 passed / 0 failed
- [x] `cargo test -p stratadb --test integration branching` → 161 passed / 0 failed (B1/B2/B3/B4.1 regressions + new B4.2)
- [x] `cargo test -p stratadb --test integration` → 213 passed / 0 failed / 4 ignored
- [x] `cargo test -p strata-engine --lib` → 1114 passed / 0 failed
- [x] `cargo clippy --workspace --all-targets` — no errors (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)