### PR TITLE
ES2: move checkpoint and WAL compaction mechanics into strata-storage

### DIFF
--- a/crates/engine/src/database/compaction.rs
+++ b/crates/engine/src/database/compaction.rs
@@ -1,13 +1,14 @@
 //! Flush, checkpoint, and compaction.
 
 use crate::{StrataError, StrataResult};
-use std::sync::Arc;
+use std::num::NonZeroU64;
 use strata_core::id::{CommitVersion, TxnId};
 use strata_storage::durability::__internal::WalWriterEngineExt;
 use strata_storage::durability::{
-    BranchSnapshotEntry, CheckpointCoordinator, CheckpointData, CheckpointError, CompactionError,
-    EventSnapshotEntry, JsonSnapshotEntry, KvSnapshotEntry, ManifestError, ManifestManager,
-    VectorCollectionSnapshotEntry, VectorSnapshotEntry, WalOnlyCompactor,
+    BranchSnapshotEntry, CheckpointData, EventSnapshotEntry, JsonSnapshotEntry, KvSnapshotEntry,
+    StorageCheckpointError, StorageCheckpointInput, StorageManifestRuntimeError,
+    StorageWalCompactionError, StorageWalCompactionInput, VectorCollectionSnapshotEntry,
+    VectorSnapshotEntry,
 };
 use strata_storage::{Key, TypeTag};
 use tracing::info;
@@ -106,69 +107,43 @@ impl Database {
         // Collect data from storage
         let data = self.collect_checkpoint_data();
 
-        // Create snapshots directory
-        let snapshots_dir = self.data_dir.join("snapshots");
-        std::fs::create_dir_all(&snapshots_dir).map_err(StrataError::from)?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ =
-                std::fs::set_permissions(&snapshots_dir, std::fs::Permissions::from_mode(0o700));
-        }
-
-        // Load or create MANIFEST
-        let mut manifest = self.load_or_create_manifest()?;
-
-        // Build watermark state from existing MANIFEST if present
-        let existing_watermark = {
-            let m = manifest.manifest();
-            match (m.snapshot_id, m.snapshot_watermark) {
-                (Some(sid), Some(wtxn)) => Some(
-                    strata_storage::durability::SnapshotWatermark::with_values(sid, TxnId(wtxn), 0),
-                ),
-                _ => None,
-            }
-        };
-
-        // Create CheckpointCoordinator with the configured codec and database UUID
-        let db_uuid = self.database_uuid;
         let codec_id = self.config.read().storage.codec.clone();
         let codec = strata_storage::durability::get_codec(&codec_id)
             .map_err(|e| StrataError::internal(format!("checkpoint codec: {}", e)))?;
-        let mut coordinator = if let Some(wm) = existing_watermark {
-            CheckpointCoordinator::with_watermark(snapshots_dir, codec, db_uuid, wm)
-                .map_err(|e| StrataError::internal(format!("checkpoint coordinator: {}", e)))?
-        } else {
-            CheckpointCoordinator::new(snapshots_dir, codec, db_uuid)
-                .map_err(|e| StrataError::internal(format!("checkpoint coordinator: {}", e)))?
-        };
+        let current_segment = self
+            .wal_writer
+            .as_ref()
+            .expect("non-ephemeral non-follower must have wal_writer")
+            .lock()
+            .current_segment();
+        let active_wal_segment = NonZeroU64::new(current_segment)
+            .ok_or_else(|| StrataError::internal("WAL writer reported active segment 0"))?;
+        let layout = strata_storage::durability::DatabaseLayout::from_root(&self.data_dir);
 
-        // Create the checkpoint
-        let info =
-            coordinator
-                .checkpoint(TxnId(watermark_txn), data)
-                .map_err(|e: CheckpointError| {
-                    StrataError::internal(format!("checkpoint failed: {}", e))
-                })?;
-
-        // Update MANIFEST with snapshot watermark
-        manifest
-            .set_snapshot_watermark(info.snapshot_id, info.watermark_txn)
-            .map_err(|e: ManifestError| {
-                StrataError::internal(format!("manifest update failed: {}", e))
-            })?;
+        let outcome = strata_storage::durability::run_storage_checkpoint(StorageCheckpointInput {
+            layout,
+            database_uuid: self.database_uuid,
+            checkpoint_codec: codec,
+            // Preserve the current checkpoint/compact path behavior for
+            // databases missing a MANIFEST.
+            manifest_create_codec_id: "identity".to_string(),
+            checkpoint_data: data,
+            watermark_txn: TxnId(watermark_txn),
+            active_wal_segment,
+        })
+        .map_err(map_storage_checkpoint_error)?;
 
         info!(
             target: "strata::db",
-            snapshot_id = info.snapshot_id,
-            watermark_txn = info.watermark_txn.as_u64(),
+            snapshot_id = outcome.snapshot_id,
+            watermark_txn = outcome.watermark_txn.as_u64(),
             "Checkpoint created"
         );
 
