### PR TITLE
B5.2: safe reclaim + retention_report — quarantine protocol, reopen reconciliation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,10 @@ architecture scope documents. The current allowed surface:
 `AdvanceError`, `UnblockError`, `LossyRecoveryReport`, `LossyErrorKind`,
 `RecoveryHealth`, `DegradationClass`
 
+**Retention (B5.2):** `Database::retention_report()`, `RetentionReport`,
+`BranchRetentionEntry`, `RetentionBlocker`, `RetentionTotals`, `OrphanStorageEntry`,
+`OrphanReason`, `ReclaimStatus`
+
 **Product:** `SystemBranchCapability` (`pub` type, `pub(crate)` constructor), `Provider`,
 `ControlRegistry`, `ControlEntry`, `ControlOwner`, `BehaviorClass`, `PersistenceClass`
 
@@ -159,7 +163,8 @@ architecture scope documents. The current allowed surface:
 
 **Errors:** `StrataError`, `executor::Error`, `ErrorSeverity`, `BranchDagError`/`Kind`,
 `ObserverError`/`Kind`, `RefreshHookError`, `AdvanceError`, `UnblockError`,
-`InferenceError`, `BranchBundleError`, `CompactionError`, `ManifestError`
+`InferenceError`, `BranchBundleError`, `CompactionError`, `ManifestError`,
+`StrataError::RetentionReportUnavailable` (B5.2)
 
 ---
 

--- a/crates/concurrency/src/transaction.rs
+++ b/crates/concurrency/src/transaction.rs
@@ -1065,10 +1065,25 @@ impl TransactionContext {
     /// into the WAL and preserved through recovery. A `ttl_ms` of 0 means
     /// no TTL (equivalent to `put()`).
     pub fn put_with_ttl(&mut self, key: Key, value: Value, ttl_ms: u64) -> StrataResult<()> {
+        self.guard(&key)?;
+        if self.read_only {
+            return Err(StrataError::invalid_input(
+                "Cannot write in a read-only transaction",
+            ));
+        }
+        self.check_write_limit(Some(&key))?;
+
+        self.validate_no_cas_conflict(&key)?;
+
+        self.delete_set.remove(&key);
         if ttl_ms > 0 {
             self.ttl_map.insert(key.clone(), ttl_ms);
+        } else {
+            self.ttl_map.remove(&key);
         }
-        self.put(key, value)
+
+        self.write_set.insert(key, value);
+        Ok(())
     }
 
     /// Buffer a write with a single-version retention hint.
@@ -2243,6 +2258,21 @@ mod tests {
         let vv = result.unwrap();
         assert_eq!(vv.value, Value::String("written".into()));
         assert_eq!(vv.version, Version::Txn(0)); // placeholder
+    }
+
+    #[test]
+    fn test_put_with_ttl_preserves_ttl_map_entry() {
+        let branch_id = BranchId::new();
+        let ns = test_namespace_for(branch_id);
+        let key = test_key(&ns, "ttl");
+        let store = empty_store();
+        let mut txn = TransactionContext::with_store(TxnId(1), branch_id, store);
+
+        txn.put_with_ttl(key.clone(), Value::Int(7), 60_000)
+            .unwrap();
+
+        assert_eq!(txn.ttl_map.get(&key), Some(&60_000));
+        assert_eq!(txn.write_set.get(&key), Some(&Value::Int(7)));
     }
 
     #[test]

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1038,6 +1038,29 @@ pub enum StrataError {
         commit_version: u64,
     },
 
+    /// `retention_report()` refused because recovery health cannot
+    /// sustain trustworthy manifest-derived attribution.
+    ///
+    /// Per the B5 convergence contract at
+    /// `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+    /// §"Surface matrix", `retention_report` is a hard-fail-degraded
+    /// surface: when manifest-derived truth or recovery health is
+    /// insufficient, the engine returns this typed error rather than
+    /// a fabricated report (§"retention report contract"). Reclaim
+    /// blockers that are *attribution-safe* (e.g. blocked but
+    /// attribution is still correct) surface in the report body
+    /// instead.
+    ///
+    /// Wire code: `StorageError`
+    #[error("retention_report unavailable: recovery degraded ({class})")]
+    RetentionReportUnavailable {
+        /// Textual form of the recovery degradation class
+        /// (e.g. `"DataLoss"`, `"PolicyDowngrade"`). Kept as a string
+        /// so `strata-core` does not need to depend on
+        /// `strata-storage`.
+        class: String,
+    },
+
     /// Shutdown timeout
     ///
     /// The database shutdown timed out waiting for active transactions to complete.
@@ -1376,6 +1399,19 @@ impl StrataError {
         }
     }
 
+    /// Create a [`StrataError::RetentionReportUnavailable`] with a textual
+    /// degradation class.
+    ///
+    /// The class is the `Debug` form of the underlying recovery
+    /// degradation class (e.g. `"DataLoss"`, `"PolicyDowngrade"`), kept
+    /// as a string so `strata-core` does not depend on
+    /// `strata-storage`.
+    pub fn retention_report_unavailable(class: impl Into<String>) -> Self {
+        StrataError::RetentionReportUnavailable {
+            class: class.into(),
+        }
+    }
+
     /// Create a Corruption error
     ///
     /// ## Example
