### PR TITLE
EG8: close intelligence dependency boundary

### DIFF
--- a/crates/intelligence/Cargo.toml
+++ b/crates/intelligence/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [features]
 default = []
-embed = ["dep:strata-inference"]
+embed = ["dep:strata-inference", "strata-inference/local", "strata-inference/download"]
 # Cloud generation providers — each enables the corresponding
 # strata-inference feature. Requires 'embed' to be useful.
 anthropic = ["embed", "strata-inference/anthropic"]
@@ -28,7 +28,7 @@ tracing = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-strata-inference = { path = "../inference", optional = true, features = ["local", "download"] }
+strata-inference = { path = "../inference", optional = true, default-features = false }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/intelligence/src/embed/runtime.rs
+++ b/crates/intelligence/src/embed/runtime.rs
@@ -705,17 +705,13 @@ fn serde_json_to_value(json: SerdeValue) -> StrataResult<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use strata_engine::database::OpenSpec;
-    use strata_engine::{SearchSubsystem, VectorSubsystem};
+    use strata_engine::database::{open_product_cache, ProductOpenOutcome};
 
     fn test_db() -> Arc<Database> {
-        let db = Database::open_runtime(
-            OpenSpec::cache()
-                .with_subsystem(strata_engine::GraphSubsystem)
-                .with_subsystem(VectorSubsystem)
-                .with_subsystem(SearchSubsystem),
-        )
-        .unwrap();
+        let db = match open_product_cache().unwrap() {
+            ProductOpenOutcome::Local { db, .. } => db,
+            _ => panic!("product cache should always open locally"),
+        };
         db.set_auto_embed(true);
         db
     }

--- a/crates/intelligence/src/expand.rs
+++ b/crates/intelligence/src/expand.rs
@@ -2,8 +2,7 @@
 //!
 //! Generates typed query variants (lex/vec/hyde) using a generation model
 //! with grammar constraints, then filters via a hallucination guard.
-//! The caller (search handler) routes each variant to the appropriate
-//! substrate retrieval pass.
+//! The caller routes each variant through engine-owned search retrieval.
 
 use strata_core::BranchId;
 use strata_engine::search::expand::parser::parse_expansion_with_filter;

--- a/crates/intelligence/src/expand_cache.rs
+++ b/crates/intelligence/src/expand_cache.rs
@@ -1,10 +1,11 @@
 //! Persistent FIFO cache for query expansion results.
 //!
-//! Cache lives in `_system_` space on the branch using the same KV-write-via-
-//! transaction pattern as `recipe_store`. Per-branch storage means a branch
-//! fork inherits the parent's warm cache for free via the existing COW path.
+//! Cache lives in engine-owned `_system_` space on the branch using the same
+//! KV-write-via-transaction pattern as `recipe_store`. Per-branch engine
+//! versioning means a branch fork inherits the parent's warm cache without an
+//! explicit cache copy.
 //!
-//! # Storage layout
+//! # Engine system-space layout
 //!
 //! Two key shapes in `_system_` space, both per-branch:
 //!

--- a/crates/intelligence/src/rag/mod.rs
+++ b/crates/intelligence/src/rag/mod.rs
@@ -1,6 +1,6 @@
 //! RAG (retrieval-augmented generation) for Strata search.
 //!
-//! Takes the top-N hits from the substrate, builds a prompt
+//! Takes the top-N engine search hits, builds a prompt
 //! (sandwich-ordered, type-tagged — see `prompt.rs` and the v0.6 plan),
 //! calls the generation model specified by `recipe.models.generate`, and
 //! parses citations from the result. Returns `None` on any failure

--- a/crates/intelligence/tests/expand_cache_fork_test.rs
+++ b/crates/intelligence/tests/expand_cache_fork_test.rs
@@ -1,16 +1,18 @@
 //! Integration test: forking a branch inherits the parent's expansion cache
-//! via the storage layer's COW semantics.
+//! through engine branch/version semantics.
 //!
 //! This test must use a disk-backed runtime because branch fork goes through
-//! `BranchService` and the storage-layer COW path, which an in-memory
+//! `BranchService` and durable engine branch state, which an in-memory
 //! `Database::cache()` runtime does not exercise.
 
 #![cfg(feature = "embed")]
 
-use strata_engine::database::search_only_primary_spec;
+use strata_engine::database::{
+    open_product_database, OpenOptions, ProductOpenError, ProductOpenOutcome,
+};
 use strata_engine::primitives::branch::resolve_branch_name;
 use strata_engine::search::expand::{ExpandedQuery, QueryType};
-use strata_engine::{Database, GraphSubsystem};
+use strata_engine::Database;
 use strata_intelligence::expand_cache;
 use tempfile::TempDir;
 
@@ -21,12 +23,21 @@ fn lex(text: &str) -> ExpandedQuery {
     }
 }
 
