### PR TITLE
ES5: route all open paths through storage-owned StorageRuntimeConfig

### DIFF
--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -65,7 +65,10 @@ pub struct StorageConfig {
     /// Default: 0 (disabled — individual fields take effect).
     #[serde(default)]
     pub memory_budget: usize,
-    /// Maximum number of branches allowed. Default: 1024. Set to 0 for unlimited.
+    /// Public advisory branch-limit setting. Default: 1024. Set to 0 for unlimited.
+    ///
+    /// Storage records this runtime value on the store, but current storage
+    /// mechanics do not enforce a branch-creation limit.
     #[serde(default = "default_max_branches")]
     pub max_branches: usize,
     /// Maximum entries in a single transaction's write buffer. Default: 500_000.
@@ -544,7 +547,7 @@ auto_embed = false
 # Storage resource limits.
 # [storage]
 # memory_budget = 0             # 0 = disabled; when >0, storage derives cache/buffer/immutable values.
-# max_branches = 1024
+# max_branches = 1024          # advisory; stored by storage, not yet enforced
 # max_write_buffer_entries = 500000 # per-transaction coordinator limit
 # max_versions_per_key = 0    # 0 = unlimited; set to e.g. 100 to cap MVCC history
 # block_cache_size = 0          # 0 = storage auto-detect; nonzero = explicit bytes

--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use strata_security::SensitiveString;
 use strata_storage::durability::wal::DurabilityMode;
+use strata_storage::runtime_config::StorageRuntimeConfig;
 
 // ============================================================================
 // Shadow Collection Names
@@ -47,22 +48,19 @@ fn default_timeout_ms() -> u64 {
     5000
 }
 
-/// Storage layer resource limits.
+/// Public storage configuration.
 ///
-/// Controls maximum branches and per-transaction write buffer sizes.
-/// All limits default to generous values suitable for production use.
-/// Set to `0` for unlimited (backward-compatible default).
+/// Engine owns this serialized product configuration and adapts the
+/// storage-facing fields into `StorageRuntimeConfig`. Storage owns the runtime
+/// mechanics and effective-value derivation for storage knobs; transaction and
+/// database lifecycle policy fields remain engine-owned.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StorageConfig {
-    /// Unified memory budget in bytes for storage data structures.
+    /// Unified public memory budget in bytes for storage data structures.
     ///
-    /// When set (> 0), automatically derives `block_cache_size`,
-    /// `write_buffer_size`, and `max_immutable_memtables`:
-    /// - 50% → block cache (read path)
-    /// - 25% → write buffer (×2 with 1 frozen = 50% write path)
-    ///
-    /// Individual field values are **ignored** when `memory_budget > 0`.
-    /// Actual RSS ≈ `memory_budget` + ~25 MB fixed process overhead.
+    /// When set (> 0), storage derives effective block-cache, write-buffer,
+    /// and immutable-memtable runtime values from this unified budget.
+    /// Individual storage resource fields are ignored for that derivation.
     ///
     /// Default: 0 (disabled — individual fields take effect).
     #[serde(default)]
@@ -70,7 +68,8 @@ pub struct StorageConfig {
     /// Maximum number of branches allowed. Default: 1024. Set to 0 for unlimited.
     #[serde(default = "default_max_branches")]
     pub max_branches: usize,
-    /// Maximum entries in a single transaction's write buffer. Default: 500_000. Set to 0 for unlimited.
+    /// Maximum entries in a single transaction's write buffer. Default: 500_000.
+    /// Set to 0 for unlimited.
     #[serde(default = "default_max_write_buffer_entries")]
     pub max_write_buffer_entries: usize,
     /// Maximum versions to retain per key. Default: 0 (unlimited).
@@ -78,63 +77,74 @@ pub struct StorageConfig {
     /// versions exceeding this limit. Explicit KeepLast(n) overrides.
     #[serde(default)]
     pub max_versions_per_key: usize,
-    /// Block cache size in bytes. Caches decompressed segment data blocks.
+    /// Public block-cache size in bytes.
     ///
-    /// Default: 0 (auto-tuned). When 0, the hardware profile detector
-    /// picks an appropriate size for the host:
-    /// - **Embedded** (< 1 GiB RAM): `min(ram / 8, 64 MiB)` — capped for
-    ///   Pi Zero–class devices.
-    /// - **Desktop** / **Server**: falls through to `auto_detect_capacity`,
-    ///   which uses `min(available_ram / 4, 4 GiB)` from `/proc/meminfo`.
-    ///
-    /// Set a non-zero value to override auto-tuning. Set `memory_budget`
-    /// to derive from a unified budget (takes precedence over this field).
+    /// Default: 0 (storage auto-detects at runtime after engine profile
+    /// adjustments). Set a non-zero value to request an explicit cache size.
+    /// Set `memory_budget` to derive from a unified budget; that takes
+    /// precedence over this field.
     #[serde(default)]
     pub block_cache_size: usize,
-    /// Memtable write buffer size in bytes. When a branch's active memtable
-    /// exceeds this threshold, it is frozen and a new active memtable is swapped in.
+    /// Public memtable write-buffer size in bytes.
+    ///
+    /// Storage applies this as the active memtable rotation threshold when
+    /// `memory_budget == 0`.
     /// Default: 128 MiB. Set to 0 to disable automatic rotation.
     #[serde(default = "default_write_buffer_size")]
     pub write_buffer_size: usize,
-    /// Maximum number of frozen (immutable) memtables allowed per branch before
-    /// write stalling kicks in. Default: 4. Set to 0 for unlimited.
+    /// Public frozen-memtable limit per branch.
+    ///
+    /// Storage applies this to memtable rotation when `memory_budget == 0`.
+    /// Engine also uses the effective storage value to decide when transaction
+    /// write-pressure handling should ask storage to flush/compact.
+    /// Default: 4. Set to 0 for unlimited.
     #[serde(default = "default_max_immutable_memtables")]
     pub max_immutable_memtables: usize,
-    /// L0 file count that triggers write slowdown (1 ms yield per write).
-    /// Mirrors RocksDB's `level0_slowdown_writes_trigger`. Default: 20.
+    /// L0 file count that triggers engine transaction slowdown.
+    ///
+    /// This is transaction runtime policy, not storage runtime configuration.
+    /// Default: 0 (disabled).
     #[serde(default = "default_l0_slowdown_writes_trigger")]
     pub l0_slowdown_writes_trigger: usize,
-    /// L0 file count that completely stalls writes until compaction catches up.
-    /// Mirrors RocksDB's `level0_stop_writes_trigger`. Default: 36.
+    /// L0 file count that makes engine transaction commits wait for compaction.
+    ///
+    /// This is transaction runtime policy, not storage runtime configuration.
+    /// Default: 0 (disabled).
     #[serde(default = "default_l0_stop_writes_trigger")]
     pub l0_stop_writes_trigger: usize,
-    /// Number of background worker threads for compaction, flush, and maintenance.
+    /// Number of engine background worker threads for compaction, flush, and
+    /// maintenance.
     /// Default: min(4, available CPU cores). On single-core devices set to 1.
     ///
     /// Class: open-time-only. See `docs/design/architecture-cleanup/durability-recovery-config-matrix.md`.
     #[serde(default = "default_background_threads")]
     pub background_threads: usize,
-    /// Target size for a single output segment file in bytes.
+    /// Target size for a single storage output segment file in bytes.
     /// Default: 64 MiB. On embedded devices (Pi), use 4–8 MiB.
     #[serde(default = "default_target_file_size")]
     pub target_file_size: u64,
-    /// Target total size for L1 in bytes. Higher levels are multiplied by 10×.
+    /// Target storage L1 size in bytes. Higher levels are multiplied by 10×.
     /// Default: 256 MiB. On embedded devices (Pi), use 32 MiB.
     #[serde(default = "default_level_base_bytes")]
     pub level_base_bytes: u64,
-    /// Data block size in bytes for segment files.
-    /// Default: 4096 (4 KiB). Larger blocks improve throughput at the cost of read amplification.
+    /// Storage segment data block size in bytes.
+    /// Default: 4096 (4 KiB). Larger blocks improve throughput at the cost of
+    /// read amplification.
     #[serde(default = "default_data_block_size")]
     pub data_block_size: usize,
-    /// Bloom filter bits per key. Higher values reduce false positives but use more memory.
+    /// Storage bloom-filter bits per key. Higher values reduce false positives
+    /// but use more memory.
     /// Default: 10.
     #[serde(default = "default_bloom_bits_per_key")]
     pub bloom_bits_per_key: usize,
-    /// Compaction I/O rate limit in bytes per second. 0 = unlimited (default).
+    /// Storage compaction I/O rate limit in bytes per second. 0 = unlimited
+    /// (default).
     /// On slow storage (SD cards), set to e.g. 5–10 MB/s to avoid starving user I/O.
     #[serde(default)]
     pub compaction_rate_limit: u64,
-    /// Maximum time (milliseconds) a write can be stalled waiting for L0 compaction.
+    /// Maximum time (milliseconds) an engine transaction can wait for L0 compaction.
+    ///
+    /// This is transaction runtime policy, not storage runtime configuration.
     /// If exceeded, the write returns an error instead of blocking indefinitely.
     /// Default: 30000 (30 seconds). Set to 0 for unlimited (not recommended).
     #[serde(default = "default_write_stall_timeout_ms")]
@@ -213,30 +223,38 @@ fn default_codec() -> String {
 impl StorageConfig {
     /// Effective block cache size, accounting for `memory_budget`.
     pub fn effective_block_cache_size(&self) -> usize {
-        if self.memory_budget > 0 {
-            self.memory_budget / 2
-        } else {
-            self.block_cache_size
-        }
+        storage_runtime_config_from(self).block_cache_configured_bytes()
     }
 
     /// Effective write buffer size, accounting for `memory_budget`.
     pub fn effective_write_buffer_size(&self) -> usize {
-        if self.memory_budget > 0 {
-            self.memory_budget / 4
-        } else {
-            self.write_buffer_size
-        }
+        storage_runtime_config_from(self).write_buffer_size
     }
 
     /// Effective max immutable memtables, accounting for `memory_budget`.
     pub fn effective_max_immutable_memtables(&self) -> usize {
-        if self.memory_budget > 0 {
-            1
-        } else {
-            self.max_immutable_memtables
-        }
+        storage_runtime_config_from(self).max_immutable_memtables
     }
+}
+
+/// Adapt engine-owned public storage config into storage-owned runtime config.
+///
+/// This passes raw public field values to storage. Storage owns the
+/// effective-value derivation for storage resources.
+pub(crate) fn storage_runtime_config_from(config: &StorageConfig) -> StorageRuntimeConfig {
+    StorageRuntimeConfig::builder()
+        .memory_budget(config.memory_budget)
+        .block_cache_size(config.block_cache_size)
+        .write_buffer_size(config.write_buffer_size)
+        .max_branches(config.max_branches)
+        .max_versions_per_key(config.max_versions_per_key)
+        .max_immutable_memtables(config.max_immutable_memtables)
+        .target_file_size(config.target_file_size)
+        .level_base_bytes(config.level_base_bytes)
+        .data_block_size(config.data_block_size)
+        .bloom_bits_per_key(config.bloom_bits_per_key)
+        .compaction_rate_limit(config.compaction_rate_limit)
+        .build()
 }
 
 impl Default for StorageConfig {
@@ -271,7 +289,10 @@ impl Default for StorageConfig {
 /// never broken by pruning.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SnapshotRetentionPolicy {
-    /// Maximum number of snapshot files to keep. Must be `>= 1`.
+    /// Maximum number of snapshot files to keep.
+    ///
+    /// Storage pruning preserves at least one snapshot; `0` is accepted for
+    /// config-file compatibility and is treated as `1` by the pruning runtime.
     /// Default: 10.
     #[serde(default = "default_snapshot_retain_count")]
     pub retain_count: usize,
@@ -374,9 +395,9 @@ pub struct StrataConfig {
     /// Individual collections can override via VectorConfig.
     #[serde(default = "default_vector_dtype")]
     pub default_vector_dtype: String,
-    /// Snapshot retention policy. Controls how many `snap-NNNNNN.chk` files
-    /// are kept on disk after each successful checkpoint. The live MANIFEST
-    /// snapshot is always retained.
+    /// Snapshot retention policy. Engine owns the public retention setting;
+    /// storage owns pruning mechanics. The live MANIFEST snapshot is always
+    /// retained.
     #[serde(default)]
     pub snapshot_retention: SnapshotRetentionPolicy,
 }
@@ -522,23 +543,22 @@ auto_embed = false
 
 # Storage resource limits.
 # [storage]
-# memory_budget = 0             # 0 = unlimited; e.g. 33554432 for 32 MiB.
-#                                # Derives cache/buffer/immutable automatically.
-#                                # Actual RSS ≈ memory_budget + ~25 MB overhead.
+# memory_budget = 0             # 0 = disabled; when >0, storage derives cache/buffer/immutable values.
 # max_branches = 1024
-# max_write_buffer_entries = 500000
+# max_write_buffer_entries = 500000 # per-transaction coordinator limit
 # max_versions_per_key = 0    # 0 = unlimited; set to e.g. 100 to cap MVCC history
-# block_cache_size = 0          # 0 = auto-tuned per hardware profile:
-#                                #   Embedded  (< 1 GiB RAM): min(ram/8, 64 MiB)
-#                                #   Desktop/Server: min(available_ram/4, 4 GiB)
+# block_cache_size = 0          # 0 = storage auto-detect; nonzero = explicit bytes
 # write_buffer_size = 134217728  # 128 MiB; memtable rotation threshold
 # max_immutable_memtables = 4   # max frozen memtables per branch before write stalling
+# l0_slowdown_writes_trigger = 0 # engine transaction slowdown disabled by default
+# l0_stop_writes_trigger = 0     # engine transaction stall disabled by default
 # background_threads = 4        # compaction/flush workers; default min(4, CPU cores)
 # target_file_size = 67108864   # 64 MiB; segment file target (Pi: 4-8 MiB)
 # level_base_bytes = 268435456  # 256 MiB; L1 target size (Pi: 32 MiB)
 # data_block_size = 4096        # 4 KiB; segment data block size
 # bloom_bits_per_key = 10       # bloom filter bits per key
 # compaction_rate_limit = 0     # 0 = unlimited; bytes/sec cap for compaction I/O
+# write_stall_timeout_ms = 30000 # engine transaction L0 stall timeout
 
 # Snapshot retention. After each successful checkpoint, snapshot files older
 # than the retain window are pruned. The snapshot referenced by the live
@@ -721,6 +741,19 @@ mod tests {
     fn default_toml_parses_correctly() {
         let config: StrataConfig = toml::from_str(StrataConfig::default_toml()).unwrap();
         assert_eq!(config.durability, "standard");
+    }
+
+    #[test]
+    fn default_toml_documents_residual_storage_config_owners() {
+        let default_toml = StrataConfig::default_toml();
+
+        assert!(default_toml.contains("# l0_slowdown_writes_trigger = 0"));
+        assert!(default_toml.contains("# l0_stop_writes_trigger = 0"));
+        assert!(default_toml.contains("# write_stall_timeout_ms = 30000"));
+        assert!(default_toml.contains("per-transaction coordinator limit"));
+        assert!(default_toml.contains("storage auto-detect"));
+        assert!(!default_toml.contains(concat!("Actual", " RSS")));
+        assert!(!default_toml.contains(concat!("Embedded  (< 1 GiB RAM): ", "min")));
     }
 
     #[test]
@@ -1129,6 +1162,9 @@ auto_embed = false
         assert_eq!(config.storage.max_versions_per_key, 0);
         assert_eq!(config.storage.write_buffer_size, 128 * 1024 * 1024);
         assert_eq!(config.storage.max_immutable_memtables, 4);
+        assert_eq!(config.storage.l0_slowdown_writes_trigger, 0);
+        assert_eq!(config.storage.l0_stop_writes_trigger, 0);
+        assert_eq!(config.storage.write_stall_timeout_ms, 30_000);
     }
 
     #[test]
@@ -1169,6 +1205,24 @@ max_immutable_memtables = 8
         assert_eq!(
             config.storage.max_versions_per_key, 0,
             "default must be 0 (unlimited) for backward compat"
+        );
+    }
+
+    #[test]
+    fn storage_runtime_adapter_ignores_engine_owned_and_non_runtime_fields() {
+        let base = StorageConfig::default();
+        let mut changed = base.clone();
+        changed.max_write_buffer_entries = base.max_write_buffer_entries.saturating_add(17);
+        changed.l0_slowdown_writes_trigger = 3;
+        changed.l0_stop_writes_trigger = 7;
+        changed.background_threads = base.background_threads.saturating_add(5).max(1);
+        changed.write_stall_timeout_ms = base.write_stall_timeout_ms.saturating_add(11);
+        changed.codec = "aes-gcm-256".to_string();
+
+        assert_eq!(
+            storage_runtime_config_from(&base),
+            storage_runtime_config_from(&changed),
+            "engine-owned policy and non-runtime fields must not be absorbed into StorageRuntimeConfig"
         );
     }
 

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -2114,7 +2114,7 @@ impl Database {
             }
         }
         // Apply storage/coordinator/cache parameters to the live database
-        self.apply_storage_config_inner(&applied_cfg);
+        self.apply_runtime_storage_config_inner(&applied_cfg);
         Ok(())
     }
 
@@ -2122,37 +2122,17 @@ impl Database {
     ///
     /// Called after every `update_config()` to make storage, coordinator,
     /// and block cache parameters take effect immediately.
-    fn apply_storage_config_inner(&self, cfg: &StrataConfig) {
-        self.storage.set_max_branches(cfg.storage.max_branches);
-        self.storage
-            .set_max_versions_per_key(cfg.storage.max_versions_per_key);
-        self.storage
-            .set_max_immutable_memtables(cfg.storage.effective_max_immutable_memtables());
-        self.storage
-            .set_write_buffer_size(cfg.storage.effective_write_buffer_size());
-        self.storage
-            .set_target_file_size(cfg.storage.target_file_size);
-        self.storage
-            .set_level_base_bytes(cfg.storage.level_base_bytes);
-        self.storage
-            .set_data_block_size(cfg.storage.data_block_size);
-        self.storage
-            .set_bloom_bits_per_key(cfg.storage.bloom_bits_per_key);
-        self.storage
-            .set_compaction_rate_limit(cfg.storage.compaction_rate_limit);
+    fn apply_runtime_storage_config_inner(&self, cfg: &StrataConfig) {
+        let runtime_config = config::storage_runtime_config_from(&cfg.storage);
+        // Storage owns the static `SegmentedStore::set_*` application list.
+        // Engine adapts public config and keeps the coordinator/cache side
+        // effects that are not store setter mechanics.
+        runtime_config.apply_to_store(&self.storage);
 
         self.coordinator
             .set_max_write_buffer_entries(cfg.storage.max_write_buffer_entries);
 
-        // Block cache
-        use strata_storage::block_cache;
-        let effective_cache = cfg.storage.effective_block_cache_size();
-        let cache_bytes = if effective_cache > 0 {
-            effective_cache
-        } else {
-            block_cache::auto_detect_capacity()
-        };
-        block_cache::set_global_capacity(cache_bytes);
+        runtime_config.apply_global_runtime();
     }
 
     /// Switch the durability mode at runtime (Standard ↔ Always only).

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -1,6 +1,5 @@
 //! Database opening and initialization.
 
-use super::config::StorageConfig;
 use crate::background::BackgroundScheduler;
 use crate::coordinator::TransactionCoordinator;
 use crate::{StrataError, StrataResult};
@@ -11,29 +10,11 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use strata_storage::durability::__internal::WalWriterEngineExt;
-use strata_storage::durability::codec::clone_codec;
+use strata_storage::durability::codec::{clone_codec, get_codec, validate_codec_id};
 use strata_storage::durability::layout::DatabaseLayout;
 use strata_storage::durability::wal::{DurabilityMode, WalConfig, WalWriter};
 use strata_storage::SegmentedStore;
 use tracing::{info, warn};
-
-/// Apply all storage configuration settings to a SegmentedStore.
-///
-/// Centralizes storage-config setters for engine-owned store construction.
-/// Disk recovery applies the same knobs through storage's recovery runtime
-/// config before segment recovery runs.
-pub(crate) fn apply_storage_config(storage: &SegmentedStore, cfg: &StorageConfig) {
-    storage.set_max_branches(cfg.max_branches);
-    storage.set_max_versions_per_key(cfg.max_versions_per_key);
-    storage.set_max_immutable_memtables(cfg.effective_max_immutable_memtables());
-    storage.set_target_file_size(cfg.target_file_size);
-    storage.set_level_base_bytes(cfg.level_base_bytes);
-    storage.set_data_block_size(cfg.data_block_size);
-    storage.set_bloom_bits_per_key(cfg.bloom_bits_per_key);
-    if cfg.compaction_rate_limit > 0 {
-        storage.set_compaction_rate_limit(cfg.compaction_rate_limit);
-    }
-}
 
 use strata_core::id::CommitVersion;
 
@@ -80,7 +61,7 @@ fn restrict_file(path: &Path) {
 #[cfg(not(unix))]
 fn restrict_file(_path: &Path) {}
 
-use super::config::{self, StrataConfig};
+use super::config::{self, storage_runtime_config_from, StrataConfig};
 use super::registry::OPEN_DATABASES;
 use super::{Database, PersistenceMode, WalWriterHealth};
 
@@ -425,15 +406,19 @@ impl Database {
         // Build canonical layout for this database
         let layout = DatabaseLayout::from_root(&canonical_path);
         let wal_dir = layout.wal_dir().to_path_buf();
+        let recovery_config = super::recovery::RecoveryRuntimeConfig::from_strata_config(&cfg);
+        let runtime_config = recovery_config.storage_runtime_config();
 
         // Recovery orchestration is centralized in `run_recovery`.
         let outcome = Database::run_recovery(
             &canonical_path,
             &layout,
-            &cfg,
+            recovery_config,
             super::recovery::RecoveryMode::Follower,
         )
         .map_err(StrataError::from)?;
+
+        runtime_config.apply_global_runtime();
 
         let bg_threads = cfg.storage.background_threads.max(1);
 
@@ -488,6 +473,9 @@ impl Database {
         });
 
         if let Some(state) = outcome.persisted_follower_state {
+            // Follower-state restore sets the live MVCC version recovered by
+            // engine follower policy. This is not static storage runtime
+            // config and does not belong in `StorageRuntimeConfig::apply_to_store`.
             db.storage.set_version(state.visible_version);
             db.coordinator
                 .restore_visible_version(state.visible_version);
@@ -697,12 +685,14 @@ impl Database {
     ) -> StrataResult<Arc<Self>> {
         // Build canonical layout for this database
         let layout = DatabaseLayout::from_root(&canonical_path);
+        let recovery_config = super::recovery::RecoveryRuntimeConfig::from_strata_config(&cfg);
+        let runtime_config = recovery_config.storage_runtime_config();
 
         // Recovery orchestration is centralized in `run_recovery`.
         let outcome = Database::run_recovery(
             &canonical_path,
             &layout,
-            &cfg,
+            recovery_config,
             super::recovery::RecoveryMode::Primary,
         )
         .map_err(StrataError::from)?;
@@ -737,6 +727,8 @@ impl Database {
             wal_dir.clone(),
             outcome.database_uuid,
             durability_mode,
+            // WAL defaults and validation are storage-owned mechanics; engine
+            // still owns the writer lifecycle and health policy.
             WalConfig::default(),
             outcome.wal_codec,
         )?;
@@ -751,23 +743,14 @@ impl Database {
         // completed segment recovery; post-open reads will hit this
         // cache, so configuring it here is functionally equivalent to
         // the pre-D3 ordering.
-        {
-            use strata_storage::block_cache;
-            let effective_cache = cfg.storage.effective_block_cache_size();
-            let cache_bytes = if effective_cache > 0 {
-                effective_cache
-            } else {
-                block_cache::auto_detect_capacity()
-            };
-            block_cache::set_global_capacity(cache_bytes);
-        }
+        runtime_config.apply_global_runtime();
 
         if cfg.storage.memory_budget > 0 {
             info!(target: "strata::db",
                 memory_budget = cfg.storage.memory_budget,
-                effective_cache = cfg.storage.effective_block_cache_size(),
-                effective_write_buffer = cfg.storage.effective_write_buffer_size(),
-                effective_max_immutable = cfg.storage.effective_max_immutable_memtables(),
+                effective_cache = runtime_config.block_cache_configured_bytes(),
+                effective_write_buffer = runtime_config.write_buffer_size,
+                effective_max_immutable = runtime_config.max_immutable_memtables,
                 "Memory budget active — derived storage parameters"
             );
         }
@@ -908,17 +891,17 @@ impl Database {
         crate::database::profile::apply_hardware_profile_if_defaults(&mut cfg);
 
         // Apply effective block cache size to the global singleton so that
-        // in-memory reads use the profile-tuned capacity instead of the
-        // 256 MB default. On Desktop/Server this is a no-op (effective == 0
-        // triggers the existing auto-detect behavior elsewhere).
-        let effective_cache = cfg.storage.effective_block_cache_size();
-        if effective_cache > 0 {
-            strata_storage::block_cache::set_global_capacity(effective_cache);
-        }
+        // in-memory reads use the profile-tuned or auto-detected capacity
+        // instead of inheriting stale process-wide state.
+        let runtime_config = storage_runtime_config_from(&cfg.storage);
+        runtime_config.apply_global_runtime();
 
         // Create fresh storage with config limits
         let storage = SegmentedStore::new();
-        apply_storage_config(&storage, &cfg.storage);
+        // Storage owns the static `SegmentedStore::set_*` application list.
+        // Cache databases remain in-memory; this only applies runtime knobs
+        // to the fresh store.
+        runtime_config.apply_to_store(&storage);
 
         let bg_threads = cfg.storage.background_threads.max(1);
 
@@ -931,13 +914,12 @@ impl Database {
         // `Option`, so the type signature does not leak "this is a
         // cache database" into the field type. `IdentityCodec` is the
         // typical resolution here and is effectively a no-op at runtime.
-        let wal_codec_for_cache = strata_storage::durability::get_codec(&cfg.storage.codec)
-            .map_err(|e| {
-                StrataError::internal(format!(
-                    "cache database could not initialize codec '{}': {}",
-                    cfg.storage.codec, e
-                ))
-            })?;
+        let wal_codec_for_cache = get_codec(&cfg.storage.codec).map_err(|e| {
+            StrataError::internal(format!(
+                "cache database could not initialize codec '{}': {}",
+                cfg.storage.codec, e
+            ))
+        })?;
 
         let db = Arc::new(Self {
             data_dir: PathBuf::new(), // Empty path for ephemeral
@@ -1234,7 +1216,7 @@ impl Database {
         // Validate the configured codec exists before touching any state.
         // Mirrors the primary path so a follower with an unknown codec is
         // rejected consistently — with or without an on-disk MANIFEST.
-        strata_storage::durability::get_codec(&cfg.storage.codec).map_err(|e| {
+        validate_codec_id(&cfg.storage.codec).map_err(|e| {
             StrataError::internal(format!(
                 "invalid storage codec '{}': {}",
                 cfg.storage.codec, e

--- a/crates/engine/src/database/open.rs
+++ b/crates/engine/src/database/open.rs
@@ -890,6 +890,19 @@ impl Database {
         // which is fatal on 512 MB devices.
         crate::database::profile::apply_hardware_profile_if_defaults(&mut cfg);
 
+        // T3-E12 §D7: cache-mode databases still populate `wal_codec`
+        // uniformly — the field is always `Box<dyn StorageCodec>`, not
+        // `Option`, so the type signature does not leak "this is a
+        // cache database" into the field type. Construct the codec before
+        // applying process-global runtime config so invalid cache opens fail
+        // without mutating shared storage state.
+        let wal_codec_for_cache = get_codec(&cfg.storage.codec).map_err(|e| {
+            StrataError::internal(format!(
+                "cache database could not initialize codec '{}': {}",
+                cfg.storage.codec, e
+            ))
+        })?;
+
         // Apply effective block cache size to the global singleton so that
         // in-memory reads use the profile-tuned or auto-detected capacity
         // instead of inheriting stale process-wide state.
@@ -908,18 +921,6 @@ impl Database {
         // Create coordinator starting at version 1 (no recovery needed), with write buffer limit
         let coordinator = TransactionCoordinator::new(CommitVersion(1));
         coordinator.set_max_write_buffer_entries(cfg.storage.max_write_buffer_entries);
-
-        // T3-E12 §D7: cache-mode databases still populate `wal_codec`
-        // uniformly — the field is always `Box<dyn StorageCodec>`, not
-        // `Option`, so the type signature does not leak "this is a
-        // cache database" into the field type. `IdentityCodec` is the
-        // typical resolution here and is effectively a no-op at runtime.
-        let wal_codec_for_cache = get_codec(&cfg.storage.codec).map_err(|e| {
-            StrataError::internal(format!(
-                "cache database could not initialize codec '{}': {}",
-                cfg.storage.codec, e
-            ))
-        })?;
 
         let db = Arc::new(Self {
             data_dir: PathBuf::new(), // Empty path for ephemeral

--- a/crates/engine/src/database/recovery.rs
+++ b/crates/engine/src/database/recovery.rs
@@ -29,12 +29,13 @@ use strata_storage::durability::wal::WalReaderError;
 use strata_storage::durability::{
     run_storage_recovery, CoordinatorPlanError, CoordinatorRecoveryError, LoadedSnapshot,
     ManifestError, RecoveryResult, SnapshotReadError, StorageLossyWalReplayFacts,
-    StorageRecoveryError, StorageRecoveryInput, StorageRecoveryMode, StorageRuntimeConfig,
+    StorageRecoveryError, StorageRecoveryInput, StorageRecoveryMode,
 };
+use strata_storage::runtime_config::StorageRuntimeConfig;
 use strata_storage::{DegradationClass, RecoveryHealth, SegmentedStore, StorageError};
 use tracing::{info, warn};
 
-use super::config::{StorageConfig, StrataConfig};
+use super::config::{storage_runtime_config_from, StrataConfig};
 use super::recovery_error::{
     classify_manifest_load_error, from_coordinator_error, ErrorRole, RecoveryError,
 };
@@ -81,6 +82,34 @@ impl RecoveryMode {
     }
 }
 
+/// Engine-owned recovery config bundle.
+///
+/// `run_recovery` needs both public engine config and storage runtime config.
+/// Keeping them in one value makes the invariant explicit: the storage runtime
+/// config is always adapted from the same `StrataConfig` passed to recovery.
+#[derive(Clone, Copy)]
+pub(crate) struct RecoveryRuntimeConfig<'a> {
+    strata_config: &'a StrataConfig,
+    storage_runtime_config: StorageRuntimeConfig,
+}
+
+impl<'a> RecoveryRuntimeConfig<'a> {
+    pub(crate) fn from_strata_config(strata_config: &'a StrataConfig) -> Self {
+        Self {
+            strata_config,
+            storage_runtime_config: storage_runtime_config_from(&strata_config.storage),
+        }
+    }
+
+    pub(crate) fn storage_runtime_config(&self) -> StorageRuntimeConfig {
+        self.storage_runtime_config
+    }
+
+    fn strata_config(&self) -> &'a StrataConfig {
+        self.strata_config
+    }
+}
+
 /// Output of [`Database::run_recovery`].
 ///
 /// Carries the owned resources the caller needs to finish constructing
@@ -121,7 +150,8 @@ impl Database {
     /// 2. MANIFEST load or primary-mode create.
     /// 3. WAL codec resolution (stored id on reopen, configured id on
     ///    first-open or follower-without-MANIFEST).
-    /// 4. `SegmentedStore` construction at the segments directory.
+    /// 4. `SegmentedStore` construction at the segments directory using the
+    ///    caller-supplied storage runtime config.
     /// 5. Storage-owned durability recovery via an engine primitive snapshot
     ///    install callback.
     /// 6. `TransactionCoordinator::from_recovery_with_limits` +
@@ -132,9 +162,12 @@ impl Database {
     pub(crate) fn run_recovery(
         canonical_path: &Path,
         layout: &DatabaseLayout,
-        cfg: &StrataConfig,
+        recovery_config: RecoveryRuntimeConfig<'_>,
         mode: RecoveryMode,
     ) -> Result<RecoveryOutcome, RecoveryError> {
+        let cfg = recovery_config.strata_config();
+        let runtime_config = recovery_config.storage_runtime_config();
+
         // 1-5. Storage-owned durability recovery. Storage owns MANIFEST/codec
         //      prep, generic WAL replay, the mechanical lossy fallback,
         //      runtime config application, and segment recovery. Engine keeps
@@ -151,8 +184,7 @@ impl Database {
             layout.clone(),
             mode.as_storage_mode(),
             cfg.storage.codec.clone(),
-            cfg.storage.effective_write_buffer_size(),
-            storage_runtime_config_from(&cfg.storage),
+            runtime_config,
             cfg.allow_lossy_recovery,
             &snapshot_install,
         ))
@@ -286,19 +318,6 @@ fn degraded_recovery_permitted(
     allow_lossy_recovery: bool,
 ) -> bool {
     allow_lossy_recovery || !policy_refuses(class, allow_missing_manifest)
-}
-
-fn storage_runtime_config_from(config: &StorageConfig) -> StorageRuntimeConfig {
-    StorageRuntimeConfig::new(
-        config.max_branches,
-        config.max_versions_per_key,
-        config.effective_max_immutable_memtables(),
-        config.target_file_size,
-        config.level_base_bytes,
-        config.data_block_size,
-        config.bloom_bits_per_key,
-        config.compaction_rate_limit,
-    )
 }
 
 fn map_storage_recovery_error(
@@ -560,6 +579,20 @@ mod tests {
         }
     }
 
+    fn run_recovery_for_test(
+        canonical_path: &Path,
+        layout: &DatabaseLayout,
+        cfg: &StrataConfig,
+        mode: RecoveryMode,
+    ) -> Result<RecoveryOutcome, RecoveryError> {
+        Database::run_recovery(
+            canonical_path,
+            layout,
+            RecoveryRuntimeConfig::from_strata_config(cfg),
+            mode,
+        )
+    }
+
     #[test]
     fn snapshot_plan_failure_bypasses_lossy_fallback() {
         let temp_dir = TempDir::new().unwrap();
@@ -570,7 +603,7 @@ mod tests {
             allow_lossy_recovery: true,
             ..StrataConfig::default()
         };
-        let result = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary);
+        let result = run_recovery_for_test(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary);
 
         match result {
             Err(RecoveryError::SnapshotMissing {
@@ -601,7 +634,7 @@ mod tests {
             ..StrataConfig::default()
         };
 
-        let outcome = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
+        let outcome = run_recovery_for_test(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
             .expect("primary first-open recovery should succeed");
 
         assert!(
@@ -633,20 +666,46 @@ mod tests {
         let layout = DatabaseLayout::from_root(temp_dir.path());
         let cfg = StrataConfig {
             storage: StorageConfig {
+                max_branches: 31,
+                max_versions_per_key: 7,
+                write_buffer_size: 512 * 1024,
+                max_immutable_memtables: 3,
                 target_file_size: 3 * 1024 * 1024,
+                level_base_bytes: 11 * 1024 * 1024,
                 data_block_size: 8 * 1024,
                 bloom_bits_per_key: 13,
+                compaction_rate_limit: 5 * 1024 * 1024,
                 ..StorageConfig::default()
             },
             ..StrataConfig::default()
         };
 
-        let outcome = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
+        let outcome = run_recovery_for_test(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
             .expect("recovery should succeed with non-default storage config");
 
         assert_eq!(
+            outcome.storage.write_buffer_size_for_test(),
+            cfg.storage.effective_write_buffer_size()
+        );
+        assert_eq!(
+            outcome.storage.max_branches_for_test(),
+            cfg.storage.max_branches
+        );
+        assert_eq!(
+            outcome.storage.max_versions_per_key_for_test(),
+            cfg.storage.max_versions_per_key
+        );
+        assert_eq!(
+            outcome.storage.max_immutable_memtables_for_test(),
+            cfg.storage.effective_max_immutable_memtables()
+        );
+        assert_eq!(
             outcome.storage.target_file_size(),
             cfg.storage.target_file_size
+        );
+        assert_eq!(
+            outcome.storage.level_base_bytes(),
+            cfg.storage.level_base_bytes
         );
         assert_eq!(
             outcome.storage.data_block_size(),
@@ -656,6 +715,10 @@ mod tests {
             outcome.storage.bloom_bits_per_key(),
             cfg.storage.bloom_bits_per_key
         );
+        assert_eq!(
+            outcome.storage.compaction_rate_limit_for_test(),
+            cfg.storage.compaction_rate_limit
+        );
     }
 
     #[test]
@@ -664,9 +727,8 @@ mod tests {
         let layout = DatabaseLayout::from_root(temp_dir.path());
         let cfg = StrataConfig::default();
 
-        let outcome =
-            Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Follower)
-                .expect("follower without MANIFEST should fall back to WAL-only recovery");
+        let outcome = run_recovery_for_test(temp_dir.path(), &layout, &cfg, RecoveryMode::Follower)
+            .expect("follower without MANIFEST should fall back to WAL-only recovery");
 
         assert!(
             !layout.manifest_path().exists(),
@@ -715,9 +777,8 @@ mod tests {
             .unwrap()
             .is_some());
 
-        let outcome =
-            Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Follower)
-                .expect("follower recovery should ignore invalid persisted state");
+        let outcome = run_recovery_for_test(temp_dir.path(), &layout, &cfg, RecoveryMode::Follower)
+            .expect("follower recovery should ignore invalid persisted state");
 
         assert!(outcome.persisted_follower_state.is_none());
         assert!(load_persisted_follower_state(temp_dir.path())
@@ -756,7 +817,7 @@ mod tests {
             .unwrap();
         write_db_manifest_with_snapshot(&layout, database_uuid, "identity", 11, TxnId(9));
 
-        let outcome = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
+        let outcome = run_recovery_for_test(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
             .expect("snapshot-only recovery should succeed");
 
         assert_eq!(
@@ -798,7 +859,7 @@ mod tests {
             23,
         );
 
-        let outcome = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
+        let outcome = run_recovery_for_test(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
             .expect("WAL-only recovery should succeed");
 
         assert_eq!(outcome.storage.current_version(), CommitVersion(23));
@@ -827,7 +888,7 @@ mod tests {
             allow_lossy_recovery: true,
             ..StrataConfig::default()
         };
-        let result = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary);
+        let result = run_recovery_for_test(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary);
 
         match result {
             Err(RecoveryError::WalLegacyFormat {
@@ -865,7 +926,7 @@ mod tests {
             allow_lossy_recovery: true,
             ..StrataConfig::default()
         };
-        let outcome = Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
+        let outcome = run_recovery_for_test(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
             .expect("lossy recovery should convert replay failure into an empty recovered store");
 
         let report = outcome
@@ -997,7 +1058,7 @@ mod tests {
 
         let cfg = StrataConfig::default();
         let mapped =
-            match Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary) {
+            match run_recovery_for_test(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary) {
                 Err(err) => err,
                 Ok(_) => panic!("callback error should map to public recovery error"),
             };
@@ -1037,7 +1098,7 @@ mod tests {
             ..StrataConfig::default()
         };
         let mapped =
-            match Database::run_recovery(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary) {
+            match run_recovery_for_test(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary) {
                 Err(err) => err,
                 Ok(_) => panic!("snapshot install failure must not lossy-open as empty storage"),
             };

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -272,6 +272,251 @@ fn test_cache_open_rejects_cache_durability_string() {
     );
 }
 
+fn es5a_observable_storage_config() -> StorageConfig {
+    StorageConfig {
+        max_branches: 17,
+        max_versions_per_key: 3,
+        write_buffer_size: 256 * 1024,
+        max_immutable_memtables: 2,
+        target_file_size: 3 * 1024 * 1024,
+        level_base_bytes: 11 * 1024 * 1024,
+        data_block_size: 8 * 1024,
+        bloom_bits_per_key: 13,
+        compaction_rate_limit: 7 * 1024 * 1024,
+        ..StorageConfig::default()
+    }
+}
+
+struct BlockCacheCapacityGuard {
+    previous_capacity: usize,
+}
+
+impl BlockCacheCapacityGuard {
+    fn capture() -> Self {
+        Self {
+            previous_capacity: strata_storage::block_cache::global_capacity(),
+        }
+    }
+}
+
+impl Drop for BlockCacheCapacityGuard {
+    fn drop(&mut self) {
+        strata_storage::block_cache::set_global_capacity(self.previous_capacity);
+    }
+}
+
+fn assert_es5a_observable_storage_config(
+    db: &Database,
+    cfg: &StorageConfig,
+    expected_write_buffer_size: usize,
+) {
+    let storage = db.storage();
+    assert_eq!(
+        storage.write_buffer_size_for_test(),
+        expected_write_buffer_size
+    );
+    assert_eq!(storage.max_branches_for_test(), cfg.max_branches);
+    assert_eq!(
+        storage.max_versions_per_key_for_test(),
+        cfg.max_versions_per_key
+    );
+    assert_eq!(
+        storage.max_immutable_memtables_for_test(),
+        cfg.effective_max_immutable_memtables()
+    );
+    assert_eq!(storage.target_file_size(), cfg.target_file_size);
+    assert_eq!(storage.level_base_bytes(), cfg.level_base_bytes);
+    assert_eq!(storage.data_block_size(), cfg.data_block_size);
+    assert_eq!(storage.bloom_bits_per_key(), cfg.bloom_bits_per_key);
+    assert_eq!(
+        storage.compaction_rate_limit_for_test(),
+        cfg.compaction_rate_limit
+    );
+}
+
+#[test]
+#[serial(open_databases)]
+fn es5a_persistent_open_applies_observable_storage_runtime_knobs() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("es5a_persistent_runtime_config");
+    let storage = es5a_observable_storage_config();
+    let cfg = StrataConfig {
+        storage: storage.clone(),
+        ..StrataConfig::default()
+    };
+
+    let db = Database::open_runtime(super::spec::OpenSpec::primary(&db_path).with_config(cfg))
+        .expect("primary open should apply storage runtime config");
+
+    assert!(!db.is_cache());
+    assert_es5a_observable_storage_config(&db, &storage, storage.effective_write_buffer_size());
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
+#[test]
+#[serial(open_databases)]
+fn es5a_cache_open_applies_observable_storage_runtime_knobs() {
+    let storage = es5a_observable_storage_config();
+    let cfg = StrataConfig {
+        storage: storage.clone(),
+        ..StrataConfig::default()
+    };
+
+    let db = Database::open_runtime(super::spec::OpenSpec::cache().with_config(cfg))
+        .expect("cache open should apply storage runtime config");
+
+    assert!(db.is_cache());
+    assert_es5a_observable_storage_config(&db, &storage, storage.effective_write_buffer_size());
+}
+
+#[test]
+#[serial(open_databases)]
+fn es5a_update_config_reapplies_observable_storage_runtime_knobs() {
+    let initial_storage = es5a_observable_storage_config();
+    let initial_cfg = StrataConfig {
+        storage: initial_storage.clone(),
+        ..StrataConfig::default()
+    };
+    let db = Database::open_runtime(super::spec::OpenSpec::cache().with_config(initial_cfg))
+        .expect("cache open should succeed");
+    assert_es5a_observable_storage_config(
+        &db,
+        &initial_storage,
+        initial_storage.effective_write_buffer_size(),
+    );
+
+    let updated_storage = StorageConfig {
+        write_buffer_size: 384 * 1024,
+        max_branches: 23,
+        max_versions_per_key: 5,
+        max_immutable_memtables: 4,
+        target_file_size: 5 * 1024 * 1024,
+        level_base_bytes: 19 * 1024 * 1024,
+        data_block_size: 16 * 1024,
+        bloom_bits_per_key: 15,
+        compaction_rate_limit: 3 * 1024 * 1024,
+        ..initial_storage
+    };
+
+    db.update_config(|cfg| {
+        cfg.storage = updated_storage.clone();
+    })
+    .expect("storage runtime config update should succeed");
+
+    assert_es5a_observable_storage_config(
+        &db,
+        &updated_storage,
+        updated_storage.effective_write_buffer_size(),
+    );
+}
+
+#[test]
+#[serial(open_databases)]
+fn es5a_persistent_open_applies_memory_budget_runtime_derivations() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("es5a_persistent_memory_budget");
+    let storage = StorageConfig {
+        memory_budget: 32 << 20,
+        write_buffer_size: 512 * 1024,
+        max_immutable_memtables: 7,
+        ..es5a_observable_storage_config()
+    };
+    let cfg = StrataConfig {
+        storage: storage.clone(),
+        ..StrataConfig::default()
+    };
+
+    let db = Database::open_runtime(super::spec::OpenSpec::primary(&db_path).with_config(cfg))
+        .expect("primary open should apply memory-budget-derived storage config");
+
+    assert_es5a_observable_storage_config(&db, &storage, 8 << 20);
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
+#[test]
+#[serial(open_databases)]
+fn es5c_cache_open_applies_memory_budget_runtime_derivations() {
+    let storage = StorageConfig {
+        memory_budget: 32 << 20,
+        write_buffer_size: 512 * 1024,
+        max_immutable_memtables: 7,
+        ..es5a_observable_storage_config()
+    };
+    let cfg = StrataConfig {
+        storage: storage.clone(),
+        ..StrataConfig::default()
+    };
+
+    let db = Database::open_runtime(super::spec::OpenSpec::cache().with_config(cfg))
+        .expect("cache open should apply memory-budget-derived storage config");
+
+    assert_es5a_observable_storage_config(&db, &storage, 8 << 20);
+}
+
+#[test]
+#[serial(open_databases)]
+fn es5e_cache_open_applies_default_block_cache_runtime_config() {
+    let _capacity_guard = BlockCacheCapacityGuard::capture();
+    let mut cfg = StrataConfig::default();
+    crate::database::profile::apply_hardware_profile_if_defaults(&mut cfg);
+    let runtime_config = crate::database::config::storage_runtime_config_from(&cfg.storage);
+
+    strata_storage::block_cache::set_global_capacity(1);
+
+    let db =
+        Database::open_runtime(super::spec::OpenSpec::cache().with_config(StrataConfig::default()))
+            .expect("cache open should apply default block-cache runtime config");
+
+    assert!(db.is_cache());
+    let applied_capacity = strata_storage::block_cache::global_capacity();
+    match runtime_config.block_cache {
+        strata_storage::runtime_config::StorageBlockCacheConfig::Bytes(bytes) => {
+            assert_eq!(applied_capacity, bytes);
+        }
+        strata_storage::runtime_config::StorageBlockCacheConfig::Auto => {
+            assert_ne!(applied_capacity, 1);
+            assert!(applied_capacity > 0);
+        }
+        _ => unreachable!("unknown storage block-cache config variant"),
+    }
+}
+
+#[test]
+#[serial(open_databases)]
+fn es5c_follower_open_applies_block_cache_runtime_config() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("es5c_follower_block_cache");
+    let _capacity_guard = BlockCacheCapacityGuard::capture();
+    let storage = StorageConfig {
+        block_cache_size: 7 << 20,
+        ..StorageConfig::default()
+    };
+    let cfg = StrataConfig {
+        storage,
+        ..StrataConfig::default()
+    };
+
+    let primary =
+        Database::open_runtime(super::spec::OpenSpec::primary(&db_path).with_config(cfg.clone()))
+            .expect("primary open should create recoverable database state");
+    primary.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+
+    strata_storage::block_cache::set_global_capacity(1);
+
+    let follower =
+        Database::open_runtime(super::spec::OpenSpec::follower(&db_path).with_config(cfg))
+            .expect("follower open should apply storage runtime config");
+
+    assert_eq!(strata_storage::block_cache::global_capacity(), 7 << 20);
+
+    follower.shutdown().unwrap();
+}
+
 #[test]
 fn test_flush() {
     let temp_dir = TempDir::new().unwrap();
@@ -510,7 +755,7 @@ fn run_primary_recovery(
     Database::run_recovery(
         db_path,
         &layout,
-        &cfg,
+        crate::database::recovery::RecoveryRuntimeConfig::from_strata_config(&cfg),
         crate::database::recovery::RecoveryMode::Primary,
     )
 }

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -487,6 +487,33 @@ fn es5e_cache_open_applies_default_block_cache_runtime_config() {
 
 #[test]
 #[serial(open_databases)]
+fn es5g_cache_open_rejects_invalid_codec_before_global_cache_mutation() {
+    let _capacity_guard = BlockCacheCapacityGuard::capture();
+    let cfg = StrataConfig {
+        storage: StorageConfig {
+            block_cache_size: 7 << 20,
+            codec: "missing-codec".to_string(),
+            ..StorageConfig::default()
+        },
+        ..StrataConfig::default()
+    };
+
+    strata_storage::block_cache::set_global_capacity(1);
+
+    let error = Database::open_runtime(super::spec::OpenSpec::cache().with_config(cfg))
+        .expect_err("cache open should reject an unknown storage codec");
+
+    assert!(
+        error
+            .to_string()
+            .contains("cache database could not initialize codec 'missing-codec'"),
+        "error should name the rejected cache codec, got: {error}"
+    );
+    assert_eq!(strata_storage::block_cache::global_capacity(), 1);
+}
+
+#[test]
+#[serial(open_databases)]
 fn es5c_follower_open_applies_block_cache_runtime_config() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("es5c_follower_block_cache");

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -500,8 +500,10 @@ fn es5g_cache_open_rejects_invalid_codec_before_global_cache_mutation() {
 
     strata_storage::block_cache::set_global_capacity(1);
 
-    let error = Database::open_runtime(super::spec::OpenSpec::cache().with_config(cfg))
-        .expect_err("cache open should reject an unknown storage codec");
+    let error = match Database::open_runtime(super::spec::OpenSpec::cache().with_config(cfg)) {
+        Ok(_) => panic!("cache open should reject an unknown storage codec"),
+        Err(error) => error,
+    };
 
     assert!(
         error

--- a/crates/engine/src/database/tests/snapshot_retention.rs
+++ b/crates/engine/src/database/tests/snapshot_retention.rs
@@ -84,6 +84,42 @@ fn prune_preserves_live_manifest_snapshot_in_steady_state() {
 }
 
 #[test]
+fn retain_count_zero_is_treated_as_one_by_engine_pruning() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    let db = Database::open(&db_path).unwrap();
+
+    {
+        let mut cfg = db.config.write();
+        cfg.snapshot_retention.retain_count = 0;
+    }
+
+    let branch_id = BranchId::new();
+    for i in 0..5 {
+        write_one(&db, branch_id, &format!("zero-retain-{i}"));
+        db.checkpoint().unwrap();
+    }
+
+    let canonical = db_path.canonicalize().unwrap();
+    let snapshots_dir = canonical.join("snapshots");
+    let kept_ids: Vec<u64> = list_snapshots(&snapshots_dir)
+        .unwrap()
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect();
+
+    assert_eq!(
+        kept_ids.len(),
+        1,
+        "public retain_count=0 should be accepted and pruned as retain_count=1"
+    );
+
+    let manifest_path = canonical.join("MANIFEST");
+    let manifest = strata_storage::durability::ManifestManager::load(manifest_path).unwrap();
+    assert_eq!(kept_ids[0], manifest.manifest().snapshot_id.unwrap());
+}
+
+#[test]
 fn prune_preserves_live_manifest_snapshot_when_outside_retain_window() {
     // Corner case: MANIFEST.snapshot_id points to an OLD snapshot that
     // would otherwise fall outside `retain_count`. This can happen in

--- a/crates/engine/src/database/transaction.rs
+++ b/crates/engine/src/database/transaction.rs
@@ -45,6 +45,19 @@ fn release_freed_memory() {
 /// re-submitting through `schedule_background_compaction`.
 const MAX_IDLE_ROUNDS: u32 = 5;
 
+fn memtable_backpressure_threshold_from_storage_config(
+    storage_config: &super::config::StorageConfig,
+) -> Option<u64> {
+    let runtime_config = super::config::storage_runtime_config_from(storage_config);
+    let write_buffer_size = runtime_config.write_buffer_size as u64;
+    if write_buffer_size == 0 {
+        return None;
+    }
+
+    let max_frozen = runtime_config.max_immutable_memtables as u64;
+    Some(write_buffer_size.saturating_mul(max_frozen.saturating_add(2)))
+}
+
 /// One round of the self-re-scheduling compaction chain.
 ///
 /// Each invocation picks the highest-scoring compaction across all branches,
@@ -255,7 +268,9 @@ impl Database {
             return;
         }
 
-        // Update snapshot floor so compaction respects active snapshots (#1697).
+        // Snapshot floor is engine MVCC policy computed from active
+        // transactions before compaction. It is intentionally not part of the
+        // static storage runtime config setter list.
         self.storage.set_snapshot_floor(self.gc_safe_point());
 
         // Coalesce flush scheduling: skip if a flush task is already in flight.
@@ -442,12 +457,10 @@ impl Database {
 
         // Memtable-based stalling (protects memory usage)
         let cfg = self.config.read();
-        let wbs = cfg.storage.effective_write_buffer_size() as u64;
-        let max_frozen = cfg.storage.effective_max_immutable_memtables() as u64;
+        let threshold = memtable_backpressure_threshold_from_storage_config(&cfg.storage);
         drop(cfg);
 
-        if wbs > 0 {
-            let threshold = wbs * (max_frozen + 2);
+        if let Some(threshold) = threshold {
             let current = self.storage.total_memtable_bytes();
             if current > threshold {
                 std::thread::sleep(std::time::Duration::from_millis(1));
@@ -1058,5 +1071,54 @@ impl Database {
             Arc::increment_strong_count(ptr);
             Arc::from_raw(ptr)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::config::StorageConfig;
+
+    #[test]
+    fn memtable_backpressure_threshold_uses_storage_runtime_memory_budget() {
+        let storage = StorageConfig {
+            memory_budget: 32 << 20,
+            write_buffer_size: 512 * 1024,
+            max_immutable_memtables: 7,
+            ..StorageConfig::default()
+        };
+
+        assert_eq!(
+            memtable_backpressure_threshold_from_storage_config(&storage),
+            Some((8 << 20) * 3)
+        );
+    }
+
+    #[test]
+    fn memtable_backpressure_threshold_allows_explicit_zero_write_buffer() {
+        let storage = StorageConfig {
+            write_buffer_size: 0,
+            max_immutable_memtables: 7,
+            ..StorageConfig::default()
+        };
+
+        assert_eq!(
+            memtable_backpressure_threshold_from_storage_config(&storage),
+            None
+        );
+    }
+
+    #[test]
+    fn memtable_backpressure_threshold_saturates_extreme_values() {
+        let storage = StorageConfig {
+            write_buffer_size: usize::MAX,
+            max_immutable_memtables: usize::MAX,
+            ..StorageConfig::default()
+        };
+
+        assert_eq!(
+            memtable_backpressure_threshold_from_storage_config(&storage),
+            Some(u64::MAX)
+        );
     }
 }

--- a/crates/storage/src/durability/checkpoint_runtime.rs
+++ b/crates/storage/src/durability/checkpoint_runtime.rs
@@ -741,6 +741,14 @@ mod tests {
     }
 
     #[test]
+    fn storage_snapshot_retention_clamps_zero_to_one() {
+        let retention = StorageSnapshotRetention::new(0);
+
+        assert_eq!(retention.retain_count, 1);
+        assert_eq!(retention.effective_retain_count(), 1);
+    }
+
+    #[test]
     fn storage_checkpoint_creates_snapshot_and_updates_manifest() {
         let temp_dir = TempDir::new().unwrap();
         let layout = layout(&temp_dir);

--- a/crates/storage/src/durability/codec/mod.rs
+++ b/crates/storage/src/durability/codec/mod.rs
@@ -84,9 +84,23 @@ pub fn get_codec(codec_id: &str) -> Result<Box<dyn StorageCodec>, CodecError> {
     }
 }
 
+/// Validate that a codec id resolves in the storage codec registry.
+///
+/// This intentionally follows the same path as [`get_codec`] so validation
+/// includes any storage-local constructor requirements for the codec.
+pub fn validate_codec_id(codec_id: &str) -> Result<(), CodecError> {
+    get_codec(codec_id).map(|_| ())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn encryption_env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
 
     #[test]
     fn test_get_identity_codec() {
@@ -101,10 +115,21 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_codec_id() {
+        assert!(validate_codec_id("identity").is_ok());
+        assert!(matches!(
+            validate_codec_id("unknown"),
+            Err(CodecError::UnknownCodec(_))
+        ));
+    }
+
+    #[test]
     fn test_get_aes_gcm_codec_without_env_var() {
+        let _env_guard = encryption_env_lock();
         // Ensure the env var is unset for this test
         std::env::remove_var("STRATA_ENCRYPTION_KEY");
         let result = get_codec("aes-gcm-256");
+        let validation = validate_codec_id("aes-gcm-256");
         match result {
             Err(e) => {
                 let msg = e.to_string();
@@ -116,10 +141,22 @@ mod tests {
             }
             Ok(_) => panic!("Expected error when env var is not set"),
         }
+        match validation {
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("STRATA_ENCRYPTION_KEY"),
+                    "Validation error should mention the env var: {}",
+                    msg
+                );
+            }
+            Ok(_) => panic!("Expected validation error when env var is not set"),
+        }
     }
 
     #[test]
     fn test_get_aes_gcm_codec_with_valid_env_var() {
+        let _env_guard = encryption_env_lock();
         let hex = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
         std::env::set_var("STRATA_ENCRYPTION_KEY", hex);
         let result = get_codec("aes-gcm-256");
@@ -137,6 +174,7 @@ mod tests {
 
     #[test]
     fn test_get_aes_gcm_codec_with_invalid_env_var() {
+        let _env_guard = encryption_env_lock();
         std::env::set_var("STRATA_ENCRYPTION_KEY", "too-short");
         let result = get_codec("aes-gcm-256");
         std::env::remove_var("STRATA_ENCRYPTION_KEY");

--- a/crates/storage/src/durability/mod.rs
+++ b/crates/storage/src/durability/mod.rs
@@ -54,7 +54,9 @@ pub use decoded_snapshot_install::{
 };
 
 // Codec
-pub use codec::{clone_codec, get_codec, CodecError, IdentityCodec, StorageCodec};
+pub use codec::{
+    clone_codec, get_codec, validate_codec_id, CodecError, IdentityCodec, StorageCodec,
+};
 
 // Disk snapshot
 pub use disk_snapshot::{
@@ -90,11 +92,13 @@ pub use recovery::{
     RecoveryCoordinator, RecoveryPlan, RecoveryResult, RecoveryStats,
 };
 
+// Runtime config
+pub use crate::runtime_config::{StorageBlockCacheConfig, StorageRuntimeConfig};
+
 // Recovery bootstrap
 pub use recovery_bootstrap::{
     run_storage_recovery, RecoverySnapshotInstallCallback, StorageLossyWalReplayFacts,
     StorageRecoveryError, StorageRecoveryInput, StorageRecoveryMode, StorageRecoveryOutcome,
-    StorageRuntimeConfig,
 };
 
 // WAL

--- a/crates/storage/src/durability/recovery_bootstrap.rs
+++ b/crates/storage/src/durability/recovery_bootstrap.rs
@@ -61,7 +61,12 @@ pub struct StorageRecoveryInput<'a> {
     pub mode: StorageRecoveryMode,
     /// Codec id supplied by the caller's runtime configuration.
     pub configured_codec_id: String,
-    /// Runtime knobs applied before segment recovery.
+    /// Runtime knobs used to construct and configure recovered storage.
+    ///
+    /// Recovery has no separate constructor write-buffer argument; it uses
+    /// `runtime_config.write_buffer_size` to create the recovered
+    /// `SegmentedStore`, then applies the remaining runtime knobs through
+    /// `StorageRuntimeConfig::apply_to_store`.
     pub runtime_config: StorageRuntimeConfig,
     /// Whether storage may perform the mechanical lossy WAL replay fallback.
     pub allow_lossy_wal_replay: bool,

--- a/crates/storage/src/durability/recovery_bootstrap.rs
+++ b/crates/storage/src/durability/recovery_bootstrap.rs
@@ -17,6 +17,7 @@ use crate::durability::{
     apply_wal_record_to_memory_storage, CoordinatorRecoveryError, LoadedSnapshot, ManifestError,
     ManifestManager, RecoveryCoordinator, RecoveryStats,
 };
+use crate::runtime_config::StorageRuntimeConfig;
 use crate::{RecoveredState, SegmentedStore, StorageError};
 
 /// Install a loaded snapshot into storage during recovery.
@@ -60,8 +61,6 @@ pub struct StorageRecoveryInput<'a> {
     pub mode: StorageRecoveryMode,
     /// Codec id supplied by the caller's runtime configuration.
     pub configured_codec_id: String,
-    /// Memtable write buffer size for the recovered store.
-    pub write_buffer_size: usize,
     /// Runtime knobs applied before segment recovery.
     pub runtime_config: StorageRuntimeConfig,
     /// Whether storage may perform the mechanical lossy WAL replay fallback.
@@ -77,7 +76,6 @@ impl<'a> StorageRecoveryInput<'a> {
         layout: DatabaseLayout,
         mode: StorageRecoveryMode,
         configured_codec_id: impl Into<String>,
-        write_buffer_size: usize,
         runtime_config: StorageRuntimeConfig,
         allow_lossy_wal_replay: bool,
         snapshot_install: &'a dyn RecoverySnapshotInstallCallback,
@@ -86,7 +84,6 @@ impl<'a> StorageRecoveryInput<'a> {
             layout,
             mode,
             configured_codec_id: configured_codec_id.into(),
-            write_buffer_size,
             runtime_config,
             allow_lossy_wal_replay,
             snapshot_install,
@@ -100,7 +97,6 @@ impl fmt::Debug for StorageRecoveryInput<'_> {
             .field("layout", &self.layout)
             .field("mode", &self.mode)
             .field("configured_codec_id", &self.configured_codec_id)
-            .field("write_buffer_size", &self.write_buffer_size)
             .field("runtime_config", &self.runtime_config)
             .field("allow_lossy_wal_replay", &self.allow_lossy_wal_replay)
             .field("snapshot_install", &"<callback>")
@@ -124,11 +120,11 @@ pub fn run_storage_recovery(
         layout,
         mode,
         configured_codec_id,
-        write_buffer_size,
         runtime_config,
         allow_lossy_wal_replay,
         snapshot_install,
     } = input;
+    let write_buffer_size = runtime_config.write_buffer_size;
 
     let StorageManifestRecoveryPreparation {
         database_uuid,
@@ -168,82 +164,6 @@ pub enum StorageRecoveryMode {
     PrimaryCreateManifestIfMissing,
     /// Follower-style storage recovery never creates a missing MANIFEST.
     FollowerNeverCreateManifest,
-}
-
-/// Runtime storage knobs needed before `SegmentedStore::recover_segments()`.
-///
-/// This mirrors the storage setter types rather than higher-layer product
-/// defaults. Higher layers remain responsible for building this from their
-/// configuration until the public configuration split is complete.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct StorageRuntimeConfig {
-    /// Maximum branches allowed by the store; `0` means unlimited.
-    pub max_branches: usize,
-    /// Maximum retained versions per key; `0` means unlimited.
-    pub max_versions_per_key: usize,
-    /// Maximum frozen memtables per branch before rotation is skipped.
-    pub max_immutable_memtables: usize,
-    /// Target size for a single segment file in bytes.
-    pub target_file_size: u64,
-    /// Target total size for L1 in bytes.
-    pub level_base_bytes: u64,
-    /// Data block size for newly built segment files.
-    pub data_block_size: usize,
-    /// Bloom filter bits per key for newly built segment files.
-    pub bloom_bits_per_key: usize,
-    /// Compaction I/O rate limit in bytes per second; `0` means unlimited.
-    pub compaction_rate_limit: u64,
-}
-
-impl StorageRuntimeConfig {
-    /// Default target size for a single segment file in bytes.
-    pub const DEFAULT_TARGET_FILE_SIZE: u64 = 64 << 20;
-    /// Default target total size for L1 in bytes.
-    pub const DEFAULT_LEVEL_BASE_BYTES: u64 = 256 << 20;
-    /// Default segment data block size in bytes.
-    pub const DEFAULT_DATA_BLOCK_SIZE: usize = 4096;
-    /// Default bloom filter bits per key.
-    pub const DEFAULT_BLOOM_BITS_PER_KEY: usize = 10;
-
-    /// Build a storage runtime config from explicit storage-layer knobs.
-    #[allow(clippy::too_many_arguments)]
-    pub const fn new(
-        max_branches: usize,
-        max_versions_per_key: usize,
-        max_immutable_memtables: usize,
-        target_file_size: u64,
-        level_base_bytes: u64,
-        data_block_size: usize,
-        bloom_bits_per_key: usize,
-        compaction_rate_limit: u64,
-    ) -> Self {
-        Self {
-            max_branches,
-            max_versions_per_key,
-            max_immutable_memtables,
-            target_file_size,
-            level_base_bytes,
-            data_block_size,
-            bloom_bits_per_key,
-            compaction_rate_limit,
-        }
-    }
-}
-
-impl Default for StorageRuntimeConfig {
-    fn default() -> Self {
-        Self {
-            max_branches: 0,
-            max_versions_per_key: 0,
-            max_immutable_memtables: 0,
-            target_file_size: Self::DEFAULT_TARGET_FILE_SIZE,
-            level_base_bytes: Self::DEFAULT_LEVEL_BASE_BYTES,
-            data_block_size: Self::DEFAULT_DATA_BLOCK_SIZE,
-            bloom_bits_per_key: Self::DEFAULT_BLOOM_BITS_PER_KEY,
-            compaction_rate_limit: 0,
-        }
-    }
 }
 
 /// Storage-local MANIFEST and codec preparation result for recovery.
@@ -455,7 +375,7 @@ fn complete_storage_recovery_after_replay(
     lossy_wal_replay: Option<StorageLossyWalReplayFacts>,
 ) -> Result<StorageRecoveryOutcome, StorageRecoveryError> {
     wal_replay.final_version = wal_replay.final_version.max(storage.current_version());
-    apply_storage_runtime_config(&storage, runtime_config);
+    runtime_config.apply_to_store(&storage);
     let segment_recovery = storage
         .recover_segments()
         .map_err(|source| StorageRecoveryError::SegmentRecovery { source })?;
@@ -505,17 +425,6 @@ fn handle_storage_wal_replay_outcome(
     *storage = SegmentedStore::with_dir(layout.segments_dir().to_path_buf(), write_buffer_size);
 
     Ok((RecoveryStats::default(), Some(facts)))
-}
-
-fn apply_storage_runtime_config(storage: &SegmentedStore, config: StorageRuntimeConfig) {
-    storage.set_max_branches(config.max_branches);
-    storage.set_max_versions_per_key(config.max_versions_per_key);
-    storage.set_max_immutable_memtables(config.max_immutable_memtables);
-    storage.set_target_file_size(config.target_file_size);
-    storage.set_level_base_bytes(config.level_base_bytes);
-    storage.set_data_block_size(config.data_block_size);
-    storage.set_bloom_bits_per_key(config.bloom_bits_per_key);
-    storage.set_compaction_rate_limit(config.compaction_rate_limit);
 }
 
 fn install_recovery_snapshot(
@@ -740,8 +649,16 @@ mod tests {
             DatabaseLayout::from_root("/tmp/strata-es4b"),
             StorageRecoveryMode::PrimaryCreateManifestIfMissing,
             "identity",
-            4096,
-            StorageRuntimeConfig::new(128, 16, 2, 1 << 20, 4 << 20, 4096, 10, 0),
+            StorageRuntimeConfig::builder()
+                .write_buffer_size(4096)
+                .max_branches(128)
+                .max_versions_per_key(16)
+                .max_immutable_memtables(2)
+                .target_file_size(1 << 20)
+                .level_base_bytes(4 << 20)
+                .data_block_size(4096)
+                .bloom_bits_per_key(10)
+                .build(),
             true,
             &callback,
         );
@@ -752,21 +669,6 @@ mod tests {
         );
         assert_eq!(input.runtime_config.target_file_size, 1 << 20);
         assert!(format!("{input:?}").contains("<callback>"));
-    }
-
-    #[test]
-    fn runtime_config_default_matches_segmented_store_defaults() {
-        let cfg = StorageRuntimeConfig::default();
-        let store = SegmentedStore::new();
-
-        assert_eq!(cfg.max_branches, 0);
-        assert_eq!(cfg.max_versions_per_key, 0);
-        assert_eq!(cfg.max_immutable_memtables, 0);
-        assert_eq!(cfg.target_file_size, store.target_file_size());
-        assert_eq!(cfg.level_base_bytes, store.level_base_bytes());
-        assert_eq!(cfg.data_block_size, store.data_block_size());
-        assert_eq!(cfg.bloom_bits_per_key, store.bloom_bits_per_key());
-        assert_eq!(cfg.compaction_rate_limit, 0);
     }
 
     #[test]
@@ -932,8 +834,9 @@ mod tests {
             layout.clone(),
             StorageRecoveryMode::PrimaryCreateManifestIfMissing,
             "identity",
-            4096,
-            StorageRuntimeConfig::default(),
+            StorageRuntimeConfig::builder()
+                .write_buffer_size(4096)
+                .build(),
             false,
             &snapshot_install,
         ))
@@ -983,8 +886,9 @@ mod tests {
             layout,
             StorageRecoveryMode::PrimaryCreateManifestIfMissing,
             "identity",
-            4096,
-            StorageRuntimeConfig::default(),
+            StorageRuntimeConfig::builder()
+                .write_buffer_size(4096)
+                .build(),
             true,
             &snapshot_install,
         ))
@@ -1525,8 +1429,17 @@ mod tests {
             final_version: CommitVersion(5),
             ..RecoveryStats::default()
         };
-        let runtime_config =
-            StorageRuntimeConfig::new(128, 16, 2, 2 << 20, 5 << 20, 8 << 10, 12, 1_234_567);
+        let runtime_config = StorageRuntimeConfig::builder()
+            .write_buffer_size(4096)
+            .max_branches(128)
+            .max_versions_per_key(16)
+            .max_immutable_memtables(2)
+            .target_file_size(2 << 20)
+            .level_base_bytes(5 << 20)
+            .data_block_size(8 << 10)
+            .bloom_bits_per_key(12)
+            .compaction_rate_limit(1_234_567)
+            .build();
 
         let outcome = complete_storage_recovery_after_replay(
             [0x77; 16],
@@ -1590,7 +1503,9 @@ mod tests {
             Box::new(IdentityCodec),
             storage,
             RecoveryStats::default(),
-            StorageRuntimeConfig::default(),
+            StorageRuntimeConfig::builder()
+                .write_buffer_size(4096)
+                .build(),
             Some(lossy),
         )
         .expect("post-replay storage recovery should carry lossy facts");

--- a/crates/storage/src/durability/wal/config.rs
+++ b/crates/storage/src/durability/wal/config.rs
@@ -5,7 +5,7 @@
 /// Default maximum segment size: 64 MB.
 pub const DEFAULT_SEGMENT_SIZE: u64 = 64 * 1024 * 1024;
 
-/// Default bytes between fsyncs in Standard mode: 4 MB.
+/// Compatibility default for the retained buffered-sync threshold.
 pub const DEFAULT_BUFFERED_SYNC_BYTES: u64 = 4 * 1024 * 1024;
 
 /// WAL configuration parameters.
@@ -16,10 +16,13 @@ pub struct WalConfig {
     /// When a segment exceeds this size, a new segment is created.
     pub segment_size: u64,
 
-    /// Bytes between fsyncs in Standard mode (default: 4MB).
+    /// Retained buffered-sync threshold (default: 4MB).
     ///
-    /// For Standard durability mode, fsync is triggered when this many
-    /// bytes have been written since the last fsync.
+    /// The current writer does not use this field as an inline fsync trigger;
+    /// Standard-mode sync timing is driven by `DurabilityMode::Standard` and
+    /// the engine-owned background flush lifecycle. `validate()` still checks
+    /// it for callers that intentionally require a self-consistent full
+    /// `WalConfig`.
     pub buffered_sync_bytes: u64,
 }
 
@@ -50,13 +53,25 @@ impl WalConfig {
         self
     }
 
-    /// Validate configuration.
+    /// Validate all configuration fields for static consistency.
     pub fn validate(&self) -> Result<(), WalConfigError> {
         if self.segment_size < 1024 {
             return Err(WalConfigError::SegmentSizeTooSmall);
         }
         if self.buffered_sync_bytes > self.segment_size {
             return Err(WalConfigError::BufferedSyncExceedsSegment);
+        }
+        Ok(())
+    }
+
+    /// Validate only invariants the current writer runtime actively consumes.
+    ///
+    /// `buffered_sync_bytes` is retained configuration metadata and is not
+    /// currently an inline fsync trigger, so `WalWriter::new` must not reject
+    /// a writer solely because that inert field exceeds `segment_size`.
+    pub(crate) fn validate_writer_runtime(&self) -> Result<(), WalConfigError> {
+        if self.segment_size < 1024 {
+            return Err(WalConfigError::SegmentSizeTooSmall);
         }
         Ok(())
     }

--- a/crates/storage/src/durability/wal/mode.rs
+++ b/crates/storage/src/durability/wal/mode.rs
@@ -5,7 +5,7 @@
 /// Default maximum time between fsyncs in Standard mode: 100 ms.
 pub const DEFAULT_SYNC_INTERVAL_MS: u64 = 100;
 
-/// Default maximum writes between fsyncs in Standard mode.
+/// Default retained write-count threshold in Standard mode.
 pub const DEFAULT_SYNC_BATCH_SIZE: usize = 1000;
 
 /// Durability mode for WAL operations
@@ -19,7 +19,7 @@ pub const DEFAULT_SYNC_BATCH_SIZE: usize = 1000;
 /// |------|-------|-----------------|
 /// | Cache | Never | All uncommitted |
 /// | Always | Every commit | Zero |
-/// | Standard | Periodic | Up to interval/batch |
+/// | Standard | Background/periodic, plus interval fallback | Up to interval |
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DurabilityMode {
     /// In-memory cache — all data lost on crash (fastest mode)
@@ -39,15 +39,17 @@ pub enum DurabilityMode {
     /// Expect 10ms+ latency per write.
     Always,
 
-    /// fsync every N commits OR every T milliseconds (the default)
+    /// fsync through the background flush lifecycle plus interval fallback.
     ///
-    /// Good balance of speed and safety. May lose up to batch_size
-    /// writes or interval_ms of data on crash.
+    /// Good balance of speed and safety. May lose up to `interval_ms` of data
+    /// on crash while the background flush thread is active. `batch_size` is
+    /// retained in the public type for compatibility, but the current writer
+    /// does not use it as an inline fsync trigger.
     /// Target latency: <30µs.
     Standard {
         /// Maximum time between fsyncs in milliseconds
         interval_ms: u64,
-        /// Maximum writes between fsyncs
+        /// Retained write-count threshold. Not currently an inline fsync trigger.
         batch_size: usize,
     },
 }
@@ -83,14 +85,15 @@ impl DurabilityMode {
     /// # Default Values
     ///
     /// - **interval_ms**: 100 - Maximum 100ms between fsyncs
-    /// - **batch_size**: 1000 - Maximum 1000 writes before fsync
+    /// - **batch_size**: 1000 - retained write-count threshold
     ///
     /// # Rationale
     ///
     /// These defaults balance performance and durability:
     /// - 100ms interval keeps data loss window bounded
-    /// - 1000 batch size handles burst writes efficiently
-    /// - Both thresholds work together - whichever is reached first triggers fsync
+    /// - 1000 batch size remains available to callers that persist or compare
+    ///   the full durability mode, but it is not an inline fsync trigger in the
+    ///   current writer runtime
     ///
     /// This is the recommended mode for production workloads.
     pub fn standard_default() -> Self {

--- a/crates/storage/src/durability/wal/reader.rs
+++ b/crates/storage/src/durability/wal/reader.rs
@@ -1473,10 +1473,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let wal_dir = dir.path().join("wal");
 
-        // Use tiny segment size to force rotation
+        // Use the smallest valid segment size to force rotation.
         let config = crate::durability::wal::config::WalConfig::new()
-            .with_segment_size(100)
-            .with_buffered_sync_bytes(50);
+            .with_segment_size(1024)
+            .with_buffered_sync_bytes(512);
 
         let mut writer = WalWriter::new(
             wal_dir.to_path_buf(),
@@ -1489,13 +1489,13 @@ mod tests {
 
         // Write enough records to force at least one rotation
         writer
-            .append(&WalRecord::new(TxnId(1), [1u8; 16], 1000, vec![0; 50]))
+            .append(&WalRecord::new(TxnId(1), [1u8; 16], 1000, vec![0; 500]))
             .unwrap();
         writer
-            .append(&WalRecord::new(TxnId(2), [1u8; 16], 2000, vec![0; 50]))
+            .append(&WalRecord::new(TxnId(2), [1u8; 16], 2000, vec![0; 500]))
             .unwrap();
         writer
-            .append(&WalRecord::new(TxnId(3), [1u8; 16], 3000, vec![0; 50]))
+            .append(&WalRecord::new(TxnId(3), [1u8; 16], 3000, vec![0; 500]))
             .unwrap();
 
         writer.close().unwrap();
@@ -1980,15 +1980,15 @@ mod tests {
 
     #[test]
     fn test_read_after_watermark_with_writer_rotation() {
-        // End-to-end test using WalWriter with forced rotation (tiny segment size).
+        // End-to-end test using WalWriter with forced rotation.
         // Verifies the optimization works correctly with real WalWriter-produced
         // segments and .meta files.
         let dir = tempdir().unwrap();
         let wal_dir = dir.path().join("wal");
 
         let config = WalConfig::new()
-            .with_segment_size(100)
-            .with_buffered_sync_bytes(50);
+            .with_segment_size(1024)
+            .with_buffered_sync_bytes(512);
 
         let mut writer = WalWriter::new(
             wal_dir.to_path_buf(),
@@ -2002,7 +2002,7 @@ mod tests {
         // Write enough records to force multiple rotations
         for i in 1..=6 {
             writer
-                .append(&WalRecord::new(TxnId(i), [1u8; 16], i * 1000, vec![0; 50]))
+                .append(&WalRecord::new(TxnId(i), [1u8; 16], i * 1000, vec![0; 500]))
                 .unwrap();
         }
         // close() writes .meta for the final segment too
@@ -2085,10 +2085,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let wal_dir = dir.path().join("wal");
 
-        // Use tiny segment size to force rotation across multiple segments
+        // Use the smallest valid segment size to force rotation across multiple segments.
         let config = WalConfig::new()
-            .with_segment_size(100)
-            .with_buffered_sync_bytes(50);
+            .with_segment_size(1024)
+            .with_buffered_sync_bytes(512);
 
         let mut writer = WalWriter::new(
             wal_dir.to_path_buf(),
@@ -2101,7 +2101,7 @@ mod tests {
 
         for i in 1..=6u64 {
             writer
-                .append(&WalRecord::new(TxnId(i), [1u8; 16], i * 1000, vec![0; 50]))
+                .append(&WalRecord::new(TxnId(i), [1u8; 16], i * 1000, vec![0; 500]))
                 .unwrap();
         }
         writer.close().unwrap();
@@ -2229,7 +2229,7 @@ mod tests {
 
     /// Issue #1556: Multi-segment WAL corruption recovery.
     ///
-    /// Write records across multiple segments (via tiny segment size), corrupt
+    /// Write records across multiple segments, corrupt
     /// a record payload in the middle segment (preserving the length field so
     /// it triggers CRC mismatch, not InsufficientData), and verify:
     /// - Strict reader returns an error
@@ -2239,10 +2239,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let wal_dir = dir.path().join("wal");
 
-        // Use tiny segments to force rotation
+        // Use the smallest valid segment size to force rotation.
         let config = WalConfig::new()
-            .with_segment_size(100)
-            .with_buffered_sync_bytes(50);
+            .with_segment_size(1024)
+            .with_buffered_sync_bytes(512);
 
         let mut writer = WalWriter::new(
             wal_dir.to_path_buf(),
@@ -2253,14 +2253,14 @@ mod tests {
         )
         .unwrap();
 
-        // Write 10 records with large enough payloads to spread across segments
+        // Write 10 records with large enough payloads to spread across segments.
         for i in 1..=10u64 {
             writer
                 .append(&WalRecord::new(
                     TxnId(i),
                     [1u8; 16],
                     i * 1000,
-                    vec![0xAA; 40],
+                    vec![0xAA; 500],
                 ))
                 .unwrap();
         }
@@ -2320,8 +2320,8 @@ mod tests {
             "Lossy reader should recover some records"
         );
 
-        // With tiny segments (1 record each), corrupting the only record
-        // in a segment means there's no next record to scan to, so
+        // With forced-rotation segments (1 record each), corrupting the only
+        // record in a segment means there's no next record to scan to, so
         // skipped_corrupted may be 0. The key guarantee is that records
         // from OTHER segments are still recovered.
 

--- a/crates/storage/src/durability/wal/writer.rs
+++ b/crates/storage/src/durability/wal/writer.rs
@@ -236,6 +236,10 @@ impl WalWriter {
             });
         }
 
+        config
+            .validate_writer_runtime()
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+
         // Ensure WAL directory exists
         std::fs::create_dir_all(&wal_dir)?;
 
@@ -713,9 +717,9 @@ impl WalWriter {
 
     /// Refresh the Standard-mode inline-sync deadline without clearing dirty state.
     ///
-    /// The engine uses this after unrelated durable control-artifact writes
-    /// (`strata.toml`, MANIFEST-like metadata) so their fsync cost does not
-    /// make `maybe_sync` treat the background WAL thread as overdue.
+    /// Higher layers use this after unrelated durable control-artifact writes
+    /// so their fsync cost does not make `maybe_sync` treat the background WAL
+    /// thread as overdue.
     ///
     /// This intentionally does NOT move `last_sync_time`: the background
     /// flush thread and `sync_if_overdue()` must still observe the real WAL
@@ -1068,6 +1072,73 @@ mod tests {
     }
 
     #[test]
+    fn invalid_wal_segment_size_is_rejected_before_creating_wal_dir() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+        let invalid_config = WalConfig::new().with_segment_size(512);
+
+        let result = WalWriter::new(
+            wal_dir.clone(),
+            [1u8; 16],
+            DurabilityMode::Always,
+            invalid_config,
+            Box::new(IdentityCodec),
+        );
+
+        match result {
+            Err(err) => assert_eq!(err.kind(), io::ErrorKind::InvalidInput),
+            Ok(_) => panic!("invalid WAL config should be rejected"),
+        }
+        assert!(
+            !wal_dir.exists(),
+            "invalid WAL config must fail before creating the WAL directory"
+        );
+    }
+
+    #[test]
+    fn buffered_sync_threshold_above_segment_size_does_not_reject_writer() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+        let config = WalConfig::new()
+            .with_segment_size(1024)
+            .with_buffered_sync_bytes(4096);
+
+        let writer = WalWriter::new(
+            wal_dir.clone(),
+            [1u8; 16],
+            DurabilityMode::Always,
+            config,
+            Box::new(IdentityCodec),
+        )
+        .expect("writer should not reject an inert buffered_sync_bytes value");
+
+        assert!(
+            wal_dir.exists(),
+            "valid writer-runtime config should create the WAL directory"
+        );
+        drop(writer);
+    }
+
+    #[test]
+    fn cache_mode_skips_wal_config_validation_and_files() {
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+        let invalid_config = WalConfig::new().with_segment_size(512);
+
+        let mut writer = WalWriter::new(
+            wal_dir,
+            [1u8; 16],
+            DurabilityMode::Cache,
+            invalid_config,
+            Box::new(IdentityCodec),
+        )
+        .expect("cache mode should not validate unused WAL config");
+
+        writer.append(&make_record(1)).unwrap();
+        assert!(std::fs::read_dir(dir.path()).unwrap().next().is_none());
+    }
+
+    #[test]
     fn test_strict_mode_creates_segment() {
         let dir = tempdir().unwrap();
         let wal_dir = dir.path().join("wal");
@@ -1084,10 +1155,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let wal_dir = dir.path().join("wal");
 
-        // Use very small segment size to force rotation
+        // Use the smallest valid segment size to force rotation.
         let config = WalConfig::new()
-            .with_segment_size(100) // Very small
-            .with_buffered_sync_bytes(50);
+            .with_segment_size(1024)
+            .with_buffered_sync_bytes(512);
 
         let mut writer = WalWriter::new(
             wal_dir.clone(),
@@ -1101,7 +1172,7 @@ mod tests {
         // Write enough records to trigger rotation
         for i in 0..10 {
             writer
-                .append(&WalRecord::new(TxnId(i), [1u8; 16], 0, vec![0; 50]))
+                .append(&WalRecord::new(TxnId(i), [1u8; 16], 0, vec![0; 500]))
                 .unwrap();
         }
 
@@ -1235,10 +1306,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let wal_dir = dir.path().join("wal");
 
-        // Use small segments to force rotation
+        // Use the smallest valid segment size to force rotation.
         let config = WalConfig::new()
-            .with_segment_size(100)
-            .with_buffered_sync_bytes(50);
+            .with_segment_size(1024)
+            .with_buffered_sync_bytes(512);
 
         let mut writer_a = WalWriter::new(
             wal_dir.clone(),
@@ -1267,7 +1338,7 @@ mod tests {
             .unwrap();
             for i in 2..=5 {
                 writer_b
-                    .append_and_flush(&WalRecord::new(TxnId(i), [1u8; 16], 0, vec![0; 50]))
+                    .append_and_flush(&WalRecord::new(TxnId(i), [1u8; 16], 0, vec![0; 500]))
                     .unwrap();
             }
             assert!(
@@ -1416,8 +1487,8 @@ mod tests {
         let wal_dir = dir.path().join("wal");
 
         let config = WalConfig::new()
-            .with_segment_size(100) // Very small to force rotation
-            .with_buffered_sync_bytes(50);
+            .with_segment_size(1024)
+            .with_buffered_sync_bytes(512);
 
         let mut writer = WalWriter::new(
             wal_dir.clone(),
@@ -1430,7 +1501,7 @@ mod tests {
 
         // Write enough records via pre_serialized to trigger rotation
         for i in 0..10u64 {
-            let record = WalRecord::new(TxnId(i), [1u8; 16], i * 1000, vec![0; 50]);
+            let record = WalRecord::new(TxnId(i), [1u8; 16], i * 1000, vec![0; 500]);
             let record_bytes = record.to_bytes();
             writer
                 .append_pre_serialized(&record_bytes, TxnId(i), i * 1000)
@@ -1856,8 +1927,8 @@ mod tests {
         let wal_dir = dir.path().join("wal");
 
         let config = WalConfig::new()
-            .with_segment_size(100)
-            .with_buffered_sync_bytes(50);
+            .with_segment_size(1024)
+            .with_buffered_sync_bytes(512);
 
         let mut writer = WalWriter::new(
             wal_dir.clone(),
@@ -1874,7 +1945,7 @@ mod tests {
         // Write enough to force rotation
         for i in 0..10 {
             writer
-                .append(&WalRecord::new(TxnId(i), [1u8; 16], 0, vec![0; 50]))
+                .append(&WalRecord::new(TxnId(i), [1u8; 16], 0, vec![0; 500]))
                 .unwrap();
         }
 
@@ -1914,10 +1985,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let wal_dir = dir.path().join("wal");
 
-        // Use very small segment size to force many rotations
+        // Use the smallest valid segment size to force many rotations.
         let config = WalConfig::new()
-            .with_segment_size(100)
-            .with_buffered_sync_bytes(50);
+            .with_segment_size(1024)
+            .with_buffered_sync_bytes(512);
 
         let mut writer = WalWriter::new(
             wal_dir.clone(),
@@ -1931,7 +2002,7 @@ mod tests {
         // Write enough records to force several rotations
         for i in 1..=20 {
             writer
-                .append(&WalRecord::new(TxnId(i), [1u8; 16], i * 1000, vec![0; 50]))
+                .append(&WalRecord::new(TxnId(i), [1u8; 16], i * 1000, vec![0; 500]))
                 .unwrap();
         }
 
@@ -2176,10 +2247,12 @@ mod tests {
     fn test_append_during_inflight_sync_does_not_rotate_away_from_synced_segment() {
         let dir = tempdir().unwrap();
         let wal_dir = dir.path().join("wal");
-        let record = make_record_with_payload(1, 32);
-        let record_len = record.to_bytes().len() as u64;
+        let record = make_record_with_payload(1, 1000);
+        let total_record_bytes = record.to_bytes().len() + WAL_RECORD_ENVELOPE_OVERHEAD;
+        let segment_size = SEGMENT_HEADER_SIZE_V2 as u64 + total_record_bytes as u64 + 1;
         let config = WalConfig::for_testing()
-            .with_segment_size(SEGMENT_HEADER_SIZE_V2 as u64 + record_len + 1);
+            .with_segment_size(segment_size)
+            .with_buffered_sync_bytes(segment_size);
         let mut writer = make_writer_with_config(
             &wal_dir,
             DurabilityMode::Standard {
@@ -2197,7 +2270,7 @@ mod tests {
             .unwrap()
             .expect("expected a sync handle");
 
-        writer.append(&make_record_with_payload(2, 32)).unwrap();
+        writer.append(&make_record_with_payload(2, 1000)).unwrap();
 
         assert_eq!(
             writer.current_segment(),

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -26,6 +26,7 @@ pub mod merge_iter;
 pub mod pressure;
 pub mod quarantine;
 pub mod rate_limiter;
+pub mod runtime_config;
 pub mod seekable;
 pub mod segment;
 pub mod segment_builder;
@@ -48,6 +49,7 @@ pub use quarantine::{
     QUARANTINE_DIR, QUARANTINE_FILENAME,
 };
 pub use rate_limiter::RateLimiter;
+pub use runtime_config::{StorageBlockCacheConfig, StorageRuntimeConfig};
 pub use segment::{KVSegment, OwnedSegmentIter};
 pub use segment_builder::{CompressionCodec, SegmentBuilder, SegmentMeta, SplittingSegmentBuilder};
 pub use segmented::{

--- a/crates/storage/src/runtime_config.rs
+++ b/crates/storage/src/runtime_config.rs
@@ -83,8 +83,15 @@ pub struct StorageRuntimeConfig {
     /// Global block-cache runtime sizing.
     pub block_cache: StorageBlockCacheConfig,
     /// Effective memtable write buffer size in bytes.
+    ///
+    /// `apply_to_store` applies this value only when the builder received an
+    /// explicit write-buffer input or derived one from `memory_budget`. Default
+    /// runtime configs preserve the constructor-provided write-buffer size.
     pub write_buffer_size: usize,
-    /// Maximum branches allowed by the store; `0` means unlimited.
+    /// Advisory branch-limit value stored on the store; `0` means unlimited.
+    ///
+    /// Current storage mechanics record and expose this value, but ES5 does
+    /// not introduce new branch-creation enforcement.
     pub max_branches: usize,
     /// Maximum retained versions per key; `0` means unlimited.
     pub max_versions_per_key: usize,
@@ -141,7 +148,10 @@ impl StorageRuntimeConfig {
     /// This is the storage-owned application point for static
     /// `SegmentedStore` runtime knobs. Higher layers should adapt their public
     /// config into `StorageRuntimeConfig` and call this helper rather than
-    /// carrying their own `SegmentedStore::set_*` list.
+    /// carrying their own `SegmentedStore::set_*` list. Default runtime configs
+    /// preserve a store's constructor-provided write-buffer size; the
+    /// write-buffer setter is applied only when the builder receives
+    /// `write_buffer_size` explicitly or derives it from `memory_budget`.
     pub fn apply_to_store(&self, storage: &SegmentedStore) {
         if self.apply_write_buffer_size {
             storage.set_write_buffer_size(self.write_buffer_size);
@@ -207,6 +217,8 @@ pub struct StorageRuntimeConfigBuilder {
     memory_budget: usize,
     block_cache_size: usize,
     write_buffer_size: usize,
+    // Tracks whether `write_buffer_size` is an explicit apply request instead
+    // of the default constructor-preserving placeholder.
     apply_write_buffer_size: bool,
     max_branches: usize,
     max_versions_per_key: usize,
@@ -237,13 +249,19 @@ impl StorageRuntimeConfigBuilder {
     }
 
     /// Set the raw write buffer size in bytes.
+    ///
+    /// Calling this marks the write-buffer size as explicitly configured, so
+    /// `apply_to_store` will apply it even when the value is zero.
     pub fn write_buffer_size(mut self, bytes: usize) -> Self {
         self.write_buffer_size = bytes;
         self.apply_write_buffer_size = true;
         self
     }
 
-    /// Set the branch limit; `0` means unlimited.
+    /// Store an advisory branch-limit value; `0` means unlimited.
+    ///
+    /// ES5 centralizes where the value is stored on `SegmentedStore`; it does
+    /// not add branch-creation enforcement.
     pub fn max_branches(mut self, max: usize) -> Self {
         self.max_branches = max;
         self
@@ -468,14 +486,13 @@ mod tests {
     fn apply_global_runtime_resolves_auto_block_cache_capacity() {
         let _capacity_guard = GlobalBlockCacheCapacityGuard::capture();
         let cfg = StorageRuntimeConfig::builder().block_cache_size(0).build();
-        let expected = cfg.resolved_block_cache_capacity();
-        crate::block_cache::set_global_capacity(usize::MAX);
+        crate::block_cache::set_global_capacity(1);
 
         assert_eq!(cfg.block_cache, StorageBlockCacheConfig::Auto);
         cfg.apply_global_runtime();
 
-        assert_eq!(crate::block_cache::global_capacity(), expected);
-        assert_ne!(crate::block_cache::global_capacity(), usize::MAX);
+        assert_ne!(crate::block_cache::global_capacity(), 1);
+        assert!(crate::block_cache::global_capacity() > 0);
     }
 
     #[test]

--- a/crates/storage/src/runtime_config.rs
+++ b/crates/storage/src/runtime_config.rs
@@ -1,0 +1,521 @@
+//! Storage runtime configuration mechanics.
+//!
+//! This module owns storage-local runtime knobs and their application to
+//! `SegmentedStore`. Higher layers may adapt public/product configuration into
+//! this type, but storage remains the owner of the setter list and storage
+//! defaults represented here.
+
+use crate::segmented::SegmentedStore;
+
+/// Storage-owned block-cache runtime configuration.
+///
+/// Public/product config may still use `0` as its compatibility spelling for
+/// automatic sizing. That sentinel is converted at the storage runtime boundary
+/// so storage no longer carries an ambiguous raw integer for global cache
+/// application.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum StorageBlockCacheConfig {
+    /// Resolve capacity from storage's host-memory auto-detection.
+    Auto,
+    /// Set the global block cache to an explicit byte capacity.
+    ///
+    /// `Bytes(0)` is allowed and means an explicit zero-capacity cache. This is
+    /// distinct from [`Self::Auto`] and prevents small derived memory budgets
+    /// from accidentally expanding into host-level auto-detection.
+    Bytes(usize),
+}
+
+impl StorageBlockCacheConfig {
+    /// Interpret a raw public block-cache byte value.
+    ///
+    /// The public compatibility convention is `0 == auto`; callers that derive
+    /// an explicit byte capacity should use [`Self::bytes`] instead.
+    pub const fn from_raw_size(bytes: usize) -> Self {
+        if bytes == 0 {
+            Self::Auto
+        } else {
+            Self::Bytes(bytes)
+        }
+    }
+
+    /// Build an explicit byte-capacity config.
+    pub const fn bytes(bytes: usize) -> Self {
+        Self::Bytes(bytes)
+    }
+
+    /// Return the compatibility byte value; `0` represents auto-detect.
+    pub const fn configured_bytes(self) -> usize {
+        match self {
+            Self::Auto => 0,
+            Self::Bytes(bytes) => bytes,
+        }
+    }
+
+    /// Resolve the capacity to apply to the global block cache.
+    pub fn resolved_capacity(self) -> usize {
+        match self {
+            Self::Auto => crate::block_cache::auto_detect_capacity(),
+            Self::Bytes(bytes) => bytes,
+        }
+    }
+
+    /// Whether this config requests storage auto-detection.
+    pub const fn is_auto(self) -> bool {
+        matches!(self, Self::Auto)
+    }
+}
+
+impl Default for StorageBlockCacheConfig {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
+/// Runtime storage knobs applied to a `SegmentedStore`.
+///
+/// This mirrors storage setter types rather than higher-layer product defaults.
+/// Higher layers remain responsible for building this from their public
+/// configuration until the public configuration split is complete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct StorageRuntimeConfig {
+    /// Global block-cache runtime sizing.
+    pub block_cache: StorageBlockCacheConfig,
+    /// Effective memtable write buffer size in bytes.
+    pub write_buffer_size: usize,
+    /// Maximum branches allowed by the store; `0` means unlimited.
+    pub max_branches: usize,
+    /// Maximum retained versions per key; `0` means unlimited.
+    pub max_versions_per_key: usize,
+    /// Maximum frozen memtables per branch before rotation is skipped.
+    pub max_immutable_memtables: usize,
+    /// Target size for a single segment file in bytes.
+    pub target_file_size: u64,
+    /// Target total size for L1 in bytes.
+    pub level_base_bytes: u64,
+    /// Data block size for newly built segment files.
+    pub data_block_size: usize,
+    /// Bloom filter bits per key for newly built segment files.
+    pub bloom_bits_per_key: usize,
+    /// Compaction I/O rate limit in bytes per second; `0` means unlimited.
+    pub compaction_rate_limit: u64,
+    apply_write_buffer_size: bool,
+}
+
+impl StorageRuntimeConfig {
+    /// Default block cache runtime configuration.
+    pub const DEFAULT_BLOCK_CACHE: StorageBlockCacheConfig = StorageBlockCacheConfig::Auto;
+    /// Default write buffer size for store constructors that do not receive a
+    /// public runtime configuration. `SegmentedStore::with_dir` still uses its
+    /// explicit constructor argument for write-buffer sizing.
+    pub const DEFAULT_WRITE_BUFFER_SIZE: usize = 0;
+    /// Default target size for a single segment file in bytes.
+    ///
+    /// `SegmentedStore` constructors use this value for their initial runtime
+    /// configuration.
+    pub const DEFAULT_TARGET_FILE_SIZE: u64 = 64 << 20;
+    /// Default target total size for L1 in bytes.
+    ///
+    /// `SegmentedStore` constructors use this value for their initial runtime
+    /// configuration.
+    pub const DEFAULT_LEVEL_BASE_BYTES: u64 = 256 << 20;
+    /// Default segment data block size in bytes.
+    ///
+    /// `SegmentedStore` constructors use this value for their initial runtime
+    /// configuration.
+    pub const DEFAULT_DATA_BLOCK_SIZE: usize = 4096;
+    /// Default bloom filter bits per key.
+    ///
+    /// `SegmentedStore` constructors use this value for their initial runtime
+    /// configuration.
+    pub const DEFAULT_BLOOM_BITS_PER_KEY: usize = 10;
+
+    /// Start a builder for storage runtime config from raw storage-layer inputs.
+    pub fn builder() -> StorageRuntimeConfigBuilder {
+        StorageRuntimeConfigBuilder::default()
+    }
+
+    /// Apply these storage runtime knobs to `storage`.
+    ///
+    /// This is the storage-owned application point for static
+    /// `SegmentedStore` runtime knobs. Higher layers should adapt their public
+    /// config into `StorageRuntimeConfig` and call this helper rather than
+    /// carrying their own `SegmentedStore::set_*` list.
+    pub fn apply_to_store(&self, storage: &SegmentedStore) {
+        if self.apply_write_buffer_size {
+            storage.set_write_buffer_size(self.write_buffer_size);
+        }
+        storage.set_max_branches(self.max_branches);
+        storage.set_max_versions_per_key(self.max_versions_per_key);
+        storage.set_max_immutable_memtables(self.max_immutable_memtables);
+        storage.set_target_file_size(self.target_file_size);
+        storage.set_level_base_bytes(self.level_base_bytes);
+        storage.set_data_block_size(self.data_block_size);
+        storage.set_bloom_bits_per_key(self.bloom_bits_per_key);
+        storage.set_compaction_rate_limit(self.compaction_rate_limit);
+    }
+
+    /// Apply process-global storage runtime knobs.
+    ///
+    /// Store-local knobs belong in [`Self::apply_to_store`]. This helper owns
+    /// storage-wide global mechanics such as block-cache capacity.
+    pub fn apply_global_runtime(&self) {
+        crate::block_cache::set_global_capacity(self.resolved_block_cache_capacity());
+    }
+
+    /// Resolve the block-cache capacity, applying storage auto-detection when
+    /// the runtime config requests automatic sizing.
+    pub fn resolved_block_cache_capacity(&self) -> usize {
+        self.block_cache.resolved_capacity()
+    }
+
+    /// Return the compatibility byte value for the block-cache config.
+    ///
+    /// This is primarily for legacy public config helpers and logging surfaces
+    /// that still report `0` as auto-detect.
+    pub const fn block_cache_configured_bytes(&self) -> usize {
+        self.block_cache.configured_bytes()
+    }
+}
+
+impl Default for StorageRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            block_cache: Self::DEFAULT_BLOCK_CACHE,
+            write_buffer_size: Self::DEFAULT_WRITE_BUFFER_SIZE,
+            max_branches: 0,
+            max_versions_per_key: 0,
+            max_immutable_memtables: 0,
+            target_file_size: Self::DEFAULT_TARGET_FILE_SIZE,
+            level_base_bytes: Self::DEFAULT_LEVEL_BASE_BYTES,
+            data_block_size: Self::DEFAULT_DATA_BLOCK_SIZE,
+            bloom_bits_per_key: Self::DEFAULT_BLOOM_BITS_PER_KEY,
+            compaction_rate_limit: 0,
+            apply_write_buffer_size: false,
+        }
+    }
+}
+
+/// Builder for storage runtime config from raw storage-facing inputs.
+///
+/// Higher layers pass public field values through this builder without
+/// reimplementing storage-local effective-value derivation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct StorageRuntimeConfigBuilder {
+    memory_budget: usize,
+    block_cache_size: usize,
+    write_buffer_size: usize,
+    apply_write_buffer_size: bool,
+    max_branches: usize,
+    max_versions_per_key: usize,
+    max_immutable_memtables: usize,
+    target_file_size: u64,
+    level_base_bytes: u64,
+    data_block_size: usize,
+    bloom_bits_per_key: usize,
+    compaction_rate_limit: u64,
+}
+
+impl StorageRuntimeConfigBuilder {
+    /// Set a unified storage memory budget in bytes.
+    ///
+    /// When non-zero, storage derives the effective runtime resource split:
+    /// half of the budget becomes block cache, one quarter becomes the active
+    /// write buffer, and one immutable memtable is retained so the active plus
+    /// frozen write path accounts for the other half.
+    pub fn memory_budget(mut self, bytes: usize) -> Self {
+        self.memory_budget = bytes;
+        self
+    }
+
+    /// Set the raw block cache size in bytes; `0` means auto-detect.
+    pub fn block_cache_size(mut self, bytes: usize) -> Self {
+        self.block_cache_size = bytes;
+        self
+    }
+
+    /// Set the raw write buffer size in bytes.
+    pub fn write_buffer_size(mut self, bytes: usize) -> Self {
+        self.write_buffer_size = bytes;
+        self.apply_write_buffer_size = true;
+        self
+    }
+
+    /// Set the branch limit; `0` means unlimited.
+    pub fn max_branches(mut self, max: usize) -> Self {
+        self.max_branches = max;
+        self
+    }
+
+    /// Set the retained-versions-per-key limit; `0` means unlimited.
+    pub fn max_versions_per_key(mut self, max: usize) -> Self {
+        self.max_versions_per_key = max;
+        self
+    }
+
+    /// Set the raw immutable-memtable limit.
+    pub fn max_immutable_memtables(mut self, max: usize) -> Self {
+        self.max_immutable_memtables = max;
+        self
+    }
+
+    /// Set the target segment file size in bytes.
+    pub fn target_file_size(mut self, bytes: u64) -> Self {
+        self.target_file_size = bytes;
+        self
+    }
+
+    /// Set the target total L1 size in bytes.
+    pub fn level_base_bytes(mut self, bytes: u64) -> Self {
+        self.level_base_bytes = bytes;
+        self
+    }
+
+    /// Set the segment data block size in bytes.
+    pub fn data_block_size(mut self, bytes: usize) -> Self {
+        self.data_block_size = bytes;
+        self
+    }
+
+    /// Set the bloom filter bits per key.
+    pub fn bloom_bits_per_key(mut self, bits: usize) -> Self {
+        self.bloom_bits_per_key = bits;
+        self
+    }
+
+    /// Set the compaction I/O rate limit in bytes per second; `0` means unlimited.
+    pub fn compaction_rate_limit(mut self, bytes_per_sec: u64) -> Self {
+        self.compaction_rate_limit = bytes_per_sec;
+        self
+    }
+
+    /// Build the effective storage runtime config.
+    pub fn build(self) -> StorageRuntimeConfig {
+        let (block_cache, write_buffer_size, max_immutable_memtables) = if self.memory_budget > 0 {
+            (
+                StorageBlockCacheConfig::bytes(self.memory_budget / 2),
+                self.memory_budget / 4,
+                1,
+            )
+        } else {
+            (
+                StorageBlockCacheConfig::from_raw_size(self.block_cache_size),
+                self.write_buffer_size,
+                self.max_immutable_memtables,
+            )
+        };
+        let apply_write_buffer_size = self.apply_write_buffer_size || self.memory_budget > 0;
+
+        StorageRuntimeConfig {
+            block_cache,
+            write_buffer_size,
+            max_branches: self.max_branches,
+            max_versions_per_key: self.max_versions_per_key,
+            max_immutable_memtables,
+            target_file_size: self.target_file_size,
+            level_base_bytes: self.level_base_bytes,
+            data_block_size: self.data_block_size,
+            bloom_bits_per_key: self.bloom_bits_per_key,
+            compaction_rate_limit: self.compaction_rate_limit,
+            apply_write_buffer_size,
+        }
+    }
+}
+
+impl Default for StorageRuntimeConfigBuilder {
+    fn default() -> Self {
+        let defaults = StorageRuntimeConfig::default();
+        Self {
+            memory_budget: 0,
+            block_cache_size: defaults.block_cache_configured_bytes(),
+            write_buffer_size: defaults.write_buffer_size,
+            apply_write_buffer_size: false,
+            max_branches: defaults.max_branches,
+            max_versions_per_key: defaults.max_versions_per_key,
+            max_immutable_memtables: defaults.max_immutable_memtables,
+            target_file_size: defaults.target_file_size,
+            level_base_bytes: defaults.level_base_bytes,
+            data_block_size: defaults.data_block_size,
+            bloom_bits_per_key: defaults.bloom_bits_per_key,
+            compaction_rate_limit: defaults.compaction_rate_limit,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    static GLOBAL_BLOCK_CACHE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct GlobalBlockCacheCapacityGuard {
+        previous_capacity: usize,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl GlobalBlockCacheCapacityGuard {
+        fn capture() -> Self {
+            let lock = GLOBAL_BLOCK_CACHE_TEST_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            Self {
+                previous_capacity: crate::block_cache::global_capacity(),
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for GlobalBlockCacheCapacityGuard {
+        fn drop(&mut self) {
+            crate::block_cache::set_global_capacity(self.previous_capacity);
+        }
+    }
+
+    #[test]
+    fn default_matches_segmented_store_defaults() {
+        let cfg = StorageRuntimeConfig::default();
+        let store = SegmentedStore::new();
+
+        assert_eq!(cfg.block_cache, StorageBlockCacheConfig::Auto);
+        assert_eq!(cfg.block_cache_configured_bytes(), 0);
+        assert_eq!(cfg.write_buffer_size, 0);
+        assert_eq!(cfg.max_branches, 0);
+        assert_eq!(cfg.max_versions_per_key, 0);
+        assert_eq!(cfg.max_immutable_memtables, 0);
+        assert_eq!(cfg.target_file_size, store.target_file_size());
+        assert_eq!(cfg.level_base_bytes, store.level_base_bytes());
+        assert_eq!(cfg.data_block_size, store.data_block_size());
+        assert_eq!(cfg.bloom_bits_per_key, store.bloom_bits_per_key());
+        assert_eq!(cfg.compaction_rate_limit, 0);
+    }
+
+    #[test]
+    fn default_apply_preserves_constructor_write_buffer_size() {
+        let cfg = StorageRuntimeConfig::default();
+        let store = SegmentedStore::new();
+        store.set_write_buffer_size(4 << 20);
+
+        cfg.apply_to_store(&store);
+
+        assert_eq!(store.write_buffer_size_for_test(), 4 << 20);
+    }
+
+    #[test]
+    fn explicit_zero_write_buffer_disables_rotation() {
+        let cfg = StorageRuntimeConfig::builder().write_buffer_size(0).build();
+        let store = SegmentedStore::new();
+        store.set_write_buffer_size(4 << 20);
+
+        cfg.apply_to_store(&store);
+
+        assert_eq!(store.write_buffer_size_for_test(), 0);
+    }
+
+    #[test]
+    fn applies_runtime_knobs_to_store() {
+        let cfg = StorageRuntimeConfig::builder()
+            .write_buffer_size(4 << 20)
+            .max_branches(128)
+            .max_versions_per_key(16)
+            .max_immutable_memtables(2)
+            .target_file_size(2 << 20)
+            .level_base_bytes(5 << 20)
+            .data_block_size(8 << 10)
+            .bloom_bits_per_key(12)
+            .compaction_rate_limit(1_234_567)
+            .build();
+        let store = SegmentedStore::new();
+
+        cfg.apply_to_store(&store);
+
+        assert_eq!(store.write_buffer_size_for_test(), 4 << 20);
+        assert_eq!(store.max_branches_for_test(), 128);
+        assert_eq!(store.max_versions_per_key_for_test(), 16);
+        assert_eq!(store.max_immutable_memtables_for_test(), 2);
+        assert_eq!(store.target_file_size(), 2 << 20);
+        assert_eq!(store.level_base_bytes(), 5 << 20);
+        assert_eq!(store.data_block_size(), 8 << 10);
+        assert_eq!(store.bloom_bits_per_key(), 12);
+        assert_eq!(store.compaction_rate_limit_for_test(), 1_234_567);
+    }
+
+    #[test]
+    fn builder_uses_individual_values_without_memory_budget() {
+        let cfg = StorageRuntimeConfig::builder()
+            .block_cache_size(64 << 20)
+            .write_buffer_size(32 << 20)
+            .max_immutable_memtables(3)
+            .build();
+
+        assert_eq!(cfg.block_cache, StorageBlockCacheConfig::Bytes(64 << 20));
+        assert_eq!(cfg.block_cache_configured_bytes(), 64 << 20);
+        assert_eq!(cfg.write_buffer_size, 32 << 20);
+        assert_eq!(cfg.max_immutable_memtables, 3);
+    }
+
+    #[test]
+    fn builder_maps_raw_zero_block_cache_to_auto_without_memory_budget() {
+        let cfg = StorageRuntimeConfig::builder().block_cache_size(0).build();
+
+        assert_eq!(cfg.block_cache, StorageBlockCacheConfig::Auto);
+        assert_eq!(cfg.block_cache_configured_bytes(), 0);
+    }
+
+    #[test]
+    fn apply_global_runtime_resolves_auto_block_cache_capacity() {
+        let _capacity_guard = GlobalBlockCacheCapacityGuard::capture();
+        let cfg = StorageRuntimeConfig::builder().block_cache_size(0).build();
+        let expected = cfg.resolved_block_cache_capacity();
+        crate::block_cache::set_global_capacity(usize::MAX);
+
+        assert_eq!(cfg.block_cache, StorageBlockCacheConfig::Auto);
+        cfg.apply_global_runtime();
+
+        assert_eq!(crate::block_cache::global_capacity(), expected);
+        assert_ne!(crate::block_cache::global_capacity(), usize::MAX);
+    }
+
+    #[test]
+    fn builder_derives_effective_values_from_memory_budget() {
+        let cfg = StorageRuntimeConfig::builder()
+            .memory_budget(32 << 20)
+            .block_cache_size(64 << 20)
+            .write_buffer_size(32 << 20)
+            .max_immutable_memtables(3)
+            .build();
+
+        assert_eq!(cfg.block_cache, StorageBlockCacheConfig::Bytes(16 << 20));
+        assert_eq!(cfg.block_cache_configured_bytes(), 16 << 20);
+        assert_eq!(cfg.write_buffer_size, 8 << 20);
+        assert_eq!(cfg.max_immutable_memtables, 1);
+        let total = cfg.block_cache_configured_bytes()
+            + cfg.write_buffer_size * (1 + cfg.max_immutable_memtables);
+        assert_eq!(total, 32 << 20);
+    }
+
+    #[test]
+    fn memory_budget_zero_byte_derivation_is_explicit_not_auto() {
+        let _capacity_guard = GlobalBlockCacheCapacityGuard::capture();
+        let cfg = StorageRuntimeConfig::builder().memory_budget(1).build();
+
+        assert_eq!(cfg.block_cache, StorageBlockCacheConfig::Bytes(0));
+        cfg.apply_global_runtime();
+
+        assert_eq!(crate::block_cache::global_capacity(), 0);
+    }
+
+    #[test]
+    fn apply_global_runtime_sets_resolved_block_cache_capacity() {
+        let _capacity_guard = GlobalBlockCacheCapacityGuard::capture();
+        let cfg = StorageRuntimeConfig::builder()
+            .block_cache_size(32 << 20)
+            .build();
+
+        cfg.apply_global_runtime();
+
+        assert_eq!(crate::block_cache::global_capacity(), 32 << 20);
+    }
+}

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -17,6 +17,7 @@ use crate::memory_stats::{BranchMemoryStats, StorageMemoryStats};
 use crate::memtable::{Memtable, MemtableEntry};
 use crate::merge_iter::{MergeIterator, MvccIterator, RewritingIterator};
 use crate::pressure::{MemoryPressure, PressureLevel};
+use crate::runtime_config::StorageRuntimeConfig;
 use crate::seekable::{self, SeekableIterator as _};
 use crate::segment::{KVSegment, LevelSegmentIter, OwnedSegmentIter, SegmentEntry};
 use crate::segment_builder::{SegmentBuilder, SplittingSegmentBuilder};
@@ -95,11 +96,8 @@ const NUM_LEVELS: usize = 7;
 /// Number of L0 segments that triggers L0→L1 compaction.
 const L0_COMPACTION_TRIGGER: usize = 4;
 
-/// Target size for a single output segment file (64MB).
-const TARGET_FILE_SIZE: u64 = 64 << 20;
-
 /// Target total size for L1 (256MB).  L_n = LEVEL_BASE_BYTES × LEVEL_MULTIPLIER^(n-1).
-const LEVEL_BASE_BYTES: u64 = 256 << 20;
+const LEVEL_BASE_BYTES: u64 = StorageRuntimeConfig::DEFAULT_LEVEL_BASE_BYTES;
 
 /// Size multiplier between adjacent levels.
 const LEVEL_MULTIPLIER: u64 = 10;
@@ -844,6 +842,7 @@ impl SegmentedStore {
     /// Rotation still works (frozen memtables accumulate), but flush is a no-op
     /// because there is no directory to write segments into.
     pub fn new() -> Self {
+        let runtime_config = StorageRuntimeConfig::default();
         Self {
             branches: DashMap::new(),
             version: AtomicU64::new(0),
@@ -852,18 +851,18 @@ impl SegmentedStore {
             next_segment_id: AtomicU64::new(1),
             pressure: MemoryPressure::disabled(),
             bulk_load_branches: DashMap::new(),
-            max_branches: AtomicUsize::new(0),
-            max_versions_per_key: AtomicUsize::new(0),
+            max_branches: AtomicUsize::new(runtime_config.max_branches),
+            max_versions_per_key: AtomicUsize::new(runtime_config.max_versions_per_key),
             snapshot_floor: AtomicU64::new(0),
             total_frozen_count: AtomicUsize::new(0),
-            max_immutable_memtables: AtomicUsize::new(0),
+            max_immutable_memtables: AtomicUsize::new(runtime_config.max_immutable_memtables),
             compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
             ref_registry: ref_registry::SegmentRefRegistry::new(),
             materializing_branches: DashMap::new(),
-            target_file_size: AtomicU64::new(TARGET_FILE_SIZE),
-            level_base_bytes: AtomicU64::new(LEVEL_BASE_BYTES),
-            data_block_size: AtomicUsize::new(4096),
-            bloom_bits_per_key: AtomicUsize::new(10),
+            target_file_size: AtomicU64::new(runtime_config.target_file_size),
+            level_base_bytes: AtomicU64::new(runtime_config.level_base_bytes),
+            data_block_size: AtomicUsize::new(runtime_config.data_block_size),
+            bloom_bits_per_key: AtomicUsize::new(runtime_config.bloom_bits_per_key),
             publish_health: Mutex::new(None),
             last_recovery_health: ArcSwap::from_pointee(RecoveryHealth::Healthy),
             recovery_applied: AtomicBool::new(false),
@@ -876,6 +875,7 @@ impl SegmentedStore {
     /// frozen on the next write.  Call [`flush_oldest_frozen`] to persist
     /// frozen memtables to disk as KV segments.
     pub fn with_dir(segments_dir: PathBuf, write_buffer_size: usize) -> Self {
+        let runtime_config = StorageRuntimeConfig::default();
         Self {
             branches: DashMap::new(),
             version: AtomicU64::new(0),
@@ -884,18 +884,18 @@ impl SegmentedStore {
             next_segment_id: AtomicU64::new(1),
             pressure: MemoryPressure::disabled(),
             bulk_load_branches: DashMap::new(),
-            max_branches: AtomicUsize::new(0),
-            max_versions_per_key: AtomicUsize::new(0),
+            max_branches: AtomicUsize::new(runtime_config.max_branches),
+            max_versions_per_key: AtomicUsize::new(runtime_config.max_versions_per_key),
             snapshot_floor: AtomicU64::new(0),
             total_frozen_count: AtomicUsize::new(0),
-            max_immutable_memtables: AtomicUsize::new(0),
+            max_immutable_memtables: AtomicUsize::new(runtime_config.max_immutable_memtables),
             compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
             ref_registry: ref_registry::SegmentRefRegistry::new(),
             materializing_branches: DashMap::new(),
-            target_file_size: AtomicU64::new(TARGET_FILE_SIZE),
-            level_base_bytes: AtomicU64::new(LEVEL_BASE_BYTES),
-            data_block_size: AtomicUsize::new(4096),
-            bloom_bits_per_key: AtomicUsize::new(10),
+            target_file_size: AtomicU64::new(runtime_config.target_file_size),
+            level_base_bytes: AtomicU64::new(runtime_config.level_base_bytes),
+            data_block_size: AtomicUsize::new(runtime_config.data_block_size),
+            bloom_bits_per_key: AtomicUsize::new(runtime_config.bloom_bits_per_key),
             publish_health: Mutex::new(None),
             last_recovery_health: ArcSwap::from_pointee(RecoveryHealth::Healthy),
             recovery_applied: AtomicBool::new(false),
@@ -908,6 +908,7 @@ impl SegmentedStore {
         write_buffer_size: usize,
         pressure: MemoryPressure,
     ) -> Self {
+        let runtime_config = StorageRuntimeConfig::default();
         Self {
             branches: DashMap::new(),
             version: AtomicU64::new(0),
@@ -916,18 +917,18 @@ impl SegmentedStore {
             next_segment_id: AtomicU64::new(1),
             pressure,
             bulk_load_branches: DashMap::new(),
-            max_branches: AtomicUsize::new(0),
-            max_versions_per_key: AtomicUsize::new(0),
+            max_branches: AtomicUsize::new(runtime_config.max_branches),
+            max_versions_per_key: AtomicUsize::new(runtime_config.max_versions_per_key),
             snapshot_floor: AtomicU64::new(0),
             total_frozen_count: AtomicUsize::new(0),
-            max_immutable_memtables: AtomicUsize::new(0),
+            max_immutable_memtables: AtomicUsize::new(runtime_config.max_immutable_memtables),
             compaction_rate_limiter: arc_swap::ArcSwapOption::empty(),
             ref_registry: ref_registry::SegmentRefRegistry::new(),
             materializing_branches: DashMap::new(),
-            target_file_size: AtomicU64::new(TARGET_FILE_SIZE),
-            level_base_bytes: AtomicU64::new(LEVEL_BASE_BYTES),
-            data_block_size: AtomicUsize::new(4096),
-            bloom_bits_per_key: AtomicUsize::new(10),
+            target_file_size: AtomicU64::new(runtime_config.target_file_size),
+            level_base_bytes: AtomicU64::new(runtime_config.level_base_bytes),
+            data_block_size: AtomicUsize::new(runtime_config.data_block_size),
+            bloom_bits_per_key: AtomicUsize::new(runtime_config.bloom_bits_per_key),
             publish_health: Mutex::new(None),
             last_recovery_health: ArcSwap::from_pointee(RecoveryHealth::Healthy),
             recovery_applied: AtomicBool::new(false),
@@ -1113,23 +1114,38 @@ impl SegmentedStore {
         self.bloom_bits_per_key.load(Ordering::Relaxed)
     }
 
-    #[cfg(test)]
-    pub(crate) fn max_branches_for_test(&self) -> usize {
+    /// Return the configured write buffer size for cross-crate characterization tests.
+    #[cfg(any(test, feature = "fault-injection"))]
+    #[doc(hidden)]
+    pub fn write_buffer_size_for_test(&self) -> usize {
+        self.write_buffer_size.load(Ordering::Relaxed) as usize
+    }
+
+    /// Return the configured branch limit for cross-crate characterization tests.
+    #[cfg(any(test, feature = "fault-injection"))]
+    #[doc(hidden)]
+    pub fn max_branches_for_test(&self) -> usize {
         self.max_branches.load(Ordering::Relaxed)
     }
 
-    #[cfg(test)]
-    pub(crate) fn max_versions_per_key_for_test(&self) -> usize {
+    /// Return the configured per-key version limit for characterization tests.
+    #[cfg(any(test, feature = "fault-injection"))]
+    #[doc(hidden)]
+    pub fn max_versions_per_key_for_test(&self) -> usize {
         self.max_versions_per_key.load(Ordering::Relaxed)
     }
 
-    #[cfg(test)]
-    pub(crate) fn max_immutable_memtables_for_test(&self) -> usize {
+    /// Return the configured immutable-memtable limit for characterization tests.
+    #[cfg(any(test, feature = "fault-injection"))]
+    #[doc(hidden)]
+    pub fn max_immutable_memtables_for_test(&self) -> usize {
         self.max_immutable_memtables.load(Ordering::Relaxed)
     }
 
-    #[cfg(test)]
-    pub(crate) fn compaction_rate_limit_for_test(&self) -> u64 {
+    /// Return the configured compaction rate limit for characterization tests.
+    #[cfg(any(test, feature = "fault-injection"))]
+    #[doc(hidden)]
+    pub fn compaction_rate_limit_for_test(&self) -> u64 {
         self.compaction_rate_limiter
             .load_full()
             .map_or(0, |limiter| limiter.rate_bytes_per_sec())

--- a/docs/engine/engine-storage-boundary-normalization-plan.md
+++ b/docs/engine/engine-storage-boundary-normalization-plan.md
@@ -537,7 +537,7 @@ now bypass lossy WAL replay instead of allowing an empty lossy open.
 Split public database configuration from storage-only runtime configuration
 application.
 
-Potential detailed execution plan:
+Detailed execution plan:
 
 - `docs/engine/es5-storage-config-application-plan.md`
 

--- a/docs/engine/es5-storage-config-application-plan.md
+++ b/docs/engine/es5-storage-config-application-plan.md
@@ -1,0 +1,734 @@
+# ES5 Storage Config Application Plan
+
+## Purpose
+
+`ES5` is the storage-configuration application epic in the engine/storage
+boundary normalization workstream.
+
+`ES2` moved checkpoint, WAL compaction, snapshot pruning, and generic MANIFEST
+sync mechanics toward storage. `ES3` moved generic decoded-row snapshot install
+mechanics into storage while keeping primitive snapshot decode in engine. `ES4`
+moved recovery bootstrap mechanics into storage and introduced the first
+storage-owned `StorageRuntimeConfig` needed by recovery.
+
+`ES5` completes that configuration boundary across the remaining open paths.
+The goal is not to redesign public configuration. The goal is to stop
+`strata-engine` from hand-applying storage setter lists and deriving
+storage-local effective values while keeping engine in charge of public config
+files, product profiles, compatibility behavior, and database open policy.
+
+Read this together with:
+
+- [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
+- [es1-boundary-baseline-and-guardrails-plan.md](./es1-boundary-baseline-and-guardrails-plan.md)
+- [es2-es4-storage-runtime-boundary-api-sketch.md](./es2-es4-storage-runtime-boundary-api-sketch.md)
+- [es4-recovery-bootstrap-mechanics-plan.md](./es4-recovery-bootstrap-mechanics-plan.md)
+- [../storage/storage-engine-ownership-audit.md](../storage/storage-engine-ownership-audit.md)
+- [../storage/storage-charter.md](../storage/storage-charter.md)
+
+## Boundary Rule
+
+Storage owns storage runtime configuration mechanics.
+
+Engine owns product configuration meaning.
+
+Storage may know:
+
+- `SegmentedStore`
+- storage-local defaults for storage runtime knobs
+- storage-local validation of storage runtime knob combinations
+- effective-value derivation for storage resources
+- global block-cache capacity application
+- WAL writer config structs and durability mechanics
+- storage codec ids and codec construction
+- storage runtime config structs, builders, and application helpers
+
+Storage must not know:
+
+- `StrataConfig` or engine `StorageConfig`
+- `strata.toml` file layout
+- executor, CLI, intelligence, or profile-level config vocabulary
+- product hardware-profile policy
+- engine compatibility signatures
+- `TransactionCoordinator`
+- primitive snapshot section meaning
+- primary/follower database open policy except where ES4 already requires a
+  storage-neutral recovery mode
+
+The ES5 target is:
+
+```text
+engine adapts public config into storage runtime config
+storage derives and applies storage runtime mechanics
+```
+
+## Starting State
+
+The important asymmetry after ES4 was:
+
+- disk recovery already passes a storage-owned `StorageRuntimeConfig` into
+  `run_storage_recovery`
+- normal persistent open still configures block cache in
+  `database/open.rs`
+- ephemeral/cache open still calls `apply_storage_config` from
+  `database/open.rs`
+- engine still owns `StorageConfig::effective_block_cache_size`,
+  `StorageConfig::effective_write_buffer_size`, and
+  `StorageConfig::effective_max_immutable_memtables`
+- engine still hand-applies store setters in `apply_storage_config`
+- `StorageRuntimeConfig` currently lives under recovery bootstrap even though
+  its purpose is broader than recovery
+
+That means storage runtime configuration has two paths:
+
+```text
+persistent recovery:
+    StrataConfig.storage -> engine helper -> StorageRuntimeConfig
+    -> storage recovery applies to SegmentedStore
+
+ephemeral/cache open:
+    StrataConfig.storage -> engine effective values
+    -> engine apply_storage_config -> SegmentedStore setters
+```
+
+ES5 makes those paths converge.
+
+## Non-Negotiables
+
+`StrataConfig` remains engine-owned.
+
+The public config format remains stable unless a later PR explicitly adds a
+compatibility migration. ES5 should not force users to edit existing
+`strata.toml` files.
+
+Storage must not depend on engine.
+
+Storage must not learn product profiles. Hardware-profile adjustment may still
+mutate engine `StrataConfig` before adaptation; storage should receive a
+storage-shaped runtime input after that product decision has been made.
+
+`TransactionCoordinator` write-buffer-entry limits stay engine-owned for ES5.
+`max_write_buffer_entries` limits transaction coordinator behavior, not
+`SegmentedStore` mechanics.
+
+Ephemeral/cache databases remain truly in-memory. ES5 must not introduce a
+persistent cache mode or any terminology that implies one exists.
+
+WAL flush-thread lifecycle stays engine-owned unless a later ES5 step
+explicitly designs a smaller storage-owned worker surface. The first ES5 pass
+should not move shutdown latches, WAL writer health, accepting-transaction
+halts, or database lifecycle callbacks into storage.
+
+## Target API Sketch
+
+The exact naming belongs to implementation, but the shape should be close to:
+
+```rust
+pub struct StorageRuntimeConfig {
+    pub block_cache: StorageBlockCacheConfig,
+    pub write_buffer_size: usize,
+    pub max_branches: usize,
+    pub max_versions_per_key: usize,
+    pub max_immutable_memtables: usize,
+    pub target_file_size: u64,
+    pub level_base_bytes: u64,
+    pub data_block_size: usize,
+    pub bloom_bits_per_key: usize,
+    pub compaction_rate_limit: u64,
+}
+
+pub enum StorageBlockCacheConfig {
+    Auto,
+    Bytes(usize),
+}
+
+impl StorageRuntimeConfig {
+    pub fn builder() -> StorageRuntimeConfigBuilder;
+    pub fn apply_to_store(&self, store: &SegmentedStore);
+    pub fn apply_global_runtime(&self);
+}
+```
+
+Engine should adapt public config by passing raw storage-facing fields into a
+storage builder:
+
+```rust
+fn storage_runtime_config_from(config: &StorageConfig) -> StorageRuntimeConfig {
+    StorageRuntimeConfig::builder()
+        .memory_budget(config.memory_budget)
+        .block_cache_size(config.block_cache_size)
+        .write_buffer_size(config.write_buffer_size)
+        .max_immutable_memtables(config.max_immutable_memtables)
+        .max_branches(config.max_branches)
+        .max_versions_per_key(config.max_versions_per_key)
+        .target_file_size(config.target_file_size)
+        .level_base_bytes(config.level_base_bytes)
+        .data_block_size(config.data_block_size)
+        .bloom_bits_per_key(config.bloom_bits_per_key)
+        .compaction_rate_limit(config.compaction_rate_limit)
+        .build()
+}
+```
+
+This keeps the public field names in engine while moving the storage meaning of
+those fields into storage.
+
+## Config Classification
+
+| Public config surface | ES5 target |
+|---|---|
+| `StorageConfig::memory_budget` | Engine-owned public field; storage-owned derivation into block cache, write buffer, and immutable memtable count. |
+| `StorageConfig::max_branches` | Engine-owned public field; storage-owned store application. |
+| `StorageConfig::max_write_buffer_entries` | Stay engine; transaction coordinator limit. |
+| `StorageConfig::max_versions_per_key` | Engine-owned public field; storage-owned store application. |
+| `StorageConfig::block_cache_size` | Engine-owned public field; storage-owned effective block-cache config and global application. |
+| `StorageConfig::write_buffer_size` | Engine-owned public field; storage-owned effective write-buffer derivation. |
+| `StorageConfig::max_immutable_memtables` | Engine-owned public field; storage-owned effective value derivation and store application. |
+| `StorageConfig::l0_slowdown_writes_trigger` | Stay engine; transaction runtime slowdown policy. |
+| `StorageConfig::l0_stop_writes_trigger` | Stay engine; transaction runtime stall policy. |
+| `StorageConfig::background_threads` | Stay engine; scheduler sizing. |
+| `StorageConfig::target_file_size` | Engine-owned public field; storage-owned store application. |
+| `StorageConfig::level_base_bytes` | Engine-owned public field; storage-owned store application. |
+| `StorageConfig::data_block_size` | Engine-owned public field; storage-owned store application. |
+| `StorageConfig::bloom_bits_per_key` | Engine-owned public field; storage-owned store application. |
+| `StorageConfig::compaction_rate_limit` | Engine-owned public field; storage-owned store application. |
+| `StorageConfig::write_stall_timeout_ms` | Stay engine; transaction runtime timeout policy. |
+| `StorageConfig::codec` | Split; engine owns public string compatibility, storage owns registry/construction and the current AES environment requirement. Future product secret-source policy remains engine-owned. |
+| `StrataConfig::durability_mode` | Split; engine owns public string compatibility, storage owns WAL durability mechanics. |
+| `SnapshotRetentionPolicy` | Split; engine owns public retention policy, storage owns snapshot prune mechanics. |
+
+## ES5A - Inventory and Characterization
+
+Create a focused inventory of every storage config application path.
+
+Deliverables:
+
+- map all `StorageConfig::effective_*` users
+- map all `apply_storage_config` users
+- map all direct `SegmentedStore::set_*` calls outside storage
+- map block-cache global capacity configuration
+- map WAL config construction and durability mode parsing
+- identify which config fields are live, unused, engine-owned, or storage-owned
+- add or update characterization tests before moving behavior
+
+Expected characterization:
+
+- persistent open with explicit storage config preserves current applied values
+- persistent open with `memory_budget` preserves derived storage values
+- ephemeral/cache open with explicit storage config preserves current applied
+  values
+- ephemeral/cache open with `memory_budget` preserves current derived storage
+  values where they are currently applied
+- ephemeral/cache open explicitly characterizes the current first-open
+  `write_buffer_size` gap
+- explicit write-buffer/max-immutable values still override defaults when
+  `memory_budget == 0`
+- compaction-related setters still land on `SegmentedStore`
+- configured codec validation behavior remains unchanged
+- block-cache global capacity is mapped and deferred from order-dependent
+  assertions until ES5F because it is process-wide state
+
+Acceptance:
+
+- the ES5 plan has a concrete field-by-field map against the current code
+- characterization fails if persistent and ephemeral/cache paths diverge for
+  characterized common knobs
+- known path divergence is captured as an explicit characterization test and
+  follow-up gap
+- no behavior movement happens before the current behavior is observable
+
+### ES5A Current Inventory
+
+As of ES5A, the live storage-configuration application surfaces are:
+
+| Surface | Current owner | Current call sites | ES5 disposition |
+|---|---|---|---|
+| `StorageConfig::effective_block_cache_size` | Engine | `database/open.rs` persistent open, `database/open.rs` cache open, `database/mod.rs` runtime `update_config`, config tests | Move the derivation into storage runtime config; keep public input in engine. |
+| `StorageConfig::effective_write_buffer_size` | Engine | `database/recovery.rs` recovery input, `database/mod.rs` runtime `update_config`, `database/transaction.rs` write-pressure checks, config tests | Move storage derivation into storage runtime config; keep transaction-pressure policy explicit in engine until redesigned. |
+| `StorageConfig::effective_max_immutable_memtables` | Engine | `database/recovery.rs` runtime config adapter, `database/open.rs` cache open, `database/mod.rs` runtime `update_config`, `database/transaction.rs` write-pressure checks, config tests | Move storage derivation into storage runtime config; keep transaction-pressure policy explicit in engine until redesigned. |
+| `database/open.rs::apply_storage_config` | Engine | Cache/ephemeral store construction | Replace with storage-owned runtime config application. |
+| `database/mod.rs::apply_storage_config_inner` | Engine | Runtime `Database::update_config` path | Replace storage setter portion with storage-owned runtime config application; leave coordinator write-entry limit in engine. |
+| `durability/recovery_bootstrap.rs::apply_storage_runtime_config` | Storage | ES4 recovery bootstrap | Promote out of recovery bootstrap and make it the common storage apply helper. |
+| Direct `SegmentedStore::set_*` storage-knob calls in engine | Engine | `database/open.rs`, `database/mod.rs` | Remove or route through storage runtime config. |
+| `SegmentedStore::set_snapshot_floor` | Engine | `database/transaction.rs` before compaction | Intentional engine exception; snapshot floor is engine MVCC policy, not static config application. |
+| Block-cache global capacity | Mixed | `database/open.rs` persistent open, `database/open.rs` cache open, `database/mod.rs` runtime `update_config` | Move capacity selection/application into storage runtime config; engine keeps product profile mutation and operator-facing logging. |
+| `WalConfig::default()` for primary WAL writer | Engine call site, storage type | `database/open.rs` | Audit in ES5G; do not move WAL lifecycle in the first ES5 pass. |
+| `StrataConfig::durability_mode` | Engine public parser | config validation, primary/follower/cache open, runtime durability changes | Split later only if storage gets a lower runtime durability adapter; public string compatibility stays engine-owned. |
+| `StorageConfig::l0_*` and `write_stall_timeout_ms` | Engine | `database/transaction.rs` write-stall policy | Stay engine for ES5 unless a later storage backpressure design moves the mechanism. |
+
+ES5A characterization added/extended:
+
+- persistent open applies observable store runtime knobs, including write
+  buffer, branch/version limits, immutable-memtable limits, compaction rate
+  limit, target file size, level-base bytes, block size, and bloom bits
+- persistent open applies `memory_budget` derivations for write buffer and
+  immutable-memtable limits
+- cache/ephemeral open applies observable store runtime knobs
+- cache/ephemeral open applies memory-budget-derived write buffer and
+  immutable-memtable limits
+- runtime `update_config` reapplies observable store runtime knobs, including
+  write buffer and compaction rate limit
+- recovery runtime config now characterizes the full storage runtime setter set
+  that is safely inspectable from engine tests
+
+Known ES5 follow-up gaps:
+
+- block-cache global capacity remains a shared process-wide side effect, so
+  tests should avoid order-dependent assertions until storage owns an explicit
+  runtime helper for it
+
+## ES5B - Promote StorageRuntimeConfig
+
+Move `StorageRuntimeConfig` out of the recovery bootstrap module into a stable
+storage runtime config module.
+
+Likely target:
+
+```text
+crates/storage/src/runtime_config.rs
+```
+
+or:
+
+```text
+crates/storage/src/durability/runtime_config.rs
+```
+
+The module should be storage-neutral and reusable by recovery, persistent open,
+and ephemeral/cache open.
+
+Deliverables:
+
+- move `StorageRuntimeConfig` and its defaults out of
+  `durability/recovery_bootstrap.rs`
+- re-export the type from an intentional storage module path
+- keep `#[non_exhaustive]` on public config structs/enums
+- preserve the ES4 recovery API behavior
+- update docs and imports so recovery bootstrap is a consumer, not the owner
+
+Acceptance:
+
+- `StorageRuntimeConfig` no longer lives in recovery bootstrap
+- storage recovery still accepts a storage runtime config
+- engine still adapts from public `StorageConfig`
+- no storage dependency on engine appears
+
+### ES5B Current State
+
+As of ES5B:
+
+- `StorageRuntimeConfig` lives in `crates/storage/src/runtime_config.rs`
+- storage re-exports `StorageRuntimeConfig` from the crate root and from
+  `durability` for recovery-call-site compatibility
+- recovery bootstrap imports the runtime config type instead of defining it
+- `StorageRuntimeConfig::apply_to_store` owns the existing storage setter list
+  used by recovery
+- `SegmentedStore` constructors initialize storage runtime fields from
+  `StorageRuntimeConfig::default()` so runtime-config defaults are the source
+  of truth for those knobs
+- runtime-config defaults and setter application are tested in the owning
+  storage module
+- recovery bootstrap tests only recovery input construction and recovery-time
+  application behavior
+
+## ES5C - Move Effective Storage Values Into Storage
+
+Move the storage meaning of memory-budget derivation into the storage runtime
+config builder.
+
+Current engine helpers:
+
+- `StorageConfig::effective_block_cache_size`
+- `StorageConfig::effective_write_buffer_size`
+- `StorageConfig::effective_max_immutable_memtables`
+
+Target:
+
+- engine passes public field values into a storage builder
+- storage computes effective block cache, write buffer, and immutable memtable
+  values
+- engine may keep compatibility helpers temporarily if public tests depend on
+  them, but production open paths should use the storage runtime config output
+
+Acceptance:
+
+- recovery write-buffer size comes from storage runtime config
+- persistent block-cache capacity comes from storage runtime config
+- ephemeral/cache store creation uses storage runtime config
+- engine no longer needs to know the memory-budget derivation formula in open
+  and recovery code
+
+### ES5C Current State
+
+As of ES5C:
+
+- `StorageRuntimeConfig::builder()` accepts raw storage-facing fields plus
+  `memory_budget`
+- storage derives effective block-cache size, write-buffer size, and
+  immutable-memtable limit inside the builder
+- default storage runtime config preserves a store's constructor-provided
+  write-buffer size unless a caller explicitly sets `write_buffer_size` or
+  supplies `memory_budget`
+- engine `StorageConfig::effective_*` helpers remain as compatibility wrappers
+  that delegate to the storage builder instead of carrying the formula
+- recovery no longer passes a separate write-buffer size; storage recovery uses
+  `StorageRecoveryInput::runtime_config.write_buffer_size`
+- persistent and follower open resolve block-cache capacity through
+  `StorageRuntimeConfig`
+- cache/ephemeral open applies `StorageRuntimeConfig` directly to the new
+  `SegmentedStore`, fixing the ES5A write-buffer first-open gap
+- runtime `update_config` applies `StorageRuntimeConfig` directly and resolves
+  block-cache capacity through it
+- engine write-pressure checks use `StorageRuntimeConfig` for the effective
+  write-buffer and immutable-memtable values while retaining engine-owned
+  transaction pressure policy
+
+## ES5D - Centralize Store Application In Storage
+
+Close out the remaining store-application cleanup around the storage-owned
+application helper introduced in ES5B and used by ES5C.
+
+Existing target API shape:
+
+```rust
+runtime_config.apply_to_store(&storage);
+```
+
+Deliverables:
+
+- keep storage as the owner of the `SegmentedStore::set_*` list for storage
+  runtime knobs
+- recovery bootstrap continues using the same apply helper
+- ephemeral/cache open continues using the same apply helper
+- direct engine-side setter lists stay gone
+- remaining direct `SegmentedStore::set_*` calls in engine are documented as
+  engine-owned exceptions
+
+Acceptance:
+
+- `rg "fn apply_storage_config|apply_storage_config" crates/engine/src` has no
+  production matches
+- direct `SegmentedStore::set_*` calls in engine are either gone or documented
+  as engine-owned exceptions
+- recovery and ephemeral/cache open apply the same runtime config mechanics
+
+### ES5D Current State
+
+As of ES5D:
+
+- `StorageRuntimeConfig::apply_to_store` is the storage-owned application point
+  for static `SegmentedStore` runtime knobs
+- recovery bootstrap, cache/ephemeral open, and runtime `update_config` all use
+  `StorageRuntimeConfig::apply_to_store`
+- engine has no `apply_storage_config` helper and no hand-written store setter
+  list for storage runtime knobs
+- the only remaining production engine `SegmentedStore::set_*` calls are
+  documented exceptions:
+  - `Database::schedule_flush_if_needed` calls `set_snapshot_floor` because the
+    floor is engine MVCC policy computed from active transactions before
+    compaction
+  - follower open calls `set_version` only when restoring validated persisted
+    follower state, paired with coordinator visible-version restore
+- block-cache global application remains intentionally out of ES5D and is
+  handled by ES5F
+
+## ES5E - Route All Open Paths Through Runtime Config
+
+Make persistent open and ephemeral/cache open share one adapter from public
+engine config to storage runtime config.
+
+Deliverables:
+
+- introduce one engine-local adapter function from `StorageConfig` to
+  `StorageRuntimeConfig`
+- call it before persistent recovery
+- call it before ephemeral/cache store construction
+- pass the effective write-buffer size to `SegmentedStore::with_dir` through
+  storage runtime config
+- apply store-level runtime config through the storage-owned helper
+- configure global block-cache capacity through the storage-owned runtime
+  helper
+
+Acceptance:
+
+- persistent open, follower refresh, and ephemeral/cache open use the same
+  storage runtime config adapter where applicable
+- no open path recomputes storage effective values by hand
+- no new disk behavior is introduced for ephemeral/cache databases
+
+### ES5E Current State
+
+As of ES5E:
+
+- `database/config.rs::storage_runtime_config_from` is the single engine-local
+  adapter from public `StorageConfig` to storage-owned `StorageRuntimeConfig`
+- primary and follower open compute `StorageRuntimeConfig` before calling
+  `Database::run_recovery` and pass that value through to storage recovery
+- `Database::run_recovery` no longer adapts public engine config into storage
+  runtime config internally
+- storage recovery constructs `SegmentedStore::with_dir` from
+  `StorageRecoveryInput::runtime_config.write_buffer_size` and then applies the
+  same `StorageRuntimeConfig::apply_to_store` helper used by cache open and
+  runtime `update_config`
+- primary open, follower open, cache/ephemeral open, and runtime
+  `update_config` configure global block-cache capacity through
+  `StorageRuntimeConfig::apply_global_runtime`
+- engine open code no longer calls `strata_storage::block_cache::set_global_capacity`
+  directly outside tests
+- ES5E includes a serial characterization for default cache open so
+  `block_cache_size == 0` no longer silently inherits stale process-wide
+  capacity; explicit profile-derived values are asserted exactly, while
+  host-dependent auto-detect mode is asserted as a positive non-stale capacity
+- `Database::run_recovery` accepts an engine-owned recovery config bundle that
+  pairs `StrataConfig` with the `StorageRuntimeConfig` derived from the same
+  public storage config, preventing future call-site drift
+
+## ES5F - Block Cache Boundary
+
+Normalize block-cache configuration as storage runtime mechanics.
+
+The public input remains `StorageConfig::block_cache_size` and
+`StorageConfig::memory_budget`. Storage should own:
+
+- `Auto` versus explicit-byte runtime representation
+- auto-detect capacity call
+- global block-cache capacity application
+- validation for impossible storage-local capacity values if needed
+
+Engine should still own:
+
+- hardware-profile mutations before adaptation
+- operator-facing comments in `strata.toml`
+- logging that describes product-level memory-budget behavior
+
+Acceptance:
+
+- block-cache global capacity is not configured by ad hoc engine code
+- `memory_budget > 0` still derives the same block-cache capacity
+- `block_cache_size > 0` with `memory_budget == 0` still behaves the same
+- `block_cache_size == 0` with no memory budget still uses storage auto-detect
+
+### ES5F Current State
+
+As of ES5F:
+
+- storage runtime config represents block-cache sizing as
+  `StorageBlockCacheConfig::{Auto, Bytes(usize)}` instead of carrying the public
+  `0 == auto` sentinel as the runtime representation
+- engine public config remains unchanged: `StorageConfig::block_cache_size == 0`
+  is still the compatibility spelling for automatic sizing in `strata.toml`
+- `StorageRuntimeConfig::builder().block_cache_size(0)` converts raw public zero
+  into `StorageBlockCacheConfig::Auto`
+- `memory_budget > 0` derives an explicit `StorageBlockCacheConfig::Bytes(...)`
+  value, including the degenerate `Bytes(0)` case for extremely small budgets,
+  so a tiny derived budget cannot accidentally expand into host-level
+  auto-detection
+- `StorageRuntimeConfig::apply_global_runtime` remains the storage-owned global
+  block-cache application point, and it resolves `Auto` through storage's
+  `block_cache::auto_detect_capacity`
+- engine logging and legacy `StorageConfig::effective_block_cache_size` use
+  `StorageRuntimeConfig::block_cache_configured_bytes()` so operator-facing
+  compatibility remains `0 == auto`
+
+## ES5G - Codec and WAL Runtime Boundary
+
+Audit codec and WAL writer settings after the storage runtime config path is
+centralized.
+
+This step should be conservative. The first target is not moving the WAL flush
+thread. The first target is deciding which runtime settings are storage-owned
+mechanics and which are engine-owned policy.
+
+Likely storage-owned:
+
+- codec registry lookup
+- storage codec id validation against MANIFEST
+- `WalConfig` defaults and storage-local validation
+- durability mode mechanics inside `WalWriter`
+
+Likely engine-owned:
+
+- public durability string parsing and compatibility
+- environment-secret override behavior for encrypted codecs
+- WAL writer health latch
+- accepting-transaction halt policy
+- background flush thread lifecycle
+- resume-after-halt public API
+
+Acceptance:
+
+- codec and WAL settings have an explicit field-by-field owner map
+- no WAL lifecycle code moves without a narrower follow-up design
+- any API changes preserve existing config-file compatibility
+
+### ES5G Current State
+
+As of ES5G:
+
+| Surface | Owner | Current state |
+|---|---|---|
+| `StorageConfig::codec` public string | Engine | Remains a `strata.toml` field and compatibility-signature input. Engine owns when the public string is read, persisted, and compared for primary/follower/cache open compatibility. |
+| Codec registry lookup and construction | Storage | `durability::get_codec` remains the storage-owned constructor. `durability::validate_codec_id` is the storage-owned preflight helper for call sites that need validation but not a codec value. |
+| Encrypted codec secret source | Split/future | The current AES codec constructor still reads its storage-local environment requirement. ES5G does not add a second engine override path; future product-level secret-source policy stays engine-owned and should be designed separately from registry construction. |
+| MANIFEST codec validation | Storage | `run_storage_recovery` validates the configured codec before recovery-managed side effects, checks existing MANIFEST codec ids, creates missing primary MANIFESTs with the configured codec id, and returns the resolved WAL codec. |
+| Cache-mode `wal_codec` field population | Split | Engine keeps the uniform `Database::wal_codec` field because follower refresh/lifecycle code lives in engine; storage constructs the codec value via `get_codec`. |
+| Checkpoint codec construction | Split | Engine chooses the public codec id from its config snapshot; storage constructs the codec and owns checkpoint byte-format mechanics. |
+| `StrataConfig::durability` public string | Engine | Public values remain `"standard"` and `"always"`; `"cache"` stays rejected as a disk durability string. Existing config files remain compatible. |
+| `DurabilityMode::Cache` | Storage type, engine policy input | Storage owns the no-WAL mechanics; engine owns where cache mode is allowed and how it maps to public open modes. `WalWriter::new` intentionally skips WAL config validation and file creation in this mode. |
+| `DurabilityMode::Always` | Storage type, engine policy input | Storage owns per-append fsync mechanics; engine owns where the mode is allowed, runtime switching policy, compatibility signatures, and lifecycle decisions. |
+| `DurabilityMode::Standard::interval_ms` | Storage type, engine policy input | Storage uses this as the active inline fallback deadline. Engine owns background flush thread scheduling and halt/resume policy. |
+| `DurabilityMode::Standard::batch_size` | Storage type, compatibility field | Retained in the public type and compatibility signatures, but the current writer does not use it as an inline fsync trigger. Re-activating or removing it needs a separate WAL-runtime design. |
+| `WalConfig::segment_size` | Storage | Storage owns the default, minimum-size validation, and segment-rotation interpretation. `WalWriter::new` validates this active non-cache invariant before creating the WAL directory. |
+| `WalConfig::buffered_sync_bytes` | Storage compatibility field | Storage owns the default and full `WalConfig::validate()` consistency check, but the current writer does not consume this field as an inline fsync trigger. `WalWriter::new` does not reject a writer solely because this inert field exceeds `segment_size`. |
+| WAL writer construction | Split | Engine constructs the primary `WalWriter` because it owns database open/lifecycle, lock ownership, health latches, and background flush thread wiring; storage owns writer internals, durability mechanics, segment rotation, and config validation. |
+| Background WAL flush thread | Engine | No code moved. Engine still owns thread spawning, shutdown coordination, WAL writer health halt/resume policy, and accepting-transaction latches. |
+
+ES5G intentionally does not move WAL lifecycle code. A future WAL-runtime epic
+would need a narrower design before storage owns a worker surface.
+
+## ES5H - Retention and Residual Config Cleanup
+
+Close out the storage config application epic by documenting or moving the
+remaining storage-shaped config surfaces.
+
+Candidate surfaces:
+
+- `SnapshotRetentionPolicy`
+- compaction trigger knobs that are currently configured but may not be
+  applied
+- write-stall timeout ownership
+- storage-local validation for impossible runtime combinations
+- doc comments in public config that describe storage behavior now owned by
+  storage
+
+Acceptance:
+
+- every storage-shaped field in `StorageConfig` has an explicit owner
+- residual engine-owned fields are documented as product policy or transaction
+  runtime policy
+- storage-owned fields are either applied by storage runtime config or tracked
+  as a future implementation gap
+
+### ES5H Current State
+
+As of ES5H, the final ownership map for public storage-shaped configuration is:
+
+| Public surface | Owner | Current state |
+|---|---|---|
+| `StorageConfig::memory_budget` | Split | Engine owns the serialized public field. Storage derives effective block-cache, write-buffer, and immutable-memtable runtime values in `StorageRuntimeConfig::builder`. |
+| `StorageConfig::max_branches` | Split | Engine owns the public field. Storage applies the branch limit through `StorageRuntimeConfig::apply_to_store`. |
+| `StorageConfig::max_write_buffer_entries` | Engine | Transaction coordinator write-entry limit; not part of storage runtime config. |
+| `StorageConfig::max_versions_per_key` | Split | Engine owns the public field. Storage applies MVCC version retention through `StorageRuntimeConfig::apply_to_store`. |
+| `StorageConfig::block_cache_size` | Split | Engine owns `0 == auto` public compatibility. Storage owns `StorageBlockCacheConfig::{Auto, Bytes}` and global capacity application. |
+| `StorageConfig::write_buffer_size` | Split | Engine owns the public field. Storage applies the effective memtable rotation threshold. |
+| `StorageConfig::max_immutable_memtables` | Split | Engine owns the public field. Storage applies the effective frozen-memtable limit. Engine reads the same effective storage value only to drive transaction backpressure policy. |
+| `StorageConfig::l0_slowdown_writes_trigger` | Engine | Transaction runtime slowdown policy in `database/transaction.rs`; disabled by default. |
+| `StorageConfig::l0_stop_writes_trigger` | Engine | Transaction runtime stall policy in `database/transaction.rs`; disabled by default. |
+| `StorageConfig::background_threads` | Engine | Database lifecycle scheduler sizing, open-time compatibility dimension, and hardware-profile product policy. |
+| `StorageConfig::target_file_size` | Split | Engine owns the public field. Storage applies segment output sizing. |
+| `StorageConfig::level_base_bytes` | Split | Engine owns the public field. Storage applies level sizing. |
+| `StorageConfig::data_block_size` | Split | Engine owns the public field. Storage applies segment data-block sizing. |
+| `StorageConfig::bloom_bits_per_key` | Split | Engine owns the public field. Storage applies segment bloom-filter sizing. |
+| `StorageConfig::compaction_rate_limit` | Split | Engine owns the public field. Storage applies compaction I/O rate limiting. |
+| `StorageConfig::write_stall_timeout_ms` | Engine | Transaction runtime timeout while waiting for L0 compaction; not part of storage runtime config. |
+| `StorageConfig::codec` | Split | Engine owns the public string, compatibility signatures, and when it is read. Storage owns registry validation and codec construction. |
+| `StrataConfig::durability` | Split | Engine owns public string compatibility and where modes are allowed. Storage owns WAL durability mechanics. |
+| `SnapshotRetentionPolicy::retain_count` | Split | Engine owns the public policy. Storage owns pruning mechanics through `StorageSnapshotRetention`, including the minimum one-snapshot retention invariant. |
+
+ES5H also leaves one intentional validation gap: storage runtime config now owns
+where segment sizing and bloom/filter compaction knobs are applied, but ES5 does
+not introduce new config-file rejection for historically accepted values such
+as zero-sized segment-layout knobs. Tightening those values should be a future
+storage validation PR with explicit compatibility notes.
+
+Public `StorageConfig` comments and generated `strata.toml` comments were
+updated to describe this final ownership split instead of embedding storage
+derivation formulas or stale external-default claims in engine docs.
+
+## Test Plan
+
+Run focused characterization before and after each code-moving step:
+
+```text
+cargo test -p strata-engine --lib database::config
+cargo test -p strata-engine --lib database::recovery
+cargo test -p strata-engine --lib database::open
+cargo test -p strata-engine --test recovery_storage_policy
+cargo test -p strata-engine --test recovery_parity
+cargo test -p strata-storage runtime_config
+cargo test -p strata-storage recovery_bootstrap
+```
+
+Run package checks for each implementation PR:
+
+```text
+cargo fmt --all --check
+cargo check -p strata-storage --all-targets
+cargo check -p strata-engine --all-targets
+```
+
+Run broader suites when behavior moves across open/recovery paths:
+
+```text
+cargo test -p strata-storage
+cargo test -p strata-engine
+```
+
+If known unrelated failures remain in the full engine suite, document the exact
+failure count and confirm the focused ES5 tests pass.
+
+## Boundary Guards
+
+Useful guard commands:
+
+```text
+rg -n "strata_engine|strata-engine" crates/storage/src crates/storage/Cargo.toml
+rg -n "StorageConfig|StrataConfig|strata.toml" crates/storage/src
+rg -n "fn apply_storage_config|apply_storage_config" crates/engine/src
+rg -n "set_max_branches|set_max_versions_per_key|set_max_immutable_memtables|set_write_buffer_size|set_target_file_size|set_level_base_bytes|set_data_block_size|set_bloom_bits_per_key|set_compaction_rate_limit" crates/engine/src
+rg -n "storage\\.set_[A-Za-z0-9_]+|storage\\(\\)\\.set_[A-Za-z0-9_]+|self\\.storage\\.set_[A-Za-z0-9_]+|db\\.storage\\.set_[A-Za-z0-9_]+" crates/engine/src
+rg -n "strata_storage::block_cache::set_global_capacity" crates/engine/src -g'!**/tests/**'
+rg -n "StorageRuntimeConfig" crates/storage/src crates/engine/src
+```
+
+Expected end state:
+
+- storage has no dependency on engine
+- storage does not mention `StorageConfig` or `StrataConfig`
+- engine has no hand-written `SegmentedStore` storage setter list
+- the broad engine `storage.set_*` guard only reports documented non-runtime
+  exceptions, currently `set_snapshot_floor` and follower `set_version`
+- engine production code does not call the block-cache global setter directly
+- `StorageRuntimeConfig` appears in storage as the owner type and in engine as
+  an adapter target
+
+## Risks
+
+The main risk is moving product policy into storage under the label of
+"defaults." Storage defaults are acceptable only when they describe storage
+mechanics. Product profiles, operator-facing comments, compatibility
+fingerprints, and public config migration stay in engine.
+
+The second risk is accidentally changing open behavior while converging the
+paths. This is why ES5A should characterize persistent and ephemeral/cache open
+before any code movement.
+
+The third risk is broadening ES5 into WAL lifecycle redesign. WAL writer
+runtime construction can be cleaned up, but WAL health, shutdown, transaction
+halt, and resume policy are engine lifecycle concerns unless a later subplan
+draws a smaller callback-based surface.
+
+## Done Criteria
+
+ES5 is done when:
+
+- all open paths use a storage-owned runtime config application path
+- engine owns only the public config adapter, not storage setter mechanics
+- storage owns effective storage resource derivation
+- block-cache capacity application is no longer ad hoc in engine open code
+- recovery still preserves ES4 ordering guarantees
+- existing config files remain compatible
+- tests cover persistent open, ephemeral/cache open, recovery, and memory-budget
+  behavior
+- residual WAL/retention/config fields are either resolved or explicitly
+  documented for the next cleanup phase

--- a/docs/engine/es5-storage-config-application-plan.md
+++ b/docs/engine/es5-storage-config-application-plan.md
@@ -178,11 +178,11 @@ those fields into storage.
 | Public config surface | ES5 target |
 |---|---|
 | `StorageConfig::memory_budget` | Engine-owned public field; storage-owned derivation into block cache, write buffer, and immutable memtable count. |
-| `StorageConfig::max_branches` | Engine-owned public field; storage-owned store application. |
+| `StorageConfig::max_branches` | Engine-owned public field; storage-owned storage of the advisory branch-limit value. Branch-creation enforcement remains unchanged. |
 | `StorageConfig::max_write_buffer_entries` | Stay engine; transaction coordinator limit. |
 | `StorageConfig::max_versions_per_key` | Engine-owned public field; storage-owned store application. |
 | `StorageConfig::block_cache_size` | Engine-owned public field; storage-owned effective block-cache config and global application. |
-| `StorageConfig::write_buffer_size` | Engine-owned public field; storage-owned effective write-buffer derivation. |
+| `StorageConfig::write_buffer_size` | Engine-owned public field; storage-owned effective write-buffer derivation and application when explicit or memory-budget-derived. |
 | `StorageConfig::max_immutable_memtables` | Engine-owned public field; storage-owned effective value derivation and store application. |
 | `StorageConfig::l0_slowdown_writes_trigger` | Stay engine; transaction runtime slowdown policy. |
 | `StorageConfig::l0_stop_writes_trigger` | Stay engine; transaction runtime stall policy. |
@@ -616,11 +616,11 @@ As of ES5H, the final ownership map for public storage-shaped configuration is:
 | Public surface | Owner | Current state |
 |---|---|---|
 | `StorageConfig::memory_budget` | Split | Engine owns the serialized public field. Storage derives effective block-cache, write-buffer, and immutable-memtable runtime values in `StorageRuntimeConfig::builder`. |
-| `StorageConfig::max_branches` | Split | Engine owns the public field. Storage applies the branch limit through `StorageRuntimeConfig::apply_to_store`. |
+| `StorageConfig::max_branches` | Split | Engine owns the public field. Storage stores the advisory branch-limit value through `StorageRuntimeConfig::apply_to_store`; branch-creation enforcement remains unchanged. |
 | `StorageConfig::max_write_buffer_entries` | Engine | Transaction coordinator write-entry limit; not part of storage runtime config. |
 | `StorageConfig::max_versions_per_key` | Split | Engine owns the public field. Storage applies MVCC version retention through `StorageRuntimeConfig::apply_to_store`. |
 | `StorageConfig::block_cache_size` | Split | Engine owns `0 == auto` public compatibility. Storage owns `StorageBlockCacheConfig::{Auto, Bytes}` and global capacity application. |
-| `StorageConfig::write_buffer_size` | Split | Engine owns the public field. Storage applies the effective memtable rotation threshold. |
+| `StorageConfig::write_buffer_size` | Split | Engine owns the public field. Storage applies the effective memtable rotation threshold when explicit or memory-budget-derived; default runtime configs preserve constructor-provided sizing. |
 | `StorageConfig::max_immutable_memtables` | Split | Engine owns the public field. Storage applies the effective frozen-memtable limit. Engine reads the same effective storage value only to drive transaction backpressure policy. |
 | `StorageConfig::l0_slowdown_writes_trigger` | Engine | Transaction runtime slowdown policy in `database/transaction.rs`; disabled by default. |
 | `StorageConfig::l0_stop_writes_trigger` | Engine | Transaction runtime stall policy in `database/transaction.rs`; disabled by default. |
@@ -640,6 +640,12 @@ where segment sizing and bloom/filter compaction knobs are applied, but ES5 does
 not introduce new config-file rejection for historically accepted values such
 as zero-sized segment-layout knobs. Tightening those values should be a future
 storage validation PR with explicit compatibility notes.
+
+ES5H also leaves the `max_branches` behavior as-is: the value is now routed
+through the storage runtime boundary and stored on `SegmentedStore`, but ES5
+does not introduce a new branch-creation enforcement path. If that public field
+is meant to become a hard limit, it should be designed as a separate storage
+semantics change with characterization for existing multi-branch users.
 
 Public `StorageConfig` comments and generated `strata.toml` comments were
 updated to describe this final ownership split instead of embedding storage


### PR DESCRIPTION
## Summary

Closes the storage-configuration application boundary across persistent, follower, and ephemeral/cache opens. Engine no longer hand-applies storage setter lists, derives storage-local effective values, or configures the global block-cache capacity. Storage owns runtime knob mechanics, effective-value derivation, and global cache application.

This is the **final code-moving epic in the four-epic engine/storage boundary normalization workstream** (ES2 checkpoint/WAL compaction → ES3 snapshot install split → ES4 recovery bootstrap → ES5 storage config).

## New storage runtime config (`crates/storage/src/runtime_config.rs`)

- `StorageRuntimeConfig` with the 10 storage runtime knobs and a private `apply_write_buffer_size` flag so `Default::default().apply_to_store()` preserves a constructor-supplied write-buffer while explicit builder values still override
- `StorageBlockCacheConfig::{Auto, Bytes(usize)}` replaces the public `0 == auto` sentinel as the runtime representation; `Bytes(0)` is preserved as explicit zero so tiny derived budgets cannot expand into host-level auto-detection
- `StorageRuntimeConfigBuilder` accepts raw storage-facing fields and `memory_budget`; storage owns the budget split formula (cache=budget/2, write_buffer=budget/4, max_immutable=1)
- `apply_to_store` applies the static `SegmentedStore` setter list
- `apply_global_runtime` resolves `Auto` via `block_cache::auto_detect_capacity` and sets the global cache capacity

## Engine adapter (`crates/engine/src/database/config.rs`)

- `storage_runtime_config_from(&StorageConfig) -> StorageRuntimeConfig` is the single engine-local adapter
- `StorageConfig::effective_block_cache_size`, `effective_write_buffer_size`, and `effective_max_immutable_memtables` are now thin compatibility wrappers that delegate to the storage builder; engine no longer carries the `memory_budget` formula

## Recovery integration

- New `RecoveryRuntimeConfig<'a>` engine bundle pairs `&StrataConfig` with the derived `StorageRuntimeConfig` so call sites cannot drift between the value used for recovery and the value used for runtime config application
- `StorageRecoveryInput::write_buffer_size` field deleted; storage uses `runtime_config.write_buffer_size` as the single source of truth
- `run_storage_recovery` applies `StorageRuntimeConfig::apply_to_store` internally

## Open path convergence

- Primary, follower, cache/ephemeral, and runtime `update_config` all apply `StorageRuntimeConfig` via the storage-owned helper
- Block-cache global capacity is configured through `apply_global_runtime` on every path; no engine code calls `strata_storage::block_cache::set_global_capacity` directly
- `engine::database::open::apply_storage_config` is deleted
- `engine::database::mod::apply_storage_config_inner` renamed to `apply_runtime_storage_config_inner` and routes through the storage helper

The only direct `storage.set_*` calls left in engine production code are the two documented exceptions: `set_snapshot_floor` (engine MVCC policy) and follower `set_version` (state restore).

## Codec and WAL contract docs

- `codec/mod.rs` and `codec/traits.rs` docs no longer claim that all bytes pass through the storage codec; snapshot containers record/validate the codec id but section payloads own their own format
- New `validate_codec_id` storage helper for follower preflight that validates without producing a codec value
- `WalConfig::buffered_sync_bytes` documented as a retained compatibility field, not an inline fsync trigger
- `WalConfig::validate_writer_runtime()` is the writer-side preflight that does not reject a writer for inert fields
- `DurabilityMode::Standard::batch_size` docs corrected to reflect that the writer does not consume it as an inline trigger

## Snapshot retention

- `StorageSnapshotRetention::new` clamps `retain_count` to a minimum of 1 at construction
- Engine `SnapshotRetentionPolicy::retain_count` doc explains that `0` is accepted for config-file compatibility and treated as `1` by the pruning runtime
- New engine test `retain_count_zero_is_treated_as_one_by_engine_pruning`

## Behavior change: `WalWriter::new` strict segment size minimum

`WalConfig` has documented `WalConfigError::SegmentSizeTooSmall` (segment size < 1024) since before ES5, but the check was only on `WalConfig::validate()` and was not enforced at writer construction. ES5G's `WalConfig::validate_writer_runtime()` preflight now enforces the 1024-byte minimum at `WalWriter::new` time.

Tests that used `with_segment_size(100)` had to be updated to `1024`. Production code could not have used a smaller value without breaking elsewhere, but this tightens the invariant at the construction boundary for symmetry with the rest of the boundary cleanup. The cache mode path skips this validation since cache writers do not create WAL files.

## ES5 boundary guards (clean)

- `rg 'strata_engine|strata-engine' crates/storage/src crates/storage/Cargo.toml` — 0 matches
- `rg 'StorageConfig|StrataConfig|strata\.toml' crates/storage/src` — 0 matches
- `rg 'fn apply_storage_config|apply_storage_config' crates/engine/src` — 0 matches
- `rg 'storage\.set_[A-Za-z0-9_]+|...self\.storage\.set_[A-Za-z0-9_]+' crates/engine/src` — only the two documented exceptions (`set_snapshot_floor`, follower `set_version`)
- `rg 'strata_storage::block_cache::set_global_capacity' crates/engine/src -g'!**/tests/**'` — 0 matches

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test -p strata-storage --quiet` — 1213 passed (1203 in ES4; +10)
- [x] `cargo test -p strata-storage runtime_config` — 10 passed
- [x] `cargo test -p strata-engine --lib database::config` — 53 passed
- [x] `cargo test -p strata-engine --lib database::tests::open` — 43 passed
- [x] `cargo test -p strata-engine --lib database::recovery` — 27 passed
- [x] `cargo test -p strata-engine --test recovery_parity` — 7 passed
- [x] `cargo test -p strata-engine` — 1617 passed (1604 in ES4; +13), 10 failed (same pre-existing architecture-cleanup-period failures verified against `main` during ES2; no new regressions)
- [x] `cargo test -p strata-executor` — 113 passed

## Workstream status

- ES2 (#2482) — checkpoint & WAL compaction mechanics ✅
- ES3 (#2483) — snapshot decode/install boundary ✅
- ES4 (#2484) — recovery bootstrap mechanics ✅
- ES5 (this PR) — storage configuration application

After this lands, ES6 (boundary closeout, engine shape, and documentation) is the final epic — primarily docs/crate-map alignment, deletion of obsolete forwarding adapters, and final guardrail enforcement. No further code-moving epics are planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)