### PR TITLE
EG9: close out engine consolidation

### DIFF
--- a/docs/engine/eg9-implementation-plan.md
+++ b/docs/engine/eg9-implementation-plan.md
@@ -1,0 +1,722 @@
+# EG9 Implementation Plan
+
+## Purpose
+
+`EG9` closes the engine consolidation project.
+
+`EG2` through `EG8` already moved security/open options, product open behavior,
+graph, vector, search, executor storage access, and intelligence boundary
+cleanup into the intended shape. `EG9` should not be another migration phase.
+It is the final ratchet: prove the absorbed crates are gone, make the final
+dependency graph enforceable, refresh active architecture documents, and record
+the exact verification ledger before the next architecture effort begins.
+
+The target stack remains:
+
+```text
+core -> storage -> engine -> intelligence -> executor -> cli
+```
+
+The default normal graph should be:
+
+```text
+strata-storage      -> strata-core
+strata-engine       -> strata-core, strata-storage
+strata-intelligence -> strata-core, strata-engine
+strata-executor     -> strata-core, strata-engine, strata-intelligence
+strata-cli          -> strata-executor
+stratadb            -> strata-executor
+```
+
+With `embed` enabled, `strata-intelligence` may add the optional
+`strata-inference` edge, and `strata-cli` may reach intelligence as an optional
+command surface. No crate should import `strata-inference` directly except
+`strata-intelligence`.
+
+Read this with:
+
+- [engine-consolidation-plan.md](./engine-consolidation-plan.md)
+- [engine-crate-map.md](./engine-crate-map.md)
+- [eg7-implementation-plan.md](./eg7-implementation-plan.md)
+- [eg8-implementation-plan.md](./eg8-implementation-plan.md)
+- [../storage/v1-storage-consumption-contract.md](../storage/v1-storage-consumption-contract.md)
+
+## Scope
+
+`EG9` owns:
+
+- proving retired crates are absent from the filesystem, workspace metadata,
+  manifests, lockfile, and production source
+- tightening the final graph guards so production crates above engine cannot
+  regain storage or retired runtime-crate dependencies
+- documenting the optional `embed`/inference edges separately from the default
+  normal graph
+- refreshing active engine/storage architecture documents so they describe the
+  consolidated state rather than the migration state
+- recording the final verification ledger and any known, explicitly accepted
+  residual risks
+
+`EG9` does not own:
+
+- engine-next modular redesign
+- storage-next design or implementation
+- changing WAL, manifest, checkpoint, snapshot, search segment, or vector
+  sidecar formats
+- removing `strata-intelligence`
+- removing `strata-inference`
+- changing product behavior, command semantics, or model/provider behavior
+- removing archive documents that intentionally preserve migration history
+
+## Starting State
+
+The absorbed crates are already deleted:
+
+```text
+crates/security          missing
+crates/executor-legacy   missing
+crates/graph             missing
+crates/vector            missing
+crates/search            missing
+crates/core-legacy       missing
+crates/concurrency       missing
+crates/durability        missing
+```
+
+The current workspace members are:
+
+```text
+crates/core
+crates/storage
+crates/engine
+crates/inference
+crates/intelligence
+crates/cli
+crates/executor
+```
+
+The verified default normal graph is:
+
+```text
+strata-engine        -> strata-core, strata-storage
+strata-intelligence  -> strata-core, strata-engine
+strata-executor      -> strata-core, strata-engine, strata-intelligence
+strata-cli           -> strata-executor
+stratadb             -> strata-executor
+```
+
+With `--features embed`, `strata-intelligence` adds `strata-inference`.
+
+Existing guards already enforce much of the target:
+
+- retired security, executor-legacy, graph, vector, and search crate references
+  are guarded in `tests/storage_surface_imports.rs`
+- production direct storage bypasses above engine are guarded with an empty
+  allowlist
+- intelligence storage/retired-crate/subsystem-assembly regressions are guarded
+- engine imports of intelligence/inference are guarded
+- executor/CLI/root direct inference imports are guarded
+
+Known allowed exceptions:
+
+- `strata-engine` is the normal production consumer of `strata-storage`
+- storage tests, engine tests, and root storage-facing tests may inspect storage
+  directly where the test is intentionally about storage mechanics
+- `strata-cli` may depend on `strata-intelligence` only through the optional
+  `embed` command surface
+- archive documents may mention deleted crates as historical migration context
+
+## Load-Bearing Boundary Rules
+
+### 1. Retired Crates Stay Deleted
+
+These package names and directories must not return:
+
+- `strata-security` / `crates/security`
+- `strata-executor-legacy` / `crates/executor-legacy`
+- `strata-graph` / `crates/graph`
+- `strata-vector` / `crates/vector`
+- `strata-search` / `crates/search`
+- `strata-core-legacy` / `crates/core-legacy`
+- `strata-concurrency` / `crates/concurrency`
+- `strata-durability` / `crates/durability`
+
+If a future compatibility shell is proposed, it must be a new architecture
+decision, not an EG9 leftover.
+
+### 2. Storage Has One Production Consumer
+
+Normal production dependency on `strata-storage` is allowed only from
+`strata-engine`.
+
+Not allowed:
+
+- `strata-executor -> strata-storage`
+- `strata-intelligence -> strata-storage`
+- `strata-cli -> strata-storage`
+- `stratadb -> strata-storage`
+- resurrected graph/vector/search/security/bootstrap crates depending on
+  storage
+
+### 3. Engine Does Not Point Upward
+
+Engine must not depend on:
+
+- `strata-intelligence`
+- `strata-inference`
+- executor or CLI crates
+- model/provider HTTP clients through inference features
+
+Engine owns semantic runtime behavior. Intelligence owns model/inference
+adaptation above engine.
+
+### 4. Subsystem Assembly Is Not An Upper-Layer Pattern
+
+The low-level `OpenSpec`/`Subsystem` machinery may remain inside engine for
+engine tests and engine-local runtime construction, but upper product crates
+should use engine-owned product open helpers.
+
+Upper production crates and intelligence tests must not assemble:
+
+- `GraphSubsystem`
+- `VectorSubsystem`
+- `SearchSubsystem`
+- `OpenSpec::with_subsystem`
+- `OpenSpec::with_subsystems`
+
+### 5. Optional Inference Stays Behind Intelligence
+
+`strata-inference` remains optional and is reached through
+`strata-intelligence`.
+
+Allowed:
+
+- `strata-intelligence --features embed -> strata-inference`
+- executor feature forwarding to `strata-intelligence`
+- CLI optional `embed` feature that enables executor/intelligence model
+  commands
+
+Not allowed:
+
+- `strata-engine -> strata-inference`
+- `strata-executor -> strata-inference`
+- `strata-cli -> strata-inference`
+- root `stratadb -> strata-inference`
+
+## EG9A - Baseline Closeout Ledger
+
+**Goal:**
+
+Record the exact final state before changing guards or docs.
+
+**Work:**
+
+- run filesystem checks for deleted crate directories
+- run `cargo metadata --format-version 1 --no-deps` and confirm retired
+  packages are absent
+- run default and feature-enabled `cargo tree` checks for engine-adjacent crates
+- scan active manifests and `Cargo.lock` for retired package names
+- scan production source/manifests for direct storage imports above engine
+- scan active docs for "current" statements that contradict the final graph
+
+**Acceptance:**
+
+- deleted crate directories are absent
+- workspace metadata contains no retired package
+- `Cargo.lock` contains no retired package entry
+- default graph matches the target graph
+- `embed` graph adds inference only through intelligence
+- any residual production source, manifest, or lockfile match is either
+  archive/history text or a documented active exception
+- active-doc statements that contradict the final graph are recorded as `EG9D`
+  refresh items
+
+**Implementation ledger, 2026-05-08:**
+
+Deleted crate directory check passed. The following paths are absent:
+
+```text
+crates/security
+crates/executor-legacy
+crates/graph
+crates/vector
+crates/search
+crates/core-legacy
+crates/concurrency
+crates/durability
+```
+
+Workspace metadata check passed. `cargo metadata --format-version 1 --no-deps`
+contains no package named:
+
+```text
+strata-security
+strata-executor-legacy
+strata-graph
+strata-vector
+strata-search
+strata-core-legacy
+strata-concurrency
+strata-durability
+```
+
+Active manifest and lockfile checks passed. `Cargo.lock`, the root manifest,
+and active crate manifests contain no retired package entry or dependency edge.
+The active production source scan has one benign historical comment:
+
+```text
+crates/engine/src/error.rs
+```
+
+That comment explicitly says engine does not depend on the retired
+`strata-durability` package; it is not a live import or manifest edge.
+
+The default normal graph matches the target:
+
+```text
+strata-storage      -> strata-core
+strata-engine       -> strata-core, strata-storage
+strata-intelligence -> strata-core, strata-engine
+strata-executor     -> strata-core, strata-engine, strata-intelligence
+strata-cli          -> strata-executor
+stratadb            -> strata-executor
+```
+
+The inverse storage graph at normal depth 1 is:
+
+```text
+strata-storage -> strata-engine
+```
+
+The `embed` graph adds inference only through intelligence:
+
+```text
+strata-intelligence --features embed -> strata-inference
+strata-executor --features embed     -> strata-intelligence -> strata-inference
+strata-cli --features embed          -> strata-executor, strata-intelligence
+```
+
+The direct production storage-bypass scan over `src`, `crates/executor/src`,
+`crates/intelligence/src`, `crates/cli/src`, and the upper-crate manifests found
+no production storage imports above engine. The only storage matches in the
+root manifest are expected:
+
+- `crates/storage` as a workspace member
+- root `strata-storage` as a dev-dependency for storage-facing integration tests
+
+Active document scan findings for `EG9D`:
+
+- [../storage/v1-storage-consumption-contract.md](../storage/v1-storage-consumption-contract.md)
+  still has current-tense transitional notes about executor importing storage
+  directly and documented temporary migration shims.
+- [../storage/storage-crate-map.md](../storage/storage-crate-map.md) still says
+  the incoming storage graph includes `strata-executor` as a current
+  transitional storage dependent.
+- [engine-consolidation-plan.md](./engine-consolidation-plan.md) still has
+  active Direct Storage Rule wording that permits temporary migration shims
+  named in the plan and deleted by closeout. `EG9` is closeout, so that
+  permission must be removed or rewritten.
+- [engine-consolidation-plan.md](./engine-consolidation-plan.md) still has
+  lower-section migration/risk prose that says executor currently constructs
+  storage keys or calls primitive stores directly.
+
+Those are documentation-refresh items, not code or graph regressions. Historical
+phase plans such as `eg1` through `eg8` and storage `ST*` plans intentionally
+mention retired crates as migration history.
+
+## EG9B - Final Graph And Retired-Crate Guards
+
+**Goal:**
+
+Make the final graph fail closed.
+
+**Work:**
+
+- tighten `tests/storage_surface_imports.rs` so the final guards cover:
+  - retired crate directories and package names
+  - retired package names in active manifests and `Cargo.lock`
+  - no production direct storage imports above engine
+  - no engine imports of intelligence or inference
+  - no direct inference imports outside intelligence
+  - no upper-layer subsystem assembly
+- remove any stale transitional allowlist entry; the production storage bypass
+  allowlist should remain empty
+- keep root dev-dependency and storage-facing test exceptions explicit rather
+  than broadening production scan exclusions
+- add self-tests for any new scanner logic
+
+**Acceptance:**
+
+- guard tests fail if any retired crate directory or package name returns
+- guard tests fail if executor, intelligence, CLI, or root product code imports
+  storage
+- guard tests fail if engine points to intelligence/inference
+- guard tests fail if inference is imported directly outside intelligence
+- guard tests fail if upper layers instantiate product runtime subsystems
+- `cargo test -p stratadb --test storage_surface_imports` passes
+
+**Implementation, 2026-05-08:**
+
+- added a unified retired-crate closeout guard for deleted directories, active
+  source, active manifests, and `Cargo.lock`
+- extended retired package checks to cover `strata-security`,
+  `strata-core-legacy`, `strata-concurrency`, and `strata-durability` in the
+  same final scanner as graph/vector/search/executor-legacy
+- kept the production storage-bypass allowlist empty and retained the explicit
+  root dev-dependency exception for storage-facing tests
+- added a generic upper-layer runtime assembly guard for `OpenSpec`,
+  `with_subsystem`, `with_subsystems`, `dyn Subsystem`, and engine-owned
+  graph/vector/search subsystem names
+- added scanner self-tests for manifest/lockfile/source retired-crate markers,
+  comment/literal/substring handling, whitespace-separated method calls,
+  qualified or aliased `Subsystem` trait references, and feature-enabled
+  `cfg(any(test, feature = "..."))` modules
+- verified `cargo test -p stratadb --test storage_surface_imports`: 40 passed
+
+## EG9C - Optional Edge Policy And Feature Surface
+
+**Goal:**
+
+Document and enforce the remaining optional edges so future readers do not
+mistake them for storage/engine consolidation leaks.
+
+**Work:**
+
+- confirm default `strata-cli` has no normal `strata-intelligence` edge
+- confirm `strata-cli --features embed` only reaches intelligence through the
+  documented optional command surface
+- confirm executor still has the intended intelligence edge for product
+  command handling and inference-facing facades
+- confirm no executor/CLI/root direct `strata-inference` edge exists
+- document the accepted CLI optional `embed` exception in the crate map and main
+  plan if not already clear
+
+**Acceptance:**
+
+- default `cargo tree -p strata-cli --edges normal --depth 1` shows only
+  `strata-executor` as a Strata dependency
+- `cargo tree -p strata-cli --features embed --edges normal --depth 3` and
+  `cargo tree -p strata-cli --features embed --edges normal -i strata-inference`
+  show inference only through intelligence
+- direct inference import guard remains green
+- active docs describe default and feature-enabled graphs separately
+
+**Implementation, 2026-05-08:**
+
+- added `engine_consolidation_optional_embed_edges_are_policy_bound` to
+  `tests/storage_surface_imports.rs`
+- root `embed`/provider features are guarded so they forward only through
+  `strata-executor`, and the root package may not add a normal
+  `strata-intelligence` dependency
+- CLI's default feature set is guarded as empty; its direct
+  `strata-intelligence` dependency must stay `optional = true`, must enable
+  intelligence's `embed` feature, and must be reached only through CLI's
+  `embed` feature
+- executor's normal `strata-intelligence` dependency is guarded as
+  non-optional, while executor `embed`/provider features may forward only to
+  `strata-intelligence` and the engine marker `embed` feature
+- intelligence remains the only crate whose feature table may reference
+  `strata-inference`; its inference dependency must stay optional with
+  `default-features = false`
+- verified default CLI graph:
+  `cargo tree -p strata-cli --edges normal --depth 1`
+- verified feature-enabled inference path:
+  `cargo tree -p strata-cli --features embed --edges normal -i strata-inference`
+  reports inference only under `strata-intelligence`
+- verified `cargo test -p stratadb --test storage_surface_imports`: 44 passed
+
+## EG9D - Active Architecture Document Refresh
+
+**Goal:**
+
+Leave active docs in the consolidated state and archive migration details.
+
+**Work:**
+
+- update [engine-consolidation-plan.md](./engine-consolidation-plan.md) so
+  `EG9` is the closeout phase, not a future migration bucket
+- update [engine-crate-map.md](./engine-crate-map.md) with the final verified
+  graph and a short closeout ledger
+- review [../storage/v1-storage-consumption-contract.md](../storage/v1-storage-consumption-contract.md)
+  for stale "temporary migration shim" wording and clarify that normal
+  production consumption is engine-only after EG9
+- remove closeout-incompatible temporary migration shim permission from active
+  engine/storage docs
+- leave `docs/engine/archive/` as history, but avoid active docs saying deleted
+  crates are still current
+- add a short handoff note for the next architecture effort: engine-next and
+  storage-next are new design phases, not continuation of EG cleanup
+
+**Acceptance:**
+
+- active docs agree on the default graph and optional embed graph
+- active docs agree that retired peer crates are deleted
+- active docs agree that storage consumption above engine is forbidden
+- archive docs remain historical and do not drive current guard policy
+
+**Implementation, 2026-05-08:**
+
+- refreshed [engine-crate-map.md](./engine-crate-map.md) so it describes the
+  post-`EG9` graph, optional-edge policy, retired compatibility-shell state, and
+  v1 architecture handoff
+- refreshed [../storage/storage-crate-map.md](../storage/storage-crate-map.md)
+  so `strata-engine` is the only normal production storage consumer and the
+  root storage dependency is explicitly test/dev-only
+- refreshed [../storage/v1-storage-consumption-contract.md](../storage/v1-storage-consumption-contract.md)
+  so engine-consolidation migration shims are no longer allowed consumers,
+  executor is no longer described as a direct storage importer, and the closeout
+  notes match the completed graph/vector/search/executor cleanup
+- refreshed [../storage/storage-engine-ownership-audit.md](../storage/storage-engine-ownership-audit.md)
+  so accepted residue no longer claims upper crates have transitional direct
+  storage dependencies
+- updated [engine-consolidation-plan.md](./engine-consolidation-plan.md) to
+  mark `EG9D` complete, replace stale follow-up plan names with the actual
+  phase-plan files, and state that future storage-next/engine-next work is a v1
+  design phase rather than continuation of `EG`
+
+## EG9E - Final Verification And Closeout
+
+**Goal:**
+
+Run the final matrix and record what passed.
+
+**Required commands:**
+
+```bash
+cargo fmt --check
+cargo check --workspace --all-targets
+cargo test -p stratadb --test storage_surface_imports
+cargo test -p strata-engine
+cargo test -p strata-executor
+cargo test -p strata-intelligence
+STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p strata-intelligence --features embed --tests
+STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p strata-executor --features embed --tests
+STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p strata-cli --features embed --tests
+```
+
+**Graph checks:**
+
+```bash
+cargo tree -p strata-engine --edges normal --depth 1
+cargo tree -p strata-intelligence --edges normal --depth 1
+cargo tree -p strata-intelligence --features embed --edges normal --depth 1
+cargo tree -p strata-executor --edges normal --depth 1
+cargo tree -p strata-cli --edges normal --depth 1
+cargo tree -p strata-cli --features embed --edges normal --depth 3
+cargo tree -p strata-cli --features embed --edges normal -i strata-inference
+cargo tree -p stratadb --edges normal --depth 1
+cargo tree -i strata-storage --workspace --edges normal --depth 1
+```
+
+**Retired-crate checks:**
+
+```bash
+for d in \
+  crates/security \
+  crates/executor-legacy \
+  crates/graph \
+  crates/vector \
+  crates/search \
+  crates/core-legacy \
+  crates/concurrency \
+  crates/durability
+do
+  if test -e "$d"; then
+    echo "retired crate directory still exists: $d" >&2
+    exit 1
+  fi
+done
+
+metadata="$(cargo metadata --format-version 1 --no-deps)" || exit $?
+rg_status=0
+printf '%s\n' "$metadata" \
+  | rg '"name":"strata-(security|executor-legacy|graph|vector|search|core-legacy|concurrency|durability)"|crates/(security|executor-legacy|graph|vector|search|core-legacy|concurrency|durability)' \
+  || rg_status=$?
+case "$rg_status" in
+  0) echo "retired crate metadata entry found" >&2; exit 1 ;;
+  1) ;;
+  *) exit "$rg_status" ;;
+esac
+
+tracked_manifests="$(git ls-files \
+    Cargo.lock \
+    Cargo.toml \
+    'crates/**/Cargo.toml' \
+    'benchmarks/**/Cargo.toml' \
+    'benchmarks/**/Cargo.lock')" || exit $?
+if test -n "$tracked_manifests"; then
+  rg_status=0
+  printf '%s\n' "$tracked_manifests" \
+    | xargs rg -n 'name = "strata-(security|executor-legacy|graph|vector|search|core-legacy|concurrency|durability)"|strata-(security|executor-legacy|graph|vector|search|core-legacy|concurrency|durability)' \
+    || rg_status=$?
+  case "$rg_status" in
+    0) echo "retired crate manifest or lockfile reference found" >&2; exit 1 ;;
+    1) ;;
+    *) exit "$rg_status" ;;
+  esac
+fi
+
+rg_status=0
+rg -n 'strata_(security|executor_legacy|graph|vector|search)' \
+  src crates/{executor,intelligence,cli} \
+  -g '*.rs' \
+  || rg_status=$?
+case "$rg_status" in
+  0) echo "retired crate Rust import found" >&2; exit 1 ;;
+  1) ;;
+  *) exit "$rg_status" ;;
+esac
+```
+
+**Boundary checks:**
+
+```bash
+rg_status=0
+rg -n "strata_storage::|use strata_storage|strata-storage|strata_storage" \
+  src crates/{executor,intelligence,cli} \
+  -g 'Cargo.toml' -g '*.rs' \
+  || rg_status=$?
+case "$rg_status" in
+  0) echo "direct storage import above engine found" >&2; exit 1 ;;
+  1) ;;
+  *) exit "$rg_status" ;;
+esac
+
+rg_status=0
+rg -n "strata_intelligence|strata-inference|strata_inference" \
+  crates/engine \
+  -g 'Cargo.toml' -g '*.rs' \
+  || rg_status=$?
+case "$rg_status" in
+  0) echo "engine upward dependency marker found" >&2; exit 1 ;;
+  1) ;;
+  *) exit "$rg_status" ;;
+esac
+
+rg_status=0
+rg -n "strata_inference|strata-inference" \
+  Cargo.toml src crates/executor crates/cli \
+  -g 'Cargo.toml' -g '*.rs' \
+  || rg_status=$?
+case "$rg_status" in
+  0) echo "direct inference dependency outside intelligence found" >&2; exit 1 ;;
+  1) ;;
+  *) exit "$rg_status" ;;
+esac
+
+rg_status=0
+rg -n "OpenSpec|GraphSubsystem|VectorSubsystem|SearchSubsystem|with_subsystem|with_subsystems" \
+  crates/intelligence \
+  -g '*.rs' \
+  || rg_status=$?
+case "$rg_status" in
+  0) echo "intelligence runtime subsystem assembly found" >&2; exit 1 ;;
+  1) ;;
+  *) exit "$rg_status" ;;
+esac
+```
+
+The no-match commands above accept only `rg` exit code `1` as success. Guard-test
+source, archive documents, and ignored local generated lockfiles may mention
+retired package names as test fixtures, history, or stale cache state; they are
+intentionally outside these closeout source/import checks.
+
+**Feature-enabled test note:**
+
+Real `cargo test -p strata-intelligence --features embed` may require a
+populated local inference vendor/native build and model assets. If it cannot be
+run in the current workspace, record the exact missing prerequisite and rely on
+the feature-enabled `cargo check` gates above for this closeout.
+
+**Acceptance:**
+
+- all required compile/test gates pass, or any pre-existing unrelated failure
+  is named with the exact failing test and reason
+- the final graph is recorded in active docs
+- no temporary compatibility shell survives without being explicitly named
+- EG cleanup is closed, and the next work item is a new architecture design
+  phase rather than more consolidation cleanup
+
+**Implementation, 2026-05-08:**
+
+Compile and test gates:
+
+- `cargo fmt --check`: passed
+- `cargo check --workspace --all-targets`: failed before Rust checking because
+  the `strata-inference` build script attempted to configure the local
+  `llama.cpp` native source and
+  `crates/inference/vendor/llama.cpp/CMakeLists.txt` is absent in this
+  checkout
+- `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check --workspace --all-targets`:
+  passed
+- `cargo test -p stratadb --test storage_surface_imports`: passed, 44 tests
+- `cargo test -p strata-engine`: failed with 2553 passed, 10 failed, 8 ignored
+- `cargo test -p strata-executor`: passed, 116 tests
+- `cargo test -p strata-intelligence`: passed; default-feature intelligence
+  test targets currently contain no enabled tests
+- `cargo test -p strata-intelligence --features embed`: not run because the
+  feature-enabled test path requires the same missing local
+  `crates/inference/vendor/llama.cpp/CMakeLists.txt` native-source prerequisite
+  as the raw workspace check, plus any test-specific model assets
+- `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p strata-intelligence --features embed --tests`:
+  passed
+- `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p strata-executor --features embed --tests`:
+  passed
+- `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p strata-cli --features embed --tests`:
+  passed
+
+The `strata-engine` failures were:
+
+- `database::branch_mutation::tests::test_rollback_delete_true_surfaces_storage_cleanup_failure`
+- `database::tests::shutdown::shutdown_timeout_halt_interleaving_preserves_invariant`
+- `database::tests::shutdown::shutdown_timeout_preserves_writer_halt_signal`
+- `database::tests::shutdown::test_background_sync_failure_halts_writer_and_rejects_manual_commit`
+- `database::tests::shutdown::test_begin_sync_failure_halts_writer_and_rejects_manual_commit`
+- `database::tests::shutdown::test_commit_sync_failure_halts_writer_and_rejects_manual_commit`
+- `database::tests::shutdown::test_resume_waits_for_inflight_halt_publication_before_restoring_accepting`
+- `database::tests::shutdown::test_resume_while_still_failing_increments_failed_sync_count`
+- `database::tests::shutdown::test_set_durability_mode_spawn_failure_rolls_back_state`
+- `primitives::branch::index::tests::test_complete_delete_post_commit_classifies_default_marker_clear_failure`
+
+Those failures are outside the EG9 closeout graph/storage-boundary guards. They
+remain named here so a reviewer can distinguish closeout verification from the
+separate engine shutdown/fault-injection and branch cleanup/classification
+queue.
+
+Graph checks passed:
+
+- default `strata-engine` normal graph depends on `strata-core` and
+  `strata-storage`, with no upper-layer Strata crates
+- default `strata-intelligence` normal graph depends on `strata-core` and
+  `strata-engine`, with no `strata-storage`
+- `strata-intelligence --features embed` adds `strata-inference`
+- default `strata-executor` depends on `strata-core`, `strata-engine`, and
+  `strata-intelligence`, with no storage or retired peer crate edge
+- default `strata-cli` depends on `strata-executor` only among Strata crates
+- `strata-cli --features embed` reaches inference through intelligence
+- default `stratadb` depends on `strata-executor` only among Strata crates
+- inverse storage graph at depth 1 is `strata-storage -> strata-engine`
+
+Retired-crate and boundary checks passed:
+
+- deleted crate directories remain absent
+- tracked active manifests and lockfiles contain no retired crate package names
+  or paths
+- active upper-layer Rust source contains no retired crate imports
+- executor, intelligence, CLI, and root production code have no direct storage
+  imports
+- engine has no intelligence/inference import or manifest edge
+- executor, CLI, and root product code have no direct inference import or
+  manifest edge
+- intelligence does not assemble engine product runtime subsystems
+
+An ignored local `benchmarks/Cargo.lock` in this checkout initially contained
+stale `strata-search` entries. `cargo generate-lockfile` was run in
+`benchmarks/` to refresh that ignored file locally. That is local non-committed
+hygiene only: the committed closeout check uses `git ls-files` so ignored local
+lockfile cache state cannot create a false active-manifest failure. When working
+inside `benchmarks/`, regenerate that ignored lockfile before running benchmark
+crate commands if stale dependency output appears.
+
+No temporary engine-consolidation compatibility shell survives closeout. The
+remaining work is a new v1 architecture design phase, not another `EG` cleanup
+phase.

