### PR TITLE
Remove dead Output::MaybeVersion variant (#2472 item 1)

### DIFF
--- a/crates/cli/src/render.rs
+++ b/crates/cli/src/render.rs
@@ -40,12 +40,9 @@ fn render_raw(output: &Output) -> String {
         }
         Output::Uint(value) | Output::Version(value) => value.to_string(),
         Output::Text(text) => text.clone(),
-        Output::Maybe(None) | Output::MaybeVersioned(None) | Output::MaybeVersion(None) => {
-            String::new()
-        }
+        Output::Maybe(None) | Output::MaybeVersioned(None) => String::new(),
         Output::Maybe(Some(value)) => render_raw_value(value),
         Output::MaybeVersioned(Some(versioned)) => render_raw_value(&versioned.value),
-        Output::MaybeVersion(Some(version)) => version.to_string(),
         Output::Keys(keys) | Output::SpaceList(keys) => keys.join("\n"),
         Output::VectorMatches(matches) => matches
             .iter()
@@ -76,12 +73,9 @@ fn render_human(output: &Output) -> String {
         }
         Output::Uint(value) | Output::Version(value) => value.to_string(),
         Output::Text(text) => text.clone(),
-        Output::Maybe(None) | Output::MaybeVersioned(None) | Output::MaybeVersion(None) => {
-            "(nil)".to_string()
-        }
+        Output::Maybe(None) | Output::MaybeVersioned(None) => "(nil)".to_string(),
         Output::Maybe(Some(value)) => render_human_value(value),
         Output::MaybeVersioned(Some(versioned)) => render_human_value(&versioned.value),
-        Output::MaybeVersion(Some(version)) => version.to_string(),
         Output::Keys(keys) | Output::SpaceList(keys) => keys.join("\n"),
         Output::TxnBegun => "OK".to_string(),
         Output::TxnCommitted { version } => format!("committed v{version}"),

--- a/crates/executor/src/output.rs
+++ b/crates/executor/src/output.rs
@@ -45,9 +45,6 @@ pub enum Output {
     /// Optional versioned value (most common for get operations)
     MaybeVersioned(Option<VersionedValue>),
 
-    /// Optional version number (for CAS operations)
-    MaybeVersion(Option<u64>),
-
     /// Version number
     Version(u64),
 


### PR DESCRIPTION
## Summary

Addresses **item 1 of #2472** — removes the dead `Output::MaybeVersion` variant.

- `crates/executor/src/output.rs:48` — `MaybeVersion(Option<u64>)` deleted
- `crates/cli/src/render.rs:43, 48, 79, 84` — four unreachable match arms removed

The variant was defined in the `Output` enum but never produced by any handler. The render arms that matched it were therefore unreachable. Confirmed dead via two greps: zero `Output::MaybeVersion(` constructor sites outside the enum definition, and zero `Returns: \`Output::MaybeVersion\`` doc strings on any `Command` variant. Likely a leftover from the executor rewrite (#2465).

2 files changed, 2 insertions, 11 deletions.

## Test plan

- [x] `cargo check -p strata-executor -p strata-cli` passes clean
- [ ] Workspace tests in CI

## Remaining for #2472

This PR closes only item 1. Issue #2472 stays open for:
- **Item 2** — `Error::Internal` overuse: 70 occurrences across the crate, 38 of them concentrated in AI handlers (`generate.rs`, `embed.rs`, `recipe.rs`, `models.rs`). Need typed variants (`ModelNotFound`, `GenerationFailed`, etc.) to replace the catch-all.
- **Item 3** — `generate.rs` repeats a misleading boilerplate hint at lines 48, 101, 133, 168, 175, 199, 202: *"This is likely a bug. Please report it…"* — wrong message for non-bug failures. Extract a helper, fix the wording, and replace the call sites with the typed variants from item 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)