### PR TITLE
ES4: move recovery bootstrap mechanics into strata-storage

### DIFF
--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -19,10 +19,9 @@ use tracing::{info, warn};
 
 /// Apply all storage configuration settings to a SegmentedStore.
 ///
-/// Centralizes the 7 storage-config setters so every open path
-/// (primary, follower, cache) applies the same set of knobs. Visible to
-/// `super::recovery` so the unified `run_recovery` entry point can apply
-/// the same knobs after it finishes MANIFEST + WAL + segment recovery.
+/// Centralizes storage-config setters for engine-owned store construction.
+/// Disk recovery applies the same knobs through storage's recovery runtime
+/// config before segment recovery runs.
 pub(crate) fn apply_storage_config(storage: &SegmentedStore, cfg: &StorageConfig) {
     storage.set_max_branches(cfg.max_branches);
     storage.set_max_versions_per_key(cfg.max_versions_per_key);
@@ -721,8 +720,8 @@ impl Database {
         let wal_dir = layout.wal_dir().to_path_buf();
 
         // Defensive: tighten segments-dir permissions on reopen. On
-        // first-open `run_recovery` already restricted it via
-        // `prepare_manifest`; on reopen we don't know the historical
+        // first-open `run_recovery` already restricted it via storage
+        // MANIFEST preparation; on reopen we don't know the historical
         // perms of an existing dir.
         if matches!(layout.segments_dir().try_exists(), Ok(true)) {
             restrict_dir(layout.segments_dir());

--- a/crates/engine/src/database/recovery.rs
+++ b/crates/engine/src/database/recovery.rs
@@ -8,8 +8,8 @@
 //! # Scope
 //!
 //! This module owns orchestration and typed taxonomy. Recovery policy still
-//! branches on `RecoveryHealth::Degraded` inside the storage step, and the
-//! WAL-replay lossy fallback preserves the existing runtime behavior.
+//! branches on `RecoveryHealth::Degraded` after storage recovery returns, and
+//! WAL-replay lossy reports remain engine-owned.
 //!
 //! # First-open ordering
 //!
@@ -19,24 +19,22 @@
 //! open could not repair.
 
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use crate::StrataError;
 use strata_core::id::CommitVersion;
-use strata_storage::durability::codec::{clone_codec, StorageCodec};
+use strata_storage::durability::codec::StorageCodec;
 use strata_storage::durability::layout::DatabaseLayout;
 use strata_storage::durability::wal::WalReaderError;
 use strata_storage::durability::{
-    apply_wal_record_to_memory_storage, CoordinatorPlanError, CoordinatorRecoveryError,
-    LoadedSnapshot, ManifestError, ManifestManager, RecoveryCoordinator, RecoveryResult,
-    RecoveryStats, SnapshotReadError,
+    run_storage_recovery, CoordinatorPlanError, CoordinatorRecoveryError, LoadedSnapshot,
+    ManifestError, RecoveryResult, SnapshotReadError, StorageLossyWalReplayFacts,
+    StorageRecoveryError, StorageRecoveryInput, StorageRecoveryMode, StorageRuntimeConfig,
 };
 use strata_storage::{DegradationClass, RecoveryHealth, SegmentedStore, StorageError};
 use tracing::{info, warn};
 
-use super::config::StrataConfig;
-use super::open::{apply_storage_config, restrict_dir};
+use super::config::{StorageConfig, StrataConfig};
 use super::recovery_error::{
     classify_manifest_load_error, from_coordinator_error, ErrorRole, RecoveryError,
 };
@@ -74,6 +72,13 @@ impl RecoveryMode {
             RecoveryMode::Follower => ErrorRole::Follower,
         }
     }
+
+    fn as_storage_mode(self) -> StorageRecoveryMode {
+        match self {
+            RecoveryMode::Primary => StorageRecoveryMode::PrimaryCreateManifestIfMissing,
+            RecoveryMode::Follower => StorageRecoveryMode::FollowerNeverCreateManifest,
+        }
+    }
 }
 
 /// Output of [`Database::run_recovery`].
@@ -81,7 +86,7 @@ impl RecoveryMode {
 /// Carries the owned resources the caller needs to finish constructing
 /// `Arc<Database>`. All public fields are `pub(crate)` because
 /// `RecoveryOutcome` is an implementation detail of `open.rs`; it is
-/// not part of the D4 public surface.
+/// not part of the ES4 public surface.
 pub(crate) struct RecoveryOutcome {
     /// MANIFEST-recorded database UUID (or `[0u8; 16]` for follower
     /// without a MANIFEST).
@@ -117,16 +122,12 @@ impl Database {
     /// 3. WAL codec resolution (stored id on reopen, configured id on
     ///    first-open or follower-without-MANIFEST).
     /// 4. `SegmentedStore` construction at the segments directory.
-    /// 5. `RecoveryCoordinator::recover` — snapshot install + WAL
-    ///    replay via caller-supplied closures.
-    /// 6. WAL-replay lossy fallback.
-    /// 7. Snapshot-version fold.
-    /// 8. `TransactionCoordinator::from_recovery_with_limits` +
-    ///    `apply_storage_config`.
-    /// 9. `SegmentedStore::recover_segments` → classified outcome →
+    /// 5. Storage-owned durability recovery via an engine primitive snapshot
+    ///    install callback.
+    /// 6. `TransactionCoordinator::from_recovery_with_limits` +
     ///    `coordinator.apply_storage_recovery`.
-    /// 10. Follower-state restore (follower mode only).
-    /// 11. Watermark construction.
+    /// 7. Follower-state restore (follower mode only).
+    /// 8. Watermark construction.
     #[allow(clippy::too_many_lines)] // orchestrator: splitting further would scatter sequential state.
     pub(crate) fn run_recovery(
         canonical_path: &Path,
@@ -134,64 +135,36 @@ impl Database {
         cfg: &StrataConfig,
         mode: RecoveryMode,
     ) -> Result<RecoveryOutcome, RecoveryError> {
-        // 1. Configured-codec validation before any recovery-managed
-        //    directory or MANIFEST creation — preserves the pre-D3
-        //    first-open safety guard.
-        strata_storage::durability::get_codec(&cfg.storage.codec).map_err(|e| {
-            RecoveryError::CodecInit {
-                codec_id: cfg.storage.codec.clone(),
-                detail: e.to_string(),
-            }
-        })?;
-
-        // 2. MANIFEST load or create.
-        let ManifestPreparation {
-            database_uuid,
-            install_codec_for_snapshot,
-        } = prepare_manifest(canonical_path, layout, cfg, mode)?;
-
-        // 3. WAL codec resolution. On reopen we fetch by stored id;
-        //    on first-open / follower-without-MANIFEST we fetch by
-        //    config id (already validated in step 1).
-        let wal_codec_id = install_codec_for_snapshot
-            .as_ref()
-            .map_or(cfg.storage.codec.as_str(), |c| c.codec_id());
-        let wal_codec = strata_storage::durability::get_codec(wal_codec_id).map_err(|e| {
-            RecoveryError::CodecInit {
-                codec_id: wal_codec_id.to_owned(),
-                detail: e.to_string(),
-            }
-        })?;
-
-        // 4. SegmentedStore at the segments directory.
-        let mut storage = SegmentedStore::with_dir(
-            layout.segments_dir().to_path_buf(),
+        // 1-5. Storage-owned durability recovery. Storage owns MANIFEST/codec
+        //      prep, generic WAL replay, the mechanical lossy fallback,
+        //      runtime config application, and segment recovery. Engine keeps
+        //      primitive snapshot decode and install telemetry in this
+        //      callback.
+        let snapshot_install = |snapshot: &LoadedSnapshot,
+                                install_codec: &dyn StorageCodec,
+                                storage: &SegmentedStore|
+         -> Result<(), StorageError> {
+            install_recovery_snapshot(snapshot, install_codec, storage)?;
+            Ok(())
+        };
+        let storage_outcome = run_storage_recovery(StorageRecoveryInput::new(
+            layout.clone(),
+            mode.as_storage_mode(),
+            cfg.storage.codec.clone(),
             cfg.storage.effective_write_buffer_size(),
-        );
-
-        // 5. RecoveryCoordinator::recover via callbacks.
-        let records_applied_before_failure = Arc::new(AtomicU64::new(0));
-        let recover_result = run_coordinator_recovery(
-            layout,
-            cfg,
-            wal_codec.as_ref(),
-            install_codec_for_snapshot.as_deref(),
-            &storage,
-            &records_applied_before_failure,
-        );
-
-        // 6. Lossy fallback on WAL-replay error.
-        let (mut stats, lossy_report) = handle_wal_recovery_outcome(
-            recover_result,
-            cfg,
-            layout,
-            &mut storage,
-            records_applied_before_failure.load(Ordering::SeqCst),
-            mode,
-        )?;
-
-        // 7. Snapshot-version fold.
-        stats.final_version = stats.final_version.max(CommitVersion(storage.version()));
+            storage_runtime_config_from(&cfg.storage),
+            cfg.allow_lossy_recovery,
+            &snapshot_install,
+        ))
+        .map_err(|err| map_storage_recovery_error(canonical_path, mode, err))?;
+        let database_uuid = storage_outcome.database_uuid;
+        let wal_codec = storage_outcome.wal_codec;
+        let stats = storage_outcome.wal_replay;
+        let seg_outcome = storage_outcome.segment_recovery;
+        let lossy_report = storage_outcome
+            .lossy_wal_replay
+            .as_ref()
+            .map(|facts| storage_lossy_wal_replay_facts_to_report(facts, mode));
 
         info!(
             target: "strata::db",
@@ -207,18 +180,17 @@ impl Database {
             "Recovery complete"
         );
 
-        // 8. Coordinator bootstrap + storage config.
-        let result = RecoveryResult { storage, stats };
+        // 6. Coordinator bootstrap + storage recovery policy.
+        let result = RecoveryResult {
+            storage: storage_outcome.storage,
+            stats,
+        };
         let coordinator = TransactionCoordinator::from_recovery_with_limits(
             &result,
             cfg.storage.max_write_buffer_entries,
         );
         let storage = Arc::new(result.storage);
-        apply_storage_config(&storage, &cfg.storage);
 
-        // 9. Storage recovery (SE2 outcome). D3 plumbs only; D4 adds
-        //    the health-policy branch between these two lines.
-        let seg_outcome = storage.recover_segments().map_err(RecoveryError::from)?;
         if seg_outcome.segments_loaded > 0 {
             info!(
                 target: "strata::db",
@@ -235,22 +207,24 @@ impl Database {
                 "storage recovered with degraded state"
             );
         }
-        // D4 health-policy branch. Strict mode refuses authoritative
+        // ES4 health-policy branch. Strict mode refuses authoritative
         // loss; the no-manifest legacy fallback is opt-in; rebuildable
         // caches are always accepted. Lossy recovery (`allow_lossy_recovery`)
         // is the blanket escape hatch and permits every class — it leaves
         // `LossyRecoveryReport` untouched because no WAL wipe occurred;
         // operators read the classification via `Database::recovery_health()`.
         if let RecoveryHealth::Degraded { class, .. } = &seg_outcome.health {
-            let permitted =
-                cfg.allow_lossy_recovery || !policy_refuses(*class, cfg.allow_missing_manifest);
-            if !permitted {
+            if !degraded_recovery_permitted(
+                *class,
+                cfg.allow_missing_manifest,
+                cfg.allow_lossy_recovery,
+            ) {
                 return Err(RecoveryError::StorageDegraded(seg_outcome.health.clone()));
             }
         }
         coordinator.apply_storage_recovery(&seg_outcome);
 
-        // 10. Follower state restore.
+        // 7. Follower state restore.
         let persisted_follower_state = match mode {
             RecoveryMode::Primary => None,
             RecoveryMode::Follower => restore_follower_state(
@@ -260,7 +234,7 @@ impl Database {
             ),
         };
 
-        // 11. Watermark.
+        // 8. Watermark.
         let watermark = match persisted_follower_state.as_ref() {
             Some(follower_state) => ContiguousWatermark::from_state(
                 follower_state.received_watermark,
@@ -282,7 +256,7 @@ impl Database {
     }
 }
 
-/// D4 strict-mode policy. `true` = refuse to open on this class; `false`
+/// ES4 strict-mode policy. `true` = refuse to open on this class; `false`
 /// = accept. The caller combines this with `allow_lossy_recovery` so
 /// that lossy mode is a blanket override regardless of class.
 ///
@@ -307,147 +281,68 @@ fn policy_refuses(class: DegradationClass, allow_missing_manifest: bool) -> bool
     }
 }
 
-/// Output of [`prepare_manifest`].
-struct ManifestPreparation {
-    database_uuid: [u8; 16],
-    /// `Some(clone)` when an on-disk MANIFEST exists and its codec is
-    /// available; `None` for a primary first-open (no MANIFEST yet)
-    /// and for follower-without-MANIFEST where the coordinator falls
-    /// back to WAL-only recovery. Those `None` cases do not have a
-    /// manifest-recorded snapshot, so the snapshot callback must not fire.
-    /// If it does fire without a codec, recovery hard-fails instead of
-    /// silently skipping snapshot install.
-    install_codec_for_snapshot: Option<Box<dyn StorageCodec>>,
+fn degraded_recovery_permitted(
+    class: DegradationClass,
+    allow_missing_manifest: bool,
+    allow_lossy_recovery: bool,
+) -> bool {
+    allow_lossy_recovery || !policy_refuses(class, allow_missing_manifest)
 }
 
-/// MANIFEST load or create. Primary mode creates on absent; follower
-/// mode defers (mirrors `open.rs:479-491` pre-D3 behaviour).
-///
-/// Error mapping preserves the pre-D3 variants: codec mismatch →
-/// `IncompatibleReuse`, parse failure → `Corruption`, create failure
-/// → `Internal`, codec-init failure → `Internal`.
-fn prepare_manifest(
-    canonical_path: &Path,
-    layout: &DatabaseLayout,
-    cfg: &StrataConfig,
-    mode: RecoveryMode,
-) -> Result<ManifestPreparation, RecoveryError> {
-    let manifest_path = layout.manifest_path().to_path_buf();
-    let manifest_exists = ManifestManager::exists(&manifest_path);
-    let role = mode.as_error_role();
-
-    if manifest_exists {
-        let mgr = ManifestManager::load(manifest_path.clone())
-            .map_err(|e| classify_manifest_load_error(manifest_path.clone(), role, e))?;
-        let manifest = mgr.manifest();
-        if manifest.codec_id != cfg.storage.codec {
-            return Err(RecoveryError::ManifestCodecMismatch {
-                stored: manifest.codec_id.clone(),
-                configured: cfg.storage.codec.clone(),
-                db_path: canonical_path.to_path_buf(),
-                role,
-            });
-        }
-        let codec = strata_storage::durability::get_codec(&manifest.codec_id).map_err(|e| {
-            RecoveryError::CodecInit {
-                codec_id: manifest.codec_id.clone(),
-                detail: e.to_string(),
-            }
-        })?;
-        return Ok(ManifestPreparation {
-            database_uuid: manifest.database_uuid,
-            install_codec_for_snapshot: Some(codec),
-        });
-    }
-
-    match mode {
-        RecoveryMode::Primary => {
-            // First-open: create segments dir + MANIFEST. Codec was
-            // already validated in `run_recovery` step 1.
-            layout.create_segments_dir().map_err(RecoveryError::Io)?;
-            restrict_dir(layout.segments_dir());
-            let uuid = *uuid::Uuid::new_v4().as_bytes();
-            ManifestManager::create(
-                layout.manifest_path().to_path_buf(),
-                uuid,
-                cfg.storage.codec.clone(),
-            )
-            .map_err(RecoveryError::ManifestCreate)?;
-            Ok(ManifestPreparation {
-                database_uuid: uuid,
-                install_codec_for_snapshot: None,
-            })
-        }
-        RecoveryMode::Follower => {
-            // Follower-without-MANIFEST falls back to WAL-only
-            // recovery. We still ensure the segments dir exists so
-            // `SegmentedStore::with_dir` has something to read.
-            if !layout
-                .segments_dir()
-                .try_exists()
-                .map_err(RecoveryError::Io)?
-            {
-                layout.create_segments_dir().map_err(RecoveryError::Io)?;
-                restrict_dir(layout.segments_dir());
-            }
-            Ok(ManifestPreparation {
-                database_uuid: [0u8; 16],
-                install_codec_for_snapshot: None,
-            })
-        }
-    }
-}
-
-/// Drive the coordinator's callback-based recovery (`plan_recovery`,
-/// snapshot install, WAL replay) and return its typed coordinator error.
-///
-/// Error classification into `RecoveryError` is deferred to
-/// [`handle_wal_recovery_outcome`] so the lossy-fallback arm can run
-/// `LossyErrorKind::from_strata_error(&e)` on the original
-/// `StrataError` before the engine maps the failure into a typed
-/// `RecoveryError`.
-fn run_coordinator_recovery(
-    layout: &DatabaseLayout,
-    cfg: &StrataConfig,
-    wal_codec: &dyn StorageCodec,
-    install_codec: Option<&dyn StorageCodec>,
-    storage: &SegmentedStore,
-    records_counter: &Arc<AtomicU64>,
-) -> Result<RecoveryStats, CoordinatorRecoveryError> {
-    let recovery =
-        RecoveryCoordinator::new(layout.clone(), cfg.storage.effective_write_buffer_size())
-            .with_lossy_recovery(cfg.allow_lossy_recovery)
-            .with_codec(clone_codec(wal_codec));
-
-    let counter = Arc::clone(records_counter);
-    recovery.recover_typed(
-        |snapshot| {
-            install_recovery_snapshot(&snapshot, install_codec, storage)?;
-            Ok(())
-        },
-        |record| {
-            let result = apply_wal_record_to_memory_storage(storage, record);
-            if result.is_ok() {
-                counter.fetch_add(1, Ordering::SeqCst);
-            }
-            result
-        },
+fn storage_runtime_config_from(config: &StorageConfig) -> StorageRuntimeConfig {
+    StorageRuntimeConfig::new(
+        config.max_branches,
+        config.max_versions_per_key,
+        config.effective_max_immutable_memtables(),
+        config.target_file_size,
+        config.level_base_bytes,
+        config.data_block_size,
+        config.bloom_bits_per_key,
+        config.compaction_rate_limit,
     )
 }
 
+fn map_storage_recovery_error(
+    canonical_path: &Path,
+    mode: RecoveryMode,
+    err: StorageRecoveryError,
+) -> RecoveryError {
+    let role = mode.as_error_role();
+    match err {
+        StorageRecoveryError::CodecInit { codec_id, detail } => {
+            RecoveryError::CodecInit { codec_id, detail }
+        }
+        StorageRecoveryError::ManifestLoad { path, source } => {
+            classify_manifest_load_error(path, role, source)
+        }
+        StorageRecoveryError::ManifestCreate { source } => RecoveryError::ManifestCreate(source),
+        StorageRecoveryError::ManifestCodecMismatch { stored, configured } => {
+            RecoveryError::ManifestCodecMismatch {
+                stored,
+                configured,
+                db_path: canonical_path.to_path_buf(),
+                role,
+            }
+        }
+        StorageRecoveryError::Io { source } => RecoveryError::Io(source),
+        StorageRecoveryError::Coordinator { source } => from_coordinator_error(role, source),
+        StorageRecoveryError::SegmentRecovery { source } => RecoveryError::Storage(source),
+        _ => RecoveryError::WalRecoveryFailed {
+            role,
+            inner: StrataError::internal(format!("unknown storage recovery error: {err}")),
+        },
+    }
+}
+
+/// Install one loaded recovery snapshot through the engine-owned primitive
+/// decode path.
 fn install_recovery_snapshot(
     snapshot: &LoadedSnapshot,
-    install_codec: Option<&dyn StorageCodec>,
+    install_codec: &dyn StorageCodec,
     storage: &SegmentedStore,
 ) -> Result<InstallStats, StorageError> {
-    let Some(codec) = install_codec else {
-        return Err(StorageError::corruption(format!(
-            "snapshot {} reached recovery install callback without an install codec",
-            snapshot.snapshot_id()
-        )));
-    };
-
-    let installed = install_snapshot(snapshot, codec, storage).map_err(StorageError::from)?;
+    let installed =
+        install_snapshot(snapshot, install_codec, storage).map_err(StorageError::from)?;
     log_recovery_snapshot_install(snapshot, &installed);
     Ok(installed)
 }
@@ -470,53 +365,18 @@ fn log_recovery_snapshot_install(snapshot: &LoadedSnapshot, installed: &InstallS
     );
 }
 
-/// Classify the outcome of `RecoveryCoordinator::recover` and apply
-/// the WAL-replay lossy fallback when configured.
-///
-/// - `Ok(stats)` → `(stats, None)`.
-/// - `Err(CoordinatorRecoveryError)` from the coordinator's planning step or
-///   carrying a legacy-format source is a hard-fail regardless of
-///   `allow_lossy_recovery`. The lossy wipe only recreates in-memory
-///   `SegmentedStore` state; it cannot heal a MANIFEST/snapshot plan failure
-///   and would re-observe legacy on-disk artifacts on the next open.
-/// - `Err(e)` with `cfg.allow_lossy_recovery=false` →
-///   typed `RecoveryError` via `from_coordinator_error`.
-/// - `Err(e)` with lossy enabled → build `LossyRecoveryReport`,
-///   replace `storage` with a fresh `SegmentedStore::with_dir`,
-///   return `(RecoveryStats::default(), Some(report))`.
-fn handle_wal_recovery_outcome(
-    recover_result: Result<RecoveryStats, CoordinatorRecoveryError>,
-    cfg: &StrataConfig,
-    layout: &DatabaseLayout,
-    storage: &mut SegmentedStore,
-    records_applied_before_failure: u64,
+fn storage_lossy_wal_replay_facts_to_report(
+    facts: &StorageLossyWalReplayFacts,
     mode: RecoveryMode,
-) -> Result<(RecoveryStats, Option<LossyRecoveryReport>), RecoveryError> {
-    let err = match recover_result {
-        Ok(stats) => return Ok((stats, None)),
-        Err(e) => e,
-    };
-
-    if err.should_bypass_lossy() {
-        return Err(from_coordinator_error(mode.as_error_role(), err));
-    }
-
-    if !cfg.allow_lossy_recovery {
-        return Err(from_coordinator_error(mode.as_error_role(), err));
-    }
-
-    let err = coordinator_error_to_lossy_strata_error(err);
-
-    // Sample progress BEFORE the wipe so the report reflects what was
-    // discarded.
-    let version_reached_before_failure = CommitVersion(storage.version());
+) -> LossyRecoveryReport {
+    let err = coordinator_error_to_lossy_strata_error(&facts.source);
     let error_kind = LossyErrorKind::from_strata_error(&err);
     let report = LossyRecoveryReport {
         error: err.to_string(),
         error_kind,
-        records_applied_before_failure,
-        version_reached_before_failure,
-        discarded_on_wipe: true,
+        records_applied_before_failure: facts.records_applied_before_failure,
+        version_reached_before_failure: facts.version_reached_before_failure,
+        discarded_on_wipe: facts.discarded_on_wipe,
     };
     let follower_flag = matches!(mode, RecoveryMode::Follower);
     warn!(
@@ -536,18 +396,10 @@ fn handle_wal_recovery_outcome(
     };
     warn!(target: "strata::db", error = %err, "{}", db_target_message);
 
-    // Discard any partial writes accumulated before the failure so
-    // lossy-mode semantics match the pre-Epic-5 `RecoveryResult::empty()`
-    // fallback: no user data surfaces from a failed recovery pass.
-    *storage = SegmentedStore::with_dir(
-        layout.segments_dir().to_path_buf(),
-        cfg.storage.effective_write_buffer_size(),
-    );
-
-    Ok((RecoveryStats::default(), Some(report)))
+    report
 }
 
-fn coordinator_error_to_lossy_strata_error(err: CoordinatorRecoveryError) -> StrataError {
+fn coordinator_error_to_lossy_strata_error(err: &CoordinatorRecoveryError) -> StrataError {
     match err {
         CoordinatorRecoveryError::Plan(CoordinatorPlanError::Manifest(
             ManifestError::LegacyFormat {
@@ -556,7 +408,7 @@ fn coordinator_error_to_lossy_strata_error(err: CoordinatorRecoveryError) -> Str
                 remediation,
             },
         )) => StrataError::legacy_format(
-            detected_version,
+            *detected_version,
             format!("{supported_range}. {remediation}"),
         ),
         CoordinatorRecoveryError::Plan(CoordinatorPlanError::Manifest(inner)) => {
@@ -584,7 +436,7 @@ fn coordinator_error_to_lossy_strata_error(err: CoordinatorRecoveryError) -> Str
                     remediation,
                 },
         } => StrataError::legacy_format(
-            detected_version,
+            *detected_version,
             format!("{supported_range}. {remediation}"),
         ),
         CoordinatorRecoveryError::SnapshotRead {
@@ -596,12 +448,12 @@ fn coordinator_error_to_lossy_strata_error(err: CoordinatorRecoveryError) -> Str
             path.display()
         )),
         CoordinatorRecoveryError::WalRead(WalReaderError::CodecDecode { detail, .. }) => {
-            StrataError::codec_decode(detail)
+            StrataError::codec_decode(detail.clone())
         }
         CoordinatorRecoveryError::WalRead(WalReaderError::LegacyFormat {
             found_version,
             hint,
-        }) => StrataError::legacy_format(found_version, hint),
+        }) => StrataError::legacy_format(*found_version, hint.clone()),
         CoordinatorRecoveryError::WalRead(inner) => {
             StrataError::storage(format!("WAL read failed: {inner}"))
         }
@@ -610,8 +462,15 @@ fn coordinator_error_to_lossy_strata_error(err: CoordinatorRecoveryError) -> Str
                 "Failed to decode transaction payload for txn {txn_id}: {detail}"
             ))
         }
-        CoordinatorRecoveryError::Callback(inner) => StrataError::from(inner),
+        CoordinatorRecoveryError::Callback(inner) => storage_error_to_lossy_strata_error(inner),
         _ => StrataError::internal("unknown coordinator recovery error"),
+    }
+}
+
+fn storage_error_to_lossy_strata_error(err: &StorageError) -> StrataError {
+    match err {
+        StorageError::Corruption { message } => StrataError::corruption(message.clone()),
+        _ => StrataError::storage(err.to_string()),
     }
 }
 
@@ -619,7 +478,7 @@ fn coordinator_error_to_lossy_strata_error(err: CoordinatorRecoveryError) -> Str
 /// validation failure the slot is cleared so a restart does not
 /// re-observe the inconsistent state.
 ///
-/// Mirrors the pre-D3 block at `open.rs:634-672` verbatim.
+/// Mirrors the previous follower-state restoration block from `open.rs`.
 fn restore_follower_state(
     canonical_path: &Path,
     recovered_max_txn: strata_core::id::TxnId,
@@ -665,73 +524,419 @@ fn restore_follower_state(
 
 #[cfg(test)]
 mod tests {
+    use super::super::config::StorageConfig;
+    use super::super::refresh::{persist_follower_state, BlockReason, BlockedTxn, BlockedTxnState};
     use super::*;
+    use serial_test::serial;
     use strata_core::id::TxnId;
     use strata_core::{BranchId, Value};
     use strata_storage::durability::codec::IdentityCodec;
+    use strata_storage::durability::format::{Manifest, WalRecord};
+    use strata_storage::durability::wal::{DurabilityMode, WalConfig, WalWriter};
     use strata_storage::durability::{
         primitive_tags, KvSnapshotEntry, LoadedSection, SnapshotHeader, SnapshotSection,
-        SnapshotSerializer, SnapshotWriter,
+        SnapshotSerializer, SnapshotWriter, TransactionPayload,
     };
     use strata_storage::{Key, Namespace, TypeTag};
     use tempfile::TempDir;
 
-    #[test]
-    fn coordinator_plan_failure_bypasses_lossy_fallback() {
-        let temp_dir = TempDir::new().unwrap();
-        let layout = DatabaseLayout::from_root(temp_dir.path());
-        let mut storage = SegmentedStore::new();
-        let cfg = StrataConfig {
-            allow_lossy_recovery: true,
-            ..StrataConfig::default()
-        };
+    const TEST_AES_KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
 
-        let result = handle_wal_recovery_outcome(
-            Err(CoordinatorRecoveryError::Plan(
-                CoordinatorPlanError::CodecMismatch {
-                    stored: "identity".into(),
-                    expected: "aes-gcm-256".into(),
-                },
-            )),
-            &cfg,
-            &layout,
-            &mut storage,
-            0,
-            RecoveryMode::Primary,
-        );
+    struct EnvVarGuard {
+        name: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
 
-        match result {
-            Err(RecoveryError::CoordinatorPlan(inner)) => {
-                assert!(matches!(inner, StrataError::IncompatibleReuse { .. }));
+    impl EnvVarGuard {
+        fn set(name: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(name);
+            std::env::set_var(name, value);
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = self.previous.take() {
+                std::env::set_var(self.name, value);
+            } else {
+                std::env::remove_var(self.name);
             }
-            other => panic!("plan failure must hard-fail without lossy wipe, got: {other:?}"),
         }
     }
 
     #[test]
-    fn recovery_snapshot_install_rejects_when_install_codec_absent() {
-        let branch_id = BranchId::new();
-        let snapshot = loaded_snapshot(
-            "identity",
-            vec![kv_section(branch_id, "skipped", Value::Int(7), 11)],
-        );
-        let storage = SegmentedStore::new();
+    fn snapshot_plan_failure_bypasses_lossy_fallback() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        layout.create_segments_dir().unwrap();
+        write_db_manifest_with_snapshot(&layout, [0x11; 16], "identity", 404, TxnId(99));
+        let cfg = StrataConfig {
+            allow_lossy_recovery: true,
+            ..StrataConfig::default()
+        };
+        let result = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary);
 
-        let err = install_recovery_snapshot(&snapshot, None, &storage)
-            .expect_err("loaded snapshot without install codec should violate recovery invariant");
-
-        match err {
-            StorageError::Corruption { message } => {
-                assert!(message.contains(
-                    "snapshot 7 reached recovery install callback without an install codec"
-                ));
+        match result {
+            Err(RecoveryError::SnapshotMissing {
+                role: ErrorRole::Primary,
+                snapshot_id: 404,
+                ..
+            }) => {}
+            Err(other) => {
+                panic!("snapshot plan failure mapped to the wrong error: {other:?}");
             }
-            other => panic!("expected corruption storage error, got {other:?}"),
+            Ok(_) => {
+                panic!("snapshot plan failure must hard-fail without lossy wipe");
+            }
         }
-        assert!(storage
-            .get_versioned(&kv_key(branch_id, "skipped"), CommitVersion::MAX)
+    }
+
+    #[test]
+    #[serial(open_databases)]
+    fn primary_first_open_creates_manifest_with_configured_codec() {
+        let _key_guard = EnvVarGuard::set("STRATA_ENCRYPTION_KEY", TEST_AES_KEY);
+        let temp_dir = TempDir::new().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let cfg = StrataConfig {
+            storage: StorageConfig {
+                codec: "aes-gcm-256".to_string(),
+                ..StorageConfig::default()
+            },
+            ..StrataConfig::default()
+        };
+
+        let outcome = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
+            .expect("primary first-open recovery should succeed");
+
+        assert!(
+            layout.manifest_path().exists(),
+            "primary first-open must create MANIFEST"
+        );
+        assert!(
+            layout.segments_dir().exists(),
+            "primary first-open must create the storage segments dir"
+        );
+        let manifest = read_db_manifest(&layout);
+        assert_eq!(
+            manifest.codec_id, cfg.storage.codec,
+            "first-open MANIFEST must record the configured storage codec"
+        );
+        assert_eq!(outcome.database_uuid, manifest.database_uuid);
+        assert_ne!(
+            outcome.database_uuid, [0u8; 16],
+            "primary first-open must allocate a real database UUID"
+        );
+        assert_eq!(outcome.wal_codec.codec_id(), cfg.storage.codec);
+        assert!(outcome.lossy_report.is_none());
+        assert!(outcome.persisted_follower_state.is_none());
+    }
+
+    #[test]
+    fn recovery_applies_storage_runtime_config() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let cfg = StrataConfig {
+            storage: StorageConfig {
+                target_file_size: 3 * 1024 * 1024,
+                data_block_size: 8 * 1024,
+                bloom_bits_per_key: 13,
+                ..StorageConfig::default()
+            },
+            ..StrataConfig::default()
+        };
+
+        let outcome = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
+            .expect("recovery should succeed with non-default storage config");
+
+        assert_eq!(
+            outcome.storage.target_file_size(),
+            cfg.storage.target_file_size
+        );
+        assert_eq!(
+            outcome.storage.data_block_size(),
+            cfg.storage.data_block_size
+        );
+        assert_eq!(
+            outcome.storage.bloom_bits_per_key(),
+            cfg.storage.bloom_bits_per_key
+        );
+    }
+
+    #[test]
+    fn follower_without_manifest_does_not_create_manifest() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let cfg = StrataConfig::default();
+
+        let outcome =
+            Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Follower)
+                .expect("follower without MANIFEST should fall back to WAL-only recovery");
+
+        assert!(
+            !layout.manifest_path().exists(),
+            "follower recovery must not create a missing MANIFEST"
+        );
+        assert!(
+            layout.segments_dir().exists(),
+            "follower recovery may create the storage segments dir"
+        );
+        assert_eq!(
+            outcome.database_uuid, [0u8; 16],
+            "follower without MANIFEST preserves the sentinel UUID"
+        );
+        assert_eq!(
+            outcome.wal_codec.codec_id(),
+            cfg.storage.codec,
+            "follower without MANIFEST uses the configured WAL codec"
+        );
+        assert!(outcome.lossy_report.is_none());
+        assert!(outcome.persisted_follower_state.is_none());
+    }
+
+    #[test]
+    fn follower_recovery_clears_invalid_persisted_state_after_replay() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let cfg = StrataConfig::default();
+        let stale_state = PersistedFollowerState {
+            received_watermark: TxnId(50),
+            applied_watermark: TxnId(10),
+            visible_version: CommitVersion(10),
+            blocked: BlockedTxnState {
+                blocked: BlockedTxn {
+                    txn_id: TxnId(11),
+                    reason: BlockReason::Decode {
+                        message: "stale blocked record".to_string(),
+                    },
+                },
+                visibility_version: None,
+                skip_allowed: true,
+            },
+        };
+        persist_follower_state(temp_dir.path(), &stale_state)
+            .expect("test should persist follower state");
+        assert!(load_persisted_follower_state(temp_dir.path())
+            .unwrap()
+            .is_some());
+
+        let outcome =
+            Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Follower)
+                .expect("follower recovery should ignore invalid persisted state");
+
+        assert!(outcome.persisted_follower_state.is_none());
+        assert!(load_persisted_follower_state(temp_dir.path())
             .unwrap()
             .is_none());
+        assert_eq!(outcome.watermark.applied(), TxnId(0));
+    }
+
+    #[test]
+    fn snapshot_versions_fold_into_coordinator_before_bootstrap() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let database_uuid = [0x44; 16];
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "snapshot-version-fold");
+        let cfg = StrataConfig::default();
+
+        layout.create_segments_dir().unwrap();
+        let writer = SnapshotWriter::new(
+            layout.snapshots_dir().to_path_buf(),
+            Box::new(IdentityCodec),
+            database_uuid,
+        )
+        .unwrap();
+        writer
+            .create_snapshot(
+                11,
+                9,
+                vec![kv_snapshot_section(
+                    branch_id,
+                    "snapshot-version-fold",
+                    Value::String("from-snapshot".into()),
+                    73,
+                )],
+            )
+            .unwrap();
+        write_db_manifest_with_snapshot(&layout, database_uuid, "identity", 11, TxnId(9));
+
+        let outcome = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
+            .expect("snapshot-only recovery should succeed");
+
+        assert_eq!(
+            outcome.storage.current_version(),
+            CommitVersion(73),
+            "snapshot install should advance storage current_version"
+        );
+        assert_eq!(
+            outcome.coordinator.current_version(),
+            CommitVersion(73),
+            "coordinator bootstrap must see the snapshot-version fold"
+        );
+        assert_eq!(
+            outcome.coordinator.visible_version(),
+            CommitVersion(73),
+            "visible version should start at the folded snapshot version"
+        );
+        let recovered = outcome
+            .storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("snapshot row should be visible after recovery");
+        assert_eq!(recovered.value, Value::String("from-snapshot".into()));
+    }
+
+    #[test]
+    fn wal_replay_success_bootstraps_storage_and_coordinator() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "wal-success-bootstrap");
+        let cfg = StrataConfig::default();
+        write_wal_txn(
+            layout.wal_dir(),
+            TxnId(17),
+            branch_id,
+            vec![(key.clone(), Value::String("from-wal".to_string()))],
+            Vec::new(),
+            23,
+        );
+
+        let outcome = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
+            .expect("WAL-only recovery should succeed");
+
+        assert_eq!(outcome.storage.current_version(), CommitVersion(23));
+        assert_eq!(outcome.coordinator.current_version(), CommitVersion(23));
+        assert_eq!(outcome.watermark.applied(), TxnId(17));
+        assert!(outcome.lossy_report.is_none());
+        let recovered = outcome
+            .storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("WAL row should be visible after recovery");
+        assert_eq!(recovered.value, Value::String("from-wal".to_string()));
+    }
+
+    #[test]
+    fn wal_legacy_failure_bypasses_lossy_fallback() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        std::fs::create_dir_all(layout.wal_dir()).unwrap();
+        std::fs::write(
+            layout.wal_dir().join("wal-000001.seg"),
+            legacy_wal_segment_header(1),
+        )
+        .unwrap();
+        let cfg = StrataConfig {
+            allow_lossy_recovery: true,
+            ..StrataConfig::default()
+        };
+        let result = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary);
+
+        match result {
+            Err(RecoveryError::WalLegacyFormat {
+                found_version,
+                hint,
+            }) => {
+                assert_eq!(found_version, 1);
+                assert!(hint.contains("wal/"));
+            }
+            Err(other) => panic!("legacy WAL mapped to the wrong error: {other:?}"),
+            Ok(_) => panic!("legacy WAL must hard-fail without lossy wipe"),
+        }
+    }
+
+    #[test]
+    fn lossy_replay_discards_partial_storage_and_reports_progress() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "discarded-before-corruption");
+        write_wal_txn(
+            layout.wal_dir(),
+            TxnId(23),
+            branch_id,
+            vec![(key.clone(), Value::String("partial".into()))],
+            Vec::new(),
+            19,
+        );
+        std::fs::write(
+            layout.wal_dir().join("wal-000099.seg"),
+            b"GARBAGE_NOT_A_VALID_SEGMENT_HEADER",
+        )
+        .unwrap();
+        let cfg = StrataConfig {
+            allow_lossy_recovery: true,
+            ..StrataConfig::default()
+        };
+        let outcome = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
+            .expect("lossy recovery should convert replay failure into an empty recovered store");
+
+        let report = outcome
+            .lossy_report
+            .expect("lossy fallback must report discarded progress");
+        assert_eq!(report.records_applied_before_failure, 1);
+        assert_eq!(report.version_reached_before_failure, CommitVersion(19));
+        assert!(report.discarded_on_wipe);
+        assert!(
+            report.error.contains("WAL read failed"),
+            "report should render the coordinator failure, got: {}",
+            report.error
+        );
+        assert!(
+            outcome
+                .storage
+                .get_versioned(&key, CommitVersion::MAX)
+                .unwrap()
+                .is_none(),
+            "lossy fallback must replace partial storage with an empty store"
+        );
+        assert_eq!(outcome.storage.current_version(), CommitVersion::ZERO);
+    }
+
+    #[test]
+    fn degraded_storage_policy_matrix_is_engine_owned() {
+        assert!(
+            policy_refuses(DegradationClass::DataLoss, false),
+            "strict recovery refuses authoritative data loss"
+        );
+        assert!(
+            policy_refuses(DegradationClass::DataLoss, true),
+            "allow_missing_manifest does not permit data loss"
+        );
+        assert!(
+            policy_refuses(DegradationClass::PolicyDowngrade, false),
+            "policy downgrade is refused unless explicitly allowed"
+        );
+        assert!(
+            !policy_refuses(DegradationClass::PolicyDowngrade, true),
+            "allow_missing_manifest permits the legacy no-MANIFEST fallback"
+        );
+        assert!(
+            !policy_refuses(DegradationClass::Telemetry, false),
+            "telemetry degradation is accepted in strict mode"
+        );
+        assert!(
+            !policy_refuses(DegradationClass::Telemetry, true),
+            "telemetry degradation is independent of missing-MANIFEST policy"
+        );
+        assert!(
+            degraded_recovery_permitted(DegradationClass::DataLoss, false, true),
+            "lossy recovery permits authoritative data-loss degradation"
+        );
+        assert!(
+            degraded_recovery_permitted(DegradationClass::PolicyDowngrade, false, true),
+            "lossy recovery overrides the missing-MANIFEST policy gate"
+        );
+        assert!(
+            degraded_recovery_permitted(DegradationClass::PolicyDowngrade, true, false),
+            "allow_missing_manifest permits only the policy downgrade class"
+        );
+        assert!(
+            !degraded_recovery_permitted(DegradationClass::DataLoss, true, false),
+            "allow_missing_manifest does not permit authoritative data loss"
+        );
     }
 
     #[test]
@@ -740,7 +945,7 @@ mod tests {
         let storage = SegmentedStore::new();
         let codec = IdentityCodec;
 
-        let err = install_recovery_snapshot(&snapshot, Some(&codec), &storage)
+        let err = install_recovery_snapshot(&snapshot, &codec, &storage)
             .expect_err("codec mismatch should surface as callback storage error");
 
         match err {
@@ -761,7 +966,7 @@ mod tests {
         let storage = SegmentedStore::new();
         let codec = IdentityCodec;
 
-        let installed = install_recovery_snapshot(&snapshot, Some(&codec), &storage)
+        let installed = install_recovery_snapshot(&snapshot, &codec, &storage)
             .expect("snapshot install should succeed");
 
         assert_eq!(installed.kv, 1);
@@ -780,8 +985,6 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let layout = DatabaseLayout::from_root(temp_dir.path());
         let database_uuid = [0x55; 16];
-        let codec = IdentityCodec;
-
         let writer = SnapshotWriter::new(
             layout.snapshots_dir().to_path_buf(),
             Box::new(IdentityCodec),
@@ -795,38 +998,54 @@ mod tests {
                 vec![SnapshotSection::new(primitive_tags::KV, vec![1, 0, 0, 0])],
             )
             .unwrap();
-        let mut manifest = ManifestManager::create(
-            layout.manifest_path().to_path_buf(),
-            database_uuid,
-            "identity".to_string(),
-        )
-        .unwrap();
-        manifest.set_snapshot_watermark(3, TxnId(9)).unwrap();
+        write_db_manifest_with_snapshot(&layout, database_uuid, "identity", 3, TxnId(9));
 
         let cfg = StrataConfig::default();
-        let storage = SegmentedStore::new();
-        let counter = Arc::new(AtomicU64::new(0));
-        let recover_result =
-            run_coordinator_recovery(&layout, &cfg, &codec, Some(&codec), &storage, &counter);
-
-        let err = recover_result.expect_err("corrupt snapshot install should fail recovery");
-        match &err {
-            CoordinatorRecoveryError::Callback(StorageError::Corruption { message }) => {
+        let mapped =
+            match Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary) {
+                Err(err) => err,
+                Ok(_) => panic!("callback error should map to public recovery error"),
+            };
+        match mapped {
+            RecoveryError::WalRecoveryFailed {
+                role: ErrorRole::Primary,
+                inner: StrataError::Corruption { message },
+            } => {
                 assert!(message.contains("KV section decode failed"));
             }
-            other => panic!("expected callback corruption from snapshot install, got {other:?}"),
+            other => panic!("expected primary WalRecoveryFailed corruption, got {other:?}"),
         }
+    }
 
-        let mut mapped_storage = storage;
-        let mapped = handle_wal_recovery_outcome(
-            Err(err),
-            &cfg,
-            &layout,
-            &mut mapped_storage,
-            0,
-            RecoveryMode::Primary,
+    #[test]
+    fn recovery_snapshot_install_failure_bypasses_lossy_fallback_when_enabled() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let database_uuid = [0x56; 16];
+        let writer = SnapshotWriter::new(
+            layout.snapshots_dir().to_path_buf(),
+            Box::new(IdentityCodec),
+            database_uuid,
         )
-        .expect_err("callback error should map to public recovery error");
+        .unwrap();
+        writer
+            .create_snapshot(
+                4,
+                10,
+                vec![SnapshotSection::new(primitive_tags::KV, vec![1, 0, 0, 0])],
+            )
+            .unwrap();
+        write_db_manifest_with_snapshot(&layout, database_uuid, "identity", 4, TxnId(10));
+
+        let cfg = StrataConfig {
+            allow_lossy_recovery: true,
+            ..StrataConfig::default()
+        };
+        let mapped =
+            match Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary) {
+                Err(err) => err,
+                Ok(_) => panic!("snapshot install failure must not lossy-open as empty storage"),
+            };
         match mapped {
             RecoveryError::WalRecoveryFailed {
                 role: ErrorRole::Primary,
@@ -848,6 +1067,19 @@ mod tests {
     }
 
     fn kv_section(branch_id: BranchId, key: &str, value: Value, version: u64) -> LoadedSection {
+        let section = kv_snapshot_section(branch_id, key, value, version);
+        LoadedSection {
+            primitive_type: section.primitive_type,
+            data: section.data,
+        }
+    }
+
+    fn kv_snapshot_section(
+        branch_id: BranchId,
+        key: &str,
+        value: Value,
+        version: u64,
+    ) -> SnapshotSection {
         let serializer = SnapshotSerializer::canonical_primitive_section();
         let entries = [KvSnapshotEntry {
             branch_id: *branch_id.as_bytes(),
@@ -860,13 +1092,68 @@ mod tests {
             ttl_ms: 0,
             is_tombstone: false,
         }];
-        LoadedSection {
-            primitive_type: primitive_tags::KV,
-            data: serializer.serialize_kv(&entries),
-        }
+        SnapshotSection::new(primitive_tags::KV, serializer.serialize_kv(&entries))
     }
 
     fn kv_key(branch_id: BranchId, key: &str) -> Key {
         Key::new_kv(Arc::new(Namespace::for_branch(branch_id)), key)
+    }
+
+    fn write_db_manifest_with_snapshot(
+        layout: &DatabaseLayout,
+        database_uuid: [u8; 16],
+        codec_id: &str,
+        snapshot_id: u64,
+        watermark_txn: TxnId,
+    ) {
+        let mut manifest = Manifest::new(database_uuid, codec_id.to_string());
+        manifest.snapshot_id = Some(snapshot_id);
+        manifest.snapshot_watermark = Some(watermark_txn.as_u64());
+        std::fs::write(layout.manifest_path(), manifest.to_bytes())
+            .expect("test should write database MANIFEST");
+    }
+
+    fn read_db_manifest(layout: &DatabaseLayout) -> Manifest {
+        let bytes = std::fs::read(layout.manifest_path()).expect("test MANIFEST should exist");
+        Manifest::from_bytes(&bytes).expect("test MANIFEST should parse")
+    }
+
+    fn write_wal_txn(
+        wal_dir: &Path,
+        txn_id: TxnId,
+        branch_id: BranchId,
+        puts: Vec<(Key, Value)>,
+        deletes: Vec<Key>,
+        version: u64,
+    ) {
+        let mut wal = WalWriter::new(
+            wal_dir.to_path_buf(),
+            [0u8; 16],
+            DurabilityMode::Always,
+            WalConfig::for_testing(),
+            Box::new(IdentityCodec),
+        )
+        .unwrap();
+
+        let payload = TransactionPayload {
+            version,
+            puts,
+            deletes,
+            put_ttls: vec![],
+        };
+        let record = WalRecord::new(txn_id, *branch_id.as_bytes(), 1_000, payload.to_bytes());
+        wal.append(&record).unwrap();
+        wal.flush().unwrap();
+    }
+
+    fn legacy_wal_segment_header(segment_number: u64) -> [u8; 36] {
+        let mut header = [0u8; 36];
+        header[0..4].copy_from_slice(b"STRA");
+        header[4..8].copy_from_slice(&1u32.to_le_bytes());
+        header[8..16].copy_from_slice(&segment_number.to_le_bytes());
+        header[16..32].copy_from_slice(&[0xAA; 16]);
+        let header_crc = crc32fast::hash(&header[0..32]);
+        header[32..36].copy_from_slice(&header_crc.to_le_bytes());
+        header
     }
 }

--- a/crates/engine/src/database/snapshot_install.rs
+++ b/crates/engine/src/database/snapshot_install.rs
@@ -5,10 +5,10 @@
 //! each section via [`SnapshotSerializer`], stages generic decoded row groups,
 //! and hands those groups to storage's decoded-row install helper.
 //!
-//! Recovery calls this from the `on_snapshot` callback passed to
-//! `RecoveryCoordinator::recover` so checkpoint-only restart (no WAL covering
-//! some pre-snapshot range) produces the same observable state as the
-//! original commits. The T3-E5 follow-up made snapshot install
+//! Recovery calls this from the snapshot callback passed through storage's
+//! recovery replay driver so checkpoint-only restart (no WAL covering some
+//! pre-snapshot range) produces the same observable state as the original
+//! commits. The T3-E5 follow-up made snapshot install
 //! retention-complete: tombstones are installed as `DecodedSnapshotValue::
 //! Tombstone` so deletes survive checkpoint+compact+reopen; KV TTL carries
 //! through; and the Branch section is dispatched via the new `branch_id`

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -34,6 +34,7 @@ serde = { workspace = true }
 rmp-serde = { workspace = true }
 aes-gcm = { workspace = true }
 rand = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/storage/src/durability/mod.rs
+++ b/crates/storage/src/durability/mod.rs
@@ -19,6 +19,7 @@ pub mod format;
 pub mod layout;
 pub mod payload;
 pub mod recovery;
+mod recovery_bootstrap;
 pub mod wal;
 
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -87,6 +88,13 @@ pub use payload::{serialize_wal_record_into, PayloadError, TransactionPayload};
 pub use recovery::{
     apply_wal_record_to_memory_storage, CoordinatorPlanError, CoordinatorRecoveryError,
     RecoveryCoordinator, RecoveryPlan, RecoveryResult, RecoveryStats,
+};
+
+// Recovery bootstrap
+pub use recovery_bootstrap::{
+    run_storage_recovery, RecoverySnapshotInstallCallback, StorageLossyWalReplayFacts,
+    StorageRecoveryError, StorageRecoveryInput, StorageRecoveryMode, StorageRecoveryOutcome,
+    StorageRuntimeConfig,
 };
 
 // WAL

--- a/crates/storage/src/durability/recovery.rs
+++ b/crates/storage/src/durability/recovery.rs
@@ -92,12 +92,12 @@ impl RecoveryPlan {
 /// 1. `plan_recovery` validates MANIFEST codec identity before any WAL read.
 /// 2. `recover(on_snapshot, on_record)` streams snapshot install and WAL
 ///    replay through caller-supplied closures. The coordinator owns the
-///    directory layout and record streaming; the engine owns storage
+///    directory layout and record streaming; the caller owns storage
 ///    construction and application.
 ///
 /// A `recover_into_memory_storage` convenience wrapper is kept for
 /// in-crate tests and snapshot-less tooling paths that construct the
-/// coordinator directly; `Database::open_runtime` uses the direct
+/// coordinator directly; storage recovery bootstrap uses the direct
 /// callback API with a codec wired in.
 pub struct RecoveryCoordinator {
     /// Canonical database layout.
@@ -109,8 +109,8 @@ pub struct RecoveryCoordinator {
     /// Storage codec used to decode snapshot payloads. When unset, the
     /// coordinator skips snapshot loading and falls back to full WAL
     /// replay. The `recover_into_memory_storage` wrapper does not
-    /// install a codec; engine opens drive `recover` directly and
-    /// install the codec via `with_codec`.
+    /// install a codec; storage recovery bootstrap drives `recover`
+    /// with a codec installed via `with_codec`.
     codec: Option<Box<dyn StorageCodec>>,
 }
 
@@ -195,13 +195,18 @@ impl CoordinatorRecoveryError {
         )
     }
 
-    /// Returns `true` when the engine must bypass its lossy WAL fallback.
+    /// Returns `true` when callers must bypass the lossy WAL fallback.
     ///
-    /// Coordinator `Plan(...)` failures come from the MANIFEST /
-    /// snapshot-planning step rather than WAL bytes, so recreating the
-    /// in-memory store cannot heal them.
+    /// Coordinator `Plan(...)` and snapshot load failures come from the
+    /// MANIFEST / snapshot-planning step rather than WAL bytes, so recreating
+    /// the in-memory store cannot heal them.
     pub fn should_bypass_lossy(&self) -> bool {
-        matches!(self, CoordinatorRecoveryError::Plan(_)) || self.is_legacy_format()
+        matches!(
+            self,
+            CoordinatorRecoveryError::Plan(_)
+                | CoordinatorRecoveryError::SnapshotMissing { .. }
+                | CoordinatorRecoveryError::SnapshotRead { .. }
+        ) || self.is_legacy_format()
     }
 }
 
@@ -375,7 +380,7 @@ impl RecoveryCoordinator {
 
     /// Drive recovery through caller-supplied callbacks.
     ///
-    /// The engine owns storage construction; the coordinator only:
+    /// The caller owns storage construction; the coordinator only:
     ///
     /// 1. Loads the snapshot declared in the MANIFEST (when a codec is
     ///    installed via `with_codec`) and invokes `on_snapshot` with the
@@ -625,10 +630,10 @@ impl RecoveryCoordinator {
     /// it, returning the fully-materialized `RecoveryResult`.
     ///
     /// Used by in-crate tests and snapshot-less tooling paths that
-    /// construct the coordinator directly. `Database::open_runtime`
-    /// drives `recover` directly with its own snapshot and WAL apply
-    /// closures, so the shipped open path does not go through this
-    /// wrapper. Snapshot loading is not performed here — this entry
+    /// construct the coordinator directly. Database open drives
+    /// storage recovery through `recovery_bootstrap`, so the shipped
+    /// open path does not go through this wrapper. Snapshot loading is
+    /// not performed here — this entry
     /// point intentionally drops any installed codec and uses full WAL
     /// replay only, keeping the convenience API deterministic for
     /// snapshot-less tests and tooling fixtures.
@@ -660,9 +665,8 @@ impl RecoveryCoordinator {
 /// (`#1619` / `#1740`).
 ///
 /// This is the default apply used by
-/// [`RecoveryCoordinator::recover_into_memory_storage`] and is exposed so
-/// engine open paths that drive the callback-driven [`RecoveryCoordinator::recover`]
-/// directly can reuse the exact same apply semantics in their `on_record`
+/// [`RecoveryCoordinator::recover_into_memory_storage`] and the storage
+/// recovery bootstrap's callback-driven [`RecoveryCoordinator::recover`] path.
 pub fn apply_wal_record_to_memory_storage(
     storage: &SegmentedStore,
     record: &WalRecord,

--- a/crates/storage/src/durability/recovery_bootstrap.rs
+++ b/crates/storage/src/durability/recovery_bootstrap.rs
@@ -1,0 +1,1715 @@
+//! Storage-owned recovery bootstrap surface.
+//!
+//! This module defines the primitive-neutral boundary that ES4 uses to move
+//! durability recovery mechanics into storage. The public entry point is
+//! `run_storage_recovery`; the smaller helper seams below stay private to keep
+//! higher layers from driving the lower recovery runtime piecemeal.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use strata_core::id::CommitVersion;
+use tracing::warn;
+
+use crate::durability::codec::{clone_codec, get_codec, StorageCodec};
+use crate::durability::layout::DatabaseLayout;
+use crate::durability::{
+    apply_wal_record_to_memory_storage, CoordinatorRecoveryError, LoadedSnapshot, ManifestError,
+    ManifestManager, RecoveryCoordinator, RecoveryStats,
+};
+use crate::{RecoveredState, SegmentedStore, StorageError};
+
+/// Install a loaded snapshot into storage during recovery.
+///
+/// Storage owns MANIFEST and codec resolution in the ES4 target, but it must
+/// not decode primitive snapshot sections. The callback therefore receives the
+/// resolved install codec and the generic `LoadedSnapshot` container; higher
+/// layers keep ownership of primitive decode and install telemetry.
+pub trait RecoverySnapshotInstallCallback: Send + Sync {
+    /// Install `snapshot` into `storage` using `install_codec`.
+    fn install_snapshot(
+        &self,
+        snapshot: &LoadedSnapshot,
+        install_codec: &dyn StorageCodec,
+        storage: &SegmentedStore,
+    ) -> Result<(), StorageError>;
+}
+
+impl<F> RecoverySnapshotInstallCallback for F
+where
+    F: Fn(&LoadedSnapshot, &dyn StorageCodec, &SegmentedStore) -> Result<(), StorageError>
+        + Send
+        + Sync,
+{
+    fn install_snapshot(
+        &self,
+        snapshot: &LoadedSnapshot,
+        install_codec: &dyn StorageCodec,
+        storage: &SegmentedStore,
+    ) -> Result<(), StorageError> {
+        self(snapshot, install_codec, storage)
+    }
+}
+
+/// Input for storage-owned durability recovery.
+#[non_exhaustive]
+pub struct StorageRecoveryInput<'a> {
+    /// Canonical database disk layout.
+    pub layout: DatabaseLayout,
+    /// Storage-neutral recovery mode.
+    pub mode: StorageRecoveryMode,
+    /// Codec id supplied by the caller's runtime configuration.
+    pub configured_codec_id: String,
+    /// Memtable write buffer size for the recovered store.
+    pub write_buffer_size: usize,
+    /// Runtime knobs applied before segment recovery.
+    pub runtime_config: StorageRuntimeConfig,
+    /// Whether storage may perform the mechanical lossy WAL replay fallback.
+    pub allow_lossy_wal_replay: bool,
+    /// Callback used when the recovery coordinator loads a snapshot.
+    pub snapshot_install: &'a dyn RecoverySnapshotInstallCallback,
+}
+
+impl<'a> StorageRecoveryInput<'a> {
+    /// Build storage-owned recovery input without requiring callers to construct
+    /// the public struct literally.
+    pub fn new(
+        layout: DatabaseLayout,
+        mode: StorageRecoveryMode,
+        configured_codec_id: impl Into<String>,
+        write_buffer_size: usize,
+        runtime_config: StorageRuntimeConfig,
+        allow_lossy_wal_replay: bool,
+        snapshot_install: &'a dyn RecoverySnapshotInstallCallback,
+    ) -> Self {
+        Self {
+            layout,
+            mode,
+            configured_codec_id: configured_codec_id.into(),
+            write_buffer_size,
+            runtime_config,
+            allow_lossy_wal_replay,
+            snapshot_install,
+        }
+    }
+}
+
+impl fmt::Debug for StorageRecoveryInput<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StorageRecoveryInput")
+            .field("layout", &self.layout)
+            .field("mode", &self.mode)
+            .field("configured_codec_id", &self.configured_codec_id)
+            .field("write_buffer_size", &self.write_buffer_size)
+            .field("runtime_config", &self.runtime_config)
+            .field("allow_lossy_wal_replay", &self.allow_lossy_wal_replay)
+            .field("snapshot_install", &"<callback>")
+            .finish()
+    }
+}
+
+/// Run storage-owned durability recovery.
+///
+/// This is the ES4 target wrapper for lower recovery mechanics. It validates
+/// and prepares MANIFEST state, resolves codecs, constructs the recovered
+/// `SegmentedStore`, drives snapshot/WAL replay through the storage
+/// coordinator, applies the mechanical lossy WAL fallback when configured, and
+/// finishes segment recovery. Higher layers still own primitive snapshot decode
+/// through `StorageRecoveryInput::snapshot_install`, public error mapping,
+/// degraded-state policy, and operator-facing lossy reports.
+pub fn run_storage_recovery(
+    input: StorageRecoveryInput<'_>,
+) -> Result<StorageRecoveryOutcome, StorageRecoveryError> {
+    let StorageRecoveryInput {
+        layout,
+        mode,
+        configured_codec_id,
+        write_buffer_size,
+        runtime_config,
+        allow_lossy_wal_replay,
+        snapshot_install,
+    } = input;
+
+    let StorageManifestRecoveryPreparation {
+        database_uuid,
+        wal_codec,
+        snapshot_install_codec,
+    } = prepare_storage_manifest_for_recovery(&layout, mode, &configured_codec_id)?;
+
+    let mut storage =
+        SegmentedStore::with_dir(layout.segments_dir().to_path_buf(), write_buffer_size);
+    let replay = run_storage_coordinator_replay(
+        &layout,
+        write_buffer_size,
+        allow_lossy_wal_replay,
+        wal_codec.as_ref(),
+        snapshot_install_codec.as_deref(),
+        &storage,
+        snapshot_install,
+    );
+    let (wal_replay, lossy_wal_replay) =
+        handle_storage_wal_replay_outcome(replay, &layout, write_buffer_size, &mut storage)?;
+
+    complete_storage_recovery_after_replay(
+        database_uuid,
+        wal_codec,
+        storage,
+        wal_replay,
+        runtime_config,
+        lossy_wal_replay,
+    )
+}
+
+/// Storage-neutral recovery mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum StorageRecoveryMode {
+    /// Primary-style storage recovery creates a missing MANIFEST.
+    PrimaryCreateManifestIfMissing,
+    /// Follower-style storage recovery never creates a missing MANIFEST.
+    FollowerNeverCreateManifest,
+}
+
+/// Runtime storage knobs needed before `SegmentedStore::recover_segments()`.
+///
+/// This mirrors the storage setter types rather than higher-layer product
+/// defaults. Higher layers remain responsible for building this from their
+/// configuration until the public configuration split is complete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct StorageRuntimeConfig {
+    /// Maximum branches allowed by the store; `0` means unlimited.
+    pub max_branches: usize,
+    /// Maximum retained versions per key; `0` means unlimited.
+    pub max_versions_per_key: usize,
+    /// Maximum frozen memtables per branch before rotation is skipped.
+    pub max_immutable_memtables: usize,
+    /// Target size for a single segment file in bytes.
+    pub target_file_size: u64,
+    /// Target total size for L1 in bytes.
+    pub level_base_bytes: u64,
+    /// Data block size for newly built segment files.
+    pub data_block_size: usize,
+    /// Bloom filter bits per key for newly built segment files.
+    pub bloom_bits_per_key: usize,
+    /// Compaction I/O rate limit in bytes per second; `0` means unlimited.
+    pub compaction_rate_limit: u64,
+}
+
+impl StorageRuntimeConfig {
+    /// Default target size for a single segment file in bytes.
+    pub const DEFAULT_TARGET_FILE_SIZE: u64 = 64 << 20;
+    /// Default target total size for L1 in bytes.
+    pub const DEFAULT_LEVEL_BASE_BYTES: u64 = 256 << 20;
+    /// Default segment data block size in bytes.
+    pub const DEFAULT_DATA_BLOCK_SIZE: usize = 4096;
+    /// Default bloom filter bits per key.
+    pub const DEFAULT_BLOOM_BITS_PER_KEY: usize = 10;
+
+    /// Build a storage runtime config from explicit storage-layer knobs.
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(
+        max_branches: usize,
+        max_versions_per_key: usize,
+        max_immutable_memtables: usize,
+        target_file_size: u64,
+        level_base_bytes: u64,
+        data_block_size: usize,
+        bloom_bits_per_key: usize,
+        compaction_rate_limit: u64,
+    ) -> Self {
+        Self {
+            max_branches,
+            max_versions_per_key,
+            max_immutable_memtables,
+            target_file_size,
+            level_base_bytes,
+            data_block_size,
+            bloom_bits_per_key,
+            compaction_rate_limit,
+        }
+    }
+}
+
+impl Default for StorageRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            max_branches: 0,
+            max_versions_per_key: 0,
+            max_immutable_memtables: 0,
+            target_file_size: Self::DEFAULT_TARGET_FILE_SIZE,
+            level_base_bytes: Self::DEFAULT_LEVEL_BASE_BYTES,
+            data_block_size: Self::DEFAULT_DATA_BLOCK_SIZE,
+            bloom_bits_per_key: Self::DEFAULT_BLOOM_BITS_PER_KEY,
+            compaction_rate_limit: 0,
+        }
+    }
+}
+
+/// Storage-local MANIFEST and codec preparation result for recovery.
+///
+/// This intentionally carries only raw storage facts. Higher layers still
+/// decide public recovery policy and wording after `run_storage_recovery`
+/// returns.
+struct StorageManifestRecoveryPreparation {
+    /// MANIFEST-recorded database UUID, or `[0; 16]` for follower recovery
+    /// when no MANIFEST exists.
+    database_uuid: [u8; 16],
+    /// WAL codec resolved for recovery replay.
+    wal_codec: Box<dyn StorageCodec>,
+    /// Snapshot install codec when an on-disk MANIFEST exists.
+    snapshot_install_codec: Option<Box<dyn StorageCodec>>,
+}
+
+impl fmt::Debug for StorageManifestRecoveryPreparation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StorageManifestRecoveryPreparation")
+            .field("database_uuid", &self.database_uuid)
+            .field("wal_codec_id", &self.wal_codec.codec_id())
+            .field(
+                "snapshot_install_codec_id",
+                &self.snapshot_install_codec.as_ref().map(|c| c.codec_id()),
+            )
+            .finish()
+    }
+}
+
+/// Prepare MANIFEST state and recovery codecs for the storage recovery path.
+///
+/// The configured codec is validated before any recovery-managed directory or
+/// MANIFEST is created. Primary mode creates a missing MANIFEST; follower mode
+/// never creates a MANIFEST, but may create the segments directory so storage
+/// replay has a stable root.
+fn prepare_storage_manifest_for_recovery(
+    layout: &DatabaseLayout,
+    mode: StorageRecoveryMode,
+    configured_codec_id: &str,
+) -> Result<StorageManifestRecoveryPreparation, StorageRecoveryError> {
+    let configured_codec =
+        get_codec(configured_codec_id).map_err(|source| StorageRecoveryError::CodecInit {
+            codec_id: configured_codec_id.to_string(),
+            detail: source.to_string(),
+        })?;
+
+    let manifest_path = layout.manifest_path().to_path_buf();
+    if ManifestManager::exists(&manifest_path) {
+        let manager = ManifestManager::load(manifest_path.clone()).map_err(|source| {
+            StorageRecoveryError::ManifestLoad {
+                path: manifest_path,
+                source,
+            }
+        })?;
+        let manifest = manager.manifest();
+        if manifest.codec_id != configured_codec_id {
+            return Err(StorageRecoveryError::ManifestCodecMismatch {
+                stored: manifest.codec_id.clone(),
+                configured: configured_codec_id.to_string(),
+            });
+        }
+
+        return Ok(StorageManifestRecoveryPreparation {
+            database_uuid: manifest.database_uuid,
+            snapshot_install_codec: Some(clone_codec(configured_codec.as_ref())),
+            wal_codec: configured_codec,
+        });
+    }
+
+    match mode {
+        StorageRecoveryMode::PrimaryCreateManifestIfMissing => {
+            layout
+                .create_segments_dir()
+                .map_err(|source| StorageRecoveryError::Io { source })?;
+            restrict_storage_dir(layout.segments_dir());
+            let database_uuid = *uuid::Uuid::new_v4().as_bytes();
+            ManifestManager::create(
+                layout.manifest_path().to_path_buf(),
+                database_uuid,
+                configured_codec_id.to_string(),
+            )
+            .map_err(|source| StorageRecoveryError::ManifestCreate { source })?;
+
+            Ok(StorageManifestRecoveryPreparation {
+                database_uuid,
+                wal_codec: configured_codec,
+                snapshot_install_codec: None,
+            })
+        }
+        StorageRecoveryMode::FollowerNeverCreateManifest => {
+            if !layout
+                .segments_dir()
+                .try_exists()
+                .map_err(|source| StorageRecoveryError::Io { source })?
+            {
+                layout
+                    .create_segments_dir()
+                    .map_err(|source| StorageRecoveryError::Io { source })?;
+                restrict_storage_dir(layout.segments_dir());
+            }
+
+            Ok(StorageManifestRecoveryPreparation {
+                database_uuid: [0u8; 16],
+                wal_codec: configured_codec,
+                snapshot_install_codec: None,
+            })
+        }
+    }
+}
+
+/// Result of the storage-owned coordinator replay driver.
+///
+/// This private value is consumed by the storage-owned lossy replay outcome
+/// helper before higher layers build public recovery reports.
+struct StorageCoordinatorReplay {
+    /// Coordinator replay result, mapped into the storage-local recovery error
+    /// taxonomy without losing the structured coordinator source.
+    recover_result: Result<RecoveryStats, StorageRecoveryError>,
+    /// Number of WAL records successfully applied before the replay result was
+    /// produced.
+    records_applied: u64,
+    /// Whether the coordinator replay was configured to scan past WAL
+    /// corruption and storage may apply the matching whole-store fallback.
+    allow_lossy_wal_replay: bool,
+    /// Whether a callback failure came from snapshot installation rather than
+    /// WAL record application. Snapshot install failures are not lossy-WAL
+    /// replay failures and must not be converted into an empty open.
+    snapshot_install_failed: bool,
+}
+
+impl fmt::Debug for StorageCoordinatorReplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StorageCoordinatorReplay")
+            .field("recover_result", &self.recover_result)
+            .field("records_applied", &self.records_applied)
+            .field("allow_lossy_wal_replay", &self.allow_lossy_wal_replay)
+            .field("snapshot_install_failed", &self.snapshot_install_failed)
+            .finish()
+    }
+}
+
+/// Drive recovery coordinator snapshot install and WAL replay into storage.
+///
+/// Storage owns the coordinator and generic WAL record application. Primitive
+/// snapshot decode remains in the caller-provided callback, which receives the
+/// resolved install codec and the target `SegmentedStore`.
+fn run_storage_coordinator_replay(
+    layout: &DatabaseLayout,
+    write_buffer_size: usize,
+    allow_lossy_wal_replay: bool,
+    wal_codec: &dyn StorageCodec,
+    snapshot_install_codec: Option<&dyn StorageCodec>,
+    storage: &SegmentedStore,
+    snapshot_install: &dyn RecoverySnapshotInstallCallback,
+) -> StorageCoordinatorReplay {
+    let recovery = RecoveryCoordinator::new(layout.clone(), write_buffer_size)
+        .with_lossy_recovery(allow_lossy_wal_replay)
+        .with_codec(clone_codec(wal_codec));
+
+    let mut records_applied = 0_u64;
+    let mut snapshot_install_failed = false;
+    let recover_result = recovery
+        .recover_typed(
+            |snapshot| {
+                let result = install_recovery_snapshot(
+                    &snapshot,
+                    snapshot_install_codec,
+                    storage,
+                    snapshot_install,
+                );
+                if result.is_err() {
+                    snapshot_install_failed = true;
+                }
+                result
+            },
+            |record| {
+                let result = apply_wal_record_to_memory_storage(storage, record);
+                if result.is_ok() {
+                    records_applied += 1;
+                }
+                result
+            },
+        )
+        .map_err(|source| StorageRecoveryError::Coordinator { source });
+
+    StorageCoordinatorReplay {
+        recover_result,
+        records_applied,
+        allow_lossy_wal_replay,
+        snapshot_install_failed,
+    }
+}
+
+/// Complete storage-owned recovery mechanics after coordinator replay.
+///
+/// Storage folds the in-memory version reached by snapshot install / WAL replay
+/// into WAL replay stats, applies storage-native runtime knobs, and runs segment
+/// recovery. Versions discovered only from segment files remain in
+/// `StorageRecoveryOutcome::segment_recovery.version_floor`; callers must
+/// combine that floor with `wal_replay.final_version` when bootstrapping their
+/// own version counters.
+fn complete_storage_recovery_after_replay(
+    database_uuid: [u8; 16],
+    wal_codec: Box<dyn StorageCodec>,
+    storage: SegmentedStore,
+    mut wal_replay: RecoveryStats,
+    runtime_config: StorageRuntimeConfig,
+    lossy_wal_replay: Option<StorageLossyWalReplayFacts>,
+) -> Result<StorageRecoveryOutcome, StorageRecoveryError> {
+    wal_replay.final_version = wal_replay.final_version.max(storage.current_version());
+    apply_storage_runtime_config(&storage, runtime_config);
+    let segment_recovery = storage
+        .recover_segments()
+        .map_err(|source| StorageRecoveryError::SegmentRecovery { source })?;
+
+    Ok(StorageRecoveryOutcome::new(
+        database_uuid,
+        wal_codec,
+        storage,
+        wal_replay,
+        segment_recovery,
+        lossy_wal_replay,
+    ))
+}
+
+/// Classify a coordinator replay result and apply the mechanical lossy WAL
+/// replay fallback when configured.
+///
+/// Storage owns the raw replay mechanics: honoring hard-fail bypass rules,
+/// sampling partial progress before any wipe, and replacing partially-applied
+/// storage with a fresh layout-rooted store. Higher layers remain responsible
+/// for mapping the source error into public taxonomy, wording, and logs.
+fn handle_storage_wal_replay_outcome(
+    replay: StorageCoordinatorReplay,
+    layout: &DatabaseLayout,
+    write_buffer_size: usize,
+    storage: &mut SegmentedStore,
+) -> Result<(RecoveryStats, Option<StorageLossyWalReplayFacts>), StorageRecoveryError> {
+    let StorageCoordinatorReplay {
+        recover_result,
+        records_applied,
+        allow_lossy_wal_replay,
+        snapshot_install_failed,
+    } = replay;
+    let source = match recover_result {
+        Ok(stats) => return Ok((stats, None)),
+        Err(StorageRecoveryError::Coordinator { source }) => source,
+        Err(other) => return Err(other),
+    };
+
+    if source.should_bypass_lossy() || snapshot_install_failed || !allow_lossy_wal_replay {
+        return Err(StorageRecoveryError::Coordinator { source });
+    }
+
+    let facts =
+        StorageLossyWalReplayFacts::new(records_applied, storage.current_version(), true, source);
+
+    *storage = SegmentedStore::with_dir(layout.segments_dir().to_path_buf(), write_buffer_size);
+
+    Ok((RecoveryStats::default(), Some(facts)))
+}
+
+fn apply_storage_runtime_config(storage: &SegmentedStore, config: StorageRuntimeConfig) {
+    storage.set_max_branches(config.max_branches);
+    storage.set_max_versions_per_key(config.max_versions_per_key);
+    storage.set_max_immutable_memtables(config.max_immutable_memtables);
+    storage.set_target_file_size(config.target_file_size);
+    storage.set_level_base_bytes(config.level_base_bytes);
+    storage.set_data_block_size(config.data_block_size);
+    storage.set_bloom_bits_per_key(config.bloom_bits_per_key);
+    storage.set_compaction_rate_limit(config.compaction_rate_limit);
+}
+
+fn install_recovery_snapshot(
+    snapshot: &LoadedSnapshot,
+    install_codec: Option<&dyn StorageCodec>,
+    storage: &SegmentedStore,
+    snapshot_install: &dyn RecoverySnapshotInstallCallback,
+) -> Result<(), StorageError> {
+    let Some(codec) = install_codec else {
+        return Err(StorageError::corruption(format!(
+            "snapshot {} reached recovery install callback without an install codec",
+            snapshot.snapshot_id()
+        )));
+    };
+
+    snapshot_install.install_snapshot(snapshot, codec, storage)
+}
+
+#[cfg(unix)]
+fn restrict_storage_dir(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    if let Err(error) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)) {
+        warn!(
+            target: "strata::storage",
+            path = %path.display(),
+            error = %error,
+            "Failed to restrict directory permissions"
+        );
+    }
+}
+
+#[cfg(not(unix))]
+fn restrict_storage_dir(_path: &Path) {}
+
+/// Raw storage recovery outcome.
+///
+/// Higher layers use these facts to construct database runtime state, follower
+/// state, public errors, and operator-facing lossy recovery reports.
+#[non_exhaustive]
+pub struct StorageRecoveryOutcome {
+    /// MANIFEST-recorded database UUID, or `[0; 16]` when follower recovery had
+    /// no MANIFEST to read.
+    pub database_uuid: [u8; 16],
+    /// WAL codec resolved by storage recovery.
+    pub wal_codec: Box<dyn StorageCodec>,
+    /// Recovered storage.
+    pub storage: SegmentedStore,
+    /// WAL/snapshot replay stats from the recovery coordinator.
+    ///
+    /// `final_version` includes the in-memory version reached before segment
+    /// recovery. Segment-only versions are reported separately through
+    /// `segment_recovery.version_floor`.
+    pub wal_replay: RecoveryStats,
+    /// Segment recovery facts from `SegmentedStore::recover_segments()`.
+    pub segment_recovery: RecoveredState,
+    /// Mechanical lossy WAL replay facts, when the fallback ran.
+    pub lossy_wal_replay: Option<StorageLossyWalReplayFacts>,
+}
+
+impl StorageRecoveryOutcome {
+    /// Build a raw storage recovery outcome without requiring callers to
+    /// construct the public struct literally.
+    pub fn new(
+        database_uuid: [u8; 16],
+        wal_codec: Box<dyn StorageCodec>,
+        storage: SegmentedStore,
+        wal_replay: RecoveryStats,
+        segment_recovery: RecoveredState,
+        lossy_wal_replay: Option<StorageLossyWalReplayFacts>,
+    ) -> Self {
+        Self {
+            database_uuid,
+            wal_codec,
+            storage,
+            wal_replay,
+            segment_recovery,
+            lossy_wal_replay,
+        }
+    }
+}
+
+impl fmt::Debug for StorageRecoveryOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StorageRecoveryOutcome")
+            .field("database_uuid", &self.database_uuid)
+            .field("wal_codec_id", &self.wal_codec.codec_id())
+            .field("storage", &"<SegmentedStore>")
+            .field("wal_replay", &self.wal_replay)
+            .field("segment_recovery", &self.segment_recovery)
+            .field("lossy_wal_replay", &self.lossy_wal_replay)
+            .finish()
+    }
+}
+
+/// Mechanical facts from the lossy WAL replay fallback.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct StorageLossyWalReplayFacts {
+    /// Number of WAL records applied before the failure that triggered the
+    /// fallback.
+    pub records_applied_before_failure: u64,
+    /// Storage version reached before the fallback wiped partial state.
+    pub version_reached_before_failure: CommitVersion,
+    /// Whether storage discarded partial state during the fallback.
+    pub discarded_on_wipe: bool,
+    /// Original coordinator failure that caused the fallback.
+    pub source: CoordinatorRecoveryError,
+}
+
+impl StorageLossyWalReplayFacts {
+    /// Build mechanical lossy WAL replay facts without requiring callers to
+    /// construct the public struct literally.
+    pub fn new(
+        records_applied_before_failure: u64,
+        version_reached_before_failure: CommitVersion,
+        discarded_on_wipe: bool,
+        source: CoordinatorRecoveryError,
+    ) -> Self {
+        Self {
+            records_applied_before_failure,
+            version_reached_before_failure,
+            discarded_on_wipe,
+            source,
+        }
+    }
+}
+
+/// Storage-local recovery bootstrap errors.
+///
+/// These variants intentionally avoid higher-layer public wording. Higher
+/// layers map them into their own error taxonomy at the database-open boundary.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StorageRecoveryError {
+    /// The configured or MANIFEST-recorded codec could not be initialized.
+    #[error("could not initialize storage codec {codec_id:?}: {detail}")]
+    CodecInit {
+        /// Codec id that failed to initialize.
+        codec_id: String,
+        /// Codec initialization detail.
+        detail: String,
+    },
+
+    /// MANIFEST load failed.
+    #[error("failed to load MANIFEST at {path}: {source}")]
+    ManifestLoad {
+        /// MANIFEST path.
+        path: PathBuf,
+        /// Underlying MANIFEST error.
+        #[source]
+        source: ManifestError,
+    },
+
+    /// MANIFEST creation failed.
+    #[error("failed to create MANIFEST: {source}")]
+    ManifestCreate {
+        /// Underlying MANIFEST error.
+        #[source]
+        source: ManifestError,
+    },
+
+    /// MANIFEST codec id disagreed with the configured codec id.
+    #[error("MANIFEST codec mismatch: stored={stored:?}, configured={configured:?}")]
+    ManifestCodecMismatch {
+        /// Codec id stored in MANIFEST.
+        stored: String,
+        /// Codec id supplied by runtime configuration.
+        configured: String,
+    },
+
+    /// I/O outside MANIFEST-specific paths failed.
+    #[error("storage recovery I/O error: {source}")]
+    Io {
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Recovery coordinator planning, snapshot load, WAL read, payload decode,
+    /// or callback execution failed.
+    #[error("storage recovery coordinator failed: {source}")]
+    Coordinator {
+        /// Structured coordinator failure.
+        #[source]
+        source: CoordinatorRecoveryError,
+    },
+
+    /// Segment recovery failed before it could return classified health.
+    #[error("segment recovery failed: {source}")]
+    SegmentRecovery {
+        /// Underlying storage failure.
+        #[source]
+        source: StorageError,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::durability::codec::IdentityCodec;
+    use crate::durability::format::WalRecord;
+    use crate::durability::wal::{DurabilityMode, WalConfig, WalReaderError, WalWriter};
+    use crate::durability::{
+        CoordinatorPlanError, SnapshotHeader, SnapshotWriter, TransactionPayload,
+    };
+    use crate::manifest::{write_manifest, ManifestEntry};
+    use crate::segmented::hex_encode_branch;
+    use crate::{Key, Namespace, WriteMode};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use strata_core::id::TxnId;
+    use strata_core::{BranchId, Value};
+
+    #[test]
+    fn constructs_storage_recovery_input_without_higher_layer_types() {
+        let callback = |_snapshot: &LoadedSnapshot,
+                        _install_codec: &dyn StorageCodec,
+                        _storage: &SegmentedStore|
+         -> Result<(), StorageError> { Ok(()) };
+        let input = StorageRecoveryInput::new(
+            DatabaseLayout::from_root("/tmp/strata-es4b"),
+            StorageRecoveryMode::PrimaryCreateManifestIfMissing,
+            "identity",
+            4096,
+            StorageRuntimeConfig::new(128, 16, 2, 1 << 20, 4 << 20, 4096, 10, 0),
+            true,
+            &callback,
+        );
+
+        assert_eq!(
+            input.mode,
+            StorageRecoveryMode::PrimaryCreateManifestIfMissing
+        );
+        assert_eq!(input.runtime_config.target_file_size, 1 << 20);
+        assert!(format!("{input:?}").contains("<callback>"));
+    }
+
+    #[test]
+    fn runtime_config_default_matches_segmented_store_defaults() {
+        let cfg = StorageRuntimeConfig::default();
+        let store = SegmentedStore::new();
+
+        assert_eq!(cfg.max_branches, 0);
+        assert_eq!(cfg.max_versions_per_key, 0);
+        assert_eq!(cfg.max_immutable_memtables, 0);
+        assert_eq!(cfg.target_file_size, store.target_file_size());
+        assert_eq!(cfg.level_base_bytes, store.level_base_bytes());
+        assert_eq!(cfg.data_block_size, store.data_block_size());
+        assert_eq!(cfg.bloom_bits_per_key, store.bloom_bits_per_key());
+        assert_eq!(cfg.compaction_rate_limit, 0);
+    }
+
+    #[test]
+    fn manifest_preparation_rejects_invalid_codec_before_side_effects() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path().join("db"));
+
+        let err = prepare_storage_manifest_for_recovery(
+            &layout,
+            StorageRecoveryMode::PrimaryCreateManifestIfMissing,
+            "does-not-exist",
+        )
+        .expect_err("invalid configured codec should fail");
+
+        assert!(matches!(err, StorageRecoveryError::CodecInit { .. }));
+        assert!(
+            !layout.manifest_path().exists(),
+            "invalid codec must not create MANIFEST"
+        );
+        assert!(
+            !layout.segments_dir().exists(),
+            "invalid codec must not create segments dir"
+        );
+    }
+
+    #[test]
+    fn primary_manifest_preparation_creates_manifest_and_segments() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+
+        let prepared = prepare_storage_manifest_for_recovery(
+            &layout,
+            StorageRecoveryMode::PrimaryCreateManifestIfMissing,
+            "identity",
+        )
+        .expect("primary missing-MANIFEST preparation should succeed");
+
+        assert_ne!(prepared.database_uuid, [0u8; 16]);
+        assert_eq!(prepared.wal_codec.codec_id(), "identity");
+        assert!(prepared.snapshot_install_codec.is_none());
+        assert!(layout.segments_dir().exists());
+        let manifest = ManifestManager::load(layout.manifest_path().to_path_buf()).unwrap();
+        assert_eq!(manifest.manifest().database_uuid, prepared.database_uuid);
+        assert_eq!(manifest.manifest().codec_id, "identity");
+    }
+
+    #[test]
+    fn follower_manifest_preparation_never_creates_manifest() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path().join("follower"));
+
+        let prepared = prepare_storage_manifest_for_recovery(
+            &layout,
+            StorageRecoveryMode::FollowerNeverCreateManifest,
+            "identity",
+        )
+        .expect("follower missing-MANIFEST preparation should succeed");
+
+        assert_eq!(prepared.database_uuid, [0u8; 16]);
+        assert_eq!(prepared.wal_codec.codec_id(), "identity");
+        assert!(prepared.snapshot_install_codec.is_none());
+        assert!(layout.segments_dir().exists());
+        assert!(
+            !layout.manifest_path().exists(),
+            "follower preparation must not create MANIFEST"
+        );
+    }
+
+    #[test]
+    fn existing_manifest_preparation_returns_install_codec_and_mismatch_error() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let database_uuid = [0x33; 16];
+        ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            database_uuid,
+            "unknown-stored-codec".to_string(),
+        )
+        .unwrap();
+
+        let mismatch = prepare_storage_manifest_for_recovery(
+            &layout,
+            StorageRecoveryMode::PrimaryCreateManifestIfMissing,
+            "identity",
+        )
+        .expect_err("stored/configured codec mismatch should be typed");
+
+        assert!(matches!(
+            mismatch,
+            StorageRecoveryError::ManifestCodecMismatch { .. }
+        ));
+
+        ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            database_uuid,
+            "identity".to_string(),
+        )
+        .unwrap();
+        let prepared = prepare_storage_manifest_for_recovery(
+            &layout,
+            StorageRecoveryMode::PrimaryCreateManifestIfMissing,
+            "identity",
+        )
+        .expect("matching existing MANIFEST should prepare codecs");
+
+        assert_eq!(prepared.database_uuid, database_uuid);
+        assert_eq!(prepared.wal_codec.codec_id(), "identity");
+        assert_eq!(
+            prepared
+                .snapshot_install_codec
+                .as_ref()
+                .expect("existing MANIFEST should provide snapshot install codec")
+                .codec_id(),
+            "identity"
+        );
+    }
+
+    #[test]
+    fn snapshot_install_callback_receives_codec_and_storage() {
+        let callback = |snapshot: &LoadedSnapshot,
+                        install_codec: &dyn StorageCodec,
+                        storage: &SegmentedStore|
+         -> Result<(), StorageError> {
+            assert_eq!(snapshot.snapshot_id(), 7);
+            assert_eq!(install_codec.codec_id(), "identity");
+            assert_eq!(storage.version(), 0);
+            Ok(())
+        };
+        let snapshot = LoadedSnapshot {
+            header: SnapshotHeader::new(7, 3, 1, [0x77; 16], "identity".len() as u8),
+            codec_id: "identity".to_string(),
+            sections: Vec::new(),
+            crc: 0,
+        };
+        let storage = SegmentedStore::new();
+        let codec = IdentityCodec;
+
+        callback
+            .install_snapshot(&snapshot, &codec, &storage)
+            .expect("callback should succeed");
+    }
+
+    #[test]
+    fn run_storage_recovery_replays_wal_and_returns_raw_outcome() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "storage-wrapper-wal");
+        write_wal_txn(
+            layout.wal_dir(),
+            TxnId(31),
+            branch_id,
+            vec![(key.clone(), Value::String("from-wrapper".to_string()))],
+            Vec::new(),
+            41,
+        );
+        let snapshot_install = |_snapshot: &LoadedSnapshot,
+                                _install_codec: &dyn StorageCodec,
+                                _storage: &SegmentedStore|
+         -> Result<(), StorageError> { Ok(()) };
+
+        let outcome = run_storage_recovery(StorageRecoveryInput::new(
+            layout.clone(),
+            StorageRecoveryMode::PrimaryCreateManifestIfMissing,
+            "identity",
+            4096,
+            StorageRuntimeConfig::default(),
+            false,
+            &snapshot_install,
+        ))
+        .expect("storage recovery wrapper should replay WAL");
+
+        assert!(layout.manifest_path().exists());
+        assert!(layout.segments_dir().exists());
+        assert_ne!(outcome.database_uuid, [0u8; 16]);
+        assert_eq!(outcome.wal_codec.codec_id(), "identity");
+        assert_eq!(outcome.wal_replay.txns_replayed, 1);
+        assert_eq!(outcome.wal_replay.writes_applied, 1);
+        assert_eq!(outcome.wal_replay.final_version, CommitVersion(41));
+        assert!(outcome.lossy_wal_replay.is_none());
+        let recovered = outcome
+            .storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("WAL row should be visible after storage recovery");
+        assert_eq!(recovered.value, Value::String("from-wrapper".to_string()));
+    }
+
+    #[test]
+    fn run_storage_recovery_carries_lossy_facts_after_wipe() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "storage-wrapper-lossy");
+        write_wal_txn(
+            layout.wal_dir(),
+            TxnId(33),
+            branch_id,
+            vec![(key.clone(), Value::String("discarded".to_string()))],
+            Vec::new(),
+            43,
+        );
+        std::fs::write(
+            layout.wal_dir().join("wal-000099.seg"),
+            b"GARBAGE_NOT_A_VALID_SEGMENT_HEADER",
+        )
+        .unwrap();
+        let snapshot_install = |_snapshot: &LoadedSnapshot,
+                                _install_codec: &dyn StorageCodec,
+                                _storage: &SegmentedStore|
+         -> Result<(), StorageError> { Ok(()) };
+
+        let outcome = run_storage_recovery(StorageRecoveryInput::new(
+            layout,
+            StorageRecoveryMode::PrimaryCreateManifestIfMissing,
+            "identity",
+            4096,
+            StorageRuntimeConfig::default(),
+            true,
+            &snapshot_install,
+        ))
+        .expect("allowed lossy storage recovery should return a raw outcome");
+
+        assert_eq!(outcome.wal_replay, RecoveryStats::default());
+        let facts = outcome
+            .lossy_wal_replay
+            .expect("lossy fallback should preserve mechanical facts");
+        assert_eq!(facts.records_applied_before_failure, 1);
+        assert_eq!(facts.version_reached_before_failure, CommitVersion(43));
+        assert!(facts.discarded_on_wipe);
+        assert!(
+            outcome
+                .storage
+                .get_versioned(&key, CommitVersion::MAX)
+                .unwrap()
+                .is_none(),
+            "storage wrapper must return the wiped store"
+        );
+    }
+
+    #[test]
+    fn coordinator_replay_applies_wal_records_and_counts_successes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "storage-replay");
+        write_wal_txn(
+            layout.wal_dir(),
+            TxnId(17),
+            branch_id,
+            vec![(key.clone(), Value::String("from-wal".to_string()))],
+            Vec::new(),
+            23,
+        );
+        let storage = SegmentedStore::with_dir(layout.segments_dir().to_path_buf(), 4096);
+        let codec = IdentityCodec;
+        let snapshot_install = |_snapshot: &LoadedSnapshot,
+                                _install_codec: &dyn StorageCodec,
+                                _storage: &SegmentedStore|
+         -> Result<(), StorageError> { Ok(()) };
+
+        let replay = run_storage_coordinator_replay(
+            &layout,
+            4096,
+            false,
+            &codec,
+            None,
+            &storage,
+            &snapshot_install,
+        );
+
+        let stats = replay
+            .recover_result
+            .expect("WAL replay should succeed through storage driver");
+        assert_eq!(replay.records_applied, 1);
+        assert_eq!(stats.txns_replayed, 1);
+        assert_eq!(stats.writes_applied, 1);
+        assert_eq!(stats.final_version, CommitVersion(23));
+        let recovered = storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("WAL row should be applied to storage");
+        assert_eq!(recovered.value, Value::String("from-wal".to_string()));
+    }
+
+    #[test]
+    fn coordinator_replay_counts_records_before_real_wal_failure() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "storage-replay-before-failure");
+        write_wal_txn(
+            layout.wal_dir(),
+            TxnId(19),
+            branch_id,
+            vec![(key.clone(), Value::String("before-failure".to_string()))],
+            Vec::new(),
+            29,
+        );
+        std::fs::write(
+            layout.wal_dir().join("wal-000099.seg"),
+            b"GARBAGE_NOT_A_VALID_SEGMENT_HEADER",
+        )
+        .unwrap();
+        let storage = SegmentedStore::with_dir(layout.segments_dir().to_path_buf(), 4096);
+        let codec = IdentityCodec;
+        let snapshot_install = |_snapshot: &LoadedSnapshot,
+                                _install_codec: &dyn StorageCodec,
+                                _storage: &SegmentedStore|
+         -> Result<(), StorageError> { Ok(()) };
+
+        let replay = run_storage_coordinator_replay(
+            &layout,
+            4096,
+            false,
+            &codec,
+            None,
+            &storage,
+            &snapshot_install,
+        );
+
+        assert_eq!(replay.records_applied, 1);
+        match replay
+            .recover_result
+            .expect_err("corrupt later WAL segment should fail replay")
+        {
+            StorageRecoveryError::Coordinator {
+                source: CoordinatorRecoveryError::WalRead(_),
+            } => {}
+            other => panic!("expected WAL read coordinator error, got {other:?}"),
+        }
+        let recovered = storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("successful records before the real failure should have been applied");
+        assert_eq!(recovered.value, Value::String("before-failure".to_string()));
+    }
+
+    #[test]
+    fn coordinator_replay_rejects_loaded_snapshot_without_install_codec() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let database_uuid = [0x55; 16];
+        SnapshotWriter::new(
+            layout.snapshots_dir().to_path_buf(),
+            Box::new(IdentityCodec),
+            database_uuid,
+        )
+        .unwrap()
+        .create_snapshot(7, 5, Vec::new())
+        .unwrap();
+        let mut manifest = ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            database_uuid,
+            "identity".to_string(),
+        )
+        .unwrap();
+        manifest.set_snapshot_watermark(7, TxnId(5)).unwrap();
+
+        let storage = SegmentedStore::new();
+        let codec = IdentityCodec;
+        let snapshot_install = |_snapshot: &LoadedSnapshot,
+                                _install_codec: &dyn StorageCodec,
+                                _storage: &SegmentedStore|
+         -> Result<(), StorageError> {
+            panic!("storage must reject missing install codec before invoking callback")
+        };
+
+        let replay = run_storage_coordinator_replay(
+            &layout,
+            4096,
+            false,
+            &codec,
+            None,
+            &storage,
+            &snapshot_install,
+        );
+
+        assert_eq!(replay.records_applied, 0);
+        match replay
+            .recover_result
+            .expect_err("loaded snapshot without install codec should hard-fail")
+        {
+            StorageRecoveryError::Coordinator {
+                source: CoordinatorRecoveryError::Callback(StorageError::Corruption { message }),
+            } => {
+                assert!(
+                    message.contains(
+                        "snapshot 7 reached recovery install callback without an install codec"
+                    ),
+                    "missing-codec error should carry snapshot id, got: {message}"
+                );
+            }
+            other => panic!("expected missing-codec coordinator callback error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lossy_wal_replay_snapshot_callback_failure_preserves_partial_storage() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let database_uuid = [0x56; 16];
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "preserved-by-snapshot-callback-bypass");
+        SnapshotWriter::new(
+            layout.snapshots_dir().to_path_buf(),
+            Box::new(IdentityCodec),
+            database_uuid,
+        )
+        .unwrap()
+        .create_snapshot(8, 6, Vec::new())
+        .unwrap();
+        let mut manifest = ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            database_uuid,
+            "identity".to_string(),
+        )
+        .unwrap();
+        manifest.set_snapshot_watermark(8, TxnId(6)).unwrap();
+
+        let mut storage = storage_with_partial_row(&layout, key.clone(), CommitVersion(41));
+        let codec = IdentityCodec;
+        let snapshot_install = |_snapshot: &LoadedSnapshot,
+                                _install_codec: &dyn StorageCodec,
+                                _storage: &SegmentedStore|
+         -> Result<(), StorageError> {
+            panic!("storage must reject missing install codec before invoking callback")
+        };
+
+        let replay = run_storage_coordinator_replay(
+            &layout,
+            4096,
+            true,
+            &codec,
+            None,
+            &storage,
+            &snapshot_install,
+        );
+
+        assert_eq!(replay.records_applied, 0);
+        assert!(
+            replay.snapshot_install_failed,
+            "missing install codec is a snapshot callback failure, not a WAL replay failure"
+        );
+        let err = handle_storage_wal_replay_outcome(replay, &layout, 4096, &mut storage)
+            .expect_err("snapshot callback failures must bypass lossy WAL fallback");
+        match err {
+            StorageRecoveryError::Coordinator {
+                source: CoordinatorRecoveryError::Callback(StorageError::Corruption { message }),
+            } => {
+                assert!(
+                    message.contains(
+                        "snapshot 8 reached recovery install callback without an install codec"
+                    ),
+                    "missing-codec error should carry snapshot id, got: {message}"
+                );
+            }
+            other => panic!("expected missing-codec coordinator callback error, got {other:?}"),
+        }
+        let preserved = storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("snapshot callback bypass must not wipe partial storage");
+        assert_eq!(preserved.value, Value::String("partial".to_string()));
+        assert_eq!(storage.current_version(), CommitVersion(41));
+    }
+
+    #[test]
+    fn lossy_wal_replay_fallback_discards_partial_storage_and_returns_facts() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "discarded-by-storage-lossy");
+        let mut storage = storage_with_partial_row(&layout, key.clone(), CommitVersion(19));
+
+        let (stats, facts) = handle_storage_wal_replay_outcome(
+            replay_error(
+                CoordinatorRecoveryError::WalRead(WalReaderError::CorruptedSegment {
+                    offset: 128,
+                    records_before: 3,
+                }),
+                true,
+                3,
+            ),
+            &layout,
+            4096,
+            &mut storage,
+        )
+        .expect("storage lossy fallback should convert replay failure into empty stats");
+
+        assert_eq!(stats, RecoveryStats::default());
+        let facts = facts.expect("allowed lossy fallback should return facts");
+        assert_eq!(facts.records_applied_before_failure, 3);
+        assert_eq!(facts.version_reached_before_failure, CommitVersion(19));
+        assert!(facts.discarded_on_wipe);
+        assert!(matches!(
+            facts.source,
+            CoordinatorRecoveryError::WalRead(WalReaderError::CorruptedSegment { .. })
+        ));
+        assert!(
+            storage
+                .get_versioned(&key, CommitVersion::MAX)
+                .unwrap()
+                .is_none(),
+            "lossy fallback must replace partial storage with an empty store"
+        );
+        assert_eq!(storage.current_version(), CommitVersion::ZERO);
+    }
+
+    #[test]
+    fn lossy_wal_replay_disabled_preserves_partial_storage() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "preserved-when-lossy-disabled");
+        let mut storage = storage_with_partial_row(&layout, key.clone(), CommitVersion(23));
+
+        let err = handle_storage_wal_replay_outcome(
+            replay_error(
+                CoordinatorRecoveryError::WalRead(WalReaderError::CorruptedSegment {
+                    offset: 256,
+                    records_before: 4,
+                }),
+                false,
+                4,
+            ),
+            &layout,
+            4096,
+            &mut storage,
+        )
+        .expect_err("disabled lossy fallback must preserve the coordinator error");
+
+        assert!(matches!(
+            err,
+            StorageRecoveryError::Coordinator {
+                source: CoordinatorRecoveryError::WalRead(WalReaderError::CorruptedSegment { .. })
+            }
+        ));
+        let preserved = storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("disabled lossy fallback must not wipe partial storage");
+        assert_eq!(preserved.value, Value::String("partial".to_string()));
+        assert_eq!(storage.current_version(), CommitVersion(23));
+    }
+
+    #[test]
+    fn lossy_wal_replay_bypass_preserves_partial_storage() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "preserved-by-bypass");
+        let mut storage = storage_with_partial_row(&layout, key.clone(), CommitVersion(31));
+
+        let err = handle_storage_wal_replay_outcome(
+            replay_error(
+                CoordinatorRecoveryError::WalRead(WalReaderError::LegacyFormat {
+                    found_version: 1,
+                    hint: "delete wal/ or migrate".to_string(),
+                }),
+                true,
+                5,
+            ),
+            &layout,
+            4096,
+            &mut storage,
+        )
+        .expect_err("legacy WAL must bypass lossy fallback");
+
+        assert!(matches!(
+            err,
+            StorageRecoveryError::Coordinator {
+                source: CoordinatorRecoveryError::WalRead(WalReaderError::LegacyFormat { .. })
+            }
+        ));
+        let preserved = storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("lossy bypass must not wipe partial storage");
+        assert_eq!(preserved.value, Value::String("partial".to_string()));
+        assert_eq!(storage.current_version(), CommitVersion(31));
+    }
+
+    #[test]
+    fn lossy_wal_replay_plan_failure_preserves_partial_storage() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "preserved-by-plan-bypass");
+        let mut storage = storage_with_partial_row(&layout, key.clone(), CommitVersion(37));
+
+        let err = handle_storage_wal_replay_outcome(
+            replay_error(
+                CoordinatorRecoveryError::Plan(CoordinatorPlanError::CodecMismatch {
+                    stored: "identity".to_string(),
+                    expected: "aes-gcm-256".to_string(),
+                }),
+                true,
+                0,
+            ),
+            &layout,
+            4096,
+            &mut storage,
+        )
+        .expect_err("coordinator planning errors must bypass lossy fallback");
+
+        assert!(matches!(
+            err,
+            StorageRecoveryError::Coordinator {
+                source: CoordinatorRecoveryError::Plan(CoordinatorPlanError::CodecMismatch { .. })
+            }
+        ));
+        let preserved = storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("planning bypass must not wipe partial storage");
+        assert_eq!(preserved.value, Value::String("partial".to_string()));
+        assert_eq!(storage.current_version(), CommitVersion(37));
+    }
+
+    #[test]
+    fn lossy_wal_replay_snapshot_failure_preserves_partial_storage() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "preserved-by-snapshot-bypass");
+        let mut storage = storage_with_partial_row(&layout, key.clone(), CommitVersion(39));
+
+        let err = handle_storage_wal_replay_outcome(
+            replay_error(
+                CoordinatorRecoveryError::SnapshotMissing {
+                    snapshot_id: 9,
+                    path: layout.snapshots_dir().join("snapshot-9.strata"),
+                },
+                true,
+                0,
+            ),
+            &layout,
+            4096,
+            &mut storage,
+        )
+        .expect_err("snapshot failures must bypass lossy fallback");
+
+        assert!(matches!(
+            err,
+            StorageRecoveryError::Coordinator {
+                source: CoordinatorRecoveryError::SnapshotMissing { .. }
+            }
+        ));
+        let preserved = storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("snapshot bypass must not wipe partial storage");
+        assert_eq!(preserved.value, Value::String("partial".to_string()));
+        assert_eq!(storage.current_version(), CommitVersion(39));
+    }
+
+    #[test]
+    fn coordinator_replay_invokes_snapshot_callback_with_install_codec() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let database_uuid = [0x66; 16];
+        SnapshotWriter::new(
+            layout.snapshots_dir().to_path_buf(),
+            Box::new(IdentityCodec),
+            database_uuid,
+        )
+        .unwrap()
+        .create_snapshot(11, 8, Vec::new())
+        .unwrap();
+        let mut manifest = ManifestManager::create(
+            layout.manifest_path().to_path_buf(),
+            database_uuid,
+            "identity".to_string(),
+        )
+        .unwrap();
+        manifest.set_snapshot_watermark(11, TxnId(8)).unwrap();
+
+        let storage = SegmentedStore::new();
+        let codec = IdentityCodec;
+        let callback_called = AtomicBool::new(false);
+        let snapshot_install = |snapshot: &LoadedSnapshot,
+                                install_codec: &dyn StorageCodec,
+                                callback_storage: &SegmentedStore|
+         -> Result<(), StorageError> {
+            callback_called.store(true, Ordering::SeqCst);
+            assert_eq!(snapshot.snapshot_id(), 11);
+            assert_eq!(install_codec.codec_id(), "identity");
+            assert!(std::ptr::eq(callback_storage, &storage));
+            Ok(())
+        };
+
+        let replay = run_storage_coordinator_replay(
+            &layout,
+            4096,
+            false,
+            &codec,
+            Some(&codec),
+            &storage,
+            &snapshot_install,
+        );
+
+        let stats = replay
+            .recover_result
+            .expect("snapshot callback should succeed through storage driver");
+        assert!(stats.from_checkpoint);
+        assert_eq!(stats.max_txn_id, TxnId(8));
+        assert!(callback_called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn post_replay_completion_folds_applies_config_and_recovers_segments() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        let branch_id = BranchId::new();
+        let key = kv_key(branch_id, "segment-recovery");
+        {
+            let writer = SegmentedStore::with_dir(layout.segments_dir().to_path_buf(), 4096);
+            writer
+                .put_with_version_mode(
+                    key.clone(),
+                    Value::String("from-segment".to_string()),
+                    CommitVersion(42),
+                    None,
+                    WriteMode::Append,
+                )
+                .unwrap();
+            writer.rotate_memtable(&branch_id);
+            writer.flush_oldest_frozen(&branch_id).unwrap();
+        }
+
+        let branch_dir = layout.segments_dir().join(hex_encode_branch(&branch_id));
+        let segment_filename = std::fs::read_dir(&branch_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter_map(|entry| {
+                let path = entry.path();
+                (path.extension().and_then(|ext| ext.to_str()) == Some("sst"))
+                    .then(|| entry.file_name().to_string_lossy().into_owned())
+            })
+            .next()
+            .expect("flush should create one segment file");
+        write_manifest(
+            &branch_dir,
+            &[ManifestEntry {
+                filename: segment_filename,
+                level: 2,
+            }],
+            &[],
+        )
+        .expect("test should pin flushed segment at L2");
+
+        let storage = SegmentedStore::with_dir(layout.segments_dir().to_path_buf(), 4096);
+        storage.set_version(CommitVersion(73));
+        let wal_replay = RecoveryStats {
+            final_version: CommitVersion(5),
+            ..RecoveryStats::default()
+        };
+        let runtime_config =
+            StorageRuntimeConfig::new(128, 16, 2, 2 << 20, 5 << 20, 8 << 10, 12, 1_234_567);
+
+        let outcome = complete_storage_recovery_after_replay(
+            [0x77; 16],
+            Box::new(IdentityCodec),
+            storage,
+            wal_replay,
+            runtime_config,
+            None,
+        )
+        .expect("post-replay storage recovery should succeed");
+
+        assert_eq!(outcome.database_uuid, [0x77; 16]);
+        assert_eq!(outcome.wal_codec.codec_id(), "identity");
+        assert_eq!(
+            outcome.wal_replay.final_version,
+            CommitVersion(73),
+            "pre-segment storage version should be folded into replay stats"
+        );
+        assert_eq!(outcome.segment_recovery.segments_loaded, 1);
+        assert_eq!(outcome.segment_recovery.version_floor, CommitVersion(42));
+        assert_eq!(outcome.storage.max_branches_for_test(), 128);
+        assert_eq!(outcome.storage.max_versions_per_key_for_test(), 16);
+        assert_eq!(outcome.storage.max_immutable_memtables_for_test(), 2);
+        assert_eq!(outcome.storage.target_file_size(), 2 << 20);
+        assert_eq!(outcome.storage.level_base_bytes(), 5 << 20);
+        assert_eq!(
+            outcome.storage.branch_level_target_for_test(&branch_id, 1),
+            Some(5 << 20),
+            "recover_segments should compute level targets with the configured base"
+        );
+        assert_eq!(outcome.storage.data_block_size(), 8 << 10);
+        assert_eq!(outcome.storage.bloom_bits_per_key(), 12);
+        assert_eq!(outcome.storage.compaction_rate_limit_for_test(), 1_234_567);
+        assert!(outcome.lossy_wal_replay.is_none());
+        let recovered = outcome
+            .storage
+            .get_versioned(&key, CommitVersion::MAX)
+            .unwrap()
+            .expect("segment recovery should load the flushed row");
+        assert_eq!(recovered.value, Value::String("from-segment".to_string()));
+    }
+
+    #[test]
+    fn post_replay_completion_carries_lossy_wal_replay_facts() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let layout = DatabaseLayout::from_root(temp_dir.path());
+        layout.create_segments_dir().unwrap();
+        let storage = SegmentedStore::with_dir(layout.segments_dir().to_path_buf(), 4096);
+        let lossy = StorageLossyWalReplayFacts::new(
+            2,
+            CommitVersion(11),
+            true,
+            CoordinatorRecoveryError::WalRead(WalReaderError::CorruptedSegment {
+                offset: 64,
+                records_before: 2,
+            }),
+        );
+
+        let outcome = complete_storage_recovery_after_replay(
+            [0x88; 16],
+            Box::new(IdentityCodec),
+            storage,
+            RecoveryStats::default(),
+            StorageRuntimeConfig::default(),
+            Some(lossy),
+        )
+        .expect("post-replay storage recovery should carry lossy facts");
+
+        let facts = outcome
+            .lossy_wal_replay
+            .expect("lossy facts should survive post-replay completion");
+        assert_eq!(facts.records_applied_before_failure, 2);
+        assert_eq!(facts.version_reached_before_failure, CommitVersion(11));
+        assert!(facts.discarded_on_wipe);
+    }
+
+    #[test]
+    fn constructs_storage_recovery_outcome() {
+        let outcome = StorageRecoveryOutcome::new(
+            [0x44; 16],
+            Box::new(IdentityCodec),
+            SegmentedStore::new(),
+            RecoveryStats::default(),
+            RecoveredState::empty(),
+            None,
+        );
+
+        assert_eq!(outcome.wal_codec.codec_id(), "identity");
+        assert_eq!(outcome.segment_recovery.segments_loaded, 0);
+        assert!(format!("{outcome:?}").contains("wal_codec_id"));
+    }
+
+    #[test]
+    fn recovery_error_display_preserves_storage_context() {
+        let codec = StorageRecoveryError::CodecInit {
+            codec_id: "missing".to_string(),
+            detail: "unknown codec".to_string(),
+        };
+        assert_eq!(
+            codec.to_string(),
+            "could not initialize storage codec \"missing\": unknown codec"
+        );
+
+        let mismatch = StorageRecoveryError::ManifestCodecMismatch {
+            stored: "identity".to_string(),
+            configured: "aes-gcm-256".to_string(),
+        };
+        assert_eq!(
+            mismatch.to_string(),
+            "MANIFEST codec mismatch: stored=\"identity\", configured=\"aes-gcm-256\""
+        );
+
+        let coordinator = StorageRecoveryError::Coordinator {
+            source: CoordinatorRecoveryError::Callback(StorageError::corruption(
+                "snapshot callback failed",
+            )),
+        };
+        assert_eq!(
+            coordinator.to_string(),
+            "storage recovery coordinator failed: snapshot callback failed"
+        );
+    }
+
+    fn write_wal_txn(
+        wal_dir: &Path,
+        txn_id: TxnId,
+        branch_id: BranchId,
+        puts: Vec<(Key, Value)>,
+        deletes: Vec<Key>,
+        version: u64,
+    ) {
+        let mut wal = WalWriter::new(
+            wal_dir.to_path_buf(),
+            [0u8; 16],
+            DurabilityMode::Always,
+            WalConfig::for_testing(),
+            Box::new(IdentityCodec),
+        )
+        .unwrap();
+
+        let payload = TransactionPayload {
+            version,
+            puts,
+            deletes,
+            put_ttls: vec![],
+        };
+        let record = WalRecord::new(txn_id, *branch_id.as_bytes(), 1_000, payload.to_bytes());
+        wal.append(&record).unwrap();
+        wal.flush().unwrap();
+    }
+
+    fn kv_key(branch_id: BranchId, key: &str) -> Key {
+        Key::new_kv(Arc::new(Namespace::for_branch(branch_id)), key)
+    }
+
+    fn storage_with_partial_row(
+        layout: &DatabaseLayout,
+        key: Key,
+        version: CommitVersion,
+    ) -> SegmentedStore {
+        let storage = SegmentedStore::with_dir(layout.segments_dir().to_path_buf(), 4096);
+        storage
+            .put_with_version_mode(
+                key,
+                Value::String("partial".to_string()),
+                version,
+                None,
+                WriteMode::Append,
+            )
+            .unwrap();
+        storage
+    }
+
+    fn replay_error(
+        source: CoordinatorRecoveryError,
+        allow_lossy_wal_replay: bool,
+        records_applied: u64,
+    ) -> StorageCoordinatorReplay {
+        StorageCoordinatorReplay {
+            recover_result: Err(StorageRecoveryError::Coordinator { source }),
+            records_applied,
+            allow_lossy_wal_replay,
+            snapshot_install_failed: false,
+        }
+    }
+}

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -1113,6 +1113,39 @@ impl SegmentedStore {
         self.bloom_bits_per_key.load(Ordering::Relaxed)
     }
 
