### PR TITLE
ES3: split snapshot install into engine primitive decode + storage row install

### DIFF
--- a/crates/engine/src/database/recovery.rs
+++ b/crates/engine/src/database/recovery.rs
@@ -29,8 +29,8 @@ use strata_storage::durability::layout::DatabaseLayout;
 use strata_storage::durability::wal::WalReaderError;
 use strata_storage::durability::{
     apply_wal_record_to_memory_storage, CoordinatorPlanError, CoordinatorRecoveryError,
-    ManifestError, ManifestManager, RecoveryCoordinator, RecoveryResult, RecoveryStats,
-    SnapshotReadError,
+    LoadedSnapshot, ManifestError, ManifestManager, RecoveryCoordinator, RecoveryResult,
+    RecoveryStats, SnapshotReadError,
 };
 use strata_storage::{DegradationClass, RecoveryHealth, SegmentedStore, StorageError};
 use tracing::{info, warn};
@@ -44,7 +44,7 @@ use super::refresh::{
     clear_persisted_follower_state, load_persisted_follower_state, validate_blocked_state,
     ContiguousWatermark, PersistedFollowerState,
 };
-use super::snapshot_install::install_snapshot;
+use super::snapshot_install::{install_snapshot, InstallStats};
 use super::{Database, LossyErrorKind, LossyRecoveryReport};
 use crate::coordinator::TransactionCoordinator;
 
@@ -313,8 +313,10 @@ struct ManifestPreparation {
     /// `Some(clone)` when an on-disk MANIFEST exists and its codec is
     /// available; `None` for a primary first-open (no MANIFEST yet)
     /// and for follower-without-MANIFEST where the coordinator falls
-    /// back to WAL-only recovery. Used to gate the snapshot-install
-    /// callback in `run_coordinator_recovery`.
+    /// back to WAL-only recovery. Those `None` cases do not have a
+    /// manifest-recorded snapshot, so the snapshot callback must not fire.
+    /// If it does fire without a codec, recovery hard-fails instead of
+    /// silently skipping snapshot install.
     install_codec_for_snapshot: Option<Box<dyn StorageCodec>>,
 }
 