--- a/docs/engine/engine-consolidation-plan.md
+++ b/docs/engine/engine-consolidation-plan.md
@@ -103,7 +103,9 @@ edge:
 - storage-specific tests, benches, fuzz targets, and format/recovery tools
 - future `storage-next` migration or validation tools whose purpose is to test
   or build the storage substrate
-- temporary migration shims named in this plan and deleted by closeout
+
+No temporary engine-consolidation migration shim remains after `EG9`. Future
+exceptions belong in a new design document, not in this consolidation plan.
 
 Executor, intelligence, CLI, and product code are not storage
 tests. If they need a storage fact, engine must expose a semantic API or a
@@ -192,16 +194,16 @@ It should not mix large behavior redesigns into ownership moves.
 
 ### 5. Temporary Shims Must Have Deletion Criteria
 
-Short-lived compatibility modules are acceptable when they reduce risk, but they
-must state:
+During implementation, short-lived compatibility modules were acceptable when
+they reduced risk, but they had to state:
 
 - what old path they preserve
 - which downstream callers still need it
 - which `EG` slice deletes it
 - which guard fails if it becomes permanent by accident
 
-Do not introduce broad facades that hide storage access. That recreates the
-problem in a new location.
+No compatibility shell or broad facade is allowed to survive closeout unless a
+new active architecture document names it explicitly.
 
 ### 6. Engine Must Expose The Right Storage-Backed Endpoints
 