+    #[cfg(test)]
+    pub(crate) fn max_branches_for_test(&self) -> usize {
+        self.max_branches.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn max_versions_per_key_for_test(&self) -> usize {
+        self.max_versions_per_key.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn max_immutable_memtables_for_test(&self) -> usize {
+        self.max_immutable_memtables.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn compaction_rate_limit_for_test(&self) -> u64 {
+        self.compaction_rate_limiter
+            .load_full()
+            .map_or(0, |limiter| limiter.rate_bytes_per_sec())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn branch_level_target_for_test(
+        &self,
+        branch_id: &BranchId,
+        level: usize,
+    ) -> Option<u64> {
+        self.branches
+            .get(branch_id)
+            .and_then(|branch| branch.level_targets.max_bytes.get(level).copied())
+    }
+
     /// Create a `SegmentBuilder` pre-configured with this store's
     /// `data_block_size` and `bloom_bits_per_key`.
     fn make_segment_builder(&self) -> SegmentBuilder {

--- a/docs/engine/engine-crate-map.md
+++ b/docs/engine/engine-crate-map.md
@@ -21,8 +21,8 @@ crate. It is currently:
 - the subsystem composition host
 - the search/runtime behavior host
 - the branch-bundle import/export host
-- and still, in some places, a host for lower storage-runtime mechanics that
-  should eventually sink into `storage`
+- and, in a smaller set of remaining places, the adapter layer that turns raw
+  storage facts into engine policy and public database behavior
 
 ## High-Level Shape
 
@@ -116,7 +116,7 @@ This means engine is currently both:
 1. the semantic/domain owner
 2. the database runtime owner
 3. the search/runtime owner
-4. the host of some lower storage-runtime mechanics
+4. the host of storage-boundary adapters and public database policy
 
 Those are related, but they are not identical roles.
 
@@ -139,6 +139,7 @@ dependency graph at all.
 The internal incoming graph today is:
 
 - `strata-executor`
+- `strata-executor-legacy`
 - `strata-graph`
 - `strata-search`
 - `strata-vector`
@@ -206,31 +207,39 @@ In [bundle/mod.rs](../../crates/engine/src/bundle/mod.rs) and
 These are engine-level workflows built on top of lower persistence/runtime
 machinery.
 
-## Where Engine Still Owns Lower-Runtime Mechanics
+## Storage-Boundary Adapters Engine Still Owns
 
-The current engine crate also contains code that looks much closer to
-`storage` than to engine semantics.
+The ES2-ES4 cleanup moved the generic checkpoint, decoded-row snapshot
+install, and recovery bootstrap mechanics into `strata-storage`. Engine still
+contains adapter modules at those boundaries because the public APIs,
+primitive decode, lifecycle policy, and public error taxonomy remain
+engine-owned.
 
-The strongest examples are:
+The remaining storage-boundary modules are:
 
 - [database/compaction.rs](../../crates/engine/src/database/compaction.rs)
-  - checkpoint creation
-  - WAL compaction
-  - snapshot pruning
-  - MANIFEST watermark updates
+  - public `Database::checkpoint()` / `Database::compact()` orchestration
+  - conversion of storage checkpoint and retention facts into engine reports
+  - lifecycle-aware shutdown and retention policy around storage mechanics
 - [database/snapshot_install.rs](../../crates/engine/src/database/snapshot_install.rs)
-  - snapshot decoding and install into `SegmentedStore`
+  - primitive snapshot section decode
+  - primitive-shaped install telemetry
+  - construction of a generic decoded-row install plan for storage
 - [database/recovery.rs](../../crates/engine/src/database/recovery.rs)
-  - MANIFEST preparation
-  - WAL codec resolution
-  - storage recovery orchestration
-  - replay bootstrap
+  - `Database::run_recovery()` orchestration
+  - engine snapshot-install callback around primitive decode
+  - mapping `StorageRecoveryError` into `RecoveryError`
+  - degraded-storage policy and lossy recovery reporting
+  - `TransactionCoordinator`, follower-state, and watermark bootstrap
 - parts of [database/open.rs](../../crates/engine/src/database/open.rs)
-  - storage configuration application
+  - public open/lifecycle sequencing
   - WAL-writer wiring
 
-That code may need an engine-owned public API, but the underlying mechanics
-look like substrate/runtime concerns rather than semantic/domain concerns.
+The lower storage mechanics behind these adapters now live in storage-owned
+modules such as `durability/checkpoint_runtime.rs`,
+`durability/decoded_snapshot_install.rs`, and
+`durability/recovery_bootstrap.rs`. ES5 is expected to narrow the remaining
+storage-configuration and WAL-writer runtime seams.
 
 ## Current Architectural Role
 
@@ -240,8 +249,8 @@ If you describe the crate honestly as it exists today, `strata-engine` is:
 - the branch and primitive semantics owner
 - the search/runtime host
 - the branch bundle workflow host
-- plus a partial host for lower storage-runtime mechanics that have not yet
-  sunk into `storage`
+- the layer that converts raw storage recovery/checkpoint facts into public
+  database behavior
 
 ## Main Takeaway
 
@@ -253,5 +262,6 @@ whether code in the crate is:
 - semantic/domain behavior that should stay in `engine`, or
 - generic persistence/runtime machinery that should move to `storage`
 
-Right now the answer is mixed. The semantic side of engine is real, but some
-of the storage-runtime implementation is still living there.
+After ES2-ES4, the semantic side of engine is real and the most critical
+durability mechanics have sunk into storage. The remaining cleanup is to keep
+the adapter code explicit while ES5 finishes the storage-configuration split.

--- a/docs/engine/engine-storage-boundary-normalization-plan.md
+++ b/docs/engine/engine-storage-boundary-normalization-plan.md
@@ -128,7 +128,7 @@ While this plan is in progress:
 - do not add new engine modules that deepen lower-runtime ownership
 - do not move product policy into storage as a convenience
 
-## Current Starting Point
+## Starting Point
 
 The workspace is already past the older storage consolidation milestones:
 
@@ -140,10 +140,10 @@ The workspace is already past the older storage consolidation milestones:
   in transitional locations
 - storage depends only on foundational lower crates and must stay below engine
 
-The remaining problem is not a temporary peer crate. It is lower-runtime code
-still physically hosted inside engine.
+The remaining problem at the start of this plan was not a temporary peer
+crate. It was lower-runtime code still physically hosted inside engine.
 
-The strongest current candidates are:
+The strongest original candidates were:
 
 - [database/compaction.rs](../../crates/engine/src/database/compaction.rs)
   - checkpoint creation
@@ -439,7 +439,7 @@ Keep in engine:
 Move lower storage recovery bootstrap and replay orchestration from engine
 into storage, while keeping database-level recovery policy in engine.
 
-Potential detailed execution plan:
+Detailed execution plan:
 
 - `docs/engine/es4-recovery-bootstrap-mechanics-plan.md`
 
@@ -506,6 +506,23 @@ Keep in engine:
 - recovery tests pass from storage and engine layers
 - normal, degraded, and lossy recovery outcomes have characterization before
   refactoring
+
+### Implementation Status
+
+ES4 now routes `Database::run_recovery()` through
+`strata_storage::durability::run_storage_recovery`. Storage owns MANIFEST and
+codec preparation, `RecoveryCoordinator` replay, generic WAL record
+application, mechanical lossy WAL replay fallback, storage runtime config
+application before segment recovery, and `SegmentedStore::recover_segments()`.
+
+Engine still owns the primitive snapshot-install callback, public
+`RecoveryError` conversion, degraded-storage open policy,
+`LossyRecoveryReport`, `TransactionCoordinator` bootstrap, follower-state
+restore, and watermark construction.
+
+The one intentional correctness tightening found during ES4 is documented in
+the ES4 behavior-change ledger: primitive snapshot install callback failures
+now bypass lossy WAL replay instead of allowing an empty lossy open.
 
 ### Non-Goals
 
@@ -704,7 +721,8 @@ This plan is not complete until all of the following are true at once:
 2. `strata-engine` owns database orchestration, public APIs, primitive
    semantics, branch semantics, search/runtime behavior, and product policy.
 3. Engine database modules no longer host low-level storage recovery,
-   snapshot install, or checkpoint/WAL compaction implementations.
+   generic decoded-row snapshot install, or checkpoint/WAL compaction
+   implementations.
 4. Storage APIs used by engine expose raw substrate facts and storage-local
    errors, not engine reports or product vocabulary.
 5. Engine converts storage facts into `StrataError`, health reports,

--- a/docs/engine/es2-es4-storage-runtime-boundary-api-sketch.md
+++ b/docs/engine/es2-es4-storage-runtime-boundary-api-sketch.md
@@ -24,6 +24,7 @@ Read this together with:
 - [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
 - [es1-boundary-baseline-and-guardrails-plan.md](./es1-boundary-baseline-and-guardrails-plan.md)
 - [es2-checkpoint-wal-compaction-mechanics-plan.md](./es2-checkpoint-wal-compaction-mechanics-plan.md)
+- [es4-recovery-bootstrap-mechanics-plan.md](./es4-recovery-bootstrap-mechanics-plan.md)
 
 ## Boundary Decision
 
@@ -298,14 +299,22 @@ StorageRecoveryInput {
     configured_codec_id: String,
     write_buffer_size: usize,
     runtime_config: StorageRuntimeConfig,
-    lossy_wal_replay: bool,
-    on_loaded_snapshot: RecoverySnapshotCallback,
+    allow_lossy_wal_replay: bool,
+    snapshot_install: RecoverySnapshotInstallCallback,
 }
 
-RecoverySnapshotCallback {
-    on_snapshot(snapshot: &LoadedSnapshot, storage: &SegmentedStore) -> Result<(), StorageError>,
+RecoverySnapshotInstallCallback {
+    install_snapshot(
+        snapshot: &LoadedSnapshot,
+        install_codec: &dyn StorageCodec,
+        storage: &SegmentedStore,
+    ) -> Result<(), StorageError>,
 }
 ```
+
+The ES4 implementation plan refines this callback to pass the resolved
+snapshot install codec as well. That keeps MANIFEST/codec resolution in
+storage while letting engine continue to own primitive snapshot decode.
 
 Candidate mode:
 
@@ -338,9 +347,9 @@ StorageRecoveryOutcome {
 ```
 
 `StorageRecoveryOutcome` intentionally does not contain primitive snapshot
-install stats. Storage invokes the engine-supplied `on_loaded_snapshot`
-callback when recovery loads a snapshot, but storage does not inspect or own
-the callback's primitive decode counters. If engine needs install telemetry, it
+install stats. Storage invokes the engine-supplied `snapshot_install` callback
+when recovery loads a snapshot, but storage does not inspect or own the
+callback's primitive decode counters. If engine needs install telemetry, it
 captures `InstallStats` in the engine wrapper that supplies the callback.
 
 Candidate lossy facts:
@@ -356,15 +365,20 @@ StorageLossyWalReplayFacts {
 
 Engine decides whether to request lossy WAL replay from config. Storage may
 perform the mechanical wipe only after engine opts in via
-`lossy_wal_replay: true`. Engine still owns `LossyRecoveryReport` wording and
-public error classification.
+`allow_lossy_wal_replay: true`. The ES4F implementation keeps that opt-in
+inside the opaque storage replay object so engine cannot pass a mismatched
+policy flag, replay result, or pre-failure applied-record count into the lossy
+outcome helper. Engine still owns `LossyRecoveryReport` wording and public
+error classification.
 
 Lossy replay must preserve the current hard-fail bypass rules. Even when
-`lossy_wal_replay` is true, storage must not wipe and continue for recovery
-planning failures, MANIFEST failures, snapshot plan failures, or legacy-format
-failures where `CoordinatorRecoveryError::should_bypass_lossy()` returns
-`true`. Those errors remain hard failures and engine maps them into
-`RecoveryError`.
+`allow_lossy_wal_replay` is true, storage must not wipe and continue for
+recovery planning failures, MANIFEST failures, snapshot plan failures, or
+legacy-format failures where `CoordinatorRecoveryError::should_bypass_lossy()`
+returns `true`. Storage must also bypass lossy replay for snapshot install
+callback failures because those are primitive snapshot decode/install failures,
+not WAL replay failures. Those errors remain hard failures and engine maps them
+into `RecoveryError`.
 
 Engine also keeps degraded-storage policy. Storage returns
 `RecoveredState.health`; engine decides whether `DataLoss`,
@@ -403,10 +417,9 @@ After ES4, `Database::run_recovery()` should remain the engine entry point.
 It should do roughly:
 
 ```text
-validate configured codec for public error behavior
 build StorageRecoveryInput from StrataConfig and RecoveryMode
 outcome = storage::durability::run_storage_recovery(input)
-map raw storage errors into RecoveryError
+map raw storage errors, including codec-init failures, into RecoveryError
 apply engine degraded/lossy policy and reports
 result = RecoveryResult { storage: outcome.storage, stats: outcome.wal_replay }
 coordinator = TransactionCoordinator::from_recovery_with_limits(&result, ...)
@@ -454,9 +467,12 @@ StorageRecoveryError
 StorageSnapshotPruneError
 ```
 
-Public storage-local error enums should be `#[non_exhaustive]`, and engine
-adapters should include catch-all mappings. Storage can add more precise phases
-later without forcing every engine release to exhaustively enumerate them.
+Public storage-local errors, enums, and data structs should be
+`#[non_exhaustive]`, and engine adapters should include catch-all mappings.
+Storage can add more precise phases or facts later without forcing every engine
+release to exhaustively enumerate them. Public data structs should also expose
+constructors or defaults so callers do not need to depend on struct literal
+exhaustiveness.
 
 Existing lower errors may be reused if they are already precise enough:
 

--- a/docs/engine/es4-recovery-bootstrap-mechanics-plan.md
+++ b/docs/engine/es4-recovery-bootstrap-mechanics-plan.md
@@ -1,0 +1,973 @@
+# ES4 Recovery Bootstrap Mechanics Plan
+
+## Purpose
+
+`ES4` is the recovery-bootstrap epic in the engine/storage boundary
+normalization workstream.
+
+`ES2` moved checkpoint, WAL compaction, snapshot pruning, and generic MANIFEST
+sync mechanics toward storage. `ES3` moved only generic decoded-row snapshot
+install mechanics into storage while keeping primitive snapshot decode in
+engine. `ES4` completes the next link in that chain: recovery should use
+storage-owned mechanics for MANIFEST preparation, WAL replay, snapshot install
+callback wiring, lossy WAL replay mechanics, storage runtime config
+application, and segment recovery.
+
+The goal is not to redesign database recovery. The goal is to move the lower
+durability runtime out of `strata-engine` while keeping engine in charge of
+database open policy, public recovery classification, and transaction runtime
+bootstrap.
+
+Read this together with:
+
+- [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
+- [es1-boundary-baseline-and-guardrails-plan.md](./es1-boundary-baseline-and-guardrails-plan.md)
+- [es2-es4-storage-runtime-boundary-api-sketch.md](./es2-es4-storage-runtime-boundary-api-sketch.md)
+- [es2-checkpoint-wal-compaction-mechanics-plan.md](./es2-checkpoint-wal-compaction-mechanics-plan.md)
+- [es3-snapshot-decode-install-mechanics-plan.md](./es3-snapshot-decode-install-mechanics-plan.md)
+- [../storage/storage-engine-ownership-audit.md](../storage/storage-engine-ownership-audit.md)
+- [../storage/storage-charter.md](../storage/storage-charter.md)
+- [../architecture/architecture-recovery-target.md](../architecture/architecture-recovery-target.md)
+
+## Boundary Rule
+
+Storage owns durable substrate recovery mechanics.
+
+Engine owns database recovery meaning.
+
+Storage may know:
+
+- `DatabaseLayout`
+- `ManifestManager` and MANIFEST load/create mechanics
+- storage codec ids and `StorageCodec` values
+- `RecoveryCoordinator`
+- `RecoveryStats`
+- `LoadedSnapshot` as a snapshot container supplied to a callback
+- `SegmentedStore`
+- `RecoveredState` and `RecoveryHealth`
+- storage runtime knobs needed by `SegmentedStore`
+- WAL record application into `SegmentedStore`
+- storage-local recovery errors and raw lossy replay facts
+
+Storage must not know:
+
+- `Database::open` or `Database::run_recovery` public semantics
+- primary/follower product policy beyond storage-neutral MANIFEST behavior
+- `TransactionCoordinator`
+- `RecoveryOutcome`
+- engine `RecoveryError` or `StrataError` wording
+- `LossyRecoveryReport` or `LossyErrorKind`
+- follower blocked-state persistence or restore policy
+- subsystem recovery ordering above raw storage replay
+- primitive snapshot section decode or primitive install stats
+- degraded-storage open policy
+
+The ES4 target is:
+
+```text
+storage recovers durable state and returns raw facts
+engine decides whether those facts permit database open
+```
+
+## Non-Negotiables
+
+`TransactionCoordinator` stays engine-owned for ES4.
+
+This is the load-bearing decision from the ES2-ES4 API sketch. Storage should
+not call into engine per replayed record to mutate coordinator state. Storage
+should replay durable bytes into `SegmentedStore`, return `RecoveryStats` and
+`RecoveredState`, and let engine bootstrap `TransactionCoordinator` after the
+storage recovery call returns.
+
+ES4 must preserve these current ordering guarantees:
+
+- configured codec validation occurs before any recovery-managed directory or
+  MANIFEST creation
+- primary first-open may create a MANIFEST; follower without a MANIFEST must
+  not create one
+- a recovery snapshot callback must not silently skip install when no install
+  codec exists
+- snapshot-installed versions are folded into `RecoveryStats::final_version`
+  before `TransactionCoordinator` bootstrap
+- storage runtime config is applied before `recover_segments()` runs
+- `RecoveredState` is applied to the coordinator after coordinator bootstrap
+- follower-state restore runs after raw storage recovery and coordinator
+  bootstrap, not inside storage
+- lossy replay bypass rules remain hard failures for planning, MANIFEST,
+  snapshot-plan, and legacy-format errors
+
+ES4 must not:
+
+- change public recovery/open behavior
+- weaken corruption or quarantine behavior
+- move primitive snapshot decode into storage
+- move branch-domain recovery policy into storage
+- expose engine error types from storage
+- introduce a storage dependency on engine
+- turn lossy recovery into a storage-owned product policy
+
+## Existing Code Map
+
+The target surface is concentrated in:
+
+- [database/recovery.rs](../../crates/engine/src/database/recovery.rs)
+  - configured codec validation
+  - `prepare_manifest`
+  - WAL codec resolution
+  - `SegmentedStore::with_dir`
+  - `run_coordinator_recovery`
+  - `install_recovery_snapshot`
+  - `handle_wal_recovery_outcome`
+  - snapshot-version fold
+  - `apply_storage_config`
+  - `recover_segments`
+  - degraded-storage policy
+  - coordinator bootstrap
+  - follower-state restore
+  - watermark construction
+- [database/recovery_error.rs](../../crates/engine/src/database/recovery_error.rs)
+  - engine recovery taxonomy
+  - public `StrataError` conversion
+  - primary/follower error wording
+- [database/open.rs](../../crates/engine/src/database/open.rs)
+  - `apply_storage_config`
+  - directory permission helper currently used by recovery
+  - primary/follower open tail after recovery
+- [database/snapshot_install.rs](../../crates/engine/src/database/snapshot_install.rs)
+  - engine-owned primitive decode
+  - ES3 decoded-row install adapter
+  - recovery snapshot install helper target callback
+
+The storage-owned building blocks already exist:
+
+- `strata_storage::durability::DatabaseLayout`
+- `strata_storage::durability::ManifestManager`
+- `strata_storage::durability::RecoveryCoordinator`
+- `strata_storage::durability::RecoveryStats`
+- `strata_storage::durability::RecoveryResult`
+- `strata_storage::durability::apply_wal_record_to_memory_storage`
+- `strata_storage::SegmentedStore`
+- `SegmentedStore::recover_segments`
+
+ES4 should assemble these storage-owned pieces inside storage instead of
+inside engine.
+
+## Target Module
+
+Use a storage-owned recovery bootstrap module:
+
+```text
+crates/storage/src/durability/recovery_bootstrap.rs
+```
+
+`bootstrap.rs` was the name in the original ES2-ES4 sketch. The more explicit
+`recovery_bootstrap.rs` is preferred for implementation because `durability`
+already contains several bootstrap-like paths around checkpoint, WAL, and
+MANIFEST setup.
+
+The completed ES4 module should be re-exported through
+`strata_storage::durability` with a small public surface:
+
+```text
+run_storage_recovery
+StorageRecoveryInput
+StorageRecoveryMode
+StorageRecoveryOutcome
+StorageRuntimeConfig
+StorageRecoveryError
+StorageLossyWalReplayFacts
+RecoverySnapshotInstallCallback
+```
+
+ES4B intentionally introduces and re-exports only the type/callback surface.
+`run_storage_recovery` is introduced in ES4G once the lower-runtime behavior
+has moved far enough to implement the function without a panic or fake no-op.
+
+ES4C temporarily exposed `prepare_storage_manifest_for_recovery` and
+`StorageManifestRecoveryPreparation` only through storage's
+`engine-internal`/`__internal` seam so engine could delegate MANIFEST and codec
+preparation before `run_storage_recovery` existed. ES4G removes that public
+transitional bridge; storage may keep smaller private helper seams inside
+`recovery_bootstrap.rs`, but higher layers should call only
+`run_storage_recovery`.
+
+All public storage-local errors, enums, and data structs introduced for ES4
+should be `#[non_exhaustive]`. Public data structs should also have
+constructors or defaults so later ES4 steps can add fields without requiring
+external callers to use struct literals.
+
+## Target API
+
+The storage recovery input should be primitive-neutral and engine-policy
+neutral:
+
+```text
+StorageRecoveryInput<'a> {
+    layout: DatabaseLayout,
+    mode: StorageRecoveryMode,
+    configured_codec_id: String,
+    write_buffer_size: usize,
+    runtime_config: StorageRuntimeConfig,
+    allow_lossy_wal_replay: bool,
+    snapshot_install: &'a dyn RecoverySnapshotInstallCallback,
+}
+```
+
+The mode should describe storage behavior, not database policy:
+
+```text
+StorageRecoveryMode {
+    PrimaryCreateManifestIfMissing,
+    FollowerNeverCreateManifest,
+}
+```
+
+The follower mode name is intentionally about MANIFEST behavior. Follower
+recovery may still create a missing segments directory and replay durable
+state into a local `SegmentedStore`; it must not create a MANIFEST.
+
+`StorageRuntimeConfig` should contain only the knobs storage needs before
+`recover_segments()`:
+
+```text
+StorageRuntimeConfig {
+    max_branches: usize,
+    max_versions_per_key: usize,
+    max_immutable_memtables: usize,
+    target_file_size: u64,
+    level_base_bytes: u64,
+    data_block_size: usize,
+    bloom_bits_per_key: usize,
+    compaction_rate_limit: u64,
+}
+```
+
+Engine builds this from `StrataConfig.storage` until ES5 completes the public
+configuration split. That adapter does not make storage own product defaults.
+`StorageRuntimeConfig::default()` uses the same storage defaults as
+`SegmentedStore`, so a partially wired test or synthetic construction never
+creates zero-sized segment/block settings by accident.
+
+The snapshot callback must receive the install codec:
+
+```text
+RecoverySnapshotInstallCallback {
+    install_snapshot(
+        snapshot: &LoadedSnapshot,
+        install_codec: &dyn StorageCodec,
+        storage: &SegmentedStore,
+    ) -> Result<(), StorageError>
+}
+```
+
+This refines the older ES2-ES4 sketch. Once storage owns MANIFEST preparation
+and codec resolution, storage is the layer that knows which codec the snapshot
+install callback must use. Passing the codec to the engine callback keeps
+primitive decode in engine without forcing engine to redo MANIFEST prep.
+
+The outcome should remain raw:
+
+```text
+StorageRecoveryOutcome {
+    database_uuid: [u8; 16],
+    wal_codec: Box<dyn StorageCodec>,
+    storage: SegmentedStore,
+    wal_replay: RecoveryStats,
+    segment_recovery: RecoveredState,
+    lossy_wal_replay: Option<StorageLossyWalReplayFacts>,
+}
+```
+
+`StorageRecoveryOutcome` must not contain:
+
+- `TransactionCoordinator`
+- `RecoveryOutcome`
+- `RecoveryError`
+- `LossyRecoveryReport`
+- follower persisted state
+- primitive install stats
+
+If engine wants snapshot install telemetry, it should capture `InstallStats`
+inside the callback it passes to storage.
+
+Lossy replay facts should be mechanical:
+
+```text
+StorageLossyWalReplayFacts {
+    records_applied_before_failure: u64,
+    version_reached_before_failure: CommitVersion,
+    discarded_on_wipe: bool,
+    source: CoordinatorRecoveryError,
+}
+```
+
+Engine uses these facts to build `LossyRecoveryReport`, choose
+`LossyErrorKind`, and emit operator-facing logs.
+
+## Error Contract
+
+Storage should return a storage-local error:
+
+```text
+StorageRecoveryError {
+    CodecInit { codec_id, detail },
+    ManifestLoad { path, source },
+    ManifestCreate { source },
+    ManifestCodecMismatch { stored, configured },
+    Io { source },
+    Coordinator { source },
+    SegmentRecovery { source },
+}
+```
+
+The exact variant names can change during implementation, but the contract
+must hold:
+
+- storage errors do not mention engine `RecoveryError`
+- storage errors do not include primary/follower public wording
+- storage errors preserve enough source structure for engine to reconstruct
+  today's public error behavior
+- legacy-format errors remain structurally recoverable by engine
+- coordinator errors are not stringified before engine maps them
+- callback failures preserve their `StorageError` source
+
+Engine remains responsible for mapping storage errors into:
+
+- `RecoveryError::ManifestLoad`
+- `RecoveryError::ManifestLegacyFormat`
+- `RecoveryError::ManifestCodecMismatch`
+- `RecoveryError::ManifestCreate`
+- `RecoveryError::CodecInit`
+- `RecoveryError::CoordinatorPlan`
+- `RecoveryError::SnapshotMissing`
+- `RecoveryError::SnapshotRead`
+- `RecoveryError::WalLegacyFormat`
+- `RecoveryError::WalCodecDecode`
+- `RecoveryError::WalChecksum`
+- `RecoveryError::WalRead`
+- `RecoveryError::PayloadDecode`
+- `RecoveryError::WalRecoveryFailed`
+- `RecoveryError::StorageDegraded`
+- `RecoveryError::Storage`
+- `RecoveryError::Io`
+
+The mapping can move code around, but it must preserve public `StrataError`
+conversion behavior.
+
+## Engine Wrapper Shape
+
+After ES4, `Database::run_recovery()` remains the engine entry point.
+
+Target shape:
+
+```text
+validate / build engine-facing recovery inputs
+build StorageRuntimeConfig from StrataConfig.storage
+build engine snapshot callback around install_snapshot()
+outcome = strata_storage::durability::run_storage_recovery(input)
+map StorageRecoveryError into RecoveryError
+apply degraded-storage policy from outcome.segment_recovery.health
+build RecoveryResult { storage: outcome.storage, stats: outcome.wal_replay }
+coordinator = TransactionCoordinator::from_recovery_with_limits(...)
+coordinator.apply_storage_recovery(outcome.segment_recovery)
+restore follower state when needed
+construct ContiguousWatermark
+construct RecoveryOutcome
+```
+
+Engine still owns:
+
+- `RecoveryMode`
+- conversion to `StorageRecoveryMode`
+- degraded-storage policy
+- lossy report wording and warnings
+- `TransactionCoordinator` construction
+- follower-state restore
+- watermark construction
+- `RecoveryOutcome`
+
+Engine no longer owns:
+
+- MANIFEST load/create mechanics
+- WAL codec resolution mechanics
+- `RecoveryCoordinator` construction
+- WAL replay callback that applies records into storage
+- lossy replay wipe mechanics
+- snapshot-version fold
+- storage config application before segment recovery
+- `recover_segments()` execution
+
+## ES4A - Characterization And Inventory
+
+Goal: lock the current behavior before moving recovery mechanics.
+
+Tasks:
+
+- inventory every branch in `Database::run_recovery`
+- inventory every `RecoveryError` mapping reachable from recovery
+- document current primary and follower MANIFEST behavior
+- document current lossy fallback bypass behavior
+- document current degraded-storage policy behavior
+- add or tighten tests before moving code
+
+Characterization should cover:
+
+- invalid configured codec fails before creating recovery-managed directories
+  or MANIFEST files
+- primary first-open creates MANIFEST with the configured codec id
+- primary reopen rejects MANIFEST/config codec mismatch with the existing
+  public error class and wording shape
+- follower without MANIFEST does not create a MANIFEST and uses WAL-only
+  recovery behavior
+- follower with MANIFEST uses the stored codec path and preserves follower
+  mismatch wording
+- recovery snapshot callback hard-fails when a loaded snapshot reaches the
+  callback without an install codec
+- snapshot install failure maps through the coordinator callback path
+- WAL replay success returns the same `RecoveryStats`
+- snapshot-installed versions are folded into final recovery version before
+  coordinator bootstrap
+- lossy replay is bypassed for coordinator planning errors
+- lossy replay is bypassed for legacy-format errors
+- lossy replay discards partial storage state when enabled for replay failure
+- lossy replay report fields preserve records-applied and version-reached
+  facts
+- storage degraded `DataLoss`, `PolicyDowngrade`, and `Telemetry` classes keep
+  the same open/refuse behavior under current config flags
+- `recover_segments()` sees the configured storage knobs, not default knobs
+- follower persisted state restore still runs after recovery and still clears
+  invalid blocked state
+
+Suggested commands:
+
+```text
+cargo test -p strata-engine --lib database::recovery -- --nocapture
+cargo test -p strata-engine --test recovery_parity -- --nocapture
+cargo test -p strata-engine --lib checkpoint -- --nocapture
+```
+
+Acceptance:
+
+- ES4 behavior matrix exists in this document or in test names
+- characterization tests fail on at least one intentionally broken ordering
+  if locally mutated
+- no production code moves in ES4A unless needed for test seams
+
+ES4A characterization status:
+
+| Behavior | Guard |
+| --- | --- |
+| Invalid configured codec fails before recovery-managed artifacts are created. | `first_open_rejects_invalid_codec_without_touching_disk` |
+| Primary first-open creates a MANIFEST with the configured codec and a real database UUID. | `primary_first_open_creates_manifest_with_configured_codec` |
+| Runtime storage config is applied before segment recovery. | `recovery_applies_storage_runtime_config` |
+| Primary/follower corrupt MANIFEST error classes match coordinator planning errors. | `parity_missing_magic`, `parity_checksum_mismatch`, `parity_codec_id_mismatch`, `parity_unsupported_version`, `parity_truncated` |
+| Follower without MANIFEST does not create one and uses the configured WAL codec. | `follower_without_manifest_does_not_create_manifest` |
+| Follower invalid persisted state is restored only after replay validation and cleared when stale. | `follower_recovery_clears_invalid_persisted_state_after_replay` |
+| Recovery snapshot callback hard-fails when no install codec exists. | `coordinator_replay_rejects_loaded_snapshot_without_install_codec` |
+| Snapshot callback failures map through the public recovery path. | `recovery_snapshot_install_failure_maps_through_callback_public_error_path` |
+| Snapshot-installed versions are folded into coordinator bootstrap. | `snapshot_versions_fold_into_coordinator_before_bootstrap` |
+| WAL replay success still bootstraps storage, coordinator, and watermark from replay stats. | `wal_replay_success_bootstraps_storage_and_coordinator` |
+| Snapshot planning failures bypass lossy replay. | `snapshot_plan_failure_bypasses_lossy_fallback` |
+| Snapshot callback failures bypass lossy replay. | `lossy_wal_replay_snapshot_callback_failure_preserves_partial_storage`, `recovery_snapshot_install_failure_bypasses_lossy_fallback_when_enabled` |
+| Legacy WAL format failures bypass lossy replay. | `wal_legacy_failure_bypasses_lossy_fallback` |
+| Lossy replay discards partial storage and reports progress facts. | `lossy_replay_discards_partial_storage_and_reports_progress`, `test_lossy_recovery_discards_valid_data_before_corruption`, `test_lossy_recovery_report_on_immediate_failure` |
+| Degraded-storage refusal remains engine policy. | `degraded_storage_policy_matrix_is_engine_owned` |
+| Snapshot-only recovery still works with non-identity snapshot header codecs. | `test_aes_checkpoint_compact_reopen_installs_snapshot` |
+| Checkpoint-only and checkpoint-plus-delta recovery remain covered. | `test_checkpoint_only_restart_recovers_kv_from_snapshot`, `test_checkpoint_plus_delta_wal_replay_merges_sources` |
+
+## ES4B - Storage API Skeleton
+
+Goal: introduce the storage-owned type surface without moving behavior.
+
+Tasks:
+
+- add `crates/storage/src/durability/recovery_bootstrap.rs`
+- define `StorageRecoveryInput`
+- define `StorageRecoveryMode`
+- define `StorageRuntimeConfig`
+- define `StorageRecoveryOutcome`
+- define `StorageLossyWalReplayFacts`
+- define `StorageRecoveryError`
+- define the snapshot install callback shape
+- re-export only the intended public storage surface
+- add compile-only or synthetic unit tests for type construction and error
+  display where useful
+- do not expose `run_storage_recovery` yet; ES4B is type-only, and ES4G adds
+  the function when it can delegate to real moved behavior
+
+Rules:
+
+- no engine types in storage
+- no primitive DTOs or primitive tags in the recovery bootstrap module
+- no `TransactionCoordinator`
+- no `RecoveryError`
+- no `LossyRecoveryReport`
+
+Acceptance:
+
+- storage compiles with the new API surface
+- engine still uses the old recovery implementation
+- storage ownership grep guards stay clean
+
+## ES4C - Manifest And Codec Preparation
+
+Goal: move generic MANIFEST preparation and WAL codec resolution into storage.
+
+Current engine code to split:
+
+- configured codec validation
+- `prepare_manifest`
+- `ManifestPreparation`
+- WAL codec id choice
+- segments directory creation for first-open/follower-without-MANIFEST
+- best-effort directory permission restriction if that remains part of storage
+  directory creation
+
+Storage should preserve:
+
+- configured codec validation before side effects
+- primary missing-MANIFEST creates a MANIFEST
+- follower missing-MANIFEST never creates a MANIFEST
+- follower missing-MANIFEST may create the segments directory
+- manifest codec mismatch remains typed enough for engine role-specific
+  public wording
+- missing-MANIFEST `database_uuid` behavior remains `[0u8; 16]` for follower
+- the no-snapshot/no-codec cases remain explicit and cannot silently skip a
+  loaded snapshot install
+
+Implementation direction:
+
+```text
+prepare_storage_manifest_for_recovery(input) -> StorageManifestRecoveryPreparation
+
+StorageManifestRecoveryPreparation {
+    database_uuid: [u8; 16],
+    wal_codec: Box<dyn StorageCodec>,
+    snapshot_install_codec: Option<Box<dyn StorageCodec>>,
+}
+```
+
+Because `run_storage_recovery` intentionally waits until ES4G, this helper is
+temporarily exposed through storage's `engine-internal`/`__internal` seam for
+the engine wrapper during ES4C. It should become storage-private again once
+ES4G routes recovery through the completed storage bootstrap API, unless ES5
+needs the narrower helper directly.
+
+Acceptance:
+
+- `Database::run_recovery` no longer imports `ManifestManager`
+- public primary/follower manifest errors remain unchanged
+- first-open invalid codec still leaves no poisoned storage directory
+- follower missing-MANIFEST still does not create a MANIFEST
+
+## ES4D - Coordinator Replay Driver
+
+Goal: move `RecoveryCoordinator` construction and replay driving into storage.
+
+Current engine code to move:
+
+- `run_coordinator_recovery`
+- `RecoveryCoordinator::new(...).with_lossy_recovery(...).with_codec(...)`
+- WAL record callback around `apply_wal_record_to_memory_storage`
+- records-applied counter
+- callback wiring around a loaded snapshot
+
+Storage should call the engine snapshot callback as:
+
+```text
+snapshot_install.install_snapshot(snapshot, install_codec, &storage)
+```
+
+Storage should return `StorageRecoveryError::Coordinator { source }` on hard
+coordinator failure. It should not map coordinator failures into public engine
+errors.
+
+The no-codec snapshot callback invariant should live in storage once storage
+owns manifest prep:
+
+```text
+if loaded_snapshot_callback_fired && snapshot_install_codec.is_none() {
+    return Err(StorageRecoveryError::Coordinator {
+        source: CoordinatorRecoveryError::Callback(StorageError::corruption(...)),
+    });
+}
+```
+
+The exact wrapping can differ, but the behavior must remain a hard failure
+with snapshot id context.
+
+Because `run_storage_recovery` intentionally waits until ES4G, ES4D uses a
+temporary `run_storage_coordinator_replay` helper exposed only through
+storage's `engine-internal`/`__internal` seam. The helper returns the raw
+coordinator result and the records-applied count so ES4F can move lossy replay
+mechanics without changing report fields. ES4G should absorb this helper into
+the completed storage recovery API.
+
+Acceptance:
+
+- `Database::run_recovery` no longer imports `RecoveryCoordinator`
+- `Database::run_recovery` no longer imports
+  `apply_wal_record_to_memory_storage`
+- engine snapshot install remains engine-owned
+- primitive install stats, if logged, are captured in the engine callback
+- callback install failures still map through the same public recovery path
+
+## ES4E - Snapshot Fold, Runtime Config, And Segment Recovery
+
+Goal: move the post-replay storage mechanics into storage while keeping
+engine policy outside storage.
+
+Current engine code to move:
+
+- `stats.final_version = max(stats.final_version, CommitVersion(storage.version()))`
+- `apply_storage_config(&storage, &cfg.storage)` mechanics
+- `storage.recover_segments()`
+- raw `RecoveredState` return
+
+Storage should run this order:
+
+```text
+snapshot install / WAL replay
+snapshot-version fold
+apply StorageRuntimeConfig to SegmentedStore
+recover_segments()
+return StorageRecoveryOutcome
+```
+
+Storage should not decide whether degraded state permits database open.
+Storage returns `RecoveredState` and its `RecoveryHealth` unchanged.
+
+Because `run_storage_recovery` intentionally waits until ES4G, ES4E uses a
+temporary `complete_storage_recovery_after_replay` helper exposed only through
+storage's `engine-internal`/`__internal` seam. The helper consumes the replayed
+store and raw `RecoveryStats`, folds the installed snapshot version into those
+stats, applies `StorageRuntimeConfig`, runs `recover_segments()`, and returns a
+raw `StorageRecoveryOutcome`. ES4G should absorb this helper into the completed
+storage recovery API.
+
+Engine should still:
+
+- log database-level recovery completion
+- apply `policy_refuses`
+- decide `allow_lossy_recovery` override behavior for degraded storage
+- convert disallowed degraded state into `RecoveryError::StorageDegraded`
+- apply `RecoveredState` to `TransactionCoordinator`
+
+Acceptance:
+
+- `apply_storage_config` no longer needs to be called from recovery
+- `SegmentedStore::recover_segments()` is no longer called by engine recovery
+- degraded-storage behavior remains public-policy equivalent
+- coordinator bootstrap still sees the folded final version
+
+## ES4F - Lossy WAL Replay Mechanics
+
+Goal: move the mechanical lossy wipe into storage while keeping lossy policy
+and operator reporting in engine.
+
+Current engine code to split:
+
+- `handle_wal_recovery_outcome`
+- `records_applied_before_failure`
+- `version_reached_before_failure`
+- partial-state discard via fresh `SegmentedStore::with_dir`
+- bypass handling through `CoordinatorRecoveryError::should_bypass_lossy()`
+- conversion of coordinator error into lossy report text
+- warning logs
+
+Storage should own:
+
+- checking whether lossy replay was requested
+- preserving hard-fail bypass rules
+- sampling records-applied and version-before-wipe facts
+- replacing partial storage state with a fresh store after an allowed replay
+  failure
+- returning `StorageLossyWalReplayFacts`
+
+Engine should own:
+
+- whether `allow_lossy_recovery` is set in public config
+- constructing `LossyRecoveryReport`
+- choosing `LossyErrorKind`
+- public warning wording and tracing targets
+- mapping non-lossy and bypassed failures into `RecoveryError`
+
+Important rule:
+
+Even with `allow_lossy_wal_replay=true`, storage must not wipe and continue
+for any error where `CoordinatorRecoveryError::should_bypass_lossy()` is true,
+or for failures from the snapshot install callback. The fallback is for WAL
+replay failures, not primitive snapshot decode/install failures.
+
+Acceptance:
+
+- lossy replay still discards partial pre-failure state
+- lossy replay report fields remain unchanged
+- planning, MANIFEST, snapshot-plan, snapshot-callback, and legacy-format
+  failures still hard-fail
+- storage does not construct `LossyRecoveryReport`
+
+Implementation shape:
+
+- introduce a storage-local `handle_storage_wal_replay_outcome`
+- route it through the temporary `durability::__internal` engine bridge
+- have storage consume the opaque `StorageCoordinatorReplay` returned by
+  `run_storage_coordinator_replay`; that object carries the replay result,
+  pre-failure applied-record count, and lossy-enabled flag so engine cannot
+  pass a mismatched policy/count pair back into storage
+- have storage apply bypass and lossy-enabled checks, wipe partial storage when
+  allowed, and return `StorageLossyWalReplayFacts`
+- thread `StorageLossyWalReplayFacts` through
+  `StorageRecoveryOutcome::lossy_wal_replay`
+- have engine convert outcome facts into `LossyRecoveryReport`,
+  `LossyErrorKind`, and warning logs
+- leave public `allow_lossy_recovery` configuration and public error mapping in
+  engine
+
+## ES4G - Engine Wrapper Cleanup
+
+Goal: reduce `Database::run_recovery` to engine orchestration and policy.
+
+Tasks:
+
+- define and re-export `run_storage_recovery`
+- replace direct lower-runtime assembly with `run_storage_recovery`
+- map `StorageRecoveryError` into `RecoveryError`
+- keep `RecoveryMode` and role-specific public error conversion in engine
+- keep degraded-storage policy in engine
+- keep lossy report construction in engine
+- keep follower persisted state restore in engine
+- keep watermark construction in engine
+- keep `TransactionCoordinator` bootstrap in engine
+- remove obsolete private helpers from `database/recovery.rs`
+
+The resulting engine flow should be short enough that each remaining branch is
+clearly policy or public-open orchestration.
+
+Acceptance:
+
+- `Database::run_recovery` remains the only engine recovery entry point
+- `RecoveryOutcome` shape remains engine-local
+- `open.rs` does not learn about storage recovery internals
+- engine no longer manually wires `RecoveryCoordinator`
+- engine no longer manually applies WAL records into `SegmentedStore`
+
+Implementation notes:
+
+- `strata_storage::durability::run_storage_recovery` is the public ES4G wrapper
+  around MANIFEST/codec preparation, `SegmentedStore` construction,
+  coordinator replay, mechanical lossy WAL fallback, storage runtime config,
+  and segment recovery
+- `Database::run_recovery` supplies only the primitive snapshot install
+  callback, maps `StorageRecoveryError`, builds `LossyRecoveryReport`, applies
+  degraded-storage policy, restores follower state, bootstraps
+  `TransactionCoordinator`, and constructs the watermark
+- the temporary ES4C/ES4D/ES4E/ES4F engine bridge helpers are no longer
+  exported through `durability::__internal`
+- snapshot-plan failures (`SnapshotMissing` and `SnapshotRead`) explicitly
+  bypass the lossy WAL fallback alongside MANIFEST planning and legacy-format
+  failures
+- snapshot callback failures explicitly bypass the lossy WAL fallback; lossy
+  replay remains limited to failures from WAL replay, not primitive snapshot
+  decode/install
+
+## ES4H - Guards, Documentation, And Full Parity
+
+Goal: finish the cleanup with explicit guardrails.
+
+Guards:
+
+```text
+rg -n 'use strata_engine|strata_engine::|strata-engine' crates/storage/src crates/storage/Cargo.toml
+rg -n 'RecoveryCoordinator|ManifestManager|apply_wal_record_to_memory_storage' crates/engine/src/database/recovery.rs
+rg -n 'strata_engine::.*(TransactionCoordinator|RecoveryError|LossyRecoveryReport|LossyErrorKind)|use .*\b(TransactionCoordinator|RecoveryError|LossyRecoveryReport|LossyErrorKind)\b' crates/storage/src
+rg -n 'primitive_tags|SnapshotSerializer|KvSnapshotEntry|EventSnapshotEntry|JsonSnapshotEntry|VectorSnapshotEntry|BranchSnapshotEntry' crates/storage/src/durability/recovery_bootstrap.rs
+```
+
+The second guard may need a narrow exception if `RecoveryError` mapping still
+references storage coordinator error types indirectly. It should not allow
+engine to keep constructing or driving `RecoveryCoordinator`.
+
+Test commands:
+
+```text
+cargo fmt --all --check
+git diff --check
+cargo check -p strata-storage --all-targets
+cargo check -p strata-engine --all-targets
+cargo test -p strata-storage recovery_bootstrap -- --nocapture
+cargo test -p strata-engine --lib database::recovery -- --nocapture
+cargo test -p strata-engine --test recovery_parity -- --nocapture
+cargo test -p strata-engine --test recovery_storage_policy -- --nocapture
+cargo test -p strata-engine --lib checkpoint -- --nocapture
+```
+
+Full assurance before declaring ES4 complete:
+
+```text
+cargo test -p strata-engine
+```
+
+Known pre-existing unrelated failures should be called out with exact test
+names if the full package suite is not green.
+
+ES4H full-package status:
+
+`cargo test -p strata-engine` currently passes the ES4 recovery/checkpoint
+coverage. `cargo test -p strata-engine --test recovery_storage_policy -- --nocapture`
+also passes separately. The full package suite remains blocked by the same
+broader architecture-cleanup-period failures outside ES4 recovery bootstrap:
+
+- `database::branch_mutation::tests::test_rollback_delete_true_surfaces_storage_cleanup_failure`
+- `database::tests::shutdown::shutdown_timeout_halt_interleaving_preserves_invariant`
+- `database::tests::shutdown::shutdown_timeout_preserves_writer_halt_signal`
+- `database::tests::shutdown::test_background_sync_failure_halts_writer_and_rejects_manual_commit`
+- `database::tests::shutdown::test_begin_sync_failure_halts_writer_and_rejects_manual_commit`
+- `database::tests::shutdown::test_commit_sync_failure_halts_writer_and_rejects_manual_commit`
+- `database::tests::shutdown::test_resume_waits_for_inflight_halt_publication_before_restoring_accepting`
+- `database::tests::shutdown::test_resume_while_still_failing_increments_failed_sync_count`
+- `database::tests::shutdown::test_set_durability_mode_spawn_failure_rolls_back_state`
+- `primitives::branch::index::tests::test_complete_delete_post_commit_classifies_default_marker_clear_failure`
+
+Documentation updates:
+
+- [engine-crate-map.md](./engine-crate-map.md) now describes
+  `database/recovery.rs` as an engine policy/public-error adapter over
+  `run_storage_recovery`, not as the owner of lower replay mechanics.
+- [../storage/storage-crate-map.md](../storage/storage-crate-map.md) now
+  lists `durability/recovery_bootstrap.rs` as storage-owned lower durability
+  runtime.
+- [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
+  records the ES4 implementation status and the one intentional correctness
+  tightening.
+- This document records the ES4H guard list, behavior-change ledger, and
+  completion criteria.
+
+ES4H implementation status:
+
+| Check | Status |
+| --- | --- |
+| Storage owns the recovery bootstrap implementation. | `run_storage_recovery` is re-exported from `strata_storage::durability` and owns MANIFEST/codec prep, coordinator replay, lossy WAL replay mechanics, runtime config application, and segment recovery. |
+| Engine owns recovery policy and public recovery conversion. | `Database::run_recovery()` supplies the primitive snapshot callback, maps `StorageRecoveryError`, applies degraded policy, builds `LossyRecoveryReport`, bootstraps `TransactionCoordinator`, restores follower state, and constructs the watermark. |
+| Temporary ES4 bridge helpers are not public. | `prepare_storage_manifest_for_recovery`, `run_storage_coordinator_replay`, `handle_storage_wal_replay_outcome`, and `complete_storage_recovery_after_replay` are private to `recovery_bootstrap.rs`. |
+| Primitive semantics stay out of storage recovery bootstrap. | `recovery_bootstrap.rs` carries `LoadedSnapshot`, codecs, `SegmentedStore`, and raw recovery facts only; primitive section decode remains in engine. |
+
+Acceptance:
+
+- storage owns the recovery bootstrap implementation
+- engine owns recovery policy and public recovery conversion
+- all ES4 guard commands are clean or have documented intentional exceptions
+- all ES4 characterization tests still pass
+
+## Behavior Changes
+
+No broad behavior redesign is intended for ES4. The implementation did uncover
+one recovery correctness bug that is intentionally tightened below.
+
+If implementation discovers a correctness bug that must be fixed while moving
+recovery code, the PR must call it out explicitly in this section before the
+fix lands. The call-out must include:
+
+- the old behavior
+- the new behavior
+- why preserving the old behavior would be unsafe
+- compatibility risk
+- focused tests proving the new behavior
+
+Examples of changes that require explicit call-out:
+
+- changing whether follower-without-MANIFEST creates a MANIFEST
+- changing which errors bypass lossy recovery
+- changing when partial state is discarded during lossy replay
+- changing public codec mismatch classification
+- changing legacy-format handling
+- changing degraded-storage open/refuse behavior
+- changing snapshot trailing-data or WAL trailing-data acceptance
+
+### Snapshot Install Callback Failure Lossy Bypass
+
+Old behavior:
+
+When `allow_lossy_recovery=true`, a primitive snapshot install callback failure
+could be treated like a lossy WAL replay failure. Recovery could wipe
+partially installed state and continue with an empty recovered store even
+though the failure came from primitive snapshot decode/install, not from WAL
+replay.
+
+New behavior:
+
+Snapshot install callback failures hard-fail and bypass the lossy WAL replay
+fallback even when lossy recovery is enabled. Storage records that the
+coordinator failure came from snapshot installation and returns the original
+coordinator callback error without wiping partial storage.
+
+Why preserving the old behavior would be unsafe:
+
+The lossy fallback is a whole-store discard for WAL replay corruption. Applying
+it to primitive snapshot decode/install failures can hide authoritative
+snapshot corruption or incompatible primitive bytes behind a successful empty
+open.
+
+Compatibility risk:
+
+Databases that previously opened by silently discarding state after a corrupt
+or incompatible recovery snapshot now fail recovery. That is intentional:
+successful empty open would be data loss, while a hard failure preserves the
+evidence and forces operator action.
+
+Focused tests:
+
+- `lossy_wal_replay_snapshot_callback_failure_preserves_partial_storage`
+- `recovery_snapshot_install_failure_bypasses_lossy_fallback_when_enabled`
+
+## Residual Ownership After ES4
+
+Some recovery-adjacent code should intentionally remain in engine after ES4:
+
+- `RecoveryError` public taxonomy
+- `RecoveryMode`
+- `RecoveryOutcome`
+- `TransactionCoordinator` bootstrap
+- degraded-storage policy
+- lossy report construction
+- follower persisted state restore
+- watermark construction
+- subsystem recovery integration
+- primitive snapshot install callback
+
+Some recovery-adjacent work should wait for ES5:
+
+- public `StrataConfig` split
+- storage-owned defaults for every storage runtime knob
+- remaining open-path config application outside recovery
+- block-cache global capacity configuration
+- WAL writer runtime construction cleanup
+
+Some work should remain explicitly out of scope:
+
+- moving `TransactionCoordinator`
+- branch bundle recovery/import/export semantics
+- search/index recovery redesign
+- primitive snapshot format redesign
+- WAL/snapshot/MANIFEST format migrations
+
+## Completion Criteria
+
+ES4 is complete when:
+
+1. `Database::run_recovery` calls a storage-owned recovery bootstrap API for
+   raw recovery mechanics.
+2. Engine no longer constructs `RecoveryCoordinator`.
+3. Engine no longer wires WAL record replay into `SegmentedStore`.
+4. Engine no longer performs MANIFEST recovery prep directly.
+5. Engine no longer calls `recover_segments()` directly in recovery.
+6. Storage returns raw recovery facts and storage-local errors.
+7. Engine maps those facts into `RecoveryError`, `StrataError`,
+   `LossyRecoveryReport`, `TransactionCoordinator`, and `RecoveryOutcome`.
+8. Snapshot install still decodes primitive sections in engine through the ES3
+   callback.
+9. `TransactionCoordinator` remains engine-owned.
+10. The configured-codec, snapshot-version-fold, runtime-config, lossy-bypass,
+    and follower-state ordering guarantees are characterized by tests.
+11. Storage has no engine dependency and no primitive snapshot install logic.
+12. The ES4 guard commands pass.

--- a/docs/storage/storage-crate-map.md
+++ b/docs/storage/storage-crate-map.md
@@ -46,6 +46,8 @@ Major subtrees:
 
 - `segmented/` — the real storage engine surface, including recovery,
   compaction, ref tracking, and quarantine protocol
+- `durability/` — WAL, snapshot/checkpoint, MANIFEST, decoded-row install,
+  and recovery-bootstrap mechanics
 
 The crate is already substantial. The heaviest ownership points are:
 
@@ -76,6 +78,11 @@ Today `strata-storage` re-exports:
   - `SegmentedStore`
   - `VersionedValue`
   - `StoredValue`
+- durability runtime types:
+  - WAL reader/writer, codec, layout, and format types
+  - checkpoint, compaction, snapshot-prune, and MANIFEST-sync helpers
+  - decoded snapshot-row install helpers
+  - storage recovery bootstrap input/outcome/error types
 - compaction and quarantine support:
   - compaction helpers
   - quarantine helpers
@@ -98,12 +105,13 @@ That is the clean shape we wanted from the earlier storage boundary cleanup.
 
 The internal incoming graph today is:
 
-- `strata-core-legacy`
 - `strata-engine`
 - `strata-executor`
 - `strata-graph`
 - `strata-search`
 - `strata-vector`
+
+The root `stratadb` package also depends on storage in dev/test paths.
 
 This confirms that storage is already the effective substrate node of the
 workspace.
@@ -152,6 +160,18 @@ In [error.rs](../../crates/storage/src/error.rs), storage owns:
 - `StorageResult`
 - storage corruption and IO classification
 
+### 5. Durability Runtime
+
+In [durability/](../../crates/storage/src/durability), storage owns:
+
+- WAL read/write, codec, and payload mechanics
+- snapshot/checkpoint file mechanics
+- generic MANIFEST load/create/update mechanics
+- checkpoint, WAL compaction, snapshot pruning, and MANIFEST sync helpers
+- generic decoded-row snapshot install into `SegmentedStore`
+- recovery bootstrap mechanics through
+  [recovery_bootstrap.rs](../../crates/storage/src/durability/recovery_bootstrap.rs)
+
 ## What Storage Now Owns
 
 Storage now owns the full lower runtime substrate.
@@ -163,7 +183,9 @@ The major substrate responsibilities now physically owned here are:
 - commit coordination
 - WAL runtime
 - snapshot runtime
-- recovery coordination
+- checkpoint and WAL compaction runtime
+- generic decoded-row snapshot install runtime
+- recovery bootstrap and replay coordination
 
 ## Current Architectural Role
 
@@ -172,6 +194,7 @@ If you describe the crate honestly as it exists today, `strata-storage` is:
 - the physical keyspace owner
 - the MVCC persistence engine
 - the storage error owner
+- the durability runtime owner
 - the substrate API boundary for the rest of the stack
 
 It is not merely a bag of data structures. It is the real lower-runtime owner
@@ -186,5 +209,4 @@ is already visible.
 The remaining work is above the substrate now:
 
 - keep primitive semantics out of the lower layer
-- sever the final `core-legacy` dependencies
 - let `engine` converge on its own clean domain/runtime boundary


### PR DESCRIPTION
## Summary

- Moves the durability recovery bootstrap (MANIFEST/codec preparation, `RecoveryCoordinator` driving, WAL record application, mechanical lossy WAL fallback, snapshot-version fold, runtime-config application, and `recover_segments()`) out of `strata-engine` and behind `strata_storage::durability::run_storage_recovery`.
- `Database::run_recovery` shrinks to engine policy/orchestration: build storage-neutral input, supply the primitive snapshot install callback, map storage errors into `RecoveryError`, build `LossyRecoveryReport`, apply degraded-storage policy, bootstrap `TransactionCoordinator`, restore follower state, construct watermark.
- **TransactionCoordinator stays engine-owned** (load-bearing decision from the ES2-ES4 sketch). Storage returns raw `RecoveryStats`/`RecoveredState`; engine bootstraps the coordinator after the call returns.
- One **explicit behavior change** is called out in the ES4 plan: snapshot install callback failures now hard-fail and bypass the lossy WAL replay fallback even when `allow_lossy_recovery=true`. Pre-ES4, a primitive snapshot decode/install failure could be silently discarded and the database opened empty — that is data loss masquerading as a successful open.

## New storage surface

`crates/storage/src/durability/recovery_bootstrap.rs`:

- `run_storage_recovery(input) -> Result<StorageRecoveryOutcome, StorageRecoveryError>`
- `StorageRecoveryInput<'a>` (layout, mode, configured_codec_id, write_buffer_size, runtime_config, allow_lossy_wal_replay, snapshot_install)
- `StorageRecoveryMode` { `PrimaryCreateManifestIfMissing`, `FollowerNeverCreateManifest` } — storage-neutral, no product policy
- `StorageRuntimeConfig` (8 storage knobs, `Default` matches `SegmentedStore` defaults — verified by test)
- `StorageRecoveryOutcome` (raw facts only)
- `StorageLossyWalReplayFacts`
- `StorageRecoveryError` (`#[non_exhaustive]`, 7 variants)
- `RecoverySnapshotInstallCallback` trait + blanket `Fn` impl

All public types are `#[non_exhaustive]` with `new()` constructors. The ES4C-F bridge helpers used during phased landing are private to `recovery_bootstrap.rs` — no engine-internal seam exposes them.

## `run_storage_recovery` execution order

1. validate configured codec (no side effects on failure)
2. prepare MANIFEST (primary creates, follower never creates)
3. resolve WAL/snapshot-install codecs
4. build `SegmentedStore` at the segments dir
5. drive `RecoveryCoordinator` replay (snapshot install via callback + `apply_wal_record_to_memory_storage`)
6. classify replay outcome and apply mechanical lossy fallback when allowed (bypassing snapshot-plan / legacy-format / snapshot-callback failures)
7. fold snapshot-installed version into `RecoveryStats::final_version`
8. apply `StorageRuntimeConfig` to `SegmentedStore`
9. run `SegmentedStore::recover_segments()`
10. return raw outcome

## Engine wrapper shape

`Database::run_recovery` now:

- builds storage-neutral mode + `StorageRuntimeConfig` from `StrataConfig`
- creates an install closure that calls `install_snapshot()` and logs per-primitive stats
- calls `run_storage_recovery`
- maps `StorageRecoveryError` → `RecoveryError` (`CodecInit` / `ManifestLoad` via `classify_manifest_load_error` to preserve legacy-format extraction / `ManifestCreate` / `ManifestCodecMismatch` with role / `Io` / `Coordinator` via `from_coordinator_error` / `SegmentRecovery` / catch-all for `#[non_exhaustive]` evolution)
- builds `LossyRecoveryReport` from `StorageLossyWalReplayFacts` (engine owns wording, tracing targets, `LossyErrorKind` classification)
- applies degraded-storage policy (`allow_missing_manifest` / `allow_lossy_recovery` / `DegradationClass` matrix)
- bootstraps `TransactionCoordinator` + calls `apply_storage_recovery`
- restores follower persisted state (engine-only)
- constructs `ContiguousWatermark`

Engine no longer imports `RecoveryCoordinator`, `ManifestManager`, or `apply_wal_record_to_memory_storage` from `strata_storage`.

## Behavior change: snapshot install callback failure lossy bypass

**Old**: with `allow_lossy_recovery=true`, a primitive snapshot install callback failure could be treated like a lossy WAL replay failure — recovery wiped partially installed state and continued with an empty store.

**New**: snapshot install callback failures hard-fail and bypass the lossy WAL replay fallback even when lossy recovery is enabled. The lossy fallback is a whole-store discard for WAL replay corruption; applying it to primitive snapshot decode/install failures can hide authoritative snapshot corruption or incompatible primitive bytes behind a successful empty open. Hard failure preserves the evidence.

**Compatibility risk**: databases that previously opened by silently discarding state after a corrupt or incompatible recovery snapshot now fail recovery. Successful empty open in that case would be data loss.

**Related**: `CoordinatorRecoveryError::should_bypass_lossy()` now also returns `true` for `SnapshotMissing` and `SnapshotRead`. Snapshot-planning failures already bypassed via `Plan`/legacy-format; this extends the bypass to MANIFEST-referenced-but-unreadable snapshots so the mechanical wipe never runs against snapshot-plan errors that would recur after a wipe.

**Focused tests**: `lossy_wal_replay_snapshot_callback_failure_preserves_partial_storage`, `recovery_snapshot_install_failure_bypasses_lossy_fallback_when_enabled`, `snapshot_plan_failure_bypasses_lossy_fallback`.

## ES4H ownership guards (clean)

- `rg 'use strata_engine|strata_engine::|strata-engine' crates/storage/src crates/storage/Cargo.toml` — 0 matches
- `rg 'TransactionCoordinator|RecoveryError|LossyRecoveryReport|LossyErrorKind' crates/storage/src/durability/recovery_bootstrap.rs` — 0 matches (only storage-internal `CoordinatorRecoveryError` / `StorageRecoveryError`)
- `rg 'primitive_tags|SnapshotSerializer|*SnapshotEntry' crates/storage/src/durability/recovery_bootstrap.rs` — 0 matches
- `rg 'RecoveryCoordinator|ManifestManager|apply_wal_record_to_memory_storage' crates/engine/src/database/recovery.rs` — 0 matches

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test -p strata-storage --quiet` — 1203 passed (1180 in ES3; +23)
- [x] `cargo test -p strata-storage recovery_bootstrap` — 23 passed
- [x] `cargo test -p strata-engine --lib database::recovery` — 27 passed
- [x] `cargo test -p strata-engine --test recovery_parity` — 7 passed
- [x] `cargo test -p strata-engine` — 1604 passed (1595 in ES3; +9), 10 failed (same pre-existing architecture-cleanup-period failures verified against `main` during ES2; no new regressions)
- [x] `cargo test -p strata-executor` — 113 passed

## Documentation

- `docs/engine/engine-crate-map.md` updated: `database/recovery.rs` is now an engine policy/public-error adapter over `run_storage_recovery`
- `docs/storage/storage-crate-map.md` updated: `durability/recovery_bootstrap.rs` listed as storage-owned lower durability runtime
- `docs/engine/engine-storage-boundary-normalization-plan.md` records ES4 implementation status and the one intentional behavior tightening
- `docs/engine/es4-recovery-bootstrap-mechanics-plan.md` (new) captures the full ES4A-H plan, behavior matrix, and completion criteria

## Out of scope (later epics)

- ES5: storage-only configuration application across all open paths (`apply_storage_config` in `open.rs`, public `StrataConfig` split, block-cache global capacity, WAL writer runtime construction)
- Out of program: `TransactionCoordinator` ownership move (would be a separate plan), branch bundle recovery semantics, search/index recovery redesign, primitive snapshot format redesign

🤖 Generated with [Claude Code](https://claude.com/claude-code)