### PR TITLE
ES6: close out the engine/storage boundary normalization workstream

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -48,7 +48,7 @@ xxhash-rust = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]
-strata-storage = { path = "../storage", features = ["engine-internal", "fault-injection"] }
+strata-storage = { path = "../storage", features = ["engine-internal", "fault-injection", "test-utils"] }
 tempfile = { workspace = true }
 criterion = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/engine/src/database/config.rs
+++ b/crates/engine/src/database/config.rs
@@ -224,17 +224,32 @@ fn default_codec() -> String {
 }
 
 impl StorageConfig {
-    /// Effective block cache size, accounting for `memory_budget`.
+    /// Compatibility helper for the derived block-cache size.
+    ///
+    /// This helper remains for downstream callers that previously read the
+    /// derived value from `StorageConfig`. Engine-internal production code
+    /// should use the storage runtime adapter instead, so storage remains the
+    /// owner of effective-value derivation.
     pub fn effective_block_cache_size(&self) -> usize {
         storage_runtime_config_from(self).block_cache_configured_bytes()
     }
 
-    /// Effective write buffer size, accounting for `memory_budget`.
+    /// Compatibility helper for the derived write-buffer size.
+    ///
+    /// This helper remains for downstream callers that previously read the
+    /// derived value from `StorageConfig`. Engine-internal production code
+    /// should use the storage runtime adapter instead, so storage remains the
+    /// owner of effective-value derivation.
     pub fn effective_write_buffer_size(&self) -> usize {
         storage_runtime_config_from(self).write_buffer_size
     }
 
-    /// Effective max immutable memtables, accounting for `memory_budget`.
+    /// Compatibility helper for the derived immutable-memtable limit.
+    ///
+    /// This helper remains for downstream callers that previously read the
+    /// derived value from `StorageConfig`. Engine-internal production code
+    /// should use the storage runtime adapter instead, so storage remains the
+    /// owner of effective-value derivation.
     pub fn effective_max_immutable_memtables(&self) -> usize {
         storage_runtime_config_from(self).max_immutable_memtables
     }
@@ -289,10 +304,12 @@ impl Default for StorageConfig {
 /// Controls how many on-disk checkpoint snapshots (`snap-NNNNNN.chk`) are kept
 /// after each successful checkpoint. The snapshot referenced by the live
 /// MANIFEST is always retained regardless of `retain_count` so recovery is
-/// never broken by pruning.
+/// never broken by pruning. `retain_count` is the raw public configuration
+/// value; `0` is accepted for compatibility and is clamped to an effective
+/// value of `1` by the storage pruning runtime.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SnapshotRetentionPolicy {
-    /// Maximum number of snapshot files to keep.
+    /// Raw maximum number of newest snapshot files to keep.
     ///
     /// Storage pruning preserves at least one snapshot; `0` is accepted for
     /// config-file compatibility and is treated as `1` by the pruning runtime.
@@ -1406,17 +1423,43 @@ max_branches = 512
     }
 
     #[test]
+    fn effective_storage_config_helpers_delegate_to_runtime_config() {
+        let cfg = StorageConfig {
+            memory_budget: 32 << 20,
+            block_cache_size: 64 << 20,
+            write_buffer_size: 32 << 20,
+            max_immutable_memtables: 3,
+            ..StorageConfig::default()
+        };
+        let runtime_config = storage_runtime_config_from(&cfg);
+
+        assert_eq!(
+            cfg.effective_block_cache_size(),
+            runtime_config.block_cache_configured_bytes()
+        );
+        assert_eq!(
+            cfg.effective_write_buffer_size(),
+            runtime_config.write_buffer_size
+        );
+        assert_eq!(
+            cfg.effective_max_immutable_memtables(),
+            runtime_config.max_immutable_memtables
+        );
+    }
+
+    #[test]
     fn memory_budget_derives_effective_values() {
         let cfg = StorageConfig {
             memory_budget: 32 << 20, // 32 MiB
             ..StorageConfig::default()
         };
-        assert_eq!(cfg.effective_block_cache_size(), 16 << 20);
-        assert_eq!(cfg.effective_write_buffer_size(), 8 << 20);
-        assert_eq!(cfg.effective_max_immutable_memtables(), 1);
+        let runtime_config = storage_runtime_config_from(&cfg);
+        assert_eq!(runtime_config.block_cache_configured_bytes(), 16 << 20);
+        assert_eq!(runtime_config.write_buffer_size, 8 << 20);
+        assert_eq!(runtime_config.max_immutable_memtables, 1);
         // Total: 16 + 8*2 = 32 MiB = budget
-        let total = cfg.effective_block_cache_size()
-            + cfg.effective_write_buffer_size() * (1 + cfg.effective_max_immutable_memtables());
+        let total = runtime_config.block_cache_configured_bytes()
+            + runtime_config.write_buffer_size * (1 + runtime_config.max_immutable_memtables);
         assert_eq!(total, 32 << 20);
     }
 
@@ -1429,9 +1472,10 @@ max_branches = 512
             max_immutable_memtables: 3,
             ..StorageConfig::default()
         };
-        assert_eq!(cfg.effective_block_cache_size(), 64 << 20);
-        assert_eq!(cfg.effective_write_buffer_size(), 32 << 20);
-        assert_eq!(cfg.effective_max_immutable_memtables(), 3);
+        let runtime_config = storage_runtime_config_from(&cfg);
+        assert_eq!(runtime_config.block_cache_configured_bytes(), 64 << 20);
+        assert_eq!(runtime_config.write_buffer_size, 32 << 20);
+        assert_eq!(runtime_config.max_immutable_memtables, 3);
     }
 
     #[test]
@@ -1457,9 +1501,10 @@ max_branches = 512
 "#;
         let config: StrataConfig = toml::from_str(old_toml).unwrap();
         assert_eq!(config.storage.memory_budget, 0);
-        // All effective values match raw fields when budget is 0
+        // All runtime values match raw fields when budget is 0
+        let runtime_config = storage_runtime_config_from(&config.storage);
         assert_eq!(
-            config.storage.effective_write_buffer_size(),
+            runtime_config.write_buffer_size,
             config.storage.write_buffer_size
         );
     }

--- a/crates/engine/src/database/lifecycle.rs
+++ b/crates/engine/src/database/lifecycle.rs
@@ -117,11 +117,11 @@ impl Database {
         (safe_point, pruned, expired)
     }
 
-    /// Prune old checkpoint snapshot files according to the configured
-    /// `snapshot_retention.retain_count` (DG-015).
+    /// Prune old checkpoint snapshot files according to the effective snapshot
+    /// retention count derived from `snapshot_retention.retain_count` (DG-015).
     ///
     /// Always retains:
-    ///   - the `retain_count` newest snapshots, and
+    ///   - the newest snapshots up to the effective retain count, and
     ///   - the snapshot referenced by the live MANIFEST (recovery-critical).
     ///
     /// Per-file delete failures are logged but do not abort the loop. The

--- a/crates/engine/src/database/recovery.rs
+++ b/crates/engine/src/database/recovery.rs
@@ -101,6 +101,8 @@ impl<'a> RecoveryRuntimeConfig<'a> {
         }
     }
 
+    /// Exposed to open orchestration so it can apply storage runtime globals
+    /// after recovery; the public engine config stays private to this module.
     pub(crate) fn storage_runtime_config(&self) -> StorageRuntimeConfig {
         self.storage_runtime_config
     }
@@ -115,7 +117,7 @@ impl<'a> RecoveryRuntimeConfig<'a> {
 /// Carries the owned resources the caller needs to finish constructing
 /// `Arc<Database>`. All public fields are `pub(crate)` because
 /// `RecoveryOutcome` is an implementation detail of `open.rs`; it is
-/// not part of the ES4 public surface.
+/// not part of the public database recovery surface.
 pub(crate) struct RecoveryOutcome {
     /// MANIFEST-recorded database UUID (or `[0u8; 16]` for follower
     /// without a MANIFEST).
@@ -238,7 +240,7 @@ impl Database {
                 "storage recovered with degraded state"
             );
         }
-        // ES4 health-policy branch. Strict mode refuses authoritative
+        // Recovery health-policy branch. Strict mode refuses authoritative
         // loss; the no-manifest legacy fallback is opt-in; rebuildable
         // caches are always accepted. Lossy recovery (`allow_lossy_recovery`)
         // is the blanket escape hatch and permits every class — it leaves
@@ -287,7 +289,7 @@ impl Database {
     }
 }
 
-/// ES4 strict-mode policy. `true` = refuse to open on this class; `false`
+/// Strict-mode recovery policy. `true` = refuse to open on this class; `false`
 /// = accept. The caller combines this with `allow_lossy_recovery` so
 /// that lossy mode is a blanket override regardless of class.
 ///
