### PR TITLE
B4.3: bypass collapse — delete dead wrappers, tighten mutation helpers to pub(crate)

### DIFF
--- a/crates/engine/src/branch_ops/dag_hooks.rs
+++ b/crates/engine/src/branch_ops/dag_hooks.rs
@@ -70,18 +70,22 @@ pub type BranchCreateHook = fn(db: &Arc<Database>, branch: &str);
 /// historical lineage is preserved).
 pub type BranchDeleteHook = fn(db: &Arc<Database>, branch: &str);
 
-/// Hook fired when `branch_ops::fork_branch` (or its `_with_metadata`
-/// variant) succeeds. The implementation should create a `fork` event node
-/// and the parent → event → child edges, recording `fork_version`,
-/// `message`, and `creator`.
+/// Hook fired when
+/// `BranchService::fork` / `BranchService::fork_with_options` succeeds.
+/// Internally this is dispatched from the crate-private
+/// `branch_ops::fork_branch_with_metadata` helper. The implementation
+/// should create a `fork` event node and the parent → event → child
+/// edges, recording `fork_version`, `message`, and `creator`.
 pub type BranchForkHook =
     fn(db: &Arc<Database>, info: &ForkInfo, message: Option<&str>, creator: Option<&str>);
 
-/// Hook fired when `branch_ops::merge_branches` (or its `_with_metadata`
-/// variant) succeeds. The implementation should create a `merge` event node
-/// and the source → event → target edges, recording `merge_version`,
-/// `keys_applied`, `spaces_merged`, the conflict count, the strategy,
-/// `message`, and `creator`.
+/// Hook fired when
+/// `BranchService::merge` / `BranchService::merge_with_options`
+/// succeeds. Internally this is dispatched from the crate-private
+/// `branch_ops::merge_branches_with_metadata` helper. The implementation
+/// should create a `merge` event node and the source → event → target
+/// edges, recording `merge_version`, `keys_applied`, `spaces_merged`,
+/// the conflict count, the strategy, `message`, and `creator`.
 pub type BranchMergeHook = fn(
     db: &Arc<Database>,
     info: &MergeInfo,
@@ -90,18 +94,23 @@ pub type BranchMergeHook = fn(
     creator: Option<&str>,
 );
 
-/// Hook fired when `branch_ops::revert_version_range` (or its `_with_metadata`
-/// variant) succeeds. The implementation should create a `revert` event node
-/// linked from the affected branch, recording `from_version`, `to_version`,
+/// Hook fired when `BranchService::revert` succeeds. Internally this is
+/// dispatched from the crate-private
+/// `branch_ops::revert_version_range_with_metadata` helper. The
+/// implementation should create a `revert` event node linked from the
+/// affected branch, recording `from_version`, `to_version`,
 /// `revert_version`, `keys_reverted`, `message`, and `creator`.
 pub type BranchRevertHook =
     fn(db: &Arc<Database>, info: &RevertInfo, message: Option<&str>, creator: Option<&str>);
 
-/// Hook fired when `branch_ops::cherry_pick_from_diff` or `cherry_pick_keys`
-/// succeeds. The implementation should create a `cherry_pick` event node and
-/// source → event → target edges, recording `keys_applied`, `keys_deleted`,
-/// and `cherry_pick_version`. Cherry-picks are auditable as a distinct event
-/// type from merges because they apply only a filtered subset of the diff.
+/// Hook fired when `BranchService::cherry_pick` or
+/// `BranchService::cherry_pick_from_diff` succeeds. Internally this is
+/// dispatched from the crate-private `branch_ops::cherry_pick_from_diff`
+/// or `branch_ops::cherry_pick_keys` helper. The implementation should
+/// create a `cherry_pick` event node and source → event → target edges,
+/// recording `keys_applied`, `keys_deleted`, and `cherry_pick_version`.
+/// Cherry-picks are auditable as a distinct event type from merges
+/// because they apply only a filtered subset of the diff.
 pub type BranchCherryPickHook =
     fn(db: &Arc<Database>, source: &str, target: &str, info: &CherryPickInfo);
 
@@ -114,13 +123,18 @@ pub struct BranchDagHooks {
     pub on_create: BranchCreateHook,
     /// Fired by `BranchIndex::delete_branch`.
     pub on_delete: BranchDeleteHook,
-    /// Fired by `branch_ops::fork_branch` (and the `_with_metadata` variant).
+    /// Fired by `BranchService::fork` via the crate-private
+    /// `branch_ops::fork_branch_with_metadata` helper.
     pub on_fork: BranchForkHook,
-    /// Fired by `branch_ops::merge_branches` (and the `_with_metadata` variant).
+    /// Fired by `BranchService::merge` via the crate-private
+    /// `branch_ops::merge_branches_with_metadata` helper.
     pub on_merge: BranchMergeHook,
-    /// Fired by `branch_ops::revert_version_range` (and the `_with_metadata` variant).
+    /// Fired by `BranchService::revert` via the crate-private
+    /// `branch_ops::revert_version_range_with_metadata` helper.
     pub on_revert: BranchRevertHook,
-    /// Fired by `branch_ops::cherry_pick_from_diff` and `cherry_pick_keys`.
+    /// Fired by `BranchService::cherry_pick` /
+    /// `BranchService::cherry_pick_from_diff` via the crate-private
+    /// `branch_ops::cherry_pick_from_diff` and `cherry_pick_keys` helpers.
     pub on_cherry_pick: BranchCherryPickHook,
 }
 

--- a/crates/engine/src/branch_ops/mod.rs
+++ b/crates/engine/src/branch_ops/mod.rs
@@ -751,7 +751,8 @@ fn resolve_and_verify(db: &Arc<Database>, name: &str) -> StrataResult<BranchId> 
 // Fork
 // =============================================================================
 
-/// Fork a branch via O(1) COW (copy-on-write).
+/// Fork a branch via O(1) COW (copy-on-write), recording `message` and
+/// `creator` on the resulting branch DAG fork event.
 ///
 /// Creates a new branch with `destination` name and shares the source's
 /// segments via inherited layers. No data is copied — writes to the
@@ -760,30 +761,6 @@ fn resolve_and_verify(db: &Arc<Database>, name: &str) -> StrataResult<BranchId> 
 /// Requires a disk-backed database. Ephemeral (in-memory) databases
 /// return an error.
 ///
-/// # Errors
-///
-/// - Source branch does not exist
-/// - Destination branch already exists
-/// - Database is ephemeral (no segments directory)
-///
-/// # See also
-///
-/// [`fork_branch_with_metadata`] — same operation but accepts an optional
-/// human-readable message and creator that flow into the branch DAG event
-/// for audit / lineage queries.
-pub fn fork_branch(db: &Arc<Database>, source: &str, destination: &str) -> StrataResult<ForkInfo> {
-    let dest_gen = resolve_fork_generation(db, destination)?;
-    fork_branch_with_metadata(db, source, destination, None, None, dest_gen)
-}
-
-/// Same as [`fork_branch`] but records `message` and `creator` on the
-/// resulting branch DAG fork event.
-///
-/// The executor's `branch_fork` handler calls this variant so that
-/// user-supplied audit metadata (`fork_with_options(message, creator)`)
-/// flows through to the DAG. Engine-direct callers (tests, internal
-/// subsystems) typically use the no-metadata [`fork_branch`] wrapper.
-///
 /// `dest_gen` is preallocated by the caller (see
 /// [`resolve_fork_generation`]). The source `BranchRef` is resolved
 /// inside fork's quiesce guard so the control-store fork anchor points
@@ -791,7 +768,17 @@ pub fn fork_branch(db: &Arc<Database>, source: &str, destination: &str) -> Strat
 /// forked. Storage-fork-first ordering is preserved: the storage fork
 /// commits before the KV txn, so a crash between them leaves harmless
 /// orphan storage (refcounts rebuild from manifests on recovery).
-pub fn fork_branch_with_metadata(
+///
+/// Canonical entry point: [`crate::database::BranchService::fork`] /
+/// [`crate::database::BranchService::fork_with_options`]. This helper is
+/// `pub(crate)` and must not be called from outside the engine crate.
+///
+/// # Errors
+///
+/// - Source branch does not exist
+/// - Destination branch already exists
+/// - Database is ephemeral (no segments directory)
+pub(crate) fn fork_branch_with_metadata(
     db: &Arc<Database>,
     source: &str,
     destination: &str,
@@ -2004,10 +1991,11 @@ fn reload_secondary_backends(db: &Arc<Database>, target_id: BranchId, source_id:
 }
 
 // =============================================================================
-// Merge (public entry point)
+// Merge
 // =============================================================================
 
-/// Merge data from source branch into target branch using three-way merge.
+/// Merge data from source branch into target branch using three-way merge,
+/// recording `message` and `creator` on the resulting branch DAG merge event.
 ///
 /// Computes the common ancestor (merge base) from the fork/merge relationship
 /// between the branches, then classifies each key using a 14-case decision matrix.
@@ -2016,31 +2004,16 @@ fn reload_secondary_backends(db: &Arc<Database>, target_id: BranchId, source_id:
 /// B3.3: merge base comes from [`BranchControlStore::find_merge_base`] — no
 /// caller-supplied override.
 ///
+/// Canonical entry point: [`crate::database::BranchService::merge`] /
+/// [`crate::database::BranchService::merge_with_options`]. This helper is
+/// `pub(crate)` and must not be called from outside the engine crate.
+///
 /// # Errors
 ///
 /// - Either branch does not exist
 /// - No fork or merge relationship between branches
 /// - `Strict` strategy with conflicts
-///
-/// # See also
-///
-/// [`merge_branches_with_metadata`] — same operation but accepts an optional
-/// human-readable message and creator that flow into the branch DAG event.
-pub fn merge_branches(
-    db: &Arc<Database>,
-    source: &str,
-    target: &str,
-    strategy: MergeStrategy,
-) -> StrataResult<MergeInfo> {
-    merge_branches_with_metadata(db, source, target, strategy, None, None)
-}
-
-/// Same as [`merge_branches`] but records `message` and `creator` on the
-/// resulting branch DAG merge event.
-///
-/// The executor's `branch_merge` handler calls this variant so that
-/// user-supplied audit metadata flows through to the DAG.
-pub fn merge_branches_with_metadata(
+pub(crate) fn merge_branches_with_metadata(
     db: &Arc<Database>,
     source: &str,
     target: &str,
@@ -2626,11 +2599,15 @@ pub struct TagInfo {
 ///
 /// If `version` is `None`, tags the current database version.
 ///
+/// Canonical entry point: [`crate::database::BranchService::tag`]. This
+/// helper is `pub(crate)` and must not be called from outside the engine
+/// crate.
+///
 /// # Errors
 ///
 /// - Branch does not exist
 /// - Serialization failure (internal)
-pub fn create_tag(
+pub(crate) fn create_tag(
     db: &Arc<Database>,
     branch: &str,
     name: &str,
@@ -2701,7 +2678,11 @@ pub(crate) fn create_tag_with_expected(
 /// Delete a tag.
 ///
 /// Returns `true` if the tag existed and was deleted.
-pub fn delete_tag(db: &Arc<Database>, branch: &str, name: &str) -> StrataResult<bool> {
+///
+/// Canonical entry point: [`crate::database::BranchService::untag`]. This
+/// helper is `pub(crate)` and must not be called from outside the engine
+/// crate.
+pub(crate) fn delete_tag(db: &Arc<Database>, branch: &str, name: &str) -> StrataResult<bool> {
     delete_tag_with_expected(db, branch, name, None)
 }
 
@@ -2808,11 +2789,15 @@ pub struct NoteInfo {
 
 /// Add a note to a specific version of a branch.
 ///
+/// Canonical entry point: [`crate::database::BranchService::add_note`].
+/// This helper is `pub(crate)` and must not be called from outside the
+/// engine crate.
+///
 /// # Errors
 ///
 /// - Branch does not exist
 /// - Serialization failure (internal)
-pub fn add_note(
+pub(crate) fn add_note(
     db: &Arc<Database>,
     branch: &str,
     version: CommitVersion,
@@ -2908,7 +2893,15 @@ pub fn get_notes(
 /// Delete a note at a specific version.
 ///
 /// Returns `true` if the note existed and was deleted.
-pub fn delete_note(db: &Arc<Database>, branch: &str, version: CommitVersion) -> StrataResult<bool> {
+///
+/// Canonical entry point: [`crate::database::BranchService::delete_note`].
+/// This helper is `pub(crate)` and must not be called from outside the
+/// engine crate.
+pub(crate) fn delete_note(
+    db: &Arc<Database>,
+    branch: &str,
+    version: CommitVersion,
+) -> StrataResult<bool> {
     delete_note_with_expected(db, branch, version, None)
 }
 
@@ -2964,30 +2957,18 @@ pub struct RevertInfo {
     pub revert_version: Option<CommitVersion>,
 }
 
-/// Revert a version range on a branch.
+/// Revert a version range on a branch, recording `message` and `creator`
+/// on the resulting branch DAG revert event.
 ///
 /// For each key modified in [from_version, to_version], restores its value
 /// to what it was at (from_version - 1). Only reverts keys whose current
 /// value matches the state at to_version — keys modified after to_version
 /// are left untouched (preserving subsequent work).
 ///
-/// # See also
-///
-/// [`revert_version_range_with_metadata`] — same operation but accepts an
-/// optional human-readable message and creator that flow into the branch
-/// DAG revert event.
-pub fn revert_version_range(
-    db: &Arc<Database>,
-    branch: &str,
-    from_version: CommitVersion,
-    to_version: CommitVersion,
-) -> StrataResult<RevertInfo> {
-    revert_version_range_with_metadata(db, branch, from_version, to_version, None, None)
-}
-
-/// Same as [`revert_version_range`] but records `message` and `creator`
-/// on the resulting branch DAG revert event.
-pub fn revert_version_range_with_metadata(
+/// Canonical entry point: [`crate::database::BranchService::revert`]. This
+/// helper is `pub(crate)` and must not be called from outside the engine
+/// crate.
+pub(crate) fn revert_version_range_with_metadata(
     db: &Arc<Database>,
     branch: &str,
     from_version: CommitVersion,
@@ -3164,7 +3145,11 @@ pub struct CherryPickFilter {
 ///
 /// Reads the current value of each specified key from source and writes
 /// it to target in a single transaction.
-pub fn cherry_pick_keys(
+///
+/// Canonical entry point:
+/// [`crate::database::BranchService::cherry_pick`]. This helper is
+/// `pub(crate)` and must not be called from outside the engine crate.
+pub(crate) fn cherry_pick_keys(
     db: &Arc<Database>,
     source: &str,
     target: &str,
@@ -3355,7 +3340,11 @@ fn check_graph_action_atomicity(
 ///
 /// B3.3: merge base comes from [`BranchControlStore::find_merge_base`] —
 /// no caller-supplied override.
-pub fn cherry_pick_from_diff(
+///
+/// Canonical entry point:
+/// [`crate::database::BranchService::cherry_pick_from_diff`]. This helper
+/// is `pub(crate)` and must not be called from outside the engine crate.
+pub(crate) fn cherry_pick_from_diff(
     db: &Arc<Database>,
     source: &str,
     target: &str,
@@ -3643,6 +3632,34 @@ mod tests {
         // from the control store after B3.3.
         db.branches().create(name).unwrap();
         (temp_dir, db)
+    }
+
+    // Test-only low-level helpers. B4.3 deleted the public no-metadata
+    // `fork_branch` / `merge_branches` / `revert_version_range` wrappers
+    // from the module surface; the characterization tests below exercise
+    // the underlying `_with_metadata` helpers directly, so we re-introduce
+    // the convenience wrappers here scoped to the test module.
+    fn fork_branch(db: &Arc<Database>, source: &str, destination: &str) -> StrataResult<ForkInfo> {
+        let dest_gen = resolve_fork_generation(db, destination)?;
+        fork_branch_with_metadata(db, source, destination, None, None, dest_gen)
+    }
+
+    fn merge_branches(
+        db: &Arc<Database>,
+        source: &str,
+        target: &str,
+        strategy: MergeStrategy,
+    ) -> StrataResult<MergeInfo> {
+        merge_branches_with_metadata(db, source, target, strategy, None, None)
+    }
+
+    fn revert_version_range(
+        db: &Arc<Database>,
+        branch: &str,
+        from_version: CommitVersion,
+        to_version: CommitVersion,
+    ) -> StrataResult<RevertInfo> {
+        revert_version_range_with_metadata(db, branch, from_version, to_version, None, None)
     }
 
     fn write_kv(db: &Arc<Database>, branch: &str, space: &str, key: &str, value: Value) {

--- a/tests/integration/branching_guardrails.rs
+++ b/tests/integration/branching_guardrails.rs
@@ -430,6 +430,24 @@ const BRANCH_OPS_PUB_FN_ALLOWLIST: &[&str] = &[
     "resolve_tag",
 ];
 
+/// Low-level branch mutation helpers that must never be re-exposed on the
+/// engine crate's public surface. B4.3 tightens these to `pub(crate)` and
+/// routes external callers through `BranchService`.
+const FORBIDDEN_BRANCH_OPS_EXPORT_NAMES: &[&str] = &[
+    "fork_branch",
+    "fork_branch_with_metadata",
+    "merge_branches",
+    "merge_branches_with_metadata",
+    "revert_version_range",
+    "revert_version_range_with_metadata",
+    "cherry_pick_keys",
+    "cherry_pick_from_diff",
+    "create_tag",
+    "delete_tag",
+    "add_note",
+    "delete_note",
+];
+
 fn branch_ops_mod_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("crates")
@@ -437,6 +455,14 @@ fn branch_ops_mod_path() -> PathBuf {
         .join("src")
         .join("branch_ops")
         .join("mod.rs")
+}
+
+fn engine_lib_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("crates")
+        .join("engine")
+        .join("src")
+        .join("lib.rs")
 }
 
 /// Extract the identifier after `pub fn ` on a code line, if any. Returns
@@ -493,6 +519,57 @@ fn branch_ops_pub_mutation_surface_is_empty() {
              tests/integration/branching_guardrails.rs.\n\
              Otherwise move the callers to BranchService and tighten the\n\
              helper to `pub(crate)`."
+        );
+    }
+}
+
+/// B4.3 re-export audit. The crate root may still re-export branch-op types
+/// such as `ForkInfo` or `MergeInfo`, but it must not re-expose the low-level
+/// mutation helpers themselves. This complements the `pub fn` scan above by
+/// catching `pub use branch_ops::...` regressions at the engine crate root.
+#[test]
+fn branch_ops_mutators_are_not_reexported_at_crate_root() {
+    let path = engine_lib_path();
+    let src = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+    let mut in_block_comment = false;
+    let mut in_branch_ops_reexport = false;
+    let mut violations: Vec<String> = Vec::new();
+
+    for (lineno, line) in src.lines().enumerate() {
+        let Some(code) = strip_comments_from_line(line, &mut in_block_comment) else {
+            continue;
+        };
+
+        if code.contains("pub use branch_ops") {
+            in_branch_ops_reexport = true;
+        }
+
+        if !in_branch_ops_reexport {
+            continue;
+        }
+
+        for name in FORBIDDEN_BRANCH_OPS_EXPORT_NAMES {
+            if code.contains(name) {
+                violations.push(format!(
+                    "  {}:{}: crate root re-exports forbidden branch_ops helper `{name}`",
+                    path.display(),
+                    lineno + 1,
+                ));
+            }
+        }
+
+        if code.contains(';') {
+            in_branch_ops_reexport = false;
+        }
+    }
+
+    if !violations.is_empty() {
+        let joined = violations.join("\n");
+        panic!(
+            "B4.3 tripwire: forbidden branch_ops helper re-export at crate root:\n\n\
+             {joined}\n\n\
+             Remove the public re-export or route callers through BranchService."
         );
     }
 }

--- a/tests/integration/branching_guardrails.rs
+++ b/tests/integration/branching_guardrails.rs
@@ -409,3 +409,108 @@ fn strip_comments_ignores_comment_only_occurrences() {
     );
     assert!(!in_block);
 }
+
+// =============================================================================
+// B4.3 tripwire: branch_ops low-level mutation surface is empty
+// =============================================================================
+
+/// Known `pub fn` items in `crates/engine/src/branch_ops/mod.rs` that are
+/// deliberately left on the public surface. Read-only diff / merge-base /
+/// annotation query helpers plus storage-maintenance (`materialize_branch`)
+/// are the full allow-list. Every other `pub fn` in that file must go
+/// through `BranchService`.
+const BRANCH_OPS_PUB_FN_ALLOWLIST: &[&str] = &[
+    "diff_branches",
+    "diff_branches_with_options",
+    "diff_three_way",
+    "get_merge_base",
+    "get_notes",
+    "list_tags",
+    "materialize_branch",
+    "resolve_tag",
+];
+
+fn branch_ops_mod_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("crates")
+        .join("engine")
+        .join("src")
+        .join("branch_ops")
+        .join("mod.rs")
+}
+
+/// Extract the identifier after `pub fn ` on a code line, if any. Returns
+/// `None` for non-matching lines or lines that are inside a comment (those
+/// are already stripped by `strip_comments_from_line`).
+fn parse_pub_fn_name(code: &str) -> Option<&str> {
+    let after = code.strip_prefix("pub fn ")?;
+    let end = after
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .unwrap_or(after.len());
+    if end == 0 {
+        None
+    } else {
+        Some(&after[..end])
+    }
+}
+
+/// B4.3 tripwire. After bypass collapse, every `pub fn` in
+/// `crates/engine/src/branch_ops/mod.rs` must either be a declared
+/// read-only helper on the allow-list or be tightened to `pub(crate)`.
+/// Any new unlisted `pub fn` is a regression — either move the callsite
+/// to `BranchService` or bump the allow-list with justification.
+#[test]
+fn branch_ops_pub_mutation_surface_is_empty() {
+    let path = branch_ops_mod_path();
+    let src = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+    let mut in_block_comment = false;
+    let mut violations: Vec<String> = Vec::new();
+
+    for (lineno, line) in src.lines().enumerate() {
+        let Some(code) = strip_comments_from_line(line, &mut in_block_comment) else {
+            continue;
+        };
+        let Some(name) = parse_pub_fn_name(code) else {
+            continue;
+        };
+        if !BRANCH_OPS_PUB_FN_ALLOWLIST.contains(&name) {
+            violations.push(format!(
+                "  {}:{}: `pub fn {name}` is not on the branch_ops allow-list",
+                path.display(),
+                lineno + 1,
+            ));
+        }
+    }
+
+    if !violations.is_empty() {
+        let joined = violations.join("\n");
+        panic!(
+            "B4.3 tripwire: unlisted public mutation surface in branch_ops/mod.rs:\n\n\
+             {joined}\n\n\
+             If this is a new read-only helper, add its name to\n\
+             `BRANCH_OPS_PUB_FN_ALLOWLIST` in\n\
+             tests/integration/branching_guardrails.rs.\n\
+             Otherwise move the callers to BranchService and tighten the\n\
+             helper to `pub(crate)`."
+        );
+    }
+}
+
+#[test]
+fn parse_pub_fn_name_extracts_identifier() {
+    assert_eq!(
+        parse_pub_fn_name("pub fn diff_branches("),
+        Some("diff_branches")
+    );
+    assert_eq!(
+        parse_pub_fn_name("pub fn materialize_branch(db: &Arc<Database>) {"),
+        Some("materialize_branch")
+    );
+    assert_eq!(
+        parse_pub_fn_name("pub(crate) fn fork_branch_with_metadata"),
+        None
+    );
+    assert_eq!(parse_pub_fn_name("fn private_helper()"), None);
+    assert_eq!(parse_pub_fn_name("pub fn "), None);
+}


### PR DESCRIPTION
## Summary

B4.3 of the branching truth sprint (`docs/design/branching/b4-phasing-plan.md`). Closes the remaining low-level bypass surface on `branch_ops::*` so every branch mutation routes through `BranchService` and the B4.1 lifecycle gate.

- **Delete 3 unused `pub fn` wrappers** from `crates/engine/src/branch_ops/mod.rs`: `fork_branch`, `merge_branches`, `revert_version_range`. Each delegated to its `_with_metadata` sibling with `None, None` defaults; zero production callers.
- **Tighten 9 mutation helpers to `pub(crate) fn`**: `fork_branch_with_metadata`, `merge_branches_with_metadata`, `revert_version_range_with_metadata`, `cherry_pick_keys`, `cherry_pick_from_diff`, `create_tag`, `delete_tag`, `add_note`, `delete_note`. Read-only helpers (`diff_*`, `get_merge_base`, `list_tags`, `resolve_tag`, `get_notes`, `materialize_branch`) stay `pub`.
- **Re-introduce the three deleted wrappers as `#[cfg(test)]` module-scoped helpers** so in-file characterization tests keep exercising the lower-level helpers directly without re-exposing the public surface.
- **Append `branch_ops_pub_mutation_surface_is_empty` tripwire** to `tests/integration/branching_guardrails.rs`. The test parses every `pub fn` in `branch_ops/mod.rs` and fails if any name is not on the explicit read-only allow-list.

## Change class / assurance

- Change class: **refactor-only** — visibility tightening and dead-code deletion; no behavior, storage format, or public semantic changes. The `pub fn` symbols affected had no callers outside the engine crate (`branch_ops` module itself is declared `mod branch_ops;`, not `pub mod`, in `crates/engine/src/lib.rs`).
- Assurance class: **S2** — visibility + module structure. No new public API; D4 surface strictly narrows.
- Locked decisions preserved (`b4-phasing-plan.md` §Done when): no public low-level mutation helper bypasses `BranchService`; tripwire pins the state; existing callers compile unchanged.

## Files changed

- `crates/engine/src/branch_ops/mod.rs`
- `tests/integration/branching_guardrails.rs`

No `Cargo.toml` changes.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --check`
- [x] `cargo test -p strata-engine --lib` (1114/1114 pass)
- [x] `cargo test -p stratadb --test integration -- branching` (163/163 pass)
- [x] `cargo test -p stratadb --test integration -- branching_guardrails` (7/7 pass incl. new tripwire)
- [x] `cargo test -p stratadb --test engine` (284/284 pass)
- [x] `cargo run --release -p strata-benchmarks --bin regression -- --quick --tranche 4 --epic B4.3` (ran; no repo baseline to diff; visibility-only change, no codegen delta expected on monomorphized paths)

## Sequencing

Per `b4-phasing-plan.md`: B4.1 (#2452) and B4.2 (#2453) already merged on `main`. B4.3 is independently mergeable. B4.4 (same-name serialization hardening) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)