@@ -1232,16 +1234,37 @@ reintroduction.
 Record the final filesystem, workspace metadata, lockfile, dependency graph,
 and production import state before tightening the last guards.
 
+Current status: complete as of 2026-05-08. The closeout ledger is recorded in
+[eg9-implementation-plan.md](./eg9-implementation-plan.md) and confirms deleted
+crate directories are absent, retired packages are absent from metadata and
+lockfile state, the default graph matches the target, `embed` adds inference
+only through intelligence, and remaining active-doc inconsistencies are queued
+for `EG9D`.
+
 ### EG9B - Final Graph And Retired-Crate Guards
 
 Make the final graph fail closed. Retired crates must stay deleted, direct
 storage access above engine must fail, inference must stay behind
 intelligence, and upper layers must not assemble engine subsystems.
 
+Current status: complete as of 2026-05-08. `tests/storage_surface_imports.rs`
+now includes final closeout guards for retired crate directories, active
+manifest and lockfile package references, production direct storage bypasses,
+engine upward dependency markers, direct inference imports outside
+intelligence, and upper-layer product runtime assembly.
+
 ### EG9C - Optional Edge Policy And Feature Surface
 
 Document and enforce the remaining optional edges, especially CLI's optional
 `embed` edge to intelligence and intelligence's optional inference edge.
+
+Current status: complete as of 2026-05-08. The guard suite now enforces the
+feature-routing policy: root `embed`/provider features forward only through
+executor, the root package does not add intelligence as a normal dependency,
+CLI's direct intelligence dependency is optional and enabled only by CLI
+`embed`, executor reaches intelligence directly but forwards provider features
+through intelligence, and `strata-inference` remains referenced only by
+`strata-intelligence`.
 
 ### EG9D - Active Architecture Document Refresh
 
@@ -1249,10 +1272,27 @@ Update the engine crate map, storage consumption contract, and active
 architecture docs so they describe the consolidated graph rather than the
 migration.
 
+Current status: complete as of 2026-05-08. Active engine/storage architecture
+docs now describe the consolidated graph, the final storage-consumer rule, the
+retired peer-crate state, and the handoff to future v1 architecture documents.
+Temporary engine-consolidation migration shims are no longer listed as allowed
+storage consumers.
+
 ### EG9E - Final Verification And Closeout
 
 Run the full required test matrix, record known residual risks, and explicitly
-name any temporary compatibility shell that survives closeout.
+confirm that no temporary compatibility shell survives closeout.
+
+Current status: complete as of 2026-05-08. The final closeout ledger is recorded
+in [eg9-implementation-plan.md](./eg9-implementation-plan.md). The storage
+boundary, retired-crate, optional-edge, and product-runtime assembly guards
+passed; executor and intelligence package gates passed; feature-enabled
+`embed` check gates passed with the documented native inference build skip.
+The raw workspace check is blocked by the missing local
+`crates/inference/vendor/llama.cpp/CMakeLists.txt` prerequisite, and
+`cargo test -p strata-engine` still has 10 named shutdown/fault-injection and
+branch cleanup/classification failures outside the EG9 graph closeout. No
+temporary engine-consolidation compatibility shell survives.
 
 ## Guard Commands
 
@@ -1264,7 +1304,7 @@ Current graph inspection:
 cargo metadata --format-version 1 --no-deps \
   | jq -r '.packages[]
       | select((.name|test("^strata-(storage|engine|search|intelligence|executor|cli)$")) or .name=="stratadb")
-      | "\(.name) -> \([.dependencies[] | select(.kind == null and .path != null) | .name] | join(", "))"'
+      | "\(.name) -> \([.dependencies[] | select(.kind == null and .path != null and (.optional|not)) | .name] | join(", "))"'
 ```
 
 Current production direct storage bypass inventory:
@@ -1366,12 +1406,13 @@ Search orchestration belongs in engine, but model execution belongs in
 intelligence/inference. The move must preserve that direction. Engine should
 accept model-backed adapters; it should not depend on inference providers.
 
-### Executor Has Accumulated Primitive Runtime Knowledge
+### Executor Had Accumulated Primitive Runtime Knowledge
 
-Executor currently performs some operations by directly constructing storage
-keys or calling primitive stores. That is too much runtime knowledge for the
-command layer. Removing those paths may require new engine APIs, not just import
-renames.
+Before `EG7`, executor performed some operations by directly constructing
+storage keys or calling primitive stores. That was too much runtime knowledge
+for the command layer. `EG7` removed those direct storage paths by adding
+engine-owned APIs; future command-layer work should preserve that direction
+rather than reintroducing raw storage access.
 
 ### Compatibility Shells Can Hide In The Graph
 
@@ -1389,25 +1430,29 @@ before any major rebuild begins.
 
 ## Follow-Up Documents
 
-Each `EG` phase should have one implementation plan when implementation starts.
-The lettered sections for that phase live inside the phase plan. Likely phase
-plans:
+Each `EG` phase has one implementation plan. The lettered sections for that
+phase live inside the phase plan.
+
+Completed phase plans:
 
 - `eg1-implementation-plan.md`
 - `eg2-implementation-plan.md`
-- `eg3-product-open-bootstrap-plan.md`
-- `eg4-graph-absorption-plan.md`
-- `eg5-vector-absorption-plan.md`
-- `eg6-search-absorption-plan.md`
-- `eg7-executor-storage-bypass-removal-plan.md`
-- `eg8-intelligence-dependency-cleanup-plan.md`
-- `eg9-crate-deletion-workspace-closeout-plan.md`
+- `eg3-implementation-plan.md`
+- `eg4-implementation-plan.md`
+- `eg5-implementation-plan.md`
+- `eg6-implementation-plan.md`
+- `eg7-implementation-plan.md`
+- `eg8-implementation-plan.md`
+- `eg9-implementation-plan.md`
+
+Future v1 architecture documents should be written after consolidation
+closeout:
+
 - `strata-v1-target-architecture.md`
 - `storage-next-target-architecture.md`
 - `engine-next-target-architecture.md`
 - `strata-v1-testing-strategy.md`
 - `storage-engine-product-experience.md`
 
-The phase plans should keep the same storage-access rule: no crate above engine
-talks to storage directly unless the exception is explicit, narrow, and
-temporary.
+Those future plans should keep the same storage-access rule: no normal
+production crate above engine talks to storage directly.

--- a/docs/engine/engine-crate-map.md
+++ b/docs/engine/engine-crate-map.md
@@ -5,8 +5,7 @@
 This document maps `crates/engine` after the storage-boundary normalization.
 
 It describes the settled engine responsibilities at the storage boundary and
-the remaining higher-layer consolidation work that will happen above that
-boundary.
+the post-consolidation workspace graph.
 
 For the broader engine cleanup ledger, see
 [engine-pending-items.md](./archive/engine-pending-items.md).
@@ -23,7 +22,7 @@ orchestration layer. It is currently:
 
 - the database open/runtime/bootstrap layer
 - the branch-domain and primitive-semantics owner
-- the subsystem composition host
+- the internal runtime composition host
 - the search/runtime behavior host
 - the branch-bundle import/export host
 - the adapter layer that turns raw storage facts into engine policy and public
@@ -173,9 +172,9 @@ above engine.
 ### Current Normal Workspace Graph
 
 The verified default normal dependency graph for engine-adjacent crates is
-below. `EG8E` re-verified this graph on 2026-05-07 after closing the
-intelligence boundary and adding dependency-direction guards. The phase
-tracking plans include
+below. `EG9D` refreshed this active map on 2026-05-08 after closing the
+optional-edge policy and final storage-bypass guards. The phase tracking plans
+include
 [eg1-implementation-plan.md](./eg1-implementation-plan.md),
 [eg3-implementation-plan.md](./eg3-implementation-plan.md),
 [eg7-implementation-plan.md](./eg7-implementation-plan.md), and
@@ -194,12 +193,28 @@ With `embed` enabled, `strata-intelligence` adds the optional
 `strata-inference` edge and `strata-cli` reaches intelligence only through its
 optional embed feature.
 
+The feature-enabled policy is intentionally narrow:
+
+```text
+stratadb --features embed   -> strata-executor/embed
+strata-cli --features embed -> strata-executor/embed, strata-intelligence/embed
+strata-executor embed       -> strata-intelligence/embed, strata-engine/embed
+strata-intelligence embed   -> strata-inference/local, strata-inference/download
+```
+
+Provider features follow the same direction. Root and CLI provider features
+forward to executor; executor provider features forward to intelligence; only
+intelligence provider features reference `strata-inference`. CLI's direct
+`strata-intelligence` dependency is optional command-surface wiring, not part
+of the default normal graph.
+
 Security/open options are engine-owned after `EG2`, product open/bootstrap is
 engine-owned after `EG3`, graph is engine-owned after `EG4`, vector is
 engine-owned after `EG5`, search is engine-owned after `EG6`, and executor's
 direct storage bypass is closed after `EG7`. `EG8` keeps intelligence as an
 engine consumer and guards inference as an optional dependency behind
-intelligence.
+intelligence. `EG9` closes the retired-crate and optional-edge guard policy; no
+temporary engine-consolidation compatibility shell remains active.
 
 The current inverse normal storage graph is:
 
@@ -362,6 +377,10 @@ If you describe the crate honestly as it exists today, `strata-engine` is:
 
 The next cleanup should treat the storage boundary as settled but keep
 engine's internal domain/runtime boundaries explicit.
+
+The next architecture work is not another `EG` migration phase. It should be a
+v1 design pass for the target engine, storage, testing, and product experience
+before any engine-next or storage-next implementation begins.
 
 The important ownership question is not whether engine is too large. It is
 whether code in the crate is:

--- a/docs/storage/storage-crate-map.md
+++ b/docs/storage/storage-crate-map.md
@@ -5,8 +5,7 @@
 This document maps `crates/storage` after the storage consolidation and the
 storage-boundary normalization.
 
-It describes the settled lower-runtime substrate that engine and the current
-upper crates build on.
+It describes the settled lower-runtime substrate that engine builds on.
 
 For the target boundary of the clean storage layer, see
 [storage-charter.md](./storage-charter.md).
@@ -18,11 +17,11 @@ consume, see
 For the cross-boundary ownership question with engine, see
 [storage-engine-ownership-audit.md](./storage-engine-ownership-audit.md).
 
-The important takeaway is that `strata-storage` is the real lower runtime
-anchor of the system. Engine consolidation has absorbed security/open options,
-product open/bootstrap, graph, vector, and search. Storage should remain the
-generic persistence substrate while the remaining upper-layer cleanup removes
-executor's direct storage bypass.
+The important takeaway is that `strata-storage` is the lower runtime anchor of
+the system. Engine consolidation has absorbed security/open options, product
+open/bootstrap, graph, vector, and search, and removed executor's direct
+storage bypass. Storage remains the generic persistence substrate; normal
+production storage consumption above storage goes through `strata-engine`.
 
 ## High-Level Shape
 
@@ -111,16 +110,16 @@ That is the clean shape we wanted from the earlier storage boundary cleanup.
 
 ### Incoming Workspace Dependents
 
-The internal incoming graph today is:
+The internal normal production incoming graph today is:
 
 - `strata-engine`
-- `strata-executor`
 
-The root `stratadb` package also depends on storage in dev/test paths.
+The root `stratadb` package still depends on storage in dev/test paths for
+storage-facing integration tests. That is not a product/runtime storage
+consumer.
 
-This confirms that storage is already the effective substrate node of the
-workspace. The direct upper-crate storage edges are current transitional
-workspace shape, not permission for upper layers to drive database recovery,
+This confirms that storage is the effective substrate node of the workspace.
+No production crate above engine is allowed to drive database recovery,
 checkpoint, open, retention, or product policy below engine.
 
 `EG4` removed `strata-graph` as a separate storage consumer by moving the graph

--- a/docs/storage/storage-engine-ownership-audit.md
+++ b/docs/storage/storage-engine-ownership-audit.md
@@ -7,8 +7,10 @@ This document records the settled storage/engine boundary between
 
 The original audit existed because crate location was not reliable evidence of
 rightful ownership: lower-runtime checkpoint, recovery, snapshot, and config
-mechanics were still hosted in engine. The storage-boundary normalization corrected those targeted
-surfaces without flattening the architecture.
+mechanics were still hosted in engine. The storage-boundary normalization
+corrected those targeted surfaces without flattening the architecture. The
+later engine consolidation closed the remaining production direct-storage
+bypasses above engine.
 
 The current rule is:
 
@@ -31,9 +33,9 @@ This audit should be read together with:
 ## Current Verdict
 
 The targeted storage/engine ownership split is documented and guarded for the
-storage-boundary normalization surfaces. This closeout record does not replace
-the final broad regression gate in the main normalization plan; the full
-workstream is complete only after that gate is run and recorded.
+storage-boundary normalization surfaces. Engine consolidation has also made
+`strata-engine` the only normal production crate above storage that may depend
+on `strata-storage`.
 
 That does not mean engine has no storage calls. The intended architecture is a
 layered call direction:
@@ -244,20 +246,17 @@ The following residue is intentional after boundary closeout:
 - block-cache capacity is process-global storage runtime state. Sequential
   applications overwrite earlier values; concurrent database opens race and do
   not promise a deterministic winner.
-- upper crates still have some direct storage dependencies for current
-  transitional primitive/runtime crates. They must not bypass engine to drive
-  checkpoint, recovery, open, retention, or database policy. The next engine
-  consolidation phase is expected to absorb graph, vector, search,
-  executor-legacy, and security responsibilities into engine.
+- root dev-dependencies and storage-facing integration tests may still import
+  storage directly. Normal production crates above engine may not.
 
 ## Regression Guards
 
 Useful closeout checks:
 
 ```bash
