### PR TITLE
ci: drop stale vector_benchmarks DAG guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,6 @@ jobs:
           if cargo tree --package strata-engine --edges=normal --format="{p}" | grep -q strata-graph; then
             echo "ERROR: strata-engine has normal dep on strata-graph" && exit 1
           fi
-          # Guard: vector_benchmarks must live in vector crate, not engine
-          if [ -f crates/engine/benches/vector_benchmarks.rs ]; then
-            echo "ERROR: vector_benchmarks.rs belongs in crates/vector/benches/" && exit 1
-          fi
           # Manifest guard: engine must not depend on vector/graph (neither normal nor dev-deps)
           if grep -qE "^strata-(vector|graph)" crates/engine/Cargo.toml; then
             echo "ERROR: engine Cargo.toml must not list strata-vector or strata-graph" && exit 1


### PR DESCRIPTION
## Summary
EG5 (#2492) moved `vector_benchmarks.rs` from `crates/vector/benches/` into `crates/engine/benches/`, but the CI DAG-guard step still rejected the file under its old "must live in vector crate" check. Now that `crates/vector` is deleted entirely, that assertion is wrong by construction — every PR fails `check` on:

```
ERROR: vector_benchmarks.rs belongs in crates/vector/benches/
```

This drops the broken assertion. The other two checks in the same step (engine must not have a normal dep on `strata-vector`/`strata-graph`, manifest must not list them) are now no-ops because the crates do not exist, but they remain as cheap belt-and-suspenders against re-introduction.

The substantive boundary guards live in `tests/storage_surface_imports.rs` and run under `cargo test`:
- `engine_consolidation_vector_crate_is_retired`
- `engine_consolidation_vector_subsystem_is_engine_product_owned`
- `engine_consolidation_vector_consumers_use_engine_surface`
- `engine_consolidation_executor_vector_transaction_surface_is_engine_owned`
- `engine_consolidation_vector_storage_key_layout_is_engine_owned`
- `engine_consolidation_graph_crate_is_retired`
- `engine_consolidation_graph_subsystem_is_engine_product_owned`

Those replace what this CI step was trying to express.

## Test plan
- [ ] CI `check` passes (it did not on PR #2492, which had to be admin-merged because of this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)