@@ -682,10 +684,11 @@ mod tests {
 
         let outcome = run_recovery_for_test(temp_dir.path(), &layout, &cfg, RecoveryMode::Primary)
             .expect("recovery should succeed with non-default storage config");
+        let runtime_config = storage_runtime_config_from(&cfg.storage);
 
         assert_eq!(
             outcome.storage.write_buffer_size_for_test(),
-            cfg.storage.effective_write_buffer_size()
+            runtime_config.write_buffer_size
         );
         assert_eq!(
             outcome.storage.max_branches_for_test(),
@@ -697,7 +700,7 @@ mod tests {
         );
         assert_eq!(
             outcome.storage.max_immutable_memtables_for_test(),
-            cfg.storage.effective_max_immutable_memtables()
+            runtime_config.max_immutable_memtables
         );
         assert_eq!(
             outcome.storage.target_file_size(),

--- a/crates/engine/src/database/tests/open.rs
+++ b/crates/engine/src/database/tests/open.rs
@@ -272,7 +272,7 @@ fn test_cache_open_rejects_cache_durability_string() {
     );
 }
 
-fn es5a_observable_storage_config() -> StorageConfig {
+fn observable_storage_runtime_config() -> StorageConfig {
     StorageConfig {
         max_branches: 17,
         max_versions_per_key: 3,
@@ -305,15 +305,12 @@ impl Drop for BlockCacheCapacityGuard {
     }
 }
 
-fn assert_es5a_observable_storage_config(
-    db: &Database,
-    cfg: &StorageConfig,
-    expected_write_buffer_size: usize,
-) {
+fn assert_observable_storage_runtime_config(db: &Database, cfg: &StorageConfig) {
     let storage = db.storage();
+    let runtime_config = crate::database::config::storage_runtime_config_from(cfg);
     assert_eq!(
         storage.write_buffer_size_for_test(),
-        expected_write_buffer_size
+        runtime_config.write_buffer_size
     );
     assert_eq!(storage.max_branches_for_test(), cfg.max_branches);
     assert_eq!(
@@ -322,7 +319,7 @@ fn assert_es5a_observable_storage_config(
     );
     assert_eq!(
         storage.max_immutable_memtables_for_test(),
-        cfg.effective_max_immutable_memtables()
+        runtime_config.max_immutable_memtables
     );
     assert_eq!(storage.target_file_size(), cfg.target_file_size);
     assert_eq!(storage.level_base_bytes(), cfg.level_base_bytes);
@@ -336,10 +333,10 @@ fn assert_es5a_observable_storage_config(
 
 #[test]
 #[serial(open_databases)]
-fn es5a_persistent_open_applies_observable_storage_runtime_knobs() {
+fn persistent_open_applies_observable_storage_runtime_knobs() {
     let temp_dir = TempDir::new().unwrap();
-    let db_path = temp_dir.path().join("es5a_persistent_runtime_config");
-    let storage = es5a_observable_storage_config();
+    let db_path = temp_dir.path().join("persistent_runtime_config");
+    let storage = observable_storage_runtime_config();
     let cfg = StrataConfig {
         storage: storage.clone(),
         ..StrataConfig::default()
@@ -349,7 +346,7 @@ fn es5a_persistent_open_applies_observable_storage_runtime_knobs() {
         .expect("primary open should apply storage runtime config");
 
     assert!(!db.is_cache());
-    assert_es5a_observable_storage_config(&db, &storage, storage.effective_write_buffer_size());
+    assert_observable_storage_runtime_config(&db, &storage);
 
     db.shutdown().unwrap();
     OPEN_DATABASES.lock().clear();
@@ -357,8 +354,8 @@ fn es5a_persistent_open_applies_observable_storage_runtime_knobs() {
 
 #[test]
 #[serial(open_databases)]
-fn es5a_cache_open_applies_observable_storage_runtime_knobs() {
-    let storage = es5a_observable_storage_config();
+fn cache_open_applies_observable_storage_runtime_knobs() {
+    let storage = observable_storage_runtime_config();
     let cfg = StrataConfig {
         storage: storage.clone(),
         ..StrataConfig::default()
@@ -368,24 +365,20 @@ fn es5a_cache_open_applies_observable_storage_runtime_knobs() {
         .expect("cache open should apply storage runtime config");
 
     assert!(db.is_cache());
-    assert_es5a_observable_storage_config(&db, &storage, storage.effective_write_buffer_size());
+    assert_observable_storage_runtime_config(&db, &storage);
 }
 
 #[test]
 #[serial(open_databases)]
-fn es5a_update_config_reapplies_observable_storage_runtime_knobs() {
-    let initial_storage = es5a_observable_storage_config();
+fn update_config_reapplies_observable_storage_runtime_knobs() {
+    let initial_storage = observable_storage_runtime_config();
     let initial_cfg = StrataConfig {
         storage: initial_storage.clone(),
         ..StrataConfig::default()
     };
     let db = Database::open_runtime(super::spec::OpenSpec::cache().with_config(initial_cfg))
         .expect("cache open should succeed");
-    assert_es5a_observable_storage_config(
-        &db,
-        &initial_storage,
-        initial_storage.effective_write_buffer_size(),
-    );
+    assert_observable_storage_runtime_config(&db, &initial_storage);
 
     let updated_storage = StorageConfig {
         write_buffer_size: 384 * 1024,
@@ -405,23 +398,19 @@ fn es5a_update_config_reapplies_observable_storage_runtime_knobs() {
     })
     .expect("storage runtime config update should succeed");
 
-    assert_es5a_observable_storage_config(
-        &db,
-        &updated_storage,
-        updated_storage.effective_write_buffer_size(),
-    );
+    assert_observable_storage_runtime_config(&db, &updated_storage);
 }
 
 #[test]
 #[serial(open_databases)]
-fn es5a_persistent_open_applies_memory_budget_runtime_derivations() {
+fn persistent_open_applies_memory_budget_runtime_derivations() {
     let temp_dir = TempDir::new().unwrap();
-    let db_path = temp_dir.path().join("es5a_persistent_memory_budget");
+    let db_path = temp_dir.path().join("persistent_memory_budget");
     let storage = StorageConfig {
         memory_budget: 32 << 20,
         write_buffer_size: 512 * 1024,
         max_immutable_memtables: 7,
-        ..es5a_observable_storage_config()
+        ..observable_storage_runtime_config()
     };
     let cfg = StrataConfig {
         storage: storage.clone(),
@@ -431,7 +420,7 @@ fn es5a_persistent_open_applies_memory_budget_runtime_derivations() {
     let db = Database::open_runtime(super::spec::OpenSpec::primary(&db_path).with_config(cfg))
         .expect("primary open should apply memory-budget-derived storage config");
 
-    assert_es5a_observable_storage_config(&db, &storage, 8 << 20);
+    assert_observable_storage_runtime_config(&db, &storage);
 
     db.shutdown().unwrap();
     OPEN_DATABASES.lock().clear();
@@ -439,12 +428,12 @@ fn es5a_persistent_open_applies_memory_budget_runtime_derivations() {
 
 #[test]
 #[serial(open_databases)]
-fn es5c_cache_open_applies_memory_budget_runtime_derivations() {
+fn cache_open_applies_memory_budget_runtime_derivations() {
     let storage = StorageConfig {
         memory_budget: 32 << 20,
         write_buffer_size: 512 * 1024,
         max_immutable_memtables: 7,
-        ..es5a_observable_storage_config()
+        ..observable_storage_runtime_config()
     };
     let cfg = StrataConfig {
         storage: storage.clone(),
@@ -454,12 +443,56 @@ fn es5c_cache_open_applies_memory_budget_runtime_derivations() {
     let db = Database::open_runtime(super::spec::OpenSpec::cache().with_config(cfg))
         .expect("cache open should apply memory-budget-derived storage config");
 
-    assert_es5a_observable_storage_config(&db, &storage, 8 << 20);
+    assert_observable_storage_runtime_config(&db, &storage);
 }
 
 #[test]
 #[serial(open_databases)]
-fn es5e_cache_open_applies_default_block_cache_runtime_config() {
+fn primary_open_characterizes_tiny_memory_budget() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("primary_tiny_memory_budget");
+    let _capacity_guard = BlockCacheCapacityGuard::capture();
+    let storage = StorageConfig {
+        memory_budget: 1,
+        block_cache_size: 64 << 20,
+        write_buffer_size: 128 << 20,
+        max_immutable_memtables: 7,
+        ..observable_storage_runtime_config()
+    };
+    let cfg = StrataConfig {
+        storage,
+        ..StrataConfig::default()
+    };
+
+    strata_storage::block_cache::set_global_capacity(8 << 20);
+
+    let db = Database::open_runtime(super::spec::OpenSpec::primary(&db_path).with_config(cfg))
+        .expect("primary open should accept and apply tiny memory budgets");
+
+    assert!(!db.is_cache());
+    assert_eq!(
+        strata_storage::block_cache::global_capacity(),
+        0,
+        "memory_budget=1 derives an explicit zero-byte block cache, not auto"
+    );
+    assert_eq!(
+        db.storage().write_buffer_size_for_test(),
+        0,
+        "memory_budget=1 derives a zero-byte active write buffer"
+    );
+    assert_eq!(
+        db.storage().max_immutable_memtables_for_test(),
+        1,
+        "memory_budget derivation still retains one immutable memtable"
+    );
+
+    db.shutdown().unwrap();
+    OPEN_DATABASES.lock().clear();
+}
+
+#[test]
+#[serial(open_databases)]
+fn cache_open_applies_default_block_cache_runtime_config() {
     let _capacity_guard = BlockCacheCapacityGuard::capture();
     let mut cfg = StrataConfig::default();
     crate::database::profile::apply_hardware_profile_if_defaults(&mut cfg);
@@ -487,18 +520,14 @@ fn es5e_cache_open_applies_default_block_cache_runtime_config() {
 
 #[test]
 #[serial(open_databases)]
-fn es5g_cache_open_rejects_invalid_codec_before_global_cache_mutation() {
-    let _capacity_guard = BlockCacheCapacityGuard::capture();
+fn cache_open_rejects_invalid_codec() {
     let cfg = StrataConfig {
         storage: StorageConfig {
-            block_cache_size: 7 << 20,
             codec: "missing-codec".to_string(),
             ..StorageConfig::default()
         },
         ..StrataConfig::default()
     };
-
-    strata_storage::block_cache::set_global_capacity(1);
 
     let error = match Database::open_runtime(super::spec::OpenSpec::cache().with_config(cfg)) {
         Ok(_) => panic!("cache open should reject an unknown storage codec"),
@@ -511,14 +540,64 @@ fn es5g_cache_open_rejects_invalid_codec_before_global_cache_mutation() {
             .contains("cache database could not initialize codec 'missing-codec'"),
         "error should name the rejected cache codec, got: {error}"
     );
-    assert_eq!(strata_storage::block_cache::global_capacity(), 1);
 }
 
 #[test]
 #[serial(open_databases)]
-fn es5c_follower_open_applies_block_cache_runtime_config() {
+fn primary_open_rejects_invalid_codec() {
     let temp_dir = TempDir::new().unwrap();
-    let db_path = temp_dir.path().join("es5c_follower_block_cache");
+    let db_path = temp_dir.path().join("primary_invalid_codec");
+    let cfg = StrataConfig {
+        storage: StorageConfig {
+            codec: "missing-codec".to_string(),
+            ..StorageConfig::default()
+        },
+        ..StrataConfig::default()
+    };
+
+    let error =
+        match Database::open_runtime(super::spec::OpenSpec::primary(&db_path).with_config(cfg)) {
+            Ok(_) => panic!("primary open should reject an unknown storage codec"),
+            Err(error) => error,
+        };
+
+    assert!(
+        error.to_string().contains("missing-codec"),
+        "error should name the rejected primary codec, got: {error}"
+    );
+}
+
+#[test]
+#[serial(open_databases)]
+fn follower_open_rejects_invalid_codec() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("follower_invalid_codec");
+    std::fs::create_dir_all(&db_path).unwrap();
+    let cfg = StrataConfig {
+        storage: StorageConfig {
+            codec: "missing-codec".to_string(),
+            ..StorageConfig::default()
+        },
+        ..StrataConfig::default()
+    };
+
+    let error =
+        match Database::open_runtime(super::spec::OpenSpec::follower(&db_path).with_config(cfg)) {
+            Ok(_) => panic!("follower open should reject an unknown storage codec"),
+            Err(error) => error,
+        };
+
+    assert!(
+        error.to_string().contains("missing-codec"),
+        "error should name the rejected follower codec, got: {error}"
+    );
+}
+
+#[test]
+#[serial(open_databases)]
+fn follower_open_applies_block_cache_runtime_config() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("follower_block_cache");
     let _capacity_guard = BlockCacheCapacityGuard::capture();
     let storage = StorageConfig {
         block_cache_size: 7 << 20,

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 default = []
 engine-internal = []
 fault-injection = []
+test-utils = []
 perf-trace = []
 
 [dependencies]

--- a/crates/storage/src/block_cache.rs
+++ b/crates/storage/src/block_cache.rs
@@ -886,7 +886,10 @@ static GLOBAL_CAPACITY: AtomicUsize = AtomicUsize::new(DEFAULT_CAPACITY_BYTES);
 ///
 /// If the cache is already initialized, updates the capacity on the live
 /// instance. If not yet initialized, stores the value for use when
-/// `global_cache()` first creates the cache.
+/// `global_cache()` first creates the cache. This is process-global storage
+/// runtime state: sequential later calls overwrite earlier calls. Concurrent
+/// database opens race, and callers should not rely on a deterministic winner
+/// or on a total ordering between `global_capacity()` and the live cache.
 pub fn set_global_capacity(bytes: usize) {
     GLOBAL_CAPACITY.store(bytes, Ordering::Relaxed);
     if let Some(cache) = GLOBAL_CACHE.get() {

--- a/crates/storage/src/durability/checkpoint_runtime.rs
+++ b/crates/storage/src/durability/checkpoint_runtime.rs
@@ -22,9 +22,15 @@ use crate::durability::layout::DatabaseLayout;
 use crate::SegmentedStore;
 
 /// Storage-level snapshot retention settings.
+///
+/// `retain_count` accepts compatibility values from public callers. The
+/// constructor normalizes it to at least one, while direct struct literals may
+/// still set it to zero; storage pruning clamps again before applying retention
+/// so zero can never delete every snapshot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StorageSnapshotRetention {
-    /// Number of newest snapshots to retain. Effective value is at least one.
+    /// Public retention count. Pruning treats zero as an effective value of
+    /// one.
     pub retain_count: usize,
 }
 
@@ -746,6 +752,37 @@ mod tests {
 
         assert_eq!(retention.retain_count, 1);
         assert_eq!(retention.effective_retain_count(), 1);
+    }
+
+    #[test]
+    fn prune_storage_snapshots_clamps_direct_zero_retention_to_one() {
+        let temp_dir = TempDir::new().unwrap();
+        let layout = layout(&temp_dir);
+
+        for id in 1..=5 {
+            run_storage_checkpoint(checkpoint_input(
+                layout.clone(),
+                kv_checkpoint_data(b"k", b"v"),
+                id,
+                1,
+            ))
+            .unwrap();
+        }
+
+        let pruned =
+            prune_storage_snapshots(&layout, StorageSnapshotRetention { retain_count: 0 }).unwrap();
+        assert_eq!(pruned, 4);
+
+        let kept: Vec<u64> = list_snapshots(layout.snapshots_dir())
+            .unwrap()
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+        assert_eq!(
+            kept,
+            vec![5],
+            "raw retain_count=0 must be treated as retain_count=1 by pruning"
+        );
     }
 
     #[test]

--- a/crates/storage/src/durability/format/wal_record.rs
+++ b/crates/storage/src/durability/format/wal_record.rs
@@ -939,7 +939,7 @@ mod tests {
         // T3-E12 Phase 2: v2 (and older) segment headers must surface
         // a typed `LegacyFormat` error, not silently parse. This is the
         // discriminator the engine's open path uses to produce
-        // `StrataError::LegacyFormat` and skip the T3-E10 wipe.
+        // legacy-format error and skip the T3-E10 wipe.
         let mut bytes = [0u8; SEGMENT_HEADER_SIZE_V2];
         bytes[0..4].copy_from_slice(&SEGMENT_MAGIC);
         bytes[4..8].copy_from_slice(&2u32.to_le_bytes()); // v2

--- a/crates/storage/src/durability/recovery.rs
+++ b/crates/storage/src/durability/recovery.rs
@@ -397,7 +397,7 @@ impl RecoveryCoordinator {
     /// callers that need the decoded payload perform their own decode
     /// inside `on_record` to preserve the inline-decode invariant.
     ///
-    /// Typed recovery driver used by the engine's recovery orchestration.
+    /// Typed recovery driver used by upper-layer recovery orchestration.
     ///
     /// [`recover`](Self::recover) is the canonical storage-owned callback API
     /// and forwards directly to this method.

--- a/crates/storage/src/durability/recovery_bootstrap.rs
+++ b/crates/storage/src/durability/recovery_bootstrap.rs
@@ -1,7 +1,7 @@
 //! Storage-owned recovery bootstrap surface.
 //!
-//! This module defines the primitive-neutral boundary that ES4 uses to move
-//! durability recovery mechanics into storage. The public entry point is
+//! This module defines the primitive-neutral boundary for storage-owned
+//! durability recovery mechanics. The public entry point is
 //! `run_storage_recovery`; the smaller helper seams below stay private to keep
 //! higher layers from driving the lower recovery runtime piecemeal.
 
@@ -22,8 +22,8 @@ use crate::{RecoveredState, SegmentedStore, StorageError};
 
 /// Install a loaded snapshot into storage during recovery.
 ///
-/// Storage owns MANIFEST and codec resolution in the ES4 target, but it must
-/// not decode primitive snapshot sections. The callback therefore receives the
+/// Storage owns MANIFEST and codec resolution, but it must not decode primitive
+/// snapshot sections. The callback therefore receives the
 /// resolved install codec and the generic `LoadedSnapshot` container; higher
 /// layers keep ownership of primitive decode and install telemetry.
 pub trait RecoverySnapshotInstallCallback: Send + Sync {
@@ -111,7 +111,7 @@ impl fmt::Debug for StorageRecoveryInput<'_> {
 
 /// Run storage-owned durability recovery.
 ///
-/// This is the ES4 target wrapper for lower recovery mechanics. It validates
+/// This is the storage-owned wrapper for lower recovery mechanics. It validates
 /// and prepares MANIFEST state, resolves codecs, constructs the recovered
 /// `SegmentedStore`, drives snapshot/WAL replay through the storage
 /// coordinator, applies the mechanical lossy WAL fallback when configured, and
@@ -651,7 +651,7 @@ mod tests {
                         _storage: &SegmentedStore|
          -> Result<(), StorageError> { Ok(()) };
         let input = StorageRecoveryInput::new(
-            DatabaseLayout::from_root("/tmp/strata-es4b"),
+            DatabaseLayout::from_root("/tmp/strata-recovery-bootstrap"),
             StorageRecoveryMode::PrimaryCreateManifestIfMissing,
             "identity",
             StorageRuntimeConfig::builder()

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -109,7 +109,8 @@ pub enum StorageError {
     /// Recovery itself returns [`StorageResult<RecoveredState>`] with the full
     /// classified health; this variant exists for call sites that need to
     /// carry exactly one fault across a `Result` boundary without reshaping
-    /// the outcome type (e.g. cross-crate conversions into `StrataError`).
+    /// the outcome type (e.g. cross-crate conversions into upper-layer
+    /// errors).
     ///
     /// [`RecoveredState`]: crate::segmented::RecoveredState
     #[error(transparent)]

--- a/crates/storage/src/runtime_config.rs
+++ b/crates/storage/src/runtime_config.rs
@@ -90,8 +90,8 @@ pub struct StorageRuntimeConfig {
     pub write_buffer_size: usize,
     /// Advisory branch-limit value stored on the store; `0` means unlimited.
     ///
-    /// Current storage mechanics record and expose this value, but ES5 does
-    /// not introduce new branch-creation enforcement.
+    /// Current storage mechanics record and expose this value, but runtime
+    /// config application does not introduce new branch-creation enforcement.
     pub max_branches: usize,
     /// Maximum retained versions per key; `0` means unlimited.
     pub max_versions_per_key: usize,
@@ -169,7 +169,10 @@ impl StorageRuntimeConfig {
     /// Apply process-global storage runtime knobs.
     ///
     /// Store-local knobs belong in [`Self::apply_to_store`]. This helper owns
-    /// storage-wide global mechanics such as block-cache capacity.
+    /// storage-wide global mechanics such as block-cache capacity. Block-cache
+    /// capacity is process-global by design; repeated calls overwrite the
+    /// previous capacity when applied sequentially. Concurrent opens race and
+    /// have no deterministic winner.
     pub fn apply_global_runtime(&self) {
         crate::block_cache::set_global_capacity(self.resolved_block_cache_capacity());
     }
@@ -260,8 +263,8 @@ impl StorageRuntimeConfigBuilder {
 
     /// Store an advisory branch-limit value; `0` means unlimited.
     ///
-    /// ES5 centralizes where the value is stored on `SegmentedStore`; it does
-    /// not add branch-creation enforcement.
+    /// Storage runtime config centralizes where the value is stored on
+    /// `SegmentedStore`; it does not add branch-creation enforcement.
     pub fn max_branches(mut self, max: usize) -> Self {
         self.max_branches = max;
         self
@@ -534,5 +537,22 @@ mod tests {
         cfg.apply_global_runtime();
 
         assert_eq!(crate::block_cache::global_capacity(), 32 << 20);
+    }
+
+    #[test]
+    fn apply_global_runtime_sequential_calls_overwrite_process_global_capacity() {
+        let _capacity_guard = GlobalBlockCacheCapacityGuard::capture();
+        let first = StorageRuntimeConfig::builder()
+            .block_cache_size(11 << 20)
+            .build();
+        let second = StorageRuntimeConfig::builder()
+            .block_cache_size(13 << 20)
+            .build();
+
+        first.apply_global_runtime();
+        assert_eq!(crate::block_cache::global_capacity(), 11 << 20);
+
+        second.apply_global_runtime();
+        assert_eq!(crate::block_cache::global_capacity(), 13 << 20);
     }
 }

--- a/crates/storage/src/segmented/mod.rs
+++ b/crates/storage/src/segmented/mod.rs
@@ -1115,35 +1115,35 @@ impl SegmentedStore {
     }
 
     /// Return the configured write buffer size for cross-crate characterization tests.
-    #[cfg(any(test, feature = "fault-injection"))]
+    #[cfg(any(test, feature = "test-utils"))]
     #[doc(hidden)]
     pub fn write_buffer_size_for_test(&self) -> usize {
         self.write_buffer_size.load(Ordering::Relaxed) as usize
     }
 
     /// Return the configured branch limit for cross-crate characterization tests.
-    #[cfg(any(test, feature = "fault-injection"))]
+    #[cfg(any(test, feature = "test-utils"))]
     #[doc(hidden)]
     pub fn max_branches_for_test(&self) -> usize {
         self.max_branches.load(Ordering::Relaxed)
     }
 
     /// Return the configured per-key version limit for characterization tests.
-    #[cfg(any(test, feature = "fault-injection"))]
+    #[cfg(any(test, feature = "test-utils"))]
     #[doc(hidden)]
     pub fn max_versions_per_key_for_test(&self) -> usize {
         self.max_versions_per_key.load(Ordering::Relaxed)
     }
 
     /// Return the configured immutable-memtable limit for characterization tests.
-    #[cfg(any(test, feature = "fault-injection"))]
+    #[cfg(any(test, feature = "test-utils"))]
     #[doc(hidden)]
     pub fn max_immutable_memtables_for_test(&self) -> usize {
         self.max_immutable_memtables.load(Ordering::Relaxed)
     }
 
     /// Return the configured compaction rate limit for characterization tests.
-    #[cfg(any(test, feature = "fault-injection"))]
+    #[cfg(any(test, feature = "test-utils"))]
     #[doc(hidden)]
     pub fn compaction_rate_limit_for_test(&self) -> u64 {
         self.compaction_rate_limiter
@@ -2719,7 +2719,8 @@ impl SegmentedStore {
     ///
     /// This provides per-key read consistency without the overhead of
     /// transaction allocation, coordinator mutex, or read-set tracking.
-    /// For multi-key snapshot isolation, use `Database::transaction()`.
+    /// For multi-key snapshot isolation, use a transaction-level API with a
+    /// bounded snapshot.
     pub fn get_versioned_direct(&self, key: &Key) -> StorageResult<Option<VersionedValue>> {
         let snapshot = match self.snapshot_branch(&key.namespace.branch_id) {
             Some(s) => s,
@@ -3692,10 +3693,9 @@ impl SegmentedStore {
     /// the same `SegmentedStore` instance would duplicate recovered state, so
     /// repeated invocations return [`StorageError::RecoveryAlreadyApplied`].
     ///
-    /// Callers should pass the returned outcome to
-    /// `TransactionCoordinator::apply_storage_recovery` rather than reading
-    /// individual fields: that entry point owns version-floor adoption and
-    /// future per-branch version wiring.
+    /// Callers should pass the returned outcome to an upper-layer coordinator
+    /// recovery hook rather than reading individual fields: that entry point
+    /// owns version-floor adoption and future per-branch version wiring.
     ///
     /// ## B5.1 retention contract
     ///

--- a/crates/storage/src/segmented/recovery.rs
+++ b/crates/storage/src/segmented/recovery.rs
@@ -32,10 +32,9 @@ use thiserror::Error;
 
 /// Self-contained outcome of [`SegmentedStore::recover_segments`].
 ///
-/// The engine consumes this directly via
-/// `TransactionCoordinator::apply_storage_recovery`; it never needs to reach
-/// into storage internals to rebuild version state or interpret a raw fault
-/// list.
+/// Upper layers consume this directly through their coordinator recovery hook;
+/// they never need to reach into storage internals to rebuild version state or
+/// interpret a raw fault list.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct RecoveredState {

--- a/crates/storage/src/txn/context.rs
+++ b/crates/storage/src/txn/context.rs
@@ -15,9 +15,6 @@ use strata_core::id::{CommitVersion, TxnId};
 use strata_core::value::Value;
 use strata_core::{BranchId, Version, Versioned, VersionedValue};
 
-type StrataError = StorageError;
-type StrataResult<T> = StorageResult<T>;
-
 /// Error type for commit failures
 ///
 /// Per spec Core Invariants:
@@ -451,8 +448,8 @@ impl TransactionContext {
 
     /// Return the snapshot store backing this transaction, if any.
     ///
-    /// Engine-owned transaction semantics use the same bounded snapshot view
-    /// as generic reads, so exposing the shared store handle is sufficient.
+    /// Higher-level transaction semantics use the same bounded snapshot view as
+    /// generic reads, so exposing the shared store handle is sufficient.
     pub fn snapshot_store(&self) -> Option<Arc<SegmentedStore>> {
         self.store.clone()
     }
@@ -473,7 +470,7 @@ impl TransactionContext {
     /// - If key doesn't exist in snapshot: tracks `(key, 0)`
     ///
     /// # Errors
-    /// Returns `StrataError::invalid_input` if transaction is not active.
+    /// Returns `StorageError::invalid_input` if transaction is not active.
     ///
     /// # Example
     ///
@@ -492,7 +489,7 @@ impl TransactionContext {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn get(&mut self, key: &Key) -> StrataResult<Option<Value>> {
+    pub fn get(&mut self, key: &Key) -> StorageResult<Option<Value>> {
         self.guard(key)?;
 
         // 1. Check write_set first (read-your-writes)
@@ -515,9 +512,9 @@ impl TransactionContext {
     ///
     /// This is the core read path that tracks reads for conflict detection.
     /// Reads are bounded by `start_version` for MVCC isolation.
-    fn read_from_snapshot(&mut self, key: &Key) -> StrataResult<Option<Value>> {
+    fn read_from_snapshot(&mut self, key: &Key) -> StorageResult<Option<Value>> {
         let store = self.store.as_ref().ok_or_else(|| {
-            StrataError::invalid_input("Transaction has no store for reads".to_string())
+            StorageError::invalid_input("Transaction has no store for reads".to_string())
         })?;
 
         match store.get_versioned(key, self.start_version)? {
@@ -550,8 +547,8 @@ impl TransactionContext {
     /// 3. **snapshot read:** returns full `VersionedValue` from snapshot, tracks in read_set
     ///
     /// # Errors
-    /// Returns `StrataError::invalid_input` if transaction is not active.
-    pub fn get_versioned(&mut self, key: &Key) -> StrataResult<Option<VersionedValue>> {
+    /// Returns `StorageError::invalid_input` if transaction is not active.
+    pub fn get_versioned(&mut self, key: &Key) -> StorageResult<Option<VersionedValue>> {
         self.guard(key)?;
 
         // 1. Check write_set first (read-your-writes)
@@ -573,9 +570,9 @@ impl TransactionContext {
     }
 
     /// Read from store preserving version metadata, and track in read_set
-    fn get_versioned_from_snapshot(&mut self, key: &Key) -> StrataResult<Option<VersionedValue>> {
+    fn get_versioned_from_snapshot(&mut self, key: &Key) -> StorageResult<Option<VersionedValue>> {
         let store = self.store.as_ref().ok_or_else(|| {
-            StrataError::invalid_input("Transaction has no store for reads".to_string())
+            StorageError::invalid_input("Transaction has no store for reads".to_string())
         })?;
 
         let versioned = store.get_versioned(key, self.start_version)?;
@@ -599,8 +596,8 @@ impl TransactionContext {
     /// Note: This DOES track the read in read_set if the key is read from snapshot.
     ///
     /// # Errors
-    /// Returns `StrataError::invalid_input` if transaction is not active.
-    pub fn exists(&mut self, key: &Key) -> StrataResult<bool> {
+    /// Returns `StorageError::invalid_input` if transaction is not active.
+    pub fn exists(&mut self, key: &Key) -> StorageResult<bool> {
         Ok(self.get(key)?.is_some())
     }
 
@@ -614,7 +611,7 @@ impl TransactionContext {
     /// Results are sorted by key order.
     ///
     /// # Errors
-    /// Returns `StrataError::invalid_input` if transaction is not active or has no snapshot.
+    /// Returns `StorageError::invalid_input` if transaction is not active or has no snapshot.
     ///
     /// # Example
     ///
@@ -634,11 +631,11 @@ impl TransactionContext {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn scan_prefix(&mut self, prefix: &Key) -> StrataResult<Vec<(Key, Value)>> {
+    pub fn scan_prefix(&mut self, prefix: &Key) -> StorageResult<Vec<(Key, Value)>> {
         self.guard(prefix)?;
 
         let store = self.store.as_ref().ok_or_else(|| {
-            StrataError::invalid_input("Transaction has no store for reads".to_string())
+            StorageError::invalid_input("Transaction has no store for reads".to_string())
         })?;
 
         // Get all matching keys from store (bounded by start_version)
@@ -769,7 +766,7 @@ impl TransactionContext {
     /// keys (the operation won't increase the total count). For CAS, pass `None`
     /// because CAS always appends to the cas_set.
     #[inline]
-    fn check_write_limit(&self, key: Option<&Key>) -> StrataResult<()> {
+    fn check_write_limit(&self, key: Option<&Key>) -> StorageResult<()> {
         if self.max_write_entries == 0 {
             return Ok(());
         }
@@ -782,7 +779,7 @@ impl TransactionContext {
         }
         let total = self.write_set.len() + self.delete_set.len() + self.cas_set.len();
         if total >= self.max_write_entries {
-            return Err(StrataError::capacity_exceeded(
+            return Err(StorageError::capacity_exceeded(
                 "transaction_write_buffer",
                 self.max_write_entries,
                 total + 1,
@@ -802,7 +799,7 @@ impl TransactionContext {
     /// - Writes are "blind" - no read_set entry unless you explicitly read first
     ///
     /// # Errors
-    /// Returns `StrataError::invalid_input` if transaction is not active.
+    /// Returns `StorageError::invalid_input` if transaction is not active.
     ///
     /// # Example
     ///
@@ -821,10 +818,10 @@ impl TransactionContext {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn put(&mut self, key: Key, value: Value) -> StrataResult<()> {
+    pub fn put(&mut self, key: Key, value: Value) -> StorageResult<()> {
         self.guard(&key)?;
         if self.read_only {
-            return Err(StrataError::invalid_input(
+            return Err(StorageError::invalid_input(
                 "Cannot write in a read-only transaction",
             ));
         }
@@ -847,10 +844,10 @@ impl TransactionContext {
     /// Same as `put()`, but also records a TTL so the entry is serialized
     /// into the WAL and preserved through recovery. A `ttl_ms` of 0 means
     /// no TTL (equivalent to `put()`).
-    pub fn put_with_ttl(&mut self, key: Key, value: Value, ttl_ms: u64) -> StrataResult<()> {
+    pub fn put_with_ttl(&mut self, key: Key, value: Value, ttl_ms: u64) -> StorageResult<()> {
         self.guard(&key)?;
         if self.read_only {
-            return Err(StrataError::invalid_input(
+            return Err(StorageError::invalid_input(
                 "Cannot write in a read-only transaction",
             ));
         }
@@ -876,7 +873,7 @@ impl TransactionContext {
     /// versions are pruned later during compaction, not at write time.
     /// Use for internal data (e.g., graph adjacency lists) where version
     /// history is not needed and would waste memory.
-    pub fn put_replace(&mut self, key: Key, value: Value) -> StrataResult<()> {
+    pub fn put_replace(&mut self, key: Key, value: Value) -> StorageResult<()> {
         self.key_write_modes
             .insert(key.clone(), WriteMode::KeepLast(1));
         self.put(key, value)
@@ -893,7 +890,7 @@ impl TransactionContext {
     /// - At commit, creates a tombstone in storage
     ///
     /// # Errors
-    /// Returns `StrataError::invalid_input` if transaction is not active.
+    /// Returns `StorageError::invalid_input` if transaction is not active.
     ///
     /// # Example
     ///
@@ -912,10 +909,10 @@ impl TransactionContext {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn delete(&mut self, key: Key) -> StrataResult<()> {
+    pub fn delete(&mut self, key: Key) -> StorageResult<()> {
         self.guard(&key)?;
         if self.read_only {
-            return Err(StrataError::invalid_input(
+            return Err(StorageError::invalid_input(
                 "Cannot write in a read-only transaction",
             ));
         }
@@ -947,7 +944,7 @@ impl TransactionContext {
     /// - Multiple CAS operations on different keys are allowed
     ///
     /// # Errors
-    /// Returns `StrataError::invalid_input` if transaction is not active.
+    /// Returns `StorageError::invalid_input` if transaction is not active.
     ///
     /// # Example
     ///
@@ -976,10 +973,10 @@ impl TransactionContext {
         key: Key,
         expected_version: CommitVersion,
         new_value: Value,
-    ) -> StrataResult<()> {
+    ) -> StorageResult<()> {
         self.guard(&key)?;
         if self.read_only {
-            return Err(StrataError::invalid_input(
+            return Err(StorageError::invalid_input(
                 "Cannot write in a read-only transaction",
             ));
         }
@@ -1005,10 +1002,10 @@ impl TransactionContext {
         key: Key,
         expected_version: CommitVersion,
         new_value: Value,
-    ) -> StrataResult<()> {
+    ) -> StorageResult<()> {
         self.guard(&key)?;
         if self.read_only {
-            return Err(StrataError::invalid_input(
+            return Err(StorageError::invalid_input(
                 "Cannot write in a read-only transaction",
             ));
         }
@@ -1035,8 +1032,8 @@ impl TransactionContext {
     /// Note: Does not change transaction state or snapshot.
     ///
     /// # Errors
-    /// Returns `StrataError::invalid_input` if transaction is not active.
-    pub fn clear_operations(&mut self) -> StrataResult<()> {
+    /// Returns `StorageError::invalid_input` if transaction is not active.
+    pub fn clear_operations(&mut self) -> StorageResult<()> {
         self.ensure_active()?;
 
         self.read_set.clear();
@@ -1127,12 +1124,12 @@ impl TransactionContext {
     /// Check if transaction can accept operations
     ///
     /// # Errors
-    /// Returns `StrataError::invalid_input` if transaction is not in `Active` state.
-    pub fn ensure_active(&self) -> StrataResult<()> {
+    /// Returns `StorageError::invalid_input` if transaction is not in `Active` state.
+    pub fn ensure_active(&self) -> StorageResult<()> {
         if self.is_active() {
             Ok(())
         } else {
-            Err(StrataError::invalid_input(format!(
+            Err(StorageError::invalid_input(format!(
                 "Transaction {} is not active: {:?}",
                 self.txn_id, self.status
             )))
@@ -1144,9 +1141,9 @@ impl TransactionContext {
     /// Commit serialization locks only `self.branch_id`. Allowing keys from
     /// other branches would let cross-branch reads bypass that lock, creating
     /// a TOCTOU vulnerability (#1709).
-    fn enforce_branch_scope(&self, key: &Key) -> StrataResult<()> {
+    fn enforce_branch_scope(&self, key: &Key) -> StorageResult<()> {
         if !self.allow_cross_branch && key.namespace.branch_id != self.branch_id {
-            return Err(StrataError::invalid_input(format!(
+            return Err(StorageError::invalid_input(format!(
                 "Key branch {} does not match transaction branch {} — \
                  cross-branch operations are not supported in a single transaction",
                 key.namespace.branch_id, self.branch_id
@@ -1157,13 +1154,13 @@ impl TransactionContext {
 
     /// Common pre-operation guard: verify the transaction is active and the key
     /// belongs to this transaction's branch.
-    fn guard(&mut self, key: &Key) -> StrataResult<()> {
+    fn guard(&mut self, key: &Key) -> StorageResult<()> {
         self.ensure_active()?;
         self.maybe_seed_branch_generation_read_guard(key)?;
         self.enforce_branch_scope(key)
     }
 
-    fn maybe_seed_branch_generation_read_guard(&mut self, key: &Key) -> StrataResult<()> {
+    fn maybe_seed_branch_generation_read_guard(&mut self, key: &Key) -> StorageResult<()> {
         if self.read_only
             || self.branch_generation_guard.is_none()
             || self.branch_generation_guard_seeded
@@ -1197,9 +1194,9 @@ impl TransactionContext {
 
     /// Reject if the same key already has a CAS operation in this transaction.
     /// Used by `put()` and `delete()` to prevent ambiguous CAS+write mixing (#1739 OCC-M1).
-    fn validate_no_cas_conflict(&self, key: &Key) -> StrataResult<()> {
+    fn validate_no_cas_conflict(&self, key: &Key) -> StorageResult<()> {
         if self.cas_set.iter().any(|op| op.key == *key) {
-            return Err(StrataError::invalid_input(
+            return Err(StorageError::invalid_input(
                 "Key already has a CAS operation in this transaction; \
                  mixing put/delete and CAS on the same key is ambiguous",
             ));
@@ -1209,9 +1206,9 @@ impl TransactionContext {
 
     /// Reject if the same key already has a put or delete in this transaction.
     /// Used by `cas()` and `cas_with_read()` to prevent ambiguous write+CAS mixing (#1739 OCC-M1).
-    fn validate_no_write_conflict(&self, key: &Key) -> StrataResult<()> {
+    fn validate_no_write_conflict(&self, key: &Key) -> StorageResult<()> {
         if self.write_set.contains_key(key) || self.delete_set.contains(key) {
-            return Err(StrataError::invalid_input(
+            return Err(StorageError::invalid_input(
                 "Key already has a put/delete in this transaction; \
                  mixing put/delete and CAS on the same key is ambiguous",
             ));
@@ -1225,11 +1222,11 @@ impl TransactionContext {
     /// the transaction should be validated against current storage state.
     ///
     /// # Errors
-    /// Returns `StrataError::invalid_input` if not in `Active` state.
+    /// Returns `StorageError::invalid_input` if not in `Active` state.
     ///
     /// # State Transition
     /// `Active` → `Validating`
-    pub fn mark_validating(&mut self) -> StrataResult<()> {
+    pub fn mark_validating(&mut self) -> StorageResult<()> {
         self.ensure_active()?;
         self.status = TransactionStatus::Validating;
         Ok(())
@@ -1241,17 +1238,17 @@ impl TransactionContext {
     /// applied to storage.
     ///
     /// # Errors
-    /// Returns `StrataError::invalid_input` if not in `Validating` state.
+    /// Returns `StorageError::invalid_input` if not in `Validating` state.
     ///
     /// # State Transition
     /// `Validating` → `Committed`
-    pub fn mark_committed(&mut self) -> StrataResult<()> {
+    pub fn mark_committed(&mut self) -> StorageResult<()> {
         match &self.status {
             TransactionStatus::Validating => {
                 self.status = TransactionStatus::Committed;
                 Ok(())
             }
-            _ => Err(StrataError::invalid_input(format!(
+            _ => Err(StorageError::invalid_input(format!(
                 "Cannot commit transaction {} from state {:?}",
                 self.txn_id, self.status
             ))),
@@ -1271,18 +1268,18 @@ impl TransactionContext {
     /// * `reason` - Human-readable reason for abort
     ///
     /// # Errors
-    /// Returns `StrataError::invalid_input` if already `Committed` or `Aborted`.
+    /// Returns `StorageError::invalid_input` if already `Committed` or `Aborted`.
     ///
     /// # State Transitions
     /// - `Active` → `Aborted`
     /// - `Validating` → `Aborted`
-    pub fn mark_aborted(&mut self, reason: String) -> StrataResult<()> {
+    pub fn mark_aborted(&mut self, reason: String) -> StorageResult<()> {
         match &self.status {
-            TransactionStatus::Committed => Err(StrataError::invalid_input(format!(
+            TransactionStatus::Committed => Err(StorageError::invalid_input(format!(
                 "Cannot abort committed transaction {}",
                 self.txn_id
             ))),
-            TransactionStatus::Aborted { .. } => Err(StrataError::invalid_input(format!(
+            TransactionStatus::Aborted { .. } => Err(StorageError::invalid_input(format!(
                 "Transaction {} already aborted",
                 self.txn_id
             ))),
@@ -1391,15 +1388,15 @@ impl TransactionContext {
     /// - Transaction must be in Committed state (validation passed)
     ///
     /// # Errors
-    /// - StrataError::invalid_input if transaction is not in Committed state
+    /// - StorageError::invalid_input if transaction is not in Committed state
     /// - Error from storage operations if they fail
     pub fn apply_writes<S: Storage>(
         &mut self,
         store: &S,
         commit_version: CommitVersion,
-    ) -> StrataResult<ApplyResult> {
+    ) -> StorageResult<ApplyResult> {
         if !self.is_committed() {
-            return Err(StrataError::invalid_input(format!(
+            return Err(StorageError::invalid_input(format!(
                 "Cannot apply writes: transaction {} is {:?}, must be Committed",
                 self.txn_id, self.status
             )));

--- a/crates/storage/src/txn/validation.rs
+++ b/crates/storage/src/txn/validation.rs
@@ -42,8 +42,6 @@ use crate::{Key, Storage, StorageResult};
 use std::collections::HashMap;
 use strata_core::id::CommitVersion;
 
-type StrataResult<T> = StorageResult<T>;
-
 /// Types of conflicts that can occur during transaction validation
 ///
 /// See spec Section 3.1 for when each conflict type occurs.
@@ -136,7 +134,7 @@ impl ValidationResult {
 pub fn validate_read_set<S: Storage>(
     read_set: &HashMap<Key, CommitVersion>,
     store: &S,
-) -> StrataResult<ValidationResult> {
+) -> StorageResult<ValidationResult> {
     let mut result = ValidationResult::ok();
 
     for (key, read_version) in read_set {
@@ -179,7 +177,7 @@ pub fn validate_read_set<S: Storage>(
 pub fn validate_cas_set<S: Storage>(
     cas_set: &[CASOperation],
     store: &S,
-) -> StrataResult<ValidationResult> {
+) -> StorageResult<ValidationResult> {
     let mut result = ValidationResult::ok();
 
     for cas_op in cas_set {
@@ -232,7 +230,7 @@ pub fn validate_cas_set<S: Storage>(
 pub fn validate_transaction<S: Storage>(
     txn: &TransactionContext,
     store: &S,
-) -> StrataResult<ValidationResult> {
+) -> StorageResult<ValidationResult> {
     // Per spec Section 3.2 Scenario 3: Read-only transactions ALWAYS commit.
     // "Read-Only Transaction: T1 only reads keys, never writes any → ALWAYS COMMITS"
     // "Why: Read-only transactions have no writes to validate. They simply return their snapshot view."

--- a/docs/engine/boundary-baseline-and-guardrails-plan.md
+++ b/docs/engine/boundary-baseline-and-guardrails-plan.md
@@ -1,17 +1,17 @@
-# ES1 Boundary Baseline And Guardrails Plan
+# Boundary Baseline And Guardrails Plan
 
 ## Purpose
 
-This document is the detailed execution plan for `ES1` in
+This document is the detailed execution plan for `boundary baseline` in
 [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md).
 
-`ES1` does not move runtime code. It establishes the inventory, split
+`boundary baseline` does not move runtime code. It establishes the inventory, split
 decisions, and guardrails needed before the later mechanics moves:
 
-- `ES2` - checkpoint and WAL compaction mechanics
-- `ES3` - snapshot decode and install mechanics
-- `ES4` - recovery bootstrap mechanics
-- `ES5` - storage configuration application
+- `checkpoint/WAL cleanup` - checkpoint and WAL compaction mechanics
+- `snapshot-install cleanup` - snapshot decode and install mechanics
+- `recovery-bootstrap cleanup` - recovery bootstrap mechanics
+- `storage-runtime-config cleanup` - storage configuration application
 
 The point of this phase is to make the boundary concrete enough that the next
 PRs can move code without accidentally moving engine policy or primitive
@@ -31,7 +31,7 @@ The current crate graph is structurally correct:
 - upper crates should continue to enter database runtime behavior through
   engine, not storage
 
-Observed ES1 guard results:
+Observed boundary baseline guard results:
 
 - `cargo tree -p strata-storage --depth 2` shows no `strata-engine`
   dependency.
@@ -42,8 +42,8 @@ Observed ES1 guard results:
   engine.
 - the engine lower-runtime residue guard still finds checkpoint, compaction,
   snapshot install, recovery coordinator, manifest, and config-application
-  mechanics under `crates/engine/src/database`; those matches are the ES1
-  baseline for ES2-ES5 to reduce.
+  mechanics under `crates/engine/src/database`; those matches are the boundary baseline
+  baseline for the earlier mechanics cleanup phases to reduce.
 
 The remaining problem is physical ownership inside engine:
 
@@ -55,7 +55,7 @@ The remaining problem is physical ownership inside engine:
 
 ## Files In Scope
 
-The ES1 inventory covers these files:
+The boundary baseline inventory covers these files:
 
 - [database/compaction.rs](../../crates/engine/src/database/compaction.rs)
 - [database/snapshot_install.rs](../../crates/engine/src/database/snapshot_install.rs)
@@ -92,13 +92,13 @@ checkpoint mechanics.
 |---|---|---|---|
 | `Database::flush` | Public guarded WAL flush API. Checks shutdown state and delegates to the unguarded body. | Stay Engine | None |
 | `Database::flush_internal` | WAL writer flush body used by public flush and shutdown paths. It is tied to engine shutdown semantics and WAL writer health. | Stay Engine, Watch | None |
-| `Database::checkpoint` | Public API plus storage mechanics: WAL flush, quiesced watermark, checkpoint data collection, snapshot dir creation, manifest load/update, checkpoint coordinator call, snapshot pruning. | Split | ES2 |
-| `Database::compact` | Public API plus storage mechanics: manifest load, active WAL segment lookup, codec-aware WAL compactor, compaction result mapping. | Split | ES2 |
+| `Database::checkpoint` | Public API plus storage mechanics: WAL flush, quiesced watermark, checkpoint data collection, snapshot dir creation, manifest load/update, checkpoint coordinator call, snapshot pruning. | Split | checkpoint/WAL cleanup |
+| `Database::compact` | Public API plus storage mechanics: manifest load, active WAL segment lookup, codec-aware WAL compactor, compaction result mapping. | Split | checkpoint/WAL cleanup |
 | `Database::disk_usage` | Public diagnostic API aggregating WAL writer facts and snapshot directory size. | Stay Engine | None |
-| `Database::collect_checkpoint_data` | Walks `SegmentedStore` by physical type tags and builds storage durability snapshot DTOs. Includes primitive-specific checkpoint serialization details. | Split | ES2 or ES3 |
-| `Database::load_or_create_manifest` | Loads/creates storage manifest and updates active WAL segment. | Move Storage | ES2 / ES4 |
+| `Database::collect_checkpoint_data` | Walks `SegmentedStore` by physical type tags and builds storage durability snapshot DTOs. Includes primitive-specific checkpoint serialization details. | Split | checkpoint/WAL cleanup or snapshot-install cleanup |
+| `Database::load_or_create_manifest` | Loads/creates storage manifest and updates active WAL segment. | Move Storage | checkpoint/WAL cleanup / recovery-bootstrap cleanup |
 
-### ES2 split decision
+### checkpoint/WAL cleanup split decision
 
 `Database::checkpoint()` should stay as the public engine method. The storage
 side should own a helper shaped roughly like:
@@ -107,7 +107,7 @@ side should own a helper shaped roughly like:
 storage_checkpoint(input) -> StorageCheckpointOutcome
 ```
 
-The exact type names belong in the ES2 subplan, but the ownership split is:
+The exact type names belong in the checkpoint/WAL cleanup subplan, but the ownership split is:
 
 - engine supplies lifecycle-safe inputs: storage handle, data directory or
   layout, codec id, database UUID, WAL writer facts, quiesced watermark
@@ -128,7 +128,7 @@ snapshot DTOs. But it also knows how engine primitives are represented:
 - branch index keys are skipped
 - vector config rows and vector record bytes are interpreted
 
-ES2 should not blindly move this function into storage as-is. The likely
+checkpoint/WAL cleanup should not blindly move this function into storage as-is. The likely
 split is:
 
 - storage owns generic snapshot DTO construction and storage scan mechanics
@@ -139,35 +139,35 @@ split is:
 
 This is likely the long-term split, not merely a fallback. Checkpoint
 construction naturally needs primitive materialization knowledge that should
-not sink into storage. ES2 should assume the collector, or at least the
+not sink into storage. checkpoint/WAL cleanup should assume the collector, or at least the
 primitive materialization part of it, remains engine-owned and is supplied to
 storage as data or callbacks. The storage-owned part should be the generic
 checkpoint runtime around that materialized data.
 
 ## Inventory: `database/snapshot_install.rs`
 
-This module looked storage-shaped during ES1 because it installs rows into
-`SegmentedStore`, but the ES3 deep pass corrected the boundary: primitive
+This module looked storage-shaped during boundary baseline because it installs rows into
+`SegmentedStore`, but the snapshot-install cleanup deep pass corrected the boundary: primitive
 section dispatch and DTO decode are engine concerns. Storage owns only the
 generic decoded-row install helper that starts after engine has produced
 storage rows.
 
 | Surface | Current role | Classification | Target epic |
 |---|---|---|---|
-| `InstallStats` | Primitive-specific counts of entries installed by decoded snapshot section. | Stay Engine | ES3 |
-| `InstallStats::total_installed` | Engine invariant over primitive-specific counters. | Stay Engine | ES3 |
-| `install_snapshot` | Engine wrapper: validates codec policy, decodes primitive sections, builds generic storage-row plan, calls storage install helper. | Stay Engine, Split | ES3 |
-| `decode_kv_section` | Decodes KV section, preserves tombstones/TTL, dispatches by `TypeTag`. | Stay Engine | ES3 |
-| `decode_event_section` | Decodes Event section and reconstructs event user keys from sequence numbers. | Stay Engine | ES3 |
-| `decode_json_section` | Decodes JSON section and installs doc IDs as user keys. | Stay Engine | ES3 |
-| `decode_branch_section` | Decodes branch snapshot section and installs branch metadata rows. | Stay Engine | ES3 |
-| `decode_vector_section` | Decodes vector collection/config rows and reinstalls raw vector record bytes. | Stay Engine | ES3 |
-| `decode_value_json` | Decodes persisted `Value` bytes from primitive snapshot sections. | Stay Engine | ES3 |
-| `install_decoded_snapshot_rows` | Validates and installs already-decoded generic storage rows. | Move Storage | ES3 |
+| `InstallStats` | Primitive-specific counts of entries installed by decoded snapshot section. | Stay Engine | snapshot-install cleanup |
+| `InstallStats::total_installed` | Engine invariant over primitive-specific counters. | Stay Engine | snapshot-install cleanup |
+| `install_snapshot` | Engine wrapper: validates codec policy, decodes primitive sections, builds generic storage-row plan, calls storage install helper. | Stay Engine, Split | snapshot-install cleanup |
+| `decode_kv_section` | Decodes KV section, preserves tombstones/TTL, dispatches by `TypeTag`. | Stay Engine | snapshot-install cleanup |
+| `decode_event_section` | Decodes Event section and reconstructs event user keys from sequence numbers. | Stay Engine | snapshot-install cleanup |
+| `decode_json_section` | Decodes JSON section and installs doc IDs as user keys. | Stay Engine | snapshot-install cleanup |
+| `decode_branch_section` | Decodes branch snapshot section and installs branch metadata rows. | Stay Engine | snapshot-install cleanup |
+| `decode_vector_section` | Decodes vector collection/config rows and reinstalls raw vector record bytes. | Stay Engine | snapshot-install cleanup |
+| `decode_value_json` | Decodes persisted `Value` bytes from primitive snapshot sections. | Stay Engine | snapshot-install cleanup |
+| `install_decoded_snapshot_rows` | Validates and installs already-decoded generic storage rows. | Move Storage | snapshot-install cleanup |
 
-### ES3 split decision
+### snapshot-install cleanup split decision
 
-The original ES1 instinct was to move most of the install path downward because
+The original boundary baseline instinct was to move most of the install path downward because
 it performs inverse persistence mechanics:
 
 - decode snapshot section DTOs
@@ -175,7 +175,7 @@ it performs inverse persistence mechanics:
 - preserve tombstones, TTL, versions, and timestamps
 - call `SegmentedStore::install_snapshot_entries`
 
-ES3 tightened that caution into the actual ownership rule. The primitive DTO
+snapshot-install cleanup tightened that caution into the actual ownership rule. The primitive DTO
 decode remains engine-owned because `KV`, `Event`, `Json`, `Vector`, `Branch`,
 and Graph-as-KV routing are engine primitive persistence semantics, not generic
 storage mechanics. Storage receives only generic decoded row groups.
@@ -208,19 +208,19 @@ This module intentionally centralizes recovery, but it mixes three layers:
 
 | Surface | Current role | Classification | Target epic |
 |---|---|---|---|
-| `RecoveryMode` | Engine open mode: primary vs follower. Used for policy and error role. | Stay Engine | ES4 may introduce storage-neutral mode facts |
+| `RecoveryMode` | Engine open mode: primary vs follower. Used for policy and error role. | Stay Engine | recovery-bootstrap cleanup may introduce storage-neutral mode facts |
 | `RecoveryMode::as_error_role` | Engine error presentation mapping. | Stay Engine | None |
-| `RecoveryOutcome` | Engine open result bundle: UUID, codec, storage, coordinator, watermark, lossy report, follower state. | Stay Engine, Split | ES4 |
-| `Database::run_recovery` | High-level recovery sequence: config validation, manifest prep, WAL codec, storage construction, coordinator recovery, lossy fallback, segment recovery, follower state, watermark. | Split | ES4 |
+| `RecoveryOutcome` | Engine open result bundle: UUID, codec, storage, coordinator, watermark, lossy report, follower state. | Stay Engine, Split | recovery-bootstrap cleanup |
+| `Database::run_recovery` | High-level recovery sequence: config validation, manifest prep, WAL codec, storage construction, coordinator recovery, lossy fallback, segment recovery, follower state, watermark. | Split | recovery-bootstrap cleanup |
 | `policy_refuses` | Engine policy for degraded storage classes. | Stay Engine | None |
-| `ManifestPreparation` | Manifest result containing database UUID and snapshot install codec. | Move Storage or Split | ES4 |
-| `prepare_manifest` | Manifest load/create, codec validation, segments dir creation, follower no-manifest fallback. | Split | ES4 |
-| `run_coordinator_recovery` | Builds `RecoveryCoordinator`, wires snapshot install and WAL record application callbacks. | Move Storage, with callback split | ES4 |
-| `handle_wal_recovery_outcome` | Engine lossy-recovery policy and report construction. | Stay Engine, with storage raw facts | ES4 |
+| `ManifestPreparation` | Manifest result containing database UUID and snapshot install codec. | Move Storage or Split | recovery-bootstrap cleanup |
+| `prepare_manifest` | Manifest load/create, codec validation, segments dir creation, follower no-manifest fallback. | Split | recovery-bootstrap cleanup |
+| `run_coordinator_recovery` | Builds `RecoveryCoordinator`, wires snapshot install and WAL record application callbacks. | Move Storage, with callback split | recovery-bootstrap cleanup |
+| `handle_wal_recovery_outcome` | Engine lossy-recovery policy and report construction. | Stay Engine, with storage raw facts | recovery-bootstrap cleanup |
 | `coordinator_error_to_lossy_strata_error` | Engine error conversion for lossy report classification. | Stay Engine | None |
 | `restore_follower_state` | Engine follower-state validation and cleanup. | Stay Engine | None |
 
-### ES4 split decision
+### recovery-bootstrap cleanup split decision
 
 `Database::run_recovery` should remain the engine entry point. It composes
 database open semantics and returns engine-owned state.
@@ -246,11 +246,11 @@ Engine should keep:
 ### Coordinator ownership caution
 
 `TransactionCoordinator` is currently in engine even though earlier storage
-work moved generic transaction runtime into storage. ES4 should not casually
+work moved generic transaction runtime into storage. recovery-bootstrap cleanup should not casually
 move coordinator policy while moving recovery bootstrap. If coordinator
-ownership changes, that needs its own subplan or a clearly scoped ES4 section.
+ownership changes, that needs its own subplan or a clearly scoped recovery-bootstrap cleanup section.
 
-This is a load-bearing ES4 decision. If storage owns WAL replay mechanics while
+This is a load-bearing recovery-bootstrap cleanup decision. If storage owns WAL replay mechanics while
 `TransactionCoordinator` stays engine-owned, the boundary probably needs a
 callback or adapter shape for per-record replay and final coordinator
 bootstrap. That can be correct, but it must be designed intentionally before
@@ -263,7 +263,7 @@ storage-facing utilities and WAL runtime wiring are candidates for movement.
 
 | Surface | Current role | Classification | Target epic |
 |---|---|---|---|
-| `apply_storage_config` | Applies seven storage knobs to `SegmentedStore`. | Move Storage | ES5 |
+| `apply_storage_config` | Applies seven storage knobs to `SegmentedStore`. | Move Storage | storage-runtime-config cleanup |
 | `restrict_dir` | Database data directory permission hardening. | Stay Engine, Watch | None |
 | `sanitize_config` | Engine/product behavior for feature-gated `auto_embed`. | Stay Engine | None |
 | `restrict_file` | Lock/config support file permission hardening. | Stay Engine, Watch | None |
@@ -273,14 +273,14 @@ storage-facing utilities and WAL runtime wiring are candidates for movement.
 | `Database::acquire_primary_db` | Registry, path lock, subsystem recovery, lifecycle publication. | Stay Engine | None |
 | `Database::repair_space_metadata_on_open` | Engine primitive/space metadata repair. | Stay Engine | None |
 | `Database::open_follower` | Engine follower opener. | Stay Engine | None |
-| `Database::acquire_follower_db` | Engine follower construction around recovery outcome. | Stay Engine | ES4 touches recovery call only |
-| `Database::spawn_wal_flush_thread` | WAL background sync thread with engine shutdown and health latching. | Split / Watch | ES5 or later |
-| `Database::open_finish` | Primary open tail: recovery, support dirs, WAL writer, block cache, DB struct, flush thread, compaction scheduling. | Split | ES4 / ES5 |
+| `Database::acquire_follower_db` | Engine follower construction around recovery outcome. | Stay Engine | recovery-bootstrap cleanup touches recovery call only |
+| `Database::spawn_wal_flush_thread` | WAL background sync thread with engine shutdown and health latching. | Split / Watch | storage-runtime-config cleanup or later |
+| `Database::open_finish` | Primary open tail: recovery, support dirs, WAL writer, block cache, DB struct, flush thread, compaction scheduling. | Split | recovery-bootstrap cleanup / storage-runtime-config cleanup |
 | `Database::cache` | Engine cache-mode public opener. | Stay Engine | None |
-| `Database::create_ephemeral_bare` | Engine cache DB construction plus storage config application. | Split | ES5 |
-| `Database::open_runtime` and mode helpers | Engine product/runtime composition entry point. | Stay Engine | ES6 |
+| `Database::create_ephemeral_bare` | Engine cache DB construction plus storage config application. | Split | storage-runtime-config cleanup |
+| `Database::open_runtime` and mode helpers | Engine product/runtime composition entry point. | Stay Engine | boundary closeout |
 
-### ES5 split decision
+### storage-runtime-config cleanup split decision
 
 `apply_storage_config` should move first. It is a narrow, low-risk helper that
 already takes only `SegmentedStore` and `StorageConfig`.
@@ -297,7 +297,7 @@ or:
 storage::runtime_config::apply_to_store(&SegmentedStore, &StorageRuntimeConfig)
 ```
 
-The exact naming belongs in ES5. The important ownership point is that engine
+The exact naming belongs in storage-runtime-config cleanup. The important ownership point is that engine
 should not keep a hand-written list of storage setter calls once storage owns
 those knobs.
 
@@ -310,7 +310,7 @@ those knobs.
 - engine policy: accepting transaction halt, health latch, shutdown signal,
   test hooks, lifecycle integration
 
-Do not move it as part of ES1. A later ES5 or follow-up runtime subplan should
+Do not move it as part of boundary baseline. A later storage-runtime-config cleanup or follow-up runtime subplan should
 decide whether storage owns a generic WAL sync worker while engine owns
 health/shutdown callbacks.
 
@@ -320,16 +320,16 @@ health/shutdown callbacks.
 
 | Surface | Current role | Classification | Target epic |
 |---|---|---|---|
-| `SHADOW_KV`, `SHADOW_JSON`, `SHADOW_EVENT` | Intelligence/embedding shadow collection names. | Stay Engine now, possible intelligence/runtime follow-up | ES6 |
+| `SHADOW_KV`, `SHADOW_JSON`, `SHADOW_EVENT` | Intelligence/embedding shadow collection names. | Stay Engine now, possible intelligence/runtime follow-up | boundary closeout |
 | `CONFIG_FILE_NAME` | Engine database config artifact name. | Stay Engine | None |
-| `ModelConfig` | Inference/search model endpoint config. | Stay Engine or Intelligence later | ES6 |
-| `StorageConfig` | Public engine config section containing storage knobs. | Split | ES5 |
-| `StorageConfig::effective_*` | Storage-only derived values from memory budget. | Move Storage or Split | ES5 |
-| `Default for StorageConfig` and storage default helpers | Storage-only defaults currently exposed through engine config. | Split | ES5 |
-| `SnapshotRetentionPolicy` | Public config for storage checkpoint retention. | Split | ES5 |
+| `ModelConfig` | Inference/search model endpoint config. | Stay Engine or Intelligence later | boundary closeout |
+| `StorageConfig` | Public engine config section containing storage knobs. | Split | storage-runtime-config cleanup |
+| `StorageConfig::effective_*` | Storage-only derived values from memory budget. | Move Storage or Split | storage-runtime-config cleanup |
+| `Default for StorageConfig` and storage default helpers | Storage-only defaults currently exposed through engine config. | Split | storage-runtime-config cleanup |
+| `SnapshotRetentionPolicy` | Public config for storage checkpoint retention. | Split | storage-runtime-config cleanup |
 | `StrataConfig` | Public database/product config surface. | Stay Engine | None |
-| `StrataConfig::vector_storage_dtype` | Engine/vector semantic config helper. | Stay Engine | ES6 if vector folds into engine |
-| `StrataConfig::durability_mode` | Public config parse into storage WAL durability mode. | Split | ES5 |
+| `StrataConfig::vector_storage_dtype` | Engine/vector semantic config helper. | Stay Engine | boundary closeout if vector folds into engine |
+| `StrataConfig::durability_mode` | Public config parse into storage WAL durability mode. | Split | storage-runtime-config cleanup |
 | `StrataConfig::default_toml` | User/operator-facing config template. | Stay Engine | None |
 | `StrataConfig::from_file` | Engine config file parse, validation, env secret overrides. | Stay Engine | None |
 | `StrataConfig::apply_env_overrides` | Product/runtime secret injection. | Stay Engine | None |
@@ -337,7 +337,7 @@ health/shutdown callbacks.
 | `StrataConfig::write_to_file` | Engine config serialization. | Stay Engine | None |
 | `atomic_write_config` | Crash-safe config file write. It is file persistence, but for engine product config, not storage MANIFEST. | Stay Engine | None |
 
-### ES5 split decision
+### storage-runtime-config cleanup split decision
 
 `StrataConfig` remains the public engine config.
 
@@ -370,7 +370,7 @@ StorageRuntimeConfig::builder()
     ...
 ```
 
-The exact shape belongs in ES5. The key rule is:
+The exact shape belongs in storage-runtime-config cleanup. The key rule is:
 
 - storage owns the meaning and application of storage-only knobs
 - engine owns the public config file and product-facing names
@@ -380,16 +380,16 @@ The exact shape belongs in ES5. The key rule is:
 These are not final signatures. They are the API families later subplans
 should refine.
 
-Before ES2 moves code, write one joint API sketch for ES2, ES3, and ES4:
+Before checkpoint/WAL cleanup moves code, write one joint API sketch for checkpoint/WAL cleanup, snapshot-install cleanup, and recovery-bootstrap cleanup:
 
 ```text
-docs/engine/es2-es4-storage-runtime-boundary-api-sketch.md
+docs/engine/storage-runtime-boundary-api-sketch.md
 ```
 
 Checkpoint output feeds snapshot install, and snapshot install feeds recovery.
 Designing these boundary types independently will likely create rework.
 
-### ES2 checkpoint / compaction
+### checkpoint/WAL cleanup checkpoint / compaction
 
 Candidate module:
 
@@ -418,7 +418,7 @@ Engine responsibilities remain:
 - provide checkpoint data or primitive callbacks
 - map `NoSnapshot` into the existing invalid-input behavior for compact
 
-### ES3 snapshot install
+### snapshot-install cleanup snapshot install
 
 Settled modules:
 
@@ -454,7 +454,7 @@ Storage responsibilities:
 - avoid `LoadedSnapshot`, `SnapshotSerializer`, primitive tags, and primitive
   snapshot DTOs in runtime install modules
 
-### ES4 recovery bootstrap
+### recovery-bootstrap work
 
 Candidate module:
 
@@ -479,7 +479,7 @@ Engine responsibilities remain:
 - bootstrap engine coordinator or adapt from storage stats
 - convert storage recovery errors into `RecoveryError`
 
-### ES5 storage config
+### storage-runtime-config cleanup storage config
 
 Candidate module:
 
@@ -503,7 +503,7 @@ Engine responsibilities remain:
 
 ## Guardrails
 
-These guardrails should be run during ES1 and reused in later epics.
+These guardrails should be run during boundary baseline and reused in later epics.
 
 ### Cargo dependency guard
 
@@ -542,7 +542,7 @@ guarded surface.
 
 ### Primitive semantic guard for moved storage modules
 
-Once ES2-ES5 create new storage modules, they must not accumulate primitive
+Once the earlier mechanics cleanup phases create new storage modules, they must not accumulate primitive
 semantics:
 
 ```sh
@@ -565,15 +565,15 @@ rg -n 'CheckpointCoordinator|WalOnlyCompactor|ManifestManager|RecoveryCoordinato
 
 Expected behavior:
 
-- ES1: matches are expected and form the baseline
-- ES2: checkpoint/compaction matches should disappear or remain only in
+- boundary baseline: matches are expected and form the baseline
+- checkpoint/WAL cleanup: checkpoint/compaction matches should disappear or remain only in
   engine wrappers
-- ES3: `SnapshotSerializer` and `install_snapshot` remain only as intentional
+- snapshot-install cleanup: `SnapshotSerializer` and `install_snapshot` remain only as intentional
   engine-owned primitive decode and recovery policy residue; storage install
   modules must not import primitive snapshot DTOs or tags
-- ES4: recovery coordinator and manifest-prep mechanics should move down or
+- recovery-bootstrap cleanup: recovery coordinator and manifest-prep mechanics should move down or
   become storage API calls
-- ES5: `apply_storage_config` should disappear from engine
+- storage-runtime-config cleanup: `apply_storage_config` should disappear from engine
 
 ### Upper-layer bypass guard
 
@@ -591,8 +591,9 @@ Expected behavior:
 
 ## Characterization Requirements
 
-ES1 should make the later characterization burden explicit. ES2-ES5 should not
-move code first and backfill parity later.
+Boundary baseline should make the later characterization burden explicit. The
+earlier mechanics cleanup phases should not move code first and backfill parity
+later.
 
 Before the relevant code move, add or identify characterization coverage for:
 
@@ -622,27 +623,27 @@ than inventing a one-off microbenchmark:
 - search-facing benchmarks where recovery or snapshot install affects
   recovered search state
 
-## ES1 Acceptance Checklist
+## Acceptance Checklist
 
-ES1 is complete when:
+Boundary baseline is complete when:
 
 1. This inventory document exists and is linked from the main engine/storage
    normalization plan.
-2. The target surfaces for ES2-ES5 are classified as `Stay Engine`,
-   `Move Storage`, `Split`, or `Watch`.
+2. The target surfaces for the earlier mechanics cleanup phases are classified
+   as `Stay Engine`, `Move Storage`, `Split`, or `Watch`.
 3. Candidate storage API families are named well enough for later subplans to
    refine them.
 4. Guard commands are documented with expected current behavior.
-5. The ES2-ES4 joint API sketch is called out as a prerequisite before ES2
-   code movement.
+5. The storage-runtime boundary joint API sketch is called out as a
+   prerequisite before checkpoint/WAL cleanup code movement.
 6. The `TransactionCoordinator` ownership question is explicitly marked as an
-   ES4 design decision.
+   recovery-bootstrap cleanup design decision.
 7. Characterization requirements are documented before any runtime code moves.
-8. No runtime code has moved as part of ES1.
+8. No runtime code has moved as part of boundary baseline.
 
 ## Non-Goals
 
-ES1 does not:
+Boundary baseline does not:
 
 - move checkpoint code
 - move snapshot install code
@@ -653,4 +654,4 @@ ES1 does not:
 - change open/recovery behavior
 - change executor or CLI behavior
 
-Those changes belong in ES2-ES5, each with a narrower implementation plan.
+Those changes belong in the earlier mechanics cleanup phases, each with a narrower implementation plan.

--- a/docs/engine/boundary-closeout-plan.md
+++ b/docs/engine/boundary-closeout-plan.md
@@ -1,0 +1,699 @@
+# Boundary Closeout Plan
+
+## Purpose
+
+This is the closeout plan for the engine/storage boundary normalization
+workstream.
+
+The earlier cleanup moved checkpoint, WAL compaction, snapshot pruning, generic
+MANIFEST mechanics, generic decoded-row snapshot install, storage recovery
+bootstrap, and storage runtime configuration application into storage. Engine
+kept primitive snapshot decode, recovery policy, and public config.
+
+Boundary closeout should not be another large mechanics migration. The goal is
+to prove the new boundary is coherent, remove temporary residue where that is
+safe, and add guardrails so the next engine cleanup phase does not accidentally
+move storage concerns back into engine or engine semantics down into storage.
+
+Read this together with:
+
+- [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
+- [boundary-baseline-and-guardrails-plan.md](./boundary-baseline-and-guardrails-plan.md)
+- [checkpoint-wal-compaction-mechanics-plan.md](./checkpoint-wal-compaction-mechanics-plan.md)
+- [snapshot-decode-install-mechanics-plan.md](./snapshot-decode-install-mechanics-plan.md)
+- [recovery-bootstrap-mechanics-plan.md](./recovery-bootstrap-mechanics-plan.md)
+- [storage-config-application-plan.md](./storage-config-application-plan.md)
+- [../storage/storage-engine-ownership-audit.md](../storage/storage-engine-ownership-audit.md)
+- [../storage/storage-charter.md](../storage/storage-charter.md)
+
+## Boundary Rule
+
+Boundary closeout closes the boundary. It does not redraw it.
+
+Storage owns:
+
+- generic persistence mechanics
+- generic transaction/runtime substrate mechanics
+- WAL, snapshot, checkpoint, manifest, recovery, and storage config mechanics
+- storage-local runtime defaults and validation
+- raw substrate facts and storage-local errors
+
+Engine owns:
+
+- database orchestration and public database APIs
+- product and open/bootstrap policy
+- public config format and compatibility
+- primitive semantics
+- branch semantics and workflow policy
+- recovery policy, lifecycle policy, and operator-facing reporting
+- search/runtime behavior
+- conversion from storage facts into engine behavior and `StrataError`
+
+Storage must not learn:
+
+- `StrataConfig` or engine `StorageConfig`
+- primitive semantics or primitive section meaning outside storage-owned
+  durable format surfaces
+- graph, JSON, event, vector, search, executor, CLI, intelligence, or security
+  policy vocabulary outside storage-owned durable format surfaces
+- `TransactionCoordinator`
+- operator-facing recovery/report language
+- product hardware-profile policy
+
+Engine should not regain:
+
+- hand-written `SegmentedStore::set_*` storage-runtime application lists
+- low-level checkpoint/WAL/snapshot/manifest/recovery mechanics
+- storage codec registry construction logic outside the narrow public-config
+  adapter and open orchestration paths
+- direct inspection of storage test-only runtime fields from production code
+
+The boundary closeout target is:
+
+```text
+storage owns substrate mechanics
+engine owns semantics, policy, and orchestration
+the remaining boundary calls are explicit, narrow, and guarded
+```
+
+## Starting State
+
+At the end of the storage-runtime-config cleanup, the intended implementation shape is:
+
+- engine public APIs still expose checkpoint, compact, open, recovery, config,
+  and retention behavior
+- storage owns checkpoint and WAL compaction runtime helpers
+- storage owns generic decoded-row snapshot install
+- storage owns storage recovery bootstrap and replay mechanics
+- storage owns `StorageRuntimeConfig`, storage runtime derivation, store-local
+  application, and global block-cache capacity application
+- engine adapts public `StrataConfig.storage` into storage runtime config
+- engine still owns primitive snapshot decode, recovery policy, subsystem
+  recovery, transaction coordinator bootstrap, lifecycle checks, and public
+  errors
+
+Known closeout residue from the storage-runtime-config review:
+
+- storage `_for_test` accessors are reachable to engine when the storage crate
+  is built with `fault-injection`; engine production code does not currently
+  call them, but the surface is broader than ideal
+- `StorageConfig::effective_*` compatibility wrappers remain even though this
+  repo now uses them only in tests
+- snapshot-retention types clamp invalid zero values at construction and
+  runtime application, but public fields can still be set to zero by direct
+  struct literal
+- tiny `memory_budget = 1` is covered at the storage builder level but not by
+  an engine open end-to-end characterization
+- recovery runtime accessors have correct visibility, but their comments do not
+  fully document why `strata_config()` is private while
+  `storage_runtime_config()` is `pub(crate)`
+- block-cache capacity remains process-global; sequential updates overwrite
+  earlier values, while concurrent opens can race with no deterministic winner.
+  This is a pre-existing design constraint, not a storage-runtime-config
+  regression
+
+## Non-Negotiables
+
+Do not move primitive semantics into storage.
+
+Do not move `TransactionCoordinator` into storage as part of boundary closeout.
+Coordinator ownership is a separate architecture question if we ever reopen it.
+
+Do not change on-disk WAL, snapshot, manifest, or segment formats.
+
+Do not change recovery loss/degradation policy.
+
+Do not change public config serialization without an explicit compatibility
+story.
+
+Do not treat every remaining cross-boundary call as residue. Some seams are
+intentional:
+
+- engine primitive snapshot decode calling storage decoded-row install
+- engine recovery policy calling storage recovery bootstrap
+- engine open policy adapting public config into storage runtime config
+- engine public APIs wrapping storage checkpoint/compact mechanics
+- engine reports mapping raw storage facts into user-facing language
+
+Do not broaden boundary closeout into graph/vector/search/security/executor
+absorption. Boundary closeout should finish the storage boundary so that later
+engine consolidation can start from a stable substrate split.
+
+## Phase A - Boundary Audit And Guardrails
+
+### Goal
+
+Turn the final storage/engine boundary into runnable checks and a current
+inventory.
+
+### Scope
+
+- audit current imports and dependency graph
+- audit moved storage modules for primitive or engine vocabulary
+- audit engine production code for direct storage test-accessor calls
+- audit engine production code for duplicated storage setter lists
+- record guard commands in this plan or a closeout note
+
+### Guard Commands And Expected Results
+
+Dependency direction:
+
+```bash
+cargo tree -p strata-storage --edges normal,build --depth 2
+cargo tree -p strata-engine --depth 2
+cargo tree -p strata-storage --edges normal,build --depth 4 | rg "strata-(engine|executor|executor-legacy|graph|search|vector|intelligence|security)|stratadb"
+```
+
+The final command should return no matches. The first two commands are
+inspection commands for reviewers; the storage tree should contain only lower
+crates and third-party dependencies, while the engine tree should show the
+intended `engine -> storage` edge. The final guard rejects storage learning any
+upper-crate dependency, not only `strata-engine`.
+
+The inverse tree is useful context, but it is not a clean Phase A guard yet:
+
+```bash
+cargo tree -i strata-storage --workspace --depth 2
+```
+
+As of Phase A, this still shows direct upper-crate users such as graph, search,
+vector, executor, and stratadb. That is existing pre-engine-consolidation
+crate shape. Phase A only guards the storage/engine boundary direction; later
+engine consolidation should reduce those upper-layer direct storage edges.
+
+Primitive vocabulary below moved generic storage runtime/config surfaces:
+
+```bash
+rg -n "SnapshotSerializer|primitive_tags|KvSnapshotEntry|GraphSnapshotEntry|EventSnapshotEntry|JsonSnapshotEntry|VectorSnapshotEntry|VectorConfigSnapshotEntry" crates/storage/src/durability/decoded_snapshot_install.rs crates/storage/src/durability/recovery_bootstrap.rs crates/storage/src/runtime_config.rs
+```
+
+This is intentionally not a repo-wide storage grep. Storage still owns snapshot
+format modules that contain primitive section tags and primitive snapshot DTO
+codecs. The boundary violation would be those concepts leaking into the generic
+decoded install, recovery bootstrap, or runtime config helpers moved by
+the snapshot-install through storage-runtime-config cleanup.
+
+Engine production use of storage test accessors:
+
+```bash
+rg -n "write_buffer_size_for_test|max_branches_for_test|max_versions_per_key_for_test|max_immutable_memtables_for_test|compaction_rate_limit_for_test" crates/engine/src --glob '*.rs' \
+  | rg -v '^crates/engine/src/database/tests/open.rs:' \
+  | rg -v '^crates/engine/src/database/recovery.rs:[0-9]+:\s+outcome\.storage\.(write_buffer_size_for_test|max_branches_for_test|max_versions_per_key_for_test|max_immutable_memtables_for_test|compaction_rate_limit_for_test)\(\),'
+```
+
+This allowlist guard should return no matches. The broad inventory still returns ten
+expected matches, all in engine test code:
+
+```bash
+rg -n "write_buffer_size_for_test|max_branches_for_test|max_versions_per_key_for_test|max_immutable_memtables_for_test|compaction_rate_limit_for_test" crates/engine/src --glob '*.rs'
+```
+
+- `crates/engine/src/database/tests/open.rs`
+- the `#[cfg(test)]` module in `crates/engine/src/database/recovery.rs`
+
+Matches outside test modules are boundary regressions. Phase C decides whether
+to narrow the storage test-accessor surface further.
+
+Duplicated storage setter application in engine:
+
+```bash
+rg -n "set_max_branches|set_max_versions_per_key|set_max_immutable_memtables|set_write_buffer_size|set_target_file_size|set_level_base_bytes|set_data_block_size|set_bloom_bits_per_key|set_compaction_rate_limit" crates/engine/src --glob '*.rs'
+```
+
+Storage mentions of engine-owned config, error, and coordinator type names:
+
+```bash
+rg -n "StrataConfig|StorageConfig|StrataError|StrataResult|TransactionCoordinator" crates/storage/src --glob '*.rs'
+```
+
+### Deliverables
+
+1. A current boundary audit section in this document or a successor closeout
+   note.
+2. Runnable guard commands with expected results.
+3. Any necessary code or doc fixes for false positives that obscure real
+   regressions.
+
+### Acceptance
+
+- guard commands are documented
+- known expected matches are explained
+- no unexplained storage-to-engine dependency exists
+- no storage module moved by the earlier mechanics cleanup phases imports primitive snapshot DTOs or engine
+  policy types
+
+### Phase A Current State
+
+As of Phase A:
+
+- `cargo tree -p strata-storage --edges normal,build --depth 4 | rg "strata-(engine|executor|executor-legacy|graph|search|vector|intelligence|security)|stratadb"` returns no matches
+- the moved generic storage runtime/config primitive-vocabulary guard returns
+  no matches
+- the duplicated engine storage-setter guard returns no matches
+- the storage engine-owned type/config/error guard returns no matches
+- the storage runtime test-accessor production guards return no matches; the
+  broad inventory returns ten expected matches, all in engine tests
+
+Phase A also removed legacy storage-local `StrataError` / `StrataResult`
+terminology from `txn/context.rs` and `txn/validation.rs`, plus stale comments
+that mentioned engine error or coordinator names. Those aliases were local
+names for storage errors, not actual engine dependencies, but they made the
+guard noisy and obscured real future regressions.
+
+## Phase B - Compatibility Residue
+
+### Goal
+
+Decide which migration-era compatibility helpers should remain public API,
+which should be deprecated, and which can be deleted.
+
+### Scope
+
+- audit `StorageConfig::effective_block_cache_size`
+- audit `StorageConfig::effective_write_buffer_size`
+- audit `StorageConfig::effective_max_immutable_memtables`
+- audit any other helper whose only remaining purpose was bridging old
+  engine-side derivation to storage-owned runtime config
+- check downstream public API exposure before deletion
+
+### Decision Rule
+
+If a helper is crate-private or test-only, delete it after replacing tests with
+direct storage runtime config assertions.
+
+If a helper is public and may have downstream callers, prefer one of:
+
+- keep it as a compatibility wrapper with explicit docs
+- deprecate it with a migration note
+- remove it only in a planned breaking-change window
+
+Do not reimplement storage derivation in engine to preserve a helper.
+
+### Deliverables
+
+1. A compatibility decision for each `effective_*` wrapper.
+2. Tests updated to avoid hiding production ownership behind compatibility
+   wrappers where possible.
+3. Public docs/comments updated if wrappers remain.
+
+### Acceptance
+
+- no engine production code relies on `effective_*` wrappers for storage
+  runtime behavior
+- remaining wrappers delegate to storage-owned runtime config
+- deleted wrappers do not break intended public compatibility
+
+### Phase B Current State
+
+As of Phase B, the compatibility decision is:
+
+| Helper | Decision | Rationale |
+|---|---|---|
+| `StorageConfig::effective_block_cache_size` | Keep as compatibility wrapper | Public method; deleting it would be a breaking API change. |
+| `StorageConfig::effective_write_buffer_size` | Keep as compatibility wrapper | Public method; deleting it would be a breaking API change. |
+| `StorageConfig::effective_max_immutable_memtables` | Keep as compatibility wrapper | Public method; deleting it would be a breaking API change. |
+
+These helpers are explicitly documented as compatibility helpers. They must
+continue delegating to `storage_runtime_config_from`; they must not reintroduce
+engine-owned effective-value derivation.
+
+Repo-local production code no longer calls the wrappers. Tests generally assert
+through `storage_runtime_config_from` so storage remains the owner of runtime
+derivation; the only wrapper calls are in one compatibility test that proves the
+public helpers still delegate to the storage runtime adapter. The enforcement
+guard is:
+
+```bash
+if rg -n "effective_(block_cache_size|write_buffer_size|max_immutable_memtables)" crates/engine/src --glob '*.rs' \
+  | rg -v '^crates/engine/src/database/config.rs:[0-9]+:\s+pub fn effective_' \
+  | rg -v '^crates/engine/src/database/config.rs:[0-9]+:\s+cfg\.effective_(block_cache_size|write_buffer_size|max_immutable_memtables)\(\),'
+then
+  exit 1
+fi
+```
+
+This exits non-zero only when unapproved wrapper calls are present.
+
+## Phase C - Test Accessor Surface
+
+### Goal
+
+Make storage test-only observability harder to use from engine production code.
+
+### Scope
+
+- audit `SegmentedStore::*_for_test` accessors
+- decide whether `fault-injection` should expose runtime introspection to
+  engine production builds
+- consider moving test accessors into a storage test-utils module or feature
+  with a narrower name
+- preserve current tests that need characterization access
+
+### Design Options
+
+Option 1: keep current accessors and add guardrails.
+
+This is low risk and likely sufficient if Phase A guard commands become part of
+review practice.
+
+Option 2: move accessors behind a dedicated `test-utils` feature.
+
+This makes intent clearer but may require feature plumbing in engine tests.
+
+Option 3: expose structured storage runtime snapshots only under test builds.
+
+This can reduce the number of individual `_for_test` methods, but it is a
+larger API shape change and should be justified by actual misuse risk.
+
+### Deliverables
+
+1. A chosen test-accessor strategy.
+2. Code changes if the chosen strategy is more than guardrails.
+3. A guard proving engine production code does not call storage `_for_test`
+   methods.
+
+### Acceptance
+
+- engine tests can still characterize storage runtime application
+- engine production code does not call storage test accessors
+- storage does not expose test accessors as an accidental product API
+
+### Phase C Current State
+
+Phase C chooses option 2: storage runtime introspection accessors are behind a
+dedicated `test-utils` feature instead of `fault-injection`.
+
+`fault-injection` remains available for tests that need actual failure hooks,
+such as storage-apply failure injection. Engine dev-dependencies enable both
+`fault-injection` and `test-utils`; the normal engine dependency on storage
+continues to enable only `engine-internal`.
+
+The storage-side feature split guard is:
+
+```bash
+if rg -n 'feature = "fault-injection"' crates/storage/src/segmented/mod.rs
+then
+  exit 1
+fi
+```
+
+This exits non-zero only when segmented runtime introspection is still gated by
+`fault-injection`.
+
+The normal engine dependency feature guard is:
+
+```bash
+if cargo tree -p strata-engine --edges normal -e features \
+  | rg 'strata-storage feature "(fault-injection|test-utils)"'
+then
+  exit 1
+fi
+```
+
+This exits non-zero if normal engine builds expose storage fault hooks or
+runtime test introspection. Dev builds intentionally enable both features for
+tests.
+
+The engine production guard is:
+
+```bash
+if rg -n "write_buffer_size_for_test|max_branches_for_test|max_versions_per_key_for_test|max_immutable_memtables_for_test|compaction_rate_limit_for_test" crates/engine/src --glob '*.rs' \
+  | rg -v '^crates/engine/src/database/tests/open.rs:' \
+  | rg -v '^crates/engine/src/database/recovery.rs:[0-9]+:\s+outcome\.storage\.(write_buffer_size_for_test|max_branches_for_test|max_versions_per_key_for_test|max_immutable_memtables_for_test|compaction_rate_limit_for_test)\(\),'
+then
+  exit 1
+fi
+```
+
+This exits non-zero only when production engine code or an unapproved test path
+calls the storage runtime introspection methods.
+
+## Phase D - Retention API Tightening
+
+### Goal
+
+Clarify whether snapshot retention types expose raw configured values or only
+valid effective values.
+
+### Scope
+
+- audit `SnapshotRetentionPolicy`
+- audit `StorageSnapshotRetention`
+- decide whether public fields should remain directly constructible
+- decide whether runtime clamps are the authoritative compatibility behavior
+
+### Current Contract
+
+At the storage-runtime-config closeout point, `retain_count = 0` is tolerated
+and clamped to one by constructor and runtime application paths. This preserves
+the invariant that storage should retain at least one snapshot when snapshot
+pruning runs.
+
+### Design Options
+
+Option 1: keep public fields and document raw-versus-effective behavior.
+
+This is maximally compatible and matches current runtime clamps.
+
+Option 2: make fields private and expose constructors plus
+`effective_retain_count()`.
+
+This prevents direct invalid literals but may be a public API break.
+
+Option 3: introduce a validated newtype for effective retention count.
+
+This is the strongest type-level model, but likely more ceremony than closeout
+needs unless retention becomes a larger public API.
+
+### Deliverables
+
+1. A retention API decision.
+2. Docs/comments updated to match the decision.
+3. Tests proving direct zero inputs still behave according to the chosen
+   compatibility story.
+
+### Acceptance
+
+- retention invariants are documented where the types are defined
+- runtime behavior for `retain_count = 0` is explicit
+- no storage pruning path can delete the last snapshot because of a raw zero
+  field
+
+### Phase D Current State
+
+Phase D chooses option 1: keep the public fields and document raw-versus-effective
+behavior.
+
+`SnapshotRetentionPolicy::retain_count` remains engine-owned public
+configuration. `StorageSnapshotRetention::retain_count` remains storage-owned
+runtime input. Both fields accept compatibility values: `0` is accepted and is
+clamped to an effective retention count of `1` before storage pruning applies
+retention. `StorageSnapshotRetention::new(0)` stores the normalized value `1`,
+while direct struct literals can still carry raw `0`; the pruning runtime
+clamps again so the safety invariant does not depend on callers using the
+constructor.
+
+The storage regression test for direct raw zero is:
+
+```bash
+cargo test -p strata-storage prune_storage_snapshots_clamps_direct_zero_retention_to_one
+```
+
+The engine public-config regression test is:
+
+```bash
+cargo test -p strata-engine --lib retain_count_zero_is_treated_as_one_by_engine_pruning
+```
+
+## Phase E - Final Characterization Coverage
+
+### Goal
+
+Close small coverage gaps that are useful for future refactors but were not
+required to land the storage-runtime-config cleanup.
+
+### Scope
+
+- add an engine end-to-end open test for `memory_budget = 1`
+- consider primary/follower companions for "invalid open does not mutate global
+  block cache" if current coverage is too cache-mode-specific
+- add a one-line doc comment for recovery runtime accessor visibility
+- document the process-global block-cache behavior, including sequential
+  overwrite semantics and the pre-existing concurrent-open race
+
+### Non-Goals
+
+- no broad benchmark campaign
+- no new storage validation semantics
+- no behavior change to concurrent open handling
+
+### Deliverables
+
+1. Focused tests for any remaining high-signal edge cases.
+2. Comments/docs for intentional asymmetries.
+3. No changes to normal runtime behavior except bug fixes found by the tests.
+
+### Acceptance
+
+- tiny memory budgets are characterized through at least one engine open path
+- global block-cache behavior is documented as process-global
+- recovery runtime accessor visibility has an explicit comment
+
+### Phase E Current State
+
+Phase E adds the final narrow characterization coverage without changing runtime
+behavior:
+
+- primary open now characterizes `memory_budget = 1` end-to-end, proving the
+  derived block-cache capacity is explicit `0` rather than auto-detect, the
+  active write buffer is `0`, and the immutable-memtable count is `1`
+- primary, follower, and cache invalid-codec opens all reject the unknown codec
+  with stable, mode-specific errors; engine tests do not assert intermediate
+  process-global block-cache capacity because concurrent opens can overwrite it
+- `StorageRuntimeConfig::apply_global_runtime` and
+  `block_cache::set_global_capacity` document that block-cache capacity is
+  process-global, sequential updates overwrite earlier values, and concurrent
+  opens can race
+- `RecoveryRuntimeConfig::storage_runtime_config()` documents why storage
+  runtime config is exposed to open orchestration while the public
+  `StrataConfig` accessor remains private to recovery
+
+The focused Phase E tests are:
+
+```bash
+cargo test -p strata-engine --lib primary_open_characterizes_tiny_memory_budget
+cargo test -p strata-engine --lib rejects_invalid_codec
+cargo test -p strata-storage apply_global_runtime_sequential_calls_overwrite_process_global_capacity
+```
+
+## Phase F - Final Boundary Map And Closeout
+
+### Goal
+
+Refresh the docs so they describe the settled architecture, not the migration
+state.
+
+### Scope
+
+- update `engine-crate-map.md`
+- update `../storage/storage-crate-map.md`
+- update `../storage/storage-engine-ownership-audit.md` or add a successor
+  closeout note
+- update `engine-storage-boundary-normalization-plan.md` with the
+  storage-boundary normalization implementation status
+- record intentionally remaining seams
+
+### Final Boundary Map
+
+The closeout doc should explicitly classify these surfaces:
+
+| Surface | Storage Owns | Engine Owns | Intentional Seam |
+|---|---|---|---|
+| Checkpoint | File construction, raw checkpoint facts, manifest/watermark mechanics | `Database::checkpoint()`, lifecycle checks, public result/error mapping | Engine API calls storage runtime helper |
+| WAL compaction | WAL pruning and manifest active-segment mechanics | `Database::compact()`, lifecycle checks, public result/error mapping | Engine API calls storage runtime helper |
+| Snapshot pruning | Filesystem pruning and raw prune facts | lifecycle-aware retention report | Engine maps raw prune facts to public report |
+| Snapshot install | Generic decoded-row validation and install | primitive section decode, primitive install stats, recovery policy | Engine builds decoded-row plan, storage installs it |
+| Recovery bootstrap | MANIFEST prep, codec validation, replay, raw recovery facts | open policy, degraded/lossy policy, subsystem recovery, coordinator bootstrap | Engine calls storage recovery and interprets outcome |
+| Storage config | storage runtime config builder, effective storage values, store/global application | public `StrataConfig`, product profiles, config compatibility | Engine adapts public config into storage runtime config |
+| Retention | storage pruning mechanics and minimum-retain invariant | public retention policy and lifecycle behavior | Engine passes storage-shaped retention input |
+| Test observability | storage-local runtime snapshots/accessors under test gates | characterization tests | Guardrails prevent production dependence |
+
+### Deliverables
+
+1. Refreshed crate maps.
+2. Refreshed audit or closeout note.
+3. Updated main normalization plan status.
+4. A final list of accepted boundary seams and why they remain.
+
+### Acceptance
+
+- docs and code agree on the engine/storage split
+- there is no stale doc claiming engine owns moved storage mechanics
+- every remaining seam has a short justification
+- future engine consolidation work can cite this closeout as the storage
+  boundary baseline
+
+### Phase F Current State
+
+Phase F refreshes the canonical boundary docs so they describe the settled
+architecture after the storage-boundary normalization:
+
+- [engine-crate-map.md](./engine-crate-map.md) now describes engine as the
+  database orchestration and semantics layer over storage-owned mechanics
+- [../storage/storage-crate-map.md](../storage/storage-crate-map.md) now
+  describes storage as the persistence, transaction, durability, recovery, and
+  storage-runtime config substrate
+- [../storage/storage-engine-ownership-audit.md](../storage/storage-engine-ownership-audit.md)
+  is the closeout audit for the accepted seams
+- [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
+  records checkpoint/WAL, snapshot-install, recovery-bootstrap,
+  storage-runtime-config, and closeout implementation status
+
+Phase F is a documentation closeout. It does not by itself satisfy the final
+broad closeout gate below; the full workstream should not be declared complete
+until that gate is run and recorded.
+
+The closeout intentionally keeps these seams:
+
+| Surface | Storage Owns | Engine Owns | Why It Remains Split |
+|---|---|---|---|
+| Checkpoint | File construction, raw checkpoint facts, manifest/watermark mechanics | public API, lifecycle checks, public result/error mapping | Engine API over storage mechanics |
+| WAL compaction | WAL pruning and manifest active-segment mechanics | public API, lifecycle checks, public result/error mapping | Engine decides when, storage executes how |
+| Snapshot pruning | Filesystem pruning and raw facts | lifecycle-aware retention report | Storage counts files; engine reports policy |
+| Snapshot install | Generic decoded-row validation/install | primitive decode, primitive stats, recovery policy | Primitive meaning stays in engine |
+| Recovery bootstrap | MANIFEST prep, codec validation, replay, raw facts | open policy, degraded/lossy policy, subsystem recovery, coordinator bootstrap | Storage recovers state; engine decides database behavior |
+| Storage config | effective storage values and application | public config, product profiles, compatibility | Engine adapts user config into storage runtime config |
+| Retention | prune mechanics and minimum-retain invariant | public retention policy and lifecycle behavior | Storage preserves invariants; engine owns reports |
+| Test observability | storage-local accessors under gates | characterization tests and production-use guards | Tests need visibility without production dependence |
+
+Phase F does not change runtime behavior.
+
+## Test Plan
+
+Use focused tests for each boundary closeout change plus one final broad gate.
+
+Focused commands likely include:
+
+```bash
+cargo fmt --all --check
+cargo test -p strata-storage runtime_config
+cargo test -p strata-storage snapshot_retention
+cargo test -p strata-engine --lib database::tests::open::storage_runtime
+cargo test -p strata-engine --lib database::config
+cargo test -p strata-engine --lib database::tests::snapshot_retention
+git diff --check
+```
+
+Final closeout gate should include the broader program checks where the local
+environment supports them:
+
+```bash
+cargo check --workspace --all-targets
+cargo test -p strata-storage --quiet
+cargo test -p strata-engine --quiet
+cargo test -p strata-executor --quiet
+cargo test -p strata-intelligence --quiet
+cargo test -p stratadb --tests --quiet
+```
+
+If known architecture-cleanup-period failures remain outside boundary closeout
+scope, record the exact failing tests and verify they reproduce on the
+pre-closeout baseline.
+
+## Done Criteria
+
+Boundary closeout is complete when:
+
+1. The moved mechanics surfaces are guarded against boundary regression.
+2. Compatibility helpers are deleted, deprecated, or explicitly documented.
+3. Storage test observability cannot quietly become an engine production
+   dependency.
+4. Snapshot retention raw/effective behavior is explicit and tested.
+5. Small storage-runtime-config edge coverage gaps are closed or intentionally
+   deferred with rationale.
+6. The main boundary plan and crate maps describe the settled architecture.
+7. The remaining engine/storage seams are few, intentional, and documented.
+
+The end state is not "engine has no storage calls." The end state is that every
+engine-to-storage call is an explicit orchestration boundary from engine-owned
+semantics and policy into storage-owned substrate mechanics.

--- a/docs/engine/checkpoint-wal-compaction-mechanics-plan.md
+++ b/docs/engine/checkpoint-wal-compaction-mechanics-plan.md
@@ -1,8 +1,8 @@
-# ES2 Checkpoint And WAL Compaction Mechanics Plan
+# Checkpoint And WAL Compaction Mechanics Plan
 
 ## Purpose
 
-`ES2` is the first runtime-code movement epic in the engine/storage boundary
+`this cleanup` is the first runtime-code movement epic in the engine/storage boundary
 normalization workstream.
 
 Its purpose is to move generic checkpoint, WAL compaction, snapshot pruning,
@@ -12,31 +12,31 @@ database API and policy owner.
 
 This epic is split into straight lettered phases:
 
-- `ES2A` - boundary API sketch
-- `ES2B` - checkpoint and compaction characterization
-- `ES2C` - storage checkpoint runtime
-- `ES2D` - engine checkpoint wrapper
-- `ES2E` - storage WAL compaction runtime
-- `ES2F` - engine compaction wrapper
-- `ES2G` - residue cleanup and guard pass
+- `Phase A` - boundary API sketch
+- `Phase B` - checkpoint and compaction characterization
+- `Phase C` - storage checkpoint runtime
+- `Phase D` - engine checkpoint wrapper
+- `Phase E` - storage WAL compaction runtime
+- `Phase F` - engine compaction wrapper
+- `Phase G` - residue cleanup and guard pass
 
 Read this together with:
 
 - [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
-- [es1-boundary-baseline-and-guardrails-plan.md](./es1-boundary-baseline-and-guardrails-plan.md)
+- [boundary-baseline-and-guardrails-plan.md](./boundary-baseline-and-guardrails-plan.md)
 - [../storage/storage-engine-ownership-audit.md](../storage/storage-engine-ownership-audit.md)
 - [../storage/storage-charter.md](../storage/storage-charter.md)
 - [../architecture/architecture-recovery-target.md](../architecture/architecture-recovery-target.md)
 
-Before ES2C code movement starts, also write:
+Before Phase C code movement starts, also write:
 
-- [es2-es4-storage-runtime-boundary-api-sketch.md](./es2-es4-storage-runtime-boundary-api-sketch.md)
+- [storage-runtime-boundary-api-sketch.md](./storage-runtime-boundary-api-sketch.md)
 
 Checkpoint output feeds snapshot install, and snapshot install feeds recovery.
-ES2C through ES2G can move code sequentially, but ES2 should not design
-checkpoint boundary types in isolation from ES3 and ES4.
+Phase C through Phase G can move code sequentially, but this cleanup should not design
+checkpoint boundary types in isolation from snapshot-install cleanup and recovery-bootstrap cleanup.
 
-## ES2 Verdict
+## this cleanup Verdict
 
 The following should move to `strata-storage`:
 
@@ -67,16 +67,16 @@ The key rule: storage should own what to do with already-materialized
 durability DTOs. Engine should own deciding when to checkpoint, what primitive
 state goes into the DTOs, and how raw storage facts are presented to callers.
 
-ES2 intentionally includes the storage mechanics behind the shutdown
+this cleanup intentionally includes the storage mechanics behind the shutdown
 `fsync_manifest()` path because that path only needs generic MANIFEST
 load/create/active-segment/persist behavior. Engine still owns the shutdown
 barrier, final flush, freeze hooks, registry/file-lock release, and all public
-shutdown semantics. ES4 remains responsible for the broader recovery/open
+shutdown semantics. recovery-bootstrap cleanup remains responsible for the broader recovery/open
 manifest policy move.
 
 ## Current Code Map
 
-The ES2 target surface is concentrated in:
+The this cleanup target surface is concentrated in:
 
 - [database/compaction.rs](../../crates/engine/src/database/compaction.rs)
 
@@ -134,7 +134,7 @@ The current method also mixes policy with storage mechanics:
 
 ### `Database::collect_checkpoint_data`
 
-This function should not move wholesale in ES2.
+This function should not move wholesale in this cleanup.
 
 It walks `SegmentedStore`, but it also knows primitive materialization rules:
 
@@ -145,7 +145,7 @@ It walks `SegmentedStore`, but it also knows primitive materialization rules:
 - vector collection config rows are recognized by key convention
 - vector record bytes are decoded to populate vector snapshot metadata
 
-The ES2 split should assume this stays engine-owned for now. Storage should
+The this cleanup split should assume this stays engine-owned for now. Storage should
 accept `CheckpointData` as an input, not learn how to create all primitive
 sections from live engine state.
 
@@ -158,14 +158,14 @@ engine or primitive-owned adapters.
 This helper is generic storage mechanics, but it is shared with nearby engine
 open/recovery code.
 
-ES2 should avoid duplicating it. The preferred direction is to move a generic
+This cleanup should avoid duplicating it. The preferred direction is to move a generic
 manifest helper into storage as part of the checkpoint/compaction runtime. If
-that creates awkward ES4 coupling, ES2 may leave an engine wrapper temporarily,
-but the helper should have a clear owner by the ES4 recovery move.
+that creates awkward recovery-bootstrap cleanup coupling, this cleanup may leave an engine wrapper temporarily,
+but the helper should have a clear owner by the recovery-bootstrap move.
 
 ## Target Storage Surface
 
-Exact names can change during implementation, but ES2C should introduce one
+Exact names can change during implementation, but Phase C should introduce one
 storage-owned runtime module for checkpoint and WAL compaction mechanics.
 
 Candidate module:
@@ -212,7 +212,7 @@ checkpoint_data
 active_wal_segment
 ```
 
-Resolved by ES2A:
+Resolved by Phase A:
 
 - use `DatabaseLayout`, not ad-hoc `data_dir` paths
 - engine passes an already-created checkpoint codec or an equivalent codec
@@ -222,7 +222,7 @@ Resolved by ES2A:
 - active WAL segment is represented as `NonZeroU64`; segment `0` is rejected
   at the engine boundary instead of being persisted into MANIFEST
 
-Resolved by ES2D:
+Resolved by Phase D:
 
 - snapshot pruning is split out of the checkpoint outcome; storage owns the
   raw pruning helper, while engine keeps lifecycle/configuration policy and
@@ -242,7 +242,7 @@ active_wal_segment
 Engine should translate this outcome into existing database logging and public
 behavior.
 
-ES2C must preserve current missing-MANIFEST behavior unless it explicitly
+Phase C must preserve current missing-MANIFEST behavior unless it explicitly
 documents a behavior change. Today `Database::load_or_create_manifest()`
 creates a missing MANIFEST with `"identity"` in the checkpoint/compact path.
 Passing the configured codec id instead may be the right fix, but it must not
@@ -260,9 +260,9 @@ active_wal_segment
 wal_codec
 ```
 
-ES2A chose `DatabaseLayout` for this boundary.
+Phase A chose `DatabaseLayout` for this boundary.
 
-Resolved by ES2E:
+Resolved by Phase E:
 
 - `active_wal_segment` is `Option<NonZeroU64>` so storage can preserve the
   existing engine behavior exactly: `Some(segment)` updates MANIFEST and
@@ -291,7 +291,7 @@ No checkpoint exists yet. Run checkpoint() before compact().
 
 ## Engine Wrapper Shape
 
-After ES2, `Database::checkpoint()` should be thin:
+After this cleanup, `Database::checkpoint()` should be thin:
 
 ```text
 check_not_shutting_down()
@@ -305,7 +305,7 @@ log database-level outcome
 return Ok
 ```
 
-After ES2, `Database::compact()` should be thin:
+After this cleanup, `Database::compact()` should be thin:
 
 ```text
 check_not_shutting_down()
@@ -322,37 +322,37 @@ of the public database API and carry lifecycle semantics.
 
 ## Implementation Plan
 
-ES2 should land as straight lettered phases unless the code review finds a
+This cleanup should land as straight lettered phases unless the code review finds a
 smaller split is needed:
 
-- `ES2A` writes the joint ES2-ES4 API sketch.
-- `ES2B` locks characterization coverage for checkpoint and WAL compaction
+- `Phase A` writes storage-runtime boundary API sketch.
+- `Phase B` locks characterization coverage for checkpoint and WAL compaction
   behavior.
-- `ES2C` moves generic checkpoint mechanics into storage.
-- `ES2D` thins the engine checkpoint wrapper.
-- `ES2E` moves generic WAL compaction mechanics into storage.
-- `ES2F` thins the engine compaction wrapper.
-- `ES2G` cleans residue and reruns ownership guards.
+- `Phase C` moves generic checkpoint mechanics into storage.
+- `Phase D` thins the engine checkpoint wrapper.
+- `Phase E` moves generic WAL compaction mechanics into storage.
+- `Phase F` thins the engine compaction wrapper.
+- `Phase G` cleans residue and reruns ownership guards.
 
-### ES2A Boundary Sketch
+### Phase A Boundary Sketch
 
-Write [es2-es4-storage-runtime-boundary-api-sketch.md](./es2-es4-storage-runtime-boundary-api-sketch.md)
+Write [storage-runtime-boundary-api-sketch.md](./storage-runtime-boundary-api-sketch.md)
 before moving code.
 
 The sketch should define the relationship between:
 
 - `StorageCheckpointOutcome`
-- snapshot install stats from ES3
-- `StorageRecoveryOutcome` from ES4
+- snapshot install stats from snapshot-install cleanup
+- `StorageRecoveryOutcome` from recovery-bootstrap cleanup
 
 It should also decide whether common storage layout and manifest helpers are
-introduced now or deferred to ES4.
+introduced now or deferred to recovery-bootstrap cleanup.
 
-### ES2B Characterization Before Movement
+### Phase B Characterization Before Movement
 
 Add or identify tests that characterize current behavior before refactoring.
 
-Minimum ES2B coverage:
+Minimum Phase B coverage:
 
 - checkpoint creates a snapshot and updates the MANIFEST watermark
 - repeated checkpoint of unchanged state is deterministic where current
@@ -373,10 +373,10 @@ Prefer existing engine integration tests where the behavior crosses public
 database APIs. Add storage-layer tests only where the new storage helper can
 be tested without primitive semantics.
 
-ES2B is complete when the characterization suite is green against the pre-move
+Phase B is complete when the characterization suite is green against the pre-move
 engine implementation.
 
-### ES2C Add Storage Checkpoint Runtime
+### Phase C Add Storage Checkpoint Runtime
 
 Create the storage module and move generic checkpoint mechanics behind a
 storage-owned function.
@@ -399,7 +399,7 @@ If snapshot pruning currently depends on engine config types, split the raw
 storage pruning helper from the engine config adapter rather than moving
 engine config into storage.
 
-### ES2D Thin Engine Checkpoint Wrapper
+### Phase D Thin Engine Checkpoint Wrapper
 
 Update `Database::checkpoint()` to call the storage checkpoint runtime.
 
@@ -415,7 +415,7 @@ Keep in engine:
 
 Do not move `collect_checkpoint_data()` in this step.
 
-### ES2E Add Storage WAL Compaction Runtime
+### Phase E Add Storage WAL Compaction Runtime
 
 Move generic WAL compaction construction and execution behind a storage-owned
 function.
@@ -428,7 +428,7 @@ The storage helper should:
 - compact with active segment override
 - return raw removed segment and reclaimed byte counts
 
-### ES2F Thin Engine Compaction Wrapper
+### Phase F Thin Engine Compaction Wrapper
 
 Update `Database::compact()` to call the storage WAL compaction runtime.
 
@@ -440,7 +440,7 @@ Keep in engine:
 - public mapping of no-checkpoint compaction to invalid input
 - database-level logging
 
-### ES2G Clean Residue And Re-run Guards
+### Phase G Clean Residue And Re-run Guards
 
 After the code movement, remove engine imports that should no longer be
 needed:
@@ -453,7 +453,7 @@ needed:
 - `WalOnlyCompactor`
 - `SnapshotWatermark`
 
-ES2G also routes remaining generic MANIFEST mechanics through storage-owned
+Phase G also routes remaining generic MANIFEST mechanics through storage-owned
 helpers where doing so does not move engine policy:
 
 - disk-primary shutdown MANIFEST fsync uses `sync_storage_manifest`, while
@@ -461,7 +461,7 @@ helpers where doing so does not move engine policy:
 - flush-time WAL truncation uses `truncate_storage_wal_after_flush`, while
   engine still decides that the post-flush truncation is best-effort
 
-Then run the guard commands from ES1 and record any intentional remaining
+Then run the guard commands from boundary baseline and record any intentional remaining
 matches.
 
 ## Error Mapping
@@ -495,9 +495,9 @@ storage terms:
 
 Engine owns the public configuration vocabulary and any product defaults.
 
-If the current pruning path is too entangled with `StrataConfig`, ES2 should
-move the filesystem pruning helper and leave engine as the adapter from public
-config to storage pruning options. The direction should still be toward
+If the current pruning path is too entangled with `StrataConfig`, this cleanup
+should move the filesystem pruning helper and leave engine as the adapter from
+public config to storage pruning options. The direction should still be toward
 storage owning the pruning mechanics.
 
 ## Manifest Ownership
@@ -505,8 +505,8 @@ storage owning the pruning mechanics.
 MANIFEST mechanics are shared by checkpoint, compaction, snapshot install, and
 recovery.
 
-ES2C should introduce only the manifest helpers needed for checkpoint and WAL
-compaction, but the shape should anticipate ES4:
+Phase C should introduce only the manifest helpers needed for checkpoint and WAL
+compaction, but the shape should anticipate recovery-bootstrap cleanup:
 
 - load existing MANIFEST
 - create missing MANIFEST with database UUID and codec information
@@ -516,7 +516,7 @@ compaction, but the shape should anticipate ES4:
 
 The helper should not decide primary/follower recovery policy or shutdown
 success semantics. Those belong to engine now; the recovery/open policy move
-belongs to ES4.
+belongs to recovery-bootstrap cleanup.
 
 ## Verification Gates
 
@@ -544,17 +544,17 @@ rg -n 'JsonPath|JsonPatch|SearchSubsystem|Recipe|VectorConfig|DistanceMetric|Cha
 rg -n 'CheckpointCoordinator|WalOnlyCompactor|ManifestManager|RecoveryCoordinator|SnapshotSerializer|install_snapshot|apply_storage_config' crates/engine/src/database
 ```
 
-Expected ES2G direction:
+Expected Phase G direction:
 
 - no new `storage -> engine` dependency
 - no primitive semantic vocabulary in the new storage checkpoint module
 - checkpoint and WAL compaction coordinator usage disappears from engine
   wrappers or remains only in tests/comments
-- recovery and snapshot install residue remains until ES3/ES4
+- recovery and snapshot install residue remains until snapshot-install cleanup/recovery-bootstrap cleanup
 
-## ES2G Guard Results
+## Phase G Guard Results
 
-Recorded after the ES2G cleanup:
+Recorded after the Phase G cleanup:
 
 - `cargo tree -p strata-storage --depth 2`: clean. `strata-storage`
   depends on `strata-core` and external crates, not `strata-engine`.
@@ -570,9 +570,9 @@ Recorded after the ES2G cleanup:
     `compaction.rs` is public error mapping for storage-owned checkpoint
     runtime; engine no longer constructs the checkpoint coordinator there.
   - `snapshot_install.rs` keeps `SnapshotSerializer` and `install_snapshot`
-    until ES3.
+    until snapshot-install cleanup.
   - `recovery.rs` keeps `RecoveryCoordinator`, `ManifestManager`, and
-    snapshot install callbacks until ES4.
+    snapshot install callbacks until recovery-bootstrap cleanup.
   - `open.rs` and `mod.rs` keep `apply_storage_config` as engine-owned
     configuration policy.
   - `recovery_error.rs` has documentation text for recovery-owned
@@ -582,53 +582,53 @@ Recorded after the ES2G cleanup:
   - test matches use `ManifestManager` for assertions, corrupt fixture setup,
     shutdown coverage, and characterization.
 
-ES2G also removes the stale disk-backed cache mode from primary opens:
+Phase G also removes the stale disk-backed cache mode from primary opens:
 `durability = "cache"` is rejected by `StrataConfig`. Cache remains an
 explicit open mode through `Database::cache()` and `OpenSpec::cache()`.
 
 ## Acceptance Checklist
 
-ES2A is complete when:
+Phase A is complete when:
 
-1. The ES2-ES4 joint API sketch exists.
-2. The sketch's own ES2A acceptance checklist is satisfied.
+1. The storage-runtime boundary joint API sketch exists.
+2. The sketch's own Phase A acceptance checklist is satisfied.
 
-ES2B is complete when:
+Phase B is complete when:
 
 1. Checkpoint characterization exists before behavior-preserving movement.
 2. WAL compaction characterization exists before behavior-preserving
    movement.
 
-ES2C is complete when:
+Phase C is complete when:
 
 1. Storage owns generic checkpoint runtime around `CheckpointCoordinator`.
 
-ES2D is complete when:
+Phase D is complete when:
 
 1. Engine `Database::checkpoint()` remains public and thin.
 2. `collect_checkpoint_data()` remains engine-owned or is split through a
    primitive-materialization callback that keeps semantics out of storage.
 
-ES2E is complete when:
+Phase E is complete when:
 
 1. Storage owns generic WAL compaction runtime around `WalOnlyCompactor`.
 
-ES2F is complete when:
+Phase F is complete when:
 
 1. Engine `Database::compact()` remains public and thin.
 2. Existing checkpoint, compaction, and reopen behavior is unchanged.
 3. Storage APIs expose raw facts and storage-local errors only.
 4. No on-disk format changes are introduced.
 
-ES2G is complete when:
+Phase G is complete when:
 
-1. ES1 guard commands have been rerun and intentional residue is recorded.
+1. boundary baseline guard commands have been rerun and intentional residue is recorded.
 
-ES2 as a whole is complete when ES2A through ES2G are complete.
+this cleanup as a whole is complete when Phase A through Phase G are complete.
 
 ## Non-Goals
 
-ES2 does not:
+this cleanup does not:
 
 - move snapshot install machinery
 - move recovery bootstrap machinery

--- a/docs/engine/engine-crate-map.md
+++ b/docs/engine/engine-crate-map.md
@@ -2,10 +2,11 @@
 
 ## Purpose
 
-This document is a baseline map of `crates/engine` as it exists today.
+This document maps `crates/engine` after the storage-boundary normalization.
 
-It is not a target design. It is a description of current ownership and
-behavior, written to support the next serious engine/storage boundary cleanup.
+It describes the settled engine responsibilities at the storage boundary and
+the remaining higher-layer consolidation work that will happen above that
+boundary.
 
 For the broader engine cleanup ledger, see
 [engine-pending-items.md](./engine-pending-items.md).
@@ -13,16 +14,16 @@ For the broader engine cleanup ledger, see
 For the cross-boundary audit with storage, see
 [../storage/storage-engine-ownership-audit.md](../storage/storage-engine-ownership-audit.md).
 
-The important takeaway is that `strata-engine` is not just a database-kernel
-crate. It is currently:
+The important takeaway is that `strata-engine` is the database semantics and
+orchestration layer. It is currently:
 
 - the database open/runtime/bootstrap layer
 - the branch-domain and primitive-semantics owner
 - the subsystem composition host
 - the search/runtime behavior host
 - the branch-bundle import/export host
-- and, in a smaller set of remaining places, the adapter layer that turns raw
-  storage facts into engine policy and public database behavior
+- the adapter layer that turns raw storage facts into engine policy and public
+  database behavior
 
 ## High-Level Shape
 
@@ -40,7 +41,7 @@ Top-level source files:
 Major subtrees:
 
 - `database/` — database open/close/runtime orchestration, recovery, config,
-  follower handling, retention reporting, and compatibility seams
+  follower handling, retention reporting, and storage-boundary adapters
 - `primitives/` — KV/JSON/event/space behavior and primitive extension traits
 - `semantics/` — branch/limits/event/json/vector/value surfaces used as the
   authoritative engine-side import boundary
@@ -209,17 +210,19 @@ machinery.
 
 ## Storage-Boundary Adapters Engine Still Owns
 
-The ES2-ES4 cleanup moved the generic checkpoint, decoded-row snapshot
-install, and recovery bootstrap mechanics into `strata-storage`. Engine still
-contains adapter modules at those boundaries because the public APIs,
-primitive decode, lifecycle policy, and public error taxonomy remain
+The storage-boundary cleanup moved generic checkpoint, WAL compaction, decoded-row
+snapshot install, recovery bootstrap, storage runtime config application, and
+storage retention mechanics into `strata-storage`. Engine still contains
+adapter modules at those boundaries because the public APIs, primitive decode,
+lifecycle policy, product config, and public error taxonomy remain
 engine-owned.
 
 The remaining storage-boundary modules are:
 
 - [database/compaction.rs](../../crates/engine/src/database/compaction.rs)
   - public `Database::checkpoint()` / `Database::compact()` orchestration
-  - conversion of storage checkpoint and retention facts into engine reports
+  - conversion of storage checkpoint, compaction, snapshot-prune, and
+    retention facts into engine reports
   - lifecycle-aware shutdown and retention policy around storage mechanics
 - [database/snapshot_install.rs](../../crates/engine/src/database/snapshot_install.rs)
   - primitive snapshot section decode
@@ -234,12 +237,29 @@ The remaining storage-boundary modules are:
 - parts of [database/open.rs](../../crates/engine/src/database/open.rs)
   - public open/lifecycle sequencing
   - WAL-writer wiring
+  - deriving storage runtime config from public engine config before calling
+    storage-owned application helpers
+- [database/config.rs](../../crates/engine/src/database/config.rs)
+  - public `StrataConfig` and `StorageConfig` compatibility surface
+  - adapter logic that builds storage-owned `StorageRuntimeConfig`
 
 The lower storage mechanics behind these adapters now live in storage-owned
 modules such as `durability/checkpoint_runtime.rs`,
 `durability/decoded_snapshot_install.rs`, and
-`durability/recovery_bootstrap.rs`. ES5 is expected to narrow the remaining
-storage-configuration and WAL-writer runtime seams.
+`durability/recovery_bootstrap.rs`, plus `runtime_config.rs`.
+
+## Final Storage Boundary Map
+
+| Surface | Storage Owns | Engine Owns | Intentional Seam |
+|---|---|---|---|
+| Checkpoint | File construction, raw checkpoint facts, manifest/watermark mechanics | `Database::checkpoint()`, lifecycle checks, public result/error mapping | Engine API calls storage runtime helper |
+| WAL compaction | WAL pruning and manifest active-segment mechanics | `Database::compact()`, lifecycle checks, public result/error mapping | Engine API calls storage runtime helper |
+| Snapshot pruning | Filesystem pruning and raw prune facts | lifecycle-aware retention report | Engine maps raw prune facts to public report |
+| Snapshot install | Generic decoded-row validation and install | primitive section decode, primitive install stats, recovery policy | Engine builds decoded-row plan, storage installs it |
+| Recovery bootstrap | MANIFEST prep, codec validation, replay, raw recovery facts | open policy, degraded/lossy policy, subsystem recovery, coordinator bootstrap | Engine calls storage recovery and interprets outcome |
+| Storage config | storage runtime config builder, effective storage values, store/global application | public `StrataConfig`, product profiles, config compatibility | Engine adapts public config into storage runtime config |
+| Retention | storage pruning mechanics and minimum-retain invariant | public retention policy and lifecycle behavior | Engine passes storage-shaped retention input |
+| Test observability | storage-local runtime snapshots/accessors under test gates | characterization tests and production-use guardrails | Guardrails prevent production dependence |
 
 ## Current Architectural Role
 
@@ -254,14 +274,18 @@ If you describe the crate honestly as it exists today, `strata-engine` is:
 
 ## Main Takeaway
 
-The next cleanup should not treat current engine boundaries as already clean.
+The next cleanup should treat the storage boundary as settled but keep
+engine's internal domain/runtime boundaries explicit.
 
 The important ownership question is not whether engine is too large. It is
 whether code in the crate is:
 
 - semantic/domain behavior that should stay in `engine`, or
-- generic persistence/runtime machinery that should move to `storage`
+- generic persistence/runtime machinery that should stay delegated to
+  `storage`
 
-After ES2-ES4, the semantic side of engine is real and the most critical
-durability mechanics have sunk into storage. The remaining cleanup is to keep
-the adapter code explicit while ES5 finishes the storage-configuration split.
+After the storage-boundary closeout, the semantic side of engine is real and
+the targeted lower storage mechanics have sunk into storage. The remaining cleanup is above this
+boundary: engine can absorb graph, vector, search, executor-legacy, and
+security responsibilities only if the substrate/mechanics boundary documented
+here stays explicit.

--- a/docs/engine/engine-storage-boundary-normalization-plan.md
+++ b/docs/engine/engine-storage-boundary-normalization-plan.md
@@ -5,11 +5,12 @@
 This document turns the storage/engine ownership audit into a concrete
 normalization plan.
 
-The storage consolidation work has already collapsed the old lower-runtime
-split into `strata-storage`. That solved the most visible crate graph problem,
-but it did not fully normalize the boundary above the substrate. Some
-storage-runtime mechanics still live under `strata-engine`, especially around
-database recovery, checkpointing, snapshot install, and storage configuration.
+When this plan started, the storage consolidation work had already collapsed
+the old lower-runtime split into `strata-storage`. That solved the most visible
+crate graph problem, but it had not fully normalized the boundary above the
+substrate. Some storage-runtime mechanics still lived under `strata-engine`,
+especially around database recovery, checkpointing, snapshot install, and
+storage configuration.
 
 The goal of this plan is to finish the ownership correction without flattening
 the architecture:
@@ -33,8 +34,8 @@ At the end of this plan:
 - engine should expose checkpoint, compact, open, recovery, and health APIs
   as database/runtime operations
 - storage should physically own the substrate mechanics behind checkpointing,
-  WAL compaction, snapshot replay/install, manifest preparation, and
-  storage-only config application
+  WAL compaction, generic decoded-row snapshot install, manifest preparation,
+  storage recovery, and storage-only config application
 - engine should be easier to describe as semantic/runtime orchestration rather
   than a mixed host for lower persistence machinery
 
@@ -49,7 +50,7 @@ This plan should be read together with:
 - [../storage/storage-minimal-surface-implementation-plan.md](../storage/storage-minimal-surface-implementation-plan.md)
 - [../storage/st2-primitive-transaction-semantics-extraction-plan.md](../storage/st2-primitive-transaction-semantics-extraction-plan.md)
 - [../storage/st3-generic-transaction-runtime-absorption-plan.md](../storage/st3-generic-transaction-runtime-absorption-plan.md)
-- [../architecture/architecture-recovery-target.md](../architecture/architecture-recovery-target.md)
+- [storage-runtime-boundary-api-sketch.md](./storage-runtime-boundary-api-sketch.md)
 
 ## Rewrite Rules
 
@@ -67,7 +68,8 @@ runtime.
 ### 2. No Primitive Semantics In `storage`
 
 Storage may own durable bytes, versioned records, generic transaction
-runtime, WAL/snapshot replay mechanics, and manifest updates.
+runtime, WAL replay mechanics, generic decoded-row snapshot install mechanics,
+and manifest updates.
 
 Storage must not own:
 
@@ -180,7 +182,7 @@ true:
    - WAL compaction
    - snapshot pruning
    - storage manifest/watermark updates
-   - snapshot decode/replay/install machinery
+   - generic decoded-row snapshot install machinery
    - storage recovery bootstrap
    - storage-only config application
 3. Engine physically owns:
@@ -205,7 +207,8 @@ The following decisions are not deferred:
 - `Database::checkpoint()` remains in engine as public API.
 - `Database::compact()` remains in engine as public API.
 - database open and runtime composition remain in engine.
-- storage owns checkpoint/WAL/snapshot/MANIFEST mechanics.
+- storage owns checkpoint/WAL/MANIFEST mechanics, snapshot file mechanics, and
+  generic decoded-row snapshot install.
 - storage owns storage recovery and replay mechanics.
 - engine owns recovery policy, public error classification, and operator
   reporting.
@@ -216,22 +219,22 @@ The following decisions are not deferred:
 - JSON/event/vector/search semantics do not move down.
 - branch bundle import/export stays in engine.
 
-## Epic Structure
+## Cleanup Structure
 
-This plan is organized as six epics. The list below is the intended
+This plan is organized as six cleanup areas. The list below is the intended
 execution order.
 
-- `ES1` - Boundary Baseline And Guardrails
-- `ES2` - Checkpoint And WAL Compaction Mechanics
-- `ES3` - Snapshot Decode And Install Mechanics
-- `ES4` - Recovery Bootstrap Mechanics
-- `ES5` - Storage Configuration Application
-- `ES6` - Boundary Closeout, Engine Shape, And Documentation
+- Boundary Baseline And Guardrails
+- Checkpoint And WAL Compaction Mechanics
+- Snapshot Decode And Install Mechanics
+- Recovery Bootstrap Mechanics
+- Storage Configuration Application
+- Boundary Closeout, Engine Shape, And Documentation
 
-Each epic may get its own detailed subplan as the cleanup reaches that
+Each area may get its own detailed subplan as the cleanup reaches that
 surface. This document defines the main sequence and ownership contract.
 
-## ES1 - Boundary Baseline And Guardrails
+## Boundary Baseline And Guardrails
 
 ### Goal
 
@@ -239,7 +242,7 @@ Freeze the intended storage/engine boundary before moving runtime mechanics.
 
 Detailed execution plan:
 
-- [es1-boundary-baseline-and-guardrails-plan.md](./es1-boundary-baseline-and-guardrails-plan.md)
+- [boundary-baseline-and-guardrails-plan.md](./boundary-baseline-and-guardrails-plan.md)
 
 ### Scope
 
@@ -282,36 +285,37 @@ Detailed execution plan:
 - no recovery migration yet
 - no public API redesign
 
-## ES2 - Checkpoint And WAL Compaction Mechanics
+## Checkpoint And WAL Compaction Mechanics
 
 ### Goal
 
 Move generic checkpoint, WAL compaction, snapshot pruning, and storage
 manifest update mechanics from engine into storage.
 
-Potential detailed execution plan:
+Detailed execution plan:
 
-- [es2-checkpoint-wal-compaction-mechanics-plan.md](./es2-checkpoint-wal-compaction-mechanics-plan.md)
+- [checkpoint-wal-compaction-mechanics-plan.md](./checkpoint-wal-compaction-mechanics-plan.md)
 
 Prerequisite design sketch:
 
-- [es2-es4-storage-runtime-boundary-api-sketch.md](./es2-es4-storage-runtime-boundary-api-sketch.md)
+- [storage-runtime-boundary-api-sketch.md](./storage-runtime-boundary-api-sketch.md)
 
-ES2 is split into straight lettered phases:
+The checkpoint/WAL cleanup is split into straight lettered phases:
 
-- `ES2A` - boundary API sketch
-- `ES2B` - checkpoint and compaction characterization
-- `ES2C` - storage checkpoint runtime
-- `ES2D` - engine checkpoint wrapper
-- `ES2E` - storage WAL compaction runtime
-- `ES2F` - engine compaction wrapper
-- `ES2G` - residue cleanup and guard pass
+- Phase A - boundary API sketch
+- Phase B - checkpoint and compaction characterization
+- Phase C - storage checkpoint runtime
+- Phase D - engine checkpoint wrapper
+- Phase E - storage WAL compaction runtime
+- Phase F - engine compaction wrapper
+- Phase G - residue cleanup and guard pass
 
-`ES2`, `ES3`, and `ES4` are sequential code moves, but they are not
-independent designs. Checkpoint output feeds snapshot install, and snapshot
-install feeds recovery. Before ES2C code moves, write a joint API sketch for
-the checkpoint, snapshot install, and recovery boundary types so ES2 does not
-choose a storage API shape that ES3 or ES4 immediately has to undo.
+The checkpoint/WAL, snapshot-install, and recovery-bootstrap cleanups are
+sequential code moves, but they are not independent designs. Checkpoint output
+feeds snapshot install, and snapshot install feeds recovery. Before Phase C code
+moves, write a joint API sketch for the checkpoint, snapshot install, and
+recovery boundary types so this cleanup does not choose a storage API shape that
+the later snapshot-install or recovery-bootstrap work immediately has to undo.
 
 ### Scope
 
@@ -360,10 +364,27 @@ Keep in engine:
 
 - no full recovery bootstrap migration
 - no snapshot install migration unless required as a narrow helper agreed in
-  the joint ES2-ES4 API sketch
+  storage-runtime boundary API sketch
 - no config split yet
 
-## ES3 - Snapshot Decode And Install Mechanics
+### Implementation Status
+
+The checkpoint/WAL cleanup is complete. Storage owns the generic checkpoint, WAL compaction,
+snapshot-prune, MANIFEST sync, and flush-time WAL truncation mechanics through
+the storage-owned
+[checkpoint_runtime.rs](../../crates/storage/src/durability/checkpoint_runtime.rs)
+module, re-exported through public durability helpers such as
+`run_storage_checkpoint`, `compact_storage_wal`, `prune_storage_snapshots`,
+`sync_storage_manifest`, and flush-time WAL truncation support. Engine keeps
+`Database::checkpoint()`, `Database::compact()`, shutdown sequencing,
+flush-policy decisions, lifecycle checks, and public error/result mapping.
+
+The intentional seam is that engine passes already materialized checkpoint
+facts and public-operation context into storage helpers. Storage returns raw
+checkpoint, compaction, prune, and manifest facts; engine turns those facts
+into public database behavior.
+
+## Snapshot Decode And Install Mechanics
 
 ### Goal
 
@@ -372,9 +393,9 @@ storage. Engine keeps `LoadedSnapshot` section dispatch and primitive snapshot
 DTO decode. Storage owns only the generic mechanics for installing already
 decoded storage rows into `SegmentedStore`.
 
-Potential detailed execution plan:
+Detailed execution plan:
 
-- `docs/engine/es3-snapshot-decode-install-mechanics-plan.md`
+- [snapshot-decode-install-mechanics-plan.md](./snapshot-decode-install-mechanics-plan.md)
 
 ### Scope
 
@@ -432,7 +453,20 @@ Keep in engine:
 - no public recovery API redesign
 - no search/index recovery redesign
 
-## ES4 - Recovery Bootstrap Mechanics
+### Implementation Status
+
+snapshot-install cleanup is complete. Storage owns only generic decoded-row validation and install
+through `strata_storage::durability::install_decoded_snapshot_rows`. Engine
+keeps `LoadedSnapshot` section iteration, primitive tag dispatch,
+`SnapshotSerializer` primitive DTO decode, primitive-shaped install telemetry,
+snapshot-install recovery policy, and public error mapping.
+
+The snapshot-install correction explicitly rejected moving primitive snapshot decode into
+storage. Engine builds a complete decoded-row plan before storage mutation;
+storage validates and installs rows without knowing JSON, event, vector,
+search, or branch-domain meaning.
+
+## Recovery Bootstrap Mechanics
 
 ### Goal
 
@@ -441,27 +475,29 @@ into storage, while keeping database-level recovery policy in engine.
 
 Detailed execution plan:
 
-- `docs/engine/es4-recovery-bootstrap-mechanics-plan.md`
+- [recovery-bootstrap-mechanics-plan.md](./recovery-bootstrap-mechanics-plan.md)
 
-ES2A baseline decision:
+Storage runtime boundary sketch baseline decision:
 
-- `TransactionCoordinator` stays engine-owned during ES4.
+- `TransactionCoordinator` stays engine-owned during recovery bootstrap.
 
 This is load-bearing. Storage should own recovery replay mechanics and return
 raw `RecoveryStats` / `RecoveredState` facts. Engine should bootstrap
 `TransactionCoordinator` from those facts after storage recovery returns. If
 later work wants to move coordinator ownership, that needs a separate
-coordinator ownership plan, not an incidental ES4 side effect.
+coordinator ownership plan, not an incidental recovery-bootstrap side effect.
 
-ES4 must also preserve two current recovery ordering guarantees:
+Recovery bootstrap must also preserve two current recovery ordering guarantees:
 
 - snapshot-installed versions are folded into `RecoveryStats::final_version`
   before `TransactionCoordinator` bootstrap
 - storage runtime config is applied before `recover_segments()` runs
 
-Until ES5 completes the public config split, engine may build a
-storage-owned runtime config from `StrataConfig.storage` and pass it into the
-ES4 storage recovery API.
+During the recovery-bootstrap cleanup, before the storage-runtime-config cleanup
+completed the public config split, engine built a storage-owned runtime config
+from `StrataConfig.storage` and passed it into the storage recovery API. The
+storage-runtime-config cleanup later made that adapter the standard open/config
+path.
 
 ### Scope
 
@@ -509,7 +545,7 @@ Keep in engine:
 
 ### Implementation Status
 
-ES4 now routes `Database::run_recovery()` through
+The recovery-bootstrap cleanup now routes `Database::run_recovery()` through
 `strata_storage::durability::run_storage_recovery`. Storage owns MANIFEST and
 codec preparation, `RecoveryCoordinator` replay, generic WAL record
 application, mechanical lossy WAL replay fallback, storage runtime config
@@ -520,9 +556,10 @@ Engine still owns the primitive snapshot-install callback, public
 `LossyRecoveryReport`, `TransactionCoordinator` bootstrap, follower-state
 restore, and watermark construction.
 
-The one intentional correctness tightening found during ES4 is documented in
-the ES4 behavior-change ledger: primitive snapshot install callback failures
-now bypass lossy WAL replay instead of allowing an empty lossy open.
+The one intentional correctness tightening found during recovery bootstrap is
+documented in the recovery-bootstrap behavior-change ledger: primitive snapshot
+install callback failures now bypass lossy WAL replay instead of allowing an
+empty lossy open.
 
 ### Non-Goals
 
@@ -530,7 +567,7 @@ now bypass lossy WAL replay instead of allowing an empty lossy open.
 - no branch-domain recovery policy migration into storage
 - no operator report redesign beyond necessary translation updates
 
-## ES5 - Storage Configuration Application
+## Storage Configuration Application
 
 ### Goal
 
@@ -539,7 +576,7 @@ application.
 
 Detailed execution plan:
 
-- `docs/engine/es5-storage-config-application-plan.md`
+- [storage-config-application-plan.md](./storage-config-application-plan.md)
 
 ### Scope
 
@@ -552,9 +589,10 @@ Move downward into storage where storage-only:
 - validation of storage-local config combinations
 - conversion into lower runtime structs
 
-ES4 may introduce the first storage-owned runtime config needed to preserve
-recovery ordering. ES5 completes that split across all open paths and removes
-the remaining engine-side hand-written storage setter application.
+Recovery bootstrap introduced the first storage-owned runtime config needed to
+preserve recovery ordering. The storage-runtime-config cleanup completed that
+split across all open paths and removed the remaining engine-side hand-written
+storage setter application.
 
 Keep in engine:
 
@@ -592,13 +630,31 @@ Keep in engine:
 - no new config format unless explicitly required
 - no executor command redesign
 
-## ES6 - Boundary Closeout, Engine Shape, And Documentation
+### Implementation Status
+
+The storage-runtime-config cleanup is complete. Storage owns `StorageRuntimeConfig`,
+`StorageBlockCacheConfig`, effective storage-value derivation, store-local
+application to `SegmentedStore`, and process-global block-cache capacity
+application. Engine owns public `StrataConfig` / `StorageConfig`, product and
+hardware profiles, compatibility behavior, open policy, and the adapter from
+public config into storage runtime config.
+
+The old engine-side `apply_storage_config` helper and hand-written store
+setter list are gone. Public `StorageConfig::effective_*` methods remain as
+compatibility wrappers, but production engine storage setup uses
+`StorageRuntimeConfig`.
+
+## Boundary Closeout, Engine Shape, And Documentation
 
 ### Goal
 
 Close the normalization workstream, make the new boundary enforceable, and
 document engine's remaining responsibilities explicitly after lower mechanics
 move down.
+
+Detailed execution plan:
+
+- [boundary-closeout-plan.md](./boundary-closeout-plan.md)
 
 ### Scope
 
@@ -613,8 +669,8 @@ move down.
   - primitive semantics
   - branch/domain workflow
   - search/runtime behavior
-- reduce executor-owned workflow where engine should own runtime/product
-  behavior
+- record executor-owned workflow cleanup as future engine-consolidation work
+  where it would otherwise blur runtime/product ownership
 - keep storage-facing adapters narrow and explicit
 
 ### Deliverables
@@ -629,8 +685,8 @@ move down.
    - storage mechanics regressing into engine
    - direct upper-layer bypasses of engine runtime policy
 4. A final list of accepted split surfaces and why they remain split.
-5. Follow-up issues or plans for executor-owned workflows that should move
-   into engine.
+5. Follow-up notes for executor-owned workflows that may need to move into
+   engine during the later engine-consolidation phase.
 6. No reintroduction of lower-runtime mechanics into engine.
 
 ### Constraints
@@ -650,8 +706,8 @@ move down.
 - remaining cross-boundary calls are explicit and justified
 - engine can be described as orchestration and semantics, not storage
   mechanics
-- executor remains a command boundary rather than a workflow host where
-  practical
+- executor workflow cleanup is recorded as future engine-consolidation work
+  rather than treated as a storage-boundary deliverable
 - docs and code structure agree on the main engine pillars
 
 ### Non-Goals
@@ -660,6 +716,27 @@ move down.
 - no CLI presentation changes
 - no broad search redesign unless separately planned
 - no unrelated executor/CLI cleanup
+
+### Implementation Status
+
+The final documentation pass completes the closeout for the storage boundary. The full
+workstream is not complete until the final broad regression gate below is run
+and recorded. The closeout keeps the remaining seams explicit rather than
+trying to remove every engine call into storage.
+
+The accepted post-boundary closeout shape is:
+
+- storage owns generic mechanics and raw substrate facts
+- engine owns public database APIs, lifecycle/open policy, primitive and
+  branch semantics, product config, and public error/report conversion
+- storage test-observability helpers remain behind test/fault-injection gates
+  and are guarded against production engine dependence
+- block-cache capacity remains process-global storage runtime state:
+  sequential applications overwrite earlier values, while concurrent opens
+  race with no deterministic winner
+- direct upper-crate storage dependencies are current transitional workspace
+  shape and must not bypass engine for checkpoint, recovery, open, retention,
+  or database policy
 
 ## Program Verification Gates
 
@@ -717,7 +794,8 @@ Characterization gates should include, before the relevant epic changes code:
 This plan is not complete until all of the following are true at once:
 
 1. `strata-storage` owns generic persistence, transaction, durability,
-   checkpoint, snapshot, recovery, and storage-config mechanics.
+   checkpoint, snapshot file, generic decoded-row snapshot install, recovery,
+   and storage-config mechanics.
 2. `strata-engine` owns database orchestration, public APIs, primitive
    semantics, branch semantics, search/runtime behavior, and product policy.
 3. Engine database modules no longer host low-level storage recovery,

--- a/docs/engine/recovery-bootstrap-mechanics-plan.md
+++ b/docs/engine/recovery-bootstrap-mechanics-plan.md
@@ -1,14 +1,14 @@
-# ES4 Recovery Bootstrap Mechanics Plan
+# Recovery Bootstrap Mechanics Plan
 
 ## Purpose
 
-`ES4` is the recovery-bootstrap epic in the engine/storage boundary
+`recovery-bootstrap cleanup` is the recovery-bootstrap epic in the engine/storage boundary
 normalization workstream.
 
-`ES2` moved checkpoint, WAL compaction, snapshot pruning, and generic MANIFEST
-sync mechanics toward storage. `ES3` moved only generic decoded-row snapshot
+`checkpoint/WAL cleanup` moved checkpoint, WAL compaction, snapshot pruning, and generic MANIFEST
+sync mechanics toward storage. `snapshot-install cleanup` moved only generic decoded-row snapshot
 install mechanics into storage while keeping primitive snapshot decode in
-engine. `ES4` completes the next link in that chain: recovery should use
+engine. `recovery-bootstrap cleanup` completes the next link in that chain: recovery should use
 storage-owned mechanics for MANIFEST preparation, WAL replay, snapshot install
 callback wiring, lossy WAL replay mechanics, storage runtime config
 application, and segment recovery.
@@ -21,10 +21,10 @@ bootstrap.
 Read this together with:
 
 - [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
-- [es1-boundary-baseline-and-guardrails-plan.md](./es1-boundary-baseline-and-guardrails-plan.md)
-- [es2-es4-storage-runtime-boundary-api-sketch.md](./es2-es4-storage-runtime-boundary-api-sketch.md)
-- [es2-checkpoint-wal-compaction-mechanics-plan.md](./es2-checkpoint-wal-compaction-mechanics-plan.md)
-- [es3-snapshot-decode-install-mechanics-plan.md](./es3-snapshot-decode-install-mechanics-plan.md)
+- [boundary-baseline-and-guardrails-plan.md](./boundary-baseline-and-guardrails-plan.md)
+- [storage-runtime-boundary-api-sketch.md](./storage-runtime-boundary-api-sketch.md)
+- [checkpoint-wal-compaction-mechanics-plan.md](./checkpoint-wal-compaction-mechanics-plan.md)
+- [snapshot-decode-install-mechanics-plan.md](./snapshot-decode-install-mechanics-plan.md)
 - [../storage/storage-engine-ownership-audit.md](../storage/storage-engine-ownership-audit.md)
 - [../storage/storage-charter.md](../storage/storage-charter.md)
 - [../architecture/architecture-recovery-target.md](../architecture/architecture-recovery-target.md)
@@ -62,7 +62,7 @@ Storage must not know:
 - primitive snapshot section decode or primitive install stats
 - degraded-storage open policy
 
-The ES4 target is:
+The recovery-bootstrap cleanup target is:
 
 ```text
 storage recovers durable state and returns raw facts
@@ -71,15 +71,15 @@ engine decides whether those facts permit database open
 
 ## Non-Negotiables
 
-`TransactionCoordinator` stays engine-owned for ES4.
+`TransactionCoordinator` stays engine-owned for recovery-bootstrap cleanup.
 
-This is the load-bearing decision from the ES2-ES4 API sketch. Storage should
+This is the load-bearing decision from storage-runtime boundary API sketch. Storage should
 not call into engine per replayed record to mutate coordinator state. Storage
 should replay durable bytes into `SegmentedStore`, return `RecoveryStats` and
 `RecoveredState`, and let engine bootstrap `TransactionCoordinator` after the
 storage recovery call returns.
 
-ES4 must preserve these current ordering guarantees:
+recovery-bootstrap cleanup must preserve these current ordering guarantees:
 
 - configured codec validation occurs before any recovery-managed directory or
   MANIFEST creation
@@ -96,7 +96,7 @@ ES4 must preserve these current ordering guarantees:
 - lossy replay bypass rules remain hard failures for planning, MANIFEST,
   snapshot-plan, and legacy-format errors
 
-ES4 must not:
+recovery-bootstrap cleanup must not:
 
 - change public recovery/open behavior
 - weaken corruption or quarantine behavior
@@ -135,7 +135,7 @@ The target surface is concentrated in:
   - primary/follower open tail after recovery
 - [database/snapshot_install.rs](../../crates/engine/src/database/snapshot_install.rs)
   - engine-owned primitive decode
-  - ES3 decoded-row install adapter
+  - snapshot-install cleanup decoded-row install adapter
   - recovery snapshot install helper target callback
 
 The storage-owned building blocks already exist:
@@ -149,7 +149,7 @@ The storage-owned building blocks already exist:
 - `strata_storage::SegmentedStore`
 - `SegmentedStore::recover_segments`
 
-ES4 should assemble these storage-owned pieces inside storage instead of
+recovery-bootstrap cleanup should assemble these storage-owned pieces inside storage instead of
 inside engine.
 
 ## Target Module
@@ -160,12 +160,12 @@ Use a storage-owned recovery bootstrap module:
 crates/storage/src/durability/recovery_bootstrap.rs
 ```
 
-`bootstrap.rs` was the name in the original ES2-ES4 sketch. The more explicit
+`bootstrap.rs` was the name in the original storage-runtime boundary sketch. The more explicit
 `recovery_bootstrap.rs` is preferred for implementation because `durability`
 already contains several bootstrap-like paths around checkpoint, WAL, and
 MANIFEST setup.
 
-The completed ES4 module should be re-exported through
+The completed recovery-bootstrap cleanup module should be re-exported through
 `strata_storage::durability` with a small public surface:
 
 ```text
@@ -179,21 +179,21 @@ StorageLossyWalReplayFacts
 RecoverySnapshotInstallCallback
 ```
 
-ES4B intentionally introduces and re-exports only the type/callback surface.
-`run_storage_recovery` is introduced in ES4G once the lower-runtime behavior
+Phase B intentionally introduces and re-exports only the type/callback surface.
+`run_storage_recovery` is introduced in Phase G once the lower-runtime behavior
 has moved far enough to implement the function without a panic or fake no-op.
 
-ES4C temporarily exposed `prepare_storage_manifest_for_recovery` and
+Phase C temporarily exposed `prepare_storage_manifest_for_recovery` and
 `StorageManifestRecoveryPreparation` only through storage's
 `engine-internal`/`__internal` seam so engine could delegate MANIFEST and codec
-preparation before `run_storage_recovery` existed. ES4G removes that public
+preparation before `run_storage_recovery` existed. Phase G removes that public
 transitional bridge; storage may keep smaller private helper seams inside
 `recovery_bootstrap.rs`, but higher layers should call only
 `run_storage_recovery`.
 
-All public storage-local errors, enums, and data structs introduced for ES4
+All public storage-local errors, enums, and data structs introduced for recovery-bootstrap cleanup
 should be `#[non_exhaustive]`. Public data structs should also have
-constructors or defaults so later ES4 steps can add fields without requiring
+constructors or defaults so later recovery-bootstrap cleanup steps can add fields without requiring
 external callers to use struct literals.
 
 ## Target API
@@ -242,7 +242,7 @@ StorageRuntimeConfig {
 }
 ```
 
-Engine builds this from `StrataConfig.storage` until ES5 completes the public
+Engine builds this from `StrataConfig.storage` until storage-runtime-config cleanup completes the public
 configuration split. That adapter does not make storage own product defaults.
 `StorageRuntimeConfig::default()` uses the same storage defaults as
 `SegmentedStore`, so a partially wired test or synthetic construction never
@@ -260,7 +260,7 @@ RecoverySnapshotInstallCallback {
 }
 ```
 
-This refines the older ES2-ES4 sketch. Once storage owns MANIFEST preparation
+This refines the older storage-runtime boundary sketch. Once storage owns MANIFEST preparation
 and codec resolution, storage is the layer that knows which codec the snapshot
 install callback must use. Passing the codec to the engine callback keeps
 primitive decode in engine without forcing engine to redo MANIFEST prep.
@@ -356,7 +356,7 @@ conversion behavior.
 
 ## Engine Wrapper Shape
 
-After ES4, `Database::run_recovery()` remains the engine entry point.
+After recovery-bootstrap cleanup, `Database::run_recovery()` remains the engine entry point.
 
 Target shape:
 
@@ -397,7 +397,7 @@ Engine no longer owns:
 - storage config application before segment recovery
 - `recover_segments()` execution
 
-## ES4A - Characterization And Inventory
+## Phase A - Characterization And Inventory
 
 Goal: lock the current behavior before moving recovery mechanics.
 
@@ -448,12 +448,12 @@ cargo test -p strata-engine --lib checkpoint -- --nocapture
 
 Acceptance:
 
-- ES4 behavior matrix exists in this document or in test names
+- recovery-bootstrap cleanup behavior matrix exists in this document or in test names
 - characterization tests fail on at least one intentionally broken ordering
   if locally mutated
-- no production code moves in ES4A unless needed for test seams
+- no production code moves in Phase A unless needed for test seams
 
-ES4A characterization status:
+Phase A characterization status:
 
 | Behavior | Guard |
 | --- | --- |
@@ -475,7 +475,7 @@ ES4A characterization status:
 | Snapshot-only recovery still works with non-identity snapshot header codecs. | `test_aes_checkpoint_compact_reopen_installs_snapshot` |
 | Checkpoint-only and checkpoint-plus-delta recovery remain covered. | `test_checkpoint_only_restart_recovers_kv_from_snapshot`, `test_checkpoint_plus_delta_wal_replay_merges_sources` |
 
-## ES4B - Storage API Skeleton
+## Phase B - Storage API Skeleton
 
 Goal: introduce the storage-owned type surface without moving behavior.
 
@@ -492,7 +492,7 @@ Tasks:
 - re-export only the intended public storage surface
 - add compile-only or synthetic unit tests for type construction and error
   display where useful
-- do not expose `run_storage_recovery` yet; ES4B is type-only, and ES4G adds
+- do not expose `run_storage_recovery` yet; Phase B is type-only, and Phase G adds
   the function when it can delegate to real moved behavior
 
 Rules:
@@ -509,7 +509,7 @@ Acceptance:
 - engine still uses the old recovery implementation
 - storage ownership grep guards stay clean
 
-## ES4C - Manifest And Codec Preparation
+## Phase C - Manifest And Codec Preparation
 
 Goal: move generic MANIFEST preparation and WAL codec resolution into storage.
 
@@ -547,10 +547,10 @@ StorageManifestRecoveryPreparation {
 }
 ```
 
-Because `run_storage_recovery` intentionally waits until ES4G, this helper is
+Because `run_storage_recovery` intentionally waits until Phase G, this helper is
 temporarily exposed through storage's `engine-internal`/`__internal` seam for
-the engine wrapper during ES4C. It should become storage-private again once
-ES4G routes recovery through the completed storage bootstrap API, unless ES5
+the engine wrapper during Phase C. It should become storage-private again once
+Phase G routes recovery through the completed storage bootstrap API, unless storage-runtime-config cleanup
 needs the narrower helper directly.
 
 Acceptance:
@@ -560,7 +560,7 @@ Acceptance:
 - first-open invalid codec still leaves no poisoned storage directory
 - follower missing-MANIFEST still does not create a MANIFEST
 
-## ES4D - Coordinator Replay Driver
+## Phase D - Coordinator Replay Driver
 
 Goal: move `RecoveryCoordinator` construction and replay driving into storage.
 
@@ -596,11 +596,11 @@ if loaded_snapshot_callback_fired && snapshot_install_codec.is_none() {
 The exact wrapping can differ, but the behavior must remain a hard failure
 with snapshot id context.
 
-Because `run_storage_recovery` intentionally waits until ES4G, ES4D uses a
+Because `run_storage_recovery` intentionally waits until Phase G, Phase D uses a
 temporary `run_storage_coordinator_replay` helper exposed only through
 storage's `engine-internal`/`__internal` seam. The helper returns the raw
-coordinator result and the records-applied count so ES4F can move lossy replay
-mechanics without changing report fields. ES4G should absorb this helper into
+coordinator result and the records-applied count so Phase F can move lossy replay
+mechanics without changing report fields. Phase G should absorb this helper into
 the completed storage recovery API.
 
 Acceptance:
@@ -612,7 +612,7 @@ Acceptance:
 - primitive install stats, if logged, are captured in the engine callback
 - callback install failures still map through the same public recovery path
 
-## ES4E - Snapshot Fold, Runtime Config, And Segment Recovery
+## Phase E - Snapshot Fold, Runtime Config, And Segment Recovery
 
 Goal: move the post-replay storage mechanics into storage while keeping
 engine policy outside storage.
@@ -637,12 +637,12 @@ return StorageRecoveryOutcome
 Storage should not decide whether degraded state permits database open.
 Storage returns `RecoveredState` and its `RecoveryHealth` unchanged.
 
-Because `run_storage_recovery` intentionally waits until ES4G, ES4E uses a
+Because `run_storage_recovery` intentionally waits until Phase G, Phase E uses a
 temporary `complete_storage_recovery_after_replay` helper exposed only through
 storage's `engine-internal`/`__internal` seam. The helper consumes the replayed
 store and raw `RecoveryStats`, folds the installed snapshot version into those
 stats, applies `StorageRuntimeConfig`, runs `recover_segments()`, and returns a
-raw `StorageRecoveryOutcome`. ES4G should absorb this helper into the completed
+raw `StorageRecoveryOutcome`. Phase G should absorb this helper into the completed
 storage recovery API.
 
 Engine should still:
@@ -660,7 +660,7 @@ Acceptance:
 - degraded-storage behavior remains public-policy equivalent
 - coordinator bootstrap still sees the folded final version
 
-## ES4F - Lossy WAL Replay Mechanics
+## Phase F - Lossy WAL Replay Mechanics
 
 Goal: move the mechanical lossy wipe into storage while keeping lossy policy
 and operator reporting in engine.
@@ -724,7 +724,7 @@ Implementation shape:
 - leave public `allow_lossy_recovery` configuration and public error mapping in
   engine
 
-## ES4G - Engine Wrapper Cleanup
+## Phase G - Engine Wrapper Cleanup
 
 Goal: reduce `Database::run_recovery` to engine orchestration and policy.
 
@@ -754,7 +754,7 @@ Acceptance:
 
 Implementation notes:
 
-- `strata_storage::durability::run_storage_recovery` is the public ES4G wrapper
+- `strata_storage::durability::run_storage_recovery` is the public Phase G wrapper
   around MANIFEST/codec preparation, `SegmentedStore` construction,
   coordinator replay, mechanical lossy WAL fallback, storage runtime config,
   and segment recovery
@@ -762,7 +762,7 @@ Implementation notes:
   callback, maps `StorageRecoveryError`, builds `LossyRecoveryReport`, applies
   degraded-storage policy, restores follower state, bootstraps
   `TransactionCoordinator`, and constructs the watermark
-- the temporary ES4C/ES4D/ES4E/ES4F engine bridge helpers are no longer
+- the temporary Phase C/Phase D/Phase E/Phase F engine bridge helpers are no longer
   exported through `durability::__internal`
 - snapshot-plan failures (`SnapshotMissing` and `SnapshotRead`) explicitly
   bypass the lossy WAL fallback alongside MANIFEST planning and legacy-format
@@ -771,7 +771,7 @@ Implementation notes:
   replay remains limited to failures from WAL replay, not primitive snapshot
   decode/install
 
-## ES4H - Guards, Documentation, And Full Parity
+## Phase H - Guards, Documentation, And Full Parity
 
 Goal: finish the cleanup with explicit guardrails.
 
@@ -802,7 +802,7 @@ cargo test -p strata-engine --test recovery_storage_policy -- --nocapture
 cargo test -p strata-engine --lib checkpoint -- --nocapture
 ```
 
-Full assurance before declaring ES4 complete:
+Full assurance before declaring recovery-bootstrap cleanup complete:
 
 ```text
 cargo test -p strata-engine
@@ -811,12 +811,12 @@ cargo test -p strata-engine
 Known pre-existing unrelated failures should be called out with exact test
 names if the full package suite is not green.
 
-ES4H full-package status:
+Phase H full-package status:
 
-`cargo test -p strata-engine` currently passes the ES4 recovery/checkpoint
+`cargo test -p strata-engine` currently passes the recovery-bootstrap and checkpoint
 coverage. `cargo test -p strata-engine --test recovery_storage_policy -- --nocapture`
 also passes separately. The full package suite remains blocked by the same
-broader architecture-cleanup-period failures outside ES4 recovery bootstrap:
+broader architecture-cleanup-period failures outside recovery-bootstrap work:
 
 - `database::branch_mutation::tests::test_rollback_delete_true_surfaces_storage_cleanup_failure`
 - `database::tests::shutdown::shutdown_timeout_halt_interleaving_preserves_invariant`
@@ -838,30 +838,30 @@ Documentation updates:
   lists `durability/recovery_bootstrap.rs` as storage-owned lower durability
   runtime.
 - [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
-  records the ES4 implementation status and the one intentional correctness
+  records the recovery-bootstrap cleanup implementation status and the one intentional correctness
   tightening.
-- This document records the ES4H guard list, behavior-change ledger, and
+- This document records the Phase H guard list, behavior-change ledger, and
   completion criteria.
 
-ES4H implementation status:
+Phase H implementation status:
 
 | Check | Status |
 | --- | --- |
 | Storage owns the recovery bootstrap implementation. | `run_storage_recovery` is re-exported from `strata_storage::durability` and owns MANIFEST/codec prep, coordinator replay, lossy WAL replay mechanics, runtime config application, and segment recovery. |
 | Engine owns recovery policy and public recovery conversion. | `Database::run_recovery()` supplies the primitive snapshot callback, maps `StorageRecoveryError`, applies degraded policy, builds `LossyRecoveryReport`, bootstraps `TransactionCoordinator`, restores follower state, and constructs the watermark. |
-| Temporary ES4 bridge helpers are not public. | `prepare_storage_manifest_for_recovery`, `run_storage_coordinator_replay`, `handle_storage_wal_replay_outcome`, and `complete_storage_recovery_after_replay` are private to `recovery_bootstrap.rs`. |
+| Temporary recovery-bootstrap cleanup bridge helpers are not public. | `prepare_storage_manifest_for_recovery`, `run_storage_coordinator_replay`, `handle_storage_wal_replay_outcome`, and `complete_storage_recovery_after_replay` are private to `recovery_bootstrap.rs`. |
 | Primitive semantics stay out of storage recovery bootstrap. | `recovery_bootstrap.rs` carries `LoadedSnapshot`, codecs, `SegmentedStore`, and raw recovery facts only; primitive section decode remains in engine. |
 
 Acceptance:
 
 - storage owns the recovery bootstrap implementation
 - engine owns recovery policy and public recovery conversion
-- all ES4 guard commands are clean or have documented intentional exceptions
-- all ES4 characterization tests still pass
+- all recovery-bootstrap cleanup guard commands are clean or have documented intentional exceptions
+- all recovery-bootstrap cleanup characterization tests still pass
 
 ## Behavior Changes
 
-No broad behavior redesign is intended for ES4. The implementation did uncover
+No broad behavior redesign is intended for recovery-bootstrap cleanup. The implementation did uncover
 one recovery correctness bug that is intentionally tightened below.
 
 If implementation discovers a correctness bug that must be fixed while moving
@@ -920,9 +920,9 @@ Focused tests:
 - `lossy_wal_replay_snapshot_callback_failure_preserves_partial_storage`
 - `recovery_snapshot_install_failure_bypasses_lossy_fallback_when_enabled`
 
-## Residual Ownership After ES4
+## Residual Ownership After recovery-bootstrap cleanup
 
-Some recovery-adjacent code should intentionally remain in engine after ES4:
+Some recovery-adjacent code should intentionally remain in engine after recovery-bootstrap cleanup:
 
 - `RecoveryError` public taxonomy
 - `RecoveryMode`
@@ -935,7 +935,7 @@ Some recovery-adjacent code should intentionally remain in engine after ES4:
 - subsystem recovery integration
 - primitive snapshot install callback
 
-Some recovery-adjacent work should wait for ES5:
+Some recovery-adjacent work should wait for storage-runtime-config cleanup:
 
 - public `StrataConfig` split
 - storage-owned defaults for every storage runtime knob
@@ -953,7 +953,7 @@ Some work should remain explicitly out of scope:
 
 ## Completion Criteria
 
-ES4 is complete when:
+recovery-bootstrap cleanup is complete when:
 
 1. `Database::run_recovery` calls a storage-owned recovery bootstrap API for
    raw recovery mechanics.
@@ -964,10 +964,10 @@ ES4 is complete when:
 6. Storage returns raw recovery facts and storage-local errors.
 7. Engine maps those facts into `RecoveryError`, `StrataError`,
    `LossyRecoveryReport`, `TransactionCoordinator`, and `RecoveryOutcome`.
-8. Snapshot install still decodes primitive sections in engine through the ES3
+8. Snapshot install still decodes primitive sections in engine through the snapshot-install cleanup
    callback.
 9. `TransactionCoordinator` remains engine-owned.
 10. The configured-codec, snapshot-version-fold, runtime-config, lossy-bypass,
     and follower-state ordering guarantees are characterized by tests.
 11. Storage has no engine dependency and no primitive snapshot install logic.
-12. The ES4 guard commands pass.
+12. The recovery-bootstrap cleanup guard commands pass.

--- a/docs/engine/snapshot-decode-install-mechanics-plan.md
+++ b/docs/engine/snapshot-decode-install-mechanics-plan.md
@@ -1,16 +1,16 @@
-# ES3 Snapshot Install Boundary Plan
+# snapshot-install cleanup Snapshot Install Boundary Plan
 
 ## Purpose
 
-`ES3` is the second runtime cleanup epic in the engine/storage boundary
+`snapshot-install cleanup` is the second runtime cleanup epic in the engine/storage boundary
 normalization workstream.
 
-The original ES3 direction was too broad: it would have moved primitive
+The original snapshot-install cleanup direction was too broad: it would have moved primitive
 snapshot section decode into `strata-storage`. That creates the inverse of the
 current problem. Instead of engine owning storage mechanics, storage would
 start owning engine primitive concerns.
 
-This revised ES3 keeps the ownership rule strict:
+This revised snapshot-install cleanup keeps the ownership rule strict:
 
 ```text
 storage owns durable row mechanics
@@ -24,9 +24,9 @@ in engine.
 Read this together with:
 
 - [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
-- [es1-boundary-baseline-and-guardrails-plan.md](./es1-boundary-baseline-and-guardrails-plan.md)
-- [es2-es4-storage-runtime-boundary-api-sketch.md](./es2-es4-storage-runtime-boundary-api-sketch.md)
-- [es2-checkpoint-wal-compaction-mechanics-plan.md](./es2-checkpoint-wal-compaction-mechanics-plan.md)
+- [boundary-baseline-and-guardrails-plan.md](./boundary-baseline-and-guardrails-plan.md)
+- [storage-runtime-boundary-api-sketch.md](./storage-runtime-boundary-api-sketch.md)
+- [checkpoint-wal-compaction-mechanics-plan.md](./checkpoint-wal-compaction-mechanics-plan.md)
 - [../storage/storage-engine-ownership-audit.md](../storage/storage-engine-ownership-audit.md)
 - [../storage/storage-charter.md](../storage/storage-charter.md)
 - [../architecture/architecture-recovery-target.md](../architecture/architecture-recovery-target.md)
@@ -64,13 +64,13 @@ Storage must not know:
   guidance
 
 `TypeTag` is an existing storage family identifier with primitive-shaped
-variant names. ES3 should not expand that leak. Storage install code may carry
+variant names. snapshot-install cleanup should not expand that leak. Storage install code may carry
 `TypeTag` as an opaque routing value because `SegmentedStore` already uses it,
 but it should not branch on primitive-specific variants for snapshot install
 statistics or behavior. A later cleanup can consider replacing this with an
 opaque storage family id.
 
-## ES3 Verdict
+## snapshot-install cleanup Verdict
 
 The following should remain in `strata-engine`:
 
@@ -105,20 +105,20 @@ into generic storage rows. Storage only installs those rows.
 
 ## Existing Code Map
 
-The ES3 target surface is concentrated in:
+The snapshot-install cleanup target surface is concentrated in:
 
 - [database/snapshot_install.rs](../../crates/engine/src/database/snapshot_install.rs)
 - [database/recovery.rs](../../crates/engine/src/database/recovery.rs)
 - `SegmentedStore::install_snapshot_entries`
 
 Existing storage format modules already define snapshot DTOs and primitive tag
-constants. ES3 does not need to erase that existing format ownership. The line
+constants. snapshot-install cleanup does not need to erase that existing format ownership. The line
 is runtime behavior: storage should not gain a runtime snapshot installer that
 decodes or interprets those primitive sections.
 
 ## Target Shape
 
-Engine should continue to expose its current recovery-facing helper while ES3
+Engine should continue to expose its current recovery-facing helper while snapshot-install cleanup
 is in progress:
 
 ```text
@@ -189,7 +189,7 @@ Ownership:
 - `SnapshotReader` remains responsible for snapshot header codec validation
   before engine receives `LoadedSnapshot`.
 
-ES3 must add characterization for non-identity snapshot files so this contract
+snapshot-install cleanup must add characterization for non-identity snapshot files so this contract
 does not regress.
 
 ## Partial Mutation Contract
@@ -278,7 +278,7 @@ mention engine policy.
 
 ## Explicit Behavior Changes
 
-ES3 is primarily a boundary cleanup, but two strictness changes intentionally
+snapshot-install cleanup is primarily a boundary cleanup, but two strictness changes intentionally
 land with it because they close recovery/snapshot correctness gaps exposed by
 the new characterization:
 
@@ -298,9 +298,9 @@ allocations. That is defensive implementation detail, not a new boundary owner.
 
 ## Implementation Plan
 
-ES3 restarts from `ES3A`. Each phase is a straight lettered slice.
+snapshot-install cleanup restarts from `Phase A`. Each phase is a straight lettered slice.
 
-### ES3A Snapshot Install Characterization Rebaseline
+### Phase A Snapshot Install Characterization Rebaseline
 
 Restore the pre-move crate state and pin current behavior in engine before any
 new extraction.
@@ -332,11 +332,11 @@ Coverage should include:
 - invalid later section does not partially install earlier valid sections
 - invalid KV type tag does not partially install earlier valid KV rows
 
-ES3A should not move code into storage. It should make the existing behavior
+Phase A should not move code into storage. It should make the existing behavior
 and the desired no-partial-mutation behavior explicit.
 
-Because the pre-ES3A engine installer decoded and mutated section-by-section,
-some ES3A characterization targets cannot be made true with tests alone. ES3A
+Because the pre-Phase A engine installer decoded and mutated section-by-section,
+some Phase A characterization targets cannot be made true with tests alone. Phase A
 may therefore include engine-local fixes that do not move code across the
 storage boundary:
 
@@ -344,10 +344,10 @@ storage boundary:
 - validate KV-section `TypeTag` bytes before mutation
 - keep primitive section decode on the canonical checkpoint section codec
 
-If those fixes land during ES3A, the later ES3C and ES3D phases should be
+If those fixes land during Phase A, the later Phase C and Phase D phases should be
 treated as phase-accounting checkpoints rather than reimplemented work.
 
-### ES3B Generic Storage Row Install Surface
+### Phase B Generic Storage Row Install Surface
 
 Add a storage-owned helper that installs already-decoded generic row groups.
 
@@ -369,16 +369,16 @@ Forbidden storage inputs:
 Storage tests should use synthetic decoded row groups. They should not build
 snapshot primitive sections.
 
-ES3B is complete when storage can install generic decoded row groups without
+Phase B is complete when storage can install generic decoded row groups without
 knowing which primitive produced them.
 
-### ES3C Engine Decode Plan Extraction
+### Phase C Engine Decode Plan Extraction
 
 Refactor engine `database::snapshot_install` into a decode-then-install flow.
 
-If ES3A already introduced this engine-local decode plan to satisfy
-no-partial-mutation characterization, ES3C should verify and preserve that
-shape while integrating the storage generic row install surface from ES3B.
+If Phase A already introduced this engine-local decode plan to satisfy
+no-partial-mutation characterization, Phase C should verify and preserve that
+shape while integrating the storage generic row install surface from Phase B.
 
 Engine should:
 
@@ -394,13 +394,13 @@ Engine should:
 This phase should fix partial mutation from corrupt snapshots by ensuring the
 full plan is built before calling the storage helper.
 
-### ES3D Canonical Section Codec Fix
+### Phase D Canonical Section Codec Fix
 
 Make the engine decode plan use the canonical primitive-section codec used by
 checkpoint construction, not the snapshot header codec id.
 
-If ES3A already made this codec separation explicit, ES3D should retain the
-coverage and ensure the new ES3B storage install surface does not reintroduce
+If Phase A already made this codec separation explicit, Phase D should retain the
+coverage and ensure the new Phase B storage install surface does not reintroduce
 snapshot header codec use for primitive section payloads.
 
 Add or keep tests proving:
@@ -411,10 +411,10 @@ Add or keep tests proving:
   section codec
 - checkpoint + compact + reopen restores rows from the snapshot-only path
 
-If this fix naturally lands with ES3C, the PR should still call it out as the
-ES3D acceptance item.
+If this fix naturally lands with Phase C, the PR should still call it out as the
+Phase D acceptance item.
 
-### ES3E Recovery Wrapper Integration
+### Phase E Recovery Wrapper Integration
 
 Wire the engine snapshot install helper to call the generic storage row install
 surface after engine decode succeeds.
@@ -432,7 +432,7 @@ Storage keeps:
 
 - decoded row group install mechanics only
 
-### ES3F Residue Cleanup And Guards
+### Phase F Residue Cleanup And Guards
 
 Clean up duplicate code and document intentional residue.
 
@@ -443,9 +443,9 @@ Expected result:
 - no storage snapshot install module imports `SnapshotSerializer`
 - no storage snapshot install module imports `primitive_tags`
 - no storage snapshot install module imports primitive snapshot DTOs
-- engine recovery/open MANIFEST policy remains until ES4
+- engine recovery/open MANIFEST policy remains until recovery-bootstrap cleanup
 
-Intentional ES3 residue after cleanup:
+Intentional snapshot-install cleanup residue after cleanup:
 
 - `crates/engine/src/database/snapshot_install.rs` keeps
   `SnapshotSerializer`, `primitive_tags`, primitive snapshot DTO decode, and
@@ -461,9 +461,9 @@ Intentional ES3 residue after cleanup:
   is not runtime install ownership.
 - The strict trailing-data checks and count-preallocation removal in the
   snapshot format/container modules are intentional format-hardening residue
-  bundled with ES3. They do not move primitive install semantics into storage.
+  bundled with snapshot-install cleanup. They do not move primitive install semantics into storage.
 - `RecoveryCoordinator`, MANIFEST/open policy, and recovery outcome mapping
-  remain engine/recovery residue for ES4.
+  remain engine/recovery residue for recovery-bootstrap cleanup.
 
 ## Guardrails
 
@@ -483,7 +483,7 @@ Interpretation:
 - Generic install modules must not use those DTOs or tags. The `*install*.rs`
   guard is intentionally broader than the current
   `decoded_snapshot_install.rs` file so a future storage install module cannot
-  bypass the ES3 boundary by choosing a new filename.
+  bypass the snapshot-install cleanup boundary by choosing a new filename.
 - Any new match in storage outside established format/container code needs an
   explicit boundary justification.
 - A broad search over all `crates/storage/src/durability` is still useful as an
@@ -497,7 +497,7 @@ rg -n 'RecoveryCoordinator|ManifestManager|apply_storage_config' crates/engine/s
 ```
 
 `RecoveryCoordinator`, `ManifestManager`, and open/recovery policy residue are
-not ES3 cleanup targets. They belong to ES4.
+not snapshot-install cleanup targets. They belong to recovery-bootstrap cleanup.
 
 ## Verification Gates
 
@@ -531,7 +531,7 @@ cargo test -p strata-engine --lib test_issue_1730 -- --nocapture
 
 ## Acceptance Checklist
 
-ES3A is complete when:
+Phase A is complete when:
 
 1. Crate code is back to the pre-move boundary.
 2. Engine snapshot install characterization covers current primitive decode
@@ -541,33 +541,33 @@ ES3A is complete when:
 4. Tests cover no partial mutation for decode/validation failures that happen
    before storage install.
 
-ES3B is complete when:
+Phase B is complete when:
 
 1. Storage exposes only a generic decoded row install surface.
 2. Storage install stats are generic.
 3. Storage install errors are storage-local and primitive-agnostic.
 4. Storage tests use synthetic decoded row groups, not primitive snapshot DTOs.
 
-ES3C is complete when:
+Phase C is complete when:
 
 1. Engine builds a complete decoded row install plan before storage mutation.
 2. Engine retains primitive section decode and primitive-specific stats.
 3. Invalid primitive data fails before any storage write.
 
-ES3D is complete when:
+Phase D is complete when:
 
 1. Primitive section decode uses the canonical section codec.
 2. Snapshot header codec validation remains separate.
 3. Non-identity checkpoint + compact + reopen coverage is green.
 
-ES3E is complete when:
+Phase E is complete when:
 
 1. Engine calls the storage generic row install helper only after successful
    primitive decode.
 2. Recovery callback policy remains engine-owned.
 3. Public error behavior is preserved.
 
-ES3F is complete when:
+Phase F is complete when:
 
 1. Storage has no new primitive runtime install concerns.
 2. Engine decode residue is intentional and documented.
@@ -575,7 +575,7 @@ ES3F is complete when:
 
 ## Non-Goals
 
-ES3 does not move:
+snapshot-install cleanup does not move:
 
 - `RecoveryCoordinator`
 - MANIFEST/open policy
@@ -585,4 +585,4 @@ ES3 does not move:
 - branch lifecycle behavior
 - vector/search/graph semantics
 
-Those are either engine responsibilities or later ES4-plus decisions.
+Those are either engine responsibilities or later recovery-bootstrap cleanup-plus decisions.

--- a/docs/engine/storage-config-application-plan.md
+++ b/docs/engine/storage-config-application-plan.md
@@ -1,17 +1,17 @@
-# ES5 Storage Config Application Plan
+# Storage Config Application Plan
 
 ## Purpose
 
-`ES5` is the storage-configuration application epic in the engine/storage
+`storage-runtime-config cleanup` is the storage-configuration application epic in the engine/storage
 boundary normalization workstream.
 
-`ES2` moved checkpoint, WAL compaction, snapshot pruning, and generic MANIFEST
-sync mechanics toward storage. `ES3` moved generic decoded-row snapshot install
-mechanics into storage while keeping primitive snapshot decode in engine. `ES4`
+`checkpoint/WAL cleanup` moved checkpoint, WAL compaction, snapshot pruning, and generic MANIFEST
+sync mechanics toward storage. `snapshot-install cleanup` moved generic decoded-row snapshot install
+mechanics into storage while keeping primitive snapshot decode in engine. `recovery-bootstrap cleanup`
 moved recovery bootstrap mechanics into storage and introduced the first
 storage-owned `StorageRuntimeConfig` needed by recovery.
 
-`ES5` completes that configuration boundary across the remaining open paths.
+`storage-runtime-config cleanup` completes that configuration boundary across the remaining open paths.
 The goal is not to redesign public configuration. The goal is to stop
 `strata-engine` from hand-applying storage setter lists and deriving
 storage-local effective values while keeping engine in charge of public config
@@ -20,9 +20,9 @@ files, product profiles, compatibility behavior, and database open policy.
 Read this together with:
 
 - [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
-- [es1-boundary-baseline-and-guardrails-plan.md](./es1-boundary-baseline-and-guardrails-plan.md)
-- [es2-es4-storage-runtime-boundary-api-sketch.md](./es2-es4-storage-runtime-boundary-api-sketch.md)
-- [es4-recovery-bootstrap-mechanics-plan.md](./es4-recovery-bootstrap-mechanics-plan.md)
+- [boundary-baseline-and-guardrails-plan.md](./boundary-baseline-and-guardrails-plan.md)
+- [storage-runtime-boundary-api-sketch.md](./storage-runtime-boundary-api-sketch.md)
+- [recovery-bootstrap-mechanics-plan.md](./recovery-bootstrap-mechanics-plan.md)
 - [../storage/storage-engine-ownership-audit.md](../storage/storage-engine-ownership-audit.md)
 - [../storage/storage-charter.md](../storage/storage-charter.md)
 
@@ -52,10 +52,10 @@ Storage must not know:
 - engine compatibility signatures
 - `TransactionCoordinator`
 - primitive snapshot section meaning
-- primary/follower database open policy except where ES4 already requires a
+- primary/follower database open policy except where recovery-bootstrap cleanup already requires a
   storage-neutral recovery mode
 
-The ES5 target is:
+The storage-runtime-config cleanup target is:
 
 ```text
 engine adapts public config into storage runtime config
@@ -64,7 +64,7 @@ storage derives and applies storage runtime mechanics
 
 ## Starting State
 
-The important asymmetry after ES4 was:
+The important asymmetry after recovery-bootstrap cleanup was:
 
 - disk recovery already passes a storage-owned `StorageRuntimeConfig` into
   `run_storage_recovery`
@@ -91,14 +91,14 @@ ephemeral/cache open:
     -> engine apply_storage_config -> SegmentedStore setters
 ```
 
-ES5 makes those paths converge.
+storage-runtime-config cleanup makes those paths converge.
 
 ## Non-Negotiables
 
 `StrataConfig` remains engine-owned.
 
 The public config format remains stable unless a later PR explicitly adds a
-compatibility migration. ES5 should not force users to edit existing
+compatibility migration. storage-runtime-config cleanup should not force users to edit existing
 `strata.toml` files.
 
 Storage must not depend on engine.
@@ -107,15 +107,15 @@ Storage must not learn product profiles. Hardware-profile adjustment may still
 mutate engine `StrataConfig` before adaptation; storage should receive a
 storage-shaped runtime input after that product decision has been made.
 
-`TransactionCoordinator` write-buffer-entry limits stay engine-owned for ES5.
+`TransactionCoordinator` write-buffer-entry limits stay engine-owned for storage-runtime-config cleanup.
 `max_write_buffer_entries` limits transaction coordinator behavior, not
 `SegmentedStore` mechanics.
 
-Ephemeral/cache databases remain truly in-memory. ES5 must not introduce a
+Ephemeral/cache databases remain truly in-memory. storage-runtime-config cleanup must not introduce a
 persistent cache mode or any terminology that implies one exists.
 
-WAL flush-thread lifecycle stays engine-owned unless a later ES5 step
-explicitly designs a smaller storage-owned worker surface. The first ES5 pass
+WAL flush-thread lifecycle stays engine-owned unless a later storage-runtime-config cleanup step
+explicitly designs a smaller storage-owned worker surface. The first storage-runtime-config cleanup pass
 should not move shutdown latches, WAL writer health, accepting-transaction
 halts, or database lifecycle callbacks into storage.
 
@@ -175,7 +175,7 @@ those fields into storage.
 
 ## Config Classification
 
-| Public config surface | ES5 target |
+| Public config surface | storage-runtime-config cleanup target |
 |---|---|
 | `StorageConfig::memory_budget` | Engine-owned public field; storage-owned derivation into block cache, write buffer, and immutable memtable count. |
 | `StorageConfig::max_branches` | Engine-owned public field; storage-owned storage of the advisory branch-limit value. Branch-creation enforcement remains unchanged. |
@@ -197,7 +197,7 @@ those fields into storage.
 | `StrataConfig::durability_mode` | Split; engine owns public string compatibility, storage owns WAL durability mechanics. |
 | `SnapshotRetentionPolicy` | Split; engine owns public retention policy, storage owns snapshot prune mechanics. |
 
-## ES5A - Inventory and Characterization
+## Phase A - Inventory and Characterization
 
 Create a focused inventory of every storage config application path.
 
@@ -226,37 +226,37 @@ Expected characterization:
 - compaction-related setters still land on `SegmentedStore`
 - configured codec validation behavior remains unchanged
 - block-cache global capacity is mapped and deferred from order-dependent
-  assertions until ES5F because it is process-wide state
+  assertions until Phase F because it is process-wide state
 
 Acceptance:
 
-- the ES5 plan has a concrete field-by-field map against the current code
+- the storage-runtime-config cleanup plan has a concrete field-by-field map against the current code
 - characterization fails if persistent and ephemeral/cache paths diverge for
   characterized common knobs
 - known path divergence is captured as an explicit characterization test and
   follow-up gap
 - no behavior movement happens before the current behavior is observable
 
-### ES5A Current Inventory
+### Phase A Current Inventory
 
-As of ES5A, the live storage-configuration application surfaces are:
+As of Phase A, the live storage-configuration application surfaces are:
 
-| Surface | Current owner | Current call sites | ES5 disposition |
+| Surface | Current owner | Current call sites | storage-runtime-config cleanup disposition |
 |---|---|---|---|
 | `StorageConfig::effective_block_cache_size` | Engine | `database/open.rs` persistent open, `database/open.rs` cache open, `database/mod.rs` runtime `update_config`, config tests | Move the derivation into storage runtime config; keep public input in engine. |
 | `StorageConfig::effective_write_buffer_size` | Engine | `database/recovery.rs` recovery input, `database/mod.rs` runtime `update_config`, `database/transaction.rs` write-pressure checks, config tests | Move storage derivation into storage runtime config; keep transaction-pressure policy explicit in engine until redesigned. |
 | `StorageConfig::effective_max_immutable_memtables` | Engine | `database/recovery.rs` runtime config adapter, `database/open.rs` cache open, `database/mod.rs` runtime `update_config`, `database/transaction.rs` write-pressure checks, config tests | Move storage derivation into storage runtime config; keep transaction-pressure policy explicit in engine until redesigned. |
 | `database/open.rs::apply_storage_config` | Engine | Cache/ephemeral store construction | Replace with storage-owned runtime config application. |
 | `database/mod.rs::apply_storage_config_inner` | Engine | Runtime `Database::update_config` path | Replace storage setter portion with storage-owned runtime config application; leave coordinator write-entry limit in engine. |
-| `durability/recovery_bootstrap.rs::apply_storage_runtime_config` | Storage | ES4 recovery bootstrap | Promote out of recovery bootstrap and make it the common storage apply helper. |
+| `durability/recovery_bootstrap.rs::apply_storage_runtime_config` | Storage | recovery-bootstrap work | Promote out of recovery bootstrap and make it the common storage apply helper. |
 | Direct `SegmentedStore::set_*` storage-knob calls in engine | Engine | `database/open.rs`, `database/mod.rs` | Remove or route through storage runtime config. |
 | `SegmentedStore::set_snapshot_floor` | Engine | `database/transaction.rs` before compaction | Intentional engine exception; snapshot floor is engine MVCC policy, not static config application. |
 | Block-cache global capacity | Mixed | `database/open.rs` persistent open, `database/open.rs` cache open, `database/mod.rs` runtime `update_config` | Move capacity selection/application into storage runtime config; engine keeps product profile mutation and operator-facing logging. |
-| `WalConfig::default()` for primary WAL writer | Engine call site, storage type | `database/open.rs` | Audit in ES5G; do not move WAL lifecycle in the first ES5 pass. |
+| `WalConfig::default()` for primary WAL writer | Engine call site, storage type | `database/open.rs` | Audit in Phase G; do not move WAL lifecycle in the first storage-runtime-config cleanup pass. |
 | `StrataConfig::durability_mode` | Engine public parser | config validation, primary/follower/cache open, runtime durability changes | Split later only if storage gets a lower runtime durability adapter; public string compatibility stays engine-owned. |
-| `StorageConfig::l0_*` and `write_stall_timeout_ms` | Engine | `database/transaction.rs` write-stall policy | Stay engine for ES5 unless a later storage backpressure design moves the mechanism. |
+| `StorageConfig::l0_*` and `write_stall_timeout_ms` | Engine | `database/transaction.rs` write-stall policy | Stay engine for storage-runtime-config cleanup unless a later storage backpressure design moves the mechanism. |
 
-ES5A characterization added/extended:
+Phase A characterization added/extended:
 
 - persistent open applies observable store runtime knobs, including write
   buffer, branch/version limits, immutable-memtable limits, compaction rate
@@ -271,13 +271,13 @@ ES5A characterization added/extended:
 - recovery runtime config now characterizes the full storage runtime setter set
   that is safely inspectable from engine tests
 
-Known ES5 follow-up gaps:
+Known storage-runtime-config cleanup follow-up gaps:
 
 - block-cache global capacity remains a shared process-wide side effect, so
   tests should avoid order-dependent assertions until storage owns an explicit
   runtime helper for it
 
-## ES5B - Promote StorageRuntimeConfig
+## Phase B - Promote StorageRuntimeConfig
 
 Move `StorageRuntimeConfig` out of the recovery bootstrap module into a stable
 storage runtime config module.
@@ -303,7 +303,7 @@ Deliverables:
   `durability/recovery_bootstrap.rs`
 - re-export the type from an intentional storage module path
 - keep `#[non_exhaustive]` on public config structs/enums
-- preserve the ES4 recovery API behavior
+- preserve the recovery-bootstrap API behavior
 - update docs and imports so recovery bootstrap is a consumer, not the owner
 
 Acceptance:
@@ -313,9 +313,9 @@ Acceptance:
 - engine still adapts from public `StorageConfig`
 - no storage dependency on engine appears
 
-### ES5B Current State
+### Phase B Current State
 
-As of ES5B:
+As of Phase B:
 
 - `StorageRuntimeConfig` lives in `crates/storage/src/runtime_config.rs`
 - storage re-exports `StorageRuntimeConfig` from the crate root and from
@@ -331,7 +331,7 @@ As of ES5B:
 - recovery bootstrap tests only recovery input construction and recovery-time
   application behavior
 
-## ES5C - Move Effective Storage Values Into Storage
+## Phase C - Move Effective Storage Values Into Storage
 
 Move the storage meaning of memory-budget derivation into the storage runtime
 config builder.
@@ -358,9 +358,9 @@ Acceptance:
 - engine no longer needs to know the memory-budget derivation formula in open
   and recovery code
 
-### ES5C Current State
+### Phase C Current State
 
-As of ES5C:
+As of Phase C:
 
 - `StorageRuntimeConfig::builder()` accepts raw storage-facing fields plus
   `memory_budget`
@@ -376,17 +376,17 @@ As of ES5C:
 - persistent and follower open resolve block-cache capacity through
   `StorageRuntimeConfig`
 - cache/ephemeral open applies `StorageRuntimeConfig` directly to the new
-  `SegmentedStore`, fixing the ES5A write-buffer first-open gap
+  `SegmentedStore`, fixing the Phase A write-buffer first-open gap
 - runtime `update_config` applies `StorageRuntimeConfig` directly and resolves
   block-cache capacity through it
 - engine write-pressure checks use `StorageRuntimeConfig` for the effective
   write-buffer and immutable-memtable values while retaining engine-owned
   transaction pressure policy
 
-## ES5D - Centralize Store Application In Storage
+## Phase D - Centralize Store Application In Storage
 
 Close out the remaining store-application cleanup around the storage-owned
-application helper introduced in ES5B and used by ES5C.
+application helper introduced in Phase B and used by Phase C.
 
 Existing target API shape:
 
@@ -412,9 +412,9 @@ Acceptance:
   as engine-owned exceptions
 - recovery and ephemeral/cache open apply the same runtime config mechanics
 
-### ES5D Current State
+### Phase D Current State
 
-As of ES5D:
+As of Phase D:
 
 - `StorageRuntimeConfig::apply_to_store` is the storage-owned application point
   for static `SegmentedStore` runtime knobs
@@ -429,10 +429,10 @@ As of ES5D:
     compaction
   - follower open calls `set_version` only when restoring validated persisted
     follower state, paired with coordinator visible-version restore
-- block-cache global application remains intentionally out of ES5D and is
-  handled by ES5F
+- block-cache global application remains intentionally out of Phase D and is
+  handled by Phase F
 
-## ES5E - Route All Open Paths Through Runtime Config
+## Phase E - Route All Open Paths Through Runtime Config
 
 Make persistent open and ephemeral/cache open share one adapter from public
 engine config to storage runtime config.
@@ -456,9 +456,9 @@ Acceptance:
 - no open path recomputes storage effective values by hand
 - no new disk behavior is introduced for ephemeral/cache databases
 
-### ES5E Current State
+### Phase E Current State
 
-As of ES5E:
+As of Phase E:
 
 - `database/config.rs::storage_runtime_config_from` is the single engine-local
   adapter from public `StorageConfig` to storage-owned `StorageRuntimeConfig`
@@ -475,7 +475,7 @@ As of ES5E:
   `StorageRuntimeConfig::apply_global_runtime`
 - engine open code no longer calls `strata_storage::block_cache::set_global_capacity`
   directly outside tests
-- ES5E includes a serial characterization for default cache open so
+- Phase E includes a serial characterization for default cache open so
   `block_cache_size == 0` no longer silently inherits stale process-wide
   capacity; explicit profile-derived values are asserted exactly, while
   host-dependent auto-detect mode is asserted as a positive non-stale capacity
@@ -483,7 +483,7 @@ As of ES5E:
   pairs `StrataConfig` with the `StorageRuntimeConfig` derived from the same
   public storage config, preventing future call-site drift
 
-## ES5F - Block Cache Boundary
+## Phase F - Block Cache Boundary
 
 Normalize block-cache configuration as storage runtime mechanics.
 
@@ -508,9 +508,9 @@ Acceptance:
 - `block_cache_size > 0` with `memory_budget == 0` still behaves the same
 - `block_cache_size == 0` with no memory budget still uses storage auto-detect
 
-### ES5F Current State
+### Phase F Current State
 
-As of ES5F:
+As of Phase F:
 
 - storage runtime config represents block-cache sizing as
   `StorageBlockCacheConfig::{Auto, Bytes(usize)}` instead of carrying the public
@@ -530,7 +530,7 @@ As of ES5F:
   `StorageRuntimeConfig::block_cache_configured_bytes()` so operator-facing
   compatibility remains `0 == auto`
 
-## ES5G - Codec and WAL Runtime Boundary
+## Phase G - Codec and WAL Runtime Boundary
 
 Audit codec and WAL writer settings after the storage runtime config path is
 centralized.
@@ -561,15 +561,15 @@ Acceptance:
 - no WAL lifecycle code moves without a narrower follow-up design
 - any API changes preserve existing config-file compatibility
 
-### ES5G Current State
+### Phase G Current State
 
-As of ES5G:
+As of Phase G:
 
 | Surface | Owner | Current state |
 |---|---|---|
 | `StorageConfig::codec` public string | Engine | Remains a `strata.toml` field and compatibility-signature input. Engine owns when the public string is read, persisted, and compared for primary/follower/cache open compatibility. |
 | Codec registry lookup and construction | Storage | `durability::get_codec` remains the storage-owned constructor. `durability::validate_codec_id` is the storage-owned preflight helper for call sites that need validation but not a codec value. |
-| Encrypted codec secret source | Split/future | The current AES codec constructor still reads its storage-local environment requirement. ES5G does not add a second engine override path; future product-level secret-source policy stays engine-owned and should be designed separately from registry construction. |
+| Encrypted codec secret source | Split/future | The current AES codec constructor still reads its storage-local environment requirement. Phase G does not add a second engine override path; future product-level secret-source policy stays engine-owned and should be designed separately from registry construction. |
 | MANIFEST codec validation | Storage | `run_storage_recovery` validates the configured codec before recovery-managed side effects, checks existing MANIFEST codec ids, creates missing primary MANIFESTs with the configured codec id, and returns the resolved WAL codec. |
 | Cache-mode `wal_codec` field population | Split | Engine keeps the uniform `Database::wal_codec` field because follower refresh/lifecycle code lives in engine; storage constructs the codec value via `get_codec`. |
 | Checkpoint codec construction | Split | Engine chooses the public codec id from its config snapshot; storage constructs the codec and owns checkpoint byte-format mechanics. |
@@ -583,10 +583,10 @@ As of ES5G:
 | WAL writer construction | Split | Engine constructs the primary `WalWriter` because it owns database open/lifecycle, lock ownership, health latches, and background flush thread wiring; storage owns writer internals, durability mechanics, segment rotation, and config validation. |
 | Background WAL flush thread | Engine | No code moved. Engine still owns thread spawning, shutdown coordination, WAL writer health halt/resume policy, and accepting-transaction latches. |
 
-ES5G intentionally does not move WAL lifecycle code. A future WAL-runtime epic
+Phase G intentionally does not move WAL lifecycle code. A future WAL-runtime epic
 would need a narrower design before storage owns a worker surface.
 
-## ES5H - Retention and Residual Config Cleanup
+## Phase H - Retention and Residual Config Cleanup
 
 Close out the storage config application epic by documenting or moving the
 remaining storage-shaped config surfaces.
@@ -609,9 +609,9 @@ Acceptance:
 - storage-owned fields are either applied by storage runtime config or tracked
   as a future implementation gap
 
-### ES5H Current State
+### Phase H Current State
 
-As of ES5H, the final ownership map for public storage-shaped configuration is:
+As of Phase H, the final ownership map for public storage-shaped configuration is:
 
 | Public surface | Owner | Current state |
 |---|---|---|
@@ -635,15 +635,15 @@ As of ES5H, the final ownership map for public storage-shaped configuration is:
 | `StrataConfig::durability` | Split | Engine owns public string compatibility and where modes are allowed. Storage owns WAL durability mechanics. |
 | `SnapshotRetentionPolicy::retain_count` | Split | Engine owns the public policy. Storage owns pruning mechanics through `StorageSnapshotRetention`, including the minimum one-snapshot retention invariant. |
 
-ES5H also leaves one intentional validation gap: storage runtime config now owns
-where segment sizing and bloom/filter compaction knobs are applied, but ES5 does
-not introduce new config-file rejection for historically accepted values such
+Phase H also leaves one intentional validation gap: storage runtime config now
+owns where segment sizing and bloom/filter compaction knobs are applied, but
+this cleanup does not introduce new config-file rejection for historically accepted values such
 as zero-sized segment-layout knobs. Tightening those values should be a future
 storage validation PR with explicit compatibility notes.
 
-ES5H also leaves the `max_branches` behavior as-is: the value is now routed
-through the storage runtime boundary and stored on `SegmentedStore`, but ES5
-does not introduce a new branch-creation enforcement path. If that public field
+Phase H also leaves the `max_branches` behavior as-is: the value is now routed
+through the storage-runtime boundary and stored on `SegmentedStore`, but this
+cleanup does not introduce a new branch-creation enforcement path. If that public field
 is meant to become a hard limit, it should be designed as a separate storage
 semantics change with characterization for existing multi-branch users.
 
@@ -681,7 +681,7 @@ cargo test -p strata-engine
 ```
 
 If known unrelated failures remain in the full engine suite, document the exact
-failure count and confirm the focused ES5 tests pass.
+failure count and confirm the focused storage-runtime-config cleanup tests pass.
 
 ## Boundary Guards
 
@@ -716,23 +716,23 @@ mechanics. Product profiles, operator-facing comments, compatibility
 fingerprints, and public config migration stay in engine.
 
 The second risk is accidentally changing open behavior while converging the
-paths. This is why ES5A should characterize persistent and ephemeral/cache open
+paths. This is why Phase A should characterize persistent and ephemeral/cache open
 before any code movement.
 
-The third risk is broadening ES5 into WAL lifecycle redesign. WAL writer
+The third risk is broadening storage-runtime-config cleanup into WAL lifecycle redesign. WAL writer
 runtime construction can be cleaned up, but WAL health, shutdown, transaction
 halt, and resume policy are engine lifecycle concerns unless a later subplan
 draws a smaller callback-based surface.
 
 ## Done Criteria
 
-ES5 is done when:
+storage-runtime-config cleanup is done when:
 
 - all open paths use a storage-owned runtime config application path
 - engine owns only the public config adapter, not storage setter mechanics
 - storage owns effective storage resource derivation
 - block-cache capacity application is no longer ad hoc in engine open code
-- recovery still preserves ES4 ordering guarantees
+- recovery still preserves recovery-bootstrap cleanup ordering guarantees
 - existing config files remain compatible
 - tests cover persistent open, ephemeral/cache open, recovery, and memory-budget
   behavior

--- a/docs/engine/storage-runtime-boundary-api-sketch.md
+++ b/docs/engine/storage-runtime-boundary-api-sketch.md
@@ -1,12 +1,12 @@
-# ES2-ES4 Storage Runtime Boundary API Sketch
+# Storage Runtime Boundary API Sketch
 
 ## Purpose
 
-This is the `ES2A` design sketch for the storage/runtime boundary shared by:
+This is the initial design sketch for the storage/runtime boundary shared by:
 
-- `ES2` - checkpoint and WAL compaction mechanics
-- `ES3` - snapshot decode and install mechanics
-- `ES4` - recovery bootstrap mechanics
+- `checkpoint/WAL cleanup` - checkpoint and WAL compaction mechanics
+- `snapshot-install cleanup` - snapshot decode and install mechanics
+- `recovery-bootstrap cleanup` - recovery bootstrap mechanics
 
 The code moves are sequential, but the APIs are coupled:
 
@@ -16,15 +16,15 @@ The code moves are sequential, but the APIs are coupled:
 - recovery composes MANIFEST preparation, snapshot install, WAL replay, and
   segmented-store bootstrap
 
-This sketch defines the intended type families before ES2 moves checkpoint
-mechanics down into storage.
+This sketch defines the intended type families before the checkpoint/WAL cleanup
+moves checkpoint mechanics down into storage.
 
 Read this together with:
 
 - [engine-storage-boundary-normalization-plan.md](./engine-storage-boundary-normalization-plan.md)
-- [es1-boundary-baseline-and-guardrails-plan.md](./es1-boundary-baseline-and-guardrails-plan.md)
-- [es2-checkpoint-wal-compaction-mechanics-plan.md](./es2-checkpoint-wal-compaction-mechanics-plan.md)
-- [es4-recovery-bootstrap-mechanics-plan.md](./es4-recovery-bootstrap-mechanics-plan.md)
+- [boundary-baseline-and-guardrails-plan.md](./boundary-baseline-and-guardrails-plan.md)
+- [checkpoint-wal-compaction-mechanics-plan.md](./checkpoint-wal-compaction-mechanics-plan.md)
+- [recovery-bootstrap-mechanics-plan.md](./recovery-bootstrap-mechanics-plan.md)
 
 ## Boundary Decision
 
@@ -32,8 +32,8 @@ Use storage-owned runtime APIs around `DatabaseLayout`.
 
 Do not pass ad-hoc `data_dir.join(...)` paths across the boundary. Storage
 already owns `strata_storage::durability::DatabaseLayout`, and recovery already
-uses it. ES2 should extend checkpoint and compaction to use the same layout
-vocabulary.
+uses it. The checkpoint/WAL cleanup should extend checkpoint and compaction to
+use the same layout vocabulary.
 
 Engine remains the public API and policy owner:
 
@@ -60,20 +60,21 @@ those facts into public database behavior.
 
 ## Coordinator Decision
 
-`TransactionCoordinator` stays engine-owned for ES4.
+`TransactionCoordinator` stays engine-owned for recovery bootstrap.
 
 This is the least invasive split and matches the intended architecture:
 storage recovers durable substrate state, while engine owns transaction-facing
 runtime orchestration and public database semantics.
 
-ES4 should therefore not make storage call into engine per replayed record to
-update coordinator state. Storage should replay WAL records directly into
+Recovery bootstrap should therefore not make storage call into engine per
+replayed record to update coordinator state. Storage should replay WAL records directly into
 `SegmentedStore` using storage-owned mechanics, then return `RecoveryStats`
 and `RecoveredState`. Engine then constructs or updates
 `TransactionCoordinator` from those raw facts.
 
 If later work wants to move `TransactionCoordinator`, that should be a
-separate coordinator ownership plan, not an incidental ES4 side effect.
+separate coordinator ownership plan, not an incidental recovery-bootstrap side
+effect.
 
 ## Shared Layout And Manifest Helpers
 
@@ -89,8 +90,9 @@ StorageRuntimeConfig
 CheckpointData
 ```
 
-ES2C should introduce only the manifest helpers needed for checkpoint and WAL
-compaction, but the helper shape should be reusable by ES4.
+The checkpoint/WAL cleanup should introduce only the manifest helpers needed
+for checkpoint and WAL compaction, but the helper shape should be reusable by
+recovery bootstrap.
 
 Candidate internal storage helpers:
 
@@ -112,7 +114,7 @@ These helpers should not decide:
 
 Those remain engine decisions.
 
-## ES2 Checkpoint Boundary
+## Checkpoint Boundary
 
 Candidate module:
 
@@ -134,7 +136,7 @@ StorageCheckpointInput {
 }
 ```
 
-`checkpoint_data` is supplied by engine. ES2 should not move
+`checkpoint_data` is supplied by engine. checkpoint/WAL cleanup should not move
 `Database::collect_checkpoint_data()` wholesale because that function contains
 primitive materialization rules:
 
@@ -160,7 +162,7 @@ StorageCheckpointOutcome {
 The outcome is deliberately raw. Engine logs the database-level message and
 maps storage errors into `StrataError`.
 
-ES2D split snapshot pruning out of the checkpoint outcome. Storage owns the
+Phase D split snapshot pruning out of the checkpoint outcome. Storage owns the
 raw pruning helper and retention minimum, while engine keeps the lifecycle and
 configuration adapter. `Database::checkpoint()` runs pruning after the
 checkpoint and MANIFEST update, preserving the existing non-fatal warning
@@ -168,11 +170,11 @@ behavior for pruning failure.
 
 `manifest_create_codec_id` is explicit because current
 `Database::load_or_create_manifest()` writes `"identity"` when it creates a
-missing MANIFEST in the checkpoint/compact path. ES2C must either preserve
+missing MANIFEST in the checkpoint/compact path. Phase C must either preserve
 that behavior or call out an intentional behavior change with compatibility
 tests before passing the configured checkpoint codec id instead.
 
-## ES2 WAL Compaction Boundary
+## WAL Compaction Boundary
 
 Candidate input:
 
@@ -195,13 +197,13 @@ zero-override fallback.
 
 `database_uuid` and `manifest_create_codec_id` are explicit because current
 `Database::compact()` can create a missing MANIFEST before returning the
-no-checkpoint error. ES2F should preserve that behavior unless it deliberately
+no-checkpoint error. Phase F should preserve that behavior unless it deliberately
 changes the missing-MANIFEST compatibility contract.
 
-ES2G also uses a small `StorageManifestSyncInput` for shutdown-time MANIFEST
+The checkpoint/WAL cleanup also uses a small `StorageManifestSyncInput` for shutdown-time MANIFEST
 fsync. That boundary is intentionally limited to generic MANIFEST
 load/create/active-segment/persist mechanics. Engine still owns shutdown
-sequencing and ES4 still owns recovery/open MANIFEST policy.
+sequencing and recovery bootstrap still owns recovery/open MANIFEST policy.
 
 Candidate output:
 
@@ -216,7 +218,7 @@ StorageWalCompactionOutcome {
 `snapshot_watermark` mirrors `CompactInfo::snapshot_watermark`, the raw
 retention fact currently produced by `WalOnlyCompactor`. It is useful for
 tests and diagnostics, but engine should not turn it into an operator report
-in ES2.
+in checkpoint/WAL cleanup.
 
 Storage should preserve `CompactionError::NoSnapshot` or an equivalent
 storage-local variant. Engine continues mapping that case to the existing
@@ -226,7 +228,7 @@ public invalid-input message:
 No checkpoint exists yet. Run checkpoint() before compact().
 ```
 
-## ES3 Snapshot Install Boundary
+## snapshot-install cleanup Snapshot Install Boundary
 
 Candidate module:
 
@@ -279,10 +281,10 @@ Storage must not learn:
 - graph query semantics
 
 Engine remains responsible for converting a loaded snapshot into this generic
-storage-row plan. The ES3 engine wrapper should become the function ES4
+storage-row plan. The snapshot-install cleanup engine wrapper should become the function recovery-bootstrap cleanup
 recovery calls when the `RecoveryCoordinator` supplies a loaded snapshot.
 
-## ES4 Recovery Boundary
+## recovery-bootstrap cleanup Recovery Boundary
 
 Candidate module:
 
@@ -312,7 +314,7 @@ RecoverySnapshotInstallCallback {
 }
 ```
 
-The ES4 implementation plan refines this callback to pass the resolved
+The recovery-bootstrap cleanup implementation plan refines this callback to pass the resolved
 snapshot install codec as well. That keeps MANIFEST/codec resolution in
 storage while letting engine continue to own primitive snapshot decode.
 
@@ -365,7 +367,7 @@ StorageLossyWalReplayFacts {
 
 Engine decides whether to request lossy WAL replay from config. Storage may
 perform the mechanical wipe only after engine opts in via
-`allow_lossy_wal_replay: true`. The ES4F implementation keeps that opt-in
+`allow_lossy_wal_replay: true`. The recovery-bootstrap implementation keeps that opt-in
 inside the opaque storage replay object so engine cannot pass a mismatched
 policy flag, replay result, or pre-failure applied-record count into the lossy
 outcome helper. Engine still owns `LossyRecoveryReport` wording and public
@@ -393,7 +395,7 @@ wal_replay.final_version = max(wal_replay.final_version, CommitVersion(storage.v
 
 The current `RecoveryCoordinator` does not fold snapshot-installed entry
 versions into `RecoveryStats`; the current engine does that before
-`TransactionCoordinator` bootstrap. ES4 must preserve that behavior.
+`TransactionCoordinator` bootstrap. Recovery bootstrap must preserve that behavior.
 
 Storage recovery must also preserve the current ordering around storage
 configuration:
@@ -406,14 +408,14 @@ recover_segments()
 return StorageRecoveryOutcome
 ```
 
-Until ES5 completes the public config split, engine builds
+Until the storage-runtime-config cleanup completes the public config split, engine builds
 `StorageRuntimeConfig` from `StrataConfig.storage` and passes it down. This
-does not move public config ownership into storage; it only prevents ES4 from
-running `recover_segments()` with default storage knobs.
+does not move public config ownership into storage; it only prevents recovery
+bootstrap from running `recover_segments()` with default storage knobs.
 
-## ES4 Engine Wrapper Shape
+## Recovery Bootstrap Engine Wrapper Shape
 
-After ES4, `Database::run_recovery()` should remain the engine entry point.
+After recovery bootstrap, `Database::run_recovery()` should remain the engine entry point.
 It should do roughly:
 
 ```text
@@ -442,7 +444,7 @@ StorageCheckpointOutcome
     -> recovery uses MANIFEST snapshot_id/watermark to install snapshot and skip WAL
 
 StorageDecodedSnapshotInstallStats
-    -> returned by storage decoded-row install in ES3
+    -> returned by storage decoded-row install in snapshot-install cleanup
     -> may be observed inside the engine snapshot callback
     -> is not embedded in StorageRecoveryOutcome because storage recovery does
        not own primitive decode or primitive install telemetry
@@ -500,9 +502,9 @@ major boundary decisions above.
 
 Deferred details:
 
-- whether ES2 stores `checkpoint_codec` by object or codec id
+- whether checkpoint/WAL cleanup stores `checkpoint_codec` by object or codec id
 - whether pruning stats include bytes
-- whether ES4 recovery returns `StorageRecoveryOutcome.storage` by value or
+- whether recovery bootstrap returns `StorageRecoveryOutcome.storage` by value or
   through a smaller recovered-store wrapper
 - whether manifest helpers are public within `durability` or private to the
   checkpoint/recovery modules
@@ -510,29 +512,29 @@ Deferred details:
 Not deferred:
 
 - use `DatabaseLayout` rather than ad-hoc paths
-- keep `TransactionCoordinator` in engine for ES4
+- keep `TransactionCoordinator` in engine for recovery bootstrap
 - keep primitive checkpoint materialization out of storage
 - preserve snapshot-version folding before coordinator bootstrap
 - preserve storage-config-before-`recover_segments()` ordering
 - preserve lossy hard-fail bypass behavior
 - keep engine policy and public error/report conversion out of storage
 
-## ES2A Acceptance
+## Phase A Acceptance
 
-ES2A is complete when:
+Phase A is complete when:
 
-1. This sketch exists and is linked from the ES2 plan.
-2. ES2 checkpoint and WAL compaction APIs are sketched using
+1. This sketch exists and is linked from the checkpoint/WAL cleanup plan.
+2. Checkpoint and WAL compaction APIs are sketched using
    `DatabaseLayout`.
-3. ES3 snapshot install stats are sketched as physical storage counters.
-4. ES4 recovery outcome is sketched without `TransactionCoordinator`.
+3. Snapshot install stats are sketched as physical storage counters.
+4. Recovery bootstrap outcome is sketched without `TransactionCoordinator`.
 5. The coordinator ownership decision is explicit.
 6. The sketch explains how checkpoint, snapshot install, and recovery
    outcomes compose.
-7. ES4 recovery invariants are explicit:
+7. Recovery bootstrap invariants are explicit:
    - snapshot-version fold before coordinator bootstrap
    - storage config before `recover_segments()`
    - lossy hard-fail bypass preservation
-8. ES2 checkpoint edge cases are explicit:
+8. checkpoint/WAL cleanup checkpoint edge cases are explicit:
    - missing-MANIFEST codec id behavior cannot change silently
    - pruning failure remains nonfatal to checkpoint success

--- a/docs/storage/storage-crate-map.md
+++ b/docs/storage/storage-crate-map.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 
-This document is a baseline map of `crates/storage` as it exists today.
+This document maps `crates/storage` after the storage consolidation and the
+storage-boundary normalization.
 
-It is not a target design. It is a description of the current ownership and
-behavior in the storage crate, written to support the next major storage-side
-consolidation effort.
+It describes the settled lower-runtime substrate that engine and the current
+upper crates build on.
 
 For the target boundary of the clean storage layer, see
 [storage-charter.md](./storage-charter.md).
@@ -14,10 +14,10 @@ For the target boundary of the clean storage layer, see
 For the cross-boundary ownership question with engine, see
 [storage-engine-ownership-audit.md](./storage-engine-ownership-audit.md).
 
-The important takeaway is that `strata-storage` is already the real lower
-runtime anchor of the system. The remaining work is no longer about finding
-the right lower-runtime owner. It is about severing the final legacy
-dependencies above it cleanly.
+The important takeaway is that `strata-storage` is the real lower runtime
+anchor of the system. The remaining work is above storage: future engine
+consolidation may absorb graph, vector, search, executor-legacy, and security
+responsibilities, but storage should remain the generic persistence substrate.
 
 ## High-Level Shape
 
@@ -41,6 +41,7 @@ Major supporting files:
 - [manifest.rs](../../crates/storage/src/manifest.rs)
 - [compaction.rs](../../crates/storage/src/compaction.rs)
 - [key_encoding.rs](../../crates/storage/src/key_encoding.rs)
+- [runtime_config.rs](../../crates/storage/src/runtime_config.rs)
 
 Major subtrees:
 
@@ -48,6 +49,7 @@ Major subtrees:
   compaction, ref tracking, and quarantine protocol
 - `durability/` — WAL, snapshot/checkpoint, MANIFEST, decoded-row install,
   and recovery-bootstrap mechanics
+- `txn/` — generic transaction context, validation, and manager mechanics
 
 The crate is already substantial. The heaviest ownership points are:
 
@@ -76,8 +78,11 @@ Today `strata-storage` re-exports:
   - `StorageResult`
 - storage engine types:
   - `SegmentedStore`
-  - `VersionedValue`
+  - `VersionedEntry`
   - `StoredValue`
+- storage runtime config types:
+  - `StorageRuntimeConfig`
+  - `StorageBlockCacheConfig`
 - durability runtime types:
   - WAL reader/writer, codec, layout, and format types
   - checkpoint, compaction, snapshot-prune, and MANIFEST-sync helpers
@@ -87,9 +92,7 @@ Today `strata-storage` re-exports:
   - compaction helpers
   - quarantine helpers
 
-This means storage already owns the persistence substrate boundary in active
-code, even though some neighboring runtime responsibilities still live in
-other crates.
+This means storage owns the persistence substrate boundary in active code.
 
 ## Current Dependency Shape
 
@@ -114,7 +117,9 @@ The internal incoming graph today is:
 The root `stratadb` package also depends on storage in dev/test paths.
 
 This confirms that storage is already the effective substrate node of the
-workspace.
+workspace. The direct upper-crate storage edges are current transitional
+workspace shape, not permission for upper layers to drive database recovery,
+checkpoint, open, retention, or product policy below engine.
 
 ## What Storage Already Owns
 
@@ -172,6 +177,19 @@ In [durability/](../../crates/storage/src/durability), storage owns:
 - recovery bootstrap mechanics through
   [recovery_bootstrap.rs](../../crates/storage/src/durability/recovery_bootstrap.rs)
 
+### 6. Storage Runtime Configuration
+
+In [runtime_config.rs](../../crates/storage/src/runtime_config.rs), storage
+owns:
+
+- storage runtime config defaults
+- effective storage knob derivation from raw storage inputs
+- store-local application to `SegmentedStore`
+- process-global block-cache capacity application
+
+Engine owns the public `StrataConfig` / `StorageConfig` surface and adapts it
+into this storage-owned runtime config.
+
 ## What Storage Now Owns
 
 Storage now owns the full lower runtime substrate.
@@ -186,6 +204,7 @@ The major substrate responsibilities now physically owned here are:
 - checkpoint and WAL compaction runtime
 - generic decoded-row snapshot install runtime
 - recovery bootstrap and replay coordination
+- storage runtime config derivation and application
 
 ## Current Architectural Role
 
@@ -210,3 +229,21 @@ The remaining work is above the substrate now:
 
 - keep primitive semantics out of the lower layer
 - let `engine` converge on its own clean domain/runtime boundary
+- keep the documented storage seams raw, mechanical, and policy-free
+
+## Engine Boundary Seams
+
+Storage exposes a small set of storage-owned runtime helpers to engine. These
+helpers are intentional seams, not invitations for engine policy to move down:
+
+| Surface | Storage Owns |
+|---|---|
+| Checkpoint and WAL compaction | `checkpoint_runtime.rs` helpers that operate on checkpoint files, WAL segments, MANIFEST state, and raw outcomes |
+| Snapshot install | `decoded_snapshot_install.rs` validation and install for already decoded storage rows |
+| Recovery bootstrap | `recovery_bootstrap.rs` MANIFEST prep, codec validation, replay, segment recovery, and raw recovery facts |
+| Runtime config | `runtime_config.rs` effective storage values and application to stores/global cache |
+| Retention | storage snapshot pruning mechanics and minimum-retain invariant |
+
+The matching engine responsibilities are documented in
+[../engine/engine-crate-map.md](../engine/engine-crate-map.md) and
+[storage-engine-ownership-audit.md](./storage-engine-ownership-audit.md).

--- a/docs/storage/storage-engine-ownership-audit.md
+++ b/docs/storage/storage-engine-ownership-audit.md
@@ -2,76 +2,74 @@
 
 ## Purpose
 
-This document audits the current boundary between `strata-storage` and
-`strata-engine`.
+This document records the settled storage/engine boundary between
+`strata-storage` and `strata-engine`.
 
-It exists because the storage consolidation work cannot safely proceed by
-assuming either crate is already clean. The lower-runtime split across
-`storage`, `concurrency`, and `durability` already proves that current crate
-location is not reliable evidence of rightful ownership.
+The original audit existed because crate location was not reliable evidence of
+rightful ownership: lower-runtime checkpoint, recovery, snapshot, and config
+mechanics were still hosted in engine. The storage-boundary normalization corrected those targeted
+surfaces without flattening the architecture.
 
-This audit answers one question directly:
+The current rule is:
 
-**What in `storage` truly belongs in `storage`, what in `engine` truly belongs
-in `engine`, and what code is currently sitting on the wrong side of that
-boundary?**
+- `strata-storage` owns generic persistence, transaction, durability, recovery,
+  retention, and storage-runtime mechanics
+- `strata-engine` owns database orchestration, public APIs, primitive
+  semantics, branch/domain semantics, search/runtime behavior, and product
+  policy
+- cross-boundary calls are allowed only where engine-owned semantics or policy
+  intentionally invoke storage-owned substrate mechanics
 
-It should be read together with:
+This audit should be read together with:
 
 - [storage-charter.md](./storage-charter.md)
 - [storage-crate-map.md](./storage-crate-map.md)
 - [../engine/engine-crate-map.md](../engine/engine-crate-map.md)
-- [concurrency-crate-map.md](./concurrency-crate-map.md)
-- [durability-crate-map.md](./durability-crate-map.md)
+- [../engine/engine-storage-boundary-normalization-plan.md](../engine/engine-storage-boundary-normalization-plan.md)
+- [../engine/boundary-closeout-plan.md](../engine/boundary-closeout-plan.md)
 
-## Audit Rule
+## Current Verdict
 
-The classification rule is simple:
+The targeted storage/engine ownership split is documented and guarded for the
+storage-boundary normalization surfaces. This closeout record does not replace
+the final broad regression gate in the main normalization plan; the full
+workstream is complete only after that gate is run and recorded.
 
-- if code implements **generic persistence or runtime mechanics**, it belongs
-  in `storage`
-- if code implements **primitive meaning, branch/domain meaning, or
-  product/runtime behavior above the substrate**, it belongs in `engine`
+That does not mean engine has no storage calls. The intended architecture is a
+layered call direction:
 
-This audit does not use crate names as proof.
+```text
+core -> storage -> engine -> intelligence -> executor -> cli
+```
 
-## Summary Verdict
+Engine is expected to call storage because engine is the database orchestration
+layer. The closeout condition is that those calls now cross explicit seams from
+engine-owned semantics and policy into storage-owned mechanics.
 
-The current boundary is not clean.
+The crate graph remains one-way: `strata-storage` depends on `strata-core` and
+does not depend on `strata-engine`. `strata-engine` depends on
+`strata-storage`.
 
-The dirt is uneven:
+## Storage-Owned Surfaces
 
-- `storage` is already mostly a real storage crate
-- `engine` still contains a meaningful amount of lower storage-runtime code
+The following areas are storage-owned and should stay below engine.
 
-So the main corrective movement is likely:
-
-- **more code from `engine` down into `storage`**
-- not a large amount of storage code up into `engine`
-
-There are still a few storage-side surfaces that need careful watching so they
-do not become engine policy by accident, but the larger ownership problem is
-on the engine side.
-
-## What Clearly Belongs In `storage`
-
-The following `storage` areas look correctly placed and should stay there.
-
-### 1. Physical Layout And Addressing
+### Physical Layout And Addressing
 
 - [layout.rs](../../crates/storage/src/layout.rs)
 - [key_encoding.rs](../../crates/storage/src/key_encoding.rs)
 
-These own:
+Storage owns:
 
 - `Key`
 - `Namespace`
 - `TypeTag`
-- physical key encoding/layout rules
+- physical key encoding and space-name validation
 
-This is substrate ownership, not engine semantics.
+These are substrate identifiers. `TypeTag` may be used as an opaque storage
+family byte, but storage must not attach primitive semantics to it.
 
-### 2. MVCC Storage State
+### MVCC Storage State
 
 - [segment.rs](../../crates/storage/src/segment.rs)
 - [memtable.rs](../../crates/storage/src/memtable.rs)
@@ -79,280 +77,210 @@ This is substrate ownership, not engine semantics.
 - [seekable.rs](../../crates/storage/src/seekable.rs)
 - [merge_iter.rs](../../crates/storage/src/merge_iter.rs)
 - [ttl.rs](../../crates/storage/src/ttl.rs)
-- [segmented/mod.rs](../../crates/storage/src/segmented/mod.rs)
+- [segmented/](../../crates/storage/src/segmented)
 
-These implement:
+Storage owns:
 
 - versioned state
-- reads/writes/scans
+- reads, writes, scans, and counts
 - tombstones and TTL
-- segment/memtable mechanics
+- segment and memtable mechanics
+- branch-scoped physical state
+- quarantine and corruption handling
 
-This is exactly what storage should own.
+Branch identifiers are physical storage partition keys here, not branch
+workflow policy.
 
-### 3. Storage-Local Error And Health Surface
+### Generic Transaction Runtime
+
+- [txn/](../../crates/storage/src/txn)
+- [durability/commit_adapter.rs](../../crates/storage/src/durability/commit_adapter.rs)
+
+Storage owns:
+
+- transaction context storage state
+- OCC validation
+- CAS and read-set validation
+- storage commit adaptation into WAL-backed or memory-backed persistence
+
+Primitive transaction semantics remain in engine.
+
+### Durability Runtime
+
+- [durability/](../../crates/storage/src/durability)
+- [durability/checkpoint_runtime.rs](../../crates/storage/src/durability/checkpoint_runtime.rs)
+- [durability/decoded_snapshot_install.rs](../../crates/storage/src/durability/decoded_snapshot_install.rs)
+- [durability/recovery_bootstrap.rs](../../crates/storage/src/durability/recovery_bootstrap.rs)
+- [runtime_config.rs](../../crates/storage/src/runtime_config.rs)
+
+Storage owns:
+
+- WAL read/write, codec, and payload mechanics
+- snapshot/checkpoint file mechanics
+- generic MANIFEST load/create/update mechanics
+- checkpoint, WAL compaction, snapshot pruning, and MANIFEST sync helpers
+- generic decoded-row snapshot install into `SegmentedStore`
+- storage recovery bootstrap and replay coordination
+- storage runtime config derivation and application
+
+These APIs expose raw substrate facts and storage-local errors. They must not
+grow engine reports, `StrataError`, recovery policy wording, or product config
+vocabulary.
+
+### Storage-Local Error And Retention Facts
 
 - [error.rs](../../crates/storage/src/error.rs)
-
-This owns storage-local corruption, manifest, quarantine, and recovery fault
-classification. That is lower-runtime health, not engine behavior.
-
-### 4. Storage-Retention Mechanics
-
-- [manifest.rs](../../crates/storage/src/manifest.rs)
-- [quarantine.rs](../../crates/storage/src/quarantine.rs)
 - [segmented/quarantine_protocol.rs](../../crates/storage/src/segmented/quarantine_protocol.rs)
 - [segmented/recovery.rs](../../crates/storage/src/segmented/recovery.rs)
 
-These own:
+Storage owns:
 
-- segment manifests
-- quarantine manifests
-- retention protocol mechanics
-- raw recovery outcomes
+- `StorageError`
+- storage corruption and IO classification
+- raw recovery health and degradation facts
+- raw retention and inherited-layer facts
 
-These are storage/runtime concerns even though they mention branches and
-recovery classes.
+Engine turns these into public errors, health reports, and operator-facing
+retention reports.
 
-## Storage-Side Surfaces That Need Careful Discipline
+## Engine-Owned Surfaces
 
-These do not obviously need to move today, but they can drift upward into
-engine-shaped policy if left unchecked.
+The following areas are engine-owned and should stay above storage.
 
-### 1. Retention Fact Surfaces
+### Database Runtime And Lifecycle
 
-- `StorageBranchRetention`
-- `StorageInheritedLayerInfo`
+- [database/](../../crates/engine/src/database)
 
-Defined in:
+Engine owns:
 
-- [segmented/quarantine_protocol.rs](../../crates/storage/src/segmented/quarantine_protocol.rs)
+- `Database::open_runtime()`
+- `Database::checkpoint()`
+- `Database::compact()`
+- lifecycle/open-state checks
+- primary vs follower mode policy
+- subsystem recovery and initialization ordering
+- public health, retention, recovery, and lossiness reporting
+- conversion into `StrataError` and `RecoveryError`
 
-These are acceptable **only as raw storage facts**:
+Engine may call storage runtime helpers, but it remains the public database API
+owner and policy interpreter.
 
-- physical bytes
-- inherited-layer bytes
-- quarantined bytes
-- manifest-derived reachability facts
-
-They should not accumulate:
-
-- lifecycle attribution
-- operator-facing policy
-- user-facing report semantics
-
-That richer interpretation belongs in engine code like
-[database/retention_report.rs](../../crates/engine/src/database/retention_report.rs).
-
-### 2. Branch-Scoped Physical Operations
-
-- `materialize_layer`
-- reclaim/quarantine protocol
-- inherited-layer state
-
-These may look branch-flavored, but they are still storage concerns as long as
-they remain about **physical retention and copy-on-write mechanics**, not
-branch lifecycle semantics.
-
-The line is:
-
-- physical branch storage mechanics stay in `storage`
-- branch workflow semantics stay in `engine`
-
-## What Clearly Belongs In `engine`
-
-The following engine areas look correctly placed and should stay there.
-
-### 1. Branch Domain And Workflow
+### Branch Domain And Workflow
 
 - [branch_domain.rs](../../crates/engine/src/branch_domain.rs)
 - [branch_ops/](../../crates/engine/src/branch_ops)
 
-These own:
+Engine owns:
 
 - branch lifecycle/control
 - branch DAG semantics
 - merge/cherry-pick/revert workflow
 - branch-level business rules
 
-That is engine territory.
+Storage may store branch-scoped physical rows and inherited layers. It must not
+own branch workflow policy.
 
-### 2. Primitive Semantics
+### Primitive Semantics
 
-- [semantics/event.rs](../../crates/engine/src/semantics/event.rs)
-- [semantics/json.rs](../../crates/engine/src/semantics/json.rs)
-- [semantics/vector.rs](../../crates/engine/src/semantics/vector.rs)
-- [semantics/value.rs](../../crates/engine/src/semantics/value.rs)
+- [semantics/](../../crates/engine/src/semantics)
 - [primitives/](../../crates/engine/src/primitives)
-
-These own:
-
-- JSON path/patch behavior
-- event semantics
-- vector metric/config behavior
-- search/runtime-facing value extraction
-
-This should not sink into storage.
-
-### 3. Branch Bundle Import/Export
-
-- [bundle.rs](../../crates/engine/src/bundle.rs)
-
-This is a product/domain workflow layered on top of lower persistence formats.
-It belongs in engine, not storage.
-
-### 4. Search And Higher Runtime Behavior
-
 - [search/](../../crates/engine/src/search)
-- [background.rs](../../crates/engine/src/background.rs) for non-storage tasks
 
-Search indexing, search manifests, tokenization, and higher runtime behavior
-belong above storage.
+Engine owns:
 
-## What Is Probably On The Wrong Side Today
+- JSON path and patch behavior
+- event semantics
+- vector config and metric semantics
+- search-facing value extraction
+- primitive snapshot section decode
+- primitive-shaped install and recovery telemetry
+- search indexing and runtime behavior
 
-This is the main outcome of the audit.
+These semantics must not move into storage, even when their durable
+representation is KV rows.
 
-Several engine modules look much closer to storage-runtime implementation than
-to engine semantics.
+### Product-Facing Runtime Workflows
 
-### 1. Checkpoint / WAL Compaction Mechanics
-
-- [database/compaction.rs](../../crates/engine/src/database/compaction.rs)
-
-This module currently owns:
-
-- checkpoint creation
-- WAL compaction
-- snapshot pruning
-- MANIFEST watermark updates
-
-Those are substrate runtime mechanics. Engine may expose public methods such as
-`Database::checkpoint()` or `Database::compact()`, but the underlying
-implementation wants to live in `storage`.
-
-### 2. Snapshot Decode And Install Mechanics
-
-- [database/snapshot_install.rs](../../crates/engine/src/database/snapshot_install.rs)
-
-This module decodes snapshot sections and installs them into
-`SegmentedStore`. That is very close to durability/storage replay mechanics,
-not semantic engine behavior.
-
-### 3. Recovery Bootstrap Mechanics
-
-- [database/recovery.rs](../../crates/engine/src/database/recovery.rs)
-
-This module currently owns:
-
-- MANIFEST preparation
-- WAL codec resolution
-- `SegmentedStore` recovery orchestration
-- replay bootstrap
-- lossiness/degradation branching around storage recovery
-
-Some of the final classification and operator policy belongs in engine, but a
-large part of this module looks like lower-runtime recovery code that should
-sink into `storage`.
-
-### 4. Storage Configuration Application
-
-- [database/open.rs](../../crates/engine/src/database/open.rs)
+- [bundle/](../../crates/engine/src/bundle)
+- [background.rs](../../crates/engine/src/background.rs)
+- [database/profile.rs](../../crates/engine/src/database/profile.rs)
 - [database/config.rs](../../crates/engine/src/database/config.rs)
 
-The public `StrataConfig` belongs in engine because it is part of database
-runtime orchestration. But the **mechanics** of:
+Engine owns:
 
-- applying storage knobs
-- wiring WAL writer settings
-- interpreting storage-only config
+- branch bundle import/export
+- product and hardware profiles
+- public `StrataConfig` and compatibility behavior
+- background task orchestration above storage mechanics
 
-want a stronger storage-side home.
+Storage owns only the storage-shaped runtime config derived from that public
+engine config.
 
-The likely end state is split ownership:
+## Intentional Boundary Seams
 
-- engine owns the database-facing config surface
-- storage owns the storage-runtime config application and defaults for its own
-  subsystem
+| Surface | Storage Owns | Engine Owns | Why The Seam Remains |
+|---|---|---|---|
+| Checkpoint | File construction, raw checkpoint facts, manifest and watermark mechanics | `Database::checkpoint()`, lifecycle checks, public result and error mapping | Checkpoint is a public database operation, but its durable mechanics are generic storage work. |
+| WAL compaction | WAL pruning and manifest active-segment mechanics | `Database::compact()`, lifecycle checks, public result and error mapping | Engine decides when compaction is requested; storage executes the lower WAL/manifest mechanics. |
+| Snapshot pruning | Filesystem pruning and raw prune facts | lifecycle-aware retention report | Storage knows files and counts; engine knows operator-facing retention vocabulary. |
+| Snapshot install | Generic decoded-row validation and install | primitive section decode, primitive install stats, recovery policy | Primitive snapshot DTOs and section meaning are engine semantics; decoded row install is storage mechanics. |
+| Recovery bootstrap | MANIFEST prep, codec validation, replay, raw recovery facts | open policy, degraded/lossy policy, subsystem recovery, coordinator bootstrap | Storage recovers durable substrate state; engine decides whether and how the database opens. |
+| Storage config | `StorageRuntimeConfig`, effective storage values, store/global application | public `StrataConfig`, product profiles, compatibility | Public config is an engine API; effective storage knobs belong to storage. |
+| Retention | storage pruning mechanics and minimum-retain invariant | public retention policy and lifecycle behavior | Storage preserves mechanical invariants; engine owns user-facing policy and reports. |
+| Test observability | storage-local runtime snapshots/accessors under test gates | characterization tests and production-use guardrails | Tests need visibility into storage state; production engine code must not depend on test-only accessors. |
 
-## Split Surfaces: API In `engine`, Mechanics In `storage`
+## Accepted Residue
 
-A number of surfaces should not move wholesale in either direction.
+The following residue is intentional after boundary closeout:
 
-They need a split between:
+- `strata_storage::durability::__internal` is gated by the
+  `engine-internal` feature and exposes the WAL background-sync extension seam
+  used by engine lifecycle orchestration.
+- `StorageConfig::effective_*` wrappers remain as public compatibility methods
+  in engine, but production engine code uses `StorageRuntimeConfig` for storage
+  derivation and application.
+- `SnapshotRetentionPolicy::retain_count` remains an engine-owned public field;
+  storage normalizes retention input through `StorageSnapshotRetention`.
+- block-cache capacity is process-global storage runtime state. Sequential
+  applications overwrite earlier values; concurrent database opens race and do
+  not promise a deterministic winner.
+- upper crates still have some direct storage dependencies for current
+  transitional primitive/runtime crates. They must not bypass engine to drive
+  checkpoint, recovery, open, retention, or database policy. The next engine
+  consolidation phase is expected to absorb graph, vector, search,
+  executor-legacy, and security responsibilities into engine.
 
-- engine-owned public database/runtime API
-- storage-owned implementation machinery
+## Regression Guards
 
-The main examples are:
+Useful closeout checks:
 
-### 1. `Database::checkpoint()` / `Database::compact()`
+```bash
+cargo tree -p strata-storage --depth 2
+cargo tree -p strata-engine --depth 1
+cargo tree -i strata-storage --workspace --depth 2
+rg -n 'use strata_engine|strata_engine::|strata-engine' crates/storage/src crates/storage/Cargo.toml
+rg -n 'JsonPath|JsonPatch|SearchSubsystem|Recipe|VectorConfig|DistanceMetric|ChainVerification|BranchLifecycle|RetentionReport|HealthReport|StrataConfig|StrataError|executor' crates/storage/src
+rg -n 'fn apply_storage_config|apply_storage_config' crates/engine/src
+```
 
-Public API should stay in engine.
+Expected results:
 
-But the checkpoint/WAL/snapshot/MANIFEST machinery underneath should become
-storage-owned.
+- `strata-storage` depends on `strata-core` and external crates, not
+  `strata-engine`
+- storage source has no engine imports
+- moved generic storage modules have no primitive semantics, and storage source
+  has no engine report or product policy vocabulary outside storage-owned
+  durable format surfaces
+- engine has no `apply_storage_config` helper or hand-written storage setter
+  list
 
-### 2. Open / Recovery Entry Points
+## Closeout Conclusion
 
-`Database::open_runtime()` stays in engine because engine composes the runtime.
+The accepted storage-boundary ownership split is now documented for the target
+surfaces, with guard commands recorded above and the main plan still carrying
+the final broad regression gate.
 
-But:
-
-- storage recovery
-- snapshot install
-- WAL/snapshot replay mechanics
-- durability bootstrap
-
-should move downward as much as possible.
-
-### 3. Retention Reporting
-
-The raw retention snapshot belongs in storage.
-
-The lifecycle-aware, branch-vocabulary, operator-facing report belongs in
-engine.
-
-That split is already mostly correct and should be preserved.
-
-## What Should Not Move Down Even If It Mentions Transactions
-
-The most important caution is JSON.
-
-Engine JSON code in:
-
-- [primitives/json/mod.rs](../../crates/engine/src/primitives/json/mod.rs)
-
-still interacts with `TransactionContext`, but that does **not** mean JSON
-path/patch semantics belong in storage.
-
-The correct move is:
-
-- generic transaction mechanics go to `storage`
-- JSON transaction semantics stay in `engine`
-
-This is the same rule that should govern the `concurrency` absorption work.
-
-## Audit Conclusion
-
-The storage consolidation should not be treated as only:
-
-- `concurrency -> storage`
-- `durability -> storage`
-
-It also needs an explicit **engine -> storage ownership correction**.
-
-The most likely broad shape is:
-
-- keep the semantic/domain side of engine where it is
-- keep the substrate/mechanical side of storage where it is
-- move lower-runtime checkpoint/recovery/snapshot/durability mechanics from
-  engine down into storage
-- keep only the public database/runtime orchestration API in engine
-
-In short:
-
-- `storage` is mostly already the right crate
-- `engine` still hosts too much lower-runtime implementation
-- the next plan must treat that as part of the consolidation, not as a later
-  afterthought
+`strata-storage` is the lower persistence/runtime substrate. `strata-engine`
+is the database orchestration and semantics layer. The remaining
+engine-to-storage calls are intentional seams where engine-owned public APIs,
+semantics, or policy invoke storage-owned mechanics.


### PR DESCRIPTION
## Summary

Final epic in the four-epic engine/storage boundary normalization. ES6 does not move runtime mechanics; it proves the new boundary is coherent, removes migration-era residue where safe, and adds runnable guardrails so the next engine cleanup phase cannot accidentally move storage concerns back into engine or engine semantics down into storage.

The four code-moving epics finished at ES5:

- **ES2 (#2482)** — checkpoint and WAL compaction mechanics into storage
- **ES3 (#2483)** — snapshot install split (engine primitive decode, storage generic decoded-row install)
- **ES4 (#2484)** — recovery bootstrap mechanics into storage
- **ES5 (#2486)** — storage config application convergence behind `StorageRuntimeConfig`

## ES6 phases

**ES6A — boundary audit and guardrails.** Five runnable guards documented in the closeout plan and verified clean:
- no storage tree edges into upper crates
- no primitive vocabulary in moved generic storage runtime surfaces
- no duplicated `SegmentedStore::set_*` lists in engine
- no storage mentions of engine type names
- no production engine use of storage `_for_test` accessors

ES6A also removes legacy storage-local `StrataError` / `StrataResult` aliases from `txn/context.rs` and `txn/validation.rs` plus stale comments referencing engine error or coordinator names. Those aliases were storage-internal, but they made the boundary guard noisy.

**ES6B — compatibility residue.** `StorageConfig::effective_*` helpers stay as documented compatibility wrappers that delegate to `storage_runtime_config_from`. Repo-local production code no longer calls them; the only remaining call is one delegation test.

**ES6C — test accessor surface.** `SegmentedStore` `_for_test` runtime introspection is moved off the `fault-injection` feature onto a dedicated storage `test-utils` feature. Engine dev-dependencies enable both `fault-injection` and `test-utils`; the normal engine dependency on storage remains `engine-internal` only. Production engine builds therefore cannot reach the storage runtime introspection accessors.

**ES6D — retention API.** Decision: keep public `retain_count` fields and document raw versus effective behavior. `SnapshotRetentionPolicy` and `StorageSnapshotRetention` both accept compatibility raw zero values; the storage pruning runtime clamps to an effective count of one before retention runs. New storage regression test covers the direct struct-literal raw zero case.

**ES6E — final characterization coverage.** Adds primary-open characterization for `memory_budget = 1` (derived block-cache becomes explicit zero, write buffer becomes zero, immutable-memtable count becomes one). Adds primary and follower companions to the existing cache codec-rejection test. Documents block-cache capacity as process-global with sequential overwrite and the pre-existing concurrent-open race. The codec-rejection tests assert only the public error message; the prior global-cache assertion was incompatible with the documented process-global concurrent-overwrite contract.

**ES6F — final boundary map and closeout.** `engine-crate-map.md`, `storage-crate-map.md`, `storage-engine-ownership-audit.md`, and the main `engine-storage-boundary-normalization-plan.md` are refreshed to describe the settled architecture rather than migration state. The intentionally remaining cross-boundary seams are listed in the closeout plan with a short justification each. The ES1-ES5 plan files are renamed to drop the migration-era `esN` prefixes; their content remains as the canonical plan docs for each surface.

## Behavior preservation

- on-disk WAL, snapshot, manifest, and segment formats unchanged
- public `StrataConfig` serialization unchanged
- recovery loss/degradation policy unchanged
- `TransactionCoordinator` stays engine-owned
- no new storage validation or rejection of historically accepted values
- engine production code paths unchanged outside test-accessor feature gating and the txn alias scrub

## ES6 boundary guards (clean)

- `cargo tree -p strata-storage --edges normal,build --depth 4 | rg "strata-(engine|executor|graph|search|vector|intelligence|security)|stratadb"` — 0 matches
- `rg 'SnapshotSerializer|primitive_tags|*SnapshotEntry' crates/storage/src/durability/decoded_snapshot_install.rs crates/storage/src/durability/recovery_bootstrap.rs crates/storage/src/runtime_config.rs` — 0 matches
- `rg 'StrataConfig|StorageConfig|StrataError|StrataResult|TransactionCoordinator' crates/storage/src --glob '*.rs'` — 0 matches
- engine production `_for_test` calls (excluding test files) — 0 matches
- `rg 'feature = "fault-injection"' crates/storage/src/segmented/mod.rs` — 0 matches
- engine normal dependency does not enable `fault-injection` or `test-utils` on storage
- `effective_*` unapproved engine callers (excluding declarations and the delegation test) — 0 matches

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p strata-storage --quiet` — 1219 passed (lib) + 13 (integration), 0 failed
- [x] `cargo test -p strata-engine --quiet` — 1622 passed (1617 in ES5; +5), 10 failed (same pre-existing architecture-cleanup-period failures verified against `main` during ES2; no new regressions)
- [x] `cargo test -p strata-engine --test recovery_parity --quiet` — 7 passed
- [x] `cargo test -p strata-executor --quiet` — 113 passed

## Workstream closeout

The end state is not "engine has no storage calls." The end state is that every engine-to-storage call is an explicit orchestration boundary from engine-owned semantics and policy into storage-owned substrate mechanics. The settled boundary, intentional seams, and runnable guards are documented in:

- `docs/engine/engine-storage-boundary-normalization-plan.md`
- `docs/engine/boundary-closeout-plan.md`
- `docs/engine/engine-crate-map.md`
- `docs/storage/storage-crate-map.md`
- `docs/storage/storage-engine-ownership-audit.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)