-        if let Err(e) = self.prune_snapshots_once() {
+        if let Err(error) = self.prune_snapshots_once() {
             tracing::warn!(
                 target: "strata::durability",
-                error = %e,
+                error = %error,
                 "Snapshot pruning failed after checkpoint (non-fatal)"
             );
         }
@@ -179,10 +154,12 @@ impl Database {
     /// Compact WAL segments that are no longer needed for recovery.
     ///
     /// Removes closed WAL segments whose max transaction ID is at or below the
-    /// latest snapshot watermark. The active segment is never removed.
+    /// effective retention watermark from MANIFEST. The effective watermark is
+    /// the max of the snapshot watermark and flush watermark. The active
+    /// segment is never removed.
     ///
-    /// A checkpoint must exist before compaction can run. For ephemeral (cache)
-    /// databases, this is a no-op.
+    /// A checkpoint or flush watermark must exist before compaction can run.
+    /// For ephemeral (cache) databases, this is a no-op.
     ///
     /// See: `docs/architecture/STORAGE_DURABILITY_ARCHITECTURE.md` Section 5.6
     pub fn compact(&self) -> StrataResult<()> {
@@ -191,40 +168,33 @@ impl Database {
             return Ok(());
         }
 
-        let wal_dir = self.data_dir.join("wal");
-
-        // Load or create MANIFEST
-        let manifest = self.load_or_create_manifest()?;
-        let manifest_arc = Arc::new(parking_lot::Mutex::new(manifest));
-
         // Get the writer's in-memory segment number (may be ahead of MANIFEST)
-        let writer_active = self
+        let active_wal_segment = self
             .wal_writer
             .as_ref()
-            .map(|w| w.lock().current_segment())
-            .unwrap_or(0);
+            .map(|w| {
+                let current_segment = w.lock().current_segment();
+                NonZeroU64::new(current_segment)
+                    .ok_or_else(|| StrataError::internal("WAL writer reported active segment 0"))
+            })
+            .transpose()?;
+        let layout = strata_storage::durability::DatabaseLayout::from_root(&self.data_dir);
 
-        // Create compactor and run with the writer's active segment override.
-        // D2 / DG-001: thread the cached `wal_codec` so the `.meta`-miss
-        // fallback parses records through the codec-aware reader rather
-        // than the raw-byte path that bypasses both the v3 envelope and
-        // the installed codec.
-        let compactor = WalOnlyCompactor::new(wal_dir, manifest_arc).with_codec(
-            strata_storage::durability::codec::clone_codec(self.wal_codec.as_ref()),
-        );
-        let compact_info = compactor
-            .compact_with_active_override(writer_active)
-            .map_err(|e: CompactionError| match e {
-                CompactionError::NoSnapshot => StrataError::invalid_input(
-                    "No checkpoint exists yet. Run checkpoint() before compact().".to_string(),
-                ),
-                other => StrataError::internal(format!("compaction failed: {}", other)),
-            })?;
+        let outcome = strata_storage::durability::compact_storage_wal(StorageWalCompactionInput {
+            layout,
+            database_uuid: self.database_uuid,
+            wal_codec: strata_storage::durability::clone_codec(self.wal_codec.as_ref()),
+            // Preserve the current checkpoint/compact path behavior for
+            // databases missing a MANIFEST.
+            manifest_create_codec_id: "identity".to_string(),
+            active_wal_segment,
+        })
+        .map_err(map_storage_wal_compaction_error)?;
 
         info!(
             target: "strata::db",
-            segments_removed = compact_info.wal_segments_removed,
-            bytes_reclaimed = compact_info.reclaimed_bytes,
+            segments_removed = outcome.wal_segments_removed,
+            bytes_reclaimed = outcome.reclaimed_bytes,
             "WAL compaction completed"
         );
 
@@ -526,34 +496,52 @@ impl Database {
         }
         data
     }
+}
 
-    /// Load an existing MANIFEST or create a new one.
-    ///
-    /// Also updates the active WAL segment from the current WAL writer.
-    pub(super) fn load_or_create_manifest(&self) -> StrataResult<ManifestManager> {
-        let manifest_path = self.data_dir.join("MANIFEST");
-
-        let mut manifest = if ManifestManager::exists(&manifest_path) {
-            ManifestManager::load(manifest_path).map_err(|e: ManifestError| {
-                StrataError::internal(format!("failed to load MANIFEST: {}", e))
-            })?
-        } else {
-            ManifestManager::create(manifest_path, self.database_uuid, "identity".to_string())
-                .map_err(|e: ManifestError| {
-                    StrataError::internal(format!("failed to create MANIFEST: {}", e))
-                })?
-        };
-
-        // Update active WAL segment from the writer
-        if let Some(ref wal) = self.wal_writer {
-            let wal = wal.lock();
-            let current_seg = wal.current_segment();
-            manifest.manifest_mut().active_wal_segment = current_seg;
-            manifest.persist().map_err(|e: ManifestError| {
-                StrataError::internal(format!("failed to persist MANIFEST: {}", e))
-            })?;
+fn map_storage_checkpoint_error(error: StorageCheckpointError) -> StrataError {
+    match error {
+        StorageCheckpointError::CreateSnapshotsDir { source, .. } => StrataError::from(source),
+        StorageCheckpointError::Manifest(error) => map_storage_manifest_error(error),
+        StorageCheckpointError::CheckpointCoordinator(source) => {
+            StrataError::internal(format!("checkpoint coordinator: {}", source))
         }
+        StorageCheckpointError::Checkpoint(source) => {
+            StrataError::internal(format!("checkpoint failed: {}", source))
+        }
+        other => StrataError::internal(format!("storage checkpoint failed: {}", other)),
+    }
+}
 
-        Ok(manifest)
+fn map_storage_wal_compaction_error(error: StorageWalCompactionError) -> StrataError {
+    match error {
+        StorageWalCompactionError::Manifest(error) => map_storage_manifest_error(error),
+        StorageWalCompactionError::NoSnapshot => StrataError::invalid_input(
+            "No checkpoint exists yet. Run checkpoint() before compact().".to_string(),
+        ),
+        StorageWalCompactionError::Compaction(source) => {
+            StrataError::internal(format!("compaction failed: {}", source))
+        }
+        other => StrataError::internal(format!("storage WAL compaction failed: {}", other)),
+    }
+}
+
+fn map_storage_manifest_error(error: StorageManifestRuntimeError) -> StrataError {
+    match error {
+        StorageManifestRuntimeError::Load { source } => {
+            StrataError::internal(format!("failed to load MANIFEST: {}", source))
+        }
+        StorageManifestRuntimeError::Create { source } => {
+            StrataError::internal(format!("failed to create MANIFEST: {}", source))
+        }
+        StorageManifestRuntimeError::PersistActiveSegment { source } => {
+            StrataError::internal(format!("failed to persist MANIFEST: {}", source))
+        }
+        StorageManifestRuntimeError::SetSnapshotWatermark { source } => {
+            StrataError::internal(format!("manifest update failed: {}", source))
+        }
+        StorageManifestRuntimeError::Persist { source } => {
+            StrataError::internal(format!("failed to persist MANIFEST: {}", source))
+        }
+        other => StrataError::internal(format!("storage MANIFEST operation failed: {}", other)),
     }
 }

--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -306,9 +306,10 @@ impl Default for SnapshotRetentionPolicy {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StrataConfig {
     /// Durability mode: `"standard"` or `"always"` (switchable at runtime).
-    /// `"cache"` is valid in strata.toml for backward compat but cannot be set at runtime.
+    /// Cache behavior is selected by opening a cache database, not by this
+    /// disk-backed durability setting.
     ///
-    /// Class: live-safe (Standard ↔ Always); `"cache"` is open-time-only.
+    /// Class: live-safe (Standard ↔ Always).
     /// See `docs/design/architecture-cleanup/durability-recovery-config-matrix.md`.
     #[serde(default = "default_durability_str")]
     pub durability: String,
@@ -459,14 +460,13 @@ impl StrataConfig {
     ///
     /// # Errors
     ///
-    /// Returns an error if the string is not `"standard"`, `"always"`, or `"cache"`.
+    /// Returns an error if the string is not `"standard"` or `"always"`.
     pub fn durability_mode(&self) -> StrataResult<DurabilityMode> {
         match self.durability.as_str() {
             "standard" => Ok(DurabilityMode::standard_default()),
             "always" => Ok(DurabilityMode::Always),
-            "cache" => Ok(DurabilityMode::Cache),
             other => Err(StrataError::invalid_input(format!(
-                "Invalid durability mode '{}' in strata.toml. Expected \"standard\", \"always\", or \"cache\".",
+                "Invalid durability mode '{}' in strata.toml. Expected \"standard\" or \"always\". Cache mode is selected via Database::cache() or OpenSpec::cache().",
                 other
             ))),
         }
@@ -1052,17 +1052,18 @@ auto_embed = true
     }
 
     // -----------------------------------------------------------------------
-    // Cache durability mode
+    // Cache is an open mode, not a disk durability setting
     // -----------------------------------------------------------------------
 
     #[test]
-    fn parse_cache_durability() {
+    fn parse_cache_durability_is_rejected() {
         let config: StrataConfig = toml::from_str("durability = \"cache\"").unwrap();
-        assert_eq!(config.durability_mode().unwrap(), DurabilityMode::Cache);
+        let error = config.durability_mode().unwrap_err();
+        assert!(error.to_string().contains("Database::cache()"));
     }
 
     #[test]
-    fn cache_durability_round_trip() {
+    fn cache_durability_round_trip_still_rejects_runtime_mode() {
         let config = StrataConfig {
             durability: "cache".to_string(),
             ..StrataConfig::default()
@@ -1070,7 +1071,7 @@ auto_embed = true
         let toml_str = toml::to_string_pretty(&config).unwrap();
         let parsed: StrataConfig = toml::from_str(&toml_str).unwrap();
         assert_eq!(parsed.durability, "cache");
-        assert_eq!(parsed.durability_mode().unwrap(), DurabilityMode::Cache);
+        assert!(parsed.durability_mode().is_err());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -1,11 +1,11 @@
 //! GC, maintenance, follower refresh, and shutdown.
 
 use crate::{StrataError, StrataResult};
+use std::num::NonZeroU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use strata_core::id::{CommitVersion, TxnId};
 use strata_core::BranchId;
-use strata_storage::durability::{ManifestError, ManifestManager};
 use strata_storage::Key;
 use tracing::{info, warn};
 
@@ -124,17 +124,18 @@ impl Database {
     ///   - the `retain_count` newest snapshots, and
     ///   - the snapshot referenced by the live MANIFEST (recovery-critical).
     ///
-    /// Best-effort: per-file delete failures are logged but do not abort the
-    /// loop. The snapshots directory is fsynced once at the end if any file
-    /// was actually removed. Returns the number of files deleted.
+    /// Per-file delete failures are logged but do not abort the loop. The
+    /// snapshots directory is fsynced once at the end if any file was actually
+    /// removed. Returns the number of files deleted. Directory open/fsync
+    /// failures are returned to the caller; post-checkpoint callers treat them
+    /// as nonfatal to checkpoint success.
     ///
     /// Skipped (returns `Ok(0)`) for ephemeral mode, follower mode, and
     /// while shutdown is in progress.
     ///
-    /// Called from `Database::checkpoint` after the new snapshot is durable.
-    /// A future executor / CLI surface will expose this as an admin entry
-    /// point — see `docs/design/durability/durability-storage-closure-epics.md`
-    /// "What Comes After" section.
+    /// Kept as the engine config/lifecycle adapter for `Database::checkpoint`,
+    /// direct admin pruning tests, and a future executor / CLI surface.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn prune_snapshots_once(&self) -> StrataResult<usize> {
         if self.check_not_shutting_down().is_err() {
             return Ok(0);
@@ -143,87 +144,16 @@ impl Database {
             return Ok(0);
         }
 
-        let snapshots_dir = self.data_dir.join("snapshots");
-        if !snapshots_dir.exists() {
-            return Ok(0);
-        }
-
-        let retain_count = self.config.read().snapshot_retention.retain_count.max(1);
-
-        let manifest_path = self.data_dir.join("MANIFEST");
-        let live_snapshot_id = if ManifestManager::exists(&manifest_path) {
-            ManifestManager::load(manifest_path)
-                .map_err(|e: ManifestError| {
-                    StrataError::internal(format!(
-                        "prune_snapshots: failed to load MANIFEST: {}",
-                        e
-                    ))
-                })?
-                .manifest()
-                .snapshot_id
-        } else {
-            None
+        let layout = strata_storage::durability::DatabaseLayout::from_root(&self.data_dir);
+        let retention = {
+            let cfg = self.config.read();
+            strata_storage::durability::StorageSnapshotRetention::new(
+                cfg.snapshot_retention.retain_count,
+            )
         };
 
-        let snapshots =
-            strata_storage::durability::list_snapshots(&snapshots_dir).map_err(|e| {
-                StrataError::internal(format!(
-                    "prune_snapshots: failed to list snapshots in {}: {}",
-                    snapshots_dir.display(),
-                    e
-                ))
-            })?;
-
-        if snapshots.len() <= retain_count {
-            return Ok(0);
-        }
-
-        let keep_from = snapshots.len().saturating_sub(retain_count);
-        let mut deleted = 0usize;
-
-        for (i, (id, path)) in snapshots.iter().enumerate() {
-            if i >= keep_from {
-                break;
-            }
-            if Some(*id) == live_snapshot_id {
-                continue;
-            }
-            match std::fs::remove_file(path) {
-                Ok(_) => deleted += 1,
-                Err(e) => {
-                    warn!(
-                        target: "strata::durability",
-                        snapshot_id = id,
-                        path = ?path,
-                        error = %e,
-                        "Failed to delete pruned snapshot file"
-                    );
-                }
-            }
-        }
-
-        if deleted > 0 {
-            let dir_fd = std::fs::File::open(&snapshots_dir).map_err(|e| {
-                StrataError::internal(format!(
-                    "prune_snapshots: failed to open snapshots dir for fsync: {}",
-                    e
-                ))
-            })?;
-            dir_fd.sync_all().map_err(|e| {
-                StrataError::internal(format!(
-                    "prune_snapshots: failed to fsync snapshots dir: {}",
-                    e
-                ))
-            })?;
-            info!(
-                target: "strata::durability",
-                deleted,
-                retained = retain_count,
-                "Snapshot pruning complete"
-            );
-        }
-
-        Ok(deleted)
+        strata_storage::durability::prune_storage_snapshots(&layout, retention)
+            .map_err(|e| StrataError::internal(e.to_string()))
     }
 
     /// Remove the per-branch commit lock after a branch is deleted.
@@ -911,15 +841,33 @@ impl Database {
 
     /// Atomically persist the MANIFEST so it is durable before freeze hooks run.
     ///
-    /// `ManifestManager::persist()` performs tmp-write → `sync_all` → rename →
+    /// Storage manifest persistence performs tmp-write → `sync_all` → rename →
     /// parent-dir fsync. Skipped for ephemeral databases (no data_dir).
     fn fsync_manifest(&self) -> StrataResult<()> {
         if self.data_dir.as_os_str().is_empty() {
             return Ok(());
         }
-        let mut mgr = self.load_or_create_manifest()?;
-        mgr.persist()
-            .map_err(|e| StrataError::internal(format!("manifest fsync on shutdown failed: {}", e)))
+
+        let active_wal_segment = self
+            .wal_writer
+            .as_ref()
+            .map(|wal| {
+                let current_segment = wal.lock().current_segment();
+                NonZeroU64::new(current_segment)
+                    .ok_or_else(|| StrataError::internal("WAL writer reported active segment 0"))
+            })
+            .transpose()?;
+        let layout = strata_storage::durability::DatabaseLayout::from_root(&self.data_dir);
+
+        strata_storage::durability::sync_storage_manifest(
+            strata_storage::durability::StorageManifestSyncInput {
+                layout,
+                database_uuid: self.database_uuid,
+                manifest_create_codec_id: "identity".to_string(),
+                active_wal_segment,
+            },
+        )
+        .map_err(map_storage_manifest_sync_error)
     }
 
     /// Release this database's entry from the global `OPEN_DATABASES` registry.
@@ -932,5 +880,28 @@ impl Database {
         if self.persistence_mode == PersistenceMode::Disk {
             registry::unregister(&self.data_dir);
         }
+    }
+}
+
+fn map_storage_manifest_sync_error(
+    error: strata_storage::durability::StorageManifestRuntimeError,
+) -> StrataError {
+    match error {
+        strata_storage::durability::StorageManifestRuntimeError::Load { source } => {
+            StrataError::internal(format!("failed to load MANIFEST: {}", source))
+        }
+        strata_storage::durability::StorageManifestRuntimeError::Create { source } => {
+            StrataError::internal(format!("failed to create MANIFEST: {}", source))
+        }
+        strata_storage::durability::StorageManifestRuntimeError::PersistActiveSegment {
+            source,
+        } => StrataError::internal(format!("failed to persist MANIFEST: {}", source)),
+        strata_storage::durability::StorageManifestRuntimeError::SetSnapshotWatermark {
+            source,
+        } => StrataError::internal(format!("manifest update failed: {}", source)),
+        strata_storage::durability::StorageManifestRuntimeError::Persist { source } => {
+            StrataError::internal(format!("manifest fsync on shutdown failed: {}", source))
+        }
+        other => StrataError::internal(format!("manifest fsync on shutdown failed: {}", other)),
     }
 }

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -110,14 +110,12 @@ use strata_storage::{RecoveryHealth, SegmentedStore, StorageIterator, StorageRes
 /// | PersistenceMode | DurabilityMode | Behavior |
 /// |-----------------|----------------|----------|
 /// | Ephemeral | (ignored) | No files, data lost on drop |
-/// | Disk | Cache | Files created, no fsync |
 /// | Disk | Standard | Files created, periodic fsync |
 /// | Disk | Always | Files created, immediate fsync |
 ///
 /// # Use Cases
 ///
 /// - **Ephemeral**: Unit tests, caching, temporary computations
-/// - **Disk + Cache**: Integration tests (fast, isolated, but files exist)
 /// - **Disk + Standard**: Production workloads
 /// - **Disk + Always**: Audit logs, critical data
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -1317,12 +1317,15 @@ impl Database {
             default_branch,
         } = spec;
 
+        let validation_cfg = sanitize_config(config.as_ref().cloned().unwrap_or_default());
+        validation_cfg.durability_mode()?;
+
         // Create ephemeral database with spec.config if provided.
         // Cache databases are not in the registry, so no reuse check needed.
         let db = Self::create_ephemeral_bare(config.as_ref())?;
 
         let resolved_cfg = db.config();
-        let durability_mode = resolved_cfg.durability_mode()?;
+        let durability_mode = DurabilityMode::Cache;
         let codec_name = resolved_cfg.storage.codec.clone();
         let background_threads = resolved_cfg.storage.background_threads;
         let allow_lossy_recovery = resolved_cfg.allow_lossy_recovery;

--- a/crates/engine/src/database/tests/checkpoint.rs
+++ b/crates/engine/src/database/tests/checkpoint.rs
@@ -1,5 +1,59 @@
 use super::*;
 
+const TEST_AES_KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+struct EnvVarGuard {
+    name: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(name: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(name);
+        std::env::set_var(name, value);
+        Self { name, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(value) = self.previous.take() {
+            std::env::set_var(self.name, value);
+        } else {
+            std::env::remove_var(self.name);
+        }
+    }
+}
+
+fn aes_gcm_standard_config() -> StrataConfig {
+    StrataConfig {
+        durability: "standard".to_string(),
+        storage: StorageConfig {
+            codec: "aes-gcm-256".to_string(),
+            ..StorageConfig::default()
+        },
+        ..StrataConfig::default()
+    }
+}
+
+fn latest_snapshot_sections(db_path: &std::path::Path) -> Vec<(u8, Vec<u8>)> {
+    let snapshots_dir = db_path.join("snapshots");
+    let snapshots = strata_storage::durability::list_snapshots(&snapshots_dir).unwrap();
+    let (_, snapshot_path) = snapshots
+        .last()
+        .expect("checkpoint should create at least one snapshot");
+    let snapshot = strata_storage::durability::SnapshotReader::new(Box::new(IdentityCodec))
+        .load(snapshot_path)
+        .unwrap();
+
+    let sections: Vec<(u8, Vec<u8>)> = snapshot
+        .sections
+        .into_iter()
+        .map(|section| (section.primitive_type, section.data))
+        .collect();
+    sections
+}
+
 #[test]
 fn test_checkpoint_ephemeral_noop() {
     let db = Database::cache().unwrap();
@@ -21,7 +75,15 @@ fn test_compact_without_checkpoint_fails() {
 
     // Compact before any checkpoint should fail (no snapshot watermark)
     let result = db.compact();
-    assert!(result.is_err());
+    match result {
+        Err(StrataError::InvalidInput { message }) => {
+            assert_eq!(
+                message,
+                "No checkpoint exists yet. Run checkpoint() before compact()."
+            );
+        }
+        other => panic!("expected InvalidInput for compact without checkpoint, got {other:?}"),
+    }
 }
 
 #[test]
@@ -35,11 +97,12 @@ fn test_checkpoint_creates_snapshot() {
     let key = Key::new_kv(ns, "checkpoint_test");
 
     // Write some data
-    db.transaction(branch_id, |txn| {
-        txn.put(key.clone(), Value::String("hello".to_string()))?;
-        Ok(())
-    })
-    .unwrap();
+    let ((), commit_version) = db
+        .transaction_with_version(branch_id, |txn| {
+            txn.put(key.clone(), Value::String("hello".to_string()))?;
+            Ok(())
+        })
+        .unwrap();
 
     // Checkpoint should succeed
     assert!(db.checkpoint().is_ok());
@@ -47,10 +110,218 @@ fn test_checkpoint_creates_snapshot() {
     // Snapshots directory should exist with files
     let snapshots_dir = db_path.canonicalize().unwrap().join("snapshots");
     assert!(snapshots_dir.exists());
+    let snapshots = strata_storage::durability::list_snapshots(&snapshots_dir).unwrap();
+    assert_eq!(
+        snapshots.len(),
+        1,
+        "first checkpoint should create one snapshot file"
+    );
 
-    // MANIFEST should exist
+    // MANIFEST should exist and point at the snapshot watermark.
     let manifest_path = db_path.canonicalize().unwrap().join("MANIFEST");
     assert!(manifest_path.exists());
+    let manifest = strata_storage::durability::ManifestManager::load(manifest_path).unwrap();
+    let manifest_snapshot_id = manifest
+        .manifest()
+        .snapshot_id
+        .expect("checkpoint should persist a snapshot id");
+    assert_eq!(
+        manifest.manifest().snapshot_watermark,
+        Some(commit_version),
+        "checkpoint MANIFEST watermark should match the quiesced commit version"
+    );
+    assert!(
+        strata_storage::durability::snapshot_path(&snapshots_dir, manifest_snapshot_id).exists(),
+        "MANIFEST snapshot id should reference an existing snapshot file"
+    );
+}
+
+#[test]
+fn test_checkpoint_is_deterministic_without_intervening_writes() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let db = Database::open(&db_path).unwrap();
+
+    let branch_id = BranchId::from_bytes([0x22; 16]);
+    let ns = Arc::new(Namespace::new(branch_id, "stable".to_string()));
+    let key_a = Key::new_kv(ns.clone(), "a");
+    let key_b = Key::new_graph(ns.clone(), "b");
+
+    let ((), commit_version) = db
+        .transaction_with_version(branch_id, |txn| {
+            txn.put(key_a.clone(), Value::String("alpha".to_string()))?;
+            txn.put(key_b.clone(), Value::String("beta".to_string()))?;
+            Ok(())
+        })
+        .unwrap();
+    let recovery_version = CommitVersion(commit_version);
+    db.storage
+        .put_recovery_entry(
+            Key::new_event(ns.clone(), 1),
+            Value::String("event".to_string()),
+            recovery_version,
+            11_000,
+            0,
+        )
+        .unwrap();
+    db.storage
+        .put_recovery_entry(
+            Key::new_branch_with_id(ns.clone(), "branch-record"),
+            Value::String("branch".to_string()),
+            recovery_version,
+            12_000,
+            0,
+        )
+        .unwrap();
+    db.storage
+        .put_recovery_entry(
+            Key::new_json(ns, "doc-1"),
+            Value::String("{\"stable\":true}".to_string()),
+            recovery_version,
+            13_000,
+            0,
+        )
+        .unwrap();
+
+    db.checkpoint().unwrap();
+    let first_sections = latest_snapshot_sections(&db_path);
+    let first_tags: Vec<u8> = first_sections.iter().map(|(tag, _)| *tag).collect();
+    assert_eq!(
+        first_tags,
+        vec![
+            strata_storage::durability::primitive_tags::KV,
+            strata_storage::durability::primitive_tags::EVENT,
+            strata_storage::durability::primitive_tags::BRANCH,
+            strata_storage::durability::primitive_tags::JSON,
+        ],
+        "checkpoint sections should retain the storage snapshot writer order"
+    );
+
+    db.checkpoint().unwrap();
+    let second_sections = latest_snapshot_sections(&db_path);
+
+    assert_eq!(
+        first_sections, second_sections,
+        "snapshot primitive sections should be byte-identical when storage state is unchanged"
+    );
+}
+
+#[test]
+#[serial(open_databases)]
+fn test_checkpoint_recreates_missing_manifest_with_identity_codec_even_when_configured_aes() {
+    OPEN_DATABASES.lock().clear();
+    let _key_guard = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(aes_gcm_standard_config())
+            .with_subsystem(crate::SearchSubsystem),
+    )
+    .unwrap();
+
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    db.transaction(branch_id, |txn| {
+        txn.put(Key::new_kv(ns.clone(), "manifest_recreate"), Value::Int(1))?;
+        Ok(())
+    })
+    .unwrap();
+
+    let manifest_path = db_path.join("MANIFEST");
+    std::fs::remove_file(&manifest_path).unwrap();
+
+    db.checkpoint().unwrap();
+
+    let snapshots_dir = db_path.join("snapshots");
+    let snapshots = strata_storage::durability::list_snapshots(&snapshots_dir).unwrap();
+    let (_, snapshot_path) = snapshots
+        .last()
+        .expect("checkpoint should create an AES snapshot");
+    let snapshot = strata_storage::durability::SnapshotReader::new(
+        strata_storage::durability::get_codec("aes-gcm-256").unwrap(),
+    )
+    .load(snapshot_path)
+    .unwrap();
+    assert_eq!(
+        snapshot.codec_id, "aes-gcm-256",
+        "snapshot writer should still use the configured AES codec"
+    );
+
+    let manifest = strata_storage::durability::ManifestManager::load(manifest_path).unwrap();
+    assert_eq!(
+        manifest.manifest().codec_id,
+        "identity",
+        "missing MANIFEST recreation currently pins identity even when the DB is configured for AES"
+    );
+    assert!(
+        manifest.manifest().snapshot_id.is_some(),
+        "recreated MANIFEST should still receive checkpoint snapshot metadata"
+    );
+
+    drop(db);
+    OPEN_DATABASES.lock().clear();
+}
+
+#[test]
+#[serial(open_databases)]
+fn test_compact_missing_manifest_loses_snapshot_metadata_even_when_configured_aes() {
+    OPEN_DATABASES.lock().clear();
+    let _key_guard = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let db = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(aes_gcm_standard_config())
+            .with_subsystem(crate::SearchSubsystem),
+    )
+    .unwrap();
+
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+    db.transaction(branch_id, |txn| {
+        txn.put(Key::new_kv(ns.clone(), "manifest_recreate"), Value::Int(1))?;
+        Ok(())
+    })
+    .unwrap();
+    db.checkpoint().unwrap();
+
+    let manifest_path = db_path.join("MANIFEST");
+    std::fs::remove_file(&manifest_path).unwrap();
+
+    match db.compact() {
+        Err(StrataError::InvalidInput { message }) => {
+            assert_eq!(
+                message,
+                "No checkpoint exists yet. Run checkpoint() before compact()."
+            );
+        }
+        other => {
+            panic!("expected InvalidInput after compact recreates missing MANIFEST, got {other:?}")
+        }
+    }
+
+    let manifest = strata_storage::durability::ManifestManager::load(manifest_path).unwrap();
+    assert_eq!(
+        manifest.manifest().codec_id,
+        "identity",
+        "missing MANIFEST recreation during compact currently pins identity even under AES config"
+    );
+    assert_eq!(
+        manifest.manifest().snapshot_id,
+        None,
+        "compact-created MANIFEST should not infer prior snapshot metadata"
+    );
+    assert_eq!(
+        manifest.manifest().snapshot_watermark,
+        None,
+        "compact-created MANIFEST should not infer prior snapshot watermark"
+    );
+
+    drop(db);
+    OPEN_DATABASES.lock().clear();
 }
 
 #[test]

--- a/crates/engine/src/database/tests/codec.rs
+++ b/crates/engine/src/database/tests/codec.rs
@@ -26,28 +26,35 @@ const TEST_AES_KEY: &str = "000102030405060708090a0b0c0d0e0f10111213141516171819
 /// RAII guard that sets an env var on construction and removes it on drop.
 /// Ensures the encryption-key env var does not leak to sibling tests even
 /// if an assertion panics mid-body.
-struct EnvVarGuard(&'static str);
+struct EnvVarGuard {
+    name: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
 
 impl EnvVarGuard {
     fn set(name: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(name);
         std::env::set_var(name, value);
-        Self(name)
+        Self { name, previous }
     }
 }
 
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
-        std::env::remove_var(self.0);
+        if let Some(value) = self.previous.take() {
+            std::env::set_var(self.name, value);
+        } else {
+            std::env::remove_var(self.name);
+        }
     }
 }
 
 /// Registry-reuse path: an already-open database rejects a second opener
 /// that asks for a different codec, with [`StrataError::IncompatibleReuse`].
 ///
-/// Uses cache durability so neither opener hits the WAL-codec block at
-/// `open.rs:842`. The first handle is held alive for the duration of the
-/// second call so the reuse path is actually exercised (not the cold-reopen
-/// path that goes through the MANIFEST check).
+/// The first handle is held alive for the duration of the second call so the
+/// reuse path is actually exercised (not the cold-reopen path that goes
+/// through the MANIFEST check).
 #[test]
 #[serial(open_databases)]
 fn test_registry_reuse_rejects_different_codec() {
@@ -58,7 +65,7 @@ fn test_registry_reuse_rejects_different_codec() {
     let db_path = temp_dir.path().join("db");
 
     let cfg_aes = StrataConfig {
-        durability: "cache".to_string(),
+        durability: "standard".to_string(),
         storage: StorageConfig {
             codec: "aes-gcm-256".to_string(),
             ..StorageConfig::default()
@@ -74,7 +81,7 @@ fn test_registry_reuse_rejects_different_codec() {
 
     // Second opener, same path, same durability, DIFFERENT codec.
     let cfg_identity = StrataConfig {
-        durability: "cache".to_string(),
+        durability: "standard".to_string(),
         storage: StorageConfig {
             codec: "identity".to_string(),
             ..StorageConfig::default()
@@ -128,13 +135,12 @@ fn test_follower_rejects_codec_mismatch_with_manifest() {
     }
     OPEN_DATABASES.lock().clear();
 
-    // Attempt to open a follower that claims a different codec.
-    // Use cache durability on the follower so the earlier
-    // non-identity + WAL rejection (which would fire on Standard/Always)
-    // does not mask the MANIFEST drift check we're exercising here.
+    // Attempt to open a follower that claims a different codec. Non-identity
+    // WAL replay is codec-aware now, so the MANIFEST drift check is the
+    // expected failure.
     let _key_guard = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
     let cfg_follower = StrataConfig {
-        durability: "cache".to_string(),
+        durability: "standard".to_string(),
         storage: StorageConfig {
             codec: "aes-gcm-256".to_string(),
             ..StorageConfig::default()
@@ -181,7 +187,7 @@ fn test_follower_rejects_unknown_codec_without_manifest() {
     std::fs::create_dir_all(&db_path).unwrap();
 
     let cfg = StrataConfig {
-        durability: "cache".to_string(),
+        durability: "standard".to_string(),
         storage: StorageConfig {
             codec: "lz4-does-not-exist".to_string(),
             ..StorageConfig::default()
@@ -250,7 +256,7 @@ fn test_registry_reuse_rejects_different_background_threads() {
     let db_path = temp_dir.path().join("db");
 
     let mut cfg_a = StrataConfig {
-        durability: "cache".to_string(),
+        durability: "standard".to_string(),
         ..StrataConfig::default()
     };
     cfg_a.storage.background_threads = 2;
@@ -263,7 +269,7 @@ fn test_registry_reuse_rejects_different_background_threads() {
     .expect("first opener with background_threads=2 must succeed");
 
     let mut cfg_b = StrataConfig {
-        durability: "cache".to_string(),
+        durability: "standard".to_string(),
         ..StrataConfig::default()
     };
     cfg_b.storage.background_threads = 8;
@@ -330,7 +336,7 @@ fn test_profiled_defaults_are_not_persisted_to_strata_toml() {
     let db = Database::open_runtime(
         super::spec::OpenSpec::primary(&db_path)
             .with_config(StrataConfig {
-                durability: "cache".to_string(),
+                durability: "standard".to_string(),
                 ..StrataConfig::default()
             })
             .with_subsystem(SearchSubsystem),
@@ -367,7 +373,7 @@ fn test_profiled_defaults_are_not_persisted_to_strata_toml() {
     let db2 = Database::open_runtime(
         super::spec::OpenSpec::primary(&db_path)
             .with_config(StrataConfig {
-                durability: "cache".to_string(),
+                durability: "standard".to_string(),
                 ..StrataConfig::default()
             })
             .with_subsystem(SearchSubsystem),
@@ -404,7 +410,7 @@ fn test_profile_applies_before_signature_so_reuse_with_explicit_value_succeeds()
     let db1 = Database::open_runtime(
         super::spec::OpenSpec::primary(&db_path)
             .with_config(StrataConfig {
-                durability: "cache".to_string(),
+                durability: "standard".to_string(),
                 ..StrataConfig::default()
             })
             .with_subsystem(SearchSubsystem),
@@ -417,7 +423,7 @@ fn test_profile_applies_before_signature_so_reuse_with_explicit_value_succeeds()
         .background_threads;
 
     let mut cfg_explicit = StrataConfig {
-        durability: "cache".to_string(),
+        durability: "standard".to_string(),
         ..StrataConfig::default()
     };
     cfg_explicit.storage.background_threads = effective_threads;
@@ -553,7 +559,7 @@ fn test_update_config_rejects_open_time_only_field_changes() {
     let db = Database::open_runtime(
         super::spec::OpenSpec::primary(&db_path)
             .with_config(StrataConfig {
-                durability: "cache".to_string(),
+                durability: "standard".to_string(),
                 ..StrataConfig::default()
             })
             .with_subsystem(SearchSubsystem),
@@ -633,7 +639,7 @@ fn test_registry_reuse_rejects_different_allow_lossy_recovery() {
     let db_path = temp_dir.path().join("db");
 
     let cfg_strict = StrataConfig {
-        durability: "cache".to_string(),
+        durability: "standard".to_string(),
         allow_lossy_recovery: false,
         ..StrataConfig::default()
     };
@@ -645,7 +651,7 @@ fn test_registry_reuse_rejects_different_allow_lossy_recovery() {
     .expect("first opener with allow_lossy_recovery=false must succeed");
 
     let cfg_lossy = StrataConfig {
-        durability: "cache".to_string(),
+        durability: "standard".to_string(),
         allow_lossy_recovery: true,
         ..StrataConfig::default()
     };

--- a/crates/engine/src/database/tests/contention.rs
+++ b/crates/engine/src/database/tests/contention.rs
@@ -4,9 +4,11 @@ use super::*;
 fn test_put_direct_contention_scaling() {
     const OPS_PER_THREAD: usize = 10_000;
     let temp_dir = TempDir::new().unwrap();
-    let db =
-        Database::open_with_durability(temp_dir.path().join("contention"), DurabilityMode::Cache)
-            .unwrap();
+    let db = Database::open_with_durability(
+        temp_dir.path().join("contention"),
+        DurabilityMode::standard_default(),
+    )
+    .unwrap();
 
     // Phase 1: Concurrent writes — measure throughput scaling
     let thread_counts = [1, 4, 8, 16];

--- a/crates/engine/src/database/tests/mod.rs
+++ b/crates/engine/src/database/tests/mod.rs
@@ -58,7 +58,11 @@ impl Database {
     ) -> StrataResult<Arc<Self>> {
         let dur_str = match durability_mode {
             DurabilityMode::Always => "always",
-            DurabilityMode::Cache => "cache",
+            DurabilityMode::Cache => {
+                return Err(StrataError::invalid_input(
+                    "DurabilityMode::Cache is only valid for Database::cache()".to_string(),
+                ));
+            }
             _ => "standard",
         };
         let cfg = StrataConfig {

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -199,13 +199,77 @@ fn test_open_with_different_durability_modes() {
         assert!(!db.is_cache());
     }
 
-    // Cache mode
-    {
-        let db =
-            Database::open_with_durability(temp_dir.path().join("none"), DurabilityMode::Cache)
-                .unwrap();
-        assert!(!db.is_cache());
-    }
+    // Ephemeral cache is an open mode, not a disk-backed durability.
+    let cache = Database::cache().unwrap();
+    assert!(cache.is_cache());
+}
+
+#[test]
+fn test_primary_open_rejects_cache_durability_string() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("cache_is_not_disk_durability");
+
+    let result = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(StrataConfig {
+                durability: "cache".to_string(),
+                ..StrataConfig::default()
+            })
+            .with_subsystem(crate::search::SearchSubsystem),
+    );
+
+    let error = match result {
+        Ok(_) => panic!("primary open must reject durability = cache"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("Database::cache()"),
+        "error must point callers at cache open mode, got: {error}"
+    );
+}
+
+#[test]
+fn test_cache_open_rejects_invalid_durability_string() {
+    let result = Database::open_runtime(
+        super::spec::OpenSpec::cache()
+            .with_config(StrataConfig {
+                durability: "turbo".to_string(),
+                ..StrataConfig::default()
+            })
+            .with_subsystem(crate::search::SearchSubsystem),
+    );
+
+    let error = match result {
+        Ok(_) => panic!("cache open must still validate durability config strings"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("Invalid durability mode 'turbo'"),
+        "cache open must reject invalid durability strings, got: {error}"
+    );
+}
+
+#[test]
+fn test_cache_open_rejects_cache_durability_string() {
+    let result = Database::open_runtime(
+        super::spec::OpenSpec::cache()
+            .with_config(StrataConfig {
+                durability: "cache".to_string(),
+                ..StrataConfig::default()
+            })
+            .with_subsystem(crate::search::SearchSubsystem),
+    );
+
+    let error = match result {
+        Ok(_) => panic!("cache open mode must not accept durability = cache"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("Database::cache()"),
+        "error should explain cache is selected by open mode, got: {error}"
+    );
 }
 
 #[test]

--- a/crates/engine/src/database/tests/regressions.rs
+++ b/crates/engine/src/database/tests/regressions.rs
@@ -419,6 +419,50 @@ fn test_issue_1732_checkpoint_data_preserves_branch_names() {
 }
 
 #[test]
+fn test_checkpoint_data_skips_branch_secondary_index_keys() {
+    let db = Database::cache().unwrap();
+    let branch_id = BranchId::from_bytes([0x31; 16]);
+    let namespace = Arc::new(Namespace::new(branch_id, "branch_index".to_string()));
+    let value = Value::String("branch-payload".to_string());
+
+    db.storage
+        .put_recovery_entry(
+            Key::new_branch_with_id(namespace.clone(), "branch-record"),
+            value.clone(),
+            CommitVersion(41),
+            41_000,
+            0,
+        )
+        .unwrap();
+    db.storage
+        .put_recovery_entry(
+            Key::new_branch_index(namespace, "name", "feature", "branch-record"),
+            Value::String("derived-index".to_string()),
+            CommitVersion(42),
+            42_000,
+            0,
+        )
+        .unwrap();
+
+    let branch_entries = db.collect_checkpoint_data().branches.unwrap_or_default();
+    let matching_entries: Vec<_> = branch_entries
+        .iter()
+        .filter(|entry| entry.branch_id == *branch_id.as_bytes())
+        .collect();
+
+    assert_eq!(
+        matching_entries.len(),
+        1,
+        "checkpoint should include only source branch metadata, not derived __idx_ rows: {matching_entries:?}"
+    );
+    let entry = matching_entries[0];
+    assert_eq!(entry.key, "branch-record");
+    assert_eq!(entry.value, serde_json::to_vec(&value).unwrap());
+    assert_eq!(entry.version, 41);
+    assert_eq!(entry.timestamp, 41_000);
+}
+
+#[test]
 fn test_checkpoint_data_preserves_branch_space_and_type_for_kv_entries() {
     let db = Database::cache().unwrap();
     let branch_a = BranchId::from_bytes([1; 16]);
@@ -559,6 +603,60 @@ fn test_checkpoint_data_preserves_event_space_metadata() {
             && entry.version == version.as_u64()
             && entry.timestamp == timestamp_micros
     }));
+}
+
+#[test]
+fn test_checkpoint_data_skips_event_metadata_and_type_index_keys() {
+    let db = Database::cache().unwrap();
+    let branch_id = BranchId::from_bytes([0x32; 16]);
+    let namespace = Arc::new(Namespace::new(branch_id, "tenant_events".to_string()));
+    let event_value = Value::String("event-payload".to_string());
+
+    db.storage
+        .put_recovery_entry(
+            Key::new_event(namespace.clone(), 11),
+            event_value.clone(),
+            CommitVersion(51),
+            51_000,
+            0,
+        )
+        .unwrap();
+    db.storage
+        .put_recovery_entry(
+            Key::new_event_meta(namespace.clone()),
+            Value::String("derived-meta".to_string()),
+            CommitVersion(52),
+            52_000,
+            0,
+        )
+        .unwrap();
+    db.storage
+        .put_recovery_entry(
+            Key::new_event_type_idx(namespace, "user.created", 11),
+            Value::String("derived-type-index".to_string()),
+            CommitVersion(53),
+            53_000,
+            0,
+        )
+        .unwrap();
+
+    let event_entries = db.collect_checkpoint_data().events.unwrap_or_default();
+    let matching_entries: Vec<_> = event_entries
+        .iter()
+        .filter(|entry| entry.branch_id == *branch_id.as_bytes())
+        .collect();
+
+    assert_eq!(
+        matching_entries.len(),
+        1,
+        "checkpoint should include only append event rows, not __meta__ or __tidx__ rows: {matching_entries:?}"
+    );
+    let entry = matching_entries[0];
+    assert_eq!(entry.space, "tenant_events");
+    assert_eq!(entry.sequence, 11);
+    assert_eq!(entry.payload, serde_json::to_vec(&event_value).unwrap());
+    assert_eq!(entry.version, 51);
+    assert_eq!(entry.timestamp, 51_000);
 }
 
 #[test]
@@ -1122,7 +1220,7 @@ fn test_issue_1924_write_stall_timeout_surfaced_to_caller() {
     // stop trigger of 1 (any L0 segment triggers stall), and 1ms timeout
     // so the stall expires before compaction can drain L0.
     let cfg = StrataConfig {
-        durability: "cache".to_string(),
+        durability: "standard".to_string(),
         storage: StorageConfig {
             write_buffer_size: 128,        // tiny: forces memtable rotation
             l0_stop_writes_trigger: 1,     // stall when ANY L0 segment exists
@@ -1179,7 +1277,7 @@ fn test_issue_1924_write_stall_timeout_manual_commit() {
     let ns = Arc::new(Namespace::new(branch_id, "default".to_string()));
 
     let cfg = StrataConfig {
-        durability: "cache".to_string(),
+        durability: "standard".to_string(),
         storage: StorageConfig {
             write_buffer_size: 128,
             l0_stop_writes_trigger: 1,
@@ -1248,15 +1346,15 @@ static ENV_VAR_TEST_LOCK: once_cell::sync::Lazy<std::sync::Mutex<()>> =
 #[serial(open_databases)]
 fn test_issue_1380_codec_mismatch_rejected() {
     // A database created with "identity" must reject reopen with a different codec.
-    // Use Cache mode to bypass the WAL-not-supported guard (encryption works in
-    // Cache mode, WAL codec support is pending).
+    // WAL codec support is available, so this exercises the disk-backed
+    // primary path directly.
     let _env_guard = ENV_VAR_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let temp_dir = TempDir::new().unwrap();
 
-    // First open with Cache mode: creates MANIFEST with "identity"
+    // First open creates MANIFEST with "identity".
     {
         let cfg = StrataConfig {
-            durability: "cache".to_string(),
+            durability: "standard".to_string(),
             ..StrataConfig::default()
         };
         let spec = super::spec::OpenSpec::primary(temp_dir.path())
@@ -1266,7 +1364,7 @@ fn test_issue_1380_codec_mismatch_rejected() {
         drop(db);
     }
 
-    // Second open with mismatched codec in Cache mode: must fail with codec mismatch
+    // Second open with mismatched codec must fail with codec mismatch
     // (We need the env var set so get_codec validation passes before hitting the
     // MANIFEST mismatch check)
     std::env::set_var(
@@ -1274,7 +1372,7 @@ fn test_issue_1380_codec_mismatch_rejected() {
         "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
     );
     let cfg = StrataConfig {
-        durability: "cache".to_string(),
+        durability: "standard".to_string(),
         storage: StorageConfig {
             codec: "aes-gcm-256".to_string(),
             ..StorageConfig::default()

--- a/crates/engine/src/database/tests/snapshot_retention.rs
+++ b/crates/engine/src/database/tests/snapshot_retention.rs
@@ -151,6 +151,87 @@ fn prune_preserves_live_manifest_snapshot_when_outside_retain_window() {
 }
 
 #[test]
+fn checkpoint_succeeds_when_snapshot_pruning_cannot_delete_old_entry() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let db = Database::open(&db_path).unwrap();
+
+    {
+        let mut cfg = db.config.write();
+        cfg.snapshot_retention.retain_count = 1;
+    }
+
+    let canonical = db_path.canonicalize().unwrap();
+    let snapshots_dir = canonical.join("snapshots");
+    std::fs::create_dir_all(&snapshots_dir).unwrap();
+
+    // Force snapshot id 1 into the deletion window, but make it a directory.
+    // The pruner uses remove_file(), so this delete fails portably. The
+    // surrounding checkpoint must still return success after writing id 2.
+    let undeletable_old_snapshot = strata_storage::durability::snapshot_path(&snapshots_dir, 1);
+    std::fs::create_dir(&undeletable_old_snapshot).unwrap();
+    assert!(
+        list_snapshots(&snapshots_dir)
+            .unwrap()
+            .iter()
+            .any(|(id, path)| *id == 1 && path == &undeletable_old_snapshot),
+        "directory-shaped snap-000001.chk must be a prune candidate for this characterization"
+    );
+
+    let manifest_path = canonical.join("MANIFEST");
+    {
+        let mut manifest =
+            strata_storage::durability::ManifestManager::load(manifest_path.clone()).unwrap();
+        manifest.set_snapshot_watermark(1, TxnId(1)).unwrap();
+    }
+
+    let branch_id = BranchId::new();
+    write_one(&db, branch_id, "prune-failure");
+
+    db.checkpoint()
+        .expect("checkpoint must remain non-fatal when post-checkpoint pruning fails");
+
+    let manifest = strata_storage::durability::ManifestManager::load(manifest_path).unwrap();
+    assert_eq!(
+        manifest.manifest().snapshot_id,
+        Some(2),
+        "checkpoint should advance MANIFEST despite non-fatal prune delete failure"
+    );
+    assert!(
+        undeletable_old_snapshot.is_dir(),
+        "failed prune candidate should remain when remove_file cannot delete it"
+    );
+    assert!(
+        strata_storage::durability::snapshot_path(&snapshots_dir, 2).exists(),
+        "new checkpoint snapshot should be durable"
+    );
+}
+
+#[test]
+fn prune_snapshots_once_reports_manifest_load_errors() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let db = Database::open(&db_path).unwrap();
+
+    let branch_id = BranchId::new();
+    write_one(&db, branch_id, "manifest-load-error");
+    db.checkpoint().unwrap();
+
+    let manifest_path = db_path.canonicalize().unwrap().join("MANIFEST");
+    std::fs::write(&manifest_path, b"not a manifest").unwrap();
+
+    match db.prune_snapshots_once() {
+        Err(StrataError::Internal { message }) => {
+            assert!(
+                message.contains("prune_snapshots: failed to load MANIFEST"),
+                "unexpected prune error message: {message}"
+            );
+        }
+        other => panic!("expected MANIFEST load failure from prune_snapshots_once, got {other:?}"),
+    }
+}
+
+#[test]
 fn prune_noop_when_under_retain_count() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("db");

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -1,7 +1,6 @@
 //! Transaction API and write backpressure.
 
 use crate::{StrataError, StrataResult};
-use parking_lot::Mutex as ParkingMutex;
 use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -9,7 +8,6 @@ use strata_core::id::CommitVersion;
 use strata_core::BranchId;
 use strata_core::{EntityRef, Version};
 use strata_storage::durability::wal::DurabilityMode;
-use strata_storage::durability::{ManifestManager, WalOnlyCompactor};
 use strata_storage::{SegmentedStore, TransactionContext};
 
 use super::Database;
@@ -225,7 +223,6 @@ impl Database {
                         Self::update_flush_watermark(
                             &self.storage,
                             &self.data_dir,
-                            &self.wal_dir,
                             self.wal_codec.as_ref(),
                         );
                     }
@@ -278,7 +275,6 @@ impl Database {
         {
             let storage = Arc::clone(&self.storage);
             let data_dir = self.data_dir.clone();
-            let wal_dir = self.wal_dir.clone();
             let flush_flag = Arc::clone(&self.flush_in_flight);
             let wal_codec = strata_storage::durability::codec::clone_codec(self.wal_codec.as_ref());
             let _ = self
@@ -301,7 +297,6 @@ impl Database {
                                         Self::update_flush_watermark(
                                             &storage,
                                             &data_dir,
-                                            &wal_dir,
                                             wal_codec.as_ref(),
                                         );
                                     }
@@ -490,79 +485,64 @@ impl Database {
     fn update_flush_watermark(
         storage: &SegmentedStore,
         data_dir: &Path,
-        wal_dir: &Path,
         wal_codec: &dyn strata_storage::durability::codec::StorageCodec,
     ) {
-        // Compute global flush watermark: min of max_flushed_commit across all branches
-        let branch_ids = storage.branch_ids();
-        if branch_ids.is_empty() {
-            return;
-        }
-
-        // Compute watermark: min of max_flushed_commit across branches
-        // that participate in the flush pipeline (have segments).
-        // Branches with no segments (e.g. _system_) are excluded — their
-        // data is small and replayed from WAL on recovery.
-        let mut watermark = CommitVersion::MAX;
-        let mut has_any_segments = false;
-        for bid in &branch_ids {
-            if let Some(commit) = storage.max_flushed_commit(bid) {
-                if commit > CommitVersion::ZERO {
-                    watermark = watermark.min(commit);
-                    has_any_segments = true;
-                }
-            }
-            // Branches with no segments are intentionally excluded
-        }
-        if !has_any_segments || watermark == CommitVersion::MAX {
-            return;
-        }
-
-        // Update MANIFEST
-        let manifest_path = data_dir.join("MANIFEST");
-        let mut mgr = match ManifestManager::load(manifest_path) {
-            Ok(mgr) => mgr,
-            Err(e) => {
-                tracing::debug!(
-                    target: "strata::flush",
-                    error = %e,
-                    "No MANIFEST found, skipping WAL truncation"
-                );
-                return;
-            }
-        };
-
-        if let Err(e) = mgr.set_flush_watermark(watermark) {
-            tracing::warn!(
-                target: "strata::flush",
-                error = %e,
-                watermark = watermark.as_u64(),
-                "Failed to update flush watermark in MANIFEST"
-            );
-            return; // Don't truncate WAL if watermark wasn't persisted
-        }
-
-        // Truncate WAL segments below watermark
-        let manifest_arc = Arc::new(ParkingMutex::new(mgr));
-        let compactor = WalOnlyCompactor::new(wal_dir.to_path_buf(), manifest_arc)
-            .with_codec(strata_storage::durability::codec::clone_codec(wal_codec));
-        match compactor.compact() {
-            Ok(info) => {
-                if info.wal_segments_removed > 0 {
+        let layout = strata_storage::durability::DatabaseLayout::from_root(data_dir);
+        match strata_storage::durability::truncate_storage_wal_after_flush(
+            strata_storage::durability::StorageFlushWalTruncationInput {
+                layout,
+                storage,
+                wal_codec: strata_storage::durability::clone_codec(wal_codec),
+            },
+        ) {
+            Ok(Some(outcome)) => {
+                if outcome.wal_segments_removed > 0 {
                     tracing::debug!(
                         target: "strata::wal",
-                        segments_removed = info.wal_segments_removed,
-                        bytes_reclaimed = info.reclaimed_bytes,
-                        watermark = watermark.as_u64(),
+                        segments_removed = outcome.wal_segments_removed,
+                        bytes_reclaimed = outcome.reclaimed_bytes,
+                        watermark = outcome.flush_watermark.as_u64(),
                         "WAL segments truncated after flush"
                     );
                 }
             }
-            Err(e) => {
+            Ok(None) => {}
+            Err(strata_storage::durability::StorageFlushWalTruncationError::LoadManifest {
+                source,
+            }) => {
+                tracing::debug!(
+                    target: "strata::flush",
+                    error = %source,
+                    "No MANIFEST found, skipping WAL truncation"
+                );
+            }
+            Err(
+                strata_storage::durability::StorageFlushWalTruncationError::SetFlushWatermark {
+                    watermark,
+                    source,
+                },
+            ) => {
+                tracing::warn!(
+                    target: "strata::flush",
+                    error = %source,
+                    watermark = watermark.as_u64(),
+                    "Failed to update flush watermark in MANIFEST"
+                );
+            }
+            Err(strata_storage::durability::StorageFlushWalTruncationError::Compaction {
+                source,
+            }) => {
                 tracing::warn!(
                     target: "strata::wal",
-                    error = %e,
+                    error = %source,
                     "WAL compaction failed after flush"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "strata::wal",
+                    error = %error,
+                    "Storage WAL truncation failed after flush"
                 );
             }
         }

--- a/crates/engine/tests/recovery_parity.rs
+++ b/crates/engine/tests/recovery_parity.rs
@@ -301,7 +301,7 @@ fn first_open_rejects_invalid_codec_without_touching_disk() {
 
     let mut cfg = strata_engine::database::config::StrataConfig::default();
     cfg.storage.codec = "does-not-exist".to_string();
-    cfg.durability = "cache".to_string();
+    cfg.durability = "standard".to_string();
 
     strata_engine::database::OPEN_DATABASES.lock().clear();
     let Err(err) = Database::open_runtime(

--- a/crates/storage/src/durability/checkpoint_runtime.rs
+++ b/crates/storage/src/durability/checkpoint_runtime.rs
@@ -1,0 +1,1121 @@
+//! Storage-owned checkpoint and WAL compaction runtime.
+//!
+//! This module owns generic snapshot, MANIFEST, snapshot-pruning, and WAL
+//! compaction mechanics. Callers remain responsible for lifecycle policy and
+//! primitive checkpoint materialization.
+
+use std::num::NonZeroU64;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use strata_core::id::{CommitVersion, TxnId};
+use tracing::{info, warn};
+
+use crate::durability::codec::StorageCodec;
+use crate::durability::compaction::{CompactionError, WalOnlyCompactor};
+use crate::durability::disk_snapshot::{CheckpointCoordinator, CheckpointData, CheckpointError};
+use crate::durability::format::{
+    list_snapshots, ManifestError, ManifestManager, SnapshotWatermark,
+};
+use crate::durability::layout::DatabaseLayout;
+use crate::SegmentedStore;
+
+/// Storage-level snapshot retention settings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StorageSnapshotRetention {
+    /// Number of newest snapshots to retain. Effective value is at least one.
+    pub retain_count: usize,
+}
+
+impl StorageSnapshotRetention {
+    /// Create a retention setting while preserving the storage minimum.
+    pub fn new(retain_count: usize) -> Self {
+        Self {
+            retain_count: retain_count.max(1),
+        }
+    }
+
+    fn effective_retain_count(self) -> usize {
+        self.retain_count.max(1)
+    }
+}
+
+/// Input for a storage-owned checkpoint run.
+pub struct StorageCheckpointInput {
+    /// Canonical database layout.
+    pub layout: DatabaseLayout,
+    /// Database UUID persisted in checkpoint snapshots and new MANIFEST files.
+    pub database_uuid: [u8; 16],
+    /// Codec used for the snapshot file.
+    pub checkpoint_codec: Box<dyn StorageCodec>,
+    /// Codec id to write if this run has to create a missing MANIFEST.
+    pub manifest_create_codec_id: String,
+    /// Already-materialized primitive checkpoint DTOs.
+    pub checkpoint_data: CheckpointData,
+    /// Transaction watermark covered by this checkpoint.
+    pub watermark_txn: TxnId,
+    /// Active WAL segment to persist into MANIFEST before checkpointing.
+    pub active_wal_segment: NonZeroU64,
+}
+
+/// Raw checkpoint outcome returned to the engine/runtime caller.
+#[derive(Debug)]
+pub struct StorageCheckpointOutcome {
+    /// Snapshot id written by the checkpoint coordinator.
+    pub snapshot_id: u64,
+    /// Transaction watermark covered by the snapshot.
+    pub watermark_txn: TxnId,
+    /// Snapshot creation timestamp from the snapshot writer.
+    pub checkpoint_timestamp_micros: u64,
+    /// Active WAL segment persisted into MANIFEST.
+    pub active_wal_segment: u64,
+}
+
+/// Input for a storage-owned WAL compaction run.
+pub struct StorageWalCompactionInput {
+    /// Canonical database layout.
+    pub layout: DatabaseLayout,
+    /// Database UUID persisted in new MANIFEST files if one is missing.
+    pub database_uuid: [u8; 16],
+    /// Codec used to read WAL records when `.meta` sidecars are unavailable.
+    pub wal_codec: Box<dyn StorageCodec>,
+    /// Codec id to write if this run has to create a missing MANIFEST.
+    pub manifest_create_codec_id: String,
+    /// One-based active WAL segment observed by the caller, when a writer exists.
+    pub active_wal_segment: Option<NonZeroU64>,
+}
+
+/// Input for syncing a storage MANIFEST without exposing MANIFEST mechanics to
+/// engine wrappers.
+pub struct StorageManifestSyncInput {
+    /// Canonical database layout.
+    pub layout: DatabaseLayout,
+    /// Database UUID persisted in a new MANIFEST if one is missing.
+    pub database_uuid: [u8; 16],
+    /// Codec id to write if this run has to create a missing MANIFEST.
+    pub manifest_create_codec_id: String,
+    /// One-based active WAL segment observed by the caller, when a writer exists.
+    pub active_wal_segment: Option<NonZeroU64>,
+}
+
+/// Input for best-effort WAL truncation after memtable flush.
+pub struct StorageFlushWalTruncationInput<'a> {
+    /// Canonical database layout.
+    pub layout: DatabaseLayout,
+    /// Segmented storage used to compute the global flush watermark.
+    pub storage: &'a SegmentedStore,
+    /// Codec used to read WAL records when `.meta` sidecars are unavailable.
+    pub wal_codec: Box<dyn StorageCodec>,
+}
+
+/// Raw WAL compaction outcome returned to the engine/runtime caller.
+#[derive(Debug)]
+pub struct StorageWalCompactionOutcome {
+    /// Number of WAL segment files removed.
+    pub wal_segments_removed: usize,
+    /// Bytes reclaimed from removed WAL segment files.
+    pub reclaimed_bytes: u64,
+    /// Effective MANIFEST watermark used for compaction.
+    pub snapshot_watermark: Option<u64>,
+}
+
+/// Raw WAL truncation facts after a flush watermark update.
+#[derive(Debug)]
+pub struct StorageFlushWalTruncationOutcome {
+    /// Flush watermark persisted to MANIFEST.
+    pub flush_watermark: CommitVersion,
+    /// Number of WAL segment files removed.
+    pub wal_segments_removed: usize,
+    /// Bytes reclaimed from removed WAL segment files.
+    pub reclaimed_bytes: u64,
+}
+
+/// Storage-local checkpoint runtime errors.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StorageCheckpointError {
+    /// Snapshot directory creation failed.
+    #[error("failed to create snapshots directory {}: {source}", snapshots_dir.display())]
+    CreateSnapshotsDir {
+        /// Snapshots directory path.
+        snapshots_dir: PathBuf,
+        /// Underlying IO error.
+        source: std::io::Error,
+    },
+
+    /// MANIFEST helper failed.
+    #[error("{0}")]
+    Manifest(#[from] StorageManifestRuntimeError),
+
+    /// Checkpoint coordinator construction failed.
+    #[error("checkpoint coordinator: {0}")]
+    CheckpointCoordinator(#[source] std::io::Error),
+
+    /// Checkpoint execution failed.
+    #[error("checkpoint failed: {0}")]
+    Checkpoint(#[source] CheckpointError),
+}
+
+/// Storage-local WAL compaction runtime errors.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StorageWalCompactionError {
+    /// MANIFEST helper failed.
+    #[error("{0}")]
+    Manifest(#[from] StorageManifestRuntimeError),
+
+    /// No snapshot or flush watermark exists for WAL compaction.
+    #[error("No snapshot available for compaction")]
+    NoSnapshot,
+
+    /// WAL compaction failed.
+    #[error("compaction failed: {0}")]
+    Compaction(#[source] CompactionError),
+}
+
+/// Storage-local flush-time WAL truncation errors.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StorageFlushWalTruncationError {
+    /// Existing MANIFEST could not be loaded.
+    #[error("failed to load MANIFEST for flush WAL truncation: {source}")]
+    LoadManifest {
+        /// Underlying MANIFEST error.
+        source: ManifestError,
+    },
+
+    /// Flush watermark could not be persisted.
+    #[error("failed to persist flush watermark {watermark:?}: {source}")]
+    SetFlushWatermark {
+        /// Flush watermark that failed to persist.
+        watermark: CommitVersion,
+        /// Underlying MANIFEST error.
+        source: ManifestError,
+    },
+
+    /// WAL compaction failed after the flush watermark was persisted.
+    #[error("WAL compaction failed after flush: {source}")]
+    Compaction {
+        /// Underlying compaction error.
+        source: CompactionError,
+    },
+}
+
+/// Storage-local MANIFEST helper errors.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StorageManifestRuntimeError {
+    /// Existing MANIFEST could not be loaded.
+    #[error("failed to load MANIFEST: {source}")]
+    Load {
+        /// Underlying MANIFEST error.
+        source: ManifestError,
+    },
+
+    /// Missing MANIFEST could not be created.
+    #[error("failed to create MANIFEST: {source}")]
+    Create {
+        /// Underlying MANIFEST error.
+        source: ManifestError,
+    },
+
+    /// Active WAL segment update could not be persisted.
+    #[error("failed to persist MANIFEST active WAL segment: {source}")]
+    PersistActiveSegment {
+        /// Underlying MANIFEST error.
+        source: ManifestError,
+    },
+
+    /// Snapshot watermark update could not be persisted.
+    #[error("manifest update failed: {source}")]
+    SetSnapshotWatermark {
+        /// Underlying MANIFEST error.
+        source: ManifestError,
+    },
+
+    /// MANIFEST fsync/persist could not complete.
+    #[error("failed to persist MANIFEST: {source}")]
+    Persist {
+        /// Underlying MANIFEST error.
+        source: ManifestError,
+    },
+}
+
+/// Storage-local snapshot pruning errors.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StorageSnapshotPruneError {
+    /// Live MANIFEST could not be loaded.
+    #[error("prune_snapshots: failed to load MANIFEST: {source}")]
+    ManifestLoad {
+        /// Error from the MANIFEST layer.
+        source: ManifestError,
+    },
+
+    /// Snapshot directory listing failed.
+    #[error("prune_snapshots: failed to list snapshots in {}: {source}", snapshots_dir.display())]
+    ListSnapshots {
+        /// Snapshots directory path.
+        snapshots_dir: PathBuf,
+        /// Error from the filesystem layer.
+        source: std::io::Error,
+    },
+
+    /// Snapshots directory could not be opened for fsync.
+    #[error("prune_snapshots: failed to open snapshots dir for fsync: {source}")]
+    OpenSnapshotsDir {
+        /// Error from the filesystem layer.
+        source: std::io::Error,
+    },
+
+    /// Snapshots directory fsync failed.
+    #[error("prune_snapshots: failed to fsync snapshots dir: {source}")]
+    FsyncSnapshotsDir {
+        /// Error from the filesystem layer.
+        source: std::io::Error,
+    },
+}
+
+/// Run the storage-owned checkpoint mechanics.
+pub fn run_storage_checkpoint(
+    input: StorageCheckpointInput,
+) -> Result<StorageCheckpointOutcome, StorageCheckpointError> {
+    let StorageCheckpointInput {
+        layout,
+        database_uuid,
+        checkpoint_codec,
+        manifest_create_codec_id,
+        checkpoint_data,
+        watermark_txn,
+        active_wal_segment,
+    } = input;
+
+    let snapshots_dir = layout.snapshots_dir().to_path_buf();
+    std::fs::create_dir_all(&snapshots_dir).map_err(|source| {
+        StorageCheckpointError::CreateSnapshotsDir {
+            snapshots_dir: snapshots_dir.clone(),
+            source,
+        }
+    })?;
+    harden_snapshots_dir(&snapshots_dir);
+
+    let mut manifest = load_or_create_manifest(&layout, database_uuid, manifest_create_codec_id)?;
+    update_manifest_active_wal_segment(&mut manifest, active_wal_segment)?;
+    let active_wal_segment = active_wal_segment.get();
+
+    let existing_watermark = current_snapshot_watermark(&manifest);
+    let mut coordinator = if let Some(watermark) = existing_watermark {
+        CheckpointCoordinator::with_watermark(
+            snapshots_dir,
+            checkpoint_codec,
+            database_uuid,
+            watermark,
+        )
+        .map_err(StorageCheckpointError::CheckpointCoordinator)?
+    } else {
+        CheckpointCoordinator::new(snapshots_dir, checkpoint_codec, database_uuid)
+            .map_err(StorageCheckpointError::CheckpointCoordinator)?
+    };
+
+    let info = coordinator
+        .checkpoint(watermark_txn, checkpoint_data)
+        .map_err(StorageCheckpointError::Checkpoint)?;
+
+    set_manifest_snapshot_watermark(&mut manifest, info.snapshot_id, info.watermark_txn)?;
+
+    Ok(StorageCheckpointOutcome {
+        snapshot_id: info.snapshot_id,
+        watermark_txn: info.watermark_txn,
+        checkpoint_timestamp_micros: info.timestamp,
+        active_wal_segment,
+    })
+}
+
+/// Run the storage-owned WAL compaction mechanics.
+pub fn compact_storage_wal(
+    input: StorageWalCompactionInput,
+) -> Result<StorageWalCompactionOutcome, StorageWalCompactionError> {
+    let StorageWalCompactionInput {
+        layout,
+        database_uuid,
+        wal_codec,
+        manifest_create_codec_id,
+        active_wal_segment,
+    } = input;
+
+    let writer_active_segment = active_wal_segment;
+    let mut manifest = load_or_create_manifest(&layout, database_uuid, manifest_create_codec_id)?;
+    if let Some(active_wal_segment) = writer_active_segment {
+        update_manifest_active_wal_segment(&mut manifest, active_wal_segment)?;
+    }
+    let writer_active_segment = writer_active_segment.map(NonZeroU64::get);
+
+    let compactor = WalOnlyCompactor::new(
+        layout.wal_dir().to_path_buf(),
+        Arc::new(Mutex::new(manifest)),
+    )
+    .with_codec(wal_codec);
+    let compact_info = compactor
+        .compact_with_active_override(writer_active_segment.unwrap_or(0))
+        .map_err(map_wal_compaction_error)?;
+
+    Ok(StorageWalCompactionOutcome {
+        wal_segments_removed: compact_info.wal_segments_removed,
+        reclaimed_bytes: compact_info.reclaimed_bytes,
+        snapshot_watermark: compact_info.snapshot_watermark,
+    })
+}
+
+/// Load or create the MANIFEST, refresh the active segment if supplied, and
+/// persist it durably.
+pub fn sync_storage_manifest(
+    input: StorageManifestSyncInput,
+) -> Result<(), StorageManifestRuntimeError> {
+    let StorageManifestSyncInput {
+        layout,
+        database_uuid,
+        manifest_create_codec_id,
+        active_wal_segment,
+    } = input;
+
+    let mut manifest = load_or_create_manifest(&layout, database_uuid, manifest_create_codec_id)?;
+    if let Some(active_wal_segment) = active_wal_segment {
+        update_manifest_active_wal_segment(&mut manifest, active_wal_segment)?;
+    } else {
+        manifest
+            .persist()
+            .map_err(|source| StorageManifestRuntimeError::Persist { source })?;
+    }
+    Ok(())
+}
+
+/// Persist the storage flush watermark and truncate covered WAL segments.
+///
+/// Returns `Ok(None)` when no branch has flushed segment state yet. Callers
+/// remain responsible for deciding whether errors are fatal or best-effort.
+pub fn truncate_storage_wal_after_flush(
+    input: StorageFlushWalTruncationInput<'_>,
+) -> Result<Option<StorageFlushWalTruncationOutcome>, StorageFlushWalTruncationError> {
+    let StorageFlushWalTruncationInput {
+        layout,
+        storage,
+        wal_codec,
+    } = input;
+
+    let branch_ids = storage.branch_ids();
+    if branch_ids.is_empty() {
+        return Ok(None);
+    }
+
+    // Branches without flushed segments are excluded; their data remains
+    // recoverable from WAL.
+    let mut watermark = CommitVersion::MAX;
+    let mut has_any_segments = false;
+    for branch_id in &branch_ids {
+        if let Some(commit) = storage.max_flushed_commit(branch_id) {
+            if commit > CommitVersion::ZERO {
+                watermark = watermark.min(commit);
+                has_any_segments = true;
+            }
+        }
+    }
+    if !has_any_segments || watermark == CommitVersion::MAX {
+        return Ok(None);
+    }
+
+    let mut manifest = ManifestManager::load(layout.manifest_path().to_path_buf())
+        .map_err(|source| StorageFlushWalTruncationError::LoadManifest { source })?;
+    manifest.set_flush_watermark(watermark).map_err(|source| {
+        StorageFlushWalTruncationError::SetFlushWatermark { watermark, source }
+    })?;
+
+    let compactor = WalOnlyCompactor::new(
+        layout.wal_dir().to_path_buf(),
+        Arc::new(Mutex::new(manifest)),
+    )
+    .with_codec(wal_codec);
+    let compact_info = compactor
+        .compact()
+        .map_err(|source| StorageFlushWalTruncationError::Compaction { source })?;
+
+    Ok(Some(StorageFlushWalTruncationOutcome {
+        flush_watermark: watermark,
+        wal_segments_removed: compact_info.wal_segments_removed,
+        reclaimed_bytes: compact_info.reclaimed_bytes,
+    }))
+}
+
+fn map_wal_compaction_error(error: CompactionError) -> StorageWalCompactionError {
+    match error {
+        CompactionError::NoSnapshot => StorageWalCompactionError::NoSnapshot,
+        other => StorageWalCompactionError::Compaction(other),
+    }
+}
+
+/// Load an existing MANIFEST or create one with the provided codec id.
+pub(crate) fn load_or_create_manifest(
+    layout: &DatabaseLayout,
+    database_uuid: [u8; 16],
+    manifest_create_codec_id: String,
+) -> Result<ManifestManager, StorageManifestRuntimeError> {
+    let manifest_path = layout.manifest_path().to_path_buf();
+
+    if ManifestManager::exists(&manifest_path) {
+        ManifestManager::load(manifest_path)
+            .map_err(|source| StorageManifestRuntimeError::Load { source })
+    } else {
+        ManifestManager::create(manifest_path, database_uuid, manifest_create_codec_id)
+            .map_err(|source| StorageManifestRuntimeError::Create { source })
+    }
+}
+
+/// Persist the active WAL segment into MANIFEST.
+pub(crate) fn update_manifest_active_wal_segment(
+    manifest: &mut ManifestManager,
+    active_wal_segment: NonZeroU64,
+) -> Result<(), StorageManifestRuntimeError> {
+    manifest.manifest_mut().active_wal_segment = active_wal_segment.get();
+    manifest
+        .persist()
+        .map_err(|source| StorageManifestRuntimeError::PersistActiveSegment { source })
+}
+
+/// Build the storage checkpoint watermark from a MANIFEST.
+pub(crate) fn current_snapshot_watermark(manifest: &ManifestManager) -> Option<SnapshotWatermark> {
+    let manifest = manifest.manifest();
+    match (manifest.snapshot_id, manifest.snapshot_watermark) {
+        (Some(snapshot_id), Some(snapshot_watermark)) => Some(SnapshotWatermark::with_values(
+            snapshot_id,
+            TxnId(snapshot_watermark),
+            0,
+        )),
+        _ => None,
+    }
+}
+
+/// Persist snapshot watermark facts into MANIFEST.
+pub(crate) fn set_manifest_snapshot_watermark(
+    manifest: &mut ManifestManager,
+    snapshot_id: u64,
+    watermark_txn: TxnId,
+) -> Result<(), StorageManifestRuntimeError> {
+    manifest
+        .set_snapshot_watermark(snapshot_id, watermark_txn)
+        .map_err(|source| StorageManifestRuntimeError::SetSnapshotWatermark { source })
+}
+
+/// Prune old snapshot files with storage-owned retention mechanics.
+pub fn prune_storage_snapshots(
+    layout: &DatabaseLayout,
+    retention: StorageSnapshotRetention,
+) -> Result<usize, StorageSnapshotPruneError> {
+    let snapshots_dir = layout.snapshots_dir();
+    if !snapshots_dir.exists() {
+        return Ok(0);
+    }
+
+    let retain_count = retention.effective_retain_count();
+    let manifest_path = layout.manifest_path().to_path_buf();
+    let live_snapshot_id = if ManifestManager::exists(&manifest_path) {
+        ManifestManager::load(manifest_path)
+            .map_err(|source| StorageSnapshotPruneError::ManifestLoad { source })?
+            .manifest()
+            .snapshot_id
+    } else {
+        None
+    };
+
+    let snapshots = list_snapshots(snapshots_dir).map_err(|source| {
+        StorageSnapshotPruneError::ListSnapshots {
+            snapshots_dir: snapshots_dir.to_path_buf(),
+            source,
+        }
+    })?;
+
+    if snapshots.len() <= retain_count {
+        return Ok(0);
+    }
+
+    let keep_from = snapshots.len().saturating_sub(retain_count);
+    let mut deleted = 0usize;
+
+    for (i, (id, path)) in snapshots.iter().enumerate() {
+        if i >= keep_from {
+            break;
+        }
+        if Some(*id) == live_snapshot_id {
+            continue;
+        }
+        if let Err(error) = std::fs::remove_file(path) {
+            warn!(
+                target: "strata::durability",
+                snapshot_id = id,
+                path = ?path,
+                error = %error,
+                "Failed to delete pruned snapshot file"
+            );
+            continue;
+        }
+        deleted += 1;
+    }
+
+    if deleted > 0 {
+        let dir_fd = std::fs::File::open(snapshots_dir)
+            .map_err(|source| StorageSnapshotPruneError::OpenSnapshotsDir { source })?;
+        dir_fd
+            .sync_all()
+            .map_err(|source| StorageSnapshotPruneError::FsyncSnapshotsDir { source })?;
+        info!(
+            target: "strata::durability",
+            deleted,
+            retained = retain_count,
+            "Snapshot pruning complete"
+        );
+    }
+
+    Ok(deleted)
+}
+
+#[cfg(unix)]
+fn harden_snapshots_dir(snapshots_dir: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(snapshots_dir, std::fs::Permissions::from_mode(0o700));
+}
+
+#[cfg(not(unix))]
+fn harden_snapshots_dir(_snapshots_dir: &std::path::Path) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::durability::codec::{CodecError, IdentityCodec};
+    use crate::durability::disk_snapshot::SnapshotReader;
+    use crate::durability::format::{
+        primitive_tags, snapshot_path, KvSnapshotEntry, SnapshotSerializer, WalRecord, WalSegment,
+    };
+    use crate::TypeTag;
+    use strata_core::id::CommitVersion;
+    use tempfile::TempDir;
+
+    #[derive(Clone)]
+    struct NamedIdentityCodec(&'static str);
+
+    impl StorageCodec for NamedIdentityCodec {
+        fn encode(&self, data: &[u8]) -> Vec<u8> {
+            data.to_vec()
+        }
+
+        fn decode(&self, data: &[u8]) -> Result<Vec<u8>, CodecError> {
+            Ok(data.to_vec())
+        }
+
+        fn codec_id(&self) -> &str {
+            self.0
+        }
+
+        fn clone_box(&self) -> Box<dyn StorageCodec> {
+            Box::new(self.clone())
+        }
+    }
+
+    #[derive(Clone)]
+    struct XorCodec(u8);
+
+    impl StorageCodec for XorCodec {
+        fn encode(&self, data: &[u8]) -> Vec<u8> {
+            data.iter().map(|byte| byte ^ self.0).collect()
+        }
+
+        fn decode(&self, data: &[u8]) -> Result<Vec<u8>, CodecError> {
+            Ok(self.encode(data))
+        }
+
+        fn codec_id(&self) -> &str {
+            "xor-test"
+        }
+
+        fn clone_box(&self) -> Box<dyn StorageCodec> {
+            Box::new(self.clone())
+        }
+    }
+
+    fn layout(temp_dir: &TempDir) -> DatabaseLayout {
+        DatabaseLayout::from_root(temp_dir.path().join("db"))
+    }
+
+    fn kv_checkpoint_data(user_key: &'static [u8], value: &'static [u8]) -> CheckpointData {
+        CheckpointData::new().with_kv(vec![KvSnapshotEntry {
+            branch_id: [0xAB; 16],
+            space: "default".to_string(),
+            type_tag: TypeTag::KV.as_byte(),
+            user_key: user_key.to_vec(),
+            value: value.to_vec(),
+            version: 7,
+            timestamp: 700,
+            ttl_ms: 0,
+            is_tombstone: false,
+        }])
+    }
+
+    fn checkpoint_input(
+        layout: DatabaseLayout,
+        checkpoint_data: CheckpointData,
+        watermark_txn: u64,
+        active_wal_segment: u64,
+    ) -> StorageCheckpointInput {
+        StorageCheckpointInput {
+            layout,
+            database_uuid: [0x11; 16],
+            checkpoint_codec: Box::new(IdentityCodec),
+            manifest_create_codec_id: "identity".to_string(),
+            checkpoint_data,
+            watermark_txn: TxnId(watermark_txn),
+            active_wal_segment: NonZeroU64::new(active_wal_segment)
+                .expect("active WAL segment must be non-zero"),
+        }
+    }
+
+    fn wal_compaction_input(
+        layout: DatabaseLayout,
+        manifest_create_codec_id: &str,
+        active_wal_segment: Option<NonZeroU64>,
+    ) -> StorageWalCompactionInput {
+        StorageWalCompactionInput {
+            layout,
+            database_uuid: [0x33; 16],
+            wal_codec: Box::new(IdentityCodec),
+            manifest_create_codec_id: manifest_create_codec_id.to_string(),
+            active_wal_segment,
+        }
+    }
+
+    fn active_segment(segment_number: u64) -> Option<NonZeroU64> {
+        Some(NonZeroU64::new(segment_number).expect("active WAL segment must be non-zero"))
+    }
+
+    fn create_wal_segment_with_records(
+        layout: &DatabaseLayout,
+        segment_number: u64,
+        txn_ids: &[u64],
+    ) {
+        create_wal_segment_with_records_using_codec(
+            layout,
+            segment_number,
+            txn_ids,
+            &IdentityCodec,
+        );
+    }
+
+    fn create_wal_segment_with_records_using_codec(
+        layout: &DatabaseLayout,
+        segment_number: u64,
+        txn_ids: &[u64],
+        codec: &dyn StorageCodec,
+    ) {
+        std::fs::create_dir_all(layout.wal_dir()).unwrap();
+        let mut segment = WalSegment::create(layout.wal_dir(), segment_number, [0x33; 16]).unwrap();
+
+        for &txn_id in txn_ids {
+            let record = WalRecord::new(
+                TxnId(txn_id),
+                [0x33; 16],
+                txn_id * 1_000,
+                vec![txn_id as u8; 8],
+            );
+            let encoded = codec.encode(&record.to_bytes());
+            let outer_len = encoded.len() as u32;
+            let outer_len_bytes = outer_len.to_le_bytes();
+            let outer_len_crc = {
+                let mut hasher = crc32fast::Hasher::new();
+                hasher.update(&outer_len_bytes);
+                hasher.finalize()
+            };
+
+            segment.write(&outer_len_bytes).unwrap();
+            segment.write(&outer_len_crc.to_le_bytes()).unwrap();
+            segment.write(&encoded).unwrap();
+        }
+
+        segment.close().unwrap();
+    }
+
+    #[test]
+    fn storage_checkpoint_creates_snapshot_and_updates_manifest() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+
+        let outcome = run_storage_checkpoint(checkpoint_input(
+            layout.clone(),
+            kv_checkpoint_data(b"k1", b"v1"),
+            42,
+            3,
+        ))
+        .unwrap();
+
+        assert_eq!(outcome.snapshot_id, 1);
+        assert_eq!(outcome.watermark_txn, TxnId(42));
+        assert_eq!(outcome.active_wal_segment, 3);
+
+        let manifest = ManifestManager::load(layout.manifest_path().to_path_buf()).unwrap();
+        assert_eq!(manifest.manifest().active_wal_segment, 3);
+        assert_eq!(manifest.manifest().snapshot_id, Some(1));
+        assert_eq!(manifest.manifest().snapshot_watermark, Some(42));
+
+        let snapshot = SnapshotReader::new(Box::new(IdentityCodec))
+            .load(&snapshot_path(layout.snapshots_dir(), 1))
+            .unwrap();
+        assert_eq!(snapshot.header.snapshot_id, 1);
+        assert_eq!(snapshot.header.watermark_txn, 42);
+        assert_eq!(snapshot.sections.len(), 1);
+        assert_eq!(snapshot.sections[0].primitive_type, primitive_tags::KV);
+
+        let serializer = SnapshotSerializer::new(Box::new(IdentityCodec));
+        let kv = serializer
+            .deserialize_kv(&snapshot.sections[0].data)
+            .unwrap();
+        assert_eq!(kv[0].user_key, b"k1");
+        assert_eq!(kv[0].value, b"v1");
+    }
+
+    #[test]
+    fn missing_manifest_uses_explicit_create_codec_id_not_checkpoint_codec() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+
+        let outcome = run_storage_checkpoint(StorageCheckpointInput {
+            layout: layout.clone(),
+            database_uuid: [0x22; 16],
+            checkpoint_codec: Box::new(NamedIdentityCodec("checkpoint-test-codec")),
+            manifest_create_codec_id: "identity".to_string(),
+            checkpoint_data: kv_checkpoint_data(b"k2", b"v2"),
+            watermark_txn: TxnId(8),
+            active_wal_segment: active_segment(4).unwrap(),
+        })
+        .unwrap();
+
+        let manifest = ManifestManager::load(layout.manifest_path().to_path_buf()).unwrap();
+        assert_eq!(manifest.manifest().codec_id, "identity");
+
+        let snapshot = SnapshotReader::new(Box::new(NamedIdentityCodec("checkpoint-test-codec")))
+            .load(&snapshot_path(layout.snapshots_dir(), outcome.snapshot_id))
+            .unwrap();
+        assert_eq!(snapshot.codec_id, "checkpoint-test-codec");
+    }
+
+    #[test]
+    fn storage_checkpoint_reconstructs_existing_snapshot_watermark() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+
+        run_storage_checkpoint(checkpoint_input(
+            layout.clone(),
+            kv_checkpoint_data(b"k1", b"v1"),
+            1,
+            1,
+        ))
+        .unwrap();
+        let outcome = run_storage_checkpoint(checkpoint_input(
+            layout.clone(),
+            kv_checkpoint_data(b"k2", b"v2"),
+            2,
+            1,
+        ))
+        .unwrap();
+
+        assert_eq!(outcome.snapshot_id, 2);
+        assert!(snapshot_path(layout.snapshots_dir(), 1).exists());
+        assert!(snapshot_path(layout.snapshots_dir(), 2).exists());
+    }
+
+    #[test]
+    fn storage_checkpoint_reports_corrupt_manifest_before_snapshot_write() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+
+        std::fs::create_dir_all(layout.root()).unwrap();
+        std::fs::write(layout.manifest_path(), b"not a manifest").unwrap();
+
+        match run_storage_checkpoint(checkpoint_input(
+            layout.clone(),
+            kv_checkpoint_data(b"k1", b"v1"),
+            1,
+            1,
+        )) {
+            Err(StorageCheckpointError::Manifest(StorageManifestRuntimeError::Load { .. })) => {}
+            other => panic!("expected corrupt MANIFEST load failure, got {other:?}"),
+        }
+
+        assert!(
+            list_snapshots(layout.snapshots_dir()).unwrap().is_empty(),
+            "checkpoint should fail before writing a snapshot when MANIFEST load fails"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn storage_checkpoint_hardens_snapshots_dir_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+
+        run_storage_checkpoint(checkpoint_input(
+            layout.clone(),
+            kv_checkpoint_data(b"k1", b"v1"),
+            1,
+            1,
+        ))
+        .unwrap();
+
+        let mode = std::fs::metadata(layout.snapshots_dir())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+
+    #[test]
+    fn prune_storage_snapshots_preserves_live_manifest_snapshot() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+
+        for id in 1..=5 {
+            run_storage_checkpoint(checkpoint_input(
+                layout.clone(),
+                kv_checkpoint_data(b"k", b"v"),
+                id,
+                1,
+            ))
+            .unwrap();
+        }
+
+        {
+            let mut manifest = ManifestManager::load(layout.manifest_path().to_path_buf()).unwrap();
+            manifest.set_snapshot_watermark(2, TxnId(5)).unwrap();
+        }
+
+        let pruned = prune_storage_snapshots(&layout, StorageSnapshotRetention::new(2)).unwrap();
+        assert_eq!(pruned, 2);
+
+        let kept: Vec<u64> = list_snapshots(layout.snapshots_dir())
+            .unwrap()
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+        assert_eq!(kept, vec![2, 4, 5]);
+    }
+
+    #[test]
+    fn prune_storage_snapshots_logs_delete_errors_and_continues() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+
+        std::fs::create_dir_all(layout.snapshots_dir()).unwrap();
+        let mut manifest = ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            [0x11; 16],
+            "identity".to_string(),
+        )
+        .unwrap();
+        manifest.set_snapshot_watermark(4, TxnId(4)).unwrap();
+
+        let undeletable = snapshot_path(layout.snapshots_dir(), 1);
+        std::fs::create_dir(&undeletable).unwrap();
+        std::fs::write(snapshot_path(layout.snapshots_dir(), 2), b"old").unwrap();
+        std::fs::write(snapshot_path(layout.snapshots_dir(), 3), b"older").unwrap();
+        std::fs::write(snapshot_path(layout.snapshots_dir(), 4), b"newest").unwrap();
+
+        let pruned = prune_storage_snapshots(&layout, StorageSnapshotRetention::new(1)).unwrap();
+        assert_eq!(pruned, 2);
+        assert!(undeletable.is_dir());
+        assert!(!snapshot_path(layout.snapshots_dir(), 2).exists());
+        assert!(!snapshot_path(layout.snapshots_dir(), 3).exists());
+        assert!(snapshot_path(layout.snapshots_dir(), 4).exists());
+    }
+
+    #[test]
+    fn prune_storage_snapshots_reports_manifest_load_errors() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+
+        run_storage_checkpoint(checkpoint_input(
+            layout.clone(),
+            kv_checkpoint_data(b"k1", b"v1"),
+            1,
+            1,
+        ))
+        .unwrap();
+        std::fs::write(layout.manifest_path(), b"not a manifest").unwrap();
+
+        match prune_storage_snapshots(&layout, StorageSnapshotRetention::new(1)) {
+            Err(StorageSnapshotPruneError::ManifestLoad { source }) => {
+                let message = source.to_string();
+                assert!(message.contains("too short") || message.contains("invalid magic"));
+            }
+            other => panic!("expected manifest load pruning error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_wal_compaction_creates_missing_manifest_before_no_snapshot_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+        std::fs::create_dir_all(layout.root()).unwrap();
+
+        match compact_storage_wal(wal_compaction_input(
+            layout.clone(),
+            "manifest-test-codec",
+            active_segment(7),
+        )) {
+            Err(StorageWalCompactionError::NoSnapshot) => {}
+            other => panic!("expected no-snapshot compaction error, got {other:?}"),
+        }
+
+        let manifest = ManifestManager::load(layout.manifest_path().to_path_buf()).unwrap();
+        assert_eq!(manifest.manifest().codec_id, "manifest-test-codec");
+        assert_eq!(manifest.manifest().active_wal_segment, 7);
+        assert_eq!(manifest.manifest().snapshot_watermark, None);
+    }
+
+    #[test]
+    fn storage_manifest_sync_creates_and_refreshes_active_segment() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+        std::fs::create_dir_all(layout.root()).unwrap();
+
+        sync_storage_manifest(StorageManifestSyncInput {
+            layout: layout.clone(),
+            database_uuid: [0x44; 16],
+            manifest_create_codec_id: "sync-test-codec".to_string(),
+            active_wal_segment: active_segment(5),
+        })
+        .unwrap();
+
+        let manifest = ManifestManager::load(layout.manifest_path().to_path_buf()).unwrap();
+        assert_eq!(manifest.manifest().codec_id, "sync-test-codec");
+        assert_eq!(manifest.manifest().active_wal_segment, 5);
+
+        sync_storage_manifest(StorageManifestSyncInput {
+            layout: layout.clone(),
+            database_uuid: [0x44; 16],
+            manifest_create_codec_id: "ignored-on-existing".to_string(),
+            active_wal_segment: active_segment(6),
+        })
+        .unwrap();
+
+        let manifest = ManifestManager::load(layout.manifest_path().to_path_buf()).unwrap();
+        assert_eq!(manifest.manifest().codec_id, "sync-test-codec");
+        assert_eq!(manifest.manifest().active_wal_segment, 6);
+    }
+
+    #[test]
+    fn storage_wal_compaction_removes_covered_segments_with_active_override() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+        std::fs::create_dir_all(layout.root()).unwrap();
+
+        let mut manifest = ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            [0x33; 16],
+            "identity".to_string(),
+        )
+        .unwrap();
+        manifest.set_snapshot_watermark(1, TxnId(10)).unwrap();
+        manifest.manifest_mut().active_wal_segment = 2;
+        manifest.persist().unwrap();
+
+        create_wal_segment_with_records(&layout, 1, &[1, 2]);
+        create_wal_segment_with_records(&layout, 2, &[3, 4]);
+        create_wal_segment_with_records(&layout, 3, &[5]);
+        create_wal_segment_with_records(&layout, 4, &[11]);
+
+        let outcome = compact_storage_wal(wal_compaction_input(
+            layout.clone(),
+            "identity",
+            active_segment(4),
+        ))
+        .unwrap();
+
+        assert_eq!(outcome.wal_segments_removed, 3);
+        assert!(outcome.reclaimed_bytes > 0);
+        assert_eq!(outcome.snapshot_watermark, Some(10));
+        assert!(!WalSegment::segment_path(layout.wal_dir(), 1).exists());
+        assert!(!WalSegment::segment_path(layout.wal_dir(), 2).exists());
+        assert!(!WalSegment::segment_path(layout.wal_dir(), 3).exists());
+        assert!(WalSegment::segment_path(layout.wal_dir(), 4).exists());
+
+        let manifest = ManifestManager::load(layout.manifest_path().to_path_buf()).unwrap();
+        assert_eq!(manifest.manifest().active_wal_segment, 4);
+    }
+
+    #[test]
+    fn storage_wal_compaction_full_scan_uses_supplied_codec() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+        std::fs::create_dir_all(layout.root()).unwrap();
+
+        let mut manifest = ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            [0x33; 16],
+            "xor-test".to_string(),
+        )
+        .unwrap();
+        manifest.set_snapshot_watermark(1, TxnId(10)).unwrap();
+        manifest.manifest_mut().active_wal_segment = 3;
+        manifest.persist().unwrap();
+
+        let codec = XorCodec(0xA5);
+        create_wal_segment_with_records_using_codec(&layout, 1, &[1, 2], &codec);
+
+        let outcome = compact_storage_wal(StorageWalCompactionInput {
+            layout: layout.clone(),
+            database_uuid: [0x33; 16],
+            wal_codec: Box::new(codec),
+            manifest_create_codec_id: "xor-test".to_string(),
+            active_wal_segment: active_segment(3),
+        })
+        .unwrap();
+
+        assert_eq!(
+            outcome.wal_segments_removed, 1,
+            "codec-encoded segment without .meta should compact via codec-aware full scan"
+        );
+        assert_eq!(outcome.snapshot_watermark, Some(10));
+        assert!(!WalSegment::segment_path(layout.wal_dir(), 1).exists());
+    }
+
+    #[test]
+    fn storage_wal_compaction_without_active_observation_preserves_manifest_active() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+        std::fs::create_dir_all(layout.root()).unwrap();
+
+        let mut manifest = ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            [0x33; 16],
+            "identity".to_string(),
+        )
+        .unwrap();
+        manifest.set_flush_watermark(CommitVersion(10)).unwrap();
+        manifest.manifest_mut().active_wal_segment = 3;
+        manifest.persist().unwrap();
+
+        create_wal_segment_with_records(&layout, 1, &[1, 2]);
+        create_wal_segment_with_records(&layout, 2, &[3, 4]);
+        create_wal_segment_with_records(&layout, 3, &[5]);
+
+        let outcome =
+            compact_storage_wal(wal_compaction_input(layout.clone(), "identity", None)).unwrap();
+
+        assert_eq!(outcome.wal_segments_removed, 2);
+        assert_eq!(outcome.snapshot_watermark, Some(10));
+        assert!(!WalSegment::segment_path(layout.wal_dir(), 1).exists());
+        assert!(!WalSegment::segment_path(layout.wal_dir(), 2).exists());
+        assert!(WalSegment::segment_path(layout.wal_dir(), 3).exists());
+
+        let manifest = ManifestManager::load(layout.manifest_path().to_path_buf()).unwrap();
+        assert_eq!(manifest.manifest().active_wal_segment, 3);
+    }
+}

--- a/crates/storage/src/durability/compaction/mod.rs
+++ b/crates/storage/src/durability/compaction/mod.rs
@@ -33,10 +33,11 @@ pub use wal_only::WalOnlyCompactor;
 /// Determines how aggressively compaction reclaims disk space.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CompactMode {
-    /// Remove WAL segments covered by snapshot
+    /// Remove WAL segments covered by a snapshot or flush watermark
     ///
-    /// Only removes WAL segments whose transactions
-    /// are fully captured in a snapshot. All version history preserved.
+    /// Only removes WAL segments whose transactions are fully reconstructible
+    /// from a checkpoint snapshot or flushed segment state. All version
+    /// history is preserved.
     WALOnly,
 }
 

--- a/crates/storage/src/durability/compaction/wal_only.rs
+++ b/crates/storage/src/durability/compaction/wal_only.rs
@@ -1,12 +1,14 @@
 //! WAL-only compaction
 //!
-//! Removes WAL segments that are fully covered by a snapshot watermark.
+//! Removes WAL segments that are fully covered by the effective retention
+//! watermark.
 //! This is the safest compaction mode - it only removes data that is
 //! guaranteed to be recoverable from the snapshot.
 //!
 //! # Algorithm
 //!
-//! 1. Get snapshot watermark (transaction ID) from MANIFEST
+//! 1. Get the effective watermark from MANIFEST: max of the snapshot and
+//!    flush watermarks
 //! 2. List all WAL segments
 //! 3. For each segment (except the active segment):
 //!    - Read all records and find the highest txn_id
@@ -17,8 +19,8 @@
 //! # Safety
 //!
 //! - Never removes the active segment
-//! - Only removes segments fully covered by snapshot
-//! - Requires a valid snapshot to exist
+//! - Only removes segments fully covered by snapshot or flushed segment state
+//! - Requires a snapshot or flush watermark to exist
 
 use crate::durability::codec::{clone_codec, StorageCodec};
 use crate::durability::format::segment_meta::SegmentMeta;
@@ -33,7 +35,7 @@ use super::{CompactInfo, CompactMode, CompactionError};
 
 /// WAL-only compactor
 ///
-/// Removes WAL segments covered by snapshot watermark.
+/// Removes WAL segments covered by the effective retention watermark.
 pub struct WalOnlyCompactor {
     wal_dir: PathBuf,
     manifest: Arc<Mutex<ManifestManager>>,

--- a/crates/storage/src/durability/disk_snapshot/reader.rs
+++ b/crates/storage/src/durability/disk_snapshot/reader.rs
@@ -286,11 +286,10 @@ pub enum SnapshotReadError {
     ///
     /// Produced when the snapshot's `format_version` is older than
     /// [`crate::durability::format::snapshot::MIN_SUPPORTED_SNAPSHOT_FORMAT_VERSION`].
-    /// Surfaces unconditionally (strict and lossy open alike); the engine's
-    /// open path re-raises as
-    /// [`strata_engine::StrataError::LegacyFormat`] and the operator must
-    /// delete the file manually before reopening. Mirrors the WAL
-    /// `SegmentHeaderError::LegacyFormat` contract.
+    /// Surfaces unconditionally (strict and lossy open alike); the
+    /// engine-facing recovery layer re-raises it as the public legacy-format
+    /// error and the operator must delete the file manually before reopening.
+    /// Mirrors the WAL `SegmentHeaderError::LegacyFormat` contract.
     #[error(
         "legacy snapshot format: found version {detected_version}. {supported_range}. {remediation}"
     )]

--- a/crates/storage/src/durability/format/manifest.rs
+++ b/crates/storage/src/durability/format/manifest.rs
@@ -371,8 +371,8 @@ pub enum ManifestError {
     ///
     /// Produced when a file's `format_version` is older than
     /// [`MIN_SUPPORTED_MANIFEST_FORMAT_VERSION`]. Surfaces unconditionally
-    /// (strict and lossy open alike); the engine's open path re-raises as
-    /// [`strata_engine::StrataError::LegacyFormat`] and the operator must
+    /// (strict and lossy open alike); the engine-facing recovery layer
+    /// re-raises it as the public legacy-format error and the operator must
     /// delete the file manually before reopening. Mirrors the WAL
     /// `SegmentHeaderError::LegacyFormat` contract.
     #[error(

--- a/crates/storage/src/durability/format/primitives.rs
+++ b/crates/storage/src/durability/format/primitives.rs
@@ -143,10 +143,9 @@ pub struct EventSnapshotEntry {
 ///
 /// The explicit `branch_id` field was added in the T3-E5 follow-up so
 /// install can dispatch entries to the correct branch on reopen. In today's
-/// engine all branch metadata lives under the global nil-UUID sentinel
-/// (see `strata_engine::primitives::branch::index::global_branch_id`),
-/// but the DTO carries the id explicitly so future per-branch metadata
-/// scoping works without another format break.
+/// engine all branch metadata lives under the global nil-UUID sentinel, but
+/// the DTO carries the id explicitly so future per-branch metadata scoping
+/// works without another format break.
 ///
 /// `is_tombstone` is explicit (matching the KV/JSON/Vector pattern) so
 /// `branches.delete(name)` round-trips losslessly through checkpoint +

--- a/crates/storage/src/durability/format/wal_record.rs
+++ b/crates/storage/src/durability/format/wal_record.rs
@@ -83,8 +83,8 @@ pub const WAL_RECORD_FORMAT_VERSION: u8 = 2;
 /// checks into a single call so callers see a typed variant rather than
 /// the `io::Error` / `Option<Self>` collapse the pre-T3-E12 code used.
 /// `LegacyFormat` in particular is the load-bearing diagnostic the
-/// engine's open path routes to [`strata_engine::StrataError::LegacyFormat`]
-/// — see the T3-E12 tracking doc §D6 / §D8.
+/// engine-facing recovery layer routes to the public legacy-format error —
+/// see the T3-E12 tracking doc §D6 / §D8.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum SegmentHeaderError {

--- a/crates/storage/src/durability/mod.rs
+++ b/crates/storage/src/durability/mod.rs
@@ -9,6 +9,7 @@
 //! - database disk layout
 //! - WAL-oriented compaction
 
+mod checkpoint_runtime;
 pub mod codec;
 mod commit_adapter;
 pub mod compaction;
@@ -32,6 +33,16 @@ pub fn now_micros() -> u64 {
 }
 
 pub use wal::DurabilityMode;
+
+// Checkpoint runtime
+pub use checkpoint_runtime::{
+    compact_storage_wal, prune_storage_snapshots, run_storage_checkpoint, sync_storage_manifest,
+    truncate_storage_wal_after_flush, StorageCheckpointError, StorageCheckpointInput,
+    StorageCheckpointOutcome, StorageFlushWalTruncationError, StorageFlushWalTruncationInput,
+    StorageFlushWalTruncationOutcome, StorageManifestRuntimeError, StorageManifestSyncInput,
+    StorageSnapshotPruneError, StorageSnapshotRetention, StorageWalCompactionError,
+    StorageWalCompactionInput, StorageWalCompactionOutcome,
+};
 
 // Codec
 pub use codec::{clone_codec, get_codec, CodecError, IdentityCodec, StorageCodec};

--- a/crates/storage/src/durability/wal/reader.rs
+++ b/crates/storage/src/durability/wal/reader.rs
@@ -1194,9 +1194,9 @@ pub enum WalReaderError {
     ///
     /// Produced when a segment's `SEGMENT_FORMAT_VERSION` is older than
     /// this build supports. Surfaces unconditionally (strict and lossy
-    /// alike); the engine's open path re-raises as
-    /// [`strata_engine::StrataError::LegacyFormat`] and the operator
-    /// must delete the `wal/` subdirectory manually before reopening.
+    /// alike); the engine-facing recovery layer re-raises it as the public
+    /// legacy-format error and the operator must delete the `wal/`
+    /// subdirectory manually before reopening.
     /// Lossy recovery does not bypass format incompatibility (T3-E12 §D6).
     ///
     /// The `hint` carries the full operator-facing message including

--- a/crates/storage/src/segmented/quarantine_protocol.rs
+++ b/crates/storage/src/segmented/quarantine_protocol.rs
@@ -40,14 +40,12 @@
 //! and blocks reclaim until a full rebuild-equivalent reconciliation
 //! completes (KD10).
 //!
-//! Engine-facing attribution (`retention_report()` at the engine layer)
-//! consumes the storage-layer snapshot produced by
-//! [`SegmentedStore::retention_snapshot`] below, joins it with
-//! `BranchControlStore` for generation-aware `BranchRef` attribution,
-//! and returns `Err(StrataError::RetentionReportUnavailable)` when
-//! recovery health cannot sustain trustworthy attribution (contract
-//! §"Canonical blocker attribution", convergence doc §"retention
-//! report contract" hard-fail rule).
+//! Engine-facing attribution consumes the storage-layer snapshot produced by
+//! [`SegmentedStore::retention_snapshot`] below, joins it with branch-control
+//! metadata for generation-aware attribution, and returns an unavailable
+//! result when recovery health cannot sustain trustworthy attribution
+//! (contract §"Canonical blocker attribution", convergence doc hard-fail
+//! rule).
 
 use std::collections::{HashMap, HashSet};
 use std::io;

--- a/crates/storage/src/segmented/tests/quarantine_reconciliation.rs
+++ b/crates/storage/src/segmented/tests/quarantine_reconciliation.rs
@@ -171,8 +171,8 @@ fn reopen_drops_stale_inventory_entries_without_degrade() {
 
 /// The in-session retention/report path must treat the same stale inventory
 /// shape as benign. Recovery reconciliation rewrites these entries away on
-/// reopen, but callers must not get `RetentionReportUnavailable` simply
-/// because publish happened and rename never did.
+/// reopen, but callers must not get an unavailable-report error simply because
+/// publish happened and rename never did.
 #[test]
 fn retention_snapshot_ignores_stale_missing_quarantine_inventory_entries() {
     let dir = tempfile::tempdir().unwrap();

--- a/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
+++ b/docs/design/architecture-cleanup/durability-recovery-config-matrix.md
@@ -98,7 +98,10 @@ The classification is load-bearing in three places:
 ## Durability/recovery coverage
 
 **Open-time-only:** `codec`, `background_threads`, `allow_lossy_recovery`,
-`allow_missing_manifest`, `durability = "cache"` (discriminant).
+`allow_missing_manifest`.
+
+Cache is selected by open mode (`Database::cache()` / `OpenSpec::cache()`),
+not by the `durability` config string.
 
 **Live-safe (durability/recovery domain):** `durability` (Standard↔Always
 switch). All other `StorageConfig` entries are live-safe but LSM-tuning, not

--- a/docs/engine/engine-storage-boundary-normalization-plan.md
+++ b/docs/engine/engine-storage-boundary-normalization-plan.md
@@ -1,0 +1,706 @@
+# Engine / Storage Boundary Normalization Plan
+
+## Purpose
+
+This document turns the storage/engine ownership audit into a concrete
+normalization plan.
+
+The storage consolidation work has already collapsed the old lower-runtime
+split into `strata-storage`. That solved the most visible crate graph problem,
+but it did not fully normalize the boundary above the substrate. Some
+storage-runtime mechanics still live under `strata-engine`, especially around
+database recovery, checkpointing, snapshot install, and storage configuration.
+
+The goal of this plan is to finish the ownership correction without flattening
+the architecture:
+
+- `strata-storage` owns generic persistence and lower-runtime mechanics
+- `strata-engine` owns database orchestration, primitive semantics, branch
+  semantics, product/runtime policy, and public database APIs
+- public engine APIs remain stable while lower mechanics move behind
+  storage-owned implementation surfaces
+- no primitive or branch-domain semantics move down into storage
+
+This work is not primarily feature-unblocking. The crate graph is already
+structurally correct: storage does not depend on engine. The return on this
+work is architectural clarity and future-proofing before engine absorbs more
+semantic/runtime crates. A broader engine crate is acceptable only if its
+internal boundary between substrate mechanics and engine semantics remains
+explicit.
+
+At the end of this plan:
+
+- engine should expose checkpoint, compact, open, recovery, and health APIs
+  as database/runtime operations
+- storage should physically own the substrate mechanics behind checkpointing,
+  WAL compaction, snapshot replay/install, manifest preparation, and
+  storage-only config application
+- engine should be easier to describe as semantic/runtime orchestration rather
+  than a mixed host for lower persistence machinery
+
+This plan should be read together with:
+
+- [engine-crate-map.md](./engine-crate-map.md)
+- [engine-pending-items.md](./engine-pending-items.md)
+- [engine-error-architecture.md](./engine-error-architecture.md)
+- [../storage/storage-charter.md](../storage/storage-charter.md)
+- [../storage/storage-crate-map.md](../storage/storage-crate-map.md)
+- [../storage/storage-engine-ownership-audit.md](../storage/storage-engine-ownership-audit.md)
+- [../storage/storage-minimal-surface-implementation-plan.md](../storage/storage-minimal-surface-implementation-plan.md)
+- [../storage/st2-primitive-transaction-semantics-extraction-plan.md](../storage/st2-primitive-transaction-semantics-extraction-plan.md)
+- [../storage/st3-generic-transaction-runtime-absorption-plan.md](../storage/st3-generic-transaction-runtime-absorption-plan.md)
+- [../architecture/architecture-recovery-target.md](../architecture/architecture-recovery-target.md)
+
+## Rewrite Rules
+
+These rules apply to every epic in this plan.
+
+### 1. Preserve Engine APIs, Move Mechanics
+
+The work is not to delete `Database::checkpoint()`, `Database::compact()`,
+or engine-owned open/recovery entry points.
+
+The work is to make those APIs thin orchestration surfaces over
+storage-owned mechanics where the behavior is genuinely generic substrate
+runtime.
+
+### 2. No Primitive Semantics In `storage`
+
+Storage may own durable bytes, versioned records, generic transaction
+runtime, WAL/snapshot replay mechanics, and manifest updates.
+
+Storage must not own:
+
+- JSON path or patch semantics
+- event-chain meaning
+- vector metric/model semantics
+- search indexing behavior
+- branch lifecycle or workflow policy
+- operator-facing branch report language
+
+If a migration is forced to pass primitive meaning through storage, the design
+is wrong and needs to be split differently.
+
+### 3. No Silent Runtime Redesign
+
+This workstream is about ownership and boundary correction first.
+
+Do not change:
+
+- recovery semantics
+- data-loss/degradation policy
+- checkpoint behavior
+- WAL compaction behavior
+- snapshot format behavior
+- database open behavior
+
+unless a subplan explicitly calls out the behavior change and its
+compatibility story.
+
+### 4. No Format Churn Without A Migration
+
+Moving mechanics into storage does not justify changing on-disk formats.
+
+WAL, snapshot, manifest, and segmented-store compatibility should be
+preserved unless a later explicit format migration says otherwise.
+
+### 5. Engine Owns Interpretation And Policy
+
+Storage can return raw recovery facts, retention facts, replay outcomes,
+and storage health information.
+
+Engine owns:
+
+- operator-facing classification
+- database lifecycle decisions
+- branch/report vocabulary
+- product defaults
+- public error conversion into `StrataError`
+- executor-facing behavior through higher layers
+
+### 6. No Transitional Dependency Drift
+
+While this plan is in progress:
+
+- do not add `storage -> engine`
+- do not add primitive-specific behavior to storage APIs
+- do not make executor call storage directly for database-runtime behavior
+- do not add new engine modules that deepen lower-runtime ownership
+- do not move product policy into storage as a convenience
+
+## Current Starting Point
+
+The workspace is already past the older storage consolidation milestones:
+
+- `strata-concurrency` has been deleted
+- `strata-durability` has been deleted
+- `strata-core-legacy` has been deleted
+- `strata-storage` now owns the lower transaction and durability runtime
+- `strata-engine` now owns primitive/domain families that previously lived
+  in transitional locations
+- storage depends only on foundational lower crates and must stay below engine
+
+The remaining problem is not a temporary peer crate. It is lower-runtime code
+still physically hosted inside engine.
+
+The strongest current candidates are:
+
+- [database/compaction.rs](../../crates/engine/src/database/compaction.rs)
+  - checkpoint creation
+  - WAL compaction
+  - snapshot pruning
+  - MANIFEST watermark updates
+- [database/snapshot_install.rs](../../crates/engine/src/database/snapshot_install.rs)
+  - snapshot section decoding
+  - replay/install into `SegmentedStore`
+- [database/recovery.rs](../../crates/engine/src/database/recovery.rs)
+  - MANIFEST preparation
+  - WAL codec resolution
+  - storage recovery orchestration
+  - replay bootstrap
+  - storage recovery degradation/lossiness plumbing
+- [database/open.rs](../../crates/engine/src/database/open.rs)
+  - storage-only configuration application
+  - WAL writer settings and runtime wiring
+- [database/config.rs](../../crates/engine/src/database/config.rs)
+  - storage-facing config defaults and interpretation mixed with
+    engine-facing config surface
+
+Some of this code will remain engine-owned orchestration. The plan is to split
+the boundary explicitly instead of moving files wholesale.
+
+## End-State Definition
+
+The boundary normalization is complete only when all of the following are
+true:
+
+1. Public database/runtime APIs remain engine-owned.
+2. Storage physically owns generic mechanics for:
+   - checkpoint construction
+   - WAL compaction
+   - snapshot pruning
+   - storage manifest/watermark updates
+   - snapshot decode/replay/install machinery
+   - storage recovery bootstrap
+   - storage-only config application
+3. Engine physically owns:
+   - open/runtime orchestration
+   - product/database lifecycle policy
+   - recovery policy and operator-facing classification
+   - branch and primitive semantics
+   - search/runtime behavior
+   - branch bundle import/export
+4. Storage APIs used by engine are primitive-agnostic and branch-domain
+   neutral, except for raw physical branch identifiers required by the storage
+   substrate.
+5. Engine converts storage facts into engine errors, health reports,
+   retention reports, and product decisions explicitly.
+6. No upper crate bypasses engine to drive storage recovery/checkpoint/open
+   policy directly.
+
+## Ownership Decisions Closed Up Front
+
+The following decisions are not deferred:
+
+- `Database::checkpoint()` remains in engine as public API.
+- `Database::compact()` remains in engine as public API.
+- database open and runtime composition remain in engine.
+- storage owns checkpoint/WAL/snapshot/MANIFEST mechanics.
+- storage owns storage recovery and replay mechanics.
+- engine owns recovery policy, public error classification, and operator
+  reporting.
+- storage owns storage-only config application and defaults.
+- engine owns the public `StrataConfig` surface and product defaults.
+- storage owns raw retention facts.
+- engine owns lifecycle-aware retention reports.
+- JSON/event/vector/search semantics do not move down.
+- branch bundle import/export stays in engine.
+
+## Epic Structure
+
+This plan is organized as six epics. The list below is the intended
+execution order.
+
+- `ES1` - Boundary Baseline And Guardrails
+- `ES2` - Checkpoint And WAL Compaction Mechanics
+- `ES3` - Snapshot Decode And Install Mechanics
+- `ES4` - Recovery Bootstrap Mechanics
+- `ES5` - Storage Configuration Application
+- `ES6` - Boundary Closeout, Engine Shape, And Documentation
+
+Each epic may get its own detailed subplan as the cleanup reaches that
+surface. This document defines the main sequence and ownership contract.
+
+## ES1 - Boundary Baseline And Guardrails
+
+### Goal
+
+Freeze the intended storage/engine boundary before moving runtime mechanics.
+
+Detailed execution plan:
+
+- [es1-boundary-baseline-and-guardrails-plan.md](./es1-boundary-baseline-and-guardrails-plan.md)
+
+### Scope
+
+- inventory current lower-runtime mechanics still hosted in engine
+- identify public APIs that must remain engine-owned
+- identify private helper surfaces that can move to storage
+- add or refresh dependency/import guardrails where useful
+- decide the naming convention for storage-owned runtime helper modules
+
+### Deliverables
+
+1. A current code inventory for:
+   - `database/compaction.rs`
+   - `database/snapshot_install.rs`
+   - `database/recovery.rs`
+   - storage-facing parts of `database/open.rs`
+   - storage-facing parts of `database/config.rs`
+2. A list of engine APIs that must remain as wrappers/orchestrators.
+3. A list of storage APIs needed to absorb the lower mechanics.
+4. Guard commands that detect:
+   - new `storage -> engine` dependencies
+   - primitive semantics added to storage-owned modules
+   - new lower-runtime mechanics added under `engine::database`
+
+### Constraints
+
+- do not move code before the split between API and mechanics is explicit
+- do not treat file location alone as proof of rightful ownership
+- do not create storage APIs that mention executor/product behavior
+
+### Acceptance
+
+- the boundary correction targets are enumerated
+- follow-up epics have clear migration surfaces
+- future PRs can be evaluated against written ownership rules
+
+### Non-Goals
+
+- no checkpoint migration yet
+- no recovery migration yet
+- no public API redesign
+
+## ES2 - Checkpoint And WAL Compaction Mechanics
+
+### Goal
+
+Move generic checkpoint, WAL compaction, snapshot pruning, and storage
+manifest update mechanics from engine into storage.
+
+Potential detailed execution plan:
+
+- [es2-checkpoint-wal-compaction-mechanics-plan.md](./es2-checkpoint-wal-compaction-mechanics-plan.md)
+
+Prerequisite design sketch:
+
+- [es2-es4-storage-runtime-boundary-api-sketch.md](./es2-es4-storage-runtime-boundary-api-sketch.md)
+
+ES2 is split into straight lettered phases:
+
+- `ES2A` - boundary API sketch
+- `ES2B` - checkpoint and compaction characterization
+- `ES2C` - storage checkpoint runtime
+- `ES2D` - engine checkpoint wrapper
+- `ES2E` - storage WAL compaction runtime
+- `ES2F` - engine compaction wrapper
+- `ES2G` - residue cleanup and guard pass
+
+`ES2`, `ES3`, and `ES4` are sequential code moves, but they are not
+independent designs. Checkpoint output feeds snapshot install, and snapshot
+install feeds recovery. Before ES2C code moves, write a joint API sketch for
+the checkpoint, snapshot install, and recovery boundary types so ES2 does not
+choose a storage API shape that ES3 or ES4 immediately has to undo.
+
+### Scope
+
+Move downward into storage where generic:
+
+- checkpoint construction
+- snapshot pruning
+- WAL compaction sequencing
+- manifest watermark updates
+- low-level checkpoint result facts
+- storage-side compaction coordination
+
+Keep in engine:
+
+- `Database::checkpoint()`
+- `Database::compact()`
+- public result translation
+- lifecycle/open-state checks
+- engine error conversion
+- product/runtime policy about when checkpoint/compact is called
+
+### Deliverables
+
+1. Storage-owned checkpoint/compaction implementation surface.
+2. Engine `Database` methods reduced to orchestration and translation.
+3. Tests proving checkpoint and compaction behavior is unchanged.
+4. No new primitive or product policy in storage.
+
+### Constraints
+
+- do not change checkpoint file formats
+- do not change WAL compaction semantics
+- do not make storage aware of engine health/report types
+- do not collapse engine lifecycle checks into storage
+
+### Acceptance
+
+- checkpoint/WAL mechanics are physically owned by storage
+- engine checkpoint/compact APIs remain stable
+- recovery after checkpoint/compaction remains covered by tests
+- storage APIs expose raw substrate facts, not operator-facing reports
+- checkpoint characterization exists before behavior-preserving refactors
+  land
+
+### Non-Goals
+
+- no full recovery bootstrap migration
+- no snapshot install migration unless required as a narrow helper agreed in
+  the joint ES2-ES4 API sketch
+- no config split yet
+
+## ES3 - Snapshot Decode And Install Mechanics
+
+### Goal
+
+Move generic snapshot decode, section iteration, and install/replay mechanics
+from engine into storage.
+
+Potential detailed execution plan:
+
+- `docs/engine/es3-snapshot-decode-install-mechanics-plan.md`
+
+### Scope
+
+Move downward into storage where generic:
+
+- snapshot section reading
+- snapshot record decoding
+- installation into `SegmentedStore`
+- replay-safe batch application
+- storage-local snapshot install errors
+- raw install statistics
+
+Keep in engine:
+
+- decisions about when a snapshot should be installed
+- recovery policy around degraded or lossy outcomes
+- public error/report conversion
+- database lifecycle orchestration around the install
+
+### Deliverables
+
+1. Storage-owned snapshot install/replay module or API.
+2. Engine recovery/open code calling storage for raw install mechanics.
+3. Tests proving existing snapshots still install and recover identically.
+4. Compatibility coverage for existing snapshot sections.
+
+### Constraints
+
+- do not change snapshot format
+- do not move primitive decode semantics into storage
+- do not let storage decide engine recovery policy
+- do not entangle snapshot install with branch bundle import/export
+
+### Acceptance
+
+- `database/snapshot_install.rs` is deleted or reduced to engine policy
+  glue
+- storage owns the generic snapshot install machinery
+- engine still owns recovery decisions and public reporting
+- snapshot install round-trip characterization exists before
+  behavior-preserving refactors land
+
+### Non-Goals
+
+- no branch bundle changes
+- no public recovery API redesign
+- no search/index recovery redesign
+
+## ES4 - Recovery Bootstrap Mechanics
+
+### Goal
+
+Move lower storage recovery bootstrap and replay orchestration from engine
+into storage, while keeping database-level recovery policy in engine.
+
+Potential detailed execution plan:
+
+- `docs/engine/es4-recovery-bootstrap-mechanics-plan.md`
+
+ES2A baseline decision:
+
+- `TransactionCoordinator` stays engine-owned during ES4.
+
+This is load-bearing. Storage should own recovery replay mechanics and return
+raw `RecoveryStats` / `RecoveredState` facts. Engine should bootstrap
+`TransactionCoordinator` from those facts after storage recovery returns. If
+later work wants to move coordinator ownership, that needs a separate
+coordinator ownership plan, not an incidental ES4 side effect.
+
+ES4 must also preserve two current recovery ordering guarantees:
+
+- snapshot-installed versions are folded into `RecoveryStats::final_version`
+  before `TransactionCoordinator` bootstrap
+- storage runtime config is applied before `recover_segments()` runs
+
+Until ES5 completes the public config split, engine may build a
+storage-owned runtime config from `StrataConfig.storage` and pass it into the
+ES4 storage recovery API.
+
+### Scope
+
+Move downward into storage where generic:
+
+- MANIFEST preparation
+- WAL codec resolution for storage replay
+- segmented-store recovery orchestration
+- replay bootstrap
+- raw recovery outcomes
+- storage-local loss/degradation facts
+- storage runtime config application needed before segment recovery
+
+Keep in engine:
+
+- `Database::open_runtime()` orchestration
+- database mode selection
+- lifecycle policy
+- operator-facing recovery classification
+- conversion into `StrataError` / `RecoveryError`
+- subsystem recovery integration above raw storage replay
+
+### Deliverables
+
+1. Storage-owned recovery bootstrap API.
+2. Engine recovery code reduced to orchestration, policy, and conversion.
+3. Raw storage recovery outcome types that do not mention engine policy.
+4. Regression tests for normal, degraded, and lossy recovery paths.
+
+### Constraints
+
+- do not change recovery correctness semantics
+- do not weaken corruption/quarantine behavior
+- do not move product policy into storage
+- do not expose engine error types from storage
+
+### Acceptance
+
+- engine no longer performs low-level storage recovery assembly itself
+- storage returns raw recovery facts and errors
+- engine still decides what those facts mean for database open behavior
+- recovery tests pass from storage and engine layers
+- normal, degraded, and lossy recovery outcomes have characterization before
+  refactoring
+
+### Non-Goals
+
+- no broad lifecycle redesign
+- no branch-domain recovery policy migration into storage
+- no operator report redesign beyond necessary translation updates
+
+## ES5 - Storage Configuration Application
+
+### Goal
+
+Split public database configuration from storage-only runtime configuration
+application.
+
+Potential detailed execution plan:
+
+- `docs/engine/es5-storage-config-application-plan.md`
+
+### Scope
+
+Move downward into storage where storage-only:
+
+- config defaults
+- WAL writer settings
+- snapshot/checkpoint knobs
+- block/cache/storage runtime knobs
+- validation of storage-local config combinations
+- conversion into lower runtime structs
+
+ES4 may introduce the first storage-owned runtime config needed to preserve
+recovery ordering. ES5 completes that split across all open paths and removes
+the remaining engine-side hand-written storage setter application.
+
+Keep in engine:
+
+- public `StrataConfig`
+- product defaults
+- profile-level runtime choices
+- database open policy
+- compatibility behavior for existing config files
+- user/operator-facing config vocabulary
+
+### Deliverables
+
+1. Storage-owned runtime config type or builder for storage mechanics.
+2. Engine-owned adapter from `StrataConfig` into storage config.
+3. Reduced storage-facing logic in `database/open.rs` and
+   `database/config.rs`.
+4. Tests proving existing configs still open the same way.
+
+### Constraints
+
+- do not make storage own product profiles
+- do not make storage parse executor/CLI-facing concepts
+- do not break existing config serialization without a migration
+
+### Acceptance
+
+- storage-only config interpretation is storage-owned
+- engine remains the public config owner
+- database open behavior is unchanged
+- config-related tests pass across engine and CLI-facing paths
+
+### Non-Goals
+
+- no product bootstrap redesign
+- no new config format unless explicitly required
+- no executor command redesign
+
+## ES6 - Boundary Closeout, Engine Shape, And Documentation
+
+### Goal
+
+Close the normalization workstream, make the new boundary enforceable, and
+document engine's remaining responsibilities explicitly after lower mechanics
+move down.
+
+### Scope
+
+- delete or collapse obsolete engine-side lower-runtime modules
+- remove temporary forwarding/adapters that only supported migration
+- refresh documentation to describe the settled architecture
+- add dependency/import checks where practical
+- create a final inventory of intentionally remaining engine/storage seams
+- clarify internal structure for:
+  - database kernel/runtime orchestration
+  - product/open/bootstrap policy
+  - primitive semantics
+  - branch/domain workflow
+  - search/runtime behavior
+- reduce executor-owned workflow where engine should own runtime/product
+  behavior
+- keep storage-facing adapters narrow and explicit
+
+### Deliverables
+
+1. Updated:
+   - `engine-crate-map.md`
+   - `storage-crate-map.md`
+   - `storage-engine-ownership-audit.md` or a successor closeout note
+2. A clear internal ownership split for engine runtime/product/primitives.
+3. Guardrails preventing:
+   - primitive semantics in storage
+   - storage mechanics regressing into engine
+   - direct upper-layer bypasses of engine runtime policy
+4. A final list of accepted split surfaces and why they remain split.
+5. Follow-up issues or plans for executor-owned workflows that should move
+   into engine.
+6. No reintroduction of lower-runtime mechanics into engine.
+
+### Constraints
+
+- do not leave migration-only APIs as permanent surface area
+- do not preserve old module names if they now misrepresent ownership
+- do not rewrite history in docs; mark what changed and why
+- do not move primitive semantics down
+- do not move executor presentation concerns into engine
+- do not use this epic as an excuse for broad product redesign
+
+### Acceptance
+
+- the documented crate maps match the code
+- lower storage mechanics are storage-owned
+- engine public APIs remain stable
+- remaining cross-boundary calls are explicit and justified
+- engine can be described as orchestration and semantics, not storage
+  mechanics
+- executor remains a command boundary rather than a workflow host where
+  practical
+- docs and code structure agree on the main engine pillars
+
+### Non-Goals
+
+- no new architecture initiative after closeout
+- no CLI presentation changes
+- no broad search redesign unless separately planned
+- no unrelated executor/CLI cleanup
+
+## Program Verification Gates
+
+Each epic should prove correctness from both below and above.
+
+These surfaces are recovery/durability/storage-runtime surfaces. Later code
+movement PRs should be treated as high-assurance refactors: characterize
+current behavior before moving code, then prove parity after the move.
+
+The recurring verification gates for this workstream should include:
+
+- `cargo check --workspace --all-targets`
+- `cargo test -p strata-storage --quiet`
+- `cargo test -p strata-engine --quiet`
+- `cargo test -p strata-executor --quiet`
+- `cargo test -p strata-intelligence --quiet`
+- `cargo test -p stratadb --tests --quiet`
+
+Where feature availability or local vendored dependencies block a full gate,
+the epic should record the blocker explicitly and run the closest valid
+subset.
+
+Ownership guard checks should include:
+
+- `cargo tree -p strata-storage --depth 2`
+- `cargo tree -p strata-engine --depth 2`
+- `cargo tree -i strata-storage --workspace --depth 2`
+- `rg` checks for forbidden imports or primitive vocabulary in moved
+  storage modules
+- `rg` checks for remaining lower-runtime mechanics in engine database
+  modules after each epic
+
+The exact guard commands can evolve. The principles cannot:
+
+- no `storage -> engine`
+- no primitive semantics below engine
+- no public engine API break from mechanical moves
+- no silent on-disk format churn
+- no operator/product policy moved into storage
+
+Characterization gates should include, before the relevant epic changes code:
+
+- checkpoint determinism and manifest watermark behavior
+- checkpoint then compact then reopen behavior
+- snapshot install round-trip coverage for KV, graph-as-KV, event, JSON,
+  branch, vector config, vector rows, tombstones, TTL, and timestamps
+- recovery outcomes for normal replay, degraded storage, lossy fallback, and
+  follower state restore where applicable
+- performance characterization appropriate to the touched surface, such as
+  redb/YCSB-style storage paths and search benchmarks where recovery affects
+  search-facing state
+
+## Final Closeout Gate
+
+This plan is not complete until all of the following are true at once:
+
+1. `strata-storage` owns generic persistence, transaction, durability,
+   checkpoint, snapshot, recovery, and storage-config mechanics.
+2. `strata-engine` owns database orchestration, public APIs, primitive
+   semantics, branch semantics, search/runtime behavior, and product policy.
+3. Engine database modules no longer host low-level storage recovery,
+   snapshot install, or checkpoint/WAL compaction implementations.
+4. Storage APIs used by engine expose raw substrate facts and storage-local
+   errors, not engine reports or product vocabulary.
+5. Engine converts storage facts into `StrataError`, health reports,
+   retention reports, and public database behavior explicitly.
+6. The broad regression suites above storage remain green.
+7. The crate maps and ownership audit have been refreshed to describe the
+   settled boundary.
+
+That is the real closeout condition: not fewer files in engine, but a clear
+and enforceable split between substrate mechanics and engine semantics.

--- a/docs/engine/es1-boundary-baseline-and-guardrails-plan.md
+++ b/docs/engine/es1-boundary-baseline-and-guardrails-plan.md
@@ -1,0 +1,631 @@
+# ES1 Boundary Baseline And Guardrails Plan
+
+## Purpose
+
+This document is the detailed execution plan for `ES1` in
+[engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md).
+
+`ES1` does not move runtime code. It establishes the inventory, split
+decisions, and guardrails needed before the later mechanics moves:
+
+- `ES2` - checkpoint and WAL compaction mechanics
+- `ES3` - snapshot decode and install mechanics
+- `ES4` - recovery bootstrap mechanics
+- `ES5` - storage configuration application
+
+The point of this phase is to make the boundary concrete enough that the next
+PRs can move code without accidentally moving engine policy or primitive
+semantics down into `storage`.
+
+This workstream is worth doing because engine is expected to become broader in
+the next cleanup phase. It may absorb graph, vector, search, executor legacy,
+and security responsibilities. That makes the storage boundary more important:
+engine can be broad, but it must not be blurry.
+
+## Baseline Result
+
+The current crate graph is structurally correct:
+
+- `strata-storage` has no Cargo dependency on `strata-engine`
+- `strata-engine` depends on `strata-storage`
+- upper crates should continue to enter database runtime behavior through
+  engine, not storage
+
+Observed ES1 guard results:
+
+- `cargo tree -p strata-storage --depth 2` shows no `strata-engine`
+  dependency.
+- `cargo tree -p strata-engine --depth 1` shows `strata-engine` depending on
+  `strata-storage`, which is the intended direction.
+- the storage import guard finds documentation references to
+  `strata_engine::...`, but no storage code imports or Cargo dependency on
+  engine.
+- the engine lower-runtime residue guard still finds checkpoint, compaction,
+  snapshot install, recovery coordinator, manifest, and config-application
+  mechanics under `crates/engine/src/database`; those matches are the ES1
+  baseline for ES2-ES5 to reduce.
+
+The remaining problem is physical ownership inside engine:
+
+- several `crates/engine/src/database/*` modules host lower storage-runtime
+  mechanics
+- those mechanics should move to storage behind raw substrate APIs
+- engine should keep public APIs, lifecycle orchestration, policy, reporting,
+  and error interpretation
+
+## Files In Scope
+
+The ES1 inventory covers these files:
+
+- [database/compaction.rs](../../crates/engine/src/database/compaction.rs)
+- [database/snapshot_install.rs](../../crates/engine/src/database/snapshot_install.rs)
+- [database/recovery.rs](../../crates/engine/src/database/recovery.rs)
+- [database/open.rs](../../crates/engine/src/database/open.rs)
+- [database/config.rs](../../crates/engine/src/database/config.rs)
+
+The plan intentionally does not inventory all of `engine::database`. Modules
+such as lifecycle, follower refresh, health reporting, retention reporting,
+and compatibility remain engine-shaped unless a later subplan proves a smaller
+storage mechanic is hidden inside them.
+
+## Classification Labels
+
+Each surface is classified as one of:
+
+- `Stay Engine` - public API, lifecycle orchestration, product/runtime policy,
+  operator interpretation, primitive semantics, branch semantics, or engine
+  error conversion.
+- `Move Storage` - generic persistence mechanics, WAL/snapshot/manifest
+  mechanics, segmented-store install/replay mechanics, or storage-only config
+  application.
+- `Split` - currently mixes both. Later epics should extract a storage-owned
+  helper and leave an engine wrapper or policy layer behind.
+- `Watch` - not moved by this program now, but should be protected from
+  drifting into the wrong layer.
+
+## Inventory: `database/compaction.rs`
+
+This module currently mixes public engine methods with storage-owned
+checkpoint mechanics.
+
+| Surface | Current role | Classification | Target epic |
+|---|---|---|---|
+| `Database::flush` | Public guarded WAL flush API. Checks shutdown state and delegates to the unguarded body. | Stay Engine | None |
+| `Database::flush_internal` | WAL writer flush body used by public flush and shutdown paths. It is tied to engine shutdown semantics and WAL writer health. | Stay Engine, Watch | None |
+| `Database::checkpoint` | Public API plus storage mechanics: WAL flush, quiesced watermark, checkpoint data collection, snapshot dir creation, manifest load/update, checkpoint coordinator call, snapshot pruning. | Split | ES2 |
+| `Database::compact` | Public API plus storage mechanics: manifest load, active WAL segment lookup, codec-aware WAL compactor, compaction result mapping. | Split | ES2 |
+| `Database::disk_usage` | Public diagnostic API aggregating WAL writer facts and snapshot directory size. | Stay Engine | None |
+| `Database::collect_checkpoint_data` | Walks `SegmentedStore` by physical type tags and builds storage durability snapshot DTOs. Includes primitive-specific checkpoint serialization details. | Split | ES2 or ES3 |
+| `Database::load_or_create_manifest` | Loads/creates storage manifest and updates active WAL segment. | Move Storage | ES2 / ES4 |
+
+### ES2 split decision
+
+`Database::checkpoint()` should stay as the public engine method. The storage
+side should own a helper shaped roughly like:
+
+```text
+storage_checkpoint(input) -> StorageCheckpointOutcome
+```
+
+The exact type names belong in the ES2 subplan, but the ownership split is:
+
+- engine supplies lifecycle-safe inputs: storage handle, data directory or
+  layout, codec id, database UUID, WAL writer facts, quiesced watermark
+- storage performs checkpoint coordinator construction, manifest updates,
+  WAL/snapshot mechanics, and returns raw outcome facts
+- engine logs and maps storage errors into engine errors
+
+### Checkpoint collector caution
+
+`collect_checkpoint_data` is the most sensitive part of `compaction.rs`.
+
+It is physically close to storage because it walks `SegmentedStore` and builds
+snapshot DTOs. But it also knows how engine primitives are represented:
+
+- graph rows are currently routed through the KV section with
+  `TypeTag::Graph`
+- event metadata keys are skipped
+- branch index keys are skipped
+- vector config rows and vector record bytes are interpreted
+
+ES2 should not blindly move this function into storage as-is. The likely
+split is:
+
+- storage owns generic snapshot DTO construction and storage scan mechanics
+- engine or primitive-owned adapters provide primitive record materialization
+  where semantic knowledge is required
+- storage must not learn branch-index, event-chain, vector-model, or search
+  meaning
+
+This is likely the long-term split, not merely a fallback. Checkpoint
+construction naturally needs primitive materialization knowledge that should
+not sink into storage. ES2 should assume the collector, or at least the
+primitive materialization part of it, remains engine-owned and is supplied to
+storage as data or callbacks. The storage-owned part should be the generic
+checkpoint runtime around that materialized data.
+
+## Inventory: `database/snapshot_install.rs`
+
+This module is mostly storage-shaped replay/install machinery, with some
+primitive-section caution.
+
+| Surface | Current role | Classification | Target epic |
+|---|---|---|---|
+| `InstallStats` | Raw counts of installed entries by snapshot section. | Move Storage | ES3 |
+| `InstallStats::total_installed` | Raw aggregate count. | Move Storage | ES3 |
+| `install_snapshot` | Iterates loaded snapshot sections, routes by primitive tag, installs into `SegmentedStore`. | Move Storage, with semantic review | ES3 |
+| `install_kv_section` | Decodes KV section, preserves tombstones/TTL, dispatches by `TypeTag`. | Move Storage | ES3 |
+| `install_event_section` | Decodes Event section and reconstructs event user keys from sequence numbers. | Move Storage, Watch | ES3 |
+| `install_json_section` | Decodes JSON section and installs doc IDs as user keys. | Move Storage, Watch | ES3 |
+| `install_branch_section` | Decodes branch snapshot section and installs branch metadata rows. | Move Storage, Watch | ES3 |
+| `install_vector_section` | Decodes vector collection/config rows and reinstalls raw vector record bytes. | Move Storage, Watch | ES3 |
+| `decode_value_json` | Decodes persisted `Value` bytes from snapshot sections. | Move Storage | ES3 |
+
+### ES3 split decision
+
+The install path is a stronger storage candidate than the checkpoint collector
+because it mostly performs inverse persistence mechanics:
+
+- decode snapshot section DTOs
+- reconstruct storage keys
+- preserve tombstones, TTL, versions, and timestamps
+- call `SegmentedStore::install_snapshot_entries`
+
+The caution is that section names correspond to engine primitives. This is
+acceptable only if storage treats them as persistence section tags and storage
+type tags, not as semantic behavior.
+
+Storage may know:
+
+- primitive section byte tags
+- snapshot DTO schemas
+- `TypeTag`
+- raw key reconstruction needed to restore bytes
+
+Storage must not learn:
+
+- JSON path behavior
+- event-chain verification
+- vector metric/model policy
+- branch workflow policy
+- graph semantics
+
+## Inventory: `database/recovery.rs`
+
+This module intentionally centralizes recovery, but it mixes three layers:
+
+1. engine open orchestration
+2. engine recovery policy and classification
+3. lower storage recovery bootstrap mechanics
+
+| Surface | Current role | Classification | Target epic |
+|---|---|---|---|
+| `RecoveryMode` | Engine open mode: primary vs follower. Used for policy and error role. | Stay Engine | ES4 may introduce storage-neutral mode facts |
+| `RecoveryMode::as_error_role` | Engine error presentation mapping. | Stay Engine | None |
+| `RecoveryOutcome` | Engine open result bundle: UUID, codec, storage, coordinator, watermark, lossy report, follower state. | Stay Engine, Split | ES4 |
+| `Database::run_recovery` | High-level recovery sequence: config validation, manifest prep, WAL codec, storage construction, coordinator recovery, lossy fallback, segment recovery, follower state, watermark. | Split | ES4 |
+| `policy_refuses` | Engine policy for degraded storage classes. | Stay Engine | None |
+| `ManifestPreparation` | Manifest result containing database UUID and snapshot install codec. | Move Storage or Split | ES4 |
+| `prepare_manifest` | Manifest load/create, codec validation, segments dir creation, follower no-manifest fallback. | Split | ES4 |
+| `run_coordinator_recovery` | Builds `RecoveryCoordinator`, wires snapshot install and WAL record application callbacks. | Move Storage, with callback split | ES4 |
+| `handle_wal_recovery_outcome` | Engine lossy-recovery policy and report construction. | Stay Engine, with storage raw facts | ES4 |
+| `coordinator_error_to_lossy_strata_error` | Engine error conversion for lossy report classification. | Stay Engine | None |
+| `restore_follower_state` | Engine follower-state validation and cleanup. | Stay Engine | None |
+
+### ES4 split decision
+
+`Database::run_recovery` should remain the engine entry point. It composes
+database open semantics and returns engine-owned state.
+
+The storage-owned helper should take over lower replay mechanics:
+
+- manifest preparation/load/create mechanics
+- WAL codec resolution for replay
+- segmented-store recovery orchestration
+- snapshot install callback wiring
+- WAL record application
+- raw replay stats and storage health facts
+
+Engine should keep:
+
+- primary/follower open policy
+- whether degraded storage may open
+- lossy fallback decision and report wording
+- follower state restore
+- `TransactionCoordinator` bootstrap if coordinator remains engine-owned
+- conversion into `RecoveryError` and `StrataError`
+
+### Coordinator ownership caution
+
+`TransactionCoordinator` is currently in engine even though earlier storage
+work moved generic transaction runtime into storage. ES4 should not casually
+move coordinator policy while moving recovery bootstrap. If coordinator
+ownership changes, that needs its own subplan or a clearly scoped ES4 section.
+
+This is a load-bearing ES4 decision. If storage owns WAL replay mechanics while
+`TransactionCoordinator` stays engine-owned, the boundary probably needs a
+callback or adapter shape for per-record replay and final coordinator
+bootstrap. That can be correct, but it must be designed intentionally before
+recovery code moves.
+
+## Inventory: `database/open.rs`
+
+Most of `open.rs` is engine-owned runtime/product orchestration. Only small
+storage-facing utilities and WAL runtime wiring are candidates for movement.
+
+| Surface | Current role | Classification | Target epic |
+|---|---|---|---|
+| `apply_storage_config` | Applies seven storage knobs to `SegmentedStore`. | Move Storage | ES5 |
+| `restrict_dir` | Database data directory permission hardening. | Stay Engine, Watch | None |
+| `sanitize_config` | Engine/product behavior for feature-gated `auto_embed`. | Stay Engine | None |
+| `restrict_file` | Lock/config support file permission hardening. | Stay Engine, Watch | None |
+| `AcquiredDatabase` | Engine registry/open orchestration state. | Stay Engine | None |
+| `Database::open` | Public/internal database opener with default subsystem shape. | Stay Engine | None |
+| `Database::open_with_config` | Public/internal config-driven opener. | Stay Engine | None |
+| `Database::acquire_primary_db` | Registry, path lock, subsystem recovery, lifecycle publication. | Stay Engine | None |
+| `Database::repair_space_metadata_on_open` | Engine primitive/space metadata repair. | Stay Engine | None |
+| `Database::open_follower` | Engine follower opener. | Stay Engine | None |
+| `Database::acquire_follower_db` | Engine follower construction around recovery outcome. | Stay Engine | ES4 touches recovery call only |
+| `Database::spawn_wal_flush_thread` | WAL background sync thread with engine shutdown and health latching. | Split / Watch | ES5 or later |
+| `Database::open_finish` | Primary open tail: recovery, support dirs, WAL writer, block cache, DB struct, flush thread, compaction scheduling. | Split | ES4 / ES5 |
+| `Database::cache` | Engine cache-mode public opener. | Stay Engine | None |
+| `Database::create_ephemeral_bare` | Engine cache DB construction plus storage config application. | Split | ES5 |
+| `Database::open_runtime` and mode helpers | Engine product/runtime composition entry point. | Stay Engine | ES6 |
+
+### ES5 split decision
+
+`apply_storage_config` should move first. It is a narrow, low-risk helper that
+already takes only `SegmentedStore` and `StorageConfig`.
+
+The likely storage API shape is:
+
+```text
+SegmentedStore::apply_runtime_config(&StorageRuntimeConfig)
+```
+
+or:
+
+```text
+storage::runtime_config::apply_to_store(&SegmentedStore, &StorageRuntimeConfig)
+```
+
+The exact naming belongs in ES5. The important ownership point is that engine
+should not keep a hand-written list of storage setter calls once storage owns
+those knobs.
+
+### WAL flush thread caution
+
+`spawn_wal_flush_thread` is mixed:
+
+- lower mechanics: periodic WAL sync, writer background sync handles,
+  meta-file publishing
+- engine policy: accepting transaction halt, health latch, shutdown signal,
+  test hooks, lifecycle integration
+
+Do not move it as part of ES1. A later ES5 or follow-up runtime subplan should
+decide whether storage owns a generic WAL sync worker while engine owns
+health/shutdown callbacks.
+
+## Inventory: `database/config.rs`
+
+`config.rs` contains both public engine config and storage-only runtime knobs.
+
+| Surface | Current role | Classification | Target epic |
+|---|---|---|---|
+| `SHADOW_KV`, `SHADOW_JSON`, `SHADOW_EVENT` | Intelligence/embedding shadow collection names. | Stay Engine now, possible intelligence/runtime follow-up | ES6 |
+| `CONFIG_FILE_NAME` | Engine database config artifact name. | Stay Engine | None |
+| `ModelConfig` | Inference/search model endpoint config. | Stay Engine or Intelligence later | ES6 |
+| `StorageConfig` | Public engine config section containing storage knobs. | Split | ES5 |
+| `StorageConfig::effective_*` | Storage-only derived values from memory budget. | Move Storage or Split | ES5 |
+| `Default for StorageConfig` and storage default helpers | Storage-only defaults currently exposed through engine config. | Split | ES5 |
+| `SnapshotRetentionPolicy` | Public config for storage checkpoint retention. | Split | ES5 |
+| `StrataConfig` | Public database/product config surface. | Stay Engine | None |
+| `StrataConfig::vector_storage_dtype` | Engine/vector semantic config helper. | Stay Engine | ES6 if vector folds into engine |
+| `StrataConfig::durability_mode` | Public config parse into storage WAL durability mode. | Split | ES5 |
+| `StrataConfig::default_toml` | User/operator-facing config template. | Stay Engine | None |
+| `StrataConfig::from_file` | Engine config file parse, validation, env secret overrides. | Stay Engine | None |
+| `StrataConfig::apply_env_overrides` | Product/runtime secret injection. | Stay Engine | None |
+| `StrataConfig::write_default_if_missing` | Engine config artifact management. | Stay Engine | None |
+| `StrataConfig::write_to_file` | Engine config serialization. | Stay Engine | None |
+| `atomic_write_config` | Crash-safe config file write. It is file persistence, but for engine product config, not storage MANIFEST. | Stay Engine | None |
+
+### ES5 split decision
+
+`StrataConfig` remains the public engine config.
+
+Storage should get its own storage-runtime config type that can be built from
+the public config section:
+
+```text
+StorageRuntimeConfig
+```
+
+or:
+
+```text
+SegmentedStoreConfig
+```
+
+Engine should own the adapter:
+
+```text
+impl From<&StorageConfig> for StorageRuntimeConfig
+```
+
+if that impl does not introduce a `storage -> engine` dependency. More likely,
+engine calls a storage constructor/builder with field values:
+
+```text
+StorageRuntimeConfig::builder()
+    .memory_budget(...)
+    .max_branches(...)
+    ...
+```
+
+The exact shape belongs in ES5. The key rule is:
+
+- storage owns the meaning and application of storage-only knobs
+- engine owns the public config file and product-facing names
+
+## Candidate Storage APIs By Epic
+
+These are not final signatures. They are the API families later subplans
+should refine.
+
+Before ES2 moves code, write one joint API sketch for ES2, ES3, and ES4:
+
+```text
+docs/engine/es2-es4-storage-runtime-boundary-api-sketch.md
+```
+
+Checkpoint output feeds snapshot install, and snapshot install feeds recovery.
+Designing these boundary types independently will likely create rework.
+
+### ES2 checkpoint / compaction
+
+Candidate module:
+
+```text
+crates/storage/src/durability/checkpoint_runtime.rs
+```
+
+Candidate surfaces:
+
+```text
+StorageCheckpointInput
+StorageCheckpointOutcome
+run_storage_checkpoint(input) -> StorageResult<StorageCheckpointOutcome>
+
+StorageWalCompactionInput
+StorageWalCompactionOutcome
+compact_wal(input) -> StorageResult<StorageWalCompactionOutcome>
+```
+
+Engine responsibilities remain:
+
+- call `check_not_shutting_down`
+- handle ephemeral/follower no-op behavior
+- flush WAL through engine shutdown semantics
+- quiesce coordinator
+- provide checkpoint data or primitive callbacks
+- map `NoSnapshot` into the existing invalid-input behavior for compact
+
+### ES3 snapshot install
+
+Candidate module:
+
+```text
+crates/storage/src/durability/snapshot_install.rs
+```
+
+Candidate surfaces:
+
+```text
+SnapshotInstallStats
+install_loaded_snapshot(snapshot, codec, storage) -> StorageResult<SnapshotInstallStats>
+```
+
+Engine responsibilities remain:
+
+- decide when install runs
+- log recovery outcome
+- classify install failure in recovery policy
+
+### ES4 recovery bootstrap
+
+Candidate module:
+
+```text
+crates/storage/src/durability/bootstrap.rs
+```
+
+Candidate surfaces:
+
+```text
+StorageRecoveryMode
+StorageRecoveryInput
+StorageRecoveryOutcome
+run_storage_recovery(input) -> StorageResult<StorageRecoveryOutcome>
+```
+
+Engine responsibilities remain:
+
+- map primary/follower modes to storage-neutral inputs
+- decide degraded/lossy policy
+- restore follower state
+- bootstrap engine coordinator or adapt from storage stats
+- convert storage recovery errors into `RecoveryError`
+
+### ES5 storage config
+
+Candidate module:
+
+```text
+crates/storage/src/runtime_config.rs
+```
+
+Candidate surfaces:
+
+```text
+StorageRuntimeConfig
+StorageRuntimeConfig::apply_to(&self, store: &SegmentedStore)
+```
+
+Engine responsibilities remain:
+
+- parse `strata.toml`
+- apply product profiles and feature-gated config sanitization
+- preserve config file compatibility
+- adapt public `StorageConfig` into storage runtime config
+
+## Guardrails
+
+These guardrails should be run during ES1 and reused in later epics.
+
+### Cargo dependency guard
+
+Storage must not depend on engine:
+
+```sh
+cargo tree -p strata-storage --depth 2
+```
+
+Expected current baseline:
+
+- no `strata-engine` in the `strata-storage` dependency tree
+- storage depends on `strata-core` but not on engine
+
+Engine may depend on storage:
+
+```sh
+cargo tree -p strata-engine --depth 1
+```
+
+Expected current baseline:
+
+- `strata-engine` depends on `strata-storage`
+
+### Source import guard
+
+Storage code must not import engine:
+
+```sh
+rg -n 'use strata_engine|strata_engine::|strata-engine' crates/storage/src crates/storage/Cargo.toml
+```
+
+Documentation comments may mention engine to describe upper-layer error
+mapping or historical context. Code imports and Cargo dependencies are the
+guarded surface.
+
+### Primitive semantic guard for moved storage modules
+
+Once ES2-ES5 create new storage modules, they must not accumulate primitive
+semantics:
+
+```sh
+rg -n 'JsonPath|JsonPatch|SearchSubsystem|Recipe|VectorConfig|DistanceMetric|ChainVerification|BranchLifecycle|RetentionReport|HealthReport|executor' crates/storage/src
+```
+
+Expected behavior:
+
+- no matches in newly moved storage-runtime modules
+- existing documentation matches must be reviewed before treating them as
+  failures
+
+### Engine lower-runtime residue guard
+
+After each move, check that engine is shrinking toward orchestration:
+
+```sh
+rg -n 'CheckpointCoordinator|WalOnlyCompactor|ManifestManager|RecoveryCoordinator|SnapshotSerializer|install_snapshot|apply_storage_config' crates/engine/src/database
+```
+
+Expected behavior:
+
+- ES1: matches are expected and form the baseline
+- ES2: checkpoint/compaction matches should disappear or remain only in
+  engine wrappers
+- ES3: snapshot install matches should disappear from engine mechanics
+- ES4: recovery coordinator and manifest-prep mechanics should move down or
+  become storage API calls
+- ES5: `apply_storage_config` should disappear from engine
+
+### Upper-layer bypass guard
+
+Executor and CLI should not drive storage recovery/checkpoint/open policy
+directly:
+
+```sh
+rg -n 'strata_storage::.*(RecoveryCoordinator|CheckpointCoordinator|WalOnlyCompactor|ManifestManager|SnapshotSerializer)' crates/executor crates/cli
+```
+
+Expected behavior:
+
+- no matches
+- upper layers continue through engine/executor abstractions
+
+## Characterization Requirements
+
+ES1 should make the later characterization burden explicit. ES2-ES5 should not
+move code first and backfill parity later.
+
+Before the relevant code move, add or identify characterization coverage for:
+
+- checkpoint determinism and manifest watermark behavior
+- checkpoint then compact then reopen behavior
+- snapshot install round-trip coverage for:
+  - KV rows
+  - graph rows stored in the KV section with `TypeTag::Graph`
+  - event rows and skipped event metadata keys
+  - JSON rows and tombstones
+  - branch metadata rows and skipped branch index keys
+  - vector collection config rows
+  - vector record rows, including tombstones
+  - TTL, timestamps, and version preservation
+- recovery outcomes for:
+  - normal replay
+  - degraded storage accepted by policy
+  - degraded storage refused by policy
+  - lossy fallback
+  - follower state restore and invalid persisted follower state cleanup
+
+For performance-sensitive moves, use the existing benchmark vocabulary rather
+than inventing a one-off microbenchmark:
+
+- redb/YCSB-style storage characterization where checkpoint/recovery affects
+  storage paths
+- search-facing benchmarks where recovery or snapshot install affects
+  recovered search state
+
+## ES1 Acceptance Checklist
+
+ES1 is complete when:
+
+1. This inventory document exists and is linked from the main engine/storage
+   normalization plan.
+2. The target surfaces for ES2-ES5 are classified as `Stay Engine`,
+   `Move Storage`, `Split`, or `Watch`.
+3. Candidate storage API families are named well enough for later subplans to
+   refine them.
+4. Guard commands are documented with expected current behavior.
+5. The ES2-ES4 joint API sketch is called out as a prerequisite before ES2
+   code movement.
+6. The `TransactionCoordinator` ownership question is explicitly marked as an
+   ES4 design decision.
+7. Characterization requirements are documented before any runtime code moves.
+8. No runtime code has moved as part of ES1.
+
+## Non-Goals
+
+ES1 does not:
+
+- move checkpoint code
+- move snapshot install code
+- move recovery code
+- move storage config code
+- rename public database APIs
+- change on-disk formats
+- change open/recovery behavior
+- change executor or CLI behavior
+
+Those changes belong in ES2-ES5, each with a narrower implementation plan.

--- a/docs/engine/es2-checkpoint-wal-compaction-mechanics-plan.md
+++ b/docs/engine/es2-checkpoint-wal-compaction-mechanics-plan.md
@@ -1,0 +1,641 @@
+# ES2 Checkpoint And WAL Compaction Mechanics Plan
+
+## Purpose
+
+`ES2` is the first runtime-code movement epic in the engine/storage boundary
+normalization workstream.
+
+Its purpose is to move generic checkpoint, WAL compaction, snapshot pruning,
+flush-time WAL truncation, and MANIFEST watermark/persist mechanics out of
+`strata-engine` and into `strata-storage`, while keeping engine as the public
+database API and policy owner.
+
+This epic is split into straight lettered phases:
+
+- `ES2A` - boundary API sketch
+- `ES2B` - checkpoint and compaction characterization
+- `ES2C` - storage checkpoint runtime
+- `ES2D` - engine checkpoint wrapper
+- `ES2E` - storage WAL compaction runtime
+- `ES2F` - engine compaction wrapper
+- `ES2G` - residue cleanup and guard pass
+
+Read this together with:
+
+- [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
+- [es1-boundary-baseline-and-guardrails-plan.md](./es1-boundary-baseline-and-guardrails-plan.md)
+- [../storage/storage-engine-ownership-audit.md](../storage/storage-engine-ownership-audit.md)
+- [../storage/storage-charter.md](../storage/storage-charter.md)
+- [../architecture/architecture-recovery-target.md](../architecture/architecture-recovery-target.md)
+
+Before ES2C code movement starts, also write:
+
+- [es2-es4-storage-runtime-boundary-api-sketch.md](./es2-es4-storage-runtime-boundary-api-sketch.md)
+
+Checkpoint output feeds snapshot install, and snapshot install feeds recovery.
+ES2C through ES2G can move code sequentially, but ES2 should not design
+checkpoint boundary types in isolation from ES3 and ES4.
+
+## ES2 Verdict
+
+The following should move to `strata-storage`:
+
+- checkpoint runtime around `CheckpointCoordinator`
+- snapshot directory creation and permission hardening
+- MANIFEST load/create/update mechanics needed by checkpoint and compaction
+- existing snapshot watermark extraction from MANIFEST
+- checkpoint coordinator construction and execution
+- post-checkpoint snapshot pruning mechanics
+- WAL compactor construction and execution around `WalOnlyCompactor`
+- flush-time WAL truncation mechanics after engine-owned flush decisions
+- generic MANIFEST fsync/persist mechanics used by disk-primary shutdown
+- raw checkpoint and compaction outcome types
+
+The following must remain in `strata-engine`:
+
+- `Database::checkpoint()`
+- `Database::compact()`
+- shutdown sequencing and lifecycle checks
+- ephemeral and follower no-op policy
+- WAL flush through engine shutdown semantics
+- coordinator quiescing and transaction watermark choice
+- primitive checkpoint data materialization
+- public engine error wording and `StrataError` conversion
+- database-level logging and operator-facing interpretation
+
+The key rule: storage should own what to do with already-materialized
+durability DTOs. Engine should own deciding when to checkpoint, what primitive
+state goes into the DTOs, and how raw storage facts are presented to callers.
+
+ES2 intentionally includes the storage mechanics behind the shutdown
+`fsync_manifest()` path because that path only needs generic MANIFEST
+load/create/active-segment/persist behavior. Engine still owns the shutdown
+barrier, final flush, freeze hooks, registry/file-lock release, and all public
+shutdown semantics. ES4 remains responsible for the broader recovery/open
+manifest policy move.
+
+## Current Code Map
+
+The ES2 target surface is concentrated in:
+
+- [database/compaction.rs](../../crates/engine/src/database/compaction.rs)
+
+Relevant storage-owned types already live below engine:
+
+- `strata_storage::durability::CheckpointCoordinator`
+- `strata_storage::durability::CheckpointData`
+- `strata_storage::durability::CheckpointError`
+- `strata_storage::durability::CompactionError`
+- `strata_storage::durability::ManifestManager`
+- `strata_storage::durability::ManifestError`
+- `strata_storage::durability::WalOnlyCompactor`
+- `strata_storage::durability::SnapshotWatermark`
+- storage codec helpers under `strata_storage::durability::codec`
+
+### `Database::checkpoint`
+
+The current method mixes engine policy with storage mechanics:
+
+- engine-owned:
+  - `check_not_shutting_down()`
+  - ephemeral/follower no-op
+  - `flush()`
+  - `coordinator.quiesced_version()`
+  - `collect_checkpoint_data()`
+  - `StrataError` mapping
+  - database log message
+- storage-owned:
+  - `snapshots` directory creation
+  - MANIFEST load/create
+  - existing snapshot watermark reconstruction
+  - codec lookup for checkpoint serialization
+  - `CheckpointCoordinator` construction
+  - checkpoint execution
+  - MANIFEST snapshot watermark update
+  - snapshot pruning mechanics
+
+### `Database::compact`
+
+The current method also mixes policy with storage mechanics:
+
+- engine-owned:
+  - `check_not_shutting_down()`
+  - ephemeral/follower no-op
+  - writer active segment observation
+  - public invalid-input wording when no checkpoint exists
+  - database log message
+- storage-owned:
+  - WAL directory selection from database layout
+  - MANIFEST load/create
+  - `WalOnlyCompactor` construction
+  - codec-aware compactor setup
+  - compaction execution
+  - raw removed-segment and reclaimed-byte facts
+
+### `Database::collect_checkpoint_data`
+
+This function should not move wholesale in ES2.
+
+It walks `SegmentedStore`, but it also knows primitive materialization rules:
+
+- graph rows are emitted through the KV snapshot section with
+  `TypeTag::Graph`
+- event metadata keys are skipped
+- branch index keys are skipped
+- vector collection config rows are recognized by key convention
+- vector record bytes are decoded to populate vector snapshot metadata
+
+The ES2 split should assume this stays engine-owned for now. Storage should
+accept `CheckpointData` as an input, not learn how to create all primitive
+sections from live engine state.
+
+Longer term, storage may own generic scan helpers if they can be kept
+primitive-agnostic. The primitive materialization rules should remain in
+engine or primitive-owned adapters.
+
+### `Database::load_or_create_manifest`
+
+This helper is generic storage mechanics, but it is shared with nearby engine
+open/recovery code.
+
+ES2 should avoid duplicating it. The preferred direction is to move a generic
+manifest helper into storage as part of the checkpoint/compaction runtime. If
+that creates awkward ES4 coupling, ES2 may leave an engine wrapper temporarily,
+but the helper should have a clear owner by the ES4 recovery move.
+
+## Target Storage Surface
+
+Exact names can change during implementation, but ES2C should introduce one
+storage-owned runtime module for checkpoint and WAL compaction mechanics.
+
+Candidate module:
+
+```text
+crates/storage/src/durability/checkpoint_runtime.rs
+```
+
+Candidate exports:
+
+```text
+StorageCheckpointInput
+StorageCheckpointOutcome
+run_storage_checkpoint(input) -> StorageResult<StorageCheckpointOutcome>
+
+StorageWalCompactionInput
+StorageWalCompactionOutcome
+compact_storage_wal(input) -> Result<StorageWalCompactionOutcome, StorageWalCompactionError>
+
+StorageManifestSyncInput
+sync_storage_manifest(input) -> Result<(), StorageManifestRuntimeError>
+
+StorageFlushWalTruncationInput
+StorageFlushWalTruncationOutcome
+truncate_storage_wal_after_flush(input) -> Result<Option<StorageFlushWalTruncationOutcome>, StorageFlushWalTruncationError>
+```
+
+If the existing durability error hierarchy is sufficient, do not create new
+error types just to rename them. If a new error type is needed, it should be
+storage-local and should not mention `StrataError`, engine health reports, or
+operator policy.
+
+### `StorageCheckpointInput`
+
+The input should contain only storage facts and already-materialized data:
+
+```text
+layout
+database_uuid
+checkpoint_codec
+manifest_create_codec_id
+watermark_txn
+checkpoint_data
+active_wal_segment
+```
+
+Resolved by ES2A:
+
+- use `DatabaseLayout`, not ad-hoc `data_dir` paths
+- engine passes an already-created checkpoint codec or an equivalent codec
+  handle, plus an explicit `manifest_create_codec_id`
+- active WAL segment is a checkpoint input so storage can persist the
+  MANIFEST active segment before checkpoint/compaction decisions
+- active WAL segment is represented as `NonZeroU64`; segment `0` is rejected
+  at the engine boundary instead of being persisted into MANIFEST
+
+Resolved by ES2D:
+
+- snapshot pruning is split out of the checkpoint outcome; storage owns the
+  raw pruning helper, while engine keeps lifecycle/configuration policy and
+  preserves non-fatal post-checkpoint warning behavior
+
+### `StorageCheckpointOutcome`
+
+The output should return raw facts:
+
+```text
+snapshot_id
+watermark_txn
+checkpoint_timestamp_micros
+active_wal_segment
+```
+
+Engine should translate this outcome into existing database logging and public
+behavior.
+
+ES2C must preserve current missing-MANIFEST behavior unless it explicitly
+documents a behavior change. Today `Database::load_or_create_manifest()`
+creates a missing MANIFEST with `"identity"` in the checkpoint/compact path.
+Passing the configured codec id instead may be the right fix, but it must not
+be silent.
+
+### `StorageWalCompactionInput`
+
+The input should contain only compaction mechanics:
+
+```text
+layout
+database_uuid
+manifest_create_codec_id
+active_wal_segment
+wal_codec
+```
+
+ES2A chose `DatabaseLayout` for this boundary.
+
+Resolved by ES2E:
+
+- `active_wal_segment` is `Option<NonZeroU64>` so storage can preserve the
+  existing engine behavior exactly: `Some(segment)` updates MANIFEST and
+  supplies the one-based active override, while `None` leaves MANIFEST
+  unchanged and uses the compactor's existing zero-override fallback.
+- `database_uuid` and `manifest_create_codec_id` are included so the storage
+  helper can preserve current missing-MANIFEST compact behavior.
+
+### `StorageWalCompactionOutcome`
+
+The output should return raw facts already produced by `WalOnlyCompactor`:
+
+```text
+wal_segments_removed
+reclaimed_bytes
+snapshot_watermark
+```
+
+Storage should preserve `CompactionError::NoSnapshot` or an equivalent
+storage-local variant. Engine should continue mapping that one case to the
+existing invalid-input message:
+
+```text
+No checkpoint exists yet. Run checkpoint() before compact().
+```
+
+## Engine Wrapper Shape
+
+After ES2, `Database::checkpoint()` should be thin:
+
+```text
+check_not_shutting_down()
+return Ok for ephemeral/follower
+flush()
+watermark = coordinator.quiesced_version()
+data = collect_checkpoint_data()
+active_wal_segment = NonZeroU64(wal_writer.current_segment())
+outcome = storage::durability::run_storage_checkpoint(...)
+log database-level outcome
+return Ok
+```
+
+After ES2, `Database::compact()` should be thin:
+
+```text
+check_not_shutting_down()
+return Ok for ephemeral/follower
+active_wal_segment = wal_writer.current_segment_if_present()
+outcome = storage::durability::compact_storage_wal(...)
+map NoSnapshot to existing invalid input error
+log database-level outcome
+return Ok
+```
+
+The wrappers should remain in engine even if they become small. They are part
+of the public database API and carry lifecycle semantics.
+
+## Implementation Plan
+
+ES2 should land as straight lettered phases unless the code review finds a
+smaller split is needed:
+
+- `ES2A` writes the joint ES2-ES4 API sketch.
+- `ES2B` locks characterization coverage for checkpoint and WAL compaction
+  behavior.
+- `ES2C` moves generic checkpoint mechanics into storage.
+- `ES2D` thins the engine checkpoint wrapper.
+- `ES2E` moves generic WAL compaction mechanics into storage.
+- `ES2F` thins the engine compaction wrapper.
+- `ES2G` cleans residue and reruns ownership guards.
+
+### ES2A Boundary Sketch
+
+Write [es2-es4-storage-runtime-boundary-api-sketch.md](./es2-es4-storage-runtime-boundary-api-sketch.md)
+before moving code.
+
+The sketch should define the relationship between:
+
+- `StorageCheckpointOutcome`
+- snapshot install stats from ES3
+- `StorageRecoveryOutcome` from ES4
+
+It should also decide whether common storage layout and manifest helpers are
+introduced now or deferred to ES4.
+
+### ES2B Characterization Before Movement
+
+Add or identify tests that characterize current behavior before refactoring.
+
+Minimum ES2B coverage:
+
+- checkpoint creates a snapshot and updates the MANIFEST watermark
+- repeated checkpoint of unchanged state is deterministic where current
+  formats make determinism meaningful
+- checkpoint preserves tombstones, TTL, timestamps, and versions
+- checkpoint includes graph-as-KV rows
+- checkpoint skips event metadata keys
+- checkpoint skips branch index keys
+- checkpoint includes vector collection config rows and vector record rows
+- checkpoint then compact then reopen preserves readable state
+- `compact()` before checkpoint returns the existing invalid-input behavior
+- WAL compaction uses the active writer segment override
+- snapshot pruning after checkpoint remains non-fatal on pruning failure
+- missing-MANIFEST checkpoint/compaction behavior around MANIFEST codec id is
+  either preserved or deliberately changed with compatibility coverage
+
+Prefer existing engine integration tests where the behavior crosses public
+database APIs. Add storage-layer tests only where the new storage helper can
+be tested without primitive semantics.
+
+ES2B is complete when the characterization suite is green against the pre-move
+engine implementation.
+
+### ES2C Add Storage Checkpoint Runtime
+
+Create the storage module and move generic checkpoint mechanics behind a
+storage-owned function.
+
+The first version should preserve behavior closely:
+
+- create the snapshots directory
+- apply existing Unix `0700` permission behavior
+- load or create MANIFEST
+- preserve or explicitly change the current missing-MANIFEST codec id
+  behavior
+- reconstruct existing snapshot watermark
+- create `CheckpointCoordinator`
+- call checkpoint with supplied `CheckpointData`
+- set MANIFEST snapshot watermark
+- run snapshot pruning if this is already generic and can be moved cleanly,
+  while keeping pruning failure nonfatal to checkpoint success
+
+If snapshot pruning currently depends on engine config types, split the raw
+storage pruning helper from the engine config adapter rather than moving
+engine config into storage.
+
+### ES2D Thin Engine Checkpoint Wrapper
+
+Update `Database::checkpoint()` to call the storage checkpoint runtime.
+
+Keep in engine:
+
+- lifecycle guard
+- ephemeral/follower no-op
+- `flush()`
+- coordinator quiescing
+- checkpoint data collection
+- storage error to `StrataError` conversion
+- database-level logging
+
+Do not move `collect_checkpoint_data()` in this step.
+
+### ES2E Add Storage WAL Compaction Runtime
+
+Move generic WAL compaction construction and execution behind a storage-owned
+function.
+
+The storage helper should:
+
+- load/create MANIFEST through the same manifest helper used by checkpoint
+- construct `WalOnlyCompactor`
+- install the codec-aware reader path
+- compact with active segment override
+- return raw removed segment and reclaimed byte counts
+
+### ES2F Thin Engine Compaction Wrapper
+
+Update `Database::compact()` to call the storage WAL compaction runtime.
+
+Keep in engine:
+
+- lifecycle guard
+- ephemeral/follower no-op
+- active WAL segment observation from the writer
+- public mapping of no-checkpoint compaction to invalid input
+- database-level logging
+
+### ES2G Clean Residue And Re-run Guards
+
+After the code movement, remove engine imports that should no longer be
+needed:
+
+- `CheckpointCoordinator`
+- `CheckpointError`
+- `CompactionError` unless still used for mapping
+- `ManifestManager`
+- `ManifestError`
+- `WalOnlyCompactor`
+- `SnapshotWatermark`
+
+ES2G also routes remaining generic MANIFEST mechanics through storage-owned
+helpers where doing so does not move engine policy:
+
+- disk-primary shutdown MANIFEST fsync uses `sync_storage_manifest`, while
+  shutdown sequencing remains in engine
+- flush-time WAL truncation uses `truncate_storage_wal_after_flush`, while
+  engine still decides that the post-flush truncation is best-effort
+
+Then run the guard commands from ES1 and record any intentional remaining
+matches.
+
+## Error Mapping
+
+Storage should return storage-local errors. Engine should map them.
+Public storage-local error enums should be `#[non_exhaustive]`; engine mappings
+must keep a catch-all arm so future storage variants do not become semver
+breaks.
+
+Preserve existing public behavior:
+
+- checkpoint coordinator failures remain internal engine errors at the public
+  API boundary
+- MANIFEST load/create/persist failures remain internal engine errors at the
+  public API boundary
+- `compact()` before checkpoint remains invalid input with the current message
+- post-checkpoint pruning failure remains non-fatal and warning-level
+
+Do not add `StrataError` to storage and do not make storage format
+operator-facing recovery language.
+
+## Snapshot Pruning
+
+Snapshot pruning belongs with checkpoint mechanics if it can be expressed in
+storage terms:
+
+- current snapshots
+- retention count/age/bytes policy
+- filesystem deletion results
+- raw pruning stats
+
+Engine owns the public configuration vocabulary and any product defaults.
+
+If the current pruning path is too entangled with `StrataConfig`, ES2 should
+move the filesystem pruning helper and leave engine as the adapter from public
+config to storage pruning options. The direction should still be toward
+storage owning the pruning mechanics.
+
+## Manifest Ownership
+
+MANIFEST mechanics are shared by checkpoint, compaction, snapshot install, and
+recovery.
+
+ES2C should introduce only the manifest helpers needed for checkpoint and WAL
+compaction, but the shape should anticipate ES4:
+
+- load existing MANIFEST
+- create missing MANIFEST with database UUID and codec information
+- update active WAL segment
+- set snapshot watermark
+- persist changes
+
+The helper should not decide primary/follower recovery policy or shutdown
+success semantics. Those belong to engine now; the recovery/open policy move
+belongs to ES4.
+
+## Verification Gates
+
+Run the standard formatting and relevant tests:
+
+```sh
+cargo fmt --check
+cargo test -p strata-storage --quiet
+cargo test -p strata-engine --quiet
+```
+
+If the change touches workspace-visible API exports, also run:
+
+```sh
+cargo check --workspace --all-targets
+```
+
+Ownership guards:
+
+```sh
+cargo tree -p strata-storage --depth 2
+cargo tree -p strata-engine --depth 1
+rg -n 'use strata_engine|strata_engine::|strata-engine' crates/storage/src crates/storage/Cargo.toml
+rg -n 'JsonPath|JsonPatch|SearchSubsystem|Recipe|VectorConfig|DistanceMetric|ChainVerification|BranchLifecycle|RetentionReport|HealthReport|executor' crates/storage/src
+rg -n 'CheckpointCoordinator|WalOnlyCompactor|ManifestManager|RecoveryCoordinator|SnapshotSerializer|install_snapshot|apply_storage_config' crates/engine/src/database
+```
+
+Expected ES2G direction:
+
+- no new `storage -> engine` dependency
+- no primitive semantic vocabulary in the new storage checkpoint module
+- checkpoint and WAL compaction coordinator usage disappears from engine
+  wrappers or remains only in tests/comments
+- recovery and snapshot install residue remains until ES3/ES4
+
+## ES2G Guard Results
+
+Recorded after the ES2G cleanup:
+
+- `cargo tree -p strata-storage --depth 2`: clean. `strata-storage`
+  depends on `strata-core` and external crates, not `strata-engine`.
+- `cargo tree -p strata-engine --depth 1`: expected dependency on
+  `strata-storage`; no reverse edge.
+- `rg -n 'use strata_engine|strata_engine::|strata-engine' crates/storage/src crates/storage/Cargo.toml`:
+  no matches.
+- `rg -n 'JsonPath|JsonPatch|SearchSubsystem|Recipe|VectorConfig|DistanceMetric|ChainVerification|BranchLifecycle|RetentionReport|HealthReport|executor' crates/storage/src`:
+  no matches.
+- `rg -n 'CheckpointCoordinator|WalOnlyCompactor|ManifestManager|RecoveryCoordinator|SnapshotSerializer|install_snapshot|apply_storage_config' crates/engine/src/database`:
+  intentional remaining matches:
+  - `StorageCheckpointError::CheckpointCoordinator` in
+    `compaction.rs` is public error mapping for storage-owned checkpoint
+    runtime; engine no longer constructs the checkpoint coordinator there.
+  - `snapshot_install.rs` keeps `SnapshotSerializer` and `install_snapshot`
+    until ES3.
+  - `recovery.rs` keeps `RecoveryCoordinator`, `ManifestManager`, and
+    snapshot install callbacks until ES4.
+  - `open.rs` and `mod.rs` keep `apply_storage_config` as engine-owned
+    configuration policy.
+  - `recovery_error.rs` has documentation text for recovery-owned
+    `ManifestManager::create` failures.
+  - `lifecycle.rs` and `transaction.rs` no longer match this guard; shutdown
+    MANIFEST fsync and flush-time WAL truncation call storage helpers.
+  - test matches use `ManifestManager` for assertions, corrupt fixture setup,
+    shutdown coverage, and characterization.
+
+ES2G also removes the stale disk-backed cache mode from primary opens:
+`durability = "cache"` is rejected by `StrataConfig`. Cache remains an
+explicit open mode through `Database::cache()` and `OpenSpec::cache()`.
+
+## Acceptance Checklist
+
+ES2A is complete when:
+
+1. The ES2-ES4 joint API sketch exists.
+2. The sketch's own ES2A acceptance checklist is satisfied.
+
+ES2B is complete when:
+
+1. Checkpoint characterization exists before behavior-preserving movement.
+2. WAL compaction characterization exists before behavior-preserving
+   movement.
+
+ES2C is complete when:
+
+1. Storage owns generic checkpoint runtime around `CheckpointCoordinator`.
+
+ES2D is complete when:
+
+1. Engine `Database::checkpoint()` remains public and thin.
+2. `collect_checkpoint_data()` remains engine-owned or is split through a
+   primitive-materialization callback that keeps semantics out of storage.
+
+ES2E is complete when:
+
+1. Storage owns generic WAL compaction runtime around `WalOnlyCompactor`.
+
+ES2F is complete when:
+
+1. Engine `Database::compact()` remains public and thin.
+2. Existing checkpoint, compaction, and reopen behavior is unchanged.
+3. Storage APIs expose raw facts and storage-local errors only.
+4. No on-disk format changes are introduced.
+
+ES2G is complete when:
+
+1. ES1 guard commands have been rerun and intentional residue is recorded.
+
+ES2 as a whole is complete when ES2A through ES2G are complete.
+
+## Non-Goals
+
+ES2 does not:
+
+- move snapshot install machinery
+- move recovery bootstrap machinery
+- move storage configuration application
+- change WAL, snapshot, or MANIFEST formats
+- change checkpoint or compaction public API behavior
+- move primitive checkpoint materialization into storage
+- redesign snapshot retention policy
+- alter recovery policy or lossy/degraded behavior
+- make executor or CLI call storage checkpoint/compaction APIs directly

--- a/docs/engine/es2-es4-storage-runtime-boundary-api-sketch.md
+++ b/docs/engine/es2-es4-storage-runtime-boundary-api-sketch.md
@@ -1,0 +1,502 @@
+# ES2-ES4 Storage Runtime Boundary API Sketch
+
+## Purpose
+
+This is the `ES2A` design sketch for the storage/runtime boundary shared by:
+
+- `ES2` - checkpoint and WAL compaction mechanics
+- `ES3` - snapshot decode and install mechanics
+- `ES4` - recovery bootstrap mechanics
+
+The code moves are sequential, but the APIs are coupled:
+
+- checkpoint creates the snapshot and MANIFEST state that compaction and
+  recovery consume
+- snapshot install is the inverse of checkpoint materialization
+- recovery composes MANIFEST preparation, snapshot install, WAL replay, and
+  segmented-store bootstrap
+
+This sketch defines the intended type families before ES2 moves checkpoint
+mechanics down into storage.
+
+Read this together with:
+
+- [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
+- [es1-boundary-baseline-and-guardrails-plan.md](./es1-boundary-baseline-and-guardrails-plan.md)
+- [es2-checkpoint-wal-compaction-mechanics-plan.md](./es2-checkpoint-wal-compaction-mechanics-plan.md)
+
+## Boundary Decision
+
+Use storage-owned runtime APIs around `DatabaseLayout`.
+
+Do not pass ad-hoc `data_dir.join(...)` paths across the boundary. Storage
+already owns `strata_storage::durability::DatabaseLayout`, and recovery already
+uses it. ES2 should extend checkpoint and compaction to use the same layout
+vocabulary.
+
+Engine remains the public API and policy owner:
+
+- `Database::checkpoint()`
+- `Database::compact()`
+- database open/recovery orchestration
+- lifecycle checks and shutdown behavior
+- primitive checkpoint materialization
+- recovery policy and operator-facing reports
+- `TransactionCoordinator` bootstrap
+- `StrataError` and `RecoveryError` conversion
+
+Storage owns raw mechanics:
+
+- snapshot directory and MANIFEST mechanics
+- checkpoint coordinator execution
+- WAL compaction execution
+- snapshot section decode/install mechanics
+- recovery coordinator replay mechanics
+- raw replay, install, and segment recovery facts
+
+Storage APIs should return storage-local errors and raw facts. Engine converts
+those facts into public database behavior.
+
+## Coordinator Decision
+
+`TransactionCoordinator` stays engine-owned for ES4.
+
+This is the least invasive split and matches the intended architecture:
+storage recovers durable substrate state, while engine owns transaction-facing
+runtime orchestration and public database semantics.
+
+ES4 should therefore not make storage call into engine per replayed record to
+update coordinator state. Storage should replay WAL records directly into
+`SegmentedStore` using storage-owned mechanics, then return `RecoveryStats`
+and `RecoveredState`. Engine then constructs or updates
+`TransactionCoordinator` from those raw facts.
+
+If later work wants to move `TransactionCoordinator`, that should be a
+separate coordinator ownership plan, not an incidental ES4 side effect.
+
+## Shared Layout And Manifest Helpers
+
+The shared input vocabulary should center on:
+
+```text
+DatabaseLayout
+StorageCodec / codec_id
+database_uuid
+active_wal_segment
+write_buffer_size
+StorageRuntimeConfig
+CheckpointData
+```
+
+ES2C should introduce only the manifest helpers needed for checkpoint and WAL
+compaction, but the helper shape should be reusable by ES4.
+
+Candidate internal storage helpers:
+
+```text
+load_manifest(layout) -> StorageResult<ManifestManager>
+load_or_create_manifest(layout, database_uuid, manifest_create_codec_id) -> StorageResult<ManifestManager>
+update_manifest_active_wal_segment(manifest, active_wal_segment) -> StorageResult<()>
+current_snapshot_watermark(manifest) -> Option<SnapshotWatermark>
+set_manifest_snapshot_watermark(manifest, snapshot_id, watermark_txn) -> StorageResult<()>
+```
+
+These helpers should not decide:
+
+- primary vs follower open policy
+- codec mismatch presentation
+- lossy recovery policy
+- degraded storage acceptance
+- public error wording
+
+Those remain engine decisions.
+
+## ES2 Checkpoint Boundary
+
+Candidate module:
+
+```text
+crates/storage/src/durability/checkpoint_runtime.rs
+```
+
+Candidate input:
+
+```text
+StorageCheckpointInput {
+    layout: DatabaseLayout,
+    database_uuid: [u8; 16],
+    checkpoint_codec: Box<dyn StorageCodec>,
+    manifest_create_codec_id: String,
+    checkpoint_data: CheckpointData,
+    watermark_txn: TxnId,
+    active_wal_segment: NonZeroU64,
+}
+```
+
+`checkpoint_data` is supplied by engine. ES2 should not move
+`Database::collect_checkpoint_data()` wholesale because that function contains
+primitive materialization rules:
+
+- graph rows are encoded in the KV section with `TypeTag::Graph`
+- event metadata keys are skipped
+- branch index keys are skipped
+- vector config keys and vector record payloads are interpreted
+
+`active_wal_segment` is non-zero by construction. Engine rejects a writer that
+reports segment `0` before entering the storage checkpoint runtime.
+
+Candidate output:
+
+```text
+StorageCheckpointOutcome {
+    snapshot_id: u64,
+    watermark_txn: TxnId,
+    checkpoint_timestamp_micros: u64,
+    active_wal_segment: u64,
+}
+```
+
+The outcome is deliberately raw. Engine logs the database-level message and
+maps storage errors into `StrataError`.
+
+ES2D split snapshot pruning out of the checkpoint outcome. Storage owns the
+raw pruning helper and retention minimum, while engine keeps the lifecycle and
+configuration adapter. `Database::checkpoint()` runs pruning after the
+checkpoint and MANIFEST update, preserving the existing non-fatal warning
+behavior for pruning failure.
+
+`manifest_create_codec_id` is explicit because current
+`Database::load_or_create_manifest()` writes `"identity"` when it creates a
+missing MANIFEST in the checkpoint/compact path. ES2C must either preserve
+that behavior or call out an intentional behavior change with compatibility
+tests before passing the configured checkpoint codec id instead.
+
+## ES2 WAL Compaction Boundary
+
+Candidate input:
+
+```text
+StorageWalCompactionInput {
+    layout: DatabaseLayout,
+    wal_codec: Box<dyn StorageCodec>,
+    database_uuid: [u8; 16],
+    manifest_create_codec_id: String,
+    active_wal_segment: Option<NonZeroU64>,
+}
+```
+
+`active_wal_segment` is optional to preserve the current engine wrapper
+semantics: when a WAL writer exists, engine passes `Some(segment)` with a
+one-based segment number and storage persists that segment into MANIFEST
+before compaction; when there is no writer, engine passes `None`, storage
+leaves MANIFEST unchanged, and the underlying compactor receives the existing
+zero-override fallback.
+
+`database_uuid` and `manifest_create_codec_id` are explicit because current
+`Database::compact()` can create a missing MANIFEST before returning the
+no-checkpoint error. ES2F should preserve that behavior unless it deliberately
+changes the missing-MANIFEST compatibility contract.
+
+ES2G also uses a small `StorageManifestSyncInput` for shutdown-time MANIFEST
+fsync. That boundary is intentionally limited to generic MANIFEST
+load/create/active-segment/persist mechanics. Engine still owns shutdown
+sequencing and ES4 still owns recovery/open MANIFEST policy.
+
+Candidate output:
+
+```text
+StorageWalCompactionOutcome {
+    wal_segments_removed: usize,
+    reclaimed_bytes: u64,
+    snapshot_watermark: Option<u64>,
+}
+```
+
+`snapshot_watermark` mirrors `CompactInfo::snapshot_watermark`, the raw
+retention fact currently produced by `WalOnlyCompactor`. It is useful for
+tests and diagnostics, but engine should not turn it into an operator report
+in ES2.
+
+Storage should preserve `CompactionError::NoSnapshot` or an equivalent
+storage-local variant. Engine continues mapping that case to the existing
+public invalid-input message:
+
+```text
+No checkpoint exists yet. Run checkpoint() before compact().
+```
+
+## ES3 Snapshot Install Boundary
+
+Candidate module:
+
+```text
+crates/storage/src/durability/snapshot_install.rs
+```
+
+Candidate input:
+
+```text
+StorageSnapshotInstallInput<'a> {
+    snapshot: &'a LoadedSnapshot,
+    codec: &'a dyn StorageCodec,
+    storage: &'a SegmentedStore,
+}
+```
+
+Candidate output:
+
+```text
+StorageSnapshotInstallStats {
+    kv_rows: usize,
+    graph_rows: usize,
+    event_rows: usize,
+    json_rows: usize,
+    vector_config_rows: usize,
+    vector_rows: usize,
+    branch_rows: usize,
+    sections_skipped: usize,
+}
+```
+
+These names are physical snapshot/storage counters, not engine semantic
+reports. Storage may know snapshot section tags, `TypeTag`, raw key
+reconstruction, tombstones, TTLs, versions, and timestamps.
+
+Storage must not learn:
+
+- JSON path or patch semantics
+- event-chain verification
+- vector metric/model policy
+- branch workflow policy
+- graph query semantics
+
+The ES3 install API should become the function ES4 recovery calls when the
+`RecoveryCoordinator` supplies a loaded snapshot.
+
+## ES4 Recovery Boundary
+
+Candidate module:
+
+```text
+crates/storage/src/durability/bootstrap.rs
+```
+
+Candidate input:
+
+```text
+StorageRecoveryInput {
+    layout: DatabaseLayout,
+    mode: StorageRecoveryMode,
+    configured_codec_id: String,
+    write_buffer_size: usize,
+    runtime_config: StorageRuntimeConfig,
+    lossy_wal_replay: bool,
+}
+```
+
+Candidate mode:
+
+```text
+StorageRecoveryMode {
+    PrimaryCreateManifestIfMissing,
+    FollowerNeverCreateManifest,
+}
+```
+
+This mode is storage-neutral. Engine maps its own `RecoveryMode` into it and
+still owns the policy meaning.
+
+The follower mode name is intentionally about MANIFEST behavior, not
+read-only database policy. Follower recovery may still create missing storage
+directories and replay durable state into a local `SegmentedStore`; it must
+not create a MANIFEST.
+
+Candidate output:
+
+```text
+StorageRecoveryOutcome {
+    database_uuid: [u8; 16],
+    wal_codec: Box<dyn StorageCodec>,
+    storage: SegmentedStore,
+    wal_replay: RecoveryStats,
+    snapshot_install: Option<StorageSnapshotInstallStats>,
+    segment_recovery: RecoveredState,
+    lossy_wal_replay: Option<StorageLossyWalReplayFacts>,
+}
+```
+
+Candidate lossy facts:
+
+```text
+StorageLossyWalReplayFacts {
+    records_applied_before_failure: u64,
+    version_reached_before_failure: CommitVersion,
+    discarded_on_wipe: bool,
+    source: CoordinatorRecoveryError,
+}
+```
+
+Engine decides whether to request lossy WAL replay from config. Storage may
+perform the mechanical wipe only after engine opts in via
+`lossy_wal_replay: true`. Engine still owns `LossyRecoveryReport` wording and
+public error classification.
+
+Lossy replay must preserve the current hard-fail bypass rules. Even when
+`lossy_wal_replay` is true, storage must not wipe and continue for recovery
+planning failures, MANIFEST failures, snapshot plan failures, or legacy-format
+failures where `CoordinatorRecoveryError::should_bypass_lossy()` returns
+`true`. Those errors remain hard failures and engine maps them into
+`RecoveryError`.
+
+Engine also keeps degraded-storage policy. Storage returns
+`RecoveredState.health`; engine decides whether `DataLoss`,
+`PolicyDowngrade`, or `Telemetry` permits opening under the active config.
+
+`RecoveryStats::final_version` in `StorageRecoveryOutcome.wal_replay` must
+already include the snapshot-version fold:
+
+```text
+wal_replay.final_version = max(wal_replay.final_version, CommitVersion(storage.version()))
+```
+
+The current `RecoveryCoordinator` does not fold snapshot-installed entry
+versions into `RecoveryStats`; the current engine does that before
+`TransactionCoordinator` bootstrap. ES4 must preserve that behavior.
+
+Storage recovery must also preserve the current ordering around storage
+configuration:
+
+```text
+snapshot install / WAL replay
+snapshot-version fold
+apply StorageRuntimeConfig to SegmentedStore
+recover_segments()
+return StorageRecoveryOutcome
+```
+
+Until ES5 completes the public config split, engine builds
+`StorageRuntimeConfig` from `StrataConfig.storage` and passes it down. This
+does not move public config ownership into storage; it only prevents ES4 from
+running `recover_segments()` with default storage knobs.
+
+## ES4 Engine Wrapper Shape
+
+After ES4, `Database::run_recovery()` should remain the engine entry point.
+It should do roughly:
+
+```text
+validate configured codec for public error behavior
+build StorageRecoveryInput from StrataConfig and RecoveryMode
+outcome = storage::durability::run_storage_recovery(input)
+map raw storage errors into RecoveryError
+apply engine degraded/lossy policy and reports
+result = RecoveryResult { storage: outcome.storage, stats: outcome.wal_replay }
+coordinator = TransactionCoordinator::from_recovery_with_limits(&result, ...)
+coordinator.apply_storage_recovery(outcome.segment_recovery)
+restore follower state when needed
+build RecoveryOutcome for open.rs
+```
+
+Storage should not return a `TransactionCoordinator`, `RecoveryError`,
+`LossyRecoveryReport`, or engine follower state.
+
+## Type Relationship
+
+The three outcome families should compose without circular ownership:
+
+```text
+StorageCheckpointOutcome
+    -> records snapshot_id and watermark persisted in MANIFEST
+    -> WAL compaction consumes MANIFEST watermark to delete covered WAL
+    -> recovery uses MANIFEST snapshot_id/watermark to install snapshot and skip WAL
+
+StorageSnapshotInstallStats
+    -> returned by standalone snapshot install in ES3
+    -> embedded in StorageRecoveryOutcome in ES4 when recovery installs a snapshot
+
+StorageRecoveryOutcome
+    -> returns raw WAL replay stats, optional snapshot install stats,
+       segmented-store recovery health, and optional lossy replay facts
+    -> engine builds coordinator, reports, and public open result
+```
+
+## Error Boundary
+
+Storage errors should stay storage-local:
+
+```text
+StorageCheckpointError
+StorageWalCompactionError
+StorageManifestRuntimeError
+StorageFlushWalTruncationError
+StorageSnapshotInstallError
+StorageRecoveryError
+StorageSnapshotPruneError
+```
+
+Public storage-local error enums should be `#[non_exhaustive]`, and engine
+adapters should include catch-all mappings. Storage can add more precise phases
+later without forcing every engine release to exhaustively enumerate them.
+
+Existing lower errors may be reused if they are already precise enough:
+
+- `CheckpointError`
+- `CompactionError`
+- `ManifestError`
+- `SnapshotReadError`
+- `CoordinatorRecoveryError`
+- `StorageError`
+
+Engine maps these into:
+
+- `StrataError`
+- `RecoveryError`
+- `LossyRecoveryReport`
+- database log messages
+
+Do not add an engine dependency, engine error type, operator report type, or
+product vocabulary to storage.
+
+## Open Questions Deferred To Subplans
+
+The subplans may refine names and ownership details, but should not reopen the
+major boundary decisions above.
+
+Deferred details:
+
+- whether ES2 stores `checkpoint_codec` by object or codec id
+- whether pruning stats include bytes
+- whether ES4 recovery returns `StorageRecoveryOutcome.storage` by value or
+  through a smaller recovered-store wrapper
+- whether manifest helpers are public within `durability` or private to the
+  checkpoint/recovery modules
+
+Not deferred:
+
+- use `DatabaseLayout` rather than ad-hoc paths
+- keep `TransactionCoordinator` in engine for ES4
+- keep primitive checkpoint materialization out of storage
+- preserve snapshot-version folding before coordinator bootstrap
+- preserve storage-config-before-`recover_segments()` ordering
+- preserve lossy hard-fail bypass behavior
+- keep engine policy and public error/report conversion out of storage
+
+## ES2A Acceptance
+
+ES2A is complete when:
+
+1. This sketch exists and is linked from the ES2 plan.
+2. ES2 checkpoint and WAL compaction APIs are sketched using
+   `DatabaseLayout`.
+3. ES3 snapshot install stats are sketched as physical storage counters.
+4. ES4 recovery outcome is sketched without `TransactionCoordinator`.
+5. The coordinator ownership decision is explicit.
+6. The sketch explains how checkpoint, snapshot install, and recovery
+   outcomes compose.
+7. ES4 recovery invariants are explicit:
+   - snapshot-version fold before coordinator bootstrap
+   - storage config before `recover_segments()`
+   - lossy hard-fail bypass preservation
+8. ES2 checkpoint edge cases are explicit:
+   - missing-MANIFEST codec id behavior cannot change silently
+   - pruning failure remains nonfatal to checkpoint success


### PR DESCRIPTION
## Summary

- Moves generic checkpoint, WAL compaction, snapshot pruning, MANIFEST sync, and flush-time WAL truncation mechanics out of `strata-engine` and behind storage-owned runtime APIs in a new `crates/storage/src/durability/checkpoint_runtime.rs` module
- Thins `Database::checkpoint`, `Database::compact`, `prune_snapshots_once`, `fsync_manifest`, and `update_flush_watermark` to thin lifecycle/policy/translation wrappers
- `collect_checkpoint_data` stays engine-owned: it knows primitive section rules (graph rows in the KV section, event metadata keys skipped, vector record decode, etc.) which must not leak into storage
- Drops the stale `DurabilityMode::Cache` config axis: cache is an open mode (`Database::cache()` / `OpenSpec::cache()`), not a fsync policy; `durability = "cache"` in `strata.toml` is now rejected with a remediation hint
- Lands the umbrella plan, ES1 inventory, ES2 detailed plan, and the joint ES2-ES4 boundary API sketch alongside the code

## What's new in storage

- `run_storage_checkpoint` — snapshot dir, MANIFEST, coordinator construction and execution, snapshot watermark update
- `compact_storage_wal` — MANIFEST + `WalOnlyCompactor` pipeline, codec-aware reader, raw removed-segment / reclaimed-byte facts
- `prune_storage_snapshots` — retention with live-MANIFEST snapshot preservation and fsync, per-file delete tolerance
- `sync_storage_manifest` — engine-callable MANIFEST persist helper used by the shutdown path
- `truncate_storage_wal_after_flush` — global flush watermark + WAL truncation pipeline, replaces the inline `ManifestManager` / `WalOnlyCompactor` usage that was in `transaction.rs`
- All inputs vocabulary uses `DatabaseLayout`. All public storage error enums are `#[non_exhaustive]` and storage-local: no `StrataError`, no engine report types, no operator vocabulary

## Behavior preservation

- On-disk format unchanged: same MANIFEST, same WAL envelope, same snapshot sections, same `SnapshotWatermark`, same active-segment semantics
- Existing missing-MANIFEST checkpoint/compact behavior preserved by passing `manifest_create_codec_id: \"identity\"` explicitly rather than silently using the configured codec
- Snapshot pruning failure remains non-fatal to checkpoint success (warn-level log)
- Active WAL segment is now `NonZeroU64` at the engine boundary; segment 0 is rejected with `StrataError::internal` before reaching storage
- `compact()` still accepts `None` for active_wal_segment (no writer): storage leaves MANIFEST unchanged and uses the existing zero-override fallback
- `StorageWalCompactionError::NoSnapshot` continues to map to the exact invalid-input wording: `\"No checkpoint exists yet. Run checkpoint() before compact().\"`

## ES2G ownership guards (clean)

- `cargo tree -p strata-storage --depth 2` — no `strata-engine`
- `rg 'use strata_engine|strata_engine::|strata-engine' crates/storage/src crates/storage/Cargo.toml` — 0 matches
- `rg 'JsonPath|JsonPatch|SearchSubsystem|Recipe|VectorConfig|DistanceMetric|ChainVerification|BranchLifecycle|RetentionReport|HealthReport|executor' crates/storage/src` — 0 matches
- `rg 'CheckpointCoordinator|WalOnlyCompactor|ManifestManager|RecoveryCoordinator|SnapshotSerializer|install_snapshot|apply_storage_config' crates/engine/src/database` — only intentional remaining matches in `compaction.rs` (public error variant name), `open.rs` / `mod.rs` (`apply_storage_config` — ES5), `snapshot_install.rs` (ES3), `recovery.rs` (ES4), and test characterization files. `transaction.rs` no longer imports `ManifestManager` or `WalOnlyCompactor`

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test -p strata-storage --quiet` — 1166 passed, 0 failed
- [x] `cargo test -p strata-engine --quiet` — 1572 passed, 10 failed; the 10 failures are pre-existing on `main` (architecture-cleanup-period red CI: fault-injection shutdown/halt timing tests and one branch-index post-commit classification test, confirmed to fail identically against `main` without these changes)
- [x] `cargo test -p strata-executor --quiet` — 113 passed, 0 failed
- [x] `cargo test -p strata-engine --test recovery_parity --quiet` — 7 passed
- [x] ES2G ownership guards rerun and recorded in plan

## Out of scope (later epics)

- ES3: snapshot decode and install mechanics → storage
- ES4: recovery bootstrap mechanics → storage (and the engine-side residue of `RecoveryCoordinator` / `ManifestManager` / `install_snapshot` in `recovery.rs`)
- ES5: storage-only config application → storage (`apply_storage_config`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)