@@ -420,17 +422,7 @@ fn run_coordinator_recovery(
     let counter = Arc::clone(records_counter);
     recovery.recover_typed(
         |snapshot| {
-            if let Some(codec) = install_codec {
-                let installed =
-                    install_snapshot(&snapshot, codec, storage).map_err(StorageError::from)?;
-                info!(
-                    target: "strata::recovery",
-                    snapshot_id = snapshot.snapshot_id(),
-                    watermark = snapshot.watermark_txn(),
-                    entries = installed.total_installed(),
-                    "Installed snapshot into SegmentedStore"
-                );
-            }
+            install_recovery_snapshot(&snapshot, install_codec, storage)?;
             Ok(())
         },
         |record| {
@@ -441,6 +433,41 @@ fn run_coordinator_recovery(
             result
         },
     )
+}
+
+fn install_recovery_snapshot(
+    snapshot: &LoadedSnapshot,
+    install_codec: Option<&dyn StorageCodec>,
+    storage: &SegmentedStore,
+) -> Result<InstallStats, StorageError> {
+    let Some(codec) = install_codec else {
+        return Err(StorageError::corruption(format!(
+            "snapshot {} reached recovery install callback without an install codec",
+            snapshot.snapshot_id()
+        )));
+    };
+
+    let installed = install_snapshot(snapshot, codec, storage).map_err(StorageError::from)?;
+    log_recovery_snapshot_install(snapshot, &installed);
+    Ok(installed)
+}
+
+fn log_recovery_snapshot_install(snapshot: &LoadedSnapshot, installed: &InstallStats) {
+    info!(
+        target: "strata::recovery",
+        snapshot_id = snapshot.snapshot_id(),
+        watermark = snapshot.watermark_txn(),
+        entries = installed.total_installed(),
+        kv = installed.kv,
+        graph = installed.graph,
+        events = installed.events,
+        json = installed.json,
+        vector_configs = installed.vector_configs,
+        vectors = installed.vectors,
+        branches = installed.branches,
+        sections_skipped = installed.sections_skipped,
+        "Installed snapshot into SegmentedStore"
+    );
 }
 
 /// Classify the outcome of `RecoveryCoordinator::recover` and apply
@@ -639,6 +666,14 @@ fn restore_follower_state(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use strata_core::id::TxnId;
+    use strata_core::{BranchId, Value};
+    use strata_storage::durability::codec::IdentityCodec;
+    use strata_storage::durability::{
+        primitive_tags, KvSnapshotEntry, LoadedSection, SnapshotHeader, SnapshotSection,
+        SnapshotSerializer, SnapshotWriter,
+    };
+    use strata_storage::{Key, Namespace, TypeTag};
     use tempfile::TempDir;
 
     #[test]
@@ -671,5 +706,167 @@ mod tests {
             }
             other => panic!("plan failure must hard-fail without lossy wipe, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn recovery_snapshot_install_rejects_when_install_codec_absent() {
+        let branch_id = BranchId::new();
+        let snapshot = loaded_snapshot(
+            "identity",
+            vec![kv_section(branch_id, "skipped", Value::Int(7), 11)],
+        );
+        let storage = SegmentedStore::new();
+
+        let err = install_recovery_snapshot(&snapshot, None, &storage)
+            .expect_err("loaded snapshot without install codec should violate recovery invariant");
+
+        match err {
+            StorageError::Corruption { message } => {
+                assert!(message.contains(
+                    "snapshot 7 reached recovery install callback without an install codec"
+                ));
+            }
+            other => panic!("expected corruption storage error, got {other:?}"),
+        }
+        assert!(storage
+            .get_versioned(&kv_key(branch_id, "skipped"), CommitVersion::MAX)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn recovery_snapshot_install_maps_engine_errors_into_storage_callback_errors() {
+        let snapshot = loaded_snapshot("other-codec", Vec::new());
+        let storage = SegmentedStore::new();
+        let codec = IdentityCodec;
+
+        let err = install_recovery_snapshot(&snapshot, Some(&codec), &storage)
+            .expect_err("codec mismatch should surface as callback storage error");
+
+        match err {
+            StorageError::Corruption { message } => {
+                assert!(message.contains("Snapshot codec mismatch during install"));
+            }
+            other => panic!("expected corruption storage error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn recovery_snapshot_install_returns_primitive_stats_after_storage_install() {
+        let branch_id = BranchId::new();
+        let snapshot = loaded_snapshot(
+            "identity",
+            vec![kv_section(branch_id, "installed", Value::Int(42), 13)],
+        );
+        let storage = SegmentedStore::new();
+        let codec = IdentityCodec;
+
+        let installed = install_recovery_snapshot(&snapshot, Some(&codec), &storage)
+            .expect("snapshot install should succeed");
+
+        assert_eq!(installed.kv, 1);
+        assert_eq!(installed.graph, 0);
+        assert_eq!(installed.total_installed(), 1);
+
+        let value = storage
+            .get_versioned(&kv_key(branch_id, "installed"), CommitVersion::MAX)
+            .unwrap()
+            .expect("snapshot row should be installed");
+        assert_eq!(value.value, Value::Int(42));
+    }
+
+    #[test]
+    fn recovery_snapshot_install_failure_maps_through_callback_public_error_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let database_uuid = [0x55; 16];
+        let codec = IdentityCodec;
+
+        let writer = SnapshotWriter::new(
+            layout.snapshots_dir().to_path_buf(),
+            Box::new(IdentityCodec),
+            database_uuid,
+        )
+        .unwrap();
+        writer
+            .create_snapshot(
+                3,
+                9,
+                vec![SnapshotSection::new(primitive_tags::KV, vec![1, 0, 0, 0])],
+            )
+            .unwrap();
+        let mut manifest = ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            database_uuid,
+            "identity".to_string(),
+        )
+        .unwrap();
+        manifest.set_snapshot_watermark(3, TxnId(9)).unwrap();
+
+        let cfg = StrataConfig::default();
+        let storage = SegmentedStore::new();
+        let counter = Arc::new(AtomicU64::new(0));
+        let recover_result =
+            run_coordinator_recovery(&layout, &cfg, &codec, Some(&codec), &storage, &counter);
+
+        let err = recover_result.expect_err("corrupt snapshot install should fail recovery");
+        match &err {
+            CoordinatorRecoveryError::Callback(StorageError::Corruption { message }) => {
+                assert!(message.contains("KV section decode failed"));
+            }
+            other => panic!("expected callback corruption from snapshot install, got {other:?}"),
+        }
+
+        let mut mapped_storage = storage;
+        let mapped = handle_wal_recovery_outcome(
+            Err(err),
+            &cfg,
+            &layout,
+            &mut mapped_storage,
+            0,
+            RecoveryMode::Primary,
+        )
+        .expect_err("callback error should map to public recovery error");
+        match mapped {
+            RecoveryError::WalRecoveryFailed {
+                role: ErrorRole::Primary,
+                inner: StrataError::Corruption { message },
+            } => {
+                assert!(message.contains("KV section decode failed"));
+            }
+            other => panic!("expected primary WalRecoveryFailed corruption, got {other:?}"),
+        }
+    }
+
+    fn loaded_snapshot(codec_id: &str, sections: Vec<LoadedSection>) -> LoadedSnapshot {
+        LoadedSnapshot {
+            header: SnapshotHeader::new(7, 7, 1, [0x77; 16], codec_id.len() as u8),
+            codec_id: codec_id.to_string(),
+            sections,
+            crc: 0,
+        }
+    }
+
+    fn kv_section(branch_id: BranchId, key: &str, value: Value, version: u64) -> LoadedSection {
+        let serializer = SnapshotSerializer::canonical_primitive_section();
+        let entries = [KvSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "default".to_string(),
+            type_tag: TypeTag::KV.as_byte(),
+            user_key: key.as_bytes().to_vec(),
+            value: serde_json::to_vec(&value).expect("test value should serialize"),
+            version,
+            timestamp: 1_000,
+            ttl_ms: 0,
+            is_tombstone: false,
+        }];
+        LoadedSection {
+            primitive_type: primitive_tags::KV,
+            data: serializer.serialize_kv(&entries),
+        }
+    }
+
+    fn kv_key(branch_id: BranchId, key: &str) -> Key {
+        Key::new_kv(Arc::new(Namespace::for_branch(branch_id)), key)
     }
 }

--- a/crates/engine/src/database/snapshot_install.rs
+++ b/crates/engine/src/database/snapshot_install.rs
@@ -2,9 +2,8 @@
 //!
 //! This is the engine-side inverse of `compaction::collect_checkpoint_data`.
 //! It walks the per-primitive sections of a `LoadedSnapshot`, deserializes
-//! each section via [`SnapshotSerializer`], and routes decoded entries into
-//! [`SegmentedStore::install_snapshot_entries`] grouped by
-//! `(branch_id, type_tag)`.
+//! each section via [`SnapshotSerializer`], stages generic decoded row groups,
+//! and hands those groups to storage's decoded-row install helper.
 //!
 //! Recovery calls this from the `on_snapshot` callback passed to
 //! `RecoveryCoordinator::recover` so checkpoint-only restart (no WAL covering
@@ -27,10 +26,16 @@ use crate::{StrataError, StrataResult};
 use strata_core::id::CommitVersion;
 use strata_core::BranchId;
 use strata_core::Value;
-use strata_storage::durability::codec::{clone_codec, StorageCodec};
+use strata_storage::durability::codec::StorageCodec;
 use strata_storage::durability::format::primitive_tags;
-use strata_storage::durability::{LoadedSnapshot, SnapshotSerializer};
-use strata_storage::{DecodedSnapshotEntry, DecodedSnapshotValue, SegmentedStore, TypeTag};
+use strata_storage::durability::{
+    install_decoded_snapshot_rows, LoadedSnapshot, SnapshotSerializer,
+    StorageDecodedSnapshotInstallError, StorageDecodedSnapshotInstallGroup,
+    StorageDecodedSnapshotInstallInput, StorageDecodedSnapshotInstallPlan,
+};
+use strata_storage::{
+    DecodedSnapshotEntry, DecodedSnapshotValue, SegmentedStore, StorageError, TypeTag,
+};
 use tracing::warn;
 
 /// Counts of entries installed per primitive during a snapshot install.
@@ -67,6 +72,78 @@ impl InstallStats {
             + self.vectors
             + self.branches
     }
+
+    fn add_installed(&mut self, other: &InstallStats) {
+        self.kv += other.kv;
+        self.graph += other.graph;
+        self.events += other.events;
+        self.json += other.json;
+        self.vector_configs += other.vector_configs;
+        self.vectors += other.vectors;
+        self.branches += other.branches;
+        self.sections_skipped += other.sections_skipped;
+    }
+}
+
+#[derive(Debug, Default)]
+struct SnapshotInstallPlan {
+    sections_skipped: usize,
+    groups: Vec<PendingInstallGroup>,
+}
+
+impl SnapshotInstallPlan {
+    fn push_staged_group(
+        &mut self,
+        branch_bytes: [u8; 16],
+        type_tag: TypeTag,
+        staged: StagedGroup,
+    ) {
+        let branch_id = BranchId::from_bytes(branch_bytes);
+        self.groups.push(PendingInstallGroup {
+            group: StorageDecodedSnapshotInstallGroup::new(branch_id, type_tag, staged.entries),
+            stats: staged.stats,
+        });
+    }
+
+    fn push_branch_groups(&mut self, type_tag: TypeTag, groups: HashMap<[u8; 16], StagedGroup>) {
+        for (branch_bytes, staged) in groups {
+            self.push_staged_group(branch_bytes, type_tag, staged);
+        }
+    }
+
+    fn push_typed_groups(&mut self, groups: HashMap<([u8; 16], TypeTag), StagedGroup>) {
+        for ((branch_bytes, type_tag), staged) in groups {
+            self.push_staged_group(branch_bytes, type_tag, staged);
+        }
+    }
+
+    fn into_storage_plan(self) -> (StorageDecodedSnapshotInstallPlan, InstallStats) {
+        let mut stats = InstallStats {
+            sections_skipped: self.sections_skipped,
+            ..InstallStats::default()
+        };
+        let mut storage_groups = Vec::with_capacity(self.groups.len());
+        for group in self.groups {
+            stats.add_installed(&group.stats);
+            storage_groups.push(group.group);
+        }
+        (
+            StorageDecodedSnapshotInstallPlan::new(storage_groups),
+            stats,
+        )
+    }
+}
+
+#[derive(Debug)]
+struct PendingInstallGroup {
+    group: StorageDecodedSnapshotInstallGroup,
+    stats: InstallStats,
+}
+
+#[derive(Debug, Default)]
+struct StagedGroup {
+    entries: Vec<DecodedSnapshotEntry>,
+    stats: InstallStats,
 }
 
 /// Install every section of `snapshot` into `storage`, preserving the original
@@ -81,25 +158,95 @@ pub(crate) fn install_snapshot(
     codec: &dyn StorageCodec,
     storage: &SegmentedStore,
 ) -> StrataResult<InstallStats> {
-    let serializer = SnapshotSerializer::new(clone_codec(codec));
-    let mut stats = InstallStats::default();
+    if snapshot.codec_id != codec.codec_id() {
+        return Err(StrataError::corruption(format!(
+            "Snapshot codec mismatch during install: snapshot header {}, install codec {}",
+            snapshot.codec_id,
+            codec.codec_id()
+        )));
+    }
+
+    // SnapshotReader already validated the snapshot file's codec id. The
+    // primitive section payloads are checkpoint-format bytes and must be
+    // decoded with the same canonical codec used by CheckpointCoordinator.
+    let serializer = SnapshotSerializer::canonical_primitive_section();
+    let (storage_plan, stats) =
+        decode_snapshot_install_plan(snapshot, &serializer)?.into_storage_plan();
+    let expected_groups = storage_plan.groups.len();
+    let expected_rows = storage_plan
+        .groups
+        .iter()
+        .map(|group| group.entries.len())
+        .sum::<usize>();
+    let storage_stats = install_decoded_snapshot_rows(StorageDecodedSnapshotInstallInput {
+        storage,
+        plan: &storage_plan,
+    })
+    .map_err(|err| map_decoded_snapshot_install_error(snapshot.snapshot_id(), err))?;
+
+    if storage_stats.groups_installed != expected_groups
+        || storage_stats.rows_installed != expected_rows
+    {
+        return Err(StrataError::internal(format!(
+            "snapshot {} decoded-row install reported {} groups/{} rows, expected {} groups/{} rows",
+            snapshot.snapshot_id(),
+            storage_stats.groups_installed,
+            storage_stats.rows_installed,
+            expected_groups,
+            expected_rows
+        )));
+    }
+    if stats.total_installed() != expected_rows {
+        return Err(StrataError::internal(format!(
+            "snapshot {} primitive install stats counted {} rows, decoded plan contained {} rows",
+            snapshot.snapshot_id(),
+            stats.total_installed(),
+            expected_rows
+        )));
+    }
+    Ok(stats)
+}
+
+fn map_decoded_snapshot_install_error(
+    snapshot_id: u64,
+    err: StorageDecodedSnapshotInstallError,
+) -> StrataError {
+    match err {
+        StorageDecodedSnapshotInstallError::Install {
+            group_index,
+            branch_id,
+            storage_family,
+            source,
+        } => {
+            let message = format!(
+                "Snapshot {snapshot_id} decoded-row install group {group_index} for branch \
+                 {branch_id} storage family 0x{storage_family:02x} failed: {source}"
+            );
+            match source {
+                StorageError::Corruption { .. } => StrataError::corruption(message),
+                StorageError::Io(inner) => StrataError::storage_with_source(message, inner),
+                _ => StrataError::storage(message),
+            }
+        }
+        other => StrataError::corruption(format!(
+            "Snapshot {} decoded-row install rejected generic storage rows: {}",
+            snapshot_id, other
+        )),
+    }
+}
+
+fn decode_snapshot_install_plan(
+    snapshot: &LoadedSnapshot,
+    serializer: &SnapshotSerializer,
+) -> StrataResult<SnapshotInstallPlan> {
+    let mut plan = SnapshotInstallPlan::default();
     for section in &snapshot.sections {
         match section.primitive_type {
-            primitive_tags::KV => {
-                install_kv_section(&serializer, &section.data, storage, &mut stats)?
-            }
-            primitive_tags::EVENT => {
-                install_event_section(&serializer, &section.data, storage, &mut stats)?
-            }
-            primitive_tags::JSON => {
-                install_json_section(&serializer, &section.data, storage, &mut stats)?
-            }
-            primitive_tags::VECTOR => {
-                install_vector_section(&serializer, &section.data, storage, &mut stats)?
-            }
-            primitive_tags::BRANCH => {
-                install_branch_section(&serializer, &section.data, storage, &mut stats)?
-            }
+            primitive_tags::KV => decode_kv_section(serializer, &section.data, &mut plan)?,
+            primitive_tags::EVENT => decode_event_section(serializer, &section.data, &mut plan)?,
+            primitive_tags::JSON => decode_json_section(serializer, &section.data, &mut plan)?,
+            primitive_tags::VECTOR => decode_vector_section(serializer, &section.data, &mut plan)?,
+            primitive_tags::BRANCH => decode_branch_section(serializer, &section.data, &mut plan)?,
             primitive_tags::GRAPH => {
                 // Graph entries are written inside the KV section today; a
                 // standalone Graph section is not emitted by
@@ -113,7 +260,7 @@ pub(crate) fn install_snapshot(
                         "Skipping standalone Graph snapshot section: no decoder wired; \
                          Graph entries are expected in the KV section"
                     );
-                    stats.sections_skipped += 1;
+                    plan.sections_skipped += 1;
                 }
             }
             other => {
@@ -124,26 +271,40 @@ pub(crate) fn install_snapshot(
             }
         }
     }
-    Ok(stats)
+    Ok(plan)
 }
 
-/// Decode one KV section and install entries grouped by `(branch_id, type_tag)`.
+/// Decode one KV section and stage entries grouped by `(branch_id, type_tag)`.
 ///
 /// The KV section carries both KV and Graph entries (`type_tag` discriminates);
 /// install routes them to the appropriate storage type. Tombstones are
 /// installed as `DecodedSnapshotValue::Tombstone`; TTL is propagated.
-fn install_kv_section(
+fn decode_kv_section(
     serializer: &SnapshotSerializer,
     data: &[u8],
-    storage: &SegmentedStore,
-    stats: &mut InstallStats,
+    plan: &mut SnapshotInstallPlan,
 ) -> StrataResult<()> {
     let entries = serializer
         .deserialize_kv(data)
         .map_err(|e| StrataError::corruption(format!("KV section decode failed: {}", e)))?;
 
-    let mut groups: HashMap<([u8; 16], u8), Vec<DecodedSnapshotEntry>> = HashMap::new();
+    let mut groups: HashMap<([u8; 16], TypeTag), StagedGroup> = HashMap::new();
     for entry in entries {
+        let type_tag = TypeTag::from_byte(entry.type_tag).ok_or_else(|| {
+            StrataError::corruption(format!(
+                "Invalid TypeTag 0x{:02x} in KV snapshot entry",
+                entry.type_tag
+            ))
+        })?;
+        match type_tag {
+            TypeTag::KV | TypeTag::Graph => {}
+            other => {
+                return Err(StrataError::corruption(format!(
+                    "Invalid TypeTag 0x{:02x} ({:?}) in KV snapshot entry: KV section only supports KV and Graph",
+                    entry.type_tag, other
+                )));
+            }
+        }
         let payload = if entry.is_tombstone {
             DecodedSnapshotValue::Tombstone
         } else {
@@ -157,25 +318,15 @@ fn install_kv_section(
             timestamp_micros: entry.timestamp,
             ttl_ms: entry.ttl_ms,
         };
-        groups
-            .entry((entry.branch_id, entry.type_tag))
-            .or_default()
-            .push(decoded);
-    }
-    for ((branch_bytes, tag_byte), group_entries) in groups {
-        let branch_id = BranchId::from_bytes(branch_bytes);
-        let type_tag = TypeTag::from_byte(tag_byte).ok_or_else(|| {
-            StrataError::corruption(format!(
-                "Invalid TypeTag 0x{:02x} in KV snapshot entry",
-                tag_byte
-            ))
-        })?;
-        let count = storage.install_snapshot_entries(branch_id, type_tag, &group_entries)?;
+        let group = groups.entry((entry.branch_id, type_tag)).or_default();
+        group.entries.push(decoded);
         match type_tag {
-            TypeTag::Graph => stats.graph += count,
-            _ => stats.kv += count,
+            TypeTag::Graph => group.stats.graph += 1,
+            TypeTag::KV => group.stats.kv += 1,
+            _ => unreachable!("KV section type tag was validated above"),
         }
     }
+    plan.push_typed_groups(groups);
     Ok(())
 }
 
@@ -183,17 +334,16 @@ fn install_kv_section(
 ///
 /// Event keys are reconstructed from the 8-byte big-endian sequence number,
 /// matching the invariant in `Key::new_event`.
-fn install_event_section(
+fn decode_event_section(
     serializer: &SnapshotSerializer,
     data: &[u8],
-    storage: &SegmentedStore,
-    stats: &mut InstallStats,
+    plan: &mut SnapshotInstallPlan,
 ) -> StrataResult<()> {
     let entries = serializer
         .deserialize_events(data)
         .map_err(|e| StrataError::corruption(format!("Event section decode failed: {}", e)))?;
 
-    let mut groups: HashMap<[u8; 16], Vec<DecodedSnapshotEntry>> = HashMap::new();
+    let mut groups: HashMap<[u8; 16], StagedGroup> = HashMap::new();
     for entry in entries {
         let value = decode_value_json(&entry.payload, "Event")?;
         let decoded = DecodedSnapshotEntry {
@@ -204,30 +354,27 @@ fn install_event_section(
             timestamp_micros: entry.timestamp,
             ttl_ms: 0,
         };
-        groups.entry(entry.branch_id).or_default().push(decoded);
+        let group = groups.entry(entry.branch_id).or_default();
+        group.entries.push(decoded);
+        group.stats.events += 1;
     }
-    for (branch_bytes, group_entries) in groups {
-        let branch_id = BranchId::from_bytes(branch_bytes);
-        let count = storage.install_snapshot_entries(branch_id, TypeTag::Event, &group_entries)?;
-        stats.events += count;
-    }
+    plan.push_branch_groups(TypeTag::Event, groups);
     Ok(())
 }
 
 /// Decode a JSON section and install entries per-branch with doc-id as the
 /// user key (matching the Json primitive's key encoding). Tombstones on
 /// deleted documents are preserved as `DecodedSnapshotValue::Tombstone`.
-fn install_json_section(
+fn decode_json_section(
     serializer: &SnapshotSerializer,
     data: &[u8],
-    storage: &SegmentedStore,
-    stats: &mut InstallStats,
+    plan: &mut SnapshotInstallPlan,
 ) -> StrataResult<()> {
     let entries = serializer
         .deserialize_json(data)
         .map_err(|e| StrataError::corruption(format!("JSON section decode failed: {}", e)))?;
 
-    let mut groups: HashMap<[u8; 16], Vec<DecodedSnapshotEntry>> = HashMap::new();
+    let mut groups: HashMap<[u8; 16], StagedGroup> = HashMap::new();
     for entry in entries {
         let payload = if entry.is_tombstone {
             DecodedSnapshotValue::Tombstone
@@ -242,13 +389,11 @@ fn install_json_section(
             timestamp_micros: entry.timestamp,
             ttl_ms: 0,
         };
-        groups.entry(entry.branch_id).or_default().push(decoded);
+        let group = groups.entry(entry.branch_id).or_default();
+        group.entries.push(decoded);
+        group.stats.json += 1;
     }
-    for (branch_bytes, group_entries) in groups {
-        let branch_id = BranchId::from_bytes(branch_bytes);
-        let count = storage.install_snapshot_entries(branch_id, TypeTag::Json, &group_entries)?;
-        stats.json += count;
-    }
+    plan.push_branch_groups(TypeTag::Json, groups);
     Ok(())
 }
 
@@ -262,17 +407,16 @@ fn install_json_section(
 /// `user_key` is the UTF-8 bytes of the original key string. Values are
 /// stored as JSON-encoded bytes (matching the checkpoint collector) unless
 /// the entry is a tombstone, in which case the value is empty.
-fn install_branch_section(
+fn decode_branch_section(
     serializer: &SnapshotSerializer,
     data: &[u8],
-    storage: &SegmentedStore,
-    stats: &mut InstallStats,
+    plan: &mut SnapshotInstallPlan,
 ) -> StrataResult<()> {
     let entries = serializer
         .deserialize_branches(data)
         .map_err(|e| StrataError::corruption(format!("Branch section decode failed: {}", e)))?;
 
-    let mut groups: HashMap<[u8; 16], Vec<DecodedSnapshotEntry>> = HashMap::new();
+    let mut groups: HashMap<[u8; 16], StagedGroup> = HashMap::new();
     for entry in entries {
         // Explicit tombstone marker (matches KV/JSON/Vector). Using the flag
         // instead of inferring from empty-value bytes prevents a silent
@@ -284,9 +428,8 @@ fn install_branch_section(
         };
         let decoded = DecodedSnapshotEntry {
             // Branch metadata lives in the conventional "default" space per
-            // `Namespace::for_branch`; install reconstructs the full
-            // `Namespace` from branch_id + space inside
-            // `SegmentedStore::install_snapshot_entries`.
+            // `Namespace::for_branch`; storage reconstructs the full
+            // `Namespace` from branch_id + space during decoded-row install.
             space: "default".to_string(),
             user_key: entry.key.into_bytes(),
             payload,
@@ -294,13 +437,11 @@ fn install_branch_section(
             timestamp_micros: entry.timestamp,
             ttl_ms: 0,
         };
-        groups.entry(entry.branch_id).or_default().push(decoded);
+        let group = groups.entry(entry.branch_id).or_default();
+        group.entries.push(decoded);
+        group.stats.branches += 1;
     }
-    for (branch_bytes, group_entries) in groups {
-        let branch_id = BranchId::from_bytes(branch_bytes);
-        let count = storage.install_snapshot_entries(branch_id, TypeTag::Branch, &group_entries)?;
-        stats.branches += count;
-    }
+    plan.push_branch_groups(TypeTag::Branch, groups);
     Ok(())
 }
 
@@ -309,17 +450,16 @@ fn install_branch_section(
 /// 1. The collection-config row keyed `__config__/{name}`.
 /// 2. One row per vector keyed `{name}/{vector_key}`, carrying the raw
 ///    `VectorRecord` bytes so subsystem recovery can reconstruct the index.
-fn install_vector_section(
+fn decode_vector_section(
     serializer: &SnapshotSerializer,
     data: &[u8],
-    storage: &SegmentedStore,
-    stats: &mut InstallStats,
+    plan: &mut SnapshotInstallPlan,
 ) -> StrataResult<()> {
     let collections = serializer
         .deserialize_vectors(data)
         .map_err(|e| StrataError::corruption(format!("Vector section decode failed: {}", e)))?;
 
-    let mut groups: HashMap<[u8; 16], Vec<DecodedSnapshotEntry>> = HashMap::new();
+    let mut groups: HashMap<[u8; 16], StagedGroup> = HashMap::new();
     for collection in collections {
         let branch_bytes = collection.branch_id;
         let space = collection.space.clone();
@@ -329,18 +469,16 @@ fn install_vector_section(
         // serialized config bytes as Value::Bytes (matches the compaction
         // collect path which also treats config as Value::Bytes).
         let config_key = format!("__config__/{}", name).into_bytes();
-        groups
-            .entry(branch_bytes)
-            .or_default()
-            .push(DecodedSnapshotEntry {
-                space: space.clone(),
-                user_key: config_key,
-                payload: DecodedSnapshotValue::Value(Value::Bytes(collection.config.clone())),
-                version: CommitVersion(collection.config_version),
-                timestamp_micros: collection.config_timestamp,
-                ttl_ms: 0,
-            });
-        stats.vector_configs += 1;
+        let group = groups.entry(branch_bytes).or_default();
+        group.entries.push(DecodedSnapshotEntry {
+            space: space.clone(),
+            user_key: config_key,
+            payload: DecodedSnapshotValue::Value(Value::Bytes(collection.config.clone())),
+            version: CommitVersion(collection.config_version),
+            timestamp_micros: collection.config_timestamp,
+            ttl_ms: 0,
+        });
+        group.stats.vector_configs += 1;
 
         for vector in collection.vectors {
             let vec_key = format!("{}/{}", name, vector.key).into_bytes();
@@ -352,25 +490,20 @@ fn install_vector_section(
                 // payload that subsystem recovery expects to decode.
                 DecodedSnapshotValue::Value(Value::Bytes(vector.raw_value))
             };
-            groups
-                .entry(branch_bytes)
-                .or_default()
-                .push(DecodedSnapshotEntry {
-                    space: space.clone(),
-                    user_key: vec_key,
-                    payload,
-                    version: CommitVersion(vector.version),
-                    timestamp_micros: vector.timestamp,
-                    ttl_ms: 0,
-                });
-            stats.vectors += 1;
+            let group = groups.entry(branch_bytes).or_default();
+            group.entries.push(DecodedSnapshotEntry {
+                space: space.clone(),
+                user_key: vec_key,
+                payload,
+                version: CommitVersion(vector.version),
+                timestamp_micros: vector.timestamp,
+                ttl_ms: 0,
+            });
+            group.stats.vectors += 1;
         }
     }
 
-    for (branch_bytes, group_entries) in groups {
-        let branch_id = BranchId::from_bytes(branch_bytes);
-        storage.install_snapshot_entries(branch_id, TypeTag::Vector, &group_entries)?;
-    }
+    plan.push_branch_groups(TypeTag::Vector, groups);
     Ok(())
 }
 
@@ -392,20 +525,23 @@ mod tests {
     use strata_core::id::CommitVersion;
     use strata_core::BranchId;
     use strata_core::Value;
-    use strata_storage::durability::codec::IdentityCodec;
+    use strata_storage::durability::codec::{CodecError, IdentityCodec, StorageCodec};
     use strata_storage::durability::format::{
-        EventSnapshotEntry, JsonSnapshotEntry, KvSnapshotEntry, VectorCollectionSnapshotEntry,
-        VectorSnapshotEntry,
+        BranchSnapshotEntry, EventSnapshotEntry, JsonSnapshotEntry, KvSnapshotEntry,
+        VectorCollectionSnapshotEntry, VectorSnapshotEntry,
     };
     use strata_storage::durability::{
         disk_snapshot::{SnapshotSection, SnapshotWriter},
         SnapshotReader,
     };
-    use strata_storage::Storage;
     use strata_storage::{Key, Namespace};
 
     fn writer_for(dir: &std::path::Path) -> SnapshotWriter {
         SnapshotWriter::new(dir.to_path_buf(), Box::new(IdentityCodec), [9u8; 16]).unwrap()
+    }
+
+    fn writer_for_codec(dir: &std::path::Path, codec: Box<dyn StorageCodec>) -> SnapshotWriter {
+        SnapshotWriter::new(dir.to_path_buf(), codec, [9u8; 16]).unwrap()
     }
 
     fn load_snapshot(path: &std::path::Path) -> LoadedSnapshot {
@@ -414,12 +550,76 @@ mod tests {
             .unwrap()
     }
 
+    fn load_snapshot_with_codec(
+        path: &std::path::Path,
+        codec: Box<dyn StorageCodec>,
+    ) -> LoadedSnapshot {
+        SnapshotReader::new(codec).load(path).unwrap()
+    }
+
     fn serializer() -> SnapshotSerializer {
-        SnapshotSerializer::new(Box::new(IdentityCodec))
+        SnapshotSerializer::canonical_primitive_section()
     }
 
     fn ns(branch_id: BranchId, space: &str) -> Arc<Namespace> {
         Arc::new(Namespace::for_branch_space(branch_id, space))
+    }
+
+    fn assert_error_contains(err: impl std::fmt::Display, expected: &str) {
+        let msg = err.to_string();
+        assert!(
+            msg.contains(expected),
+            "error should contain `{}`, got: {}",
+            expected,
+            msg
+        );
+    }
+
+    #[test]
+    fn decoded_storage_install_error_mapping_preserves_snapshot_group_context() {
+        let branch_id = BranchId::from_bytes([0x42; 16]);
+        let err = StorageDecodedSnapshotInstallError::Install {
+            group_index: 7,
+            branch_id,
+            storage_family: TypeTag::KV.as_byte(),
+            source: StorageError::corruption("synthetic lower install failure"),
+        };
+
+        let mapped = map_decoded_snapshot_install_error(99, err);
+
+        assert!(
+            matches!(mapped, StrataError::Corruption { .. }),
+            "lower storage corruption should remain a corruption error"
+        );
+        assert_error_contains(&mapped, "Snapshot 99 decoded-row install group 7");
+        assert_error_contains(&mapped, &branch_id.to_string());
+        assert_error_contains(&mapped, "storage family 0x01");
+        assert_error_contains(&mapped, "synthetic lower install failure");
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct RejectingDecodeCodec;
+
+    impl StorageCodec for RejectingDecodeCodec {
+        fn encode(&self, data: &[u8]) -> Vec<u8> {
+            data.to_vec()
+        }
+
+        fn decode(&self, data: &[u8]) -> Result<Vec<u8>, CodecError> {
+            Err(CodecError::decode(
+                "test codec must not decode primitive snapshot sections",
+                self.codec_id(),
+                data.len(),
+            ))
+        }
+
+        fn codec_id(&self) -> &str {
+            "rejecting-decode-test"
+        }
+
+        fn clone_box(&self) -> Box<dyn StorageCodec> {
+            Box::new(*self)
+        }
     }
 
     #[test]
@@ -724,16 +924,16 @@ mod tests {
         // the DTO carries it explicitly so install dispatches correctly.
         let global_branch = BranchId::from_bytes([0; 16]);
 
-        let branch_bytes =
-            strata_storage::durability::SnapshotSerializer::new(Box::new(IdentityCodec))
-                .serialize_branches(&[strata_storage::durability::format::BranchSnapshotEntry {
-                    branch_id: *global_branch.as_bytes(),
-                    key: "my-branch".to_string(),
-                    value: serde_json::to_vec(&Value::String("branch-metadata".into())).unwrap(),
-                    version: 42,
-                    timestamp: 1_234,
-                    is_tombstone: false,
-                }]);
+        let branch_bytes = serializer().serialize_branches(&[
+            strata_storage::durability::format::BranchSnapshotEntry {
+                branch_id: *global_branch.as_bytes(),
+                key: "my-branch".to_string(),
+                value: serde_json::to_vec(&Value::String("branch-metadata".into())).unwrap(),
+                version: 42,
+                timestamp: 1_234,
+                is_tombstone: false,
+            },
+        ]);
 
         let info = writer_for(dir.path())
             .create_snapshot(
@@ -770,16 +970,24 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let global_branch = BranchId::from_bytes([0; 16]);
 
-        let branch_bytes =
-            strata_storage::durability::SnapshotSerializer::new(Box::new(IdentityCodec))
-                .serialize_branches(&[strata_storage::durability::format::BranchSnapshotEntry {
-                    branch_id: *global_branch.as_bytes(),
-                    key: "dropped".to_string(),
-                    value: Vec::new(),
-                    version: 99,
-                    timestamp: 2_000,
-                    is_tombstone: true,
-                }]);
+        let branch_bytes = serializer().serialize_branches(&[
+            strata_storage::durability::format::BranchSnapshotEntry {
+                branch_id: *global_branch.as_bytes(),
+                key: "dropped".to_string(),
+                value: serde_json::to_vec(&Value::String("before-delete".into())).unwrap(),
+                version: 98,
+                timestamp: 1_000,
+                is_tombstone: false,
+            },
+            strata_storage::durability::format::BranchSnapshotEntry {
+                branch_id: *global_branch.as_bytes(),
+                key: "dropped".to_string(),
+                value: Vec::new(),
+                version: 99,
+                timestamp: 2_000,
+                is_tombstone: true,
+            },
+        ]);
 
         let info = writer_for(dir.path())
             .create_snapshot(
@@ -795,6 +1003,12 @@ mod tests {
 
         let ns = Arc::new(Namespace::for_branch(global_branch));
         let key = Key::new(ns, TypeTag::Branch, b"dropped".to_vec());
+        let before_delete = storage
+            .get_versioned(&key, CommitVersion(98))
+            .unwrap()
+            .expect("older branch metadata should still be present below the tombstone");
+        assert_eq!(before_delete.value, Value::String("before-delete".into()));
+
         let observed = storage.get_versioned(&key, CommitVersion::MAX).unwrap();
         assert!(
             observed.is_none(),
@@ -809,17 +1023,30 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let branch_id = BranchId::new();
 
-        let kv_bytes = serializer().serialize_kv(&[KvSnapshotEntry {
-            branch_id: *branch_id.as_bytes(),
-            space: "default".to_string(),
-            type_tag: TypeTag::KV.as_byte(),
-            user_key: b"deleted".to_vec(),
-            value: Vec::new(),
-            version: 10,
-            timestamp: 500,
-            ttl_ms: 0,
-            is_tombstone: true,
-        }]);
+        let kv_bytes = serializer().serialize_kv(&[
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: TypeTag::KV.as_byte(),
+                user_key: b"deleted".to_vec(),
+                value: serde_json::to_vec(&Value::String("before-delete".into())).unwrap(),
+                version: 9,
+                timestamp: 400,
+                ttl_ms: 0,
+                is_tombstone: false,
+            },
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: TypeTag::KV.as_byte(),
+                user_key: b"deleted".to_vec(),
+                value: Vec::new(),
+                version: 10,
+                timestamp: 500,
+                ttl_ms: 0,
+                is_tombstone: true,
+            },
+        ]);
 
         let info = writer_for(dir.path())
             .create_snapshot(
@@ -835,6 +1062,12 @@ mod tests {
 
         // A tombstoned snapshot entry surfaces as `None` on read.
         let key = Key::new_kv(ns(branch_id, "default"), "deleted");
+        let before_delete = storage
+            .get_versioned(&key, CommitVersion(9))
+            .unwrap()
+            .expect("older KV row should still be present below the tombstone");
+        assert_eq!(before_delete.value, Value::String("before-delete".into()));
+
         let observed = storage.get_versioned(&key, CommitVersion::MAX).unwrap();
         assert!(observed.is_none(), "tombstone must hide the key from reads");
     }
@@ -944,5 +1177,761 @@ mod tests {
             "error should mention the unknown tag, got: {}",
             err
         );
+    }
+
+    #[test]
+    fn install_rejects_invalid_kv_type_tag() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let kv_bytes = serializer().serialize_kv(&[KvSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "default".to_string(),
+            type_tag: 0xfd,
+            user_key: b"bad-tag".to_vec(),
+            value: serde_json::to_vec(&Value::Int(1)).unwrap(),
+            version: 1,
+            timestamp: 10,
+            ttl_ms: 0,
+            is_tombstone: false,
+        }]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                13,
+                1,
+                vec![SnapshotSection::new(primitive_tags::KV, kv_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+            .expect_err("invalid KV type tag must be rejected");
+        assert_error_contains(err, "Invalid TypeTag 0xfd in KV snapshot entry");
+    }
+
+    #[test]
+    fn install_rejects_known_non_kv_type_tag_in_kv_section() {
+        for disallowed in [
+            TypeTag::Event,
+            TypeTag::Branch,
+            TypeTag::Space,
+            TypeTag::Vector,
+            TypeTag::Json,
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let branch_id = BranchId::new();
+
+            let kv_bytes = serializer().serialize_kv(&[KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: disallowed.as_byte(),
+                user_key: b"wrong-family".to_vec(),
+                value: serde_json::to_vec(&Value::Int(1)).unwrap(),
+                version: 1,
+                timestamp: 10,
+                ttl_ms: 0,
+                is_tombstone: false,
+            }]);
+
+            let info = writer_for(dir.path())
+                .create_snapshot(
+                    30 + disallowed.as_byte() as u64,
+                    1,
+                    vec![SnapshotSection::new(primitive_tags::KV, kv_bytes)],
+                )
+                .unwrap();
+            let snapshot = load_snapshot(&info.path);
+
+            let storage = SegmentedStore::new();
+            let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+                .expect_err("known non-KV type tag must be rejected inside KV section");
+            assert_error_contains(err, "KV section only supports KV and Graph");
+        }
+    }
+
+    #[test]
+    fn install_uses_canonical_section_codec_even_when_snapshot_file_codec_differs() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+        let kv_bytes = serializer().serialize_kv(&[KvSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "default".to_string(),
+            type_tag: TypeTag::KV.as_byte(),
+            user_key: b"codec-key".to_vec(),
+            value: serde_json::to_vec(&Value::String("codec-value".into())).unwrap(),
+            version: 1,
+            timestamp: 10,
+            ttl_ms: 0,
+            is_tombstone: false,
+        }]);
+
+        let info = writer_for_codec(dir.path(), Box::new(RejectingDecodeCodec))
+            .create_snapshot(
+                14,
+                1,
+                vec![SnapshotSection::new(primitive_tags::KV, kv_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot_with_codec(&info.path, Box::new(RejectingDecodeCodec));
+        assert_eq!(snapshot.codec_id, "rejecting-decode-test");
+
+        let storage = SegmentedStore::new();
+        let codec = RejectingDecodeCodec;
+        let stats = install_snapshot(&snapshot, &codec, &storage)
+            .expect("primitive section decode must not use the snapshot header codec");
+        assert_eq!(stats.kv, 1);
+
+        let observed = storage
+            .get_versioned(
+                &Key::new_kv(ns(branch_id, "default"), "codec-key"),
+                CommitVersion::MAX,
+            )
+            .unwrap()
+            .expect("KV row must install through canonical section decode");
+        assert_eq!(observed.value, Value::String("codec-value".into()));
+    }
+
+    #[test]
+    fn install_rejects_snapshot_codec_mismatch_before_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+        let kv_bytes = serializer().serialize_kv(&[KvSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "default".to_string(),
+            type_tag: TypeTag::KV.as_byte(),
+            user_key: b"codec-mismatch".to_vec(),
+            value: serde_json::to_vec(&Value::Int(1)).unwrap(),
+            version: 1,
+            timestamp: 10,
+            ttl_ms: 0,
+            is_tombstone: false,
+        }]);
+
+        let info = writer_for_codec(dir.path(), Box::new(RejectingDecodeCodec))
+            .create_snapshot(
+                40,
+                1,
+                vec![SnapshotSection::new(primitive_tags::KV, kv_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot_with_codec(&info.path, Box::new(RejectingDecodeCodec));
+
+        let storage = SegmentedStore::new();
+        let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+            .expect_err("install must reject a caller-supplied codec mismatch");
+        assert_error_contains(err, "Snapshot codec mismatch during install");
+
+        let observed = storage
+            .get_versioned(
+                &Key::new_kv(ns(branch_id, "default"), "codec-mismatch"),
+                CommitVersion::MAX,
+            )
+            .unwrap();
+        assert!(
+            observed.is_none(),
+            "codec mismatch must fail before mutating storage"
+        );
+    }
+
+    #[test]
+    fn install_rejects_invalid_kv_type_tag_without_partial_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let kv_bytes = serializer().serialize_kv(&[
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: TypeTag::KV.as_byte(),
+                user_key: b"valid-before-invalid".to_vec(),
+                value: serde_json::to_vec(&Value::Int(1)).unwrap(),
+                version: 1,
+                timestamp: 10,
+                ttl_ms: 0,
+                is_tombstone: false,
+            },
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: 0xfd,
+                user_key: b"invalid".to_vec(),
+                value: serde_json::to_vec(&Value::Int(2)).unwrap(),
+                version: 2,
+                timestamp: 20,
+                ttl_ms: 0,
+                is_tombstone: false,
+            },
+        ]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                15,
+                2,
+                vec![SnapshotSection::new(primitive_tags::KV, kv_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+            .expect_err("invalid tag must reject the whole snapshot before mutation");
+        assert_error_contains(err, "Invalid TypeTag 0xfd in KV snapshot entry");
+
+        let key = Key::new_kv(ns(branch_id, "default"), "valid-before-invalid");
+        let observed = storage.get_versioned(&key, CommitVersion::MAX).unwrap();
+        assert!(
+            observed.is_none(),
+            "valid earlier KV entry must not be installed when the same snapshot has an invalid tag"
+        );
+    }
+
+    #[test]
+    fn install_rejects_known_non_kv_type_tag_without_partial_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let kv_bytes = serializer().serialize_kv(&[
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: TypeTag::KV.as_byte(),
+                user_key: b"valid-before-wrong-family".to_vec(),
+                value: serde_json::to_vec(&Value::Int(1)).unwrap(),
+                version: 1,
+                timestamp: 10,
+                ttl_ms: 0,
+                is_tombstone: false,
+            },
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: TypeTag::Event.as_byte(),
+                user_key: b"wrong-family".to_vec(),
+                value: serde_json::to_vec(&Value::Int(2)).unwrap(),
+                version: 2,
+                timestamp: 20,
+                ttl_ms: 0,
+                is_tombstone: false,
+            },
+        ]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                41,
+                2,
+                vec![SnapshotSection::new(primitive_tags::KV, kv_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+            .expect_err("known non-KV tag must reject the whole snapshot before mutation");
+        assert_error_contains(err, "KV section only supports KV and Graph");
+
+        let key = Key::new_kv(ns(branch_id, "default"), "valid-before-wrong-family");
+        let observed = storage.get_versioned(&key, CommitVersion::MAX).unwrap();
+        assert!(
+            observed.is_none(),
+            "valid earlier KV entry must not be installed when the same snapshot has a wrong-family tag"
+        );
+    }
+
+    #[test]
+    fn install_rejects_zero_version_from_storage_helper_without_partial_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let kv_bytes = serializer().serialize_kv(&[
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: TypeTag::KV.as_byte(),
+                user_key: b"valid-before-zero-version".to_vec(),
+                value: serde_json::to_vec(&Value::Int(1)).unwrap(),
+                version: 1,
+                timestamp: 10,
+                ttl_ms: 0,
+                is_tombstone: false,
+            },
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: TypeTag::KV.as_byte(),
+                user_key: b"zero-version".to_vec(),
+                value: serde_json::to_vec(&Value::Int(2)).unwrap(),
+                version: 0,
+                timestamp: 20,
+                ttl_ms: 0,
+                is_tombstone: false,
+            },
+        ]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                42,
+                1,
+                vec![SnapshotSection::new(primitive_tags::KV, kv_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+            .expect_err("zero-version storage rows must reject the whole snapshot before mutation");
+        assert_error_contains(err, "zero commit version");
+
+        let key = Key::new_kv(ns(branch_id, "default"), "valid-before-zero-version");
+        let observed = storage.get_versioned(&key, CommitVersion::MAX).unwrap();
+        assert!(
+            observed.is_none(),
+            "valid earlier KV entry must not be installed when storage generic validation rejects a later row"
+        );
+    }
+
+    #[test]
+    fn install_rejects_duplicate_rows_from_storage_helper_without_partial_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let kv_bytes = serializer().serialize_kv(&[
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: TypeTag::KV.as_byte(),
+                user_key: b"duplicate-row".to_vec(),
+                value: serde_json::to_vec(&Value::Int(1)).unwrap(),
+                version: 3,
+                timestamp: 10,
+                ttl_ms: 0,
+                is_tombstone: false,
+            },
+            KvSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "default".to_string(),
+                type_tag: TypeTag::KV.as_byte(),
+                user_key: b"duplicate-row".to_vec(),
+                value: serde_json::to_vec(&Value::Int(2)).unwrap(),
+                version: 3,
+                timestamp: 20,
+                ttl_ms: 0,
+                is_tombstone: false,
+            },
+        ]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                43,
+                3,
+                vec![SnapshotSection::new(primitive_tags::KV, kv_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+            .expect_err("duplicate storage rows must reject the whole snapshot before mutation");
+        assert_error_contains(err, "duplicate row");
+
+        let key = Key::new_kv(ns(branch_id, "default"), "duplicate-row");
+        let observed = storage.get_versioned(&key, CommitVersion::MAX).unwrap();
+        assert!(
+            observed.is_none(),
+            "duplicate row rejection must happen before installing the first duplicate"
+        );
+    }
+
+    #[test]
+    fn install_rejects_duplicate_rows_across_sections_without_partial_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let first_kv_bytes = serializer().serialize_kv(&[KvSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "default".to_string(),
+            type_tag: TypeTag::KV.as_byte(),
+            user_key: b"duplicate-across-sections".to_vec(),
+            value: serde_json::to_vec(&Value::Int(1)).unwrap(),
+            version: 4,
+            timestamp: 10,
+            ttl_ms: 0,
+            is_tombstone: false,
+        }]);
+        let second_kv_bytes = serializer().serialize_kv(&[KvSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "default".to_string(),
+            type_tag: TypeTag::KV.as_byte(),
+            user_key: b"duplicate-across-sections".to_vec(),
+            value: serde_json::to_vec(&Value::Int(2)).unwrap(),
+            version: 4,
+            timestamp: 20,
+            ttl_ms: 0,
+            is_tombstone: false,
+        }]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                44,
+                4,
+                vec![
+                    SnapshotSection::new(primitive_tags::KV, first_kv_bytes),
+                    SnapshotSection::new(primitive_tags::KV, second_kv_bytes),
+                ],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+            .expect_err("duplicate storage rows across sections must reject before mutation");
+        assert_error_contains(&err, "Snapshot 44 decoded-row install rejected");
+        assert_error_contains(&err, "duplicate row");
+        let key_hex = b"duplicate-across-sections"
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        assert_error_contains(&err, &key_hex);
+
+        let key = Key::new_kv(ns(branch_id, "default"), "duplicate-across-sections");
+        let observed = storage.get_versioned(&key, CommitVersion::MAX).unwrap();
+        assert!(
+            observed.is_none(),
+            "duplicate row rejection across sections must happen before installing the first row"
+        );
+    }
+
+    #[test]
+    fn install_rejects_unknown_later_section_without_partial_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let kv_bytes = serializer().serialize_kv(&[KvSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "default".to_string(),
+            type_tag: TypeTag::KV.as_byte(),
+            user_key: b"valid-before-unknown-section".to_vec(),
+            value: serde_json::to_vec(&Value::Int(1)).unwrap(),
+            version: 1,
+            timestamp: 10,
+            ttl_ms: 0,
+            is_tombstone: false,
+        }]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                16,
+                1,
+                vec![
+                    SnapshotSection::new(primitive_tags::KV, kv_bytes),
+                    SnapshotSection::new(primitive_tags::GRAPH, Vec::new()),
+                ],
+            )
+            .unwrap();
+        let mut snapshot = load_snapshot(&info.path);
+        snapshot.sections[1].primitive_type = 0xfe;
+
+        let storage = SegmentedStore::new();
+        let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+            .expect_err("unknown later section must reject the whole snapshot before mutation");
+        assert_error_contains(err, "Unknown snapshot primitive tag 0xfe");
+
+        let key = Key::new_kv(ns(branch_id, "default"), "valid-before-unknown-section");
+        let observed = storage.get_versioned(&key, CommitVersion::MAX).unwrap();
+        assert!(
+            observed.is_none(),
+            "earlier valid section must not be installed when a later section is invalid"
+        );
+    }
+
+    #[test]
+    fn install_propagates_json_tombstone_as_tombstone() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let json_bytes = serializer().serialize_json(&[
+            JsonSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "docs".to_string(),
+                doc_id: "deleted-doc".to_string(),
+                content: serde_json::to_vec(&Value::String("before-delete".into())).unwrap(),
+                version: 1,
+                timestamp: 10,
+                is_tombstone: false,
+            },
+            JsonSnapshotEntry {
+                branch_id: *branch_id.as_bytes(),
+                space: "docs".to_string(),
+                doc_id: "deleted-doc".to_string(),
+                content: Vec::new(),
+                version: 2,
+                timestamp: 20,
+                is_tombstone: true,
+            },
+        ]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                17,
+                2,
+                vec![SnapshotSection::new(primitive_tags::JSON, json_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let stats = install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
+        assert_eq!(stats.json, 2);
+
+        let key = Key::new(
+            ns(branch_id, "docs"),
+            TypeTag::Json,
+            b"deleted-doc".to_vec(),
+        );
+        let before_delete = storage
+            .get_versioned(&key, CommitVersion(1))
+            .unwrap()
+            .expect("older JSON version should still be present below the tombstone");
+        assert_eq!(before_delete.value, Value::String("before-delete".into()));
+
+        let observed = storage.get_versioned(&key, CommitVersion::MAX).unwrap();
+        assert!(
+            observed.is_none(),
+            "JSON tombstone must hide the older live row"
+        );
+    }
+
+    #[test]
+    fn install_propagates_vector_tombstone_as_tombstone() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch_id = BranchId::new();
+
+        let vector_bytes = serializer().serialize_vectors(&[VectorCollectionSnapshotEntry {
+            branch_id: *branch_id.as_bytes(),
+            space: "default".to_string(),
+            name: "col".to_string(),
+            config: b"collection-config".to_vec(),
+            config_version: 1,
+            config_timestamp: 10,
+            vectors: vec![
+                VectorSnapshotEntry {
+                    key: "vec1".to_string(),
+                    vector_id: 1,
+                    embedding: vec![0.1, 0.2],
+                    metadata: Vec::new(),
+                    raw_value: b"raw-live".to_vec(),
+                    version: 2,
+                    timestamp: 20,
+                    is_tombstone: false,
+                },
+                VectorSnapshotEntry {
+                    key: "vec1".to_string(),
+                    vector_id: 1,
+                    embedding: Vec::new(),
+                    metadata: Vec::new(),
+                    raw_value: Vec::new(),
+                    version: 3,
+                    timestamp: 30,
+                    is_tombstone: true,
+                },
+            ],
+        }]);
+
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                18,
+                3,
+                vec![SnapshotSection::new(primitive_tags::VECTOR, vector_bytes)],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let stats = install_snapshot(&snapshot, &IdentityCodec, &storage).unwrap();
+        assert_eq!(stats.vector_configs, 1);
+        assert_eq!(stats.vectors, 2);
+
+        let key = Key::new(
+            ns(branch_id, "default"),
+            TypeTag::Vector,
+            b"col/vec1".to_vec(),
+        );
+        let before_delete = storage
+            .get_versioned(&key, CommitVersion(2))
+            .unwrap()
+            .expect("older vector row should still be present below the tombstone");
+        assert_eq!(before_delete.value, Value::Bytes(b"raw-live".to_vec()));
+
+        let observed = storage.get_versioned(&key, CommitVersion::MAX).unwrap();
+        assert!(
+            observed.is_none(),
+            "Vector tombstone must hide the older live row"
+        );
+    }
+
+    #[test]
+    fn install_rejects_corrupt_kv_section_with_section_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let info = writer_for(dir.path())
+            .create_snapshot(
+                19,
+                1,
+                vec![SnapshotSection::new(primitive_tags::KV, vec![1, 0, 0, 0])],
+            )
+            .unwrap();
+        let snapshot = load_snapshot(&info.path);
+
+        let storage = SegmentedStore::new();
+        let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+            .expect_err("corrupt KV section must be rejected");
+        assert_error_contains(err, "KV section decode failed");
+    }
+
+    #[test]
+    fn install_rejects_corrupt_non_kv_sections_with_section_context() {
+        for (snapshot_id, tag, expected) in [
+            (20, primitive_tags::EVENT, "Event section decode failed"),
+            (21, primitive_tags::JSON, "JSON section decode failed"),
+            (22, primitive_tags::BRANCH, "Branch section decode failed"),
+            (23, primitive_tags::VECTOR, "Vector section decode failed"),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let info = writer_for(dir.path())
+                .create_snapshot(
+                    snapshot_id,
+                    1,
+                    vec![SnapshotSection::new(tag, vec![1, 0, 0, 0])],
+                )
+                .unwrap();
+            let snapshot = load_snapshot(&info.path);
+
+            let storage = SegmentedStore::new();
+            let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+                .expect_err("corrupt primitive section must be rejected");
+            assert_error_contains(err, expected);
+        }
+    }
+
+    #[test]
+    fn install_rejects_trailing_section_data_with_section_context() {
+        for (snapshot_id, tag, expected) in [
+            (50, primitive_tags::KV, "KV section decode failed"),
+            (51, primitive_tags::EVENT, "Event section decode failed"),
+            (52, primitive_tags::JSON, "JSON section decode failed"),
+            (53, primitive_tags::BRANCH, "Branch section decode failed"),
+            (54, primitive_tags::VECTOR, "Vector section decode failed"),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let mut data = 0u32.to_le_bytes().to_vec();
+            data.push(0xff);
+            let info = writer_for(dir.path())
+                .create_snapshot(snapshot_id, 1, vec![SnapshotSection::new(tag, data)])
+                .unwrap();
+            let snapshot = load_snapshot(&info.path);
+
+            let storage = SegmentedStore::new();
+            let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+                .expect_err("trailing primitive section data must be rejected");
+            assert_error_contains(&err, expected);
+            assert_error_contains(&err, "Trailing data after snapshot section");
+        }
+    }
+
+    #[test]
+    fn install_rejects_huge_entry_counts_with_section_context() {
+        for (snapshot_id, tag, expected) in [
+            (60, primitive_tags::KV, "KV section decode failed"),
+            (61, primitive_tags::EVENT, "Event section decode failed"),
+            (62, primitive_tags::JSON, "JSON section decode failed"),
+            (63, primitive_tags::BRANCH, "Branch section decode failed"),
+            (64, primitive_tags::VECTOR, "Vector section decode failed"),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let data = u32::MAX.to_le_bytes().to_vec();
+            let info = writer_for(dir.path())
+                .create_snapshot(snapshot_id, 1, vec![SnapshotSection::new(tag, data)])
+                .unwrap();
+            let snapshot = load_snapshot(&info.path);
+
+            let storage = SegmentedStore::new();
+            let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+                .expect_err("huge primitive section counts must be rejected without preallocation");
+            assert_error_contains(&err, expected);
+            assert_error_contains(&err, "Unexpected end of data");
+        }
+    }
+
+    #[test]
+    fn install_rejects_corrupt_value_json_with_section_context() {
+        let branch_id = BranchId::new();
+        let global_branch = BranchId::from_bytes([0; 16]);
+        let cases = vec![
+            (
+                primitive_tags::KV,
+                serializer().serialize_kv(&[KvSnapshotEntry {
+                    branch_id: *branch_id.as_bytes(),
+                    space: "default".to_string(),
+                    type_tag: TypeTag::KV.as_byte(),
+                    user_key: b"bad-json".to_vec(),
+                    value: b"not-json".to_vec(),
+                    version: 1,
+                    timestamp: 10,
+                    ttl_ms: 0,
+                    is_tombstone: false,
+                }]),
+                "KV snapshot Value JSON decode failed",
+            ),
+            (
+                primitive_tags::EVENT,
+                serializer().serialize_events(&[EventSnapshotEntry {
+                    branch_id: *branch_id.as_bytes(),
+                    space: "stream".to_string(),
+                    sequence: 1,
+                    payload: b"not-json".to_vec(),
+                    version: 1,
+                    timestamp: 10,
+                }]),
+                "Event snapshot Value JSON decode failed",
+            ),
+            (
+                primitive_tags::JSON,
+                serializer().serialize_json(&[JsonSnapshotEntry {
+                    branch_id: *branch_id.as_bytes(),
+                    space: "docs".to_string(),
+                    doc_id: "bad-json".to_string(),
+                    content: b"not-json".to_vec(),
+                    version: 1,
+                    timestamp: 10,
+                    is_tombstone: false,
+                }]),
+                "Json snapshot Value JSON decode failed",
+            ),
+            (
+                primitive_tags::BRANCH,
+                serializer().serialize_branches(&[BranchSnapshotEntry {
+                    branch_id: *global_branch.as_bytes(),
+                    key: "bad-json".to_string(),
+                    value: b"not-json".to_vec(),
+                    version: 1,
+                    timestamp: 10,
+                    is_tombstone: false,
+                }]),
+                "Branch snapshot Value JSON decode failed",
+            ),
+        ];
+
+        for (index, (tag, bytes, expected)) in cases.into_iter().enumerate() {
+            let dir = tempfile::tempdir().unwrap();
+            let info = writer_for(dir.path())
+                .create_snapshot(24 + index as u64, 1, vec![SnapshotSection::new(tag, bytes)])
+                .unwrap();
+            let snapshot = load_snapshot(&info.path);
+
+            let storage = SegmentedStore::new();
+            let err = install_snapshot(&snapshot, &IdentityCodec, &storage)
+                .expect_err("corrupt JSON-encoded Value must be rejected");
+            assert_error_contains(err, expected);
+        }
     }
 }

--- a/crates/engine/src/database/tests/checkpoint.rs
+++ b/crates/engine/src/database/tests/checkpoint.rs
@@ -325,6 +325,98 @@ fn test_compact_missing_manifest_loses_snapshot_metadata_even_when_configured_ae
 }
 
 #[test]
+#[serial(open_databases)]
+fn test_aes_checkpoint_compact_reopen_installs_snapshot() {
+    OPEN_DATABASES.lock().clear();
+    let _key_guard = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let branch_id = BranchId::new();
+    let ns = create_test_namespace(branch_id);
+
+    {
+        let db = Database::open_runtime(
+            super::spec::OpenSpec::primary(&db_path)
+                .with_config(aes_gcm_standard_config())
+                .with_subsystem(crate::SearchSubsystem),
+        )
+        .unwrap();
+
+        for i in 0..3 {
+            let key = Key::new_kv(ns.clone(), format!("aes-snapshot-{}", i));
+            db.transaction(branch_id, |txn| {
+                txn.put(key, Value::String(format!("value-{}", i)))?;
+                Ok(())
+            })
+            .unwrap();
+        }
+
+        db.checkpoint().unwrap();
+        db.compact()
+            .expect("AES checkpoint must be compactable after snapshot install support");
+        db.shutdown().unwrap();
+    }
+    OPEN_DATABASES.lock().clear();
+
+    let snapshots_dir = db_path.join("snapshots");
+    let snapshots = strata_storage::durability::list_snapshots(&snapshots_dir).unwrap();
+    let (_, snapshot_path) = snapshots
+        .last()
+        .expect("checkpoint should create an AES snapshot");
+    let snapshot = strata_storage::durability::SnapshotReader::new(
+        strata_storage::durability::get_codec("aes-gcm-256").unwrap(),
+    )
+    .load(snapshot_path)
+    .unwrap();
+    assert_eq!(
+        snapshot.codec_id, "aes-gcm-256",
+        "test must exercise a non-identity snapshot header codec id"
+    );
+    let kv_section = snapshot
+        .sections
+        .iter()
+        .find(|section| section.primitive_type == strata_storage::durability::primitive_tags::KV)
+        .expect("AES snapshot must contain a KV primitive section");
+    let kv_rows = strata_storage::durability::SnapshotSerializer::canonical_primitive_section()
+        .deserialize_kv(&kv_section.data)
+        .expect("primitive section bytes must decode with the canonical section codec");
+    assert_eq!(
+        kv_rows.len(),
+        3,
+        "canonical section decode should expose all checkpointed KV rows"
+    );
+
+    let wal_dir = db_path.join("wal");
+    for entry in std::fs::read_dir(&wal_dir).unwrap().flatten() {
+        let path = entry.path();
+        if path.is_file() {
+            std::fs::remove_file(path).unwrap();
+        }
+    }
+
+    let reopened = Database::open_runtime(
+        super::spec::OpenSpec::primary(&db_path)
+            .with_config(aes_gcm_standard_config())
+            .with_subsystem(crate::SearchSubsystem),
+    )
+    .unwrap();
+
+    for i in 0..3 {
+        let key = Key::new_kv(ns.clone(), format!("aes-snapshot-{}", i));
+        let observed = reopened
+            .storage()
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .unwrap_or_else(|| panic!("aes-snapshot-{} must recover from snapshot", i));
+        assert_eq!(observed.value, Value::String(format!("value-{}", i)));
+    }
+
+    drop(reopened);
+    OPEN_DATABASES.lock().clear();
+}
+
+#[test]
 fn test_checkpoint_then_compact_without_flush_succeeds() {
     // Inverted in the T3-E5 follow-up (retention-complete DTOs + install).
     //

--- a/crates/storage/src/durability/checkpoint_runtime.rs
+++ b/crates/storage/src/durability/checkpoint_runtime.rs
@@ -770,7 +770,7 @@ mod tests {
         assert_eq!(snapshot.sections.len(), 1);
         assert_eq!(snapshot.sections[0].primitive_type, primitive_tags::KV);
 
-        let serializer = SnapshotSerializer::new(Box::new(IdentityCodec));
+        let serializer = SnapshotSerializer::canonical_primitive_section();
         let kv = serializer
             .deserialize_kv(&snapshot.sections[0].data)
             .unwrap();

--- a/crates/storage/src/durability/codec/mod.rs
+++ b/crates/storage/src/durability/codec/mod.rs
@@ -1,8 +1,9 @@
 //! Storage codec abstraction.
 //!
-//! The codec seam provides a hook point for encryption-at-rest and
-//! compression. All bytes passing through the storage layer go through the
-//! codec for encode/decode operations.
+//! The codec seam provides a hook point for durability artifacts that encode
+//! payload bytes, such as WAL records. Snapshot containers only record and
+//! validate the configured codec id; their section payloads own separate
+//! wire-format encoding.
 //!
 //! # Available Codecs
 //!

--- a/crates/storage/src/durability/codec/traits.rs
+++ b/crates/storage/src/durability/codec/traits.rs
@@ -2,8 +2,14 @@
 
 /// Storage codec trait.
 ///
-/// All bytes passing through the storage layer go through the codec.
-/// This provides a seam for future encryption-at-rest and compression.
+/// Durability artifacts that opt into storage codec protection pass their
+/// payload bytes through this codec. WAL records use it for record payloads.
+///
+/// Snapshot files are different: their header records and validates the
+/// database storage codec id, but the snapshot container does not wrap section
+/// bytes in this codec. Each snapshot section owns its own wire-format
+/// encoding; primitive checkpoint sections currently use the canonical
+/// primitive-section codec.
 ///
 /// # Thread Safety
 ///

--- a/crates/storage/src/durability/decoded_snapshot_install.rs
+++ b/crates/storage/src/durability/decoded_snapshot_install.rs
@@ -1,0 +1,754 @@
+//! Generic decoded-row snapshot install mechanics.
+//!
+//! This module intentionally starts after higher layers have decoded any
+//! snapshot format or primitive-specific section. Its input is only storage
+//! routing metadata plus already-decoded storage rows.
+
+use std::collections::HashMap;
+
+use strata_core::{BranchId, CommitVersion};
+
+use crate::{DecodedSnapshotEntry, SegmentedStore, StorageError, TypeTag};
+
+type RowIdentity<'a> = (BranchId, TypeTag, &'a str, &'a [u8], CommitVersion);
+
+/// A complete generic decoded snapshot install plan.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct StorageDecodedSnapshotInstallPlan {
+    /// Decoded row groups to install.
+    pub groups: Vec<StorageDecodedSnapshotInstallGroup>,
+}
+
+impl StorageDecodedSnapshotInstallPlan {
+    /// Construct a plan from decoded row groups.
+    pub fn new(groups: Vec<StorageDecodedSnapshotInstallGroup>) -> Self {
+        Self { groups }
+    }
+
+    /// Returns true when the plan has no row groups.
+    pub fn is_empty(&self) -> bool {
+        self.groups.is_empty()
+    }
+}
+
+/// A decoded storage row group for one branch and storage family.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StorageDecodedSnapshotInstallGroup {
+    /// Branch whose storage state receives these rows.
+    pub branch_id: BranchId,
+    /// Storage family identifier used by `SegmentedStore` key routing.
+    pub type_tag: TypeTag,
+    /// Already-decoded rows for this branch and storage family.
+    pub entries: Vec<DecodedSnapshotEntry>,
+}
+
+impl StorageDecodedSnapshotInstallGroup {
+    /// Construct a decoded row group.
+    pub fn new(branch_id: BranchId, type_tag: TypeTag, entries: Vec<DecodedSnapshotEntry>) -> Self {
+        Self {
+            branch_id,
+            type_tag,
+            entries,
+        }
+    }
+}
+
+/// Input for installing a decoded snapshot plan into storage.
+#[derive(Debug, Clone, Copy)]
+pub struct StorageDecodedSnapshotInstallInput<'a> {
+    /// Target store.
+    pub storage: &'a SegmentedStore,
+    /// Generic decoded row plan to install.
+    pub plan: &'a StorageDecodedSnapshotInstallPlan,
+}
+
+/// Generic storage install stats.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StorageDecodedSnapshotInstallStats {
+    /// Number of groups installed.
+    pub groups_installed: usize,
+    /// Number of rows installed.
+    pub rows_installed: usize,
+}
+
+/// Storage-local errors from decoded-row snapshot install.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StorageDecodedSnapshotInstallError {
+    /// A row group had no entries.
+    #[error("decoded snapshot install group {group_index} for branch {branch_id} storage family 0x{storage_family:02x} is empty")]
+    EmptyGroup {
+        /// Index of the invalid group in the plan.
+        group_index: usize,
+        /// Branch receiving the invalid group.
+        branch_id: BranchId,
+        /// Opaque storage family byte.
+        storage_family: u8,
+    },
+
+    /// A decoded row had no storage space.
+    #[error("decoded snapshot install group {group_index} entry {entry_index} for branch {branch_id} storage family 0x{storage_family:02x} key 0x{user_key} ({user_key_len} bytes) has an empty storage space")]
+    EmptySpace {
+        /// Index of the invalid group in the plan.
+        group_index: usize,
+        /// Index of the invalid entry inside the group.
+        entry_index: usize,
+        /// Branch receiving the invalid row.
+        branch_id: BranchId,
+        /// Short user-key diagnostic.
+        user_key: String,
+        /// Full user-key length in bytes.
+        user_key_len: usize,
+        /// Opaque storage family byte.
+        storage_family: u8,
+    },
+
+    /// A decoded row used the reserved zero commit version.
+    #[error("decoded snapshot install group {group_index} entry {entry_index} for branch {branch_id} space {space:?} storage family 0x{storage_family:02x} key 0x{user_key} ({user_key_len} bytes) has zero commit version")]
+    ZeroVersion {
+        /// Index of the invalid group in the plan.
+        group_index: usize,
+        /// Index of the invalid entry inside the group.
+        entry_index: usize,
+        /// Branch receiving the invalid row.
+        branch_id: BranchId,
+        /// Storage space containing the invalid row.
+        space: String,
+        /// Short user-key diagnostic.
+        user_key: String,
+        /// Full user-key length in bytes.
+        user_key_len: usize,
+        /// Opaque storage family byte.
+        storage_family: u8,
+    },
+
+    /// The same branch, storage family, space, key, and version appeared twice.
+    #[error("decoded snapshot install duplicate row for branch {branch_id} space {space:?} storage family 0x{storage_family:02x} key 0x{user_key} ({user_key_len} bytes) version {version}: first at group {first_group_index} entry {first_entry_index}, duplicate at group {duplicate_group_index} entry {duplicate_entry_index}")]
+    DuplicateRow {
+        /// First group index where the row identity appeared.
+        first_group_index: usize,
+        /// First entry index where the row identity appeared.
+        first_entry_index: usize,
+        /// Duplicate group index.
+        duplicate_group_index: usize,
+        /// Duplicate entry index inside the duplicate group.
+        duplicate_entry_index: usize,
+        /// Branch receiving the duplicate row.
+        branch_id: BranchId,
+        /// Storage space containing the duplicate row.
+        space: String,
+        /// Short user-key diagnostic.
+        user_key: String,
+        /// Full user-key length in bytes.
+        user_key_len: usize,
+        /// Duplicate commit version.
+        version: CommitVersion,
+        /// Opaque storage family byte.
+        storage_family: u8,
+    },
+
+    /// The lower storage install failed.
+    #[error("decoded snapshot install group {group_index} for branch {branch_id} storage family 0x{storage_family:02x} failed: {source}")]
+    Install {
+        /// Index of the group in the plan.
+        group_index: usize,
+        /// Branch receiving the failed group.
+        branch_id: BranchId,
+        /// Opaque storage family byte.
+        storage_family: u8,
+        /// Underlying storage failure.
+        #[source]
+        source: StorageError,
+    },
+
+    /// Lower storage reported that it installed fewer or more rows than submitted.
+    #[error("decoded snapshot install group {group_index} for branch {branch_id} storage family 0x{storage_family:02x} installed {actual} rows, expected {expected}")]
+    RowCountMismatch {
+        /// Index of the group in the plan.
+        group_index: usize,
+        /// Branch receiving the failed group.
+        branch_id: BranchId,
+        /// Opaque storage family byte.
+        storage_family: u8,
+        /// Rows submitted to lower storage.
+        expected: usize,
+        /// Rows reported by lower storage.
+        actual: usize,
+    },
+}
+
+/// Install already-decoded snapshot rows into `SegmentedStore`.
+///
+/// This helper validates all generic groups before mutation. It does not know
+/// which snapshot section, primitive DTO, or higher-layer subsystem produced
+/// the rows.
+pub fn install_decoded_snapshot_rows(
+    input: StorageDecodedSnapshotInstallInput<'_>,
+) -> Result<StorageDecodedSnapshotInstallStats, StorageDecodedSnapshotInstallError> {
+    validate_plan(input.plan)?;
+
+    let mut stats = StorageDecodedSnapshotInstallStats::default();
+    for (group_index, group) in input.plan.groups.iter().enumerate() {
+        let storage_family = group.type_tag.as_byte();
+        let rows_expected = group.entries.len();
+        let rows_installed = input
+            .storage
+            .install_snapshot_entries(group.branch_id, group.type_tag, &group.entries)
+            .map_err(|source| StorageDecodedSnapshotInstallError::Install {
+                group_index,
+                branch_id: group.branch_id,
+                storage_family,
+                source,
+            })?;
+        if rows_installed != rows_expected {
+            return Err(StorageDecodedSnapshotInstallError::RowCountMismatch {
+                group_index,
+                branch_id: group.branch_id,
+                storage_family,
+                expected: rows_expected,
+                actual: rows_installed,
+            });
+        }
+        stats.groups_installed += 1;
+        // Trust lower storage only after verifying it installed every row the
+        // group submitted.
+        stats.rows_installed += rows_installed;
+    }
+
+    Ok(stats)
+}
+
+fn validate_plan(
+    plan: &StorageDecodedSnapshotInstallPlan,
+) -> Result<(), StorageDecodedSnapshotInstallError> {
+    let mut seen_rows: HashMap<RowIdentity<'_>, (usize, usize)> = HashMap::new();
+
+    for (group_index, group) in plan.groups.iter().enumerate() {
+        let storage_family = group.type_tag.as_byte();
+        if group.entries.is_empty() {
+            return Err(StorageDecodedSnapshotInstallError::EmptyGroup {
+                group_index,
+                branch_id: group.branch_id,
+                storage_family,
+            });
+        }
+
+        for (entry_index, entry) in group.entries.iter().enumerate() {
+            if entry.space.is_empty() {
+                return Err(StorageDecodedSnapshotInstallError::EmptySpace {
+                    group_index,
+                    entry_index,
+                    branch_id: group.branch_id,
+                    user_key: user_key_preview(&entry.user_key),
+                    user_key_len: entry.user_key.len(),
+                    storage_family,
+                });
+            }
+            if entry.version == CommitVersion::ZERO {
+                return Err(StorageDecodedSnapshotInstallError::ZeroVersion {
+                    group_index,
+                    entry_index,
+                    branch_id: group.branch_id,
+                    space: entry.space.clone(),
+                    user_key: user_key_preview(&entry.user_key),
+                    user_key_len: entry.user_key.len(),
+                    storage_family,
+                });
+            }
+
+            let identity = (
+                group.branch_id,
+                group.type_tag,
+                entry.space.as_str(),
+                entry.user_key.as_slice(),
+                entry.version,
+            );
+            if let Some(&(first_group_index, first_entry_index)) = seen_rows.get(&identity) {
+                return Err(StorageDecodedSnapshotInstallError::DuplicateRow {
+                    first_group_index,
+                    first_entry_index,
+                    duplicate_group_index: group_index,
+                    duplicate_entry_index: entry_index,
+                    branch_id: group.branch_id,
+                    space: entry.space.clone(),
+                    user_key: user_key_preview(&entry.user_key),
+                    user_key_len: entry.user_key.len(),
+                    version: entry.version,
+                    storage_family,
+                });
+            }
+            seen_rows.insert(identity, (group_index, entry_index));
+        }
+    }
+
+    Ok(())
+}
+
+fn user_key_preview(user_key: &[u8]) -> String {
+    const MAX_PREVIEW_BYTES: usize = 32;
+    let mut preview = String::with_capacity(MAX_PREVIEW_BYTES * 2 + 3);
+    for byte in user_key.iter().take(MAX_PREVIEW_BYTES) {
+        use std::fmt::Write as _;
+        let _ = write!(&mut preview, "{byte:02x}");
+    }
+    if user_key.len() > MAX_PREVIEW_BYTES {
+        preview.push_str("...");
+    }
+    preview
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use strata_core::id::CommitVersion;
+    use strata_core::Value;
+
+    use super::*;
+    use crate::{DecodedSnapshotValue, Key, Namespace};
+
+    fn branch(byte: u8) -> BranchId {
+        BranchId::from_bytes([byte; 16])
+    }
+
+    fn live(space: &str, key: &[u8], value: Value, version: u64) -> DecodedSnapshotEntry {
+        live_with_metadata(space, key, value, version, 1_700_000 + version, 0)
+    }
+
+    fn live_with_metadata(
+        space: &str,
+        key: &[u8],
+        value: Value,
+        version: u64,
+        timestamp_micros: u64,
+        ttl_ms: u64,
+    ) -> DecodedSnapshotEntry {
+        DecodedSnapshotEntry {
+            space: space.to_string(),
+            user_key: key.to_vec(),
+            payload: DecodedSnapshotValue::Value(value),
+            version: CommitVersion(version),
+            timestamp_micros,
+            ttl_ms,
+        }
+    }
+
+    fn tombstone(space: &str, key: &[u8], version: u64) -> DecodedSnapshotEntry {
+        DecodedSnapshotEntry {
+            space: space.to_string(),
+            user_key: key.to_vec(),
+            payload: DecodedSnapshotValue::Tombstone,
+            version: CommitVersion(version),
+            timestamp_micros: 1_800_000 + version,
+            ttl_ms: 0,
+        }
+    }
+
+    fn key(branch_id: BranchId, space: &str, type_tag: TypeTag, user_key: &[u8]) -> Key {
+        Key::new(
+            Arc::new(Namespace::for_branch_space(branch_id, space)),
+            type_tag,
+            user_key.to_vec(),
+        )
+    }
+
+    #[test]
+    fn decoded_snapshot_install_installs_generic_groups_and_stats() {
+        let storage = SegmentedStore::new();
+        let branch_a = branch(1);
+        let branch_b = branch(2);
+        let plan = StorageDecodedSnapshotInstallPlan::new(vec![
+            StorageDecodedSnapshotInstallGroup::new(
+                branch_a,
+                TypeTag::KV,
+                vec![
+                    live("alpha", b"a", Value::Int(10), 7),
+                    live("alpha", b"b", Value::String("value-b".into()), 8),
+                ],
+            ),
+            StorageDecodedSnapshotInstallGroup::new(
+                branch_b,
+                TypeTag::Json,
+                vec![live("docs", b"doc-1", Value::Bool(true), 9)],
+            ),
+        ]);
+
+        let stats = install_decoded_snapshot_rows(StorageDecodedSnapshotInstallInput {
+            storage: &storage,
+            plan: &plan,
+        })
+        .unwrap();
+
+        assert_eq!(
+            stats,
+            StorageDecodedSnapshotInstallStats {
+                groups_installed: 2,
+                rows_installed: 3,
+            }
+        );
+
+        let observed_a = storage
+            .get_versioned(
+                &key(branch_a, "alpha", TypeTag::KV, b"a"),
+                CommitVersion::MAX,
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(observed_a.value, Value::Int(10));
+        assert_eq!(observed_a.version, strata_core::Version::txn(7));
+
+        let observed_b = storage
+            .get_versioned(
+                &key(branch_b, "docs", TypeTag::Json, b"doc-1"),
+                CommitVersion::MAX,
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(observed_b.value, Value::Bool(true));
+        assert_eq!(observed_b.version, strata_core::Version::txn(9));
+    }
+
+    #[test]
+    fn decoded_snapshot_install_preserves_tombstones() {
+        let storage = SegmentedStore::new();
+        let branch_id = branch(3);
+        let plan =
+            StorageDecodedSnapshotInstallPlan::new(vec![StorageDecodedSnapshotInstallGroup::new(
+                branch_id,
+                TypeTag::KV,
+                vec![
+                    live("default", b"deleted", Value::String("before".into()), 4),
+                    tombstone("default", b"deleted", 5),
+                ],
+            )]);
+
+        let stats = install_decoded_snapshot_rows(StorageDecodedSnapshotInstallInput {
+            storage: &storage,
+            plan: &plan,
+        })
+        .unwrap();
+        assert_eq!(stats.rows_installed, 2);
+
+        let deleted_key = key(branch_id, "default", TypeTag::KV, b"deleted");
+        let before_delete = storage
+            .get_versioned(&deleted_key, CommitVersion(4))
+            .unwrap()
+            .unwrap();
+        assert_eq!(before_delete.value, Value::String("before".into()));
+
+        let latest = storage
+            .get_versioned(&deleted_key, CommitVersion::MAX)
+            .unwrap();
+        assert!(
+            latest.is_none(),
+            "decoded tombstone row must hide the older live row"
+        );
+    }
+
+    #[test]
+    fn decoded_snapshot_install_allows_empty_plan() {
+        let storage = SegmentedStore::new();
+        let plan = StorageDecodedSnapshotInstallPlan::default();
+
+        let stats = install_decoded_snapshot_rows(StorageDecodedSnapshotInstallInput {
+            storage: &storage,
+            plan: &plan,
+        })
+        .unwrap();
+
+        assert_eq!(stats, StorageDecodedSnapshotInstallStats::default());
+    }
+
+    #[test]
+    fn decoded_snapshot_install_rejects_empty_group_before_mutation() {
+        let storage = SegmentedStore::new();
+        let branch_id = branch(4);
+        let plan = StorageDecodedSnapshotInstallPlan::new(vec![
+            StorageDecodedSnapshotInstallGroup::new(
+                branch_id,
+                TypeTag::KV,
+                vec![live("default", b"valid-before-invalid", Value::Int(1), 1)],
+            ),
+            StorageDecodedSnapshotInstallGroup::new(branch_id, TypeTag::Graph, Vec::new()),
+        ]);
+
+        let err = install_decoded_snapshot_rows(StorageDecodedSnapshotInstallInput {
+            storage: &storage,
+            plan: &plan,
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            StorageDecodedSnapshotInstallError::EmptyGroup { group_index: 1, .. }
+        ));
+        let observed = storage
+            .get_versioned(
+                &key(branch_id, "default", TypeTag::KV, b"valid-before-invalid"),
+                CommitVersion::MAX,
+            )
+            .unwrap();
+        assert!(
+            observed.is_none(),
+            "preflight failure must not install earlier valid groups"
+        );
+    }
+
+    #[test]
+    fn decoded_snapshot_install_rejects_empty_space_before_mutation() {
+        let storage = SegmentedStore::new();
+        let branch_id = branch(5);
+        let plan =
+            StorageDecodedSnapshotInstallPlan::new(vec![StorageDecodedSnapshotInstallGroup::new(
+                branch_id,
+                TypeTag::KV,
+                vec![
+                    live("default", b"valid-before-invalid", Value::Int(1), 1),
+                    live("", b"invalid-space", Value::Int(2), 2),
+                ],
+            )]);
+
+        let err = install_decoded_snapshot_rows(StorageDecodedSnapshotInstallInput {
+            storage: &storage,
+            plan: &plan,
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            StorageDecodedSnapshotInstallError::EmptySpace {
+                group_index: 0,
+                entry_index: 1,
+                ..
+            }
+        ));
+        let observed = storage
+            .get_versioned(
+                &key(branch_id, "default", TypeTag::KV, b"valid-before-invalid"),
+                CommitVersion::MAX,
+            )
+            .unwrap();
+        assert!(
+            observed.is_none(),
+            "preflight failure must not install earlier valid rows in the same group"
+        );
+    }
+
+    #[test]
+    fn decoded_snapshot_install_rejects_zero_version_before_mutation() {
+        let storage = SegmentedStore::new();
+        let branch_id = branch(6);
+        let plan =
+            StorageDecodedSnapshotInstallPlan::new(vec![StorageDecodedSnapshotInstallGroup::new(
+                branch_id,
+                TypeTag::KV,
+                vec![
+                    live("default", b"valid-before-invalid", Value::Int(1), 1),
+                    live("default", b"zero-version", Value::Int(2), 0),
+                ],
+            )]);
+
+        let err = install_decoded_snapshot_rows(StorageDecodedSnapshotInstallInput {
+            storage: &storage,
+            plan: &plan,
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            StorageDecodedSnapshotInstallError::ZeroVersion {
+                group_index: 0,
+                entry_index: 1,
+                ..
+            }
+        ));
+        let observed = storage
+            .get_versioned(
+                &key(branch_id, "default", TypeTag::KV, b"valid-before-invalid"),
+                CommitVersion::MAX,
+            )
+            .unwrap();
+        assert!(
+            observed.is_none(),
+            "preflight failure must not install earlier valid rows"
+        );
+    }
+
+    #[test]
+    fn decoded_snapshot_install_rejects_duplicate_rows_before_mutation() {
+        let storage = SegmentedStore::new();
+        let branch_id = branch(7);
+        let plan = StorageDecodedSnapshotInstallPlan::new(vec![
+            StorageDecodedSnapshotInstallGroup::new(
+                branch_id,
+                TypeTag::KV,
+                vec![live("default", b"dup", Value::Int(1), 11)],
+            ),
+            StorageDecodedSnapshotInstallGroup::new(
+                branch_id,
+                TypeTag::KV,
+                vec![live("default", b"dup", Value::Int(2), 11)],
+            ),
+        ]);
+
+        let err = install_decoded_snapshot_rows(StorageDecodedSnapshotInstallInput {
+            storage: &storage,
+            plan: &plan,
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            StorageDecodedSnapshotInstallError::DuplicateRow {
+                first_group_index: 0,
+                first_entry_index: 0,
+                duplicate_group_index: 1,
+                duplicate_entry_index: 0,
+                ..
+            }
+        ));
+        let observed = storage
+            .get_versioned(
+                &key(branch_id, "default", TypeTag::KV, b"dup"),
+                CommitVersion::MAX,
+            )
+            .unwrap();
+        assert!(
+            observed.is_none(),
+            "preflight failure must not install the first duplicate row"
+        );
+    }
+
+    #[test]
+    fn decoded_snapshot_install_rejects_duplicate_rows_in_same_group() {
+        let storage = SegmentedStore::new();
+        let branch_id = branch(8);
+        let plan =
+            StorageDecodedSnapshotInstallPlan::new(vec![StorageDecodedSnapshotInstallGroup::new(
+                branch_id,
+                TypeTag::KV,
+                vec![
+                    live("default", b"dup", Value::Int(1), 11),
+                    live("default", b"dup", Value::Int(2), 11),
+                ],
+            )]);
+
+        let err = install_decoded_snapshot_rows(StorageDecodedSnapshotInstallInput {
+            storage: &storage,
+            plan: &plan,
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            StorageDecodedSnapshotInstallError::DuplicateRow {
+                first_group_index: 0,
+                first_entry_index: 0,
+                duplicate_group_index: 0,
+                duplicate_entry_index: 1,
+                ..
+            }
+        ));
+        let observed = storage
+            .get_versioned(
+                &key(branch_id, "default", TypeTag::KV, b"dup"),
+                CommitVersion::MAX,
+            )
+            .unwrap();
+        assert!(
+            observed.is_none(),
+            "preflight failure must not install any duplicate rows"
+        );
+    }
+
+    #[test]
+    fn decoded_snapshot_install_preserves_metadata_and_current_version_across_groups() {
+        let storage = SegmentedStore::new();
+        let branch_a = branch(9);
+        let branch_b = branch(10);
+        let timestamp_micros = 4_200_000;
+        let expired_timestamp_micros = 1_000_000;
+        let plan = StorageDecodedSnapshotInstallPlan::new(vec![
+            StorageDecodedSnapshotInstallGroup::new(
+                branch_a,
+                TypeTag::KV,
+                vec![
+                    live_with_metadata(
+                        "default",
+                        b"timed",
+                        Value::String("kept timestamp".into()),
+                        6,
+                        timestamp_micros,
+                        0,
+                    ),
+                    live_with_metadata(
+                        "default",
+                        b"expired",
+                        Value::String("short ttl".into()),
+                        7,
+                        expired_timestamp_micros,
+                        1,
+                    ),
+                ],
+            ),
+            StorageDecodedSnapshotInstallGroup::new(
+                branch_b,
+                TypeTag::Json,
+                vec![live_with_metadata(
+                    "docs",
+                    b"high-version",
+                    Value::Bool(true),
+                    12,
+                    5_000_000,
+                    0,
+                )],
+            ),
+        ]);
+
+        let stats = install_decoded_snapshot_rows(StorageDecodedSnapshotInstallInput {
+            storage: &storage,
+            plan: &plan,
+        })
+        .unwrap();
+
+        assert_eq!(
+            stats,
+            StorageDecodedSnapshotInstallStats {
+                groups_installed: 2,
+                rows_installed: 3,
+            }
+        );
+        assert_eq!(storage.current_version(), CommitVersion(12));
+
+        let timed = storage
+            .get_at_timestamp(
+                &key(branch_a, "default", TypeTag::KV, b"timed"),
+                timestamp_micros,
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(timed.timestamp.as_micros(), timestamp_micros);
+        assert_eq!(timed.version, strata_core::Version::txn(6));
+        assert_eq!(timed.value, Value::String("kept timestamp".into()));
+
+        let expired = storage
+            .get_at_timestamp(
+                &key(branch_a, "default", TypeTag::KV, b"expired"),
+                expired_timestamp_micros + 1_001,
+            )
+            .unwrap();
+        assert!(
+            expired.is_none(),
+            "decoded snapshot install must preserve TTL metadata"
+        );
+
+        let high_version = storage
+            .get_versioned(
+                &key(branch_b, "docs", TypeTag::Json, b"high-version"),
+                CommitVersion::MAX,
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(high_version.version, strata_core::Version::txn(12));
+    }
+}

--- a/crates/storage/src/durability/disk_snapshot/checkpoint.rs
+++ b/crates/storage/src/durability/disk_snapshot/checkpoint.rs
@@ -32,10 +32,8 @@ impl CheckpointCoordinator {
         codec: Box<dyn StorageCodec>,
         database_uuid: [u8; 16],
     ) -> std::io::Result<Self> {
-        let serializer_codec: Box<dyn StorageCodec> =
-            Box::new(crate::durability::codec::IdentityCodec);
         let snapshot_writer = SnapshotWriter::new(snapshots_dir, codec, database_uuid)?;
-        let serializer = SnapshotSerializer::new(serializer_codec);
+        let serializer = SnapshotSerializer::canonical_primitive_section();
 
         Ok(CheckpointCoordinator {
             snapshot_writer,
@@ -51,10 +49,8 @@ impl CheckpointCoordinator {
         database_uuid: [u8; 16],
         watermark: SnapshotWatermark,
     ) -> std::io::Result<Self> {
-        let serializer_codec: Box<dyn StorageCodec> =
-            Box::new(crate::durability::codec::IdentityCodec);
         let snapshot_writer = SnapshotWriter::new(snapshots_dir, codec, database_uuid)?;
-        let serializer = SnapshotSerializer::new(serializer_codec);
+        let serializer = SnapshotSerializer::canonical_primitive_section();
 
         Ok(CheckpointCoordinator {
             snapshot_writer,
@@ -236,11 +232,39 @@ pub enum CheckpointError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::durability::codec::IdentityCodec;
+    use crate::durability::codec::{CodecError, IdentityCodec};
+    use crate::durability::disk_snapshot::SnapshotReader;
     use crate::durability::format::primitives::{EventSnapshotEntry, KvSnapshotEntry};
 
     fn test_uuid() -> [u8; 16] {
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct PrefixingFileCodec;
+
+    impl StorageCodec for PrefixingFileCodec {
+        fn encode(&self, data: &[u8]) -> Vec<u8> {
+            let mut encoded = b"file-codec:".to_vec();
+            encoded.extend_from_slice(data);
+            encoded
+        }
+
+        fn decode(&self, data: &[u8]) -> Result<Vec<u8>, CodecError> {
+            data.strip_prefix(b"file-codec:")
+                .map(<[u8]>::to_vec)
+                .ok_or_else(|| {
+                    CodecError::decode("missing test prefix", self.codec_id(), data.len())
+                })
+        }
+
+        fn codec_id(&self) -> &str {
+            "prefixing-file-codec"
+        }
+
+        fn clone_box(&self) -> Box<dyn StorageCodec> {
+            Box::new(*self)
+        }
     }
 
     #[test]
@@ -307,6 +331,54 @@ mod tests {
 
         assert_eq!(info.snapshot_id, 1);
         assert_eq!(info.watermark_txn, TxnId(50));
+    }
+
+    #[test]
+    fn checkpoint_primitive_sections_use_canonical_codec_not_snapshot_file_codec() {
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let mut coordinator = CheckpointCoordinator::new(
+            temp_dir.path().to_path_buf(),
+            Box::new(PrefixingFileCodec),
+            test_uuid(),
+        )
+        .unwrap();
+
+        let data = CheckpointData::new().with_kv(vec![KvSnapshotEntry {
+            branch_id: test_uuid(),
+            space: "default".to_string(),
+            type_tag: 0x01,
+            user_key: b"key".to_vec(),
+            value: b"value".to_vec(),
+            version: 7,
+            timestamp: 1_000,
+            ttl_ms: 0,
+            is_tombstone: false,
+        }]);
+        let info = coordinator.checkpoint(TxnId(50), data).unwrap();
+
+        let snapshot = SnapshotReader::new(Box::new(PrefixingFileCodec))
+            .load(&crate::durability::snapshot_path(
+                temp_dir.path(),
+                info.snapshot_id,
+            ))
+            .unwrap();
+        assert_eq!(snapshot.codec_id, "prefixing-file-codec");
+
+        let kv_section = snapshot
+            .sections
+            .iter()
+            .find(|section| section.primitive_type == primitive_tags::KV)
+            .expect("checkpoint must write a KV primitive section");
+        let rows = SnapshotSerializer::canonical_primitive_section()
+            .deserialize_kv(&kv_section.data)
+            .expect("KV section must decode with the canonical primitive-section codec");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].value, b"value");
+        assert!(
+            !rows[0].value.starts_with(b"file-codec:"),
+            "primitive section values must not be encoded with the snapshot header codec"
+        );
     }
 
     #[test]

--- a/crates/storage/src/durability/disk_snapshot/reader.rs
+++ b/crates/storage/src/durability/disk_snapshot/reader.rs
@@ -1,6 +1,11 @@
 //! Snapshot reader for recovery
 //!
 //! Loads and validates snapshot files for database recovery.
+//!
+//! The reader validates the snapshot header codec id against the configured
+//! storage codec. It does not decode section payloads through that codec;
+//! section payload formats are decoded by their owning layer after the
+//! container has been loaded.
 
 use std::fs::File;
 use std::io::{BufReader, Read};
@@ -24,10 +29,10 @@ impl SnapshotReader {
         SnapshotReader { codec }
     }
 
-    /// Load a snapshot from file
+    /// Load a snapshot from file.
     ///
-    /// Validates magic bytes, format version, and codec ID.
-    /// Returns the loaded snapshot data with all sections.
+    /// Validates magic bytes, format version, codec ID, CRC, and section
+    /// framing. Returns the loaded snapshot data with raw section bytes.
     pub fn load(&self, path: &Path) -> Result<LoadedSnapshot, SnapshotReadError> {
         let file = File::open(path)?;
         let metadata = file.metadata()?;
@@ -143,8 +148,9 @@ impl SnapshotReader {
         while cursor < data.len() {
             // Check if we have enough bytes for section header
             if cursor + SectionHeader::SIZE > data.len() {
-                // Might be at the end with no more sections
-                break;
+                return Err(SnapshotReadError::TrailingSectionBytes {
+                    remaining: data.len() - cursor,
+                });
             }
 
             let section_header_bytes: [u8; SectionHeader::SIZE] = data
@@ -335,6 +341,12 @@ pub enum SnapshotReadError {
         expected: usize,
         /// Available data length
         available: usize,
+    },
+    /// Bytes remained after the last complete section.
+    #[error("Trailing snapshot section bytes after complete sections: {remaining} bytes")]
+    TrailingSectionBytes {
+        /// Number of unparsed trailing bytes.
+        remaining: usize,
     },
     /// IO error
     #[error("IO error: {0}")]
@@ -576,6 +588,31 @@ mod tests {
         assert!(matches!(
             result,
             Err(SnapshotReadError::FileTooSmall { .. })
+        ));
+    }
+
+    #[test]
+    fn test_trailing_container_bytes_rejected_after_crc_validation() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("snap-000001.chk");
+        let codec_id = "identity";
+        let header = SnapshotHeader::new(1, 100, 1_700_000, test_uuid(), codec_id.len() as u8);
+
+        let mut bytes = header.to_bytes().to_vec();
+        bytes.extend_from_slice(codec_id.as_bytes());
+        bytes.extend_from_slice(&[0xAA, 0xBB]);
+
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(&bytes);
+        bytes.extend_from_slice(&hasher.finalize().to_le_bytes());
+        std::fs::write(&path, &bytes).unwrap();
+
+        let reader = SnapshotReader::new(Box::new(IdentityCodec));
+        let result = reader.load(&path);
+
+        assert!(matches!(
+            result,
+            Err(SnapshotReadError::TrailingSectionBytes { remaining: 2 })
         ));
     }
 

--- a/crates/storage/src/durability/disk_snapshot/writer.rs
+++ b/crates/storage/src/durability/disk_snapshot/writer.rs
@@ -2,6 +2,11 @@
 //!
 //! Uses write-fsync-rename pattern for atomic snapshot creation.
 //!
+//! The configured storage codec is recorded in the snapshot header as a
+//! database compatibility marker and is validated by `SnapshotReader`. The
+//! snapshot container writes section bytes exactly as provided by the caller;
+//! section payload formats are responsible for their own encoding.
+//!
 //! # Crash Safety
 //!
 //! The snapshot creation follows this pattern:
@@ -23,7 +28,10 @@ use crate::durability::format::snapshot::{snapshot_path, SectionHeader, Snapshot
 #[cfg(test)]
 use crate::durability::format::snapshot::SNAPSHOT_FORMAT_VERSION;
 
-/// Snapshot writer with crash-safe semantics
+/// Snapshot writer with crash-safe semantics.
+///
+/// The `codec` is used for the header codec id only. It does not encode section
+/// bytes; callers must pass already-encoded section payloads.
 pub struct SnapshotWriter {
     snapshots_dir: PathBuf,
     codec: Box<dyn StorageCodec>,

--- a/crates/storage/src/durability/format/primitives.rs
+++ b/crates/storage/src/durability/format/primitives.rs
@@ -9,7 +9,13 @@
 //! Strings are length-prefixed (4-byte length + bytes).
 //! All integers are little-endian.
 
-use crate::durability::codec::StorageCodec;
+use crate::durability::codec::{IdentityCodec, StorageCodec};
+
+/// Codec id used for primitive snapshot section payloads.
+///
+/// This is part of the primitive-section wire format and is intentionally
+/// independent from the storage codec id recorded in the snapshot header.
+pub const CANONICAL_PRIMITIVE_SECTION_CODEC_ID: &str = "identity";
 
 /// Cursor-based reader for length-prefixed binary snapshot data.
 ///
@@ -78,6 +84,17 @@ impl<'a> CursorReader<'a> {
     fn read_blob(&mut self) -> Result<&'a [u8], PrimitiveSerializeError> {
         let len = self.read_u32()? as usize;
         self.read_exact(len)
+    }
+
+    /// Require that the section bytes were consumed exactly.
+    fn finish(&self) -> Result<(), PrimitiveSerializeError> {
+        if self.pos == self.data.len() {
+            Ok(())
+        } else {
+            Err(PrimitiveSerializeError::TrailingData {
+                remaining: self.data.len() - self.pos,
+            })
+        }
     }
 }
 
@@ -257,9 +274,29 @@ pub struct SnapshotSerializer {
 }
 
 impl SnapshotSerializer {
-    /// Create a new serializer with the given codec
+    /// Create a serializer with an explicit primitive-section codec.
+    ///
+    /// This constructor is for tests and explicit custom section formats.
+    /// Checkpoint construction and snapshot install must use
+    /// [`SnapshotSerializer::canonical_primitive_section`] so primitive
+    /// section payloads stay independent from the snapshot header codec id.
     pub fn new(codec: Box<dyn StorageCodec>) -> Self {
         SnapshotSerializer { codec }
+    }
+
+    /// Create the serializer used for checkpoint primitive sections.
+    ///
+    /// Snapshot files may record a non-identity storage codec id in their
+    /// headers. Primitive section payloads remain encoded with this canonical
+    /// serializer so checkpoint construction and snapshot install agree on the
+    /// section payload format.
+    pub fn canonical_primitive_section() -> Self {
+        SnapshotSerializer::new(Box::new(IdentityCodec))
+    }
+
+    /// Return the codec id used by this serializer.
+    pub fn codec_id(&self) -> &str {
+        self.codec.codec_id()
     }
 
     /// Serialize KV entries to bytes (v2 format).
@@ -305,7 +342,7 @@ impl SnapshotSerializer {
     ) -> Result<Vec<KvSnapshotEntry>, PrimitiveSerializeError> {
         let mut r = CursorReader::new(data);
         let count = r.read_u32()? as usize;
-        let mut entries = Vec::with_capacity(count);
+        let mut entries = Vec::new();
         for _ in 0..count {
             let branch_id: [u8; 16] = r.read_exact(16)?.try_into().unwrap();
             let space = r.read_string()?;
@@ -328,6 +365,7 @@ impl SnapshotSerializer {
                 is_tombstone,
             });
         }
+        r.finish()?;
         Ok(entries)
     }
 
@@ -364,7 +402,7 @@ impl SnapshotSerializer {
     ) -> Result<Vec<EventSnapshotEntry>, PrimitiveSerializeError> {
         let mut r = CursorReader::new(data);
         let count = r.read_u32()? as usize;
-        let mut entries = Vec::with_capacity(count);
+        let mut entries = Vec::new();
         for _ in 0..count {
             let branch_id: [u8; 16] = r.read_exact(16)?.try_into().unwrap();
             let space = r.read_string()?;
@@ -381,6 +419,7 @@ impl SnapshotSerializer {
                 timestamp,
             });
         }
+        r.finish()?;
         Ok(entries)
     }
 
@@ -419,7 +458,7 @@ impl SnapshotSerializer {
     ) -> Result<Vec<BranchSnapshotEntry>, PrimitiveSerializeError> {
         let mut r = CursorReader::new(data);
         let count = r.read_u32()? as usize;
-        let mut entries = Vec::with_capacity(count);
+        let mut entries = Vec::new();
         for _ in 0..count {
             let branch_id: [u8; 16] = r.read_exact(16)?.try_into().unwrap();
             let key = r.read_string()?;
@@ -436,6 +475,7 @@ impl SnapshotSerializer {
                 is_tombstone,
             });
         }
+        r.finish()?;
         Ok(entries)
     }
 
@@ -477,7 +517,7 @@ impl SnapshotSerializer {
     ) -> Result<Vec<JsonSnapshotEntry>, PrimitiveSerializeError> {
         let mut r = CursorReader::new(data);
         let count = r.read_u32()? as usize;
-        let mut entries = Vec::with_capacity(count);
+        let mut entries = Vec::new();
         for _ in 0..count {
             let branch_id: [u8; 16] = r.read_exact(16)?.try_into().unwrap();
             let space = r.read_string()?;
@@ -496,6 +536,7 @@ impl SnapshotSerializer {
                 is_tombstone,
             });
         }
+        r.finish()?;
         Ok(entries)
     }
 
@@ -565,7 +606,7 @@ impl SnapshotSerializer {
     ) -> Result<Vec<VectorCollectionSnapshotEntry>, PrimitiveSerializeError> {
         let mut r = CursorReader::new(data);
         let collections_count = r.read_u32()? as usize;
-        let mut collections = Vec::with_capacity(collections_count);
+        let mut collections = Vec::new();
 
         for _ in 0..collections_count {
             let branch_id: [u8; 16] = r.read_exact(16)?.try_into().unwrap();
@@ -576,12 +617,12 @@ impl SnapshotSerializer {
             let config_timestamp = r.read_u64()?;
             let vectors_count = r.read_u32()? as usize;
 
-            let mut vectors = Vec::with_capacity(vectors_count);
+            let mut vectors = Vec::new();
             for _ in 0..vectors_count {
                 let key = r.read_string()?;
                 let vector_id = r.read_u64()?;
                 let dims = r.read_u32()? as usize;
-                let mut embedding = Vec::with_capacity(dims);
+                let mut embedding = Vec::new();
                 for _ in 0..dims {
                     embedding.push(r.read_f32()?);
                 }
@@ -613,6 +654,7 @@ impl SnapshotSerializer {
             });
         }
 
+        r.finish()?;
         Ok(collections)
     }
 }
@@ -630,19 +672,30 @@ pub enum PrimitiveSerializeError {
     /// Codec error
     #[error("Codec error: {0}")]
     Codec(#[from] crate::durability::codec::CodecError),
+    /// Section had extra bytes after the declared entries.
+    #[error("Trailing data after snapshot section: {remaining} bytes")]
+    TrailingData {
+        /// Number of unconsumed bytes.
+        remaining: usize,
+    },
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::durability::codec::IdentityCodec;
 
     fn test_serializer() -> SnapshotSerializer {
-        SnapshotSerializer::new(Box::new(IdentityCodec))
+        SnapshotSerializer::canonical_primitive_section()
     }
 
     fn test_branch(bytes: u8) -> [u8; 16] {
         [bytes; 16]
+    }
+
+    #[test]
+    fn canonical_primitive_section_serializer_uses_identity_codec() {
+        let serializer = SnapshotSerializer::canonical_primitive_section();
+        assert_eq!(serializer.codec_id(), CANONICAL_PRIMITIVE_SECTION_CODEC_ID);
     }
 
     #[test]
@@ -913,6 +966,61 @@ mod tests {
         let result = serializer.deserialize_kv(&[0, 0]);
         assert!(matches!(
             result,
+            Err(PrimitiveSerializeError::UnexpectedEof)
+        ));
+    }
+
+    #[test]
+    fn test_deserialize_rejects_trailing_data() {
+        let serializer = test_serializer();
+        let mut data = 0u32.to_le_bytes().to_vec();
+        data.push(0xff);
+
+        assert!(matches!(
+            serializer.deserialize_kv(&data),
+            Err(PrimitiveSerializeError::TrailingData { remaining: 1 })
+        ));
+        assert!(matches!(
+            serializer.deserialize_events(&data),
+            Err(PrimitiveSerializeError::TrailingData { remaining: 1 })
+        ));
+        assert!(matches!(
+            serializer.deserialize_branches(&data),
+            Err(PrimitiveSerializeError::TrailingData { remaining: 1 })
+        ));
+        assert!(matches!(
+            serializer.deserialize_json(&data),
+            Err(PrimitiveSerializeError::TrailingData { remaining: 1 })
+        ));
+        assert!(matches!(
+            serializer.deserialize_vectors(&data),
+            Err(PrimitiveSerializeError::TrailingData { remaining: 1 })
+        ));
+    }
+
+    #[test]
+    fn test_deserialize_huge_counts_do_not_preallocate() {
+        let serializer = test_serializer();
+        let data = u32::MAX.to_le_bytes();
+
+        assert!(matches!(
+            serializer.deserialize_kv(&data),
+            Err(PrimitiveSerializeError::UnexpectedEof)
+        ));
+        assert!(matches!(
+            serializer.deserialize_events(&data),
+            Err(PrimitiveSerializeError::UnexpectedEof)
+        ));
+        assert!(matches!(
+            serializer.deserialize_branches(&data),
+            Err(PrimitiveSerializeError::UnexpectedEof)
+        ));
+        assert!(matches!(
+            serializer.deserialize_json(&data),
+            Err(PrimitiveSerializeError::UnexpectedEof)
+        ));
+        assert!(matches!(
+            serializer.deserialize_vectors(&data),
             Err(PrimitiveSerializeError::UnexpectedEof)
         ));
     }

--- a/crates/storage/src/durability/mod.rs
+++ b/crates/storage/src/durability/mod.rs
@@ -13,6 +13,7 @@ mod checkpoint_runtime;
 pub mod codec;
 mod commit_adapter;
 pub mod compaction;
+mod decoded_snapshot_install;
 pub mod disk_snapshot;
 pub mod format;
 pub mod layout;
@@ -42,6 +43,13 @@ pub use checkpoint_runtime::{
     StorageFlushWalTruncationOutcome, StorageManifestRuntimeError, StorageManifestSyncInput,
     StorageSnapshotPruneError, StorageSnapshotRetention, StorageWalCompactionError,
     StorageWalCompactionInput, StorageWalCompactionOutcome,
+};
+
+// Decoded snapshot install runtime
+pub use decoded_snapshot_install::{
+    install_decoded_snapshot_rows, StorageDecodedSnapshotInstallError,
+    StorageDecodedSnapshotInstallGroup, StorageDecodedSnapshotInstallInput,
+    StorageDecodedSnapshotInstallPlan, StorageDecodedSnapshotInstallStats,
 };
 
 // Codec

--- a/docs/engine/engine-storage-boundary-normalization-plan.md
+++ b/docs/engine/engine-storage-boundary-normalization-plan.md
@@ -367,8 +367,10 @@ Keep in engine:
 
 ### Goal
 
-Move generic snapshot decode, section iteration, and install/replay mechanics
-from engine into storage.
+Normalize the snapshot install boundary without moving primitive semantics into
+storage. Engine keeps `LoadedSnapshot` section dispatch and primitive snapshot
+DTO decode. Storage owns only the generic mechanics for installing already
+decoded storage rows into `SegmentedStore`.
 
 Potential detailed execution plan:
 
@@ -378,15 +380,18 @@ Potential detailed execution plan:
 
 Move downward into storage where generic:
 
-- snapshot section reading
-- snapshot record decoding
-- installation into `SegmentedStore`
-- replay-safe batch application
-- storage-local snapshot install errors
-- raw install statistics
+- validation of decoded storage row groups before mutation
+- installation of decoded rows into `SegmentedStore`
+- generic row/group install statistics
+- storage-local errors for invalid generic row input and lower storage install
+  failure
 
 Keep in engine:
 
+- `LoadedSnapshot` section iteration
+- primitive tag dispatch
+- `SnapshotSerializer` primitive DTO decode
+- primitive-specific snapshot install statistics
 - decisions about when a snapshot should be installed
 - recovery policy around degraded or lossy outcomes
 - public error/report conversion
@@ -394,10 +399,14 @@ Keep in engine:
 
 ### Deliverables
 
-1. Storage-owned snapshot install/replay module or API.
-2. Engine recovery/open code calling storage for raw install mechanics.
-3. Tests proving existing snapshots still install and recover identically.
-4. Compatibility coverage for existing snapshot sections.
+1. Storage-owned decoded-row install API.
+2. Engine snapshot install code that builds a complete decoded storage-row plan
+   before any storage mutation.
+3. Engine recovery/open code calling storage only for generic row install
+   mechanics.
+4. Tests proving existing snapshots still install and recover identically.
+5. Guardrails proving storage install code does not import primitive snapshot
+   DTOs, primitive tags, or `SnapshotSerializer`.
 
 ### Constraints
 
@@ -408,10 +417,12 @@ Keep in engine:
 
 ### Acceptance
 
-- `database/snapshot_install.rs` is deleted or reduced to engine policy
-  glue
-- storage owns the generic snapshot install machinery
-- engine still owns recovery decisions and public reporting
+- `database/snapshot_install.rs` is reduced to intentional engine-owned
+  primitive decode, install policy, and public error mapping glue
+- storage owns the generic decoded-row install machinery
+- engine still owns primitive decode, recovery decisions, and public reporting
+- storage install modules do not import primitive snapshot DTOs, primitive
+  tags, or `SnapshotSerializer`
 - snapshot install round-trip characterization exists before
   behavior-preserving refactors land
 

--- a/docs/engine/es1-boundary-baseline-and-guardrails-plan.md
+++ b/docs/engine/es1-boundary-baseline-and-guardrails-plan.md
@@ -146,44 +146,52 @@ checkpoint runtime around that materialized data.
 
 ## Inventory: `database/snapshot_install.rs`
 
-This module is mostly storage-shaped replay/install machinery, with some
-primitive-section caution.
+This module looked storage-shaped during ES1 because it installs rows into
+`SegmentedStore`, but the ES3 deep pass corrected the boundary: primitive
+section dispatch and DTO decode are engine concerns. Storage owns only the
+generic decoded-row install helper that starts after engine has produced
+storage rows.
 
 | Surface | Current role | Classification | Target epic |
 |---|---|---|---|
-| `InstallStats` | Raw counts of installed entries by snapshot section. | Move Storage | ES3 |
-| `InstallStats::total_installed` | Raw aggregate count. | Move Storage | ES3 |
-| `install_snapshot` | Iterates loaded snapshot sections, routes by primitive tag, installs into `SegmentedStore`. | Move Storage, with semantic review | ES3 |
-| `install_kv_section` | Decodes KV section, preserves tombstones/TTL, dispatches by `TypeTag`. | Move Storage | ES3 |
-| `install_event_section` | Decodes Event section and reconstructs event user keys from sequence numbers. | Move Storage, Watch | ES3 |
-| `install_json_section` | Decodes JSON section and installs doc IDs as user keys. | Move Storage, Watch | ES3 |
-| `install_branch_section` | Decodes branch snapshot section and installs branch metadata rows. | Move Storage, Watch | ES3 |
-| `install_vector_section` | Decodes vector collection/config rows and reinstalls raw vector record bytes. | Move Storage, Watch | ES3 |
-| `decode_value_json` | Decodes persisted `Value` bytes from snapshot sections. | Move Storage | ES3 |
+| `InstallStats` | Primitive-specific counts of entries installed by decoded snapshot section. | Stay Engine | ES3 |
+| `InstallStats::total_installed` | Engine invariant over primitive-specific counters. | Stay Engine | ES3 |
+| `install_snapshot` | Engine wrapper: validates codec policy, decodes primitive sections, builds generic storage-row plan, calls storage install helper. | Stay Engine, Split | ES3 |
+| `decode_kv_section` | Decodes KV section, preserves tombstones/TTL, dispatches by `TypeTag`. | Stay Engine | ES3 |
+| `decode_event_section` | Decodes Event section and reconstructs event user keys from sequence numbers. | Stay Engine | ES3 |
+| `decode_json_section` | Decodes JSON section and installs doc IDs as user keys. | Stay Engine | ES3 |
+| `decode_branch_section` | Decodes branch snapshot section and installs branch metadata rows. | Stay Engine | ES3 |
+| `decode_vector_section` | Decodes vector collection/config rows and reinstalls raw vector record bytes. | Stay Engine | ES3 |
+| `decode_value_json` | Decodes persisted `Value` bytes from primitive snapshot sections. | Stay Engine | ES3 |
+| `install_decoded_snapshot_rows` | Validates and installs already-decoded generic storage rows. | Move Storage | ES3 |
 
 ### ES3 split decision
 
-The install path is a stronger storage candidate than the checkpoint collector
-because it mostly performs inverse persistence mechanics:
+The original ES1 instinct was to move most of the install path downward because
+it performs inverse persistence mechanics:
 
 - decode snapshot section DTOs
 - reconstruct storage keys
 - preserve tombstones, TTL, versions, and timestamps
 - call `SegmentedStore::install_snapshot_entries`
 
-The caution is that section names correspond to engine primitives. This is
-acceptable only if storage treats them as persistence section tags and storage
-type tags, not as semantic behavior.
+ES3 tightened that caution into the actual ownership rule. The primitive DTO
+decode remains engine-owned because `KV`, `Event`, `Json`, `Vector`, `Branch`,
+and Graph-as-KV routing are engine primitive persistence semantics, not generic
+storage mechanics. Storage receives only generic decoded row groups.
 
 Storage may know:
 
-- primitive section byte tags
-- snapshot DTO schemas
-- `TypeTag`
-- raw key reconstruction needed to restore bytes
+- `TypeTag` as an opaque storage-family router
+- `DecodedSnapshotEntry`
+- tombstones, TTLs, versions, timestamps, spaces, and user keys
+- generic preflight validation and row installation
 
 Storage must not learn:
 
+- primitive section byte tags
+- primitive snapshot DTO schemas
+- `SnapshotSerializer`
 - JSON path behavior
 - event-chain verification
 - vector metric/model policy
@@ -412,24 +420,39 @@ Engine responsibilities remain:
 
 ### ES3 snapshot install
 
-Candidate module:
+Settled modules:
 
 ```text
-crates/storage/src/durability/snapshot_install.rs
+crates/engine/src/database/snapshot_install.rs
+crates/storage/src/durability/decoded_snapshot_install.rs
 ```
 
-Candidate surfaces:
+Settled surfaces:
 
 ```text
-SnapshotInstallStats
-install_loaded_snapshot(snapshot, codec, storage) -> StorageResult<SnapshotInstallStats>
+engine::database::install_snapshot(snapshot, codec, storage) -> StrataResult<InstallStats>
+storage::durability::install_decoded_snapshot_rows(input)
+    -> Result<StorageDecodedSnapshotInstallStats, StorageDecodedSnapshotInstallError>
 ```
 
-Engine responsibilities remain:
+Engine responsibilities:
 
+- iterate `LoadedSnapshot.sections`
+- dispatch by primitive section tags
+- decode primitive snapshot DTOs with `SnapshotSerializer`
+- reconstruct primitive-owned storage row keys
+- retain primitive-specific `InstallStats`
 - decide when install runs
 - log recovery outcome
 - classify install failure in recovery policy
+
+Storage responsibilities:
+
+- validate generic decoded row groups before mutation
+- install already-decoded rows into `SegmentedStore`
+- return generic row/group stats and storage-local errors
+- avoid `LoadedSnapshot`, `SnapshotSerializer`, primitive tags, and primitive
+  snapshot DTOs in runtime install modules
 
 ### ES4 recovery bootstrap
 
@@ -545,7 +568,9 @@ Expected behavior:
 - ES1: matches are expected and form the baseline
 - ES2: checkpoint/compaction matches should disappear or remain only in
   engine wrappers
-- ES3: snapshot install matches should disappear from engine mechanics
+- ES3: `SnapshotSerializer` and `install_snapshot` remain only as intentional
+  engine-owned primitive decode and recovery policy residue; storage install
+  modules must not import primitive snapshot DTOs or tags
 - ES4: recovery coordinator and manifest-prep mechanics should move down or
   become storage API calls
 - ES5: `apply_storage_config` should disappear from engine

--- a/docs/engine/es2-es4-storage-runtime-boundary-api-sketch.md
+++ b/docs/engine/es2-es4-storage-runtime-boundary-api-sketch.md
@@ -230,48 +230,56 @@ No checkpoint exists yet. Run checkpoint() before compact().
 Candidate module:
 
 ```text
-crates/storage/src/durability/snapshot_install.rs
+crates/storage/src/durability/decoded_snapshot_install.rs
 ```
 
-Candidate input:
+Storage candidate input:
 
 ```text
-StorageSnapshotInstallInput<'a> {
-    snapshot: &'a LoadedSnapshot,
-    codec: &'a dyn StorageCodec,
+StorageDecodedSnapshotInstallInput<'a> {
     storage: &'a SegmentedStore,
+    plan: &'a StorageDecodedSnapshotInstallPlan,
+}
+
+StorageDecodedSnapshotInstallPlan {
+    groups: Vec<StorageDecodedSnapshotInstallGroup>,
+}
+
+StorageDecodedSnapshotInstallGroup {
+    branch_id: BranchId,
+    type_tag: TypeTag,
+    entries: Vec<DecodedSnapshotEntry>,
 }
 ```
 
-Candidate output:
+Storage candidate output:
 
 ```text
-StorageSnapshotInstallStats {
-    kv_rows: usize,
-    graph_rows: usize,
-    event_rows: usize,
-    json_rows: usize,
-    vector_config_rows: usize,
-    vector_rows: usize,
-    branch_rows: usize,
-    sections_skipped: usize,
+StorageDecodedSnapshotInstallStats {
+    groups_installed: usize,
+    rows_installed: usize,
 }
 ```
 
-These names are physical snapshot/storage counters, not engine semantic
-reports. Storage may know snapshot section tags, `TypeTag`, raw key
-reconstruction, tombstones, TTLs, versions, and timestamps.
+The storage API starts after primitive snapshot decode. It may know
+`SegmentedStore`, `TypeTag` as an opaque storage-family router,
+`DecodedSnapshotEntry`, tombstones, TTLs, versions, and timestamps.
 
 Storage must not learn:
 
+- `LoadedSnapshot` install policy
+- `SnapshotSerializer`
+- primitive snapshot DTOs such as `KvSnapshotEntry`
+- primitive section tags such as `primitive_tags::KV`
 - JSON path or patch semantics
 - event-chain verification
 - vector metric/model policy
 - branch workflow policy
 - graph query semantics
 
-The ES3 install API should become the function ES4 recovery calls when the
-`RecoveryCoordinator` supplies a loaded snapshot.
+Engine remains responsible for converting a loaded snapshot into this generic
+storage-row plan. The ES3 engine wrapper should become the function ES4
+recovery calls when the `RecoveryCoordinator` supplies a loaded snapshot.
 
 ## ES4 Recovery Boundary
 
@@ -291,6 +299,11 @@ StorageRecoveryInput {
     write_buffer_size: usize,
     runtime_config: StorageRuntimeConfig,
     lossy_wal_replay: bool,
+    on_loaded_snapshot: RecoverySnapshotCallback,
+}
+
+RecoverySnapshotCallback {
+    on_snapshot(snapshot: &LoadedSnapshot, storage: &SegmentedStore) -> Result<(), StorageError>,
 }
 ```
 
@@ -319,11 +332,16 @@ StorageRecoveryOutcome {
     wal_codec: Box<dyn StorageCodec>,
     storage: SegmentedStore,
     wal_replay: RecoveryStats,
-    snapshot_install: Option<StorageSnapshotInstallStats>,
     segment_recovery: RecoveredState,
     lossy_wal_replay: Option<StorageLossyWalReplayFacts>,
 }
 ```
+
+`StorageRecoveryOutcome` intentionally does not contain primitive snapshot
+install stats. Storage invokes the engine-supplied `on_loaded_snapshot`
+callback when recovery loads a snapshot, but storage does not inspect or own
+the callback's primitive decode counters. If engine needs install telemetry, it
+captures `InstallStats` in the engine wrapper that supplies the callback.
 
 Candidate lossy facts:
 
@@ -367,7 +385,7 @@ Storage recovery must also preserve the current ordering around storage
 configuration:
 
 ```text
-snapshot install / WAL replay
+engine snapshot callback / WAL replay
 snapshot-version fold
 apply StorageRuntimeConfig to SegmentedStore
 recover_segments()
@@ -410,13 +428,15 @@ StorageCheckpointOutcome
     -> WAL compaction consumes MANIFEST watermark to delete covered WAL
     -> recovery uses MANIFEST snapshot_id/watermark to install snapshot and skip WAL
 
-StorageSnapshotInstallStats
-    -> returned by standalone snapshot install in ES3
-    -> embedded in StorageRecoveryOutcome in ES4 when recovery installs a snapshot
+StorageDecodedSnapshotInstallStats
+    -> returned by storage decoded-row install in ES3
+    -> may be observed inside the engine snapshot callback
+    -> is not embedded in StorageRecoveryOutcome because storage recovery does
+       not own primitive decode or primitive install telemetry
 
 StorageRecoveryOutcome
-    -> returns raw WAL replay stats, optional snapshot install stats,
-       segmented-store recovery health, and optional lossy replay facts
+    -> returns raw WAL replay stats, segmented-store recovery health, and
+       optional lossy replay facts
     -> engine builds coordinator, reports, and public open result
 ```
 
@@ -429,7 +449,7 @@ StorageCheckpointError
 StorageWalCompactionError
 StorageManifestRuntimeError
 StorageFlushWalTruncationError
-StorageSnapshotInstallError
+StorageDecodedSnapshotInstallError
 StorageRecoveryError
 StorageSnapshotPruneError
 ```

--- a/docs/engine/es3-snapshot-decode-install-mechanics-plan.md
+++ b/docs/engine/es3-snapshot-decode-install-mechanics-plan.md
@@ -1,0 +1,588 @@
+# ES3 Snapshot Install Boundary Plan
+
+## Purpose
+
+`ES3` is the second runtime cleanup epic in the engine/storage boundary
+normalization workstream.
+
+The original ES3 direction was too broad: it would have moved primitive
+snapshot section decode into `strata-storage`. That creates the inverse of the
+current problem. Instead of engine owning storage mechanics, storage would
+start owning engine primitive concerns.
+
+This revised ES3 keeps the ownership rule strict:
+
+```text
+storage owns durable row mechanics
+engine owns primitive meaning and primitive persistence encodings
+```
+
+The goal is to extract only the generic decoded-row install mechanics that
+belong to storage, while keeping snapshot primitive section dispatch and decode
+in engine.
+
+Read this together with:
+
+- [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
+- [es1-boundary-baseline-and-guardrails-plan.md](./es1-boundary-baseline-and-guardrails-plan.md)
+- [es2-es4-storage-runtime-boundary-api-sketch.md](./es2-es4-storage-runtime-boundary-api-sketch.md)
+- [es2-checkpoint-wal-compaction-mechanics-plan.md](./es2-checkpoint-wal-compaction-mechanics-plan.md)
+- [../storage/storage-engine-ownership-audit.md](../storage/storage-engine-ownership-audit.md)
+- [../storage/storage-charter.md](../storage/storage-charter.md)
+- [../architecture/architecture-recovery-target.md](../architecture/architecture-recovery-target.md)
+
+## Boundary Rule
+
+Storage may know:
+
+- `SegmentedStore`
+- branch ids as storage routing identifiers
+- storage family identifiers such as the existing `TypeTag`
+- namespace space strings
+- opaque user-key bytes
+- `DecodedSnapshotEntry`
+- `DecodedSnapshotValue`
+- commit version, timestamp, TTL, and tombstone metadata
+- generic decoded row groups
+- filesystem/container mechanics for WALs, snapshots, manifests, and segments
+- storage-local errors for row install failures
+
+Storage must not know:
+
+- primitive snapshot section dispatch
+- `primitive_tags::EVENT`, `primitive_tags::JSON`, `primitive_tags::VECTOR`,
+  `primitive_tags::BRANCH`, or graph-as-KV meaning in install logic
+- `EventSnapshotEntry`, `JsonSnapshotEntry`, `VectorSnapshotEntry`,
+  `BranchSnapshotEntry`, or `KvSnapshotEntry` decode during install
+- Event sequence-key reconstruction
+- JSON doc-id key reconstruction
+- Vector config key or vector record key conventions
+- Branch metadata key conventions
+- Graph row interpretation beyond receiving an already selected storage family
+- `SnapshotSerializer` use for primitive sections inside storage install logic
+- public `StrataError`, recovery reports, lossy/degraded policy, or operator
+  guidance
+
+`TypeTag` is an existing storage family identifier with primitive-shaped
+variant names. ES3 should not expand that leak. Storage install code may carry
+`TypeTag` as an opaque routing value because `SegmentedStore` already uses it,
+but it should not branch on primitive-specific variants for snapshot install
+statistics or behavior. A later cleanup can consider replacing this with an
+opaque storage family id.
+
+## ES3 Verdict
+
+The following should remain in `strata-engine`:
+
+- `LoadedSnapshot` section iteration for install
+- dispatch by `primitive_tags`
+- primitive section decode through `SnapshotSerializer`
+- choice of canonical primitive-section codec
+- KV snapshot DTO decode
+- graph-as-KV interpretation through `TypeTag::Graph`
+- Event sequence-key reconstruction
+- JSON doc-id key reconstruction
+- Branch metadata row reconstruction
+- Vector config and vector record row reconstruction
+- primitive-specific install stats
+- mapping decode failures to public engine corruption errors
+- deciding when snapshot install runs
+- recovery callback wiring around `RecoveryCoordinator`
+- lossy/degraded recovery policy
+- database lifecycle orchestration and operator-facing logging
+
+The following may move to `strata-storage`:
+
+- installing an already-decoded set of storage row groups into
+  `SegmentedStore`
+- generic preflight validation of decoded row groups before mutation
+- generic row install stats such as total rows and groups installed
+- storage-local install errors around invalid generic input and
+  `SegmentedStore` write failures
+
+The important distinction is that engine converts primitive snapshot sections
+into generic storage rows. Storage only installs those rows.
+
+## Existing Code Map
+
+The ES3 target surface is concentrated in:
+
+- [database/snapshot_install.rs](../../crates/engine/src/database/snapshot_install.rs)
+- [database/recovery.rs](../../crates/engine/src/database/recovery.rs)
+- `SegmentedStore::install_snapshot_entries`
+
+Existing storage format modules already define snapshot DTOs and primitive tag
+constants. ES3 does not need to erase that existing format ownership. The line
+is runtime behavior: storage should not gain a runtime snapshot installer that
+decodes or interprets those primitive sections.
+
+## Target Shape
+
+Engine should continue to expose its current recovery-facing helper while ES3
+is in progress:
+
+```text
+engine::database::install_snapshot(
+    snapshot: &LoadedSnapshot,
+    codec: &dyn StorageCodec,
+    storage: &SegmentedStore,
+) -> StrataResult<EngineSnapshotInstallStats>
+```
+
+Inside that helper, engine should do two separate phases:
+
+```text
+decoded_plan = engine_decode_snapshot_sections(snapshot)
+storage_stats = storage::install_decoded_snapshot_rows(decoded_plan, storage)
+engine_stats = merge primitive decode stats + storage install stats
+```
+
+The storage API should take only generic decoded rows:
+
+```text
+StorageDecodedSnapshotInstallInput<'a> {
+    plan: &'a StorageDecodedSnapshotInstallPlan,
+    storage: &'a SegmentedStore,
+}
+
+StorageDecodedSnapshotInstallPlan {
+    groups: Vec<StorageDecodedSnapshotInstallGroup>,
+}
+
+StorageDecodedSnapshotInstallGroup {
+    branch_id: BranchId,
+    type_tag: TypeTag,
+    entries: Vec<DecodedSnapshotEntry>,
+}
+
+StorageDecodedSnapshotInstallStats {
+    groups_installed: usize,
+    rows_installed: usize,
+}
+```
+
+Names can change during implementation, but the API must not accept
+`LoadedSnapshot`, `SnapshotSerializer`, primitive tags, or primitive DTOs.
+
+## Codec Contract
+
+There are two codec markers involved in snapshot recovery:
+
+- Snapshot container codec id: the codec id recorded in the snapshot file
+  header and validated by `SnapshotReader` as a database compatibility marker.
+  The snapshot container does not encode section bytes through this codec.
+- Primitive section codec: the codec used by `SnapshotSerializer` for section
+  DTO payloads.
+
+Checkpoint construction currently serializes primitive section DTOs with the
+canonical identity section codec, while the snapshot header records the
+configured storage codec id. Therefore snapshot install must not decode
+primitive sections with the snapshot header codec.
+
+Ownership:
+
+- Storage may own snapshot file container read/write mechanics and codec-id
+  validation.
+- Engine owns primitive section decode during install.
+- Engine should use the same canonical primitive-section codec that checkpoint
+  construction used.
+- `SnapshotReader` remains responsible for snapshot header codec validation
+  before engine receives `LoadedSnapshot`.
+
+ES3 must add characterization for non-identity snapshot files so this contract
+does not regress.
+
+## Partial Mutation Contract
+
+Corrupt snapshot data must not partially mutate storage.
+
+The corrected flow is:
+
+```text
+engine decodes every section
+engine validates every primitive row conversion
+engine builds complete generic storage row plan
+storage validates generic row groups
+storage mutates SegmentedStore
+```
+
+Decode failures, unknown primitive tags, invalid KV `TypeTag` bytes, corrupt
+JSON `Value` payloads, and primitive DTO shape errors should all fail before
+any storage write.
+
+Storage does not need to understand why a plan was produced. It only needs to
+avoid mutating on generic input validation failures that it can detect before
+calling `SegmentedStore::install_snapshot_entries`.
+
+Generic storage preflight validation should include empty groups, empty storage
+space names, reserved zero commit versions, and duplicate row identities across
+the complete plan. The duplicate identity is only storage routing data:
+`(branch_id, storage_family, space, user_key, version)`.
+
+## Stats Contract
+
+Engine may keep primitive-specific stats:
+
+```text
+EngineSnapshotInstallStats {
+    kv_rows
+    graph_rows
+    event_rows
+    json_rows
+    vector_config_rows
+    vector_rows
+    branch_rows
+    sections_skipped
+}
+```
+
+Storage stats should be generic:
+
+```text
+StorageDecodedSnapshotInstallStats {
+    groups_installed
+    rows_installed
+}
+```
+
+Storage should not return `json_rows`, `vector_rows`, `event_rows`, or similar
+primitive-shaped counters.
+
+## Error Contract
+
+Engine owns errors for primitive decode and public recovery interpretation:
+
+- unknown primitive tag
+- corrupt primitive section payload
+- corrupt JSON-encoded `Value`
+- invalid type tag byte in KV snapshot DTO
+- public `StrataError`
+- lossy/degraded classification
+
+Storage owns errors for generic decoded-row install mechanics:
+
+```text
+StorageDecodedSnapshotInstallError {
+    EmptyGroup { ... }
+    EmptySpace { ... }
+    ZeroVersion { ... }
+    DuplicateRow { ... }
+    RowCountMismatch { ... }
+    Install { storage_family, source }
+}
+```
+
+The exact shape can change, but storage-local errors must be
+`#[non_exhaustive]` if public, must not mention primitive names, and must not
+mention engine policy.
+
+## Explicit Behavior Changes
+
+ES3 is primarily a boundary cleanup, but two strictness changes intentionally
+land with it because they close recovery/snapshot correctness gaps exposed by
+the new characterization:
+
+- Recovery now hard-fails if a loaded snapshot reaches the engine install
+  callback without an install codec. `None` is still used for deliberate
+  no-snapshot paths such as primary first-open and follower-without-MANIFEST;
+  those paths have no manifest-recorded snapshot, so the callback should not
+  fire. If it does, silently skipping snapshot install would be data loss.
+- Snapshot primitive deserializers and the outer snapshot section parser reject
+  trailing bytes after the declared entries/sections. Writers do not emit those
+  bytes, so this is a strict-input hardening change rather than a format change
+  for valid snapshots.
+
+The same format-hardening pass also removes declared-count preallocation from
+primitive deserializers so hostile counts fail by EOF instead of requesting huge
+allocations. That is defensive implementation detail, not a new boundary owner.
+
+## Implementation Plan
+
+ES3 restarts from `ES3A`. Each phase is a straight lettered slice.
+
+### ES3A Snapshot Install Characterization Rebaseline
+
+Restore the pre-move crate state and pin current behavior in engine before any
+new extraction.
+
+Coverage should include:
+
+- KV section installs live entries
+- KV section preserves commit version and timestamp
+- KV section preserves tombstones
+- KV section preserves TTL
+- KV section routes graph-as-KV rows into graph storage
+- invalid KV `TypeTag` returns a hard error
+- Event section reconstructs big-endian sequence keys
+- JSON section uses doc id as the user key
+- JSON section preserves tombstones
+- Branch section installs branch metadata rows
+- Branch section preserves branch tombstones
+- Vector section installs collection config rows
+- Vector section installs raw vector record rows
+- Vector section preserves vector tombstones
+- standalone non-empty Graph section preserves current skip behavior if still
+  compatible
+- unknown primitive section tag returns a hard error
+- corrupt section payloads return section-specific decode errors
+- corrupt JSON-encoded `Value` payloads return section-specific value errors
+- checkpoint + compact + reopen preserves tombstones, TTL, and branch metadata
+- follower open installs checkpoint snapshot before delta WAL replay
+- non-identity snapshot header codec id does not drive primitive section decode
+- invalid later section does not partially install earlier valid sections
+- invalid KV type tag does not partially install earlier valid KV rows
+
+ES3A should not move code into storage. It should make the existing behavior
+and the desired no-partial-mutation behavior explicit.
+
+Because the pre-ES3A engine installer decoded and mutated section-by-section,
+some ES3A characterization targets cannot be made true with tests alone. ES3A
+may therefore include engine-local fixes that do not move code across the
+storage boundary:
+
+- build the complete engine decoded-row plan before calling storage
+- validate KV-section `TypeTag` bytes before mutation
+- keep primitive section decode on the canonical checkpoint section codec
+
+If those fixes land during ES3A, the later ES3C and ES3D phases should be
+treated as phase-accounting checkpoints rather than reimplemented work.
+
+### ES3B Generic Storage Row Install Surface
+
+Add a storage-owned helper that installs already-decoded generic row groups.
+
+Allowed storage inputs:
+
+- `BranchId`
+- `TypeTag` as an opaque storage family id
+- `DecodedSnapshotEntry`
+- `SegmentedStore`
+
+Forbidden storage inputs:
+
+- `LoadedSnapshot`
+- `SnapshotSerializer`
+- `primitive_tags`
+- primitive snapshot DTOs
+- primitive-specific stats
+
+Storage tests should use synthetic decoded row groups. They should not build
+snapshot primitive sections.
+
+ES3B is complete when storage can install generic decoded row groups without
+knowing which primitive produced them.
+
+### ES3C Engine Decode Plan Extraction
+
+Refactor engine `database::snapshot_install` into a decode-then-install flow.
+
+If ES3A already introduced this engine-local decode plan to satisfy
+no-partial-mutation characterization, ES3C should verify and preserve that
+shape while integrating the storage generic row install surface from ES3B.
+
+Engine should:
+
+- iterate `LoadedSnapshot.sections`
+- dispatch by primitive section tag
+- decode each primitive DTO section
+- reconstruct storage row keys
+- decode JSON `Value` blobs where required by the existing format
+- validate `TypeTag` bytes before any storage write
+- build a full generic storage row install plan
+- retain primitive-specific stats
+
+This phase should fix partial mutation from corrupt snapshots by ensuring the
+full plan is built before calling the storage helper.
+
+### ES3D Canonical Section Codec Fix
+
+Make the engine decode plan use the canonical primitive-section codec used by
+checkpoint construction, not the snapshot header codec id.
+
+If ES3A already made this codec separation explicit, ES3D should retain the
+coverage and ensure the new ES3B storage install surface does not reintroduce
+snapshot header codec use for primitive section payloads.
+
+Add or keep tests proving:
+
+- an AES/non-identity snapshot file can be loaded with the configured storage
+  codec id
+- primitive sections inside that snapshot are decoded with the canonical
+  section codec
+- checkpoint + compact + reopen restores rows from the snapshot-only path
+
+If this fix naturally lands with ES3C, the PR should still call it out as the
+ES3D acceptance item.
+
+### ES3E Recovery Wrapper Integration
+
+Wire the engine snapshot install helper to call the generic storage row install
+surface after engine decode succeeds.
+
+Engine keeps:
+
+- `install_codec` option handling
+- recovery callback ownership
+- snapshot-id and watermark logging
+- primitive-specific install stats
+- storage error mapping into the current callback error type
+- lossy/degraded recovery classification
+
+Storage keeps:
+
+- decoded row group install mechanics only
+
+### ES3F Residue Cleanup And Guards
+
+Clean up duplicate code and document intentional residue.
+
+Expected result:
+
+- engine still owns primitive snapshot decode
+- storage owns only generic decoded row install
+- no storage snapshot install module imports `SnapshotSerializer`
+- no storage snapshot install module imports `primitive_tags`
+- no storage snapshot install module imports primitive snapshot DTOs
+- engine recovery/open MANIFEST policy remains until ES4
+
+Intentional ES3 residue after cleanup:
+
+- `crates/engine/src/database/snapshot_install.rs` keeps
+  `SnapshotSerializer`, `primitive_tags`, primitive snapshot DTO decode, and
+  primitive-specific `InstallStats`. This is the desired boundary because the
+  section layout encodes engine primitive persistence semantics.
+- `crates/storage/src/durability/decoded_snapshot_install.rs` is the only new
+  storage install surface. It accepts `StorageDecodedSnapshotInstallPlan`
+  values made of generic row groups and must not import primitive tags,
+  primitive snapshot DTOs, `LoadedSnapshot`, or `SnapshotSerializer`.
+- `crates/storage/src/durability/format/*` and
+  `crates/storage/src/durability/disk_snapshot/*` may still define and carry
+  primitive snapshot tags/DTOs as on-disk format and container mechanics. That
+  is not runtime install ownership.
+- The strict trailing-data checks and count-preallocation removal in the
+  snapshot format/container modules are intentional format-hardening residue
+  bundled with ES3. They do not move primitive install semantics into storage.
+- `RecoveryCoordinator`, MANIFEST/open policy, and recovery outcome mapping
+  remain engine/recovery residue for ES4.
+
+## Guardrails
+
+Run these ownership checks after each implementation phase that touches
+storage install code:
+
+```sh
+rg -n 'use strata_engine|strata_engine::|strata-engine' crates/storage/src crates/storage/Cargo.toml
+rg -n 'SnapshotSerializer|primitive_tags|KvSnapshotEntry|EventSnapshotEntry|JsonSnapshotEntry|VectorSnapshotEntry|BranchSnapshotEntry|LoadedSnapshot' crates/storage/src/durability -g '*install*.rs'
+rg -n 'JsonPath|JsonPatch|SearchSubsystem|Recipe|VectorConfig|DistanceMetric|ChainVerification|BranchLifecycle|RetentionReport|HealthReport|executor' crates/storage/src
+```
+
+Interpretation:
+
+- Existing format modules may legitimately define primitive snapshot DTOs and
+  tag constants.
+- Generic install modules must not use those DTOs or tags. The `*install*.rs`
+  guard is intentionally broader than the current
+  `decoded_snapshot_install.rs` file so a future storage install module cannot
+  bypass the ES3 boundary by choosing a new filename.
+- Any new match in storage outside established format/container code needs an
+  explicit boundary justification.
+- A broad search over all `crates/storage/src/durability` is still useful as an
+  audit, but it is expected to report established format/container modules.
+
+Run these engine residue checks:
+
+```sh
+rg -n 'install_decoded_snapshot|StorageDecodedSnapshotInstall' crates/engine/src/database
+rg -n 'RecoveryCoordinator|ManifestManager|apply_storage_config' crates/engine/src/database
+```
+
+`RecoveryCoordinator`, `ManifestManager`, and open/recovery policy residue are
+not ES3 cleanup targets. They belong to ES4.
+
+## Verification Gates
+
+Run the standard formatting and relevant tests:
+
+```sh
+cargo fmt --all --check
+cargo check -p strata-storage --all-targets
+cargo check -p strata-engine --all-targets
+cargo test -p strata-engine --lib database::snapshot_install -- --nocapture
+cargo test -p strata-engine --lib database::tests::checkpoint -- --nocapture
+cargo test -p strata-engine --lib database::tests::open -- --nocapture
+cargo test -p strata-engine --lib database::tests::codec -- --nocapture
+cargo test -p strata-engine --test recovery_parity -- --nocapture
+```
+
+When storage generic install code is introduced, add and run the focused
+storage tests for that helper:
+
+```sh
+cargo test -p strata-storage decoded_snapshot_install -- --nocapture
+```
+
+Run recovery and follower tests when callback wiring changes:
+
+```sh
+cargo test -p strata-engine --test recovery_tests -- --nocapture
+cargo test -p strata-engine --test follower_tests -- --nocapture
+cargo test -p strata-engine --lib test_issue_1730 -- --nocapture
+```
+
+## Acceptance Checklist
+
+ES3A is complete when:
+
+1. Crate code is back to the pre-move boundary.
+2. Engine snapshot install characterization covers current primitive decode
+   behavior.
+3. Tests cover canonical section codec behavior for non-identity snapshot
+   files.
+4. Tests cover no partial mutation for decode/validation failures that happen
+   before storage install.
+
+ES3B is complete when:
+
+1. Storage exposes only a generic decoded row install surface.
+2. Storage install stats are generic.
+3. Storage install errors are storage-local and primitive-agnostic.
+4. Storage tests use synthetic decoded row groups, not primitive snapshot DTOs.
+
+ES3C is complete when:
+
+1. Engine builds a complete decoded row install plan before storage mutation.
+2. Engine retains primitive section decode and primitive-specific stats.
+3. Invalid primitive data fails before any storage write.
+
+ES3D is complete when:
+
+1. Primitive section decode uses the canonical section codec.
+2. Snapshot header codec validation remains separate.
+3. Non-identity checkpoint + compact + reopen coverage is green.
+
+ES3E is complete when:
+
+1. Engine calls the storage generic row install helper only after successful
+   primitive decode.
+2. Recovery callback policy remains engine-owned.
+3. Public error behavior is preserved.
+
+ES3F is complete when:
+
+1. Storage has no new primitive runtime install concerns.
+2. Engine decode residue is intentional and documented.
+3. Ownership guards and verification tests pass.
+
+## Non-Goals
+
+ES3 does not move:
+
+- `RecoveryCoordinator`
+- MANIFEST/open policy
+- lossy/degraded recovery classification
+- primitive checkpoint DTO definitions
+- primitive query/index/rebuild behavior
+- branch lifecycle behavior
+- vector/search/graph semantics
+
+Those are either engine responsibilities or later ES4-plus decisions.


### PR DESCRIPTION
## Summary

- Revised ES3 keeps primitive snapshot section decode in engine and extracts only the **generic decoded-row install mechanics** into storage (`crates/storage/src/durability/decoded_snapshot_install.rs`). The original ES3 direction would have moved primitive decode into storage, which is the inverse of the boundary problem.
- Engine `snapshot_install.rs` rewritten as **decode-then-install**: the entire decoded row plan is built before any storage mutation. Corrupt later sections, unknown primitive tags, and invalid KV `TypeTag` bytes all fail before storage writes anything.
- **Canonical primitive section codec separation (ES3D)**: primitive section payloads are decoded with `SnapshotSerializer::canonical_primitive_section()` regardless of the snapshot file codec. AES-encrypted snapshot files now recover correctly through snapshot-only paths (verified end-to-end).
- Two **explicit behavior changes** are called out in the ES3 plan: recovery hard-fails on absent install codec (was: silent skip = data loss), and primitive deserializers + snapshot reader reject trailing bytes (strict-input hardening; valid snapshots have none).

## Storage surface

`crates/storage/src/durability/decoded_snapshot_install.rs`:

- `StorageDecodedSnapshotInstallPlan` / `Group` / `Input`
- `StorageDecodedSnapshotInstallStats { groups_installed, rows_installed }` — generic; no kv/json/event/vector counters in storage
- `StorageDecodedSnapshotInstallError` (`#[non_exhaustive]`): `EmptyGroup` / `EmptySpace` / `ZeroVersion` / `DuplicateRow` / `Install { group_index, branch_id, storage_family, source }` / `RowCountMismatch`
- `install_decoded_snapshot_rows()` preflights the plan against generic invariants before any mutation, then verifies `SegmentedStore::install_snapshot_entries` returned exactly as many rows as submitted (`RowCountMismatch` fires in release, not just debug).

The helper does not see `LoadedSnapshot`, `SnapshotSerializer`, `primitive_tags`, or primitive snapshot DTOs. `TypeTag` is carried as an opaque storage family id; storage does not branch on primitive variants.

## Engine

`crates/engine/src/database/snapshot_install.rs` (decode-then-install):

- `decode_snapshot_install_plan` walks `LoadedSnapshot.sections`, dispatches by `primitive_tags`, decodes each primitive DTO via `SnapshotSerializer::canonical_primitive_section()`, reconstructs storage row keys (event `sequence.to_be_bytes()`, json `doc_id`, branch key, vector `__config__/{name}` and `{name}/{vec_key}`), validates the KV-section `TypeTag` byte before staging, decodes JSON `Value` blobs, and stages generic `DecodedSnapshotEntry` groups.
- The full plan is built before any storage mutation.
- Engine retains primitive-shaped `InstallStats { kv, graph, events, json, vector_configs, vectors, branches, sections_skipped }` and cross-checks the primitive total against the storage-reported row count.

`crates/engine/src/database/recovery.rs`:

- `install_recovery_snapshot` extracts and validates the install codec
- `log_recovery_snapshot_install` records per-primitive counters in addition to the existing `entries=` total
- 4 new wrapper tests: absent-codec hard-fail, codec-mismatch through the storage callback, primitive stats after success, full corrupt-snapshot → `CoordinatorRecoveryError::Callback` → `RecoveryError::WalRecoveryFailed` mapping

## Codec doc cleanup (ES3D)

`format::primitives` now exposes:
- `CANONICAL_PRIMITIVE_SECTION_CODEC_ID = \"identity\"` constant
- `SnapshotSerializer::canonical_primitive_section()` constructor
- `SnapshotSerializer::codec_id()` accessor

`CheckpointCoordinator::{new, with_watermark}` use the canonical serializer instead of an inline `IdentityCodec` (same on-disk format, named intent).

`codec/{mod,traits}.rs` and `disk_snapshot/{reader,writer}.rs` rustdoc now describes the codec contract accurately: WAL records use the storage codec; snapshot containers record/validate the codec id but section payloads own their own format.

## Explicit behavior changes

Documented in the new `docs/engine/es3-snapshot-decode-install-mechanics-plan.md` (\"Explicit Behavior Changes\" section):

1. **Recovery hard-fails on absent install codec.** Pre-ES3, `install_codec = None` reaching the snapshot install callback silently skipped install while still returning success. `None` is still used for deliberate no-snapshot paths (primary first-open and follower-without-MANIFEST), but those paths have no manifest-recorded snapshot, so the callback should not fire. If it does, silently skipping = data loss.
2. **Trailing bytes in snapshot sections / containers are rejected.** `PrimitiveSerializeError::TrailingData` and `SnapshotReadError::TrailingSectionBytes`. Writers do not emit those bytes, so this is strict-input hardening rather than a wire-format change for valid snapshots.

Defensive (not a boundary change): primitive deserializers no longer preallocate `Vec::with_capacity(declared_count)`. A hostile `u32::MAX`-prefixed payload now fails by EOF instead of requesting a ~17 GB allocation.

## End-to-end ES3D coverage

`engine::tests::checkpoint::test_aes_checkpoint_compact_reopen_installs_snapshot`:

1. Open AES-GCM-256 database
2. Write 3 KV entries
3. Checkpoint and compact (compact previously could fail under AES due to the codec mismatch ES3D fixes)
4. Verify snapshot file is encoded with AES (`snapshot.codec_id == \"aes-gcm-256\"`)
5. Decode primitive sections with `canonical_primitive_section()` to verify section payloads aren't double-encoded
6. Delete WAL segments (forcing snapshot-only recovery)
7. Reopen and verify all 3 keys recover with correct values

## ES3F ownership guards (clean)

- `rg 'use strata_engine|strata_engine::|strata-engine' crates/storage/src crates/storage/Cargo.toml` — 0 matches
- `rg 'SnapshotSerializer|primitive_tags|*SnapshotEntry' crates/storage/src/durability/decoded_snapshot_install.rs` — 0 matches
- Engine residue (`RecoveryCoordinator`, `ManifestManager`, `apply_storage_config`, `install_snapshot`, `SnapshotSerializer`, `primitive_tags`) belongs to ES4/ES5

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p strata-storage --quiet` — 1180 passed, 0 failed (+14 from ES2)
- [x] `cargo test -p strata-engine --lib database::snapshot_install` — 30 passed
- [x] `cargo test -p strata-engine --lib database::tests::checkpoint` — 22 passed
- [x] `cargo test -p strata-engine --lib database::tests::open` — 36 passed
- [x] `cargo test -p strata-engine --lib database::tests::codec` — 17 passed
- [x] `cargo test -p strata-engine --test recovery_parity` — 7 passed
- [x] `cargo test -p strata-engine` — 1595 passed (+23 from ES2), 10 failed (same pre-existing architecture-cleanup-period failures verified against `main` during ES2; no new regressions)
- [x] `cargo test -p strata-executor` — 113 passed

## Out of scope (later epics)

- ES4: recovery bootstrap mechanics → storage (`RecoveryCoordinator`, `ManifestManager` in recovery, MANIFEST preparation, segmented-store recovery orchestration)
- ES5: storage-only config application → storage (`apply_storage_config`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)