### PR TITLE
B5.4: degraded primitive closure — fail-closed vector/JSON paths, degradation registry, push observer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,11 @@ architecture scope documents. The current allowed surface:
 `BranchRetentionEntry`, `RetentionBlocker`, `RetentionTotals`, `OrphanStorageEntry`,
 `OrphanReason`, `ReclaimStatus`
 
+**Primitive Degradation (B5.4):** `Database::primitive_degraded_observers()`,
+`Database::active_branch_ref()`, `RetentionReport::degraded_primitives`,
+`DegradedPrimitiveEntry`, `PrimitiveDegradationEntry`, `PrimitiveDegradationRegistry`,
+`PrimitiveDegradedEvent`, `PrimitiveDegradedObserver`, `PrimitiveDegradedObserverRegistry`
+
 **Product:** `SystemBranchCapability` (`pub` type, `pub(crate)` constructor), `Provider`,
 `ControlRegistry`, `ControlEntry`, `ControlOwner`, `BehaviorClass`, `PersistenceClass`
 
@@ -164,7 +169,8 @@ architecture scope documents. The current allowed surface:
 **Errors:** `StrataError`, `executor::Error`, `ErrorSeverity`, `BranchDagError`/`Kind`,
 `ObserverError`/`Kind`, `RefreshHookError`, `AdvanceError`, `UnblockError`,
 `InferenceError`, `BranchBundleError`, `CompactionError`, `ManifestError`,
-`StrataError::RetentionReportUnavailable` (B5.2)
+`StrataError::RetentionReportUnavailable` (B5.2),
+`StrataError::PrimitiveDegraded` + `PrimitiveDegradedReason` (B5.4)
 
 ---
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -65,11 +65,58 @@
 //! }
 //! ```
 
-use crate::contract::{EntityRef, Version};
+use crate::branch::BranchRef;
+use crate::contract::{EntityRef, PrimitiveType, Version};
 use crate::types::BranchId;
 use std::collections::HashMap;
 use std::io;
 use thiserror::Error;
+
+// =============================================================================
+// Primitive Degradation Reason (B5.4)
+// =============================================================================
+
+/// Typed reason for a [`StrataError::PrimitiveDegraded`] failure.
+///
+/// Each variant names a specific class of fail-closed degradation that a
+/// primitive subsystem may observe at recovery or read time. Per
+/// `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+/// §"Degraded-state closure targets", named degraded primitive paths must
+/// fail closed with a typed reason rather than silently serving stale or
+/// wrong data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PrimitiveDegradedReason {
+    /// Persisted primitive configuration bytes failed to decode (e.g.
+    /// `CollectionRecord::from_bytes` on a corrupt KV value).
+    ConfigDecodeFailure,
+    /// Persisted configuration decoded but could not be converted into
+    /// the primitive's in-memory config shape (e.g. a legacy vector
+    /// config shape that has since been removed).
+    ConfigShapeConversion,
+    /// Persisted configuration disagrees with persisted primitive data
+    /// (e.g. declared `VectorConfig.dimension` does not match a stored
+    /// `VectorRecord.embedding.len()`).
+    ConfigMismatch,
+    /// Secondary-index metadata bytes failed to decode (e.g. corrupt
+    /// JSON `_idx_meta/{space}/{name}` entry).
+    IndexMetadataCorrupt,
+    /// A secondary-index entry key could not be decoded (e.g. a JSON
+    /// `_idx/{space}/{name}/` row missing the value/doc_id separator).
+    IndexEntryCorrupt,
+}
+
+impl std::fmt::Display for PrimitiveDegradedReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConfigDecodeFailure => write!(f, "ConfigDecodeFailure"),
+            Self::ConfigShapeConversion => write!(f, "ConfigShapeConversion"),
+            Self::ConfigMismatch => write!(f, "ConfigMismatch"),
+            Self::IndexMetadataCorrupt => write!(f, "IndexMetadataCorrupt"),
+            Self::IndexEntryCorrupt => write!(f, "IndexEntryCorrupt"),
+        }
+    }
+}
 
 // =============================================================================
 // ErrorCode - Canonical Wire Error Codes (Frozen)
@@ -1061,6 +1108,39 @@ pub enum StrataError {
         class: String,
     },
 
+    /// A named primitive on a specific branch lifecycle instance is
+    /// degraded and must fail closed rather than serve stale or wrong
+    /// branch-visible data.
+    ///
+    /// Per the B5 convergence contract at
+    /// `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+    /// §"Degraded-state closure targets" (B5.4), named primitive failure
+    /// paths (vector config mismatch, JSON `_idx` load failure) must
+    /// surface as typed errors rather than silent fallback to
+    /// incorrect results. This is the branch-facing unavailable
+    /// contract for those paths.
+    ///
+    /// `branch` uses `BranchRef` so attribution survives same-name
+    /// recreate (`branching-retention-contract.md` §"Same-name
+    /// recreate"). `primitive` discriminates which subsystem owns the
+    /// degraded surface (e.g. `PrimitiveType::Vector` or
+    /// `PrimitiveType::Json`). `name` is the primitive-level identity
+    /// (collection name for vector, secondary-index space for JSON).
+    ///
+    /// Wire code: `StorageError`
+    #[error("primitive {primitive:?} '{name}' on branch {branch:?} is degraded: {reason}")]
+    PrimitiveDegraded {
+        /// Generation-aware branch identity — preserved across same-name
+        /// recreate so reports don't confuse lifecycle instances.
+        branch: BranchRef,
+        /// Which primitive subsystem owns the degraded surface.
+        primitive: PrimitiveType,
+        /// Primitive-level name (collection, index space, etc.).
+        name: String,
+        /// Typed reason for the degradation (no string factory).
+        reason: PrimitiveDegradedReason,
+    },
+
     /// Shutdown timeout
     ///
     /// The database shutdown timed out waiting for active transactions to complete.
@@ -1412,6 +1492,25 @@ impl StrataError {
         }
     }
 
+    /// Create a [`StrataError::PrimitiveDegraded`] for a named primitive
+    /// on a specific branch lifecycle instance.
+    ///
+    /// Contract: `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+    /// §"Degraded-state closure targets" (B5.4).
+    pub fn primitive_degraded(
+        branch: BranchRef,
+        primitive: PrimitiveType,
+        name: impl Into<String>,
+        reason: PrimitiveDegradedReason,
+    ) -> Self {
+        StrataError::PrimitiveDegraded {
+            branch,
+            primitive,
+            name: name.into(),
+            reason,
+        }
+    }
+
     /// Create a Corruption error
     ///
     /// ## Example
