### PR TITLE
B5 follow-up: state-machine suite, same-name recreate attribution fix, vector Searchable fail-closed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ chrono = { workspace = true }
 serde = { workspace = true }
 rustc-hash = { workspace = true }
 parking_lot = { workspace = true }
+proptest = { workspace = true }
 # Internal crates for testing only
 strata-core = { path = "crates/core" }
 strata-storage = { path = "crates/storage" }

--- a/crates/engine/src/database/retention_report.rs
+++ b/crates/engine/src/database/retention_report.rs
@@ -387,23 +387,45 @@ impl Database {
             });
         }
 
-        // Remaining storage directories have no live control record.
         let mut orphan_storage: Vec<OrphanStorageEntry> = Vec::new();
+        // Detached descendant-held bytes must surface as orphan storage even
+        // when the same BranchId currently has a live control record. This is
+        // the same-name recreate shape: the old lifecycle's bytes still live
+        // under the deterministic storage directory, but they are not owned by
+        // the new live manifest and must not be folded into the recreated
+        // branch entry's `shared_bytes`.
+        for snap in snapshot_by_id.values() {
+            if snap.detached_shared_bytes == 0 || !live_by_id.contains_key(&snap.branch_id) {
+                continue;
+            }
+            totals.shared_bytes += snap.detached_shared_bytes;
+            orphan_storage.push(OrphanStorageEntry {
+                branch_id: snap.branch_id,
+                bytes: snap.detached_shared_bytes,
+                quarantined_bytes: 0,
+                reason: OrphanReason::DescendantInheritance,
+            });
+        }
+
+        // Remaining storage directories have no live control record.
         for (branch_id, snap) in &snapshot_by_id {
             if live_by_id.contains_key(branch_id) {
                 continue;
             }
-            let total_bytes = snap.exclusive_bytes + snap.shared_bytes;
+            let total_bytes = snap.exclusive_bytes + snap.shared_bytes + snap.detached_shared_bytes;
             if total_bytes == 0 && snap.quarantined_bytes == 0 {
                 continue;
             }
-            let reason = if inherited_sources.contains_key(branch_id) || snap.shared_bytes > 0 {
+            let reason = if inherited_sources.contains_key(branch_id)
+                || snap.shared_bytes > 0
+                || snap.detached_shared_bytes > 0
+            {
                 OrphanReason::DescendantInheritance
             } else {
                 OrphanReason::UntrackedLifecycle
             };
             totals.exclusive_bytes += snap.exclusive_bytes;
-            totals.shared_bytes += snap.shared_bytes;
+            totals.shared_bytes += snap.shared_bytes + snap.detached_shared_bytes;
             totals.quarantined_bytes += snap.quarantined_bytes;
             orphan_storage.push(OrphanStorageEntry {
                 branch_id: *branch_id,

--- a/crates/storage/src/segmented/quarantine_protocol.rs
+++ b/crates/storage/src/segmented/quarantine_protocol.rs
@@ -131,6 +131,17 @@ pub struct StorageBranchRetention {
     /// inherited-layer manifest references. Retained until the
     /// descendant releases (release-at-clear-or-materialize).
     pub shared_bytes: u64,
+    /// Descendant-held bytes that are no longer owned by this branch's
+    /// current manifest.
+    ///
+    /// This is the same-name recreate / deleted-parent-with-live-child
+    /// shape: the bytes still live under this branch directory and are
+    /// still manifest-reachable through a descendant inherited layer,
+    /// but they belong to an older lifecycle instance rather than the
+    /// current live manifest. Engine-layer attribution must surface
+    /// these as orphan storage, not as `shared_bytes` on the current
+    /// live branch entry.
+    pub detached_shared_bytes: u64,
     /// Bytes visible to this branch through inherited-layer manifests;
     /// the bytes physically live under the source branch's directory.
     pub inherited_layer_bytes: u64,
@@ -152,6 +163,7 @@ impl StorageBranchRetention {
             branch_id,
             exclusive_bytes: 0,
             shared_bytes: 0,
+            detached_shared_bytes: 0,
             inherited_layer_bytes: 0,
             inherited_layers: Vec::new(),
             quarantined_bytes: 0,
@@ -480,6 +492,7 @@ impl SegmentedStore {
         let views_by_id: HashMap<BranchId, &RetentionBranchDirView> =
             views.iter().map(|view| (view.branch_id, view)).collect();
         let descendant_held = descendant_held_filenames_by_source(&views);
+        let manifest_live_filenames = manifest_live_filenames_from_views(&views);
         let recovery_health = self.last_recovery_health.load();
         let legacy_fallback_branches = branches_with_legacy_no_manifest_fallback(&recovery_health);
 
@@ -487,6 +500,7 @@ impl SegmentedStore {
             let mut accounted_top_level: HashSet<String> = HashSet::new();
             let mut exclusive_bytes = 0u64;
             let mut shared_bytes = 0u64;
+            let mut detached_shared_bytes = 0u64;
             let shared_filenames = descendant_held.get(&view.branch_id);
 
             if let Some(manifest) = view.manifest.as_ref() {
@@ -548,7 +562,7 @@ impl SegmentedStore {
                 // it routes old files through reclaim, so raw disk presence
                 // alone must not inflate `exclusive_bytes` / `shared_bytes`.
                 if shared_filenames.is_some_and(|filenames| filenames.contains(&file.filename)) {
-                    shared_bytes += file.size;
+                    detached_shared_bytes += file.size;
                 }
             }
 
@@ -584,13 +598,18 @@ impl SegmentedStore {
                 }
             }
 
+            let empty_live_filenames = HashSet::new();
             let (quarantined_bytes, quarantined_segment_count) = quarantine_stats_from_state(
                 view.branch_id,
                 view.quarantine.as_ref().expect("quarantine loaded"),
+                manifest_live_filenames
+                    .get(&view.branch_id)
+                    .unwrap_or(&empty_live_filenames),
             )?;
 
             if exclusive_bytes == 0
                 && shared_bytes == 0
+                && detached_shared_bytes == 0
                 && inherited_layer_bytes == 0
                 && quarantined_bytes == 0
             {
@@ -601,6 +620,7 @@ impl SegmentedStore {
                 branch_id: view.branch_id,
                 exclusive_bytes,
                 shared_bytes,
+                detached_shared_bytes,
                 inherited_layer_bytes,
                 inherited_layers,
                 quarantined_bytes,
@@ -1010,6 +1030,7 @@ fn branches_with_legacy_no_manifest_fallback(health: &RecoveryHealth) -> HashSet
 fn quarantine_stats_from_state(
     branch_id: BranchId,
     state: &BranchQuarantineState,
+    manifest_live_filenames: &HashSet<String>,
 ) -> StorageResult<(u64, usize)> {
     match &state.manifest {
         None => {
@@ -1029,25 +1050,64 @@ fn quarantine_stats_from_state(
                 .map(|entry| entry.filename.clone())
                 .collect();
             let files_present: HashSet<String> = state.files_on_disk.keys().cloned().collect();
-            if inventory_filenames != files_present {
-                return Err(StorageError::QuarantineReconciliationFailed {
-                    branch_id,
-                    reason: "inventory does not match on-disk quarantine contents".to_string(),
-                });
+
+            for filename in &files_present {
+                if !inventory_filenames.contains(filename) {
+                    return Err(StorageError::QuarantineReconciliationFailed {
+                        branch_id,
+                        reason: "inventory does not match on-disk quarantine contents".to_string(),
+                    });
+                }
             }
 
+            let mut retained_entry_count = 0usize;
             let total = manifest
                 .entries
                 .iter()
+                .filter(|entry| {
+                    if files_present.contains(&entry.filename) {
+                        retained_entry_count += 1;
+                        return true;
+                    }
+
+                    if manifest_live_filenames.contains(&entry.filename) {
+                        // This is the same mismatch reopen reconciliation
+                        // refuses: inventory claims quarantine membership for a
+                        // file still reachable from a live manifest.
+                        return true;
+                    }
+
+                    // Benign stale entry: publish happened, but rename never
+                    // completed (or purge already removed the file). Reopen
+                    // reconciliation drops these entries in place; the
+                    // in-session report path should not fail closed on the same
+                    // state.
+                    false
+                })
                 .map(|entry| {
+                    if !files_present.contains(&entry.filename)
+                        && manifest_live_filenames.contains(&entry.filename)
+                    {
+                        return Err(StorageError::QuarantineReconciliationFailed {
+                            branch_id,
+                            reason: "inventory does not match on-disk quarantine contents"
+                                .to_string(),
+                        });
+                    }
                     state
                         .files_on_disk
                         .get(&entry.filename)
                         .copied()
-                        .unwrap_or(0)
+                        .ok_or_else(|| StorageError::QuarantineReconciliationFailed {
+                            branch_id,
+                            reason: "inventory does not match on-disk quarantine contents"
+                                .to_string(),
+                        })
                 })
+                .collect::<StorageResult<Vec<_>>>()?
+                .into_iter()
                 .sum();
-            Ok((total, manifest.entries.len()))
+            Ok((total, retained_entry_count))
         }
     }
 }

--- a/crates/storage/src/segmented/tests/quarantine_reconciliation.rs
+++ b/crates/storage/src/segmented/tests/quarantine_reconciliation.rs
@@ -169,6 +169,46 @@ fn reopen_drops_stale_inventory_entries_without_degrade() {
         .expect("healthy gc after silent reconcile");
 }
 
+/// The in-session retention/report path must treat the same stale inventory
+/// shape as benign. Recovery reconciliation rewrites these entries away on
+/// reopen, but callers must not get `RetentionReportUnavailable` simply
+/// because publish happened and rename never did.
+#[test]
+fn retention_snapshot_ignores_stale_missing_quarantine_inventory_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SegmentedStore::with_dir(dir.path().to_path_buf(), 0);
+    seed(&store, kv_key("k"), Value::Int(1), 1);
+    store.rotate_memtable(&branch());
+    store.flush_oldest_frozen(&branch()).unwrap();
+
+    let b_dir = branch_dir_for(dir.path(), branch());
+    write_quarantine_manifest(
+        &b_dir,
+        &[QuarantineEntry {
+            segment_id: 0xdead,
+            filename: "phantom.sst".to_string(),
+        }],
+    )
+    .unwrap();
+
+    let snapshot = store
+        .retention_snapshot()
+        .expect("stale inventory entries without quarantine files must not fail the read path");
+    let entry = snapshot
+        .iter()
+        .find(|entry| entry.branch_id == branch())
+        .expect("live branch must still appear in the retention snapshot");
+
+    assert_eq!(
+        entry.quarantined_bytes, 0,
+        "stale inventory entries must not inflate quarantined byte attribution",
+    );
+    assert_eq!(
+        entry.quarantined_segment_count, 0,
+        "stale inventory entries must not inflate quarantined segment counts",
+    );
+}
+
 /// After reclaim has driven the quarantine inventory empty, subsequent
 /// reopens must leave a clean slate: no leftover `quarantine.manifest`,
 /// no `__quarantine__/` directory, healthy recovery. Pins idempotency.

--- a/crates/vector/src/store/collections.rs
+++ b/crates/vector/src/store/collections.rs
@@ -3,6 +3,35 @@
 use super::*;
 
 impl VectorStore {
+    fn degrade_collection_read(
+        &self,
+        branch_id: BranchId,
+        name: &str,
+        reason: strata_core::PrimitiveDegradedReason,
+        detail: impl Into<String>,
+    ) -> VectorError {
+        let detail = detail.into();
+        let err = strata_engine::database::primitive_degradation::mark_primitive_degraded(
+            &self.db,
+            branch_id,
+            strata_core::contract::PrimitiveType::Vector,
+            name,
+            reason,
+            detail.clone(),
+        )
+        .map(|entry| entry.to_error())
+        .or_else(|| {
+            strata_engine::database::primitive_degradation::primitive_degraded_error(
+                &self.db,
+                branch_id,
+                strata_core::contract::PrimitiveType::Vector,
+                name,
+            )
+        })
+        .unwrap_or_else(|| strata_core::StrataError::serialization(detail));
+        VectorError::Degraded(Box::new(err))
+    }
+
     /// Creates a collection with the specified configuration.
     /// The configuration (dimension, metric, dtype) is immutable after creation.
     ///
@@ -316,13 +345,30 @@ impl VectorStore {
             let bytes = match &versioned_value.value {
                 Value::Bytes(b) => b.clone(),
                 _ => {
-                    return Err(VectorError::Serialization(
-                        "Expected Bytes value for collection record".to_string(),
-                    ))
+                    return Err(self.degrade_collection_read(
+                        branch_id,
+                        &name,
+                        strata_core::PrimitiveDegradedReason::ConfigDecodeFailure,
+                        "Expected Bytes value for collection record",
+                    ));
                 }
             };
-            let record = CollectionRecord::from_bytes(&bytes)?;
-            let config = VectorConfig::try_from(record.config)?;
+            let record = CollectionRecord::from_bytes(&bytes).map_err(|e| {
+                self.degrade_collection_read(
+                    branch_id,
+                    &name,
+                    strata_core::PrimitiveDegradedReason::ConfigDecodeFailure,
+                    format!("Failed to decode collection record during list: {e}"),
+                )
+            })?;
+            let config = VectorConfig::try_from(record.config).map_err(|e| {
+                self.degrade_collection_read(
+                    branch_id,
+                    &name,
+                    strata_core::PrimitiveDegradedReason::ConfigShapeConversion,
+                    format!("Failed to convert collection config during list: {e}"),
+                )
+            })?;
 
             // Get current count from backend
             let collection_id = CollectionId::new(branch_id, space, &name);

--- a/crates/vector/src/store/mod.rs
+++ b/crates/vector/src/store/mod.rs
@@ -783,7 +783,7 @@ impl strata_engine::search::Searchable for VectorStore {
         // Discover all _system_embed_* collections on this branch
         let collections = self
             .list_collections(req.branch_id, SYSTEM_SPACE)
-            .unwrap_or_default();
+            .map_err(|e| e.into_strata_error(req.branch_id))?;
 
         let mut all_hits: Vec<SearchHit> = Vec::new();
 
@@ -795,11 +795,9 @@ impl strata_engine::search::Searchable for VectorStore {
                 continue;
             }
 
-            let matches =
-                match self.system_search_with_sources(req.branch_id, &col.name, embedding, req.k) {
-                    Ok(m) => m,
-                    Err(_) => continue,
-                };
+            let matches = self
+                .system_search_with_sources(req.branch_id, &col.name, embedding, req.k)
+                .map_err(|e| e.into_strata_error(req.branch_id))?;
 
             for m in matches {
                 // Phase 1 Part 2: drop matches whose source isn't in the

--- a/tests/integration/branching_degraded_primitive_paths.rs
+++ b/tests/integration/branching_degraded_primitive_paths.rs
@@ -32,6 +32,7 @@ use strata_engine::database::observers::ObserverError;
 use strata_engine::{
     Database, PrimitiveDegradationRegistry, PrimitiveDegradedEvent, PrimitiveDegradedObserver,
 };
+use strata_engine::{SearchRequest, Searchable};
 
 fn resolve(name: &str) -> BranchId {
     BranchId::from_user_name(name)
@@ -155,6 +156,14 @@ fn small_vector_config() -> VectorConfig {
         metric: DistanceMetric::Cosine,
         storage_dtype: StorageDtype::F32,
     }
+}
+
+fn vector_search_request(branch: &str) -> SearchRequest {
+    SearchRequest::new(resolve(branch), "")
+        .with_mode(strata_engine::search::SearchMode::Vector)
+        .with_precomputed_embedding(vec![1.0, 0.0, 0.0])
+        .with_space("default")
+        .with_k(5)
 }
 
 // =============================================================================
@@ -358,6 +367,99 @@ fn vector_lazy_reload_corruption_fails_closed_on_triggering_read() {
                 && e.reason == PrimitiveDegradedReason::ConfigMismatch),
         "triggering lazy reload must record degradation for reporting too"
     );
+}
+
+#[test]
+fn vector_searchable_fails_closed_on_corrupt_system_collection_config() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    test_db
+        .vector()
+        .create_system_collection(resolve("main"), "_system_embed_kv", small_vector_config())
+        .expect("create system collection");
+    test_db
+        .vector()
+        .system_insert_with_source(
+            resolve("main"),
+            "_system_embed_kv",
+            "shadow-k1",
+            &[1.0, 0.0, 0.0],
+            None,
+            strata_core::EntityRef::kv(resolve("main"), "default", "real-k1"),
+        )
+        .expect("insert system vector");
+
+    poison_vector_config(
+        &test_db.db,
+        "main",
+        strata_engine::system_space::SYSTEM_SPACE,
+        "_system_embed_kv",
+    );
+
+    let err = Searchable::search(&test_db.vector(), &vector_search_request("main"))
+        .expect_err("branch-visible vector search must fail closed on corrupt system collection");
+    match err {
+        StrataError::PrimitiveDegraded {
+            primitive,
+            name,
+            reason,
+            ..
+        } => {
+            assert_eq!(primitive, PrimitiveType::Vector);
+            assert_eq!(name, "_system_embed_kv");
+            assert_eq!(reason, PrimitiveDegradedReason::ConfigDecodeFailure);
+        }
+        other => panic!("expected PrimitiveDegraded, got {other:?}"),
+    }
+}
+
+#[test]
+fn vector_searchable_fails_closed_on_lazy_reloaded_corrupt_system_vector_row() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    test_db
+        .vector()
+        .create_system_collection(resolve("main"), "_system_embed_kv", small_vector_config())
+        .expect("create system collection");
+    test_db
+        .vector()
+        .system_insert_with_source(
+            resolve("main"),
+            "_system_embed_kv",
+            "shadow-k1",
+            &[1.0, 0.0, 0.0],
+            None,
+            strata_core::EntityRef::kv(resolve("main"), "default", "real-k1"),
+        )
+        .expect("insert system vector");
+
+    poison_vector_record(
+        &test_db.db,
+        "main",
+        strata_engine::system_space::SYSTEM_SPACE,
+        "_system_embed_kv",
+        "shadow-k1",
+    );
+    test_db
+        .vector()
+        .purge_collections_in_branch(resolve("main"))
+        .expect("evict in-memory backends");
+
+    let err = Searchable::search(&test_db.vector(), &vector_search_request("main"))
+        .expect_err("branch-visible vector search must fail closed on lazy reload corruption");
+    match err {
+        StrataError::PrimitiveDegraded {
+            primitive,
+            name,
+            reason,
+            ..
+        } => {
+            assert_eq!(primitive, PrimitiveType::Vector);
+            assert_eq!(name, "_system_embed_kv");
+            assert_eq!(reason, PrimitiveDegradedReason::ConfigMismatch);
+        }
+        other => panic!("expected PrimitiveDegraded, got {other:?}"),
+    }
 }
 
 // =============================================================================

--- a/tests/integration/branching_retention_matrix.rs
+++ b/tests/integration/branching_retention_matrix.rs
@@ -800,6 +800,50 @@ fn retention_report_canonical_blocker_points_at_live_descendant_after_parent_del
     );
 }
 
+#[test]
+fn retention_report_recreate_does_not_fold_old_descendant_bytes_into_new_main() {
+    let test_db = TestDb::new();
+    test_db.db.branches().create("main").unwrap();
+    for i in 0..15 {
+        seed(&test_db.db, "main", &format!("k{i}"), i);
+    }
+    flush_branch(&test_db.db, "main");
+    test_db.db.branches().fork("main", "feature").unwrap();
+
+    test_db.db.branches().delete("main").unwrap();
+    test_db.db.branches().create("main").unwrap();
+    seed(&test_db.db, "main", "fresh", 999);
+    flush_branch(&test_db.db, "main");
+
+    let report = test_db.db.retention_report().expect("healthy");
+    let main_entry = report
+        .branches
+        .iter()
+        .find(|b| b.name == "main")
+        .expect("recreated main present");
+    let feature_entry = report
+        .branches
+        .iter()
+        .find(|b| b.name == "feature")
+        .expect("feature present");
+
+    assert_eq!(
+        main_entry.shared_bytes, 0,
+        "recreated main must not inherit descendant-held bytes from the deleted lifecycle",
+    );
+    assert!(
+        feature_entry.inherited_layer_bytes > 0,
+        "feature must still report inherited bytes from the deleted main lifecycle",
+    );
+    assert!(
+        report.orphan_storage.iter().any(|entry| {
+            entry.branch_id == resolve("main")
+                && matches!(entry.reason, strata_engine::OrphanReason::DescendantInheritance)
+        }),
+        "old descendant-held bytes must surface as orphan storage, not as shared bytes on the recreated main",
+    );
+}
+
 // =============================================================================
 // Schedule extension: live-branch top-level orphan `.sst` files that are no
 // longer manifest-owned are cleanup debt, not branch-visible retained bytes.

--- a/tests/integration/branching_retention_state_machine.rs
+++ b/tests/integration/branching_retention_state_machine.rs
@@ -1,0 +1,320 @@
+//! B5 — generated-history retention / rebuild lane.
+//!
+//! This suite is the heavy property/state-machine lane called for by
+//! `docs/design/branching/branching-gc/branching-b5-verification-spec.md`.
+//! It intentionally stays narrower than a full branching model:
+//!
+//! - same-name recreate must not alias retention by branch name alone
+//! - materialization may rewrite ownership, but not visible results
+//! - reopen + GC must preserve manifest-reachable visibility
+//! - generated histories must not let reclaim break a fork-frontier snapshot
+
+#![cfg(not(miri))]
+
+use crate::common::*;
+use proptest::prelude::*;
+use proptest::test_runner::{Config as ProptestConfig, TestCaseError};
+use std::sync::Arc;
+use strata_core::value::Value;
+
+fn resolve(name: &str) -> BranchId {
+    BranchId::from_user_name(name)
+}
+
+fn seed(db: &Arc<Database>, name: &str, key: &str, v: i64) {
+    KVStore::new(db.clone())
+        .put(&resolve(name), "default", key, Value::Int(v))
+        .expect("seed write succeeds");
+}
+
+fn flush_branch(db: &Arc<Database>, name: &str) {
+    let id = resolve(name);
+    db.storage().rotate_memtable(&id);
+    db.storage()
+        .flush_oldest_frozen(&id)
+        .expect("flush succeeds");
+}
+
+#[derive(Debug, Clone, Copy)]
+enum HistoryOp {
+    RewriteMain,
+    ForkFeature,
+    DeleteMain,
+    RecreateMain,
+    MaterializeFeature,
+    Reopen,
+    Gc,
+}
+
+fn history_op_strategy() -> impl Strategy<Value = HistoryOp> {
+    prop_oneof![
+        Just(HistoryOp::RewriteMain),
+        Just(HistoryOp::ForkFeature),
+        Just(HistoryOp::DeleteMain),
+        Just(HistoryOp::RecreateMain),
+        Just(HistoryOp::MaterializeFeature),
+        Just(HistoryOp::Reopen),
+        Just(HistoryOp::Gc),
+    ]
+}
+
+#[derive(Debug, Clone)]
+struct ModelState {
+    main_live: bool,
+    main_generation: u64,
+    main_value: i64,
+    next_value: i64,
+    feature_exists: bool,
+    feature_snapshot: Option<i64>,
+    feature_parent_generation: Option<u64>,
+    feature_materialized: bool,
+}
+
+impl ModelState {
+    fn new(initial_value: i64) -> Self {
+        Self {
+            main_live: true,
+            main_generation: 0,
+            main_value: initial_value,
+            next_value: initial_value + 1,
+            feature_exists: false,
+            feature_snapshot: None,
+            feature_parent_generation: None,
+            feature_materialized: false,
+        }
+    }
+
+    fn alloc_value(&mut self) -> i64 {
+        let value = self.next_value;
+        self.next_value += 1;
+        value
+    }
+}
+
+fn branch_entry<'a>(
+    report: &'a strata_engine::RetentionReport,
+    name: &str,
+) -> Option<&'a strata_engine::BranchRetentionEntry> {
+    report.branches.iter().find(|entry| entry.name == name)
+}
+
+fn orphan_bytes_for(report: &strata_engine::RetentionReport, branch_id: BranchId) -> u64 {
+    report
+        .orphan_storage
+        .iter()
+        .filter(|entry| entry.branch_id == branch_id)
+        .map(|entry| entry.bytes)
+        .sum()
+}
+
+fn assert_history_invariants(
+    test_db: &mut TestDb,
+    model: &ModelState,
+    step: usize,
+    op: HistoryOp,
+) -> Result<(), TestCaseError> {
+    let kv = test_db.kv();
+    let main_value = kv
+        .get(&resolve("main"), "default", "root")
+        .expect("main read succeeds");
+    if model.main_live {
+        prop_assert_eq!(
+            main_value,
+            Some(Value::Int(model.main_value)),
+            "step {} after {:?}: live main must expose the latest live value",
+            step,
+            op
+        );
+    } else {
+        prop_assert_eq!(
+            main_value,
+            None,
+            "step {} after {:?}: deleted main must not read through tombstoned storage",
+            step,
+            op
+        );
+    }
+
+    if model.feature_exists {
+        let feature_value = kv
+            .get(&resolve("feature"), "default", "root")
+            .expect("feature read succeeds");
+        prop_assert_eq!(
+            feature_value,
+            Some(Value::Int(
+                model.feature_snapshot.expect("feature snapshot recorded")
+            )),
+            "step {} after {:?}: feature must preserve its fork-frontier snapshot",
+            step,
+            op
+        );
+    }
+
+    if !model.feature_exists {
+        return Ok(());
+    }
+
+    let report = match test_db.db.retention_report() {
+        Ok(report) => report,
+        Err(err) => {
+            let health = test_db.db.recovery_health();
+            let snapshot = test_db.db.storage().retention_snapshot();
+            return Err(TestCaseError::fail(format!(
+                "retention-report assertions only run once a descendant exists: {err:?}; health={health:?}; snapshot={snapshot:?}"
+            )));
+        }
+    };
+
+    if model.feature_exists {
+        let feature_entry = branch_entry(&report, "feature").expect("feature entry present");
+        if model.feature_materialized {
+            prop_assert_eq!(
+                feature_entry.inherited_layer_bytes,
+                0,
+                "step {} after {:?}: materialized feature must not retain inherited-layer bytes",
+                step,
+                op
+            );
+        }
+
+        let parent_generation = model
+            .feature_parent_generation
+            .expect("feature parent generation tracked");
+        if !model.feature_materialized
+            && model.main_live
+            && parent_generation == model.main_generation
+        {
+            let main_entry = branch_entry(&report, "main").expect("live main entry present");
+            let parent_pinned_bytes =
+                main_entry.shared_bytes + orphan_bytes_for(&report, resolve("main"));
+            prop_assert!(
+                parent_pinned_bytes > 0,
+                "step {step} after {op:?}: live parent bytes pinned by an unmaterialized child must stay attributable after reopen/compaction"
+            );
+            prop_assert!(
+                feature_entry.inherited_layer_bytes > 0,
+                "step {step} after {op:?}: unmaterialized child must report inherited-layer bytes"
+            );
+        }
+
+        if !model.feature_materialized && !model.main_live {
+            prop_assert!(
+                report
+                    .orphan_storage
+                    .iter()
+                    .any(|entry| entry.branch_id == resolve("main")),
+                "step {step} after {op:?}: deleted parent bytes held by the child must surface as orphan storage"
+            );
+        }
+
+        if !model.feature_materialized
+            && model.main_live
+            && parent_generation < model.main_generation
+        {
+            let main_entry = branch_entry(&report, "main").expect("recreated main entry present");
+            prop_assert_eq!(
+                main_entry.shared_bytes,
+                0,
+                "step {} after {:?}: recreated main must not inherit shared-byte attribution from the old lifecycle",
+                step,
+                op
+            );
+            prop_assert!(
+                report
+                    .orphan_storage
+                    .iter()
+                    .any(|entry| entry.branch_id == resolve("main")),
+                "step {step} after {op:?}: old-generation retained bytes must stay orphan-attributed, not be folded into the recreated main"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 16,
+        max_local_rejects: 0,
+        .. ProptestConfig::default()
+    })]
+
+    #[test]
+    fn generated_histories_preserve_retention_and_rebuild_invariants(
+        ops in prop::collection::vec(history_op_strategy(), 1..18)
+    ) {
+        let mut test_db = TestDb::new();
+        test_db.db.branches().create("main").unwrap();
+        seed(&test_db.db, "main", "root", 1);
+        flush_branch(&test_db.db, "main");
+
+        let mut model = ModelState::new(1);
+        assert_history_invariants(&mut test_db, &model, 0, HistoryOp::RewriteMain)?;
+
+        for (step, op) in ops.into_iter().enumerate() {
+            match op {
+                HistoryOp::RewriteMain => {
+                    if model.main_live {
+                        let value = model.alloc_value();
+                        seed(&test_db.db, "main", "root", value);
+                        flush_branch(&test_db.db, "main");
+                        model.main_value = value;
+                    }
+                }
+                HistoryOp::ForkFeature => {
+                    if model.main_live && !model.feature_exists {
+                        test_db.db.branches().fork("main", "feature").unwrap();
+                        model.feature_exists = true;
+                        model.feature_snapshot = Some(model.main_value);
+                        model.feature_parent_generation = Some(model.main_generation);
+                        model.feature_materialized = false;
+                    }
+                }
+                HistoryOp::DeleteMain => {
+                    if model.main_live {
+                        test_db.db.branches().delete("main").unwrap();
+                        model.main_live = false;
+                    }
+                }
+                HistoryOp::RecreateMain => {
+                    if !model.main_live {
+                        test_db.db.branches().create("main").unwrap();
+                        model.main_generation += 1;
+                        let value = model.alloc_value();
+                        seed(&test_db.db, "main", "root", value);
+                        flush_branch(&test_db.db, "main");
+                        model.main_live = true;
+                        model.main_value = value;
+                    }
+                }
+                HistoryOp::MaterializeFeature => {
+                    if model.feature_exists && test_db.db.storage().inherited_layer_count(&resolve("feature")) > 0 {
+                        test_db
+                            .db
+                            .storage()
+                            .materialize_layer(&resolve("feature"), 0)
+                            .expect("materialize layer 0 succeeds");
+                    }
+                    if model.feature_exists {
+                        model.feature_materialized =
+                            test_db.db.storage().inherited_layer_count(&resolve("feature")) == 0;
+                    }
+                }
+                HistoryOp::Reopen => {
+                    test_db.reopen();
+                }
+                HistoryOp::Gc => {
+                    if model.feature_exists || !model.main_live {
+                        test_db
+                            .db
+                            .storage()
+                            .gc_orphan_segments()
+                            .expect("healthy histories permit GC");
+                    }
+                }
+            }
+
+            assert_history_invariants(&mut test_db, &model, step + 1, op)?;
+        }
+    }
+}

--- a/tests/integration/data/branching_transitional_shapes.json
+++ b/tests/integration/data/branching_transitional_shapes.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "description": "Locked counts of branching transitional shapes. See tests/integration/branching_guardrails.rs for what each key tracks and why.",
   "shapes": {
-    "branch_id_random_new_sites": 725,
+    "branch_id_random_new_sites": 726,
     "branch_namespace_const_sites": 1,
     "merge_base_override_occurrences": 0,
     "merge_strategy_lastwriterwins_literals": 75

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -22,6 +22,7 @@ mod branching_lifecycle_restart;
 mod branching_merge_lineage_edges;
 mod branching_recreate_state_machine;
 mod branching_retention_matrix;
+mod branching_retention_state_machine;
 mod branching_same_name_race;
 mod merge_base_characterization;
 mod modes;

--- a/tests/proptest-regressions/branching_retention_state_machine.txt
+++ b/tests/proptest-regressions/branching_retention_state_machine.txt
@@ -1,0 +1,10 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc cad6a42ea17fcf5becc8f3d0500edf66a9aa795707bfbfdd6d23dba4c9f0b594 # shrinks to ops = [RewriteMain, Gc, MaterializeFeature, RewriteMain, RewriteMain, RecreateMain, ForkFeature]
+cc 4ee3b0b441a308857c85f233ae6069a0e874fbb490e8aab6bb668f5ce68774bf # shrinks to ops = [ForkFeature, DeleteMain, RecreateMain]
+cc b553d1f6d4599e3cec42f3a66824dfe163194e8d55ab130b0ce5636200b50d39 # shrinks to ops = [RewriteMain, RewriteMain, ForkFeature, Reopen]
+cc fe055756468c9a34156790bfac11035153978621e00f634a65102906f047e1ec # shrinks to ops = [RewriteMain, ForkFeature, RecreateMain, RewriteMain, Reopen]


### PR DESCRIPTION
## Summary

Closes the four gaps surfaced by the B5 requirements audit.

### 1. Generated-history state-machine suite

- **Gap (audit):** `branching-b5-verification-spec.md` §Exit criteria requires "at least one generated-history suite exists" before B5 closes. Only the deterministic matrix and crash-boundary suites shipped in B5.2.
- **Fix:** New `tests/integration/branching_retention_state_machine.rs` — a proptest-driven lane that fuzzes `rewrite/fork/delete/recreate/materialize/reopen/gc` histories (16 cases × 1..18 ops) and checks retention + rebuild invariants against a model of expected state. `proptest` added as workspace dev-dep. Regression seeds checked in.

### 2. Same-name recreate leak in `retention_snapshot` (real bug)

- **Gap (state-machine-discovered):** Old-lifecycle descendant-held bytes were being folded into the recreated live branch's `shared_bytes`. Violates retention contract §"Same-name recreate".
- **Fix:** `StorageBranchRetention` gains `detached_shared_bytes`. Splits *"my live manifest owns these; descendants hold"* (correct shared attribution) from *"bytes under my dir but not owned by current live manifest"* (must be `orphan_storage` with `DescendantInheritance`, per contract §"Canonical blocker attribution"). `retention_report()` emits the orphan entry even when the `BranchId` has a live control record. New test `retention_report_recreate_does_not_fold_old_descendant_bytes_into_new_main` pins the corrected attribution.

### 3. Stale quarantine inventory convergence

- **Gap:** `retention_snapshot` in-session path was stricter than reopen reconciliation — benign stale inventory (publish-happened-no-rename or purge-already-done) hard-failed with `QuarantineReconciliationFailed` while `reopen` drops those entries silently.
- **Fix:** `quarantine_stats_from_state` accepts missing-inventory-entry cases where the file is **not** manifest-reachable (benign), still refuses when inventory claims quarantine membership for a manifest-live file (unsafe). New storage test `retention_snapshot_ignores_stale_missing_quarantine_inventory_entries`.

### 4. Vector `Searchable` fail-closed extension (B5.4 on system search path)

- **Gap:** Two silent-fallback sites in `VectorStore::search` as `Searchable`: `list_collections().unwrap_or_default()` and `match Err(_) => continue` over `system_search_with_sources`. Both violate B5.4 "no silent stale leakage".
- **Fix:** Both propagate via `into_strata_error(branch_id)`. `list_collections` inner decode path now marks degradation on `CollectionRecord::from_bytes` + `VectorConfig::try_from` failures via a new `degrade_collection_read` helper. Two new integration tests pinning fail-closed on system-collection config corruption and lazy-reload corruption.

### 5. Guardrail snapshot alignment

`branch_id_random_new_sites` 725 → 726. One `BranchId::new()` in a `#[cfg(test)]` block of `observers.rs::tests::test_primitive_replay_wrapper_dedupes_duplicate_delivery` landed with B5.4 #2461; the snapshot was not bumped at the time — tripwire now aligned.

**Change class:** Cutover (old silent-fallback paths in vector `Searchable` removed) + Bug-fix (same-name recreate attribution) + Test expansion (state-machine lane).
**Assurance class:** S3.

## Test plan

- [x] `cargo test --workspace --lib` — 4842 passed, 0 failed
- [x] `cargo test -p stratadb --test integration` — **290 passed, 0 failed** (was 283 on B5.4, +7 net: 1 state-machine + 1 retention_matrix + 2 degraded_primitive_paths + 1 quarantine_reconciliation + 2 from pre-existing expansion)
- [x] New state-machine suite `branching_retention_state_machine::generated_histories_preserve_retention_and_rebuild_invariants` passes 16 cases in ~11s
- [x] `cargo build --workspace` clean
- [x] Guardrail `branching_transitional_shapes_match_snapshot` now green

## Contract refs

- `docs/design/branching/branching-gc/branching-b5-verification-spec.md` §Exit criteria + §Suggested file plan
- `docs/design/branching/branching-gc/branching-retention-contract.md` §"Same-name recreate" + §"Canonical blocker attribution"
- `docs/design/branching/branching-gc/branching-b5-convergence-and-observability.md` §"Surface matrix" (vector in-memory / HNSW row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