-cargo tree -p strata-storage --depth 2
-cargo tree -p strata-engine --depth 1
-cargo tree -i strata-storage --workspace --depth 2
+cargo tree -p strata-storage --edges normal --depth 2
+cargo tree -p strata-engine --edges normal --depth 1
+cargo tree -i strata-storage --workspace --edges normal --depth 2
 rg -n 'use strata_engine|strata_engine::|strata-engine' crates/storage/src crates/storage/Cargo.toml
 rg -n 'JsonPath|JsonPatch|SearchSubsystem|Recipe|VectorConfig|DistanceMetric|ChainVerification|BranchLifecycle|RetentionReport|HealthReport|StrataConfig|StrataError|executor' crates/storage/src
 rg -n 'fn apply_storage_config|apply_storage_config' crates/engine/src

--- a/docs/storage/v1-storage-consumption-contract.md
+++ b/docs/storage/v1-storage-consumption-contract.md
@@ -7,9 +7,9 @@ allowed to consume.
 
 It is intentionally narrower than the full public Rust surface of
 `strata-storage`. The storage crate exposes many implementation types because
-the current crate is still mid-consolidation and because storage has its own
-tests. That does not mean upper layers should treat every exported type as a
-supported engine boundary.
+storage has internal modules, tests, diagnostics, and fault-injection surfaces.
+That does not mean upper layers should treat every exported type as a supported
+engine boundary.
 
 The target stack is:
 
@@ -22,8 +22,8 @@ storage that may depend on `strata-storage`. Graph, vector, search, security,
 legacy bootstrap, executor, intelligence, CLI, and product code must consume
 storage-backed behavior through engine-owned APIs.
 
-This contract is a V1 boundary. It should be tightened as engine consolidation
-and storage-next proceed.
+This contract is the post-consolidation V1 boundary. It should be tightened
+during the v1 architecture design and any future storage-next work.
 
 Read this with:
 
@@ -54,8 +54,8 @@ Allowed does not mean:
 
 Anything not named in this document is not part of the engine/storage
 consumption contract. It may still be public for storage tests, storage-local
-modules, or transitional compatibility, but engine code should not add new use
-without updating this document.
+modules, diagnostics, or fault-injection, but engine code should not add new
+use without updating this document.
 
 ## Direct Consumer Rule
 
@@ -67,7 +67,6 @@ Allowed exceptions:
 - storage tests, benches, fuzz targets, and diagnostic tools
 - engine tests that intentionally inspect storage behavior
 - future storage-next migration or verification tools
-- documented temporary migration shims during engine consolidation
 
 Not allowed:
 
@@ -77,6 +76,7 @@ Not allowed:
 - `stratadb`
 - consolidated graph/vector/search/product code after it has moved out of peer
   crates
+- temporary engine-consolidation migration shims after `EG9`
 
 Upper crates should not call `Database::storage()` or import
 `strata_storage::*`. If they need a storage-backed fact, engine should expose a
@@ -343,8 +343,8 @@ Allowed usage:
 Rules:
 
 - product code should not receive raw `TransactionManager`
-- raw `TransactionContext` exposure above engine should be treated as
-  transitional unless a public engine transaction API explicitly needs it
+- raw `TransactionContext` exposure above engine must be through an
+  engine-owned public API, not direct storage imports
 - engine primitive code should prefer transactional reads through
   `TransactionContext` when OCC tracking matters
 
@@ -954,24 +954,20 @@ contract revision names them:
 - raw format constants in production engine code except where the engine is
   decoding or validating storage-owned durability format in recovery or tests
 
-## Current Transitional Notes
+## Closeout Notes
 
-The current codebase still has storage exposure that should be tightened during
-engine consolidation:
+The engine-consolidation cleanup has closed the production storage bypasses
+above engine:
 
-- `Database::storage()` exposes `Arc<SegmentedStore>` and is still used by some
-  upper-layer migration code. After the executor storage bypass is removed,
-  this should be narrowed or documented as an engine-internal/testing escape
-  hatch. Graph moved into engine during `EG4`; vector moved into engine and the
-  peer crate was deleted during `EG5`; search moved into engine and the peer
-  crate was deleted during `EG6`.
+- `Database::storage()` still exposes `Arc<SegmentedStore>` from engine. That
+  is an engine/testing escape hatch, not permission for executor,
+  intelligence, CLI, or product code to import storage directly.
 - Engine currently re-exports a small number of storage types. Each re-export
   should either become an engine-owned type or remain documented as an explicit
   public engine contract.
-- Executor currently imports storage directly. Those imports are migration
-  debt, not an extension of this contract. Graph storage use moved into engine
-  during `EG4`; vector storage use moved into engine during `EG5`; search
-  storage use moved into engine during `EG6`.
+- Graph storage use moved into engine during `EG4`; vector storage use moved
+  into engine during `EG5`; search storage use moved into engine during `EG6`;
+  executor's direct storage dependency and imports were removed during `EG7`.
 - Engine tests may inspect storage format details. That is acceptable when the
   test is explicitly characterizing recovery, checkpoint, manifest, snapshot,
   WAL, or storage-runtime behavior.
@@ -1009,11 +1005,12 @@ This should return only test-module matches.
 Storage inverse dependency guard:
 
 ```bash
-cargo tree -i strata-storage --workspace --edges normal --depth 2
+cargo tree -i strata-storage --workspace --edges normal --depth 1
 ```
 
-At closeout, normal production dependents should be storage-specific tools/tests
-and `strata-engine`; product/runtime crates above engine should not appear.
+At closeout, the only direct normal production dependent should be
+`strata-engine`. A deeper inverse tree will show ordinary engine consumers
+under the engine branch; that is not a storage bypass.
 
 Manifest/runtime helper drift guard:
 

--- a/tests/storage_surface_imports.rs
+++ b/tests/storage_surface_imports.rs
@@ -74,6 +74,19 @@ struct AllowedEngineConsolidationStorageUse {
     removal_epic: &'static str,
 }
 
