### PR TITLE
EG7: remove executor's direct storage bypass

### DIFF
--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -831,6 +831,33 @@ impl Database {
         Ok(())
     }
 
+    /// Write invalid raw JSON bytes for downstream product-boundary tests.
+    ///
+    /// This is intentionally exposed only through the `test-support` feature so
+    /// crates above engine can keep corruption fixtures without importing
+    /// storage keys or namespaces.
+    #[doc(hidden)]
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn inject_corrupt_json_bytes_for_test(
+        &self,
+        branch_id: BranchId,
+        space: &str,
+        doc_id: &str,
+        bytes: Vec<u8>,
+    ) -> StrataResult<()> {
+        let key = Key::new_json(
+            Arc::new(strata_storage::Namespace::for_branch_space(
+                branch_id, space,
+            )),
+            doc_id,
+        );
+        let value = strata_core::Value::Bytes(bytes);
+        self.transaction(branch_id, move |txn| {
+            txn.put(key, value)?;
+            Ok(())
+        })
+    }
+
     pub(crate) fn clear_branch_storage_result(&self, branch_id: &BranchId) -> StorageResult<()> {
         #[cfg(any(test, feature = "test-support"))]
         if let Some(inner) =

--- a/crates/engine/src/error.rs
+++ b/crates/engine/src/error.rs
@@ -2486,6 +2486,28 @@ impl From<serde_json::Error> for StrataError {
     }
 }
 