+fn open_product_test_database(dir: &TempDir) -> std::sync::Arc<Database> {
+    match open_product_database(dir.path(), OpenOptions::default()) {
+        Ok(ProductOpenOutcome::Local { db, .. }) => db,
+        Ok(_) => panic!("fresh product test database should open locally"),
+        Err(ProductOpenError::LockedWithoutIpcSocket { .. }) => {
+            panic!("fresh product test database should not be locked")
+        }
+        Err(error) => panic!("failed to open product test database: {error}"),
+    }
+}
+
 #[test]
 fn test_fork_branch_inherits_cache() {
     let dir = TempDir::new().unwrap();
-    let db =
-        Database::open_runtime(search_only_primary_spec(dir.path()).with_subsystem(GraphSubsystem))
-            .unwrap();
+    let db = open_product_test_database(&dir);
 
     // Create the parent branch and warm its cache with one entry.
     db.branches().create("parent").unwrap();
@@ -54,11 +65,11 @@ fn test_fork_branch_inherits_cache() {
         .expect("fork should succeed");
     let child_id = resolve_branch_name("child");
 
-    // Child should see the inherited cache entry via COW — no model call needed
-    // and no explicit cache copy. This is the free-win the per-branch storage
-    // design buys.
+    // Child should see the inherited cache entry with no model call and no
+    // explicit cache copy. This is the free-win the per-branch engine
+    // versioning design buys.
     let child_variants = expand_cache::get(&db, child_id, &key)
-        .expect("child should inherit parent's cache entry via COW");
+        .expect("child should inherit parent's cache entry after fork");
 
     assert_eq!(child_variants.len(), 2);
     assert_eq!(child_variants[0].text, "ssh keygen");
@@ -69,11 +80,9 @@ fn test_fork_branch_inherits_cache() {
 #[test]
 fn test_fork_child_writes_isolated_from_parent() {
     // After fork, writes on the child must not leak into the parent.
-    // This proves the COW path is doing copy-on-write, not aliasing.
+    // This proves child writes remain branch-local after fork.
     let dir = TempDir::new().unwrap();
-    let db =
-        Database::open_runtime(search_only_primary_spec(dir.path()).with_subsystem(GraphSubsystem))
-            .unwrap();
+    let db = open_product_test_database(&dir);
 
     db.branches().create("p").unwrap();
     let parent_id = resolve_branch_name("p");

--- a/docs/engine/eg8-implementation-plan.md
+++ b/docs/engine/eg8-implementation-plan.md
@@ -1,0 +1,512 @@
+# EG8 Implementation Plan
+
+## Purpose
+
+`EG8` closes the intelligence side of engine consolidation.
+
+After `EG4` through `EG7`, graph, vector, search, product-open behavior, and
+executor's storage access have moved behind engine. Intelligence should now be a
+model and inference adapter above engine, not a peer runtime layer and not a
+place where storage or subsystem assembly leaks back in.
+
+The target stack remains:
+
+```text
+core -> storage -> engine -> intelligence -> executor -> cli
+```
+
+In that stack, intelligence may depend on:
+
+- `strata-core` for shared value/identity DTOs
+- `strata-engine` for database, search, vector, graph, branch, and recipe
+  contracts
+- `strata-inference` for optional model execution behind the `embed` feature
+
+Intelligence must not depend on retired peer runtime crates, storage, executor,
+or CLI. Engine must not depend on intelligence or inference.
+
+This is the single implementation plan for the `EG8` phase. Lettered sections
+such as `EG8A`, `EG8B`, and `EG8C` are tracked here rather than in separate
+letter-specific documents.
+
+Read this with:
+
+- [engine-consolidation-plan.md](./engine-consolidation-plan.md)
+- [engine-crate-map.md](./engine-crate-map.md)
+- [eg4-implementation-plan.md](./eg4-implementation-plan.md)
+- [eg5-implementation-plan.md](./eg5-implementation-plan.md)
+- [eg6-implementation-plan.md](./eg6-implementation-plan.md)
+- [eg7-implementation-plan.md](./eg7-implementation-plan.md)
+- [../storage/v1-storage-consumption-contract.md](../storage/v1-storage-consumption-contract.md)
+
+## Scope
+
+`EG8` owns:
+
+- rebaselining `strata-intelligence`'s normal dependency graph after graph,
+  vector, search, security, and executor-legacy retirement
+- confirming intelligence imports engine-owned graph/vector/search contracts
+  rather than retired peer crates
+- preserving the inference boundary: optional model/provider execution stays in
+  intelligence/inference and does not move into engine
+- removing intelligence test-only subsystem assembly where tests still name
+  `GraphSubsystem`, `VectorSubsystem`, `SearchSubsystem`, `OpenSpec`, or
+  `with_subsystem`
+- tightening guard tests so intelligence cannot regain storage, retired peer
+  crates, direct inference consumers above intelligence, or subsystem assembly
+  outside engine
+- updating crate-map and consolidation docs to describe the final intelligence
+  boundary
+
+`EG8` does not own:
+
+- moving inference provider clients into engine
+- redesigning generation, embedding, rerank, RAG, or query expansion semantics
+- redesigning model registry/download behavior
+- deleting `strata-intelligence`
+- deleting `strata-inference`
+- removing executor's dependency on intelligence
+- removing CLI's optional embed dependency on intelligence; that is an `EG9`
+  final graph decision unless it blocks this phase
+- changing storage, WAL, manifest, checkpoint, snapshot, search segment, or
+  vector sidecar formats
+
+## Load-Bearing Boundary Rules
+
+Engine is below intelligence. The forbidden dependency directions are:
+
+```text
+strata-engine -> strata-intelligence
+strata-engine -> strata-inference
+strata-engine -> provider HTTP/client crates
+```
+
+Intelligence may call engine's public product/runtime APIs and engine-owned
+search/vector/graph contracts. It must not reconstruct engine runtime assembly
+by naming subsystem structs. If a test needs a database with product runtime
+hooks, add or use an engine-owned helper that expresses the desired runtime
+shape directly.
+
+Allowed intelligence imports:
+
+- `strata_engine::Database`
+- engine-owned primitive facades such as `VectorStore`, `KVStore`,
+  `JsonStore`, `EventLog`, and `SpaceIndex`
+- engine-owned search contracts such as `SearchHit`, `ExpandedQuery`,
+  `QueryType`, `RerankConfig`, `Recipe`, `BlendWeights`, and `RerankScore`
+- optional `strata_inference::*` imports behind `#[cfg(feature = "embed")]`
+
+Forbidden intelligence imports:
+
+- `strata_storage::*`
+- `strata_graph::*`
+- `strata_vector::*`
+- `strata_search::*`
+- `strata_security::*`
+- `strata_executor_legacy::*`
+- `strata_executor::*`
+- `strata_cli::*`
+
+Forbidden intelligence runtime assembly:
+
+- `GraphSubsystem`
+- `VectorSubsystem`
+- `SearchSubsystem`
+- `OpenSpec::with_subsystem`
+- `OpenSpec::with_subsystems`
+
+## Starting State
+
+The default normal dependency graph for intelligence is already close to the
+target:
+
+```text
+strata-intelligence
+├── serde
+├── serde_json
+├── sha2
+├── strata-core
+├── strata-engine
+└── tracing
+```
+
+With `--features embed`, intelligence adds `strata-inference`:
+
+```text
+strata-intelligence
+├── strata-core
+├── strata-engine
+├── strata-inference
+└── supporting crates
+```
+
+The current intelligence manifest has no normal dependency on:
+
+- `strata-storage`
+- `strata-graph`
+- `strata-vector`
+- `strata-search`
+- `strata-security`
+- `strata-executor-legacy`
+- `strata-executor`
+- `strata-cli`
+
+The current production imports are also mostly correct:
+
+- `expand.rs`, `expand_cache.rs`, `rerank.rs`, and `rag/*` import search
+  contracts from `strata_engine::search`.
+- `embed/runtime.rs` and `shadow.rs` import `VectorStore` and shadow constants
+  from engine.
+- `generate.rs`, `embed/mod.rs`, `embed/download.rs`, and `lib.rs` import or
+  re-export inference types behind the `embed` feature.
+- engine has no normal dependency on intelligence or inference.
+
+The remaining cleanup is test/runtime-shape and guard work:
+
+- `crates/intelligence/tests/expand_cache_fork_test.rs` directly names
+  `GraphSubsystem` and calls `.with_subsystem(GraphSubsystem)`.
+- `crates/intelligence/src/embed/runtime.rs` test code directly names
+  `GraphSubsystem`, `VectorSubsystem`, `SearchSubsystem`, `OpenSpec`, and
+  `.with_subsystem(...)`.
+- some intelligence tests use engine's `search_only_*_spec` helpers, which is
+  acceptable if the helper expresses an engine-owned runtime shape and does not
+  require intelligence to name subsystem structs.
+
+## EG8A - Rebaseline Intelligence Dependency And Import Surface
+
+**Goal:**
+
+Record the current intelligence graph and source import inventory before
+tightening the boundary.
+
+**Work:**
+
+- run `cargo tree -p strata-intelligence --edges normal --depth 1`
+- run `cargo tree -p strata-intelligence --features embed --edges normal --depth 1`
+- scan intelligence source, tests, and manifest for retired peer crate names:
+  both underscore and hyphen spellings of graph, vector, search, storage,
+  security, and executor-legacy
+- scan engine source and manifest for `strata_intelligence`,
+  `strata-inference`, and `strata_inference`
+- scan executor and CLI for direct `strata_inference` usage; executor should
+  consume inference-facing public types through intelligence
+- record any intentional exceptions in this file before implementing later
+  sections
+
+**Acceptance:**
+
+- intelligence's default graph is `core + engine + local support crates`
+- intelligence's `embed` graph adds inference only as an optional direct
+  dependency
+- engine has no intelligence or inference dependency
+- executor and CLI have no direct inference dependency
+- all retired peer-crate references are either absent or test/doc strings
+  intentionally covered by guard tests
+
+**Completed in EG8A:**
+
+- `cargo tree -p strata-intelligence --edges normal --depth 1` shows only
+  `serde`, `serde_json`, `sha2`, `strata-core`, `strata-engine`, and
+  `tracing`.
+- `cargo tree -p strata-intelligence --features embed --edges normal --depth 1`
+  adds `strata-inference` as the only direct Strata crate beyond core and
+  engine. `strata-storage` remains present transitively through engine, which
+  is the intended stack shape.
+- The retired peer-crate scan over `crates/intelligence` found no
+  underscore or hyphen spellings for graph, vector, search, storage, security,
+  or executor-legacy source or manifest matches.
+- The engine scan found no `strata_intelligence`, `strata-inference`, or
+  `strata_inference` source or manifest matches.
+- The executor, CLI, and root `src` scan found no direct
+  `strata_inference` or `strata-inference` matches. Executor's generation
+  handler consumes `ProviderKind` through `strata_intelligence`, which is the
+  intended facade.
+- The remaining intentional exception is test-only runtime assembly in
+  intelligence:
+  - `crates/intelligence/tests/expand_cache_fork_test.rs` names
+    `GraphSubsystem` and calls `.with_subsystem(GraphSubsystem)`.
+  - `crates/intelligence/src/embed/runtime.rs` test code names `OpenSpec`,
+    `GraphSubsystem`, `VectorSubsystem`, `SearchSubsystem`, and
+    `.with_subsystem(...)`.
+  These are the implementation inputs for `EG8D`; they are not production
+  dependency or import violations.
+- Verification: `cargo check -p strata-intelligence` and `cargo fmt --check`
+  pass. `cargo check -p strata-intelligence --features embed` currently fails
+  during `strata-inference`'s custom build script/CMake setup, before
+  `strata-intelligence` library compilation, because
+  `crates/inference/vendor/llama.cpp` is present but does not contain
+  `CMakeLists.txt`; treat that as an inference vendor setup issue to resolve or
+  document in `EG8C`, not as an intelligence dependency surface regression.
+
+## EG8B - Preserve Engine-Owned Search, Vector, And Graph Contracts
+
+**Goal:**
+
+Make intelligence's database-domain imports intentionally engine-owned.
+
+**Work:**
+
+- review `expand.rs`, `expand_cache.rs`, `rerank.rs`, `rag/*`,
+  `embed/runtime.rs`, and `shadow.rs`
+- remove any stale comments that describe graph/vector/search as peer crates
+- keep query expansion, rerank blending, search hit DTOs, recipes, and vector
+  facades imported from `strata_engine`
+- avoid creating intelligence-local mirror DTOs for engine contracts unless
+  they are serialization bridges for persisted intelligence-owned state
+- preserve current behavior for cache serialization, rerank blending, RAG
+  prompt formatting, shadow embedding cleanup, and embed queueing
+
+**Acceptance:**
+
+- no production intelligence module imports retired graph/vector/search crates
+- persisted cache DTOs remain compatible with existing engine-owned
+  `ExpandedQuery` and `QueryType`
+- `shadow.rs` and `embed/runtime.rs` use engine primitive APIs, not storage keys
+  or namespaces
+- `cargo test -p strata-intelligence` passes without behavior changes
+
+**Completed in EG8B:**
+
+- Production intelligence imports for expansion, expansion cache, rerank, RAG,
+  shadow cleanup, and auto-embed runtime all use engine-owned contracts:
+  `strata_engine::search::*`, `strata_engine::Database`,
+  `strata_engine::VectorStore`, and other engine primitive facades.
+- The persisted expansion-cache bridge remains intelligence-owned only for JSON
+  serialization compatibility and converts directly to/from engine-owned
+  `ExpandedQuery` and `QueryType`.
+- `shadow.rs` and `embed/runtime.rs` continue to use engine primitive APIs for
+  shadow vector collections; they do not import storage or construct storage
+  keys directly.
+- Stale comments that described search as a substrate or cache inheritance as a
+  storage-layer concern now describe engine-owned search retrieval and engine
+  branch/version semantics without naming storage/COW mechanics above engine.
+- The only remaining intelligence references to subsystem structs or
+  `.with_subsystem(...)` are the test-only runtime assembly cases already
+  recorded in `EG8A`; those remain assigned to `EG8D`.
+- Verification: `cargo test -p strata-intelligence` passes, but the
+  embed-gated `expand_cache_fork_test.rs` integration tests are not exercised
+  by that command. `cargo test -p strata-intelligence --features embed`
+  currently reaches the pre-existing `strata-inference` llama.cpp vendor setup
+  failure documented in `EG8A`; feature-enabled behavioral verification remains
+  blocked until `EG8C` resolves or explicitly documents that vendor setup.
+
+## EG8C - Preserve The Inference Boundary
+
+**Goal:**
+
+Keep model execution above engine and keep executor/CLI using intelligence as
+the inference facade.
+
+**Work:**
+
+- verify inference imports in intelligence are behind `#[cfg(feature = "embed")]`
+  or feature-gated modules
+- keep `strata-inference` optional in `crates/intelligence/Cargo.toml`
+- preserve feature forwarding:
+  - `embed -> dep:strata-inference + strata-inference/local +
+    strata-inference/download`
+  - `anthropic -> embed + strata-inference/anthropic`
+  - `openai -> embed + strata-inference/openai`
+  - `google -> embed + strata-inference/google`
+- keep executor free of direct `strata-inference` dependency and imports
+- keep engine free of direct `strata-inference` and provider ownership
+- decide whether the existing intelligence re-exports of inference types are
+  still the desired public facade; if they remain, document them as the
+  intentional boundary that prevents executor from depending on inference
+
+**Acceptance:**
+
+- `cargo check -p strata-intelligence`
+- `cargo check -p strata-intelligence --features embed` when the local
+  inference vendor tree is populated; in this workspace, use
+  `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1` for boundary compile
+  checks
+- `cargo check -p strata-executor --features embed` when the local inference
+  vendor tree is populated; in this workspace, use
+  `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1` for boundary compile
+  checks
+- `cargo check -p strata-cli --features embed` when the local inference vendor
+  tree is populated; in this workspace, use
+  `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1` for boundary compile
+  checks
+- `rg "strata_inference|strata-inference" crates/engine crates/executor crates/cli src`
+  returns no production dependency/import matches outside feature strings that
+  route through intelligence
+
+**Completed in EG8C:**
+
+- `strata-inference` remains an optional intelligence dependency. The manifest
+  now sets `default-features = false` and forwards the `local` and `download`
+  inference features explicitly from `embed`, so the default-feature behavior is
+  no longer hidden.
+- Intelligence remains the only crate that imports `strata_inference` directly.
+  All inference imports are behind `#[cfg(feature = "embed")]` modules,
+  feature-gated tests, or the feature-gated re-export facade in `lib.rs`.
+- The existing `strata_intelligence` re-exports of `GenerateRequest`,
+  `GenerateResponse`, `StopReason`, `InferenceError`, `ProviderKind`,
+  `ModelRegistry`, `ModelTask`, and inference engine types remain intentional:
+  executor and CLI consume inference-facing types through intelligence rather
+  than depending on `strata-inference` directly.
+- Engine has no intelligence or inference dependency/import matches. Executor,
+  CLI, and root `src` have no direct `strata_inference` or `strata-inference`
+  source/import matches; their embed feature strings route through
+  `strata-intelligence`.
+- Local inference still requires a populated `crates/inference/vendor/llama.cpp`
+  tree for real native builds. For boundary compile checks in this workspace,
+  use the existing build-script escape hatch:
+  `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check ...`.
+  This keeps EG8C honest without changing product runtime behavior.
+- Verification: `cargo fmt --check`, `cargo check -p strata-intelligence`, and
+  the embed compile checks pass with
+  `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1` for intelligence,
+  executor, and CLI. The cloud-provider feature edge was checked with
+  `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p
+  strata-intelligence --features anthropic,openai,google`. Direct inference
+  scans over engine, executor, CLI, and root `src` return no matches outside
+  intelligence.
+
+## EG8D - Remove Intelligence Subsystem Assembly
+
+**Goal:**
+
+Stop intelligence tests from assembling engine runtime subsystems directly.
+
+**Work:**
+
+- replace direct `GraphSubsystem`, `VectorSubsystem`, and `SearchSubsystem`
+  usage in intelligence tests with engine-owned open helpers
+- replace direct `OpenSpec::with_subsystem(...)` calls in intelligence tests
+  with helpers such as:
+  - an existing `Database::cache()` / `Database::open(...)` path when it
+    already creates the required engine-owned runtime hooks
+  - an existing engine-owned `search_only_*_spec` helper when the test
+    intentionally needs search-only runtime behavior
+  - a new engine test-support helper if the test needs full product runtime
+    hooks without exposing subsystem structs above engine
+- preserve disk-backed branch fork coverage in
+  `expand_cache_fork_test.rs`; it must still exercise real branch/version
+  inheritance through durable engine branch state, not a memory-only shortcut
+- preserve auto-embed runtime tests in `embed/runtime.rs`; they still need
+  graph/vector/search hooks if the tested behavior requires them, but
+  intelligence should ask engine for that runtime shape instead of constructing
+  subsystem lists
+
+**Acceptance:**
+
+- no intelligence source or test file names:
+  - `GraphSubsystem`
+  - `VectorSubsystem`
+  - `SearchSubsystem`
+  - `.with_subsystem`
+  - `.with_subsystems`
+- intelligence tests still pass without `embed`; embed-gated tests compile in
+  this workspace and execute when the local inference vendor/native build is
+  available
+- engine-owned test helpers, if added, are named by runtime intent rather than
+  by subsystem list
+
+**Completed in EG8D:**
+
+- `crates/intelligence/tests/expand_cache_fork_test.rs` now opens its
+  disk-backed runtime through engine-owned `open_product_database()` and
+  unwraps the local product-open outcome. The test still uses a real
+  disk-backed primary database, creates branches through `BranchService`, and
+  exercises branch fork/version inheritance.
+- `crates/intelligence/src/embed/runtime.rs` test setup now opens an ephemeral
+  product runtime through engine-owned `open_product_cache()` instead of
+  constructing graph, vector, and search subsystems directly.
+- No new engine helper was needed; the existing product-open API already names
+  the required runtime intent and keeps subsystem composition inside engine.
+- Verification: `cargo fmt --check`, `cargo test -p strata-intelligence`, and
+  `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p
+  strata-intelligence --features embed --tests` pass. A real embed-gated test
+  run is blocked in this workspace by the known missing
+  `crates/inference/vendor/llama.cpp/CMakeLists.txt` vendor setup, so EG8D only
+  claims embed test compilation here. The subsystem assembly scan for
+  graph/vector/search subsystem names and `with_subsystem` builders under
+  `crates/intelligence` returns no matches.
+
+## EG8E - Guard And Documentation Closeout
+
+**Goal:**
+
+Make the intelligence boundary enforceable before `EG9`.
+
+**Work:**
+
+- extend `tests/storage_surface_imports.rs` or add a focused guard so
+  intelligence cannot regain:
+  - direct storage imports
+  - retired graph/vector/search/security/executor-legacy dependencies
+  - direct `strata-inference` use outside the intelligence crate
+  - direct subsystem assembly
+- update [engine-crate-map.md](./engine-crate-map.md)
+- update [engine-consolidation-plan.md](./engine-consolidation-plan.md) if
+  EG8 implementation changes the summary
+- verify the final graph:
+
+```text
+strata-storage      -> strata-core
+strata-engine       -> strata-core, strata-storage
+strata-intelligence -> strata-core, strata-engine, strata-inference (optional)
+strata-executor     -> strata-core, strata-engine, strata-intelligence
+strata-cli          -> strata-executor, strata-intelligence (optional embed)
+stratadb            -> strata-executor
+```
+
+**Acceptance:**
+
+- guard tests fail if intelligence imports storage or a retired peer runtime
+  crate
+- guard tests fail if engine imports intelligence or inference
+- guard tests fail if executor or CLI directly import inference
+- guard tests fail if intelligence source/tests instantiate subsystem structs
+- EG9 starts from dependency graph closeout only, not intelligence cleanup
+
+**Completed in EG8E:**
+
+- Added focused guards in `tests/storage_surface_imports.rs` for intelligence's
+  boundary:
+  - intelligence Rust files and manifests under the full crate tree may not
+    import storage or retired graph/vector/search/security/executor-legacy
+    runtime crates
+  - intelligence Rust files under the full crate tree may not name `OpenSpec`,
+    `GraphSubsystem`, `VectorSubsystem`, `SearchSubsystem`, `with_subsystem`,
+    or `with_subsystems`
+  - engine may not import intelligence or inference
+  - executor, CLI, and the root package may not import inference directly
+- Updated [engine-crate-map.md](./engine-crate-map.md) to separate the default
+  normal graph from optional `embed`/`strata-inference` edges.
+- Updated [engine-consolidation-plan.md](./engine-consolidation-plan.md) so
+  `EG8E` is complete and `EG9` starts from dependency graph closeout, not
+  intelligence cleanup.
+- Verification: `cargo test -p stratadb --test storage_surface_imports` passes
+  with 29 guard/self-tests.
+
+## Verification
+
+Run targeted checks as each section lands:
+
+```bash
+cargo tree -p strata-intelligence --edges normal --depth 1
+cargo tree -p strata-intelligence --features embed --edges normal --depth 1
+cargo tree -p strata-engine --edges normal --depth 1
+cargo tree -p strata-executor --edges normal --depth 1
+cargo tree -p strata-cli --edges normal --depth 1
+rg -n "strata_(graph|vector|search|storage|security|executor_legacy)|strata-(graph|vector|search|storage|security|executor-legacy)" crates/intelligence -g '*.rs' -g 'Cargo.toml'
+rg -n "strata_intelligence|strata-inference|strata_inference" crates/engine -g '*.rs' -g 'Cargo.toml'
+rg -n "strata_inference|strata-inference" crates/executor crates/cli src -g '*.rs' -g 'Cargo.toml'
+rg -n "OpenSpec|GraphSubsystem|VectorSubsystem|SearchSubsystem|with_subsystem|with_subsystems" crates/intelligence -g '*.rs'
+cargo test -p strata-intelligence
+STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p strata-intelligence --features embed
+STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p strata-executor --features embed
+STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p strata-cli --features embed
+# Requires a real local inference vendor/native build and model assets.
+cargo test -p strata-intelligence --features embed
+cargo test -p stratadb --test storage_surface_imports
+```
+
+Feature-enabled tests require the local inference vendor/native build and model
+assets. In workspaces without a populated `crates/inference/vendor/llama.cpp`
+tree, use `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1` only for
+compile-only boundary checks; do not use that check-only escape hatch for tests.

--- a/docs/engine/engine-consolidation-plan.md
+++ b/docs/engine/engine-consolidation-plan.md
@@ -56,22 +56,26 @@ This plan should be read with:
 
 ## Current Verified Starting Point
 
-The verified normal workspace dependency graph for the engine-adjacent crates
-is:
+The verified default normal workspace dependency graph for the engine-adjacent
+crates is:
 
 ```text
 strata-storage         -> strata-core
 strata-engine          -> strata-core, strata-storage
-strata-intelligence    -> strata-core, strata-engine, strata-inference
+strata-intelligence    -> strata-core, strata-engine
 strata-executor        -> strata-core, strata-engine, strata-intelligence
-strata-cli             -> strata-executor, strata-intelligence
+strata-cli             -> strata-executor
 stratadb               -> strata-executor
 ```
 
 There is no normal production direct storage bypass above engine after `EG7`.
+With `embed` enabled, `strata-intelligence` adds the optional
+`strata-inference` edge and `strata-cli` reaches intelligence through its
+optional embed feature.
 
 `strata-intelligence` does not currently have direct normal storage imports,
-and it no longer depends on a search peer crate after `EG6`.
+and it no longer depends on graph, vector, search, security, executor-legacy, or
+storage peer crates.
 
 `EG4` removed graph from this list by moving graph runtime, storage-key mapping,
 transaction extension behavior, merge behavior, and branch DAG behavior into
@@ -280,8 +284,9 @@ The consolidation is complete when:
 6. `strata-executor` no longer depends on `strata-storage`, `strata-graph`,
    `strata-vector`, `strata-search`, `strata-security`, or
    `strata-executor-legacy`.
-7. `strata-intelligence` depends on `strata-engine` and `strata-inference`, not
-   `strata-search` or `strata-vector`.
+7. `strata-intelligence` depends on `strata-engine` by default and reaches
+   `strata-inference` only through optional embed/provider features. It does
+   not depend on `strata-search` or `strata-vector`.
 8. The only normal production path into storage is `strata-engine`.
 9. The crate graph is enforceable with tests and `cargo metadata` guards.
 10. No production crate above engine instantiates engine subsystem structs or
@@ -302,9 +307,11 @@ strata-core
 `strata-inference` remains below or beside `strata-intelligence` as the model
 provider/inference crate. Engine must not depend on it.
 
-The CLI should also stop depending on intelligence directly by closeout. It is
-not a storage bypass today, but the target stack is easier to enforce if CLI
-commands enter through executor rather than selectively bypassing it.
+The CLI should also stop depending on intelligence directly by closeout unless
+there is a documented command-surface reason to bypass executor. The current
+documented exception is the optional `embed` feature, which exposes
+intelligence-backed commands while still keeping direct inference imports out of
+CLI.
 
 ## Non-Goals
 
@@ -1059,6 +1066,8 @@ empty for production crates above engine.
 
 ## EG8 - Intelligence Dependency Cleanup
 
+Detailed plan: [eg8-implementation-plan.md](./eg8-implementation-plan.md)
+
 **Goal:**
 
 Make intelligence depend on engine for search/vector types and on inference for
@@ -1107,23 +1116,60 @@ Re-run intelligence dependency and import inventories after vector and search
 absorption. Confirm no direct storage access exists and no graph, vector,
 search, security, or storage peer-crate imports remain.
 
-### EG8B - Cut Over Search Imports And Preserve Vector Cutover
+Current status: complete. The default intelligence graph is
+`strata-core + strata-engine` plus support crates; `--features embed` adds only
+direct optional `strata-inference`. Engine has no intelligence or inference
+edge, and executor/CLI consume inference-facing types through intelligence
+rather than directly importing inference.
+
+### EG8B - Preserve Engine-Owned Search, Vector, And Graph Contracts
 
 Confirm intelligence uses engine-owned search traits, DTOs, and runtime surfaces
-while vector imports still come from engine.
+while vector and graph imports still come from engine.
+
+Current status: complete. Production intelligence modules use engine-owned
+search DTOs, recipes, database handles, and primitive facades. Expansion-cache
+serialization remains intelligence-local only as a compatibility bridge around
+engine-owned `ExpandedQuery`/`QueryType`; subsystem assembly cleanup remains
+scoped to `EG8D`.
 
 ### EG8C - Preserve The Inference Boundary
 
 Keep model execution, provider wiring, and inference-specific configuration in
 intelligence/inference. Confirm engine still has no inference dependency.
 
-### EG8D - Tighten Intelligence Dependency Guard
+Current status: complete. `strata-inference` remains optional and is reached
+only through `strata-intelligence`; intelligence forwards local/download and
+cloud-provider inference features explicitly, while executor and CLI consume
+inference-facing public types through the intelligence facade.
+
+### EG8D - Remove Intelligence Subsystem Assembly
+
+Remove intelligence test/runtime helper usage of direct engine subsystem
+construction. Intelligence should ask engine for an intended runtime shape, not
+name `GraphSubsystem`, `VectorSubsystem`, `SearchSubsystem`, or
+`OpenSpec::with_subsystem`.
+
+Current status: complete. Intelligence tests now use engine product-open
+helpers for disk-backed and ephemeral runtime setup; direct subsystem
+construction is no longer present under `crates/intelligence`.
+
+### EG8E - Guard And Documentation Closeout
 
 Rebaseline intelligence manifest/import guards for the already-removed search
 and storage edges. Remove stale allowlist entries if any remain, and keep the
-existing graph/vector/security absence enforced.
+existing graph/vector/security absence enforced. Add guards for the inference
+direction and intelligence subsystem-instantiation boundary.
+
+Current status: complete. `tests/storage_surface_imports.rs` now rejects
+intelligence storage/retired-runtime dependencies, intelligence source/test
+subsystem assembly, engine imports of intelligence/inference, and direct
+executor/CLI/root imports of inference. The crate map documents the default
+normal graph and the optional embed/inference edges separately.
 
 ## EG9 - Crate Deletion And Workspace Closeout
+
+Detailed plan: [eg9-implementation-plan.md](./eg9-implementation-plan.md)
 
 **Goal:**
 
@@ -1141,7 +1187,9 @@ by `EG3D`. `crates/graph` was deleted by `EG4G`. `crates/vector` was deleted by
 Remove workspace dependency entries and feature plumbing for deleted crates.
 
 Remove direct CLI dependencies on intelligence unless there is a documented
-reason for a CLI command to bypass executor.
+reason for a CLI command to bypass executor. The current documented exception
+is the optional `embed` feature, which exposes intelligence-backed commands
+while still keeping direct inference imports out of CLI.
 
 Tighten guard tests from transitional allowlists to final allowlists.
 
@@ -1152,11 +1200,14 @@ The final normal workspace graph should satisfy:
 ```text
 strata-storage      -> strata-core
 strata-engine       -> strata-core, strata-storage
-strata-intelligence -> strata-core, strata-engine, strata-inference
+strata-intelligence -> strata-core, strata-engine
 strata-executor     -> strata-core, strata-engine, strata-intelligence
 strata-cli          -> strata-executor
 stratadb            -> strata-executor
 ```
+
+With `embed` enabled, `strata-intelligence` adds optional `strata-inference` and
+`strata-cli` may depend on `strata-intelligence` as an optional command surface.
 
 There should be no normal production dependency on:
 
@@ -1176,23 +1227,29 @@ reintroduction.
 - do not perform broad engine-next modular redesign in this closeout
 - do not start storage-next in this closeout
 
-### EG9A - Delete Absorbed Crates And Workspace Metadata
+### EG9A - Baseline Closeout Ledger
 
-Remove absorbed crates from `crates/`, workspace members, dependency manifests,
-feature lists, and CI/test configuration after normal dependents are gone.
+Record the final filesystem, workspace metadata, lockfile, dependency graph,
+and production import state before tightening the last guards.
 
-### EG9B - Tighten Final Storage And Dependency Guards
+### EG9B - Final Graph And Retired-Crate Guards
 
-Make direct storage access above engine fail by default. The only normal
-production storage dependent should be engine.
+Make the final graph fail closed. Retired crates must stay deleted, direct
+storage access above engine must fail, inference must stay behind
+intelligence, and upper layers must not assemble engine subsystems.
 
-### EG9C - Refresh Architecture Documents
+### EG9C - Optional Edge Policy And Feature Surface
+
+Document and enforce the remaining optional edges, especially CLI's optional
+`embed` edge to intelligence and intelligence's optional inference edge.
+
+### EG9D - Active Architecture Document Refresh
 
 Update the engine crate map, storage consumption contract, and active
 architecture docs so they describe the consolidated graph rather than the
 migration.
 
-### EG9D - Full Verification And Closeout Ledger
+### EG9E - Final Verification And Closeout
 
 Run the full required test matrix, record known residual risks, and explicitly
 name any temporary compatibility shell that survives closeout.
@@ -1262,10 +1319,12 @@ Final intelligence dependency guard:
 
 ```bash
 cargo tree -p strata-intelligence --edges normal --depth 1
+cargo tree -p strata-intelligence --features embed --edges normal --depth 1
 ```
 
-At closeout, intelligence should depend on engine and inference, not graph,
-vector, search, security, or storage.
+At closeout, intelligence should depend on engine by default. With `embed`
+enabled, it may add inference. It must not depend on graph, vector, search,
+security, or storage in either graph.
 
 ## Testing Strategy
 

--- a/docs/engine/engine-crate-map.md
+++ b/docs/engine/engine-crate-map.md
@@ -162,8 +162,9 @@ And then, above those:
 - `strata-cli`
 - `stratadb`
 
-`strata-intelligence` also depends on `strata-inference`, which is currently
-outside the engine stack and supplies model/inference support.
+`strata-intelligence` can optionally depend on `strata-inference` behind its
+`embed` feature. That crate remains outside the engine stack and supplies
+model/inference support.
 
 This confirms that engine is now the main semantic/runtime hub of the
 workspace. After `EG7`, there is no normal production direct storage bypass
@@ -171,27 +172,34 @@ above engine.
 
 ### Current Normal Workspace Graph
 
-The verified normal dependency graph for engine-adjacent crates is below.
-`EG7E` re-verified this graph on 2026-05-07 after deleting executor's direct
-storage dependency and storage re-exports. The phase tracking
-plans are
+The verified default normal dependency graph for engine-adjacent crates is
+below. `EG8E` re-verified this graph on 2026-05-07 after closing the
+intelligence boundary and adding dependency-direction guards. The phase
+tracking plans include
 [eg1-implementation-plan.md](./eg1-implementation-plan.md),
-[eg3-implementation-plan.md](./eg3-implementation-plan.md), and
-[eg7-implementation-plan.md](./eg7-implementation-plan.md).
+[eg3-implementation-plan.md](./eg3-implementation-plan.md),
+[eg7-implementation-plan.md](./eg7-implementation-plan.md), and
+[eg8-implementation-plan.md](./eg8-implementation-plan.md).
 
 ```text
 strata-storage       -> strata-core
 strata-engine        -> strata-core, strata-storage
-strata-intelligence  -> strata-core, strata-engine, strata-inference
+strata-intelligence  -> strata-core, strata-engine
 strata-executor      -> strata-core, strata-engine, strata-intelligence
-strata-cli           -> strata-executor, strata-intelligence
+strata-cli           -> strata-executor
 stratadb             -> strata-executor
 ```
+
+With `embed` enabled, `strata-intelligence` adds the optional
+`strata-inference` edge and `strata-cli` reaches intelligence only through its
+optional embed feature.
 
 Security/open options are engine-owned after `EG2`, product open/bootstrap is
 engine-owned after `EG3`, graph is engine-owned after `EG4`, vector is
 engine-owned after `EG5`, search is engine-owned after `EG6`, and executor's
-direct storage bypass is closed after `EG7`.
+direct storage bypass is closed after `EG7`. `EG8` keeps intelligence as an
+engine consumer and guards inference as an optional dependency behind
+intelligence.
 
 The current inverse normal storage graph is:
 
@@ -224,7 +232,10 @@ There are no normal production direct storage dependencies above engine after
 `EG7`.
 
 `strata-intelligence`, `strata-cli`, and the root `stratadb` package do not
-have direct normal storage dependencies.
+have direct normal storage dependencies. Guard tests also reject intelligence
+regressing to retired graph/vector/search/security/executor-legacy crate edges,
+direct subsystem assembly, engine imports of intelligence/inference, and direct
+executor/CLI imports of inference.
 Root dev-dependencies and storage-facing tests do import storage directly; those
 are tracked separately in the `EG1` implementation plan for the `EG1D` guard
 policy.

--- a/tests/storage_surface_imports.rs
+++ b/tests/storage_surface_imports.rs
@@ -121,6 +121,49 @@ const RETIRED_SEARCH_IMPORT: &str = concat!("strata", "_", "search");
 const RETIRED_SEARCH_RELATIVE_PATHS: &[&str] =
     &[concat!("../", "search"), concat!("crates/", "search")];
 
+const INTELLIGENCE_BOUNDARY_SCAN_ROOT: &str = "crates/intelligence";
+const INTELLIGENCE_FORBIDDEN_DEPENDENCY_MARKERS: &[&str] = &[
+    "strata-storage",
+    "strata_storage",
+    concat!("../", "storage"),
+    concat!("crates/", "storage"),
+    RETIRED_SECURITY_PACKAGE,
+    RETIRED_SECURITY_IMPORT,
+    concat!("../", "security"),
+    concat!("crates/", "security"),
+    RETIRED_EXECUTOR_LEGACY_PACKAGE,
+    RETIRED_EXECUTOR_LEGACY_IMPORT,
+    concat!("../", "executor", "-", "legacy"),
+    concat!("crates/", "executor", "-", "legacy"),
+    RETIRED_GRAPH_PACKAGE,
+    RETIRED_GRAPH_IMPORT,
+    concat!("../", "graph"),
+    concat!("crates/", "graph"),
+    RETIRED_VECTOR_PACKAGE,
+    RETIRED_VECTOR_IMPORT,
+    concat!("../", "vector"),
+    concat!("crates/", "vector"),
+    RETIRED_SEARCH_PACKAGE,
+    RETIRED_SEARCH_IMPORT,
+    concat!("../", "search"),
+    concat!("crates/", "search"),
+];
+const INTELLIGENCE_FORBIDDEN_RUNTIME_MARKERS: &[&str] = &[
+    "OpenSpec",
+    "GraphSubsystem",
+    "VectorSubsystem",
+    "SearchSubsystem",
+    ".with_subsystems",
+    ".with_subsystem",
+];
+const ENGINE_FORBIDDEN_UPPER_LAYER_MARKERS: &[&str] = &[
+    "strata-intelligence",
+    "strata_intelligence",
+    "strata-inference",
+    "strata_inference",
+];
+const UPPER_FORBIDDEN_INFERENCE_MARKERS: &[&str] = &["strata-inference", "strata_inference"];
+
 #[test]
 fn storage_facing_types_are_not_imported_from_strata_core() {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -596,6 +639,98 @@ fn engine_consolidation_direct_storage_bypasses_are_allowlisted() {
     );
 }
 
+#[test]
+fn engine_consolidation_intelligence_boundary_is_engine_consuming() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let intelligence_root = repo_root.join(INTELLIGENCE_BOUNDARY_SCAN_ROOT);
+    let mut files = Vec::new();
+    collect_rust_files(&intelligence_root, &mut files);
+    collect_manifest_files(&intelligence_root, &mut files);
+
+    let mut violations = Vec::new();
+    for file in files {
+        if should_skip(&file) || should_skip_manifest(&file) {
+            continue;
+        }
+
+        let rel = repo_relative_path(&repo_root, &file);
+        let contents = fs::read_to_string(&file).expect("read intelligence boundary file");
+        violations.extend(find_forbidden_marker_violations(
+            &rel,
+            &contents,
+            INTELLIGENCE_FORBIDDEN_DEPENDENCY_MARKERS,
+            "intelligence must consume engine surfaces instead of storage or retired runtime crates",
+        ));
+        if rel.ends_with(".rs") {
+            violations.extend(find_forbidden_marker_violations(
+                &rel,
+                &contents,
+                INTELLIGENCE_FORBIDDEN_RUNTIME_MARKERS,
+                "intelligence source/tests must not assemble engine product subsystems directly",
+            ));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "intelligence must remain an engine consumer with no storage, retired runtime-crate, or subsystem-assembly bypasses:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn engine_consolidation_inference_boundary_stays_above_intelligence() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut engine_files = vec![repo_root.join("crates/engine/Cargo.toml")];
+    collect_rust_files(&repo_root.join("crates/engine/src"), &mut engine_files);
+
+    let mut upper_files = vec![
+        repo_root.join("Cargo.toml"),
+        repo_root.join("crates/executor/Cargo.toml"),
+        repo_root.join("crates/cli/Cargo.toml"),
+    ];
+    collect_rust_files(&repo_root.join("src"), &mut upper_files);
+    collect_rust_files(&repo_root.join("crates/executor/src"), &mut upper_files);
+    collect_rust_files(&repo_root.join("crates/cli/src"), &mut upper_files);
+
+    let mut violations = Vec::new();
+    for file in engine_files {
+        if should_skip(&file) || should_skip_manifest(&file) {
+            continue;
+        }
+
+        let rel = repo_relative_path(&repo_root, &file);
+        let contents = fs::read_to_string(&file).expect("read engine boundary file");
+        violations.extend(find_forbidden_marker_violations(
+            &rel,
+            &contents,
+            ENGINE_FORBIDDEN_UPPER_LAYER_MARKERS,
+            "engine must not depend on intelligence or inference",
+        ));
+    }
+
+    for file in upper_files {
+        if should_skip(&file) || should_skip_manifest(&file) {
+            continue;
+        }
+
+        let rel = repo_relative_path(&repo_root, &file);
+        let contents = fs::read_to_string(&file).expect("read upper boundary file");
+        violations.extend(find_forbidden_marker_violations(
+            &rel,
+            &contents,
+            UPPER_FORBIDDEN_INFERENCE_MARKERS,
+            "executor/CLI/root package must reach inference through intelligence only",
+        ));
+    }
+
+    assert!(
+        violations.is_empty(),
+        "inference must remain optional behind `strata-intelligence`; lower or sibling crates may not import it directly:\n{}",
+        violations.join("\n")
+    );
+}
+
 fn collect_rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
     if !dir.exists() {
         return;
@@ -914,6 +1049,103 @@ fn find_retired_search_violations(rel: &str, contents: &str) -> Vec<String> {
     }
 
     violations
+}
+
+fn find_forbidden_marker_violations(
+    rel: &str,
+    contents: &str,
+    markers: &[&str],
+    reason: &str,
+) -> Vec<String> {
+    let mut violations = Vec::new();
+
+    if rel.ends_with(".rs") {
+        let mut lex_state = RustCodeLexState::default();
+        for (line_no, line) in contents.lines().enumerate() {
+            let code = rust_code_only_line(line, &mut lex_state);
+            if let Some(marker) = markers
+                .iter()
+                .find(|marker| rust_code_contains_marker(&code, marker))
+            {
+                violations.push(format!(
+                    "{}:{}: {} (`{}`): {}",
+                    rel,
+                    line_no + 1,
+                    reason,
+                    marker,
+                    line.trim()
+                ));
+            }
+        }
+        return violations;
+    }
+
+    for (line_no, line) in contents.lines().enumerate() {
+        let code = toml_code_only_line(line);
+        if let Some(marker) = markers.iter().find(|marker| code.contains(**marker)) {
+            violations.push(format!(
+                "{}:{}: {} (`{}`): {}",
+                rel,
+                line_no + 1,
+                reason,
+                marker,
+                line.trim()
+            ));
+        }
+    }
+
+    violations
+}
+
+fn rust_code_contains_marker(code: &str, marker: &str) -> bool {
+    if marker.starts_with('.') {
+        return contains_method_marker(code, marker);
+    }
+
+    if marker
+        .chars()
+        .any(|ch| !(ch == '_' || ch.is_ascii_alphanumeric()))
+    {
+        return code.contains(marker);
+    }
+
+    contains_rust_identifier_token(code, marker)
+}
+
+fn contains_method_marker(code: &str, marker: &str) -> bool {
+    let mut offset = 0usize;
+    while let Some(relative) = code[offset..].find(marker) {
+        let start = offset + relative;
+        let end = start + marker.len();
+        let after = code[end..].chars().next();
+        if after.is_none_or(|ch| !is_rust_identifier_continue(ch)) {
+            return true;
+        }
+
+        offset = end;
+    }
+
+    false
+}
+
+fn contains_rust_identifier_token(code: &str, token: &str) -> bool {
+    let mut offset = 0usize;
+    while let Some(relative) = code[offset..].find(token) {
+        let start = offset + relative;
+        let end = start + token.len();
+        let before = code[..start].chars().next_back();
+        let after = code[end..].chars().next();
+
+        let before_is_boundary = before.is_none_or(|ch| !is_rust_identifier_continue(ch));
+        let after_is_boundary = after.is_none_or(|ch| !is_rust_identifier_continue(ch));
+        if before_is_boundary && after_is_boundary {
+            return true;
+        }
+
+        offset = end;
+    }
+
+    false
 }
 
 const VECTOR_STORAGE_KEY_LAYOUT_MARKERS: &[&str] = &[
@@ -1759,6 +1991,85 @@ fn product_runtime() {
     let references = find_direct_storage_references("crates/example/src/lib.rs", contents);
     assert_eq!(references.len(), 1, "{references:?}");
     assert!(references[0].1.contains("strata_storage::TypeTag"));
+}
+
+#[test]
+fn forbidden_marker_guard_detects_rust_code_markers() {
+    let contents = r#"
+use strata_storage::Key;
+use strata_engine::database::OpenSpec;
+
+fn product_runtime() {
+    let _ = OpenSpec::cache().with_subsystem(SearchSubsystem);
+    let _ = runtime.with_subsystem(SearchSubsystem);
+}
+"#;
+
+    let violations = find_forbidden_marker_violations(
+        "crates/example/src/lib.rs",
+        contents,
+        &["strata_storage", "OpenSpec", ".with_subsystem"],
+        "test marker",
+    );
+    assert_eq!(violations.len(), 4, "{violations:?}");
+}
+
+#[test]
+fn forbidden_marker_guard_ignores_rust_literals_comments_and_substrings() {
+    let contents = r###"
+const TEXT: &str = "OpenSpec";
+const RAW: &str = r#"strata_storage"#;
+
+// use strata_storage::Key;
+/* OpenSpec::cache().with_subsystem(SearchSubsystem); */
+
+fn product_runtime() {
+    let _ = OpenSpeculativeRuntime;
+    let _ = runtime.with_subsystematic();
+}
+"###;
+
+    let violations = find_forbidden_marker_violations(
+        "crates/example/src/lib.rs",
+        contents,
+        &["strata_storage", "OpenSpec", ".with_subsystem"],
+        "test marker",
+    );
+    assert!(violations.is_empty(), "{violations:?}");
+}
+
+#[test]
+fn forbidden_marker_guard_detects_toml_dependency_markers() {
+    let contents = r#"
+[dependencies]
+strata-storage = { path = "../storage" }
+inference = { package = "strata-inference", path = "../inference" }
+"#;
+
+    let violations = find_forbidden_marker_violations(
+        "crates/example/Cargo.toml",
+        contents,
+        &["strata-storage", "strata-inference"],
+        "test marker",
+    );
+    assert_eq!(violations.len(), 2, "{violations:?}");
+}
+
+#[test]
+fn forbidden_marker_guard_ignores_toml_comments() {
+    let contents = r#"
+[dependencies]
+# strata-storage = { path = "../storage" }
+strata-engine = { path = "../engine" }
+"#;
+
+    let violations = find_forbidden_marker_violations(
+        "crates/example/Cargo.toml",
+        contents,
+        &["strata-storage"],
+        "test marker",
+    );
+    assert!(violations.is_empty(), "{violations:?}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Makes intelligence's `strata-inference` edge intentionally optional via `default-features = false` + explicit `embed` feature forwarding, removing a previously-implicit `local` feature pull.
- Replaces test-only subsystem assembly (`OpenSpec::*.with_subsystem(GraphSubsystem)`/`VectorSubsystem`/`SearchSubsystem`) in intelligence with engine-owned `open_product_database` / `open_product_cache` helpers — preserves disk-backed branch fork coverage and auto-embed buffer tests.
- Adds two enforceable guards in `tests/storage_surface_imports.rs`: intelligence cannot regain storage or retired peer-crate edges or assemble subsystems; engine cannot import intelligence/inference and executor/CLI/root cannot import inference directly.

## Manifest changes

- `crates/intelligence/Cargo.toml`:
  - `strata-inference = { ..., optional = true, default-features = false }`
  - `embed = ["dep:strata-inference", "strata-inference/local", "strata-inference/download"]`
  - Cloud features (`anthropic`/`openai`/`google`) continue to forward through `embed` + the corresponding `strata-inference/*` feature.

## Subsystem assembly cleanup

- `crates/intelligence/tests/expand_cache_fork_test.rs` opens its disk-backed runtime through `open_product_database(dir.path(), OpenOptions::default())`. Branch fork inheritance via `BranchService` is preserved.
- `crates/intelligence/src/embed/runtime.rs::test_db()` opens via `open_product_cache()`. `set_auto_embed(true)` retained; the three buffer/cleanup tests still exercise the embed pipeline.
- `expand.rs`, `expand_cache.rs`, `rag/mod.rs` doc-comment cleanup replaces stale ""substrate""/""storage layer COW"" language with engine-owned search retrieval and engine branch/version semantics.

## Guards

- `engine_consolidation_intelligence_boundary_is_engine_consuming` — rejects:
  - intelligence importing storage or retired graph/vector/search/security/executor-legacy crates (source, tests, manifest)
  - intelligence source/tests naming `OpenSpec`, `GraphSubsystem`, `VectorSubsystem`, `SearchSubsystem`, `.with_subsystem`, or `.with_subsystems`
- `engine_consolidation_inference_boundary_stays_above_intelligence` — rejects:
  - engine importing `strata-intelligence` / `strata-inference`
  - executor/CLI/root manifests or source importing `strata-inference` / `strata_inference`
- Both built on a new lex-aware `find_forbidden_marker_violations` helper. Identifier markers (e.g. `OpenSpec`) require Rust word boundaries to avoid false positives like `OpenSpeculativeRuntime` or `OpenOptions`. Method markers (`.with_subsystem`/`.with_subsystems`) require non-identifier-continue character after, so `.with_subsystematic` doesn't match. Four self-tests cover positive detection, literal/comment/substring exclusion, TOML detection, and TOML comment handling.

## Test plan

- [x] `cargo test -p stratadb --test storage_surface_imports` (29 passed)
- [x] `cargo tree -p strata-intelligence --edges normal --depth 1` — `serde, serde_json, sha2, strata-core, strata-engine, tracing` only
- [x] `cargo tree -p strata-intelligence --features embed --edges normal --depth 1` — adds `strata-inference` as the only new direct edge
- [x] `cargo test -p strata-intelligence` (default features)
- [x] `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p strata-intelligence --features embed --tests`
- [x] `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p strata-intelligence --features anthropic|openai|google`
- [x] `cargo check -p strata-executor`
- [x] `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p strata-cli --features embed`
- [ ] Real `cargo test -p strata-intelligence --features embed` requires a populated `crates/inference/vendor/llama.cpp` tree; not exercised in this workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)