@@ -1641,6 +1740,7 @@ impl StrataError {
             StrataError::CodecDecode { .. } => ErrorCode::StorageError,
             StrataError::LegacyFormat { .. } => ErrorCode::StorageError,
             StrataError::RetentionReportUnavailable { .. } => ErrorCode::StorageError,
+            StrataError::PrimitiveDegraded { .. } => ErrorCode::StorageError,
 
             // Internal errors
             StrataError::Internal { .. } => ErrorCode::InternalError,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -33,7 +33,8 @@ pub use branch::{
 // Re-export commonly used types and traits
 pub use branch_types::{BranchEventOffsets, BranchMetadata, BranchStatus};
 pub use error::{
-    ConstraintReason, DetailValue, ErrorCode, ErrorDetails, StrataError, StrataResult,
+    ConstraintReason, DetailValue, ErrorCode, ErrorDetails, PrimitiveDegradedReason, StrataError,
+    StrataResult,
 };
 pub use id::{CommitVersion, TxnId};
 pub use limits::{LimitError, Limits};

--- a/crates/engine/src/branch_ops/primitive_merge.rs
+++ b/crates/engine/src/branch_ops/primitive_merge.rs
@@ -434,7 +434,7 @@ impl PrimitiveMergeHandler for JsonMergeHandler {
             let result = ctx
                 .db
                 .transaction(ctx.target_id, |txn| {
-                    JsonStore::load_indexes(txn, &ctx.target_id, &space_owned)
+                    JsonStore::load_indexes(ctx.db.as_ref(), txn, &ctx.target_id, &space_owned)
                 })
                 .unwrap_or_else(|e| {
                     tracing::warn!(

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -26,6 +26,7 @@ pub mod config;
 pub mod dag_hook;
 pub mod merge_registry;
 pub mod observers;
+pub mod primitive_degradation;
 pub mod profile;
 pub(crate) mod recovery;
 mod recovery_error;
@@ -50,16 +51,18 @@ pub use merge_registry::{
 pub use observers::{
     AbortInfo, AbortObserver, AbortObserverRegistry, BranchOpEvent, BranchOpKind, BranchOpObserver,
     BranchOpObserverRegistry, CommitInfo, CommitObserver, CommitObserverRegistry, ObserverError,
-    ObserverErrorKind, ReplayInfo, ReplayObserver, ReplayObserverRegistry,
+    ObserverErrorKind, PrimitiveDegradedEvent, PrimitiveDegradedObserver,
+    PrimitiveDegradedObserverRegistry, ReplayInfo, ReplayObserver, ReplayObserverRegistry,
 };
+pub use primitive_degradation::{PrimitiveDegradationEntry, PrimitiveDegradationRegistry};
 pub use recovery_error::{ErrorRole, RecoveryError};
 pub use refresh::{
     AdvanceError, BlockReason, BlockedTxn, FollowerStatus, RefreshHookError, RefreshOutcome,
     UnblockError,
 };
 pub use retention_report::{
-    BranchRetentionEntry, OrphanReason, OrphanStorageEntry, ReclaimStatus, RetentionBlocker,
-    RetentionReport, RetentionTotals,
+    BranchRetentionEntry, DegradedPrimitiveEntry, OrphanReason, OrphanStorageEntry, ReclaimStatus,
+    RetentionBlocker, RetentionReport, RetentionTotals,
 };
 pub use spec::{
     search_only_cache_spec, search_only_follower_spec, search_only_primary_spec, DatabaseMode,
@@ -703,6 +706,15 @@ pub struct Database {
     /// Best-effort: failures are logged, not propagated.
     replay_observers: ReplayObserverRegistry,
 
+    /// Per-database primitive-degraded observer registry (B5.4).
+    ///
+    /// Observers are notified when a named primitive is marked
+    /// fail-closed degraded (vector config mismatch, JSON `_idx` load
+    /// failure, etc.). Best-effort: failures are logged, not propagated.
+    /// See `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+    /// §"Required push events".
+    primitive_degraded_observers: observers::PrimitiveDegradedObserverRegistry,
+
     /// Lifecycle state for `open_runtime` and registry reuse.
     ///
     /// Tracks whether this instance is uninitialized, currently initializing,
@@ -982,6 +994,48 @@ impl Database {
     /// Observers are notified after each fully-applied follower replay record.
     pub fn replay_observers(&self) -> &ReplayObserverRegistry {
         &self.replay_observers
+    }
+
+    /// Get the per-database primitive-degraded observer registry (B5.4).
+    ///
+    /// Observers are notified when a named primitive is marked
+    /// fail-closed degraded. See
+    /// `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+    /// §"Required push events".
+    pub fn primitive_degraded_observers(&self) -> &observers::PrimitiveDegradedObserverRegistry {
+        &self.primitive_degraded_observers
+    }
+
+    /// Resolve the current-generation [`BranchRef`] for a storage-layer
+    /// [`BranchId`] by reading the control-store active pointer
+    /// directly from storage (no `Arc<Database>` needed).
+    ///
+    /// Used by primitive-degradation mark sites during recovery — those
+    /// paths see `&Database` or `BranchId` but still need a
+    /// generation-aware `BranchRef` so `retention_report()` can attribute
+    /// the degradation to the current live lifecycle instance per
+    /// `docs/design/branching/branching-gc/branching-retention-contract.md`
+    /// §"Same-name recreate".
+    ///
+    /// Returns `None` when the active pointer is absent (legacy /
+    /// gen-0-only branches; follower pre-migration state).
+    pub fn active_branch_ref(&self, branch_id: BranchId) -> Option<strata_core::BranchRef> {
+        use crate::branch_ops::branch_control_store::active_ptr_key;
+        use strata_core::id::CommitVersion;
+        use strata_core::traits::Storage;
+        use strata_core::value::Value;
+
+        let ap_key = active_ptr_key(branch_id);
+        let versioned = self
+            .storage
+            .get_versioned(&ap_key, CommitVersion::MAX)
+            .ok()
+            .flatten()?;
+        let generation = match versioned.value {
+            Value::Int(n) if n >= 0 => n as u64,
+            _ => return None,
+        };
+        Some(strata_core::BranchRef::new(branch_id, generation))
     }
 
     // =========================================================================

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -1006,6 +1006,55 @@ impl Database {
         &self.primitive_degraded_observers
     }
 
+    /// Register a primitive-degraded observer and replay current degraded state.
+    ///
+    /// Recovery-time degradations are often discovered while opening the
+    /// database, before user code can register observers. This helper closes
+    /// that gap by replaying the current primitive-degradation registry after
+    /// registration, so callers can observe startup degradations without
+    /// polling `retention_report()`.
+    ///
+    /// Replay is best-effort and uses the current registry contents at the time
+    /// of registration. A replay-dedup wrapper ensures a concurrent live mark
+    /// and the startup replay cannot double-deliver the same degraded key to
+    /// the observer. Subsequent live degradations continue to arrive through
+    /// the normal push path.
+    pub fn register_primitive_degraded_observer(
+        &self,
+        observer: Arc<dyn observers::PrimitiveDegradedObserver>,
+    ) {
+        let replay_safe = Arc::new(observers::ReplayDedupPrimitiveDegradedObserver::new(
+            observer,
+        ));
+        self.primitive_degraded_observers
+            .register(replay_safe.clone() as Arc<dyn observers::PrimitiveDegradedObserver>);
+
+        if let Ok(registry) =
+            self.extension::<primitive_degradation::PrimitiveDegradationRegistry>()
+        {
+            for entry in registry.list() {
+                let event = observers::PrimitiveDegradedEvent {
+                    branch_ref: entry.branch_ref,
+                    primitive: entry.primitive,
+                    name: entry.name.clone(),
+                    reason: entry.reason,
+                    detail: entry.detail.clone(),
+                    detected_at: entry.detected_at,
+                };
+                if let Err(e) = observers::PrimitiveDegradedObserver::on_primitive_degraded(
+                    &*replay_safe,
+                    &event,
+                ) {
+                    tracing::error!(
+                        observer = replay_safe.name(),
+                        error = %e,
+                        "primitive degraded observer replay failed"
+                    );
+                }
+            }
+        }
+    }
+
     /// Resolve the current-generation [`BranchRef`] for a storage-layer
     /// [`BranchId`] by reading the control-store active pointer
     /// directly from storage (no `Arc<Database>` needed).

--- a/crates/engine/src/database/observers.rs
+++ b/crates/engine/src/database/observers.rs
@@ -27,11 +27,13 @@
 use parking_lot::RwLock;
 use std::fmt;
 use std::sync::Arc;
+use std::time::SystemTime;
 
+use strata_core::contract::PrimitiveType;
 use strata_core::id::{CommitVersion, TxnId};
 use strata_core::types::{BranchId, Key};
 use strata_core::value::Value;
-use strata_core::BranchRef;
+use strata_core::{BranchRef, PrimitiveDegradedReason};
 
 // =============================================================================
 // Error Types
@@ -723,6 +725,99 @@ impl BranchOpObserverRegistry {
 }
 
 impl Default for BranchOpObserverRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// =============================================================================
+// Primitive Degraded Observer (B5.4)
+// =============================================================================
+
+/// Event fired when a named primitive is marked as fail-closed degraded.
+///
+/// Per convergence doc §"Required push events", B5.4 must surface
+/// fail-closed degraded primitive events on a push channel so operators
+/// can route on the branch contract instead of log text. This event
+/// carries the same fields as the registry entry in
+/// `primitive_degradation::PrimitiveDegradationEntry`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct PrimitiveDegradedEvent {
+    /// Generation-aware branch identity at the time of degradation.
+    pub branch_ref: BranchRef,
+    /// Which primitive subsystem owns the degraded surface.
+    pub primitive: PrimitiveType,
+    /// Primitive-level name (collection, index space, etc.).
+    pub name: String,
+    /// Typed reason for the degradation.
+    pub reason: PrimitiveDegradedReason,
+    /// Operator-facing free-form detail (e.g. decode error message).
+    pub detail: String,
+    /// Wall-clock time the degradation was first marked.
+    pub detected_at: SystemTime,
+}
+
+/// Observer called when a primitive is marked fail-closed degraded.
+///
+/// Fires at most once per `(BranchId, PrimitiveType, name)` key during
+/// the lifetime of the `PrimitiveDegradationRegistry` (first-mark
+/// wins, consistent with the registry's idempotency).
+pub trait PrimitiveDegradedObserver: Send + Sync + 'static {
+    /// Human-readable name for logging.
+    fn name(&self) -> &'static str;
+
+    /// Called after a primitive is marked fail-closed degraded.
+    fn on_primitive_degraded(&self, event: &PrimitiveDegradedEvent) -> Result<(), ObserverError>;
+}
+
+/// Registry for primitive-degraded observers.
+pub struct PrimitiveDegradedObserverRegistry {
+    observers: RwLock<Vec<Arc<dyn PrimitiveDegradedObserver>>>,
+}
+
+impl PrimitiveDegradedObserverRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            observers: RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Register a primitive-degraded observer.
+    pub fn register(&self, observer: Arc<dyn PrimitiveDegradedObserver>) {
+        self.observers.write().push(observer);
+    }
+
+    /// Notify all observers of a primitive-degraded event.
+    ///
+    /// Errors are logged but not propagated (consistent with other
+    /// observer registries at the top of this file).
+    pub fn notify(&self, event: &PrimitiveDegradedEvent) {
+        let observers = self.observers.read();
+        for observer in observers.iter() {
+            if let Err(e) = observer.on_primitive_degraded(event) {
+                tracing::error!(
+                    observer = observer.name(),
+                    error = %e,
+                    "primitive degraded observer failed"
+                );
+            }
+        }
+    }
+
+    /// Number of registered observers.
+    pub fn len(&self) -> usize {
+        self.observers.read().len()
+    }
+
+    /// Whether the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.observers.read().is_empty()
+    }
+}
+
+impl Default for PrimitiveDegradedObserverRegistry {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/engine/src/database/observers.rs
+++ b/crates/engine/src/database/observers.rs
@@ -24,7 +24,8 @@
 //! Registries use `RwLock` for safe concurrent access. Observers themselves
 //! must be `Send + Sync` since they may be called from any thread.
 
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
+use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -823,6 +824,41 @@ impl Default for PrimitiveDegradedObserverRegistry {
     }
 }
 
+type PrimitiveDegradedReplayKey = (BranchRef, PrimitiveType, String);
+
+/// Internal wrapper that deduplicates replayed and live degraded events.
+///
+/// `Database::register_primitive_degraded_observer()` uses this wrapper so a
+/// recovery-time replay and a concurrent live degradation for the same
+/// `(BranchId, PrimitiveType, name)` key cannot double-deliver to the caller.
+pub(crate) struct ReplayDedupPrimitiveDegradedObserver {
+    inner: Arc<dyn PrimitiveDegradedObserver>,
+    seen: Mutex<HashSet<PrimitiveDegradedReplayKey>>,
+}
+
+impl ReplayDedupPrimitiveDegradedObserver {
+    pub(crate) fn new(inner: Arc<dyn PrimitiveDegradedObserver>) -> Self {
+        Self {
+            inner,
+            seen: Mutex::new(HashSet::new()),
+        }
+    }
+}
+
+impl PrimitiveDegradedObserver for ReplayDedupPrimitiveDegradedObserver {
+    fn name(&self) -> &'static str {
+        self.inner.name()
+    }
+
+    fn on_primitive_degraded(&self, event: &PrimitiveDegradedEvent) -> Result<(), ObserverError> {
+        let key = (event.branch_ref, event.primitive, event.name.clone());
+        if !self.seen.lock().insert(key) {
+            return Ok(());
+        }
+        self.inner.on_primitive_degraded(event)
+    }
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -886,6 +922,36 @@ mod tests {
         }
     }
 
+    struct CountingPrimitiveObserver {
+        count: AtomicUsize,
+    }
+
+    impl CountingPrimitiveObserver {
+        fn new() -> Self {
+            Self {
+                count: AtomicUsize::new(0),
+            }
+        }
+
+        fn count(&self) -> usize {
+            self.count.load(Ordering::SeqCst)
+        }
+    }
+
+    impl PrimitiveDegradedObserver for CountingPrimitiveObserver {
+        fn name(&self) -> &'static str {
+            "counting-primitive"
+        }
+
+        fn on_primitive_degraded(
+            &self,
+            _event: &PrimitiveDegradedEvent,
+        ) -> Result<(), ObserverError> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
     #[test]
     fn test_commit_observer_registry() {
         let registry = CommitObserverRegistry::new();
@@ -926,6 +992,43 @@ mod tests {
 
         registry.notify(&info);
         assert_eq!(observer.count(), 1);
+    }
+
+    #[test]
+    fn test_primitive_replay_wrapper_dedupes_duplicate_delivery() {
+        let inner = Arc::new(CountingPrimitiveObserver::new());
+        let wrapper = ReplayDedupPrimitiveDegradedObserver::new(
+            inner.clone() as Arc<dyn PrimitiveDegradedObserver>
+        );
+
+        let branch_ref = BranchRef::new(BranchId::new(), 7);
+        let event = PrimitiveDegradedEvent {
+            branch_ref,
+            primitive: PrimitiveType::Vector,
+            name: "v1".to_string(),
+            reason: PrimitiveDegradedReason::ConfigMismatch,
+            detail: "corrupt row".to_string(),
+            detected_at: SystemTime::now(),
+        };
+
+        wrapper.on_primitive_degraded(&event).unwrap();
+        wrapper.on_primitive_degraded(&event).unwrap();
+        assert_eq!(
+            inner.count(),
+            1,
+            "same degraded lifecycle key must be delivered at most once"
+        );
+
+        let event2 = PrimitiveDegradedEvent {
+            branch_ref: BranchRef::new(branch_ref.id, branch_ref.generation + 1),
+            ..event
+        };
+        wrapper.on_primitive_degraded(&event2).unwrap();
+        assert_eq!(
+            inner.count(),
+            2,
+            "same-name degrade on a new generation must still be delivered"
+        );
     }
 
     #[test]

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -482,6 +482,8 @@ impl Database {
             commit_observers: super::CommitObserverRegistry::new(),
             abort_observers: super::AbortObserverRegistry::new(),
             replay_observers: super::ReplayObserverRegistry::new(),
+            primitive_degraded_observers: super::observers::PrimitiveDegradedObserverRegistry::new(
+            ),
             lifecycle_state: std::sync::atomic::AtomicU8::new(
                 super::LifecycleState::Uninitialized.as_u8(),
             ),
@@ -823,6 +825,8 @@ impl Database {
             commit_observers: super::CommitObserverRegistry::new(),
             abort_observers: super::AbortObserverRegistry::new(),
             replay_observers: super::ReplayObserverRegistry::new(),
+            primitive_degraded_observers: super::observers::PrimitiveDegradedObserverRegistry::new(
+            ),
             lifecycle_state: std::sync::atomic::AtomicU8::new(
                 super::LifecycleState::Uninitialized.as_u8(),
             ),
@@ -990,6 +994,8 @@ impl Database {
             commit_observers: super::CommitObserverRegistry::new(),
             abort_observers: super::AbortObserverRegistry::new(),
             replay_observers: super::ReplayObserverRegistry::new(),
+            primitive_degraded_observers: super::observers::PrimitiveDegradedObserverRegistry::new(
+            ),
             lifecycle_state: std::sync::atomic::AtomicU8::new(
                 super::LifecycleState::Uninitialized.as_u8(),
             ),

--- a/crates/engine/src/database/primitive_degradation.rs
+++ b/crates/engine/src/database/primitive_degradation.rs
@@ -1,0 +1,380 @@
+//! B5.4 — per-Database primitive degradation registry.
+//!
+//! Per the B5 convergence contract at
+//! `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+//! §"Degraded-state closure targets", named primitive failure paths
+//! (vector config mismatch, JSON `_idx` load failure) must fail closed
+//! with typed errors rather than silently serving stale or wrong
+//! branch-visible data. This module is the engine-owned record of
+//! those fail-closed events.
+//!
+//! The registry is stored as a per-`Database` extension via
+//! `db.extension::<PrimitiveDegradationRegistry>()`. It is the single
+//! source of primitive-degraded state for three callers:
+//!
+//! 1. primitive read paths consult `lookup()` to fail closed on
+//!    subsequent reads (vector `ensure_collection_loaded`, JSON
+//!    `load_indexes` / lookup fns)
+//! 2. `Database::retention_report()` joins `list()` with live
+//!    `BranchControlRecord` lifecycle and surfaces the result as
+//!    `RetentionReport::degraded_primitives`
+//! 3. `complete_delete_post_commit` calls `clear_branch()` so a
+//!    same-name recreate starts with a clean registry
+//!    (contract §"Same-name recreate")
+//!
+//! Cross-branch isolation is structural: the key is
+//! `(BranchId, PrimitiveType, String)`, so a degraded entry on one
+//! branch cannot affect reads on a sibling branch.
+//!
+//! Per CLAUDE.md rule 3 ("no process-global semantic state"), the
+//! registry lives on `Database`, not a static.
+
+use std::time::SystemTime;
+
+use dashmap::DashMap;
+use strata_core::contract::PrimitiveType;
+use strata_core::types::BranchId;
+use strata_core::{BranchRef, PrimitiveDegradedReason, StrataError};
+
+use crate::database::observers::{PrimitiveDegradedEvent, PrimitiveDegradedObserverRegistry};
+
+/// One record of a fail-closed degraded primitive state.
+///
+/// Attributed to a specific generation-aware `BranchRef` so same-name
+/// recreate does not cause old-lifecycle entries to confuse the new
+/// lifecycle's reporting (contract §"Same-name recreate").
+#[derive(Debug, Clone)]
+pub struct PrimitiveDegradationEntry {
+    /// Generation-aware branch identity at the time of degradation.
+    pub branch_ref: BranchRef,
+    /// Which primitive subsystem owns the degraded surface.
+    pub primitive: PrimitiveType,
+    /// Primitive-level name (collection, index space, etc.).
+    pub name: String,
+    /// Typed reason for the degradation.
+    pub reason: PrimitiveDegradedReason,
+    /// Operator-facing free-form detail (e.g. decode error message).
+    /// Kept on the registry entry and the push event so operators can
+    /// triage without enabling debug logging after the fact.
+    pub detail: String,
+    /// Wall-clock time the degradation was first marked.
+    pub detected_at: SystemTime,
+}
+
+impl PrimitiveDegradationEntry {
+    /// Build the matching typed `StrataError` for this degradation.
+    pub fn to_error(&self) -> StrataError {
+        StrataError::primitive_degraded(self.branch_ref, self.primitive, &self.name, self.reason)
+    }
+}
+
+/// Per-`Database` registry of fail-closed primitive degradations.
+///
+/// Keyed by `(BranchId, PrimitiveType, name)`. The key uses the
+/// storage-level `BranchId` (not `BranchRef`) because recovery and
+/// lazy-load paths often do not yet have a live `BranchControlRecord`
+/// to consult for the current generation — the full `BranchRef` is
+/// preserved in the entry value and generation-equality is enforced
+/// at `retention_report()` join time.
+#[derive(Default)]
+pub struct PrimitiveDegradationRegistry {
+    entries: DashMap<(BranchId, PrimitiveType, String), PrimitiveDegradationEntry>,
+}
+
+impl PrimitiveDegradationRegistry {
+    /// Mark a primitive as degraded.
+    ///
+    /// The first call for a given `(BranchId, primitive, name)` key
+    /// "wins": it inserts the entry, stamps `detected_at`, and fires the
+    /// observer event (when an observer registry is passed). Subsequent
+    /// calls for the same key are no-ops — they do **not** re-fire
+    /// observers, so `mark` is safe to call on every read-path encounter
+    /// of corrupt data without generating push spam.
+    ///
+    /// See convergence doc §"Required push events" for the exactly-once
+    /// push contract this implements.
+    pub fn mark(
+        &self,
+        branch_ref: BranchRef,
+        primitive: PrimitiveType,
+        name: impl Into<String>,
+        reason: PrimitiveDegradedReason,
+        detail: impl Into<String>,
+        observers: Option<&PrimitiveDegradedObserverRegistry>,
+    ) -> PrimitiveDegradationEntry {
+        use dashmap::mapref::entry::Entry;
+        let name_str = name.into();
+        let detail_str = detail.into();
+        let key = (branch_ref.id, primitive, name_str.clone());
+        let (entry, newly_inserted) = match self.entries.entry(key) {
+            Entry::Occupied(e) => (e.get().clone(), false),
+            Entry::Vacant(v) => {
+                let fresh = PrimitiveDegradationEntry {
+                    branch_ref,
+                    primitive,
+                    name: name_str,
+                    reason,
+                    detail: detail_str,
+                    detected_at: SystemTime::now(),
+                };
+                let cloned = fresh.clone();
+                v.insert(fresh);
+                (cloned, true)
+            }
+        };
+
+        if newly_inserted {
+            if let Some(observers) = observers {
+                let event = PrimitiveDegradedEvent {
+                    branch_ref: entry.branch_ref,
+                    primitive: entry.primitive,
+                    name: entry.name.clone(),
+                    reason: entry.reason,
+                    detail: entry.detail.clone(),
+                    detected_at: entry.detected_at,
+                };
+                observers.notify(&event);
+            }
+        }
+
+        entry
+    }
+
+    /// Look up a degradation record by `(BranchId, primitive, name)`.
+    ///
+    /// Returns `None` when the primitive is healthy.
+    pub fn lookup(
+        &self,
+        branch_id: BranchId,
+        primitive: PrimitiveType,
+        name: &str,
+    ) -> Option<PrimitiveDegradationEntry> {
+        self.entries
+            .get(&(branch_id, primitive, name.to_string()))
+            .map(|e| e.value().clone())
+    }
+
+    /// Remove every entry keyed by `branch_id`.
+    ///
+    /// Called from `complete_delete_post_commit` so same-name recreate
+    /// does not inherit old-lifecycle degradation state (contract
+    /// §"Same-name recreate").
+    pub fn clear_branch(&self, branch_id: BranchId) {
+        self.entries.retain(|(id, _, _), _| *id != branch_id);
+    }
+
+    /// Snapshot every current entry.
+    ///
+    /// Used by `Database::retention_report()` to join primitive
+    /// degradation state with live `BranchControlRecord` lifecycle.
+    pub fn list(&self) -> Vec<PrimitiveDegradationEntry> {
+        self.entries.iter().map(|e| e.value().clone()).collect()
+    }
+
+    /// Total number of registered degradations. Testing aid.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// True when no degradations are registered. Testing aid.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Convenience wrapper used by primitive callers that have a
+/// `&Database` (or `&Arc<Database>`) and need to mark a primitive
+/// degraded without threading the observer registry and registry
+/// lookup at every call site.
+///
+/// Resolves the active [`BranchRef`] from storage via
+/// [`Database::active_branch_ref`]; falls back to
+/// `BranchRef::new(branch_id, 0)` when the control-store active
+/// pointer is absent (legacy / pre-migration state). The gen-0
+/// fallback is defensive — per the retention contract, attribution
+/// must still be generation-aware at the report join, which enforces
+/// `entry.branch_ref.generation == live.branch.generation`.
+pub fn mark_primitive_degraded(
+    db: &crate::database::Database,
+    branch_id: BranchId,
+    primitive: PrimitiveType,
+    name: impl Into<String>,
+    reason: PrimitiveDegradedReason,
+    detail: impl Into<String>,
+) -> Option<PrimitiveDegradationEntry> {
+    let registry = db.extension::<PrimitiveDegradationRegistry>().ok()?;
+    let branch_ref = db
+        .active_branch_ref(branch_id)
+        .unwrap_or_else(|| BranchRef::new(branch_id, 0));
+    let observers = db.primitive_degraded_observers();
+    Some(registry.mark(branch_ref, primitive, name, reason, detail, Some(observers)))
+}
+
+/// Read-path helper that looks up an existing degradation entry and
+/// builds the typed [`StrataError::PrimitiveDegraded`] to return to
+/// the caller. Used before attempting to load or scan primitive state.
+pub fn primitive_degraded_error(
+    db: &crate::database::Database,
+    branch_id: BranchId,
+    primitive: PrimitiveType,
+    name: &str,
+) -> Option<StrataError> {
+    let registry = db.extension::<PrimitiveDegradationRegistry>().ok()?;
+    registry
+        .lookup(branch_id, primitive, name)
+        .map(|e| e.to_error())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn br(id: u8, gen_: u64) -> BranchRef {
+        let mut bytes = [0u8; 16];
+        bytes[15] = id;
+        BranchRef::new(BranchId::from_bytes(bytes), gen_)
+    }
+
+    #[test]
+    fn mark_and_lookup() {
+        let reg = PrimitiveDegradationRegistry::default();
+        let b = br(1, 0);
+        reg.mark(
+            b,
+            PrimitiveType::Vector,
+            "v1",
+            PrimitiveDegradedReason::ConfigDecodeFailure,
+            "oops",
+            None,
+        );
+        let got = reg.lookup(b.id, PrimitiveType::Vector, "v1").unwrap();
+        assert_eq!(got.name, "v1");
+        assert_eq!(got.reason, PrimitiveDegradedReason::ConfigDecodeFailure);
+        assert_eq!(got.detail, "oops");
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn mark_is_idempotent_on_detected_at() {
+        let reg = PrimitiveDegradationRegistry::default();
+        let b = br(1, 0);
+        let first = reg.mark(
+            b,
+            PrimitiveType::Json,
+            "users",
+            PrimitiveDegradedReason::IndexMetadataCorrupt,
+            "bad json",
+            None,
+        );
+        let again = reg.mark(
+            b,
+            PrimitiveType::Json,
+            "users",
+            PrimitiveDegradedReason::IndexMetadataCorrupt,
+            "different detail ignored",
+            None,
+        );
+        assert_eq!(first.detected_at, again.detected_at);
+        assert_eq!(again.detail, "bad json"); // original detail wins
+    }
+
+    #[test]
+    fn observer_fires_exactly_once_per_degradation_key() {
+        use crate::database::observers::{
+            ObserverError, PrimitiveDegradedEvent, PrimitiveDegradedObserver,
+            PrimitiveDegradedObserverRegistry,
+        };
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        struct Counting {
+            count: AtomicUsize,
+        }
+        impl PrimitiveDegradedObserver for Counting {
+            fn name(&self) -> &'static str {
+                "counting"
+            }
+            fn on_primitive_degraded(
+                &self,
+                _event: &PrimitiveDegradedEvent,
+            ) -> Result<(), ObserverError> {
+                self.count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let obs_reg = PrimitiveDegradedObserverRegistry::new();
+        let counter = Arc::new(Counting {
+            count: AtomicUsize::new(0),
+        });
+        obs_reg.register(counter.clone() as Arc<dyn PrimitiveDegradedObserver>);
+
+        let reg = PrimitiveDegradationRegistry::default();
+        let b = br(1, 0);
+
+        // First mark — observer fires once.
+        reg.mark(
+            b,
+            PrimitiveType::Vector,
+            "v1",
+            PrimitiveDegradedReason::ConfigDecodeFailure,
+            "first",
+            Some(&obs_reg),
+        );
+        assert_eq!(counter.count.load(Ordering::SeqCst), 1);
+
+        // Second mark on SAME key — observer must NOT fire again.
+        reg.mark(
+            b,
+            PrimitiveType::Vector,
+            "v1",
+            PrimitiveDegradedReason::ConfigDecodeFailure,
+            "second",
+            Some(&obs_reg),
+        );
+        assert_eq!(
+            counter.count.load(Ordering::SeqCst),
+            1,
+            "observer must not re-fire on repeat mark of same key"
+        );
+
+        // Different key fires again.
+        reg.mark(
+            b,
+            PrimitiveType::Vector,
+            "v2",
+            PrimitiveDegradedReason::ConfigDecodeFailure,
+            "third",
+            Some(&obs_reg),
+        );
+        assert_eq!(counter.count.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn clear_branch_drops_matching_entries_only() {
+        let reg = PrimitiveDegradationRegistry::default();
+        let a = br(1, 0);
+        let b = br(2, 0);
+        reg.mark(
+            a,
+            PrimitiveType::Vector,
+            "v1",
+            PrimitiveDegradedReason::ConfigMismatch,
+            "",
+            None,
+        );
+        reg.mark(
+            b,
+            PrimitiveType::Vector,
+            "v1",
+            PrimitiveDegradedReason::ConfigMismatch,
+            "",
+            None,
+        );
+        assert_eq!(reg.len(), 2);
+        reg.clear_branch(a.id);
+        assert_eq!(reg.len(), 1);
+        assert!(reg.lookup(a.id, PrimitiveType::Vector, "v1").is_none());
+        assert!(reg.lookup(b.id, PrimitiveType::Vector, "v1").is_some());
+    }
+}

--- a/crates/engine/src/database/retention_report.rs
+++ b/crates/engine/src/database/retention_report.rs
@@ -33,10 +33,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use strata_core::contract::PrimitiveType;
 use strata_core::id::CommitVersion;
 use strata_core::types::BranchId;
 use strata_core::{
-    BranchControlRecord, BranchLifecycleStatus, BranchRef, StrataError, StrataResult,
+    BranchControlRecord, BranchLifecycleStatus, BranchRef, PrimitiveDegradedReason, StrataError,
+    StrataResult,
 };
 use strata_storage::{
     DegradationClass, RecoveryHealth, StorageBranchRetention, StorageError,
@@ -44,6 +46,7 @@ use strata_storage::{
 };
 
 use crate::branch_ops::branch_control_store::BranchControlStore;
+use crate::database::primitive_degradation::PrimitiveDegradationRegistry;
 use crate::database::Database;
 
 /// Reclaim readiness classification for a retention report.
@@ -195,6 +198,36 @@ pub struct RetentionTotals {
     pub quarantined_bytes: u64,
 }
 
+/// A fail-closed degraded primitive state attributed to a live
+/// branch lifecycle instance (B5.4).
+///
+/// Populated by joining the per-`Database`
+/// [`PrimitiveDegradationRegistry`] with live `BranchControlRecord`
+/// records: entries whose recorded generation no longer matches a live
+/// lifecycle are filtered out (defense-in-depth against a missed
+/// `clear_branch` call during same-name recreate).
+///
+/// Per the B5 convergence contract
+/// (`docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+/// §"Degraded-state closure targets"), this surface is the
+/// branch-facing pull contract for named primitive degradation.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct DegradedPrimitiveEntry {
+    /// Generation-aware branch identity.
+    pub branch: BranchRef,
+    /// User-facing branch name recorded on the control record.
+    pub name: String,
+    /// Which primitive subsystem owns the degraded surface.
+    pub primitive: PrimitiveType,
+    /// Primitive-level name (collection, index space, etc.).
+    pub primitive_name: String,
+    /// Typed reason for the degradation.
+    pub reason: PrimitiveDegradedReason,
+    /// Operator-facing free-form detail captured at mark time.
+    pub detail: String,
+}
+
 /// Generation-aware branch-vocabulary retention attribution surface.
 ///
 /// See the module-level doc and the B5 contract for the governing rules.
@@ -209,6 +242,16 @@ pub struct RetentionReport {
     pub orphan_storage: Vec<OrphanStorageEntry>,
     /// Aggregate totals across the entire report.
     pub totals: RetentionTotals,
+    /// Named primitives in fail-closed degraded state (B5.4).
+    ///
+    /// This list is orthogonal to byte-accounting fields: a degraded
+    /// primitive is a logical lifecycle fact, not a storage retention
+    /// debt. Populated from the per-`Database`
+    /// [`PrimitiveDegradationRegistry`]; entries whose generation does
+    /// not match a live `BranchControlRecord` are filtered out
+    /// (defense-in-depth against missed `clear_branch` on same-name
+    /// recreate).
+    pub degraded_primitives: Vec<DegradedPrimitiveEntry>,
 }
 
 impl Database {
@@ -370,11 +413,40 @@ impl Database {
             });
         }
 
+        // B5.4 — join primitive-degradation registry with live lifecycle.
+        // Entries are dropped when:
+        //   - no live control record exists for the BranchId (orphan
+        //     degradation — the branch has been deleted; the physical
+        //     cleanup hook also clears the registry, so this is
+        //     defense-in-depth), or
+        //   - the recorded generation does not match the live record
+        //     (same-name recreate advanced past the old lifecycle).
+        let mut degraded_primitives: Vec<DegradedPrimitiveEntry> = Vec::new();
+        if let Ok(registry) = self.extension::<PrimitiveDegradationRegistry>() {
+            for entry in registry.list() {
+                let Some(record) = live_by_id.get(&entry.branch_ref.id) else {
+                    continue;
+                };
+                if record.branch.generation != entry.branch_ref.generation {
+                    continue;
+                }
+                degraded_primitives.push(DegradedPrimitiveEntry {
+                    branch: record.branch,
+                    name: record.name.clone(),
+                    primitive: entry.primitive,
+                    primitive_name: entry.name.clone(),
+                    reason: entry.reason,
+                    detail: entry.detail.clone(),
+                });
+            }
+        }
+
         Ok(RetentionReport {
             reclaim_status,
             branches,
             orphan_storage,
             totals,
+            degraded_primitives,
         })
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -43,8 +43,10 @@ pub use database::profile::{
     Profile,
 };
 pub use database::{
-    BranchRetentionEntry, CacheMetrics, Database, DatabaseDiskUsage, ErrorRole, HealthReport,
-    LossyErrorKind, LossyRecoveryReport, ModelConfig, OrphanReason, OrphanStorageEntry,
+    BranchRetentionEntry, CacheMetrics, Database, DatabaseDiskUsage, DegradedPrimitiveEntry,
+    ErrorRole, HealthReport, LossyErrorKind, LossyRecoveryReport, ModelConfig, OrphanReason,
+    OrphanStorageEntry, PrimitiveDegradationEntry, PrimitiveDegradationRegistry,
+    PrimitiveDegradedEvent, PrimitiveDegradedObserver, PrimitiveDegradedObserverRegistry,
     ReclaimStatus, RecoveryError, RetentionBlocker, RetentionReport, RetentionTotals,
     StorageConfig, StorageMetricsSummary, StrataConfig, SubsystemHealth, SubsystemStatus,
     SystemMetrics, WalWriterHealth,

--- a/crates/engine/src/primitives/branch/index.rs
+++ b/crates/engine/src/primitives/branch/index.rs
@@ -710,6 +710,18 @@ impl BranchIndex {
             }
         }
 
+        // B5.4 — clear any primitive-degradation entries attributed to
+        // the deleted BranchId so a same-name recreate starts with a
+        // clean registry (retention contract §"Same-name recreate").
+        // Post-commit best-effort: failure here is logged but not
+        // raised — consistent with the surrounding cleanup pattern.
+        if let Ok(registry) =
+            self.db
+                .extension::<crate::database::primitive_degradation::PrimitiveDegradationRegistry>()
+        {
+            registry.clear_branch(executor_branch_id);
+        }
+
         // Remove commit lock entry. The deleting mark is intentionally
         // kept: any pre-existing transaction that tries to commit on
         // this branch after deletion will be rejected (#1916).

--- a/crates/engine/src/primitives/json/index.rs
+++ b/crates/engine/src/primitives/json/index.rs
@@ -8,9 +8,12 @@
 
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use strata_core::contract::PrimitiveType;
 use strata_core::primitives::json::{JsonPath, JsonValue};
 use strata_core::types::{BranchId, Key, Namespace, TypeTag};
-use strata_core::{StrataError, StrataResult};
+use strata_core::{PrimitiveDegradedReason, StrataError, StrataResult};
+
+use crate::database::Database;
 
 // =============================================================================
 // Index Types
@@ -273,14 +276,63 @@ pub fn extract_field_value(doc_value: &JsonValue, field_path: &str) -> Option<Js
 use std::collections::HashSet;
 use strata_concurrency::TransactionContext;
 
+/// Fail-closed helper (B5.4): extract `doc_id` from an index entry's
+/// `user_key` or register a degradation and return a typed error.
+///
+/// Per the B5 convergence contract
+/// (`docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+/// §"Surface matrix" row "JSON secondary index rows"), a corrupt
+/// `_idx` row must fail closed rather than be silently filtered out
+/// of the result set.
+fn extract_doc_id_or_degrade(
+    db: &Database,
+    branch_id: &BranchId,
+    space: &str,
+    user_key: &[u8],
+) -> StrataResult<String> {
+    if let Some(id) = extract_doc_id_from_index_key(user_key) {
+        return Ok(id);
+    }
+    let entry = crate::database::primitive_degradation::mark_primitive_degraded(
+        db,
+        *branch_id,
+        PrimitiveType::Json,
+        space,
+        PrimitiveDegradedReason::IndexEntryCorrupt,
+        "index entry user_key missing separator or non-utf8 doc_id",
+    );
+    Err(entry
+        .map(|e| e.to_error())
+        .unwrap_or_else(|| StrataError::serialization("corrupt secondary index entry")))
+}
+
+/// Fail-closed gate (B5.4): if `(branch_id, Json, space)` is already
+/// marked degraded, return the typed error without touching storage.
+/// Callers put this at the top of every `_idx` read path so repeat
+/// lookups after a mark short-circuit rather than re-scanning the
+/// corrupt index.
+fn reject_if_space_degraded(db: &Database, branch_id: &BranchId, space: &str) -> StrataResult<()> {
+    if let Some(err) = crate::database::primitive_degradation::primitive_degraded_error(
+        db,
+        *branch_id,
+        PrimitiveType::Json,
+        space,
+    ) {
+        return Err(err);
+    }
+    Ok(())
+}
+
 /// Look up all doc_ids matching an exact value in an index.
 pub fn lookup_eq(
+    db: &Database,
     txn: &mut TransactionContext,
     branch_id: &BranchId,
     space: &str,
     index_name: &str,
     encoded_value: &[u8],
 ) -> StrataResult<Vec<String>> {
+    reject_if_space_degraded(db, branch_id, space)?;
     // Scan with encoded_value ++ separator as prefix, so "active" doesn't
     // false-match "actively" (both start with "active" but only "active\xFF"
     // matches "active\xFF<doc_id>").
@@ -289,10 +341,16 @@ pub fn lookup_eq(
     exact_prefix.push(INDEX_KEY_SEPARATOR);
     let prefix = index_value_prefix(branch_id, space, index_name, &exact_prefix);
     let entries = txn.scan_prefix(&prefix)?;
-    Ok(entries
-        .iter()
-        .filter_map(|(k, _)| extract_doc_id_from_index_key(&k.user_key))
-        .collect())
+    let mut out = Vec::with_capacity(entries.len());
+    for (k, _) in entries.iter() {
+        out.push(extract_doc_id_or_degrade(
+            db,
+            branch_id,
+            space,
+            &k.user_key,
+        )?);
+    }
+    Ok(out)
 }
 
 /// Look up all doc_ids in a value range [lower, upper].
@@ -301,6 +359,7 @@ pub fn lookup_eq(
 /// Both bounds are optional (None = unbounded on that side).
 #[allow(clippy::too_many_arguments)]
 pub fn lookup_range(
+    db: &Database,
     txn: &mut TransactionContext,
     branch_id: &BranchId,
     space: &str,
@@ -310,16 +369,30 @@ pub fn lookup_range(
     lower_inclusive: bool,
     upper_inclusive: bool,
 ) -> StrataResult<Vec<String>> {
+    reject_if_space_degraded(db, branch_id, space)?;
     let prefix = index_scan_prefix(branch_id, space, index_name);
     let entries = txn.scan_prefix(&prefix)?;
 
     let mut doc_ids = Vec::new();
     for (key, _) in &entries {
         let user_key = &key.user_key;
-        // Find the separator to split value from doc_id
+        // Find the separator to split value from doc_id. Missing
+        // separator is B5.4 fail-closed: mark degradation and error.
         let sep_pos = match user_key.iter().rposition(|&b| b == INDEX_KEY_SEPARATOR) {
             Some(pos) => pos,
-            None => continue,
+            None => {
+                let entry = crate::database::primitive_degradation::mark_primitive_degraded(
+                    db,
+                    *branch_id,
+                    PrimitiveType::Json,
+                    space,
+                    PrimitiveDegradedReason::IndexEntryCorrupt,
+                    "index entry user_key missing separator in lookup_range",
+                );
+                return Err(entry.map(|e| e.to_error()).unwrap_or_else(|| {
+                    StrataError::serialization("corrupt secondary index entry")
+                }));
+            }
         };
         let value_bytes = &user_key[..sep_pos];
 
@@ -345,27 +418,33 @@ pub fn lookup_range(
             }
         }
 
-        if let Some(doc_id) = extract_doc_id_from_index_key(user_key) {
-            doc_ids.push(doc_id);
-        }
+        doc_ids.push(extract_doc_id_or_degrade(db, branch_id, space, user_key)?);
     }
     Ok(doc_ids)
 }
 
 /// Look up all doc_ids matching a text prefix in an index.
 pub fn lookup_prefix(
+    db: &Database,
     txn: &mut TransactionContext,
     branch_id: &BranchId,
     space: &str,
     index_name: &str,
     prefix_bytes: &[u8],
 ) -> StrataResult<Vec<String>> {
+    reject_if_space_degraded(db, branch_id, space)?;
     let prefix = index_value_prefix(branch_id, space, index_name, prefix_bytes);
     let entries = txn.scan_prefix(&prefix)?;
-    Ok(entries
-        .iter()
-        .filter_map(|(k, _)| extract_doc_id_from_index_key(&k.user_key))
-        .collect())
+    let mut out = Vec::with_capacity(entries.len());
+    for (k, _) in entries.iter() {
+        out.push(extract_doc_id_or_degrade(
+            db,
+            branch_id,
+            space,
+            &k.user_key,
+        )?);
+    }
+    Ok(out)
 }
 
 /// Scan all entries of an index in order, returning doc_ids in index value order.
@@ -373,23 +452,32 @@ pub fn lookup_prefix(
 /// Used for sort-by-indexed-field: the KV layer stores index entries in
 /// order-preserving byte order, so a prefix scan returns them sorted.
 pub fn scan_index_ordered(
+    db: &Database,
     txn: &mut TransactionContext,
     branch_id: &BranchId,
     space: &str,
     index_name: &str,
 ) -> StrataResult<Vec<String>> {
+    reject_if_space_degraded(db, branch_id, space)?;
     let prefix = index_scan_prefix(branch_id, space, index_name);
     let entries = txn.scan_prefix(&prefix)?;
-    Ok(entries
-        .iter()
-        .filter_map(|(k, _)| extract_doc_id_from_index_key(&k.user_key))
-        .collect())
+    let mut out = Vec::with_capacity(entries.len());
+    for (k, _) in entries.iter() {
+        out.push(extract_doc_id_or_degrade(
+            db,
+            branch_id,
+            space,
+            &k.user_key,
+        )?);
+    }
+    Ok(out)
 }
 
 /// Resolve a FieldFilter against available indexes, returning matching doc_ids.
 ///
 /// Returns an error if a predicate references a field with no corresponding index.
 pub fn resolve_filter(
+    db: &Database,
     txn: &mut TransactionContext,
     branch_id: &BranchId,
     space: &str,
@@ -399,11 +487,11 @@ pub fn resolve_filter(
     use crate::search::FieldFilter;
 
     match filter {
-        FieldFilter::Predicate(pred) => resolve_predicate(txn, branch_id, space, pred, indexes),
+        FieldFilter::Predicate(pred) => resolve_predicate(db, txn, branch_id, space, pred, indexes),
         FieldFilter::And(filters) => {
             let mut result: Option<HashSet<String>> = None;
             for f in filters {
-                let set = resolve_filter(txn, branch_id, space, f, indexes)?;
+                let set = resolve_filter(db, txn, branch_id, space, f, indexes)?;
                 result = Some(match result {
                     Some(acc) => acc.intersection(&set).cloned().collect(),
                     None => set,
@@ -414,7 +502,7 @@ pub fn resolve_filter(
         FieldFilter::Or(filters) => {
             let mut result = HashSet::new();
             for f in filters {
-                let set = resolve_filter(txn, branch_id, space, f, indexes)?;
+                let set = resolve_filter(db, txn, branch_id, space, f, indexes)?;
                 result.extend(set);
             }
             Ok(result)
@@ -424,6 +512,7 @@ pub fn resolve_filter(
 
 /// Resolve a single predicate against indexes.
 fn resolve_predicate(
+    db: &Database,
     txn: &mut TransactionContext,
     branch_id: &BranchId,
     space: &str,
@@ -441,7 +530,7 @@ fn resolve_predicate(
                     idx.name, idx.index_type
                 ))
             })?;
-            let doc_ids = lookup_eq(txn, branch_id, space, &idx.name, &encoded)?;
+            let doc_ids = lookup_eq(db, txn, branch_id, space, &idx.name, &encoded)?;
             Ok(doc_ids.into_iter().collect())
         }
         FieldPredicate::Range {
@@ -471,6 +560,7 @@ fn resolve_predicate(
                 None => None,
             };
             let doc_ids = lookup_range(
+                db,
                 txn,
                 branch_id,
                 space,
@@ -485,7 +575,7 @@ fn resolve_predicate(
         FieldPredicate::Prefix { field, prefix } => {
             let idx = find_index_for_field(field, indexes)?;
             let prefix_bytes = encode_text(prefix);
-            let doc_ids = lookup_prefix(txn, branch_id, space, &idx.name, &prefix_bytes)?;
+            let doc_ids = lookup_prefix(db, txn, branch_id, space, &idx.name, &prefix_bytes)?;
             Ok(doc_ids.into_iter().collect())
         }
     }

--- a/crates/engine/src/primitives/json/mod.rs
+++ b/crates/engine/src/primitives/json/mod.rs
@@ -302,7 +302,7 @@ impl JsonStore {
             txn.put(key.clone(), serialized)?;
 
             // Update secondary indexes
-            let indexes = Self::load_indexes(txn, branch_id, space)?;
+            let indexes = Self::load_indexes(self.db.as_ref(), txn, branch_id, space)?;
             if !indexes.is_empty() {
                 Self::update_index_entries(
                     txn,
@@ -598,7 +598,7 @@ impl JsonStore {
         let key = self.key_for(branch_id, space, doc_id);
         let result = self.db.transaction(*branch_id, |txn| {
             crate::primitives::space::ensure_space_registered_in_txn(txn, branch_id, space)?;
-            let indexes = Self::load_indexes(txn, branch_id, space)?;
+            let indexes = Self::load_indexes(self.db.as_ref(), txn, branch_id, space)?;
             Self::set_in_txn(
                 txn, &key, doc_id, path, value, true, branch_id, space, &indexes,
             )
@@ -639,7 +639,7 @@ impl JsonStore {
 
         let results = self.db.transaction(*branch_id, |txn| {
             crate::primitives::space::ensure_space_registered_in_txn(txn, branch_id, space)?;
-            let indexes = Self::load_indexes(txn, branch_id, space)?;
+            let indexes = Self::load_indexes(self.db.as_ref(), txn, branch_id, space)?;
             let mut results = Vec::with_capacity(entries.len());
             for (doc_id, path, value) in &entries {
                 let key = self.key_for(branch_id, space, doc_id);
@@ -761,7 +761,7 @@ impl JsonStore {
         let key = self.key_for(branch_id, space, doc_id);
         let (version, doc_value) = self.db.transaction(*branch_id, |txn| {
             crate::primitives::space::ensure_space_registered_in_txn(txn, branch_id, space)?;
-            let indexes = Self::load_indexes(txn, branch_id, space)?;
+            let indexes = Self::load_indexes(self.db.as_ref(), txn, branch_id, space)?;
             Self::set_in_txn(
                 txn, &key, doc_id, path, value, false, branch_id, space, &indexes,
             )
@@ -809,7 +809,7 @@ impl JsonStore {
         let key = self.key_for(branch_id, space, doc_id);
 
         self.db.transaction(*branch_id, |txn| {
-            let indexes = Self::load_indexes(txn, branch_id, space)?;
+            let indexes = Self::load_indexes(self.db.as_ref(), txn, branch_id, space)?;
 
             // Load existing document
             let stored = txn.get(&key)?.ok_or_else(|| {
@@ -873,7 +873,7 @@ impl JsonStore {
         let key = self.key_for(branch_id, space, doc_id);
 
         self.db.transaction(*branch_id, |txn| {
-            let indexes = Self::load_indexes(txn, branch_id, space)?;
+            let indexes = Self::load_indexes(self.db.as_ref(), txn, branch_id, space)?;
 
             // Check if document exists and get value for index cleanup
             let stored = match txn.get(&key)? {
@@ -916,7 +916,7 @@ impl JsonStore {
         }
 
         self.db.transaction(*branch_id, |txn| {
-            let indexes = Self::load_indexes(txn, branch_id, space)?;
+            let indexes = Self::load_indexes(self.db.as_ref(), txn, branch_id, space)?;
             let mut results = Vec::with_capacity(doc_ids.len());
             for doc_id in doc_ids {
                 let key = self.key_for(branch_id, space, doc_id);
@@ -966,7 +966,7 @@ impl JsonStore {
         }
 
         self.db.transaction(*branch_id, |txn| {
-            let indexes = Self::load_indexes(txn, branch_id, space)?;
+            let indexes = Self::load_indexes(self.db.as_ref(), txn, branch_id, space)?;
             let mut results = Vec::with_capacity(entries.len());
             for (doc_id, path) in entries {
                 let key = self.key_for(branch_id, space, doc_id);
@@ -1356,11 +1356,32 @@ impl JsonStore {
     ///
     /// `pub(crate)` so `branch_ops::primitive_merge::JsonMergeHandler` can
     /// re-derive index entries for documents touched by a JSON merge.
+    ///
+    /// Per the B5 convergence contract
+    /// (`docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+    /// §"Surface matrix" row "JSON secondary index rows"), if `_idx`
+    /// metadata cannot be trusted this call fails closed with a typed
+    /// [`StrataError::PrimitiveDegraded`] rather than returning an
+    /// empty or partial result set. A degradation is also recorded on
+    /// the per-Database primitive-degradation registry so subsequent
+    /// reads short-circuit without re-scanning the corrupt metadata.
     pub(crate) fn load_indexes(
+        db: &Database,
         txn: &mut TransactionContext,
         branch_id: &BranchId,
         space: &str,
     ) -> StrataResult<Vec<index::IndexDef>> {
+        // B5.4 fail-closed: if this (branch, Json, space) is already
+        // marked degraded, return the typed error without re-scanning.
+        if let Some(err) = crate::database::primitive_degradation::primitive_degraded_error(
+            db,
+            *branch_id,
+            strata_core::contract::PrimitiveType::Json,
+            space,
+        ) {
+            return Err(err);
+        }
+
         let meta_space = index::index_meta_space_name(space);
         let meta_ns = Arc::new(Namespace::for_branch_space(*branch_id, &meta_space));
         let scan_prefix = Key::new_json(meta_ns, "");
@@ -1369,10 +1390,25 @@ impl JsonStore {
         let mut indexes = Vec::new();
         for (_, value) in entries {
             if let Value::Bytes(bytes) = &value {
-                let def = serde_json::from_slice::<index::IndexDef>(bytes).map_err(|e| {
-                    StrataError::serialization(format!("corrupt index metadata: {}", e))
-                })?;
-                indexes.push(def);
+                match serde_json::from_slice::<index::IndexDef>(bytes) {
+                    Ok(def) => indexes.push(def),
+                    Err(e) => {
+                        // Mark and fail closed — corrupt index metadata
+                        // means the index cannot be trusted to return
+                        // complete results.
+                        let entry = crate::database::primitive_degradation::mark_primitive_degraded(
+                            db,
+                            *branch_id,
+                            strata_core::contract::PrimitiveType::Json,
+                            space,
+                            strata_core::PrimitiveDegradedReason::IndexMetadataCorrupt,
+                            format!("{e}"),
+                        );
+                        return Err(entry.map(|e| e.to_error()).unwrap_or_else(|| {
+                            StrataError::serialization(format!("corrupt index metadata: {}", e))
+                        }));
+                    }
+                }
             }
         }
         Ok(indexes)
@@ -1550,11 +1586,12 @@ impl crate::search::Searchable for JsonStore {
         }
 
         self.db.transaction(req.branch_id, |txn| {
-            let indexes = Self::load_indexes(txn, &req.branch_id, &req.space)?;
+            let indexes = Self::load_indexes(self.db.as_ref(), txn, &req.branch_id, &req.space)?;
 
             // Resolve field filter to candidate set (if present)
             let filter_set: Option<HashSet<String>> = match &req.field_filter {
                 Some(filter) => Some(index::resolve_filter(
+                    self.db.as_ref(),
                     txn,
                     &req.branch_id,
                     &req.space,
@@ -1568,8 +1605,13 @@ impl crate::search::Searchable for JsonStore {
             let ordered_doc_ids: Vec<String> = if let Some(sort) = &req.sort_by {
                 // Sort by indexed field: scan the index in order
                 let sort_idx = index::find_index_for_field(&sort.field, &indexes)?;
-                let mut sorted =
-                    index::scan_index_ordered(txn, &req.branch_id, &req.space, &sort_idx.name)?;
+                let mut sorted = index::scan_index_ordered(
+                    self.db.as_ref(),
+                    txn,
+                    &req.branch_id,
+                    &req.space,
+                    &sort_idx.name,
+                )?;
 
                 // If there's a filter, retain only matching docs (preserving sort order)
                 if let Some(ref fset) = filter_set {

--- a/crates/vector/src/error.rs
+++ b/crates/vector/src/error.rs
@@ -114,6 +114,16 @@ pub enum VectorError {
     /// Database error
     #[error("Database error: {0}")]
     Database(String),
+
+    /// Collection is fail-closed degraded (B5.4).
+    ///
+    /// Carries a pre-built [`StrataError::PrimitiveDegraded`] so the
+    /// branch-aware attribution captured at mark time survives the
+    /// conversion to `StrataError`. See
+    /// `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+    /// §"Surface matrix" row "vector in-memory / HNSW state".
+    #[error(transparent)]
+    Degraded(#[from] Box<StrataError>),
 }
 
 impl VectorError {
@@ -136,7 +146,8 @@ impl VectorError {
             | VectorError::Serialization(_)
             | VectorError::Internal(_)
             | VectorError::Io(_)
-            | VectorError::Database(_) => false,
+            | VectorError::Database(_)
+            | VectorError::Degraded(_) => false,
 
             // Catch-all for future variants (due to #[non_exhaustive])
             #[allow(unreachable_patterns)]
@@ -170,7 +181,8 @@ impl VectorError {
             | VectorError::Serialization(_)
             | VectorError::Internal(_)
             | VectorError::Io(_)
-            | VectorError::Database(_) => false,
+            | VectorError::Database(_)
+            | VectorError::Degraded(_) => false,
 
             // Catch-all for future variants (due to #[non_exhaustive])
             #[allow(unreachable_patterns)]
@@ -219,6 +231,7 @@ impl VectorError {
                 entity_ref: Box::new(EntityRef::vector(branch_id, UNKNOWN_SPACE, collection, "")),
                 reason: format!("Config field '{}' cannot be changed", field),
             },
+            VectorError::Degraded(inner) => *inner,
             // Remaining variants don't use branch context — delegate to From impl
             other => StrataError::from(other),
         }
@@ -305,6 +318,7 @@ impl From<VectorError> for StrataError {
                 message: format!("Database error: {}", msg),
                 source: None,
             },
+            VectorError::Degraded(inner) => *inner,
 
             // Catch-all for future variants (due to #[non_exhaustive])
             #[allow(unreachable_patterns)]

--- a/crates/vector/src/recovery.rs
+++ b/crates/vector/src/recovery.rs
@@ -30,11 +30,39 @@
 //! mismatch, recovery falls back transparently to full KV-based rebuild
 //! with no data loss.
 
+#[cfg(test)]
+use std::cell::Cell;
+#[cfg(test)]
+use std::io;
+
 use strata_core::id::CommitVersion;
 use strata_core::StrataResult;
 use strata_engine::database::observers::{AbortInfo, AbortObserver};
 use strata_engine::Database;
 use tracing::info;
+
+#[cfg(test)]
+thread_local! {
+    static VECTOR_SCAN_FAILURE: Cell<Option<io::ErrorKind>> = const { Cell::new(None) };
+}
+
+#[cfg(test)]
+fn inject_vector_scan_failure_for_test(kind: io::ErrorKind) {
+    VECTOR_SCAN_FAILURE.with(|slot| slot.set(Some(kind)));
+}
+
+#[cfg(test)]
+fn clear_vector_scan_failure_for_test() {
+    VECTOR_SCAN_FAILURE.with(|slot| slot.set(None));
+}
+
+#[cfg(test)]
+fn maybe_inject_vector_scan_failure_for_test() -> Option<io::Error> {
+    VECTOR_SCAN_FAILURE.with(|slot| {
+        slot.take()
+            .map(|kind| io::Error::new(kind, "injected vector recovery scan failure"))
+    })
+}
 
 /// Recovery function for VectorStore
 ///
@@ -341,23 +369,38 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
                 // Scan KV for vector entries
                 // -----------------------------------------------------------
                 let vector_prefix = Key::new_vector(ns.clone(), &collection_name, "");
-                let vector_entries =
-                    match db.storage().scan_prefix(&vector_prefix, snapshot_version) {
-                        Ok(entries) => entries,
-                        Err(e) => {
-                            tracing::warn!(
-                                target: "strata::vector",
-                                collection = %collection_name,
-                                error = %e,
-                                "Failed to scan vectors during recovery"
-                            );
-                            // If mmap loaded, the backend has embeddings but no timestamps;
-                            // proceed anyway so rebuild_index() at least builds the graph.
-                            state.backends.insert(collection_id.clone(), backend);
-                            stats.collections_created += 1;
-                            continue;
-                        }
-                    };
+                #[cfg(test)]
+                let scan_result = if let Some(err) = maybe_inject_vector_scan_failure_for_test() {
+                    Err(err.into())
+                } else {
+                    db.storage().scan_prefix(&vector_prefix, snapshot_version)
+                };
+                #[cfg(not(test))]
+                let scan_result = db.storage().scan_prefix(&vector_prefix, snapshot_version);
+
+                let vector_entries = match scan_result {
+                    Ok(entries) => entries,
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "strata::vector",
+                            collection = %collection_name,
+                            error = %e,
+                            "Failed to scan vectors during recovery; marking collection degraded"
+                        );
+                        // B5.4 — vector rebuild failure must fail closed. A
+                        // partial mmap-only or empty backend is not trusted
+                        // enough to serve branch-visible reads.
+                        strata_engine::database::primitive_degradation::mark_primitive_degraded(
+                            db,
+                            branch_id,
+                            strata_core::contract::PrimitiveType::Vector,
+                            &collection_name,
+                            strata_core::PrimitiveDegradedReason::ConfigMismatch,
+                            format!("failed to scan vectors during recovery: {e}"),
+                        );
+                        continue;
+                    }
+                };
 
                 let collection_prefix = format!("{}/", collection_name);
                 for (vec_key, vec_versioned) in &vector_entries {
@@ -373,7 +416,15 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
                             tracing::warn!(
                                 target: "strata::vector",
                                 error = %e,
-                                "Failed to decode vector record during recovery, skipping"
+                                "Failed to decode vector record during recovery; marking collection degraded"
+                            );
+                            strata_engine::database::primitive_degradation::mark_primitive_degraded(
+                                db,
+                                branch_id,
+                                strata_core::contract::PrimitiveType::Vector,
+                                &collection_name,
+                                strata_core::PrimitiveDegradedReason::ConfigMismatch,
+                                format!("{e}"),
                             );
                             continue;
                         }
@@ -387,11 +438,28 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
                         stats.vectors_mmap_registered += 1;
                     } else if loaded_from_mmap && !vec_record.embedding.is_empty() {
                         // Vector in KV but not in mmap (added after last freeze) — insert from KV
-                        let _ = backend.insert_with_id_and_timestamp(
+                        if let Err(e) = backend.insert_with_id_and_timestamp(
                             vid,
                             &vec_record.embedding,
                             vec_record.created_at,
-                        );
+                        ) {
+                            tracing::warn!(
+                                target: "strata::vector",
+                                collection = %collection_name,
+                                vector_id = vec_record.vector_id,
+                                error = %e,
+                                "Failed to insert vector during recovery; marking collection degraded"
+                            );
+                            strata_engine::database::primitive_degradation::mark_primitive_degraded(
+                                db,
+                                branch_id,
+                                strata_core::contract::PrimitiveType::Vector,
+                                &collection_name,
+                                strata_core::PrimitiveDegradedReason::ConfigMismatch,
+                                format!("{e}"),
+                            );
+                            continue;
+                        }
                         stats.vectors_upserted += 1;
                     } else if vec_record.embedding.is_empty() {
                         // Legacy record with no embedding (pre-#1962 lite mode or
@@ -405,11 +473,28 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
                         continue;
                     } else {
                         // Full KV-based recovery: insert embedding + timestamp
-                        let _ = backend.insert_with_id_and_timestamp(
+                        if let Err(e) = backend.insert_with_id_and_timestamp(
                             vid,
                             &vec_record.embedding,
                             vec_record.created_at,
-                        );
+                        ) {
+                            tracing::warn!(
+                                target: "strata::vector",
+                                collection = %collection_name,
+                                vector_id = vec_record.vector_id,
+                                error = %e,
+                                "Failed to insert vector during recovery; marking collection degraded"
+                            );
+                            strata_engine::database::primitive_degradation::mark_primitive_degraded(
+                                db,
+                                branch_id,
+                                strata_core::contract::PrimitiveType::Vector,
+                                &collection_name,
+                                strata_core::PrimitiveDegradedReason::ConfigMismatch,
+                                format!("{e}"),
+                            );
+                            continue;
+                        }
                         stats.vectors_upserted += 1;
                     }
 
@@ -1219,6 +1304,91 @@ mod tests {
         assert_ne!(ga, gb);
         assert!(ga.to_string_lossy().contains("tenant_a"));
         assert!(gb.to_string_lossy().contains("tenant_b"));
+    }
+
+    #[test]
+    fn test_recovery_vector_scan_failure_marks_collection_degraded_and_fails_closed() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let branch_name = "main";
+        let branch_id = strata_engine::primitives::branch::resolve_branch_name(branch_name);
+
+        {
+            let db = Database::open_runtime(
+                OpenSpec::primary(temp.path())
+                    .with_subsystem(VectorSubsystem)
+                    .with_subsystem(strata_engine::SearchSubsystem),
+            )
+            .unwrap();
+            let store = VectorStore::new(db.clone());
+
+            db.branches().create(branch_name).unwrap();
+            store
+                .create_collection(
+                    branch_id,
+                    "default",
+                    "embeddings",
+                    crate::VectorConfig::new(3, DistanceMetric::Cosine).unwrap(),
+                )
+                .unwrap();
+            store
+                .insert(
+                    branch_id,
+                    "default",
+                    "embeddings",
+                    "v1",
+                    &[1.0, 0.0, 0.0],
+                    None,
+                )
+                .unwrap();
+        }
+
+        clear_vector_scan_failure_for_test();
+        inject_vector_scan_failure_for_test(std::io::ErrorKind::Other);
+
+        let db = Database::open_runtime(
+            OpenSpec::primary(temp.path())
+                .with_subsystem(VectorSubsystem)
+                .with_subsystem(strata_engine::SearchSubsystem),
+        )
+        .unwrap();
+        let store = VectorStore::new(db.clone());
+
+        let registry = db
+            .extension::<strata_engine::PrimitiveDegradationRegistry>()
+            .unwrap();
+        let entry = registry
+            .lookup(
+                branch_id,
+                strata_core::contract::PrimitiveType::Vector,
+                "embeddings",
+            )
+            .expect("scan failure must mark the collection degraded");
+        assert_eq!(
+            entry.reason,
+            strata_core::PrimitiveDegradedReason::ConfigMismatch
+        );
+
+        let err = store
+            .search(
+                branch_id,
+                "default",
+                "embeddings",
+                &[1.0, 0.0, 0.0],
+                5,
+                None,
+            )
+            .expect_err("degraded collection must fail closed after reopen");
+        match strata_core::StrataError::from(err) {
+            strata_core::StrataError::PrimitiveDegraded {
+                primitive, name, ..
+            } => {
+                assert_eq!(primitive, strata_core::contract::PrimitiveType::Vector);
+                assert_eq!(name, "embeddings");
+            }
+            other => panic!("expected PrimitiveDegraded, got {other:?}"),
+        }
+
+        clear_vector_scan_failure_for_test();
     }
 
     #[test]

--- a/crates/vector/src/recovery.rs
+++ b/crates/vector/src/recovery.rs
@@ -40,7 +40,7 @@ use tracing::info;
 ///
 /// Called by Database during startup to restore vector state from KV store.
 fn recover_vector_state(db: &std::sync::Arc<Database>) -> StrataResult<()> {
-    recover_from_db(db)?;
+    recover_from_db(db.as_ref())?;
 
     // Register the lifecycle hook used for freeze-to-disk and merge reloads.
     register_vector_lifecycle_hook(db);
@@ -238,7 +238,19 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
                     _ => continue,
                 };
 
-                // Decode the CollectionRecord
+                // Extract collection name from the key's user_key ("__config__/{name}")
+                // before decoding so we can attribute a degradation to a
+                // named primitive even if decode fails (B5.4).
+                let collection_name = match key.user_key_string() {
+                    Some(raw) => raw.strip_prefix("__config__/").unwrap_or(&raw).to_string(),
+                    None => continue,
+                };
+
+                // Decode the CollectionRecord. On failure this collection
+                // must fail closed for subsequent reads rather than be
+                // silently dropped from recovery — see
+                // `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+                // §"Surface matrix" row "vector in-memory / HNSW state".
                 let record = match super::CollectionRecord::from_bytes(config_bytes) {
                     Ok(r) => r,
                     Err(e) => {
@@ -246,16 +258,18 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
                             target: "strata::vector",
                             key = ?key,
                             error = %e,
-                            "Failed to decode collection record during recovery, skipping"
+                            "Failed to decode collection record during recovery; marking collection degraded"
+                        );
+                        strata_engine::database::primitive_degradation::mark_primitive_degraded(
+                            db,
+                            branch_id,
+                            strata_core::contract::PrimitiveType::Vector,
+                            &collection_name,
+                            strata_core::PrimitiveDegradedReason::ConfigDecodeFailure,
+                            format!("{e}"),
                         );
                         continue;
                     }
-                };
-
-                // Extract collection name from the key's user_key ("__config__/{name}")
-                let collection_name = match key.user_key_string() {
-                    Some(raw) => raw.strip_prefix("__config__/").unwrap_or(&raw).to_string(),
-                    None => continue,
                 };
 
                 // Read backend type before consuming record.config (Issue #1964)
@@ -268,7 +282,15 @@ fn recover_from_db(db: &Database) -> StrataResult<()> {
                             target: "strata::vector",
                             collection = %collection_name,
                             error = %e,
-                            "Failed to convert collection config during recovery, skipping"
+                            "Failed to convert collection config during recovery; marking collection degraded"
+                        );
+                        strata_engine::database::primitive_degradation::mark_primitive_degraded(
+                            db,
+                            branch_id,
+                            strata_core::contract::PrimitiveType::Vector,
+                            &collection_name,
+                            strata_core::PrimitiveDegradedReason::ConfigShapeConversion,
+                            format!("{e}"),
                         );
                         continue;
                     }

--- a/crates/vector/src/store/mod.rs
+++ b/crates/vector/src/store/mod.rs
@@ -356,10 +356,23 @@ impl VectorStore {
             let vec_record = match VectorRecord::from_bytes(vec_bytes) {
                 Ok(r) => r,
                 Err(e) => {
+                    // B5.4 — corrupt vector bytes mean the collection
+                    // cannot be reconstructed safely; mark degraded so
+                    // subsequent reads fail closed rather than returning
+                    // partial / wrong data. Per convergence matrix row
+                    // "vector in-memory / HNSW state".
                     warn!(
                         target: "strata::vector",
                         error = %e,
-                        "Failed to decode vector record during reload, skipping"
+                        "Failed to decode vector record during reload; marking collection degraded"
+                    );
+                    strata_engine::database::primitive_degradation::mark_primitive_degraded(
+                        &self.db,
+                        id.branch_id,
+                        strata_core::contract::PrimitiveType::Vector,
+                        &id.name,
+                        strata_core::PrimitiveDegradedReason::ConfigMismatch,
+                        format!("{e}"),
                     );
                     continue;
                 }
@@ -636,6 +649,20 @@ impl VectorStore {
     ) -> VectorResult<()> {
         let collection_id = CollectionId::new(branch_id, space, name);
         let state = self.state()?;
+
+        // B5.4 — fail closed if this collection was marked degraded by
+        // an earlier recovery or lazy-load attempt. Per the B5
+        // convergence contract matrix row "vector in-memory / HNSW
+        // state": config mismatch or rebuild failure must fail closed,
+        // not silently fall back to wrong data.
+        if let Some(err) = strata_engine::database::primitive_degradation::primitive_degraded_error(
+            &self.db,
+            branch_id,
+            strata_core::contract::PrimitiveType::Vector,
+            name,
+        ) {
+            return Err(VectorError::Degraded(Box::new(err)));
+        }
 
         // Fast path: check without entry overhead
         if state.backends.contains_key(&collection_id) {

--- a/crates/vector/src/store/mod.rs
+++ b/crates/vector/src/store/mod.rs
@@ -366,15 +366,22 @@ impl VectorStore {
                         error = %e,
                         "Failed to decode vector record during reload; marking collection degraded"
                     );
-                    strata_engine::database::primitive_degradation::mark_primitive_degraded(
-                        &self.db,
-                        id.branch_id,
-                        strata_core::contract::PrimitiveType::Vector,
-                        &id.name,
-                        strata_core::PrimitiveDegradedReason::ConfigMismatch,
-                        format!("{e}"),
-                    );
-                    continue;
+                    let err =
+                        strata_engine::database::primitive_degradation::mark_primitive_degraded(
+                            &self.db,
+                            id.branch_id,
+                            strata_core::contract::PrimitiveType::Vector,
+                            &id.name,
+                            strata_core::PrimitiveDegradedReason::ConfigMismatch,
+                            format!("{e}"),
+                        )
+                        .map(|entry| entry.to_error())
+                        .unwrap_or_else(|| {
+                            strata_core::StrataError::serialization(format!(
+                                "corrupt vector record during reload: {e}"
+                            ))
+                        });
+                    return Err(VectorError::Degraded(Box::new(err)));
                 }
             };
 
@@ -385,11 +392,35 @@ impl VectorStore {
             } else if vec_record.embedding.is_empty() {
                 continue; // legacy empty-embedding record — skip
             } else {
-                let _ = backend.insert_with_id_and_timestamp(
+                if let Err(e) = backend.insert_with_id_and_timestamp(
                     vid,
                     &vec_record.embedding,
                     vec_record.created_at,
-                );
+                ) {
+                    warn!(
+                        target: "strata::vector",
+                        collection = %id.name,
+                        vector_id = vec_record.vector_id,
+                        error = %e,
+                        "Failed to insert vector during reload; marking collection degraded"
+                    );
+                    let err =
+                        strata_engine::database::primitive_degradation::mark_primitive_degraded(
+                            &self.db,
+                            id.branch_id,
+                            strata_core::contract::PrimitiveType::Vector,
+                            &id.name,
+                            strata_core::PrimitiveDegradedReason::ConfigMismatch,
+                            format!("{e}"),
+                        )
+                        .map(|entry| entry.to_error())
+                        .unwrap_or_else(|| {
+                            strata_core::StrataError::serialization(format!(
+                                "failed to insert vector during reload: {e}"
+                            ))
+                        });
+                    return Err(VectorError::Degraded(Box::new(err)));
+                }
             }
 
             // Populate inline metadata for O(1) search resolution

--- a/tests/integration/branching.rs
+++ b/tests/integration/branching.rs
@@ -5211,8 +5211,22 @@ fn json_merge_secondary_index_refreshed_post_commit() {
     test_db
         .db
         .transaction(target_id, |txn| {
-            hits_25 = index::lookup_eq(txn, &target_id, "default", "price_idx", &encoded_25)?;
-            hits_10 = index::lookup_eq(txn, &target_id, "default", "price_idx", &encoded_10)?;
+            hits_25 = index::lookup_eq(
+                test_db.db.as_ref(),
+                txn,
+                &target_id,
+                "default",
+                "price_idx",
+                &encoded_25,
+            )?;
+            hits_10 = index::lookup_eq(
+                test_db.db.as_ref(),
+                txn,
+                &target_id,
+                "default",
+                "price_idx",
+                &encoded_10,
+            )?;
             Ok(())
         })
         .unwrap();
@@ -5296,7 +5310,14 @@ fn json_merge_source_only_new_doc_propagates() {
     test_db
         .db
         .transaction(target_id, |txn| {
-            hits = index::lookup_eq(txn, &target_id, "default", "qty_idx", &encoded_7)?;
+            hits = index::lookup_eq(
+                test_db.db.as_ref(),
+                txn,
+                &target_id,
+                "default",
+                "qty_idx",
+                &encoded_7,
+            )?;
             Ok(())
         })
         .unwrap();
@@ -5382,7 +5403,14 @@ fn json_merge_source_deletes_doc_propagates() {
     test_db
         .db
         .transaction(target_id, |txn| {
-            hits = index::lookup_eq(txn, &target_id, "default", "qty_idx", &encoded_99)?;
+            hits = index::lookup_eq(
+                test_db.db.as_ref(),
+                txn,
+                &target_id,
+                "default",
+                "qty_idx",
+                &encoded_99,
+            )?;
             Ok(())
         })
         .unwrap();
@@ -5575,8 +5603,22 @@ fn json_merge_path_level_via_cherry_pick() {
     test_db
         .db
         .transaction(target_id, |txn| {
-            hits_42 = index::lookup_eq(txn, &target_id, "default", "price_idx", &encoded_42)?;
-            hits_10 = index::lookup_eq(txn, &target_id, "default", "price_idx", &encoded_10)?;
+            hits_42 = index::lookup_eq(
+                test_db.db.as_ref(),
+                txn,
+                &target_id,
+                "default",
+                "price_idx",
+                &encoded_42,
+            )?;
+            hits_10 = index::lookup_eq(
+                test_db.db.as_ref(),
+                txn,
+                &target_id,
+                "default",
+                "price_idx",
+                &encoded_10,
+            )?;
             Ok(())
         })
         .unwrap();
@@ -5651,7 +5693,14 @@ fn json_merge_both_sides_deleted_doc_no_action() {
     test_db
         .db
         .transaction(target_id, |txn| {
-            pre_merge_hits = index::lookup_eq(txn, &target_id, "default", "qty_idx", &encoded_5)?;
+            pre_merge_hits = index::lookup_eq(
+                test_db.db.as_ref(),
+                txn,
+                &target_id,
+                "default",
+                "qty_idx",
+                &encoded_5,
+            )?;
             Ok(())
         })
         .unwrap();
@@ -5683,7 +5732,14 @@ fn json_merge_both_sides_deleted_doc_no_action() {
     test_db
         .db
         .transaction(target_id, |txn| {
-            post_merge_hits = index::lookup_eq(txn, &target_id, "default", "qty_idx", &encoded_5)?;
+            post_merge_hits = index::lookup_eq(
+                test_db.db.as_ref(),
+                txn,
+                &target_id,
+                "default",
+                "qty_idx",
+                &encoded_5,
+            )?;
             Ok(())
         })
         .unwrap();
@@ -6551,8 +6607,22 @@ fn cross_primitive_merge_invariant_sweep() {
     test_db
         .db
         .transaction(target_id, |txn| {
-            hits_25 = jindex::lookup_eq(txn, &target_id, "default", "price_idx", &encoded_25)?;
-            hits_10 = jindex::lookup_eq(txn, &target_id, "default", "price_idx", &encoded_10)?;
+            hits_25 = jindex::lookup_eq(
+                test_db.db.as_ref(),
+                txn,
+                &target_id,
+                "default",
+                "price_idx",
+                &encoded_25,
+            )?;
+            hits_10 = jindex::lookup_eq(
+                test_db.db.as_ref(),
+                txn,
+                &target_id,
+                "default",
+                "price_idx",
+                &encoded_10,
+            )?;
             Ok(())
         })
         .unwrap();
@@ -6822,8 +6892,22 @@ fn cross_primitive_merge_rollback_via_reopen() {
     test_db
         .db
         .transaction(target_id, |txn| {
-            hits_25 = jindex::lookup_eq(txn, &target_id, "default", "price_idx", &encoded_25)?;
-            hits_10 = jindex::lookup_eq(txn, &target_id, "default", "price_idx", &encoded_10)?;
+            hits_25 = jindex::lookup_eq(
+                test_db.db.as_ref(),
+                txn,
+                &target_id,
+                "default",
+                "price_idx",
+                &encoded_25,
+            )?;
+            hits_10 = jindex::lookup_eq(
+                test_db.db.as_ref(),
+                txn,
+                &target_id,
+                "default",
+                "price_idx",
+                &encoded_10,
+            )?;
             Ok(())
         })
         .unwrap();

--- a/tests/integration/branching_degraded_primitive_paths.rs
+++ b/tests/integration/branching_degraded_primitive_paths.rs
@@ -25,7 +25,7 @@ use crate::common::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use strata_core::contract::PrimitiveType;
-use strata_core::types::Namespace;
+use strata_core::types::{Namespace, TypeTag};
 use strata_core::value::Value;
 use strata_core::{BranchId, Key, PrimitiveDegradedReason, StrataError};
 use strata_engine::database::observers::ObserverError;
@@ -58,6 +58,61 @@ fn poison_vector_config(db: &Arc<Database>, branch: &str, space: &str, collectio
     .expect("poison vector config write");
 }
 
+/// Poison one persisted vector row so lazy reload from KV hits a corrupt
+/// `VectorRecord`.
+fn poison_vector_record(
+    db: &Arc<Database>,
+    branch: &str,
+    space: &str,
+    collection: &str,
+    key: &str,
+) {
+    let branch_id = resolve(branch);
+    let ns = vector_namespace(branch_id, space);
+    let kv_key = Key::new_vector(ns, collection, key);
+    db.transaction(branch_id, |txn| {
+        txn.put(
+            kv_key,
+            Value::Bytes(b"\x00\xFF\x00\xFFnot a vector record".to_vec()),
+        )
+    })
+    .expect("poison vector row");
+}
+
+fn vector_mmap_path(
+    db: &Arc<Database>,
+    branch: &str,
+    space: &str,
+    collection: &str,
+) -> std::path::PathBuf {
+    let branch_id = resolve(branch);
+    let branch_hex = format!("{:032x}", u128::from_be_bytes(*branch_id.as_bytes()));
+    db.data_dir()
+        .join("vectors")
+        .join(branch_hex)
+        .join(space)
+        .join(format!("{collection}.vec"))
+}
+
+/// Corrupt the mmap header dimension so reopen must reject the cache and rebuild
+/// from KV.
+fn poison_vector_mmap_dimension(
+    db: &Arc<Database>,
+    branch: &str,
+    space: &str,
+    collection: &str,
+    dimension: u32,
+) {
+    let path = vector_mmap_path(db, branch, space, collection);
+    let mut bytes = std::fs::read(&path).expect("read vector mmap");
+    assert!(
+        bytes.len() >= 12,
+        "mmap header must contain dimension field"
+    );
+    bytes[8..12].copy_from_slice(&dimension.to_le_bytes());
+    std::fs::write(&path, bytes).expect("rewrite vector mmap");
+}
+
 /// Poison a JSON `_idx_meta/{space}` metadata row so `load_indexes`
 /// fails closed on next search.
 fn poison_json_idx_meta(
@@ -74,6 +129,24 @@ fn poison_json_idx_meta(
         txn.put(key, Value::Bytes(b"not a valid IndexDef".to_vec()))
     })
     .expect("poison _idx_meta write");
+}
+
+/// Poison a JSON `_idx/{space}/{name}` row so prefix/range scans hit an entry
+/// whose `user_key` has no value/doc_id separator.
+fn poison_json_idx_entry_missing_separator(
+    db: &Arc<Database>,
+    branch: &str,
+    collection_space: &str,
+    index_name: &str,
+    raw_user_key: &[u8],
+) {
+    let branch_id = resolve(branch);
+    let idx_space =
+        strata_engine::primitives::json::index::index_space_name(collection_space, index_name);
+    let ns = Arc::new(Namespace::for_branch_space(branch_id, &idx_space));
+    let key = Key::new(ns, TypeTag::Json, raw_user_key.to_vec());
+    db.transaction(branch_id, |txn| txn.put(key, Value::Bytes(vec![])))
+        .expect("poison _idx entry");
 }
 
 fn small_vector_config() -> VectorConfig {
@@ -187,8 +260,12 @@ fn vector_mmap_dim_mismatch_rebuilds_from_kv_without_degradation() {
     // Reopen once so heap mmap is written (best-effort freeze on shutdown).
     test_db.reopen();
 
-    // Reopen again — since we didn't corrupt anything, the collection
-    // must be healthy and no degradation entry registered.
+    // Corrupt only the mmap header dimension. This is a cache-only failure and
+    // must trigger KV rebuild, not primitive degradation.
+    poison_vector_mmap_dimension(&test_db.db, "main", "default", "v1", 4);
+
+    // Reopen again — the collection must be healthy and no degradation entry
+    // registered.
     test_db.reopen();
     let registry = test_db
         .db
@@ -206,6 +283,81 @@ fn vector_mmap_dim_mismatch_rebuilds_from_kv_without_degradation() {
         .search(resolve("main"), "default", "v1", &[1.0, 0.0, 0.0], 5, None)
         .expect("healthy search");
     assert_eq!(hits.len(), 1);
+}
+
+#[test]
+fn vector_lazy_reload_corruption_fails_closed_on_triggering_read() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    test_db
+        .vector()
+        .create_collection(resolve("main"), "default", "v1", small_vector_config())
+        .unwrap();
+    test_db
+        .vector()
+        .insert(
+            resolve("main"),
+            "default",
+            "v1",
+            "k1",
+            &[1.0, 0.0, 0.0],
+            None,
+        )
+        .unwrap();
+    test_db
+        .vector()
+        .insert(
+            resolve("main"),
+            "default",
+            "v1",
+            "k2",
+            &[0.0, 1.0, 0.0],
+            None,
+        )
+        .unwrap();
+
+    // Force the next read through ensure_collection_loaded() instead of using
+    // the already-loaded backend.
+    {
+        let state = test_db.vector().state().unwrap();
+        let cid = strata_vector::CollectionId::new(resolve("main"), "default", "v1");
+        state.backends.remove(&cid);
+    }
+
+    // Corrupt one persisted vector row after eviction. The triggering reload
+    // must fail closed immediately rather than returning a partially rebuilt
+    // backend for the first read.
+    poison_vector_record(&test_db.db, "main", "default", "v1", "k2");
+
+    let err = test_db
+        .vector()
+        .search(resolve("main"), "default", "v1", &[1.0, 0.0, 0.0], 5, None)
+        .expect_err("lazy reload must fail closed on the triggering read");
+    let err = StrataError::from(err);
+    match &err {
+        StrataError::PrimitiveDegraded {
+            primitive,
+            name,
+            reason,
+            ..
+        } => {
+            assert_eq!(*primitive, PrimitiveType::Vector);
+            assert_eq!(name, "v1");
+            assert_eq!(*reason, PrimitiveDegradedReason::ConfigMismatch);
+        }
+        other => panic!("expected PrimitiveDegraded, got {other:?}"),
+    }
+
+    let report = test_db.db.retention_report().expect("retention_report");
+    assert!(
+        report
+            .degraded_primitives
+            .iter()
+            .any(|e| e.primitive == PrimitiveType::Vector
+                && e.primitive_name == "v1"
+                && e.reason == PrimitiveDegradedReason::ConfigMismatch),
+        "triggering lazy reload must record degradation for reporting too"
+    );
 }
 
 // =============================================================================
@@ -282,6 +434,61 @@ fn json_idx_meta_corrupt_fails_closed() {
             .any(|e| e.primitive == PrimitiveType::Json && e.primitive_name == "default"),
         "retention_report must surface JSON _idx degradation"
     );
+}
+
+#[test]
+fn json_idx_entry_corrupt_fails_closed() {
+    use strata_engine::search::{FieldFilter, FieldPredicate};
+    use strata_engine::Searchable;
+
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    let json = test_db.json();
+    json.create(
+        &resolve("main"),
+        "default",
+        "doc1",
+        json_value(serde_json::json!({ "status": "active" })),
+    )
+    .unwrap();
+    json.create_index(
+        &resolve("main"),
+        "default",
+        "by_status",
+        "$.status",
+        strata_engine::primitives::json::index::IndexType::Tag,
+    )
+    .unwrap();
+
+    // A prefix scan over "active" will see this poisoned row, then fail while
+    // extracting the doc_id because the separator is missing.
+    poison_json_idx_entry_missing_separator(&test_db.db, "main", "default", "by_status", b"active");
+
+    let req = strata_engine::SearchRequest::new(resolve("main"), "").with_field_filter(
+        FieldFilter::Predicate(FieldPredicate::Prefix {
+            field: "$.status".to_string(),
+            prefix: "active".to_string(),
+        }),
+    );
+    let err = json.search(&req).expect_err("search must fail closed");
+    match &err {
+        StrataError::PrimitiveDegraded {
+            primitive, reason, ..
+        } => {
+            assert_eq!(*primitive, PrimitiveType::Json);
+            assert_eq!(*reason, PrimitiveDegradedReason::IndexEntryCorrupt);
+        }
+        other => panic!("expected PrimitiveDegraded on JSON; got {other:?}"),
+    }
+
+    let registry = test_db
+        .db
+        .extension::<PrimitiveDegradationRegistry>()
+        .unwrap();
+    let entry = registry
+        .lookup(resolve("main"), PrimitiveType::Json, "default")
+        .expect("JSON _idx degradation entry");
+    assert_eq!(entry.reason, PrimitiveDegradedReason::IndexEntryCorrupt);
 }
 
 // =============================================================================
@@ -572,12 +779,10 @@ fn push_observer_fires_exactly_once_on_degradation() {
 }
 
 #[test]
-fn push_observer_receives_event_on_recovery_triggered_degradation() {
-    // Integration-level check: poison + reopen detects degradation
-    // during subsystem recovery, and a subsequent same-session mark
-    // attempt (e.g. via a read path, or any primitive subsystem that
-    // also encounters the issue) re-marks but does not re-fire. The
-    // post-reopen registry should contain the expected entry.
+fn register_primitive_degraded_observer_replays_recovery_discovered_entry() {
+    // Recovery-time degradations happen during open, before callers can attach
+    // observers. The Database-level registration helper must replay the current
+    // registry so startup degradations are observable on subscribe.
     let mut test_db = TestDb::new();
     test_db.db.branches().create("main").unwrap();
     test_db
@@ -598,8 +803,21 @@ fn push_observer_receives_event_on_recovery_triggered_degradation() {
     poison_vector_config(&test_db.db, "main", "default", "v1");
     test_db.reopen();
 
-    // Registry is populated by recovery (which fires to its own
-    // observers at that time — no user-registered observers yet).
+    let observer = Arc::new(CountingObserver::default());
+    test_db.db.register_primitive_degraded_observer(
+        observer.clone() as Arc<dyn PrimitiveDegradedObserver>
+    );
+    assert_eq!(
+        observer.count.load(Ordering::SeqCst),
+        1,
+        "registration must replay the existing recovery-time degradation"
+    );
+    assert_eq!(
+        *observer.last_primitive.lock(),
+        Some(PrimitiveType::Vector),
+        "replayed event must preserve the primitive kind"
+    );
+
     let registry = test_db
         .db
         .extension::<PrimitiveDegradationRegistry>()

--- a/tests/integration/branching_degraded_primitive_paths.rs
+++ b/tests/integration/branching_degraded_primitive_paths.rs
@@ -1,0 +1,684 @@
+//! B5.4 — Fail-closed degraded primitive paths.
+//!
+//! Pins the degraded-primitive closure contract from
+//! `docs/design/branching/branching-gc/b5-phasing-plan.md` §B5.4 and
+//! `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md`
+//! §"Degraded-state closure targets".
+//!
+//! The surfaces named by B5.4 are:
+//!
+//! - **vector in-memory / HNSW state** — config mismatch or rebuild
+//!   failure must fail closed, not silently fall back.
+//! - **JSON `_idx` secondary index rows** — a corrupt metadata or
+//!   entry row must fail closed rather than serve stale index answers.
+//!
+//! These tests exercise both surfaces plus the cross-branch isolation,
+//! delete-recreate clearance, and push-observer contract. All checks
+//! use the per-`Database` [`PrimitiveDegradationRegistry`] as the
+//! engine-owned record of fail-closed events and assert that
+//! [`Database::retention_report`] surfaces the degraded entries
+//! attributed to the correct `BranchRef` lifecycle instance.
+
+#![cfg(not(miri))]
+
+use crate::common::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use strata_core::contract::PrimitiveType;
+use strata_core::types::Namespace;
+use strata_core::value::Value;
+use strata_core::{BranchId, Key, PrimitiveDegradedReason, StrataError};
+use strata_engine::database::observers::ObserverError;
+use strata_engine::{
+    Database, PrimitiveDegradationRegistry, PrimitiveDegradedEvent, PrimitiveDegradedObserver,
+};
+
+fn resolve(name: &str) -> BranchId {
+    BranchId::from_user_name(name)
+}
+
+/// Namespace matching what `VectorStore::namespace_for` produces at
+/// runtime. Used by test poisoning helpers below.
+fn vector_namespace(branch_id: BranchId, space: &str) -> Arc<Namespace> {
+    Arc::new(Namespace::for_branch_space(branch_id, space))
+}
+
+/// Poison the collection's `__config__/{name}` KV entry so
+/// `CollectionRecord::from_bytes` fails during the next recovery.
+fn poison_vector_config(db: &Arc<Database>, branch: &str, space: &str, collection: &str) {
+    let branch_id = resolve(branch);
+    let ns = vector_namespace(branch_id, space);
+    let key = Key::new_vector_config(ns, collection);
+    db.transaction(branch_id, |txn| {
+        txn.put(
+            key,
+            Value::Bytes(b"\x00\xFF\x00\xFFnot a collection record".to_vec()),
+        )
+    })
+    .expect("poison vector config write");
+}
+
+/// Poison a JSON `_idx_meta/{space}` metadata row so `load_indexes`
+/// fails closed on next search.
+fn poison_json_idx_meta(
+    db: &Arc<Database>,
+    branch: &str,
+    collection_space: &str,
+    index_name: &str,
+) {
+    let branch_id = resolve(branch);
+    let meta_space = format!("_idx_meta/{}", collection_space);
+    let ns = Arc::new(Namespace::for_branch_space(branch_id, &meta_space));
+    let key = Key::new_json(ns, index_name);
+    db.transaction(branch_id, |txn| {
+        txn.put(key, Value::Bytes(b"not a valid IndexDef".to_vec()))
+    })
+    .expect("poison _idx_meta write");
+}
+
+fn small_vector_config() -> VectorConfig {
+    VectorConfig {
+        dimension: 3,
+        metric: DistanceMetric::Cosine,
+        storage_dtype: StorageDtype::F32,
+    }
+}
+
+// =============================================================================
+// §1 Vector config-mismatch closure
+// =============================================================================
+
+#[test]
+fn vector_corrupt_collection_record_fails_closed_on_reopen() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    test_db
+        .vector()
+        .create_collection(resolve("main"), "default", "v1", small_vector_config())
+        .expect("create collection");
+    test_db
+        .vector()
+        .insert(
+            resolve("main"),
+            "default",
+            "v1",
+            "k1",
+            &[1.0, 0.0, 0.0],
+            None,
+        )
+        .expect("seed vector");
+
+    // Corrupt the persisted CollectionRecord while the branch is live.
+    poison_vector_config(&test_db.db, "main", "default", "v1");
+
+    // Reopen — vector recovery should detect the corrupt config and
+    // register a PrimitiveDegradationEntry instead of silently dropping
+    // the collection.
+    test_db.reopen();
+
+    let registry = test_db
+        .db
+        .extension::<PrimitiveDegradationRegistry>()
+        .unwrap();
+    let entry = registry
+        .lookup(resolve("main"), PrimitiveType::Vector, "v1")
+        .expect("expected degradation entry after reopen");
+    assert_eq!(entry.reason, PrimitiveDegradedReason::ConfigDecodeFailure);
+
+    // Subsequent reads must fail closed with the typed error, not
+    // CollectionNotFound or silent empty results.
+    let err = test_db
+        .vector()
+        .search(resolve("main"), "default", "v1", &[1.0, 0.0, 0.0], 5, None)
+        .expect_err("search must fail closed on degraded collection");
+    let err = StrataError::from(err);
+    match &err {
+        StrataError::PrimitiveDegraded {
+            primitive,
+            name,
+            reason,
+            ..
+        } => {
+            assert_eq!(*primitive, PrimitiveType::Vector);
+            assert_eq!(name, "v1");
+            assert_eq!(*reason, PrimitiveDegradedReason::ConfigDecodeFailure);
+        }
+        other => panic!("expected PrimitiveDegraded, got {other:?}"),
+    }
+
+    // retention_report() must surface the degraded entry attributed to
+    // the live `main` BranchRef.
+    let report = test_db.db.retention_report().expect("retention_report");
+    let degraded = report
+        .degraded_primitives
+        .iter()
+        .find(|e| e.primitive == PrimitiveType::Vector && e.primitive_name == "v1")
+        .expect("retention_report must list degraded primitive");
+    assert_eq!(degraded.name, "main");
+    assert_eq!(
+        degraded.reason,
+        PrimitiveDegradedReason::ConfigDecodeFailure
+    );
+}
+
+#[test]
+fn vector_mmap_dim_mismatch_rebuilds_from_kv_without_degradation() {
+    // Negative test: mmap cache is invalidatable per contract matrix
+    // row "vector on-disk caches". Dimension mismatch in the mmap file
+    // alone must NOT register a degradation — recovery falls back to
+    // KV-based rebuild, which is contract-compliant.
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    test_db
+        .vector()
+        .create_collection(resolve("main"), "default", "v1", small_vector_config())
+        .unwrap();
+    test_db
+        .vector()
+        .insert(
+            resolve("main"),
+            "default",
+            "v1",
+            "k1",
+            &[1.0, 0.0, 0.0],
+            None,
+        )
+        .unwrap();
+    // Reopen once so heap mmap is written (best-effort freeze on shutdown).
+    test_db.reopen();
+
+    // Reopen again — since we didn't corrupt anything, the collection
+    // must be healthy and no degradation entry registered.
+    test_db.reopen();
+    let registry = test_db
+        .db
+        .extension::<PrimitiveDegradationRegistry>()
+        .unwrap();
+    assert!(
+        registry
+            .lookup(resolve("main"), PrimitiveType::Vector, "v1")
+            .is_none(),
+        "healthy mmap reopen must not mark collection degraded"
+    );
+    // Search works.
+    let hits = test_db
+        .vector()
+        .search(resolve("main"), "default", "v1", &[1.0, 0.0, 0.0], 5, None)
+        .expect("healthy search");
+    assert_eq!(hits.len(), 1);
+}
+
+// =============================================================================
+// §2 JSON _idx load-failure closure
+// =============================================================================
+
+#[test]
+fn json_idx_meta_corrupt_fails_closed() {
+    use strata_engine::search::{FieldFilter, FieldPredicate};
+    use strata_engine::Searchable;
+
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    let json = test_db.json();
+    json.create(
+        &resolve("main"),
+        "default",
+        "doc1",
+        json_value(serde_json::json!({ "status": "active" })),
+    )
+    .unwrap();
+    json.create_index(
+        &resolve("main"),
+        "default",
+        "by_status",
+        "$.status",
+        strata_engine::primitives::json::index::IndexType::Tag,
+    )
+    .unwrap();
+
+    // Corrupt the _idx_meta row.
+    poison_json_idx_meta(&test_db.db, "main", "default", "by_status");
+
+    let req = strata_engine::SearchRequest::new(resolve("main"), "").with_field_filter(
+        FieldFilter::Predicate(FieldPredicate::Eq {
+            field: "$.status".to_string(),
+            value: serde_json::json!("active").into(),
+        }),
+    );
+    let err = json.search(&req).expect_err("search must fail closed");
+    match &err {
+        StrataError::PrimitiveDegraded {
+            primitive, reason, ..
+        } => {
+            assert_eq!(*primitive, PrimitiveType::Json);
+            assert_eq!(*reason, PrimitiveDegradedReason::IndexMetadataCorrupt);
+        }
+        other => panic!("expected PrimitiveDegraded on JSON; got {other:?}"),
+    }
+
+    // Registry must contain the entry.
+    let registry = test_db
+        .db
+        .extension::<PrimitiveDegradationRegistry>()
+        .unwrap();
+    let entry = registry
+        .lookup(resolve("main"), PrimitiveType::Json, "default")
+        .expect("JSON _idx degradation entry");
+    assert_eq!(entry.reason, PrimitiveDegradedReason::IndexMetadataCorrupt);
+
+    // Subsequent search short-circuits — still fails closed without
+    // re-scanning.
+    let err2 = json
+        .search(&req)
+        .expect_err("subsequent search still fails");
+    assert!(matches!(err2, StrataError::PrimitiveDegraded { .. }));
+
+    // retention_report() lists it.
+    let report = test_db.db.retention_report().expect("retention_report");
+    assert!(
+        report
+            .degraded_primitives
+            .iter()
+            .any(|e| e.primitive == PrimitiveType::Json && e.primitive_name == "default"),
+        "retention_report must surface JSON _idx degradation"
+    );
+}
+
+// =============================================================================
+// §3 Cross-branch isolation under degraded primitive
+// =============================================================================
+
+#[test]
+fn cross_branch_isolation_under_vector_degradation() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    // Use parallel branches rather than fork: we want fully independent
+    // storage namespaces (forks inherit state until materialize, which
+    // is orthogonal to this test).
+    test_db.db.branches().create("sibling").unwrap();
+
+    // Do NOT bind `test_db.vector()` to a variable — holding an
+    // `Arc<Database>` past `reopen()` would keep the old Database
+    // alive and cause `acquire_primary_db` to weak-upgrade the existing
+    // instance without re-running recovery.
+    test_db
+        .vector()
+        .create_collection(resolve("main"), "default", "v1", small_vector_config())
+        .unwrap();
+    test_db
+        .vector()
+        .create_collection(resolve("sibling"), "default", "v1", small_vector_config())
+        .unwrap();
+    test_db
+        .vector()
+        .insert(
+            resolve("main"),
+            "default",
+            "v1",
+            "k1",
+            &[1.0, 0.0, 0.0],
+            None,
+        )
+        .unwrap();
+    test_db
+        .vector()
+        .insert(
+            resolve("sibling"),
+            "default",
+            "v1",
+            "k1",
+            &[0.0, 1.0, 0.0],
+            None,
+        )
+        .unwrap();
+
+    // Poison only `main`'s collection.
+    poison_vector_config(&test_db.db, "main", "default", "v1");
+    test_db.reopen();
+
+    // `main` fails closed.
+    let err = test_db
+        .vector()
+        .search(resolve("main"), "default", "v1", &[1.0, 0.0, 0.0], 5, None)
+        .expect_err("main must fail closed");
+    let err = StrataError::from(err);
+    assert!(
+        matches!(err, StrataError::PrimitiveDegraded { .. }),
+        "expected PrimitiveDegraded on main, got {err:?}"
+    );
+
+    // `sibling` is unaffected.
+    let hits = test_db
+        .vector()
+        .search(
+            resolve("sibling"),
+            "default",
+            "v1",
+            &[0.0, 1.0, 0.0],
+            5,
+            None,
+        )
+        .expect("sibling search unaffected by main's degradation");
+    assert_eq!(hits.len(), 1);
+
+    // retention_report attributes only to `main`.
+    let report = test_db.db.retention_report().expect("retention_report");
+    let degraded_branches: Vec<&str> = report
+        .degraded_primitives
+        .iter()
+        .filter(|e| e.primitive == PrimitiveType::Vector)
+        .map(|e| e.name.as_str())
+        .collect();
+    assert_eq!(degraded_branches, vec!["main"]);
+}
+
+// =============================================================================
+// §4 Delete / recreate clears registry
+// =============================================================================
+
+#[test]
+fn delete_recreate_clears_registry_so_same_name_starts_clean() {
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    let gen0 = test_db
+        .db
+        .active_branch_ref(resolve("main"))
+        .expect("gen-0 main ref");
+    test_db
+        .vector()
+        .create_collection(resolve("main"), "default", "v1", small_vector_config())
+        .unwrap();
+    test_db
+        .vector()
+        .insert(
+            resolve("main"),
+            "default",
+            "v1",
+            "k1",
+            &[1.0, 0.0, 0.0],
+            None,
+        )
+        .unwrap();
+
+    poison_vector_config(&test_db.db, "main", "default", "v1");
+    test_db.reopen();
+
+    let registry = test_db
+        .db
+        .extension::<PrimitiveDegradationRegistry>()
+        .unwrap();
+    let marked = registry
+        .lookup(resolve("main"), PrimitiveType::Vector, "v1")
+        .expect("recovery must register degradation");
+    assert_eq!(
+        marked.branch_ref, gen0,
+        "registered entry must be attributed to gen-0 BranchRef"
+    );
+
+    // Delete must clear the registry for this BranchId.
+    test_db.db.branches().delete("main").unwrap();
+    assert!(
+        registry
+            .lookup(resolve("main"), PrimitiveType::Vector, "v1")
+            .is_none(),
+        "delete must clear primitive-degradation registry entries"
+    );
+
+    // Recreate same name — new lifecycle instance must have an advanced
+    // generation so any straggler gen-0 registry entry would be filtered
+    // out of `retention_report` by the generation-equality join.
+    test_db.db.branches().create("main").unwrap();
+    let gen1 = test_db
+        .db
+        .active_branch_ref(resolve("main"))
+        .expect("gen-1 main ref");
+    assert!(
+        gen1.generation > gen0.generation,
+        "recreated branch must advance the generation (got {} -> {})",
+        gen0.generation,
+        gen1.generation
+    );
+
+    test_db
+        .vector()
+        .create_collection(resolve("main"), "default", "v1", small_vector_config())
+        .unwrap();
+    test_db
+        .vector()
+        .insert(
+            resolve("main"),
+            "default",
+            "v1",
+            "k1",
+            &[1.0, 0.0, 0.0],
+            None,
+        )
+        .unwrap();
+
+    // Search succeeds — no inherited degradation.
+    let hits = test_db
+        .vector()
+        .search(resolve("main"), "default", "v1", &[1.0, 0.0, 0.0], 5, None)
+        .expect("recreated main must not inherit degraded state");
+    assert_eq!(hits.len(), 1);
+
+    // retention_report for the fresh lifecycle must not carry any
+    // degraded_primitives.
+    let report = test_db.db.retention_report().expect("retention_report");
+    assert!(
+        report
+            .degraded_primitives
+            .iter()
+            .all(|e| e.primitive_name != "v1"),
+        "fresh gen-1 lifecycle must not inherit gen-0 degradation"
+    );
+}
+
+// =============================================================================
+// §5 Push observer receives degradation events
+// =============================================================================
+
+#[derive(Default)]
+struct CountingObserver {
+    count: AtomicUsize,
+    last_primitive: parking_lot::Mutex<Option<PrimitiveType>>,
+}
+
+impl PrimitiveDegradedObserver for CountingObserver {
+    fn name(&self) -> &'static str {
+        "counting-degraded"
+    }
+
+    fn on_primitive_degraded(&self, event: &PrimitiveDegradedEvent) -> Result<(), ObserverError> {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        *self.last_primitive.lock() = Some(event.primitive);
+        Ok(())
+    }
+}
+
+#[test]
+fn push_observer_fires_exactly_once_on_degradation() {
+    // Registering an observer and driving a fresh degradation through
+    // the registry must deliver exactly one event carrying the correct
+    // `BranchRef` + primitive + reason + name. Repeat marks on the same
+    // key must NOT re-fire the observer (contract: exactly-once push
+    // per `(BranchId, PrimitiveType, name)` key).
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    let main_ref = test_db
+        .db
+        .active_branch_ref(resolve("main"))
+        .expect("live main branch ref");
+
+    let observer = Arc::new(CountingObserver::default());
+    test_db
+        .db
+        .primitive_degraded_observers()
+        .register(observer.clone() as Arc<dyn PrimitiveDegradedObserver>);
+
+    // First mark fires the observer.
+    let registry = test_db
+        .db
+        .extension::<PrimitiveDegradationRegistry>()
+        .unwrap();
+    registry.mark(
+        main_ref,
+        PrimitiveType::Vector,
+        "v1",
+        PrimitiveDegradedReason::ConfigDecodeFailure,
+        "seeded",
+        Some(test_db.db.primitive_degraded_observers()),
+    );
+    assert_eq!(
+        observer.count.load(Ordering::SeqCst),
+        1,
+        "first mark must fire observer exactly once"
+    );
+    assert_eq!(
+        *observer.last_primitive.lock(),
+        Some(PrimitiveType::Vector),
+        "event must carry the correct primitive kind"
+    );
+
+    // Repeat mark of same key must NOT re-fire observer.
+    registry.mark(
+        main_ref,
+        PrimitiveType::Vector,
+        "v1",
+        PrimitiveDegradedReason::ConfigDecodeFailure,
+        "second attempt — ignored",
+        Some(test_db.db.primitive_degraded_observers()),
+    );
+    assert_eq!(
+        observer.count.load(Ordering::SeqCst),
+        1,
+        "repeat mark on same key must not re-fire observer"
+    );
+
+    // A distinct key on the same branch fires a new event.
+    registry.mark(
+        main_ref,
+        PrimitiveType::Vector,
+        "v2",
+        PrimitiveDegradedReason::ConfigDecodeFailure,
+        "distinct collection",
+        Some(test_db.db.primitive_degraded_observers()),
+    );
+    assert_eq!(
+        observer.count.load(Ordering::SeqCst),
+        2,
+        "distinct key must fire a new observer event"
+    );
+}
+
+#[test]
+fn push_observer_receives_event_on_recovery_triggered_degradation() {
+    // Integration-level check: poison + reopen detects degradation
+    // during subsystem recovery, and a subsequent same-session mark
+    // attempt (e.g. via a read path, or any primitive subsystem that
+    // also encounters the issue) re-marks but does not re-fire. The
+    // post-reopen registry should contain the expected entry.
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    test_db
+        .vector()
+        .create_collection(resolve("main"), "default", "v1", small_vector_config())
+        .unwrap();
+    test_db
+        .vector()
+        .insert(
+            resolve("main"),
+            "default",
+            "v1",
+            "k1",
+            &[1.0, 0.0, 0.0],
+            None,
+        )
+        .unwrap();
+    poison_vector_config(&test_db.db, "main", "default", "v1");
+    test_db.reopen();
+
+    // Registry is populated by recovery (which fires to its own
+    // observers at that time — no user-registered observers yet).
+    let registry = test_db
+        .db
+        .extension::<PrimitiveDegradationRegistry>()
+        .unwrap();
+    let entry = registry
+        .lookup(resolve("main"), PrimitiveType::Vector, "v1")
+        .expect("recovery must have registered the degradation");
+    assert_eq!(entry.reason, PrimitiveDegradedReason::ConfigDecodeFailure);
+    assert!(!entry.detail.is_empty(), "detail must carry decode error");
+}
+
+// =============================================================================
+// §6 retention_report separates degraded primitives from orphan storage
+// =============================================================================
+
+#[test]
+fn retention_report_separates_degraded_from_orphan_storage() {
+    // A live branch with a degraded primitive must appear in
+    // `degraded_primitives`, not `orphan_storage`. Degraded primitives
+    // are logical fail-closed facts on a live lifecycle; orphans are
+    // byte-based storage directories with no live control record.
+    //
+    // This test verifies attribution correctness: the degraded entry
+    // is attributed to the specific live `BranchRef` (name + generation)
+    // that owns the primitive, and the live branch does not leak into
+    // `orphan_storage`.
+    let mut test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    let main_ref = test_db
+        .db
+        .active_branch_ref(resolve("main"))
+        .expect("live main branch ref");
+    test_db
+        .vector()
+        .create_collection(resolve("main"), "default", "v1", small_vector_config())
+        .unwrap();
+    test_db
+        .vector()
+        .insert(
+            resolve("main"),
+            "default",
+            "v1",
+            "k1",
+            &[1.0, 0.0, 0.0],
+            None,
+        )
+        .unwrap();
+
+    poison_vector_config(&test_db.db, "main", "default", "v1");
+    test_db.reopen();
+
+    let report = test_db.db.retention_report().expect("retention_report");
+
+    // Degraded primitive is listed with correct attribution.
+    let degraded = report
+        .degraded_primitives
+        .iter()
+        .find(|e| e.primitive == PrimitiveType::Vector && e.primitive_name == "v1")
+        .expect("degraded_primitives must include the poisoned collection");
+    assert_eq!(degraded.name, "main", "attribution names the live branch");
+    assert_eq!(
+        degraded.branch, main_ref,
+        "attribution uses the live BranchRef (id + generation)"
+    );
+    assert_eq!(
+        degraded.reason,
+        PrimitiveDegradedReason::ConfigDecodeFailure
+    );
+    assert!(
+        !degraded.detail.is_empty(),
+        "detail must carry decode error text for operator triage"
+    );
+
+    // `main` is live, so it should not appear in orphan_storage.
+    assert!(
+        !report
+            .orphan_storage
+            .iter()
+            .any(|o| o.branch_id == resolve("main")),
+        "live branch must not appear in orphan_storage"
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -13,6 +13,7 @@ mod common;
 mod branching;
 mod branching_control_store_recovery;
 mod branching_convergence_differential;
+mod branching_degraded_primitive_paths;
 mod branching_gc_quarantine_recovery;
 mod branching_generation_migration;
 mod branching_guardrails;


### PR DESCRIPTION
## Summary

- Close the two named primitive-specific silent-fallback paths from B5.4: vector config mismatch and JSON `_idx` load failure now fail closed with `StrataError::PrimitiveDegraded` instead of silently serving stale/wrong branch-visible data.
- Add a per-`Database` `PrimitiveDegradationRegistry` (new engine extension) that both primitive read paths and `retention_report()` consult. Keyed by `(BranchId, PrimitiveType, name)` so cross-branch isolation is structural.
- Add `RetentionReport.degraded_primitives: Vec<DegradedPrimitiveEntry>`, populated by joining the registry with live `BranchControlRecord` lifecycle — only entries whose generation matches the live record are surfaced (same-name recreate contract).
- Add `PrimitiveDegradedObserver` push trait with exactly-once-per-key semantics. Repeat marks on the same key do not re-fire observers.
- Add `Database::register_primitive_degraded_observer()` helper that registers an observer AND replays the current registry, closing the recovery-time timing gap (degradations detected during open can now be observed via push without polling). A `ReplayDedupPrimitiveDegradedObserver` wrapper prevents double-delivery when a concurrent live mark races the startup replay.
- Vector recovery (`recover_from_db`) now marks degradation on previously-silent failure modes: failing `scan_prefix`, corrupt `VectorRecord`, and failed `backend.insert_with_id_and_timestamp`.
- Vector lazy reload (`load_backend_from_kv`) returns `VectorError::Degraded` on corrupt `VectorRecord` or failed backend insert instead of `continue` — a partial backend is not trusted enough to serve branch-visible reads.
- Delete hook (`complete_delete_post_commit`) clears the registry for the deleted `BranchId` so a same-name recreate starts clean.

Contract refs:
- `docs/design/branching/branching-gc/b5-phasing-plan.md` §B5.4
- `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md` §"Degraded-state closure targets" + §"Surface matrix" (vector / JSON / retention_report rows) + §"Required push events"
- `docs/design/branching/branching-gc/branching-retention-contract.md` §"Same-name recreate"

**Change class:** Cutover (silent vector `warn!+continue` / `let _ =` sites and silent JSON `_idx` `filter_map` filter all deleted; replaced with fail-closed).
**Assurance class:** S3 (primitive lifecycle + follower behavior).

Non-goals preserved: no change to storage `RecoveryHealth` / `DegradationClass` / `RecoveryFault`; no re-opening of B5.2 retention core; no open-time validation pass; mmap dim mismatch remains a KV-rebuild (cache contract).

## Test plan

- [x] `cargo test -p strata-engine --lib` — **1131 passed** (5 new registry/observer unit tests incl. exactly-once observer and replay-dedup wrapper)
- [x] `cargo test -p strata-vector --lib` — **332 passed** (new fault-injection test for recovery scan failure)
- [x] `cargo test -p stratadb --test integration branching_degraded_primitive_paths` — **10/10 pass**:
  - `vector_corrupt_collection_record_fails_closed_on_reopen`
  - `vector_mmap_dim_mismatch_rebuilds_from_kv_without_degradation` (actually corrupts mmap header dim now)
  - `vector_lazy_reload_corruption_fails_closed_on_triggering_read` (new — evicts backend, poisons KV row, proves triggering read fails closed)
  - `json_idx_meta_corrupt_fails_closed`
  - `json_idx_entry_corrupt_fails_closed` (new — missing separator via `lookup_prefix`)
  - `cross_branch_isolation_under_vector_degradation`
  - `delete_recreate_clears_registry_so_same_name_starts_clean` (verifies gen advance)
  - `push_observer_fires_exactly_once_on_degradation`
  - `register_primitive_degraded_observer_replays_recovery_discovered_entry` (new — replay helper end-to-end)
  - `retention_report_separates_degraded_from_orphan_storage`
- [x] All B5.1–B5.3 suites green: `branching_retention_matrix` (15), `branching_convergence_differential` (24), `branching_gc_quarantine_recovery` (11), `branching_lifecycle_restart` (10)
- [x] `cargo check --workspace` clean; `cargo clippy --workspace --all-targets` no new errors
- [x] Benchmark regression quick pass completed (redb + ycsb + branching suites)
- [x] Engine DAG preserved — engine does NOT depend on vector; vector→engine is pre-existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
