### PR TITLE
B5.1: retention contract — vocabulary, annotations, quarantine.manifest format pinned

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,12 @@ Planning:
 - `docs/design/architecture-cleanup/master-execution-plan-framework.md`
 - `docs/design/post-cleanup/post-cleanup-closeout-framework.md`
 
+Branching tranche (B5 retention / GC corpus — normative for B5.1+):
+- `docs/design/branching/branching-gc/b5-phasing-plan.md`
+- `docs/design/branching/branching-gc/branching-retention-contract.md`
+- `docs/design/branching/branching-gc/branching-b5-verification-spec.md`
+- `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+
 ---
 
 ## Active Tranche

--- a/crates/engine/src/branch_retention/mod.rs
+++ b/crates/engine/src/branch_retention/mod.rs
@@ -1,0 +1,189 @@
+//! B5.1 — Branch retention contract vocabulary.
+//!
+//! This module is the engine-side citation surface for the normative
+//! retention contract at
+//! `docs/design/branching/branching-gc/branching-retention-contract.md`.
+//!
+//! Doc comments on retention code paths cite contract sections by
+//! type name in plain backticks (e.g. `` `BarrierKind::PhysicalRetention` ``,
+//! `` `ConvergenceClass::StagedPublish` ``) so the citation survives
+//! contract paragraph renumbering. The types themselves are
+//! `pub(crate)` — B5.1 is annotation-only and does not expand the
+//! public engine surface. Bracketed rustdoc links (`[...]`) are
+//! intentionally avoided: cross-crate links to `pub(crate)` items
+//! cannot resolve, and same-crate `pub` → `pub(crate)` links emit a
+//! privacy-escape rustdoc warning.
+//!
+//! When a future B5.2+ phase needs to *match* on these vocabulary
+//! values at runtime (e.g. to classify a `RetentionBlocker` for
+//! `Database::retention_report()`), additional variants and
+//! supporting types land here. The B5.1 set is the minimum needed to
+//! make annotation citations resolve to symbols.
+//!
+//! ## Contract sections referenced
+//!
+//! - §"Barrier model" — barrier categories.
+//! - §"Authoritative and non-authoritative state" — accelerator role.
+//! - §"Reclaim protocol" — quarantine-based reclaim.
+//! - §"Recovery rebuild protocol" — runtime accelerator rebuild on
+//!   reopen.
+//! - §"Engine-facing attribution contract" — branch-vocabulary
+//!   reporting.
+//! - Convergence/observability doc §"Convergence classes" —
+//!   per-surface convergence labels.
+
+#![allow(dead_code)]
+
+/// What a retention state element *means* for branch-visible reads
+/// and physical reclamation.
+///
+/// Maps onto the retention contract's §"Barrier model". Doc comments
+/// on retention code paths cite this enum to make their barrier role
+/// legible without naming a paragraph number.
+///
+/// See `docs/design/branching/branching-gc/branching-retention-contract.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BarrierKind {
+    /// Logical visibility barrier — a tombstone or a TTL-expired head
+    /// version. Affects what reads see; does not by itself prove file
+    /// reclaimability.
+    LogicalVisibility,
+
+    /// Persisted fork-frontier barrier — `fork_version` plus the
+    /// inherited-layer manifest entries that bound descendant
+    /// visibility. Both shapes branch-visible reads *and* keeps
+    /// shared bytes reachable.
+    ForkFrontier,
+
+    /// Physical retention barrier — own-segment manifest entries and
+    /// inherited-layer manifest segment lists. The direct file-level
+    /// reasons a segment remains live.
+    PhysicalRetention,
+
+    /// Runtime acceleration barrier — `SegmentRefRegistry` and any
+    /// future in-memory per-segment refcount index. Accelerates
+    /// candidate identification; never the durable ledger.
+    RuntimeAccelerator,
+
+    /// Recovery health gate — blocks reclaim under degraded recovery.
+    /// Does not change branch-visible read meaning.
+    RecoveryHealthGate,
+}
+
+/// What role a `BranchRef` (or, in storage-local code, a branch
+/// identity by ID) plays in a reclaim reachability walk.
+///
+/// Maps onto the retention contract's reclaimability rule and the
+/// reclaim protocol's candidate-vs-proven-orphan distinction.
+///
+/// B5.1 ships this enum so doc comments on storage-side reachability
+/// walks can cite the role they consider. Production code that
+/// matches on these variants lands in B5.2 with the
+/// `retention_report()` and reclaim implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReachabilityRole {
+    /// Live lifecycle instance — contributes own + inherited
+    /// manifest references to the reachability set.
+    Live,
+
+    /// Tombstoned, but at least one descendant's inherited-layer
+    /// manifest still references segments this branch originally
+    /// produced. The lifecycle record is gone; the segments survive
+    /// until every descendant releases them.
+    DescendantPinned,
+
+    /// Tombstoned and unreferenced by any descendant inherited
+    /// layer. Segments may become reclaim candidates pending the
+    /// reclaim protocol's manifest proof and quarantine steps.
+    Reclaimable,
+}
+
+/// Convergence class for a branch-visible derived surface.
+///
+/// Maps onto §"Convergence classes" in
+/// `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`.
+/// Every B5-relevant derived surface is labeled with exactly one
+/// class. B5.1 ships this enum so the convergence audit's surface
+/// matrix and the staged-publish refresh paths can cite their
+/// convergence contract by symbol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConvergenceClass {
+    /// Surface converges as part of primary storage truth itself
+    /// (e.g. JSON `_idx/...` rows committed as ordinary KV writes).
+    /// No separate refresh contract; ordinary storage commit/replay
+    /// semantics carry the convergence.
+    StorageCoupled,
+
+    /// Derived surface whose follower visibility is staged behind
+    /// the same publish barrier as the underlying storage version
+    /// (e.g. search refresh, vector refresh, graph-search refresh).
+    /// Hook failure blocks or clamps publication rather than leaking
+    /// partial derived state.
+    StagedPublish,
+
+    /// Surface may lag in-session on documented paths; reopen
+    /// rebuilds or reconciles it to branch-visible truth (e.g.
+    /// search and vector on-disk caches). Allowed only when the lag
+    /// is documented, the stale result is not silently stronger than
+    /// current truth, and reopen healing is real and tested.
+    ReopenHealed,
+
+    /// Surface does not participate in correctness decisions
+    /// (e.g. `BranchStatusCache` post-B5.3). May lag or be missing
+    /// without affecting branch-visible reads or write safety.
+    AdvisoryOnly,
+
+    /// Surface must return a typed error rather than serve stale or
+    /// invalid data when it cannot be trusted (e.g. vector
+    /// config-mismatch path, JSON `_idx` load failure,
+    /// `retention_report()` under degraded manifest truth).
+    HardFailDegraded,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compile-time tripwire: every variant of every B5.1 vocabulary
+    /// enum must be matched here. If a future PR adds a variant
+    /// without updating this match, the build fails with a
+    /// non-exhaustive-pattern error — forcing the contract reviewer
+    /// to confirm the new variant lands in the contract document
+    /// and that downstream annotations are aware of it.
+    ///
+    /// This is the entire test surface for an annotation-only module.
+    /// Behavior tests for variant *consumption* (e.g. matching on
+    /// `RetentionBlocker` in `retention_report()`) land with B5.2.
+    #[test]
+    fn vocabulary_variants_are_pinned_to_contract() {
+        fn check_barrier(b: BarrierKind) {
+            match b {
+                BarrierKind::LogicalVisibility
+                | BarrierKind::ForkFrontier
+                | BarrierKind::PhysicalRetention
+                | BarrierKind::RuntimeAccelerator
+                | BarrierKind::RecoveryHealthGate => {}
+            }
+        }
+        fn check_role(r: ReachabilityRole) {
+            match r {
+                ReachabilityRole::Live
+                | ReachabilityRole::DescendantPinned
+                | ReachabilityRole::Reclaimable => {}
+            }
+        }
+        fn check_class(c: ConvergenceClass) {
+            match c {
+                ConvergenceClass::StorageCoupled
+                | ConvergenceClass::StagedPublish
+                | ConvergenceClass::ReopenHealed
+                | ConvergenceClass::AdvisoryOnly
+                | ConvergenceClass::HardFailDegraded => {}
+            }
+        }
+        // Touch each helper so dead-code lint doesn't elide it.
+        check_barrier(BarrierKind::LogicalVisibility);
+        check_role(ReachabilityRole::Live);
+        check_class(ConvergenceClass::StorageCoupled);
+    }
+}

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -400,6 +400,22 @@ impl Database {
     /// - `applied_watermark` is always truthful
     /// - Secondary indexes never silently fall behind
     /// - Operators can diagnose and skip blocked records explicitly
+    ///
+    /// ## B5.1 retention contract
+    ///
+    /// This is the staged-publication spine for branch-visible
+    /// derived state per
+    /// `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+    /// §"Convergence classes" / "Staged-publish". Search, vector,
+    /// and graph-search refresh hooks classify as
+    /// `ConvergenceClass::StagedPublish` (see
+    /// `branch_retention` crate-internal vocabulary): they validate
+    /// and stage updates, block publication on hook
+    /// failure, and advance visibility together with the underlying
+    /// branch-visible storage version. The "block on any failure"
+    /// rule above is the contract guarantee that no follower-visible
+    /// publication occurs before the underlying branch version is
+    /// visible.
     pub fn refresh(&self) -> RefreshOutcome {
         if !self.follower || self.persistence_mode == PersistenceMode::Ephemeral {
             return RefreshOutcome::CaughtUp {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -59,6 +59,7 @@ pub use transaction::{ScopedTransaction, Transaction, TransactionPool, MAX_POOL_
 pub use transaction_ops::TransactionOps;
 
 mod branch_ops;
+pub(crate) mod branch_retention;
 pub mod bundle;
 pub mod primitives;
 pub mod recipe_store;

--- a/crates/storage/src/manifest.rs
+++ b/crates/storage/src/manifest.rs
@@ -47,6 +47,19 @@ pub struct ManifestEntry {
 }
 
 /// An inherited layer entry in the manifest (COW branching).
+///
+/// ## B5.1 retention contract
+///
+/// One of the two durable retention barriers per
+/// `docs/design/branching/branching-gc/branching-retention-contract.md`
+/// §"Fork-frontier semantics" + §"Authoritative for reclaim
+/// safety". Encodes `BarrierKind::ForkFrontier`
+/// (`fork_version`-bounded descendant visibility) and
+/// `BarrierKind::PhysicalRetention` (the segment list keeps shared
+/// bytes reachable). Reclaim's manifest-proof step (Stage 2) walks
+/// these entries; recovery rebuilds runtime accelerator state from
+/// them. Per Invariant 3, this is one of the two durable liveness
+/// proofs — runtime caches never replace it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ManifestInheritedLayer {
     /// Branch ID of the source (parent) branch.

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -962,6 +962,17 @@ impl SegmentedStore {
     /// public `recovery_health()` accessor. The returned `Arc` is a snapshot
     /// — subsequent recovery calls replace the stored value but do not
     /// invalidate this handle.
+    ///
+    /// ## B5.1 retention contract
+    ///
+    /// Surfaces the §"Recovery-health contract" classification of
+    /// `docs/design/branching/branching-gc/branching-retention-contract.md`.
+    /// This is the `BarrierKind::RecoveryHealthGate` value the
+    /// reclaim path consults: `Healthy` and
+    /// `Degraded { class: Telemetry, .. }` permit reclaim;
+    /// `DataLoss` and `PolicyDowngrade` block reclaim per Invariant
+    /// 5 + KD8. Promoted from storage-local behavior to branch-layer
+    /// contract — non-negotiable.
     pub fn last_recovery_health(&self) -> Arc<RecoveryHealth> {
         self.last_recovery_health.load_full()
     }
@@ -1391,6 +1402,21 @@ impl SegmentedStore {
     /// Inherited segment files are NOT deleted — their refcounts are decremented
     /// and lazy cleanup happens during parent compaction.
     /// Returns true if the branch existed.
+    ///
+    /// ## B5.1 retention contract
+    ///
+    /// Implements §"Parent compaction and parent delete" / "Parent
+    /// delete" of
+    /// `docs/design/branching/branching-gc/branching-retention-contract.md`.
+    /// Parent delete must not invalidate descendant inherited-layer
+    /// manifests and must not force descendant materialization (KD4
+    /// in `b5-phasing-plan.md`). Per Invariant 1 + §"Reclaimability
+    /// rule", segments still referenced by a descendant
+    /// inherited-layer manifest are retained — the refcount check
+    /// here implements that retention as a runtime accelerator
+    /// (`BarrierKind::RuntimeAccelerator`); the durable proof remains
+    /// the descendant's manifest entries
+    /// (`BarrierKind::PhysicalRetention`).
     pub fn clear_branch(&self, branch_id: &BranchId) -> bool {
         if let Some((_, branch)) = self.branches.remove(branch_id) {
             // 1. Clean up the branch's own segments.
@@ -1501,6 +1527,21 @@ impl SegmentedStore {
     /// cleared in-place via [`SegmentedStore::reset_recovery_health`] after a
     /// successful recovery; `DataLoss` requires a fresh reopen because the
     /// current store instance cannot reload later-restored files.
+    ///
+    /// ## B5.1 retention contract
+    ///
+    /// Implements §"Reclaim protocol" stages 2 (manifest proof) and
+    /// the §"Recovery-health contract" gate of
+    /// `docs/design/branching/branching-gc/branching-retention-contract.md`.
+    /// Today this function performs an immediate-unlink reclaim,
+    /// which Invariant 4 forbids; the B5.2 cutover replaces the unlink
+    /// with the full quarantine protocol (stages 3–5) and a
+    /// per-branch `quarantine.manifest` durable publish — see KD3,
+    /// KD8, KD9 in `b5-phasing-plan.md`. The degraded-recovery
+    /// refusal already in place satisfies Invariants 2 and 5: space
+    /// leaks are acceptable, false reclaim is not. Barrier role:
+    /// `BarrierKind::RecoveryHealthGate` (the refusal) +
+    /// `BarrierKind::PhysicalRetention` (the live-set check).
     pub fn gc_orphan_segments(&self) -> StorageResult<GcReport> {
         match &**self.last_recovery_health.load() {
             // Healthy and Telemetry-only degradation (rebuildable-cache errors)
@@ -1622,6 +1663,21 @@ impl SegmentedStore {
     /// snapshot → release → I/O → re-acquire pattern as `flush_oldest_frozen`.
     ///
     /// Returns `Err` on I/O failure, `Ok(result)` on success.
+    ///
+    /// ## B5.1 retention contract
+    ///
+    /// Implements §"Materialization contract" of
+    /// `docs/design/branching/branching-gc/branching-retention-contract.md`.
+    /// Materialization rewrites ownership, not meaning (Invariant 6,
+    /// KD4): the child's visible result set, tombstone semantics,
+    /// TTL semantics, timestamps, and fork-frontier visibility are
+    /// all preserved; only manifest ownership and inherited-layer
+    /// membership change. The shadow check at the entry-copy stage
+    /// is the conservative path the contract requires (assume
+    /// shadowed on corruption rather than risk stale-data
+    /// resurrection). Crash-safety: the `Materializing` status flag
+    /// in the manifest plus the `Materializing → Active` reset on
+    /// reopen satisfy the §"Crash / reopen rule".
     pub fn materialize_layer(
         &self,
         child_branch_id: &BranchId,
@@ -2072,6 +2128,21 @@ impl SegmentedStore {
     ///
     /// Flushes source memtables, snapshots segments, attaches as inherited
     /// layer on dest, increments refcounts. Returns `(fork_version, segments_shared)`.
+    ///
+    /// ## B5.1 retention contract
+    ///
+    /// Implements §"Fork-frontier semantics" of
+    /// `docs/design/branching/branching-gc/branching-retention-contract.md`.
+    /// The captured `fork_version` and the inherited-layer entry
+    /// installed on the destination together form the durable
+    /// fork-frontier barrier (`BarrierKind::ForkFrontier`): they
+    /// bound the descendant's inherited reads (read-time clamp to
+    /// `commit_id <= fork_version`) and keep the parent's snapshot
+    /// segments reachable for the descendant even after subsequent
+    /// parent compaction or parent delete. The refcount increments
+    /// on shared segments are runtime accelerators only
+    /// (`BarrierKind::RuntimeAccelerator`); the durable retention
+    /// proof is the destination's manifest entry.
     pub fn fork_branch(
         &self,
         source_id: &BranchId,
@@ -3487,6 +3558,20 @@ impl SegmentedStore {
     /// `TransactionCoordinator::apply_storage_recovery` rather than reading
     /// individual fields: that entry point owns version-floor adoption and
     /// future per-branch version wiring.
+    ///
+    /// ## B5.1 retention contract
+    ///
+    /// Implements §"Recovery rebuild protocol" of
+    /// `docs/design/branching/branching-gc/branching-retention-contract.md`.
+    /// Per-branch manifests (own + inherited-layer entries) are the
+    /// rebuild source of truth; runtime accelerator state
+    /// (`BarrierKind::RuntimeAccelerator`) is rebuilt from them.
+    /// `RecoveryHealth` is published before return so subsequent
+    /// reclaim respects the rebuild trust rule and the
+    /// degraded-recovery refusal gate
+    /// (`BarrierKind::RecoveryHealthGate`, KD8). B5.2 extends this
+    /// path with the §"Quarantine reconciliation" step
+    /// (per-branch `quarantine.manifest` reconciliation, KD9).
     pub fn recover_segments(&self) -> StorageResult<RecoveredState> {
         let mut invocation = RecoveryInvocationGuard::begin(&self.recovery_applied)?;
         let segments_dir = match &self.segments_dir {

--- a/crates/storage/src/segmented/ref_registry.rs
+++ b/crates/storage/src/segmented/ref_registry.rs
@@ -20,6 +20,19 @@ pub(crate) type SegmentId = u64;
 /// The `deletion_barrier` RwLock prevents a TOCTOU race between
 /// `is_referenced()` + file deletion (compaction) and `increment()`
 /// (fork_branch). See issue #1682.
+///
+/// ## B5.1 retention contract
+///
+/// `BarrierKind::RuntimeAccelerator` per
+/// `docs/design/branching/branching-gc/branching-retention-contract.md`
+/// §"Authoritative and non-authoritative state". This registry is
+/// **not** authoritative for reclaim safety: refcount zero alone is
+/// not a deletion proof (Invariant 3, KD1). The reclaim protocol
+/// (§"Reclaim protocol") uses this registry only as candidate-
+/// selection input and TOCTOU guard; the durable proof remains
+/// own-segment + inherited-layer manifest reachability. Disagreement
+/// between this registry and manifest evidence must block reclaim
+/// (KD10, §"Accelerator disagreement rule").
 pub(crate) struct SegmentRefRegistry {
     refs: DashMap<SegmentId, AtomicUsize>,
     /// Fork increments hold a **read** guard (concurrent forks OK).


### PR DESCRIPTION
## Summary

- Lands the engine-owned vocabulary module (`crates/engine/src/branch_retention/`, `pub(crate)`) holding `BarrierKind`, `ReachabilityRole`, and `ConvergenceClass` — the three enums every later B5 phase will cite or match on. Match-exhaustive tripwire test pins the variant set: a future variant addition without test update fails compile.
- Annotates the nine load-bearing retention paths with their B5.1 contract roles (no logic change). Each annotation cites the exact contract section, the relevant Invariant numbers, and the relevant KDs.
- Pins the quarantine inventory format/location locally in the retention contract: per-branch `quarantine.manifest` via the same atomic `temp + rename + fsync(dir)` idiom `segments.manifest` already uses, with `STRAMFST`-style 8-byte magic + `u16` version. Inventory is in-flight reclaim protocol state — manifests stay the only durable liveness proof per Invariant 3.

## Annotated paths

| Path | Contract section + KDs |
|---|---|
| `SegmentedStore::clear_branch` | §\"Parent delete\" + KD4 |
| `SegmentedStore::gc_orphan_segments` | §\"Reclaim protocol\" stage 2 + §\"Recovery-health contract\" + KD3/KD8/KD9 |
| `SegmentedStore::materialize_layer` | §\"Materialization contract\" + Invariant 6 + KD4 |
| `SegmentedStore::fork_branch` | §\"Fork-frontier semantics\" |
| `SegmentedStore::recover_segments` | §\"Recovery rebuild protocol\" + KD8/KD9 |
| `SegmentedStore::last_recovery_health` | §\"Recovery-health contract\" + Invariant 5 + KD8 |
| `SegmentRefRegistry` | §\"Authoritative and non-authoritative state\" + Invariant 3 + KD1/KD10 |
| `ManifestInheritedLayer` | §\"Fork-frontier semantics\" + §\"Authoritative for reclaim safety\" |
| `Database::refresh` | convergence doc §\"Staged-publish\" |

## Scope

**Change class:** annotation + new `pub(crate)` vocabulary module + one local-doc design decision. **No behavior change. No public API change.** No `retention_report()` stub (deferred to B5.2 per the phasing plan). Branching-gc docs themselves stay local-only per the existing `/docs` gitignore convention; this PR's CLAUDE.md update follows the same pattern as the pre-existing program-corpus references.

**Assurance class:** S2 (annotation, no semantic surface change).

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets` — no new warnings (only pre-existing `unreachable_pub`)
- [x] `cargo test -p strata-engine -p strata-storage` — all green
- [x] `cargo test --test integration -- branching` — 174 branching tests pass
- [x] `cargo doc -p strata-engine -p strata-storage --no-deps` — no new doc warnings (no `pub` → `pub(crate)` privacy escapes)
- [x] `rg \"B5.1 retention contract\" crates/` — 9 hits across 4 files (matches plan)
- [x] New tripwire test `branch_retention::tests::vocabulary_variants_are_pinned_to_contract` runs and passes

## Code review pass — issues found and fixed in-PR

1. `clear_branch` originally cited KD7 (about `retention_report()`); corrected to KD4 only.
2. `clear_branch` referenced \"the reachability rule\"; corrected to actual contract §\"Reclaimability rule\".
3. `branch_retention` module-level doc advertised `[BarrierKind::...]` rustdoc-link form; updated to backtick form (cross-crate links to `pub(crate)` items don't resolve, same-crate `pub`→`pub(crate)` warns).
4. Module test was array-based (variant-add silently passes); replaced with match-exhaustive helpers (variant-add fails compile).
5. Contract update originally said quarantine.manifest uses \"format-version byte\"; corrected to `u16` to match existing `STRAMFST` segment-manifest convention.

## Follow-up (B5.2 scope)

- Implement quarantine-based reclaim per the contract's §\"Reclaim protocol\" stages 3–5, replacing the immediate-unlink path in `gc_orphan_segments`.
- Add `Database::retention_report()` with manifest-derived attribution.
- Land the adversarial regression suite per `branching-b5-verification-spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)