+#[derive(Debug)]
+struct ManifestDependencyEntry {
+    line_no: usize,
+    text: String,
+}
+
+#[derive(Debug)]
+struct ManifestFeatureEntry {
+    line_no: usize,
+    name: String,
+    values: Vec<String>,
+}
+
 const ENGINE_CONSOLIDATION_PRODUCTION_SCAN_ROOTS: &[&str] = &[
     "src",
     "crates/executor",
@@ -120,6 +133,56 @@ const RETIRED_SEARCH_PACKAGE: &str = concat!("strata", "-", "search");
 const RETIRED_SEARCH_IMPORT: &str = concat!("strata", "_", "search");
 const RETIRED_SEARCH_RELATIVE_PATHS: &[&str] =
     &[concat!("../", "search"), concat!("crates/", "search")];
+const RETIRED_CORE_LEGACY_PACKAGE: &str = concat!("strata", "-", "core", "-", "legacy");
+const RETIRED_CORE_LEGACY_IMPORT: &str = concat!("strata", "_", "core", "_", "legacy");
+const RETIRED_CONCURRENCY_PACKAGE: &str = concat!("strata", "-", "concurrency");
+const RETIRED_CONCURRENCY_IMPORT: &str = concat!("strata", "_", "concurrency");
+const RETIRED_DURABILITY_PACKAGE: &str = concat!("strata", "-", "durability");
+const RETIRED_DURABILITY_IMPORT: &str = concat!("strata", "_", "durability");
+const RETIRED_CRATE_DIRECTORIES: &[&str] = &[
+    concat!("crates/", "security"),
+    concat!("crates/", "executor", "-", "legacy"),
+    concat!("crates/", "graph"),
+    concat!("crates/", "vector"),
+    concat!("crates/", "search"),
+    concat!("crates/", "core", "-", "legacy"),
+    concat!("crates/", "concurrency"),
+    concat!("crates/", "durability"),
+];
+const RETIRED_CRATE_MARKERS: &[&str] = &[
+    RETIRED_SECURITY_PACKAGE,
+    RETIRED_SECURITY_IMPORT,
+    concat!("../", "security"),
+    concat!("crates/", "security"),
+    RETIRED_EXECUTOR_LEGACY_PACKAGE,
+    RETIRED_EXECUTOR_LEGACY_IMPORT,
+    concat!("../", "executor", "-", "legacy"),
+    concat!("crates/", "executor", "-", "legacy"),
+    RETIRED_GRAPH_PACKAGE,
+    RETIRED_GRAPH_IMPORT,
+    concat!("../", "graph"),
+    concat!("crates/", "graph"),
+    RETIRED_VECTOR_PACKAGE,
+    RETIRED_VECTOR_IMPORT,
+    concat!("../", "vector"),
+    concat!("crates/", "vector"),
+    RETIRED_SEARCH_PACKAGE,
+    RETIRED_SEARCH_IMPORT,
+    concat!("../", "search"),
+    concat!("crates/", "search"),
+    RETIRED_CORE_LEGACY_PACKAGE,
+    RETIRED_CORE_LEGACY_IMPORT,
+    concat!("../", "core", "-", "legacy"),
+    concat!("crates/", "core", "-", "legacy"),
+    RETIRED_CONCURRENCY_PACKAGE,
+    RETIRED_CONCURRENCY_IMPORT,
+    concat!("../", "concurrency"),
+    concat!("crates/", "concurrency"),
+    RETIRED_DURABILITY_PACKAGE,
+    RETIRED_DURABILITY_IMPORT,
+    concat!("../", "durability"),
+    concat!("crates/", "durability"),
+];
 
 const INTELLIGENCE_BOUNDARY_SCAN_ROOT: &str = "crates/intelligence";
 const INTELLIGENCE_FORBIDDEN_DEPENDENCY_MARKERS: &[&str] = &[
@@ -163,6 +226,22 @@ const ENGINE_FORBIDDEN_UPPER_LAYER_MARKERS: &[&str] = &[
     "strata_inference",
 ];
 const UPPER_FORBIDDEN_INFERENCE_MARKERS: &[&str] = &["strata-inference", "strata_inference"];
+const DIRECT_INFERENCE_FEATURE_MARKERS: &[&str] = &["strata-inference", "dep:strata-inference"];
+const UPPER_FORBIDDEN_RUNTIME_ASSEMBLY_MARKERS: &[&str] = &[
+    "OpenSpec",
+    "GraphSubsystem",
+    "VectorSubsystem",
+    "SearchSubsystem",
+    ".with_subsystem",
+    ".with_subsystems",
+];
+const UPPER_RUNTIME_ASSEMBLY_SCAN_ROOTS: &[&str] = &[
+    "src",
+    "crates/executor/src",
+    "crates/intelligence/src",
+    "crates/intelligence/tests",
+    "crates/cli/src",
+];
 
 #[test]
 fn storage_facing_types_are_not_imported_from_strata_core() {
@@ -453,6 +532,47 @@ fn engine_consolidation_search_crate_is_retired() {
 }
 
 #[test]
+fn engine_consolidation_retired_crates_are_closed_out() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut violations = Vec::new();
+
+    for retired_dir in RETIRED_CRATE_DIRECTORIES {
+        let path = repo_root.join(retired_dir);
+        if path.exists() {
+            violations.push(format!(
+                "{}: retired crate directory still exists",
+                path.display()
+            ));
+        }
+    }
+
+    let mut files = vec![repo_root.join("Cargo.toml"), repo_root.join("Cargo.lock")];
+    collect_rust_files(&repo_root.join("src"), &mut files);
+    collect_manifest_files(&repo_root.join("src"), &mut files);
+    collect_rust_files(&repo_root.join("benchmarks"), &mut files);
+    collect_manifest_files(&repo_root.join("benchmarks"), &mut files);
+    collect_rust_files(&repo_root.join("crates"), &mut files);
+    collect_manifest_files(&repo_root.join("crates"), &mut files);
+
+    for file in files {
+        if should_skip(&file) || should_skip_manifest(&file) {
+            continue;
+        }
+
+        let rel = repo_relative_path(&repo_root, &file);
+        let contents =
+            fs::read_to_string(&file).expect("read active source, manifest, or lockfile");
+        violations.extend(find_retired_crate_marker_violations(&rel, &contents));
+    }
+
+    assert!(
+        violations.is_empty(),
+        "retired engine/storage consolidation crates must stay absent from active directories, manifests, lockfile, and production source:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
 fn engine_consolidation_vector_consumers_use_engine_surface() {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let mut files = Vec::new();
@@ -526,6 +646,36 @@ fn engine_consolidation_executor_vector_transaction_surface_is_engine_owned() {
 }
 
 #[test]
+fn engine_consolidation_upper_layers_do_not_assemble_product_runtime() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut files = Vec::new();
+    for root in UPPER_RUNTIME_ASSEMBLY_SCAN_ROOTS {
+        collect_rust_files(&repo_root.join(root), &mut files);
+    }
+
+    let mut violations = Vec::new();
+    for file in files {
+        if should_skip(&file) {
+            continue;
+        }
+
+        let rel = repo_relative_path(&repo_root, &file);
+        if is_test_source_path(&rel) && !rel.starts_with("crates/intelligence/tests/") {
+            continue;
+        }
+
+        let contents = fs::read_to_string(&file).expect("read production source file");
+        violations.extend(find_upper_runtime_assembly_violations(&rel, &contents));
+    }
+
+    assert!(
+        violations.is_empty(),
+        "production crates above engine must use engine-owned product open helpers, not `OpenSpec`/`Subsystem` runtime assembly:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
 fn engine_consolidation_vector_storage_key_layout_is_engine_owned() {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let mut files = Vec::new();
@@ -558,8 +708,7 @@ fn engine_consolidation_vector_storage_key_layout_is_engine_owned() {
 #[test]
 fn storage_surface_manifests_do_not_regress_to_deleted_or_transitional_crates() {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let mut manifests = Vec::new();
-    manifests.push(repo_root.join("Cargo.toml"));
+    let mut manifests = vec![repo_root.join("Cargo.toml"), repo_root.join("Cargo.lock")];
     collect_manifest_files(&repo_root.join("benchmarks"), &mut manifests);
     collect_manifest_files(&repo_root.join("crates"), &mut manifests);
 
@@ -731,6 +880,213 @@ fn engine_consolidation_inference_boundary_stays_above_intelligence() {
     );
 }
 
+#[test]
+fn engine_consolidation_optional_embed_edges_are_policy_bound() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let root_manifest = read_repo_manifest(&repo_root, "Cargo.toml");
+    let cli_manifest = read_repo_manifest(&repo_root, "crates/cli/Cargo.toml");
+    let executor_manifest = read_repo_manifest(&repo_root, "crates/executor/Cargo.toml");
+    let intelligence_manifest = read_repo_manifest(&repo_root, "crates/intelligence/Cargo.toml");
+
+    let mut violations = Vec::new();
+
+    expect_feature_values(
+        "Cargo.toml",
+        &root_manifest,
+        "embed",
+        &["strata-executor/embed"],
+        &mut violations,
+    );
+    for (provider, expected) in [
+        ("anthropic", &["strata-executor/anthropic"][..]),
+        ("openai", &["strata-executor/openai"][..]),
+        ("google", &["strata-executor/google"][..]),
+    ] {
+        expect_feature_values(
+            "Cargo.toml",
+            &root_manifest,
+            provider,
+            expected,
+            &mut violations,
+        );
+    }
+    reject_feature_markers(
+        "Cargo.toml",
+        &root_manifest,
+        DIRECT_INFERENCE_FEATURE_MARKERS,
+        &mut violations,
+    );
+    reject_feature_markers(
+        "Cargo.toml",
+        &root_manifest,
+        &["strata-intelligence", "dep:strata-intelligence"],
+        &mut violations,
+    );
+    reject_normal_dependency(
+        "Cargo.toml",
+        &root_manifest,
+        "strata-intelligence",
+        "root package default graph must reach intelligence through executor only",
+        &mut violations,
+    );
+
+    expect_feature_values(
+        "crates/cli/Cargo.toml",
+        &cli_manifest,
+        "default",
+        &[],
+        &mut violations,
+    );
+    expect_feature_values(
+        "crates/cli/Cargo.toml",
+        &cli_manifest,
+        "embed",
+        &["strata-executor/embed", "dep:strata-intelligence"],
+        &mut violations,
+    );
+    for (provider, expected) in [
+        ("anthropic", &["embed", "strata-executor/anthropic"][..]),
+        ("openai", &["embed", "strata-executor/openai"][..]),
+        ("google", &["embed", "strata-executor/google"][..]),
+    ] {
+        expect_feature_values(
+            "crates/cli/Cargo.toml",
+            &cli_manifest,
+            provider,
+            expected,
+            &mut violations,
+        );
+    }
+    reject_feature_markers(
+        "crates/cli/Cargo.toml",
+        &cli_manifest,
+        DIRECT_INFERENCE_FEATURE_MARKERS,
+        &mut violations,
+    );
+    reject_feature_markers_outside_features(
+        "crates/cli/Cargo.toml",
+        &cli_manifest,
+        &["dep:strata-intelligence", "strata-intelligence"],
+        &["embed"],
+        &mut violations,
+    );
+    expect_dependency_line_contains(
+        "crates/cli/Cargo.toml",
+        &cli_manifest,
+        "strata-executor",
+        &["path = \"../executor\""],
+        &mut violations,
+    );
+    expect_dependency_line_contains(
+        "crates/cli/Cargo.toml",
+        &cli_manifest,
+        "strata-intelligence",
+        &[
+            "path = \"../intelligence\"",
+            "features = [\"embed\"]",
+            "optional = true",
+        ],
+        &mut violations,
+    );
+
+    expect_feature_values(
+        "crates/executor/Cargo.toml",
+        &executor_manifest,
+        "default",
+        &[],
+        &mut violations,
+    );
+    expect_feature_values(
+        "crates/executor/Cargo.toml",
+        &executor_manifest,
+        "embed",
+        &["strata-intelligence/embed", "strata-engine/embed"],
+        &mut violations,
+    );
+    for (provider, expected) in [
+        ("anthropic", &["embed", "strata-intelligence/anthropic"][..]),
+        ("openai", &["embed", "strata-intelligence/openai"][..]),
+        ("google", &["embed", "strata-intelligence/google"][..]),
+    ] {
+        expect_feature_values(
+            "crates/executor/Cargo.toml",
+            &executor_manifest,
+            provider,
+            expected,
+            &mut violations,
+        );
+    }
+    reject_feature_markers(
+        "crates/executor/Cargo.toml",
+        &executor_manifest,
+        DIRECT_INFERENCE_FEATURE_MARKERS,
+        &mut violations,
+    );
+    expect_dependency_line_contains(
+        "crates/executor/Cargo.toml",
+        &executor_manifest,
+        "strata-intelligence",
+        &["path = \"../intelligence\""],
+        &mut violations,
+    );
+    reject_dependency_line_markers(
+        "crates/executor/Cargo.toml",
+        &executor_manifest,
+        "strata-intelligence",
+        &["optional = true"],
+        &mut violations,
+    );
+
+    expect_feature_values(
+        "crates/intelligence/Cargo.toml",
+        &intelligence_manifest,
+        "default",
+        &[],
+        &mut violations,
+    );
+    expect_feature_values(
+        "crates/intelligence/Cargo.toml",
+        &intelligence_manifest,
+        "embed",
+        &[
+            "dep:strata-inference",
+            "strata-inference/local",
+            "strata-inference/download",
+        ],
+        &mut violations,
+    );
+    for (provider, expected) in [
+        ("anthropic", &["embed", "strata-inference/anthropic"][..]),
+        ("openai", &["embed", "strata-inference/openai"][..]),
+        ("google", &["embed", "strata-inference/google"][..]),
+    ] {
+        expect_feature_values(
+            "crates/intelligence/Cargo.toml",
+            &intelligence_manifest,
+            provider,
+            expected,
+            &mut violations,
+        );
+    }
+    expect_dependency_line_contains(
+        "crates/intelligence/Cargo.toml",
+        &intelligence_manifest,
+        "strata-inference",
+        &[
+            "path = \"../inference\"",
+            "optional = true",
+            "default-features = false",
+        ],
+        &mut violations,
+    );
+
+    assert!(
+        violations.is_empty(),
+        "optional embed/provider edges must keep inference behind intelligence and CLI's direct intelligence edge feature-gated:\n{}",
+        violations.join("\n")
+    );
+}
+
 fn collect_rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
     if !dir.exists() {
         return;
@@ -782,6 +1138,10 @@ fn repo_relative_path(repo_root: &Path, path: &Path) -> String {
         .expect("path should be under repository root")
         .to_string_lossy()
         .replace('\\', "/")
+}
+
+fn read_repo_manifest(repo_root: &Path, rel: &str) -> String {
+    fs::read_to_string(repo_root.join(rel)).expect("read cargo manifest")
 }
 
 fn contains_direct_storage_reference(line: &str) -> bool {
@@ -896,6 +1256,465 @@ fn parse_toml_section(trimmed: &str) -> Option<&str> {
 fn is_normal_dependency_section(section: &str) -> bool {
     section == "dependencies"
         || (section.starts_with("target.") && section.ends_with(".dependencies"))
+}
+
+fn normal_dependency_table_name(section: &str) -> Option<&str> {
+    if let Some(name) = section.strip_prefix("dependencies.") {
+        return Some(name);
+    }
+
+    if !section.starts_with("target.") {
+        return None;
+    }
+
+    let marker = ".dependencies.";
+    section
+        .find(marker)
+        .map(|index| &section[index + marker.len()..])
+}
+
+fn manifest_normal_dependency_entries(
+    contents: &str,
+    dependency: &str,
+) -> Vec<ManifestDependencyEntry> {
+    let lines = contents.lines().collect::<Vec<_>>();
+    let mut section = String::new();
+    let mut entries = Vec::new();
+    let mut index = 0usize;
+
+    while index < lines.len() {
+        let line = lines[index];
+        let code = toml_code_only_line(line);
+        let trimmed = code.trim();
+        if trimmed.is_empty() {
+            index += 1;
+            continue;
+        }
+
+        if let Some(next_section) = parse_toml_section(trimmed) {
+            if let Some(table_name) = normal_dependency_table_name(next_section) {
+                let start_line = index + 1;
+                let mut text = trimmed.to_string();
+                index += 1;
+                while index < lines.len() {
+                    let next_code = toml_code_only_line(lines[index]);
+                    let next_trimmed = next_code.trim();
+                    if parse_toml_section(next_trimmed).is_some() {
+                        break;
+                    }
+                    if !next_trimmed.is_empty() {
+                        text.push(' ');
+                        text.push_str(next_trimmed);
+                    }
+                    index += 1;
+                }
+                if dependency_entry_targets_dependency(table_name, &text, dependency) {
+                    entries.push(ManifestDependencyEntry {
+                        line_no: start_line,
+                        text,
+                    });
+                }
+                continue;
+            }
+
+            section.clear();
+            section.push_str(next_section);
+            index += 1;
+            continue;
+        }
+
+        if is_normal_dependency_section(&section) {
+            if let Some(key) = toml_assignment_key(trimmed) {
+                let start_line = index + 1;
+                let (text, next_index) = collect_toml_assignment_text(&lines, index);
+                if dependency_entry_targets_dependency(key, &text, dependency) {
+                    entries.push(ManifestDependencyEntry {
+                        line_no: start_line,
+                        text,
+                    });
+                }
+                index = next_index;
+                continue;
+            }
+        }
+
+        index += 1;
+    }
+
+    entries
+}
+
+fn dependency_entry_targets_dependency(key: &str, text: &str, dependency: &str) -> bool {
+    toml_key_matches(key, dependency)
+        || dependency_text_contains_marker(text, &format!("package = \"{dependency}\""))
+        || dependency_text_contains_marker(text, &format!("package = '{dependency}'"))
+}
+
+fn toml_key_matches(key: &str, expected: &str) -> bool {
+    let key = key.trim();
+    key == expected
+        || key
+            .strip_prefix('"')
+            .and_then(|key| key.strip_suffix('"'))
+            .is_some_and(|key| key == expected)
+        || key
+            .strip_prefix('\'')
+            .and_then(|key| key.strip_suffix('\''))
+            .is_some_and(|key| key == expected)
+}
+
+fn collect_toml_assignment_text(lines: &[&str], start_index: usize) -> (String, usize) {
+    let code = toml_code_only_line(lines[start_index]);
+    let trimmed = code.trim();
+    let mut text = trimmed.to_string();
+    let mut balance = toml_collection_balance(trimmed);
+    let mut index = start_index + 1;
+
+    while balance > 0 && index < lines.len() {
+        let next_code = toml_code_only_line(lines[index]);
+        let next_trimmed = next_code.trim();
+        if parse_toml_section(next_trimmed).is_some() {
+            break;
+        }
+        if !next_trimmed.is_empty() {
+            text.push(' ');
+            text.push_str(next_trimmed);
+            balance += toml_collection_balance(next_trimmed);
+        }
+        index += 1;
+    }
+
+    (text, index)
+}
+
+fn toml_collection_balance(line: &str) -> isize {
+    let mut balance = 0isize;
+    let mut in_string = false;
+    let mut quote = '\0';
+    let mut escaped = false;
+
+    for ch in line.chars() {
+        if in_string {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+
+            if quote == '"' && ch == '\\' {
+                escaped = true;
+            } else if ch == quote {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if ch == '"' || ch == '\'' {
+            in_string = true;
+            quote = ch;
+            continue;
+        }
+
+        match ch {
+            '{' | '[' => balance += 1,
+            '}' | ']' => balance -= 1,
+            _ => {}
+        }
+    }
+
+    balance
+}
+
+fn manifest_dependency_text(contents: &str, dependency: &str) -> Option<String> {
+    manifest_normal_dependency_entries(contents, dependency)
+        .into_iter()
+        .next()
+        .map(|entry| entry.text)
+}
+
+fn manifest_feature_values(contents: &str, feature: &str) -> Option<Vec<String>> {
+    manifest_feature_entries(contents)
+        .into_iter()
+        .find(|entry| entry.name == feature)
+        .map(|entry| entry.values)
+}
+
+fn manifest_feature_entries(contents: &str) -> Vec<ManifestFeatureEntry> {
+    let mut section = String::new();
+    let mut pending_feature = None::<String>;
+    let mut pending_line_no = 0usize;
+    let mut pending_value = String::new();
+    let mut entries = Vec::new();
+
+    for (line_no, line) in contents.lines().enumerate() {
+        let code = toml_code_only_line(line);
+        let trimmed = code.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if let Some(next_section) = parse_toml_section(trimmed) {
+            section.clear();
+            section.push_str(next_section);
+            pending_feature = None;
+            pending_line_no = 0;
+            pending_value.clear();
+            continue;
+        }
+
+        if section != "features" {
+            continue;
+        }
+
+        if let Some(pending) = pending_feature.as_ref() {
+            pending_value.push(' ');
+            pending_value.push_str(trimmed);
+            if trimmed.contains(']') {
+                let values = parse_toml_string_array(&pending_value);
+                entries.push(ManifestFeatureEntry {
+                    line_no: pending_line_no,
+                    name: pending.clone(),
+                    values,
+                });
+                pending_feature = None;
+                pending_line_no = 0;
+                pending_value.clear();
+            }
+            continue;
+        }
+
+        let Some((key, value)) = toml_assignment(trimmed) else {
+            continue;
+        };
+        if !value.contains('[') {
+            continue;
+        }
+
+        if value.contains(']') {
+            entries.push(ManifestFeatureEntry {
+                line_no: line_no + 1,
+                name: key.to_string(),
+                values: parse_toml_string_array(value),
+            });
+            continue;
+        }
+
+        pending_feature = Some(key.to_string());
+        pending_line_no = line_no + 1;
+        pending_value.clear();
+        pending_value.push_str(value);
+    }
+
+    entries
+}
+
+fn toml_assignment(trimmed: &str) -> Option<(&str, &str)> {
+    let (key, value) = trimmed.split_once('=')?;
+    Some((key.trim(), value.trim()))
+}
+
+fn toml_assignment_key(trimmed: &str) -> Option<&str> {
+    toml_assignment(trimmed).map(|(key, _)| key)
+}
+
+fn parse_toml_string_array(value: &str) -> Vec<String> {
+    let array = value
+        .split_once('[')
+        .and_then(|(_, rest)| rest.rsplit_once(']').map(|(body, _)| body))
+        .unwrap_or(value);
+    let mut values = Vec::new();
+    let mut current = String::new();
+    let mut in_string = false;
+    let mut quote = '\0';
+    let mut escaped = false;
+
+    for ch in array.chars() {
+        if in_string {
+            if escaped {
+                current.push(ch);
+                escaped = false;
+                continue;
+            }
+
+            if quote == '"' && ch == '\\' {
+                escaped = true;
+                continue;
+            }
+
+            if ch == quote {
+                values.push(std::mem::take(&mut current));
+                in_string = false;
+                continue;
+            }
+
+            current.push(ch);
+            continue;
+        }
+
+        if ch == '"' || ch == '\'' {
+            quote = ch;
+            in_string = true;
+        }
+    }
+
+    values
+}
+
+fn expect_feature_values(
+    rel: &str,
+    contents: &str,
+    feature: &str,
+    expected: &[&str],
+    violations: &mut Vec<String>,
+) {
+    match manifest_feature_values(contents, feature) {
+        Some(actual) if feature_values_match(&actual, expected) => {}
+        Some(actual) => violations.push(format!(
+            "{}: feature `{}` expected {:?}, found {:?}",
+            rel, feature, expected, actual
+        )),
+        None => violations.push(format!("{}: missing feature `{}`", rel, feature)),
+    }
+}
+
+fn feature_values_match(actual: &[String], expected: &[&str]) -> bool {
+    let actual = actual.iter().map(String::as_str).collect::<BTreeSet<_>>();
+    let expected = expected.iter().copied().collect::<BTreeSet<_>>();
+    actual == expected
+}
+
+fn reject_feature_markers(
+    rel: &str,
+    contents: &str,
+    forbidden: &[&str],
+    violations: &mut Vec<String>,
+) {
+    let mut section = String::new();
+
+    for (line_no, line) in contents.lines().enumerate() {
+        let code = toml_code_only_line(line);
+        let trimmed = code.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if let Some(next_section) = parse_toml_section(trimmed) {
+            section.clear();
+            section.push_str(next_section);
+            continue;
+        }
+
+        if section == "features" {
+            for marker in forbidden {
+                if trimmed.contains(marker) {
+                    violations.push(format!(
+                        "{}:{}: feature value must not reference `{}` directly: {}",
+                        rel,
+                        line_no + 1,
+                        marker,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+    }
+}
+
+fn reject_feature_markers_outside_features(
+    rel: &str,
+    contents: &str,
+    forbidden: &[&str],
+    allowed_features: &[&str],
+    violations: &mut Vec<String>,
+) {
+    let allowed_features = allowed_features.iter().copied().collect::<BTreeSet<_>>();
+
+    for entry in manifest_feature_entries(contents) {
+        if allowed_features.contains(entry.name.as_str()) {
+            continue;
+        }
+
+        for value in &entry.values {
+            if let Some(marker) = forbidden.iter().find(|marker| value.contains(**marker)) {
+                violations.push(format!(
+                    "{}:{}: feature `{}` must not reference `{}` directly: {:?}",
+                    rel, entry.line_no, entry.name, marker, entry.values
+                ));
+            }
+        }
+    }
+}
+
+fn reject_normal_dependency(
+    rel: &str,
+    contents: &str,
+    dependency: &str,
+    reason: &str,
+    violations: &mut Vec<String>,
+) {
+    for entry in manifest_normal_dependency_entries(contents, dependency) {
+        violations.push(format!(
+            "{}:{}: {}: {}",
+            rel, entry.line_no, reason, entry.text
+        ));
+    }
+}
+
+fn expect_dependency_line_contains(
+    rel: &str,
+    contents: &str,
+    dependency: &str,
+    expected_markers: &[&str],
+    violations: &mut Vec<String>,
+) {
+    let Some(text) = manifest_dependency_text(contents, dependency) else {
+        violations.push(format!(
+            "{}: missing normal dependency `{}`",
+            rel, dependency
+        ));
+        return;
+    };
+
+    for marker in expected_markers {
+        if !dependency_text_contains_marker(&text, marker) {
+            violations.push(format!(
+                "{}: dependency `{}` must contain `{}`: {}",
+                rel, dependency, marker, text
+            ));
+        }
+    }
+}
+
+fn reject_dependency_line_markers(
+    rel: &str,
+    contents: &str,
+    dependency: &str,
+    forbidden_markers: &[&str],
+    violations: &mut Vec<String>,
+) {
+    let Some(text) = manifest_dependency_text(contents, dependency) else {
+        violations.push(format!(
+            "{}: missing normal dependency `{}`",
+            rel, dependency
+        ));
+        return;
+    };
+
+    for marker in forbidden_markers {
+        if dependency_text_contains_marker(&text, marker) {
+            violations.push(format!(
+                "{}: dependency `{}` must not contain `{}`: {}",
+                rel, dependency, marker, text
+            ));
+        }
+    }
+}
+
+fn dependency_text_contains_marker(text: &str, marker: &str) -> bool {
+    normalize_toml_dependency_text(text).contains(&normalize_toml_dependency_text(marker))
+}
+
+fn normalize_toml_dependency_text(text: &str) -> String {
+    text.chars().filter(|ch| !ch.is_whitespace()).collect()
 }
 
 fn manifest_line_mentions_storage_dependency(trimmed: &str) -> bool {
@@ -1097,6 +1916,48 @@ fn find_forbidden_marker_violations(
     violations
 }
 
+fn find_retired_crate_marker_violations(rel: &str, contents: &str) -> Vec<String> {
+    let mut violations = Vec::new();
+
+    if rel.ends_with(".rs") {
+        let mut lex_state = RustCodeLexState::default();
+        for (line_no, line) in contents.lines().enumerate() {
+            let code = rust_code_only_line(line, &mut lex_state);
+            if let Some(marker) = RETIRED_CRATE_MARKERS
+                .iter()
+                .find(|marker| rust_code_contains_marker(&code, marker))
+            {
+                violations.push(format!(
+                    "{}:{}: active Rust source references retired crate marker `{}`: {}",
+                    rel,
+                    line_no + 1,
+                    marker,
+                    line.trim()
+                ));
+            }
+        }
+        return violations;
+    }
+
+    for (line_no, line) in contents.lines().enumerate() {
+        let code = toml_code_only_line(line);
+        if let Some(marker) = RETIRED_CRATE_MARKERS
+            .iter()
+            .find(|marker| text_contains_marker_token(&code, marker))
+        {
+            violations.push(format!(
+                "{}:{}: active manifest/lockfile references retired crate marker `{}`: {}",
+                rel,
+                line_no + 1,
+                marker,
+                line.trim()
+            ));
+        }
+    }
+
+    violations
+}
+
 fn rust_code_contains_marker(code: &str, marker: &str) -> bool {
     if marker.starts_with('.') {
         return contains_method_marker(code, marker);
@@ -1110,6 +1971,30 @@ fn rust_code_contains_marker(code: &str, marker: &str) -> bool {
     }
 
     contains_rust_identifier_token(code, marker)
+}
+
+fn text_contains_marker_token(text: &str, marker: &str) -> bool {
+    let mut offset = 0usize;
+    while let Some(relative) = text[offset..].find(marker) {
+        let start = offset + relative;
+        let end = start + marker.len();
+        let before = text[..start].chars().next_back();
+        let after = text[end..].chars().next();
+
+        let before_is_boundary = before.is_none_or(|ch| !is_manifest_marker_continue(ch));
+        let after_is_boundary = after.is_none_or(|ch| !is_manifest_marker_continue(ch));
+        if before_is_boundary && after_is_boundary {
+            return true;
+        }
+
+        offset = end;
+    }
+
+    false
+}
+
+fn is_manifest_marker_continue(ch: char) -> bool {
+    ch == '-' || ch == '_' || ch.is_ascii_alphanumeric()
 }
 
 fn contains_method_marker(code: &str, marker: &str) -> bool {
@@ -1263,28 +2148,98 @@ fn find_upper_subsystem_violations(rel: &str, contents: &str, subsystem_name: &s
     violations
 }
 
-fn is_cfg_test_attr(trimmed_code: &str) -> bool {
-    let compact = trimmed_code
-        .chars()
-        .filter(|ch| !ch.is_whitespace())
-        .collect::<String>();
+fn find_upper_runtime_assembly_violations(rel: &str, contents: &str) -> Vec<String> {
+    let mut violations = Vec::new();
+    let mut pending_cfg_test = false;
+    let mut skipped_cfg_test_depth = None;
+    let mut lex_state = RustCodeLexState::default();
 
-    compact.starts_with("#[cfg(")
-        && !compact.contains("not(test)")
-        && contains_cfg_atom(&compact, "test")
+    for (line_no, line) in contents.lines().enumerate() {
+        let code = rust_code_only_line(line, &mut lex_state);
+
+        if let Some(depth) = skipped_cfg_test_depth.as_mut() {
+            update_brace_depth(depth, &code);
+            if *depth == 0 {
+                skipped_cfg_test_depth = None;
+            }
+            continue;
+        }
+
+        let trimmed = code.trim();
+        if is_cfg_test_attr(trimmed) {
+            pending_cfg_test = true;
+            continue;
+        }
+
+        if pending_cfg_test {
+            if trimmed.is_empty() || trimmed.starts_with("#[") {
+                continue;
+            }
+
+            if line_declares_inline_module(trimmed) {
+                let mut depth = 0usize;
+                update_brace_depth(&mut depth, &code);
+                if depth > 0 {
+                    skipped_cfg_test_depth = Some(depth);
+                }
+                pending_cfg_test = false;
+                continue;
+            }
+
+            pending_cfg_test = false;
+        }
+
+        if let Some(marker) = find_upper_runtime_assembly_marker(&code) {
+            violations.push(format!(
+                "{}:{}: production upper crate assembles engine runtime via `{}`: {}",
+                rel,
+                line_no + 1,
+                marker,
+                line.trim()
+            ));
+        }
+    }
+
+    violations
 }
 
-fn contains_cfg_atom(compact_cfg_attr: &str, atom: &str) -> bool {
-    let mut offset = 0usize;
-    while let Some(relative) = compact_cfg_attr[offset..].find(atom) {
-        let start = offset + relative;
-        let end = start + atom.len();
-        let before = compact_cfg_attr[..start].chars().next_back();
-        let after = compact_cfg_attr[end..].chars().next();
+fn find_upper_runtime_assembly_marker(code: &str) -> Option<&'static str> {
+    if let Some(marker) = UPPER_FORBIDDEN_RUNTIME_ASSEMBLY_MARKERS
+        .iter()
+        .find(|marker| rust_code_contains_marker(code, marker))
+    {
+        return Some(marker);
+    }
 
+    if contains_method_call_token(code, "with_subsystem") {
+        return Some("with_subsystem");
+    }
+
+    if contains_method_call_token(code, "with_subsystems") {
+        return Some("with_subsystems");
+    }
+
+    if contains_dyn_subsystem_trait(code) {
+        return Some("dyn Subsystem");
+    }
+
+    if contains_engine_subsystem_trait_path(code) {
+        return Some("recovery::Subsystem");
+    }
+
+    None
+}
+
+fn contains_method_call_token(code: &str, method: &str) -> bool {
+    let mut offset = 0usize;
+    while let Some(relative) = code[offset..].find(method) {
+        let start = offset + relative;
+        let end = start + method.len();
+        let before = code[..start].chars().next_back();
+        let after = code[end..].chars().next();
         let before_is_boundary = before.is_none_or(|ch| !is_rust_identifier_continue(ch));
         let after_is_boundary = after.is_none_or(|ch| !is_rust_identifier_continue(ch));
-        if before_is_boundary && after_is_boundary {
+        if before_is_boundary && after_is_boundary && has_dot_before_method(code, start) {
             return true;
         }
 
@@ -1292,6 +2247,52 @@ fn contains_cfg_atom(compact_cfg_attr: &str, atom: &str) -> bool {
     }
 
     false
+}
+
+fn has_dot_before_method(code: &str, method_start: usize) -> bool {
+    code[..method_start]
+        .chars()
+        .rev()
+        .find(|ch| !ch.is_whitespace())
+        .is_some_and(|ch| ch == '.')
+}
+
+fn contains_dyn_subsystem_trait(code: &str) -> bool {
+    let tokens = code
+        .split(|ch: char| !(ch == '_' || ch.is_ascii_alphanumeric()))
+        .filter(|token| !token.is_empty());
+
+    let mut previous_was_dyn = false;
+    for token in tokens {
+        if previous_was_dyn && token == "Subsystem" {
+            return true;
+        }
+
+        previous_was_dyn = token == "dyn";
+    }
+
+    false
+}
+
+fn contains_engine_subsystem_trait_path(code: &str) -> bool {
+    let tokens = code
+        .split(|ch: char| !(ch == '_' || ch.is_ascii_alphanumeric()))
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+
+    tokens.contains(&"strata_engine")
+        && tokens
+            .windows(2)
+            .any(|window| window == ["recovery", "Subsystem"])
+}
+
+fn is_cfg_test_attr(trimmed_code: &str) -> bool {
+    let compact = trimmed_code
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect::<String>();
+
+    compact == "#[cfg(test)]"
 }
 
 fn line_declares_inline_module(trimmed_code: &str) -> bool {
@@ -1597,93 +2598,8 @@ fn find_violations(contents: &str) -> Vec<String> {
 }
 
 fn find_manifest_violations(path: &Path, contents: &str) -> Vec<String> {
-    let mut violations = Vec::new();
     let rel = path.to_string_lossy();
-
-    for (line_no, line) in contents.lines().enumerate() {
-        if line.contains("strata-concurrency")
-            || line.contains("path = \"../concurrency\"")
-            || line.contains("path = \"crates/concurrency\"")
-        {
-            violations.push(format!(
-                "{}:{}: manifest references deleted `strata-concurrency` surface",
-                rel,
-                line_no + 1
-            ));
-        }
-
-        if line.contains("strata-durability")
-            || line.contains("path = \"../durability\"")
-            || line.contains("path = \"crates/durability\"")
-        {
-            violations.push(format!(
-                "{}:{}: manifest references deleted `strata-durability` surface",
-                rel,
-                line_no + 1
-            ));
-        }
-
-        if line.contains(RETIRED_EXECUTOR_LEGACY_PACKAGE)
-            || RETIRED_EXECUTOR_LEGACY_RELATIVE_PATHS
-                .iter()
-                .any(|path| line.contains(path))
-        {
-            violations.push(format!(
-                "{}:{}: manifest references retired `strata-executor-legacy` bootstrap crate",
-                rel,
-                line_no + 1
-            ));
-        }
-
-        if line.contains(RETIRED_GRAPH_PACKAGE)
-            || RETIRED_GRAPH_RELATIVE_PATHS
-                .iter()
-                .any(|path| line.contains(path))
-        {
-            violations.push(format!(
-                "{}:{}: manifest references retired `{}` crate",
-                rel,
-                line_no + 1,
-                RETIRED_GRAPH_PACKAGE
-            ));
-        }
-
-        if line.contains(RETIRED_VECTOR_PACKAGE)
-            || RETIRED_VECTOR_RELATIVE_PATHS
-                .iter()
-                .any(|path| line.contains(path))
-        {
-            violations.push(format!(
-                "{}:{}: manifest references retired `{}` crate",
-                rel,
-                line_no + 1,
-                RETIRED_VECTOR_PACKAGE
-            ));
-        }
-
-        if line.contains(RETIRED_SEARCH_PACKAGE)
-            || RETIRED_SEARCH_RELATIVE_PATHS
-                .iter()
-                .any(|path| line.contains(path))
-        {
-            violations.push(format!(
-                "{}:{}: manifest references retired `{}` crate",
-                rel,
-                line_no + 1,
-                RETIRED_SEARCH_PACKAGE
-            ));
-        }
-
-        if line.contains("strata-core-legacy") || line.contains("core-legacy") {
-            violations.push(format!(
-                "{}:{}: manifest references retired `strata-core-legacy` crate",
-                rel,
-                line_no + 1
-            ));
-        }
-    }
-
-    violations
+    find_retired_crate_marker_violations(&rel, contents)
 }
 
 fn scan_import_blocks(contents: &str, marker: &str, forbidden_tokens: &[&str]) -> Vec<String> {
@@ -2073,6 +2989,275 @@ strata-engine = { path = "../engine" }
 }
 
 #[test]
+fn retired_crate_guard_detects_manifests_lockfiles_and_rust_imports() {
+    let manifest = r#"
+[dependencies]
+strata-security = { path = "../security" }
+graph = { package = "strata-graph", path = "../graph" }
+"#;
+    let manifest_violations =
+        find_retired_crate_marker_violations("crates/example/Cargo.toml", manifest);
+    assert_eq!(manifest_violations.len(), 2, "{manifest_violations:?}");
+
+    let lockfile = r#"
+[[package]]
+name = "strata-core-legacy"
+"#;
+    let lockfile_violations = find_retired_crate_marker_violations("Cargo.lock", lockfile);
+    assert_eq!(lockfile_violations.len(), 1, "{lockfile_violations:?}");
+
+    let source = r#"
+use strata_concurrency::TransactionManager;
+use strata_durability::wal::WalWriter;
+"#;
+    let source_violations =
+        find_retired_crate_marker_violations("crates/example/src/lib.rs", source);
+    assert_eq!(source_violations.len(), 2, "{source_violations:?}");
+}
+
+#[test]
+fn retired_crate_guard_ignores_comments_literals_and_substrings() {
+    let manifest = r#"
+[dependencies]
+# strata-security = { path = "../security" }
+strata-graphical = "0.1"
+"#;
+    let manifest_violations =
+        find_retired_crate_marker_violations("crates/example/Cargo.toml", manifest);
+    assert!(manifest_violations.is_empty(), "{manifest_violations:?}");
+
+    let source = r###"
+const TEXT: &str = "strata_durability";
+const RAW: &str = r#"strata_concurrency"#;
+
+// use strata_concurrency::TransactionManager;
+/* use strata_durability::wal::WalWriter; */
+
+fn product_runtime() {
+    let _ = strata_concurrent_runtime;
+}
+"###;
+    let source_violations =
+        find_retired_crate_marker_violations("crates/example/src/lib.rs", source);
+    assert!(source_violations.is_empty(), "{source_violations:?}");
+}
+
+#[test]
+fn upper_runtime_assembly_guard_detects_runtime_assembly_patterns() {
+    let contents = r#"
+use strata_engine::database::OpenSpec;
+use strata_engine::SearchSubsystem;
+use strata_engine::recovery::Subsystem;
+use strata_engine::recovery::Subsystem as RuntimeSubsystem;
+
+fn product_runtime() {
+    let _spec = OpenSpec::cache();
+    let _spec = _spec . with_subsystem(SearchSubsystem);
+    let _spec = _spec . with_subsystems(Vec::new());
+    let _subsystems: Vec<Box<dyn Subsystem>> = Vec::new();
+    let _qualified: Box<dyn strata_engine::recovery::Subsystem>;
+    let _aliased: Box<dyn RuntimeSubsystem>;
+    let _search = SearchSubsystem;
+}
+"#;
+
+    let violations = find_upper_runtime_assembly_violations("crates/example/src/lib.rs", contents);
+    assert!(
+        violations.len() >= 7,
+        "expected OpenSpec, whitespace with_subsystem(s), Subsystem import/alias variants, and SearchSubsystem violations: {violations:?}"
+    );
+}
+
+#[test]
+fn upper_runtime_assembly_guard_ignores_literals_comments_cfg_tests_and_substrings() {
+    let contents = r###"
+const TEXT: &str = "OpenSpec";
+const RAW: &str = r#"SearchSubsystem"#;
+
+// OpenSpec::cache().with_subsystem(SearchSubsystem);
+/* let _: Box<dyn Subsystem>; */
+
+#[cfg(test)]
+mod tests {
+    use strata_engine::database::OpenSpec;
+    use strata_engine::SearchSubsystem;
+
+    fn test_runtime() {
+        let _spec = OpenSpec::cache().with_subsystem(SearchSubsystem);
+    }
+}
+
+fn product_runtime() {
+    let _ = OpenSpeculativeRuntime;
+    let _ = search.with_subsystematic();
+}
+"###;
+
+    let violations = find_upper_runtime_assembly_violations("crates/example/src/lib.rs", contents);
+    assert!(violations.is_empty(), "{violations:?}");
+}
+
+#[test]
+fn upper_runtime_assembly_guard_requires_adjacent_dyn_subsystem_trait() {
+    let contents = r#"
+fn product_runtime() {
+    let _: Box<dyn std::fmt::Debug>;
+    let Subsystem = 1usize;
+    let _ = Subsystem;
+}
+"#;
+
+    let violations = find_upper_runtime_assembly_violations("crates/example/src/lib.rs", contents);
+    assert!(violations.is_empty(), "{violations:?}");
+}
+
+#[test]
+fn upper_runtime_assembly_guard_does_not_skip_feature_enabled_cfg_modules() {
+    let contents = r#"
+#[cfg(any(test, feature = "embed"))]
+mod runtime {
+    use strata_engine::database::OpenSpec;
+
+    fn product_runtime() {
+        let _spec = OpenSpec::cache();
+    }
+}
+"#;
+
+    let violations = find_upper_runtime_assembly_violations("crates/example/src/lib.rs", contents);
+    assert_eq!(violations.len(), 2, "{violations:?}");
+}
+
+#[test]
+fn optional_edge_guard_parses_feature_arrays_and_dependency_lines() {
+    let contents = r#"
+[features]
+default = []
+embed = [
+    "strata-executor/embed",
+    "dep:strata-intelligence",
+]
+openai = ["embed", "strata-executor/openai"]
+
+[dependencies]
+strata-executor = { path = "../executor" }
+strata-intelligence = { path = "../intelligence", features = ["embed"], optional = true }
+"#;
+
+    assert_eq!(
+        manifest_feature_values(contents, "embed").as_deref(),
+        Some(
+            &[
+                "strata-executor/embed".to_string(),
+                "dep:strata-intelligence".to_string()
+            ][..]
+        )
+    );
+    assert_eq!(
+        manifest_feature_values(contents, "openai").as_deref(),
+        Some(&["embed".to_string(), "strata-executor/openai".to_string()][..])
+    );
+    let text =
+        manifest_dependency_text(contents, "strata-intelligence").expect("parse dependency line");
+    assert!(dependency_text_contains_marker(&text, "optional = true"));
+    assert!(dependency_text_contains_marker(
+        &text,
+        "features = [\"embed\"]"
+    ));
+
+    let dotted = r#"
+[dependencies.strata-intelligence]
+path="../intelligence"
+features=["embed"]
+optional=true
+"#;
+    let text =
+        manifest_dependency_text(dotted, "strata-intelligence").expect("parse dotted dependency");
+    assert!(dependency_text_contains_marker(
+        &text,
+        "path = \"../intelligence\""
+    ));
+    assert!(dependency_text_contains_marker(
+        &text,
+        "features = [\"embed\"]"
+    ));
+    assert!(dependency_text_contains_marker(&text, "optional = true"));
+
+    let alias = r#"
+[target.'cfg(unix)'.dependencies.ai]
+package = "strata-intelligence"
+path = "../intelligence"
+features = [
+    "embed",
+]
+optional = true
+"#;
+    let text =
+        manifest_dependency_text(alias, "strata-intelligence").expect("parse aliased dependency");
+    assert!(dependency_text_contains_marker(
+        &text,
+        "package = \"strata-intelligence\""
+    ));
+    assert!(dependency_text_contains_marker(&text, "features = ["));
+    assert!(dependency_text_contains_marker(&text, "\"embed\""));
+
+    let quoted_inline = r#"
+[dependencies]
+"strata-intelligence" = { path = "../intelligence", features = ["embed"], optional = true }
+"#;
+    let text = manifest_dependency_text(quoted_inline, "strata-intelligence")
+        .expect("parse quoted inline dependency key");
+    assert!(dependency_text_contains_marker(&text, "optional = true"));
+
+    let quoted_dotted = r#"
+[dependencies."strata-intelligence"]
+path = "../intelligence"
+optional = true
+"#;
+    let text = manifest_dependency_text(quoted_dotted, "strata-intelligence")
+        .expect("parse quoted dotted dependency key");
+    assert!(dependency_text_contains_marker(&text, "optional = true"));
+}
+
+#[test]
+fn optional_edge_guard_detects_root_intelligence_and_cli_feature_leaks() {
+    let root = r#"
+[dependencies]
+"strata-intelligence" = { path = "crates/intelligence" }
+ai = { package = "strata-intelligence", path = "crates/intelligence" }
+
+[dev-dependencies]
+strata-intelligence = { path = "crates/intelligence" }
+"#;
+    let mut violations = Vec::new();
+    reject_normal_dependency(
+        "Cargo.toml",
+        root,
+        "strata-intelligence",
+        "root package default graph must reach intelligence through executor only",
+        &mut violations,
+    );
+    assert_eq!(violations.len(), 2, "{violations:?}");
+
+    let cli = r#"
+[features]
+default = []
+embed = ["strata-executor/embed", "dep:strata-intelligence"]
+experimental = ["dep:strata-intelligence"]
+provider = ["strata-intelligence/openai"]
+"#;
+    let mut violations = Vec::new();
+    reject_feature_markers_outside_features(
+        "crates/cli/Cargo.toml",
+        cli,
+        &["dep:strata-intelligence", "strata-intelligence"],
+        &["embed"],
+        &mut violations,
+    );
+    assert_eq!(violations.len(), 2, "{violations:?}");
+}
+
+#[test]
 fn root_storage_dependency_guard_allows_dev_dependency() {
     let contents = r#"
 [dependencies]
@@ -2159,7 +3344,7 @@ fn product_runtime() {
 }
 
 #[test]
-fn graph_subsystem_guard_ignores_cfg_test_modules_with_nonstandard_names() {
+fn graph_subsystem_guard_does_not_ignore_feature_enabled_cfg_modules() {
     let contents = r#"
 #[cfg(any(test, feature = "test-support"))]
 pub(crate) mod graph_tests {
@@ -2173,7 +3358,7 @@ pub(crate) mod graph_tests {
 
     let violations =
         find_upper_subsystem_violations("crates/example/src/lib.rs", contents, "GraphSubsystem");
-    assert!(violations.is_empty(), "{violations:?}");
+    assert_eq!(violations.len(), 2, "{violations:?}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Final ratchet on the engine consolidation project. EG2-EG8 already moved security/open options, product open, graph, vector, search, executor storage access, and intelligence boundary cleanup into the intended shape. EG9 makes that state enforceable and refreshes active architecture docs.
- Adds three closeout guards: retired-crate absence (8 crates), upper-layer runtime assembly bans, and optional embed/inference edge policy enforcement on root/CLI/executor/intelligence manifests.
- Scanner now parses all four TOML dependency forms (inline, dotted, target-cfg, quoted keys, `package = "..."` aliases) with whitespace-tolerant marker matching. Tightens `is_cfg_test_attr` so only strict `#[cfg(test)]` is treated as a test gate — feature-enabled modules are no longer skipped.

## Final guards

- `engine_consolidation_retired_crates_are_closed_out` — rejects any of `crates/{security, executor-legacy, graph, vector, search, core-legacy, concurrency, durability}` returning, plus package/path references in active source, manifests, and `Cargo.lock`. Uses lex-aware Rust scanning and TOML token-boundary matching.
- `engine_consolidation_upper_layers_do_not_assemble_product_runtime` — rejects `OpenSpec`, `GraphSubsystem`, `VectorSubsystem`, `SearchSubsystem`, `.with_subsystem`, `.with_subsystems`, `dyn Subsystem`, and qualified `strata_engine::recovery::Subsystem` outside engine. Scans `crates/intelligence/tests/` so integration tests can't reintroduce subsystem assembly.
- `engine_consolidation_optional_embed_edges_are_policy_bound` — enforces exact feature values for root, CLI, executor, and intelligence manifests:
  - root `embed`/provider features forward only through executor
  - CLI's `strata-intelligence` dependency stays optional and is reached only via CLI's `embed` feature
  - executor reaches intelligence as a non-optional dependency and forwards provider features through intelligence
  - `strata-inference` remains optional with `default-features = false` and is referenced only by intelligence

## Scanner improvements

- TOML manifest parser handles inline `[dependencies]`, dotted `[dependencies.<name>]`, target-cfg `[target.cfg.dependencies]`, target-cfg dotted forms, quoted keys, and `package = "..."` aliases.
- Multi-line feature array parsing.
- Whitespace-tolerant dependency-line marker matching via `normalize_toml_dependency_text`.
- `is_cfg_test_attr` is strict equality with `#[cfg(test)]`. Feature-enabled `cfg(any(test, feature = "x"))` modules are no longer skipped, since they compile in production with `x` enabled.
- New self-tests cover all manifest forms, the strict test-gate behavior, whitespace-separated method calls, aliased `dyn Subsystem`, and qualified `strata_engine::recovery::Subsystem`.

## Document refresh

- `engine-crate-map.md`: post-EG9 graph, optional-edge policy, retired peer state, v1 architecture handoff.
- `storage-crate-map.md`: storage's only normal production consumer is engine; root storage edge is dev-only.
- `v1-storage-consumption-contract.md`: removed ""temporary migration shim"" allowance, executor's removed direct storage dep recorded, `Database::storage()` reframed as engine/test escape hatch.
- `storage-engine-ownership-audit.md`: residue notes acknowledge consolidation closeout.
- `engine-consolidation-plan.md`: every EG9 sub-section status set to complete; EG7 risk wording past-tense; phase plans listed as completed; future v1 documents separately enumerated.
- new `docs/engine/eg9-implementation-plan.md` records the closeout ledger, graph snapshots, and known pre-existing engine shutdown/fault-injection failures kept out of EG9 scope.

## Test plan

- [x] `cargo test -p stratadb --test storage_surface_imports` (44 passed)
- [x] `cargo fmt --check` passes
- [x] `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check --workspace --all-targets` passes (raw check blocked by missing local llama.cpp vendor tree — pre-existing)
- [x] `cargo test -p strata-executor --lib` (116 passed)
- [x] `cargo test -p strata-intelligence` passes (default has no enabled tests)
- [x] `STRATA_INFERENCE_SKIP_LLAMA_CPP_BUILD_FOR_CHECK=1 cargo check -p strata-{intelligence,executor,cli} --features embed --tests` pass
- [x] `cargo tree -p strata-cli --edges normal --depth 1` — no intelligence/inference edges
- [x] `cargo tree -p strata-cli --features embed --edges normal -i strata-inference` — inference reaches CLI only through intelligence
- [x] `cargo tree -i strata-storage --workspace --edges normal --depth 1` — only `strata-engine`
- [ ] 10 pre-existing engine shutdown/fault-injection failures (last touched in ST4 commit `f73ff7cd`) are explicitly named in the EG9 plan ledger as out-of-scope; they are not regressions and were not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)