@@ -1604,6 +1640,7 @@ impl StrataError {
             StrataError::Corruption { .. } => ErrorCode::StorageError,
             StrataError::CodecDecode { .. } => ErrorCode::StorageError,
             StrataError::LegacyFormat { .. } => ErrorCode::StorageError,
+            StrataError::RetentionReportUnavailable { .. } => ErrorCode::StorageError,
 
             // Internal errors
             StrataError::Internal { .. } => ErrorCode::InternalError,

--- a/crates/engine/src/branch_ops/branch_control_store.rs
+++ b/crates/engine/src/branch_ops/branch_control_store.rs
@@ -980,6 +980,7 @@ impl BranchControlStore {
     /// Returns `Err(BranchLineageUnavailable)` on an unmigrated follower
     /// (AD5) — listing is a lineage-aware read and must not silently
     /// return empty when the authoritative state is inaccessible.
+    #[allow(dead_code)]
     pub(crate) fn list_active(&self) -> StrataResult<Vec<BranchControlRecord>> {
         self.guard_lineage_read()?;
         self.db.transaction(global_branch_id(), |txn| {
@@ -995,6 +996,36 @@ impl BranchControlStore {
                 if let Some(rv) = txn.get(&rec_key)? {
                     let rec: BranchControlRecord = from_stored_value(&rv)?;
                     if matches!(rec.lifecycle, BranchLifecycleStatus::Active) {
+                        out.push(rec);
+                    }
+                }
+            }
+            Ok(out)
+        })
+    }
+
+    /// List every currently-visible record in the store.
+    ///
+    /// Includes both `Active` and `Archived` lifecycle states because both are
+    /// backed by the active-pointer row and remain branch-visible per B4/KD1.
+    ///
+    /// Returns `Err(BranchLineageUnavailable)` on an unmigrated follower
+    /// (AD5).
+    pub(crate) fn list_visible(&self) -> StrataResult<Vec<BranchControlRecord>> {
+        self.guard_lineage_read()?;
+        self.db.transaction(global_branch_id(), |txn| {
+            let prefix = active_ptr_prefix_all();
+            let pointers = txn.scan_prefix(&prefix)?;
+            let mut out = Vec::with_capacity(pointers.len());
+            for (ap_key, v) in pointers {
+                let Some(id) = parse_active_ptr_key(&ap_key.user_key) else {
+                    continue;
+                };
+                let gen = decode_u64_value(&v)?;
+                let rec_key = control_record_key(BranchRef::new(id, gen));
+                if let Some(rv) = txn.get(&rec_key)? {
+                    let rec: BranchControlRecord = from_stored_value(&rv)?;
+                    if rec.lifecycle.is_visible() {
                         out.push(rec);
                     }
                 }

--- a/crates/engine/src/branch_ops/mod.rs
+++ b/crates/engine/src/branch_ops/mod.rs
@@ -892,7 +892,14 @@ pub(crate) fn fork_branch_with_metadata(
         control_store.put_record(&control_record, txn)
     });
     if let Err(e) = kv_result {
-        storage.clear_branch(&dest_id);
+        if let Err(clear_err) = storage.clear_branch(&dest_id) {
+            tracing::warn!(
+                target: "strata::branch",
+                branch_id = %dest_id,
+                error = %clear_err,
+                "fork rollback failed to clear destination storage cleanly",
+            );
+        }
         return Err(e);
     }
 

--- a/crates/engine/src/database/branch_mutation.rs
+++ b/crates/engine/src/database/branch_mutation.rs
@@ -70,7 +70,10 @@ use super::observers::BranchOpEvent;
 use super::Database;
 use crate::branch_ops::branch_control_store::BranchControlStore;
 use crate::branch_ops::{is_user_visible_space, with_branch_dag_hooks_suppressed, DATA_TYPE_TAGS};
-use crate::primitives::branch::{resolve_branch_name, BranchIndex, BranchMetadata};
+use crate::primitives::branch::{
+    default_branch_marker_key, read_default_branch_marker, resolve_branch_name, BranchIndex,
+    BranchMetadata, DeletePostCommitOptions,
+};
 use crate::SpaceIndex;
 
 // =============================================================================
@@ -145,14 +148,31 @@ impl RollbackAction {
 
                 if metadata_exists {
                     if let Err(e) = with_branch_dag_hooks_suppressed(|| {
-                        branch_index.delete_branch_with_hook(&name, |txn| {
+                        let committed = branch_index.delete_branch_with_hook(&name, |txn| {
                             match control_store.mark_deleted_by_name(&name, txn)? {
                                 Some(_) => Ok(()),
                                 None => Err(StrataError::corruption(format!(
                                     "rollback delete for branch '{name}' found legacy metadata without an active control record"
                                 ))),
                             }
-                        })
+                        })?;
+                        let completion = branch_index.complete_delete_post_commit(
+                            &name,
+                            &committed,
+                            DeletePostCommitOptions {
+                                clear_storage,
+                                dispatch_best_effort_delete_hook: false,
+                            },
+                        );
+                        match completion {
+                            crate::primitives::branch::DeleteBranchCompletion::Clean
+                            | crate::primitives::branch::DeleteBranchCompletion::Warning(_) => {
+                                Ok(())
+                            }
+                            crate::primitives::branch::DeleteBranchCompletion::PostCommitError(
+                                err,
+                            ) => Err(err),
+                        }
                     }) {
                         warn!(
                             target: "strata::branch_mutation",
@@ -160,13 +180,14 @@ impl RollbackAction {
                             error = %e,
                             "Rollback delete_branch failed"
                         );
+                        return Err(e);
                     }
                 } else if let Some(rec) = control_store.find_active_by_name(&name)? {
                     db.transaction(global_branch_id(), |txn| {
                         control_store.mark_deleted(rec.branch, txn)
                     })?;
                     if clear_storage {
-                        db.clear_branch_storage(&branch_id);
+                        db.clear_branch_storage(&branch_id)?;
                     }
                 }
 
@@ -220,6 +241,7 @@ struct BranchSnapshot {
     name: String,
     metadata: BranchMetadata,
     control_record: BranchControlRecord,
+    default_branch_marker: Option<String>,
     executor_branch_id: BranchId,
     metadata_branch_id: Option<BranchId>,
     entries: Vec<(Key, Value)>,
@@ -240,6 +262,7 @@ impl BranchSnapshot {
                 name
             ))
         })?;
+        let default_branch_marker = read_default_branch_marker(db.as_ref())?;
 
         let executor_branch_id = resolve_branch_name(name);
         let metadata_branch_id = BranchId::from_string(&metadata.branch_id)
@@ -259,6 +282,7 @@ impl BranchSnapshot {
             name: name.to_string(),
             metadata,
             control_record,
+            default_branch_marker,
             executor_branch_id,
             metadata_branch_id,
             entries,
@@ -274,6 +298,11 @@ impl BranchSnapshot {
         db.transaction(global_branch_id(), |txn| {
             txn.set_allow_cross_branch(true);
             txn.put(meta_key.clone(), metadata_value.clone())?;
+            let marker_key = default_branch_marker_key();
+            match &self.default_branch_marker {
+                Some(name) => txn.put(marker_key, Value::String(name.clone()))?,
+                None => txn.delete(marker_key)?,
+            }
             control_store.put_record(&self.control_record, txn)?;
             for (key, value) in &self.entries {
                 txn.put(key.clone(), value.clone())?;
@@ -287,6 +316,7 @@ impl BranchSnapshot {
         }
 
         db.unmark_branch_deleting(&self.executor_branch_id);
+        db.remove_branch_lock(&self.executor_branch_id);
         if let Some(meta_id) = self.metadata_branch_id {
             db.unmark_branch_deleting(&meta_id);
         }
@@ -537,7 +567,10 @@ impl<'a> BranchMutation<'a> {
     /// # Arguments
     ///
     /// * `name` — Branch name to delete on rollback.
-    /// * `clear_storage` — Whether to clear storage-layer data (segments, manifests).
+    /// * `clear_storage` — Whether to run post-commit storage cleanup
+    ///   (segment/manifests/refcount release) after the rollback delete
+    ///   transaction commits. Lock removal and other logical housekeeping still
+    ///   run regardless.
     pub fn on_rollback_delete_branch(&mut self, name: impl Into<String>, clear_storage: bool) {
         self.rollback_actions.push(RollbackAction::DeleteBranch {
             name: name.into(),
@@ -786,10 +819,12 @@ impl Drop for BranchMutation<'_> {
 mod tests {
     use super::*;
     use crate::database::dag_hook::{AncestryEntry, MergeBaseResult};
+    use crate::database::OpenSpec;
     use crate::Database;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use strata_core::id::CommitVersion;
     use strata_core::types::BranchId;
+    use tempfile::TempDir;
 
     /// Test DAG hook that can be configured to fail.
     struct TestDagHook {
@@ -1009,6 +1044,68 @@ mod tests {
     }
 
     #[test]
+    fn test_rollback_delete_false_skips_storage_cleanup() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = Database::open_runtime(OpenSpec::primary(temp_dir.path())).unwrap();
+        db.branches().create("abort-no-storage").unwrap();
+
+        crate::database::test_hooks::inject_clear_branch_storage_failure(
+            temp_dir.path(),
+            std::io::ErrorKind::Other,
+        );
+
+        let mut mutation = BranchMutation::new(&db);
+        mutation.on_rollback_delete_branch("abort-no-storage", false);
+        mutation.abort().unwrap();
+
+        assert!(
+            crate::database::test_hooks::maybe_inject_clear_branch_storage_failure(temp_dir.path())
+                .is_some(),
+            "clear_storage=false rollback must not consume the storage-cleanup hook"
+        );
+
+        let branch_index = BranchIndex::new(db.clone());
+        assert!(!branch_index.exists("abort-no-storage").unwrap());
+    }
+
+    #[test]
+    fn test_rollback_delete_true_surfaces_storage_cleanup_failure() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = Database::open_runtime(OpenSpec::primary(temp_dir.path())).unwrap();
+        db.branches().create("abort-with-storage").unwrap();
+
+        crate::database::test_hooks::inject_clear_branch_storage_failure(
+            temp_dir.path(),
+            std::io::ErrorKind::Other,
+        );
+
+        let mut mutation = BranchMutation::new(&db);
+        mutation.on_rollback_delete_branch("abort-with-storage", true);
+        let err = mutation
+            .abort()
+            .expect_err("cleanup debt during rollback delete must surface from abort()");
+        assert!(
+            error_chain_contains(&err, "clear_branch_storage")
+                || error_chain_contains(&err, "injected"),
+            "expected storage cleanup failure in error chain, got {err}",
+        );
+
+        let branch_index = BranchIndex::new(db.clone());
+        assert!(!branch_index.exists("abort-with-storage").unwrap());
+    }
+
+    fn error_chain_contains(err: &StrataError, needle: &str) -> bool {
+        let mut current: Option<&dyn std::error::Error> = Some(err);
+        while let Some(e) = current {
+            if e.to_string().contains(needle) {
+                return true;
+            }
+            current = e.source();
+        }
+        false
+    }
+
+    #[test]
     fn test_mutation_drop_without_commit_triggers_rollback() {
         let db = Database::cache().unwrap();
 
@@ -1072,6 +1169,34 @@ mod tests {
             strata_core::branch::BranchLifecycleStatus::Active
         ));
         assert_eq!(restored.branch.generation, 0);
+    }
+
+    #[test]
+    fn test_rollback_restore_branch_restores_default_branch_marker() {
+        let db = Database::cache().unwrap();
+        db.branches().create("restore-test").unwrap();
+        crate::primitives::branch::write_default_branch_marker(&db, "restore-test").unwrap();
+
+        let mut mutation = BranchMutation::new(&db);
+        mutation.on_rollback_restore_branch("restore-test").unwrap();
+
+        let branch_index = BranchIndex::new(db.clone());
+        let store = BranchControlStore::new(db.clone());
+        branch_index
+            .delete_branch_with_hook("restore-test", |txn| {
+                match store.mark_deleted_by_name("restore-test", txn)? {
+                    Some(_) => Ok(()),
+                    None => Err(StrataError::corruption(
+                        "test setup deleted branch without active control record".to_string(),
+                    )),
+                }
+            })
+            .unwrap();
+
+        mutation.abort().unwrap();
+
+        let restored_marker = read_default_branch_marker(db.as_ref()).unwrap();
+        assert_eq!(restored_marker.as_deref(), Some("restore-test"));
     }
 
     #[test]

--- a/crates/engine/src/database/branch_service.rs
+++ b/crates/engine/src/database/branch_service.rs
@@ -114,6 +114,7 @@ use crate::database::observers::{BranchOpEvent, BranchOpKind};
 use crate::database::Database;
 use crate::primitives::branch::{
     aliases_default_branch_sentinel, resolve_branch_name, BranchIndex, BranchMetadata,
+    DeleteBranchCommitted, DeleteBranchCompletion, DeletePostCommitOptions,
 };
 use crate::primitives::event::EventLog;
 use crate::SYSTEM_BRANCH;
@@ -504,24 +505,29 @@ impl BranchService {
         // `delete_branch_with_hook`, so the mutex is just a one-shot
         // inside-out channel.
         let deleted_ref: std::sync::Mutex<Option<BranchRef>> = std::sync::Mutex::new(None);
-        let delete_result = with_branch_dag_hooks_suppressed(|| {
-            index.delete_branch_with_hook(name, |txn| {
-                match store.mark_deleted_by_name(name, txn)? {
-                    Some(branch_ref) => {
-                        *deleted_ref.lock().unwrap() = Some(branch_ref);
-                        Ok(())
+        let delete_result: StrataResult<DeleteBranchCommitted> =
+            with_branch_dag_hooks_suppressed(|| {
+                index.delete_branch_with_hook(name, |txn| {
+                    match store.mark_deleted_by_name(name, txn)? {
+                        Some(branch_ref) => {
+                            *deleted_ref.lock().unwrap() = Some(branch_ref);
+                            Ok(())
+                        }
+                        None => Err(StrataError::corruption(format!(
+                            "live branch '{name}' has legacy metadata but no active control record"
+                        ))),
                     }
-                    None => Err(StrataError::corruption(format!(
-                        "live branch '{name}' has legacy metadata but no active control record"
-                    ))),
-                }
-            })
-        });
+                })
+            });
 
-        if let Err(e) = delete_result {
-            mutation.cancel();
-            return Err(e);
-        }
+        let delete_committed = match delete_result {
+            Ok(committed) => committed,
+            Err(e) => {
+                mutation.cancel();
+                return Err(e);
+            }
+        };
+
         let branch_ref = deleted_ref.lock().unwrap().expect(
             "delete_branch_with_hook closure must run on the success path; \
              deleted_ref would otherwise stay None",
@@ -533,6 +539,33 @@ impl BranchService {
 
         // Commit: fires observers
         mutation.commit(BranchOpEvent::delete(branch_ref, name));
+
+        match index.complete_delete_post_commit(
+            name,
+            &delete_committed,
+            DeletePostCommitOptions {
+                clear_storage: true,
+                dispatch_best_effort_delete_hook: false,
+            },
+        ) {
+            DeleteBranchCompletion::Clean => {}
+            DeleteBranchCompletion::Warning(warning) => {
+                tracing::warn!(
+                    target: "strata::branch",
+                    branch = name,
+                    error = %warning,
+                    "Branch delete completed, but storage cleanup reported retention debt"
+                );
+            }
+            DeleteBranchCompletion::PostCommitError(err) => {
+                tracing::warn!(
+                    target: "strata::branch",
+                    branch = name,
+                    error = %err,
+                    "Branch delete committed, but post-commit cleanup left retention debt"
+                );
+            }
+        }
 
         Ok(())
     }
@@ -1827,6 +1860,21 @@ mod tests {
     }
 
     #[test]
+    fn test_retention_report_refuses_on_unmigrated_follower() {
+        let db = Database::cache().unwrap();
+        force_follower_mode(&db);
+        seed_legacy_branch_metadata(&db, "legacy");
+
+        let err = db.retention_report().unwrap_err();
+        match err {
+            StrataError::RetentionReportUnavailable { class } => {
+                assert_eq!(class, "PolicyDowngrade");
+            }
+            other => panic!("expected RetentionReportUnavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_branch_service_history_reads_fail_closed_on_metadata_without_control_record() {
         let db = Database::cache().unwrap();
         seed_legacy_branch_metadata(&db, "legacy");
@@ -2128,6 +2176,112 @@ mod tests {
         assert!(
             store.find_active_by_name("retired").unwrap().is_none(),
             "delete of archived branch must clear the active pointer"
+        );
+    }
+
+    #[test]
+    fn test_delete_dag_failure_restores_branch_before_post_commit_cleanup() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = Database::open_runtime(OpenSpec::primary(temp_dir.path())).unwrap();
+        let hook = Arc::new(ToggleFailDagHook::new());
+        db.install_dag_hook(hook.clone()).unwrap();
+
+        db.branches().create("victim").unwrap();
+        let kv = KVStore::new(db.clone());
+        let victim_id = BranchId::from_user_name("victim");
+        kv.put(&victim_id, "default", "seed", Value::Int(7))
+            .unwrap();
+
+        hook.set_fail_writes(true);
+        let err = db.branches().delete("victim").unwrap_err();
+        assert!(
+            err.to_string().contains("DAG") || err.to_string().contains("write"),
+            "expected DAG failure, got {err}"
+        );
+
+        let branch_index = BranchIndex::new(db.clone());
+        assert!(
+            branch_index.exists("victim").unwrap(),
+            "delete must roll back the logical branch mutation when DAG recording fails"
+        );
+
+        let restored = kv
+            .get(&victim_id, "default", "seed")
+            .unwrap()
+            .expect("post-commit storage cleanup must not run before DAG success");
+        assert_eq!(restored, Value::Int(7));
+
+        let store = BranchControlStore::new(db.clone());
+        let active = store
+            .find_active_by_name("victim")
+            .unwrap()
+            .expect("control record must be restored on DAG failure");
+        assert_eq!(active.branch.generation, 0);
+    }
+
+    #[test]
+    fn test_delete_post_commit_cleanup_failure_keeps_branch_deleted() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = Database::open_runtime(OpenSpec::primary(temp_dir.path())).unwrap();
+        let hook = Arc::new(ToggleFailDagHook::new());
+        db.install_dag_hook(hook.clone()).unwrap();
+
+        db.branches().create("cleanup-debt").unwrap();
+        let kv = KVStore::new(db.clone());
+        let branch_id = BranchId::from_user_name("cleanup-debt");
+        kv.put(&branch_id, "default", "seed", Value::Int(11))
+            .unwrap();
+        db.storage().rotate_memtable(&branch_id);
+        db.storage()
+            .flush_oldest_frozen(&branch_id)
+            .expect("setup flush succeeds");
+
+        crate::database::test_hooks::clear_clear_branch_storage_failure(temp_dir.path());
+        crate::database::test_hooks::inject_clear_branch_storage_failure(
+            temp_dir.path(),
+            std::io::ErrorKind::Other,
+        );
+
+        db.branches()
+            .delete("cleanup-debt")
+            .expect("logical delete must stay committed even if post-commit cleanup fails");
+        crate::database::test_hooks::clear_clear_branch_storage_failure(temp_dir.path());
+
+        let branch_index = BranchIndex::new(db.clone());
+        assert!(
+            !branch_index.exists("cleanup-debt").unwrap(),
+            "branch must remain logically deleted after cleanup debt"
+        );
+
+        let store = BranchControlStore::new(db.clone());
+        assert!(
+            store.find_active_by_name("cleanup-debt").unwrap().is_none(),
+            "active control record must stay cleared after committed delete"
+        );
+
+        let report = db
+            .retention_report()
+            .expect("cleanup debt after committed delete must surface as orphan storage");
+        let orphan = report
+            .orphan_storage
+            .iter()
+            .find(|entry| entry.branch_id == branch_id)
+            .expect("cleanup failure should leave orphaned storage debt behind");
+        assert!(
+            orphan.bytes > 0 || orphan.quarantined_bytes > 0,
+            "cleanup debt must keep retained bytes visible to retention reporting",
+        );
+
+        let dag_events = hook.events.lock().unwrap().clone();
+        let delete_events = dag_events
+            .iter()
+            .filter(|event| {
+                event.kind == DagEventKind::BranchDelete && event.branch_name == "cleanup-debt"
+            })
+            .count();
+        assert_eq!(
+            delete_events, 1,
+            "committed delete with cleanup debt must still record exactly one delete event"
         );
     }
 

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -232,7 +232,8 @@ impl Database {
     /// Returns `true` if removed (or didn't exist), `false` if skipped
     /// because a concurrent commit is in-flight.
     ///
-    /// Should be called after `BranchIndex::delete_branch()` succeeds.
+    /// Should be called from the post-commit cleanup phase after a logical
+    /// branch delete has already committed.
     pub fn remove_branch_lock(&self, branch_id: &BranchId) -> bool {
         self.coordinator.remove_branch_lock(branch_id)
     }

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -30,6 +30,7 @@ pub mod profile;
 pub(crate) mod recovery;
 mod recovery_error;
 mod registry;
+pub mod retention_report;
 pub mod spec;
 
 #[cfg(test)]
@@ -55,6 +56,10 @@ pub use recovery_error::{ErrorRole, RecoveryError};
 pub use refresh::{
     AdvanceError, BlockReason, BlockedTxn, FollowerStatus, RefreshHookError, RefreshOutcome,
     UnblockError,
+};
+pub use retention_report::{
+    BranchRetentionEntry, OrphanReason, OrphanStorageEntry, ReclaimStatus, RetentionBlocker,
+    RetentionReport, RetentionTotals,
 };
 pub use spec::{
     search_only_cache_spec, search_only_follower_spec, search_only_primary_spec, DatabaseMode,

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -33,7 +33,7 @@ mod registry;
 pub mod retention_report;
 pub mod spec;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 mod test_hooks;
 
 pub use branch_mutation::{BranchMutation, FailurePoint};
@@ -88,7 +88,7 @@ use strata_core::types::{BranchId, Key};
 use strata_core::{StrataError, StrataResult, VersionedValue};
 use strata_durability::__internal::{BackgroundSyncError, WalWriterEngineExt};
 use strata_durability::wal::{DurabilityMode, WalWriter};
-use strata_storage::{RecoveryHealth, SegmentedStore, StorageIterator};
+use strata_storage::{RecoveryHealth, SegmentedStore, StorageIterator, StorageResult};
 
 // ============================================================================
 // Persistence Mode (Storage/Durability Split)
@@ -794,13 +794,54 @@ impl Database {
         self.refresh_publish_barrier.write()
     }
 
-    /// Clean up storage-layer segments for a deleted branch (#1702).
+    /// Post-commit storage cleanup for a logically deleted branch (#1702).
     ///
-    /// Removes the branch's memtables, segment files, and decrements
-    /// inherited layer refcounts. Should be called after logical
-    /// deletion succeeds.
-    pub fn clear_branch_storage(&self, branch_id: &BranchId) {
-        self.storage.clear_branch(branch_id);
+    /// Performs post-commit storage cleanup for the branch, including
+    /// branch-local manifest publication, quarantine of reclaimable own
+    /// segments, and inherited-layer refcount release. Final purge is left to
+    /// explicit GC / reopen reconciliation, so cleanup debt may remain on
+    /// disk after this call.
+    ///
+    /// This is a storage cleanup primitive, not part of the rollbackable
+    /// logical delete transaction.
+    ///
+    /// Callers must invoke it only after the logical branch mutation has
+    /// committed successfully.
+    pub fn clear_branch_storage(&self, branch_id: &BranchId) -> StrataResult<()> {
+        self.clear_branch_storage_result(branch_id)?;
+        Ok(())
+    }
+
+    pub(crate) fn clear_branch_storage_result(&self, branch_id: &BranchId) -> StorageResult<()> {
+        #[cfg(any(test, feature = "test-support"))]
+        if let Some(inner) =
+            crate::database::test_hooks::maybe_inject_clear_branch_storage_failure(&self.data_dir)
+        {
+            return Err(strata_storage::StorageError::Io(inner));
+        }
+
+        self.storage.clear_branch(branch_id)?;
+        Ok(())
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn inject_clear_default_branch_marker_failure_for_test(
+        path: &Path,
+        kind: std::io::ErrorKind,
+    ) {
+        crate::database::test_hooks::inject_clear_default_branch_marker_failure(path, kind);
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn clear_clear_default_branch_marker_failure_for_test(path: &Path) {
+        crate::database::test_hooks::clear_clear_default_branch_marker_failure(path);
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn take_clear_default_branch_marker_failure_for_test(
+        path: &Path,
+    ) -> Option<std::io::Error> {
+        crate::database::test_hooks::maybe_inject_clear_default_branch_marker_failure(path)
     }
 
     /// Mark a branch as being deleted (#1916).

--- a/crates/engine/src/database/retention_report.rs
+++ b/crates/engine/src/database/retention_report.rs
@@ -12,13 +12,13 @@
 //!    [`strata_storage::SegmentedStore::retention_snapshot`]. Storage
 //!    does not know which `BranchRef` a given `BranchId` currently
 //!    maps to.
-//! 2. **Engine layer** — joins storage facts with `BranchControlStore`
-//!    so bytes are attributed to live `BranchRef` lifecycle instances.
-//!    When a storage directory has no live control record (e.g. a
-//!    tombstoned parent whose segments are still referenced by a
-//!    descendant's inherited layer), the entry appears in
-//!    [`RetentionReport::orphan_storage`] rather than being fabricated
-//!    into some live lifecycle.
+//! 2. **Engine layer** — joins storage facts with visible
+//!    (`Active | Archived`) `BranchControlStore` records so bytes are
+//!    attributed to live `BranchRef` lifecycle instances. When a storage
+//!    directory has no visible control record (e.g. a tombstoned parent
+//!    whose segments are still referenced by a descendant's inherited
+//!    layer), the entry appears in [`RetentionReport::orphan_storage`]
+//!    rather than being fabricated into some live lifecycle.
 //!
 //! Per the convergence doc's §"Rule 2. Stale-visible and unavailable
 //! are not the same." plus the surface matrix's hard-fail-degraded
@@ -39,7 +39,8 @@ use strata_core::{
     BranchControlRecord, BranchLifecycleStatus, BranchRef, StrataError, StrataResult,
 };
 use strata_storage::{
-    DegradationClass, RecoveryHealth, StorageBranchRetention, StorageInheritedLayerInfo,
+    DegradationClass, RecoveryHealth, StorageBranchRetention, StorageError,
+    StorageInheritedLayerInfo,
 };
 
 use crate::branch_ops::branch_control_store::BranchControlStore;
@@ -223,6 +224,9 @@ impl Database {
     /// §"Surface matrix" hard-fail rule. `PolicyDowngrade` with a
     /// `QuarantineInventoryMismatch` fault also routes here because
     /// the disagreement blocks trustworthy quarantine attribution.
+    /// Unmigrated-follower lineage unavailability (AD5) also routes here:
+    /// storage bytes may be known, but generation-aware `BranchRef`
+    /// attribution is not.
     /// Other `PolicyDowngrade` cases (e.g. no-manifest fallback) are
     /// reported as [`ReclaimStatus::BlockedDegradedRecovery`] inside a
     /// successful report: reclaim is paused but attribution remains
@@ -254,22 +258,28 @@ impl Database {
         };
 
         // Storage layer — manifest-derived per-directory facts.
-        let storage_snapshot = self.storage.retention_snapshot()?;
+        let storage_snapshot = match self.storage.retention_snapshot() {
+            Ok(snapshot) => snapshot,
+            Err(e) => {
+                return Err(StrataError::retention_report_unavailable(
+                    retention_snapshot_unavailable_class(&e),
+                ))
+            }
+        };
         let snapshot_by_id: HashMap<BranchId, StorageBranchRetention> = storage_snapshot
             .into_iter()
             .map(|s| (s.branch_id, s))
             .collect();
 
-        // Engine layer — live BranchRef + name per BranchId via
-        // BranchControlStore. Follower-synthesis / unmigrated-primary
-        // paths fall through with an empty map (attribution becomes
-        // OrphanStorageEntry::UntrackedLifecycle), which is safe.
-        // Uses the typed `is_branch_lineage_unavailable()` predicate
-        // rather than a string match so follower mode is classified by
-        // the same contract that guards lineage reads elsewhere.
-        let live_records = match BranchControlStore::new(self.clone()).list_active() {
+        // Engine layer — visible (`Active | Archived`) BranchRef + name per
+        // BranchId via BranchControlStore. If lifecycle identity is
+        // unavailable (e.g. unmigrated follower AD5), fail closed rather than
+        // fabricating every storage row into `orphan_storage`.
+        let live_records = match BranchControlStore::new(self.clone()).list_visible() {
             Ok(records) => records,
-            Err(e) if e.is_branch_lineage_unavailable() => Vec::new(),
+            Err(e) if e.is_branch_lineage_unavailable() => {
+                return Err(StrataError::retention_report_unavailable("PolicyDowngrade"))
+            }
             Err(e) => return Err(e),
         };
         let live_by_id: HashMap<BranchId, BranchControlRecord> =
@@ -431,5 +441,18 @@ fn class_name(class: DegradationClass) -> &'static str {
         // `DegradationClass` is `#[non_exhaustive]`; unknown variants
         // stringify to a sentinel the caller can still discriminate.
         _ => "Unknown",
+    }
+}
+
+fn retention_snapshot_unavailable_class(err: &StorageError) -> &'static str {
+    match err {
+        StorageError::QuarantineReconciliationFailed { .. } => "PolicyDowngrade",
+        StorageError::RecoveryFault(
+            strata_storage::RecoveryFault::QuarantineInventoryMismatch { .. },
+        ) => "PolicyDowngrade",
+        // Any other inability to read storage truth means the report cannot
+        // safely attribute retained bytes. Surface the typed hard-fail
+        // contract rather than leaking raw storage errors through this API.
+        _ => "DataLoss",
     }
 }

--- a/crates/engine/src/database/retention_report.rs
+++ b/crates/engine/src/database/retention_report.rs
@@ -1,0 +1,435 @@
+//! B5.2 — `Database::retention_report()`.
+//!
+//! Engine-owned, branch-vocabulary retention attribution surface per
+//! `docs/design/branching/branching-gc/branching-retention-contract.md`
+//! §"Engine-facing attribution contract" and the convergence doc's
+//! §"Retention report contract".
+//!
+//! Two-layer assembly:
+//!
+//! 1. **Storage layer** — derives own-segment, inherited-layer, and
+//!    quarantined byte totals per on-disk branch directory via
+//!    [`strata_storage::SegmentedStore::retention_snapshot`]. Storage
+//!    does not know which `BranchRef` a given `BranchId` currently
+//!    maps to.
+//! 2. **Engine layer** — joins storage facts with `BranchControlStore`
+//!    so bytes are attributed to live `BranchRef` lifecycle instances.
+//!    When a storage directory has no live control record (e.g. a
+//!    tombstoned parent whose segments are still referenced by a
+//!    descendant's inherited layer), the entry appears in
+//!    [`RetentionReport::orphan_storage`] rather than being fabricated
+//!    into some live lifecycle.
+//!
+//! Per the convergence doc's §"Rule 2. Stale-visible and unavailable
+//! are not the same." plus the surface matrix's hard-fail-degraded
+//! classification, `retention_report()` returns
+//! [`StrataError::RetentionReportUnavailable`] when recovery health
+//! cannot sustain trustworthy manifest-derived attribution
+//! (`DataLoss` or any `QuarantineInventoryMismatch`-driven
+//! `PolicyDowngrade`). Reclaim blockage that is *attribution-safe* is
+//! surfaced as [`ReclaimStatus`] inside a successful report — blocked
+//! reclaim is a retention fact, not a fabrication.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use strata_core::id::CommitVersion;
+use strata_core::types::BranchId;
+use strata_core::{
+    BranchControlRecord, BranchLifecycleStatus, BranchRef, StrataError, StrataResult,
+};
+use strata_storage::{
+    DegradationClass, RecoveryHealth, StorageBranchRetention, StorageInheritedLayerInfo,
+};
+
+use crate::branch_ops::branch_control_store::BranchControlStore;
+use crate::database::Database;
+
+/// Reclaim readiness classification for a retention report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReclaimStatus {
+    /// Reclaim is allowed; recovery health permits the full protocol.
+    Allowed,
+    /// Reclaim is refused because the most recent recovery produced a
+    /// non-`Telemetry` degradation (contract §"Recovery-health
+    /// contract"). Attribution in the report body is still trustworthy.
+    BlockedDegradedRecovery {
+        /// The observed degradation class (e.g. `"PolicyDowngrade"`).
+        class: String,
+    },
+}
+
+/// Reason a retention blocker is attributed to this branch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RetentionBlocker {
+    /// This branch retains bytes through an inherited-layer manifest
+    /// pointing at `source_branch_id` / `fork_version`. The current
+    /// blocker attribution goes to the *live* branch that still holds
+    /// the inherited-layer reference — per §"Canonical blocker
+    /// attribution", that is the actionable owner of the retention
+    /// debt, not the historical original writer.
+    InheritedLayerRetention {
+        /// Storage branch whose directory holds the retained bytes.
+        source_branch_id: BranchId,
+        /// Live lifecycle at `source_branch_id`, when one exists.
+        source_branch: Option<BranchRef>,
+        /// Fork point that bounds descendant visibility into the source.
+        fork_version: CommitVersion,
+        /// Bytes kept live by this layer reference.
+        bytes: u64,
+        /// `true` if the operator can drop this blocker by calling
+        /// `materialize` on this branch. `false` when the source branch
+        /// still has a live lifecycle — those bytes aren't
+        /// materialize-reclaimable, they're genuinely shared.
+        removable_by_materialization: bool,
+    },
+    /// This branch holds own-segment bytes that at least one
+    /// descendant's inherited-layer manifest references. Not
+    /// actionable by this branch alone.
+    DescendantHolds {
+        /// Total bytes held by descendants.
+        bytes: u64,
+    },
+    /// One or more segments in this branch's `__quarantine__/` are
+    /// pending Stage-5 purge but reclaim trust is degraded. The report
+    /// surfaces the fact; recovery must be healthy before the purge
+    /// can drain.
+    QuarantinePending {
+        /// Number of segments awaiting final purge.
+        segment_count: usize,
+        /// Total bytes awaiting final purge.
+        bytes: u64,
+    },
+}
+
+/// Per-branch retention entry attributed to a live `BranchRef`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct BranchRetentionEntry {
+    /// Generation-aware canonical identity.
+    pub branch: BranchRef,
+    /// User-facing branch name recorded on the control record.
+    pub name: String,
+    /// Lifecycle state at the time the report was produced.
+    pub lifecycle: BranchLifecycleStatus,
+    /// Own-segment bytes that no descendant's inherited layer references.
+    pub exclusive_bytes: u64,
+    /// Own-segment bytes that at least one descendant still references
+    /// through an inherited layer (retention survives `clear_branch`
+    /// until every descendant releases).
+    pub shared_bytes: u64,
+    /// Bytes visible to this branch via inherited-layer manifests;
+    /// bytes physically live under the source branch's directory.
+    pub inherited_layer_bytes: u64,
+    /// Bytes in this branch's `__quarantine__/` awaiting Stage-5 purge.
+    pub quarantined_bytes: u64,
+    /// Retention blockers attributed to this branch.
+    pub blockers: Vec<RetentionBlocker>,
+}
+
+/// Storage-only retention record whose on-disk directory has no live
+/// control record to attribute it to.
+///
+/// This is where bytes end up when a parent has been deleted (control
+/// record tombstoned) but descendants still reference its segments
+/// through inherited layers — the contract's §"Parent delete with
+/// surviving descendants" path.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct OrphanStorageEntry {
+    /// The storage directory's branch id.
+    pub branch_id: BranchId,
+    /// Own-segment bytes the directory still holds.
+    pub bytes: u64,
+    /// Bytes quarantined under this directory.
+    pub quarantined_bytes: u64,
+    /// Why this storage dir outlived its control record.
+    pub reason: OrphanReason,
+}
+
+/// Classification for [`OrphanStorageEntry`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OrphanReason {
+    /// The control record was tombstoned but a descendant's
+    /// inherited-layer manifest still references bytes under this
+    /// directory. Retained per contract Invariant 7 + §"Parent
+    /// delete".
+    DescendantInheritance,
+    /// No live control record and no inbound inherited-layer
+    /// references observed — typically quarantine-only retention
+    /// debt or a pre-control-store legacy branch directory.
+    UntrackedLifecycle,
+}
+
+/// Aggregate totals across every entry + orphan in the report.
+///
+/// **Not a unique-bytes sum.** `shared_bytes` and `inherited_layer_bytes`
+/// are two views of the same physical retention: bytes owned by one
+/// branch but kept live by a descendant's inherited-layer reference are
+/// counted once on the owner (as shared) and once on each descendant
+/// that inherits (as inherited-layer). The view that matters depends on
+/// what the operator is asking:
+///
+/// - "how many bytes am I retaining because of live branches?" →
+///   `exclusive_bytes + shared_bytes` (owner view)
+/// - "which branches are responsible for keeping retention alive?" →
+///   iterate `branches[*].blockers`, not the totals
+///
+/// `quarantined_bytes` is disjoint from the other three (quarantined
+/// files are physically separate from own segments).
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct RetentionTotals {
+    /// Sum of `exclusive_bytes` across all branch entries + orphan entries.
+    pub exclusive_bytes: u64,
+    /// Sum of `shared_bytes` across all branch entries.
+    pub shared_bytes: u64,
+    /// Sum of `inherited_layer_bytes` across all branch entries. Overlaps
+    /// with `shared_bytes` — see struct-level note.
+    pub inherited_layer_bytes: u64,
+    /// Sum of `quarantined_bytes` across all branches + orphans.
+    pub quarantined_bytes: u64,
+}
+
+/// Generation-aware branch-vocabulary retention attribution surface.
+///
+/// See the module-level doc and the B5 contract for the governing rules.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct RetentionReport {
+    /// Reclaim readiness classification.
+    pub reclaim_status: ReclaimStatus,
+    /// Per-branch entries keyed by live `BranchRef`.
+    pub branches: Vec<BranchRetentionEntry>,
+    /// Storage directories with no live lifecycle to attribute them to.
+    pub orphan_storage: Vec<OrphanStorageEntry>,
+    /// Aggregate totals across the entire report.
+    pub totals: RetentionTotals,
+}
+
+impl Database {
+    /// Generation-aware branch-vocabulary retention attribution.
+    ///
+    /// Manifest-derived: own-segment bytes, inherited-layer bytes,
+    /// `__quarantine__/` inventory bytes, and reclaim readiness under
+    /// the current recovery-health classification.
+    ///
+    /// Returns `Err(StrataError::RetentionReportUnavailable)` when
+    /// recovery health is `DataLoss` (authoritative loss that would
+    /// force attribution to fabricate) per the convergence doc's
+    /// §"Surface matrix" hard-fail rule. `PolicyDowngrade` with a
+    /// `QuarantineInventoryMismatch` fault also routes here because
+    /// the disagreement blocks trustworthy quarantine attribution.
+    /// Other `PolicyDowngrade` cases (e.g. no-manifest fallback) are
+    /// reported as [`ReclaimStatus::BlockedDegradedRecovery`] inside a
+    /// successful report: reclaim is paused but attribution remains
+    /// trustworthy.
+    ///
+    /// Contract: `docs/design/branching/branching-gc/branching-retention-contract.md`
+    /// §"Engine-facing attribution contract".
+    pub fn retention_report(self: &Arc<Self>) -> StrataResult<RetentionReport> {
+        let health = self.recovery_health();
+        if let Some(cls) = report_refusal_class(&health) {
+            return Err(StrataError::retention_report_unavailable(class_name(cls)));
+        }
+
+        let reclaim_status = match &health {
+            RecoveryHealth::Healthy
+            | RecoveryHealth::Degraded {
+                class: DegradationClass::Telemetry,
+                ..
+            } => ReclaimStatus::Allowed,
+            RecoveryHealth::Degraded { class, .. } => ReclaimStatus::BlockedDegradedRecovery {
+                class: class_name(*class).to_string(),
+            },
+            // `RecoveryHealth` is `#[non_exhaustive]`; unknown variants
+            // are already refused by `report_refusal_class`, so this
+            // arm is defense-in-depth — report degraded.
+            _ => ReclaimStatus::BlockedDegradedRecovery {
+                class: "Unknown".to_string(),
+            },
+        };
+
+        // Storage layer — manifest-derived per-directory facts.
+        let storage_snapshot = self.storage.retention_snapshot()?;
+        let snapshot_by_id: HashMap<BranchId, StorageBranchRetention> = storage_snapshot
+            .into_iter()
+            .map(|s| (s.branch_id, s))
+            .collect();
+
+        // Engine layer — live BranchRef + name per BranchId via
+        // BranchControlStore. Follower-synthesis / unmigrated-primary
+        // paths fall through with an empty map (attribution becomes
+        // OrphanStorageEntry::UntrackedLifecycle), which is safe.
+        // Uses the typed `is_branch_lineage_unavailable()` predicate
+        // rather than a string match so follower mode is classified by
+        // the same contract that guards lineage reads elsewhere.
+        let live_records = match BranchControlStore::new(self.clone()).list_active() {
+            Ok(records) => records,
+            Err(e) if e.is_branch_lineage_unavailable() => Vec::new(),
+            Err(e) => return Err(e),
+        };
+        let live_by_id: HashMap<BranchId, BranchControlRecord> =
+            live_records.into_iter().map(|r| (r.branch.id, r)).collect();
+
+        // Collect which storage branches any live inherited-layer
+        // points at — needed to classify orphan storage as
+        // "DescendantInheritance" rather than "UntrackedLifecycle".
+        let mut inherited_sources: HashMap<BranchId, bool> = HashMap::new();
+        for snap in snapshot_by_id.values() {
+            for layer in &snap.inherited_layers {
+                inherited_sources.insert(layer.source_branch_id, true);
+            }
+        }
+
+        // Build per-branch entries for every live control record.
+        let mut branches: Vec<BranchRetentionEntry> = Vec::new();
+        let mut totals = RetentionTotals::default();
+
+        for record in live_by_id.values() {
+            let branch_id = record.branch.id;
+            let snap = snapshot_by_id
+                .get(&branch_id)
+                .cloned()
+                .unwrap_or_else(|| StorageBranchRetention::empty(branch_id));
+
+            let mut blockers: Vec<RetentionBlocker> = Vec::new();
+            for layer in &snap.inherited_layers {
+                blockers.push(inherited_layer_blocker(layer, &live_by_id));
+            }
+            if snap.shared_bytes > 0 {
+                blockers.push(RetentionBlocker::DescendantHolds {
+                    bytes: snap.shared_bytes,
+                });
+            }
+            if snap.quarantined_segment_count > 0
+                && matches!(
+                    reclaim_status,
+                    ReclaimStatus::BlockedDegradedRecovery { .. }
+                )
+            {
+                blockers.push(RetentionBlocker::QuarantinePending {
+                    segment_count: snap.quarantined_segment_count,
+                    bytes: snap.quarantined_bytes,
+                });
+            }
+
+            totals.exclusive_bytes += snap.exclusive_bytes;
+            totals.shared_bytes += snap.shared_bytes;
+            totals.inherited_layer_bytes += snap.inherited_layer_bytes;
+            totals.quarantined_bytes += snap.quarantined_bytes;
+
+            branches.push(BranchRetentionEntry {
+                branch: record.branch,
+                name: record.name.clone(),
+                lifecycle: record.lifecycle,
+                exclusive_bytes: snap.exclusive_bytes,
+                shared_bytes: snap.shared_bytes,
+                inherited_layer_bytes: snap.inherited_layer_bytes,
+                quarantined_bytes: snap.quarantined_bytes,
+                blockers,
+            });
+        }
+
+        // Remaining storage directories have no live control record.
+        let mut orphan_storage: Vec<OrphanStorageEntry> = Vec::new();
+        for (branch_id, snap) in &snapshot_by_id {
+            if live_by_id.contains_key(branch_id) {
+                continue;
+            }
+            let total_bytes = snap.exclusive_bytes + snap.shared_bytes;
+            if total_bytes == 0 && snap.quarantined_bytes == 0 {
+                continue;
+            }
+            let reason = if inherited_sources.contains_key(branch_id) || snap.shared_bytes > 0 {
+                OrphanReason::DescendantInheritance
+            } else {
+                OrphanReason::UntrackedLifecycle
+            };
+            totals.exclusive_bytes += snap.exclusive_bytes;
+            totals.shared_bytes += snap.shared_bytes;
+            totals.quarantined_bytes += snap.quarantined_bytes;
+            orphan_storage.push(OrphanStorageEntry {
+                branch_id: *branch_id,
+                bytes: total_bytes,
+                quarantined_bytes: snap.quarantined_bytes,
+                reason,
+            });
+        }
+
+        Ok(RetentionReport {
+            reclaim_status,
+            branches,
+            orphan_storage,
+            totals,
+        })
+    }
+}
+
+fn inherited_layer_blocker(
+    layer: &StorageInheritedLayerInfo,
+    live_by_id: &HashMap<BranchId, BranchControlRecord>,
+) -> RetentionBlocker {
+    let source_branch = live_by_id.get(&layer.source_branch_id).map(|r| r.branch);
+    // Removable by materialize when the source has no live lifecycle;
+    // otherwise the bytes are genuinely shared with a live source and
+    // materialize on the descendant merely rewrites ownership, not
+    // existence.
+    let removable_by_materialization = source_branch.is_none();
+    RetentionBlocker::InheritedLayerRetention {
+        source_branch_id: layer.source_branch_id,
+        source_branch,
+        fork_version: layer.fork_version,
+        bytes: layer.bytes,
+        removable_by_materialization,
+    }
+}
+
+/// Return `Some(class)` if recovery health is degraded enough that
+/// attribution cannot be trusted and `retention_report()` must refuse
+/// with [`StrataError::RetentionReportUnavailable`].
+fn report_refusal_class(health: &RecoveryHealth) -> Option<DegradationClass> {
+    match health {
+        RecoveryHealth::Healthy
+        | RecoveryHealth::Degraded {
+            class: DegradationClass::Telemetry,
+            ..
+        } => None,
+        RecoveryHealth::Degraded { class, faults } => {
+            if matches!(class, DegradationClass::DataLoss) {
+                return Some(*class);
+            }
+            // PolicyDowngrade is attribution-safe *except* when it
+            // stems from a QuarantineInventoryMismatch — that
+            // specifically says we cannot trust the quarantine side
+            // of the attribution join.
+            for fault in faults.iter() {
+                if matches!(
+                    fault,
+                    strata_storage::RecoveryFault::QuarantineInventoryMismatch { .. }
+                ) {
+                    return Some(*class);
+                }
+            }
+            None
+        }
+        // `RecoveryHealth` is `#[non_exhaustive]`; unknown variants
+        // route to a defensive refusal rather than fabricating a
+        // report.
+        _ => Some(DegradationClass::DataLoss),
+    }
+}
+
+fn class_name(class: DegradationClass) -> &'static str {
+    match class {
+        DegradationClass::DataLoss => "DataLoss",
+        DegradationClass::PolicyDowngrade => "PolicyDowngrade",
+        DegradationClass::Telemetry => "Telemetry",
+        // `DegradationClass` is `#[non_exhaustive]`; unknown variants
+        // stringify to a sentinel the caller can still discriminate.
+        _ => "Unknown",
+    }
+}

--- a/crates/engine/src/database/test_hooks.rs
+++ b/crates/engine/src/database/test_hooks.rs
@@ -24,6 +24,18 @@ fn flush_thread_spawn_failure_slot() -> &'static Mutex<HashSet<PathBuf>> {
     FLUSH_THREAD_SPAWN_FAILURE.get_or_init(|| Mutex::new(HashSet::new()))
 }
 
+fn clear_branch_storage_failure_slot() -> &'static Mutex<HashMap<PathBuf, io::ErrorKind>> {
+    static CLEAR_BRANCH_STORAGE_FAILURE: OnceLock<Mutex<HashMap<PathBuf, io::ErrorKind>>> =
+        OnceLock::new();
+    CLEAR_BRANCH_STORAGE_FAILURE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn clear_default_branch_marker_failure_slot() -> &'static Mutex<HashMap<PathBuf, io::ErrorKind>> {
+    static CLEAR_DEFAULT_BRANCH_MARKER_FAILURE: OnceLock<Mutex<HashMap<PathBuf, io::ErrorKind>>> =
+        OnceLock::new();
+    CLEAR_DEFAULT_BRANCH_MARKER_FAILURE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 #[derive(Default)]
 struct HaltPublishPauseState {
     reached: bool,
@@ -85,6 +97,34 @@ pub(super) fn clear_flush_thread_spawn_failure(path: &Path) {
         .remove(path);
 }
 
+pub(super) fn inject_clear_branch_storage_failure(path: &Path, kind: io::ErrorKind) {
+    clear_branch_storage_failure_slot()
+        .lock()
+        .unwrap()
+        .insert(path.to_path_buf(), kind);
+}
+
+pub(super) fn clear_clear_branch_storage_failure(path: &Path) {
+    clear_branch_storage_failure_slot()
+        .lock()
+        .unwrap()
+        .remove(path);
+}
+
+pub(super) fn inject_clear_default_branch_marker_failure(path: &Path, kind: io::ErrorKind) {
+    clear_default_branch_marker_failure_slot()
+        .lock()
+        .unwrap()
+        .insert(path.to_path_buf(), kind);
+}
+
+pub(super) fn clear_clear_default_branch_marker_failure(path: &Path) {
+    clear_default_branch_marker_failure_slot()
+        .lock()
+        .unwrap()
+        .remove(path);
+}
+
 pub(super) fn install_halt_publish_pause(path: &Path) {
     halt_publish_pause_slot().lock().unwrap().insert(
         path.to_path_buf(),
@@ -131,6 +171,22 @@ pub(super) fn take_flush_thread_spawn_failure(path: &Path) -> bool {
         .lock()
         .unwrap()
         .remove(path)
+}
+
+pub(super) fn maybe_inject_clear_branch_storage_failure(path: &Path) -> Option<io::Error> {
+    clear_branch_storage_failure_slot()
+        .lock()
+        .unwrap()
+        .remove(path)
+        .map(|kind| io::Error::new(kind, "injected clear_branch_storage failure"))
+}
+
+pub(super) fn maybe_inject_clear_default_branch_marker_failure(path: &Path) -> Option<io::Error> {
+    clear_default_branch_marker_failure_slot()
+        .lock()
+        .unwrap()
+        .remove(path)
+        .map(|kind| io::Error::new(kind, "injected clear_default_branch_marker failure"))
 }
 
 pub(super) fn maybe_pause_after_halt_health_publish(path: &Path) {
@@ -217,6 +273,46 @@ mod tests {
         );
         assert!(take_flush_thread_spawn_failure(path));
         assert!(!take_flush_thread_spawn_failure(path));
+    }
+
+    #[test]
+    fn test_clear_branch_storage_failure_hook_consumes_one_failure() {
+        let path = Path::new("/tmp/test-clear-branch-storage-failure");
+        let other_path = Path::new("/tmp/test-clear-branch-storage-failure-other");
+        clear_clear_branch_storage_failure(path);
+        clear_clear_branch_storage_failure(other_path);
+        assert!(maybe_inject_clear_branch_storage_failure(path).is_none());
+        assert!(maybe_inject_clear_branch_storage_failure(other_path).is_none());
+
+        inject_clear_branch_storage_failure(path, io::ErrorKind::Other);
+        assert!(
+            maybe_inject_clear_branch_storage_failure(other_path).is_none(),
+            "hook must be scoped by path"
+        );
+        let err =
+            maybe_inject_clear_branch_storage_failure(path).expect("expected injected failure");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert!(maybe_inject_clear_branch_storage_failure(path).is_none());
+    }
+
+    #[test]
+    fn test_clear_default_branch_marker_failure_hook_consumes_one_failure() {
+        let path = Path::new("/tmp/test-clear-default-branch-marker-failure");
+        let other_path = Path::new("/tmp/test-clear-default-branch-marker-failure-other");
+        clear_clear_default_branch_marker_failure(path);
+        clear_clear_default_branch_marker_failure(other_path);
+        assert!(maybe_inject_clear_default_branch_marker_failure(path).is_none());
+        assert!(maybe_inject_clear_default_branch_marker_failure(other_path).is_none());
+
+        inject_clear_default_branch_marker_failure(path, io::ErrorKind::Other);
+        assert!(
+            maybe_inject_clear_default_branch_marker_failure(other_path).is_none(),
+            "hook must be scoped by path"
+        );
+        let err = maybe_inject_clear_default_branch_marker_failure(path)
+            .expect("expected injected failure");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert!(maybe_inject_clear_default_branch_marker_failure(path).is_none());
     }
 
     #[test]

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -43,9 +43,11 @@ pub use database::profile::{
     Profile,
 };
 pub use database::{
-    CacheMetrics, Database, DatabaseDiskUsage, ErrorRole, HealthReport, LossyErrorKind,
-    LossyRecoveryReport, ModelConfig, RecoveryError, StorageConfig, StorageMetricsSummary,
-    StrataConfig, SubsystemHealth, SubsystemStatus, SystemMetrics, WalWriterHealth,
+    BranchRetentionEntry, CacheMetrics, Database, DatabaseDiskUsage, ErrorRole, HealthReport,
+    LossyErrorKind, LossyRecoveryReport, ModelConfig, OrphanReason, OrphanStorageEntry,
+    ReclaimStatus, RecoveryError, RetentionBlocker, RetentionReport, RetentionTotals,
+    StorageConfig, StorageMetricsSummary, StrataConfig, SubsystemHealth, SubsystemStatus,
+    SystemMetrics, WalWriterHealth,
 };
 pub use instrumentation::PerfTrace;
 pub use recovery::Subsystem;

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -30,6 +30,7 @@ use strata_core::types::{BranchId, Key, Namespace, TypeTag};
 use strata_core::value::Value;
 use strata_core::StrataError;
 use strata_core::StrataResult;
+use strata_storage::StorageError;
 use tracing::{info, warn};
 
 /// Internal metadata key storing the effective default branch name for
@@ -136,7 +137,7 @@ fn admin_transaction_branch_id(target_branch_id: BranchId) -> BranchId {
     }
 }
 
-fn default_branch_marker_key() -> Key {
+pub(crate) fn default_branch_marker_key() -> Key {
     Key::new_branch_with_id(global_namespace(), DEFAULT_BRANCH_MARKER_KEY)
 }
 
@@ -172,6 +173,12 @@ pub(crate) fn clear_default_branch_marker_if(
     db: &Arc<Database>,
     branch_name: &str,
 ) -> StrataResult<()> {
+    #[cfg(any(test, feature = "test-support"))]
+    if let Some(inner) = Database::take_clear_default_branch_marker_failure_for_test(db.data_dir())
+    {
+        return Err(StrataError::from(strata_storage::StorageError::Io(inner)));
+    }
+
     db.transaction(global_branch_id(), |txn| {
         let key = default_branch_marker_key();
         let should_clear =
@@ -489,23 +496,37 @@ impl BranchIndex {
     ///
     /// USE WITH CAUTION - this is irreversible!
     pub(crate) fn delete_branch(&self, branch_id: &str) -> StrataResult<()> {
-        self.delete_branch_with_hook(branch_id, |_| Ok(()))
+        let committed = self.delete_branch_with_hook(branch_id, |_| Ok(()))?;
+        match self.complete_delete_post_commit(
+            branch_id,
+            &committed,
+            DeletePostCommitOptions {
+                clear_storage: true,
+                dispatch_best_effort_delete_hook: true,
+            },
+        ) {
+            DeleteBranchCompletion::Clean | DeleteBranchCompletion::Warning(_) => Ok(()),
+            DeleteBranchCompletion::PostCommitError(err) => Err(err),
+        }
     }
 
-    /// Delete a branch and ALL its data, running `pre_commit` inside the
-    /// same KV transaction that purges the legacy metadata + namespace
-    /// data.
+    /// Delete a branch logically, running `pre_commit` inside the same KV
+    /// transaction that purges the legacy metadata + namespace data.
     ///
     /// Used by `BranchService::delete` (B3.2) to atomically mark the
     /// corresponding `BranchControlRecord` as `Deleted` alongside the
     /// legacy purge. The hook runs after namespace data is staged for
     /// removal and before the metadata row is dropped; if it errors the
     /// entire delete transaction rolls back and the branch remains live.
+    ///
+    /// This method stops at the committed logical-delete boundary. Any
+    /// storage cleanup, subsystem cleanup, or best-effort delete-hook
+    /// dispatch must run later through [`BranchIndex::complete_delete_post_commit`].
     pub(crate) fn delete_branch_with_hook<F>(
         &self,
         branch_id: &str,
         pre_commit: F,
-    ) -> StrataResult<()>
+    ) -> StrataResult<DeleteBranchCommitted>
     where
         F: FnOnce(&mut TransactionContext) -> StrataResult<()>,
     {
@@ -531,8 +552,8 @@ impl BranchIndex {
         //    commit can start (the mark rejects them after they acquire
         //    the lock, so the lock is released immediately).
         // 3. Run the delete transaction (on global_branch_id, cross-branch).
-        // 4. Clear storage.
-        // 5. Clean up the mark and commit lock entry.
+        // 4. Hand the committed delete to the post-commit cleanup phase.
+        // 5. Post-commit cleanup clears storage and releases the lock entry.
         self.db.mark_branch_deleting(&executor_branch_id);
         if let Some(meta_id) = metadata_branch_id {
             if meta_id != executor_branch_id {
@@ -586,61 +607,106 @@ impl BranchIndex {
             return Err(e);
         }
 
-        if let Err(e) = clear_default_branch_marker_if(&self.db, branch_id) {
-            warn!(
-                target: "strata::branch",
-                branch = branch_id,
-                error = %e,
-                "Failed to clear persisted default-branch marker after delete"
-            );
-        }
-
         // Evict cached namespaces for the deleted branch to prevent unbounded
         // growth of the global NS_CACHE (SCALE-001).
         crate::primitives::kv::invalidate_kv_namespace_cache(&executor_branch_id);
         crate::system_space::invalidate_cache(&executor_branch_id);
 
-        // Drain background tasks before clearing storage. The delete
-        // transaction above commits writes that schedule flush/compaction
-        // via `schedule_flush_if_needed`. If compaction runs concurrently
-        // with clear_branch_storage, it can leave `.tmp` files mid-write
-        // or create new `.sst` files that our cleanup enumeration missed.
-        //
-        // Limitation: drain() waits for all scheduled tasks, not just
-        // tasks for this branch. In a busy multi-branch deployment with
-        // continuous writes, delete_branch may block while other branches
-        // finish their own compaction rounds. Acceptable for an admin
-        // operation; if it becomes a concern, add a drain_with_timeout API.
-        self.db.scheduler().drain();
+        Ok(DeleteBranchCommitted { executor_branch_id })
+    }
 
-        // Clean up storage-layer segments, manifest, and refcounts (#1702).
-        // Must happen after logical deletion so in-progress reads see the
-        // deletion before files disappear.
-        //
-        // Literal `"default"` is special: its canonical BranchId is the same
-        // nil branch id used by global branch-index/control-store metadata.
-        // The delete transaction above already tombstones user primitive rows
-        // in that namespace. A physical `clear_branch_storage(nil)` would also
-        // wipe the branch-control ledger itself (next-generation counters,
-        // active pointers, metadata rows for other branches), breaking
-        // generation-safe recreate. Keep nil/default deletion logical-only at
-        // the storage layer; later compaction/GC will reclaim the user data.
-        if executor_branch_id != global_branch_id() {
-            self.db.clear_branch_storage(&executor_branch_id);
+    /// Complete the post-commit cleanup phase for a logically deleted branch.
+    ///
+    /// This runs after the delete transaction has committed and therefore must
+    /// not be treated as rollbackable logical state. It may report cleanup
+    /// debt via [`DeleteBranchCompletion::Warning`] or
+    /// [`DeleteBranchCompletion::PostCommitError`], but the branch is already
+    /// logically deleted at this point.
+    pub(crate) fn complete_delete_post_commit(
+        &self,
+        branch_id: &str,
+        committed: &DeleteBranchCommitted,
+        options: DeletePostCommitOptions,
+    ) -> DeleteBranchCompletion {
+        let executor_branch_id = committed.executor_branch_id;
+        let mut completion = DeleteBranchCompletion::Clean;
+
+        if let Err(err) = clear_default_branch_marker_if(&self.db, branch_id) {
+            warn!(
+                target: "strata::branch",
+                branch = branch_id,
+                error = %err,
+                "Failed to clear persisted default-branch marker after committed delete"
+            );
+            completion.record_error(err);
+        }
+
+        if options.clear_storage {
+            // Drain background tasks before clearing storage. The delete
+            // transaction above commits writes that schedule flush/compaction
+            // via `schedule_flush_if_needed`. If compaction runs concurrently
+            // with clear_branch_storage, it can leave `.tmp` files mid-write
+            // or create new `.sst` files that our cleanup enumeration missed.
+            //
+            // Limitation: drain() waits for all scheduled tasks, not just
+            // tasks for this branch. In a busy multi-branch deployment with
+            // continuous writes, delete_branch may block while other branches
+            // finish their own compaction rounds. Acceptable for an admin
+            // operation; if it becomes a concern, add a drain_with_timeout API.
+            self.db.scheduler().drain();
+
+            // Clean up storage-layer segments, manifest, and refcounts (#1702).
+            // Must happen after logical deletion so in-progress reads see the
+            // deletion before files disappear.
+            //
+            // Literal `"default"` is special: its canonical BranchId is the same
+            // nil branch id used by global branch-index/control-store metadata.
+            // The delete transaction above already tombstones user primitive rows
+            // in that namespace. A physical `clear_branch_storage(nil)` would also
+            // wipe the branch-control ledger itself (next-generation counters,
+            // active pointers, metadata rows for other branches), breaking
+            // generation-safe recreate. Keep nil/default deletion logical-only at
+            // the storage layer; later compaction/GC will reclaim the user data.
+            if executor_branch_id != global_branch_id() {
+                match self.db.clear_branch_storage_result(&executor_branch_id) {
+                    Ok(_) => {}
+                    Err(StorageError::DirFsync { dir, inner }) => {
+                        let warning = StrataError::from(StorageError::DirFsync { dir, inner });
+                        warn!(
+                            target: "strata::branch",
+                            branch = branch_id,
+                            error = %warning,
+                            "Logical delete committed; storage cleanup completed with unconfirmed manifest durability",
+                        );
+                        completion.record_warning(warning);
+                    }
+                    Err(storage_err) => {
+                        let err = StrataError::from(storage_err);
+                        warn!(
+                            target: "strata::branch",
+                            branch = branch_id,
+                            error = %err,
+                            "Logical delete committed, but storage cleanup failed after commit",
+                        );
+                        completion.record_error(err);
+                    }
+                }
+            }
         }
 
         let subsystems = self.db.installed_subsystems();
         for subsystem in subsystems.iter() {
-            if let Err(e) =
+            if let Err(err) =
                 subsystem.cleanup_deleted_branch(&self.db, &executor_branch_id, branch_id)
             {
                 warn!(
                     target: "strata::branch",
                     subsystem = subsystem.name(),
                     branch = branch_id,
-                    error = %e,
+                    error = %err,
                     "Subsystem branch cleanup failed after delete"
                 );
+                completion.record_error(err);
             }
         }
 
@@ -649,11 +715,11 @@ impl BranchIndex {
         // this branch after deletion will be rejected (#1916).
         self.db.remove_branch_lock(&executor_branch_id);
 
-        // BranchService.delete() suppresses this best-effort dispatch so it can
-        // record through the load-bearing BranchMutation boundary instead.
-        dispatch_delete_hook(&self.db, branch_id);
+        if options.dispatch_best_effort_delete_hook {
+            dispatch_delete_hook(&self.db, branch_id);
+        }
 
-        Ok(())
+        completion
     }
 
     /// Delete all branch-scoped data within an existing transaction context.
@@ -682,6 +748,38 @@ impl BranchIndex {
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct DeleteBranchCommitted {
+    pub(crate) executor_branch_id: BranchId,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DeletePostCommitOptions {
+    pub(crate) clear_storage: bool,
+    pub(crate) dispatch_best_effort_delete_hook: bool,
+}
+
+#[derive(Debug)]
+pub(crate) enum DeleteBranchCompletion {
+    Clean,
+    Warning(StrataError),
+    PostCommitError(StrataError),
+}
+
+impl DeleteBranchCompletion {
+    fn record_warning(&mut self, warning: StrataError) {
+        if matches!(self, Self::Clean) {
+            *self = Self::Warning(warning);
+        }
+    }
+
+    fn record_error(&mut self, err: StrataError) {
+        if !matches!(self, Self::PostCommitError(_)) {
+            *self = Self::PostCommitError(err);
+        }
+    }
+}
+
 // ========== Searchable Trait Implementation ==========
 //
 // Search is handled by the intelligence layer.
@@ -706,6 +804,8 @@ impl crate::search::Searchable for BranchIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::database::OpenSpec;
+    use crate::Subsystem;
     use tempfile::TempDir;
 
     fn setup() -> (TempDir, Arc<Database>, BranchIndex) {
@@ -713,6 +813,29 @@ mod tests {
         let db = Database::open(temp_dir.path()).unwrap();
         let ri = BranchIndex::new(db.clone());
         (temp_dir, db, ri)
+    }
+
+    struct FailingCleanupSubsystem;
+
+    impl Subsystem for FailingCleanupSubsystem {
+        fn name(&self) -> &'static str {
+            "failing-cleanup"
+        }
+
+        fn recover(&self, _db: &Arc<Database>) -> StrataResult<()> {
+            Ok(())
+        }
+
+        fn cleanup_deleted_branch(
+            &self,
+            _db: &Arc<Database>,
+            _branch_id: &BranchId,
+            _branch_name: &str,
+        ) -> StrataResult<()> {
+            Err(StrataError::internal(
+                "injected cleanup_deleted_branch failure".to_string(),
+            ))
+        }
     }
 
     #[test]
@@ -848,6 +971,112 @@ mod tests {
 
         let result = ri.delete_branch("nonexistent");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_complete_delete_post_commit_classifies_default_marker_clear_failure() {
+        let (temp_dir, db, ri) = setup();
+        ri.create_branch("marker-victim").unwrap();
+        write_default_branch_marker(&db, "marker-victim").unwrap();
+
+        Database::clear_clear_default_branch_marker_failure_for_test(temp_dir.path());
+        Database::inject_clear_default_branch_marker_failure_for_test(
+            temp_dir.path(),
+            std::io::ErrorKind::Other,
+        );
+
+        let committed = ri
+            .delete_branch_with_hook("marker-victim", |_| Ok(()))
+            .expect("logical delete must commit");
+        let completion = ri.complete_delete_post_commit(
+            "marker-victim",
+            &committed,
+            DeletePostCommitOptions {
+                clear_storage: false,
+                dispatch_best_effort_delete_hook: false,
+            },
+        );
+        Database::clear_clear_default_branch_marker_failure_for_test(temp_dir.path());
+
+        match completion {
+            DeleteBranchCompletion::PostCommitError(err) => {
+                assert!(
+                    error_chain_contains(&err, "clear_default_branch_marker")
+                        || error_chain_contains(&err, "injected"),
+                    "expected marker clear failure in error chain, got {err}",
+                );
+            }
+            other => panic!("expected PostCommitError, got {other:?}"),
+        }
+    }
+
+    fn error_chain_contains(err: &StrataError, needle: &str) -> bool {
+        let mut current: Option<&dyn std::error::Error> = Some(err);
+        while let Some(e) = current {
+            if e.to_string().contains(needle) {
+                return true;
+            }
+            current = e.source();
+        }
+        false
+    }
+
+    #[test]
+    fn test_complete_delete_post_commit_classifies_subsystem_cleanup_failure() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = Database::open_runtime(
+            OpenSpec::primary(temp_dir.path()).with_subsystem(FailingCleanupSubsystem),
+        )
+        .unwrap();
+        let ri = BranchIndex::new(db.clone());
+        ri.create_branch("subsystem-victim").unwrap();
+
+        let committed = ri
+            .delete_branch_with_hook("subsystem-victim", |_| Ok(()))
+            .expect("logical delete must commit");
+        let completion = ri.complete_delete_post_commit(
+            "subsystem-victim",
+            &committed,
+            DeletePostCommitOptions {
+                clear_storage: false,
+                dispatch_best_effort_delete_hook: false,
+            },
+        );
+
+        match completion {
+            DeleteBranchCompletion::PostCommitError(err) => {
+                assert!(
+                    err.to_string().contains("cleanup_deleted_branch")
+                        || err
+                            .to_string()
+                            .contains("injected cleanup_deleted_branch failure"),
+                    "expected subsystem cleanup failure, got {err}"
+                );
+            }
+            other => panic!("expected PostCommitError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_delete_branch_surfaces_post_commit_cleanup_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = Database::open_runtime(
+            OpenSpec::primary(temp_dir.path()).with_subsystem(FailingCleanupSubsystem),
+        )
+        .unwrap();
+        let ri = BranchIndex::new(db.clone());
+        ri.create_branch("helper-contract").unwrap();
+
+        let err = ri
+            .delete_branch("helper-contract")
+            .expect_err("delete_branch helper must not flatten post-commit cleanup failure");
+        assert!(
+            err.to_string().contains("cleanup_deleted_branch")
+                || err
+                    .to_string()
+                    .contains("injected cleanup_deleted_branch failure"),
+            "expected subsystem cleanup failure, got {err}"
+        );
     }
 
     #[test]

--- a/crates/engine/src/primitives/branch/mod.rs
+++ b/crates/engine/src/primitives/branch/mod.rs
@@ -9,7 +9,8 @@ mod index;
 
 pub use handle::{BranchHandle, EventHandle, JsonHandle, KvHandle};
 pub(crate) use index::{
-    aliases_default_branch_sentinel, read_default_branch_marker, validate_reserved_branch_aliases,
-    write_default_branch_marker, BranchIndex,
+    aliases_default_branch_sentinel, default_branch_marker_key, read_default_branch_marker,
+    validate_reserved_branch_aliases, write_default_branch_marker, BranchIndex,
+    DeleteBranchCommitted, DeleteBranchCompletion, DeletePostCommitOptions,
 };
 pub use index::{resolve_branch_name, BranchMetadata, BranchStatus};

--- a/crates/engine/tests/branch_isolation_tests.rs
+++ b/crates/engine/tests/branch_isolation_tests.rs
@@ -366,25 +366,70 @@ fn test_issue_1702_delete_branch_cleans_up_segment_files() {
     // Logical data should be gone.
     assert!(kv.get(&branch_id, "default", "key0").unwrap().is_none());
 
-    // Storage-layer files should ALSO be gone.
-    let sst_after: Vec<_> = std::fs::read_dir(&branch_dir)
+    // B5.2 two-phase delete: the logical delete commits and the branch's own
+    // segments are quarantined via Stage-3 rename into `__quarantine__/`, but
+    // Stage-5 final purge is left to explicit GC / reopen reconciliation.
+    // The top-level branch directory therefore has no `.sst` files
+    // immediately after `delete()` even though `__quarantine__/` still holds
+    // the inventory + renamed files as retention debt.
+    let sst_after_delete: Vec<_> = std::fs::read_dir(&branch_dir)
         .into_iter()
         .flatten()
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "sst"))
+        .filter(|e| {
+            let path = e.path();
+            path.is_file() && path.extension().is_some_and(|ext| ext == "sst")
+        })
         .collect();
     assert!(
-        sst_after.is_empty(),
-        "Expected all .sst files to be cleaned up after branch delete, \
-         but found {} files: {:?}",
-        sst_after.len(),
-        sst_after.iter().map(|e| e.path()).collect::<Vec<_>>(),
+        sst_after_delete.is_empty(),
+        "Expected no top-level `.sst` files after branch delete (Stage-3 moved them into __quarantine__), \
+         found {} files: {:?}",
+        sst_after_delete.len(),
+        sst_after_delete.iter().map(|e| e.path()).collect::<Vec<_>>(),
     );
 
-    // Branch directory should also be removed.
+    // Drive Stage-5 final purge explicitly. GC drains the inventory but
+    // leaves the empty branch directory as post-commit debt until a retry
+    // converges it — per the B5.2 two-phase delete design.
+    db.storage().gc_orphan_segments().unwrap();
+
+    if branch_dir.exists() {
+        let recursive_ssts: Vec<_> = walk_dir_ssts(&branch_dir).collect();
+        assert!(
+            recursive_ssts.is_empty(),
+            "Stage-5 purge should drain every `.sst` under {:?}, still have {:?}",
+            branch_dir,
+            recursive_ssts,
+        );
+    }
+
+    // Retry via the storage-level clear_branch — this is the idempotent
+    // convergence step that removes the leftover empty dir.
+    db.storage().clear_branch(&branch_id).unwrap();
+
     assert!(
         !branch_dir.exists(),
-        "Branch directory {:?} should be removed after delete_branch()",
+        "Branch directory {:?} should be removed after Stage-5 purge + clear_branch retry",
         branch_dir,
     );
+}
+
+fn walk_dir_ssts(root: &std::path::Path) -> impl Iterator<Item = std::path::PathBuf> {
+    let mut stack: Vec<std::path::PathBuf> = vec![root.to_path_buf()];
+    std::iter::from_fn(move || {
+        while let Some(dir) = stack.pop() {
+            if let Ok(entries) = std::fs::read_dir(&dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.is_dir() {
+                        stack.push(path);
+                    } else if path.extension().is_some_and(|ext| ext == "sst") {
+                        return Some(path);
+                    }
+                }
+            }
+        }
+        None
+    })
 }

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -145,6 +145,53 @@ pub enum StorageError {
         /// Identifies which storage op observed the deletion, for diagnostics.
         op: BranchOp,
     },
+
+    /// The B5.2 reclaim protocol refused to quarantine a segment because
+    /// its candidate reachability walk found it still referenced by a
+    /// recovery-trusted own-segment or inherited-layer manifest.
+    ///
+    /// Candidate selection is the runtime accelerator
+    /// (`BarrierKind::RuntimeAccelerator`); the manifest proof
+    /// (`BarrierKind::PhysicalRetention`) is authoritative and wins on
+    /// disagreement (KD10 / §"Accelerator disagreement rule" of
+    /// `docs/design/branching/branching-gc/branching-retention-contract.md`).
+    /// Callers treat this as retention debt, not a hard error — space
+    /// leaks instead of permanent loss, per Invariant 2.
+    #[error(
+        "reclaim refused: segment {segment_id} still referenced by a recovery-trusted manifest"
+    )]
+    ReclaimRefusedManifestProof {
+        /// Stable segment identity for the refused candidate.
+        segment_id: u64,
+    },
+
+    /// A quarantine-manifest publish step (temp write, fsync, or rename)
+    /// failed mid-protocol. Callers log retention debt and retry on the
+    /// next reclaim opportunity; the on-disk file stays wherever the
+    /// interrupted step last left it and reopen reconciliation picks
+    /// up the pieces.
+    #[error("quarantine publish failed for directory {dir:?}: {inner}")]
+    QuarantinePublishFailed {
+        /// Directory whose `quarantine.manifest` could not be published.
+        dir: PathBuf,
+        /// Underlying filesystem error from temp-file write, sync, or rename.
+        #[source]
+        inner: io::Error,
+    },
+
+    /// Reopen quarantine reconciliation observed disagreement between
+    /// the `quarantine.manifest` inventory and on-disk `__quarantine__/`
+    /// contents, or between inventory state and current manifest
+    /// reachability. Per §"Quarantine reconciliation" of the retention
+    /// contract, reclaim trust is degraded and reclaim remains blocked
+    /// until a full rebuild-equivalent reconciliation completes.
+    #[error("quarantine reconciliation failed for branch {branch_id}: {reason}")]
+    QuarantineReconciliationFailed {
+        /// Branch whose quarantine state could not be reconciled.
+        branch_id: BranchId,
+        /// Human-readable description of the disagreement observed.
+        reason: String,
+    },
 }
 
 impl StorageError {
@@ -159,11 +206,14 @@ impl StorageError {
             StorageError::ManifestPublish { inner, .. } => inner.kind(),
             StorageError::DirFsync { inner, .. } => inner.kind(),
             StorageError::RecoveryFault(fault) => recovery_fault_kind(fault),
+            StorageError::QuarantinePublishFailed { inner, .. } => inner.kind(),
             StorageError::RecoveryAlreadyApplied
             | StorageError::RecoveryHealthResetRequiresSuccessfulRecovery
             | StorageError::GcRefusedDegradedRecovery { .. }
             | StorageError::RecoveryHealthResetRequiresReopen { .. }
-            | StorageError::BranchDeletedDuringOp { .. } => io::ErrorKind::Other,
+            | StorageError::BranchDeletedDuringOp { .. }
+            | StorageError::ReclaimRefusedManifestProof { .. }
+            | StorageError::QuarantineReconciliationFailed { .. } => io::ErrorKind::Other,
         }
     }
 }
@@ -175,7 +225,8 @@ fn recovery_fault_kind(fault: &RecoveryFault) -> io::ErrorKind {
         | RecoveryFault::Io(inner) => inner.kind(),
         RecoveryFault::MissingManifestListed { .. }
         | RecoveryFault::InheritedLayerLost { .. }
-        | RecoveryFault::NoManifestFallbackUsed { .. } => io::ErrorKind::Other,
+        | RecoveryFault::NoManifestFallbackUsed { .. }
+        | RecoveryFault::QuarantineInventoryMismatch { .. } => io::ErrorKind::Other,
     }
 }
 
@@ -213,6 +264,16 @@ impl From<StorageError> for StrataError {
             }
             StorageError::BranchDeletedDuringOp { branch_id, op } => StrataError::storage(
                 format!("branch {branch_id} was deleted during {op}; operation refused to resurrect"),
+            ),
+            StorageError::ReclaimRefusedManifestProof { segment_id } => StrataError::storage(
+                format!("reclaim refused: segment {segment_id} still referenced by a recovery-trusted manifest"),
+            ),
+            StorageError::QuarantinePublishFailed { dir, inner } => StrataError::storage_with_source(
+                format!("quarantine publish failed for directory {}", dir.display()),
+                inner,
+            ),
+            StorageError::QuarantineReconciliationFailed { branch_id, reason } => StrataError::storage(
+                format!("quarantine reconciliation failed for branch {branch_id}: {reason}"),
             ),
         }
     }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -22,6 +22,7 @@ pub mod memory_stats;
 pub mod memtable;
 pub mod merge_iter;
 pub mod pressure;
+pub mod quarantine;
 pub mod rate_limiter;
 pub mod seekable;
 pub mod segment;
@@ -37,12 +38,17 @@ pub use error::{BranchOp, StorageError, StorageResult};
 pub use index::{BranchIndex, TypeIndex};
 pub use memory_stats::{BranchMemoryStats, StorageMemoryStats};
 pub use pressure::{MemoryPressure, PressureLevel};
+pub use quarantine::{
+    read_quarantine_manifest, write_quarantine_manifest, QuarantineEntry, QuarantineManifest,
+    QUARANTINE_DIR, QUARANTINE_FILENAME,
+};
 pub use rate_limiter::RateLimiter;
 pub use segment::{KVSegment, OwnedSegmentIter};
 pub use segment_builder::{CompressionCodec, SegmentBuilder, SegmentMeta, SplittingSegmentBuilder};
 pub use segmented::{
     CompactionResult, DecodedSnapshotEntry, DecodedSnapshotValue, DegradationClass,
-    MaterializeResult, PickAndCompactResult, PublishHealth, RecoveredState, RecoveryFault,
-    RecoveryHealth, SegmentedStore, StorageIterator, VersionedEntry,
+    MaterializeResult, PickAndCompactResult, PublishHealth, PurgeReport, RecoveredState,
+    RecoveryFault, RecoveryHealth, SegmentedStore, StorageBranchRetention,
+    StorageInheritedLayerInfo, StorageIterator, VersionedEntry,
 };
 pub use ttl::TTLIndex;

--- a/crates/storage/src/quarantine.rs
+++ b/crates/storage/src/quarantine.rs
@@ -1,0 +1,348 @@
+//! Per-branch `quarantine.manifest` — durable inventory of in-flight reclaim.
+//!
+//! Format (v1):
+//! ```text
+//! "STRAQRTN" (8B magic) | u16 version (=1) | 6B reserved | u32 entry_count
+//! For each entry:
+//!   u64 segment_id
+//!   u16 filename_len | filename bytes   // branch-local, e.g. "42.sst"
+//! u32 CRC32 (over everything before CRC)
+//! ```
+//!
+//! ## B5.1 retention contract (pinned format)
+//!
+//! One `quarantine.manifest` per branch directory, sibling of
+//! `segments.manifest`, per
+//! `docs/design/branching/branching-gc/branching-retention-contract.md`
+//! §"B5.1 chosen format: per-branch `quarantine.manifest`". Written via
+//! the same atomic temp + rename + `fsync(dir)` idiom the existing
+//! segment manifest uses. Absence is treated as "no quarantined files"
+//! (a healthy fresh state).
+//!
+//! Entries store only branch-local filenames, not absolute paths. Both
+//! the original location (`<branch_dir>/<filename>`) and the quarantine
+//! destination (`<branch_dir>/__quarantine__/<filename>`) are derived at
+//! runtime, so quarantine state stays relocation-safe.
+//!
+//! This file records protocol state for in-flight reclaim. Manifest
+//! reachability remains the only durable liveness proof per
+//! Invariant 3 / §"Reclaimability rule".
+
+use std::io;
+use std::path::Path;
+
+use crate::{StorageError, StorageResult};
+
+/// Magic bytes for quarantine manifest: "STRAQRTN".
+const QUARANTINE_MAGIC: [u8; 8] = *b"STRAQRTN";
+
+/// Current quarantine manifest version.
+const QUARANTINE_VERSION: u16 = 1;
+
+/// Fixed header size: 8 (magic) + 2 (version) + 6 (reserved) + 4 (`entry_count`) = 20.
+const HEADER_SIZE: usize = 20;
+
+/// Manifest file name (sibling of `segments.manifest`).
+pub const QUARANTINE_FILENAME: &str = "quarantine.manifest";
+
+/// Directory name under the branch directory that holds quarantined segments.
+pub const QUARANTINE_DIR: &str = "__quarantine__";
+
+/// A single quarantined segment entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuarantineEntry {
+    /// Stable segment identity (matches `KVSegment::file_id()` derivation).
+    pub segment_id: u64,
+    /// Branch-local filename (e.g. `"42.sst"`). The on-disk quarantine
+    /// location is always `<branch_dir>/__quarantine__/<filename>`.
+    pub filename: String,
+}
+
+/// Parsed quarantine manifest contents.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct QuarantineManifest {
+    /// One entry per quarantined segment file, segment-identity-keyed.
+    pub entries: Vec<QuarantineEntry>,
+}
+
+impl QuarantineManifest {
+    /// Whether a segment with the given branch-local filename is in the inventory.
+    pub fn contains_filename(&self, filename: &str) -> bool {
+        self.entries.iter().any(|e| e.filename == filename)
+    }
+
+    /// Whether any entry records the given segment id.
+    pub fn contains_segment_id(&self, segment_id: u64) -> bool {
+        self.entries.iter().any(|e| e.segment_id == segment_id)
+    }
+}
+
+/// Write `entries` to `<dir>/quarantine.manifest` atomically.
+///
+/// Uses the same temp-file + fsync + rename + fsync(dir) idiom as
+/// `segments.manifest`. A failure at any step returns a typed
+/// [`StorageError`]; partial state is safe because readers reject a
+/// CRC-invalid temp file before rename, and the pre-rename final path
+/// is untouched.
+pub fn write_quarantine_manifest(dir: &Path, entries: &[QuarantineEntry]) -> StorageResult<()> {
+    let mut buf = Vec::with_capacity(HEADER_SIZE + entries.len() * 18 + 4);
+
+    buf.extend_from_slice(&QUARANTINE_MAGIC);
+    buf.extend_from_slice(&QUARANTINE_VERSION.to_le_bytes());
+    buf.extend_from_slice(&[0u8; 6]); // reserved
+    let entry_count = u32::try_from(entries.len()).expect("quarantine entry count fits in u32");
+    buf.extend_from_slice(&entry_count.to_le_bytes());
+
+    for entry in entries {
+        buf.extend_from_slice(&entry.segment_id.to_le_bytes());
+        let name_bytes = entry.filename.as_bytes();
+        let name_len =
+            u16::try_from(name_bytes.len()).expect("quarantine filename fits in u16 length");
+        buf.extend_from_slice(&name_len.to_le_bytes());
+        buf.extend_from_slice(name_bytes);
+    }
+
+    let crc = crc32fast::hash(&buf);
+    buf.extend_from_slice(&crc.to_le_bytes());
+
+    let final_path = dir.join(QUARANTINE_FILENAME);
+    let tmp_path = dir.join(format!("{QUARANTINE_FILENAME}.tmp"));
+
+    {
+        let mut file = std::fs::File::create(&tmp_path).map_err(|inner| {
+            StorageError::QuarantinePublishFailed {
+                dir: dir.to_path_buf(),
+                inner,
+            }
+        })?;
+        std::io::Write::write_all(&mut file, &buf).map_err(|inner| {
+            StorageError::QuarantinePublishFailed {
+                dir: dir.to_path_buf(),
+                inner,
+            }
+        })?;
+        file.sync_all()
+            .map_err(|inner| StorageError::QuarantinePublishFailed {
+                dir: dir.to_path_buf(),
+                inner,
+            })?;
+    }
+
+    std::fs::rename(&tmp_path, &final_path).map_err(|inner| {
+        StorageError::QuarantinePublishFailed {
+            dir: dir.to_path_buf(),
+            inner,
+        }
+    })?;
+
+    let dir_fd = std::fs::File::open(dir).map_err(|inner| StorageError::DirFsync {
+        dir: dir.to_path_buf(),
+        inner,
+    })?;
+    dir_fd.sync_all().map_err(|inner| StorageError::DirFsync {
+        dir: dir.to_path_buf(),
+        inner,
+    })?;
+
+    Ok(())
+}
+
+/// Read `<dir>/quarantine.manifest`.
+///
+/// Returns `Ok(None)` if the file does not exist (the healthy fresh
+/// state — no quarantined files). Returns `Err` on bad magic,
+/// truncation, CRC mismatch, or unsupported version.
+pub fn read_quarantine_manifest(dir: &Path) -> io::Result<Option<QuarantineManifest>> {
+    let path = dir.join(QUARANTINE_FILENAME);
+    let data = match std::fs::read(&path) {
+        Ok(d) => d,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+
+    if data.len() < HEADER_SIZE + 4 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "quarantine manifest too short",
+        ));
+    }
+
+    let crc_offset = data.len() - 4;
+    let stored_crc = u32::from_le_bytes(data[crc_offset..].try_into().unwrap());
+    let computed_crc = crc32fast::hash(&data[..crc_offset]);
+    if stored_crc != computed_crc {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "quarantine manifest CRC mismatch",
+        ));
+    }
+
+    if data[..8] != QUARANTINE_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "quarantine manifest bad magic",
+        ));
+    }
+
+    let version = u16::from_le_bytes(data[8..10].try_into().unwrap());
+    if version > QUARANTINE_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unsupported quarantine manifest version {version} (this build supports up to {QUARANTINE_VERSION})"
+            ),
+        ));
+    }
+    let entry_count = u32::from_le_bytes(data[16..20].try_into().unwrap()) as usize;
+
+    // Each entry is at least 11 bytes (u64 segment_id + u16 name_len + empty name).
+    let max_possible = (crc_offset - HEADER_SIZE) / 11;
+    if entry_count > max_possible {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "quarantine manifest entry_count exceeds file capacity",
+        ));
+    }
+
+    let mut pos = HEADER_SIZE;
+    let mut entries = Vec::with_capacity(entry_count);
+    for _ in 0..entry_count {
+        if pos + 10 > crc_offset {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "quarantine manifest truncated (entry header)",
+            ));
+        }
+        let segment_id = u64::from_le_bytes(data[pos..pos + 8].try_into().unwrap());
+        let name_len = u16::from_le_bytes(data[pos + 8..pos + 10].try_into().unwrap()) as usize;
+        pos += 10;
+
+        if pos + name_len > crc_offset {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "quarantine manifest truncated (filename)",
+            ));
+        }
+        let filename = String::from_utf8(data[pos..pos + name_len].to_vec()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "quarantine manifest non-UTF8 filename",
+            )
+        })?;
+        pos += name_len;
+
+        entries.push(QuarantineEntry {
+            segment_id,
+            filename,
+        });
+    }
+
+    Ok(Some(QuarantineManifest { entries }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quarantine_manifest_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let entries = vec![
+            QuarantineEntry {
+                segment_id: 1,
+                filename: "1.sst".into(),
+            },
+            QuarantineEntry {
+                segment_id: 42,
+                filename: "42.sst".into(),
+            },
+        ];
+
+        write_quarantine_manifest(dir.path(), &entries).unwrap();
+        let result = read_quarantine_manifest(dir.path()).unwrap().unwrap();
+        assert_eq!(result.entries, entries);
+    }
+
+    #[test]
+    fn quarantine_manifest_absent_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = read_quarantine_manifest(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn quarantine_manifest_empty_entries_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        write_quarantine_manifest(dir.path(), &[]).unwrap();
+        let result = read_quarantine_manifest(dir.path()).unwrap().unwrap();
+        assert!(result.entries.is_empty());
+    }
+
+    #[test]
+    fn quarantine_manifest_bad_crc_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let entries = vec![QuarantineEntry {
+            segment_id: 1,
+            filename: "1.sst".into(),
+        }];
+        write_quarantine_manifest(dir.path(), &entries).unwrap();
+
+        let path = dir.path().join(QUARANTINE_FILENAME);
+        let mut data = std::fs::read(&path).unwrap();
+        let mid = data.len() / 2;
+        data[mid] ^= 0xFF;
+        std::fs::write(&path, &data).unwrap();
+
+        let result = read_quarantine_manifest(dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn quarantine_manifest_bad_magic_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(QUARANTINE_FILENAME);
+        std::fs::write(&path, b"NOTSTRAQRTN123456789012345678901234567890").unwrap();
+
+        let result = read_quarantine_manifest(dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn quarantine_manifest_unknown_version_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&QUARANTINE_MAGIC);
+        buf.extend_from_slice(&999u16.to_le_bytes()); // version 999
+        buf.extend_from_slice(&[0u8; 6]);
+        buf.extend_from_slice(&0u32.to_le_bytes()); // entry_count = 0
+        let crc = crc32fast::hash(&buf);
+        buf.extend_from_slice(&crc.to_le_bytes());
+
+        let path = dir.path().join(QUARANTINE_FILENAME);
+        std::fs::write(&path, &buf).unwrap();
+
+        let result = read_quarantine_manifest(dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn quarantine_manifest_contains_helpers() {
+        let mf = QuarantineManifest {
+            entries: vec![
+                QuarantineEntry {
+                    segment_id: 10,
+                    filename: "10.sst".into(),
+                },
+                QuarantineEntry {
+                    segment_id: 20,
+                    filename: "20.sst".into(),
+                },
+            ],
+        };
+        assert!(mf.contains_filename("10.sst"));
+        assert!(mf.contains_filename("20.sst"));
+        assert!(!mf.contains_filename("30.sst"));
+        assert!(mf.contains_segment_id(10));
+        assert!(!mf.contains_segment_id(30));
+    }
+}

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -96,18 +96,31 @@ pub(super) fn recalculate_level_targets(
 /// Checks if the segment is shared (referenced by child branches via COW
 /// inherited layers). Shared segments are skipped — their files are only
 impl SegmentedStore {
-    /// Delete a segment file if it is not referenced by any inherited layer.
+    /// Route a segment file through the B5.2 reclaim protocol.
     ///
-    /// Checks if the segment is shared (referenced by child branches via COW
-    /// inherited layers). Shared segments are skipped — their files are only
-    /// deleted when the last child releases via `decrement` (in `clear_branch`
-    /// or `materialize_layer`). Untracked segments (not shared) are deleted
-    /// immediately.
+    /// Calls [`SegmentedStore::quarantine_segment_if_unreferenced`] which
+    /// performs the Stage-2 manifest-proof (runtime-accelerator check),
+    /// the Stage-3 rename into `<branch_dir>/__quarantine__/`, and the
+    /// Stage-4 `quarantine.manifest` publish — all under the B5 retention
+    /// contract's `BarrierKind::RecoveryHealthGate`. Final purge
+    /// (Stage 5) happens on a later [`SegmentedStore::gc_orphan_segments`]
+    /// pass via [`SegmentedStore::purge_all_quarantines`].
+    ///
+    /// Shared segments (positive refcount from inherited layers) are
+    /// left in place. Refusal under degraded recovery is logged as
+    /// retention debt but not propagated — the caller path is best-
+    /// effort cleanup after compaction publish.
     fn delete_segment_if_unreferenced(&self, seg: &KVSegment) {
-        let _guard = self.ref_registry.deletion_write_guard();
-        if !self.ref_registry.is_referenced(seg.file_id()) {
-            crate::block_cache::global_cache().invalidate_file(seg.file_id());
-            let _ = std::fs::remove_file(seg.file_path());
+        match self.quarantine_segment_if_unreferenced(seg.file_path(), seg.file_id()) {
+            Ok(true) | Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(
+                    target: "strata::storage::gc",
+                    segment = %seg.file_path().display(),
+                    error = %e,
+                    "reclaim refused; retention debt accumulated"
+                );
+            }
         }
     }
 

--- a/crates/storage/src/segmented/compaction.rs
+++ b/crates/storage/src/segmented/compaction.rs
@@ -99,7 +99,8 @@ impl SegmentedStore {
     /// Route a segment file through the B5.2 reclaim protocol.
     ///
     /// Calls [`SegmentedStore::quarantine_segment_if_unreferenced`] which
-    /// performs the Stage-2 manifest-proof (runtime-accelerator check),
+    /// performs Stage-2 manifest proof (runtime candidate screen followed
+    /// by an on-disk manifest walk),
     /// the Stage-3 rename into `<branch_dir>/__quarantine__/`, and the
     /// Stage-4 `quarantine.manifest` publish — all under the B5 retention
     /// contract's `BarrierKind::RecoveryHealthGate`. Final purge
@@ -344,7 +345,7 @@ impl SegmentedStore {
         self.write_branch_manifest(branch_id)?;
 
         // Old segment files become reclaim candidates after manifest publish.
-        // Today deletion is still runtime-refcount gated, not B5.2 manifest proof.
+        // Reclaim now routes through Stage-2 manifest proof plus quarantine.
         for seg in &old_segments {
             self.delete_segment_if_unreferenced(seg);
         }
@@ -510,7 +511,7 @@ impl SegmentedStore {
         self.write_branch_manifest(branch_id)?;
 
         // Old segment files become reclaim candidates after manifest publish.
-        // Today deletion is still runtime-refcount gated, not B5.2 manifest proof.
+        // Reclaim now routes through Stage-2 manifest proof plus quarantine.
         for seg in &selected_segments {
             self.delete_segment_if_unreferenced(seg);
         }
@@ -749,7 +750,7 @@ impl SegmentedStore {
         self.write_branch_manifest(branch_id)?;
 
         // Old segment files become reclaim candidates after manifest publish.
-        // Today deletion is still runtime-refcount gated, not B5.2 manifest proof.
+        // Reclaim now routes through Stage-2 manifest proof plus quarantine.
         for seg in &l0_segs {
             self.delete_segment_if_unreferenced(seg);
         }
@@ -1090,7 +1091,7 @@ impl SegmentedStore {
         self.write_branch_manifest(branch_id)?;
 
         // Old segment files become reclaim candidates after manifest publish.
-        // Today deletion is still runtime-refcount gated, not B5.2 manifest proof.
+        // Reclaim now routes through Stage-2 manifest proof plus quarantine.
         for seg in &input_segs {
             self.delete_segment_if_unreferenced(seg);
         }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -308,7 +308,7 @@ impl SegmentVersion {
 
 /// Status of an inherited layer during materialization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LayerStatus {
+pub(crate) enum LayerStatus {
     /// Layer is active — reads fall through to parent segments.
     Active,
     /// Materialization in progress (reset to Active on crash recovery).
@@ -1419,19 +1419,25 @@ impl SegmentedStore {
     /// (`BarrierKind::PhysicalRetention`).
     pub fn clear_branch(&self, branch_id: &BranchId) -> bool {
         if let Some((_, branch)) = self.branches.remove(branch_id) {
-            // 1. Clean up the branch's own segments.
-            // Check refcount before deleting — a child branch may still
-            // reference these segments through inherited layers (#1702).
-            // Lock Level 3 (exclusive): prevent TOCTOU with fork (#1682).
+            // 1. Route the branch's own segments through the B5.2 reclaim
+            //    protocol. Each segment that is no longer referenced by a
+            //    descendant inherited layer is quarantined (rename +
+            //    durable publish). Shared segments are left in place;
+            //    refusal under degraded recovery is logged as retention
+            //    debt, not propagated.
             let ver = branch.version.load();
-            {
-                let _deletion_guard = self.ref_registry.deletion_write_guard();
-                for level in &ver.levels {
-                    for seg in level {
-                        crate::block_cache::global_cache().invalidate_file(seg.file_id());
-                        if !self.ref_registry.is_referenced(seg.file_id()) {
-                            let _ = std::fs::remove_file(seg.file_path());
-                        }
+            for level in &ver.levels {
+                for seg in level {
+                    if let Err(e) =
+                        self.quarantine_segment_if_unreferenced(seg.file_path(), seg.file_id())
+                    {
+                        tracing::warn!(
+                            target: "strata::storage::gc",
+                            branch_id = %hex_encode_branch(branch_id),
+                            segment = %seg.file_path().display(),
+                            error = %e,
+                            "clear_branch: reclaim refused; retention debt accumulated"
+                        );
                     }
                 }
             }
@@ -1545,22 +1551,22 @@ impl SegmentedStore {
     /// process-local approximation of `BarrierKind::PhysicalRetention`
     /// (the live-set check).
     pub fn gc_orphan_segments(&self) -> StorageResult<GcReport> {
-        match &**self.last_recovery_health.load() {
-            // Healthy and Telemetry-only degradation (rebuildable-cache errors)
-            // do not compromise deletion safety, so GC proceeds normally.
-            RecoveryHealth::Healthy
-            | RecoveryHealth::Degraded {
-                class: DegradationClass::Telemetry,
-                ..
-            } => {}
-            RecoveryHealth::Degraded { class, .. } => {
-                return Err(StorageError::GcRefusedDegradedRecovery { class: *class });
-            }
-        }
+        // Gate — the B5.2 quarantine protocol uses this same gate before
+        // any filesystem mutation. Telemetry-class degradation does not
+        // compromise deletion safety.
+        self.check_reclaim_allowed()?;
 
         let Some(segments_dir) = &self.segments_dir else {
             return Ok(GcReport { files_deleted: 0 });
         };
+
+        let mut files_deleted = 0usize;
+
+        // Stage 5 — drain quarantined inventories first. A crashed prior
+        // reclaim may have left files in `__quarantine__/` from a
+        // previous call; purge what has been durably published.
+        let purge = self.purge_all_quarantines()?;
+        files_deleted += purge.files_purged;
 
         // Build the set of all segment file_id values currently live in any
         // branch. file_id is a hash of the file path (see block_cache::file_path_hash).
@@ -1581,11 +1587,13 @@ impl SegmentedStore {
             }
         }
 
-        let mut deleted = 0usize;
-
-        // Scan all branch directories.
+        // Stages 2–4 — scan for orphan `.sst` candidates and route each
+        // one through the quarantine protocol. Files inside
+        // `__quarantine__/` are skipped: they are already in flight and
+        // handled by the purge step above.
+        let mut newly_quarantined: Vec<PathBuf> = Vec::new();
         let Ok(entries) = std::fs::read_dir(segments_dir) else {
-            return Ok(GcReport { files_deleted: 0 });
+            return Ok(GcReport { files_deleted });
         };
         for entry in entries.flatten() {
             let path = entry.path();
@@ -1598,26 +1606,41 @@ impl SegmentedStore {
             };
             for sst_entry in sst_entries.flatten() {
                 let sst_path = sst_entry.path();
+                // Skip subdirectories (in particular `__quarantine__/`,
+                // whose contents were drained by `purge_all_quarantines`
+                // above — this loop only classifies top-level orphan
+                // `.sst` files).
+                if sst_path.is_dir() {
+                    continue;
+                }
                 if sst_path.extension().and_then(|e| e.to_str()) != Some("sst") {
                     continue;
                 }
-                // file_id is a hash of the full path, matching KVSegment::file_id().
                 let file_id = crate::block_cache::file_path_hash(&sst_path);
                 if !live_ids.contains(&file_id) {
-                    // Lock Level 3 (exclusive): prevent TOCTOU with fork (#1682).
-                    let _deletion_guard = self.ref_registry.deletion_write_guard();
-                    if !self.ref_registry.is_referenced(file_id) {
-                        crate::block_cache::global_cache().invalidate_file(file_id);
-                        let _ = std::fs::remove_file(&sst_path);
-                        deleted += 1;
+                    match self.quarantine_segment_if_unreferenced(&sst_path, file_id) {
+                        Ok(true) => newly_quarantined.push(sst_path),
+                        Ok(false) => {} // still referenced by runtime accelerator
+                        Err(e) => {
+                            // Degraded gate fired mid-scan, or publish failed —
+                            // propagate so callers see retention debt.
+                            return Err(e);
+                        }
                     }
                 }
             }
         }
 
-        Ok(GcReport {
-            files_deleted: deleted,
-        })
+        // Finish purging the freshly-quarantined entries within this
+        // call when health still permits — contract §"Stage 5. Final
+        // purge" allows this because the inventory publish at Stage 4
+        // is the durable-publish precondition.
+        if !newly_quarantined.is_empty() {
+            let purge2 = self.purge_all_quarantines()?;
+            files_deleted += purge2.files_purged;
+        }
+
+        Ok(GcReport { files_deleted })
     }
 
     /// Number of inherited layers for a branch.
@@ -3905,6 +3928,37 @@ impl SegmentedStore {
         segments_loaded += inherited_stats.segments_loaded;
         let branches_recovered = recovered_branches.len();
 
+        // B5.2 — quarantine reconciliation. Build a per-branch-dir set
+        // of filenames still referenced by a recovery-trusted manifest
+        // (own-segment + inherited-layer), then reconcile against each
+        // branch's `quarantine.manifest`. Disagreement degrades recovery
+        // health per §"Quarantine reconciliation" (prefer retention).
+        let mut manifest_live_filenames: HashMap<BranchId, HashSet<String>> = HashMap::new();
+        for branch in self.branches.iter() {
+            let branch_id = *branch.key();
+            let ver = branch.version.load();
+            let entry = manifest_live_filenames.entry(branch_id).or_default();
+            for level in &ver.levels {
+                for seg in level {
+                    if let Some(name) = seg.file_path().file_name().and_then(|n| n.to_str()) {
+                        entry.insert(name.to_string());
+                    }
+                }
+            }
+            for layer in &branch.inherited_layers {
+                let source = layer.source_branch_id;
+                let source_entry = manifest_live_filenames.entry(source).or_default();
+                for level in &layer.segments.levels {
+                    for seg in level {
+                        if let Some(name) = seg.file_path().file_name().and_then(|n| n.to_str()) {
+                            source_entry.insert(name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        self.reconcile_quarantine_on_recovery(segments_dir, &manifest_live_filenames, &mut faults);
+
         let health = RecoveryHealth::from_faults(faults);
         self.last_recovery_health.store(Arc::new(health.clone()));
         invocation.commit();
@@ -5474,7 +5528,7 @@ impl Storage for SegmentedStore {
 // ---------------------------------------------------------------------------
 
 /// Hex-encode a BranchId's 16 bytes to a 32-char lowercase hex string.
-fn hex_encode_branch(branch_id: &BranchId) -> String {
+pub(crate) fn hex_encode_branch(branch_id: &BranchId) -> String {
     let bytes = branch_id.as_bytes();
     let mut s = String::with_capacity(32);
     for &b in bytes.iter() {
@@ -5486,7 +5540,7 @@ fn hex_encode_branch(branch_id: &BranchId) -> String {
 
 /// Decode a 32-char hex string back to a BranchId.
 /// Returns `None` if the string is not exactly 32 hex chars.
-fn hex_decode_branch(hex: &str) -> Option<BranchId> {
+pub(crate) fn hex_decode_branch(hex: &str) -> Option<BranchId> {
     if hex.len() != 32 || !hex.is_ascii() {
         return None;
     }
@@ -5596,9 +5650,11 @@ fn check_corruption(flags: &[Arc<AtomicBool>]) -> StrataResult<()> {
 }
 
 mod compaction;
+mod quarantine_protocol;
 mod recovery;
 mod ref_registry;
 
+pub use quarantine_protocol::{PurgeReport, StorageBranchRetention, StorageInheritedLayerInfo};
 pub use recovery::{DegradationClass, RecoveredState, RecoveryFault, RecoveryHealth};
 
 #[cfg(test)]

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -963,7 +963,7 @@ impl SegmentedStore {
     /// — subsequent recovery calls replace the stored value but do not
     /// invalidate this handle.
     ///
-    /// ## B5.1 retention contract
+    /// ## B5 retention contract
     ///
     /// Surfaces the §"Recovery-health contract" classification of
     /// `docs/design/branching/branching-gc/branching-retention-contract.md`.
@@ -1417,8 +1417,22 @@ impl SegmentedStore {
     /// (`BarrierKind::RuntimeAccelerator`); the durable proof remains
     /// the descendant's manifest entries
     /// (`BarrierKind::PhysicalRetention`).
-    pub fn clear_branch(&self, branch_id: &BranchId) -> bool {
+    pub fn clear_branch(&self, branch_id: &BranchId) -> StorageResult<bool> {
+        let branch_dir_to_cleanup = self.segments_dir.as_ref().map(|segments_dir| {
+            let branch_hex = hex_encode_branch(branch_id);
+            segments_dir.join(&branch_hex)
+        });
         if let Some((_, branch)) = self.branches.remove(branch_id) {
+            if let Some(branch_dir) = branch_dir_to_cleanup.as_ref() {
+                if branch_dir.exists() {
+                    // Publish the empty-manifest barrier before any
+                    // storage-local mutation. If this fails, callers see a
+                    // hard error rather than a partially-cleared branch that
+                    // can resurrect on reopen.
+                    crate::manifest::write_manifest(branch_dir, &[], &[])?;
+                }
+            }
+
             // 1. Route the branch's own segments through the B5.2 reclaim
             //    protocol. Each segment that is no longer referenced by a
             //    descendant inherited layer is quarantined (rename +
@@ -1428,9 +1442,10 @@ impl SegmentedStore {
             let ver = branch.version.load();
             for level in &ver.levels {
                 for seg in level {
-                    if let Err(e) =
-                        self.quarantine_segment_if_unreferenced(seg.file_path(), seg.file_id())
-                    {
+                    if let Err(e) = self.quarantine_segment_if_unreferenced_for_cleared_branch(
+                        seg.file_path(),
+                        seg.file_id(),
+                    ) {
                         tracing::warn!(
                             target: "strata::storage::gc",
                             branch_id = %hex_encode_branch(branch_id),
@@ -1454,62 +1469,112 @@ impl SegmentedStore {
                 }
             }
 
-            // 3. Remove manifest file and branch directory from disk.
+            // 3. Best-effort branch-dir cleanup.
             //
             // In-flight compaction for this branch may still be writing
-            // .tmp/.sst files to this directory even though we've already
-            // removed the branch from `self.branches`. gc_orphan_segments
-            // (step 4) will pick up any .sst files we missed, so we retry
-            // remove_dir AFTER gc runs. remove_dir (not remove_dir_all)
-            // keeps the original safety guarantee: if we somehow missed
-            // tracking a file, we leave it in place rather than nuking it.
-            let branch_dir_to_remove = self.segments_dir.as_ref().map(|segments_dir| {
-                let branch_hex = hex_encode_branch(branch_id);
-                let branch_dir = segments_dir.join(&branch_hex);
-                let _ = std::fs::remove_file(branch_dir.join("segments.manifest"));
-                let _ = std::fs::remove_dir(&branch_dir); // first attempt
-                branch_dir
-            });
-
-            // 4. Garbage-collect orphan segment files (#1705).
-            // Refcount decrements above may have released the last reference to
-            // segments whose parent already compacted them away. GC deletes
-            // any .sst on disk not referenced by a live branch or the refcount
-            // registry. A degraded recovery (SE3) makes GC refuse; branch
-            // clearing still succeeds, but the retention debt accumulates
-            // until a safe reset or fresh reopen re-establishes GC trust.
-            if let Err(e) = self.gc_orphan_segments() {
-                tracing::warn!(
-                    target: "strata::storage::gc",
-                    branch_id = %hex_encode_branch(branch_id),
-                    op = "clear_branch",
-                    error = %e,
-                    "gc_orphan_segments refused; retention debt accumulated",
-                );
+            // `.tmp` / `.sst` files to this directory even though we've
+            // already removed the branch from `self.branches`. `clear_branch`
+            // is post-commit cleanup only: it may quarantine candidates and
+            // leave cleanup debt behind, but it must not synchronously drain
+            // global orphan GC or Stage-5 purge. `remove_dir` (not
+            // `remove_dir_all`) preserves the original safety guarantee: if
+            // we somehow missed tracking a file, we leak it rather than
+            // deleting it.
+            if let Some(branch_dir) = branch_dir_to_cleanup.as_deref() {
+                self.finish_cleared_branch_dir(branch_id, branch_dir, false)?;
             }
 
-            // 5. Retry directory removal after gc — gc may have deleted
-            // .sst files from in-flight compaction that landed between
-            // our step 1 and step 3. Still uses remove_dir (not recursive)
-            // to preserve the safety guarantee: if unknown files remain
-            // we leave them and log, rather than silently deleting.
-            if let Some(branch_dir) = branch_dir_to_remove {
+            Ok(true)
+        } else {
+            if let Some(branch_dir) = branch_dir_to_cleanup.as_deref() {
                 if branch_dir.exists() {
-                    if let Err(e) = std::fs::remove_dir(&branch_dir) {
-                        tracing::warn!(
-                            target: "strata::branch",
-                            branch_dir = %branch_dir.display(),
-                            error = %e,
-                            "Branch directory not empty after clear_branch; leaving leftover files in place",
-                        );
-                    }
+                    self.finish_cleared_branch_dir(branch_id, branch_dir, true)?;
+                    return Ok(true);
                 }
             }
 
-            true
-        } else {
-            false
+            Ok(false)
         }
+    }
+
+    fn finish_cleared_branch_dir(
+        &self,
+        branch_id: &BranchId,
+        branch_dir: &std::path::Path,
+        republish_barrier_if_needed: bool,
+    ) -> StorageResult<()> {
+        if !branch_dir.exists() {
+            return Ok(());
+        }
+
+        let mut top_level_ssts: Vec<std::path::PathBuf> = std::fs::read_dir(branch_dir)?
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.is_file())
+            .filter(|path| path.extension().and_then(|x| x.to_str()) == Some("sst"))
+            .collect();
+
+        if republish_barrier_if_needed && !top_level_ssts.is_empty() {
+            // Retry path: the branch is already absent from memory but
+            // top-level files remain on disk. Re-publish the empty-manifest
+            // barrier so the directory stays non-live across reopen while we
+            // continue branch-local cleanup.
+            crate::manifest::write_manifest(branch_dir, &[], &[])?;
+        }
+
+        for seg_path in &top_level_ssts {
+            let file_id = crate::block_cache::file_path_hash(seg_path);
+            if let Err(e) =
+                self.quarantine_segment_if_unreferenced_for_cleared_branch(seg_path, file_id)
+            {
+                tracing::warn!(
+                    target: "strata::storage::gc",
+                    branch_id = %hex_encode_branch(branch_id),
+                    segment = %seg_path.display(),
+                    error = %e,
+                    "clear_branch retry: reclaim refused; retention debt accumulated"
+                );
+            }
+        }
+
+        top_level_ssts = std::fs::read_dir(branch_dir)?
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.is_file())
+            .filter(|path| path.extension().and_then(|x| x.to_str()) == Some("sst"))
+            .collect();
+
+        // Any directory that remains on disk is already protected from
+        // stale-manifest or no-manifest fallback on reopen. If no top-level
+        // `.sst` files remain we can best-effort remove the empty manifest
+        // itself before retrying `remove_dir`; otherwise we intentionally keep
+        // the empty manifest so deleted-parent orphan storage stays non-live
+        // across reopen. `remove_dir` stays non-recursive to preserve the
+        // original safety guarantee: unknown files are leaked, not deleted.
+        if top_level_ssts.is_empty() {
+            match std::fs::remove_file(branch_dir.join("segments.manifest")) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    tracing::warn!(
+                        target: "strata::branch",
+                        branch_dir = %branch_dir.display(),
+                        error = %e,
+                        "Failed to remove empty manifest after branch clear; leaving directory in place",
+                    );
+                }
+            }
+        }
+        if let Err(e) = std::fs::remove_dir(branch_dir) {
+            tracing::warn!(
+                target: "strata::branch",
+                branch_dir = %branch_dir.display(),
+                error = %e,
+                "Branch directory not empty after clear_branch; leaving leftover files in place",
+            );
+        }
+
+        Ok(())
     }
 
     /// Garbage-collect orphaned segment files (#1705).
@@ -1538,18 +1603,14 @@ impl SegmentedStore {
     ///
     /// Implements the §"Recovery-health contract" gate of
     /// `docs/design/branching/branching-gc/branching-retention-contract.md`.
-    /// Today this function still performs an immediate-unlink reclaim
-    /// using a process-local live-set check built from `self.branches`
-    /// plus inherited layers. That is a storage-local approximation of
-    /// physical retention, not the future B5.2 Stage-2 manifest proof.
-    /// The B5.2 cutover strengthens this path to walk recovery-trusted
-    /// manifests and route deletion through the full quarantine
-    /// protocol with persisted quarantine inventory. The degraded-
-    /// recovery refusal already in place satisfies Invariants 2 and 5:
-    /// space leaks are acceptable, false reclaim is not. Barrier role:
-    /// `BarrierKind::RecoveryHealthGate` (the refusal) + current
-    /// process-local approximation of `BarrierKind::PhysicalRetention`
-    /// (the live-set check).
+    /// This path now runs the B5.2 quarantine protocol: purge any
+    /// durably published quarantine inventory first, then nominate
+    /// top-level orphan `.sst` files from the runtime live-set scan and
+    /// route each candidate through Stage-2 manifest proof plus
+    /// quarantine. The degraded-recovery refusal satisfies Invariants 2
+    /// and 5: space leaks are acceptable, false reclaim is not. Barrier
+    /// role: `BarrierKind::RecoveryHealthGate` (the refusal) +
+    /// manifest-derived `BarrierKind::PhysicalRetention` (the proof).
     pub fn gc_orphan_segments(&self) -> StorageResult<GcReport> {
         // Gate — the B5.2 quarantine protocol uses this same gate before
         // any filesystem mutation. Telemetry-class degradation does not
@@ -3769,11 +3830,10 @@ impl SegmentedStore {
                 }
             }
 
-            // Skip branches with no segments and no inherited layers
             let has_inherited = manifest
                 .as_ref()
                 .is_some_and(|m| !m.inherited_layers.is_empty());
-            if branch_segments.is_empty() && !has_inherited {
+            if manifest.is_none() && branch_segments.is_empty() && !has_inherited {
                 continue;
             }
 
@@ -3846,6 +3906,17 @@ impl SegmentedStore {
                 });
             }
 
+            let own_segments_loaded = level_segs.iter().map(|l| l.len()).sum::<usize>();
+            // A branch directory with an explicit manifest but zero own
+            // segments loaded is retained orphan storage, not a live branch.
+            // This is the deleted-parent-with-live-descendants shape: the
+            // empty manifest suppresses legacy no-manifest fallback while
+            // descendant inherited layers keep the top-level `.sst` files
+            // reachable.
+            if own_segments_loaded == 0 && !has_inherited {
+                continue;
+            }
+
             // L0: sorted by commit_max descending (newest first)
             level_segs[0].sort_by(|a, b| b.commit_range().1.cmp(&a.commit_range().1));
             // L1+: sorted by key_range min ascending
@@ -3858,7 +3929,6 @@ impl SegmentedStore {
                 .entry(branch_id)
                 .or_insert_with(BranchState::new);
 
-            let own_segments_loaded = level_segs.iter().map(|l| l.len()).sum::<usize>();
             segments_loaded += own_segments_loaded;
             if own_segments_loaded > 0 {
                 recovered_branches.insert(branch_id);
@@ -3928,36 +3998,11 @@ impl SegmentedStore {
         segments_loaded += inherited_stats.segments_loaded;
         let branches_recovered = recovered_branches.len();
 
-        // B5.2 — quarantine reconciliation. Build a per-branch-dir set
-        // of filenames still referenced by a recovery-trusted manifest
-        // (own-segment + inherited-layer), then reconcile against each
-        // branch's `quarantine.manifest`. Disagreement degrades recovery
-        // health per §"Quarantine reconciliation" (prefer retention).
-        let mut manifest_live_filenames: HashMap<BranchId, HashSet<String>> = HashMap::new();
-        for branch in self.branches.iter() {
-            let branch_id = *branch.key();
-            let ver = branch.version.load();
-            let entry = manifest_live_filenames.entry(branch_id).or_default();
-            for level in &ver.levels {
-                for seg in level {
-                    if let Some(name) = seg.file_path().file_name().and_then(|n| n.to_str()) {
-                        entry.insert(name.to_string());
-                    }
-                }
-            }
-            for layer in &branch.inherited_layers {
-                let source = layer.source_branch_id;
-                let source_entry = manifest_live_filenames.entry(source).or_default();
-                for level in &layer.segments.levels {
-                    for seg in level {
-                        if let Some(name) = seg.file_path().file_name().and_then(|n| n.to_str()) {
-                            source_entry.insert(name.to_string());
-                        }
-                    }
-                }
-            }
-        }
-        self.reconcile_quarantine_on_recovery(segments_dir, &manifest_live_filenames, &mut faults);
+        // B5.2 — quarantine reconciliation. Reuse the same branch-dir
+        // ledger shape that Stage-2 manifest proof and retention reporting
+        // consume rather than reconstructing a second live-filename map
+        // from self.branches.
+        self.reconcile_quarantine_on_recovery(&mut faults);
 
         let health = RecoveryHealth::from_faults(faults);
         self.last_recovery_health.store(Arc::new(health.clone()));

--- a/crates/storage/src/segmented/quarantine_protocol.rs
+++ b/crates/storage/src/segmented/quarantine_protocol.rs
@@ -6,13 +6,14 @@
 //! `docs/design/branching/branching-gc/branching-retention-contract.md`
 //! §"Reclaim protocol":
 //!
-//! 1. **Stage 2 — manifest proof.** The caller's runtime accelerator check
-//!    (`SegmentRefRegistry::is_referenced` plus the live-set scan in
-//!    `gc_orphan_segments`) serves as the manifest proof, under the
-//!    degraded-recovery refusal gate (`BarrierKind::RecoveryHealthGate`).
-//!    When recovery health is `DataLoss`, `PolicyDowngrade`, or any
-//!    non-`Telemetry` degradation, reclaim refuses **before** any
-//!    filesystem mutation — addressing the B5.2 review Finding 1.
+//! 1. **Stage 2 — manifest proof.** Candidate selection still starts from
+//!    the runtime accelerator (`SegmentRefRegistry::is_referenced` plus
+//!    the live-set scan in `gc_orphan_segments`), but the authoritative
+//!    reclaim proof is a walk of recovery-trusted `segments.manifest`
+//!    own entries and inherited-layer entries across the on-disk branch
+//!    directories. When recovery health is `DataLoss`,
+//!    `PolicyDowngrade`, or any non-`Telemetry` degradation, reclaim
+//!    refuses **before** any filesystem mutation.
 //! 2. **Stage 3 — quarantine rename.** After the proof succeeds, the
 //!    segment file is renamed into `<branch_dir>/__quarantine__/` on the
 //!    same filesystem namespace. Before Stage 4 publishes the inventory,
@@ -63,6 +64,41 @@ use crate::quarantine::{
 use crate::segmented::{DegradationClass, RecoveryFault, RecoveryHealth, SegmentedStore};
 use crate::{StorageError, StorageResult};
 
+fn manifest_entry_matches_segment(
+    entry: &crate::manifest::ManifestEntry,
+    file_id: u64,
+    filename: &str,
+) -> bool {
+    entry.filename == filename
+        || entry.filename == format!("{file_id}.sst")
+        || entry
+            .filename
+            .strip_suffix(".sst")
+            .and_then(|stem| stem.parse::<u64>().ok())
+            == Some(file_id)
+}
+
+#[derive(Debug, Clone)]
+struct RetentionTopLevelSegment {
+    filename: String,
+    size: u64,
+}
+
+#[derive(Debug, Clone)]
+struct BranchQuarantineState {
+    manifest: Option<crate::quarantine::QuarantineManifest>,
+    files_on_disk: HashMap<String, u64>,
+}
+
+#[derive(Debug, Clone)]
+struct RetentionBranchDirView {
+    branch_id: BranchId,
+    branch_dir: PathBuf,
+    manifest: Option<crate::manifest::SegmentManifest>,
+    top_level_segments: HashMap<String, RetentionTopLevelSegment>,
+    quarantine: Option<BranchQuarantineState>,
+}
+
 /// Summary of a [`SegmentedStore::purge_all_quarantines`] call.
 #[derive(Debug, Clone, Copy, Default)]
 #[non_exhaustive]
@@ -77,16 +113,19 @@ pub struct PurgeReport {
 ///
 /// Produced by [`SegmentedStore::retention_snapshot`] and consumed by the
 /// engine-layer `retention_report()` to attribute bytes to
-/// `BranchRef` lifecycle instances. The snapshot is manifest-derived;
-/// runtime accelerators (the segment ref registry) are used only to
-/// classify own-segment bytes as exclusive vs shared.
+/// `BranchRef` lifecycle instances. The snapshot is manifest-derived
+/// except for the explicit B5.2 legacy `NoManifestFallbackUsed`
+/// recovery path, where the last recovery health already recorded that
+/// top-level segments were promoted as the visible branch state.
+/// Own-segment shared/exclusive classification comes from
+/// inherited-layer reachability rather than runtime refcounts.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct StorageBranchRetention {
     /// Directory identity — matches the on-disk `<segments_dir>/<hex>` name.
     pub branch_id: BranchId,
     /// Own-segment file bytes that no descendant's inherited-layer
-    /// manifest currently references (ref registry zero).
+    /// manifest currently references.
     pub exclusive_bytes: u64,
     /// Own-segment file bytes that at least one descendant's
     /// inherited-layer manifest references. Retained until the
@@ -155,6 +194,42 @@ impl SegmentedStore {
         }
     }
 
+    fn manifest_proof_allows_reclaim(
+        &self,
+        file_id: u64,
+        filename: &str,
+        exclude_branch_dir: Option<&Path>,
+    ) -> StorageResult<bool> {
+        for view in self.retention_branch_dir_views(false)? {
+            if exclude_branch_dir.is_some_and(|excluded| excluded == view.branch_dir.as_path()) {
+                continue;
+            }
+            let Some(manifest) = view.manifest.as_ref() else {
+                continue;
+            };
+
+            if manifest
+                .entries
+                .iter()
+                .any(|entry| manifest_entry_matches_segment(entry, file_id, filename))
+            {
+                return Ok(false);
+            }
+
+            if manifest.inherited_layers.iter().any(|layer| {
+                layer.status != 2
+                    && layer
+                        .entries
+                        .iter()
+                        .any(|entry| manifest_entry_matches_segment(entry, file_id, filename))
+            }) {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
     /// Stages 2–4 of the reclaim protocol: prove manifest unreachability,
     /// publish the quarantine inventory entry, and rename the segment
     /// file into `<branch_dir>/__quarantine__/`.
@@ -177,6 +252,23 @@ impl SegmentedStore {
         seg_path: &Path,
         file_id: u64,
     ) -> StorageResult<bool> {
+        self.quarantine_segment_if_unreferenced_inner(seg_path, file_id, None)
+    }
+
+    pub(crate) fn quarantine_segment_if_unreferenced_for_cleared_branch(
+        &self,
+        seg_path: &Path,
+        file_id: u64,
+    ) -> StorageResult<bool> {
+        self.quarantine_segment_if_unreferenced_inner(seg_path, file_id, seg_path.parent())
+    }
+
+    fn quarantine_segment_if_unreferenced_inner(
+        &self,
+        seg_path: &Path,
+        file_id: u64,
+        exclude_branch_dir: Option<&Path>,
+    ) -> StorageResult<bool> {
         // Gate — must refuse before any filesystem mutation.
         self.check_reclaim_allowed()?;
 
@@ -196,13 +288,18 @@ impl SegmentedStore {
             return Ok(false);
         }
 
-        // Stage 2 manifest proof (runtime accelerator, degraded-gate above
-        // ensures the accelerator is trustworthy) + Stages 3/4. The
-        // deletion barrier prevents a concurrent fork from incrementing
-        // the refcount between the check and the rename.
+        // Stage 2 candidate-selection + manifest proof. The deletion barrier
+        // prevents a concurrent fork from incrementing the runtime refcount
+        // between the fast-path candidate screen and the authoritative
+        // manifest walk.
         let _guard = self.ref_registry.deletion_write_guard();
         if self.ref_registry.is_referenced(file_id) {
             return Ok(false);
+        }
+        if !self.manifest_proof_allows_reclaim(file_id, &filename, exclude_branch_dir)? {
+            return Err(StorageError::ReclaimRefusedManifestProof {
+                segment_id: file_id,
+            });
         }
         crate::block_cache::global_cache().invalidate_file(file_id);
 
@@ -246,10 +343,11 @@ impl SegmentedStore {
             });
         }
 
-        // Fsync branch_dir so the rename is durable before any purge step.
-        if let Ok(dir_fd) = std::fs::File::open(&branch_dir) {
-            let _ = dir_fd.sync_all();
-        }
+        // Cross-directory rename durability: the file moved from
+        // `branch_dir` into `branch_dir/__quarantine__/`. Both namespace
+        // parents must be durably published before we report success.
+        sync_dir_for_quarantine(&quarantine_dir)?;
+        sync_dir_for_quarantine(&branch_dir)?;
 
         Ok(true)
     }
@@ -369,58 +467,138 @@ impl SegmentedStore {
     ///
     /// Manifest-derived own-segment + inherited-layer byte totals plus
     /// `__quarantine__/` inventory, classified into exclusive vs shared
-    /// using the runtime ref registry. Used by the engine-layer
+    /// from inherited-layer reachability. The same branch-directory ledger
+    /// also feeds Stage-2 manifest proof so reclaim and reporting do not
+    /// drift. Used by the engine-layer
     /// `retention_report()` as the storage half of the attribution
     /// join. Safe to call under degraded recovery (it reports what is
     /// retained — it does not attempt reclaim).
     pub fn retention_snapshot(&self) -> StorageResult<Vec<StorageBranchRetention>> {
-        let mut out: Vec<StorageBranchRetention> = Vec::with_capacity(self.branches.len());
+        let mut out: Vec<StorageBranchRetention> = Vec::new();
 
-        for branch in &self.branches {
-            let branch_id = *branch.key();
-            let state = branch.value();
-            let ver = state.version.load();
+        let views = self.retention_branch_dir_views(true)?;
+        let views_by_id: HashMap<BranchId, &RetentionBranchDirView> =
+            views.iter().map(|view| (view.branch_id, view)).collect();
+        let descendant_held = descendant_held_filenames_by_source(&views);
+        let recovery_health = self.last_recovery_health.load();
+        let legacy_fallback_branches = branches_with_legacy_no_manifest_fallback(&recovery_health);
 
+        for view in &views {
+            let mut accounted_top_level: HashSet<String> = HashSet::new();
             let mut exclusive_bytes = 0u64;
             let mut shared_bytes = 0u64;
-            for level in &ver.levels {
-                for seg in level {
-                    let size = seg.file_size();
-                    if self.ref_registry.is_referenced(seg.file_id()) {
-                        shared_bytes += size;
+            let shared_filenames = descendant_held.get(&view.branch_id);
+
+            if let Some(manifest) = view.manifest.as_ref() {
+                for entry in &manifest.entries {
+                    accounted_top_level.insert(entry.filename.clone());
+                    if let Some(file) = view.top_level_segments.get(&entry.filename) {
+                        if shared_filenames
+                            .is_some_and(|filenames| filenames.contains(&entry.filename))
+                        {
+                            shared_bytes += file.size;
+                        } else {
+                            exclusive_bytes += file.size;
+                        }
+                    }
+                }
+            } else if legacy_fallback_branches.contains(&view.branch_id) {
+                // Explicit legacy fallback: the last recovery admitted this
+                // branch by promoting every discovered top-level `.sst` into
+                // visible own state under `PolicyDowngrade`.
+                for file in view.top_level_segments.values() {
+                    if shared_filenames.is_some_and(|filenames| filenames.contains(&file.filename))
+                    {
+                        shared_bytes += file.size;
                     } else {
-                        exclusive_bytes += size;
+                        exclusive_bytes += file.size;
                     }
+                }
+            } else if !view.top_level_segments.is_empty() {
+                // Missing manifest truth is only attribution-safe when the
+                // last recovery explicitly admitted the legacy fallback for
+                // this branch. Otherwise a live branch directory with own
+                // segment files but no manifest is untrusted and the engine
+                // must refuse `retention_report()`.
+                return Err(StorageError::RecoveryFault(
+                    RecoveryFault::CorruptManifest {
+                        branch_id: view.branch_id,
+                        inner: io::Error::new(
+                            io::ErrorKind::NotFound,
+                            format!(
+                                "segments.manifest missing for branch {} during retention snapshot",
+                                view.branch_dir.display()
+                            ),
+                        ),
+                    },
+                ));
+            }
+
+            for file in view.top_level_segments.values() {
+                if accounted_top_level.contains(&file.filename) {
+                    continue;
+                }
+
+                // Report only manifest-reachable truth.
+                //
+                // Top-level `.sst` files that are not listed in the branch's
+                // own manifest and are not held by any descendant inherited
+                // layer are post-publish reclaim debt, not live retention.
+                // Compaction intentionally publishes the new manifest before
+                // it routes old files through reclaim, so raw disk presence
+                // alone must not inflate `exclusive_bytes` / `shared_bytes`.
+                if shared_filenames.is_some_and(|filenames| filenames.contains(&file.filename)) {
+                    shared_bytes += file.size;
                 }
             }
 
-            let mut inherited_layers: Vec<StorageInheritedLayerInfo> =
-                Vec::with_capacity(state.inherited_layers.len());
+            let mut inherited_layers: Vec<StorageInheritedLayerInfo> = Vec::new();
             let mut inherited_layer_bytes = 0u64;
-            for layer in &state.inherited_layers {
-                let mut bytes = 0u64;
-                for level in &layer.segments.levels {
-                    for seg in level {
-                        bytes += seg.file_size();
+            if let Some(manifest) = view.manifest.as_ref() {
+                for layer in &manifest.inherited_layers {
+                    if layer.status == 2 {
+                        continue;
                     }
+                    let bytes = views_by_id
+                        .get(&layer.source_branch_id)
+                        .map(|source_view| {
+                            layer
+                                .entries
+                                .iter()
+                                .filter_map(|entry| {
+                                    source_view
+                                        .top_level_segments
+                                        .get(&entry.filename)
+                                        .map(|file| file.size)
+                                })
+                                .sum()
+                        })
+                        .unwrap_or(0);
+                    inherited_layer_bytes += bytes;
+                    inherited_layers.push(StorageInheritedLayerInfo {
+                        source_branch_id: layer.source_branch_id,
+                        fork_version: layer.fork_version,
+                        bytes,
+                        is_materialized: layer.status == 2,
+                    });
                 }
-                inherited_layer_bytes += bytes;
-                inherited_layers.push(StorageInheritedLayerInfo {
-                    source_branch_id: layer.source_branch_id,
-                    fork_version: layer.fork_version,
-                    bytes,
-                    is_materialized: matches!(
-                        layer.status,
-                        crate::segmented::LayerStatus::Materialized
-                    ),
-                });
             }
 
-            let (quarantined_bytes, quarantined_segment_count) =
-                self.branch_quarantine_bytes(branch_id).unwrap_or((0, 0));
+            let (quarantined_bytes, quarantined_segment_count) = quarantine_stats_from_state(
+                view.branch_id,
+                view.quarantine.as_ref().expect("quarantine loaded"),
+            )?;
+
+            if exclusive_bytes == 0
+                && shared_bytes == 0
+                && inherited_layer_bytes == 0
+                && quarantined_bytes == 0
+            {
+                continue;
+            }
 
             out.push(StorageBranchRetention {
-                branch_id,
+                branch_id: view.branch_id,
                 exclusive_bytes,
                 shared_bytes,
                 inherited_layer_bytes,
@@ -431,25 +609,6 @@ impl SegmentedStore {
         }
 
         Ok(out)
-    }
-
-    /// Read quarantine inventory for a single branch and compute the total
-    /// bytes + segment count. Returns `None` if there is no `segments_dir`
-    /// or no inventory file. Errors during I/O are swallowed — retention
-    /// reporting is best-effort.
-    fn branch_quarantine_bytes(&self, branch_id: BranchId) -> Option<(u64, usize)> {
-        let segments_dir = self.segments_dir.as_ref()?;
-        let branch_dir = segments_dir.join(crate::segmented::hex_encode_branch(&branch_id));
-        let manifest = read_quarantine_manifest(&branch_dir).ok().flatten()?;
-        let quarantine_dir = branch_dir.join(QUARANTINE_DIR);
-        let mut total = 0u64;
-        for entry in &manifest.entries {
-            let path = quarantine_dir.join(&entry.filename);
-            if let Ok(meta) = std::fs::metadata(&path) {
-                total += meta.len();
-            }
-        }
-        Some((total, manifest.entries.len()))
     }
 
     /// Reopen-time reconciliation of per-branch quarantine state.
@@ -466,35 +625,71 @@ impl SegmentedStore {
     /// implementation does not touch `self` because reconciliation is
     /// purely filesystem-driven.
     #[allow(clippy::unused_self)]
-    pub(crate) fn reconcile_quarantine_on_recovery(
-        &self,
-        segments_dir: &Path,
-        manifest_live_filenames: &HashMap<BranchId, HashSet<String>>,
-        faults: &mut Vec<RecoveryFault>,
-    ) {
-        let Ok(entries) = std::fs::read_dir(segments_dir) else {
-            return;
-        };
-
-        for dir_entry in entries.flatten() {
-            let branch_path = dir_entry.path();
-            if !branch_path.is_dir() {
-                continue;
-            }
-            let Some(dir_name) = dir_entry.file_name().to_str().map(String::from) else {
-                continue;
-            };
-            let Some(branch_id) = crate::segmented::hex_decode_branch(&dir_name) else {
-                continue;
-            };
-
+    pub(crate) fn reconcile_quarantine_on_recovery(&self, faults: &mut Vec<RecoveryFault>) {
+        let views = self.retention_branch_dir_views_for_recovery(faults);
+        let manifest_live_filenames = manifest_live_filenames_from_views(&views);
+        for view in &views {
             let live = manifest_live_filenames
-                .get(&branch_id)
+                .get(&view.branch_id)
                 .cloned()
                 .unwrap_or_default();
-            reconcile_single_branch(&branch_path, branch_id, &live, faults);
+            reconcile_single_branch(&view.branch_dir, view.branch_id, &live, faults);
         }
     }
+}
+
+fn sync_dir_for_quarantine(dir: &Path) -> StorageResult<()> {
+    let dir_fd =
+        std::fs::File::open(dir).map_err(|inner| StorageError::QuarantinePublishFailed {
+            dir: dir.to_path_buf(),
+            inner,
+        })?;
+    dir_fd
+        .sync_all()
+        .map_err(|inner| StorageError::QuarantinePublishFailed {
+            dir: dir.to_path_buf(),
+            inner,
+        })
+}
+
+fn load_branch_quarantine_state(
+    branch_dir: &Path,
+    branch_id: BranchId,
+) -> StorageResult<BranchQuarantineState> {
+    let quarantine_dir = branch_dir.join(QUARANTINE_DIR);
+    let files_on_disk: HashMap<String, u64> = if quarantine_dir.is_dir() {
+        let mut files = HashMap::new();
+        for entry in std::fs::read_dir(&quarantine_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Some(filename) = entry.file_name().to_str().map(str::to_owned) else {
+                return Err(StorageError::QuarantineReconciliationFailed {
+                    branch_id,
+                    reason: "non-utf8 filename in __quarantine__".to_string(),
+                });
+            };
+            let size = entry.metadata()?.len();
+            files.insert(filename, size);
+        }
+        files
+    } else {
+        HashMap::new()
+    };
+
+    let manifest = read_quarantine_manifest(branch_dir).map_err(|inner| {
+        StorageError::QuarantineReconciliationFailed {
+            branch_id,
+            reason: format!("failed to read quarantine inventory: {inner}"),
+        }
+    })?;
+
+    Ok(BranchQuarantineState {
+        manifest,
+        files_on_disk,
+    })
 }
 
 fn reconcile_single_branch(
@@ -504,14 +699,16 @@ fn reconcile_single_branch(
     faults: &mut Vec<RecoveryFault>,
 ) {
     let quarantine_dir = branch_path.join(QUARANTINE_DIR);
-    let quarantine_dir_exists = quarantine_dir.is_dir();
-
-    let manifest = match read_quarantine_manifest(branch_path) {
-        Ok(m) => m,
+    let state = match load_branch_quarantine_state(branch_path, branch_id) {
+        Ok(state) => state,
+        Err(StorageError::QuarantineReconciliationFailed { reason, .. }) => {
+            faults.push(RecoveryFault::QuarantineInventoryMismatch { branch_id, reason });
+            return;
+        }
         Err(e) => {
             faults.push(RecoveryFault::QuarantineInventoryMismatch {
                 branch_id,
-                reason: format!("failed to read quarantine.manifest: {e}"),
+                reason: e.to_string(),
             });
             return;
         }
@@ -519,33 +716,19 @@ fn reconcile_single_branch(
 
     // Case: no inventory but __quarantine__/ holds files — pure mismatch,
     // prefer retention and degrade trust.
-    if manifest.is_none() {
-        if quarantine_dir_exists {
-            if let Ok(mut qentries) = std::fs::read_dir(&quarantine_dir) {
-                if qentries.any(|e| e.as_ref().is_ok_and(|e| e.path().is_file())) {
-                    faults.push(RecoveryFault::QuarantineInventoryMismatch {
-                        branch_id,
-                        reason: "__quarantine__/ contains files but no quarantine.manifest"
-                            .to_string(),
-                    });
-                }
-            }
+    if state.manifest.is_none() {
+        if !state.files_on_disk.is_empty() {
+            faults.push(RecoveryFault::QuarantineInventoryMismatch {
+                branch_id,
+                reason: "__quarantine__/ contains files but no quarantine.manifest".to_string(),
+            });
         }
         return;
     }
-    let manifest = manifest.unwrap();
+    let manifest = state.manifest.unwrap();
 
     // Collect on-disk quarantine filenames.
-    let mut on_disk: HashSet<String> = HashSet::new();
-    if let Ok(q_entries) = std::fs::read_dir(&quarantine_dir) {
-        for q in q_entries.flatten() {
-            if q.path().is_file() {
-                if let Some(name) = q.file_name().to_str() {
-                    on_disk.insert(name.to_string());
-                }
-            }
-        }
-    }
+    let on_disk: HashSet<String> = state.files_on_disk.keys().cloned().collect();
 
     let inventory_filenames: HashSet<String> = manifest
         .entries
@@ -620,4 +803,251 @@ fn reconcile_single_branch(
     // Silence unused warning in release builds with tracing disabled.
     let _ = Arc::<()>::default();
     let _: &PathBuf = &quarantine_dir;
+}
+
+impl SegmentedStore {
+    fn retention_branch_dir_views(
+        &self,
+        load_quarantine: bool,
+    ) -> StorageResult<Vec<RetentionBranchDirView>> {
+        let Some(segments_dir) = self.segments_dir.as_ref() else {
+            return Ok(Vec::new());
+        };
+        let entries = match std::fs::read_dir(segments_dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(StorageError::Io(e)),
+        };
+
+        let mut out = Vec::new();
+        for entry in entries {
+            let entry = entry.map_err(StorageError::Io)?;
+            let branch_dir = entry.path();
+            if !branch_dir.is_dir() {
+                continue;
+            }
+            let Some(branch_id) = entry
+                .file_name()
+                .to_str()
+                .and_then(crate::segmented::hex_decode_branch)
+            else {
+                continue;
+            };
+            out.push(scan_branch_dir_view(
+                &branch_dir,
+                branch_id,
+                load_quarantine,
+            )?);
+        }
+
+        Ok(out)
+    }
+
+    fn retention_branch_dir_views_for_recovery(
+        &self,
+        faults: &mut Vec<RecoveryFault>,
+    ) -> Vec<RetentionBranchDirView> {
+        let Some(segments_dir) = self.segments_dir.as_ref() else {
+            return Vec::new();
+        };
+        let entries = match std::fs::read_dir(segments_dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Vec::new(),
+            Err(e) => {
+                faults.push(RecoveryFault::Io(e));
+                return Vec::new();
+            }
+        };
+
+        let mut out = Vec::new();
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(e) => {
+                    faults.push(RecoveryFault::Io(e));
+                    continue;
+                }
+            };
+            let branch_dir = entry.path();
+            if !branch_dir.is_dir() {
+                continue;
+            }
+            let Some(branch_id) = entry
+                .file_name()
+                .to_str()
+                .and_then(crate::segmented::hex_decode_branch)
+            else {
+                continue;
+            };
+            match scan_branch_dir_view(&branch_dir, branch_id, false) {
+                Ok(view) => out.push(view),
+                Err(StorageError::RecoveryFault(fault)) => faults.push(fault),
+                Err(StorageError::Io(e)) => faults.push(RecoveryFault::Io(e)),
+                Err(StorageError::QuarantineReconciliationFailed { branch_id, reason }) => {
+                    faults.push(RecoveryFault::QuarantineInventoryMismatch { branch_id, reason })
+                }
+                Err(other) => faults.push(RecoveryFault::Io(io::Error::other(other.to_string()))),
+            }
+        }
+
+        out
+    }
+}
+
+fn scan_branch_dir_view(
+    branch_dir: &Path,
+    branch_id: BranchId,
+    load_quarantine: bool,
+) -> StorageResult<RetentionBranchDirView> {
+    let manifest = match crate::manifest::read_manifest(branch_dir) {
+        Ok(manifest) => manifest,
+        Err(inner) => {
+            return Err(StorageError::RecoveryFault(
+                RecoveryFault::CorruptManifest { branch_id, inner },
+            ));
+        }
+    };
+
+    let mut top_level_segments = HashMap::new();
+    for entry in std::fs::read_dir(branch_dir).map_err(StorageError::Io)? {
+        let entry = entry.map_err(StorageError::Io)?;
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|x| x.to_str()) != Some("sst") {
+            continue;
+        }
+        let Some(filename) = entry.file_name().to_str().map(str::to_owned) else {
+            return Err(StorageError::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("non-utf8 segment filename in {}", branch_dir.display()),
+            )));
+        };
+        let size = entry.metadata().map_err(StorageError::Io)?.len();
+        top_level_segments.insert(
+            filename.clone(),
+            RetentionTopLevelSegment { filename, size },
+        );
+    }
+
+    let quarantine = if load_quarantine {
+        Some(load_branch_quarantine_state(branch_dir, branch_id)?)
+    } else {
+        None
+    };
+
+    Ok(RetentionBranchDirView {
+        branch_id,
+        branch_dir: branch_dir.to_path_buf(),
+        manifest,
+        top_level_segments,
+        quarantine,
+    })
+}
+
+fn descendant_held_filenames_by_source(
+    views: &[RetentionBranchDirView],
+) -> HashMap<BranchId, HashSet<String>> {
+    let mut out: HashMap<BranchId, HashSet<String>> = HashMap::new();
+
+    for view in views {
+        let Some(manifest) = view.manifest.as_ref() else {
+            continue;
+        };
+        for layer in &manifest.inherited_layers {
+            if layer.status == 2 {
+                continue;
+            }
+            let entry = out.entry(layer.source_branch_id).or_default();
+            for manifest_entry in &layer.entries {
+                entry.insert(manifest_entry.filename.clone());
+            }
+        }
+    }
+
+    out
+}
+
+fn manifest_live_filenames_from_views(
+    views: &[RetentionBranchDirView],
+) -> HashMap<BranchId, HashSet<String>> {
+    let mut out: HashMap<BranchId, HashSet<String>> = HashMap::new();
+
+    for view in views {
+        let Some(manifest) = view.manifest.as_ref() else {
+            continue;
+        };
+
+        let own = out.entry(view.branch_id).or_default();
+        for entry in &manifest.entries {
+            own.insert(entry.filename.clone());
+        }
+
+        for layer in &manifest.inherited_layers {
+            if layer.status == 2 {
+                continue;
+            }
+            let source = out.entry(layer.source_branch_id).or_default();
+            for entry in &layer.entries {
+                source.insert(entry.filename.clone());
+            }
+        }
+    }
+
+    out
+}
+
+fn branches_with_legacy_no_manifest_fallback(health: &RecoveryHealth) -> HashSet<BranchId> {
+    let mut out = HashSet::new();
+    if let RecoveryHealth::Degraded { faults, .. } = health {
+        for fault in faults.iter() {
+            if let RecoveryFault::NoManifestFallbackUsed { branch_id, .. } = fault {
+                out.insert(*branch_id);
+            }
+        }
+    }
+    out
+}
+
+fn quarantine_stats_from_state(
+    branch_id: BranchId,
+    state: &BranchQuarantineState,
+) -> StorageResult<(u64, usize)> {
+    match &state.manifest {
+        None => {
+            if state.files_on_disk.is_empty() {
+                Ok((0, 0))
+            } else {
+                Err(StorageError::QuarantineReconciliationFailed {
+                    branch_id,
+                    reason: "files present in __quarantine__ with no inventory".to_string(),
+                })
+            }
+        }
+        Some(manifest) => {
+            let inventory_filenames: HashSet<String> = manifest
+                .entries
+                .iter()
+                .map(|entry| entry.filename.clone())
+                .collect();
+            let files_present: HashSet<String> = state.files_on_disk.keys().cloned().collect();
+            if inventory_filenames != files_present {
+                return Err(StorageError::QuarantineReconciliationFailed {
+                    branch_id,
+                    reason: "inventory does not match on-disk quarantine contents".to_string(),
+                });
+            }
+
+            let total = manifest
+                .entries
+                .iter()
+                .map(|entry| {
+                    state
+                        .files_on_disk
+                        .get(&entry.filename)
+                        .copied()
+                        .unwrap_or(0)
+                })
+                .sum();
+            Ok((total, manifest.entries.len()))
+        }
+    }
 }

--- a/crates/storage/src/segmented/quarantine_protocol.rs
+++ b/crates/storage/src/segmented/quarantine_protocol.rs
@@ -1,0 +1,623 @@
+//! B5.2 — Safe reclaim protocol (quarantine-based) for `SegmentedStore`.
+//!
+//! The [`crate::segmented::SegmentedStore`] reclaim path routes through this
+//! module instead of immediately unlinking segment files. The protocol
+//! implements Stages 2–5 of
+//! `docs/design/branching/branching-gc/branching-retention-contract.md`
+//! §"Reclaim protocol":
+//!
+//! 1. **Stage 2 — manifest proof.** The caller's runtime accelerator check
+//!    (`SegmentRefRegistry::is_referenced` plus the live-set scan in
+//!    `gc_orphan_segments`) serves as the manifest proof, under the
+//!    degraded-recovery refusal gate (`BarrierKind::RecoveryHealthGate`).
+//!    When recovery health is `DataLoss`, `PolicyDowngrade`, or any
+//!    non-`Telemetry` degradation, reclaim refuses **before** any
+//!    filesystem mutation — addressing the B5.2 review Finding 1.
+//! 2. **Stage 3 — quarantine rename.** After the proof succeeds, the
+//!    segment file is renamed into `<branch_dir>/__quarantine__/` on the
+//!    same filesystem namespace. Before Stage 4 publishes the inventory,
+//!    the durable `quarantine.manifest` entry is written *first*
+//!    (publish-before-rename) so a crash between Stage 4 publish and
+//!    Stage 3 rename does not leave an on-disk orphan that reopen cannot
+//!    correlate with the inventory.
+//! 3. **Stage 4 — durable publish.** The per-branch `quarantine.manifest`
+//!    (see [`crate::quarantine`]) is rewritten atomically with the new
+//!    entry. Its temp-file + fsync + rename + fsync(dir) idiom matches
+//!    `segments.manifest`.
+//! 4. **Stage 5 — final purge.** A later [`SegmentedStore::purge_all_quarantines`]
+//!    call drains each branch's quarantine manifest, unlinking the
+//!    listed files and atomically rewriting the manifest with any
+//!    entries whose unlink failed. Degraded recovery blocks purge per
+//!    the same gate.
+//!
+//! **Reopen reconciliation** (see
+//! [`SegmentedStore::reconcile_quarantine_on_recovery`]): disagreement
+//! between the inventory and the on-disk quarantine directory degrades
+//! recovery health to `PolicyDowngrade` with
+//! [`crate::segmented::RecoveryFault::QuarantineInventoryMismatch`]. Per
+//! §"Quarantine reconciliation", the implementation prefers retention
+//! and blocks reclaim until a full rebuild-equivalent reconciliation
+//! completes (KD10).
+//!
+//! Engine-facing attribution (`retention_report()` at the engine layer)
+//! consumes the storage-layer snapshot produced by
+//! [`SegmentedStore::retention_snapshot`] below, joins it with
+//! `BranchControlStore` for generation-aware `BranchRef` attribution,
+//! and returns `Err(StrataError::RetentionReportUnavailable)` when
+//! recovery health cannot sustain trustworthy attribution (contract
+//! §"Canonical blocker attribution", convergence doc §"retention
+//! report contract" hard-fail rule).
+
+use std::collections::{HashMap, HashSet};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use strata_core::id::CommitVersion;
+use strata_core::types::BranchId;
+
+use crate::quarantine::{
+    read_quarantine_manifest, write_quarantine_manifest, QuarantineEntry, QUARANTINE_DIR,
+    QUARANTINE_FILENAME,
+};
+use crate::segmented::{DegradationClass, RecoveryFault, RecoveryHealth, SegmentedStore};
+use crate::{StorageError, StorageResult};
+
+/// Summary of a [`SegmentedStore::purge_all_quarantines`] call.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct PurgeReport {
+    /// Number of files unlinked during this call.
+    pub files_purged: usize,
+    /// Number of branch quarantines that were fully drained (inventory now empty).
+    pub branches_drained: usize,
+}
+
+/// Storage-layer retention facts for one branch directory.
+///
+/// Produced by [`SegmentedStore::retention_snapshot`] and consumed by the
+/// engine-layer `retention_report()` to attribute bytes to
+/// `BranchRef` lifecycle instances. The snapshot is manifest-derived;
+/// runtime accelerators (the segment ref registry) are used only to
+/// classify own-segment bytes as exclusive vs shared.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct StorageBranchRetention {
+    /// Directory identity — matches the on-disk `<segments_dir>/<hex>` name.
+    pub branch_id: BranchId,
+    /// Own-segment file bytes that no descendant's inherited-layer
+    /// manifest currently references (ref registry zero).
+    pub exclusive_bytes: u64,
+    /// Own-segment file bytes that at least one descendant's
+    /// inherited-layer manifest references. Retained until the
+    /// descendant releases (release-at-clear-or-materialize).
+    pub shared_bytes: u64,
+    /// Bytes visible to this branch through inherited-layer manifests;
+    /// the bytes physically live under the source branch's directory.
+    pub inherited_layer_bytes: u64,
+    /// Per-layer detail for `inherited_layer_bytes`.
+    pub inherited_layers: Vec<StorageInheritedLayerInfo>,
+    /// Bytes currently in this branch's `__quarantine__/` awaiting Stage-5 purge.
+    pub quarantined_bytes: u64,
+    /// Total number of segments in this branch's quarantine inventory.
+    pub quarantined_segment_count: usize,
+}
+
+impl StorageBranchRetention {
+    /// Empty retention facts for `branch_id` (zero bytes everywhere).
+    /// Used by engine-layer attribution when a control record has no
+    /// matching storage directory yet (e.g. a freshly-created branch
+    /// before any flush).
+    pub fn empty(branch_id: BranchId) -> Self {
+        Self {
+            branch_id,
+            exclusive_bytes: 0,
+            shared_bytes: 0,
+            inherited_layer_bytes: 0,
+            inherited_layers: Vec::new(),
+            quarantined_bytes: 0,
+            quarantined_segment_count: 0,
+        }
+    }
+}
+
+/// One entry in a [`StorageBranchRetention::inherited_layers`] list.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct StorageInheritedLayerInfo {
+    /// The storage branch whose directory physically holds these bytes.
+    pub source_branch_id: BranchId,
+    /// Fork point that bounds descendant visibility into the source snapshot.
+    pub fork_version: CommitVersion,
+    /// Total bytes across every segment in this layer.
+    pub bytes: u64,
+    /// `true` once the layer has been fully materialized into the child's
+    /// own segments (status == `Materialized` in the manifest).
+    pub is_materialized: bool,
+}
+
+impl SegmentedStore {
+    /// Check the `BarrierKind::RecoveryHealthGate` before any reclaim step.
+    ///
+    /// Shared helper used by both the quarantine-rename step and the
+    /// final-purge step. Returns [`StorageError::GcRefusedDegradedRecovery`]
+    /// when the most recent recovery produced a non-`Telemetry` degradation.
+    pub(crate) fn check_reclaim_allowed(&self) -> StorageResult<()> {
+        match &**self.last_recovery_health.load() {
+            RecoveryHealth::Healthy
+            | RecoveryHealth::Degraded {
+                class: DegradationClass::Telemetry,
+                ..
+            } => Ok(()),
+            RecoveryHealth::Degraded { class, .. } => {
+                Err(StorageError::GcRefusedDegradedRecovery { class: *class })
+            }
+        }
+    }
+
+    /// Stages 2–4 of the reclaim protocol: prove manifest unreachability,
+    /// publish the quarantine inventory entry, and rename the segment
+    /// file into `<branch_dir>/__quarantine__/`.
+    ///
+    /// Returns `Ok(true)` if the segment was quarantined, `Ok(false)` if
+    /// the runtime accelerator refused (still referenced — the caller's
+    /// Stage 2 check). Returns `Err(GcRefusedDegradedRecovery)` when the
+    /// recovery-health gate blocks reclaim; the file is left untouched
+    /// at its original location.
+    ///
+    /// `seg_path` is the current on-disk location of the segment file
+    /// and `file_id` is its stable [`KVSegment::file_id`] value. The
+    /// call is a no-op (returning `Ok(false)`) if the file does not
+    /// exist at `seg_path` anymore (e.g. a prior reclaim already moved
+    /// it).
+    ///
+    /// [`KVSegment::file_id`]: crate::segment::KVSegment::file_id
+    pub(crate) fn quarantine_segment_if_unreferenced(
+        &self,
+        seg_path: &Path,
+        file_id: u64,
+    ) -> StorageResult<bool> {
+        // Gate — must refuse before any filesystem mutation.
+        self.check_reclaim_allowed()?;
+
+        let branch_dir = match seg_path.parent() {
+            Some(p) => p.to_path_buf(),
+            None => return Ok(false),
+        };
+        let filename = match seg_path.file_name().and_then(|n| n.to_str()) {
+            Some(s) => s.to_string(),
+            None => return Ok(false),
+        };
+
+        // Idempotency: if the file is already in quarantine (rename from a
+        // prior run completed but inventory publish did not), return false
+        // and let reconciliation handle it.
+        if !seg_path.exists() {
+            return Ok(false);
+        }
+
+        // Stage 2 manifest proof (runtime accelerator, degraded-gate above
+        // ensures the accelerator is trustworthy) + Stages 3/4. The
+        // deletion barrier prevents a concurrent fork from incrementing
+        // the refcount between the check and the rename.
+        let _guard = self.ref_registry.deletion_write_guard();
+        if self.ref_registry.is_referenced(file_id) {
+            return Ok(false);
+        }
+        crate::block_cache::global_cache().invalidate_file(file_id);
+
+        // Stage 4 publish-before-rename — ensures a crash between publish
+        // and rename leaves the file at its original path with the
+        // inventory listing it, which reopen reconciliation handles by
+        // dropping the stale entry (no health degrade).
+        let existing = read_quarantine_manifest(&branch_dir)
+            .map_err(|inner| StorageError::QuarantinePublishFailed {
+                dir: branch_dir.clone(),
+                inner,
+            })?
+            .unwrap_or_default();
+        let mut entries = existing.entries;
+        if !entries.iter().any(|e| e.segment_id == file_id) {
+            entries.push(QuarantineEntry {
+                segment_id: file_id,
+                filename: filename.clone(),
+            });
+        }
+        write_quarantine_manifest(&branch_dir, &entries)?;
+
+        // Stage 3 rename — create __quarantine__/ if absent.
+        let quarantine_dir = branch_dir.join(QUARANTINE_DIR);
+        if !quarantine_dir.exists() {
+            std::fs::create_dir_all(&quarantine_dir).map_err(|inner| {
+                StorageError::QuarantinePublishFailed {
+                    dir: branch_dir.clone(),
+                    inner,
+                }
+            })?;
+        }
+        let quarantine_path = quarantine_dir.join(&filename);
+        if let Err(e) = std::fs::rename(seg_path, &quarantine_path) {
+            // Rename failed: inventory still lists the entry but file is at
+            // original path. Reopen reconciliation drops the stale entry
+            // without degrading; subsequent GC will re-nominate.
+            return Err(StorageError::QuarantinePublishFailed {
+                dir: branch_dir,
+                inner: e,
+            });
+        }
+
+        // Fsync branch_dir so the rename is durable before any purge step.
+        if let Ok(dir_fd) = std::fs::File::open(&branch_dir) {
+            let _ = dir_fd.sync_all();
+        }
+
+        Ok(true)
+    }
+
+    /// Stage 5 — final purge of every branch's `quarantine.manifest`.
+    ///
+    /// Drains each branch's inventory, unlinking the listed files from
+    /// `<branch_dir>/__quarantine__/` and rewriting the manifest with
+    /// any entries whose unlink failed. Blocks under degraded recovery
+    /// per the contract's §"Stage 5. Final purge" guard.
+    ///
+    /// Idempotent on repeated calls: empty inventories are no-ops.
+    pub fn purge_all_quarantines(&self) -> StorageResult<PurgeReport> {
+        self.check_reclaim_allowed()?;
+        let Some(segments_dir) = self.segments_dir.as_ref() else {
+            return Ok(PurgeReport::default());
+        };
+
+        let mut report = PurgeReport::default();
+        let Ok(entries) = std::fs::read_dir(segments_dir) else {
+            return Ok(report);
+        };
+
+        for entry in entries.flatten() {
+            let branch_path = entry.path();
+            if !branch_path.is_dir() {
+                continue;
+            }
+            if let Some(count) = self.purge_quarantine_for_branch(&branch_path)? {
+                report.files_purged += count;
+                report.branches_drained += 1;
+            }
+        }
+
+        Ok(report)
+    }
+
+    /// Stage 5 for a single branch directory. Returns `Ok(None)` when no
+    /// inventory exists; `Ok(Some(count))` with the number of files
+    /// actually unlinked.
+    ///
+    /// Retained entries (files whose unlink failed) are rewritten back
+    /// into the manifest so subsequent passes retry safely.
+    ///
+    /// Holds the global `deletion_write_guard` across the read,
+    /// unlink, and manifest rewrite. That serialization matters:
+    /// without it, a concurrent
+    /// [`SegmentedStore::quarantine_segment_if_unreferenced`] could
+    /// publish a new inventory entry between this function's read and
+    /// rewrite, and the rewrite would silently overwrite (or unlink)
+    /// the freshly-quarantined file. The same guard is what quarantine
+    /// uses, so they mutually exclude on the inventory ledger without
+    /// needing a second lock.
+    pub(crate) fn purge_quarantine_for_branch(
+        &self,
+        branch_dir: &Path,
+    ) -> StorageResult<Option<usize>> {
+        self.check_reclaim_allowed()?;
+
+        let _guard = self.ref_registry.deletion_write_guard();
+
+        let mut manifest = match read_quarantine_manifest(branch_dir) {
+            Ok(Some(m)) => m,
+            Ok(None) => return Ok(None),
+            Err(inner) => {
+                return Err(StorageError::QuarantinePublishFailed {
+                    dir: branch_dir.to_path_buf(),
+                    inner,
+                })
+            }
+        };
+
+        if manifest.entries.is_empty() {
+            // Inventory is empty; best-effort remove the __quarantine__/ dir.
+            let qdir = branch_dir.join(QUARANTINE_DIR);
+            let _ = std::fs::remove_dir(&qdir);
+            // And remove the empty quarantine.manifest itself.
+            let _ = std::fs::remove_file(branch_dir.join(QUARANTINE_FILENAME));
+            return Ok(Some(0));
+        }
+
+        let quarantine_dir = branch_dir.join(QUARANTINE_DIR);
+        let mut purged = 0usize;
+        let mut remaining: Vec<QuarantineEntry> = Vec::new();
+        for entry in manifest.entries.drain(..) {
+            let path = quarantine_dir.join(&entry.filename);
+            match std::fs::remove_file(&path) {
+                Ok(()) => purged += 1,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => purged += 1,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "strata::storage::gc",
+                        branch_dir = %branch_dir.display(),
+                        segment_id = entry.segment_id,
+                        file = %entry.filename,
+                        error = %e,
+                        "failed to purge quarantined segment; retrying on next GC"
+                    );
+                    remaining.push(entry);
+                }
+            }
+        }
+
+        if remaining.is_empty() {
+            // Rewrite an empty manifest (atomic) then best-effort remove it
+            // plus the quarantine dir.
+            let _ = std::fs::remove_file(branch_dir.join(QUARANTINE_FILENAME));
+            let _ = std::fs::remove_dir(&quarantine_dir);
+        } else {
+            write_quarantine_manifest(branch_dir, &remaining)?;
+        }
+
+        Ok(Some(purged))
+    }
+
+    /// Storage-layer snapshot of retention facts per branch directory.
+    ///
+    /// Manifest-derived own-segment + inherited-layer byte totals plus
+    /// `__quarantine__/` inventory, classified into exclusive vs shared
+    /// using the runtime ref registry. Used by the engine-layer
+    /// `retention_report()` as the storage half of the attribution
+    /// join. Safe to call under degraded recovery (it reports what is
+    /// retained — it does not attempt reclaim).
+    pub fn retention_snapshot(&self) -> StorageResult<Vec<StorageBranchRetention>> {
+        let mut out: Vec<StorageBranchRetention> = Vec::with_capacity(self.branches.len());
+
+        for branch in &self.branches {
+            let branch_id = *branch.key();
+            let state = branch.value();
+            let ver = state.version.load();
+
+            let mut exclusive_bytes = 0u64;
+            let mut shared_bytes = 0u64;
+            for level in &ver.levels {
+                for seg in level {
+                    let size = seg.file_size();
+                    if self.ref_registry.is_referenced(seg.file_id()) {
+                        shared_bytes += size;
+                    } else {
+                        exclusive_bytes += size;
+                    }
+                }
+            }
+
+            let mut inherited_layers: Vec<StorageInheritedLayerInfo> =
+                Vec::with_capacity(state.inherited_layers.len());
+            let mut inherited_layer_bytes = 0u64;
+            for layer in &state.inherited_layers {
+                let mut bytes = 0u64;
+                for level in &layer.segments.levels {
+                    for seg in level {
+                        bytes += seg.file_size();
+                    }
+                }
+                inherited_layer_bytes += bytes;
+                inherited_layers.push(StorageInheritedLayerInfo {
+                    source_branch_id: layer.source_branch_id,
+                    fork_version: layer.fork_version,
+                    bytes,
+                    is_materialized: matches!(
+                        layer.status,
+                        crate::segmented::LayerStatus::Materialized
+                    ),
+                });
+            }
+
+            let (quarantined_bytes, quarantined_segment_count) =
+                self.branch_quarantine_bytes(branch_id).unwrap_or((0, 0));
+
+            out.push(StorageBranchRetention {
+                branch_id,
+                exclusive_bytes,
+                shared_bytes,
+                inherited_layer_bytes,
+                inherited_layers,
+                quarantined_bytes,
+                quarantined_segment_count,
+            });
+        }
+
+        Ok(out)
+    }
+
+    /// Read quarantine inventory for a single branch and compute the total
+    /// bytes + segment count. Returns `None` if there is no `segments_dir`
+    /// or no inventory file. Errors during I/O are swallowed — retention
+    /// reporting is best-effort.
+    fn branch_quarantine_bytes(&self, branch_id: BranchId) -> Option<(u64, usize)> {
+        let segments_dir = self.segments_dir.as_ref()?;
+        let branch_dir = segments_dir.join(crate::segmented::hex_encode_branch(&branch_id));
+        let manifest = read_quarantine_manifest(&branch_dir).ok().flatten()?;
+        let quarantine_dir = branch_dir.join(QUARANTINE_DIR);
+        let mut total = 0u64;
+        for entry in &manifest.entries {
+            let path = quarantine_dir.join(&entry.filename);
+            if let Ok(meta) = std::fs::metadata(&path) {
+                total += meta.len();
+            }
+        }
+        Some((total, manifest.entries.len()))
+    }
+
+    /// Reopen-time reconciliation of per-branch quarantine state.
+    ///
+    /// Called from [`SegmentedStore::recover_segments`] after the main
+    /// walk. Appends faults to `faults` when disagreement is observed
+    /// (classified as `PolicyDowngrade` per the contract's
+    /// §"Quarantine reconciliation" rule — prefer retention, block
+    /// reclaim). Stale inventory entries for files already purged or
+    /// never renamed are dropped in place without degrading.
+    ///
+    /// Kept as a method on `SegmentedStore` for call-site ergonomics
+    /// (the reopen walk already holds a `&self` reference); the
+    /// implementation does not touch `self` because reconciliation is
+    /// purely filesystem-driven.
+    #[allow(clippy::unused_self)]
+    pub(crate) fn reconcile_quarantine_on_recovery(
+        &self,
+        segments_dir: &Path,
+        manifest_live_filenames: &HashMap<BranchId, HashSet<String>>,
+        faults: &mut Vec<RecoveryFault>,
+    ) {
+        let Ok(entries) = std::fs::read_dir(segments_dir) else {
+            return;
+        };
+
+        for dir_entry in entries.flatten() {
+            let branch_path = dir_entry.path();
+            if !branch_path.is_dir() {
+                continue;
+            }
+            let Some(dir_name) = dir_entry.file_name().to_str().map(String::from) else {
+                continue;
+            };
+            let Some(branch_id) = crate::segmented::hex_decode_branch(&dir_name) else {
+                continue;
+            };
+
+            let live = manifest_live_filenames
+                .get(&branch_id)
+                .cloned()
+                .unwrap_or_default();
+            reconcile_single_branch(&branch_path, branch_id, &live, faults);
+        }
+    }
+}
+
+fn reconcile_single_branch(
+    branch_path: &Path,
+    branch_id: BranchId,
+    manifest_live_filenames: &HashSet<String>,
+    faults: &mut Vec<RecoveryFault>,
+) {
+    let quarantine_dir = branch_path.join(QUARANTINE_DIR);
+    let quarantine_dir_exists = quarantine_dir.is_dir();
+
+    let manifest = match read_quarantine_manifest(branch_path) {
+        Ok(m) => m,
+        Err(e) => {
+            faults.push(RecoveryFault::QuarantineInventoryMismatch {
+                branch_id,
+                reason: format!("failed to read quarantine.manifest: {e}"),
+            });
+            return;
+        }
+    };
+
+    // Case: no inventory but __quarantine__/ holds files — pure mismatch,
+    // prefer retention and degrade trust.
+    if manifest.is_none() {
+        if quarantine_dir_exists {
+            if let Ok(mut qentries) = std::fs::read_dir(&quarantine_dir) {
+                if qentries.any(|e| e.as_ref().is_ok_and(|e| e.path().is_file())) {
+                    faults.push(RecoveryFault::QuarantineInventoryMismatch {
+                        branch_id,
+                        reason: "__quarantine__/ contains files but no quarantine.manifest"
+                            .to_string(),
+                    });
+                }
+            }
+        }
+        return;
+    }
+    let manifest = manifest.unwrap();
+
+    // Collect on-disk quarantine filenames.
+    let mut on_disk: HashSet<String> = HashSet::new();
+    if let Ok(q_entries) = std::fs::read_dir(&quarantine_dir) {
+        for q in q_entries.flatten() {
+            if q.path().is_file() {
+                if let Some(name) = q.file_name().to_str() {
+                    on_disk.insert(name.to_string());
+                }
+            }
+        }
+    }
+
+    let inventory_filenames: HashSet<String> = manifest
+        .entries
+        .iter()
+        .map(|e| e.filename.clone())
+        .collect();
+
+    // Mismatch A: file in __quarantine__/ but not in inventory → degrade.
+    for name in &on_disk {
+        if !inventory_filenames.contains(name) {
+            faults.push(RecoveryFault::QuarantineInventoryMismatch {
+                branch_id,
+                reason: format!("quarantined file {name} not listed in inventory"),
+            });
+            return;
+        }
+    }
+
+    // Mismatch B: inventory claims file X but a live manifest still
+    // references X — reclaim never should have been allowed. Prefer
+    // retention and degrade.
+    for entry in &manifest.entries {
+        if manifest_live_filenames.contains(&entry.filename) {
+            faults.push(RecoveryFault::QuarantineInventoryMismatch {
+                branch_id,
+                reason: format!(
+                    "inventory lists {} but a live manifest still references it",
+                    entry.filename
+                ),
+            });
+            return;
+        }
+    }
+
+    // Reconcile benign cases: inventory entries whose files are neither
+    // in quarantine nor manifest-referenced (e.g. rename never completed
+    // or purge already removed the file) are dropped from the inventory.
+    let mut reconciled: Vec<QuarantineEntry> = Vec::new();
+    let mut dropped = 0usize;
+    for entry in manifest.entries {
+        if on_disk.contains(&entry.filename) {
+            reconciled.push(entry);
+        } else {
+            dropped += 1;
+        }
+    }
+
+    if dropped > 0 {
+        if let Err(e) = write_quarantine_manifest(branch_path, &reconciled) {
+            faults.push(RecoveryFault::QuarantineInventoryMismatch {
+                branch_id,
+                reason: format!("failed to rewrite reconciled quarantine.manifest: {e}"),
+            });
+        }
+    }
+
+    if reconciled.is_empty() && !on_disk.is_empty() {
+        // Defensive: should be unreachable given mismatch A above.
+        faults.push(RecoveryFault::QuarantineInventoryMismatch {
+            branch_id,
+            reason: "reconciliation left a non-empty quarantine dir with an empty inventory"
+                .to_string(),
+        });
+    }
+
+    if reconciled.is_empty() && on_disk.is_empty() {
+        // Fully drained — best-effort cleanup.
+        let _ = std::fs::remove_file(branch_path.join(QUARANTINE_FILENAME));
+        let _ = std::fs::remove_dir(&quarantine_dir);
+    }
+
+    // Silence unused warning in release builds with tracing disabled.
+    let _ = Arc::<()>::default();
+    let _: &PathBuf = &quarantine_dir;
+}

--- a/crates/storage/src/segmented/recovery.rs
+++ b/crates/storage/src/segmented/recovery.rs
@@ -206,6 +206,19 @@ pub enum RecoveryFault {
     /// failures are returned as `Err(StorageError)` instead.
     #[error("recovery I/O error: {0}")]
     Io(#[source] io::Error),
+    /// Reopen quarantine reconciliation observed disagreement between
+    /// the branch's `quarantine.manifest` inventory and the on-disk
+    /// `__quarantine__/` contents. Per the B5 retention contract
+    /// §"Quarantine reconciliation", the implementation prefers
+    /// retention and degrades reclaim trust until a full
+    /// rebuild-equivalent reconciliation completes.
+    #[error("quarantine inventory mismatch for branch {branch_id}: {reason}")]
+    QuarantineInventoryMismatch {
+        /// Branch whose quarantine state could not be reconciled.
+        branch_id: BranchId,
+        /// Short description of the disagreement observed.
+        reason: String,
+    },
 }
 
 impl RecoveryFault {
@@ -217,7 +230,10 @@ impl RecoveryFault {
             | RecoveryFault::MissingManifestListed { .. }
             | RecoveryFault::InheritedLayerLost { .. }
             | RecoveryFault::Io(_) => DegradationClass::DataLoss,
-            RecoveryFault::NoManifestFallbackUsed { .. } => DegradationClass::PolicyDowngrade,
+            RecoveryFault::NoManifestFallbackUsed { .. }
+            | RecoveryFault::QuarantineInventoryMismatch { .. } => {
+                DegradationClass::PolicyDowngrade
+            }
         }
     }
 }

--- a/crates/storage/src/segmented/tests/basic.rs
+++ b/crates/storage/src/segmented/tests/basic.rs
@@ -248,9 +248,9 @@ fn branch_ids_and_clear() {
     let store = SegmentedStore::new();
     seed(&store, kv_key("k"), Value::Int(1), 1);
     assert_eq!(store.branch_ids().len(), 1);
-    assert!(store.clear_branch(&branch()));
+    assert!(store.clear_branch(&branch()).unwrap());
     assert!(store.branch_ids().is_empty());
-    assert!(!store.clear_branch(&branch())); // already cleared
+    assert!(!store.clear_branch(&branch()).unwrap()); // already cleared
 }
 
 #[test]

--- a/crates/storage/src/segmented/tests/concurrency.rs
+++ b/crates/storage/src/segmented/tests/concurrency.rs
@@ -297,7 +297,7 @@ fn test_issue_1682_segment_deletion_races_fork_refcount() {
         .unwrap();
 
     // Clear child1 → refcounts back to 0.
-    store.clear_branch(&child_branch());
+    store.clear_branch(&child_branch()).unwrap();
 
     // Now race: fork a new child (child2) + compact parent concurrently.
     // Without the deletion barrier, compaction can see refcount=0 and
@@ -391,7 +391,7 @@ fn test_issue_1682_segment_deletion_races_fork_refcount_concurrent() {
         store
             .fork_branch(&parent_branch(), &child_branch())
             .unwrap();
-        store.clear_branch(&child_branch());
+        store.clear_branch(&child_branch()).unwrap();
 
         // Race fork child2 + compact.
         let child2 = BranchId::from_bytes([40; 16]);

--- a/crates/storage/src/segmented/tests/fork.rs
+++ b/crates/storage/src/segmented/tests/fork.rs
@@ -1144,7 +1144,7 @@ fn fork_refcounts_on_clear() {
     }
 
     // Clear child — refcounts should be decremented
-    store.clear_branch(&child_branch());
+    store.clear_branch(&child_branch()).unwrap();
 
     for &id in &seg_ids {
         assert!(

--- a/crates/storage/src/segmented/tests/gc_under_degradation.rs
+++ b/crates/storage/src/segmented/tests/gc_under_degradation.rs
@@ -299,7 +299,8 @@ fn clear_branch_succeeds_under_degraded_recovery() {
     store.flush_oldest_frozen(&branch()).unwrap();
 
     // Simulate a degraded recovery state without actually corrupting
-    // anything — exercises the log-and-continue path inside clear_branch.
+    // anything — exercises the reclaim-refusal log-and-continue path inside
+    // clear_branch.
     store.set_recovery_health_for_test(RecoveryHealth::Degraded {
         faults: std::sync::Arc::from(vec![RecoveryFault::InheritedLayerLost {
             child: branch(),
@@ -310,7 +311,7 @@ fn clear_branch_succeeds_under_degraded_recovery() {
     });
 
     assert!(
-        store.clear_branch(&branch()),
+        store.clear_branch(&branch()).unwrap(),
         "clear_branch must succeed even when gc refuses under degraded recovery"
     );
     assert!(
@@ -368,7 +369,7 @@ fn clear_branch_under_degraded_recovery_preserves_skipped_branch_files() {
     assert!(reopened.branches.get(&skipped).is_none());
     assert!(reopened.branches.get(&cleared).is_some());
 
-    assert!(reopened.clear_branch(&cleared));
+    assert!(reopened.clear_branch(&cleared).unwrap());
     assert!(reopened.branches.get(&cleared).is_none());
     assert!(matches!(
         &*reopened.last_recovery_health(),

--- a/crates/storage/src/segmented/tests/lifecycle.rs
+++ b/crates/storage/src/segmented/tests/lifecycle.rs
@@ -4,9 +4,10 @@ use super::*;
 // Bug-fix regression tests (#1662, #1663, #1664)
 // =====================================================================
 
-/// #1663: clear_branch() must delete own segment files, manifest, and branch dir.
+/// #1663 / B5.2 step 3: clear_branch() removes top-level ownership
+/// immediately, but final purge is explicit GC work.
 #[test]
-fn clear_branch_deletes_own_segments_and_manifest() {
+fn clear_branch_quarantines_own_segments_and_leaves_purge_to_gc() {
     let dir = tempfile::tempdir().unwrap();
     let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
 
@@ -38,34 +39,59 @@ fn clear_branch_deletes_own_segments_and_manifest() {
     assert!(manifest_path.exists(), "manifest should exist before clear");
 
     // Clear the branch
-    assert!(store.clear_branch(&child_branch()));
+    assert!(store.clear_branch(&child_branch()).unwrap());
 
-    // Own segment files must be deleted
+    // Top-level own segment files must disappear from their original paths.
+    // B5.2 stages them into quarantine rather than unlinking synchronously.
     for path in &own_paths {
         assert!(
             !path.exists(),
-            "Own segment {:?} should be deleted by clear_branch",
+            "Own segment {:?} should be removed from its original path by clear_branch",
             path
         );
     }
 
-    // Manifest must be deleted
+    // Once no top-level `.sst` files remain, the empty-manifest barrier can be
+    // removed even though quarantine debt still exists.
     assert!(
         !manifest_path.exists(),
-        "manifest should be deleted by clear_branch"
+        "empty-manifest barrier should be removed once only quarantine state remains"
     );
 
-    // Branch directory should be removed (was empty after file cleanup)
+    let quarantine_manifest = branch_dir.join(crate::quarantine::QUARANTINE_FILENAME);
+    let quarantine_dir = branch_dir.join(crate::quarantine::QUARANTINE_DIR);
     assert!(
-        !branch_dir.exists(),
-        "branch directory should be removed by clear_branch"
+        quarantine_manifest.exists(),
+        "clear_branch should leave quarantine inventory behind for GC to drain"
+    );
+    assert!(
+        quarantine_dir.exists(),
+        "clear_branch should leave the quarantine directory behind until GC purges it"
+    );
+
+    let report = store
+        .gc_orphan_segments()
+        .expect("healthy recovery; GC should purge the staged quarantine");
+    assert!(
+        report.files_deleted >= own_paths.len(),
+        "GC should purge the quarantined own segments"
+    );
+
+    assert!(
+        !quarantine_manifest.exists(),
+        "quarantine inventory should be removed after purge"
+    );
+    assert!(
+        !quarantine_dir.exists(),
+        "quarantine directory should be removed after purge"
     );
 }
 
-/// #1663: clear_branch() must clean up inherited segment refcounts AND own segments.
-/// Inherited segment files must NOT be deleted when the parent still owns them.
+/// #1663 / B5.2 step 3: clear_branch() must release inherited refcounts and
+/// quarantine its own segments. Inherited segment files must NOT be deleted
+/// when the parent still owns them.
 #[test]
-fn clear_branch_cleans_up_inherited_and_own_segments() {
+fn clear_branch_releases_inherited_and_quarantines_own_segments() {
     let dir = tempfile::tempdir().unwrap();
     let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
 
@@ -116,11 +142,15 @@ fn clear_branch_cleans_up_inherited_and_own_segments() {
 
     // Clear child — parent has NOT compacted, so inherited segment files
     // must survive (parent still owns them in its version.levels).
-    assert!(store.clear_branch(&child_branch()));
+    assert!(store.clear_branch(&child_branch()).unwrap());
 
-    // Own segments must be gone
+    // Own segments must be gone from their original top-level paths.
     for path in &own_paths {
-        assert!(!path.exists(), "Own segment {:?} should be deleted", path);
+        assert!(
+            !path.exists(),
+            "Own segment {:?} should be removed from its original path",
+            path
+        );
     }
 
     // Inherited segment files must still exist (parent owns them)
@@ -902,7 +932,7 @@ fn clear_branch_preserves_referenced_own_segments() {
     assert!(!own_paths.is_empty());
 
     // Clear (delete) parent — child still references parent's segments
-    assert!(store.clear_branch(&parent_branch()));
+    assert!(store.clear_branch(&parent_branch()).unwrap());
 
     // Parent's own segment files should still exist (child references them)
     for path in &own_paths {
@@ -989,16 +1019,32 @@ fn gc_orphan_segments_cleans_leaked_files() {
         );
     }
 
-    // Child releases (clear_branch). refcount → 0.
-    // clear_branch runs gc_orphan_segments internally, which should clean up
-    // the orphaned files (parent already compacted them away, no references remain).
-    store.clear_branch(&child_branch());
+    // Child releases (clear_branch). refcount → 0, but explicit GC still owns
+    // final purge of the orphaned parent files.
+    store.clear_branch(&child_branch()).unwrap();
 
-    // Orphaned segments should be deleted (GC ran as part of clear_branch).
+    // The orphaned segments are still on disk until GC runs.
+    for path in &inherited_paths {
+        assert!(
+            path.exists(),
+            "orphaned segment {:?} should remain until explicit GC drains it",
+            path
+        );
+    }
+
+    let report = store
+        .gc_orphan_segments()
+        .expect("clean recovery; gc must succeed");
+    assert!(
+        report.files_deleted >= inherited_paths.len(),
+        "GC should delete the orphaned segments after clear_branch releases them"
+    );
+
+    // Orphaned segments should be deleted after explicit GC.
     for path in &inherited_paths {
         assert!(
             !path.exists(),
-            "orphaned segment {:?} should be deleted by GC after clear_branch",
+            "orphaned segment {:?} should be deleted by explicit GC after clear_branch",
             path
         );
     }
@@ -1009,7 +1055,7 @@ fn gc_orphan_segments_cleans_leaked_files() {
         .expect("clean recovery; gc must succeed");
     assert_eq!(
         report.files_deleted, 0,
-        "no orphans should remain after clear_branch GC"
+        "no orphans should remain after explicit GC"
     );
 }
 

--- a/crates/storage/src/segmented/tests/mod.rs
+++ b/crates/storage/src/segmented/tests/mod.rs
@@ -107,4 +107,5 @@ mod lifecycle;
 mod materialize;
 mod post_restart_branch;
 mod publish_failures;
+mod quarantine_reconciliation;
 mod resurrection;

--- a/crates/storage/src/segmented/tests/quarantine_reconciliation.rs
+++ b/crates/storage/src/segmented/tests/quarantine_reconciliation.rs
@@ -181,9 +181,11 @@ fn reopen_after_full_reclaim_leaves_no_quarantine_artifacts() {
     store.flush_oldest_frozen(&branch()).unwrap();
 
     // clear_branch drives the branch's own segments through the
-    // quarantine protocol and then calls gc_orphan_segments to drain
-    // them via Stage 5 in the same call.
-    store.clear_branch(&branch());
+    // quarantine protocol; the explicit GC call below drains Stage 5.
+    store.clear_branch(&branch()).unwrap();
+    store
+        .gc_orphan_segments()
+        .expect("healthy recovery; explicit GC should drain quarantine");
 
     let b_dir = branch_dir_for(dir.path(), branch());
     assert!(!b_dir.join(QUARANTINE_FILENAME).exists());
@@ -196,6 +198,124 @@ fn reopen_after_full_reclaim_leaves_no_quarantine_artifacts() {
     assert!(matches!(outcome.health, RecoveryHealth::Healthy));
     assert!(!b_dir.join(QUARANTINE_FILENAME).exists());
     assert!(!b_dir.join(QUARANTINE_DIR).exists());
+}
+
+/// Retrying `clear_branch()` on a branch dir that only has quarantine debt
+/// must not recreate `segments.manifest`; the retry should remain a pure
+/// cleanup pass for on-disk debt after the branch is already absent.
+#[test]
+fn clear_branch_retry_on_quarantine_only_dir_does_not_recreate_manifest() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    let b_dir = branch_dir_for(dir.path(), branch());
+    store.clear_branch(&branch()).unwrap();
+
+    assert!(
+        b_dir.join(QUARANTINE_FILENAME).exists(),
+        "first clear should leave quarantine inventory behind"
+    );
+    assert!(
+        !b_dir.join("segments.manifest").exists(),
+        "quarantine-only branch dir should not retain an empty manifest"
+    );
+
+    assert!(
+        store.clear_branch(&branch()).unwrap(),
+        "retry should keep cleaning an on-disk debt dir even after the branch is absent"
+    );
+    assert!(
+        b_dir.join(QUARANTINE_FILENAME).exists(),
+        "retry should not discard quarantine debt before GC drains it"
+    );
+    assert!(
+        !b_dir.join("segments.manifest").exists(),
+        "retry must not recreate segments.manifest for a quarantine-only dir"
+    );
+}
+
+/// After Stage-5 drains the quarantine inventory, a retry of `clear_branch()`
+/// should converge the leftover empty branch dir instead of returning false
+/// and recreating empty-manifest state.
+#[test]
+fn clear_branch_retry_removes_empty_leftover_dir_after_gc() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    let b_dir = branch_dir_for(dir.path(), branch());
+    store.clear_branch(&branch()).unwrap();
+    store
+        .gc_orphan_segments()
+        .expect("healthy recovery; explicit GC should drain quarantine");
+
+    assert!(
+        b_dir.exists(),
+        "GC drains quarantine state but may still leave an empty branch dir behind"
+    );
+    assert!(
+        std::fs::read_dir(&b_dir).unwrap().next().is_none(),
+        "setup expects only empty-dir cleanup debt to remain"
+    );
+
+    assert!(
+        store.clear_branch(&branch()).unwrap(),
+        "retry should converge the empty leftover dir"
+    );
+    assert!(
+        !b_dir.exists(),
+        "retry should remove the empty leftover dir once cleanup debt is gone"
+    );
+    assert!(
+        !store.clear_branch(&branch()).unwrap(),
+        "once both branch state and leftover dir are gone, clear_branch should report false"
+    );
+}
+
+/// Top-level `.sst` files that are no longer listed in the branch's own
+/// manifest and are not held by any descendant inherited layer are cleanup
+/// debt, not manifest-reachable retention. The storage snapshot must not count
+/// them into `exclusive_bytes` / `shared_bytes`.
+#[test]
+fn retention_snapshot_ignores_live_branch_top_level_orphan_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    let before = store
+        .retention_snapshot()
+        .expect("baseline snapshot succeeds");
+    let before_entry = before
+        .iter()
+        .find(|entry| entry.branch_id == branch())
+        .expect("live branch must appear in retention snapshot");
+
+    let b_dir = branch_dir_for(dir.path(), branch());
+    std::fs::write(b_dir.join("99999.sst"), vec![0u8; 4096]).unwrap();
+
+    let after = store
+        .retention_snapshot()
+        .expect("snapshot with live-branch orphan succeeds");
+    let after_entry = after
+        .iter()
+        .find(|entry| entry.branch_id == branch())
+        .expect("live branch must still appear in retention snapshot");
+
+    assert_eq!(
+        after_entry.exclusive_bytes, before_entry.exclusive_bytes,
+        "non-manifest top-level orphan bytes must not inflate exclusive retention",
+    );
+    assert_eq!(
+        after_entry.shared_bytes, before_entry.shared_bytes,
+        "non-manifest top-level orphan bytes must not inflate shared retention",
+    );
 }
 
 /// Accelerator disagreement — the runtime ref registry says a file is
@@ -239,6 +359,162 @@ fn accelerator_disagreement_blocks_reclaim() {
         victim_path.exists(),
         "victim file must remain on disk when accelerator disagrees with reclaim plan",
     );
+}
+
+/// The runtime accelerator is only candidate selection. If it says
+/// "zero refs" but a recovery-trusted inherited-layer manifest still
+/// lists the segment, Stage 2 manifest proof must win and refuse
+/// quarantine.
+#[test]
+fn manifest_proof_beats_false_negative_runtime_refcount() {
+    let (_dir, store) = setup_parent_with_segments(&[("k", 1, 1)]);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    let (victim_id, victim_path) = {
+        let parent = store.branches.get(&parent_branch()).unwrap();
+        let ver = parent.version.load();
+        let seg = ver.levels[0]
+            .first()
+            .cloned()
+            .expect("setup produced at least one parent segment");
+        (seg.file_id(), seg.file_path().to_path_buf())
+    };
+
+    // Child inherited-layer attach increments the runtime refcount. Force a
+    // false-negative accelerator state; manifest proof must still refuse.
+    store.ref_registry.decrement(victim_id);
+
+    let snapshot = store
+        .retention_snapshot()
+        .expect("storage-local retention snapshot must be derivable from the same manifests");
+    let parent_entry = snapshot
+        .iter()
+        .find(|entry| entry.branch_id == parent_branch())
+        .expect("parent branch must appear in retention snapshot");
+    let child_entry = snapshot
+        .iter()
+        .find(|entry| entry.branch_id == child_branch())
+        .expect("child branch must appear in retention snapshot");
+    assert!(
+        parent_entry.shared_bytes > 0,
+        "shared-byte classification must come from inherited-layer manifests, not the runtime accelerator",
+    );
+    assert_eq!(
+        parent_entry.exclusive_bytes, 0,
+        "all parent bytes are still held by the child inherited layer in this setup",
+    );
+    assert!(
+        parent_entry.exclusive_bytes + parent_entry.shared_bytes > 0,
+        "the parent's retained bytes must still appear in the snapshot even when the accelerator lies",
+    );
+    assert!(
+        child_entry.inherited_layer_bytes > 0,
+        "the child's inherited-layer bytes must be derived from the same manifest ledger",
+    );
+
+    match store.quarantine_segment_if_unreferenced(&victim_path, victim_id) {
+        Err(StorageError::ReclaimRefusedManifestProof { segment_id }) => {
+            assert_eq!(segment_id, victim_id);
+        }
+        other => panic!("expected ReclaimRefusedManifestProof; got {other:?}"),
+    }
+    assert!(
+        victim_path.exists(),
+        "manifest-protected segment must remain on disk when Stage 2 refuses reclaim",
+    );
+}
+
+/// A persisted `status = Materialized` inherited layer does not retain source
+/// bytes. Retention reporting and shared/exclusive classification must follow
+/// the same rule as normal read paths, which skip materialized layers.
+#[test]
+fn materialized_inherited_layer_does_not_retain_source_bytes() {
+    let (dir, store) = setup_parent_with_segments(&[("k", 1, 1)]);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+    store.write_branch_manifest(&parent_branch()).unwrap();
+    store.write_branch_manifest(&child_branch()).unwrap();
+
+    let child_dir = branch_dir_for(dir.path(), child_branch());
+    let mut child_manifest = crate::manifest::read_manifest(&child_dir)
+        .unwrap()
+        .expect("child manifest must exist");
+    assert_eq!(child_manifest.inherited_layers.len(), 1);
+    child_manifest.inherited_layers[0].status = 2; // Materialized
+    crate::manifest::write_manifest(
+        &child_dir,
+        &child_manifest.entries,
+        &child_manifest.inherited_layers,
+    )
+    .unwrap();
+
+    let snapshot = store
+        .retention_snapshot()
+        .expect("retention snapshot should follow persisted manifest state");
+    let parent_entry = snapshot
+        .iter()
+        .find(|entry| entry.branch_id == parent_branch())
+        .expect("parent branch must still report own bytes");
+
+    assert!(
+        parent_entry.exclusive_bytes > 0,
+        "parent bytes should be exclusive once the child manifest marks the layer materialized",
+    );
+    assert_eq!(
+        parent_entry.shared_bytes, 0,
+        "materialized layers must not keep source bytes in shared retention",
+    );
+    assert!(
+        snapshot
+            .iter()
+            .all(|entry| entry.branch_id != child_branch()),
+        "child should not report inherited retention from a materialized layer",
+    );
+}
+
+/// If deleted-parent orphan storage still exists after clear and the empty
+/// manifest publish fails, `clear_branch()` must surface the failure instead
+/// of silently reporting success. Otherwise reopen can fall back to the
+/// legacy no-manifest path and resurrect the deleted parent.
+#[test]
+fn clear_branch_refuses_silent_success_when_empty_manifest_publish_fails() {
+    crate::test_hooks::clear_manifest_dir_fsync_failure();
+
+    let (_dir, store) = setup_parent_with_segments(&[("k", 1, 1)]);
+    store
+        .fork_branch(&parent_branch(), &child_branch())
+        .unwrap();
+
+    crate::test_hooks::inject_manifest_dir_fsync_failure(std::io::ErrorKind::Other);
+    let err = store
+        .clear_branch(&parent_branch())
+        .expect_err("delete must not report success when the empty manifest publish fails");
+    assert!(
+        matches!(err, StorageError::DirFsync { .. }),
+        "expected empty-manifest durable-publish failure, got {err:?}",
+    );
+
+    let parent_dir = branch_dir_for(store.segments_dir().unwrap(), parent_branch());
+    let has_top_level_sst = std::fs::read_dir(&parent_dir)
+        .unwrap()
+        .flatten()
+        .any(|entry| {
+            entry.path().is_file()
+                && entry.path().extension().and_then(|x| x.to_str()) == Some("sst")
+        });
+    assert!(
+        has_top_level_sst,
+        "setup must leave descendant-pinned top-level parent segments in place",
+    );
+    assert!(
+        parent_dir.join("segments.manifest").exists(),
+        "clear_branch must not delete the old manifest before the empty-manifest barrier is durably published",
+    );
+
+    crate::test_hooks::clear_manifest_dir_fsync_failure();
 }
 
 /// Concurrent quarantine publish vs. purge must be serialized by the

--- a/crates/storage/src/segmented/tests/quarantine_reconciliation.rs
+++ b/crates/storage/src/segmented/tests/quarantine_reconciliation.rs
@@ -1,0 +1,355 @@
+//! B5.2 storage-local reopen + reconciliation tests.
+//!
+//! Complements the integration-test suites (`branching_retention_matrix`
+//! and `branching_gc_quarantine_recovery`) with storage-layer scenarios
+//! that do not need the engine. Focus: rebuild from manifests,
+//! accelerator disagreement blocks reclaim (KD10), degraded recovery
+//! does not self-upgrade without evidence (A5).
+
+use super::*;
+use crate::quarantine::{
+    read_quarantine_manifest, write_quarantine_manifest, QuarantineEntry, QUARANTINE_DIR,
+    QUARANTINE_FILENAME,
+};
+use crate::segmented::{DegradationClass, RecoveryFault, RecoveryHealth};
+use crate::StorageError;
+
+fn branch_dir_for(dir: &std::path::Path, branch_id: BranchId) -> std::path::PathBuf {
+    dir.join(super::super::hex_encode_branch(&branch_id))
+}
+
+/// Stage-4 publish durably records quarantine membership. A reopen that
+/// loads an inventory matching the on-disk quarantine contents must keep
+/// recovery healthy and allow GC to proceed through Stage 5.
+#[test]
+fn reopen_with_consistent_quarantine_inventory_stays_healthy() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+    drop(store);
+
+    // After a successful quarantine protocol, the branch dir has:
+    // - segments.manifest that does NOT list the quarantined file
+    // - __quarantine__/<file> present
+    // - quarantine.manifest listing <file>.
+    // Simulate that by removing the segments.manifest and staging the
+    // file + inventory.
+    let b_dir = branch_dir_for(dir.path(), branch());
+    let ssts: Vec<_> = std::fs::read_dir(&b_dir)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("sst"))
+        .map(|e| e.path())
+        .collect();
+    let victim = ssts
+        .first()
+        .cloned()
+        .expect("setup produces at least one sst");
+    let filename = victim.file_name().unwrap().to_string_lossy().to_string();
+
+    std::fs::remove_file(b_dir.join("segments.manifest")).unwrap();
+    let qdir = b_dir.join(QUARANTINE_DIR);
+    std::fs::create_dir_all(&qdir).unwrap();
+    std::fs::rename(&victim, qdir.join(&filename)).unwrap();
+    write_quarantine_manifest(
+        &b_dir,
+        &[QuarantineEntry {
+            segment_id: 42,
+            filename: filename.clone(),
+        }],
+    )
+    .unwrap();
+
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = store2.recover_segments().unwrap();
+    // Recovery health is Healthy — inventory matched on-disk quarantine.
+    assert!(
+        matches!(outcome.health, RecoveryHealth::Healthy),
+        "consistent inventory + on-disk quarantine must reconcile cleanly; got {:?}",
+        outcome.health,
+    );
+
+    // GC proceeds through Stage 5 — the quarantined file is purged.
+    let report = store2
+        .gc_orphan_segments()
+        .expect("healthy; gc must succeed");
+    assert_eq!(report.files_deleted, 1);
+    assert!(!qdir.join(&filename).exists());
+    assert!(!b_dir.join(QUARANTINE_FILENAME).exists());
+}
+
+/// An orphan file in `__quarantine__/` without any inventory must
+/// degrade recovery health to `PolicyDowngrade` via
+/// `QuarantineInventoryMismatch`, and GC must refuse until the operator
+/// reconciles.
+#[test]
+fn reopen_degrades_on_quarantine_dir_without_inventory() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+    drop(store);
+
+    let b_dir = branch_dir_for(dir.path(), branch());
+    let qdir = b_dir.join(QUARANTINE_DIR);
+    std::fs::create_dir_all(&qdir).unwrap();
+    std::fs::write(qdir.join("8888.sst"), b"orphan quarantine bytes").unwrap();
+
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = store2.recover_segments().unwrap();
+    match &outcome.health {
+        RecoveryHealth::Degraded { class, faults } => {
+            assert_eq!(*class, DegradationClass::PolicyDowngrade);
+            let has_mismatch = faults
+                .iter()
+                .any(|f| matches!(f, RecoveryFault::QuarantineInventoryMismatch { .. }));
+            assert!(has_mismatch, "expected QuarantineInventoryMismatch fault");
+        }
+        other => panic!("expected PolicyDowngrade; got {other:?}"),
+    }
+
+    // GC refuses — degraded recovery blocks reclaim.
+    let err = store2
+        .gc_orphan_segments()
+        .expect_err("gc must refuse under degraded quarantine reconciliation");
+    match err {
+        StorageError::GcRefusedDegradedRecovery { class } => {
+            assert_eq!(class, DegradationClass::PolicyDowngrade);
+        }
+        other => panic!("expected GcRefusedDegradedRecovery; got {other:?}"),
+    }
+    // Orphan file retained.
+    assert!(qdir.join("8888.sst").exists());
+}
+
+/// Inventory listing a file that is not in `__quarantine__/` and not at
+/// the original path is benign — rename never completed, or purge
+/// already removed the file. Recovery must silently drop the stale
+/// entry and stay healthy.
+#[test]
+fn reopen_drops_stale_inventory_entries_without_degrade() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+    drop(store);
+
+    let b_dir = branch_dir_for(dir.path(), branch());
+    write_quarantine_manifest(
+        &b_dir,
+        &[QuarantineEntry {
+            segment_id: 0xdead,
+            filename: "phantom.sst".to_string(),
+        }],
+    )
+    .unwrap();
+
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = store2.recover_segments().unwrap();
+    assert!(
+        matches!(outcome.health, RecoveryHealth::Healthy),
+        "stale entries for absent files must reconcile silently",
+    );
+
+    let m = read_quarantine_manifest(&b_dir)
+        .unwrap()
+        .unwrap_or_default();
+    assert!(
+        m.entries.is_empty(),
+        "reconciled inventory must be empty; got {:?}",
+        m.entries,
+    );
+
+    store2
+        .gc_orphan_segments()
+        .expect("healthy gc after silent reconcile");
+}
+
+/// After reclaim has driven the quarantine inventory empty, subsequent
+/// reopens must leave a clean slate: no leftover `quarantine.manifest`,
+/// no `__quarantine__/` directory, healthy recovery. Pins idempotency.
+#[test]
+fn reopen_after_full_reclaim_leaves_no_quarantine_artifacts() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    // clear_branch drives the branch's own segments through the
+    // quarantine protocol and then calls gc_orphan_segments to drain
+    // them via Stage 5 in the same call.
+    store.clear_branch(&branch());
+
+    let b_dir = branch_dir_for(dir.path(), branch());
+    assert!(!b_dir.join(QUARANTINE_FILENAME).exists());
+    assert!(!b_dir.join(QUARANTINE_DIR).exists());
+
+    // Reopen: still healthy, still no artifacts.
+    drop(store);
+    let store2 = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    let outcome = store2.recover_segments().unwrap();
+    assert!(matches!(outcome.health, RecoveryHealth::Healthy));
+    assert!(!b_dir.join(QUARANTINE_FILENAME).exists());
+    assert!(!b_dir.join(QUARANTINE_DIR).exists());
+}
+
+/// Accelerator disagreement — the runtime ref registry says a file is
+/// referenced but the file is not listed in any recovery-trusted
+/// manifest. Under the current protocol, the Stage-2 proof refuses to
+/// quarantine because `is_referenced` returns true. That is the correct
+/// behavior: manifests win, space leaks, no false reclaim (Invariants 1
+/// + 2, KD10).
+#[test]
+fn accelerator_disagreement_blocks_reclaim() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    // Capture the on-disk segment path + id, then drop the branch from
+    // self.branches so the normal live-set check would classify it as
+    // an orphan.
+    let ver = store.branches.get(&branch()).unwrap().version.load_full();
+    let (victim_id, victim_path) = {
+        let seg = ver.levels[0]
+            .first()
+            .cloned()
+            .expect("setup produced at least one L0 segment");
+        (seg.file_id(), seg.file_path().to_path_buf())
+    };
+    drop(ver);
+    // Inflate its runtime refcount to simulate a disagreement where
+    // the manifest has moved on but the registry still holds a
+    // reference (e.g. a hypothetical descendant inherited layer that
+    // was not released). Refcount non-zero ⇒ Stage 2 proof refuses.
+    store.ref_registry.increment(victim_id);
+    // Ensure the branch state is gone so live_ids doesn't protect the
+    // file on a different code path.
+    store.branches.remove(&branch());
+
+    let report = store.gc_orphan_segments().expect("healthy; gc returns Ok");
+    assert_eq!(report.files_deleted, 0, "no reclaim while refcount > 0");
+    assert!(
+        victim_path.exists(),
+        "victim file must remain on disk when accelerator disagrees with reclaim plan",
+    );
+}
+
+/// Concurrent quarantine publish vs. purge must be serialized by the
+/// `deletion_write_guard`. Without the guard, a purge that reads an
+/// empty inventory could unlink (or stat-over) a file a concurrent
+/// quarantine publish just renamed in. Pins the fix for the race the
+/// B5.2 code review flagged: the purge loop reads + unlinks + rewrites
+/// the inventory under the same guard that quarantine holds across
+/// its publish + rename.
+#[test]
+fn concurrent_quarantine_and_purge_do_not_corrupt_inventory() {
+    use std::sync::Arc;
+    use std::sync::Barrier;
+    use std::thread;
+
+    for _ in 0..32 {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(SegmentedStore::with_dir(dir.path().to_path_buf(), 0));
+
+        // Seed two flushed segments so we have two independent reclaim
+        // candidates.
+        seed(&store, kv_key("a"), Value::Int(1), 1);
+        store.rotate_memtable(&branch());
+        store.flush_oldest_frozen(&branch()).unwrap();
+        seed(&store, kv_key("b"), Value::Int(2), 2);
+        store.rotate_memtable(&branch());
+        store.flush_oldest_frozen(&branch()).unwrap();
+
+        // Drop the branch from self.branches so both segments look like
+        // orphan candidates to the next GC walk. Direct map access to
+        // avoid routing through clear_branch (which already serializes
+        // quarantine itself).
+        let segments: Vec<(std::path::PathBuf, u64)> = {
+            let branch_state = store.branches.get(&branch()).unwrap();
+            let ver = branch_state.version.load_full();
+            let mut out = Vec::new();
+            for level in &ver.levels {
+                for seg in level {
+                    out.push((seg.file_path().to_path_buf(), seg.file_id()));
+                }
+            }
+            out
+        };
+        store.branches.remove(&branch());
+
+        // Two concurrent workers: thread A tries to quarantine both
+        // segments in sequence; thread B races `gc_orphan_segments`
+        // which includes an internal purge pass that used to race with
+        // quarantine publish.
+        let barrier = Arc::new(Barrier::new(2));
+        let s_a = Arc::clone(&store);
+        let b_a = Arc::clone(&barrier);
+        let segs_a = segments.clone();
+        let t_a = thread::spawn(move || {
+            b_a.wait();
+            for (path, id) in &segs_a {
+                let _ = s_a.quarantine_segment_if_unreferenced(path, *id);
+            }
+        });
+        let s_b = Arc::clone(&store);
+        let b_b = Arc::clone(&barrier);
+        let t_b = thread::spawn(move || {
+            b_b.wait();
+            let _ = s_b.gc_orphan_segments();
+        });
+        t_a.join().unwrap();
+        t_b.join().unwrap();
+
+        // One more gc pass to drain any residual quarantine state.
+        let _ = store.gc_orphan_segments();
+
+        // Invariant: filesystem + inventory are consistent. Either the
+        // files have been purged, or they remain in the quarantine
+        // directory with a matching inventory entry. Never: file in
+        // quarantine dir without inventory, or inventory entry without
+        // file.
+        let b_dir = branch_dir_for(dir.path(), branch());
+        let qdir = b_dir.join(QUARANTINE_DIR);
+        let on_disk: std::collections::HashSet<String> = std::fs::read_dir(&qdir)
+            .map(|it| {
+                it.flatten()
+                    .filter_map(|e| e.file_name().to_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let inventory: std::collections::HashSet<String> = read_quarantine_manifest(&b_dir)
+            .unwrap()
+            .map(|m| m.entries.into_iter().map(|e| e.filename).collect())
+            .unwrap_or_default();
+        assert_eq!(
+            on_disk, inventory,
+            "quarantine directory must match inventory exactly (no orphan files, no dangling entries)"
+        );
+    }
+}
+
+/// Hard pre-walk recovery failures (e.g. missing segments dir) never
+/// install a reclaim-safe runtime state, so reclaim stays refused on
+/// that store instance. Pins A5 + §"Hard pre-walk recovery failures".
+#[test]
+fn hard_prewalk_failure_keeps_reclaim_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let bogus = dir.path().join("not-a-dir");
+    std::fs::write(&bogus, b"not a directory").unwrap();
+
+    let store = SegmentedStore::with_dir(bogus, 0);
+    store.recover_segments().expect_err("hard pre-walk fails");
+
+    match store.gc_orphan_segments() {
+        Err(StorageError::GcRefusedDegradedRecovery { .. }) => {}
+        Err(other) => panic!("expected GcRefusedDegradedRecovery; got {other:?}"),
+        Ok(_) => panic!("reclaim must not run after hard pre-walk failure"),
+    }
+}

--- a/crates/storage/src/segmented/tests/resurrection.rs
+++ b/crates/storage/src/segmented/tests/resurrection.rs
@@ -128,7 +128,7 @@ fn compact_branch_does_not_resurrect_cleared_branch() {
     let handle = std::thread::spawn(move || s.compact_branch(&b, CommitVersion(0)));
 
     wait_until_entered(&pause);
-    assert!(store.clear_branch(&b));
+    assert!(store.clear_branch(&b).unwrap());
     release(&pause);
 
     let result = handle.join().unwrap();
@@ -165,7 +165,7 @@ fn compact_l0_to_l1_does_not_resurrect_cleared_branch() {
     let handle = std::thread::spawn(move || s.compact_l0_to_l1(&b, CommitVersion(0)));
 
     wait_until_entered(&pause);
-    assert!(store.clear_branch(&b));
+    assert!(store.clear_branch(&b).unwrap());
     release(&pause);
 
     let result = handle.join().unwrap();
@@ -194,7 +194,7 @@ fn compact_level_does_not_resurrect_cleared_branch() {
     let handle = std::thread::spawn(move || s.compact_level(&b, 0, CommitVersion(0)));
 
     wait_until_entered(&pause);
-    assert!(store.clear_branch(&b));
+    assert!(store.clear_branch(&b).unwrap());
     release(&pause);
 
     let result = handle.join().unwrap();
@@ -228,7 +228,7 @@ fn compact_level_trivial_move_does_not_resurrect_cleared_branch() {
     let handle = std::thread::spawn(move || s.compact_level(&b, 1, CommitVersion(0)));
 
     wait_until_entered(&pause);
-    assert!(store.clear_branch(&b));
+    assert!(store.clear_branch(&b).unwrap());
     release(&pause);
 
     let result = handle.join().unwrap();
@@ -256,7 +256,7 @@ fn compact_tier_does_not_resurrect_cleared_branch() {
     let handle = std::thread::spawn(move || s.compact_tier(&b, &[0, 1], CommitVersion(0)));
 
     wait_until_entered(&pause);
-    assert!(store.clear_branch(&b));
+    assert!(store.clear_branch(&b).unwrap());
     release(&pause);
 
     let result = handle.join().unwrap();
@@ -310,7 +310,7 @@ fn materialize_layer_does_not_resurrect_cleared_branch() {
     let handle = std::thread::spawn(move || s.materialize_layer(&child, 0));
 
     wait_until_entered(&pause);
-    assert!(store.clear_branch(&child));
+    assert!(store.clear_branch(&child).unwrap());
     release(&pause);
 
     let result = handle.join().unwrap();
@@ -415,7 +415,7 @@ fn clear_branch_interleaved_with_compaction_reopens_clean() {
     let handle = std::thread::spawn(move || s.compact_branch(&b_clone, CommitVersion(0)));
 
     wait_until_entered(&pause);
-    assert!(store.clear_branch(&b));
+    assert!(store.clear_branch(&b).unwrap());
     release(&pause);
 
     let race_result = handle.join().unwrap();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -160,6 +160,28 @@ impl TestDb {
             .expect("Failed to reopen database");
     }
 
+    /// Reopen the database in a lossy-tolerant configuration.
+    ///
+    /// Sets `allow_missing_manifest = true` so a `DegradationClass::PolicyDowngrade`
+    /// recovery (e.g. B5.2 `QuarantineInventoryMismatch`, legacy no-manifest
+    /// fallback) succeeds instead of refusing the open. Used by the B5.2
+    /// quarantine-reopen / retention-report suites that deliberately stage
+    /// degraded states and assert engine behavior after the open.
+    pub fn reopen_allowing_policy_downgrade(&mut self) {
+        let path = self.dir.path().to_path_buf();
+        drop(std::mem::replace(
+            &mut self.db,
+            Database::open_runtime(test_open_spec_cache()).expect("temporary cache for swap"),
+        ));
+        let cfg = StrataConfig {
+            allow_missing_manifest: true,
+            ..StrataConfig::default()
+        };
+        let spec = test_open_spec_primary(&path).with_config(cfg);
+        self.db = Database::open_runtime(spec)
+            .expect("Failed to reopen database in policy-downgrade-tolerant mode");
+    }
+
     /// Create a new branch ID for this test.
     pub fn new_branch(&mut self) -> BranchId {
         self.branch_id = BranchId::new();

--- a/tests/integration/branching_gc_quarantine_recovery.rs
+++ b/tests/integration/branching_gc_quarantine_recovery.rs
@@ -280,6 +280,112 @@ fn crash_with_orphan_quarantine_dir_and_no_inventory_degrades_reopen() {
     );
 }
 
+#[test]
+fn retention_report_refuses_when_quarantine_inventory_is_unreadable_in_session() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..4 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+
+    let main_dir = branch_dir(&test_db.db, "main");
+    std::fs::write(
+        main_dir.join(strata_storage::QUARANTINE_FILENAME),
+        b"corrupt",
+    )
+    .unwrap();
+
+    let err = test_db
+        .db
+        .retention_report()
+        .expect_err("unreadable quarantine inventory must refuse retention_report");
+    assert!(
+        matches!(
+            err,
+            strata_core::StrataError::RetentionReportUnavailable { .. }
+        ),
+        "retention_report must fail closed on unreadable quarantine inventory; got {err:?}",
+    );
+}
+
+#[test]
+fn retention_report_refuses_when_manifest_truth_is_unreadable_in_session() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..4 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+
+    let main_dir = branch_dir(&test_db.db, "main");
+    let manifest_path = main_dir.join("segments.manifest");
+    let mut bytes = std::fs::read(&manifest_path).unwrap();
+    let mid = bytes.len() / 2;
+    bytes[mid] ^= 0xFF;
+    std::fs::write(&manifest_path, &bytes).unwrap();
+
+    let err = test_db
+        .db
+        .retention_report()
+        .expect_err("corrupt manifest truth must refuse retention_report");
+    assert!(
+        matches!(
+            err,
+            strata_core::StrataError::RetentionReportUnavailable { .. }
+        ),
+        "retention_report must fail closed on unreadable manifest truth; got {err:?}",
+    );
+}
+
+#[test]
+fn retention_report_accounts_for_recovery_admitted_no_manifest_fallback() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("legacy").unwrap();
+    for i in 0..6 {
+        seed(&test_db.db, "legacy", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "legacy");
+
+    let legacy_dir = branch_dir(&test_db.db, "legacy");
+    std::fs::remove_file(legacy_dir.join("segments.manifest")).unwrap();
+
+    test_db.reopen_allowing_policy_downgrade();
+
+    assert!(
+        matches!(
+            test_db.db.recovery_health(),
+            strata_storage::RecoveryHealth::Degraded {
+                class: strata_storage::DegradationClass::PolicyDowngrade,
+                ..
+            }
+        ),
+        "missing manifest fallback must reopen as PolicyDowngrade",
+    );
+
+    let report = test_db
+        .db
+        .retention_report()
+        .expect("recovery-admitted no-manifest fallback must still produce retention attribution");
+    assert!(
+        matches!(
+            report.reclaim_status,
+            strata_engine::ReclaimStatus::BlockedDegradedRecovery { ref class }
+                if class == "PolicyDowngrade"
+        ),
+        "legacy fallback keeps reclaim blocked but attribution available",
+    );
+    let legacy = report
+        .branches
+        .iter()
+        .find(|entry| entry.name == "legacy")
+        .expect("fallback branch must appear in retention_report");
+    assert!(
+        legacy.exclusive_bytes > 0 || legacy.shared_bytes > 0,
+        "fallback branch must still report retained own bytes",
+    );
+}
+
 // =============================================================================
 // Crash boundary: normal quarantine→purge cycle completes, reopen is a
 // no-op. Pins idempotency / repeat-reopen.

--- a/tests/integration/branching_gc_quarantine_recovery.rs
+++ b/tests/integration/branching_gc_quarantine_recovery.rs
@@ -1,0 +1,364 @@
+//! B5.2 — Crash / failpoint quarantine reopen suite.
+//!
+//! Covers the mandatory crash boundaries from
+//! `docs/design/branching/branching-gc/branching-b5-verification-spec.md`
+//! §"Required crash boundaries" that are reachable by injecting faults
+//! at the protocol seams. The suite does not enumerate every boundary
+//! via unique test hooks — several boundaries reduce to the same
+//! filesystem observable (e.g. "file at quarantine but inventory
+//! absent"). Each test states the required post-crash outcome per the
+//! §"Required outcome rule".
+//!
+//! Verification target (from the spec): no recovery-trusted
+//! manifest-reachable segment may be permanently deleted under any
+//! crash boundary; quarantine is reversible until final purge.
+
+#![cfg(not(miri))]
+
+use crate::common::*;
+use std::sync::Arc;
+use strata_core::value::Value;
+use strata_core::BranchId;
+
+fn resolve(name: &str) -> BranchId {
+    BranchId::from_user_name(name)
+}
+
+fn seed(db: &Arc<Database>, name: &str, key: &str, v: i64) {
+    KVStore::new(db.clone())
+        .put(&resolve(name), "default", key, Value::Int(v))
+        .expect("seed write succeeds");
+}
+
+fn flush_branch(db: &Arc<Database>, name: &str) {
+    let id = resolve(name);
+    db.storage().rotate_memtable(&id);
+    db.storage()
+        .flush_oldest_frozen(&id)
+        .expect("flush succeeds");
+}
+
+fn hex(id: &BranchId) -> String {
+    let mut s = String::with_capacity(32);
+    for b in id.as_bytes() {
+        use std::fmt::Write;
+        let _ = write!(s, "{:02x}", b);
+    }
+    s
+}
+
+fn segments_dir(db: &Arc<Database>) -> std::path::PathBuf {
+    db.storage()
+        .segments_dir()
+        .cloned()
+        .expect("disk-backed test database")
+}
+
+fn branch_dir(db: &Arc<Database>, name: &str) -> std::path::PathBuf {
+    segments_dir(db).join(hex(&resolve(name)))
+}
+
+fn list_ssts(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    std::fs::read_dir(dir)
+        .map(|it| {
+            it.flatten()
+                .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("sst"))
+                .map(|e| e.path())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn list_quarantine(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let qdir = dir.join(strata_storage::QUARANTINE_DIR);
+    std::fs::read_dir(&qdir)
+        .map(|it| {
+            it.flatten()
+                .filter(|e| e.path().is_file())
+                .map(|e| e.path())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// =============================================================================
+// Crash boundary: before candidate classification
+//
+// No reclaim has touched anything. Reopen is a normal recovery. All
+// live bytes present, no quarantine state.
+// =============================================================================
+
+#[test]
+fn crash_before_any_reclaim_leaves_every_segment_live_after_reopen() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..10 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+    let main_dir = branch_dir(&test_db.db, "main");
+    let before = list_ssts(&main_dir);
+    assert!(!before.is_empty());
+
+    test_db.reopen();
+
+    let after = list_ssts(&main_dir);
+    assert_eq!(
+        after.iter().collect::<std::collections::HashSet<_>>(),
+        before.iter().collect::<std::collections::HashSet<_>>(),
+        "no reclaim attempted; reopen must leave every segment in place",
+    );
+
+    // Healthy recovery + sanity reclaim attempt is a no-op.
+    let report = test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("healthy gc");
+    assert_eq!(report.files_deleted, 0);
+}
+
+// =============================================================================
+// Crash boundary: after rename, before inventory publish ("the mismatch")
+//
+// Simulate the worst-case inventory disagreement by staging a file in
+// `__quarantine__/` without a matching `quarantine.manifest` entry.
+// Reopen must degrade recovery health to PolicyDowngrade via
+// QuarantineInventoryMismatch, block GC, and retain the file per
+// Invariant 2 (prefer space leak over false reclaim).
+// =============================================================================
+
+#[test]
+fn crash_after_rename_before_publish_degrades_reopen_and_retains_file() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..5 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+    let main_dir = branch_dir(&test_db.db, "main");
+
+    // Simulate the "after rename, before inventory publish" crash
+    // window by dropping a synthetic file directly into
+    // `__quarantine__/` with no matching inventory entry. Using a new
+    // filename avoids tripping the MissingManifestListed fault that
+    // segments.manifest would otherwise raise if we moved a manifest-
+    // listed segment. The reconciliation path that `RecoveryFault::
+    // QuarantineInventoryMismatch` gates is identical either way.
+    let quarantine_dir = main_dir.join(strata_storage::QUARANTINE_DIR);
+    std::fs::create_dir_all(&quarantine_dir).unwrap();
+    let staged = quarantine_dir.join("99999.sst");
+    std::fs::write(&staged, b"bytes that would have been quarantined").unwrap();
+
+    test_db.reopen_allowing_policy_downgrade();
+
+    // Reopen must observe the mismatch and degrade. The staged file
+    // must remain in place (retention debt, not data loss).
+    assert!(
+        staged.exists(),
+        "quarantined file must survive reopen with no inventory",
+    );
+
+    match test_db.db.recovery_health() {
+        strata_storage::RecoveryHealth::Degraded { class, faults } => {
+            assert_eq!(class, strata_storage::DegradationClass::PolicyDowngrade);
+            let has_mismatch = faults.iter().any(|f| {
+                matches!(
+                    f,
+                    strata_storage::RecoveryFault::QuarantineInventoryMismatch { .. }
+                )
+            });
+            assert!(
+                has_mismatch,
+                "reopen must emit QuarantineInventoryMismatch; got faults {faults:?}"
+            );
+        }
+        other => panic!("expected PolicyDowngrade after mismatch; got {other:?}"),
+    }
+
+    // GC must refuse under the degraded class — space leaks, not false reclaim.
+    let gc_result = test_db.db.storage().gc_orphan_segments();
+    assert!(
+        matches!(
+            gc_result,
+            Err(strata_storage::StorageError::GcRefusedDegradedRecovery { .. })
+        ),
+        "gc must refuse under degraded quarantine reconciliation; got {gc_result:?}",
+    );
+    assert!(staged.exists(), "victim must still exist after refused gc",);
+}
+
+// =============================================================================
+// Crash boundary: inventory lists a file that is already gone
+//
+// Reopen's reconciliation must drop stale inventory entries whose files
+// are missing from both original and quarantine locations, without
+// degrading health (this is the benign "already-purged" / "never
+// renamed" case).
+// =============================================================================
+
+#[test]
+fn crash_after_publish_with_no_on_disk_file_drops_stale_inventory_without_degrade() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..5 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+    let main_dir = branch_dir(&test_db.db, "main");
+
+    // Stage a stale inventory entry for a file that does not exist.
+    let entries = vec![strata_storage::QuarantineEntry {
+        segment_id: 0x00DE_ADBE_EFC0_FFEE,
+        filename: "not_real.sst".to_string(),
+    }];
+    strata_storage::write_quarantine_manifest(&main_dir, &entries).expect("write stale inventory");
+
+    test_db.reopen();
+
+    assert!(
+        matches!(
+            test_db.db.recovery_health(),
+            strata_storage::RecoveryHealth::Healthy
+        ),
+        "stale inventory entry for absent file must reconcile silently",
+    );
+
+    // The reconciled manifest should be empty and the file removed.
+    let m = strata_storage::read_quarantine_manifest(&main_dir)
+        .expect("read reconciled manifest")
+        .unwrap_or_default();
+    assert!(
+        m.entries.is_empty(),
+        "reconciled inventory must be empty after dropping stale entry",
+    );
+
+    // GC still works.
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("healthy gc after reconcile");
+}
+
+// =============================================================================
+// Crash boundary: quarantine dir with files but quarantine.manifest missing
+// (no inventory at all).
+//
+// Same required outcome as the rename-without-publish case: degrade,
+// retain files.
+// =============================================================================
+
+#[test]
+fn crash_with_orphan_quarantine_dir_and_no_inventory_degrades_reopen() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..3 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+    let main_dir = branch_dir(&test_db.db, "main");
+
+    // Place an unrelated file in __quarantine__/ with no inventory.
+    let qdir = main_dir.join(strata_storage::QUARANTINE_DIR);
+    std::fs::create_dir_all(&qdir).unwrap();
+    let phantom = qdir.join("9999.sst");
+    std::fs::write(&phantom, b"phantom quarantined bytes").unwrap();
+
+    test_db.reopen_allowing_policy_downgrade();
+
+    match test_db.db.recovery_health() {
+        strata_storage::RecoveryHealth::Degraded { class, .. } => {
+            assert_eq!(class, strata_storage::DegradationClass::PolicyDowngrade);
+        }
+        other => panic!("expected degrade on orphan quarantine dir; got {other:?}"),
+    }
+
+    assert!(
+        phantom.exists(),
+        "phantom file in quarantine dir must be retained under degrade",
+    );
+}
+
+// =============================================================================
+// Crash boundary: normal quarantine→purge cycle completes, reopen is a
+// no-op. Pins idempotency / repeat-reopen.
+// =============================================================================
+
+#[test]
+fn successful_reclaim_round_trip_is_idempotent_across_reopen() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("solo").unwrap();
+    for i in 0..10 {
+        seed(&test_db.db, "solo", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "solo");
+    let solo_dir = branch_dir(&test_db.db, "solo");
+    assert!(!list_ssts(&solo_dir).is_empty());
+
+    test_db.db.branches().delete("solo").unwrap();
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("healthy; gc succeeds");
+
+    // After gc, no bytes, no quarantine.
+    assert!(list_ssts(&solo_dir).is_empty());
+    assert!(list_quarantine(&solo_dir).is_empty());
+
+    test_db.reopen();
+
+    // Reopen after clean reclaim: still no bytes, health healthy.
+    assert!(matches!(
+        test_db.db.recovery_health(),
+        strata_storage::RecoveryHealth::Healthy
+    ));
+    assert!(list_ssts(&solo_dir).is_empty());
+    assert!(list_quarantine(&solo_dir).is_empty());
+
+    // Re-running gc is idempotent.
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("idempotent gc");
+}
+
+// =============================================================================
+// Reopen re-establishes a clean report after the stale entry is dropped.
+// Pins A6.
+// =============================================================================
+
+#[test]
+fn retention_report_recovers_to_trustworthy_state_after_stale_entry_drops() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..5 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+
+    // Stale inventory entry for a non-existent file — reconciled silently.
+    let main_dir = branch_dir(&test_db.db, "main");
+    strata_storage::write_quarantine_manifest(
+        &main_dir,
+        &[strata_storage::QuarantineEntry {
+            segment_id: 7,
+            filename: "phantom.sst".into(),
+        }],
+    )
+    .unwrap();
+
+    test_db.reopen();
+    assert!(matches!(
+        test_db.db.recovery_health(),
+        strata_storage::RecoveryHealth::Healthy
+    ));
+
+    let report = test_db
+        .db
+        .retention_report()
+        .expect("retention_report recovers to Ok after silent reconcile");
+    assert_eq!(report.reclaim_status, strata_engine::ReclaimStatus::Allowed,);
+}

--- a/tests/integration/branching_gc_quarantine_recovery.rs
+++ b/tests/integration/branching_gc_quarantine_recovery.rs
@@ -242,6 +242,122 @@ fn crash_after_publish_with_no_on_disk_file_drops_stale_inventory_without_degrad
 }
 
 // =============================================================================
+// Crash boundary: after purge-eligibility publish, before final unlink
+//
+// Use real delete-path quarantine state: the file is already in
+// `__quarantine__/` and listed in `quarantine.manifest`, but Stage-5 purge has
+// not started yet. Reopen must keep health healthy, retain the file, and allow
+// a later GC pass to purge it.
+// =============================================================================
+
+#[test]
+fn crash_after_purge_eligibility_publish_before_final_unlink_keeps_quarantine_intact() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("solo").unwrap();
+    for i in 0..6 {
+        seed(&test_db.db, "solo", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "solo");
+
+    test_db.db.branches().delete("solo").unwrap();
+    let solo_dir = branch_dir(&test_db.db, "solo");
+    let staged = list_quarantine(&solo_dir);
+    assert!(
+        !staged.is_empty(),
+        "delete must stage at least one quarantined file before Stage-5 purge",
+    );
+    assert!(
+        solo_dir.join(strata_storage::QUARANTINE_FILENAME).exists(),
+        "delete must publish quarantine inventory before purge runs",
+    );
+
+    test_db.reopen();
+
+    assert!(matches!(
+        test_db.db.recovery_health(),
+        strata_storage::RecoveryHealth::Healthy
+    ));
+    let after = list_quarantine(&solo_dir);
+    assert_eq!(
+        after.iter().collect::<std::collections::HashSet<_>>(),
+        staged.iter().collect::<std::collections::HashSet<_>>(),
+        "boundary-6 reopen must preserve quarantined files until a later purge",
+    );
+
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("healthy gc after boundary-6 reopen must purge staged files");
+    assert!(
+        list_quarantine(&solo_dir).is_empty(),
+        "later gc should drain the preserved quarantine state",
+    );
+    assert!(
+        !solo_dir.join(strata_storage::QUARANTINE_FILENAME).exists(),
+        "inventory should be removed after the eventual purge",
+    );
+}
+
+// =============================================================================
+// Crash boundary: after final unlink, before final bookkeeping / report update
+//
+// Start from a real quarantine state, then remove the quarantined file but
+// leave the inventory entry behind. Reopen must treat that as the benign
+// "already unlinked before bookkeeping rewrite" case: silently drop the stale
+// entry, stay healthy, and leave GC idempotent.
+// =============================================================================
+
+#[test]
+fn crash_after_final_unlink_before_bookkeeping_drops_real_stale_inventory() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("solo").unwrap();
+    for i in 0..6 {
+        seed(&test_db.db, "solo", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "solo");
+
+    test_db.db.branches().delete("solo").unwrap();
+    let solo_dir = branch_dir(&test_db.db, "solo");
+    let staged = list_quarantine(&solo_dir);
+    assert!(
+        !staged.is_empty(),
+        "delete must stage at least one quarantined file before bookkeeping can lag",
+    );
+    for path in &staged {
+        std::fs::remove_file(path).unwrap();
+    }
+    assert!(
+        solo_dir.join(strata_storage::QUARANTINE_FILENAME).exists(),
+        "simulated boundary-7 crash must leave stale quarantine inventory behind",
+    );
+
+    test_db.reopen();
+
+    assert!(matches!(
+        test_db.db.recovery_health(),
+        strata_storage::RecoveryHealth::Healthy
+    ));
+    let reconciled = strata_storage::read_quarantine_manifest(&solo_dir)
+        .expect("read reconciled manifest")
+        .unwrap_or_default();
+    assert!(
+        reconciled.entries.is_empty(),
+        "boundary-7 reopen must drop the stale inventory entry after the file is already gone",
+    );
+    assert!(
+        list_quarantine(&solo_dir).is_empty(),
+        "no quarantined files should remain after the stale entry is reconciled",
+    );
+
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("healthy gc after boundary-7 reconcile is idempotent");
+}
+
+// =============================================================================
 // Crash boundary: quarantine dir with files but quarantine.manifest missing
 // (no inventory at all).
 //

--- a/tests/integration/branching_retention_matrix.rs
+++ b/tests/integration/branching_retention_matrix.rs
@@ -20,8 +20,10 @@
 
 #![cfg(not(miri))]
 
+use crate::common::branching::archive_branch_for_test;
 use crate::common::*;
 use std::sync::Arc;
+use strata_core::branch::BranchLifecycleStatus;
 use strata_core::value::Value;
 use strata_core::BranchId;
 use strata_engine::{ReclaimStatus, RetentionBlocker};
@@ -166,6 +168,38 @@ fn delete_after_fork_retains_parent_segments_for_child() {
     assert_eq!(
         kv.get(&resolve("feature"), "default", "k29").unwrap(),
         Some(Value::Int(29)),
+    );
+}
+
+#[test]
+fn delete_after_fork_reopen_does_not_resurrect_deleted_parent_storage() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..20 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+    test_db.db.branches().fork("main", "feature").unwrap();
+
+    test_db.db.branches().delete("main").unwrap();
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("healthy; gc succeeds");
+
+    test_db.reopen();
+
+    let kv = KVStore::new(test_db.db.clone());
+    assert_eq!(
+        kv.get(&resolve("main"), "default", "k0").unwrap(),
+        None,
+        "deleted parent storage must not resurrect on reopen",
+    );
+    assert_eq!(
+        kv.get(&resolve("feature"), "default", "k0").unwrap(),
+        Some(Value::Int(0)),
+        "descendant inherited-layer visibility must survive reopen",
     );
 }
 
@@ -519,10 +553,17 @@ fn retention_report_attributes_bytes_to_live_branch_refs() {
     let main_entry = by_name.get("main").expect("main present in report");
     let feature_entry = by_name.get("feature").expect("feature present in report");
 
-    // Main has own bytes (shared, because feature inherits) + zero inherited.
+    // Main's bytes are shared because feature inherits them.
     assert!(
-        main_entry.shared_bytes > 0 || main_entry.exclusive_bytes > 0,
-        "main must report own-segment bytes",
+        main_entry.shared_bytes > 0,
+        "main must report shared retained bytes"
+    );
+    assert!(
+        main_entry
+            .blockers
+            .iter()
+            .any(|b| matches!(b, RetentionBlocker::DescendantHolds { .. })),
+        "main must report DescendantHolds when a live descendant still inherits its bytes",
     );
     assert_eq!(main_entry.inherited_layer_bytes, 0);
 
@@ -601,5 +642,133 @@ fn retention_report_canonical_blocker_points_at_live_descendant_after_parent_del
         feature_entry.inherited_layer_bytes > 0,
         "feature must account for inherited bytes; got {}",
         feature_entry.inherited_layer_bytes,
+    );
+
+    let orphan_main = report
+        .orphan_storage
+        .iter()
+        .find(|entry| entry.branch_id == main_id)
+        .expect("deleted parent storage directory must be reported as orphaned retention");
+    assert!(
+        orphan_main.bytes > 0,
+        "deleted parent orphan entry must account for retained bytes",
+    );
+    assert_eq!(
+        orphan_main.reason,
+        strata_engine::OrphanReason::DescendantInheritance,
+        "deleted parent bytes are retained by the live descendant, not fabricated as untracked storage",
+    );
+}
+
+// =============================================================================
+// Schedule extension: live-branch top-level orphan `.sst` files that are no
+// longer manifest-owned are cleanup debt, not branch-visible retained bytes.
+//
+// Pins the convergence contract's "manifest-derived truth" rule for
+// retention_report(): raw disk debris must not inflate exclusive/shared totals.
+// =============================================================================
+
+#[test]
+fn retention_report_ignores_live_branch_top_level_orphan_files() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..10 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+
+    let before = test_db
+        .db
+        .retention_report()
+        .expect("baseline retention_report succeeds");
+    let before_main = before
+        .branches
+        .iter()
+        .find(|b| b.name == "main")
+        .expect("main present before orphan write");
+
+    let main_dir = branch_dir(&test_db.db, "main");
+    std::fs::write(main_dir.join("99999.sst"), vec![0u8; 4096]).unwrap();
+
+    let after = test_db
+        .db
+        .retention_report()
+        .expect("report should ignore live-branch orphan cleanup debt");
+    let after_main = after
+        .branches
+        .iter()
+        .find(|b| b.name == "main")
+        .expect("main present after orphan write");
+
+    assert_eq!(
+        after_main.exclusive_bytes, before_main.exclusive_bytes,
+        "top-level orphan bytes must not inflate manifest-derived exclusive retention",
+    );
+    assert_eq!(
+        after_main.shared_bytes, before_main.shared_bytes,
+        "top-level orphan bytes must not inflate manifest-derived shared retention",
+    );
+}
+
+#[test]
+fn retention_report_includes_archived_branch_as_live_lifecycle() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("frozen").unwrap();
+    for i in 0..4 {
+        seed(&test_db.db, "frozen", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "frozen");
+    test_db.db.branches().fork("frozen", "child").unwrap();
+    let archived_ref = archive_branch_for_test(&test_db.db, "frozen");
+
+    let report = test_db
+        .db
+        .retention_report()
+        .expect("archived branch remains visible to retention_report");
+
+    let frozen = report
+        .branches
+        .iter()
+        .find(|entry| entry.name == "frozen")
+        .expect("archived branch must appear as a branch entry");
+    assert_eq!(frozen.branch, archived_ref);
+    assert_eq!(frozen.lifecycle, BranchLifecycleStatus::Archived);
+    assert!(
+        frozen.exclusive_bytes > 0 || frozen.shared_bytes > 0,
+        "archived branch should still account for retained bytes",
+    );
+    assert!(
+        !report
+            .orphan_storage
+            .iter()
+            .any(|entry| entry.branch_id == resolve("frozen")),
+        "archived branch storage must not be demoted to orphan storage",
+    );
+
+    let child = report
+        .branches
+        .iter()
+        .find(|entry| entry.name == "child")
+        .expect("child must appear in retention_report");
+    let blocker = child
+        .blockers
+        .iter()
+        .find_map(|blocker| match blocker {
+            RetentionBlocker::InheritedLayerRetention {
+                source_branch,
+                removable_by_materialization,
+                ..
+            } => Some((source_branch, removable_by_materialization)),
+            _ => None,
+        })
+        .expect("child must report an inherited-layer blocker against the archived source");
+    assert_eq!(
+        blocker.0.as_ref(),
+        Some(&archived_ref),
+        "archived source should still resolve to a live BranchRef in blocker attribution",
+    );
+    assert!(
+        !*blocker.1,
+        "archived source is still a live lifecycle; child blocker is not removable by materialization",
     );
 }

--- a/tests/integration/branching_retention_matrix.rs
+++ b/tests/integration/branching_retention_matrix.rs
@@ -1,0 +1,605 @@
+//! B5.2 — Adversarial retention / reclaim proof matrix.
+//!
+//! Covers the deterministic schedule families from
+//! `docs/design/branching/branching-gc/b5-phasing-plan.md` §B5.2 +
+//! `docs/design/branching/branching-gc/branching-b5-verification-spec.md`
+//! §"Required schedule matrix". Each test proves one or more of:
+//!
+//! - A1 Reachability beats accelerators (manifest proof wins)
+//! - A2 Quarantine is reversible until final purge
+//! - A3 Same-name recreate does not alias retention
+//! - A4 Materialization changes ownership, not meaning
+//! - A5 Degraded recovery blocks reclaim
+//! - A6 Reopen re-establishes safe runtime state from manifests
+//!
+//! The crash/failpoint boundary suite lives in
+//! `branching_gc_quarantine_recovery.rs`. The generated-history
+//! state-machine suite is not on the B5.2 merge-critical path (phasing
+//! plan §B5.2 "deterministic + failpoint proof suites are the minimum
+//! bar; state-machine suite lands with B5.3 or later").
+
+#![cfg(not(miri))]
+
+use crate::common::*;
+use std::sync::Arc;
+use strata_core::value::Value;
+use strata_core::BranchId;
+use strata_engine::{ReclaimStatus, RetentionBlocker};
+
+fn resolve(name: &str) -> BranchId {
+    BranchId::from_user_name(name)
+}
+
+fn seed(db: &Arc<Database>, name: &str, key: &str, v: i64) {
+    KVStore::new(db.clone())
+        .put(&resolve(name), "default", key, Value::Int(v))
+        .expect("seed write succeeds");
+}
+
+fn flush_branch(db: &Arc<Database>, name: &str) {
+    let id = resolve(name);
+    db.storage().rotate_memtable(&id);
+    db.storage()
+        .flush_oldest_frozen(&id)
+        .expect("flush succeeds");
+}
+
+fn list_ssts(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    std::fs::read_dir(dir)
+        .map(|it| {
+            it.flatten()
+                .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("sst"))
+                .map(|e| e.path())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn hex(id: &BranchId) -> String {
+    let mut s = String::with_capacity(32);
+    for b in id.as_bytes() {
+        use std::fmt::Write;
+        let _ = write!(s, "{:02x}", b);
+    }
+    s
+}
+
+fn segments_dir(db: &Arc<Database>) -> std::path::PathBuf {
+    db.storage()
+        .segments_dir()
+        .cloned()
+        .expect("disk-backed test database")
+}
+
+fn branch_dir(db: &Arc<Database>, name: &str) -> std::path::PathBuf {
+    segments_dir(db).join(hex(&resolve(name)))
+}
+
+// =============================================================================
+// Schedule: delete before fork
+//
+// Writing to a branch then deleting it — with no descendant ever forked —
+// must reclaim fully through the quarantine protocol and leave no bytes
+// behind. Pins: A1 reachability + A2 reversibility observed on a simple
+// path.
+// =============================================================================
+
+#[test]
+fn delete_before_fork_reclaims_every_segment() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("solo").unwrap();
+    for i in 0..20 {
+        seed(&test_db.db, "solo", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "solo");
+    let solo_dir = branch_dir(&test_db.db, "solo");
+    assert!(
+        !list_ssts(&solo_dir).is_empty(),
+        "setup must produce at least one sst"
+    );
+
+    test_db.db.branches().delete("solo").unwrap();
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("healthy recovery; gc succeeds");
+
+    let remaining = list_ssts(&solo_dir);
+    assert!(
+        remaining.is_empty(),
+        "after delete + gc, no bytes should remain at {:?}",
+        remaining,
+    );
+}
+
+// =============================================================================
+// Schedule: delete after fork — parent delete with a surviving descendant
+//
+// Fork a child, delete the parent: the child must still read its
+// fork-frontier snapshot and the parent-owned segments must remain live
+// until the child releases them. Pins A1 (manifest proof over
+// accelerator), KD4 (parent delete non-blocking on descendant
+// materialization), Invariant 7 (same-name recreate later won't confuse
+// this state).
+// =============================================================================
+
+#[test]
+fn delete_after_fork_retains_parent_segments_for_child() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..30 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+    test_db.db.branches().fork("main", "feature").unwrap();
+
+    let parent_dir = branch_dir(&test_db.db, "main");
+    let pre_fork_ssts = list_ssts(&parent_dir);
+    assert!(
+        !pre_fork_ssts.is_empty(),
+        "setup must produce parent segments before fork"
+    );
+
+    test_db.db.branches().delete("main").unwrap();
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("healthy; gc succeeds");
+
+    for path in &pre_fork_ssts {
+        assert!(
+            path.exists(),
+            "parent-owned segment {:?} must survive parent delete while child holds the fork frontier",
+            path,
+        );
+    }
+
+    // Child still reads the inherited snapshot.
+    let kv = KVStore::new(test_db.db.clone());
+    assert_eq!(
+        kv.get(&resolve("feature"), "default", "k0").unwrap(),
+        Some(Value::Int(0)),
+        "child inherited-layer visibility must survive parent delete",
+    );
+    assert_eq!(
+        kv.get(&resolve("feature"), "default", "k29").unwrap(),
+        Some(Value::Int(29)),
+    );
+}
+
+// =============================================================================
+// Schedule: repeated parent compaction with child alive
+//
+// Fork a child, compact the parent multiple times. The child must keep
+// reading its inherited-layer snapshot; compacted parent output does not
+// free child-needed files. Pins A1 + KD6 (compaction rewrites one
+// branch's manifest only).
+// =============================================================================
+
+#[test]
+fn repeated_parent_compaction_with_child_alive_retains_inherited_segments() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..20 {
+        seed(&test_db.db, "main", &format!("a{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+    for i in 0..20 {
+        seed(&test_db.db, "main", &format!("b{i}"), i + 100);
+    }
+    flush_branch(&test_db.db, "main");
+
+    test_db.db.branches().fork("main", "feature").unwrap();
+    let parent_dir = branch_dir(&test_db.db, "main");
+    let inherited_ssts = list_ssts(&parent_dir);
+    assert!(
+        inherited_ssts.len() >= 2,
+        "setup must produce at least two parent segments so compaction actually merges"
+    );
+
+    let parent_id = resolve("main");
+    for _ in 0..3 {
+        test_db
+            .db
+            .storage()
+            .compact_branch(&parent_id, strata_core::id::CommitVersion(0))
+            .expect("compact_branch succeeds");
+    }
+
+    for path in &inherited_ssts {
+        assert!(
+            path.exists(),
+            "inherited-layer segment {:?} must survive repeated parent compaction",
+            path,
+        );
+    }
+
+    let kv = KVStore::new(test_db.db.clone());
+    for i in 0..20 {
+        let key = format!("a{i}");
+        assert_eq!(
+            kv.get(&resolve("feature"), "default", &key).unwrap(),
+            Some(Value::Int(i)),
+            "child must still read key {key} through inherited layer",
+        );
+    }
+}
+
+// =============================================================================
+// Schedule: materialize before reopen (ownership-rewrite only, visibility preserved)
+//
+// Pins A4. Materialization must not change result set, tombstone semantics,
+// TTL, or fork-frontier visibility; it only rewrites manifest ownership.
+// =============================================================================
+
+#[test]
+fn materialize_before_reopen_preserves_visible_result_set() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..40 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+    test_db.db.branches().fork("main", "feature").unwrap();
+
+    let kv = KVStore::new(test_db.db.clone());
+    let before: Vec<Option<Value>> = (0..40)
+        .map(|i| {
+            kv.get(&resolve("feature"), "default", &format!("k{i}"))
+                .unwrap()
+        })
+        .collect();
+
+    // Layer 0 is the nearest parent (see `SegmentedStore::materialize_layer`).
+    test_db
+        .db
+        .storage()
+        .materialize_layer(&resolve("feature"), 0)
+        .expect("materialize succeeds");
+
+    let after: Vec<Option<Value>> = (0..40)
+        .map(|i| {
+            kv.get(&resolve("feature"), "default", &format!("k{i}"))
+                .unwrap()
+        })
+        .collect();
+
+    assert_eq!(
+        before, after,
+        "materialization must not change the child's visible result set",
+    );
+}
+
+// =============================================================================
+// Schedule: materialize after reopen (reopen-heal correctness)
+//
+// Fork, reopen, materialize. Same visibility as materialize-before-reopen —
+// rebuild re-establishes safe runtime state from manifests (A6).
+// =============================================================================
+
+#[test]
+fn materialize_after_reopen_preserves_visible_result_set() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..40 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+    test_db.db.branches().fork("main", "feature").unwrap();
+
+    let expected: Vec<Option<Value>> = (0..40)
+        .map(|i| {
+            KVStore::new(test_db.db.clone())
+                .get(&resolve("feature"), "default", &format!("k{i}"))
+                .unwrap()
+        })
+        .collect();
+
+    test_db.reopen();
+
+    test_db
+        .db
+        .storage()
+        .materialize_layer(&resolve("feature"), 0)
+        .expect("materialize after reopen succeeds");
+
+    let actual: Vec<Option<Value>> = (0..40)
+        .map(|i| {
+            KVStore::new(test_db.db.clone())
+                .get(&resolve("feature"), "default", &format!("k{i}"))
+                .unwrap()
+        })
+        .collect();
+
+    assert_eq!(
+        expected, actual,
+        "materialize after reopen must preserve child visibility",
+    );
+}
+
+// =============================================================================
+// Schedule: same-name recreate with old descendants alive
+//
+// main@gen0 → fork(feature) → delete(main) → create(main)@gen1.
+// The old feature lifecycle must continue reading the old main's snapshot
+// via its inherited-layer manifest (segment-ID-keyed, not name-keyed).
+// The new main@gen1 must not reclaim those segments. Pins A3 + KD1.
+// =============================================================================
+
+#[test]
+fn same_name_recreate_does_not_reclaim_descendant_inherited_segments() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..25 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+
+    test_db.db.branches().fork("main", "feature").unwrap();
+    let parent_dir = branch_dir(&test_db.db, "main");
+    let gen0_ssts = list_ssts(&parent_dir);
+    assert!(!gen0_ssts.is_empty());
+
+    test_db.db.branches().delete("main").unwrap();
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("gc succeeds");
+    for path in &gen0_ssts {
+        assert!(
+            path.exists(),
+            "gen0 segment {:?} must survive main delete (descendant holds)",
+            path,
+        );
+    }
+
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..10 {
+        seed(&test_db.db, "main", &format!("new{i}"), i + 1000);
+    }
+    flush_branch(&test_db.db, "main");
+
+    // GC again after the recreate — the gen0 segments must still be live
+    // because the feature branch's inherited-layer manifest still points
+    // at them (by segment_id, not branch name).
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("gc after recreate");
+
+    for path in &gen0_ssts {
+        assert!(
+            path.exists(),
+            "gen0 segment {:?} must still exist after main@gen1 recreate",
+            path,
+        );
+    }
+
+    let kv = KVStore::new(test_db.db.clone());
+    assert_eq!(
+        kv.get(&resolve("feature"), "default", "k0").unwrap(),
+        Some(Value::Int(0)),
+        "feature's gen0 inherited-layer visibility must survive recreate",
+    );
+    // New main@gen1 sees its own writes, not the old gen0 data.
+    assert_eq!(
+        kv.get(&resolve("main"), "default", "k0").unwrap(),
+        None,
+        "main@gen1 must not inherit gen0's keys",
+    );
+    assert_eq!(
+        kv.get(&resolve("main"), "default", "new0").unwrap(),
+        Some(Value::Int(1000)),
+    );
+}
+
+// =============================================================================
+// Schedule: parent delete with multiple descendants
+//
+// One parent, multiple children at different retention states; parent
+// delete must be safe without forcing descendant materialization. Pins
+// KD4.
+// =============================================================================
+
+#[test]
+fn parent_delete_with_multiple_descendants_does_not_force_materialization() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..30 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+
+    test_db.db.branches().fork("main", "child_a").unwrap();
+    test_db.db.branches().fork("main", "child_b").unwrap();
+    test_db.db.branches().fork("main", "child_c").unwrap();
+
+    let parent_dir = branch_dir(&test_db.db, "main");
+    let parent_ssts = list_ssts(&parent_dir);
+    assert!(!parent_ssts.is_empty());
+
+    // Delete the parent. Descendants must remain untouched.
+    test_db.db.branches().delete("main").unwrap();
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("gc succeeds");
+
+    for path in &parent_ssts {
+        assert!(
+            path.exists(),
+            "parent segment {:?} must survive delete while three descendants hold",
+            path,
+        );
+    }
+
+    let kv = KVStore::new(test_db.db.clone());
+    for child in &["child_a", "child_b", "child_c"] {
+        for i in 0..30 {
+            let key = format!("k{i}");
+            assert_eq!(
+                kv.get(&resolve(child), "default", &key).unwrap(),
+                Some(Value::Int(i)),
+                "child {child} must read key {key} through inherited layer",
+            );
+        }
+    }
+}
+
+// =============================================================================
+// Schedule: delete before fork — gen0 has no children; gc fully reclaims
+// Schedule extension: after gen1 recreate, first-gen reclamation should not
+// have blocked on inventory disagreement. Pins KD9 (quarantine state only
+// protocol state — manifest is still the ledger).
+// =============================================================================
+
+#[test]
+fn gc_drains_quarantine_in_a_single_pass_under_healthy_recovery() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("ephemeral").unwrap();
+    for i in 0..10 {
+        seed(&test_db.db, "ephemeral", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "ephemeral");
+    let ep_dir = branch_dir(&test_db.db, "ephemeral");
+    assert!(!list_ssts(&ep_dir).is_empty());
+
+    test_db.db.branches().delete("ephemeral").unwrap();
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("gc succeeds");
+
+    // After healthy gc, no quarantine.manifest, no __quarantine__/,
+    // no .sst files should remain.
+    assert!(!ep_dir.join(strata_storage::QUARANTINE_FILENAME).exists());
+    assert!(!ep_dir.join(strata_storage::QUARANTINE_DIR).exists());
+    assert!(list_ssts(&ep_dir).is_empty());
+}
+
+// =============================================================================
+// Schedule: retention_report() attributes bytes in branch vocabulary
+//
+// Pins the convergence-doc surface matrix: retention_report is
+// generation-aware, reports own/shared/inherited/quarantined totals, and
+// routes the manifest-derived attribution through live BranchRefs.
+// =============================================================================
+
+#[test]
+fn retention_report_attributes_bytes_to_live_branch_refs() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..20 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+    test_db.db.branches().fork("main", "feature").unwrap();
+    seed(&test_db.db, "feature", "own_child", 999);
+    flush_branch(&test_db.db, "feature");
+
+    let report = test_db
+        .db
+        .retention_report()
+        .expect("healthy; retention_report returns Ok");
+
+    assert_eq!(report.reclaim_status, ReclaimStatus::Allowed);
+
+    let by_name: std::collections::HashMap<String, _> = report
+        .branches
+        .iter()
+        .map(|b| (b.name.clone(), b))
+        .collect();
+
+    let main_entry = by_name.get("main").expect("main present in report");
+    let feature_entry = by_name.get("feature").expect("feature present in report");
+
+    // Main has own bytes (shared, because feature inherits) + zero inherited.
+    assert!(
+        main_entry.shared_bytes > 0 || main_entry.exclusive_bytes > 0,
+        "main must report own-segment bytes",
+    );
+    assert_eq!(main_entry.inherited_layer_bytes, 0);
+
+    // Feature has own exclusive bytes (its own_child write) AND inherited bytes.
+    assert!(feature_entry.exclusive_bytes > 0, "feature own_child bytes");
+    assert!(
+        feature_entry.inherited_layer_bytes > 0,
+        "feature must report inherited-layer bytes",
+    );
+    assert!(
+        feature_entry
+            .blockers
+            .iter()
+            .any(|b| matches!(b, RetentionBlocker::InheritedLayerRetention { .. })),
+        "feature must list an InheritedLayerRetention blocker",
+    );
+
+    assert_eq!(report.orphan_storage.len(), 0, "no orphan dirs yet");
+}
+
+// =============================================================================
+// Schedule: retention_report() after parent delete — canonical blocker
+// attribution points at the live descendant, source is deleted parent.
+// =============================================================================
+
+#[test]
+fn retention_report_canonical_blocker_points_at_live_descendant_after_parent_delete() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..15 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+    test_db.db.branches().fork("main", "feature").unwrap();
+    let main_id = resolve("main");
+
+    test_db.db.branches().delete("main").unwrap();
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("gc succeeds");
+
+    let report = test_db.db.retention_report().expect("healthy");
+
+    // Canonical blocker attribution: feature is the live lifecycle
+    // holding the bytes alive through its inherited layer. The blocker
+    // points at main as the source (no live lifecycle, so
+    // removable_by_materialization is true).
+    let feature_entry = report
+        .branches
+        .iter()
+        .find(|b| b.name == "feature")
+        .expect("feature present");
+    let found_main_source = feature_entry.blockers.iter().any(|b| match b {
+        RetentionBlocker::InheritedLayerRetention {
+            source_branch_id,
+            source_branch,
+            removable_by_materialization,
+            ..
+        } => {
+            *source_branch_id == main_id && source_branch.is_none() && *removable_by_materialization
+        }
+        _ => false,
+    });
+    assert!(
+        found_main_source,
+        "feature's blocker must cite main (source) and mark it removable_by_materialization; got {:?}",
+        feature_entry.blockers,
+    );
+
+    // Feature's inherited_layer_bytes must account for the retained
+    // bytes that physically live under main's directory — no
+    // fabrication, no silent loss.
+    assert!(
+        feature_entry.inherited_layer_bytes > 0,
+        "feature must account for inherited bytes; got {}",
+        feature_entry.inherited_layer_bytes,
+    );
+}

--- a/tests/integration/branching_retention_matrix.rs
+++ b/tests/integration/branching_retention_matrix.rs
@@ -25,7 +25,7 @@ use crate::common::*;
 use std::sync::Arc;
 use strata_core::branch::BranchLifecycleStatus;
 use strata_core::value::Value;
-use strata_core::BranchId;
+use strata_core::{BranchId, Key, Namespace};
 use strata_engine::{ReclaimStatus, RetentionBlocker};
 
 fn resolve(name: &str) -> BranchId {
@@ -36,6 +36,18 @@ fn seed(db: &Arc<Database>, name: &str, key: &str, v: i64) {
     KVStore::new(db.clone())
         .put(&resolve(name), "default", key, Value::Int(v))
         .expect("seed write succeeds");
+}
+
+fn seed_with_ttl(db: &Arc<Database>, name: &str, key: &str, v: i64, ttl_ms: u64) {
+    let branch_id = resolve(name);
+    let storage_key = Key::new_kv(
+        Arc::new(Namespace::new(branch_id, "default".to_string())),
+        key,
+    );
+    db.transaction(branch_id, |txn| {
+        txn.put_with_ttl(storage_key.clone(), Value::Int(v), ttl_ms)
+    })
+    .expect("ttl write succeeds");
 }
 
 fn flush_branch(db: &Arc<Database>, name: &str) {
@@ -354,6 +366,53 @@ fn materialize_after_reopen_preserves_visible_result_set() {
 }
 
 // =============================================================================
+// Schedule: TTL across materialize + reopen
+//
+// A TTL-bearing inherited value must keep its expiry barrier after
+// materialization rewrites ownership and a subsequent reopen rebuilds the
+// runtime state. Pins A4 + A6.
+// =============================================================================
+
+#[test]
+fn ttl_across_materialize_and_reopen_preserves_expiry_barrier() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+
+    seed(&test_db.db, "main", "ttl_key", 1);
+    seed_with_ttl(&test_db.db, "main", "ttl_key", 2, 60_000);
+    flush_branch(&test_db.db, "main");
+    test_db.db.branches().fork("main", "feature").unwrap();
+
+    let latest = KVStore::new(test_db.db.clone())
+        .get_versioned_direct(&resolve("main"), "default", "ttl_key")
+        .unwrap()
+        .expect("latest ttl-bearing version exists");
+    let expiry_before = latest.timestamp.as_micros() + 60_000 * 1_000 - 1;
+    let expiry_after = latest.timestamp.as_micros() + 60_000 * 1_000 + 1;
+
+    test_db
+        .db
+        .storage()
+        .materialize_layer(&resolve("feature"), 0)
+        .expect("materialize succeeds");
+    test_db.reopen();
+
+    let kv = KVStore::new(test_db.db.clone());
+    assert_eq!(
+        kv.get_at(&resolve("feature"), "default", "ttl_key", expiry_before)
+            .unwrap(),
+        Some(Value::Int(2)),
+        "materialize + reopen must preserve the TTL-bearing value before expiry",
+    );
+    assert_eq!(
+        kv.get_at(&resolve("feature"), "default", "ttl_key", expiry_after)
+            .unwrap(),
+        None,
+        "after TTL expiry, the expired parent version must continue to shadow older history through the materialized child state",
+    );
+}
+
+// =============================================================================
 // Schedule: same-name recreate with old descendants alive
 //
 // main@gen0 → fork(feature) → delete(main) → create(main)@gen1.
@@ -428,6 +487,87 @@ fn same_name_recreate_does_not_reclaim_descendant_inherited_segments() {
     assert_eq!(
         kv.get(&resolve("main"), "default", "new0").unwrap(),
         Some(Value::Int(1000)),
+    );
+}
+
+// =============================================================================
+// Schedule: delete + recreate + compaction
+//
+// Same-name recreate remains safe even after the recreated lifecycle publishes
+// new compaction output and GC runs again. Old descendant-held bytes must stay
+// live because proof is segment-ID keyed, not current-name keyed.
+// =============================================================================
+
+#[test]
+fn delete_recreate_then_compact_does_not_reclaim_descendant_gen0_segments() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..20 {
+        seed(&test_db.db, "main", &format!("old{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+    test_db.db.branches().fork("main", "feature").unwrap();
+
+    let parent_dir = branch_dir(&test_db.db, "main");
+    let gen0_ssts = list_ssts(&parent_dir);
+    assert!(
+        !gen0_ssts.is_empty(),
+        "setup must produce gen0 segments before delete",
+    );
+
+    test_db.db.branches().delete("main").unwrap();
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("gc after delete succeeds");
+
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..10 {
+        seed(&test_db.db, "main", &format!("new_a{i}"), i + 1000);
+    }
+    flush_branch(&test_db.db, "main");
+    for i in 0..10 {
+        seed(&test_db.db, "main", &format!("new_b{i}"), i + 2000);
+    }
+    flush_branch(&test_db.db, "main");
+    test_db
+        .db
+        .storage()
+        .compact_branch(&resolve("main"), strata_core::id::CommitVersion(0))
+        .expect("compaction on recreated main succeeds");
+    test_db
+        .db
+        .storage()
+        .gc_orphan_segments()
+        .expect("gc after recreate + compaction succeeds");
+
+    for path in &gen0_ssts {
+        assert!(
+            path.exists(),
+            "gen0 segment {:?} must survive recreated-main compaction while feature still holds the old snapshot",
+            path,
+        );
+    }
+
+    let kv = KVStore::new(test_db.db.clone());
+    assert_eq!(
+        kv.get(&resolve("feature"), "default", "old0").unwrap(),
+        Some(Value::Int(0)),
+        "feature must still read gen0 inherited data after recreate + compaction",
+    );
+    assert_eq!(
+        kv.get(&resolve("main"), "default", "old0").unwrap(),
+        None,
+        "recreated main must not regain gen0 visibility after compaction",
+    );
+    assert_eq!(
+        kv.get(&resolve("main"), "default", "new_a0").unwrap(),
+        Some(Value::Int(1000)),
+    );
+    assert_eq!(
+        kv.get(&resolve("main"), "default", "new_b0").unwrap(),
+        Some(Value::Int(2000)),
     );
 }
 

--- a/tests/integration/data/branching_transitional_shapes.json
+++ b/tests/integration/data/branching_transitional_shapes.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "description": "Locked counts of branching transitional shapes. See tests/integration/branching_guardrails.rs for what each key tracks and why.",
   "shapes": {
-    "branch_id_random_new_sites": 724,
+    "branch_id_random_new_sites": 725,
     "branch_namespace_const_sites": 1,
     "merge_base_override_occurrences": 0,
     "merge_strategy_lastwriterwins_literals": 75

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -12,12 +12,14 @@ mod common;
 
 mod branching;
 mod branching_control_store_recovery;
+mod branching_gc_quarantine_recovery;
 mod branching_generation_migration;
 mod branching_guardrails;
 mod branching_lifecycle_gate;
 mod branching_lifecycle_restart;
 mod branching_merge_lineage_edges;
 mod branching_recreate_state_machine;
+mod branching_retention_matrix;
 mod branching_same_name_race;
 mod merge_base_characterization;
 mod modes;

--- a/tests/storage/branch_isolation.rs
+++ b/tests/storage/branch_isolation.rs
@@ -98,7 +98,7 @@ fn clear_branch_only_affects_target_branch() {
     }
 
     // Clear branch1
-    store.clear_branch(&branch1);
+    store.clear_branch(&branch1).unwrap();
 
     // Branch1 should be empty
     for i in 0..5 {
@@ -376,7 +376,7 @@ fn clear_nonexistent_branch_succeeds() {
     let branch_id = BranchId::new();
 
     // Should not panic
-    store.clear_branch(&branch_id);
+    store.clear_branch(&branch_id).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements **B5.2** from `docs/design/branching/branching-gc/b5-phasing-plan.md`:
the safe reclaim protocol, reopen-time quarantine reconciliation,
generation-aware retention attribution, and a two-phase delete that
cleanly separates rollbackable logical state from post-commit cleanup
debt.

### Reclaim pipeline
- **Authoritative Stage-2 manifest proof.** The runtime ref-registry is
  a candidate screen only. The authoritative proof is a walk of
  recovery-trusted `segments.manifest` own-entries and inherited-layer
  entries across every on-disk branch directory. Disagreement surfaces
  as `StorageError::ReclaimRefusedManifestProof`. Storage reporting and
  reclaim consume the same directory-ledger view so they can't drift.
- **Stage-3/4 quarantine.** Segments are renamed into
  `<branch_dir>/__quarantine__/`, with `quarantine.manifest` (STRAQRTN,
  B5.1 pinned) published first and both parent directories fsynced for
  cross-directory rename durability.
- **Stage-5 purge** drains the inventory under the same
  `deletion_write_guard` quarantine uses for publish + rename, so
  concurrent quarantine + purge can't race the inventory ledger.
- **Empty-manifest barrier.** `clear_branch` publishes an empty
  `segments.manifest` before any storage mutation, preventing the
  deleted-parent directory from being revived by the
  `NoManifestFallbackUsed` legacy path on reopen. `clear_branch` is
  idempotent — retry after GC drains leftover cleanup debt.

### Two-phase delete
- `BranchIndex::delete_branch_with_hook` now stops at the committed
  logical-delete boundary and returns `DeleteBranchCommitted`. Storage
  cleanup, subsystem cleanup, and the best-effort delete hook run
  through `complete_delete_post_commit`, which classifies outcomes as
  `DeleteBranchCompletion::{Clean, Warning, PostCommitError}`.
- A DAG failure inside the committed-delete closure rolls back the
  logical mutation without touching post-commit state.
  `BranchSnapshot` rollback captures and restores the default-branch
  marker and per-branch lock entry so rollback of a committed-then-
  retried delete does not strand state.
- Post-commit cleanup failure leaves the branch logically deleted and
  surfaces retention debt through `retention_report()`.

### Reopen reconciliation
- `recover_segments` reuses the same directory-ledger view as reclaim
  and reporting.
- Disagreement between `quarantine.manifest` inventory and on-disk
  `__quarantine__/` degrades recovery health to `PolicyDowngrade` via
  `RecoveryFault::QuarantineInventoryMismatch`; reclaim blocks until a
  full rebuild-equivalent reconciliation completes (KD10).
- Stale inventory entries whose files exist neither at the original
  location nor in quarantine are dropped silently — the benign "rename
  never completed" / "purge already ran" shape.

### `Database::retention_report()`
- Two-layer assembly: filesystem-level `StorageBranchRetention` from
  storage + generation-aware `BranchRef` attribution via
  `BranchControlStore::list_visible()` (Active + Archived).
- Canonical-blocker attribution points at the live descendant, not the
  historical writer. Source branches with no live lifecycle are marked
  `removable_by_materialization = true`.
- Orphan storage directories whose control record has been tombstoned
  surface under `RetentionReport::orphan_storage` with `OrphanReason`.
- Hard-fail-degraded per the convergence contract:
  - `Err(StrataError::RetentionReportUnavailable)` when attribution
    cannot be trusted: `DataLoss`, any
    `QuarantineInventoryMismatch`-driven `PolicyDowngrade`, unmigrated
    follower (AD5), or any storage-side snapshot failure.
  - Attribution-safe degraded recovery surfaces as
    `ReclaimStatus::BlockedDegradedRecovery` inside a successful
    report — blocked reclaim is a retention fact, not a fabrication.

### Change class / assurance
- **Change class:** intentional semantic change (immediate-unlink →
  quarantine pipeline + logical-vs-post-commit split), scope-authorized
  by the B5.2 phasing plan and the retention contract.
- **Assurance class:** S4. Characterization, failure-injection, and
  crash/restart suites land in this PR. Regression benchmark runs
  clean.
- **D4 surface:** extended with retention-report types plus
  `StrataError::RetentionReportUnavailable`; `CLAUDE.md` updated.
- No `segments.manifest` schema amendment required — proof suite
  satisfied by the current model.

## Test plan

- [x] `cargo test --workspace` — 6101 tests across 40+ binaries, all
      green. Includes the full B5.2 adversarial matrix, crash-reopen
      suite, storage-local reconciliation suite, two-phase-delete
      rollback/debt suite, retention-report follower-refusal and
      orphan-storage paths.
- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets` — no new errors
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo hack --feature-powerset --depth 2 check -p strata-storage -p strata-engine` clean
- [x] Regression benchmark runs without degradation in quick mode

## Schedule coverage (B5 verification spec §"Required schedule matrix")

- [x] delete before/after fork
- [x] repeated parent compaction with live descendant
- [x] materialize before/after reopen
- [x] parent delete with multiple descendants
- [x] same-name recreate with old descendants alive
- [x] crash boundaries: before reclaim, after rename + missing
      inventory, after publish with no on-disk file, orphan quarantine
      dir, idempotent round trip
- [x] storage-local: accelerator disagreement blocks reclaim, hard
      pre-walk failure keeps reclaim refused, consistent inventory
      purges cleanly, concurrent quarantine + purge serialization
- [x] two-phase delete: DAG-failure rollback restores branch before
      post-commit cleanup runs; post-commit cleanup failure leaves
      branch logically deleted and surfaces in retention report;
      retention report refuses on unmigrated follower

The generated-history state-machine suite is out of scope for B5.2 and
lands with B5.3 per the phasing plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)