### PR TITLE
B5.1 follow-up: retention terminology sweep — accelerator language

### DIFF
--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -330,7 +330,8 @@ impl SegmentedStore {
         // find the new compacted segment.
         self.write_branch_manifest(branch_id)?;
 
-        // Now safe to delete old segment files (refcount-guarded).
+        // Old segment files become reclaim candidates after manifest publish.
+        // Today deletion is still runtime-refcount gated, not B5.2 manifest proof.
         for seg in &old_segments {
             self.delete_segment_if_unreferenced(seg);
         }
@@ -495,7 +496,8 @@ impl SegmentedStore {
         // Persist manifest BEFORE deleting old files (crash safety).
         self.write_branch_manifest(branch_id)?;
 
-        // Delete old segment files (refcount-guarded).
+        // Old segment files become reclaim candidates after manifest publish.
+        // Today deletion is still runtime-refcount gated, not B5.2 manifest proof.
         for seg in &selected_segments {
             self.delete_segment_if_unreferenced(seg);
         }
@@ -733,7 +735,8 @@ impl SegmentedStore {
         // Persist manifest BEFORE deleting old files (crash safety).
         self.write_branch_manifest(branch_id)?;
 
-        // Now safe to delete old files (refcount-guarded).
+        // Old segment files become reclaim candidates after manifest publish.
+        // Today deletion is still runtime-refcount gated, not B5.2 manifest proof.
         for seg in &l0_segs {
             self.delete_segment_if_unreferenced(seg);
         }
@@ -1073,7 +1076,8 @@ impl SegmentedStore {
         // Persist manifest BEFORE deleting old files (crash safety).
         self.write_branch_manifest(branch_id)?;
 
-        // Delete old segment files (refcount-guarded).
+        // Old segment files become reclaim candidates after manifest publish.
+        // Today deletion is still runtime-refcount gated, not B5.2 manifest proof.
         for seg in &input_segs {
             self.delete_segment_if_unreferenced(seg);
         }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -1530,18 +1530,20 @@ impl SegmentedStore {
     ///
     /// ## B5.1 retention contract
     ///
-    /// Implements §"Reclaim protocol" stages 2 (manifest proof) and
-    /// the §"Recovery-health contract" gate of
+    /// Implements the §"Recovery-health contract" gate of
     /// `docs/design/branching/branching-gc/branching-retention-contract.md`.
-    /// Today this function performs an immediate-unlink reclaim,
-    /// which Invariant 4 forbids; the B5.2 cutover replaces the unlink
-    /// with the full quarantine protocol (stages 3–5) and a
-    /// per-branch `quarantine.manifest` durable publish — see KD3,
-    /// KD8, KD9 in `b5-phasing-plan.md`. The degraded-recovery
-    /// refusal already in place satisfies Invariants 2 and 5: space
-    /// leaks are acceptable, false reclaim is not. Barrier role:
-    /// `BarrierKind::RecoveryHealthGate` (the refusal) +
-    /// `BarrierKind::PhysicalRetention` (the live-set check).
+    /// Today this function still performs an immediate-unlink reclaim
+    /// using a process-local live-set check built from `self.branches`
+    /// plus inherited layers. That is a storage-local approximation of
+    /// physical retention, not the future B5.2 Stage-2 manifest proof.
+    /// The B5.2 cutover strengthens this path to walk recovery-trusted
+    /// manifests and route deletion through the full quarantine
+    /// protocol with persisted quarantine inventory. The degraded-
+    /// recovery refusal already in place satisfies Invariants 2 and 5:
+    /// space leaks are acceptable, false reclaim is not. Barrier role:
+    /// `BarrierKind::RecoveryHealthGate` (the refusal) + current
+    /// process-local approximation of `BarrierKind::PhysicalRetention`
+    /// (the live-set check).
     pub fn gc_orphan_segments(&self) -> StorageResult<GcReport> {
         match &**self.last_recovery_health.load() {
             // Healthy and Telemetry-only degradation (rebuildable-cache errors)
@@ -3570,8 +3572,8 @@ impl SegmentedStore {
     /// reclaim respects the rebuild trust rule and the
     /// degraded-recovery refusal gate
     /// (`BarrierKind::RecoveryHealthGate`, KD8). B5.2 extends this
-    /// path with the §"Quarantine reconciliation" step
-    /// (per-branch `quarantine.manifest` reconciliation, KD9).
+    /// path with the §"Quarantine reconciliation" step against the
+    /// chosen persisted quarantine inventory (KD9).
     pub fn recover_segments(&self) -> StorageResult<RecoveredState> {
         let mut invocation = RecoveryInvocationGuard::begin(&self.recovery_applied)?;
         let segments_dir = match &self.segments_dir {

--- a/crates/storage/src/segmented/ref_registry.rs
+++ b/crates/storage/src/segmented/ref_registry.rs
@@ -1,7 +1,9 @@
 //! Reference counting registry for shared segments (COW branching).
 //!
 //! Tracks how many branches reference each segment file. When a segment's
-//! refcount drops to zero (or was never tracked), it is safe to delete.
+//! refcount drops to zero (or was never tracked), the segment has no
+//! remaining *runtime-registry* references. That is candidate-selection
+//! input, not a durable deletion proof.
 
 use dashmap::DashMap;
 use parking_lot::RwLock;
@@ -12,10 +14,12 @@ pub(crate) type SegmentId = u64;
 
 /// Thread-safe reference count registry for shared segments.
 ///
-/// Untracked segments (never `increment`ed) are treated as unreferenced —
-/// `decrement` returns `true`, so existing non-COW compaction deletes files
-/// normally. In Epic C, shared segments will be `increment`ed; only then
-/// does the guard become load-bearing.
+/// Untracked segments (never `increment`ed) are treated as having no
+/// registry-managed shared references — `decrement` returns `true`,
+/// which is enough for today's narrow callers to treat the segment as a
+/// deletion candidate. Per the B5 retention contract, that still is not
+/// a durable reclaim proof. In Epic C, shared segments will be
+/// `increment`ed; only then does the guard become load-bearing.
 ///
 /// The `deletion_barrier` RwLock prevents a TOCTOU race between
 /// `is_referenced()` + file deletion (compaction) and `increment()`
@@ -89,16 +93,20 @@ impl SegmentRefRegistry {
 
     /// Decrement the reference count for `id`.
     ///
-    /// Returns `true` if the segment is safe to delete:
+    /// Returns `true` if the registry now sees no remaining shared
+    /// references for this segment:
     /// - count reached zero after decrement, OR
-    /// - the segment was never tracked (untracked = owned by one branch).
+    /// - the segment was never tracked.
+    ///
+    /// This is a runtime-accelerator result only. Callers still need a
+    /// stronger reclaim proof before permanent deletion.
     ///
     /// Uses `fetch_update` to prevent underflow (wrapping to `usize::MAX`)
     /// and `DashMap::remove_if` to atomically clean up zero-count entries.
     pub(crate) fn decrement(&self, id: SegmentId) -> bool {
         let entry = match self.refs.get(&id) {
             Some(e) => e,
-            None => return true, // untracked → safe to delete
+            None => return true, // untracked → no runtime shared refs remain
         };
 
         // Atomically subtract 1 only if count > 0, preventing underflow.
@@ -181,7 +189,8 @@ mod tests {
     #[test]
     fn ref_registry_decrement_untracked() {
         let reg = SegmentRefRegistry::new();
-        // Decrement on a never-incremented ID should return true (safe to delete)
+        // Decrement on a never-incremented ID should report no remaining
+        // runtime shared refs.
         assert!(reg.decrement(42));
         assert!(!reg.is_referenced(42));
     }
@@ -190,10 +199,10 @@ mod tests {
     fn ref_registry_over_decrement_does_not_corrupt() {
         let reg = SegmentRefRegistry::new();
         reg.increment(1);
-        assert!(reg.decrement(1)); // 1 → 0, safe to delete
+        assert!(reg.decrement(1)); // 1 → 0, no runtime shared refs remain
 
         // Over-decrement: count is already 0, should not wrap to usize::MAX
-        assert!(reg.decrement(1)); // already 0, returns true (safe)
+        assert!(reg.decrement(1)); // already 0, still reports no runtime refs
         assert_eq!(reg.ref_count(1), 0);
         assert!(!reg.is_referenced(1));
 
@@ -213,7 +222,7 @@ mod tests {
 
         assert!(!reg.decrement(1)); // 3 → 2, still referenced
         assert!(!reg.decrement(1)); // 2 → 1, still referenced
-        assert!(reg.decrement(1)); // 1 → 0, safe to delete
+        assert!(reg.decrement(1)); // 1 → 0, no runtime shared refs remain
         assert!(!reg.is_referenced(1));
     }
 
@@ -326,12 +335,12 @@ mod tests {
             assert!(reg.is_referenced(1));
 
             // KEY INVARIANT: if the segment is still referenced,
-            // at most one decrement may have returned "safe to delete".
+            // at most one decrement may have reported "no runtime refs remain".
             // With the bug, both decrements could return true.
             let safe_count = d1 as usize + d2 as usize;
             assert!(
                 safe_count <= 1,
-                "at most one decrement should return safe-to-delete when segment is still referenced, got {}",
+                "at most one decrement should report no runtime refs remain when segment is still referenced, got {}",
                 safe_count,
             );
         }


### PR DESCRIPTION
## Summary

Two corrections tightening B5.1's framing in the storage layer. No behavior change; all diffs are comment/docstring updates.

### 1. `gc_orphan_segments` annotation factual correction

B5.1 claimed `gc_orphan_segments` \"implements §Reclaim protocol stages 2 (manifest proof)\" and that its immediate-unlink path \"Invariant 4 forbids.\" Both claims overstated the current code.

The live-set walk uses `self.branches` + `version.levels` (process-local in-memory state), **not** recovery-trusted manifests — so it is a storage-local *approximation* of physical retention, not the B5.2 Stage-2 proof. The Invariant-4 framing implied ongoing code was violating the contract when in reality the contract explicitly accepts this pre-B5.2 shape.

Reworded to describe current behavior accurately and mark B5.2 as the cutover that upgrades to the full proof.

Also narrowed the `recover_segments` annotation from \"`quarantine.manifest` reconciliation\" to \"the chosen persisted quarantine inventory,\" so the annotation does not prematurely lock the file-name choice that still lives in the contract only.

### 2. `SegmentRefRegistry` \"safe to delete\" terminology sweep

B5.1 correctly labeled `SegmentRefRegistry` as `BarrierKind::RuntimeAccelerator` — \"not authoritative for reclaim safety\" — but the rest of the file still said \"safe to delete\" in 11 places, contradicting Invariant 3 + §\"Authoritative and non-authoritative state\" of `branching-retention-contract.md`.

Swept all sites:

- `ref_registry.rs` module doc, struct doc, and `decrement()` docstring — \"safe to delete\" → \"has no remaining runtime-registry references\" / \"registry now sees no remaining shared references,\" with explicit caller note \"Callers still need a stronger reclaim proof before permanent deletion.\"
- 4 `ref_registry.rs` test comments + the over-decrement assertion message updated.
- 4 `compaction.rs` callsite comments (\"Now safe to delete old segment files (refcount-guarded)\") reworded to \"Old segment files become reclaim candidates after manifest publish. Today deletion is still runtime-refcount gated, not B5.2 manifest proof.\"

### Scope: not touched

The 3 remaining \"safe to delete\" hits live in `durability/compaction/wal_only.rs` — WAL segment GC under snapshot watermark, a different retention domain not covered by the B5 branch retention contract. Intentionally left alone.

## Change class

Refactor-only / doc-only. Zero behavior change. Return values, control flow, APIs unchanged. Test bodies identical; only assertion messages updated.

## Test plan

- [x] `cargo build -p strata-storage -p strata-engine` — clean
- [x] `cargo test -p strata-storage` — 718 pass, 0 fail (includes all 13 `ref_registry` tests with updated assertion messages)
- [x] Consistency sweep: `rg \"safe to delete\" crates/storage` returns 0 matches; the 3 remaining workspace-wide hits are in the WAL/durability domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)