+/// Convert a storage-local transaction failure into the engine product
+/// boundary shape expected by executor-visible command handlers.
+///
+/// This adapter is intentionally narrower than the blanket
+/// `From<StorageError>` conversion: raw transaction contexts still surface a
+/// few storage mechanics directly while the executor is being collapsed into
+/// engine, and those calls must preserve the historical product-facing error
+/// categories.
+pub fn storage_error_for_product_boundary(value: StorageError) -> StrataError {
+    match value {
+        StorageError::Io(inner) => StrataError::storage_with_source("storage I/O error", inner),
+        StorageError::InvalidInput { message } => StrataError::invalid_input(message),
+        StorageError::CapacityExceeded {
+            resource,
+            limit,
+            requested,
+        } => StrataError::capacity_exceeded(resource, limit, requested),
+        StorageError::Corruption { message } => StrataError::serialization(message),
+        other => StrataError::from(other),
+    }
+}
+
 impl From<StorageError> for StrataError {
     fn from(value: StorageError) -> Self {
         match value {
@@ -3693,6 +3715,67 @@ mod storage_error_bridge_tests {
             StrataError::Corruption { ref message }
             if message == "segment block truncated"
         ));
+    }
+
+    #[test]
+    fn product_boundary_storage_invalid_input_preserves_invalid_input_category() {
+        let parent =
+            storage_error_for_product_boundary(StorageError::invalid_input("inactive transaction"));
+
+        assert!(matches!(
+            parent,
+            StrataError::InvalidInput { ref message }
+            if message == "inactive transaction"
+        ));
+    }
+
+    #[test]
+    fn product_boundary_storage_capacity_preserves_constraint_category() {
+        let parent = storage_error_for_product_boundary(StorageError::capacity_exceeded(
+            "transaction writes",
+            10,
+            11,
+        ));
+
+        assert!(matches!(
+            parent,
+            StrataError::CapacityExceeded {
+                ref resource,
+                limit: 10,
+                requested: 11,
+            } if resource == "transaction writes"
+        ));
+    }
+
+    #[test]
+    fn product_boundary_storage_corruption_preserves_serialization_category() {
+        let parent =
+            storage_error_for_product_boundary(StorageError::corruption("malformed row payload"));
+
+        assert!(matches!(
+            parent,
+            StrataError::Serialization { ref message }
+            if message == "malformed row payload"
+        ));
+    }
+
+    #[test]
+    fn product_boundary_storage_io_preserves_io_source() {
+        let parent = storage_error_for_product_boundary(StorageError::Io(std::io::Error::new(
+            ErrorKind::PermissionDenied,
+            "permission denied",
+        )));
+
+        match parent {
+            StrataError::Storage {
+                message,
+                source: Some(source),
+            } => {
+                assert_eq!(message, "storage I/O error");
+                assert!(source.to_string().contains("permission denied"));
+            }
+            other => panic!("expected storage error with source, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -65,8 +65,8 @@ pub use database::{
     SubsystemHealth, SubsystemStatus, SystemMetrics, WalWriterHealth,
 };
 pub use error::{
-    ConstraintReason, DetailValue, ErrorCode, ErrorDetails, PrimitiveDegradedReason, StrataError,
-    StrataResult,
+    storage_error_for_product_boundary, ConstraintReason, DetailValue, ErrorCode, ErrorDetails,
+    PrimitiveDegradedReason, StrataError, StrataResult,
 };
 pub use graph::{GraphStore, GraphSubsystem, PrimitiveGraphStore};
 pub use instrumentation::PerfTrace;
@@ -88,7 +88,7 @@ pub use strata_storage::durability::wal::DurabilityMode;
 pub use strata_storage::durability::WalCounters;
 pub use strata_storage::StorageIterator;
 pub use strata_storage::VersionedEntry;
-pub use strata_storage::{DegradationClass, RecoveryHealth, TransactionContext};
+pub use strata_storage::{DegradationClass, RecoveryHealth};
 pub use transaction::{ScopedTransaction, Transaction, TransactionPool, MAX_POOL_SIZE};
 pub use transaction_ops::TransactionOps;
 pub use vector::{
@@ -131,6 +131,8 @@ pub use primitives::{
     build_search_response,
     build_search_response_with_index,
     build_search_response_with_scorer,
+    is_user_space_delete_constraint,
+    validate_space_name,
     BM25LiteScorer,
     // Handles
     BranchHandle,

--- a/crates/engine/src/primitives/extensions.rs
+++ b/crates/engine/src/primitives/extensions.rs
@@ -109,9 +109,9 @@ pub trait EventLogExt {
 /// The `_in_space` methods accept an explicit space parameter. The convenience
 /// methods (`json_get`, `json_set`, `json_create`) delegate to them with `"default"`.
 ///
-/// New JSON transaction logic should prefer the engine-owned scoped transaction
-/// path exposed by `crate::transaction::Transaction::scoped()` and the public
-/// branch transaction wrappers. The raw `TransactionContext` implementation of
+/// New JSON transaction logic should prefer the engine-owned scoped-space
+/// transaction path and the public branch transaction wrappers. The raw
+/// `TransactionContext` implementation of
 /// this trait is retained as a compatibility seam for older closure-style call
 /// sites and performs direct full-document read/modify/write operations instead
 /// of buffering JSON path semantics through `JsonTxnState`.

--- a/crates/engine/src/primitives/mod.rs
+++ b/crates/engine/src/primitives/mod.rs
@@ -52,7 +52,7 @@ pub use branch::{BranchHandle, BranchTransaction, EventHandle, JsonHandle, KvHan
 pub use event::{Event, EventLog};
 pub use json::{JsonDoc, JsonStore};
 pub use kv::KVStore;
-pub use space::SpaceIndex;
+pub use space::{is_user_space_delete_constraint, validate_space_name, SpaceIndex};
 
 // Re-export search types for convenience (from search module)
 pub use crate::search::{

--- a/crates/engine/src/primitives/space.rs
+++ b/crates/engine/src/primitives/space.rs
@@ -18,12 +18,23 @@
 //! - Key format: `<branch_namespace>:<TypeTag::Space>:<space_name>`
 
 use crate::database::Database;
-use crate::StrataResult;
+use crate::{StrataError, StrataResult};
 use std::sync::Arc;
 use strata_core::BranchId;
+use strata_core::EntityRef;
 use strata_core::Value;
 use strata_storage::{Key, Namespace, TypeTag};
 use tracing::info;
+
+/// Validate a user-visible space name.
+///
+/// This is the engine-owned validation boundary for product callers. The
+/// underlying naming rules still mirror storage's physical namespace rules, but
+/// callers above engine should receive a normal [`StrataError::InvalidInput`]
+/// instead of a storage-local error/string.
+pub fn validate_space_name(name: &str) -> StrataResult<()> {
+    strata_storage::validate_space_name(name).map_err(StrataError::invalid_input)
+}
 
 /// Space lifecycle management primitive.
 ///
@@ -102,6 +113,63 @@ impl SpaceIndex {
             info!(target: "strata::space", space, branch_id = %branch_id, "Space deleted");
             Ok(())
         })
+    }
+
+    /// Delete a user-visible space and all primitive data owned by it.
+    ///
+    /// This is the product boundary for space deletion: callers above engine
+    /// provide the branch name, space name, and force policy, while engine owns
+    /// branch validation, storage row cleanup, primitive runtime cleanup, search
+    /// index cleanup, and metadata removal.
+    ///
+    /// This method only runs engine-owned cleanup. Product layers with
+    /// additional feature-local state, such as intelligence shadow embeddings,
+    /// must call [`Self::delete_user_space_with_post_data_cleanup`] instead.
+    pub fn delete_user_space(
+        &self,
+        branch_name: &str,
+        space: &str,
+        force: bool,
+    ) -> StrataResult<()> {
+        self.delete_user_space_with_post_data_cleanup(branch_name, space, force, |_, _| Ok(()))
+    }
+
+    /// Delete a user-visible space, invoking `post_data_cleanup` after user
+    /// data/search/vector cleanup and before metadata deletion.
+    ///
+    /// This preserves the engine-owned storage boundary while letting product
+    /// layers drain feature-local runtime state before the space metadata
+    /// disappears. The hook is fallible so product-layer cleanup failures do
+    /// not get silently hidden behind a successful metadata delete.
+    pub fn delete_user_space_with_post_data_cleanup<F>(
+        &self,
+        branch_name: &str,
+        space: &str,
+        force: bool,
+        post_data_cleanup: F,
+    ) -> StrataResult<()>
+    where
+        F: FnOnce(BranchId, &str) -> StrataResult<()>,
+    {
+        let branch_id = BranchId::from_user_name(branch_name);
+
+        if space == "default" || space == crate::system_space::SYSTEM_SPACE {
+            return Err(protected_space_delete_constraint(branch_id, space));
+        }
+
+        validate_space_name(space)?;
+        self.require_branch_exists_for_delete(branch_name)?;
+        let branch_id = product_branch_id(branch_name)?;
+
+        if !force && !self.is_empty(branch_id, space)? {
+            return Err(non_empty_space_delete_constraint(branch_id, space));
+        }
+
+        self.delete_space_data_rows(branch_id, space)?;
+        self.remove_search_documents_in_space(branch_id, space);
+        self.purge_vector_collections_in_space(branch_id, space);
+        post_data_cleanup(branch_id, space)?;
+        self.delete(branch_id, space)
     }
 
     /// Check if a space has any data.
@@ -236,6 +304,117 @@ impl SpaceIndex {
     fn has_any_data(&self, branch_id: BranchId, space: &str) -> StrataResult<bool> {
         Ok(!self.is_empty(branch_id, space)?)
     }
+
+    fn require_branch_exists_for_delete(&self, branch_name: &str) -> StrataResult<()> {
+        let default_branch = self
+            .db
+            .default_branch_name()
+            .unwrap_or_else(|| "default".to_string());
+        if default_branch == branch_name {
+            return Ok(());
+        }
+
+        if self.db.branches().exists(branch_name)? {
+            Ok(())
+        } else {
+            Err(StrataError::branch_not_found_by_name(branch_name))
+        }
+    }
+
+    fn delete_space_data_rows(&self, branch_id: BranchId, space: &str) -> StrataResult<()> {
+        let vector = crate::vector::VectorStore::new(self.db.clone());
+        let namespace = Arc::new(Namespace::for_branch_space(branch_id, space));
+
+        self.db.transaction(branch_id, |txn| {
+            vector
+                .delete_space_data_in_transaction(txn, branch_id, space)
+                .map_err(|error| error.into_strata_error(branch_id))?;
+
+            for type_tag in [TypeTag::KV, TypeTag::Event, TypeTag::Json, TypeTag::Graph] {
+                let prefix = Key::new(namespace.clone(), type_tag, Vec::new());
+                let entries = txn.scan_prefix(&prefix)?;
+                for (key, _) in entries {
+                    txn.delete(key)?;
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn remove_search_documents_in_space(&self, branch_id: BranchId, space: &str) {
+        if let Ok(index) = self.db.extension::<crate::search::InvertedIndex>() {
+            let removed = index.remove_documents_in_space(branch_id, space);
+            if removed > 0 {
+                tracing::info!(
+                    target: "strata::space",
+                    branch_id = %branch_id,
+                    space = space,
+                    removed,
+                    "Removed search documents during space delete"
+                );
+            }
+        }
+    }
+
+    fn purge_vector_collections_in_space(&self, branch_id: BranchId, space: &str) {
+        let vector = crate::vector::VectorStore::new(self.db.clone());
+        if let Err(error) = vector.purge_collections_in_space(branch_id, space) {
+            tracing::warn!(
+                target: "strata::space",
+                branch_id = %branch_id,
+                space = space,
+                error = %error,
+                "Failed to purge vector collections during space delete"
+            );
+        }
+    }
+}
+
+fn product_branch_id(branch_name: &str) -> StrataResult<BranchId> {
+    if crate::branch_domain::aliases_default_branch_sentinel(branch_name) {
+        return Err(StrataError::invalid_input(
+            "branch name aliases reserved default-branch sentinel",
+        ));
+    }
+
+    Ok(BranchId::from_user_name(branch_name))
+}
+
+fn space_delete_constraint(branch_id: BranchId, reason: String) -> StrataError {
+    StrataError::invalid_operation(EntityRef::Branch { branch_id }, reason)
+}
+
+fn protected_space_delete_reason(space: &str) -> String {
+    format!("Cannot delete the '{space}' space")
+}
+
+fn non_empty_space_delete_reason(space: &str) -> String {
+    format!("Space '{space}' is not empty. Use force=true to delete anyway.")
+}
+
+fn protected_space_delete_constraint(branch_id: BranchId, space: &str) -> StrataError {
+    space_delete_constraint(branch_id, protected_space_delete_reason(space))
+}
+
+fn non_empty_space_delete_constraint(branch_id: BranchId, space: &str) -> StrataError {
+    space_delete_constraint(branch_id, non_empty_space_delete_reason(space))
+}
+
+/// Return true when an engine error should surface as a product-level space
+/// delete constraint violation above engine.
+///
+/// This keeps executor and future product facades from depending directly on
+/// engine's user-facing error strings. `StrataError` does not currently carry
+/// typed invalid-operation reasons, so the string classification remains
+/// intentionally local to the primitive that produces these errors.
+pub fn is_user_space_delete_constraint(error: &StrataError) -> bool {
+    let StrataError::InvalidOperation { reason, .. } = error else {
+        return false;
+    };
+
+    (reason.starts_with("Cannot delete the '") && reason.ends_with("' space"))
+        || (reason.starts_with("Space '")
+            && reason.ends_with("' is not empty. Use force=true to delete anyway."))
 }
 
 /// Atomically ensure a space's metadata key exists within an open
@@ -271,7 +450,15 @@ pub fn ensure_space_registered_in_txn(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::graph::types::NodeData;
+    use crate::graph::GraphStore;
+    use crate::primitives::event::EventLog;
+    use crate::primitives::json::JsonStore;
     use crate::primitives::KVStore;
+    use crate::semantics::json::{JsonPath, JsonValue};
+    use crate::semantics::vector::{DistanceMetric, VectorConfig};
+    use crate::vector::VectorStore;
+    use std::collections::HashMap;
     use tempfile::TempDir;
 
     fn setup() -> (TempDir, Arc<Database>, SpaceIndex) {
@@ -283,6 +470,23 @@ mod tests {
 
     fn default_branch() -> BranchId {
         BranchId::from_bytes([0u8; 16])
+    }
+
+    #[test]
+    fn validate_space_name_accepts_product_space_names() {
+        validate_space_name("default").unwrap();
+        validate_space_name("tenant_a-1").unwrap();
+    }
+
+    #[test]
+    fn validate_space_name_returns_engine_invalid_input() {
+        let err = validate_space_name("not allowed").unwrap_err();
+
+        assert!(matches!(
+            err,
+            StrataError::InvalidInput { ref message }
+                if message == "Space name can only contain lowercase letters, digits, hyphens, and underscores"
+        ));
     }
 
     #[test]
@@ -350,6 +554,232 @@ mod tests {
 
         si.delete(bid, "alpha").unwrap();
         assert!(!si.exists(bid, "alpha").unwrap());
+    }
+
+    #[test]
+    fn delete_user_space_rejects_protected_and_non_empty_spaces() {
+        let (_temp, db, si) = setup();
+        let bid = default_branch();
+        let kv = KVStore::new(db);
+
+        let protected = si
+            .delete_user_space("default", "default", true)
+            .unwrap_err();
+        assert!(matches!(
+            protected,
+            StrataError::InvalidOperation { ref reason, .. }
+                if reason == "Cannot delete the 'default' space"
+        ));
+
+        kv.put(&bid, "alpha", "key", Value::Int(1)).unwrap();
+
+        let non_empty = si.delete_user_space("default", "alpha", false).unwrap_err();
+        assert!(matches!(
+            non_empty,
+            StrataError::InvalidOperation { ref reason, .. }
+                if reason == "Space 'alpha' is not empty. Use force=true to delete anyway."
+        ));
+    }
+
+    #[test]
+    fn delete_user_space_force_cleans_primitive_rows_and_runtime_side_effects() {
+        let (_temp, db, si) = setup();
+        let bid = default_branch();
+        let kv = KVStore::new(db.clone());
+        let json = JsonStore::new(db.clone());
+        let events = EventLog::new(db.clone());
+        let graph = GraphStore::new(db.clone());
+        let vector = VectorStore::new(db.clone());
+        let index = db.extension::<crate::search::InvertedIndex>().unwrap();
+
+        kv.put(
+            &bid,
+            "alpha",
+            "key",
+            Value::String("searchable text".into()),
+        )
+        .unwrap();
+        kv.put(&bid, "beta", "key", Value::String("sibling text".into()))
+            .unwrap();
+        json.create(&bid, "alpha", "doc", JsonValue::from("json alpha"))
+            .unwrap();
+        json.create(&bid, "beta", "doc", JsonValue::from("json beta"))
+            .unwrap();
+        events
+            .append(
+                &bid,
+                "alpha",
+                "space.delete.test",
+                Value::object(HashMap::new()),
+            )
+            .unwrap();
+        events
+            .append(
+                &bid,
+                "beta",
+                "space.delete.test",
+                Value::object(HashMap::new()),
+            )
+            .unwrap();
+        graph.create_graph(bid, "alpha", "links", None).unwrap();
+        graph
+            .add_node(bid, "alpha", "links", "n1", NodeData::default())
+            .unwrap();
+        graph.create_graph(bid, "beta", "links", None).unwrap();
+        graph
+            .add_node(bid, "beta", "links", "n1", NodeData::default())
+            .unwrap();
+
+        let doc = EntityRef::kv(bid, "alpha", "key");
+        index.index_document(&doc, "searchable text", None);
+        assert!(index.has_document(&doc));
+
+        let config = VectorConfig::new(4, DistanceMetric::Cosine).unwrap();
+        vector
+            .create_collection(bid, "alpha", "embeddings", config.clone())
+            .unwrap();
+        vector
+            .insert(
+                bid,
+                "alpha",
+                "embeddings",
+                "v1",
+                &[1.0, 0.0, 0.0, 0.0],
+                None,
+            )
+            .unwrap();
+        vector
+            .create_collection(bid, "beta", "embeddings", config)
+            .unwrap();
+        vector
+            .insert(bid, "beta", "embeddings", "v1", &[0.0, 1.0, 0.0, 0.0], None)
+            .unwrap();
+
+        let hook_observed_metadata = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let hook_observed_metadata_clone = hook_observed_metadata.clone();
+        let db_for_hook = db.clone();
+        si.delete_user_space_with_post_data_cleanup(
+            "default",
+            "alpha",
+            true,
+            move |branch_id, space| {
+                assert_eq!(space, "alpha");
+
+                let space_index = SpaceIndex::new(db_for_hook.clone());
+                hook_observed_metadata_clone.store(
+                    space_index.exists(branch_id, space).unwrap(),
+                    std::sync::atomic::Ordering::SeqCst,
+                );
+
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert!(hook_observed_metadata.load(std::sync::atomic::Ordering::SeqCst));
+
+        assert_eq!(kv.get(&bid, "alpha", "key").unwrap(), None);
+        assert_eq!(
+            kv.get(&bid, "beta", "key").unwrap(),
+            Some(Value::String("sibling text".into()))
+        );
+        assert_eq!(
+            json.get(&bid, "alpha", "doc", &JsonPath::root()).unwrap(),
+            None
+        );
+        assert_eq!(
+            json.get(&bid, "beta", "doc", &JsonPath::root()).unwrap(),
+            Some(JsonValue::from("json beta"))
+        );
+        assert_eq!(events.len(&bid, "alpha").unwrap(), 0);
+        assert_eq!(events.len(&bid, "beta").unwrap(), 1);
+        assert!(graph.list_graphs(bid, "alpha").unwrap().is_empty());
+        assert_eq!(graph.list_graphs(bid, "beta").unwrap(), vec!["links"]);
+        assert!(!si.exists(bid, "alpha").unwrap());
+        assert!(!index.has_document(&doc));
+        assert!(vector.list_collections(bid, "alpha").unwrap().is_empty());
+        let beta_collections: Vec<_> = vector
+            .list_collections(bid, "beta")
+            .unwrap()
+            .into_iter()
+            .map(|collection| collection.name)
+            .collect();
+        assert_eq!(beta_collections, vec!["embeddings"]);
+    }
+
+    #[test]
+    fn delete_user_space_force_cleans_only_requested_branch() {
+        let (_temp, db, si) = setup();
+        let default_bid = default_branch();
+        db.branches().create("feature").unwrap();
+        let feature_bid = BranchId::from_user_name("feature");
+        let kv = KVStore::new(db);
+
+        kv.put(
+            &default_bid,
+            "alpha",
+            "key",
+            Value::String("default".into()),
+        )
+        .unwrap();
+        kv.put(
+            &feature_bid,
+            "alpha",
+            "key",
+            Value::String("feature".into()),
+        )
+        .unwrap();
+
+        si.delete_user_space("feature", "alpha", true).unwrap();
+
+        assert_eq!(
+            kv.get(&default_bid, "alpha", "key").unwrap(),
+            Some(Value::String("default".into()))
+        );
+        assert_eq!(kv.get(&feature_bid, "alpha", "key").unwrap(), None);
+        assert!(si.exists(default_bid, "alpha").unwrap());
+        assert!(!si.exists(feature_bid, "alpha").unwrap());
+    }
+
+    #[test]
+    fn delete_user_space_propagates_post_data_cleanup_failure() {
+        let (_temp, db, si) = setup();
+        let bid = default_branch();
+        let kv = KVStore::new(db);
+
+        kv.put(&bid, "alpha", "key", Value::Int(1)).unwrap();
+
+        let error = si
+            .delete_user_space_with_post_data_cleanup("default", "alpha", true, |_, _| {
+                Err(StrataError::internal("post-data cleanup failed"))
+            })
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            StrataError::Internal { ref message } if message == "post-data cleanup failed"
+        ));
+        assert_eq!(kv.get(&bid, "alpha", "key").unwrap(), None);
+        assert!(si.exists(bid, "alpha").unwrap());
+    }
+
+    #[test]
+    fn user_space_delete_constraint_classifier_is_engine_owned() {
+        let bid = default_branch();
+        let protected = protected_space_delete_constraint(bid, "default");
+        let non_empty = non_empty_space_delete_constraint(bid, "alpha");
+        let unrelated = StrataError::invalid_operation(
+            EntityRef::Branch { branch_id: bid },
+            "some other invalid operation",
+        );
+
+        assert!(is_user_space_delete_constraint(&protected));
+        assert!(is_user_space_delete_constraint(&non_empty));
+        assert!(!is_user_space_delete_constraint(&unrelated));
+        assert!(!is_user_space_delete_constraint(
+            &StrataError::invalid_input(
+                "Space 'alpha' is not empty. Use force=true to delete anyway."
+            )
+        ));
     }
 
     #[test]

--- a/crates/engine/src/transaction/context.rs
+++ b/crates/engine/src/transaction/context.rs
@@ -293,6 +293,93 @@ impl<'a> Transaction<'a> {
 
         Ok(keys.into_iter().collect())
     }
+
+    /// Read a KV value through the transaction view without exposing storage
+    /// keys to callers above engine.
+    pub fn kv_get_value(&mut self, key: &str) -> Result<Option<Value>, StrataError> {
+        Ok(<Self as TransactionOps>::kv_get(self, key)?.map(|value| value.value))
+    }
+
+    /// Delete a KV key after the caller has already performed any needed
+    /// transaction-view existence read.
+    pub fn kv_delete_without_existence_check(&mut self, key: &str) -> Result<(), StrataError> {
+        let full_key = self.kv_key(key);
+        self.ctx.delete(full_key)?;
+        Ok(())
+    }
+
+    /// Scan KV entries visible in the transaction view, sorted by user key.
+    pub fn kv_scan(
+        &mut self,
+        start: Option<&str>,
+        limit: Option<usize>,
+    ) -> Result<Vec<(String, Value)>, StrataError> {
+        let prefix_key = Key::new(self.namespace.clone(), TypeTag::KV, vec![]);
+        let mut pairs: Vec<(String, Value)> = self
+            .ctx
+            .scan_prefix(&prefix_key)?
+            .into_iter()
+            .filter_map(|(key, value)| {
+                if key.type_tag == TypeTag::KV && key.namespace == self.namespace {
+                    key.user_key_string().map(|key| (key, value))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        pairs.sort_by(|left, right| left.0.cmp(&right.0));
+        if let Some(start) = start {
+            pairs.retain(|(key, _)| key.as_str() >= start);
+        }
+        if let Some(limit) = limit {
+            pairs.truncate(limit);
+        }
+        Ok(pairs)
+    }
+
+    /// Read events by type through the transaction view.
+    pub fn event_get_by_type(
+        &mut self,
+        event_type: &str,
+        limit: Option<usize>,
+        after_sequence: Option<u64>,
+    ) -> Result<Vec<Versioned<Event>>, StrataError> {
+        let prefix = Key::new_event_type_idx_prefix(self.namespace.clone(), event_type);
+        let index_entries = self.ctx.scan_prefix(&prefix)?;
+        let mut events = Vec::new();
+
+        for (index_key, _) in index_entries {
+            let user_key = &index_key.user_key;
+            if user_key.len() < 8 {
+                continue;
+            }
+            let bytes: [u8; 8] = user_key[user_key.len() - 8..]
+                .try_into()
+                .expect("sequence suffix should be eight bytes");
+            let sequence = u64::from_be_bytes(bytes);
+            if after_sequence.is_some_and(|after| sequence <= after) {
+                continue;
+            }
+
+            let event_key = self.event_key(sequence);
+            if let Some(Value::String(json)) = self.ctx.get(&event_key)? {
+                let event: Event = serde_json::from_str(&json).map_err(|error| {
+                    StrataError::serialization(format!(
+                        "corrupt event at sequence {}: {}",
+                        sequence, error
+                    ))
+                })?;
+                events.push(Versioned::new(event, Version::seq(sequence)));
+            }
+
+            if limit.is_some_and(|limit| events.len() >= limit) {
+                break;
+            }
+        }
+
+        Ok(events)
+    }
 }
 
 impl<'a> TransactionOps for Transaction<'a> {
@@ -330,13 +417,11 @@ impl<'a> TransactionOps for Transaction<'a> {
     }
 
     fn kv_delete(&mut self, key: &str) -> Result<bool, StrataError> {
-        let full_key = self.kv_key(key);
-
         // Check if key exists (for return value)
         let existed = self.kv_exists(key)?;
 
         // Use the ctx.delete() method
-        self.ctx.delete(full_key)?;
+        self.kv_delete_without_existence_check(key)?;
 
         Ok(existed)
     }

--- a/crates/engine/src/transaction/owned.rs
+++ b/crates/engine/src/transaction/owned.rs
@@ -1,6 +1,6 @@
 //! Owned transaction handle for manual transaction lifecycle.
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
@@ -87,7 +87,7 @@ impl Transaction {
             .ok_or_else(|| StrataError::transaction_not_active("finished"))
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     fn context_mut(&mut self) -> Option<&mut TransactionContext> {
         self.ctx.as_mut()
     }
@@ -324,7 +324,7 @@ impl Transaction {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 impl Deref for Transaction {
     type Target = TransactionContext;
 
@@ -334,7 +334,7 @@ impl Deref for Transaction {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 impl DerefMut for Transaction {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.context_mut()

--- a/crates/engine/src/transaction/owned.rs
+++ b/crates/engine/src/transaction/owned.rs
@@ -1,12 +1,18 @@
 //! Owned transaction handle for manual transaction lifecycle.
 
+#[cfg(test)]
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
+use serde_json::Value as JsonValue;
+
 use super::context::Transaction as ScopedTransaction;
 use super::json_state::JsonTxnState;
+use crate::graph::types::{EdgeData, GraphMeta, Neighbor, NodeData};
+use crate::graph::{GraphStore, GraphStoreExt};
+use crate::vector::{VectorRecord, VectorStore};
 use crate::{StrataError, StrataResult};
-use strata_core::BranchId;
+use strata_core::{BranchId, Version};
 use strata_storage::{Namespace, TransactionContext};
 
 use crate::Database;
@@ -67,14 +73,28 @@ impl Transaction {
             .branch_id
     }
 
-    /// Get a mutable reference to the underlying context.
-    pub fn context_mut(&mut self) -> Option<&mut TransactionContext> {
+    /// Return the transaction ID as an engine-owned display string.
+    pub fn id_string(&self) -> String {
+        self.context()
+            .expect("id_string() requires an active transaction")
+            .txn_id
+            .to_string()
+    }
+
+    fn active_context_mut(&mut self) -> StrataResult<&mut TransactionContext> {
+        self.ctx
+            .as_mut()
+            .ok_or_else(|| StrataError::transaction_not_active("finished"))
+    }
+
+    #[cfg(test)]
+    fn context_mut(&mut self) -> Option<&mut TransactionContext> {
         self.ctx.as_mut()
     }
 
     /// Create a scoped primitive wrapper that shares this manual transaction's
     /// engine-owned JSON state.
-    pub fn scoped(&mut self, namespace: Arc<Namespace>) -> ScopedTransaction<'_> {
+    pub(crate) fn scoped(&mut self, namespace: Arc<Namespace>) -> ScopedTransaction<'_> {
         let ctx = self
             .ctx
             .as_mut()
@@ -87,11 +107,224 @@ impl Transaction {
         )
     }
 
+    /// Create a scoped primitive wrapper for a product space without exposing
+    /// storage namespaces above engine.
+    pub fn scoped_space(&mut self, space: &str) -> ScopedTransaction<'_> {
+        let namespace = Arc::new(Namespace::for_branch_space(self.branch_id(), space));
+        self.scoped(namespace)
+    }
+
+    /// Create graph metadata inside this transaction.
+    pub fn graph_create_in_space(
+        &mut self,
+        space: &str,
+        graph: &str,
+        meta: GraphMeta,
+    ) -> StrataResult<()> {
+        let branch_id = self.branch_id();
+        self.active_context_mut()?
+            .graph_create(branch_id, space, graph, meta)
+    }
+
+    /// Add or update a graph node inside this transaction.
+    pub fn graph_add_node_in_space(
+        &mut self,
+        space: &str,
+        graph: &str,
+        node_id: &str,
+        data: &NodeData,
+    ) -> StrataResult<bool> {
+        let branch_id = self.branch_id();
+        let backend_state = GraphStore::new(self.db.clone()).state()?;
+        self.active_context_mut()?.graph_add_node(
+            branch_id,
+            space,
+            graph,
+            node_id,
+            data,
+            &backend_state,
+        )
+    }
+
+    /// Get graph node data inside this transaction.
+    pub fn graph_get_node_in_space(
+        &mut self,
+        space: &str,
+        graph: &str,
+        node_id: &str,
+    ) -> StrataResult<Option<NodeData>> {
+        let branch_id = self.branch_id();
+        self.active_context_mut()?
+            .graph_get_node(branch_id, space, graph, node_id)
+    }
+
+    /// Remove a graph node inside this transaction.
+    pub fn graph_remove_node_in_space(
+        &mut self,
+        space: &str,
+        graph: &str,
+        node_id: &str,
+    ) -> StrataResult<()> {
+        let branch_id = self.branch_id();
+        let backend_state = GraphStore::new(self.db.clone()).state()?;
+        self.active_context_mut()?.graph_remove_node(
+            branch_id,
+            space,
+            graph,
+            node_id,
+            &backend_state,
+        )
+    }
+
+    /// List graph nodes inside this transaction.
+    pub fn graph_list_nodes_in_space(
+        &mut self,
+        space: &str,
+        graph: &str,
+    ) -> StrataResult<Vec<String>> {
+        let branch_id = self.branch_id();
+        self.active_context_mut()?
+            .graph_list_nodes(branch_id, space, graph)
+    }
+
+    /// Get graph metadata inside this transaction.
+    pub fn graph_get_meta_in_space(
+        &mut self,
+        space: &str,
+        graph: &str,
+    ) -> StrataResult<Option<GraphMeta>> {
+        let branch_id = self.branch_id();
+        self.active_context_mut()?
+            .graph_get_meta(branch_id, space, graph)
+    }
+
+    /// List graph names inside this transaction.
+    pub fn graph_list_in_space(&mut self, space: &str) -> StrataResult<Vec<String>> {
+        let branch_id = self.branch_id();
+        self.active_context_mut()?.graph_list(branch_id, space)
+    }
+
+    /// Add or update a graph edge inside this transaction.
+    #[allow(clippy::too_many_arguments)]
+    pub fn graph_add_edge_in_space(
+        &mut self,
+        space: &str,
+        graph: &str,
+        src: &str,
+        dst: &str,
+        edge_type: &str,
+        data: &EdgeData,
+    ) -> StrataResult<bool> {
+        let branch_id = self.branch_id();
+        self.active_context_mut()?
+            .graph_add_edge(branch_id, space, graph, src, dst, edge_type, data)
+    }
+
+    /// Remove a graph edge inside this transaction.
+    #[allow(clippy::too_many_arguments)]
+    pub fn graph_remove_edge_in_space(
+        &mut self,
+        space: &str,
+        graph: &str,
+        src: &str,
+        dst: &str,
+        edge_type: &str,
+    ) -> StrataResult<()> {
+        let branch_id = self.branch_id();
+        self.active_context_mut()?
+            .graph_remove_edge(branch_id, space, graph, src, dst, edge_type)
+    }
+
+    /// Get outgoing graph neighbors inside this transaction.
+    pub fn graph_outgoing_neighbors_in_space(
+        &mut self,
+        space: &str,
+        graph: &str,
+        node_id: &str,
+        edge_type_filter: Option<&str>,
+    ) -> StrataResult<Vec<Neighbor>> {
+        let branch_id = self.branch_id();
+        self.active_context_mut()?.graph_outgoing_neighbors(
+            branch_id,
+            space,
+            graph,
+            node_id,
+            edge_type_filter,
+        )
+    }
+
+    /// Get incoming graph neighbors inside this transaction.
+    pub fn graph_incoming_neighbors_in_space(
+        &mut self,
+        space: &str,
+        graph: &str,
+        node_id: &str,
+        edge_type_filter: Option<&str>,
+    ) -> StrataResult<Vec<Neighbor>> {
+        let branch_id = self.branch_id();
+        self.active_context_mut()?.graph_incoming_neighbors(
+            branch_id,
+            space,
+            graph,
+            node_id,
+            edge_type_filter,
+        )
+    }
+
+    /// Insert a vector inside this transaction.
+    #[allow(clippy::too_many_arguments)]
+    pub fn vector_insert_in_space(
+        &mut self,
+        store: &VectorStore,
+        space: &str,
+        collection: &str,
+        key: &str,
+        embedding: &[f32],
+        metadata: Option<JsonValue>,
+    ) -> StrataResult<Version> {
+        let branch_id = self.branch_id();
+        let ctx = self.active_context_mut()?;
+        store
+            .insert_in_transaction(ctx, branch_id, space, collection, key, embedding, metadata)
+            .map_err(|error| error.into_strata_error(branch_id))
+    }
+
+    /// Get a vector record inside this transaction.
+    pub fn vector_get_in_space(
+        &mut self,
+        store: &VectorStore,
+        space: &str,
+        collection: &str,
+        key: &str,
+    ) -> StrataResult<Option<VectorRecord>> {
+        let branch_id = self.branch_id();
+        let ctx = self.active_context_mut()?;
+        store
+            .get_in_transaction(ctx, branch_id, space, collection, key)
+            .map_err(|error| error.into_strata_error(branch_id))
+    }
+
+    /// Delete a vector inside this transaction.
+    pub fn vector_delete_in_space(
+        &mut self,
+        store: &VectorStore,
+        space: &str,
+        collection: &str,
+        key: &str,
+    ) -> StrataResult<bool> {
+        let branch_id = self.branch_id();
+        let ctx = self.active_context_mut()?;
+        store
+            .delete_in_transaction(ctx, branch_id, space, collection, key)
+            .map_err(|error| error.into_strata_error(branch_id))
+    }
+
     fn context(&self) -> Option<&TransactionContext> {
         self.ctx.as_ref()
     }
 }
 
+#[cfg(test)]
 impl Deref for Transaction {
     type Target = TransactionContext;
 
@@ -101,6 +334,7 @@ impl Deref for Transaction {
     }
 }
 
+#[cfg(test)]
 impl DerefMut for Transaction {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.context_mut()

--- a/crates/engine/tests/crash_simulation_test.rs
+++ b/crates/engine/tests/crash_simulation_test.rs
@@ -6,16 +6,11 @@ use std::sync::Arc;
 
 use strata_core::{BranchId, Value};
 use strata_engine::database::OpenSpec;
-use strata_engine::{Database, EventLog, KVStore, SearchSubsystem};
-use strata_storage::{Key, Namespace};
+use strata_engine::{Database, EventLog, KVStore, SearchSubsystem, TransactionOps};
 use tempfile::TempDir;
 
 fn open_primary(path: &Path) -> Arc<Database> {
     Database::open_runtime(OpenSpec::primary(path).with_subsystem(SearchSubsystem)).unwrap()
-}
-
-fn kv_key(branch_id: BranchId, key: &str) -> Key {
-    Key::new_kv(Arc::new(Namespace::for_branch(branch_id)), key)
 }
 
 #[test]
@@ -78,7 +73,8 @@ fn dropped_manual_transaction_does_not_publish_partial_writes() {
     {
         let db = open_primary(temp_dir.path());
         let mut txn = db.begin_transaction(branch_id).unwrap();
-        txn.put(kv_key(branch_id, "pending"), Value::Int(5))
+        txn.scoped_space("default")
+            .kv_put("pending", Value::Int(5))
             .unwrap();
         drop(txn);
         db.flush().unwrap();

--- a/crates/engine/tests/database_transaction_tests.rs
+++ b/crates/engine/tests/database_transaction_tests.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use strata_core::{BranchId, Value};
 use strata_engine::database::OpenSpec;
 use strata_engine::StrataError;
+use strata_engine::TransactionOps;
 use strata_engine::{Database, KVStore, SearchSubsystem};
 use strata_storage::{Key, Namespace};
 use tempfile::TempDir;
@@ -72,18 +73,20 @@ fn manual_transaction_commit_and_abort_follow_public_contract() {
     let temp_dir = TempDir::new().unwrap();
     let db = open_primary(temp_dir.path());
     let branch_id = BranchId::new();
-    let committed = kv_key(branch_id, "committed");
-    let aborted = kv_key(branch_id, "aborted");
 
     {
         let mut txn = db.begin_transaction(branch_id).unwrap();
-        txn.put(committed.clone(), Value::Int(7)).unwrap();
+        txn.scoped_space("default")
+            .kv_put("committed", Value::Int(7))
+            .unwrap();
         txn.commit().unwrap();
     }
 
     {
         let mut txn = db.begin_transaction(branch_id).unwrap();
-        txn.put(aborted.clone(), Value::Int(9)).unwrap();
+        txn.scoped_space("default")
+            .kv_put("aborted", Value::Int(9))
+            .unwrap();
         txn.abort();
     }
 

--- a/crates/engine/tests/follower_tests.rs
+++ b/crates/engine/tests/follower_tests.rs
@@ -13,7 +13,7 @@ use strata_engine::database::OpenSpec;
 use strata_engine::search::Searchable;
 use strata_engine::{
     Database, JsonStore, JsonValue, NoopPreparedRefresh, PreparedRefresh, RefreshHook,
-    RefreshHookError, RefreshHooks, SearchRequest, SearchSubsystem, Subsystem,
+    RefreshHookError, RefreshHooks, SearchRequest, SearchSubsystem, Subsystem, TransactionOps,
 };
 use strata_storage::{Key, Namespace};
 use tempfile::tempdir;
@@ -44,13 +44,14 @@ fn primary_del(db: &Database, branch: BranchId, key: &str) {
 
 /// Helper: read a key-value pair via a read-only transaction.
 fn read_kv(db: &Database, branch: BranchId, key: &str) -> Option<String> {
-    let k = Key::new_kv(ns(branch), key);
     let mut txn = db
         .begin_read_only_transaction(branch)
         .expect("begin_read_only_transaction");
-    match txn.get(&k) {
-        Ok(Some(Value::String(s))) => Some(s),
-        Ok(Some(other)) => Some(format!("{:?}", other)),
+    match txn.scoped_space("default").kv_get(key) {
+        Ok(Some(versioned)) => match versioned.value {
+            Value::String(s) => Some(s),
+            other => Some(format!("{:?}", other)),
+        },
         Ok(None) => None,
         Err(e) => panic!("read_kv failed unexpectedly: {}", e),
     }
@@ -675,7 +676,6 @@ fn test_issue_1707_refresh_atomic_visibility() {
             let found = found_partial.clone();
             let stop_flag = stop.clone();
             std::thread::spawn(move || {
-                let n = ns(branch);
                 while !stop_flag.load(Ordering::Relaxed) {
                     // Take a snapshot read
                     let mut txn = match f.begin_read_only_transaction(branch) {
@@ -687,12 +687,14 @@ fn test_issue_1707_refresh_atomic_visibility() {
                     let mut new_visible = 0u32;
                     let mut old_visible = 0u32;
                     for i in 0..50 {
-                        let nk = Key::new_kv(n.clone(), format!("new_{}", i));
-                        if let Ok(Some(_)) = txn.get(&nk) {
+                        if let Ok(Some(_)) =
+                            txn.scoped_space("default").kv_get(&format!("new_{}", i))
+                        {
                             new_visible += 1;
                         }
-                        let ok = Key::new_kv(n.clone(), format!("old_{}", i));
-                        if let Ok(Some(_)) = txn.get(&ok) {
+                        if let Ok(Some(_)) =
+                            txn.scoped_space("default").kv_get(&format!("old_{}", i))
+                        {
                             old_visible += 1;
                         }
                     }
@@ -792,7 +794,6 @@ fn test_issue_1707_refresh_atomic_concurrent() {
             let found = found_partial.clone();
             let stop_flag = stop.clone();
             std::thread::spawn(move || {
-                let n = ns(branch);
                 while !stop_flag.load(Ordering::Relaxed) {
                     let mut txn = match f.begin_read_only_transaction(branch) {
                         Ok(t) => t,
@@ -806,19 +807,21 @@ fn test_issue_1707_refresh_atomic_concurrent() {
                     let mut mismatch = false;
 
                     for k in 0..20u32 {
-                        let key = Key::new_kv(n.clone(), format!("batch_{}", k));
-                        match txn.get(&key) {
-                            Ok(Some(Value::String(s))) => {
-                                all_none = false;
-                                if let Some(ref expected) = first_val {
-                                    if *expected != s {
-                                        mismatch = true;
-                                        break;
+                        match txn.scoped_space("default").kv_get(&format!("batch_{}", k)) {
+                            Ok(Some(versioned)) => match versioned.value {
+                                Value::String(s) => {
+                                    all_none = false;
+                                    if let Some(ref expected) = first_val {
+                                        if *expected != s {
+                                            mismatch = true;
+                                            break;
+                                        }
+                                    } else {
+                                        first_val = Some(s);
                                     }
-                                } else {
-                                    first_val = Some(s);
                                 }
-                            }
+                                _ => continue,
+                            },
                             Ok(None) => {
                                 // Key not yet visible — fine if ALL are none
                                 if first_val.is_some() {
@@ -826,7 +829,7 @@ fn test_issue_1707_refresh_atomic_concurrent() {
                                     break;
                                 }
                             }
-                            _ => continue,
+                            Err(_) => continue,
                         }
                     }
 

--- a/crates/engine/tests/robustness_regressions.rs
+++ b/crates/engine/tests/robustness_regressions.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use strata_core::{BranchId, Value};
 use strata_engine::database::OpenSpec;
+use strata_engine::TransactionOps;
 use strata_engine::{Database, KVStore, SearchSubsystem};
 use strata_storage::{Key, Namespace};
 use tempfile::TempDir;
@@ -22,10 +23,12 @@ fn read_only_transactions_reject_writes_and_keep_state_intact() {
     let temp_dir = TempDir::new().unwrap();
     let db = open_primary(temp_dir.path());
     let branch_id = BranchId::new();
-    let key = kv_key(branch_id, "read-only");
 
     let mut txn = db.begin_read_only_transaction(branch_id).unwrap();
-    let err = txn.put(key.clone(), Value::Int(1)).unwrap_err();
+    let err = txn
+        .scoped_space("default")
+        .kv_put("read-only", Value::Int(1))
+        .unwrap_err();
     assert!(err.to_string().contains("read-only"));
 
     let kv = KVStore::new(db);
@@ -37,15 +40,17 @@ fn dropped_transaction_releases_state_for_followup_commit() {
     let temp_dir = TempDir::new().unwrap();
     let db = open_primary(temp_dir.path());
     let branch_id = BranchId::new();
-    let key = kv_key(branch_id, "followup");
 
     {
         let mut txn = db.begin_transaction(branch_id).unwrap();
-        txn.put(key.clone(), Value::Int(1)).unwrap();
+        txn.scoped_space("default")
+            .kv_put("followup", Value::Int(1))
+            .unwrap();
         drop(txn);
     }
 
     db.transaction(branch_id, |txn| {
+        let key = kv_key(branch_id, "followup");
         txn.put(key.clone(), Value::Int(2))?;
         Ok(())
     })

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -24,7 +24,6 @@ arrow = ["dep:arrow", "dep:parquet"]
 strata-core = { package = "strata-core", path = "../core" }
 strata-engine = { path = "../engine" }
 strata-intelligence = { path = "../intelligence" }
-strata-storage = { path = "../storage" }
 rmp-serde = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -38,4 +37,5 @@ arrow = { workspace = true, optional = true }
 parquet = { workspace = true, optional = true }
 
 [dev-dependencies]
+strata-engine = { path = "../engine", features = ["test-support"] }
 tempfile = { workspace = true }

--- a/crates/executor/src/bridge.rs
+++ b/crates/executor/src/bridge.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use strata_core::{Value, VersionedValue as CoreVersionedValue};
 use strata_engine::{
-    AccessMode, BranchStatus as EngineBranchStatus, Database,
+    validate_space_name, AccessMode, BranchStatus as EngineBranchStatus, Database,
     DistanceMetric as EngineDistanceMetric, EventLog as PrimitiveEventLog,
     FilterCondition as EngineFilterCondition, FilterOp as EngineFilterOp, JsonPath,
     JsonScalar as EngineJsonScalar, JsonStore as PrimitiveJsonStore, JsonValue,
@@ -10,7 +10,6 @@ use strata_engine::{
     PrimitiveGraphStore, SpaceIndex as PrimitiveSpaceIndex, StrataError, StrataResult,
     VectorStore as PrimitiveVectorStore,
 };
-use strata_storage::validate_space_name;
 
 use crate::{
     BranchId, BranchStatus, Command, DatabaseInfo, DistanceMetric, Error, FilterOp, MetadataFilter,
@@ -479,7 +478,7 @@ pub(crate) fn require_branch_exists(p: &Arc<Primitives>, branch: &BranchId) -> R
 }
 
 pub(crate) fn validate_session_space(space: &str) -> Result<()> {
-    validate_space_name(space).map_err(|reason| Error::InvalidInput { reason, hint: None })
+    validate_space_name(space).map_err(Error::from)
 }
 
 pub(crate) fn database_info(db: &Arc<Database>, default_branch: &BranchId) -> DatabaseInfo {

--- a/crates/executor/src/compat.rs
+++ b/crates/executor/src/compat.rs
@@ -2,10 +2,10 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use strata_engine::{
-    open_product_cache, open_product_database, AccessMode, Database, HealthReport, MergeInfo,
-    MergeStrategy, OpenOptions, ProductOpenError, ProductOpenOutcome, SystemMetrics, WalCounters,
+    open_product_cache, open_product_database, validate_space_name, AccessMode, Database,
+    HealthReport, MergeInfo, MergeStrategy, OpenOptions, ProductOpenError, ProductOpenOutcome,
+    SystemMetrics, WalCounters,
 };
-use strata_storage::validate_space_name;
 
 use crate::ipc::IpcClient;
 use crate::{
@@ -261,7 +261,7 @@ impl Strata {
 
     /// Switch the current space for this handle.
     pub fn set_space(&mut self, space: &str) -> Result<()> {
-        validate_space_name(space).map_err(|reason| Error::InvalidInput { reason, hint: None })?;
+        validate_space_name(space).map_err(Error::from)?;
         self.current_space = space.to_string();
         Ok(())
     }

--- a/crates/executor/src/convert.rs
+++ b/crates/executor/src/convert.rs
@@ -3,7 +3,6 @@
 use crate::Error;
 use strata_core::EntityRef;
 use strata_engine::{StrataError, StrataResult};
-use strata_storage::StorageError;
 
 pub(crate) fn convert_result<T>(result: StrataResult<T>) -> crate::Result<T> {
     result.map_err(Error::from)
@@ -156,36 +155,6 @@ impl From<StrataError> for Error {
     }
 }
 
-impl From<StorageError> for Error {
-    fn from(err: StorageError) -> Self {
-        match err {
-            StorageError::Io(inner) => Error::Io {
-                reason: inner.to_string(),
-                hint: None,
-            },
-            StorageError::InvalidInput { message } => Error::InvalidInput {
-                reason: message,
-                hint: None,
-            },
-            StorageError::CapacityExceeded {
-                resource,
-                limit,
-                requested,
-            } => Error::ConstraintViolation {
-                reason: format!(
-                    "Capacity exceeded for {}: limit {}, requested {}",
-                    resource, limit, requested
-                ),
-            },
-            StorageError::Corruption { message } => Error::Serialization { reason: message },
-            other => Error::Internal {
-                reason: other.to_string(),
-                hint: None,
-            },
-        }
-    }
-}
-
 fn io_hint(reason: &str) -> Option<String> {
     let lower = reason.to_lowercase();
     if lower.contains("permission denied") {
@@ -253,5 +222,43 @@ mod tests {
             }
             other => panic!("expected Error::Io, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn product_boundary_invalid_input_maps_to_legacy_executor_shape() {
+        let err = Error::from(StrataError::invalid_input("inactive transaction"));
+
+        assert_eq!(
+            err,
+            Error::InvalidInput {
+                reason: "inactive transaction".to_string(),
+                hint: None,
+            }
+        );
+    }
+
+    #[test]
+    fn product_boundary_capacity_maps_to_legacy_executor_shape() {
+        let err = Error::from(StrataError::capacity_exceeded("transaction writes", 10, 11));
+
+        assert_eq!(
+            err,
+            Error::ConstraintViolation {
+                reason: "Capacity exceeded for transaction writes: limit 10, requested 11"
+                    .to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn product_boundary_serialization_maps_to_legacy_executor_shape() {
+        let err = Error::from(StrataError::serialization("malformed row payload"));
+
+        assert_eq!(
+            err,
+            Error::Serialization {
+                reason: "malformed row payload".to_string(),
+            }
+        );
     }
 }

--- a/crates/executor/src/handlers/event.rs
+++ b/crates/executor/src/handlers/event.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
-use strata_engine::transaction::context::Transaction as ScopedTransaction;
 use strata_engine::transaction_ops::TransactionOps as _;
-use strata_engine::TransactionContext;
-use strata_storage::{Key, Namespace};
+use strata_engine::Transaction as EngineTransaction;
 
 use crate::bridge::{
     extract_version, require_branch_exists, to_core_branch_id, validate_value, Primitives,
@@ -96,8 +94,7 @@ pub(crate) fn batch_append(
 
 pub(crate) fn execute_in_txn(
     primitives: &Arc<Primitives>,
-    ctx: &mut TransactionContext,
-    namespace: Arc<Namespace>,
+    ctx: &mut EngineTransaction,
     space: &str,
     command: crate::Command,
     effects: &mut TxnSideEffects,
@@ -111,7 +108,7 @@ pub(crate) fn execute_in_txn(
             convert_result(validate_value(&payload, &primitives.limits))?;
             validate_event_type_input(&event_type)?;
             validate_event_payload_input(&payload)?;
-            let mut txn = ScopedTransaction::new(ctx, namespace);
+            let mut txn = ctx.scoped_space(space);
             let version = txn
                 .event_append(&event_type, payload)
                 .map_err(crate::Error::from)?;
@@ -123,7 +120,7 @@ pub(crate) fn execute_in_txn(
             })
         }
         crate::Command::EventGet { sequence, .. } => {
-            let mut txn = ScopedTransaction::new(ctx, namespace);
+            let mut txn = ctx.scoped_space(space);
             let result = txn.event_get(sequence).map_err(crate::Error::from)?;
             Ok(Output::MaybeVersioned(result.map(|value| {
                 crate::bridge::to_versioned_value(strata_core::Versioned::new(
@@ -133,7 +130,7 @@ pub(crate) fn execute_in_txn(
             })))
         }
         crate::Command::EventExists { sequence, .. } => {
-            let mut txn = ScopedTransaction::new(ctx, namespace);
+            let mut txn = ctx.scoped_space(space);
             let result = txn.event_get(sequence).map_err(crate::Error::from)?;
             Ok(Output::Bool(result.is_some()))
         }
@@ -143,48 +140,25 @@ pub(crate) fn execute_in_txn(
             after_sequence,
             ..
         } => {
-            let prefix = Key::new_event_type_idx_prefix(namespace.clone(), &event_type);
-            let index_entries = ctx.scan_prefix(&prefix).map_err(crate::Error::from)?;
-            let mut events = Vec::new();
-            for (index_key, _) in index_entries {
-                let user_key = &index_key.user_key;
-                if user_key.len() < 8 {
-                    continue;
-                }
-                let bytes: [u8; 8] = user_key[user_key.len() - 8..]
-                    .try_into()
-                    .expect("sequence suffix should be eight bytes");
-                let sequence = u64::from_be_bytes(bytes);
-                if after_sequence.is_some_and(|after| sequence <= after) {
-                    continue;
-                }
-                let event_key = Key::new_event(namespace.clone(), sequence);
-                if let Some(strata_core::Value::String(json)) =
-                    ctx.get(&event_key).map_err(crate::Error::from)?
-                {
-                    let event: strata_engine::Event =
-                        serde_json::from_str(&json).map_err(|error| {
-                            crate::Error::Serialization {
-                                reason: format!(
-                                    "corrupt event at sequence {}: {}",
-                                    sequence, error
-                                ),
-                            }
-                        })?;
-                    events.push(VersionedValue {
-                        value: event.payload.clone(),
-                        version: sequence,
-                        timestamp: event.timestamp.into(),
-                    });
-                }
-                if limit.is_some_and(|limit| events.len() >= limit as usize) {
-                    break;
-                }
-            }
+            let mut txn = ctx.scoped_space(space);
+            let events = txn
+                .event_get_by_type(
+                    &event_type,
+                    limit.map(|limit| limit as usize),
+                    after_sequence,
+                )
+                .map_err(crate::Error::from)?
+                .into_iter()
+                .map(|event| VersionedValue {
+                    version: extract_version(&event.version),
+                    timestamp: event.value.timestamp.into(),
+                    value: event.value.payload,
+                })
+                .collect();
             Ok(Output::VersionedValues(events))
         }
         crate::Command::EventLen { .. } => {
-            let mut txn = ScopedTransaction::new(ctx, namespace);
+            let mut txn = ctx.scoped_space(space);
             let len = txn.event_len().map_err(crate::Error::from)?;
             Ok(Output::Uint(len))
         }
@@ -196,7 +170,7 @@ pub(crate) fn execute_in_txn(
                 };
                 entries.len()
             ];
-            let mut txn = ScopedTransaction::new(ctx, namespace);
+            let mut txn = ctx.scoped_space(space);
             for (index, entry) in entries.into_iter().enumerate() {
                 if let Err(error) = validate_value(&entry.payload, &primitives.limits) {
                     results[index].error = Some(error.to_string());

--- a/crates/executor/src/handlers/graph.rs
+++ b/crates/executor/src/handlers/graph.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
 use strata_engine::graph::types::{CascadePolicy, Direction, EdgeData, GraphMeta, NodeData};
-use strata_engine::graph::GraphStoreExt;
-use strata_engine::TransactionContext;
+use strata_engine::Transaction as EngineTransaction;
 
 use crate::bridge::{
     require_branch_exists, serde_json_to_value_public, to_core_branch_id,
@@ -432,9 +431,8 @@ fn prepare_space_write(primitives: &Arc<Primitives>, branch: &BranchId, space: &
 }
 
 pub(crate) fn execute_in_txn(
-    primitives: &Arc<Primitives>,
-    ctx: &mut TransactionContext,
-    branch_id: strata_core::BranchId,
+    _primitives: &Arc<Primitives>,
+    ctx: &mut EngineTransaction,
     space: &str,
     command: crate::Command,
 ) -> Result<Output> {
@@ -449,7 +447,7 @@ pub(crate) fn execute_in_txn(
                 cascade_policy: policy,
                 ..Default::default()
             };
-            convert_result(ctx.graph_create(branch_id, space, &graph, meta))?;
+            convert_result(ctx.graph_create_in_space(space, &graph, meta))?;
             Ok(Output::Unit)
         }
         crate::Command::GraphAddNode {
@@ -469,19 +467,12 @@ pub(crate) fn execute_in_txn(
                 properties,
                 object_type,
             };
-            let backend_state = convert_result(primitives.graph.state())?;
-            let created = convert_result(ctx.graph_add_node(
-                branch_id,
-                space,
-                &graph,
-                &node_id,
-                &data,
-                &backend_state,
-            ))?;
+            let created =
+                convert_result(ctx.graph_add_node_in_space(space, &graph, &node_id, &data))?;
             Ok(Output::GraphWriteResult { node_id, created })
         }
         crate::Command::GraphGetNode { graph, node_id, .. } => {
-            let node = convert_result(ctx.graph_get_node(branch_id, space, &graph, &node_id))?;
+            let node = convert_result(ctx.graph_get_node_in_space(space, &graph, &node_id))?;
             match node {
                 Some(data) => {
                     let json = serde_json::to_value(&data).map_err(|error| {
@@ -497,22 +488,15 @@ pub(crate) fn execute_in_txn(
             }
         }
         crate::Command::GraphRemoveNode { graph, node_id, .. } => {
-            let backend_state = convert_result(primitives.graph.state())?;
-            convert_result(ctx.graph_remove_node(
-                branch_id,
-                space,
-                &graph,
-                &node_id,
-                &backend_state,
-            ))?;
+            convert_result(ctx.graph_remove_node_in_space(space, &graph, &node_id))?;
             Ok(Output::Unit)
         }
         crate::Command::GraphListNodes { graph, .. } => {
-            let nodes = convert_result(ctx.graph_list_nodes(branch_id, space, &graph))?;
+            let nodes = convert_result(ctx.graph_list_nodes_in_space(space, &graph))?;
             Ok(Output::Keys(nodes))
         }
         crate::Command::GraphGetMeta { graph, .. } => {
-            let meta = convert_result(ctx.graph_get_meta(branch_id, space, &graph))?;
+            let meta = convert_result(ctx.graph_get_meta_in_space(space, &graph))?;
             match meta {
                 Some(meta) => {
                     let json = serde_json::to_value(&meta).map_err(|error| {
@@ -528,7 +512,7 @@ pub(crate) fn execute_in_txn(
             }
         }
         crate::Command::GraphList { .. } => {
-            let graphs = convert_result(ctx.graph_list(branch_id, space))?;
+            let graphs = convert_result(ctx.graph_list_in_space(space))?;
             Ok(Output::Keys(graphs))
         }
         crate::Command::GraphAddEdge {
@@ -549,7 +533,7 @@ pub(crate) fn execute_in_txn(
                 properties,
             };
             let created = convert_result(
-                ctx.graph_add_edge(branch_id, space, &graph, &src, &dst, &edge_type, &data),
+                ctx.graph_add_edge_in_space(space, &graph, &src, &dst, &edge_type, &data),
             )?;
             Ok(Output::GraphEdgeWriteResult {
                 src,
@@ -565,9 +549,7 @@ pub(crate) fn execute_in_txn(
             edge_type,
             ..
         } => {
-            convert_result(
-                ctx.graph_remove_edge(branch_id, space, &graph, &src, &dst, &edge_type),
-            )?;
+            convert_result(ctx.graph_remove_edge_in_space(space, &graph, &src, &dst, &edge_type))?;
             Ok(Output::Unit)
         }
         crate::Command::GraphNeighbors {
@@ -579,30 +561,26 @@ pub(crate) fn execute_in_txn(
         } => {
             let direction = parse_direction(direction.as_deref())?;
             let neighbors = match direction {
-                Direction::Outgoing => convert_result(ctx.graph_outgoing_neighbors(
-                    branch_id,
+                Direction::Outgoing => convert_result(ctx.graph_outgoing_neighbors_in_space(
                     space,
                     &graph,
                     &node_id,
                     edge_type.as_deref(),
                 ))?,
-                Direction::Incoming => convert_result(ctx.graph_incoming_neighbors(
-                    branch_id,
+                Direction::Incoming => convert_result(ctx.graph_incoming_neighbors_in_space(
                     space,
                     &graph,
                     &node_id,
                     edge_type.as_deref(),
                 ))?,
                 Direction::Both => {
-                    let mut outgoing = convert_result(ctx.graph_outgoing_neighbors(
-                        branch_id,
+                    let mut outgoing = convert_result(ctx.graph_outgoing_neighbors_in_space(
                         space,
                         &graph,
                         &node_id,
                         edge_type.as_deref(),
                     ))?;
-                    let incoming = convert_result(ctx.graph_incoming_neighbors(
-                        branch_id,
+                    let incoming = convert_result(ctx.graph_incoming_neighbors_in_space(
                         space,
                         &graph,
                         &node_id,

--- a/crates/executor/src/handlers/json.rs
+++ b/crates/executor/src/handlers/json.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use strata_engine::primitives::json::index::IndexType;
 use strata_engine::transaction_ops::TransactionOps as _;
 use strata_engine::Transaction as EngineTransaction;
-use strata_storage::Namespace;
 
 use crate::bridge::{
     extract_version, json_to_value, parse_path, require_branch_exists, to_core_branch_id,
@@ -425,7 +424,6 @@ pub(crate) fn batch_delete(
 pub(crate) fn execute_in_txn(
     primitives: &Arc<Primitives>,
     ctx: &mut EngineTransaction,
-    namespace: Arc<Namespace>,
     space: &str,
     command: crate::Command,
     effects: &mut TxnSideEffects,
@@ -433,7 +431,7 @@ pub(crate) fn execute_in_txn(
     match command {
         crate::Command::JsonGet { key, path, .. } => {
             convert_result(validate_key(&key))?;
-            let mut txn = ctx.scoped(namespace);
+            let mut txn = ctx.scoped_space(space);
             let path = convert_result(parse_path(&path))?;
             let result = txn.json_get(&key).map_err(crate::Error::from)?;
             Ok(Output::MaybeVersioned(match result {
@@ -450,7 +448,7 @@ pub(crate) fn execute_in_txn(
         }
         crate::Command::JsonExists { key, .. } => {
             convert_result(validate_key(&key))?;
-            let mut txn = ctx.scoped(namespace);
+            let mut txn = ctx.scoped_space(space);
             Ok(Output::Bool(
                 txn.json_get(&key).map_err(crate::Error::from)?.is_some(),
             ))
@@ -460,7 +458,7 @@ pub(crate) fn execute_in_txn(
         } => {
             convert_result(validate_key(&key))?;
             convert_result(validate_value(&value, &primitives.limits))?;
-            let mut txn = ctx.scoped(namespace);
+            let mut txn = ctx.scoped_space(space);
             let path = convert_result(parse_path(&path))?;
             let value = convert_result(value_to_json(value))?;
             let version = txn
@@ -476,14 +474,14 @@ pub(crate) fn execute_in_txn(
             convert_result(validate_key(&key))?;
             let path = convert_result(parse_path(&path))?;
             if path.is_root() {
-                let mut txn = ctx.scoped(namespace);
+                let mut txn = ctx.scoped_space(space);
                 let deleted = txn.json_delete(&key).map_err(crate::Error::from)?;
                 if deleted {
                     effects.record_json(space, &key);
                 }
                 Ok(Output::DeleteResult { key, deleted })
             } else {
-                let mut txn = ctx.scoped(namespace);
+                let mut txn = ctx.scoped_space(space);
                 let Some(mut doc) = txn
                     .json_get_path(&key, &strata_engine::JsonPath::root())
                     .map_err(crate::Error::from)?
@@ -525,7 +523,7 @@ pub(crate) fn execute_in_txn(
                     convert_result(validate_key(prefix))?;
                 }
             }
-            let mut txn = ctx.scoped(namespace);
+            let mut txn = ctx.scoped_space(space);
             let mut keys = txn
                 .json_list_keys(prefix.as_deref())
                 .map_err(crate::Error::from)?;
@@ -549,7 +547,7 @@ pub(crate) fn execute_in_txn(
                 };
                 entries.len()
             ];
-            let mut txn = ctx.scoped(namespace);
+            let mut txn = ctx.scoped_space(space);
             for (index, entry) in entries.into_iter().enumerate() {
                 if let Err(error) = validate_key(&entry.key) {
                     results[index].error = Some(error.to_string());
@@ -601,7 +599,6 @@ pub(crate) fn execute_in_txn(
                 let output = match execute_in_txn(
                     primitives,
                     ctx,
-                    namespace.clone(),
                     space,
                     crate::Command::JsonGet {
                         branch: None,
@@ -652,7 +649,6 @@ pub(crate) fn execute_in_txn(
                 let output = match execute_in_txn(
                     primitives,
                     ctx,
-                    namespace.clone(),
                     space,
                     crate::Command::JsonDelete {
                         branch: None,

--- a/crates/executor/src/handlers/kv.rs
+++ b/crates/executor/src/handlers/kv.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
-use strata_engine::transaction::context::Transaction as ScopedTransaction;
 use strata_engine::transaction_ops::TransactionOps as _;
-use strata_engine::TransactionContext;
-use strata_storage::{Key, Namespace, TypeTag};
+use strata_engine::Transaction as EngineTransaction;
 
 use crate::bridge::{
     extract_version, require_branch_exists, to_core_branch_id, to_versioned_value, validate_key,
@@ -478,8 +476,7 @@ pub(crate) fn sample(
 
 pub(crate) fn execute_in_txn(
     primitives: &Arc<Primitives>,
-    ctx: &mut TransactionContext,
-    namespace: Arc<Namespace>,
+    ctx: &mut EngineTransaction,
     space: &str,
     command: crate::Command,
     effects: &mut TxnSideEffects,
@@ -487,8 +484,8 @@ pub(crate) fn execute_in_txn(
     match command {
         crate::Command::KvGet { key, .. } => {
             convert_result(validate_key(&key))?;
-            let full_key = Key::new_kv(namespace, &key);
-            let result = ctx.get(&full_key).map_err(crate::Error::from)?;
+            let mut txn = ctx.scoped_space(space);
+            let result = txn.kv_get_value(&key).map_err(crate::Error::from)?;
             Ok(Output::Maybe(result))
         }
         crate::Command::KvList {
@@ -502,42 +499,24 @@ pub(crate) fn execute_in_txn(
                     convert_result(validate_key(prefix))?;
                 }
             }
-            let prefix_key = match prefix {
-                Some(ref prefix) => Key::new_kv(namespace.clone(), prefix),
-                None => Key::new(namespace.clone(), TypeTag::KV, vec![]),
-            };
-            let entries = ctx.scan_prefix(&prefix_key).map_err(crate::Error::from)?;
-            let mut keys: Vec<String> = entries
-                .into_iter()
-                .filter_map(|(key, _)| key.user_key_string())
-                .collect();
-            keys.sort();
-            keys.dedup();
+            let mut txn = ctx.scoped_space(space);
+            let keys = txn.kv_list(prefix.as_deref()).map_err(crate::Error::from)?;
             Ok(page_keys(keys, cursor.as_deref(), limit))
         }
         crate::Command::KvScan { start, limit, .. } => {
             if let Some(start) = &start {
                 convert_result(validate_key(start))?;
             }
-            let prefix_key = Key::new(namespace, TypeTag::KV, vec![]);
-            let entries = ctx.scan_prefix(&prefix_key).map_err(crate::Error::from)?;
-            let mut pairs: Vec<(String, strata_core::Value)> = entries
-                .into_iter()
-                .filter_map(|(key, value)| key.user_key_string().map(|key| (key, value)))
-                .collect();
-            pairs.sort_by(|left, right| left.0.cmp(&right.0));
-            if let Some(start) = start {
-                pairs.retain(|(key, _)| key.as_str() >= start.as_str());
-            }
-            if let Some(limit) = limit {
-                pairs.truncate(limit as usize);
-            }
+            let mut txn = ctx.scoped_space(space);
+            let pairs = txn
+                .kv_scan(start.as_deref(), limit.map(|limit| limit as usize))
+                .map_err(crate::Error::from)?;
             Ok(Output::KvScanResult(pairs))
         }
         crate::Command::KvPut { key, value, .. } => {
             convert_result(validate_key(&key))?;
             convert_result(validate_value(&value, &primitives.limits))?;
-            let mut txn = ScopedTransaction::new(ctx, namespace);
+            let mut txn = ctx.scoped_space(space);
             let version = txn.kv_put(&key, value).map_err(crate::Error::from)?;
             effects.record_kv(space, &key);
             Ok(Output::WriteResult {
@@ -547,16 +526,12 @@ pub(crate) fn execute_in_txn(
         }
         crate::Command::KvDelete { key, .. } => {
             convert_result(validate_key(&key))?;
-            let full_key = Key::new_kv(namespace, &key);
-            let existed = ctx.exists(&full_key).map_err(crate::Error::from)?;
-            ctx.delete(full_key).map_err(crate::Error::from)?;
-            if existed {
+            let mut txn = ctx.scoped_space(space);
+            let deleted = txn.kv_delete(&key).map_err(crate::Error::from)?;
+            if deleted {
                 effects.record_kv(space, &key);
             }
-            Ok(Output::DeleteResult {
-                key,
-                deleted: existed,
-            })
+            Ok(Output::DeleteResult { key, deleted })
         }
         crate::Command::KvBatchPut { entries, .. } => {
             let mut results = vec![
@@ -566,7 +541,7 @@ pub(crate) fn execute_in_txn(
                 };
                 entries.len()
             ];
-            let mut txn = ScopedTransaction::new(ctx, namespace);
+            let mut txn = ctx.scoped_space(space);
             for (index, entry) in entries.into_iter().enumerate() {
                 if let Err(error) = validate_key(&entry.key) {
                     results[index].error = Some(error.to_string());
@@ -594,14 +569,13 @@ pub(crate) fn execute_in_txn(
                 };
                 keys.len()
             ];
+            let mut txn = ctx.scoped_space(space);
             for (index, key) in keys.into_iter().enumerate() {
                 if let Err(error) = validate_key(&key) {
                     results[index].error = Some(error.to_string());
                     continue;
                 }
-                let full_key = Key::new_kv(namespace.clone(), &key);
-                let value = ctx.get(&full_key).map_err(crate::Error::from)?;
-                results[index].value = value;
+                results[index].value = txn.kv_get_value(&key).map_err(crate::Error::from)?;
             }
             Ok(Output::BatchGetResults(results))
         }
@@ -613,17 +587,17 @@ pub(crate) fn execute_in_txn(
                 };
                 keys.len()
             ];
+            let mut txn = ctx.scoped_space(space);
             for (index, key) in keys.into_iter().enumerate() {
                 if let Err(error) = validate_key(&key) {
                     results[index].error = Some(error.to_string());
                     continue;
                 }
-                let full_key = Key::new_kv(namespace.clone(), &key);
-                let existed = ctx.exists(&full_key).map_err(crate::Error::from)?;
-                if let Err(error) = ctx.delete(full_key) {
-                    results[index].error = Some(error.to_string());
-                } else if existed {
-                    effects.record_kv(space, &key);
+                let existed = txn.kv_exists(&key).map_err(crate::Error::from)?;
+                match txn.kv_delete_without_existence_check(&key) {
+                    Ok(_) if existed => effects.record_kv(space, &key),
+                    Ok(_) => {}
+                    Err(error) => results[index].error = Some(error.to_string()),
                 }
             }
             Ok(Output::BatchResults(results))
@@ -633,17 +607,17 @@ pub(crate) fn execute_in_txn(
             for key in &keys {
                 convert_result(validate_key(key))?;
             }
+            let mut txn = ctx.scoped_space(space);
             for key in keys {
-                let full_key = Key::new_kv(namespace.clone(), &key);
-                values.push(ctx.exists(&full_key).map_err(crate::Error::from)?);
+                values.push(txn.kv_exists(&key).map_err(crate::Error::from)?);
             }
             Ok(Output::BoolList(values))
         }
         crate::Command::KvExists { key, .. } => {
             convert_result(validate_key(&key))?;
-            let full_key = Key::new_kv(namespace, &key);
+            let mut txn = ctx.scoped_space(space);
             Ok(Output::Bool(
-                ctx.exists(&full_key).map_err(crate::Error::from)?,
+                txn.kv_exists(&key).map_err(crate::Error::from)?,
             ))
         }
         other => Err(crate::Error::Internal {

--- a/crates/executor/src/handlers/space.rs
+++ b/crates/executor/src/handlers/space.rs
@@ -26,6 +26,7 @@ pub(crate) fn exists(
     branch: BranchId,
     space: String,
 ) -> Result<Output> {
+    validate_session_space(&space)?;
     let branch_id = to_core_branch_id(&branch)?;
     let exists = convert_result(primitives.space.exists(branch_id, &space))?;
     Ok(Output::Bool(exists))

--- a/crates/executor/src/handlers/space_delete.rs
+++ b/crates/executor/src/handlers/space_delete.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
-use strata_storage::{Key, Namespace, TypeTag};
+use strata_engine::{is_user_space_delete_constraint, StrataError};
 
-use crate::bridge::{require_branch_exists, to_core_branch_id, Primitives};
-use crate::convert::convert_result;
+use crate::bridge::Primitives;
 use crate::handlers::embed_runtime;
 use crate::{BranchId, Error, Output, Result};
 
@@ -13,71 +12,22 @@ pub(crate) fn delete(
     space: String,
     force: bool,
 ) -> Result<Output> {
-    if space == "default" || space == strata_engine::system_space::SYSTEM_SPACE {
-        return Err(Error::ConstraintViolation {
-            reason: format!("Cannot delete the '{space}' space"),
-        });
-    }
-
-    require_branch_exists(primitives, &branch)?;
-    let branch_id = to_core_branch_id(&branch)?;
-
-    if !force {
-        let empty = convert_result(primitives.space.is_empty(branch_id, &space))?;
-        if !empty {
-            return Err(Error::ConstraintViolation {
-                reason: format!("Space '{space}' is not empty. Use force=true to delete anyway."),
-            });
+    match primitives.space.delete_user_space_with_post_data_cleanup(
+        branch.as_str(),
+        &space,
+        force,
+        |branch_id, space| {
+            embed_runtime::delete_shadow_embeddings_for_space(primitives, branch_id, space);
+            Ok(())
+        },
+    ) {
+        Ok(()) => Ok(Output::Unit),
+        Err(error) if is_user_space_delete_constraint(&error) => {
+            let StrataError::InvalidOperation { reason, .. } = error else {
+                unreachable!("space delete constraint helper only matches invalid operations");
+            };
+            Err(Error::ConstraintViolation { reason })
         }
+        Err(error) => Err(Error::from(error)),
     }
-
-    let namespace = Arc::new(Namespace::for_branch_space(branch_id, &space));
-    convert_result(primitives.db.transaction(branch_id, |txn| {
-        primitives
-            .vector
-            .delete_space_data_in_transaction(txn, branch_id, &space)
-            .map_err(|error| error.into_strata_error(branch_id))?;
-        for type_tag in [TypeTag::KV, TypeTag::Event, TypeTag::Json, TypeTag::Graph] {
-            let prefix = Key::new(namespace.clone(), type_tag, vec![]);
-            let entries = txn.scan_prefix(&prefix)?;
-            for (key, _) in entries {
-                txn.delete(key)?;
-            }
-        }
-        Ok(())
-    }))?;
-
-    if let Ok(index) = primitives
-        .db
-        .extension::<strata_engine::search::InvertedIndex>()
-    {
-        let removed = index.remove_documents_in_space(branch_id, &space);
-        if removed > 0 {
-            tracing::info!(
-                target: "strata::space",
-                branch_id = %branch_id,
-                space = space.as_str(),
-                removed,
-                "Removed search documents during space delete"
-            );
-        }
-    }
-
-    if let Err(error) = primitives
-        .vector
-        .purge_collections_in_space(branch_id, &space)
-    {
-        tracing::warn!(
-            target: "strata::space",
-            branch_id = %branch_id,
-            space = space.as_str(),
-            error = %error,
-            "Failed to purge vector collections during space delete"
-        );
-    }
-
-    embed_runtime::delete_shadow_embeddings_for_space(primitives, branch_id, &space);
-
-    convert_result(primitives.space.delete(branch_id, &space))?;
-    Ok(Output::Unit)
 }

--- a/crates/executor/src/handlers/vector.rs
+++ b/crates/executor/src/handlers/vector.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use strata_engine::{
-    TransactionContext, VectorConfig, VectorEntry, VectorMatch as EngineVectorMatch,
+    Transaction as EngineTransaction, VectorConfig, VectorEntry, VectorMatch as EngineVectorMatch,
 };
 
 use crate::bridge::{
@@ -604,8 +604,7 @@ pub(crate) fn sample(
 
 pub(crate) fn execute_in_txn(
     primitives: &Arc<Primitives>,
-    ctx: &mut TransactionContext,
-    branch_id: strata_core::BranchId,
+    ctx: &mut EngineTransaction,
     space: &str,
     command: crate::Command,
 ) -> Result<Output> {
@@ -624,10 +623,16 @@ pub(crate) fn execute_in_txn(
                 .map(value_to_serde_json_public)
                 .transpose()
                 .map_err(Error::from)?;
-            let version = primitives
-                .vector
-                .insert_in_transaction(ctx, branch_id, space, &collection, &key, &vector, metadata)
-                .map_err(|error| Error::from(error.into_strata_error(branch_id)))?;
+            let version = ctx
+                .vector_insert_in_space(
+                    &primitives.vector,
+                    space,
+                    &collection,
+                    &key,
+                    &vector,
+                    metadata,
+                )
+                .map_err(Error::from)?;
             Ok(Output::VectorWriteResult {
                 collection,
                 key,
@@ -639,10 +644,9 @@ pub(crate) fn execute_in_txn(
         } => {
             convert_result(validate_not_internal_collection(&collection))?;
             convert_result(validate_key(&key))?;
-            let deleted = primitives
-                .vector
-                .delete_in_transaction(ctx, branch_id, space, &collection, &key)
-                .map_err(|error| Error::from(error.into_strata_error(branch_id)))?;
+            let deleted = ctx
+                .vector_delete_in_space(&primitives.vector, space, &collection, &key)
+                .map_err(Error::from)?;
             Ok(Output::VectorDeleteResult {
                 collection,
                 key,
@@ -654,10 +658,9 @@ pub(crate) fn execute_in_txn(
         } => {
             convert_result(validate_not_internal_collection(&collection))?;
             convert_result(validate_key(&key))?;
-            let record = primitives
-                .vector
-                .get_in_transaction(ctx, branch_id, space, &collection, &key)
-                .map_err(|error| Error::from(error.into_strata_error(branch_id)))?;
+            let record = ctx
+                .vector_get_in_space(&primitives.vector, space, &collection, &key)
+                .map_err(Error::from)?;
             match record {
                 Some(record) => {
                     let version = extract_version(&strata_core::Version::counter(record.version));
@@ -684,10 +687,9 @@ pub(crate) fn execute_in_txn(
         } => {
             convert_result(validate_not_internal_collection(&collection))?;
             convert_result(validate_key(&key))?;
-            let record = primitives
-                .vector
-                .get_in_transaction(ctx, branch_id, space, &collection, &key)
-                .map_err(|error| Error::from(error.into_strata_error(branch_id)))?;
+            let record = ctx
+                .vector_get_in_space(&primitives.vector, space, &collection, &key)
+                .map_err(Error::from)?;
             Ok(Output::Bool(record.is_some()))
         }
         other => Err(Error::Internal {

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -40,7 +40,6 @@ pub use strata_engine::{
     ModelConfig, OpenOptions, Profile, RevertInfo, SpaceDiff, StorageConfig, StorageIterator,
     StrataConfig, SystemMetrics, WalCounters,
 };
-pub use strata_storage::{Key, Namespace};
 
 /// Result type for executor operations.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/executor/src/session.rs
+++ b/crates/executor/src/session.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use strata_engine::{AccessMode, Database, Transaction};
-use strata_storage::Namespace;
 
 use crate::bridge::{
     access_denied, bypasses_active_transaction, is_read_only, json_to_value,
@@ -106,7 +105,7 @@ impl LocalSession {
 
     fn txn_info(&self) -> Output {
         Output::TxnInfo(self.txn.as_ref().map(|txn| TransactionInfo {
-            id: txn.txn_id.to_string(),
+            id: txn.id_string(),
             status: TxnStatus::Active,
             started_at: 0,
         }))
@@ -146,27 +145,13 @@ impl LocalSession {
             _ => {}
         }
 
-        let branch_id = self
-            .txn
-            .as_ref()
-            .expect("transaction should be active while dispatching in-transaction commands")
-            .branch_id();
         let space = command_space(&command);
-        let namespace = Arc::new(Namespace::for_branch_space(branch_id, &space));
         let txn = self
             .txn
             .as_mut()
             .expect("transaction should be active while dispatching in-transaction commands");
 
-        dispatch_in_txn(
-            executor,
-            txn,
-            namespace,
-            branch_id,
-            &space,
-            command,
-            &mut self.effects,
-        )
+        dispatch_in_txn(executor, txn, &space, command, &mut self.effects)
     }
 }
 
@@ -512,8 +497,6 @@ fn command_space(command: &Command) -> String {
 fn dispatch_in_txn(
     executor: &Executor,
     txn: &mut Transaction,
-    namespace: Arc<Namespace>,
-    branch_id: strata_core::BranchId,
     space: &str,
     command: Command,
     effects: &mut TxnSideEffects,
@@ -541,10 +524,7 @@ fn dispatch_in_txn(
         | other @ Command::KvBatchDelete { .. }
         | other @ Command::KvBatchExists { .. }
         | other @ Command::KvExists { .. } => {
-            let ctx = txn
-                .context_mut()
-                .expect("transaction context should be available until commit or rollback");
-            kv::execute_in_txn(executor.primitives(), ctx, namespace, space, other, effects)
+            kv::execute_in_txn(executor.primitives(), txn, space, other, effects)
         }
         other @ Command::JsonGet { .. }
         | other @ Command::JsonSet { .. }
@@ -554,7 +534,7 @@ fn dispatch_in_txn(
         | other @ Command::JsonBatchSet { .. }
         | other @ Command::JsonBatchGet { .. }
         | other @ Command::JsonBatchDelete { .. } => {
-            json::execute_in_txn(executor.primitives(), txn, namespace, space, other, effects)
+            json::execute_in_txn(executor.primitives(), txn, space, other, effects)
         }
         other @ Command::EventAppend { .. }
         | other @ Command::EventGet { .. }
@@ -562,10 +542,7 @@ fn dispatch_in_txn(
         | other @ Command::EventGetByType { .. }
         | other @ Command::EventLen { .. }
         | other @ Command::EventBatchAppend { .. } => {
-            let ctx = txn
-                .context_mut()
-                .expect("transaction context should be available until commit or rollback");
-            event::execute_in_txn(executor.primitives(), ctx, namespace, space, other, effects)
+            event::execute_in_txn(executor.primitives(), txn, space, other, effects)
         }
         other @ Command::GraphCreate { .. }
         | other @ Command::GraphAddNode { .. }
@@ -577,19 +554,13 @@ fn dispatch_in_txn(
         | other @ Command::GraphAddEdge { .. }
         | other @ Command::GraphRemoveEdge { .. }
         | other @ Command::GraphNeighbors { .. } => {
-            let ctx = txn
-                .context_mut()
-                .expect("transaction context should be available until commit or rollback");
-            graph::execute_in_txn(executor.primitives(), ctx, branch_id, space, other)
+            graph::execute_in_txn(executor.primitives(), txn, space, other)
         }
         other @ Command::VectorUpsert { .. }
         | other @ Command::VectorDelete { .. }
         | other @ Command::VectorGet { .. }
         | other @ Command::VectorExists { .. } => {
-            let ctx = txn
-                .context_mut()
-                .expect("transaction context should be available until commit or rollback");
-            vector::execute_in_txn(executor.primitives(), ctx, branch_id, space, other)
+            vector::execute_in_txn(executor.primitives(), txn, space, other)
         }
 
         other => executor.execute(other),
@@ -833,7 +804,6 @@ mod tests {
 
     use strata_core::Value;
     use strata_engine::AccessMode;
-    use strata_storage::{Key, Namespace};
 
     use super::SessionBackend;
     use crate::{Command, Error, Output, Session, Strata};
@@ -1037,14 +1007,12 @@ mod tests {
         let branch_id =
             crate::bridge::to_core_branch_id(&branch).expect("default branch should parse");
 
-        let corrupt_json_key = Key::new_json(
-            Arc::new(Namespace::for_branch_space(branch_id, "default")),
+        db.inject_corrupt_json_bytes_for_test(
+            branch_id,
+            "default",
             "corrupt-json",
-        );
-        db.transaction(branch_id, |txn| {
-            txn.put(corrupt_json_key.clone(), Value::Bytes(vec![0xff, 0x00]))?;
-            Ok(())
-        })
+            vec![0xff, 0x00],
+        )
         .expect("corrupt fixture should be written directly");
 
         let mut session = Session::new(db.clone());

--- a/crates/intelligence/src/embed/runtime.rs
+++ b/crates/intelligence/src/embed/runtime.rs
@@ -430,10 +430,7 @@ pub fn delete_shadow_embeddings_for_space(
     branch_id: BranchId,
     target_space: &str,
 ) -> usize {
-    if let Ok(buffer) = db.extension::<EmbedBuffer>() {
-        let mut pending = buffer.pending.lock().unwrap_or_else(|e| e.into_inner());
-        pending.retain(|entry| !(entry.branch_id == branch_id && entry.space == target_space));
-    }
+    clear_pending_shadow_embeddings_for_space(db, branch_id, target_space);
 
     let prefix = format!("{target_space}\x1f");
     let vector = VectorStore::new(db.clone());
@@ -475,6 +472,20 @@ pub fn delete_shadow_embeddings_for_space(
     }
 
     total
+}
+
+pub fn clear_pending_shadow_embeddings_for_space(
+    db: &Arc<Database>,
+    branch_id: BranchId,
+    target_space: &str,
+) -> usize {
+    let Ok(buffer) = db.extension::<EmbedBuffer>() else {
+        return 0;
+    };
+    let mut pending = buffer.pending.lock().unwrap_or_else(|e| e.into_inner());
+    let before = pending.len();
+    pending.retain(|entry| !(entry.branch_id == branch_id && entry.space == target_space));
+    before - pending.len()
 }
 
 pub fn reindex_embeddings(db: &Arc<Database>, branch_id: BranchId) -> StrataResult<ReindexStats> {
@@ -750,5 +761,37 @@ mod tests {
         let status = embed_status(&db);
         assert_eq!(status.pending, 0);
         assert_eq!(status.total_queued, 1);
+    }
+
+    #[test]
+    fn clearing_pending_shadow_embeddings_for_space_preserves_sibling_space() {
+        let db = test_db();
+        let branch_id = BranchId::default();
+
+        maybe_embed_text(
+            &db,
+            branch_id,
+            "alpha",
+            SHADOW_KV,
+            "queued",
+            "hello alpha",
+            EntityRef::kv(branch_id, "alpha", "queued"),
+        );
+        maybe_embed_text(
+            &db,
+            branch_id,
+            "beta",
+            SHADOW_KV,
+            "queued",
+            "hello beta",
+            EntityRef::kv(branch_id, "beta", "queued"),
+        );
+
+        let removed = clear_pending_shadow_embeddings_for_space(&db, branch_id, "alpha");
+
+        let status = embed_status(&db);
+        assert_eq!(removed, 1);
+        assert_eq!(status.pending, 1);
+        assert_eq!(status.total_queued, 2);
     }
 }

--- a/crates/intelligence/src/shadow.rs
+++ b/crates/intelligence/src/shadow.rs
@@ -33,7 +33,7 @@ pub fn delete_shadow_embeddings_for_space(
     branch_id: BranchId,
     target_space: &str,
 ) -> usize {
-    let prefix = format!("{target_space}\x1f");
+    let prefix = format!("{target_space}{SHADOW_KEY_SEP}");
     let vector = VectorStore::new(db.clone());
     let mut total = 0usize;
     for shadow in [SHADOW_KV, SHADOW_JSON, SHADOW_EVENT] {

--- a/docs/engine/eg7-implementation-plan.md
+++ b/docs/engine/eg7-implementation-plan.md
@@ -1,0 +1,605 @@
+# EG7 Implementation Plan
+
+## Purpose
+
+`EG7` removes executor's remaining storage bypasses after engine has absorbed
+security, product open behavior, graph, vector, and search.
+
+The target stack is:
+
+```text
+core -> storage -> engine -> intelligence -> executor -> cli
+```
+
+In that stack, executor is a command/session/product handle layer. It may own
+public command DTOs, IPC adaptation, session state, and user-facing error
+shape, but it must not construct storage keys, storage namespaces, storage type
+tags, or interpret storage-local errors. Those details are engine-owned once
+the primitive runtimes live in engine.
+
+This is the single implementation plan for the `EG7` phase. Lettered sections
+such as `EG7A`, `EG7B`, and `EG7C` are tracked in this file rather than in
+separate letter-specific documents.
+
+Read this with:
+
+- [engine-consolidation-plan.md](./engine-consolidation-plan.md)
+- [engine-crate-map.md](./engine-crate-map.md)
+- [eg1-implementation-plan.md](./eg1-implementation-plan.md)
+- [eg2-implementation-plan.md](./eg2-implementation-plan.md)
+- [eg3-implementation-plan.md](./eg3-implementation-plan.md)
+- [eg4-implementation-plan.md](./eg4-implementation-plan.md)
+- [eg5-implementation-plan.md](./eg5-implementation-plan.md)
+- [eg6-implementation-plan.md](./eg6-implementation-plan.md)
+- [../storage/v1-storage-consumption-contract.md](../storage/v1-storage-consumption-contract.md)
+
+## Scope
+
+`EG7` owns:
+
+- removing the normal `strata-executor -> strata-storage` dependency
+- removing executor imports of `strata_storage::*`
+- removing executor public re-exports of storage `Key` and `Namespace`
+- replacing executor's direct use of `validate_space_name` with an
+  engine-owned validation API
+- removing executor's direct `StorageError -> Error` conversion path
+- moving space deletion orchestration into engine
+- removing storage key, namespace, and type-tag construction from executor
+  transactional KV/event/space paths
+- replacing executor production use of raw storage transaction context APIs
+  with engine-owned transaction/session APIs
+- preserving command behavior, IPC behavior, session defaults, and public
+  output shape unless a behavior fix is explicitly called out
+- tightening guard tests so executor cannot regain direct storage access
+
+`EG7` does not own:
+
+- collapsing executor into engine
+- redesigning the command enum or public executor output DTOs
+- changing storage key encoding, WAL, manifest, checkpoint, or snapshot format
+- changing primitive semantics
+- redesigning user-facing error enums beyond the minimum conversion cleanup
+- removing root dev/test dependencies on storage where tests intentionally
+  inspect storage behavior
+- changing intelligence, CLI, or product API behavior beyond dependency guard
+  updates
+
+## Load-Bearing Boundary Rules
+
+Do not solve `EG7` by moving storage types through engine re-exports.
+
+Engine may keep transitional storage re-exports for engine-local modules and
+tests, but executor production code should not import or rely on:
+
+- `strata_storage::Key`
+- `strata_storage::Namespace`
+- `strata_storage::TypeTag`
+- `strata_storage::StorageError`
+- `strata_storage::validate_space_name`
+- `strata_engine::TransactionContext` when the call is really a storage
+  transaction-context operation
+
+Executor may keep:
+
+- `strata_engine::Database`
+- `strata_engine::Transaction`, if the methods used are engine-owned and do
+  not expose storage `Key`, `Namespace`, or raw transaction context mutation
+- engine primitive facades such as `KVStore`, `JsonStore`, `EventLog`,
+  `PrimitiveGraphStore`, `VectorStore`, `SpaceIndex`, and search types while
+  executor still dispatches commands through those facades
+- public command/session state such as current branch, current space, access
+  mode, and IPC state
+
+The practical rule is:
+
+```text
+executor says what product operation to run
+engine decides which storage rows, runtime hooks, and side effects implement it
+storage executes generic mechanics
+```
+
+## Starting State
+
+At the start of `EG7`, executor is the remaining production crate above engine
+with a normal storage dependency.
+
+The verified direct executor storage touchpoints are:
+
+| File | Storage use | Required move |
+| --- | --- | --- |
+| `crates/executor/Cargo.toml` | normal `strata-storage` dependency | remove after production imports are gone |
+| `crates/executor/src/lib.rs` | `pub use strata_storage::{Key, Namespace}` | delete or replace with engine-owned public types only if still needed |
+| `crates/executor/src/compat.rs` | `validate_space_name` | call engine-owned space validation |
+| `crates/executor/src/bridge.rs` | `validate_space_name` | call engine-owned space validation |
+| `crates/executor/src/convert.rs` | `StorageError` conversion | remove after storage errors are mapped inside engine |
+| `crates/executor/src/session.rs` | `Namespace` construction for manual transactions | use engine transaction scope APIs |
+| `crates/executor/src/handlers/kv.rs` | `Key`, `Namespace`, `TypeTag` in transaction commands | use engine transactional KV APIs |
+| `crates/executor/src/handlers/json.rs` | `Namespace` in transaction commands | use engine transaction scope APIs |
+| `crates/executor/src/handlers/event.rs` | `Key`, `Namespace` in transaction commands | add engine transactional event query APIs |
+| `crates/executor/src/handlers/space_delete.rs` | `Key`, `Namespace`, `TypeTag` and raw scans/deletes | move complete space delete orchestration into engine |
+| `crates/executor/src/session.rs` tests | `Key`, `Namespace` corruption fixture | replace with engine-owned test helper or move fixture into engine tests |
+
+That is ten production files or manifests, plus one test-only fixture row in
+`session.rs`.
+
+At the start of `EG7`, `strata-intelligence`, `strata-cli`, and root `src`
+production code do not import `strata_storage::*`. The root package still has
+storage dev/test uses, which are outside this phase unless they become
+production dependencies above engine.
+
+At the start of `EG7`, `cargo tree -p strata-executor --edges normal` still
+contains `strata-storage` both directly and through engine. The direct edge is
+the one `EG7` must remove; the transitive edge through engine is expected.
+
+## Target Engine Surfaces
+
+`EG7` should add narrow engine APIs instead of broad storage facades.
+
+### Space Validation
+
+Engine should expose one public validation entry point for executor:
+
+```text
+validate_space_name(space: &str) -> StrataResult<()>
+```
+
+or an equivalent `SpaceName`/`SpaceRef` newtype if the existing engine style
+points that way.
+
+The engine implementation may delegate to storage's physical layout validator,
+but it must return `StrataError`, not a storage-local string or
+`StorageError`. Executor then maps `StrataError` through its existing
+`Error::from(StrataError)` path.
+
+### Transaction Scope
+
+Manual executor sessions currently create storage namespaces and sometimes
+pull out raw `TransactionContext`. Engine should provide a transaction scope
+surface that lets executor say:
+
+```text
+transaction on branch X, scoped to space Y, execute primitive operation Z
+```
+
+without constructing storage keys or namespaces.
+
+Likely shape:
+
+- `Transaction::scope_space(space: &str) -> ScopedTransaction<'_>` or
+  equivalent
+- `ScopedTransaction` or a replacement engine wrapper supports the KV, JSON,
+  event, graph, and vector operations executor can run inside a transaction
+- methods return `StrataResult<T>` and engine-owned DTOs
+- no executor handler receives `Namespace`, `Key`, `TypeTag`, or raw storage
+  transaction context
+
+The existing `TransactionOps` trait covers much of KV/JSON/event, but it does
+not cover every executor transaction command. `EG7` should close only the
+needed gaps, such as:
+
+- transaction-aware KV scan with start/limit behavior
+- transaction-aware KV batch read/delete/exists helpers if a helper preserves
+  current output/error behavior better than repeating loops in executor
+- transaction-aware event type-index lookup
+- transaction-aware event exists and batch append behavior with read-your-writes
+- graph/vector transaction entry points currently reached through raw
+  `TransactionContext`
+
+### Space Deletion
+
+Space deletion should become one engine-owned operation because it coordinates:
+
+- branch existence
+- default and system-space protection
+- optional emptiness check
+- KV, JSON, event, graph, and vector data deletion
+- vector collection purge
+- search document removal
+- product-layer shadow embedding cleanup through a hook owned above engine
+- space metadata deletion
+- logging and partial-failure policy
+
+Executor should call one semantic engine API and translate the final
+`StrataResult` into `Output::Unit`.
+
+Likely shape:
+
+```text
+delete_space(branch_id, space, options) -> StrataResult<SpaceDeleteOutcome>
+```
+
+where the outcome can initially be minimal. If engine already has a better
+space service home, use that instead of inventing a parallel facade.
+
+### Error Boundary
+
+Storage-origin errors should cross into executor only as `StrataError` or a
+more specific engine error. Executor should not contain an
+`impl From<StorageError> for Error` after `EG7`.
+
+The executor conversion layer should remain responsible for user-facing
+executor error shape, but it should not know storage variants.
+
+## Implementation Sections
+
+### EG7A - Rebaseline And Characterize
+
+Status: complete.
+
+Re-run the executor storage import inventory and convert it into a code-level
+checklist.
+
+Tasks:
+
+- record every production `strata_storage::*` import in executor
+- record every executor production use of `strata_engine::TransactionContext`
+  or `Transaction::context_mut()` that expresses product behavior rather than
+  engine internals
+- identify tests that intentionally inspect raw storage and decide whether they
+  should move to engine tests or use engine-owned helpers
+- add or identify characterization coverage before behavior moves
+- update this document if the inventory finds another live storage touchpoint
+
+Characterization should cover at least:
+
+- `Strata::set_space` and `Session::set_space` validation errors
+- in-transaction KV get/list/scan/put/delete/batch behavior
+- in-transaction JSON get/set/delete/list/batch behavior
+- in-transaction event append/get/exists/get-by-type/len/batch behavior
+- in-transaction graph and vector commands that currently use raw transaction
+  context
+- transaction side effects after commit for search and embeddings
+- forced and non-forced space deletion
+- space deletion of default and system spaces
+- space deletion side effects across KV, JSON, event, graph, vector, search,
+  and the product-layer intelligence shadow cleanup hook
+- IPC-backed handle behavior where the client still sends executor commands
+
+Exit criteria:
+
+- the executor storage bypass list is current and committed to this plan
+- missing engine APIs are named before implementation starts
+- behavior tests exist or are explicitly named as existing coverage
+
+Implementation result:
+
+- Direct storage imports are the ten production files or manifests listed in
+  [Starting State](#starting-state), plus the `session.rs` test-only corruption
+  fixture listed there.
+- Raw storage transaction-context use is concentrated in:
+  - `crates/executor/src/session.rs` - creates storage `Namespace` values and
+    calls `Transaction::context_mut()` while dispatching product commands
+  - `crates/executor/src/handlers/kv.rs` - uses raw `TransactionContext`,
+    `Key`, and `TypeTag` for transactional KV reads, lists, scans, deletes,
+    batches, and existence checks
+  - `crates/executor/src/handlers/event.rs` - uses raw `TransactionContext`
+    and event storage keys for transactional type-index lookup
+  - `crates/executor/src/handlers/json.rs` - receives storage `Namespace` for
+    scoped JSON transaction operations
+  - `crates/executor/src/handlers/graph.rs` and
+    `crates/executor/src/handlers/vector.rs` - receive raw
+    `TransactionContext` for engine extension methods during transaction
+    dispatch
+- Added `tests/executor/eg7_characterization.rs` with focused behavior
+  coverage for:
+  - typed-handle and session space validation error variants and reason text
+  - transaction commands with omitted space using the active session space for
+    KV, JSON, and event operations, including transactional exists, scan, and
+    non-empty event batch append paths
+  - forced space deletion clearing mixed target-space data while preserving a
+    sibling space, including sibling graph and vector data
+- Existing characterization coverage that `EG7B`-`EG7D` should continue to
+  rely on:
+  - `tests/executor/session_transactions.rs` covers transaction lifecycle,
+    KV/JSON/event read-your-writes behavior, as-of bypass behavior, graph and
+    vector transaction behavior, batch behavior, validation errors, commit
+    visibility, and rollback discard semantics
+  - `tests/executor/command_dispatch.rs` covers space create/list/exists,
+    forced and non-forced space deletion, default-space protection, graph and
+    vector data cleanup, search hit cleanup, shadow embedding cleanup, and
+    describe-space counts
+  - `tests/executor_ex6_runtime.rs` covers product-handle context behavior,
+    IPC transaction round trips, read-only write rejection, and product runtime
+    subsystem order
+
+Missing engine APIs confirmed by the rebaseline:
+
+- engine-owned space validation returning `StrataResult<()>`
+- engine-owned transaction space scope that constructs storage namespaces
+  inside engine
+- scoped transaction methods for the KV/event cases that currently need raw
+  storage keys, especially KV scan/list/delete/batch helpers and event
+  get-by-type
+- graph/vector transaction dispatch surfaces that do not require executor to
+  touch raw `TransactionContext`
+- engine-owned forced space deletion operation with current best-effort
+  side-effect policy preserved
+
+### EG7B - Engine Space And Error Surface
+
+Status: complete.
+
+Add the small engine-owned surface needed to remove executor's easiest storage
+imports first.
+
+Tasks:
+
+- add an engine-owned space-name validation API
+- route `compat.rs`, `bridge.rs`, and space command handlers through that API
+- ensure validation failures become `StrataError::InvalidInput` before
+  executor converts them
+- remove executor's direct `StorageError` conversion once no production call
+  path needs it
+- add tests that assert executor-visible error shape is unchanged for invalid
+  spaces and representative storage-backed failures
+
+Exit criteria:
+
+- executor no longer imports `validate_space_name` from storage
+- executor no longer imports `StorageError`
+- no user-facing error messages drift unless explicitly approved
+
+Implementation result:
+
+- `strata_engine::validate_space_name(space: &str) -> StrataResult<()>`
+  is exported from the engine-owned space primitive and maps the existing
+  storage namespace rule failure strings into `StrataError::InvalidInput`
+- `compat.rs`, `bridge.rs`, `SpaceCreate`, `SpaceExists`, and `SpaceDelete`
+  now call the engine validation surface; `SpaceDelete` still preserves the
+  existing `default`/`_system_` constraint error before validating ordinary
+  user space names
+- executor's direct `impl From<StorageError> for Error` has been removed
+- before `EG7C`, the remaining raw transaction KV/event storage calls mapped
+  storage-local failures through
+  `strata_engine::storage_error_for_product_boundary`, a narrow engine-owned
+  adapter that preserved the historical executor-facing categories for storage
+  invalid-input, capacity, corruption, and I/O failures
+- EG7 characterization keeps the invalid-space user-facing message locked
+  across typed handle, session, `SpaceExists`, and `SpaceDelete` paths, and
+  engine bridge tests lock the representative storage-backed product-boundary
+  conversions while executor conversion tests lock their user-facing shapes
+
+### EG7C - Engine Transaction Session Surface
+
+Status: complete.
+
+Replace executor's storage-shaped manual transaction plumbing with engine-owned
+transaction APIs.
+
+Tasks:
+
+- add a transaction scope helper that constructs the storage namespace inside
+  engine
+- add the missing scoped KV/event helpers needed by executor transaction
+  commands
+- move graph/vector transaction entry points off raw `TransactionContext` where
+  executor currently reaches engine extension methods through the storage
+  context
+- update `session.rs` so it never constructs `Namespace` and does not call
+  `Transaction::context_mut()` for product command dispatch
+- update KV, JSON, event, graph, and vector transaction handlers to receive an
+  engine transaction scope or command facade rather than storage context
+- preserve `TxnSideEffects` behavior, or move it into engine if that makes the
+  post-commit search/embedding side effects easier to keep consistent
+
+Exit criteria:
+
+- executor production code has no `Namespace`, `Key`, `TypeTag`, or
+  `TransactionContext` import
+- in-transaction command behavior remains unchanged
+- post-commit search and embedding side effects still run once per affected
+  entity
+- transaction conflict and abort error mapping remains executor-compatible
+
+Implementation result:
+
+- `strata_engine::Transaction::scoped_space(space)` now constructs the
+  branch/space storage namespace inside engine and returns the existing scoped
+  transaction primitive wrapper without exposing `Namespace` above engine.
+- Scoped engine transactions now expose the executor-needed storage-shaped
+  read helpers as engine methods:
+  - `kv_get_value`
+  - `kv_scan`
+  - `event_get_by_type`
+- Owned engine transactions now expose graph and vector transaction entry
+  points so executor no longer reaches those runtimes through raw
+  `TransactionContext`. Those entry points derive the branch from the active
+  transaction instead of accepting a caller-supplied `BranchId`.
+- `session.rs` no longer constructs transaction namespaces and no longer calls
+  `Transaction::context_mut()` for product command dispatch. It also uses an
+  engine-owned transaction ID accessor for `TxnInfo` instead of reading the raw
+  storage transaction context through `Deref`. It passes the owned engine
+  transaction directly to the primitive command handlers.
+- Owned engine transactions no longer expose the raw storage context through
+  production `Deref`/`DerefMut`, public `context_mut`, or public
+  `scoped(Arc<Namespace>)`; the raw deref compatibility remains available only
+  under `cfg(test)` for existing engine unit fixtures.
+- KV, JSON, event, graph, and vector transaction handlers now receive
+  `strata_engine::Transaction` instead of storage `TransactionContext`,
+  `Namespace`, `Key`, or `TypeTag`.
+- The storage bypass guard allowlist was tightened by removing the completed
+  `kv.rs`, `json.rs`, `event.rs`, and `session.rs` entries. The guard now scans
+  Rust code while ignoring inline `#[cfg(test)]` modules, so a test-only
+  corruption fixture does not allow production storage references in the same
+  file.
+- The remaining executor storage references are the planned `EG7D` space
+  deletion path, the planned `EG7E` public re-export/dependency closeout, and
+  the `session.rs` test-only corruption fixture.
+
+### EG7D - Engine Space Deletion Ownership
+
+Status: complete.
+
+Move `handlers/space_delete.rs` orchestration into engine.
+
+Tasks:
+
+- add an engine-owned space deletion operation with options for `force`
+- preserve default-space and system-space protection
+- preserve non-forced emptiness checks
+- delete all primitive data families through engine-owned storage access
+- purge vector collection state and sidecar files through engine-owned vector
+  APIs
+- remove search documents for the deleted space through engine-owned search
+  APIs
+- expose a fallible post-data/pre-metadata cleanup hook so executor can invoke
+  intelligence-owned persisted and pending shadow embedding cleanup without
+  making engine depend on intelligence internals
+- delete space metadata after data cleanup
+- characterize partial-failure behavior and preserve current warn-vs-fail
+  policy unless a behavior fix is explicitly called out
+- cut executor `SpaceDelete` handling to the engine operation
+
+Exit criteria:
+
+- executor `space_delete` handler does not import storage or loop over type
+  tags
+- forced and non-forced deletion behavior is preserved
+- all primitive side effects are tested through executor-visible commands and,
+  where needed, engine-local assertions
+
+Implementation result:
+
+- `SpaceIndex::delete_user_space(branch_name, space, force)` is now the
+  engine-owned operation for deleting a space's engine-owned data. It preserves
+  the existing order: protect `default`/`_system_`, validate the space name,
+  verify branch existence, enforce the non-forced emptiness check, delete
+  primitive rows, clean engine runtime side effects, then delete space metadata.
+- Engine now owns the storage-shaped cleanup previously in
+  `handlers/space_delete.rs`: vector rows are deleted through the vector
+  runtime, KV/event/JSON/graph rows are scanned by type tag inside engine, and
+  executor no longer constructs `Key`, `Namespace`, or `TypeTag` for space
+  deletion.
+- Search document cleanup and vector collection purge moved behind the engine
+  operation with the previous warn-and-continue policy for best-effort runtime
+  cleanup failures. `SpaceIndex::delete_user_space_with_post_data_cleanup`
+  gives executor a fallible generic post-data/pre-metadata hook so
+  intelligence-owned persisted shadow embeddings and the feature-gated
+  auto-embed pending queue can be cleaned at the same point as before without
+  reintroducing executor storage access or an engine dependency on
+  intelligence shadow-key internals.
+- Executor `SpaceDelete` now calls the engine operation and translates only the
+  two preserved space-delete constraint reasons into executor
+  `ConstraintViolation`; all other failures cross as normal `StrataError`
+  conversions.
+- The storage bypass guard allowlist no longer contains
+  `crates/executor/src/handlers/space_delete.rs`.
+- Engine-local tests cover protected/non-forced rejection and forced cleanup
+  across primitive rows, search index entries, vector collection state,
+  non-default branch isolation, and sibling-space preservation. Existing executor
+  characterization continues to cover command-visible forced/non-forced delete
+  behavior, default-space protection, search cleanup, vector cleanup, graph
+  cleanup, and shadow cleanup.
+
+### EG7E - Dependency Removal And Guard Closeout
+
+Status: complete.
+
+Delete the executor storage surface after the call sites are gone.
+
+Tasks:
+
+- remove `strata-storage` from `crates/executor/Cargo.toml`
+- remove `pub use strata_storage::{Key, Namespace}` from
+  `crates/executor/src/lib.rs`
+- update in-repo consumers and tests that used those re-exports
+- tighten storage-surface guard tests so executor production code and manifests
+  cannot import storage
+- document any intentional dev/test storage exceptions outside executor
+- update `engine-crate-map.md` and the main engine consolidation plan
+
+Exit criteria:
+
+- `cargo tree -p strata-executor --edges normal` has no direct
+  `strata-storage` edge
+- no executor production Rust file imports `strata_storage`
+- executor does not publicly re-export storage types
+- guard tests fail if a production executor storage import returns
+
+Implementation result:
+
+- `crates/executor/Cargo.toml` no longer has a normal `strata-storage`
+  dependency. Executor tests enable engine's `test-support` feature instead of
+  importing storage directly.
+- `crates/executor/src/lib.rs` no longer re-exports storage `Key` or
+  `Namespace`.
+- The remaining executor corruption fixture now calls the engine-owned
+  `Database::inject_corrupt_json_bytes_for_test` helper, so executor source no
+  longer constructs storage keys or namespaces even in `#[cfg(test)]` code.
+- The direct-storage guard allowlist is empty. Any production storage import or
+  manifest dependency above engine now fails the guard unless a future phase
+  adds a new explicit exception.
+- `engine-crate-map.md` and the main consolidation plan now describe executor
+  as an ordinary engine/intelligence consumer with no direct storage edge.
+
+## Verification
+
+Run targeted checks as each section lands:
+
+```bash
+rg -n "strata_storage::|use strata_storage" crates/executor/src -g '*.rs'
+rg -n '^strata-storage\\s*=' crates/executor/Cargo.toml
+rg -n "TransactionContext|context_mut\\(|Namespace|TypeTag|Key::" crates/executor/src -g '*.rs'
+cargo tree -p strata-executor --edges normal --depth 1 | rg "strata-storage"
+cargo test -p strata-executor
+cargo test -p strata-engine --lib transaction
+cargo test -p strata-engine --lib primitives::space
+cargo test -p stratadb --test storage_surface_imports
+cargo check -p strata-cli
+```
+
+Interpretation notes:
+
+- The first three `rg` commands should eventually return no production
+  executor matches. Test-only matches should either move to engine tests or be
+  documented and guarded.
+- The manifest check should return no direct executor dependency on storage.
+  The `cargo tree` command may still show transitive storage through engine;
+  use it to confirm any remaining storage edge is not direct.
+- Root dev/test storage uses are not `EG7` failures unless they become normal
+  production dependencies above engine.
+
+## Risks
+
+### Transaction Semantics Drift
+
+The highest-risk part is replacing direct transaction-context use. Executor
+transaction commands currently depend on read-your-writes behavior, delete-set
+visibility, JSON staged writes, event metadata continuity, and post-commit
+side effects. `EG7C` must preserve those behaviors through characterization
+tests before moving code.
+
+### Space Delete Partial Cleanup
+
+Current space deletion mixes transactional data deletion with best-effort
+runtime cleanup. Moving it into engine should not accidentally make every
+best-effort cleanup failure fatal, or accidentally hide failures that used to
+abort the command. Preserve the existing policy first; improve it only with an
+explicit behavior-change note.
+
+### Public Re-Export Removal
+
+`strata-executor` currently re-exports storage `Key` and `Namespace`. Strata is
+pre-v1, so removing that surface is acceptable, but in-repo tests and examples
+must be moved to engine-owned types or deleted if they were only exposing
+storage internals.
+
+### Accidental Facade Sprawl
+
+Do not create generic pass-through wrappers for every storage operation just
+to make executor compile. The new engine APIs should be semantic and should
+exist because executor is asking engine to perform a product operation.
+
+## Completion Definition
+
+`EG7` is complete when:
+
+- executor has no normal dependency on storage
+- executor production code has no direct storage imports
+- executor production code does not use raw storage transaction context as a
+  product command runtime
+- executor public API no longer exposes storage `Key` or `Namespace`
+- storage-origin failures are mapped by engine before executor sees them
+- space deletion orchestration is engine-owned
+- guard tests enforce the boundary
+- executor, engine transaction, engine space, and storage-surface tests pass

--- a/docs/engine/engine-consolidation-plan.md
+++ b/docs/engine/engine-consolidation-plan.md
@@ -13,9 +13,10 @@ layer.
 
 The next problem is above that boundary. Several crates were engine concepts in
 practice but still existed as peer crates and, in some cases, reached directly
-into storage. `EG2` through `EG6` have now collapsed security, product open,
-graph, vector, and search ownership into engine. The remaining production
-storage bypass above engine is executor.
+into storage. `EG2` through `EG7` have now collapsed security, product open,
+graph, vector, and search ownership into engine and removed executor's direct
+storage bypass. No normal production crate above engine reaches directly into
+storage.
 
 `EG2` has already absorbed and deleted `strata-security`; it remains in this
 plan only as a completed phase record.
@@ -27,6 +28,8 @@ a completed phase record.
 a completed phase record.
 `EG6` has absorbed and deleted `strata-search`; it remains in this plan only as
 a completed phase record.
+`EG7` has removed executor's direct storage dependency and storage imports; it
+remains in this plan only as a completed phase record.
 
 This plan consolidates those responsibilities into `strata-engine` so the
 workspace can settle into the intended stack:
@@ -60,16 +63,12 @@ is:
 strata-storage         -> strata-core
 strata-engine          -> strata-core, strata-storage
 strata-intelligence    -> strata-core, strata-engine, strata-inference
-strata-executor        -> strata-core, strata-engine, strata-intelligence,
-                          strata-storage
+strata-executor        -> strata-core, strata-engine, strata-intelligence
 strata-cli             -> strata-executor, strata-intelligence
 stratadb               -> strata-executor
 ```
 
-The direct storage bypass above engine is:
-
-- `strata-executor`
-  - storage keys, namespaces, type tags, validation helpers, and storage errors
+There is no normal production direct storage bypass above engine after `EG7`.
 
 `strata-intelligence` does not currently have direct normal storage imports,
 and it no longer depends on a search peer crate after `EG6`.
@@ -955,6 +954,8 @@ reintroduction. Intelligence and executor no longer depend on `strata-search`.
 
 ## EG7 - Executor Storage Bypass Removal
 
+Detailed plan: [eg7-implementation-plan.md](./eg7-implementation-plan.md)
+
 **Goal:**
 
 Remove direct storage access from executor after engine owns the primitives and
@@ -980,10 +981,10 @@ At minimum, engine should expose domain-level operations for:
 - converting storage-origin errors into public engine errors before executor
   sees them
 
-`handlers/space_delete.rs` is the clearest starting example. It currently loops
-over storage `TypeTag` families directly, then separately purges search,
-vector, embedding, and space metadata. That orchestration should become an
-engine operation because it is a primitive/runtime consistency operation.
+`handlers/space_delete.rs` was the clearest starting example: it looped over
+storage `TypeTag` families directly, then separately purged search, vector,
+embedding, and space metadata. EG7D moved that orchestration into engine
+because it is a primitive/runtime consistency operation.
 
 **Acceptance:**
 
@@ -991,6 +992,8 @@ engine operation because it is a primitive/runtime consistency operation.
 - `strata-executor` no longer re-exports `Key` or `Namespace` from storage
 - executor behavior tests still pass through engine-owned APIs
 - no executor production file imports `strata_storage`
+- executor production code no longer uses raw storage transaction context as
+  the runtime for product commands
 
 **Non-goals:**
 
@@ -999,28 +1002,60 @@ engine operation because it is a primitive/runtime consistency operation.
 - do not redesign user-facing error enums beyond the minimum needed for engine
   error conversion
 
-### EG7A - Executor Storage Import Rebaseline
+### EG7A - Rebaseline And Characterize
 
 Re-run the executor storage import inventory after graph, vector, search,
-security, and product open movement. Separate dead imports from missing engine
-API cases.
+security, and product open movement. Add or identify characterization coverage
+for transaction commands, space validation, and space deletion before moving
+behavior.
 
-### EG7B - Add Engine Runtime APIs For Executor-Owned Commands
+Current status: complete. The direct storage bypass list is current, raw
+transaction-context product-command usage is recorded, and EG7 characterization
+tests now cover validation, session-space transaction dispatch, and forced
+space deletion behavior.
 
-Add semantic engine operations for space validation, space deletion, primitive
-side-effect cleanup, and storage-origin error conversion. The APIs should not
-expose raw storage keys or type tags.
+### EG7B - Engine Space And Error Surface
 
-### EG7C - Cut Over Executor Handlers
+Add engine-owned space validation and storage-origin error conversion surfaces.
+Cut executor over so it no longer imports `validate_space_name` or
+`StorageError` from storage.
 
-Route executor handlers and session code through engine-owned APIs. Preserve
-command behavior and public response shapes unless a bug fix is explicitly
-called out.
+Current status: complete. `strata_engine::validate_space_name` is the
+executor-facing validation boundary, executor no longer imports storage
+`validate_space_name` or `StorageError`, and the remaining raw transaction
+storage calls convert storage-local failures through engine errors until EG7C
+removes those raw calls.
 
-### EG7D - Remove Executor Storage Surface
+### EG7C - Engine Transaction Session Surface
 
-Delete executor storage imports, storage re-exports, and direct storage error
-conversion paths. Tighten the direct-storage guard for executor to zero.
+Add engine-owned transaction/session APIs so executor no longer constructs
+storage namespaces, storage keys, storage type tags, or raw storage transaction
+contexts while dispatching product commands.
+
+Current status: complete. Executor transaction dispatch now uses
+engine-owned scoped transaction methods for KV, JSON, event, graph, and vector
+commands; production `Transaction` no longer exposes raw storage context access
+above engine.
+
+### EG7D - Engine Space Deletion Ownership
+
+Move space deletion orchestration into engine, including primitive data
+deletion, vector/search side-effect cleanup, a product-layer post-data cleanup
+hook, and space metadata removal.
+
+Current status: complete. Executor `SpaceDelete` now calls
+`SpaceIndex::delete_user_space_with_post_data_cleanup`; storage row scans,
+vector purge, search cleanup, and metadata deletion are owned by engine.
+Intelligence-owned persisted shadow embeddings and the feature-gated pending
+embed queue are still cleaned above engine through the generic fallible
+post-data/pre-metadata hook because engine must not depend on intelligence
+shadow-key internals.
+
+### EG7E - Dependency Removal And Guard Closeout
+
+Status: complete. Executor storage imports, storage re-exports, and the normal
+`strata-storage` dependency are gone. The direct-storage guard allowlist is
+empty for production crates above engine.
 
 ## EG8 - Intelligence Dependency Cleanup
 
@@ -1207,7 +1242,7 @@ storage. Root dev-dependencies and storage-facing tests need their own explicit
 Final inverse dependency guard:
 
 ```bash
-cargo tree -i strata-storage --workspace --edges normal --depth 2
+cargo tree -i strata-storage --workspace --edges normal --depth 1
 ```
 
 At closeout, normal production dependents of storage should be engine only.

--- a/docs/engine/engine-crate-map.md
+++ b/docs/engine/engine-crate-map.md
@@ -166,32 +166,32 @@ And then, above those:
 outside the engine stack and supplies model/inference support.
 
 This confirms that engine is now the main semantic/runtime hub of the
-workspace. The remaining direct storage bypass above engine is in executor.
+workspace. After `EG7`, there is no normal production direct storage bypass
+above engine.
 
 ### Current Normal Workspace Graph
 
 The verified normal dependency graph for engine-adjacent crates is below.
-`EG6G` re-verified this graph on 2026-05-07 after deleting the
-`strata-search` crate and closing out search absorption. The phase tracking
+`EG7E` re-verified this graph on 2026-05-07 after deleting executor's direct
+storage dependency and storage re-exports. The phase tracking
 plans are
 [eg1-implementation-plan.md](./eg1-implementation-plan.md),
 [eg3-implementation-plan.md](./eg3-implementation-plan.md), and
-[eg6-implementation-plan.md](./eg6-implementation-plan.md).
+[eg7-implementation-plan.md](./eg7-implementation-plan.md).
 
 ```text
 strata-storage       -> strata-core
 strata-engine        -> strata-core, strata-storage
 strata-intelligence  -> strata-core, strata-engine, strata-inference
-strata-executor      -> strata-core, strata-engine,
-                        strata-intelligence, strata-storage
+strata-executor      -> strata-core, strata-engine, strata-intelligence
 strata-cli           -> strata-executor, strata-intelligence
 stratadb             -> strata-executor
 ```
 
 Security/open options are engine-owned after `EG2`, product open/bootstrap is
 engine-owned after `EG3`, graph is engine-owned after `EG4`, vector is
-engine-owned after `EG5`, and search is engine-owned after `EG6`. Today the
-remaining production direct storage bypass above engine is executor.
+engine-owned after `EG5`, search is engine-owned after `EG6`, and executor's
+direct storage bypass is closed after `EG7`.
 
 The current inverse normal storage graph is:
 
@@ -200,18 +200,18 @@ strata-storage
 |-- strata-engine
 |   |-- strata-executor
 |   `-- strata-intelligence
-`-- strata-executor
 ```
 
-`strata-engine` is the intended permanent dependent. `strata-executor` is the
-remaining transitional direct storage bypass that the engine consolidation plan
-removes. `EG4` removed `strata-graph` by moving graph implementation,
-storage-key mapping, transaction extension, runtime hooks, and branch DAG
-behavior into engine. `EG5` moved vector implementation, storage-key mapping,
-transaction extension, recovery hooks, merge behavior, and sidecar-cache policy
-into engine, then deleted the retired `strata-vector` package. `EG6` moved
-search runtime, retrieval substrate, manifest behavior, and subsystem assembly
-into engine, then deleted the retired `strata-search` package.
+`strata-engine` is the intended permanent production dependent of storage.
+`EG4` removed `strata-graph` by moving graph implementation, storage-key
+mapping, transaction extension, runtime hooks, and branch DAG behavior into
+engine. `EG5` moved vector implementation, storage-key mapping, transaction
+extension, recovery hooks, merge behavior, and sidecar-cache policy into
+engine, then deleted the retired `strata-vector` package. `EG6` moved search
+runtime, retrieval substrate, manifest behavior, and subsystem assembly into
+engine, then deleted the retired `strata-search` package. `EG7` removed
+executor's storage imports, storage re-exports, raw transaction-context product
+dispatch, space-delete storage loops, and normal storage dependency.
 
 Because most upper crates also depend on engine, the full inverse tree shows
 executor and intelligence under the engine branch as ordinary engine consumers.
@@ -220,15 +220,11 @@ direct normal storage edges above engine.
 
 ### Direct Storage Bypasses Above Engine
 
-These normal production direct storage dependencies are accurate today and
-should be treated as consolidation inputs. The source-level inventory is
-tracked in [eg1-implementation-plan.md](./eg1-implementation-plan.md):
-
-- `strata-executor` uses storage keys, namespaces, type tags, validation, and
-  storage errors directly.
+There are no normal production direct storage dependencies above engine after
+`EG7`.
 
 `strata-intelligence`, `strata-cli`, and the root `stratadb` package do not
-currently have direct normal storage dependencies.
+have direct normal storage dependencies.
 Root dev-dependencies and storage-facing tests do import storage directly; those
 are tracked separately in the `EG1` implementation plan for the `EG1D` guard
 policy.
@@ -365,6 +361,6 @@ whether code in the crate is:
 
 After the storage-boundary closeout, the semantic side of engine is real and
 the targeted lower storage mechanics have sunk into storage. Graph, vector, and
-search now live inside engine. The remaining cleanup above this boundary is to
-remove executor's direct storage bypass while keeping the substrate/mechanics
-boundary documented here explicit.
+search now live inside engine, and executor no longer talks to storage
+directly. The remaining cleanup above this boundary is internal architecture
+work, not another storage-bypass removal.

--- a/tests/executor/eg7_characterization.rs
+++ b/tests/executor/eg7_characterization.rs
@@ -1,0 +1,529 @@
+//! EG7 characterization for removing executor's direct storage bypasses.
+//!
+//! These tests lock the command/session behavior that currently depends on
+//! executor-side storage imports. Later EG7 phases should move the internals
+//! into engine without changing these public outcomes.
+
+use crate::common::*;
+use strata_core::Value;
+use strata_executor::{BatchEventEntry, Command, DistanceMetric, Error, Output, Session, Strata};
+
+fn assert_invalid_input_reason(error: Error, expected_reason: &str) {
+    match error {
+        Error::InvalidInput { reason, .. } => assert_eq!(reason, expected_reason),
+        other => panic!("expected invalid input, got {other:?}"),
+    }
+}
+
+fn assert_missing(output: Output) {
+    assert!(
+        matches!(output, Output::Maybe(None) | Output::MaybeVersioned(None)),
+        "expected missing value, got {output:?}"
+    );
+}
+
+fn assert_present_value(output: Output, expected: Value) {
+    match output {
+        Output::Maybe(Some(value)) => assert_eq!(value, expected),
+        Output::MaybeVersioned(Some(versioned)) => assert_eq!(versioned.value, expected),
+        other => panic!("expected present value {expected:?}, got {other:?}"),
+    }
+}
+
+fn assert_bool(output: Output, expected: bool) {
+    match output {
+        Output::Bool(value) => assert_eq!(value, expected),
+        other => panic!("expected bool output, got {other:?}"),
+    }
+}
+
+fn assert_event_count(output: Output, expected: usize) {
+    match output {
+        Output::VersionedValues(events) => assert_eq!(events.len(), expected),
+        other => panic!("expected event list, got {other:?}"),
+    }
+}
+
+fn assert_batch_success(output: Output, expected_len: usize) -> Vec<u64> {
+    match output {
+        Output::BatchResults(results) => {
+            assert_eq!(results.len(), expected_len);
+            results
+                .into_iter()
+                .map(|result| {
+                    assert!(
+                        result.error.is_none(),
+                        "expected successful batch item, got {result:?}"
+                    );
+                    result
+                        .version
+                        .expect("successful batch item should have a version")
+                })
+                .collect()
+        }
+        other => panic!("expected batch results, got {other:?}"),
+    }
+}
+
+#[test]
+fn eg7_space_validation_is_executor_visible_for_handle_and_session() {
+    let mut db = Strata::cache().expect("cache database should open");
+    let expected_reason =
+        "Space name can only contain lowercase letters, digits, hyphens, and underscores";
+
+    let error = db
+        .set_space("not allowed")
+        .expect_err("typed handle should reject invalid space names");
+    assert_invalid_input_reason(error, expected_reason);
+
+    let mut session = db.session().expect("session should open");
+
+    let error = session
+        .execute(Command::SpaceExists {
+            branch: None,
+            space: "not allowed".into(),
+        })
+        .expect_err("SpaceExists should reject invalid space names before storage");
+    assert_invalid_input_reason(error, expected_reason);
+
+    let error = session
+        .execute(Command::SpaceDelete {
+            branch: None,
+            space: "not allowed".into(),
+            force: true,
+        })
+        .expect_err("SpaceDelete should reject invalid space names before storage");
+    assert_invalid_input_reason(error, expected_reason);
+
+    let error = session
+        .set_space("not allowed")
+        .expect_err("session should reject invalid space names");
+    assert_invalid_input_reason(error, expected_reason);
+}
+
+#[test]
+fn eg7_transaction_omitted_space_uses_session_space_for_kv_json_and_events() {
+    let db = create_db();
+    let mut session = Session::new(db.clone());
+    session
+        .set_space("analytics")
+        .expect("session space should update before transaction");
+
+    session
+        .execute(Command::TxnBegin {
+            branch: None,
+            options: None,
+        })
+        .expect("transaction should begin");
+    session
+        .execute(Command::KvPut {
+            branch: None,
+            space: None,
+            key: "scoped-kv".into(),
+            value: Value::Int(7),
+        })
+        .expect("kv write should use session space");
+    let kv_exists = session
+        .execute(Command::KvExists {
+            branch: None,
+            space: None,
+            key: "scoped-kv".into(),
+        })
+        .expect("kv exists should use session space");
+    assert_bool(kv_exists, true);
+    let kv_scan = session
+        .execute(Command::KvScan {
+            branch: None,
+            space: None,
+            start: Some("scoped-".into()),
+            limit: None,
+        })
+        .expect("kv scan should use session space");
+    match kv_scan {
+        Output::KvScanResult(entries) => {
+            assert!(entries.contains(&("scoped-kv".into(), Value::Int(7))));
+        }
+        other => panic!("expected kv scan result, got {other:?}"),
+    }
+
+    session
+        .execute(Command::JsonSet {
+            branch: None,
+            space: None,
+            key: "scoped-json".into(),
+            path: "$".into(),
+            value: Value::String("json-value".into()),
+        })
+        .expect("json write should use session space");
+    let json_exists = session
+        .execute(Command::JsonExists {
+            branch: None,
+            space: None,
+            key: "scoped-json".into(),
+        })
+        .expect("json exists should use session space");
+    assert_bool(json_exists, true);
+
+    let event_output = session
+        .execute(Command::EventAppend {
+            branch: None,
+            space: None,
+            event_type: "eg7.audit".into(),
+            payload: event_payload("phase", Value::String("eg7".into())),
+        })
+        .expect("event append should use session space");
+    let event_sequence = match event_output {
+        Output::EventAppendResult { sequence, .. } => sequence,
+        other => panic!("expected event append result, got {other:?}"),
+    };
+    let event_exists = session
+        .execute(Command::EventExists {
+            branch: None,
+            space: None,
+            sequence: event_sequence,
+        })
+        .expect("event exists should use session space");
+    assert_bool(event_exists, true);
+    let batch_versions = assert_batch_success(
+        session
+            .execute(Command::EventBatchAppend {
+                branch: None,
+                space: None,
+                entries: vec![
+                    BatchEventEntry {
+                        event_type: "eg7.batch".into(),
+                        payload: event_payload("item", Value::Int(1)),
+                    },
+                    BatchEventEntry {
+                        event_type: "eg7.batch".into(),
+                        payload: event_payload("item", Value::Int(2)),
+                    },
+                ],
+            })
+            .expect("event batch append should use session space"),
+        2,
+    );
+    for sequence in batch_versions {
+        let exists = session
+            .execute(Command::EventExists {
+                branch: None,
+                space: None,
+                sequence,
+            })
+            .expect("batch event exists should use session space");
+        assert_bool(exists, true);
+    }
+
+    let pending_events = session
+        .execute(Command::EventGetByType {
+            branch: None,
+            space: None,
+            event_type: "eg7.audit".into(),
+            limit: None,
+            after_sequence: None,
+            as_of: None,
+        })
+        .expect("event type lookup should see transaction-local event");
+    assert_event_count(pending_events, 1);
+
+    session
+        .execute(Command::TxnCommit)
+        .expect("transaction should commit");
+
+    let verifier = strata_executor::Executor::new(db);
+
+    let default_kv = verifier
+        .execute(Command::KvGet {
+            branch: None,
+            space: Some("default".into()),
+            key: "scoped-kv".into(),
+            as_of: None,
+        })
+        .expect("default-space kv read should succeed");
+    assert_missing(default_kv);
+
+    let default_json = verifier
+        .execute(Command::JsonGet {
+            branch: None,
+            space: Some("default".into()),
+            key: "scoped-json".into(),
+            path: "$".into(),
+            as_of: None,
+        })
+        .expect("default-space json read should succeed");
+    assert_missing(default_json);
+
+    let analytics_kv = verifier
+        .execute(Command::KvGet {
+            branch: None,
+            space: Some("analytics".into()),
+            key: "scoped-kv".into(),
+            as_of: None,
+        })
+        .expect("analytics kv read should succeed");
+    assert_present_value(analytics_kv, Value::Int(7));
+
+    let analytics_json = verifier
+        .execute(Command::JsonGet {
+            branch: None,
+            space: Some("analytics".into()),
+            key: "scoped-json".into(),
+            path: "$".into(),
+            as_of: None,
+        })
+        .expect("analytics json read should succeed");
+    assert_present_value(analytics_json, Value::String("json-value".into()));
+
+    let default_events = verifier
+        .execute(Command::EventGetByType {
+            branch: None,
+            space: Some("default".into()),
+            event_type: "eg7.audit".into(),
+            limit: None,
+            after_sequence: None,
+            as_of: None,
+        })
+        .expect("default-space event read should succeed");
+    assert_event_count(default_events, 0);
+
+    let default_batch_events = verifier
+        .execute(Command::EventGetByType {
+            branch: None,
+            space: Some("default".into()),
+            event_type: "eg7.batch".into(),
+            limit: None,
+            after_sequence: None,
+            as_of: None,
+        })
+        .expect("default-space batch event read should succeed");
+    assert_event_count(default_batch_events, 0);
+
+    let analytics_events = verifier
+        .execute(Command::EventGetByType {
+            branch: None,
+            space: Some("analytics".into()),
+            event_type: "eg7.audit".into(),
+            limit: None,
+            after_sequence: None,
+            as_of: None,
+        })
+        .expect("analytics event read should succeed");
+    assert_event_count(analytics_events, 1);
+
+    let analytics_batch_events = verifier
+        .execute(Command::EventGetByType {
+            branch: None,
+            space: Some("analytics".into()),
+            event_type: "eg7.batch".into(),
+            limit: None,
+            after_sequence: None,
+            as_of: None,
+        })
+        .expect("analytics batch event read should succeed");
+    assert_event_count(analytics_batch_events, 2);
+}
+
+#[test]
+fn eg7_space_delete_force_clears_target_space_and_preserves_sibling_space() {
+    let executor = create_executor();
+
+    for space in ["tenant_x", "tenant_y"] {
+        executor
+            .execute(Command::KvPut {
+                branch: None,
+                space: Some(space.into()),
+                key: "kv".into(),
+                value: Value::String(format!("{space}-kv")),
+            })
+            .expect("kv write should succeed");
+        executor
+            .execute(Command::JsonSet {
+                branch: None,
+                space: Some(space.into()),
+                key: "doc".into(),
+                path: "$.name".into(),
+                value: Value::String(format!("{space}-json")),
+            })
+            .expect("json write should succeed");
+        executor
+            .execute(Command::EventAppend {
+                branch: None,
+                space: Some(space.into()),
+                event_type: "eg7.delete".into(),
+                payload: event_payload("space", Value::String(space.into())),
+            })
+            .expect("event append should succeed");
+        executor
+            .execute(Command::VectorCreateCollection {
+                branch: None,
+                space: Some(space.into()),
+                collection: "embeddings".into(),
+                dimension: 3,
+                metric: DistanceMetric::Cosine,
+            })
+            .expect("vector collection should be created");
+        executor
+            .execute(Command::VectorUpsert {
+                branch: None,
+                space: Some(space.into()),
+                collection: "embeddings".into(),
+                key: "v1".into(),
+                vector: vec![1.0, 0.0, 0.0],
+                metadata: None,
+            })
+            .expect("vector upsert should succeed");
+        executor
+            .execute(Command::GraphCreate {
+                branch: None,
+                space: Some(space.into()),
+                graph: "g".into(),
+                cascade_policy: None,
+            })
+            .expect("graph should be created");
+        executor
+            .execute(Command::GraphAddNode {
+                branch: None,
+                space: Some(space.into()),
+                graph: "g".into(),
+                node_id: "n1".into(),
+                entity_ref: None,
+                properties: None,
+                object_type: None,
+            })
+            .expect("graph node should be added");
+    }
+
+    let non_forced = executor
+        .execute(Command::SpaceDelete {
+            branch: None,
+            space: "tenant_x".into(),
+            force: false,
+        })
+        .expect_err("non-empty target space should require force");
+    assert!(
+        matches!(non_forced, Error::ConstraintViolation { .. }),
+        "expected constraint violation, got {non_forced:?}"
+    );
+
+    executor
+        .execute(Command::SpaceDelete {
+            branch: None,
+            space: "tenant_x".into(),
+            force: true,
+        })
+        .expect("forced space delete should succeed");
+
+    let tenant_x_kv = executor
+        .execute(Command::KvGet {
+            branch: None,
+            space: Some("tenant_x".into()),
+            key: "kv".into(),
+            as_of: None,
+        })
+        .expect("tenant_x kv read should succeed");
+    assert_missing(tenant_x_kv);
+
+    let tenant_x_json = executor
+        .execute(Command::JsonGet {
+            branch: None,
+            space: Some("tenant_x".into()),
+            key: "doc".into(),
+            path: "$.name".into(),
+            as_of: None,
+        })
+        .expect("tenant_x json read should succeed");
+    assert_missing(tenant_x_json);
+
+    let tenant_x_events = executor
+        .execute(Command::EventGetByType {
+            branch: None,
+            space: Some("tenant_x".into()),
+            event_type: "eg7.delete".into(),
+            limit: None,
+            after_sequence: None,
+            as_of: None,
+        })
+        .expect("tenant_x event read should succeed");
+    assert_event_count(tenant_x_events, 0);
+
+    let tenant_x_collections = executor
+        .execute(Command::VectorListCollections {
+            branch: None,
+            space: Some("tenant_x".into()),
+        })
+        .expect("tenant_x vector collection list should succeed");
+    match tenant_x_collections {
+        Output::VectorCollectionList(collections) => assert!(collections.is_empty()),
+        other => panic!("expected vector collection list, got {other:?}"),
+    }
+
+    let tenant_x_graphs = executor
+        .execute(Command::GraphList {
+            branch: None,
+            space: Some("tenant_x".into()),
+        })
+        .expect("tenant_x graph list should succeed");
+    match tenant_x_graphs {
+        Output::Keys(graphs) => assert!(graphs.is_empty()),
+        other => panic!("expected graph list, got {other:?}"),
+    }
+
+    let tenant_y_kv = executor
+        .execute(Command::KvGet {
+            branch: None,
+            space: Some("tenant_y".into()),
+            key: "kv".into(),
+            as_of: None,
+        })
+        .expect("tenant_y kv read should succeed");
+    assert_present_value(tenant_y_kv, Value::String("tenant_y-kv".into()));
+
+    let tenant_y_json = executor
+        .execute(Command::JsonGet {
+            branch: None,
+            space: Some("tenant_y".into()),
+            key: "doc".into(),
+            path: "$.name".into(),
+            as_of: None,
+        })
+        .expect("tenant_y json read should succeed");
+    assert_present_value(tenant_y_json, Value::String("tenant_y-json".into()));
+
+    let tenant_y_events = executor
+        .execute(Command::EventGetByType {
+            branch: None,
+            space: Some("tenant_y".into()),
+            event_type: "eg7.delete".into(),
+            limit: None,
+            after_sequence: None,
+            as_of: None,
+        })
+        .expect("tenant_y event read should succeed");
+    assert_event_count(tenant_y_events, 1);
+
+    let tenant_y_collections = executor
+        .execute(Command::VectorListCollections {
+            branch: None,
+            space: Some("tenant_y".into()),
+        })
+        .expect("tenant_y vector collection list should succeed");
+    match tenant_y_collections {
+        Output::VectorCollectionList(collections) => {
+            assert_eq!(collections.len(), 1);
+            assert_eq!(collections[0].name, "embeddings");
+            assert_eq!(collections[0].count, 1);
+        }
+        other => panic!("expected vector collection list, got {other:?}"),
+    }
+
+    let tenant_y_graphs = executor
+        .execute(Command::GraphList {
+            branch: None,
+            space: Some("tenant_y".into()),
+        })
+        .expect("tenant_y graph list should succeed");
+    match tenant_y_graphs {
+        Output::Keys(graphs) => assert_eq!(graphs, vec!["g".to_string()]),
+        other => panic!("expected graph list, got {other:?}"),
+    }
+}

--- a/tests/executor/main.rs
+++ b/tests/executor/main.rs
@@ -12,6 +12,7 @@ mod common;
 mod adversarial;
 mod branch_invariants;
 mod command_dispatch;
+mod eg7_characterization;
 mod error_handling;
 mod ex10_commands;
 mod ex11_commands;

--- a/tests/storage_surface_imports.rs
+++ b/tests/storage_surface_imports.rs
@@ -96,48 +96,7 @@ const ENGINE_CONSOLIDATION_VECTOR_CONSUMER_SCAN_ROOTS: &[&str] = &[
     "crates/cli",
 ];
 
-const ALLOWED_ENGINE_CONSOLIDATION_STORAGE_USES: &[AllowedEngineConsolidationStorageUse] = &[
-    AllowedEngineConsolidationStorageUse {
-        path: "crates/executor/Cargo.toml",
-        removal_epic: "EG7",
-    },
-    AllowedEngineConsolidationStorageUse {
-        path: "crates/executor/src/bridge.rs",
-        removal_epic: "EG7",
-    },
-    AllowedEngineConsolidationStorageUse {
-        path: "crates/executor/src/compat.rs",
-        removal_epic: "EG7",
-    },
-    AllowedEngineConsolidationStorageUse {
-        path: "crates/executor/src/convert.rs",
-        removal_epic: "EG7",
-    },
-    AllowedEngineConsolidationStorageUse {
-        path: "crates/executor/src/handlers/event.rs",
-        removal_epic: "EG7",
-    },
-    AllowedEngineConsolidationStorageUse {
-        path: "crates/executor/src/handlers/json.rs",
-        removal_epic: "EG7",
-    },
-    AllowedEngineConsolidationStorageUse {
-        path: "crates/executor/src/handlers/kv.rs",
-        removal_epic: "EG7",
-    },
-    AllowedEngineConsolidationStorageUse {
-        path: "crates/executor/src/handlers/space_delete.rs",
-        removal_epic: "EG7",
-    },
-    AllowedEngineConsolidationStorageUse {
-        path: "crates/executor/src/lib.rs",
-        removal_epic: "EG7",
-    },
-    AllowedEngineConsolidationStorageUse {
-        path: "crates/executor/src/session.rs",
-        removal_epic: "EG7",
-    },
-];
+const ALLOWED_ENGINE_CONSOLIDATION_STORAGE_USES: &[AllowedEngineConsolidationStorageUse] = &[];
 
 const RETIRED_SECURITY_PACKAGE: &str = concat!("strata", "-", "security");
 const RETIRED_SECURITY_IMPORT: &str = concat!("strata", "_", "security");
@@ -592,6 +551,12 @@ fn engine_consolidation_direct_storage_bypasses_are_allowlisted() {
 
     let mut violations = Vec::new();
     let mut observed = BTreeSet::new();
+    let root_manifest = repo_root.join("Cargo.toml");
+    let root_manifest_contents = fs::read_to_string(&root_manifest).expect("read root manifest");
+    violations.extend(find_root_normal_storage_dependency_violations(
+        &root_manifest,
+        &root_manifest_contents,
+    ));
 
     for file in files {
         if should_skip(&file) {
@@ -600,20 +565,14 @@ fn engine_consolidation_direct_storage_bypasses_are_allowlisted() {
         let rel = repo_relative_path(&repo_root, &file);
         let contents = fs::read_to_string(&file).expect("read source or manifest");
 
-        for (line_no, line) in contents.lines().enumerate() {
-            if !contains_direct_storage_reference(line) {
-                continue;
-            }
-
+        for (line_no, line) in find_direct_storage_references(&rel, &contents) {
             match allowed_engine_consolidation_storage_use(&rel) {
                 Some(allowed) => {
                     observed.insert(allowed.path);
                 }
                 None => violations.push(format!(
-                    "{}:{}: direct `strata-storage` use is not in the EG1D allowlist: {}",
-                    rel,
-                    line_no + 1,
-                    line.trim()
+                    "{}:{}: direct `strata-storage` use is not in the engine-consolidation allowlist: {}",
+                    rel, line_no, line
                 )),
             }
         }
@@ -632,7 +591,7 @@ fn engine_consolidation_direct_storage_bypasses_are_allowlisted() {
     );
     assert!(
         stale.is_empty(),
-        "EG1D storage bypass allowlist contains stale entries. Remove these entries when their epic lands:\n{}",
+        "engine-consolidation storage bypass allowlist contains stale entries. Remove these entries when their epic lands:\n{}",
         stale.join("\n")
     );
 }
@@ -695,6 +654,156 @@ fn contains_direct_storage_reference(line: &str) -> bool {
         || line.contains("strata-storage")
         || line.contains("use strata_storage")
         || line.contains("pub use strata_storage")
+}
+
+fn find_direct_storage_references(rel: &str, contents: &str) -> Vec<(usize, String)> {
+    if !rel.ends_with(".rs") {
+        return contents
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| contains_direct_storage_reference(line))
+            .map(|(line_no, line)| (line_no + 1, line.trim().to_string()))
+            .collect();
+    }
+
+    let mut references = Vec::new();
+    let mut pending_cfg_test = false;
+    let mut skipped_cfg_test_depth = None;
+    let mut lex_state = RustCodeLexState::default();
+
+    for (line_no, line) in contents.lines().enumerate() {
+        let code = rust_code_only_line(line, &mut lex_state);
+
+        if let Some(depth) = skipped_cfg_test_depth.as_mut() {
+            update_brace_depth(depth, &code);
+            if *depth == 0 {
+                skipped_cfg_test_depth = None;
+            }
+            continue;
+        }
+
+        let trimmed = code.trim();
+        if is_cfg_test_attr(trimmed) {
+            pending_cfg_test = true;
+            continue;
+        }
+
+        if pending_cfg_test {
+            if trimmed.is_empty() || trimmed.starts_with("#[") {
+                continue;
+            }
+
+            if line_declares_inline_module(trimmed) {
+                let mut depth = 0usize;
+                update_brace_depth(&mut depth, &code);
+                if depth > 0 {
+                    skipped_cfg_test_depth = Some(depth);
+                }
+                pending_cfg_test = false;
+                continue;
+            }
+
+            pending_cfg_test = false;
+        }
+
+        if contains_direct_storage_reference(&code) {
+            references.push((line_no + 1, line.trim().to_string()));
+        }
+    }
+
+    references
+}
+
+fn find_root_normal_storage_dependency_violations(path: &Path, contents: &str) -> Vec<String> {
+    let rel = path.to_string_lossy();
+    let mut violations = Vec::new();
+    let mut section = String::new();
+
+    for (line_no, line) in contents.lines().enumerate() {
+        let code = toml_code_only_line(line);
+        let trimmed = code.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if let Some(next_section) = parse_toml_section(trimmed) {
+            section.clear();
+            section.push_str(next_section);
+            continue;
+        }
+
+        if is_normal_dependency_section(&section)
+            && manifest_line_mentions_storage_dependency(trimmed)
+        {
+            violations.push(format!(
+                "{}:{}: root package has a normal `strata-storage` dependency above engine: {}",
+                rel,
+                line_no + 1,
+                line.trim()
+            ));
+        }
+    }
+
+    violations
+}
+
+fn parse_toml_section(trimmed: &str) -> Option<&str> {
+    if trimmed.starts_with("[[") || !trimmed.starts_with('[') || !trimmed.ends_with(']') {
+        return None;
+    }
+
+    trimmed
+        .strip_prefix('[')
+        .and_then(|section| section.strip_suffix(']'))
+        .map(str::trim)
+}
+
+fn is_normal_dependency_section(section: &str) -> bool {
+    section == "dependencies"
+        || (section.starts_with("target.") && section.ends_with(".dependencies"))
+}
+
+fn manifest_line_mentions_storage_dependency(trimmed: &str) -> bool {
+    trimmed.contains("strata-storage")
+        || trimmed.contains("package = \"strata-storage\"")
+        || trimmed.contains("package='strata-storage'")
+}
+
+fn toml_code_only_line(line: &str) -> String {
+    let mut code = String::with_capacity(line.len());
+    let mut in_string = false;
+    let mut quote = '\0';
+    let mut escaped = false;
+
+    for ch in line.chars() {
+        if in_string {
+            code.push(ch);
+            if escaped {
+                escaped = false;
+                continue;
+            }
+
+            if quote == '"' && ch == '\\' {
+                escaped = true;
+            } else if ch == quote {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if ch == '#' {
+            break;
+        }
+
+        if ch == '"' || ch == '\'' {
+            in_string = true;
+            quote = ch;
+        }
+
+        code.push(ch);
+    }
+
+    code
 }
 
 fn find_retired_security_surface_violations(rel: &str, contents: &str) -> Vec<String> {
@@ -1608,6 +1717,81 @@ fn product_runtime() {
     let violations =
         find_upper_subsystem_violations("crates/example/src/lib.rs", contents, "GraphSubsystem");
     assert_eq!(violations.len(), 2);
+}
+
+#[test]
+fn direct_storage_guard_detects_production_use() {
+    let contents = r#"
+use strata_storage::{Key, Namespace};
+
+fn product_runtime() {
+    let _ = strata_storage::TypeTag::KV;
+}
+"#;
+
+    let references = find_direct_storage_references("crates/example/src/lib.rs", contents);
+    assert_eq!(references.len(), 2, "{references:?}");
+}
+
+#[test]
+fn direct_storage_guard_ignores_literals_comments_and_cfg_test_modules() {
+    let contents = r###"
+const PACKAGE_TEXT: &str = "strata-storage";
+const IMPORT_TEXT: &str = r#"strata_storage"#;
+
+// use strata_storage::{Key, Namespace};
+/* strata-storage */
+
+#[cfg(test)]
+mod tests {
+    use strata_storage::{Key, Namespace};
+
+    fn fixture() {
+        let _key = Key::new_json(namespace, "doc");
+    }
+}
+
+fn product_runtime() {
+    let _ = strata_storage::TypeTag::KV;
+}
+"###;
+
+    let references = find_direct_storage_references("crates/example/src/lib.rs", contents);
+    assert_eq!(references.len(), 1, "{references:?}");
+    assert!(references[0].1.contains("strata_storage::TypeTag"));
+}
+
+#[test]
+fn root_storage_dependency_guard_allows_dev_dependency() {
+    let contents = r#"
+[dependencies]
+strata-executor = { path = "crates/executor" }
+
+[dev-dependencies]
+strata-storage = { path = "crates/storage" }
+"#;
+
+    let violations =
+        find_root_normal_storage_dependency_violations(Path::new("Cargo.toml"), contents);
+    assert!(violations.is_empty(), "{violations:?}");
+}
+
+#[test]
+fn root_storage_dependency_guard_detects_normal_dependency() {
+    let contents = r#"
+[dependencies]
+strata-storage = { path = "crates/storage" }
+
+[target.'cfg(unix)'.dependencies]
+storage = { package = "strata-storage", path = "crates/storage" }
+
+[target.'cfg(unix)'.dev-dependencies]
+strata-storage = { path = "crates/storage" }
+"#;
+
+    let violations =
+        find_root_normal_storage_dependency_violations(Path::new("Cargo.toml"), contents);
+    assert_eq!(violations.len(), 2, "{violations:?}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Closes the last production storage bypass above engine: `strata-executor` no longer depends on `strata-storage` and no production executor file imports storage types.
- Adds engine-owned space validation, storage-origin error conversion, scoped-transaction helpers, graph/vector transaction entry points, and a complete space-delete orchestration so executor expresses product operations through semantic APIs, not storage keys/namespaces/type tags.
- Tightens the storage-surface guard allowlist to empty for production crates above engine.

## Engine surfaces added

- `strata_engine::validate_space_name(space) -> StrataResult<()>` — product-boundary space-name validation.
- `strata_engine::storage_error_for_product_boundary(StorageError)` — narrow adapter that maps storage-local failures into the historical executor-visible categories.
- `Transaction::scoped_space(space)` constructs the storage namespace inside engine; `scoped(Arc<Namespace>)` is `pub(crate)`.
- Scoped read helpers on the engine transaction wrapper: `kv_get_value`, `kv_scan`, `event_get_by_type`, `kv_delete_without_existence_check`, `json_list_keys`.
- Owned-transaction graph and vector entry points (`graph_*_in_space`, `vector_*_in_space`) that derive the branch from the active transaction.
- `Transaction::id_string()` accessor for `TxnInfo`; production `Deref/DerefMut` to `TransactionContext` is now `#[cfg(test)]`.
- `SpaceIndex::delete_user_space` and `delete_user_space_with_post_data_cleanup`: full protection → validation → branch existence → emptiness → primitive rows → search → vector → product hook → metadata orchestration with the previous warn-and-continue policy for best-effort runtime cleanup.
- `is_user_space_delete_constraint` classifier so executor maps the two preserved constraint reasons into `ConstraintViolation` without hard-coding strings.
- `Database::inject_corrupt_json_bytes_for_test` (test-support feature) for downstream corruption fixtures.

## Executor changes

- Drop normal `strata-storage` dependency and `pub use strata_storage::{Key, Namespace}` re-exports. Dev/test needs use `strata-engine` `test-support`.
- Remove `impl From<StorageError> for Error`; all error conversion goes through `StrataError`.
- Handlers (`kv.rs`, `json.rs`, `event.rs`, `graph.rs`, `vector.rs`) take `&mut strata_engine::Transaction` instead of `&mut TransactionContext`.
- `session.rs` no longer constructs `Namespace` or calls `Transaction::context_mut()`; the corruption fixture calls `db.inject_corrupt_json_bytes_for_test`.
- `space_delete.rs` collapses to a one-call wrapper around the engine operation, translating only the two preserved constraint reasons.

## Guards

- `ALLOWED_ENGINE_CONSOLIDATION_STORAGE_USES` allowlist is empty for production crates above engine — any direct storage import or manifest edge fails the guard.
- `cargo tree -p strata-executor --edges normal` shows no direct `strata-storage` edge.

## Test plan

- [x] `cargo test -p strata-engine --lib transaction` (110 passed)
- [x] `cargo test -p strata-engine --lib primitives::space` (18 passed, including new `delete_user_space_*` cases)
- [x] `cargo test -p strata-executor` (116 passed)
- [x] `cargo test -p stratadb --test executor` (220 passed, including new `eg7_characterization` cases)
- [x] `cargo test -p stratadb --test storage_surface_imports` (27 passed)
- [x] `cargo tree -p strata-executor --edges normal` shows no `strata-storage` edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)